### PR TITLE
[PR #282] feat(dbt): bronze→RMT bootstrap for all 8 remaining connectors

### DIFF
--- a/src/ingestion/connectors/ai/claude-enterprise/dbt/claude_enterprise__ai_assistant_usage.sql
+++ b/src/ingestion/connectors/ai/claude-enterprise/dbt/claude_enterprise__ai_assistant_usage.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('claude_enterprise__bronze_promoted') }}
 -- Bronze → Silver: Claude Enterprise per-user per-day assistant surface usage.
 --
 -- Source: bronze_claude_enterprise.claude_enterprise_users — per-user daily metrics.

--- a/src/ingestion/connectors/ai/claude-enterprise/dbt/claude_enterprise__ai_dev_usage.sql
+++ b/src/ingestion/connectors/ai/claude-enterprise/dbt/claude_enterprise__ai_dev_usage.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('claude_enterprise__bronze_promoted') }}
 -- Bronze → Silver: Claude Enterprise per-user per-day Code activity.
 --
 -- Source: bronze_claude_enterprise.claude_enterprise_users — daily per-user

--- a/src/ingestion/connectors/ai/claude-enterprise/dbt/claude_enterprise__bronze_promoted.sql
+++ b/src/ingestion/connectors/ai/claude-enterprise/dbt/claude_enterprise__bronze_promoted.sql
@@ -1,0 +1,22 @@
+{# -------------------------------------------------------------------------
+   Bootstrap model for Claude Enterprise bronze → RMT promotion.
+
+   Counterpart of `jira__bronze_promoted` for Claude Enterprise. See
+   ADR-0002. The `promote_bronze_to_rmt` macro is idempotent — already-RMT
+   tables are detected and skipped on subsequent runs.
+   ------------------------------------------------------------------------- #}
+
+-- @cpt-principle:cpt-dataflow-principle-promote-bronze:p1
+{{ config(
+    materialized='view',
+    schema='staging',
+    tags=['claude-enterprise']
+) }}
+
+{% do promote_bronze_to_rmt(table='bronze_claude_enterprise.claude_enterprise_chat_projects', order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_claude_enterprise.claude_enterprise_connectors',    order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_claude_enterprise.claude_enterprise_skills',        order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_claude_enterprise.claude_enterprise_summaries',     order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_claude_enterprise.claude_enterprise_users',         order_by='unique_key') %}
+
+SELECT 1 AS promoted

--- a/src/ingestion/connectors/ai/cursor/dbt/cursor__ai_dev_usage.sql
+++ b/src/ingestion/connectors/ai/cursor/dbt/cursor__ai_dev_usage.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('cursor__bronze_promoted') }}
 -- Bronze → Silver step 1: Cursor per-user per-day usage → class_ai_dev_usage
 --
 -- Source: bronze_cursor.cursor_daily_usage — daily aggregate stream from

