### PR TITLE
[PR #306] fix(jira-enrich): use AS keyword for FINAL aliases (CH 25.3 strict parser)

### DIFF
--- a/src/ingestion/connectors/task-tracking/jira/enrich/src/io/reader.rs
+++ b/src/ingestion/connectors/task-tracking/jira/enrich/src/io/reader.rs
@@ -207,7 +207,7 @@ pub async fn fetch_all_snapshots(
                     COALESCE(toString(id_readable), '')     AS id_readable, \
                     COALESCE(toInt64(toUnixTimestamp64Milli(parseDateTime64BestEffortOrNull(created, 3))), 0) AS created_ms, \
                     reporter_id \
-             FROM bronze_jira.jira_issue FINAL ji \
+             FROM bronze_jira.jira_issue FINAL AS ji \
              WHERE source_id = ?",
         )
         .bind(insight_source_id)
@@ -308,7 +308,7 @@ pub fn open_events_cursor(
                     e.value_to              AS value_to, \
                     e.value_to_string       AS value_to_string \
              FROM staging.jira_changelog_items e \
-             LEFT JOIN bronze_jira.jira_issue FINAL i \
+             LEFT JOIN bronze_jira.jira_issue FINAL AS i \
                  ON e.insight_source_id = i.source_id \
                 AND e.id_readable        = i.id_readable \
              LEFT JOIN ( \


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#306](https://github.com/cyberfabric/cyber-insight/pull/306) | **Author:** mitasovr | **Opened:** 2026-05-06T15:08:11Z | **Status:** merged on 2026-05-06T15:11:27Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

Two single-line changes to fix Code 62 \`SYNTAX_ERROR\` from CH 25.3.14 in \`tt-enrich-jira-run\`. Surfaced during the live virtuozzo deploy of #1106 + #1099 + #1098 + #1096 + #1093 (issue #750).

## Bug

[\`src/ingestion/connectors/task-tracking/jira/enrich/src/io/reader.rs\`](https://github.com/constructorfabric/insight/blob/main/src/ingestion/connectors/task-tracking/jira/enrich/src/io/reader.rs) at lines 210 and 311 has table aliases attached after \`FINAL\` without the explicit \`AS\` keyword:

\`\`\`sql
FROM bronze_jira.jira_issue FINAL ji
LEFT JOIN bronze_jira.jira_issue FINAL i
\`\`\`

CH 25.3 strict analyser refuses to treat the post-\`FINAL\` identifier as a table alias and reports it as an unexpected token at the start of the next clause:

\`\`\`
Code: 62. DB::Exception: Syntax error: failed at position 329 (ji):
ji WHERE source_id = 'jira-main'.
Expected one of: SAMPLE, table, table function, subquery or list of joined tables ...
\`\`\`

Adding the explicit \`AS\` keyword resolves the ambiguity:

\`\`\`diff
- FROM bronze_jira.jira_issue FINAL ji
+ FROM bronze_jira.jira_issue FINAL AS ji
\`\`\`

\`\`\`diff
- LEFT JOIN bronze_jira.jira_issue FINAL i
+ LEFT JOIN bronze_jira.jira_issue FINAL AS i
\`\`\`

## Why this only surfaces now

The offending lines were introduced in 89721d84 on 2026-04-24, but the published \`ghcr.io/cyberfabric/insight-jira-enrich\` image in registry was last built on 2026-04-21 (\`ccb013f\`) — *before* this commit, by a manual \`docker push\` (CI for jira-enrich didn't exist until #1096 merged today). So this code path never ran in production.

After #1096 added the missing CI job, the manual \`workflow_dispatch\` on \`8db3ff0\` produced the first jira-enrich image with this code (\`2026.05.06.12.36-8db3ff0\`). It's the first time CH 25.3 sees this query, and 25.3's stricter parser bites immediately:

- First invocation against virtuozzo cluster (CH 25.3.14.14, jira backlog of ~3.9M \`jira_issue_history\` rows + 10K \`jira_issue\` rows): hard-fails on the \`fetch_all_snapshots\` headers query before any rows are emitted.

## Test plan

- [x] \`cargo check\` — passes (this is just an SQL string change).
- [ ] Re-run \`tt-enrich-jira-run\` against virtuozzo with the rebuilt image after merge.

## Notes

There is no other instance of this pattern in jira-enrich (\`grep -rn "FINAL \\w" src/ingestion/connectors/task-tracking/jira/enrich/src/\` returns only these two).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated SQL query syntax for improved consistency in database joins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#306 -->