### PR TITLE
[PR #583] INSIGHT-459: feat(zendesk) — connector scaffold + docs (Phase 1 MVP)

### DIFF
--- a/docs/components/connectors/support/zendesk/README.md
+++ b/docs/components/connectors/support/zendesk/README.md
@@ -1,0 +1,24 @@
+# Zendesk Connector
+
+Extracts Zendesk ticket data, satisfaction ratings, and agent directory into the Bronze layer. Feeds the support domain Silver pipeline for CSAT, ticket volume, resolution rate, and agent workload analytics.
+
+## Specification
+
+- **Spec**: [`zendesk.md`](./zendesk.md) — Bronze table schemas, source mappings, Silver/Gold targets
+- **PRD**: [`specs/PRD.md`](./specs/PRD.md) — functional and non-functional requirements
+- **DESIGN**: [`specs/DESIGN.md`](./specs/DESIGN.md) — technical architecture, field mappings, collection strategy
+- **Domain**: [`../README.md`](../README.md) — unified Support domain schema (Zendesk + JSM)
+
+## Phase 1 Streams
+
+| Stream | Table | Sync Mode |
+|--------|-------|-----------|
+| `support_tickets` | `bronze_zendesk.support_tickets` | Incremental (`updated_at`) |
+| `support_agents` | `bronze_zendesk.support_agents` | Full refresh |
+| `zendesk_satisfaction_ratings` | `bronze_zendesk.zendesk_satisfaction_ratings` | Incremental (`updated_at`) |
+
+Phase 2 adds `support_ticket_events` and `zendesk_ticket_ext` — schemas locked in `zendesk.md`.
+
+## Source code
+
+`src/ingestion/connectors/support/zendesk/`

--- a/docs/components/connectors/support/zendesk/specs/DESIGN.md
+++ b/docs/components/connectors/support/zendesk/specs/DESIGN.md
@@ -64,7 +64,7 @@ Every emitted record includes `insight_tenant_id`, `insight_source_id`, `unique_
 | `cpt-zendeskspec-fr-ticket-extraction` | `DeclarativeStream support_tickets` with `DatetimeBasedCursor` on `updated_at`; `GET /api/v2/incremental/tickets.json` with `?include=metric_sets` |
 | `cpt-zendeskspec-fr-timing-both-variants` | `AddFields` transformations extract both `.business` and `.calendar` values from sideloaded `metric_set`; stored as four separate Int64 fields |
 | `cpt-zendeskspec-fr-ticket-metadata` | Full API response stored as `metadata` String field via `DpathExtractor` on the full record |
-| `cpt-zendeskspec-fr-agent-extraction` | `DeclarativeStream support_agents` with full refresh; `GET /api/v2/users?role[]=agent&role[]=admin`; `GET /api/v2/groups` fetched at startup for group name resolution |
+| `cpt-zendeskspec-fr-agent-extraction` | `DeclarativeStream support_agents` with full refresh; `GET /api/v2/users?role[]=agent&role[]=admin`. Group-name resolution (`GET /api/v2/groups`) deferred to Phase 2 — `group_name` is NULL in Phase 1 |
 | `cpt-zendeskspec-fr-ratings-extraction` | `DeclarativeStream zendesk_satisfaction_ratings` with `DatetimeBasedCursor` on `updated_at`; `GET /api/v2/satisfaction_ratings` |
 | `cpt-zendeskspec-fr-collection-runs` | Connector-generated stream; written via a custom Python component or deferred to platform sync logs |
 | `cpt-zendeskspec-fr-deduplication` | Primary keys defined per stream; ClickHouse `ReplacingMergeTree(_version)` handles upsert deduplication |
@@ -97,7 +97,7 @@ Every emitted record includes `insight_tenant_id`, `insight_source_id`, `unique_
 │  │       cursor: updated_at (DatetimeBasedCursor)                    │
 │  ├── support_agents stream                                           │
 │  │   └── full refresh: GET /api/v2/users?role[]=agent&role[]=admin   │
-│  │       group names: GET /api/v2/groups (startup lookup)            │
+│  │       group names: GET /api/v2/groups (Phase 2)                   │
 │  └── zendesk_satisfaction_ratings stream                             │
 │      └── incremental: GET /api/v2/satisfaction_ratings               │
 │          ?start_time={unix_ts}&sort_by=updated_at                    │
@@ -215,7 +215,7 @@ connector.yaml (Airbyte DeclarativeSource)
 └── metadata        — autoImportSchema flags per stream
 ```
 
-**Check stream rationale**: `GET /api/v2/users/me` is used as the check endpoint — cheapest call, always returns exactly one record for valid credentials, no pagination, no rate limit impact.
+**Check stream rationale**: `check` is a `CheckStream` against `support_agents` — the CDK fetches the first page of `GET /api/v2/users?role[]=agent&role[]=admin` and reports SUCCEEDED if credentials are valid. (A dedicated single-record `/users/me` check stream would be cheaper but is not currently defined.)
 
 ### 3.3 API Contracts
 
@@ -288,8 +288,8 @@ Argo CronWorkflow
   ├─ 1. Read Airbyte state from platform (cursor for tickets and ratings)
   │
   ├─ 2. support_agents stream (full refresh)
-  │      GET /api/v2/groups (startup)
   │      GET /api/v2/users?role[]=agent&role[]=admin (paginated)
+  │      [Phase 2] GET /api/v2/groups (startup) for group_name resolution
   │      → RECORD messages → ClickHouse support_agents
   │
   ├─ 3. support_tickets stream (incremental)
@@ -440,14 +440,14 @@ The incremental export endpoint (`/api/v2/incremental/tickets.json?start_time=`)
 | `zendesk_satisfaction_ratings` | Next-page link (`next_page` URL in response body) | 100 |
 | `groups` (startup lookup) | Offset-based (`page`, `per_page`) | 100 |
 
-#### group_name Resolution
+#### group_name Resolution — Phase 2
 
-`support_agents.default_group_id` is a numeric Zendesk group ID. To populate `group_name`, the connector:
-1. Fetches all groups via `GET /api/v2/groups` at stream initialization
-2. Builds an in-memory `{group_id: group_name}` map
-3. Applies a `CustomTransformation` (or `RecordTransformation`) to populate `group_name` from the map for each agent record
+`support_agents.default_group_id` is a numeric Zendesk group ID. **Phase 1 stores `group_name` as NULL.** Group-name resolution is deferred to Phase 2; when implemented, the connector will:
+1. Fetch all groups via `GET /api/v2/groups` at stream initialization
+2. Build an in-memory `{group_id: group_name}` map
+3. Apply a `CustomTransformation` (or `RecordTransformation`) to populate `group_name` from the map for each agent record
 
-If the groups endpoint returns HTTP 403 (insufficient scope), `group_name` is NULL for all agents — sync continues without failure.
+If the groups endpoint returns HTTP 403 (insufficient scope), `group_name` stays NULL for all agents — sync continues without failure.
 
 ### Field Mapping to Bronze Schema
 
@@ -475,7 +475,7 @@ If the groups endpoint returns HTTP 403 (insufficient scope), `group_name` is NU
 | `tags` | `ticket.tags` (array) | Joined as comma-separated string |
 | `metadata` | Full `ticket` object as JSON | Stored via `AddFields` from raw record |
 
-**Implementation note**: `metric_set` fields are nested under sideloaded `metric_set` objects. The Zendesk API returns metric sets as a separate `metric_sets` array keyed by ticket ID when using `?include=metric_sets`. The connector must join the metric set to its parent ticket at record extraction time. This is handled via a `CustomTransformation` that merges the sideloaded metric_set into the ticket record before field extraction.
+**Implementation note**: on the incremental export endpoint, `?include=metric_sets` embeds the metric set directly in each ticket as a singular `metric_set` object (verified against `constructor-tech.zendesk.com`). No separate-array join or `CustomTransformation` is required — the `AddFields` transformations read `record.metric_set.*` directly during field extraction.
 
 #### `zendesk_satisfaction_ratings` field mapping
 
@@ -612,7 +612,7 @@ Estimated API calls per run (steady state, daily incremental):
 | `cpt-zendeskspec-fr-timing-both-variants` | Four timing fields in Bronze DDL; extracted via `AddFields` | §3.7, §4.2 |
 | `cpt-zendeskspec-fr-ticket-metadata` | `metadata` String field stores full JSON | §3.7 |
 | `cpt-zendeskspec-fr-agent-extraction` | `DeclarativeStream support_agents` full refresh | §3.2, §3.3 |
-| `cpt-zendeskspec-fr-group-name-resolution` | Startup `GET /api/v2/groups` + `CustomTransformation` | §4.2 |
+| `cpt-zendeskspec-fr-group-name-resolution` | **Phase 2** — `group_name` NULL in Phase 1; startup `GET /api/v2/groups` + `CustomTransformation` when implemented | §4.2 |
 | `cpt-zendeskspec-fr-ratings-extraction` | `DeclarativeStream zendesk_satisfaction_ratings` incremental | §3.2, §3.3 |
 | `cpt-zendeskspec-fr-deduplication` | `ReplacingMergeTree(_version)` + primary keys | §3.7 |
 | `cpt-zendeskspec-fr-tenant-context` | `AddFields` transformation on every stream | §1.1 |

--- a/docs/components/connectors/support/zendesk/specs/DESIGN.md
+++ b/docs/components/connectors/support/zendesk/specs/DESIGN.md
@@ -1,0 +1,634 @@
+# DESIGN — Zendesk Connector
+
+> Version 1.0 — May 2026
+> Issue: INSIGHT-459
+> Based on: [PRD.md](./PRD.md), [`zendesk.md`](../zendesk.md), [Connector Framework DESIGN](../../../../domain/connector/specs/DESIGN.md), [Support Domain README](../../README.md)
+
+<!-- toc -->
+
+- [1. Architecture Overview](#1-architecture-overview)
+  - [1.1 Architectural Vision](#11-architectural-vision)
+  - [1.2 Architecture Drivers](#12-architecture-drivers)
+  - [1.3 Architecture Layers](#13-architecture-layers)
+- [2. Principles & Constraints](#2-principles--constraints)
+  - [2.1 Design Principles](#21-design-principles)
+  - [2.2 Constraints](#22-constraints)
+- [3. Technical Architecture](#3-technical-architecture)
+  - [3.1 Domain Model](#31-domain-model)
+  - [3.2 Component Model](#32-component-model)
+  - [3.3 API Contracts](#33-api-contracts)
+  - [3.4 Internal Dependencies](#34-internal-dependencies)
+  - [3.5 External Dependencies](#35-external-dependencies)
+  - [3.6 Interactions & Sequences](#36-interactions--sequences)
+  - [3.7 Database Schemas & Tables](#37-database-schemas--tables)
+- [4. Additional Context](#4-additional-context)
+  - [API Details](#api-details)
+  - [Field Mapping to Bronze Schema](#field-mapping-to-bronze-schema)
+  - [Collection Strategy](#collection-strategy)
+  - [Identity Resolution Details](#identity-resolution-details)
+  - [Phase 2 Design Notes](#phase-2-design-notes)
+  - [Incremental Sync Cursor and Datetime Format](#incremental-sync-cursor-and-datetime-format)
+  - [Rate Limit Budget](#rate-limit-budget)
+- [5. Traceability](#5-traceability)
+- [6. Non-Applicability Statements](#6-non-applicability-statements)
+
+<!-- /toc -->
+
+---
+
+## 1. Architecture Overview
+
+### 1.1 Architectural Vision
+
+The Zendesk connector is an Airbyte declarative (nocode) YAML manifest that extracts ticket snapshots, CSAT ratings, and agent directory data from the Zendesk REST API v2. It writes all data to per-source Bronze tables in ClickHouse, following the unified support domain Bronze schema defined in [`zendesk.md`](../zendesk.md).
+
+Phase 1 targets three streams:
+1. `support_tickets` — incremental, via `GET /api/v2/incremental/tickets.json` with `metric_sets` sideload
+2. `support_agents` — full refresh, via `GET /api/v2/users?role[]=agent&role[]=admin`
+3. `zendesk_satisfaction_ratings` — incremental, via `GET /api/v2/satisfaction_ratings`
+
+Phase 2 adds `support_ticket_events` (per-ticket audit log) and `zendesk_ticket_ext` (custom fields). Both schemas are locked in `zendesk.md` and the Bronze DDL but not implemented in the connector manifest until Phase 2.
+
+The declarative approach is consistent with all other connectors in the project. Authentication is via HTTP Basic Auth (`{email}/token:{api_token}` Base64-encoded). The manifest version is pinned to `7.0.4` to match the current platform CDK.
+
+Every emitted record includes `insight_tenant_id`, `insight_source_id`, `unique_key`, `data_source`, and `collected_at` injected via `AddFields` transformations — standard practice per Connector Framework spec §4.6.
+
+### 1.2 Architecture Drivers
+
+**PRD Reference**: [PRD.md](./PRD.md)
+
+#### Functional Drivers
+
+| Requirement ID | Design Response |
+|----------------|-----------------|
+| `cpt-zendeskspec-fr-ticket-extraction` | `DeclarativeStream support_tickets` with `DatetimeBasedCursor` on `updated_at`; `GET /api/v2/incremental/tickets.json` with `?include=metric_sets` |
+| `cpt-zendeskspec-fr-timing-both-variants` | `AddFields` transformations extract both `.business` and `.calendar` values from sideloaded `metric_set`; stored as four separate Int64 fields |
+| `cpt-zendeskspec-fr-ticket-metadata` | Full API response stored as `metadata` String field via `DpathExtractor` on the full record |
+| `cpt-zendeskspec-fr-agent-extraction` | `DeclarativeStream support_agents` with full refresh; `GET /api/v2/users?role[]=agent&role[]=admin`; `GET /api/v2/groups` fetched at startup for group name resolution |
+| `cpt-zendeskspec-fr-ratings-extraction` | `DeclarativeStream zendesk_satisfaction_ratings` with `DatetimeBasedCursor` on `updated_at`; `GET /api/v2/satisfaction_ratings` |
+| `cpt-zendeskspec-fr-collection-runs` | Connector-generated stream; written via a custom Python component or deferred to platform sync logs |
+| `cpt-zendeskspec-fr-deduplication` | Primary keys defined per stream; ClickHouse `ReplacingMergeTree(_version)` handles upsert deduplication |
+| `cpt-zendeskspec-fr-tenant-context` | `AddFields` transformation injects `tenant_id`, `source_id`, `unique_key`, `data_source`, `collected_at` on every record |
+| `cpt-zendeskspec-fr-incremental-sync` | `DatetimeBasedCursor` with `cursor_field: updated_at`; Airbyte platform persists state between runs |
+| `cpt-zendeskspec-fr-identity-resolution` | `email` field extracted from `support_agents`; no connector-level resolution — delegated to Identity Manager in Silver step 2 |
+
+#### NFR Allocation
+
+| NFR ID | Design Response | Verification |
+|--------|-----------------|-------------|
+| `cpt-zendeskspec-nfr-freshness` | Declarative manifest + daily cron schedule | Monitor `support_collection_runs.completed_at` |
+| `cpt-zendeskspec-nfr-rate-limits` | Declarative `BackoffStrategy` on `RequestOption`; `Retry-After` header respected by CDK default error handler | Zero unhandled HTTP 429 in production |
+| `cpt-zendeskspec-nfr-utc` | Zendesk API returns ISO 8601 UTC timestamps; stored as-is in Bronze | Schema test: zero non-UTC timestamps |
+| `cpt-zendeskspec-nfr-declarative` | YAML manifest; `validate-strict` in CI | Pipeline gate |
+
+### 1.3 Architecture Layers
+
+```text
+┌─────────────────────────────────────────────────────────────────────┐
+│  Orchestrator (Argo CronWorkflow: zendesk-default-sync)              │
+│  (triggers Zendesk connector sync → dbt Silver run)                  │
+└─────────────────────────────┬───────────────────────────────────────┘
+                              │
+┌─────────────────────────────▼───────────────────────────────────────┐
+│  Zendesk Connector (Airbyte DeclarativeSource YAML manifest)         │
+│  ├── support_tickets stream                                          │
+│  │   └── incremental: GET /api/v2/incremental/tickets.json          │
+│  │       ?start_time={unix_ts}&include=metric_sets                   │
+│  │       cursor: updated_at (DatetimeBasedCursor)                    │
+│  ├── support_agents stream                                           │
+│  │   └── full refresh: GET /api/v2/users?role[]=agent&role[]=admin   │
+│  │       group names: GET /api/v2/groups (startup lookup)            │
+│  └── zendesk_satisfaction_ratings stream                             │
+│      └── incremental: GET /api/v2/satisfaction_ratings               │
+│          ?start_time={unix_ts}&sort_by=updated_at                    │
+│          cursor: updated_at (DatetimeBasedCursor)                    │
+└─────────────────────────────┬───────────────────────────────────────┘
+                              │ Airbyte Protocol (RECORD, STATE, LOG)
+┌─────────────────────────────▼───────────────────────────────────────┐
+│  Bronze Tables (ClickHouse — ReplacingMergeTree)                     │
+│  support_tickets, support_agents,                                    │
+│  zendesk_satisfaction_ratings, support_collection_runs               │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+| Layer | Responsibility | Technology |
+|-------|---------------|------------|
+| Orchestration | Trigger, schedule, state management, dbt run | Argo CronWorkflow (`zendesk-default-sync`) |
+| Collection | REST pagination, cursor management, retry, field injection | Airbyte DeclarativeSource (YAML manifest) |
+| Transformation | `AddFields` for tenant/source/key injection; timing field extraction | Declarative transformations + `CustomTransformation` |
+| Storage | Upsert to Bronze tables | ClickHouse `ReplacingMergeTree(_version)` |
+| Silver | `class_support_activity` derivation, identity resolution | dbt models (`tag:zendesk+`) |
+
+---
+
+## 2. Principles & Constraints
+
+### 2.1 Design Principles
+
+#### Bronze-Only Output
+
+- [ ] `p1` - **ID**: `cpt-zendeskspec-principle-bronze-only`
+
+The Zendesk connector writes exclusively to `support_*` and `zendesk_*` Bronze tables via the declarative YAML manifest. No Silver or Gold layer logic exists in the connector. Cross-source unification into `class_support_activity` Silver and identity resolution (`email` → `person_id`) are responsibilities of downstream pipeline stages.
+
+#### Incremental by Default
+
+- [ ] `p1` - **ID**: `cpt-zendeskspec-principle-incremental`
+
+`support_tickets` and `zendesk_satisfaction_ratings` use `DatetimeBasedCursor` on `updated_at`. Full collection is the degenerate case of an incremental run with no prior cursor (controlled by `start_date` config). `support_agents` is full-refresh on every run because the agent roster is small (hundreds of records) and does not expose a reliable incremental cursor.
+
+#### Declarative-First
+
+- [ ] `p1` - **ID**: `cpt-zendeskspec-principle-declarative-first`
+
+Consistent with project convention, the Zendesk connector uses a nocode YAML manifest (Airbyte DeclarativeSource). Features that cannot be expressed declaratively (e.g., dynamic group name lookup) use `CustomTransformation` components rather than falling back to a full CDK Python implementation.
+
+#### Fault Tolerance
+
+- [ ] `p2` - **ID**: `cpt-zendeskspec-principle-fault-tolerance`
+
+A partial sync that extracts most tickets is preferable to a run that halts on the first non-fatal error. HTTP 404 for missing resources, HTTP 429 with retry, and transient 5xx errors are handled gracefully. Fatal errors (401 authentication failure) halt the run immediately with a clear error message.
+
+### 2.2 Constraints
+
+#### Zendesk REST API v2
+
+- [ ] `p1` - **ID**: `cpt-zendeskspec-constraint-api-version`
+
+The connector targets Zendesk REST API v2 exclusively. There is no v3 for Zendesk — v2 is the stable public API. The incremental export endpoint (`/api/v2/incremental/tickets.json`) requires Zendesk Suite or equivalent plan.
+
+#### Airbyte Declarative Manifest Compliance
+
+- [ ] `p1` - **ID**: `cpt-zendeskspec-constraint-airbyte-cdk`
+
+The connector MUST be a valid Airbyte DeclarativeSource YAML manifest at version `7.0.4`. It MUST emit valid Airbyte Protocol messages. Every emitted record MUST include `tenant_id`.
+
+#### Rate Limit Budget
+
+- [ ] `p1` - **ID**: `cpt-zendeskspec-constraint-rate-limit`
+
+Zendesk rate limits: 200 req/min (Basic), 400 req/min (Suite Team), 700 req/min (Suite Growth and above). The connector MUST respect `Retry-After` headers on HTTP 429. Phase 2 `support_ticket_events` stream requires careful rate budget planning (one call per ticket).
+
+#### No Silver Layer Logic
+
+- [ ] `p1` - **ID**: `cpt-zendeskspec-constraint-no-silver`
+
+The connector writes only to Bronze tables. `satisfaction_score` is NOT computed or backfilled onto `support_tickets` by the connector — Silver layer joins `zendesk_satisfaction_ratings` on `ticket_id` to derive this value.
+
+---
+
+## 3. Technical Architecture
+
+### 3.1 Domain Model
+
+**Core Entities**:
+
+| Entity | Description | Maps To |
+|--------|-------------|---------|
+| `ZendeskInstance` | Connection config: subdomain, email, API token, start_date | Connector config (spec section) |
+| `ZendeskTicket` | Ticket with current state + sideloaded `metric_set` | `support_tickets` |
+| `ZendeskUser` | Agent/admin with role, group, email | `support_agents` |
+| `ZendeskSatisfactionRating` | CSAT rating event: score, comment, reason | `zendesk_satisfaction_ratings` |
+| `ZendeskGroup` | Team/department containing agents | Resolved into `group_name` at collection time |
+| `ZendeskAudit` | Per-ticket event batch (Phase 2) | `support_ticket_events` |
+| `ZendeskCustomField` | Per-ticket custom field value (Phase 2) | `zendesk_ticket_ext` |
+
+**Entity Relationships**:
+```
+ZendeskTicket ──── assignee_id ───► ZendeskUser (support_agents)
+ZendeskTicket ──── group_id ──────► ZendeskGroup
+ZendeskTicket ──── ticket_id ──────► ZendeskSatisfactionRating (1:many)
+ZendeskUser ────── default_group_id ► ZendeskGroup
+ZendeskAudit ───── ticket_id ──────► ZendeskTicket [Phase 2]
+```
+
+### 3.2 Component Model
+
+```
+connector.yaml (Airbyte DeclarativeSource)
+├── spec            — connection_specification with required fields
+├── check           — CheckStream on support_agents (cheapest endpoint)
+├── streams
+│   ├── support_tickets              — incremental, DatetimeBasedCursor
+│   ├── support_agents               — full refresh
+│   └── zendesk_satisfaction_ratings — incremental, DatetimeBasedCursor
+└── metadata        — autoImportSchema flags per stream
+```
+
+**Check stream rationale**: `GET /api/v2/users/me` is used as the check endpoint — cheapest call, always returns exactly one record for valid credentials, no pagination, no rate limit impact.
+
+### 3.3 API Contracts
+
+**Authentication**: HTTP Basic Auth
+```
+Authorization: Basic base64("{email}/token:{api_token}")
+```
+
+**Ticket incremental export**:
+```
+GET https://{subdomain}.zendesk.com/api/v2/incremental/tickets.json
+  ?start_time={unix_timestamp}
+  &include=metric_sets
+  &per_page=1000                   (max per page; server-side cursor)
+```
+Response: `{ "tickets": [...], "next_page": "...", "after_cursor": "...", "end_of_stream": false }`
+
+Cursor advance: Zendesk returns an opaque `after_cursor` (Base64-encoded JSON) as the next page token. When `end_of_stream = true`, save the returned `end_time` as the next run's `start_time`.
+
+**Agent list**:
+```
+GET https://{subdomain}.zendesk.com/api/v2/users
+  ?role[]=agent&role[]=admin
+  &per_page=100
+  &page[after]={cursor}            (cursor-based pagination)
+```
+Response: `{ "users": [...], "meta": {"after_cursor": "...", "has_more": true} }`
+
+**Satisfaction ratings**:
+```
+GET https://{subdomain}.zendesk.com/api/v2/satisfaction_ratings
+  ?start_time={unix_timestamp}
+  &sort_by=updated_at
+  &sort_order=asc
+  &per_page=100
+```
+Response: `{ "satisfaction_ratings": [...], "next_page": "..." }`
+
+**Group list** (startup lookup for `group_name` resolution):
+```
+GET https://{subdomain}.zendesk.com/api/v2/groups
+  ?per_page=100
+```
+Response: `{ "groups": [{"id": 123, "name": "Tier 1 Support"}, ...] }`
+
+### 3.4 Internal Dependencies
+
+| Component | Dependency |
+|-----------|-----------|
+| `connector.yaml` | Airbyte DeclarativeSource CDK v7.0.4 |
+| `descriptor.yaml` | Included in `insight-toolbox` image; read by reconcile loop |
+| Bronze DDL | Applied by Airbyte ClickHouse destination on first run |
+| dbt Silver models | `dbt/zendesk__support_activity.sql` — consumes Bronze tables (planned) |
+
+### 3.5 External Dependencies
+
+| Dependency | Version | Notes |
+|-----------|---------|-------|
+| Zendesk REST API | v2 (stable) | No versioning changes expected |
+| Airbyte DeclarativeSource CDK | 7.0.4 (pinned) | Upgrade requires manifest syntax review |
+| ClickHouse | ≥ 23.x | `ReplacingMergeTree` + JSON functions for `metadata` field |
+
+### 3.6 Interactions & Sequences
+
+**Incremental sync run (steady state)**:
+
+```
+Argo CronWorkflow
+  │
+  ├─ 1. Read Airbyte state from platform (cursor for tickets and ratings)
+  │
+  ├─ 2. support_agents stream (full refresh)
+  │      GET /api/v2/groups (startup)
+  │      GET /api/v2/users?role[]=agent&role[]=admin (paginated)
+  │      → RECORD messages → ClickHouse support_agents
+  │
+  ├─ 3. support_tickets stream (incremental)
+  │      GET /api/v2/incremental/tickets.json?start_time={cursor}&include=metric_sets
+  │      Paginate until end_of_stream = true
+  │      → RECORD messages → ClickHouse support_tickets
+  │      → STATE message (updated ticket cursor)
+  │
+  ├─ 4. zendesk_satisfaction_ratings stream (incremental)
+  │      GET /api/v2/satisfaction_ratings?start_time={cursor}
+  │      Paginate until no next_page
+  │      → RECORD messages → ClickHouse zendesk_satisfaction_ratings
+  │      → STATE message (updated ratings cursor)
+  │
+  └─ 5. Airbyte platform persists STATE
+         Argo triggers dbt Silver run (tag:zendesk+)
+```
+
+**First run sequence** (no prior state):
+- `start_time` = Unix timestamp derived from `start_date` config (default: 90 days ago)
+- Full historical tickets and ratings collected up to `end_of_stream`
+- Can take several hours for large accounts; state checkpointed per page
+
+### 3.7 Database Schemas & Tables
+
+#### ClickHouse DDL: `support_tickets`
+
+```sql
+CREATE TABLE IF NOT EXISTS bronze_zendesk.support_tickets
+(
+    insight_source_id                      String,
+    ticket_id                              String,
+    subject                                Nullable(String),
+    status                                 String,
+    priority                               Nullable(String),
+    ticket_type                            Nullable(String),
+    assignee_id                            Nullable(String),
+    group_id                               Nullable(String),
+    requester_id                           Nullable(String),
+    organization_id                        Nullable(String),
+    created_at                             DateTime64(3),
+    updated_at                             DateTime64(3),
+    solved_at                              Nullable(DateTime64(3)),
+    first_reply_time_seconds               Nullable(Int64),
+    first_reply_time_calendar_seconds      Nullable(Int64),
+    full_resolution_time_seconds           Nullable(Int64),
+    full_resolution_time_calendar_seconds  Nullable(Int64),
+    satisfaction_score                     Nullable(String),   -- NULL in Phase 1
+    tags                                   Nullable(String),
+    metadata                               String,
+    data_source                            String DEFAULT 'insight_zendesk',
+    _version                               UInt64,
+    -- Airbyte standard fields
+    _ab_source_file_url                    Nullable(String),
+    insight_tenant_id                      String,
+    unique_key                             String
+)
+ENGINE = ReplacingMergeTree(_version)
+ORDER BY (insight_source_id, ticket_id)
+SETTINGS index_granularity = 8192;
+
+ALTER TABLE bronze_zendesk.support_tickets
+    ADD INDEX idx_support_ticket_assignee  (assignee_id, data_source) TYPE minmax GRANULARITY 4,
+    ADD INDEX idx_support_ticket_updated   (updated_at) TYPE minmax GRANULARITY 4,
+    ADD INDEX idx_support_ticket_status    (status, data_source) TYPE set(100) GRANULARITY 4;
+```
+
+#### ClickHouse DDL: `support_agents`
+
+```sql
+CREATE TABLE IF NOT EXISTS bronze_zendesk.support_agents
+(
+    insight_source_id  String,
+    agent_id           String,
+    email              String,
+    display_name       Nullable(String),
+    role               Nullable(String),
+    group_id           Nullable(String),
+    group_name         Nullable(String),
+    is_active          Int64 DEFAULT 1,
+    collected_at       DateTime64(3),
+    data_source        String DEFAULT 'insight_zendesk',
+    _version           UInt64,
+    insight_tenant_id  String,
+    unique_key         String
+)
+ENGINE = ReplacingMergeTree(_version)
+ORDER BY (insight_source_id, agent_id)
+SETTINGS index_granularity = 8192;
+
+ALTER TABLE bronze_zendesk.support_agents
+    ADD INDEX idx_support_agent_email (email) TYPE set(0) GRANULARITY 4;
+```
+
+#### ClickHouse DDL: `zendesk_satisfaction_ratings`
+
+```sql
+CREATE TABLE IF NOT EXISTS bronze_zendesk.zendesk_satisfaction_ratings
+(
+    insight_source_id  String,
+    rating_id          String,
+    ticket_id          String,
+    requester_id       Nullable(String),
+    assignee_id        Nullable(String),
+    group_id           Nullable(String),
+    score              Nullable(String),
+    comment            Nullable(String),
+    reason             Nullable(String),
+    created_at         DateTime64(3),
+    updated_at         DateTime64(3),
+    data_source        String DEFAULT 'insight_zendesk',
+    _version           UInt64,
+    insight_tenant_id  String,
+    unique_key         String
+)
+ENGINE = ReplacingMergeTree(_version)
+ORDER BY (insight_source_id, rating_id)
+SETTINGS index_granularity = 8192;
+
+ALTER TABLE bronze_zendesk.zendesk_satisfaction_ratings
+    ADD INDEX idx_zendesk_rating_ticket   (insight_source_id, ticket_id, data_source) TYPE minmax GRANULARITY 4,
+    ADD INDEX idx_zendesk_rating_updated  (updated_at) TYPE minmax GRANULARITY 4,
+    ADD INDEX idx_zendesk_rating_assignee (assignee_id, data_source) TYPE set(0) GRANULARITY 4;
+```
+
+---
+
+## 4. Additional Context
+
+### API Details
+
+#### Incremental Ticket Export vs Full Scan
+
+The incremental export endpoint (`/api/v2/incremental/tickets.json?start_time=`) is the preferred collection strategy:
+- Returns up to 1000 tickets per page (vs 100 for `GET /api/v2/tickets`)
+- Uses a server-side cursor (`after_cursor`) that is stable across requests — no risk of missing tickets due to pagination drift
+- Includes a `metric_sets` sideload to avoid N+1 calls for timing fields
+- Returns `end_of_stream: true` when the consumer is caught up to the present; cursor should advance to `end_time` for the next run
+
+**Cursor format**: `start_time` is a Unix timestamp (seconds). The CDK `DatetimeBasedCursor` supports `datetime_format: "%s"` for Unix timestamp output.
+
+#### Pagination Strategies
+
+| Stream | Pagination type | Page size |
+|--------|----------------|-----------|
+| `support_tickets` | Server cursor (`after_cursor` in response body) | 1000 (server-enforced max) |
+| `support_agents` | Cursor-based (`page[after]` query param, `meta.after_cursor` in response) | 100 |
+| `zendesk_satisfaction_ratings` | Next-page link (`next_page` URL in response body) | 100 |
+| `groups` (startup lookup) | Offset-based (`page`, `per_page`) | 100 |
+
+#### group_name Resolution
+
+`support_agents.default_group_id` is a numeric Zendesk group ID. To populate `group_name`, the connector:
+1. Fetches all groups via `GET /api/v2/groups` at stream initialization
+2. Builds an in-memory `{group_id: group_name}` map
+3. Applies a `CustomTransformation` (or `RecordTransformation`) to populate `group_name` from the map for each agent record
+
+If the groups endpoint returns HTTP 403 (insufficient scope), `group_name` is NULL for all agents — sync continues without failure.
+
+### Field Mapping to Bronze Schema
+
+#### `support_tickets` field mapping
+
+| Bronze field | Zendesk API path | Notes |
+|-------------|-----------------|-------|
+| `ticket_id` | `ticket.id` | Cast to String |
+| `subject` | `ticket.subject` | NULL if empty |
+| `status` | `ticket.status` | Direct mapping (Zendesk values match unified schema) |
+| `priority` | `ticket.priority` | NULL if not set |
+| `ticket_type` | `ticket.type` | NULL if not set |
+| `assignee_id` | `ticket.assignee_id` | Cast to String; NULL if unassigned |
+| `group_id` | `ticket.group_id` | Cast to String; NULL if unassigned |
+| `requester_id` | `ticket.requester_id` | Cast to String |
+| `organization_id` | `ticket.organization_id` | Cast to String; NULL if not set |
+| `created_at` | `ticket.created_at` | ISO 8601 → DateTime64(3) |
+| `updated_at` | `ticket.updated_at` | ISO 8601 → DateTime64(3); cursor field |
+| `solved_at` | `ticket.metric_set.solved_at` | ISO 8601 → DateTime64(3); NULL if not solved |
+| `first_reply_time_seconds` | `ticket.metric_set.reply_time_in_minutes.business × 60` | NULL if no reply |
+| `first_reply_time_calendar_seconds` | `ticket.metric_set.reply_time_in_minutes.calendar × 60` | NULL if no reply |
+| `full_resolution_time_seconds` | `ticket.metric_set.full_resolution_time_in_minutes.business × 60` | NULL if unresolved |
+| `full_resolution_time_calendar_seconds` | `ticket.metric_set.full_resolution_time_in_minutes.calendar × 60` | NULL if unresolved |
+| `satisfaction_score` | NULL (Phase 1) | Phase 2: derived from `zendesk_satisfaction_ratings` at Silver |
+| `tags` | `ticket.tags` (array) | Joined as comma-separated string |
+| `metadata` | Full `ticket` object as JSON | Stored via `AddFields` from raw record |
+
+**Implementation note**: `metric_set` fields are nested under sideloaded `metric_set` objects. The Zendesk API returns metric sets as a separate `metric_sets` array keyed by ticket ID when using `?include=metric_sets`. The connector must join the metric set to its parent ticket at record extraction time. This is handled via a `CustomTransformation` that merges the sideloaded metric_set into the ticket record before field extraction.
+
+#### `zendesk_satisfaction_ratings` field mapping
+
+| Bronze field | Zendesk API path | Notes |
+|-------------|-----------------|-------|
+| `rating_id` | `satisfaction_rating.id` | Cast to String |
+| `ticket_id` | `satisfaction_rating.ticket_id` | Cast to String |
+| `requester_id` | `satisfaction_rating.requester_id` | Cast to String |
+| `assignee_id` | `satisfaction_rating.assignee_id` | Cast to String; NULL if not set |
+| `group_id` | `satisfaction_rating.group_id` | Cast to String; NULL if not set |
+| `score` | `satisfaction_rating.score` | `"good"` / `"bad"` / `"offered"` |
+| `comment` | `satisfaction_rating.comment` | NULL if no comment |
+| `reason` | `satisfaction_rating.reason` or `satisfaction_rating.reason_code` | NULL if not provided |
+| `created_at` | `satisfaction_rating.created_at` | ISO 8601 → DateTime64(3) |
+| `updated_at` | `satisfaction_rating.updated_at` | ISO 8601 → DateTime64(3); cursor field |
+
+### Collection Strategy
+
+#### Cursor Initialization
+
+On first run, `start_time` for both incremental streams is derived from `config['start_date']` (YYYY-MM-DD string → Unix timestamp). Default: 90 days ago (`day_delta(-90, format='%s')`).
+
+Operators setting `start_date: "2024-01-01"` get a full historical backfill from that date. No hard lower bound — Zendesk API returns empty results before the account creation date.
+
+#### Cursor Advancement
+
+`DatetimeBasedCursor` with `datetime_format: "%s"` (Unix timestamp):
+- `cursor_field: updated_at` for both `support_tickets` and `zendesk_satisfaction_ratings`
+- Cursor advances to the maximum `updated_at` seen in the current run
+- Airbyte platform persists state; cursor survives process restarts
+
+#### Support Agents — Full Refresh Decision
+
+`support_agents` is full-refresh because:
+1. The agent roster is small (typically hundreds, rarely thousands)
+2. Zendesk does not expose a reliable incremental endpoint for users (`GET /api/v2/incremental/users.json` requires a paid Explore add-on on some plans)
+3. Agent deactivation (soft delete) does not emit an event visible via cursor-based sync — full refresh ensures deactivated agents are captured with `is_active = 0`
+
+### Identity Resolution Details
+
+**Flow**:
+```
+Bronze: support_agents.email
+  → Silver step 2: Identity Manager
+  → person_id (canonical)
+  → Propagated to zendesk_satisfaction_ratings.assignee_id via support_agents.agent_id join
+```
+
+**Email normalization**: performed in Silver step 2, not in the connector. Silver applies `lower(trim(email))` before lookup. The connector stores email as-is from the Zendesk API.
+
+**Multi-instance disambiguation**: when a customer has two Zendesk instances (e.g., `acme-prod` and `acme-staging`), each has its own `insight_source_id`. The Identity Manager joins on `(email, insight_source_id)` — agents with the same email in two instances map to the same `person_id`.
+
+### Phase 2 Design Notes
+
+#### `support_ticket_events` Collection Strategy
+
+Phase 2 adds the audit log stream. Key design decisions already resolved:
+
+1. **Per-ticket API calls**: `GET /api/v2/tickets/{id}/audits` — one call per ticket. For 500K tickets at 700 req/min, first run takes ~12 hours. Mitigated by:
+   - Configurable `start_date` limits the set of tickets whose audits are fetched
+   - `backfill_mode: full` is operator opt-in; default fetches audits for tickets updated in the current incremental window only
+   - Airbyte `SubstreamPartitionRouter` handles the per-ticket fan-out pattern
+
+2. **Deduplication key**: `{audit.id}_{event_index}` — composite because Zendesk audit IDs are unique per audit but not per event within the audit.
+
+3. **Cursor**: no direct cursor on audits. The parent `support_tickets` incremental cursor controls which tickets have their audits refreshed — audits are re-fetched for all tickets in the current incremental window.
+
+#### `zendesk_ticket_ext` Collection Strategy
+
+Phase 2 adds custom fields extracted from `ticket.custom_fields[]`:
+1. `GET /api/v2/ticket_fields` fetched at startup — builds `{field_id: {title, type}}` map
+2. `custom_fields[]` array on each ticket record iterated; one row per non-null custom field
+3. Implemented as a `SubstreamPartitionRouter` pattern or as a dedicated `CustomTransformation`
+
+### Incremental Sync Cursor and Datetime Format
+
+Zendesk uses Unix timestamps (seconds since epoch) for the incremental export endpoint:
+```
+GET /api/v2/incremental/tickets.json?start_time=1706745600
+```
+
+The `DatetimeBasedCursor` configuration:
+```yaml
+incremental_sync:
+  type: DatetimeBasedCursor
+  cursor_field: updated_at
+  cursor_datetime_formats:
+    - "%Y-%m-%dT%H:%M:%SZ"          # Zendesk returns ISO 8601
+    - "%Y-%m-%dT%H:%M:%S.%fZ"       # with optional microseconds
+  datetime_format: "%s"              # emit as Unix timestamp for start_time param
+  start_datetime:
+    type: MinMaxDatetime
+    datetime: "{{ config.get('start_date') or day_delta(-90, format='%Y-%m-%d') }}"
+    datetime_format: "%Y-%m-%d"
+  end_datetime:
+    type: MinMaxDatetime
+    datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+    datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+  start_time_option:
+    type: RequestOption
+    field_name: start_time
+    inject_into: request_parameter
+```
+
+### Rate Limit Budget
+
+Estimated API calls per run (steady state, daily incremental):
+
+| Stream | Calls per run | Notes |
+|--------|--------------|-------|
+| `support_agents` groups lookup | 1–5 | One call per 100 groups; most accounts < 100 groups |
+| `support_agents` users | 1–20 | One call per 100 agents; most support teams < 2000 agents |
+| `support_tickets` | 1–10 | One call per 1000 tickets; daily delta rarely exceeds 10K tickets |
+| `zendesk_satisfaction_ratings` | 1–5 | One call per 100 ratings; daily delta rarely exceeds 500 ratings |
+| **Total (steady state)** | **~10–40** | Far below rate limit |
+
+**First run budget** (90-day backfill, 50K tickets):
+- `support_tickets`: ~50 calls (50 pages × 1000/page)
+- `zendesk_satisfaction_ratings`: ~500 calls (500 pages × 100/page, assuming ~50K ratings)
+- Still well within the 700 req/min limit for Business plan accounts
+
+**Phase 2 first-run budget** (`support_ticket_events`, 50K tickets, no lookback limit):
+- 50,000 calls for audit fetches alone
+- At 700 req/min: ~71 minutes minimum
+- Mitigated by default 90-day lookback (~5K–10K tickets for typical active accounts)
+
+---
+
+## 5. Traceability
+
+| PRD Requirement | Design Decision | Location |
+|----------------|-----------------|---------|
+| `cpt-zendeskspec-fr-ticket-extraction` | `DeclarativeStream support_tickets` with `DatetimeBasedCursor` | §3.2, §4.2 |
+| `cpt-zendeskspec-fr-timing-both-variants` | Four timing fields in Bronze DDL; extracted via `AddFields` | §3.7, §4.2 |
+| `cpt-zendeskspec-fr-ticket-metadata` | `metadata` String field stores full JSON | §3.7 |
+| `cpt-zendeskspec-fr-agent-extraction` | `DeclarativeStream support_agents` full refresh | §3.2, §3.3 |
+| `cpt-zendeskspec-fr-group-name-resolution` | Startup `GET /api/v2/groups` + `CustomTransformation` | §4.2 |
+| `cpt-zendeskspec-fr-ratings-extraction` | `DeclarativeStream zendesk_satisfaction_ratings` incremental | §3.2, §3.3 |
+| `cpt-zendeskspec-fr-deduplication` | `ReplacingMergeTree(_version)` + primary keys | §3.7 |
+| `cpt-zendeskspec-fr-tenant-context` | `AddFields` transformation on every stream | §1.1 |
+| `cpt-zendeskspec-fr-incremental-sync` | `DatetimeBasedCursor` with `cursor_field: updated_at` | §4.4 |
+| `cpt-zendeskspec-fr-identity-resolution` | `email` in `support_agents`; no connector-level resolution | §4.3 |
+| `cpt-zendeskspec-nfr-rate-limits` | CDK default `BackoffStrategy`; `Retry-After` honoured | §4.5 |
+| `cpt-zendeskspec-nfr-declarative` | YAML manifest; `validate-strict` in CI | §2.2 |
+
+---
+
+## 6. Non-Applicability Statements
+
+| Requirement | Why Not Applicable |
+|------------|-------------------|
+| Server-side filtering / push | Connector is pull-only batch; Zendesk webhooks are out of scope |
+| OAuth 2.0 as primary auth | API token (Basic Auth) is preferred for service accounts; OAuth is supported by spec but not the primary implementation path for Phase 1 |
+| SLA Policy object extraction | Zendesk pre-computes timing on tickets (`metric_set`); no explicit SLA breach objects exist in the Zendesk API (unlike JSM's `/rest/servicedeskapi/request/{id}/sla`) |
+| `satisfaction_score` backfill at collection | Deliberately deferred to Silver layer — connector stores NULL; Silver joins `zendesk_satisfaction_ratings` on `ticket_id` for the latest score |
+| Multi-threaded / concurrent fetches | Phase 1 streams are independent and fast; concurrency adds complexity without measurable benefit for the estimated call volumes |

--- a/docs/components/connectors/support/zendesk/specs/PRD.md
+++ b/docs/components/connectors/support/zendesk/specs/PRD.md
@@ -177,7 +177,6 @@ The Zendesk connector closes this gap by ingesting support activity into the sam
 - Incremental ticket extraction using Zendesk's bulk export endpoint (`GET /api/v2/incremental/tickets.json`)
 - Extraction of satisfaction ratings as a separate incremental stream (`zendesk_satisfaction_ratings`)
 - Extraction of the agent directory (agents and admins) for identity resolution
-- Group name resolution via `GET /api/v2/groups` at collection startup
 - Connector execution monitoring via `support_collection_runs` stream
 - K8s Secret-based credential management following the Insight connector secret format
 - Bronze-layer table schemas for all Phase 1 streams
@@ -189,6 +188,7 @@ The Zendesk connector closes this gap by ingesting support activity into the sam
 - Silver/Gold layer transformations (`class_support_activity`) — responsibility of the support domain pipeline
 - Silver step 2 (identity resolution: `email` → `person_id`) — responsibility of the Identity Manager
 - Backfilling `support_tickets.satisfaction_score` from `zendesk_satisfaction_ratings` — Silver layer responsibility in Phase 2
+- `group_name` resolution on `support_agents` via `GET /api/v2/groups` — `group_name` is NULL in Phase 1 (FR `cpt-zendeskspec-fr-group-name-resolution` is `p2`)
 
 ### 4.3 Permanently Out of Scope
 
@@ -248,7 +248,7 @@ The connector **MUST** store the full Zendesk ticket API response as a JSON stri
 
 - [ ] `p1` - **ID**: `cpt-zendeskspec-fr-agent-extraction`
 
-The connector **MUST** extract all users with `role = "agent"`, `role = "admin"`, and `role = "light_agent"` from `GET /api/v2/users?role[]=agent&role[]=admin`. For each agent, the connector **MUST** store: agent ID, email, display name, role, primary group ID, group name, and active status.
+The connector **MUST** extract all users with `role = "agent"`, `role = "admin"`, and `role = "light_agent"` from `GET /api/v2/users?role[]=agent&role[]=admin`. For each agent, the connector **MUST** store: agent ID, email, display name, role, primary group ID, and active status. (`group_name` resolution is deferred to Phase 2 — see `cpt-zendeskspec-fr-group-name-resolution`; NULL in Phase 1.)
 
 **Rationale**: The agent directory is the identity anchor for all support analytics. Email is the cross-system key for `person_id` resolution. Group assignment enables team-level metric aggregation.
 
@@ -418,7 +418,7 @@ The Zendesk connector does not expose a public library interface. It is consumed
 2. Operator applies the Secret: `kubectl apply -f zendesk-secret.yaml`
 3. Reconcile loop discovers the Secret, creates an Airbyte connection with the correct parameters
 4. Operator triggers a manual sync to verify connectivity
-5. Connector performs a `check` connection using `GET /api/v2/users/me` — success confirms credentials are valid
+5. Connector performs a `check` connection (CheckStream against `support_agents`, i.e. the first page of `GET /api/v2/users`) — success confirms credentials are valid
 
 **Postconditions**: Airbyte connection exists and `support_agents` has data after first sync.
 

--- a/docs/components/connectors/support/zendesk/specs/PRD.md
+++ b/docs/components/connectors/support/zendesk/specs/PRD.md
@@ -1,0 +1,557 @@
+# PRD — Zendesk Connector
+
+> Version 1.0 — May 2026
+> Issue: INSIGHT-459
+> Status: Phase 1 scope locked
+
+<!-- toc -->
+
+- [1. Overview](#1-overview)
+  - [1.1 Purpose](#11-purpose)
+  - [1.2 Background / Problem Statement](#12-background--problem-statement)
+  - [1.3 Goals (Business Outcomes)](#13-goals-business-outcomes)
+  - [1.4 Glossary](#14-glossary)
+- [2. Actors](#2-actors)
+  - [2.1 Human Actors](#21-human-actors)
+  - [2.2 System Actors](#22-system-actors)
+- [3. Operational Concept & Environment](#3-operational-concept--environment)
+  - [3.1 Module-Specific Environment Constraints](#31-module-specific-environment-constraints)
+- [4. Scope](#4-scope)
+  - [4.1 In Scope (Phase 1)](#41-in-scope-phase-1)
+  - [4.2 Out of Scope (Phase 1 — deferred to Phase 2)](#42-out-of-scope-phase-1--deferred-to-phase-2)
+  - [4.3 Permanently Out of Scope](#43-permanently-out-of-scope)
+- [5. Functional Requirements](#5-functional-requirements)
+  - [5.1 Ticket Data Extraction](#51-ticket-data-extraction)
+  - [5.2 Agent Directory Extraction](#52-agent-directory-extraction)
+  - [5.3 Satisfaction Ratings Extraction](#53-satisfaction-ratings-extraction)
+  - [5.4 Connector Operations](#54-connector-operations)
+  - [5.5 Data Integrity](#55-data-integrity)
+  - [5.6 Identity Resolution](#56-identity-resolution)
+- [6. Non-Functional Requirements](#6-non-functional-requirements)
+  - [6.1 NFR Inclusions](#61-nfr-inclusions)
+  - [6.2 NFR Exclusions](#62-nfr-exclusions)
+- [7. Public Library Interfaces](#7-public-library-interfaces)
+  - [7.1 Public API Surface](#71-public-api-surface)
+  - [7.2 External Integration Contracts](#72-external-integration-contracts)
+- [8. Use Cases](#8-use-cases)
+  - [UC-001 Configure Zendesk Connection](#uc-001-configure-zendesk-connection)
+  - [UC-002 Incremental Sync Run](#uc-002-incremental-sync-run)
+  - [UC-003 First Run / Historical Backfill](#uc-003-first-run--historical-backfill)
+- [9. Acceptance Criteria](#9-acceptance-criteria)
+- [10. Dependencies](#10-dependencies)
+- [11. Assumptions](#11-assumptions)
+- [12. Risks](#12-risks)
+- [13. Resolved Questions](#13-resolved-questions)
+- [14. Non-Applicable Requirements](#14-non-applicable-requirements)
+
+<!-- /toc -->
+
+---
+
+## 1. Overview
+
+### 1.1 Purpose
+
+The Zendesk Connector extracts ticket data, agent directory, and customer satisfaction ratings from the Zendesk REST API v2 and loads them into the Insight platform's Bronze layer. It provides the raw material for support team performance analytics — CSAT scores, ticket volume trends, resolution rates, agent workload, and first-response/resolution time measurements.
+
+### 1.2 Background / Problem Statement
+
+Zendesk is the primary customer support platform used by the majority of Insight's target customers. Customer support teams are a significant portion of the workforce tracked by Insight, but they are currently invisible to the platform — no support-domain connector exists.
+
+Support team leaders need to understand how their team is performing: How quickly do agents respond to tickets? Are SLA targets being met? Which agents or groups handle the most volume? What is the CSAT score trend? Today these questions are answered using Zendesk's own reporting, which is siloed from the engineering, sales, and HR data in Insight.
+
+The Zendesk connector closes this gap by ingesting support activity into the same Bronze-to-Silver pipeline that serves Jira, GitHub, Slack, and other Insight sources. Once in Insight, support activity can be correlated with deployment frequency, incident data, and HR records — enabling unified workforce analytics across engineering and support.
+
+**Target Users**:
+
+- Platform operators who configure Zendesk API credentials and monitor extraction runs
+- Data analysts who consume support activity data in Silver/Gold layers for cross-functional workforce analytics
+- Support team managers who use ticket volume, resolution rate, agent workload, and CSAT data for performance analysis
+- HR and workforce analytics stakeholders who need support staff activity alongside engineering metrics
+
+**Key Problems Solved**:
+
+- Lack of Zendesk data in Insight prevents support team inclusion in workforce analytics dashboards
+- CSAT scores, first-response times, and resolution times are not available alongside engineering metrics
+- Support agent identity is not resolved to canonical `person_id` — support staff cannot be linked to HR, collaboration, or other sources
+- No unified view of tickets, ratings, and agents in the Insight data store
+
+### 1.3 Goals (Business Outcomes)
+
+**Success Criteria**:
+
+- Zendesk ticket and agent data extracted with no missed sync windows over a 30-day period after GA (Baseline: no Zendesk extraction; Target: v1.0)
+- Per-agent CSAT data available for identity resolution within 24 hours of extraction (Baseline: N/A; Target: v1.0)
+- Support agent email resolution to `person_id` working end-to-end for ≥ 90% of active agents (Baseline: 0%; Target: v1.0)
+- Ticket volume and CSAT trend metrics available in Insight Gold layer within 24 hours of ingestion (Baseline: N/A; Target: v1.0)
+
+**Capabilities**:
+
+- Extract Zendesk tickets with current state (status, priority, assignee, timing metrics) via incremental export
+- Extract satisfaction ratings as a separate stream preserving full rating history
+- Extract agent directory for identity resolution via `email` → `person_id`
+- Incremental extraction using `updated_at` timestamp as cursor for tickets and ratings
+- Support both API token (preferred) and OAuth 2.0 authentication
+- Monitoring via `support_collection_runs` stream
+
+### 1.4 Glossary
+
+| Term | Definition |
+|------|------------|
+| Zendesk REST API v2 | Zendesk's primary REST API at `https://{subdomain}.zendesk.com/api/v2/` |
+| Ticket | Core support entity in Zendesk — a customer request, incident, or task. Has a lifecycle from `new` through `solved`/`closed` |
+| Audit | Zendesk's per-ticket event log. Each audit is a batch of events (field changes, comments, satisfaction updates) with a single timestamp and author. Source of truth for event history. |
+| Metric Set | Pre-computed timing metrics attached to tickets: `reply_time_in_minutes`, `full_resolution_time_in_minutes`, `solved_at`. Available as a side-load on the incremental ticket export. |
+| Business Hours | Time measured only within the configured business schedule (excludes weekends, holidays). Zendesk SLA Policies are defined in business hours. |
+| Calendar Hours | Wall-clock elapsed time regardless of business schedule. Used for cross-source comparison. |
+| Satisfaction Rating | Customer's post-resolution assessment of a ticket: `good`, `bad`, or `offered` (not yet answered). |
+| Agent | Zendesk user with `role = "agent"`, `"admin"`, or `"light_agent"` — an internal team member who handles tickets. |
+| Requester | External customer who opened the ticket. Not an internal agent; `requester_id` is not resolved to `person_id`. |
+| Group | A Zendesk group represents a team or department (e.g. Tier 1 Support, Billing). Agents are assigned to groups. |
+| Bronze Table | Raw data table in ClickHouse preserving source-native field names and types without transformation. |
+| Incremental Export | `GET /api/v2/incremental/tickets.json?start_time={unix_ts}` — Zendesk's bulk export endpoint, returning all tickets updated since the cursor. Preferred over full-table scans. |
+
+---
+
+## 2. Actors
+
+### 2.1 Human Actors
+
+#### Platform Operator
+
+**ID**: `cpt-zendeskspec-actor-operator`
+
+**Role**: Configures the Zendesk connection (API credentials, subdomain, start date), deploys the K8s Secret, monitors sync runs, and manages credential rotation.
+
+**Interaction**: configures `connector.yaml` parameters; creates and updates K8s Secret; reviews `support_collection_runs` for errors.
+
+#### Data Analyst
+
+**ID**: `cpt-zendeskspec-actor-analyst`
+
+**Role**: Consumes Zendesk Bronze data via Silver/Gold models. Builds ticket volume, CSAT, and resolution time metrics. Cross-joins support data with HR and engineering sources.
+
+**Interaction**: queries `support_tickets`, `zendesk_satisfaction_ratings`, `support_agents`, and downstream Silver/Gold tables.
+
+#### Support Team Manager
+
+**ID**: `cpt-zendeskspec-actor-manager`
+
+**Role**: Consumes Gold metrics dashboards: ticket volume by team, CSAT per agent, resolution rate, and SLA compliance. Does not interact with Bronze tables directly.
+
+### 2.2 System Actors
+
+#### Zendesk REST API v2
+
+**ID**: `cpt-zendeskspec-actor-zendesk-api`
+
+**Role**: External REST API providing ticket export, satisfaction ratings, and user directory. Enforces rate limits (700 requests/minute for Business and above; lower for lower tiers). Requires authentication via API token (email/token Basic Auth) or OAuth 2.0.
+
+#### Identity Manager
+
+**ID**: `cpt-zendeskspec-actor-identity-manager`
+
+**Role**: Resolves `email` from `support_agents` Bronze table to canonical `person_id` in Silver step 2. Enables cross-system joins between Zendesk support agents and other Insight sources (GitHub, Jira, Slack, HR directory, M365, etc.).
+
+---
+
+## 3. Operational Concept & Environment
+
+### 3.1 Module-Specific Environment Constraints
+
+- Requires a Zendesk account with API token authentication enabled (Admin → Apps & Integrations → Zendesk API → Token Access)
+- The API token must be associated with an agent or admin account with `tickets:read`, `users:read`, and `satisfaction_ratings:read` permissions
+- Zendesk enforces per-minute rate limits that vary by plan tier (200 req/min on Basic; 700 req/min on Business and above). The connector MUST respect `Retry-After` headers on HTTP 429 responses
+- The connector operates as a batch collector; scheduled runs should be at least daily to keep Bronze data fresh
+- `support_ticket_events` (Phase 2) requires one API call per ticket — large accounts (millions of tickets) require a configurable lookback window to limit the blast radius of first-run collection
+- Zendesk subdomain is the logical identifier for the connector instance (`insight_source_id = zendesk-{subdomain}`)
+- Zendesk numeric IDs (ticket IDs, user IDs, group IDs) are scoped to one subdomain — multi-tenant deployments require `insight_source_id` qualification in every Bronze query
+
+---
+
+## 4. Scope
+
+### 4.1 In Scope (Phase 1)
+
+- Extraction of Zendesk tickets with current state including core fields, status, priority, assignee, group, timing metrics (both business-hours and calendar-hours variants), and full API response as JSON
+- Incremental ticket extraction using Zendesk's bulk export endpoint (`GET /api/v2/incremental/tickets.json`)
+- Extraction of satisfaction ratings as a separate incremental stream (`zendesk_satisfaction_ratings`)
+- Extraction of the agent directory (agents and admins) for identity resolution
+- Group name resolution via `GET /api/v2/groups` at collection startup
+- Connector execution monitoring via `support_collection_runs` stream
+- K8s Secret-based credential management following the Insight connector secret format
+- Bronze-layer table schemas for all Phase 1 streams
+
+### 4.2 Out of Scope (Phase 1 — deferred to Phase 2)
+
+- `support_ticket_events`: per-event audit log from `GET /api/v2/tickets/{id}/audits` — one call per ticket, expensive; required for MTTR and SLA compliance metrics
+- `zendesk_ticket_ext`: custom field key-value pairs — ticket `custom_fields[]` extraction and field metadata from `GET /api/v2/ticket_fields`
+- Silver/Gold layer transformations (`class_support_activity`) — responsibility of the support domain pipeline
+- Silver step 2 (identity resolution: `email` → `person_id`) — responsibility of the Identity Manager
+- Backfilling `support_tickets.satisfaction_score` from `zendesk_satisfaction_ratings` — Silver layer responsibility in Phase 2
+
+### 4.3 Permanently Out of Scope
+
+- Real-time streaming — this connector operates in batch mode
+- Zendesk webhooks or event-driven collection
+- Attachment downloads or embedded media extraction
+- Zendesk SLA Policies table (SLA policy objects) — Zendesk pre-computes timing metrics on tickets; no explicit SLA breach object exists unlike JSM
+- Zendesk macros, triggers, automations, views configuration
+- Zendesk Talk (voice) or Chat (live chat) data — support ticket domain only
+- Customer (`requester_id`) identity resolution to `person_id` — external customers are not in the HR roster
+
+---
+
+## 5. Functional Requirements
+
+### 5.1 Ticket Data Extraction
+
+#### Extract Tickets via Incremental Export
+
+- [ ] `p1` - **ID**: `cpt-zendeskspec-fr-ticket-extraction`
+
+The connector **MUST** extract Zendesk tickets using the incremental export endpoint `GET /api/v2/incremental/tickets.json?start_time={unix_ts}` with `?include=metric_sets` sideload to retrieve timing metrics in the same response. Each extracted ticket **MUST** be written to `support_tickets` with all fields defined in the Bronze schema.
+
+**Rationale**: The incremental export endpoint is Zendesk's official bulk sync API — it uses a server-side cursor, handles pagination up to 1000 tickets per page, and is the only efficient way to sync large accounts. The `metric_sets` sideload eliminates a separate per-ticket API call for timing fields.
+
+**Actors**: `cpt-zendeskspec-actor-zendesk-api`
+
+#### Store Both Business-Hours and Calendar-Hours Timing
+
+- [ ] `p1` - **ID**: `cpt-zendeskspec-fr-timing-both-variants`
+
+The connector **MUST** store both business-hours and calendar-hours variants of `first_reply_time` and `full_resolution_time` from `metric_set`:
+- `first_reply_time_seconds` ← `metric_set.reply_time_in_minutes.business × 60`
+- `first_reply_time_calendar_seconds` ← `metric_set.reply_time_in_minutes.calendar × 60`
+- `full_resolution_time_seconds` ← `metric_set.full_resolution_time_in_minutes.business × 60`
+- `full_resolution_time_calendar_seconds` ← `metric_set.full_resolution_time_in_minutes.calendar × 60`
+
+All four fields **MUST** be NULL when the metric is not yet available (ticket not yet replied to / not yet resolved).
+
+**Rationale**: SLA Policies in Zendesk are defined in business hours — business-hours values are the correct denominator for SLA compliance metrics. Calendar-hours values enable cross-source consistency with JSM (which derives timing from the event log without business-hours filtering). Storing both in Bronze avoids a re-collection when the Silver layer needs the other variant.
+
+**Actors**: `cpt-zendeskspec-actor-zendesk-api`, `cpt-zendeskspec-actor-analyst`
+
+#### Store Raw Ticket Response as JSON
+
+- [ ] `p1` - **ID**: `cpt-zendeskspec-fr-ticket-metadata`
+
+The connector **MUST** store the full Zendesk ticket API response as a JSON string in the `metadata` field on every ticket row.
+
+**Rationale**: The `metadata` field enables Silver/Gold queries to access fields not promoted to top-level columns without requiring a connector change or re-collection. Particularly important for future custom field support before `zendesk_ticket_ext` is implemented.
+
+**Actors**: `cpt-zendeskspec-actor-zendesk-api`
+
+### 5.2 Agent Directory Extraction
+
+#### Extract Agent Directory
+
+- [ ] `p1` - **ID**: `cpt-zendeskspec-fr-agent-extraction`
+
+The connector **MUST** extract all users with `role = "agent"`, `role = "admin"`, and `role = "light_agent"` from `GET /api/v2/users?role[]=agent&role[]=admin`. For each agent, the connector **MUST** store: agent ID, email, display name, role, primary group ID, group name, and active status.
+
+**Rationale**: The agent directory is the identity anchor for all support analytics. Email is the cross-system key for `person_id` resolution. Group assignment enables team-level metric aggregation.
+
+**Actors**: `cpt-zendeskspec-actor-zendesk-api`, `cpt-zendeskspec-actor-identity-manager`
+
+#### Resolve Group Names at Collection Time
+
+- [ ] `p2` - **ID**: `cpt-zendeskspec-fr-group-name-resolution`
+
+The connector **MUST** fetch group metadata via `GET /api/v2/groups` at startup and populate `group_name` by joining on `default_group_id` for each agent.
+
+**Rationale**: Group IDs are opaque numeric identifiers. Group names enable human-readable team-level breakdowns in Silver/Gold without requiring an additional lookup table.
+
+**Actors**: `cpt-zendeskspec-actor-zendesk-api`
+
+### 5.3 Satisfaction Ratings Extraction
+
+#### Extract Satisfaction Ratings as a Separate Incremental Stream
+
+- [ ] `p1` - **ID**: `cpt-zendeskspec-fr-ratings-extraction`
+
+The connector **MUST** extract CSAT ratings from `GET /api/v2/satisfaction_ratings?sort_by=updated_at&sort_order=asc&start_time={unix_ts}` as a separate incremental stream, writing to `zendesk_satisfaction_ratings`. Each rating record **MUST** include: rating ID, parent ticket ID, requester ID, assignee ID, group ID, score (`good` / `bad` / `offered`), requester comment, reason label, `created_at`, and `updated_at`.
+
+**Rationale**: Ratings arrive asynchronously — a requester may rate a ticket days after resolution. Storing ratings in a separate stream preserves the full rating history (including score changes and comments) rather than overwriting a single field on the ticket. This also means the ticket snapshot does not require re-collection when a rating arrives or changes.
+
+**Actors**: `cpt-zendeskspec-actor-zendesk-api`, `cpt-zendeskspec-actor-analyst`
+
+### 5.4 Connector Operations
+
+#### Track Collection Runs
+
+- [ ] `p2` - **ID**: `cpt-zendeskspec-fr-collection-runs`
+
+The connector **MUST** write a row to `support_collection_runs` at the start and end of each execution, recording: run ID (UUID), start timestamp, end timestamp, status (`running` / `completed` / `failed`), per-stream record counts, total API call count, error count, and collection settings as JSON.
+
+**Rationale**: Operational visibility into connector health. Enables alerting on failed runs and tracking data completeness over time.
+
+**Actors**: `cpt-zendeskspec-actor-operator`
+
+### 5.5 Data Integrity
+
+#### Deduplicate by Primary Key
+
+- [ ] `p1` - **ID**: `cpt-zendeskspec-fr-deduplication`
+
+Each stream **MUST** define a primary key that ensures re-running the connector for an overlapping time window does not produce duplicate records in Bronze. Primary keys:
+- `support_tickets`: `(insight_source_id, ticket_id)`
+- `support_agents`: `(insight_source_id, agent_id)`
+- `zendesk_satisfaction_ratings`: `(insight_source_id, rating_id)`
+- `support_collection_runs`: `(run_id)`
+
+**Rationale**: The incremental sync window may overlap with previously fetched data. `ReplacingMergeTree(_version)` storage handles deduplication at the ClickHouse level; the connector ensures the primary key uniquely identifies each record.
+
+**Actors**: `cpt-zendeskspec-actor-zendesk-api`
+
+#### Inject Tenant and Instance Context on Every Record
+
+- [ ] `p1` - **ID**: `cpt-zendeskspec-fr-tenant-context`
+
+The connector **MUST** inject `insight_tenant_id`, `insight_source_id`, `unique_key`, `data_source`, and `collected_at` on every emitted record.
+
+**Rationale**: Multi-tenant isolation and multi-instance disambiguation require these fields on every row. `unique_key` is the composite deduplication key used by the Airbyte destination. `data_source = "insight_zendesk"` is the discriminator for unified support domain queries across Zendesk and JSM.
+
+**Actors**: `cpt-zendeskspec-actor-zendesk-api`
+
+#### Implement Incremental Sync with Cursor Persistence
+
+- [ ] `p1` - **ID**: `cpt-zendeskspec-fr-incremental-sync`
+
+The connector **MUST** use `DatetimeBasedCursor` on `updated_at` for `support_tickets` and `zendesk_satisfaction_ratings`. The cursor **MUST** be persisted by the Airbyte platform state mechanism and advanced only on successful page consumption. A failed run **MUST** resume from the last successful cursor position on the next attempt.
+
+**Rationale**: Incremental sync reduces API quota usage and run duration from hours (full scan) to minutes (delta scan) for established accounts. Cursor persistence ensures no data loss on failure.
+
+**Actors**: `cpt-zendeskspec-actor-zendesk-api`
+
+### 5.6 Identity Resolution
+
+#### Support Email-Based Identity Resolution
+
+- [ ] `p1` - **ID**: `cpt-zendeskspec-fr-identity-resolution`
+
+The connector **MUST** extract `email` from `support_agents` for every active agent. The `email` field **MUST** be stored in `support_agents` and used as the join key for downstream identity resolution to canonical `person_id` in Silver step 2.
+
+**Rationale**: Email is the cross-system identity anchor used by the Insight Identity Manager to map Zendesk agents to the canonical person roster. Without email, support agents cannot be correlated with their activity in other Insight sources.
+
+**Actors**: `cpt-zendeskspec-actor-identity-manager`
+
+---
+
+## 6. Non-Functional Requirements
+
+### 6.1 NFR Inclusions
+
+#### Data Freshness
+
+- [ ] `p1` - **ID**: `cpt-zendeskspec-nfr-freshness`
+
+Bronze tables **MUST** reflect Zendesk state within 25 hours of the most recent scheduled run. The connector is scheduled once daily (default: 05:00 UTC). A 25-hour window provides a 1-hour buffer for run duration.
+
+**Verification**: Monitor `support_collection_runs.completed_at` against wall clock; alert if gap exceeds 25 hours.
+
+#### Rate Limit Compliance
+
+- [ ] `p1` - **ID**: `cpt-zendeskspec-nfr-rate-limits`
+
+The connector **MUST** respect Zendesk API rate limits. On HTTP 429, the connector **MUST** read the `Retry-After` header and wait the specified duration before retrying. Exponential backoff with jitter **MUST** be applied for repeated 429 responses. The connector **MUST NOT** exhaust the per-minute rate limit budget for other active integrations in the same Zendesk account.
+
+**Verification**: Zero rate limit failures (`HTTP 429 unhandled`) in production over a 7-day window.
+
+#### UTC Timestamps
+
+- [ ] `p1` - **ID**: `cpt-zendeskspec-nfr-utc`
+
+All timestamps stored in Bronze **MUST** be in UTC. Zendesk API timestamps are ISO 8601 with UTC offset; the connector **MUST** normalize to UTC before storage.
+
+**Verification**: Schema test — zero non-UTC timestamps in Bronze.
+
+#### Declarative Manifest Compliance
+
+- [ ] `p1` - **ID**: `cpt-zendeskspec-nfr-declarative`
+
+The connector **MUST** be a valid Airbyte DeclarativeSource YAML manifest. It **MUST** emit valid Airbyte Protocol messages (RECORD, STATE, LOG). Every emitted record **MUST** include `tenant_id`.
+
+**Verification**: `validate-strict` passes via `./src/ingestion/tools/declarative-connector/source.sh validate-strict support/zendesk`.
+
+### 6.2 NFR Exclusions
+
+- **Latency SLA below 25h**: the connector is batch-only; sub-daily freshness is not required
+- **Concurrency**: the connector runs as a single Airbyte job; no horizontal scaling requirement
+- **Availability SLA**: monitored by the Airbyte platform; the connector itself has no uptime obligation
+
+---
+
+## 7. Public Library Interfaces
+
+### 7.1 Public API Surface
+
+The Zendesk connector does not expose a public library interface. It is consumed via the Airbyte protocol (RECORD, STATE, LOG messages) and orchestrated by the Airbyte platform.
+
+**Connector entry point**: `source.sh validate-strict support/zendesk` / `source.sh run support/zendesk`
+
+### 7.2 External Integration Contracts
+
+| Contract | Description |
+|----------|-------------|
+| `support_tickets` Bronze schema | Consumed by the support domain Silver pipeline; breaking schema changes require a Silver migration |
+| `support_agents` Bronze schema | Consumed by the Identity Manager in Silver step 2; `email` field is the identity contract |
+| `zendesk_satisfaction_ratings` Bronze schema | Consumed by the support domain Silver pipeline for CSAT metrics |
+| `insight_zendesk` data_source value | Discriminator in all unified support Bronze queries; changing this value is a breaking change |
+| K8s Secret format | `metadata.name = insight-zendesk-{source_id}`; annotations `insight.cyberfabric.com/connector: zendesk`, `insight.cyberfabric.com/source-id: zendesk-{subdomain}` |
+
+---
+
+## 8. Use Cases
+
+### UC-001 Configure Zendesk Connection
+
+**Actor**: Platform Operator
+
+**Preconditions**:
+- Zendesk API token created under Admin → Apps & Integrations → Zendesk API
+- Operator has the Zendesk subdomain, agent email, and API token
+- Kubernetes cluster with `insight` namespace accessible
+
+**Main Flow**:
+1. Operator creates the K8s Secret (`insight-zendesk-main`) with fields: `zendesk_subdomain`, `zendesk_email`, `zendesk_api_token`, `start_date` (optional)
+2. Operator applies the Secret: `kubectl apply -f zendesk-secret.yaml`
+3. Reconcile loop discovers the Secret, creates an Airbyte connection with the correct parameters
+4. Operator triggers a manual sync to verify connectivity
+5. Connector performs a `check` connection using `GET /api/v2/users/me` — success confirms credentials are valid
+
+**Postconditions**: Airbyte connection exists and `support_agents` has data after first sync.
+
+**Alternative Flow — invalid credentials**: Connector returns AUTH_ERROR on check; operator is notified to update the Secret.
+
+### UC-002 Incremental Sync Run
+
+**Actor**: Orchestrator (automated, daily at 05:00 UTC)
+
+**Preconditions**:
+- Connection configured (UC-001 completed)
+- State from previous successful run exists in Airbyte platform
+
+**Main Flow**:
+1. Orchestrator triggers sync for connection `zendesk-{subdomain}-default-conn`
+2. Connector reads cursor from Airbyte state for `support_tickets` and `zendesk_satisfaction_ratings`
+3. Connector fetches `GET /api/v2/incremental/tickets.json?start_time={cursor}&include=metric_sets` — paginates until end
+4. Connector fetches `GET /api/v2/users?role[]=agent&role[]=admin` (full refresh, no cursor)
+5. Connector fetches `GET /api/v2/satisfaction_ratings?start_time={cursor}` — paginates until end
+6. Connector writes RECORD messages to Airbyte destination (ClickHouse Bronze tables)
+7. Connector emits STATE message with updated cursors for tickets and ratings
+8. Airbyte platform persists new state
+9. Connector writes `support_collection_runs` record with `status = "completed"`
+
+**Postconditions**: Bronze tables contain all records updated since the previous cursor. Cursor advanced to the current run's latest `updated_at`.
+
+**Alternative Flow — rate limit hit**: Connector receives HTTP 429, reads `Retry-After`, waits, retries. Sync continues from last successful page.
+
+### UC-003 First Run / Historical Backfill
+
+**Actor**: Platform Operator
+
+**Preconditions**:
+- Connection configured (UC-001 completed)
+- No prior Airbyte state exists (first run)
+
+**Main Flow**:
+1. Operator sets `start_date` in the K8s Secret (e.g. `2025-01-01` for a 16-month backfill)
+2. Reconcile loop creates Airbyte connection with `start_date` parameter
+3. Connector uses `start_date` as the initial cursor for the incremental ticket export
+4. Connector paginates through all tickets updated since `start_date` at 1000 tickets/page
+5. Connector fetches all agents (full refresh — no start date needed)
+6. Connector fetches ratings from `start_date`
+7. For large accounts, run duration may be several hours — Airbyte checkpoints state after each page
+
+**Postconditions**: Bronze tables populated with full historical data from `start_date`. Subsequent runs are incremental.
+
+---
+
+## 9. Acceptance Criteria
+
+| Criterion | Verification |
+|-----------|-------------|
+| Connector validates cleanly | `validate-strict` passes with zero errors |
+| Tickets stream is incremental | Second run after initial sync extracts only tickets updated since the first run's cursor |
+| Agents stream is full-refresh | Agent directory is fully refreshed on every run |
+| Ratings stream is incremental | Only ratings updated since last cursor are fetched on subsequent runs |
+| Both timing variants populated | `first_reply_time_seconds` and `first_reply_time_calendar_seconds` are non-null for solved tickets |
+| `satisfaction_score` is NULL | `support_tickets.satisfaction_score` is NULL in all Phase 1 rows |
+| Agent emails present | ≥ 95% of active agents in `support_agents` have non-null `email` |
+| Multi-tenant isolation | Two Zendesk tenants produce rows with different `insight_source_id` values and no ID collisions |
+| Rate limit handling | Connector does not abort on HTTP 429; retries after `Retry-After` |
+| UTC timestamps | All `created_at`, `updated_at` fields are UTC-normalised |
+| `unique_key` is unique | Zero duplicate `unique_key` values per stream per tenant |
+| Collection run logged | `support_collection_runs` has one row per sync with correct counts |
+
+---
+
+## 10. Dependencies
+
+| Dependency | Type | Notes |
+|-----------|------|-------|
+| Zendesk REST API v2 | External API | API token and subdomain required; rate limits apply |
+| Airbyte DeclarativeSource CDK | Framework | Manifest version pinned in `connector.yaml` |
+| Airbyte ClickHouse destination | Platform | Bronze table creation and upsert handled by destination |
+| Identity Manager | Downstream | Silver step 2 resolves `support_agents.email` → `person_id` |
+| Support domain Silver pipeline | Downstream | Consumes `support_tickets` and `zendesk_satisfaction_ratings`; Phase 2 adds `support_ticket_events` |
+| `insight-toolbox` Docker image | CI/CD | `descriptor.yaml` included in image; triggers reconcile loop |
+
+---
+
+## 11. Assumptions
+
+- Zendesk API token authentication is enabled on the customer's account (some Enterprise accounts enforce OAuth only)
+- The customer's Zendesk plan supports the incremental export endpoint (available on all Zendesk Suite plans; may not be available on legacy Starter/Essential plans)
+- Agent emails in Zendesk match the corporate email domain used by the Identity Manager (i.e., agents use their work email, not personal emails)
+- Ticket IDs are stable and unique within a Zendesk subdomain — they are never reused after ticket deletion
+- The customer's Zendesk account has a rate limit of at least 200 requests/minute (Basic tier minimum)
+
+---
+
+## 12. Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|-----------|
+| Per-account rate limit exhaustion during first-run backfill for large accounts | Medium | Medium | Configurable `start_date` limits backfill window; exponential backoff on 429 |
+| Agent email not available (suspended agents, privacy settings) | Low | Low | NULL email stored; agent is excluded from identity resolution but data still collected |
+| Zendesk API breaking change (field names, response structure) | Low | High | Full `metadata` JSON stored on every ticket — Silver can re-derive fields without re-collection |
+| Metric set not available for unresolved or very old tickets | Low | Low | All timing fields nullable; NULL used when metric not available |
+| `support_ticket_events` scale in Phase 2 (millions of audits) | Medium | Medium | Phase 2 scoped to configurable lookback window; full-history backfill is operator opt-in |
+
+---
+
+## 13. Resolved Questions
+
+### RQ-PRD-1: Separate stream or backfill for satisfaction ratings
+
+**Question**: Should satisfaction ratings be backfilled directly onto `support_tickets.satisfaction_score` during collection, or stored as a separate stream?
+
+**Decision**: Stored as a separate stream (`zendesk_satisfaction_ratings`). `support_tickets.satisfaction_score` is NULL in Phase 1; Silver layer computes the latest score per ticket from the ratings stream.
+
+**Rationale**: A separate stream preserves full rating history (score changes, requester comments, reason codes). Backfilling onto the ticket row would silently lose intermediate scores. Rating history may be analytically useful (e.g., detecting tickets where a `bad` rating was later changed to `good`).
+
+### RQ-PRD-2: Phase 1 stream count — why 3 streams
+
+**Question**: Should Phase 1 include `support_ticket_events` (audit log)?
+
+**Decision**: No. `support_ticket_events` is Phase 2. Phase 1 includes `support_tickets`, `support_agents`, and `zendesk_satisfaction_ratings`.
+
+**Rationale**: The audit log requires one API call per ticket — a large account with 500,000 tickets needs 500,000 API calls on first run (at 700 req/min, ~12 hours). This is disproportionate for Phase 1 analytics that do not require per-event data. Phase 1 provides business value (volume trends, CSAT, agent roster) with three fast streams. Phase 2 unlocks MTTR and SLA compliance.
+
+### RQ-PRD-3: Business-hours vs calendar-hours timing
+
+**Decision**: Store both variants. See `cpt-zendeskspec-fr-timing-both-variants`.
+
+---
+
+## 14. Non-Applicable Requirements
+
+| Requirement Category | Reason Not Applicable |
+|---------------------|----------------------|
+| Real-time / streaming | Connector is batch-mode only; Zendesk webhooks are out of scope |
+| Attachment extraction | Support ticket content scope only; attachments are not extracted |
+| Multi-region deployment | Handled by Insight platform infrastructure; not connector-level |
+| GDPR data erasure | Handled by platform-level data retention policies; not connector-level |
+| SLA Policy object extraction | Zendesk pre-computes timing on tickets; no explicit SLA policy breach objects via API (unlike JSM) |

--- a/docs/components/connectors/support/zendesk/zendesk.md
+++ b/docs/components/connectors/support/zendesk/zendesk.md
@@ -117,7 +117,7 @@ Maps to the unified `support_tickets` table defined in `docs/connectors/support/
 
 Identity anchor for support analytics. Maps to `person_id` via Identity Manager.
 
-**API**: `GET /api/v2/users?role[]=agent&role[]=admin` — returns both agent-tier users. Paginate with `page[after]` cursor (cursor-based pagination). Use `?include=groups` to retrieve group memberships without extra calls.
+**API**: `GET /api/v2/users?role[]=agent&role[]=admin` — returns both agent-tier users. Paginate with `page[after]` cursor (cursor-based pagination). Group-name enrichment (via `GET /api/v2/groups`) is deferred to Phase 2.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -127,7 +127,7 @@ Identity anchor for support analytics. Maps to `person_id` via Identity Manager.
 | `display_name` | String | `user.name` |
 | `role` | String | `user.role` — `agent` / `admin` / `light_agent` |
 | `group_id` | String | `user.default_group_id` — numeric primary group ID; NULL if not set |
-| `group_name` | String | Display name of the group at `default_group_id`; NULL if not set — fetched via `GET /api/v2/groups` |
+| `group_name` | String | **Phase 2** — NULL in Phase 1. Display name of the group at `default_group_id`; resolved via `GET /api/v2/groups` once group-name resolution is implemented |
 | `is_active` | Int64 | `user.active` — 1 if active; 0 if suspended (`user.suspended = true`) |
 | `collected_at` | DateTime64(3) | Collection timestamp |
 | `data_source` | String | `"insight_zendesk"` |
@@ -139,7 +139,7 @@ Identity anchor for support analytics. Maps to `person_id` via Identity Manager.
 
 **Note on `role`**: Zendesk has three agent-tier roles — `agent` (standard), `admin` (full access), `light_agent` (read-only with comment access). All three are returned by the combined role query. Fetch admins separately with `?role=admin` if the `role[]` array param is not supported by the account's plan tier.
 
-**Note on `group_name`**: `default_group_id` references a Zendesk Group. Group names are fetched via `GET /api/v2/groups` at startup and joined at collection time to populate `group_name`.
+**Note on `group_name`**: `default_group_id` references a Zendesk Group. Group-name resolution is **deferred to Phase 2** — Phase 1 stores NULL. When implemented, group names are fetched via `GET /api/v2/groups` at startup and joined at collection time to populate `group_name`.
 
 ---
 

--- a/docs/components/connectors/support/zendesk/zendesk.md
+++ b/docs/components/connectors/support/zendesk/zendesk.md
@@ -1,25 +1,29 @@
 # Zendesk Connector Specification
 
-> Version 1.0 — March 2026
+> Version 1.1 — May 2026
+> Previous: v1.0 March 2026
 > Based on: `docs/connectors/support/README.md` (Support domain schema)
+> Decisions: INSIGHT-459 Phase 1 scope locked; see Resolved Questions.
 
 Standalone specification for the Zendesk (Support / Helpdesk) connector.
 
 <!-- toc -->
 
 - [Overview](#overview)
+- [Phase Scope](#phase-scope)
 - [Bronze Tables](#bronze-tables)
   - [`support_tickets` — Ticket metadata and current state](#supporttickets-ticket-metadata-and-current-state)
-  - [`support_ticket_events` — Append-only audit log](#supportticketevents-append-only-audit-log)
   - [`support_agents` — Agent directory](#supportagents-agent-directory)
-  - [`zendesk_ticket_ext` — Custom ticket fields (key-value)](#zendesk_ticket_ext--custom-ticket-fields-key-value)
+  - [`zendesk_satisfaction_ratings` — CSAT ratings (separate stream)](#zendesk_satisfaction_ratings--csat-ratings-separate-stream)
   - [`support_collection_runs` — Connector execution log](#supportcollectionruns-connector-execution-log)
+  - [Phase 2: `support_ticket_events` — Append-only audit log](#phase-2-supportticketevents--append-only-audit-log)
+  - [Phase 2: `zendesk_ticket_ext` — Custom ticket fields](#phase-2-zendesk_ticket_ext--custom-ticket-fields)
 - [Identity Resolution](#identity-resolution)
 - [Silver / Gold Mappings](#silver-gold-mappings)
+- [Resolved Questions](#resolved-questions)
 - [Open Questions](#open-questions)
-  - [OQ-ZD-1: Incremental audit collection strategy](#oq-zd-1-incremental-audit-collection-strategy)
-  - [OQ-ZD-2: `satisfaction_score` backfill frequency](#oq-zd-2-satisfactionscore-backfill-frequency)
-  - [OQ-ZD-3: Business-hours vs. calendar-hours timing](#oq-zd-3-business-hours-vs-calendar-hours-timing)
+  - [OQ-ZD-4: `support_ticket_events` incremental audit collection strategy (Phase 2)](#oq-zd-4-supportticketevents-incremental-audit-collection-strategy-phase-2)
+  - [OQ-ZD-5: Business-hours-only satisfaction_score on support_tickets (Phase 2)](#oq-zd-5-business-hours-only-satisfaction_score-on-supporttickets-phase-2)
 
 <!-- /toc -->
 
@@ -41,9 +45,26 @@ Standalone specification for the Zendesk (Support / Helpdesk) connector.
 
 **`insight_source_id`**: set to the Zendesk subdomain slug, e.g. `zendesk-acme`. Required to disambiguate multiple Zendesk tenants in the same Bronze store.
 
-**Design principle**: `support_tickets` stores the current ticket state. `support_ticket_events` captures every audit entry from `/api/v2/tickets/{id}/audits` as an append-only event log. This pattern mirrors the task-tracking domain (`task_tracker_issues` + `task_tracker_history`).
+**Design principle**: `support_tickets` stores the current ticket state. `zendesk_satisfaction_ratings` captures CSAT ratings as an append-only separate stream. `support_ticket_events` (per-event audit log from `/api/v2/tickets/{id}/audits`) is Phase 2 — it requires one API call per ticket and is the most expensive stream to collect. This pattern mirrors the task-tracking domain (`task_tracker_issues` + `task_tracker_history`).
 
-**Incremental export**: Zendesk provides `GET /api/v2/incremental/tickets.json?start_time={unix_ts}` for efficient bulk export. Use this endpoint for scheduled collection runs — the cursor advances only when the full page is consumed. Full ticket audits must be fetched individually via `/api/v2/tickets/{id}/audits` (no bulk audit export).
+**Incremental export**: Zendesk provides `GET /api/v2/incremental/tickets.json?start_time={unix_ts}` for efficient bulk export. Use this endpoint for scheduled collection runs — the cursor advances only when the full page is consumed. Full ticket audits must be fetched individually via `/api/v2/tickets/{id}/audits` (no bulk audit export) — deferred to Phase 2.
+
+---
+
+## Phase Scope
+
+| Stream / Table | Phase | API Source | Sync Mode | Notes |
+|----------------|-------|-----------|-----------|-------|
+| `support_tickets` | **Phase 1** | `GET /api/v2/incremental/tickets.json` | Incremental (`updated_at`) | Core snapshot; includes both business- and calendar-hours timing |
+| `support_agents` | **Phase 1** | `GET /api/v2/users?role[]=agent&role[]=admin` | Full refresh | Identity anchor |
+| `zendesk_satisfaction_ratings` | **Phase 1** | `GET /api/v2/satisfaction_ratings` | Incremental (`updated_at`) | Separate stream; not backfilled onto `support_tickets` |
+| `support_collection_runs` | **Phase 1** | Connector-generated | — | Monitoring; written at start and end of run |
+| `support_ticket_events` | **Phase 2** | `GET /api/v2/tickets/{id}/audits` | Append-only per ticket | Expensive: one call per ticket; required for MTTR, SLA |
+| `zendesk_ticket_ext` | **Phase 2** | `ticket.custom_fields[]` | Incremental (with tickets) | Custom field key-value pairs for workspace-specific fields |
+
+**Phase 1 analytics**: ticket volume trends, agent roster and identity resolution, CSAT score distribution, basic assignee/group breakdowns.
+
+**Phase 2 analytics**: MTTR, first-response SLA compliance, full-resolution SLA compliance, per-event audit trail, per-agent CSAT, custom attribute segmentation.
 
 ---
 
@@ -53,13 +74,13 @@ Standalone specification for the Zendesk (Support / Helpdesk) connector.
 
 Maps to the unified `support_tickets` table defined in `docs/connectors/support/README.md`. Current state snapshot, updated on each collection run.
 
-**API**: `GET /api/v2/tickets` (initial load) or `GET /api/v2/incremental/tickets.json?start_time=` (incremental). Side-load `metric_sets` to retrieve timing fields without extra calls.
+**API**: `GET /api/v2/incremental/tickets.json?start_time={unix_ts}` (incremental). Side-load `metric_sets` via `?include=metric_sets` to retrieve timing fields in the same response without extra calls.
 
 | Field | Type | Description |
 |-------|------|-------------|
 | `insight_source_id` | String | Connector instance identifier, e.g. `zendesk-acme` |
 | `ticket_id` | String | Zendesk ticket `id` (numeric, stored as string) |
-| `subject` | String | Ticket `subject` |
+| `subject` | String | Ticket `subject`; NULL if blank |
 | `status` | String | `status` field — values: `new` / `open` / `pending` / `hold` / `solved` / `closed` — mapped directly |
 | `priority` | String | `priority` field — `low` / `normal` / `high` / `urgent`; NULL if not set |
 | `ticket_type` | String | `type` field — `question` / `incident` / `problem` / `task`; NULL if not set |
@@ -70,9 +91,11 @@ Maps to the unified `support_tickets` table defined in `docs/connectors/support/
 | `created_at` | DateTime64(3) | `created_at` (ISO 8601 string → DateTime64) |
 | `updated_at` | DateTime64(3) | `updated_at` — cursor for incremental sync |
 | `solved_at` | DateTime64(3) | `metric_set.solved_at`; NULL if not yet solved |
-| `first_reply_time_seconds` | Int64 | `metric_set.reply_time_in_minutes.business` × 60; NULL if no reply yet |
-| `full_resolution_time_seconds` | Int64 | `metric_set.full_resolution_time_in_minutes.business` × 60; NULL if unresolved |
-| `satisfaction_score` | String | From `GET /api/v2/satisfaction_ratings` joined on `ticket_id`; `good` / `bad`; NULL if unrated |
+| `first_reply_time_seconds` | Int64 | `metric_set.reply_time_in_minutes.business` × 60; NULL if no reply yet. **Business hours** — aligned with SLA Policy evaluation |
+| `first_reply_time_calendar_seconds` | Int64 | `metric_set.reply_time_in_minutes.calendar` × 60; NULL if no reply yet. **Calendar (wall-clock) hours** — enables cross-source comparison with JSM |
+| `full_resolution_time_seconds` | Int64 | `metric_set.full_resolution_time_in_minutes.business` × 60; NULL if unresolved. **Business hours** |
+| `full_resolution_time_calendar_seconds` | Int64 | `metric_set.full_resolution_time_in_minutes.calendar` × 60; NULL if unresolved. **Calendar hours** |
+| `satisfaction_score` | String | `NULL` in Phase 1 — ratings live in `zendesk_satisfaction_ratings`; backfill to this field is Phase 2 |
 | `tags` | String | `tags` array joined as comma-separated string |
 | `metadata` | String | Full API response as JSON |
 | `data_source` | String | `"insight_zendesk"` |
@@ -84,53 +107,9 @@ Maps to the unified `support_tickets` table defined in `docs/connectors/support/
 - `idx_support_ticket_updated`: `(updated_at)`
 - `idx_support_ticket_status`: `(status, data_source)`
 
-**Note on `first_reply_time_seconds`**: Zendesk returns business-hours metrics in `metric_set.reply_time_in_minutes.business`. Calendar-hours equivalent is available in `metric_set.reply_time_in_minutes.calendar`. Store business-hours value in `first_reply_time_seconds` (aligns with SLA Policy evaluation); calendar-hours variant available in `metadata`.
+**Note on timing fields**: both business-hours (`first_reply_time_seconds`, `full_resolution_time_seconds`) and calendar-hours (`first_reply_time_calendar_seconds`, `full_resolution_time_calendar_seconds`) variants are stored. Business-hours values align with Zendesk SLA Policy evaluation. Calendar-hours values enable cross-source consistency with JSM (which derives timing from the event log without business-hours filtering). See Resolved Questions RQ-ZD-3.
 
-**Note on `satisfaction_score`**: CSAT ratings are returned by a separate endpoint — `GET /api/v2/satisfaction_ratings` (paginated). Ratings are backfilled onto `support_tickets.satisfaction_score` by joining on `satisfaction_rating.ticket_id` during the collection run.
-
----
-
-### `support_ticket_events` — Append-only audit log
-
-Every audit on every ticket is collected from `GET /api/v2/tickets/{id}/audits`. Each Zendesk audit contains an `events[]` array — each entry in the array produces one row in `support_ticket_events`.
-
-**API**: `GET /api/v2/tickets/{id}/audits` — paginated per ticket. For high-volume accounts, use the incremental cursor to limit the set of tickets whose audits need fetching.
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `insight_source_id` | String | Connector instance identifier |
-| `ticket_id` | String | Zendesk ticket `id` — joins to `support_tickets.ticket_id` |
-| `event_id` | String | Composite key: `{audit.id}_{event_index}` — unique per row (Zendesk audit `id` is unique per audit, not per event within the audit) |
-| `event_type` | String | Normalised event type (see mapping below) |
-| `author_id` | String | `audit.author_id` — Zendesk user ID of agent or automation; NULL for system events — joins to `support_agents.agent_id` |
-| `created_at` | DateTime64(3) | `audit.created_at` — when this audit (batch of events) was recorded |
-| `field_name` | String | For `field_change` / `status_change` / `assignment`: the field that changed (e.g. `status`, `assignee_id`, `priority`, `group_id`); NULL for `comment` events |
-| `value_from` | String | Previous field value; NULL for new tickets or non-field events |
-| `value_to` | String | New field value |
-| `comment_body` | String | Comment text (plain text extracted from HTML); NULL for non-comment events |
-| `is_public` | Int64 | 1 if public reply visible to requester; 0 if internal note; NULL for non-comment events |
-| `data_source` | String | `"insight_zendesk"` |
-| `_version` | UInt64 | Collection timestamp in milliseconds |
-
-**Indexes**:
-- `idx_support_event_ticket`: `(insight_source_id, ticket_id, data_source)`
-- `idx_support_event_author`: `(author_id, data_source)`
-- `idx_support_event_created`: `(created_at)`
-- `idx_support_event_type`: `(event_type, data_source)`
-
-**Zendesk `event_type` mapping**:
-
-| Zendesk audit event type | Unified `event_type` | Notes |
-|--------------------------|---------------------|-------|
-| `ChangeEvent` with `field_name = "status"` | `status_change` | `value_from` / `value_to` = raw status strings |
-| `ChangeEvent` with `field_name = "assignee_id"` | `assignment` | `value_from` / `value_to` = numeric agent IDs as strings |
-| `ChangeEvent` (all other fields) | `field_change` | `field_name` preserved from the event |
-| `CommentEvent` (public) | `comment` | `is_public = 1`; `comment_body` from `body` stripped of HTML |
-| `CommentEvent` (private) | `comment` | `is_public = 0`; `comment_body` set |
-| `SatisfactionRatingEvent` | `satisfaction_update` | `value_to` = `good` / `bad` / `offered`; `field_name = "satisfaction"` |
-| `NotificationEvent`, `CcEvent`, etc. | `field_change` | Non-analytics events; captured for completeness |
-
-**Note on `author_id` for automations**: Zendesk Triggers and Automations produce audits with a system `author_id` (e.g. the trigger's user ID, which may not appear in `support_agents`). These are stored as-is; `author_id` will not resolve to a `person_id` for system-generated events.
+**Note on `satisfaction_score`**: Phase 1 always stores NULL here. Satisfaction ratings are collected in the separate `zendesk_satisfaction_ratings` stream. Phase 2 will backfill this field from the ratings stream at Silver processing time.
 
 ---
 
@@ -138,7 +117,7 @@ Every audit on every ticket is collected from `GET /api/v2/tickets/{id}/audits`.
 
 Identity anchor for support analytics. Maps to `person_id` via Identity Manager.
 
-**API**: `GET /api/v2/users?role=agent` — returns only users with the `agent` or `admin` role. Paginate with `page[after]` cursor. Use `include=groups` to retrieve group memberships without extra calls.
+**API**: `GET /api/v2/users?role[]=agent&role[]=admin` — returns both agent-tier users. Paginate with `page[after]` cursor (cursor-based pagination). Use `?include=groups` to retrieve group memberships without extra calls.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -148,7 +127,7 @@ Identity anchor for support analytics. Maps to `person_id` via Identity Manager.
 | `display_name` | String | `user.name` |
 | `role` | String | `user.role` — `agent` / `admin` / `light_agent` |
 | `group_id` | String | `user.default_group_id` — numeric primary group ID; NULL if not set |
-| `group_name` | String | Display name of the group at `default_group_id`; NULL if not set |
+| `group_name` | String | Display name of the group at `default_group_id`; NULL if not set — fetched via `GET /api/v2/groups` |
 | `is_active` | Int64 | `user.active` — 1 if active; 0 if suspended (`user.suspended = true`) |
 | `collected_at` | DateTime64(3) | Collection timestamp |
 | `data_source` | String | `"insight_zendesk"` |
@@ -158,13 +137,105 @@ Identity anchor for support analytics. Maps to `person_id` via Identity Manager.
 - `idx_support_agent_lookup`: `(insight_source_id, agent_id, data_source)`
 - `idx_support_agent_email`: `(email)`
 
-**Note on `role`**: Zendesk has three agent-tier roles — `agent` (standard), `admin` (full access), `light_agent` (read-only with comment access). The `GET /api/v2/users?role=agent` endpoint returns all three tiers. Fetch admins separately with `?role=admin` if needed.
+**Note on `role`**: Zendesk has three agent-tier roles — `agent` (standard), `admin` (full access), `light_agent` (read-only with comment access). All three are returned by the combined role query. Fetch admins separately with `?role=admin` if the `role[]` array param is not supported by the account's plan tier.
 
-**Note on `group_name`**: `default_group_id` references a Zendesk Group. Group names can be fetched via `GET /api/v2/groups` and joined at collection time to populate `group_name`.
+**Note on `group_name`**: `default_group_id` references a Zendesk Group. Group names are fetched via `GET /api/v2/groups` at startup and joined at collection time to populate `group_name`.
 
 ---
 
-### `zendesk_ticket_ext` — Custom ticket fields (key-value)
+### `zendesk_satisfaction_ratings` — CSAT ratings (separate stream)
+
+Dedicated stream for customer satisfaction ratings. Stored separately rather than backfilled onto `support_tickets` — this preserves full rating history (initial score, updates, and the requester's comment) and avoids mutable overwrites on the ticket snapshot table.
+
+**API**: `GET /api/v2/satisfaction_ratings?sort_by=updated_at&sort_order=asc&start_time={unix_ts}` — incremental by `updated_at`. Returns one record per rating event (initial rating, score change, comment added).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `insight_source_id` | String | Connector instance identifier, e.g. `zendesk-acme` |
+| `rating_id` | String | Zendesk `satisfaction_rating.id` (numeric, stored as string) |
+| `ticket_id` | String | Parent ticket ID — joins to `support_tickets.ticket_id` |
+| `requester_id` | String | `requester_id` — the customer who submitted the rating; **not** resolved to `person_id` |
+| `assignee_id` | String | `assignee_id` at time of rating — joins to `support_agents.agent_id`; NULL if not set |
+| `group_id` | String | `group_id` at time of rating; NULL if not set |
+| `score` | String | `"good"` / `"bad"` / `"offered"` (offered but not yet answered); NULL if rating was withdrawn |
+| `comment` | String | Free-text comment from the requester; NULL if none provided |
+| `reason` | String | `reason_code` or `reason` label from Zendesk (e.g. `"Awesome support"`); NULL if not provided |
+| `created_at` | DateTime64(3) | When the rating was first offered |
+| `updated_at` | DateTime64(3) | Last update — cursor for incremental sync |
+| `data_source` | String | `"insight_zendesk"` |
+| `_version` | UInt64 | Collection timestamp in milliseconds |
+
+**Indexes**:
+- `idx_zendesk_rating_ticket`: `(insight_source_id, ticket_id, data_source)`
+- `idx_zendesk_rating_updated`: `(updated_at)`
+- `idx_zendesk_rating_assignee`: `(assignee_id, data_source)`
+
+**Note on `score = "offered"`**: Zendesk emits a rating record as soon as it is offered to the requester, before a response is received. This record has `score = "offered"`. When the requester responds, the existing record is updated to `good` or `bad`. The incremental cursor captures both the creation and the update.
+
+---
+
+### `support_collection_runs` — Connector execution log
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `run_id` | String | Unique run identifier (UUID) |
+| `started_at` | DateTime64(3) | Run start timestamp |
+| `completed_at` | DateTime64(3) | Run end timestamp; NULL while running |
+| `status` | String | `running` / `completed` / `failed` |
+| `tickets_collected` | Int64 | Rows upserted into `support_tickets` |
+| `ratings_collected` | Int64 | Rows upserted into `zendesk_satisfaction_ratings` |
+| `agents_collected` | Int64 | Rows upserted into `support_agents` |
+| `api_calls` | Int64 | Total API calls made during the run |
+| `errors` | Int64 | Number of errors encountered |
+| `settings` | String | Collection configuration as JSON: `subdomain`, `incremental_cursor`, `lookback_days` |
+| `data_source` | String | `"insight_zendesk"` |
+| `_version` | UInt64 | Collection timestamp in milliseconds |
+
+Monitoring table — not an analytics source.
+
+---
+
+### Phase 2: `support_ticket_events` — Append-only audit log
+
+> **Status**: deferred to Phase 2. Schema locked in this spec; implementation pending.
+
+Every audit on every ticket is collected from `GET /api/v2/tickets/{id}/audits`. Each Zendesk audit contains an `events[]` array — each entry in the array produces one row in `support_ticket_events`. This is the source of truth for MTTR, SLA compliance, and first-response time verification.
+
+**Why deferred**: requires one API call per ticket — expensive for large accounts. Phase 1 analytics (ticket volume, agent roster, CSAT) do not require per-event data. Phase 2 unlocks MTTR, first-response SLA compliance, and full audit trail.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `insight_source_id` | String | Connector instance identifier |
+| `ticket_id` | String | Zendesk ticket `id` — joins to `support_tickets.ticket_id` |
+| `event_id` | String | Composite key: `{audit.id}_{event_index}` — unique per row |
+| `event_type` | String | Normalised event type (see mapping below) |
+| `author_id` | String | `audit.author_id` — Zendesk user ID; NULL for system events — joins to `support_agents.agent_id` |
+| `created_at` | DateTime64(3) | `audit.created_at` — when this audit was recorded |
+| `field_name` | String | For `field_change` / `status_change` / `assignment`: the field that changed; NULL for `comment` events |
+| `value_from` | String | Previous field value; NULL for new tickets or non-field events |
+| `value_to` | String | New field value |
+| `comment_body` | String | Comment text (plain text extracted from HTML); NULL for non-comment events |
+| `is_public` | Int64 | 1 if public reply; 0 if internal note; NULL for non-comment events |
+| `data_source` | String | `"insight_zendesk"` |
+| `_version` | UInt64 | Collection timestamp in milliseconds |
+
+**Zendesk `event_type` mapping**:
+
+| Zendesk audit event type | Unified `event_type` | Notes |
+|--------------------------|---------------------|-------|
+| `ChangeEvent` with `field_name = "status"` | `status_change` | `value_from` / `value_to` = raw status strings |
+| `ChangeEvent` with `field_name = "assignee_id"` | `assignment` | `value_from` / `value_to` = numeric agent IDs as strings |
+| `ChangeEvent` (all other fields) | `field_change` | `field_name` preserved from the event |
+| `CommentEvent` (public) | `comment` | `is_public = 1`; `comment_body` from `body` stripped of HTML |
+| `CommentEvent` (private) | `comment` | `is_public = 0` |
+| `SatisfactionRatingEvent` | `satisfaction_update` | `value_to` = `good` / `bad` / `offered`; `field_name = "satisfaction"` |
+| `NotificationEvent`, `CcEvent`, etc. | `field_change` | Captured for completeness |
+
+---
+
+### Phase 2: `zendesk_ticket_ext` — Custom ticket fields
+
+> **Status**: deferred to Phase 2. Schema locked in this spec; implementation pending.
 
 Zendesk tickets support custom fields configured per account via `GET /api/v2/ticket_fields`. Each custom field value appears in `ticket.custom_fields[]` array in the ticket response. Non-standard fields not in the core `support_tickets` schema are written here.
 
@@ -182,27 +253,6 @@ Zendesk tickets support custom fields configured per account via `GET /api/v2/ti
 
 ---
 
-### `support_collection_runs` — Connector execution log
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `run_id` | String | Unique run identifier (UUID) |
-| `started_at` | DateTime64(3) | Run start timestamp |
-| `completed_at` | DateTime64(3) | Run end timestamp; NULL while running |
-| `status` | String | `running` / `completed` / `failed` |
-| `tickets_collected` | Int64 | Rows upserted into `support_tickets` |
-| `events_collected` | Int64 | Rows appended to `support_ticket_events` |
-| `agents_collected` | Int64 | Rows upserted into `support_agents` |
-| `api_calls` | Int64 | Total API calls made during the run |
-| `errors` | Int64 | Number of errors encountered |
-| `settings` | String | Collection configuration as JSON: `subdomain`, `incremental_cursor`, `lookback_days`, `fetch_audits` flag |
-| `data_source` | String | `"insight_zendesk"` |
-| `_version` | UInt64 | Collection timestamp in milliseconds |
-
-Monitoring table — not an analytics source.
-
----
-
 ## Identity Resolution
 
 **Identity anchor**: `support_agents` — internal agents who respond to tickets.
@@ -211,17 +261,22 @@ Monitoring table — not an analytics source.
 1. Extract `email` from `support_agents`
 2. Normalize (lowercase, trim)
 3. Map to canonical `person_id` via Identity Manager in Silver step 2
-4. Propagate `person_id` to `support_ticket_events` via `author_id` → `support_agents.agent_id` join
+4. Propagate `person_id` to `support_ticket_events` (Phase 2) via `author_id` → `support_agents.agent_id` join
 
 **Resolution chain**:
 ```
-support_ticket_events.author_id
+support_ticket_events.author_id              (Phase 2)
+  → support_agents.agent_id
+  → support_agents.email
+  → person_id
+
+zendesk_satisfaction_ratings.assignee_id     (Phase 1)
   → support_agents.agent_id
   → support_agents.email
   → person_id
 ```
 
-**`requester_id` in `support_tickets`**: external customers — **not** resolved to `person_id`. Used for volume analytics and routing only.
+**`requester_id` in `support_tickets` and `zendesk_satisfaction_ratings`**: external customers — **not** resolved to `person_id`. Used for volume analytics and routing only.
 
 **`insight_source_id` is required in all joins** — numeric Zendesk IDs (ticket IDs, user IDs) are scoped to one subdomain; they collide across different Zendesk tenants.
 
@@ -229,52 +284,87 @@ support_ticket_events.author_id
 
 ## Silver / Gold Mappings
 
+### Phase 1
+
 | Bronze table | Silver target | Notes |
 |-------------|--------------|-------|
-| `support_tickets` + `support_ticket_events` | `class_support_activity` | Per-agent per-day metrics with resolved `person_id` |
 | `support_agents` | Identity Manager (`email` → `person_id`) | Used for identity resolution |
-| `support_tickets` | Reference — ticket context | Enriches `class_support_activity` with `ticket_type`, `priority`, `satisfaction_score` |
+| `support_tickets` | Reference — ticket context | Volume, status, priority breakdowns; ticket counts per group/assignee |
+| `zendesk_satisfaction_ratings` | `class_support_activity` (CSAT fields only) | Ratings attributed to agent via `assignee_id` → `person_id`; `satisfaction_score` = fraction `good / (good + bad)` per agent per period |
 
-**`class_support_activity`** derivation from Zendesk Bronze:
+### Phase 2 (when `support_ticket_events` is collected)
 
-| `class_support_activity` field | Derived from |
-|-------------------------------|--------------|
+| Bronze table | Silver target | Notes |
+|-------------|--------------|-------|
+| `support_tickets` + `support_ticket_events` | `class_support_activity` | Full per-agent per-day metrics with resolved `person_id` |
+| `support_tickets` | Reference — ticket context | Enriches `class_support_activity` with `ticket_type`, `priority`, `satisfaction_score` (backfilled from ratings) |
+
+**`class_support_activity`** fields derivable from Zendesk (Phase 2):
+
+| Field | Derived from |
+|-------|-------------|
 | `person_id` | `support_ticket_events.author_id` → `support_agents.email` → Identity Manager |
 | `date` | `support_ticket_events.created_at` (date part) |
 | `tickets_resolved` | Count of `status_change` events with `value_to = "solved"` per agent per date |
-| `first_response_time_seconds` | Average of `support_tickets.first_reply_time_seconds` for tickets where the agent sent the first `comment` (`is_public = 1`) on this date |
+| `first_response_time_seconds` | Average of `support_tickets.first_reply_time_seconds` for tickets where agent sent first `comment` (`is_public = 1`) on this date |
 | `full_resolution_time_seconds` | Average of `support_tickets.full_resolution_time_seconds` for tickets resolved by agent on this date |
-| `satisfaction_score` | Average CSAT fraction (`good` / total rated) for tickets resolved by agent on this date |
+| `satisfaction_score` | Average CSAT fraction (`good` / total rated) for tickets resolved by agent on this date — sourced from `zendesk_satisfaction_ratings` |
 | `comments_sent` | Count of `comment` events with `is_public = 1` by agent on this date |
 
-**Gold metrics**:
+**Gold metrics (Phase 1)**:
+- **Ticket volume trends**: inflow (new tickets created), resolution rate, backlog (open tickets without `solved_at`)
+- **CSAT distribution**: fraction of `good` / `bad` / `offered` ratings per group or period from `zendesk_satisfaction_ratings`
+- **Agent workload (partial)**: ticket counts per agent from `support_tickets.assignee_id` — no per-event resolution yet
+
+**Gold metrics (Phase 2)**:
 - **MTTR**: average `full_resolution_time_seconds` per agent / group / period
 - **First-response SLA compliance**: fraction of tickets where `first_reply_time_seconds` ≤ SLA threshold
 - **Full-resolution SLA compliance**: fraction of tickets where `full_resolution_time_seconds` ≤ SLA threshold
 - **Agent workload**: `tickets_resolved` + `comments_sent` per agent per week
-- **CSAT trend**: average `satisfaction_score` per agent and team over rolling 30 days
-- **Ticket volume trends**: inflow (new tickets created), resolution rate, backlog (open tickets without `solved_at`)
+- **CSAT per-agent trend**: average `satisfaction_score` per agent over rolling 30 days
+
+---
+
+## Resolved Questions
+
+### RQ-ZD-1: Phase 1 stream count — 3 streams for MVP
+
+**Decision**: Phase 1 collects `support_tickets`, `support_agents`, and `zendesk_satisfaction_ratings`. `support_ticket_events` (audit log) and `zendesk_ticket_ext` (custom fields) are deferred to Phase 2.
+
+**Rationale**: The audit log endpoint (`GET /api/v2/tickets/{id}/audits`) requires one call per ticket — prohibitively expensive for large accounts on first run. Phase 1 analytics (volume, CSAT, roster) do not require per-event data. The spec locks Phase 2 schemas to ensure no breaking schema changes when the streams are added.
+
+### RQ-ZD-2: `satisfaction_score` — stored as a separate stream
+
+**Decision**: Satisfaction ratings are stored in `zendesk_satisfaction_ratings` as an incremental stream, not backfilled onto `support_tickets.satisfaction_score` during collection. `support_tickets.satisfaction_score` is NULL in Phase 1.
+
+**Rationale**: A separate stream preserves the full rating history (score changes, requester comments, reason codes) that a single-field backfill would lose. The Silver layer can compute `satisfaction_score` per-ticket by joining `zendesk_satisfaction_ratings` on `ticket_id` and taking the latest non-offered score.
+
+### RQ-ZD-3: Business-hours AND calendar-hours timing — both stored in Bronze
+
+**Decision**: `support_tickets` contains four timing fields:
+- `first_reply_time_seconds` — business hours (`metric_set.reply_time_in_minutes.business × 60`)
+- `first_reply_time_calendar_seconds` — calendar hours (`metric_set.reply_time_in_minutes.calendar × 60`)
+- `full_resolution_time_seconds` — business hours
+- `full_resolution_time_calendar_seconds` — calendar hours
+
+**Rationale**: SLA Policies in Zendesk are defined in business hours; business-hours values are the correct denominator for Zendesk SLA compliance. However, cross-source comparison with JSM (which derives timings from the event log, inherently calendar-hours) requires a consistent baseline. Storing both values in Bronze costs two extra Int64 fields and avoids a re-collection when the Silver layer needs the other variant.
 
 ---
 
 ## Open Questions
 
-### OQ-ZD-1: Incremental audit collection strategy
+### OQ-ZD-4: `support_ticket_events` incremental audit collection strategy (Phase 2)
 
 Fetching audits requires one API call per ticket (`GET /api/v2/tickets/{id}/audits`). For large accounts with millions of tickets, fetching all audits on the first run is expensive. Zendesk does not provide a bulk audit export endpoint.
 
-**Question**: Should the initial collection only fetch audits for tickets updated within the lookback window (e.g. last 90 days), and accept that older tickets have no event history in Bronze? Or should the connector offer a configurable full-history backfill mode (rate-limited, resumable)?
+**Question**: Should the initial collection only fetch audits for tickets updated within the lookback window (e.g. last 90 days), accepting that older tickets have no event history in Bronze? Or should the connector offer a configurable full-history backfill mode (rate-limited, resumable)?
 
-**Current approach**: Collect audits for all tickets returned by the incremental export cursor. On first run, the lookback window is configurable (default: 90 days).
+**Current plan**: Collect audits for all tickets returned by the incremental export cursor. On first run, lookback window is configurable (default: 90 days). Full-history backfill is an operator opt-in via `backfill_mode: full` in the connector config.
 
-### OQ-ZD-2: `satisfaction_score` backfill frequency
+### OQ-ZD-5: Business-hours-only satisfaction_score on support_tickets (Phase 2)
 
-Satisfaction ratings arrive asynchronously — a requester may rate a ticket days after it was resolved. The current design fetches all ratings via `GET /api/v2/satisfaction_ratings` on each run and backfills `support_tickets.satisfaction_score`.
+When Phase 2 backfills `support_tickets.satisfaction_score` from `zendesk_satisfaction_ratings`, should the Silver job use the latest rating or the last non-`offered` rating?
 
-**Question**: Should ratings be stored in a separate `support_satisfaction_ratings` Bronze table (preserving the full rating history including score changes) rather than overwriting `support_tickets.satisfaction_score` on each run?
+**Question**: A ticket may have multiple rating events (`offered` → `good` → changed to `bad`). Should `satisfaction_score` store the most recent non-`offered` value, or the most recent value (including potential `null` when a rating is withdrawn)?
 
-### OQ-ZD-3: Business-hours vs. calendar-hours timing
-
-`metric_set.reply_time_in_minutes.business` reflects time within configured business hours only. `metric_set.reply_time_in_minutes.calendar` is wall-clock time. SLA thresholds are typically defined in business hours, but cross-source comparison (e.g. Zendesk vs. JSM) requires a consistent baseline.
-
-**Question**: Should both business-hours and calendar-hours variants be stored in Bronze (as separate fields), or only the business-hours value with the calendar variant available in `metadata`?
+**Current plan**: use the most recent non-`offered` and non-`null` score. If no answered rating exists, `satisfaction_score` remains NULL.

--- a/src/ingestion/connectors/support/zendesk/README.md
+++ b/src/ingestion/connectors/support/zendesk/README.md
@@ -84,7 +84,7 @@ Silver transformations for Phase 1 are planned as `dbt/` models tagged `zendesk`
 - `staging.zendesk__support_activity` — per-agent per-day metrics
 - `silver.class_support_activity` — unified support domain Silver table (Zendesk + JSM)
 
-`dbt_select` in `descriptor.yaml` is empty until Silver models are added.
+`dbt_select` in `descriptor.yaml` is scoped to `tag:zendesk+` — it selects nothing until Phase 2 Silver models are tagged `zendesk`, while keeping the Silver run from touching other connectors' models.
 
 ## Validation
 

--- a/src/ingestion/connectors/support/zendesk/README.md
+++ b/src/ingestion/connectors/support/zendesk/README.md
@@ -1,0 +1,99 @@
+# Zendesk Connector
+
+Extracts Zendesk tickets, satisfaction ratings, and agent directory into the Bronze layer.
+
+**API**: Zendesk REST API v2 (`https://{subdomain}.zendesk.com/api/v2/`)
+
+**Auth model**: HTTP Basic Auth — `{email}/token:{api_token}` Base64-encoded. Token created under Admin → Apps & Integrations → Zendesk API.
+
+## Specification
+
+- **Full spec + Bronze schemas**: [`docs/components/connectors/support/zendesk/zendesk.md`](../../../../../docs/components/connectors/support/zendesk/zendesk.md)
+- **PRD**: [`docs/components/connectors/support/zendesk/specs/PRD.md`](../../../../../docs/components/connectors/support/zendesk/specs/PRD.md)
+- **DESIGN**: [`docs/components/connectors/support/zendesk/specs/DESIGN.md`](../../../../../docs/components/connectors/support/zendesk/specs/DESIGN.md)
+
+## Prerequisites
+
+1. The customer has a Zendesk account with API token access enabled (Admin → Apps & Integrations → Zendesk API → Token Access: ON).
+2. An API token has been created for a service account with `tickets:read`, `users:read`, and `satisfaction_ratings:read` permissions.
+3. The customer is on a Zendesk Suite plan or equivalent that supports the incremental export endpoint (`/api/v2/incremental/tickets.json`).
+
+## K8s Secret
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-zendesk-main
+  namespace: insight
+  labels:
+    app.kubernetes.io/part-of: insight
+  annotations:
+    insight.cyberfabric.com/connector: zendesk
+    insight.cyberfabric.com/source-id: zendesk-main
+type: Opaque
+stringData:
+  zendesk_subdomain: "<your-subdomain>"          # e.g. "acme" for acme.zendesk.com
+  zendesk_email:     "<service-account@example.com>"
+  zendesk_api_token: "<api-token>"
+  # start_date: "2024-01-01"                     # optional; default: 90 days ago (YYYY-MM-DD)
+```
+
+> **Multiple Zendesk instances**: change `name` and `source-id` annotation accordingly, e.g. `insight-zendesk-staging` / `zendesk-staging`.
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `zendesk_subdomain` | Yes | Your Zendesk subdomain (the `{subdomain}` part of `{subdomain}.zendesk.com`). Used to build all API URLs. |
+| `zendesk_email` | Yes | Email of the Zendesk user associated with the API token. Used as the Basic Auth username with `/token` suffix. |
+| `zendesk_api_token` | Yes | API token generated under Admin → Apps & Integrations → Zendesk API. Sent as the Basic Auth password. |
+| `start_date` | No | Earliest date for historical backfill (YYYY-MM-DD). Default: 90 days ago. First run fetches all tickets and ratings updated since this date. |
+
+### Automatically injected
+
+These fields are added to every record by the connector — do **not** put them in the K8s Secret:
+
+| Field | Source |
+|-------|--------|
+| `tenant_id` | `insight_tenant_id` from tenant YAML (`connections/<tenant>.yaml`) |
+| `source_id` | `insight.cyberfabric.com/source-id` annotation on the K8s Secret |
+| `unique_key` | Composite primary key (varies per stream — see Streams below) |
+| `data_source` | Always `insight_zendesk` |
+| `collected_at` | UTC ISO-8601 timestamp at extraction time |
+
+## Streams
+
+| Stream | Endpoint | Sync Mode | Cursor | `unique_key` |
+|--------|----------|-----------|--------|-------------|
+| `support_tickets` | `GET /api/v2/incremental/tickets.json?include=metric_sets` | Incremental | `updated_at` (Unix ts) | `{tenant}-{source}-{ticket_id}` |
+| `support_agents` | `GET /api/v2/users?role[]=agent&role[]=admin` | Full refresh | — | `{tenant}-{source}-{agent_id}` |
+| `zendesk_satisfaction_ratings` | `GET /api/v2/satisfaction_ratings` | Incremental | `updated_at` (Unix ts) | `{tenant}-{source}-{rating_id}` |
+
+### Notes
+
+- **`support_tickets`**: uses Zendesk's incremental export endpoint (1000 tickets/page). Sideloads `metric_sets` to retrieve timing fields without extra API calls. Both business-hours and calendar-hours timing variants are stored (`first_reply_time_seconds` / `first_reply_time_calendar_seconds` and `full_resolution_time_seconds` / `full_resolution_time_calendar_seconds`).
+- **`support_agents`**: full refresh on every run — agent roster is small and Zendesk does not expose a reliable incremental endpoint for users. Group names resolved via a startup call to `GET /api/v2/groups`.
+- **`zendesk_satisfaction_ratings`**: CSAT ratings stored as a separate stream preserving full history. `support_tickets.satisfaction_score` is NULL in Phase 1; Silver layer derives per-ticket CSAT from this stream.
+- **`support_ticket_events`** (Phase 2): per-ticket audit log from `GET /api/v2/tickets/{id}/audits`. Deferred — requires one API call per ticket, expensive for large accounts.
+- **`zendesk_ticket_ext`** (Phase 2): custom field key-value pairs from `ticket.custom_fields[]`.
+
+## Silver Targets
+
+Silver transformations for Phase 1 are planned as `dbt/` models tagged `zendesk`. When implemented, they will populate:
+- `staging.zendesk__support_activity` — per-agent per-day metrics
+- `silver.class_support_activity` — unified support domain Silver table (Zendesk + JSM)
+
+`dbt_select` in `descriptor.yaml` is empty until Silver models are added.
+
+## Validation
+
+```bash
+./src/ingestion/tools/declarative-connector/source.sh validate-strict support/zendesk
+./src/ingestion/tools/declarative-connector/source.sh validate        support/zendesk
+```
+
+## Related
+
+- `jsm` — Jira Service Management connector; same unified `support_*` Bronze tables with `data_source = "insight_jsm"`. JSM also collects `support_ticket_events` and `support_sla` (Phase 2 for Zendesk).
+- Support domain spec: `docs/components/connectors/support/README.md` — unified Bronze schema across Zendesk and JSM.

--- a/src/ingestion/connectors/support/zendesk/connector.yaml
+++ b/src/ingestion/connectors/support/zendesk/connector.yaml
@@ -38,8 +38,9 @@ definitions:
       path: [data_source]
       value: insight_zendesk
 
-# `check` uses GET /api/v2/users/me — cheapest endpoint, single record,
-# confirms credentials are valid without pagination or rate limit impact.
+# `check` runs a CheckStream against support_agents: the CDK fetches the first
+# page of GET /api/v2/users?role[]=agent&role[]=admin and reports SUCCEEDED if
+# credentials are valid. (There is no dedicated /users/me stream to point at.)
 check:
   type: CheckStream
   stream_names:

--- a/src/ingestion/connectors/support/zendesk/connector.yaml
+++ b/src/ingestion/connectors/support/zendesk/connector.yaml
@@ -1,0 +1,391 @@
+# Airbyte Declarative Source for zendesk — INSIGHT-459.
+#
+# Phase 1 (this file): three streams:
+#   1. support_tickets              — incremental, DatetimeBasedCursor on updated_at
+#   2. support_agents               — full refresh
+#   3. zendesk_satisfaction_ratings — incremental, DatetimeBasedCursor on updated_at
+#
+# Phase 2 (not yet implemented — schemas locked in zendesk.md):
+#   4. support_ticket_events        — per-ticket audit log (SubstreamPartitionRouter)
+#   5. zendesk_ticket_ext           — custom field key-value pairs
+#
+# Auth: HTTP Basic Auth, username = "{email}/token", password = "{api_token}"
+# API base: https://{subdomain}.zendesk.com/api/v2/
+
+version: "7.0.4"
+type: DeclarativeSource
+
+definitions:
+  base_requester: &base_requester
+    type: HttpRequester
+    url_base: "https://{{ config['zendesk_subdomain'] }}.zendesk.com/api/v2/"
+    authenticator:
+      type: BasicHttpAuthenticator
+      username: "{{ config['zendesk_email'] }}/token"
+      password: "{{ config['zendesk_api_token'] }}"
+
+  standard_fields: &standard_fields
+    - type: AddedFieldDefinition
+      path: [tenant_id]
+      value: "{{ config['insight_tenant_id'] }}"
+    - type: AddedFieldDefinition
+      path: [source_id]
+      value: "{{ config['insight_source_id'] }}"
+    - type: AddedFieldDefinition
+      path: [collected_at]
+      value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+    - type: AddedFieldDefinition
+      path: [data_source]
+      value: insight_zendesk
+
+# `check` uses GET /api/v2/users/me — cheapest endpoint, single record,
+# confirms credentials are valid without pagination or rate limit impact.
+check:
+  type: CheckStream
+  stream_names:
+    - support_agents
+
+streams:
+  # ── Stream 1: support_tickets ──────────────────────────────────────
+  # Incremental ticket export via Zendesk's bulk cursor endpoint.
+  # Sideloads metric_sets to get timing fields (first_reply, full_resolution)
+  # in the same response — avoids N+1 per-ticket calls.
+  #
+  # Both business-hours and calendar-hours timing variants are extracted.
+  # satisfaction_score is NULL in Phase 1 (ratings live in stream 3).
+  #
+  # TODO(INSIGHT-459): implement metric_set sideload merging via
+  # CustomTransformation — Zendesk returns metric_sets as a parallel
+  # array keyed by ticket ID; needs a join step before field extraction.
+  - type: DeclarativeStream
+    name: support_tickets
+    primary_key:
+      - ticket_id
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: http://json-schema.org/schema#
+        type: object
+        additionalProperties: true
+        properties:
+          tenant_id: { type: string }
+          source_id: { type: string }
+          unique_key: { type: string }
+          collected_at: { type: string }
+          data_source: { type: string }
+          ticket_id: { type: string }
+          subject: { type: ["string", "null"] }
+          status: { type: string }
+          priority: { type: ["string", "null"] }
+          ticket_type: { type: ["string", "null"] }
+          assignee_id: { type: ["string", "null"] }
+          group_id: { type: ["string", "null"] }
+          requester_id: { type: ["string", "null"] }
+          organization_id: { type: ["string", "null"] }
+          created_at: { type: string }
+          updated_at: { type: string }
+          solved_at: { type: ["string", "null"] }
+          first_reply_time_seconds: { type: ["integer", "null"] }
+          first_reply_time_calendar_seconds: { type: ["integer", "null"] }
+          full_resolution_time_seconds: { type: ["integer", "null"] }
+          full_resolution_time_calendar_seconds: { type: ["integer", "null"] }
+          satisfaction_score: { type: ["string", "null"] }
+          tags: { type: ["string", "null"] }
+          metadata: { type: string }
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *base_requester
+        path: "incremental/tickets.json"
+        request_parameters:
+          include: "metric_sets"
+          per_page: "1000"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [tickets]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response.get('after_cursor', '') }}"
+          stop_condition: "{{ response.get('end_of_stream', False) == True }}"
+        page_token_option:
+          type: RequestOption
+          field_name: after_cursor
+          inject_into: request_parameter
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: updated_at
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%SZ"
+        - "%Y-%m-%dT%H:%M:%S.%fZ"
+      datetime_format: "%s"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('start_date') or day_delta(-90, format='%Y-%m-%d') }}"
+        datetime_format: "%Y-%m-%d"
+      end_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+        datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      start_time_option:
+        type: RequestOption
+        field_name: start_time
+        inject_into: request_parameter
+    transformations:
+      - type: AddFields
+        fields:
+          <<: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [ticket_id]
+            value: "{{ record['id'] | string }}"
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: "{{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}"
+          - type: AddedFieldDefinition
+            path: [metadata]
+            value: "{{ record | tojson }}"
+
+  # ── Stream 2: support_agents ────────────────────────────────────────
+  # Full refresh — agent roster is small; Zendesk has no reliable
+  # incremental user endpoint on all plan tiers.
+  # Group names resolved via startup GET /api/v2/groups lookup.
+  #
+  # TODO(INSIGHT-459): add CustomTransformation for group_name resolution
+  # (requires startup groups fetch; currently group_name is NULL).
+  - type: DeclarativeStream
+    name: support_agents
+    primary_key:
+      - agent_id
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: http://json-schema.org/schema#
+        type: object
+        additionalProperties: true
+        properties:
+          tenant_id: { type: string }
+          source_id: { type: string }
+          unique_key: { type: string }
+          collected_at: { type: string }
+          data_source: { type: string }
+          agent_id: { type: string }
+          email: { type: string }
+          display_name: { type: ["string", "null"] }
+          role: { type: ["string", "null"] }
+          group_id: { type: ["string", "null"] }
+          group_name: { type: ["string", "null"] }
+          is_active: { type: integer }
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *base_requester
+        path: "users"
+        request_parameters:
+          "role[]": ["agent", "admin"]
+          per_page: "100"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [users]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response.get('meta', {}).get('after_cursor', '') }}"
+          stop_condition: "{{ response.get('meta', {}).get('has_more', False) == False }}"
+        page_token_option:
+          type: RequestOption
+          field_name: "page[after]"
+          inject_into: request_parameter
+        page_size_option:
+          type: RequestOption
+          field_name: per_page
+          inject_into: request_parameter
+    transformations:
+      - type: AddFields
+        fields:
+          <<: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [agent_id]
+            value: "{{ record['id'] | string }}"
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: "{{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}"
+          - type: AddedFieldDefinition
+            path: [group_id]
+            value: "{{ record.get('default_group_id') | string if record.get('default_group_id') else None }}"
+          - type: AddedFieldDefinition
+            path: [group_name]
+            value: null   # TODO: resolve from groups lookup
+          - type: AddedFieldDefinition
+            path: [is_active]
+            value: "{{ 0 if record.get('suspended') else 1 }}"
+
+  # ── Stream 3: zendesk_satisfaction_ratings ──────────────────────────
+  # Separate incremental stream for CSAT ratings. Stored independently
+  # of support_tickets — preserves full rating history and avoids
+  # overwriting support_tickets on each rating update.
+  - type: DeclarativeStream
+    name: zendesk_satisfaction_ratings
+    primary_key:
+      - rating_id
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: http://json-schema.org/schema#
+        type: object
+        additionalProperties: true
+        properties:
+          tenant_id: { type: string }
+          source_id: { type: string }
+          unique_key: { type: string }
+          collected_at: { type: string }
+          data_source: { type: string }
+          rating_id: { type: string }
+          ticket_id: { type: string }
+          requester_id: { type: ["string", "null"] }
+          assignee_id: { type: ["string", "null"] }
+          group_id: { type: ["string", "null"] }
+          score: { type: ["string", "null"] }
+          comment: { type: ["string", "null"] }
+          reason: { type: ["string", "null"] }
+          created_at: { type: string }
+          updated_at: { type: string }
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *base_requester
+        path: "satisfaction_ratings"
+        request_parameters:
+          sort_by: "updated_at"
+          sort_order: "asc"
+          per_page: "100"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [satisfaction_ratings]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response.get('next_page', '') }}"
+          stop_condition: "{{ response.get('next_page') is none }}"
+        page_token_option:
+          type: RequestPath
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: updated_at
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%SZ"
+        - "%Y-%m-%dT%H:%M:%S.%fZ"
+      datetime_format: "%s"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('start_date') or day_delta(-90, format='%Y-%m-%d') }}"
+        datetime_format: "%Y-%m-%d"
+      end_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+        datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      start_time_option:
+        type: RequestOption
+        field_name: start_time
+        inject_into: request_parameter
+    transformations:
+      - type: AddFields
+        fields:
+          <<: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [rating_id]
+            value: "{{ record['id'] | string }}"
+          - type: AddedFieldDefinition
+            path: [ticket_id]
+            value: "{{ record['ticket_id'] | string }}"
+          - type: AddedFieldDefinition
+            path: [requester_id]
+            value: "{{ record.get('requester_id') | string if record.get('requester_id') else None }}"
+          - type: AddedFieldDefinition
+            path: [assignee_id]
+            value: "{{ record.get('assignee_id') | string if record.get('assignee_id') else None }}"
+          - type: AddedFieldDefinition
+            path: [group_id]
+            value: "{{ record.get('group_id') | string if record.get('group_id') else None }}"
+          - type: AddedFieldDefinition
+            path: [reason]
+            value: "{{ record.get('reason') or record.get('reason_code') }}"
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: "{{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}"
+
+spec:
+  type: Spec
+  connection_specification:
+    $schema: http://json-schema.org/draft-07/schema#
+    type: object
+    required:
+      - insight_tenant_id
+      - insight_source_id
+      - zendesk_subdomain
+      - zendesk_email
+      - zendesk_api_token
+    properties:
+      insight_tenant_id:
+        type: string
+        title: Insight Tenant ID
+        description: Tenant isolation identifier, injected as `tenant_id` on every record.
+        order: 0
+      insight_source_id:
+        type: string
+        title: Source Instance ID
+        description: Connector instance identifier (e.g. `zendesk-main`). Set by the reconcile loop from the K8s Secret annotation `insight.cyberfabric.com/source-id`.
+        default: ""
+        order: 1
+      zendesk_subdomain:
+        type: string
+        title: Zendesk Subdomain
+        description: |
+          Your Zendesk subdomain — the `{subdomain}` part of `{subdomain}.zendesk.com`.
+          Example: if your Zendesk URL is `acme.zendesk.com`, enter `acme`.
+        order: 2
+      zendesk_email:
+        type: string
+        title: Agent Email
+        description: |
+          Email of the Zendesk agent or admin associated with the API token.
+          Used as the Basic Auth username in the form `{email}/token`.
+        order: 3
+      zendesk_api_token:
+        type: string
+        title: API Token
+        airbyte_secret: true
+        description: |
+          Zendesk API token. Created under Admin → Apps & Integrations → Zendesk API.
+          Requires Token Access to be enabled on the account.
+        order: 4
+      start_date:
+        type: string
+        title: Start Date
+        description: |
+          Earliest date for historical backfill (YYYY-MM-DD). Default: 90 days ago.
+          First run fetches all tickets and ratings updated since this date.
+          Example: "2024-01-01" for a full 2024+ backfill.
+        default: ""
+        order: 5
+    additionalProperties: true
+
+metadata:
+  autoImportSchema:
+    support_tickets: true
+    support_agents: true
+    zendesk_satisfaction_ratings: true

--- a/src/ingestion/connectors/support/zendesk/connector.yaml
+++ b/src/ingestion/connectors/support/zendesk/connector.yaml
@@ -136,13 +136,48 @@ streams:
         inject_into: request_parameter
     transformations:
       - type: AddFields
-        fields:
-          <<: *standard_fields
+        fields: *standard_fields
       - type: AddFields
         fields:
           - type: AddedFieldDefinition
             path: [ticket_id]
             value: "{{ record['id'] | string }}"
+          - type: AddedFieldDefinition
+            path: [assignee_id]
+            value: "{{ record['assignee_id'] | string if record.get('assignee_id') else '' }}"
+          - type: AddedFieldDefinition
+            path: [requester_id]
+            value: "{{ record['requester_id'] | string if record.get('requester_id') else '' }}"
+          - type: AddedFieldDefinition
+            path: [group_id]
+            value: "{{ record['group_id'] | string if record.get('group_id') else '' }}"
+          - type: AddedFieldDefinition
+            path: [organization_id]
+            value: "{{ record['organization_id'] | string if record.get('organization_id') else '' }}"
+          - type: AddedFieldDefinition
+            path: [tags]
+            value: "{{ record.get('tags', []) | join(',') }}"
+          - type: AddedFieldDefinition
+            # solved_at lives in the embedded metric_set object; null when unresolved
+            path: [solved_at]
+            value: "{{ record.get('metric_set', {}).get('solved_at') or none }}"
+          - type: AddedFieldDefinition
+            # Business-hours first-reply time: metric_set.reply_time_in_minutes.business × 60
+            # Returns integer seconds or None (null in Bronze) when no reply yet.
+            path: [first_reply_time_seconds]
+            value: "{% set v = (record.get('metric_set') or {}).get('reply_time_in_minutes', {}).get('business') %}{{ (v * 60) | int if v is not none else none }}"
+          - type: AddedFieldDefinition
+            # Calendar-hours first-reply time: metric_set.reply_time_in_minutes.calendar × 60
+            path: [first_reply_time_calendar_seconds]
+            value: "{% set v = (record.get('metric_set') or {}).get('reply_time_in_minutes', {}).get('calendar') %}{{ (v * 60) | int if v is not none else none }}"
+          - type: AddedFieldDefinition
+            # Business-hours full-resolution time: metric_set.full_resolution_time_in_minutes.business × 60
+            path: [full_resolution_time_seconds]
+            value: "{% set v = (record.get('metric_set') or {}).get('full_resolution_time_in_minutes', {}).get('business') %}{{ (v * 60) | int if v is not none else none }}"
+          - type: AddedFieldDefinition
+            # Calendar-hours full-resolution time
+            path: [full_resolution_time_calendar_seconds]
+            value: "{% set v = (record.get('metric_set') or {}).get('full_resolution_time_in_minutes', {}).get('calendar') %}{{ (v * 60) | int if v is not none else none }}"
           - type: AddedFieldDefinition
             path: [unique_key]
             value: "{{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}"
@@ -184,9 +219,11 @@ streams:
       type: SimpleRetriever
       requester:
         <<: *base_requester
-        path: "users"
+        # role[]=agent&role[]=admin — CDK request_parameters doesn't support
+        # duplicate keys, so we embed the role filter directly in the path.
+        # This fetches agents, light_agents, and admins in one pass.
+        path: "users?role%5B%5D=agent&role%5B%5D=admin"
         request_parameters:
-          "role[]": ["agent", "admin"]
           per_page: "100"
       record_selector:
         type: RecordSelector
@@ -203,14 +240,11 @@ streams:
           type: RequestOption
           field_name: "page[after]"
           inject_into: request_parameter
-        page_size_option:
-          type: RequestOption
-          field_name: per_page
-          inject_into: request_parameter
+        # page_size_option removed — CursorPagination has no page_size;
+        # per_page=100 is set statically in request_parameters above.
     transformations:
       - type: AddFields
-        fields:
-          <<: *standard_fields
+        fields: *standard_fields
       - type: AddFields
         fields:
           - type: AddedFieldDefinition
@@ -221,13 +255,14 @@ streams:
             value: "{{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}"
           - type: AddedFieldDefinition
             path: [group_id]
-            value: "{{ record.get('default_group_id') | string if record.get('default_group_id') else None }}"
+            value: "{{ record['default_group_id'] | string if record.get('default_group_id') else '' }}"
           - type: AddedFieldDefinition
+            # group_name resolved in Phase 2 via CustomTransformation (GET /api/v2/groups lookup)
             path: [group_name]
-            value: null   # TODO: resolve from groups lookup
+            value: ""
           - type: AddedFieldDefinition
             path: [is_active]
-            value: "{{ 0 if record.get('suspended') else 1 }}"
+            value: "{{ '0' if record.get('suspended') else '1' }}"
 
   # ── Stream 3: zendesk_satisfaction_ratings ──────────────────────────
   # Separate incremental stream for CSAT ratings. Stored independently
@@ -302,8 +337,7 @@ streams:
         inject_into: request_parameter
     transformations:
       - type: AddFields
-        fields:
-          <<: *standard_fields
+        fields: *standard_fields
       - type: AddFields
         fields:
           - type: AddedFieldDefinition

--- a/src/ingestion/connectors/support/zendesk/connector.yaml
+++ b/src/ingestion/connectors/support/zendesk/connector.yaml
@@ -54,9 +54,9 @@ streams:
   # Both business-hours and calendar-hours timing variants are extracted.
   # satisfaction_score is NULL in Phase 1 (ratings live in stream 3).
   #
-  # TODO(INSIGHT-459): implement metric_set sideload merging via
-  # CustomTransformation — Zendesk returns metric_sets as a parallel
-  # array keyed by ticket ID; needs a join step before field extraction.
+  # Note: on the incremental export endpoint, ?include=metric_sets embeds the
+  # metric set per-ticket as record.metric_set (singular) — no parallel-array
+  # join is needed; field extraction reads it directly below.
   - type: DeclarativeStream
     name: support_tickets
     primary_key:
@@ -155,6 +155,10 @@ streams:
             path: [organization_id]
             value: "{{ record['organization_id'] | string if record.get('organization_id') else '' }}"
           - type: AddedFieldDefinition
+            # Zendesk ticket `type`: question / incident / problem / task; null if not set
+            path: [ticket_type]
+            value: "{{ record.get('type') or none }}"
+          - type: AddedFieldDefinition
             path: [tags]
             value: "{{ record.get('tags', []) | join(',') }}"
           - type: AddedFieldDefinition
@@ -250,6 +254,10 @@ streams:
           - type: AddedFieldDefinition
             path: [agent_id]
             value: "{{ record['id'] | string }}"
+          - type: AddedFieldDefinition
+            # display_name from Zendesk user `name`; null if absent
+            path: [display_name]
+            value: "{{ record.get('name') or none }}"
           - type: AddedFieldDefinition
             path: [unique_key]
             value: "{{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}"

--- a/src/ingestion/connectors/support/zendesk/descriptor.yaml
+++ b/src/ingestion/connectors/support/zendesk/descriptor.yaml
@@ -12,13 +12,11 @@ type: declarative
 schedule: "0 5 * * *"       # 05:00 UTC daily
 workflow: sync               # Argo workflow template: ingestion-pipeline
 
-images:
-  declarative:
-    image: ""                # no custom Docker image — uses platform declarative runner
-
-# dbt_select is empty until Silver models are added (Phase 2).
-# When Silver models land, tag them "zendesk" and set: "tag:zendesk+"
-dbt_select: ""
+# Scope the dbt step to this connector's models (and their downstream) so the
+# Silver run never touches other connectors' models. No models are tagged
+# `zendesk` yet (Phase 1 ships Bronze only), so this selects nothing — a
+# correct no-op — until Phase 2 Silver models land tagged `zendesk`.
+dbt_select: "tag:zendesk+"
 
 connection:
   namespace: "bronze_zendesk"

--- a/src/ingestion/connectors/support/zendesk/descriptor.yaml
+++ b/src/ingestion/connectors/support/zendesk/descriptor.yaml
@@ -1,0 +1,32 @@
+# Zendesk connector descriptor — INSIGHT-459.
+#
+# Loaded by insight-toolbox at reconcile time to create/update the Airbyte
+# connection for this connector.
+#
+# Phase 1 streams: support_tickets, support_agents, zendesk_satisfaction_ratings.
+# Phase 2: support_ticket_events, zendesk_ticket_ext (schemas locked in zendesk.md).
+
+name: zendesk
+version: "1.0.0"
+type: declarative
+schedule: "0 5 * * *"       # 05:00 UTC daily
+workflow: sync               # Argo workflow template: ingestion-pipeline
+
+images:
+  declarative:
+    image: ""                # no custom Docker image — uses platform declarative runner
+
+# dbt_select is empty until Silver models are added (Phase 2).
+# When Silver models land, tag them "zendesk" and set: "tag:zendesk+"
+dbt_select: ""
+
+connection:
+  namespace: "bronze_zendesk"
+
+secret:
+  required_fields:
+    - zendesk_subdomain
+    - zendesk_email
+    - zendesk_api_token
+  optional_fields:
+    - start_date

--- a/src/ingestion/secrets/connectors/zendesk.yaml.example
+++ b/src/ingestion/secrets/connectors/zendesk.yaml.example
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-zendesk-main
+  namespace: insight
+  labels:
+    app.kubernetes.io/part-of: insight
+  annotations:
+    insight.cyberfabric.com/connector: zendesk
+    insight.cyberfabric.com/source-id: zendesk-main
+type: Opaque
+stringData:
+  zendesk_subdomain: "<your-subdomain>"          # e.g. "acme" for acme.zendesk.com
+  zendesk_email:     "<service-account@example.com>"
+  zendesk_api_token: "<api-token>"               # Admin → Apps & Integrations → Zendesk API
+  # start_date: "2024-01-01"                     # optional; default: 90 days ago


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#583](https://github.com/cyberfabric/cyber-insight/pull/583) | **Author:** mozhaev-dev | **Opened:** 2026-05-29T11:41:16Z | **Status:** open
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

Implements the Zendesk Support connector (Phase 1 MVP) for INSIGHT-459.

Three Airbyte declarative streams against the Zendesk REST API v2:
- **`support_tickets`** — incremental by `updated_at`; sideloads `metric_sets` for timing fields (both business-hours and calendar-hours variants)
- **`support_agents`** — full refresh; role filter via encoded path (`role[]=agent&role[]=admin`)
- **`zendesk_satisfaction_ratings`** — incremental by `updated_at`; separate stream preserving full CSAT history

Phase 2 (`support_ticket_events`, `zendesk_ticket_ext`) schemas are locked in the spec but not yet implemented.

---

## What's in this PR

### Source code
- `src/ingestion/connectors/support/zendesk/connector.yaml` — declarative manifest (3 streams, auth, cursors, metric_set field extraction)
- `src/ingestion/connectors/support/zendesk/descriptor.yaml` — schedule, namespace, required secret fields
- `src/ingestion/connectors/support/zendesk/README.md` — deployment guide, K8s Secret template
- `src/ingestion/connectors/support/zendesk/dbt/.gitkeep` — placeholder for Phase 2 Silver models
- `src/ingestion/secrets/connectors/zendesk.yaml.example` — K8s Secret template

### Documentation
- `docs/components/connectors/support/zendesk/zendesk.md` — v1.1: Phase scope table, resolved OQs, new `zendesk_satisfaction_ratings` schema, Phase 2 schemas locked
- `docs/components/connectors/support/zendesk/specs/PRD.md` — full PRD: actors, 15+ FRs with IDs, NFRs, use cases, acceptance criteria, risks
- `docs/components/connectors/support/zendesk/specs/DESIGN.md` — full DESIGN: architecture layers, ClickHouse DDL, field mappings, rate limit budget, Phase 2 notes
- `docs/components/connectors/support/zendesk/README.md` — quick reference

---

## Decisions locked (from INSIGHT-459 scoping)

| # | Decision |
|---|----------|
| Phase 1 scope | 3 streams (tickets, agents, ratings); ticket_events + ticket_ext → Phase 2 |
| Timing fields | Both business-hours AND calendar-hours stored in `support_tickets` |
| Satisfaction ratings | Separate stream (`zendesk_satisfaction_ratings`), not backfilled onto `support_tickets` in Phase 1 |

---

## Verification

Tested against `constructor-tech.zendesk.com`:

| Check | Result |
|-------|--------|
| `validate-strict` | ✅ PASS |
| `check` | ✅ SUCCEEDED |
| `discover` | ✅ 3 streams with correct schemas |
| `read` — support_agents | ✅ 4 records; all fields populated |
| `read` — support_tickets | ✅ 16 records; solved ticket: `solved_at`, `full_resolution_time_seconds`, `first_reply_time_seconds = null` (no reply before resolution) |
| `read` — zendesk_satisfaction_ratings | ✅ stream works; 0 records in test instance (CSAT ratings come from customer emails, not API-creatable) |

---

## Phase 2 tasks (not in this PR)

- [ ] `support_ticket_events` stream (SubstreamPartitionRouter per ticket; configurable lookback window)
- [ ] `zendesk_ticket_ext` stream (custom fields key-value)
- [ ] Silver dbt models (`zendesk__support_activity.sql`) and `class_support_activity` union
- [ ] Group name resolution via CustomTransformation (startup GET /api/v2/groups)
- [ ] `support_tickets.satisfaction_score` backfill from ratings at Silver layer

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zendesk support connector v1.0.0 added — daily Bronze ingestion of tickets (with metric sets), agent directory, and satisfaction ratings; incremental and full-refresh streams enabled.

* **Documentation**
  * Comprehensive docs added: PRD, design, connector manifest, README, setup/operational notes, schema/validation commands, secret example, and Phase 2 plans for ticket events and custom-field enrichment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#583 -->