### PR TITLE
[PR #279] ci: build & push insight-jira-enrich on changes to enrich/

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -29,6 +29,7 @@ jobs:
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
       ingestion: ${{ steps.filter.outputs.ingestion }}
+      jira_enrich: ${{ steps.filter.outputs.jira_enrich }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -39,6 +40,8 @@ jobs:
               - 'src/backend/**'
             ingestion:
               - 'src/ingestion/**'
+            jira_enrich:
+              - 'src/ingestion/connectors/task-tracking/jira/enrich/**'
 
   backend:
     needs: changes
@@ -118,6 +121,40 @@ jobs:
         with:
           context: src/ingestion
           file: src/ingestion/tools/toolbox/Dockerfile
+          push: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  jira-enrich:
+    needs: changes
+    if: needs.changes.outputs.jira_enrich == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.IMAGE_PREFIX }}/insight-jira-enrich
+          tags: |
+            type=raw,value={{date 'YYYY.MM.DD.HH.mm'}}-{{sha}},enable={{is_default_branch}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: src/ingestion/connectors/task-tracking/jira/enrich
+          file: src/ingestion/connectors/task-tracking/jira/enrich/Dockerfile
           push: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#279](https://github.com/cyberfabric/cyber-insight/pull/279) | **Author:** mitasovr | **Opened:** 2026-05-05T07:18:07Z | **Status:** merged on 2026-05-05T11:53:32Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

The Rust enrich binary at \`src/ingestion/connectors/task-tracking/jira/enrich/\` ships as \`ghcr.io/cyberfabric/insight-jira-enrich\` and is referenced by the \`tt-enrich-jira-run\` WorkflowTemplate, but the [build-images workflow](.github/workflows/build-images.yml) only builds the backend services and the toolbox — there is no CI for this image.

The current published tag (\`2026.04.21.09.37-ccb013f\`) was pushed manually weeks ago, so #1106's Rust changes (\`FieldHistoryInsert::From\` now computes \`unique_key\`, \`REQUIRED_FIELD_HISTORY_COLUMNS\` startup validator includes \`unique_key\`) are not in any published image yet. Without CI, every change to the Rust source needs an out-of-band push.

## What this does

Mirrors the existing \`toolbox\` job for jira-enrich:

- New path-filter output \`jira_enrich\` scoped to \`src/ingestion/connectors/task-tracking/jira/enrich/**\` so unrelated ingestion changes (dbt models, other connectors) don't rebuild the Rust image. The \`toolbox\` job keeps its broader \`src/ingestion/**\` filter — it embeds the entire tree at runtime via \`COPY . /ingestion\`.
- New \`jira-enrich\` job: same triggers (push to main / PR), same metadata tag scheme (\`{{date 'YYYY.MM.DD.HH.mm'}}-{{sha}}\` + \`latest\` on main), same build-on-PR / push-on-main / GHA cache behaviour as \`toolbox\` and \`backend\`.
- Build context is the \`enrich/\` directory (the Dockerfile's \`COPY Cargo.toml Cargo.lock* ./\` and \`COPY src ./src\` expect it as the root).

## Test plan

- [x] \`actionlint\` clean (yaml structure mirrors \`toolbox\` 1:1).
- [ ] PR CI run will exercise the build path (push: false on PRs).
- [ ] First merge to main produces \`ghcr.io/cyberfabric/insight-jira-enrich:<date>-<sha>\` + \`:latest\`.

## Why now

Needed for the upcoming virtuozzo deploy of #1106 / #1099 / #1098. The new dbt code expects \`unique_key\` in \`staging.jira__task_field_history\`, which only the new Rust binary writes. With this PR the next push to main (or a manual \`workflow_dispatch\`) produces the matching enrich image — no manual \`docker push\` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated build and deployment for the Jira enrichment component.
  * Docker image is now automatically built and published when related source files are modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#279 -->