--- a/src/ingestion/connectors/ai/cursor/dbt/cursor__bronze_promoted.sql
+++ b/src/ingestion/connectors/ai/cursor/dbt/cursor__bronze_promoted.sql
@@ -1,0 +1,22 @@
+{# -------------------------------------------------------------------------
+   Bootstrap model for Cursor bronze → RMT promotion.
+
+   Counterpart of `jira__bronze_promoted` for Cursor. See ADR-0002. The
+   `promote_bronze_to_rmt` macro is idempotent — already-RMT tables are
+   detected and skipped on subsequent runs.
+   ------------------------------------------------------------------------- #}
+
+-- @cpt-principle:cpt-dataflow-principle-promote-bronze:p1
+{{ config(
+    materialized='view',
+    schema='staging',
+    tags=['cursor']
+) }}
+
+{% do promote_bronze_to_rmt(table='bronze_cursor.cursor_audit_logs',                order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_cursor.cursor_daily_usage',               order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_cursor.cursor_members',                   order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_cursor.cursor_usage_events',              order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_cursor.cursor_usage_events_daily_resync', order_by='unique_key') %}
+
+SELECT 1 AS promoted

--- a/src/ingestion/connectors/ai/cursor/dbt/cursor__members_snapshot.sql
+++ b/src/ingestion/connectors/ai/cursor/dbt/cursor__members_snapshot.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('cursor__bronze_promoted') }}
 -- SCD2 snapshot of cursor team members
 -- Appends a new row only when name, role, or isRemoved changes
 {{ config(

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__bronze_promoted.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__bronze_promoted.sql
@@ -1,0 +1,21 @@
+{# -------------------------------------------------------------------------
+   Bootstrap model for Microsoft 365 bronze → RMT promotion.
+
+   Counterpart of `jira__bronze_promoted` for M365. See ADR-0002. The
+   `promote_bronze_to_rmt` macro is idempotent — already-RMT tables are
+   detected and skipped on subsequent runs.
+   ------------------------------------------------------------------------- #}
+
+-- @cpt-principle:cpt-dataflow-principle-promote-bronze:p1
+{{ config(
+    materialized='view',
+    schema='staging',
+    tags=['m365']
+) }}
+
+{% do promote_bronze_to_rmt(table='bronze_m365.email_activity',      order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_m365.onedrive_activity',   order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_m365.sharepoint_activity', order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_m365.teams_activity',      order_by='unique_key') %}
+
+SELECT 1 AS promoted

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_chat_activity.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_chat_activity.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('m365__bronze_promoted') }}
 {{ config(
     materialized='incremental',
     unique_key='unique_key',

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_document_activity_onedrive.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_document_activity_onedrive.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('m365__bronze_promoted') }}
 {{ config(
     materialized='incremental',
     unique_key='unique_key',

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_document_activity_sharepoint.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_document_activity_sharepoint.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('m365__bronze_promoted') }}
 {{ config(
     materialized='incremental',
     unique_key='unique_key',

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_email_activity.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_email_activity.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('m365__bronze_promoted') }}
 {{ config(
     materialized='incremental',
     unique_key='unique_key',

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_meeting_activity.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_meeting_activity.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('m365__bronze_promoted') }}
 {{ config(
     materialized='incremental',
     unique_key='unique_key',

--- a/src/ingestion/connectors/collaboration/slack/dbt/slack__bronze_promoted.sql
+++ b/src/ingestion/connectors/collaboration/slack/dbt/slack__bronze_promoted.sql
@@ -1,0 +1,21 @@
+{# -------------------------------------------------------------------------
+   Bootstrap model for Slack bronze → RMT promotion.
+
+   Counterpart of `jira__bronze_promoted` for Slack. See ADR-0002. The
+   `promote_bronze_to_rmt` macro is idempotent — already-RMT tables are
+   detected and skipped on subsequent runs.
+   ------------------------------------------------------------------------- #}
+
+-- @cpt-principle:cpt-dataflow-principle-promote-bronze:p1
+{{ config(
+    materialized='view',
+    schema='staging',
+    tags=['slack']
+) }}
+
+{% do promote_bronze_to_rmt(table='bronze_slack.channels',      order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_slack.messages',      order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_slack.users',         order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_slack.users_details', order_by='unique_key') %}
+
+SELECT 1 AS promoted

--- a/src/ingestion/connectors/collaboration/slack/dbt/slack__collab_chat_activity.sql
+++ b/src/ingestion/connectors/collaboration/slack/dbt/slack__collab_chat_activity.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('slack__bronze_promoted') }}
 {{ config(
     materialized='incremental',
     unique_key='unique_key',

--- a/src/ingestion/connectors/collaboration/slack/dbt/slack__users_latest.sql
+++ b/src/ingestion/connectors/collaboration/slack/dbt/slack__users_latest.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('slack__bronze_promoted') }}
 {{ config(
     materialized='table',
     schema='staging',

--- a/src/ingestion/connectors/collaboration/zoom/dbt/zoom__bronze_promoted.sql
+++ b/src/ingestion/connectors/collaboration/zoom/dbt/zoom__bronze_promoted.sql
@@ -1,0 +1,20 @@
+{# -------------------------------------------------------------------------
+   Bootstrap model for Zoom bronze → RMT promotion.
+
+   Counterpart of `jira__bronze_promoted` for Zoom. See ADR-0002. The
+   `promote_bronze_to_rmt` macro is idempotent — already-RMT tables are
+   detected and skipped on subsequent runs.
+   ------------------------------------------------------------------------- #}
+
+-- @cpt-principle:cpt-dataflow-principle-promote-bronze:p1
+{{ config(
+    materialized='view',
+    schema='staging',
+    tags=['zoom']
+) }}
+
+{% do promote_bronze_to_rmt(table='bronze_zoom.meetings',     order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_zoom.participants', order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_zoom.users',        order_by='unique_key') %}
+
+SELECT 1 AS promoted

--- a/src/ingestion/connectors/collaboration/zoom/dbt/zoom__collab_meeting_activity.sql
+++ b/src/ingestion/connectors/collaboration/zoom/dbt/zoom__collab_meeting_activity.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('zoom__bronze_promoted') }}
 {{ config(
     materialized='incremental',
     unique_key='unique_key',

--- a/src/ingestion/connectors/collaboration/zoom/dbt/zoom__users_snapshot.sql
+++ b/src/ingestion/connectors/collaboration/zoom/dbt/zoom__users_snapshot.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('zoom__bronze_promoted') }}
 {{ config(
     materialized='incremental',
     incremental_strategy='append',

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__bronze_promoted.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__bronze_promoted.sql
@@ -1,0 +1,24 @@
+{# -------------------------------------------------------------------------
+   Bootstrap model for Bitbucket Cloud bronze → RMT promotion.
+
+   Counterpart of `jira__bronze_promoted` for Bitbucket Cloud. See ADR-0002.
+   The `promote_bronze_to_rmt` macro is idempotent — already-RMT tables are
+   detected and skipped on subsequent runs.
+   ------------------------------------------------------------------------- #}
+
+-- @cpt-principle:cpt-dataflow-principle-promote-bronze:p1
+{{ config(
+    materialized='view',
+    schema='staging',
+    tags=['bitbucket-cloud']
+) }}
+
+{% do promote_bronze_to_rmt(table='bronze_bitbucket_cloud.branches',              order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_bitbucket_cloud.commits',               order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_bitbucket_cloud.file_changes',          order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_bitbucket_cloud.pull_requests',         order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_bitbucket_cloud.pull_request_comments', order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_bitbucket_cloud.pull_request_commits',  order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_bitbucket_cloud.repositories',          order_by='unique_key') %}
+
+SELECT 1 AS promoted

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__commits.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__commits.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('bitbucket_cloud__bronze_promoted') }}
 {{ config(
     materialized='incremental',
     unique_key='unique_key',

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__file_changes.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__file_changes.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('bitbucket_cloud__bronze_promoted') }}
 {{ config(
     materialized='incremental',
     unique_key='unique_key',

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('bitbucket_cloud__bronze_promoted') }}
 {{ config(
     materialized='incremental',
     unique_key='unique_key',

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_comments.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_comments.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('bitbucket_cloud__bronze_promoted') }}
 {{ config(
     materialized='incremental',
     unique_key='unique_key',

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_commits.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_commits.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('bitbucket_cloud__bronze_promoted') }}
 {{ config(
     materialized='incremental',
     unique_key='unique_key',

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_reviewers.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_reviewers.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('bitbucket_cloud__bronze_promoted') }}
 {{ config(
     materialized='incremental',
     unique_key='unique_key',

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__repositories.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__repositories.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('bitbucket_cloud__bronze_promoted') }}
 {{ config(
     materialized='incremental',
     unique_key='unique_key',

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__repository_branches.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__repository_branches.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('bitbucket_cloud__bronze_promoted') }}
 {{ config(
     materialized='incremental',
     unique_key='unique_key',

--- a/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__bronze_promoted.sql
+++ b/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__bronze_promoted.sql
@@ -1,0 +1,25 @@
+{# -------------------------------------------------------------------------
+   Bootstrap model for BambooHR bronze → RMT promotion.
+
+   Counterpart of `jira__bronze_promoted` for BambooHR. See ADR-0002 for the
+   reasoning; the macro `promote_bronze_to_rmt` is idempotent — already-RMT
+   tables are detected and skipped on subsequent runs.
+
+   All BambooHR bronze tables carry a `unique_key` column added by the
+   connector AddFields transformation (formula:
+   `{tenant}-{source}-{natural_id}`), so `order_by='unique_key'` is
+   equivalent to the natural-key composite.
+   ------------------------------------------------------------------------- #}
+
+-- @cpt-principle:cpt-dataflow-principle-promote-bronze:p1
+{{ config(
+    materialized='view',
+    schema='staging',
+    tags=['bamboohr']
+) }}
+
+{% do promote_bronze_to_rmt(table='bronze_bamboohr.employees',      order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_bamboohr.leave_requests', order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_bamboohr.meta_fields',    order_by='unique_key') %}
+
+SELECT 1 AS promoted

--- a/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__employees_fields_history.sql
+++ b/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__employees_fields_history.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('bamboohr__bronze_promoted') }}
 {{ config(
     materialized='table',
     schema='staging',

--- a/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__employees_snapshot.sql
+++ b/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__employees_snapshot.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('bamboohr__bronze_promoted') }}
 {{ config(
     materialized='incremental',
     incremental_strategy='append',

--- a/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__hr_events.sql
+++ b/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__hr_events.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('bamboohr__bronze_promoted') }}
 {{ config(
     materialized='view',
     schema='staging',

--- a/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__working_hours.sql
+++ b/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__working_hours.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('bamboohr__bronze_promoted') }}
 {{ config(
     materialized='view',
     schema='staging',

--- a/src/ingestion/connectors/hr-directory/bamboohr/dbt/to_class_people.sql
+++ b/src/ingestion/connectors/hr-directory/bamboohr/dbt/to_class_people.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('bamboohr__bronze_promoted') }}
 -- Bronze → Silver step 1: BambooHR Employees → class_people
 -- Full-refresh source. Maps employee records to unified person registry.
 -- SCD Type 2: valid_from = lastChanged, valid_to = NULL (current-state snapshot).

--- a/src/ingestion/connectors/wiki/confluence/dbt/confluence__bronze_promoted.sql
+++ b/src/ingestion/connectors/wiki/confluence/dbt/confluence__bronze_promoted.sql
@@ -1,0 +1,20 @@
+{# -------------------------------------------------------------------------
+   Bootstrap model for Confluence bronze → RMT promotion.
+
+   Counterpart of `jira__bronze_promoted` for Confluence. See ADR-0002. The
+   `promote_bronze_to_rmt` macro is idempotent — already-RMT tables are
+   detected and skipped on subsequent runs.
+   ------------------------------------------------------------------------- #}
+
+-- @cpt-principle:cpt-dataflow-principle-promote-bronze:p1
+{{ config(
+    materialized='view',
+    schema='staging',
+    tags=['confluence']
+) }}
+
+{% do promote_bronze_to_rmt(table='bronze_confluence.wiki_pages',         order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_confluence.wiki_page_versions', order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_confluence.wiki_spaces',        order_by='unique_key') %}
+
+SELECT 1 AS promoted

--- a/src/ingestion/connectors/wiki/confluence/dbt/confluence__wiki_activity.sql
+++ b/src/ingestion/connectors/wiki/confluence/dbt/confluence__wiki_activity.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('confluence__bronze_promoted') }}
 -- Bronze → Silver step 1: Confluence page versions → class_wiki_activity
 --
 -- Per-user per-day edit activity rolled up from wiki_page_versions. One row

--- a/src/ingestion/connectors/wiki/confluence/dbt/confluence__wiki_pages.sql
+++ b/src/ingestion/connectors/wiki/confluence/dbt/confluence__wiki_pages.sql
@@ -1,3 +1,4 @@
+-- depends_on: {{ ref('confluence__bronze_promoted') }}
 -- Bronze → Silver step 1: Confluence pages → class_wiki_pages
 --
 -- One row per (tenant, source, page). Dedupe by taking the latest extraction


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#282](https://github.com/cyberfabric/cyber-insight/pull/282) | **Author:** mitasovr | **Opened:** 2026-05-05T08:03:17Z | **Status:** merged on 2026-05-05T13:03:19Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

Completes #1106's *Out of scope* follow-up: bronze RMT promotion was only wired up for jira (\`jira__bronze_promoted\`); the eight other deployed connectors continued to leave bronze as plain \`MergeTree\`, so full-refresh streams kept accumulating duplicates across syncs without engine-side dedup.

This PR replicates the jira pattern for every other connector that currently has a \`dbt/\` directory.

## What's new

8 bootstrap views, one per connector:

| Connector | Tables promoted |
|---|---|
| bamboohr | employees, leave_requests, meta_fields |
| bitbucket-cloud | branches, commits, file_changes, pull_requests, pull_request_comments, pull_request_commits, repositories |
| claude-enterprise | claude_enterprise_chat_projects, claude_enterprise_connectors, claude_enterprise_skills, claude_enterprise_summaries, claude_enterprise_users |
| confluence | wiki_pages, wiki_page_versions, wiki_spaces |
| cursor | cursor_audit_logs, cursor_daily_usage, cursor_members, cursor_usage_events, cursor_usage_events_daily_resync |
| m365 | email_activity, onedrive_activity, sharepoint_activity, teams_activity |
| slack | channels, messages, users, users_details |
| zoom | meetings, participants, users |

Each is a \`materialized='view', schema='staging'\` model that calls \`promote_bronze_to_rmt(...)\` for every connector-owned bronze table. All connectors' Airbyte AddFields transformations write a \`unique_key\` column (formula \`{tenant}-{source}-{natural_id}\`), so \`order_by='unique_key'\` is the universal natural-key composite — same shape as jira.

Every staging model that reads bronze for these connectors gets a \`-- depends_on: {{ ref('<connector>__bronze_promoted') }}\` header so dbt's DAG always materialises the bootstrap view (and triggers the migrations) before the staging model reads bronze. Same pattern jira already uses.

## Idempotency

\`promote_bronze_to_rmt\` checks \`system.tables.engine\` and skips when it already contains \"Replacing\". Re-running on an already-promoted tenant is a no-op. Verified locally: a second \`dbt run\` against the same eight bootstrap models reported \"already ReplacingMergeTree; skipping\" 34/34 times in <1s.

## Test plan

- [x] \`dbt parse\` clean.
- [x] \`dbt run --select <each>__bronze_promoted\` end-to-end on a 9-connector tenant restore (mixed prior state — some bronze tables had been hand-promoted earlier, others were still MergeTree). Result: \`Done. PASS=9 ERROR=0\`. The macro migrated the still-MergeTree tables and skipped the rest.
- [x] Re-run same selection → all 34 promote calls reported \"already ReplacingMergeTree; skipping\".
- [x] Full \`dbt run --target local --exclude jira__changelog_items jira__issue_field_snapshot\` against staging+silver from scratch → \`Done. PASS=71 ERROR=28 SKIP=21\`. The eight new bootstrap models PASS; every error is either a pre-existing missing-bronze cascade for connectors not deployed on this tenant (\`github\`, \`hubspot\`, \`salesforce\`, \`claude_admin\`, \`openai\`), the pre-existing \`seed_persons_from_cursor\` correlated-subquery issue, or one of the three #1098-tracked first-run blockers — none introduced by this PR.

## Race window

Same race condition as for jira: rows that Airbyte writes between the swap-table CTAS and the EXCHANGE may be lost. Schedule the first dbt run after merge during an idle window (or pause Airbyte connections briefly), as #1106 noted.

## Out of scope

Bootstraps for \`claude-admin\`, \`github\` / \`github-v2\`, \`hubspot\`, \`openai\`, \`bitbucket-server\`, \`salesforce\` — those connectors don't have a bronze database on the current target tenant. Adding bootstraps for them is a straightforward copy when the connectors land on a tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#282 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized data pipeline architecture across multiple connectors (Claude Enterprise, Cursor, M365, Slack, Zoom, Bitbucket Cloud, BambooHR, and Confluence).
  * Added explicit dependency declarations to ensure proper data processing execution order.
  * Introduced promotion bootstrap models to streamline data transformation workflows across connectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->