### PR TITLE
[PR #307] fix(jira-enrich): place table alias before FINAL (CH 25.3 actually requires this)

### DIFF
--- a/src/ingestion/connectors/task-tracking/jira/enrich/src/io/reader.rs
+++ b/src/ingestion/connectors/task-tracking/jira/enrich/src/io/reader.rs
@@ -207,7 +207,7 @@ pub async fn fetch_all_snapshots(
                     COALESCE(toString(id_readable), '')     AS id_readable, \
                     COALESCE(toInt64(toUnixTimestamp64Milli(parseDateTime64BestEffortOrNull(created, 3))), 0) AS created_ms, \
                     reporter_id \
-             FROM bronze_jira.jira_issue FINAL AS ji \
+             FROM bronze_jira.jira_issue AS ji FINAL \
              WHERE source_id = ?",
         )
         .bind(insight_source_id)
@@ -308,7 +308,7 @@ pub fn open_events_cursor(
                     e.value_to              AS value_to, \
                     e.value_to_string       AS value_to_string \
              FROM staging.jira_changelog_items e \
-             LEFT JOIN bronze_jira.jira_issue FINAL AS i \
+             LEFT JOIN bronze_jira.jira_issue AS i FINAL \
                  ON e.insight_source_id = i.source_id \
                 AND e.id_readable        = i.id_readable \
              LEFT JOIN ( \


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#307](https://github.com/cyberfabric/cyber-insight/pull/307) | **Author:** mitasovr | **Opened:** 2026-05-06T15:16:20Z | **Status:** merged on 2026-05-06T15:20:02Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

Follow-up to #1078. That PR attempted to fix CH 25.3 \`SYNTAX_ERROR\` by changing \`FROM tbl FINAL ji\` to \`FROM tbl FINAL AS ji\`, but **CH 25.3 rejects both forms** — it requires the alias **before** FINAL. Verified against the live cluster:

\`\`\`
FROM bronze_jira.jira_issue FINAL ji         → SYNTAX_ERROR
FROM bronze_jira.jira_issue FINAL AS ji      → SYNTAX_ERROR  ← #1078's \"fix\"
FROM bronze_jira.jira_issue ji FINAL         → OK
FROM bronze_jira.jira_issue AS ji FINAL      → OK
FROM bronze_jira.jira_issue FINAL            → OK (no alias)
\`\`\`

The correct grammar is \`<table> [AS] <alias> [FINAL]\` — alias positionally binds to the table reference itself, FINAL is a modifier that comes after both.

## Diff

\`\`\`diff
- FROM bronze_jira.jira_issue FINAL AS ji
+ FROM bronze_jira.jira_issue AS ji FINAL

- LEFT JOIN bronze_jira.jira_issue FINAL AS i
+ LEFT JOIN bronze_jira.jira_issue AS i FINAL
\`\`\`

## Reproduction

Reproduced live on virtuozzo (CH 25.3.14.14) with the rebuilt image \`insight-jira-enrich:2026.05.06.15.11-c3fd799\` (built immediately after #1078 merged):

\`\`\`
Code: 62. DB::Exception: Syntax error: failed at position 329 (AS):
AS ji WHERE source_id = 'jira-main'.
Expected one of: SAMPLE, table, table function, subquery or list of joined tables ...
\`\`\`

The same error #1078 was meant to fix, just shifted by 3 characters because \`AS\` came before \`ji\` instead of after \`FINAL\`.

## Test plan

- [x] Verified all 5 grammar permutations against CH 25.3.14.14 directly via \`clickhouse-client\`.
- [ ] After merge, rebuild jira-enrich image, re-run \`tt-enrich-jira-run\` against virtuozzo (planned in #750 deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#307 -->