### PR TITLE
[PR #556] feat(analytics-api): add batch metric queries endpoint

### DIFF
--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -153,6 +153,7 @@ dependencies = [
  "chrono",
  "clap",
  "figment",
+ "futures",
  "insight-clickhouse",
  "redis",
  "reqwest",

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -39,6 +39,7 @@ anyhow = "1.0"
 # Async runtime
 tokio = { version = "1.47", features = ["full"] }
 async-trait = "0.1"
+futures = "0.3"
 
 # Web framework
 axum = "0.8"

--- a/src/backend/services/analytics-api/Cargo.toml
+++ b/src/backend/services/analytics-api/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = { workspace = true }
 anyhow = { workspace = true }
 tokio = { workspace = true }
 async-trait = { workspace = true }
+futures = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
 tracing = { workspace = true }

--- a/src/backend/services/analytics-api/Dockerfile
+++ b/src/backend/services/analytics-api/Dockerfile
@@ -4,7 +4,7 @@
 # Usage: cd src/backend && docker build -f services/analytics-api/Dockerfile -t insight-analytics-api:dev .
 
 # Stage 1: Builder
-FROM rust:1.92-bookworm AS builder
+FROM rust:1.95-bookworm AS builder
 
 WORKDIR /build
 

--- a/src/backend/services/analytics-api/src/api/handlers.rs
+++ b/src/backend/services/analytics-api/src/api/handlers.rs
@@ -7,7 +7,7 @@ use axum::Json;
 use axum::extract::{Extension, Path, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use modkit_canonical_errors::CanonicalError;
+use modkit_canonical_errors::{CanonicalError, Problem};
 use sea_orm::{ActiveModelTrait, ColumnTrait, Condition, EntityTrait, NotSet, QueryFilter, Set};
 use uuid::Uuid;
 
@@ -17,7 +17,9 @@ use crate::auth::SecurityContext;
 use crate::domain::metric::{
     CreateMetricRequest, Metric, MetricSummary, TableColumn, UpdateMetricRequest,
 };
-use crate::domain::query::{PageInfo, QueryRequest, QueryResponse};
+use crate::domain::query::{
+    BatchQueryRequest, BatchQueryResponse, BatchQueryResult, PageInfo, QueryRequest, QueryResponse,
+};
 use crate::domain::threshold;
 use crate::domain::threshold::{CreateThresholdRequest, Threshold, UpdateThresholdRequest};
 use crate::infra::db::entities;
@@ -189,15 +191,55 @@ pub async fn delete_metric(
 
 // ── Query ───────────────────────────────────────────────────
 
-#[allow(clippy::too_many_lines)]
 pub async fn query_metric(
     State(state): State<Arc<AppState>>,
     Extension(ctx): Extension<SecurityContext>,
     Path(id): Path<Uuid>,
     Json(req): Json<QueryRequest>,
 ) -> Result<impl IntoResponse, CanonicalError> {
+    let response = execute_metric_query(&state, &ctx, id, req).await?;
+    Ok(Json(response))
+}
+
+pub async fn query_metrics_batch(
+    State(state): State<Arc<AppState>>,
+    Extension(ctx): Extension<SecurityContext>,
+    Json(req): Json<BatchQueryRequest>,
+) -> Result<impl IntoResponse, CanonicalError> {
+    let tasks = req.queries.into_iter().map(|item| {
+        let state = state.clone();
+        let ctx = ctx.clone();
+        async move {
+            let id = item.id;
+            let metric_id = item.metric_id;
+            match execute_metric_query(&state, &ctx, metric_id, item.query).await {
+                Ok(response) => BatchQueryResult::Ok {
+                    id,
+                    metric_id,
+                    response,
+                },
+                Err(err) => BatchQueryResult::Error {
+                    id,
+                    metric_id,
+                    error: Problem::from(err),
+                },
+            }
+        }
+    });
+
+    let results = futures::future::join_all(tasks).await;
+    Ok(Json(BatchQueryResponse { results }))
+}
+
+#[allow(clippy::too_many_lines)]
+async fn execute_metric_query(
+    state: &Arc<AppState>,
+    ctx: &SecurityContext,
+    id: Uuid,
+    req: QueryRequest,
+) -> Result<QueryResponse, CanonicalError> {
     // 1. Load metric definition (must be enabled)
-    let metric = find_enabled_metric(&state, ctx.insight_tenant_id, id).await?;
+    let metric = find_enabled_metric(state, ctx.insight_tenant_id, id).await?;
 
     // 2. Validate $top
     let top = req.top.clamp(1, 200);
@@ -398,15 +440,13 @@ pub async fn query_metric(
         all_rows.into_iter().map(round_floats).collect()
     };
 
-    let response = QueryResponse {
+    Ok(QueryResponse {
         items,
         page_info: PageInfo {
             has_next,
             cursor: None,
         },
-    };
-
-    Ok(Json(response))
+    })
 }
 
 /// Round all float values in a JSON object to 4 decimal places.

--- a/src/backend/services/analytics-api/src/api/mod.rs
+++ b/src/backend/services/analytics-api/src/api/mod.rs
@@ -43,6 +43,10 @@ pub fn router(state: AppState) -> Router {
             "/v1/metrics/{id}/query",
             axum::routing::post(handlers::query_metric),
         )
+        .route(
+            "/v1/metrics/queries",
+            axum::routing::post(handlers::query_metrics_batch),
+        )
         // Thresholds
         .route(
             "/v1/metrics/{id}/thresholds",

--- a/src/backend/services/analytics-api/src/domain/query.rs
+++ b/src/backend/services/analytics-api/src/domain/query.rs
@@ -1,6 +1,8 @@
 //! Query request/response models — `OData`-style per DNA REST conventions.
 
+use modkit_canonical_errors::Problem;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 /// Query request body for `POST /v1/metrics/{id}/query`.
 ///
@@ -48,4 +50,38 @@ pub struct QueryResponse {
 pub struct PageInfo {
     pub has_next: bool,
     pub cursor: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BatchQueryItem {
+    pub id: Option<String>,
+    pub metric_id: Uuid,
+    #[serde(flatten)]
+    pub query: QueryRequest,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct BatchQueryRequest {
+    pub queries: Vec<BatchQueryItem>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "status", rename_all = "lowercase")]
+pub enum BatchQueryResult {
+    Ok {
+        id: Option<String>,
+        metric_id: Uuid,
+        #[serde(flatten)]
+        response: QueryResponse,
+    },
+    Error {
+        id: Option<String>,
+        metric_id: Uuid,
+        error: Problem,
+    },
+}
+
+#[derive(Debug, Serialize)]
+pub struct BatchQueryResponse {
+    pub results: Vec<BatchQueryResult>,
 }


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#556](https://github.com/cyberfabric/cyber-insight/pull/556) | **Author:** aleksdotbar | **Opened:** 2026-05-26T14:33:00Z | **Status:** merged on 2026-05-26T19:44:39Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for batch metric queries, enabling multiple metrics to be queried simultaneously in a single request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#556 -->