### PR TITLE
[PR #277] fix(dbt): three more first-run blockers — id_upserts cast, class_people NULLs, identity_inputs depends_on

### DIFF
--- a/src/ingestion/connectors/hr-directory/bamboohr/dbt/to_class_people.sql
+++ b/src/ingestion/connectors/hr-directory/bamboohr/dbt/to_class_people.sql
@@ -17,7 +17,7 @@ SELECT
     CAST(concat(coalesce(unique_key, ''), '-', toString(lastChanged)) AS String) AS unique_key,
     coalesce(tenant_id, '')                         AS workspace_id,
     -- person_id resolved in Silver Step 2 via Identity Manager
-    NULL                                            AS person_id,
+    CAST(NULL AS Nullable(UUID))                    AS person_id,
     lastChanged                                     AS valid_from,
     CAST(NULL AS Nullable(DateTime))                AS valid_to,
     'bamboohr'                                      AS source,
@@ -29,7 +29,7 @@ SELECT
     workEmail                                       AS email,
     jobTitle                                        AS job_title,
     department                                      AS department_name,
-    NULL                                            AS org_unit_id,
+    CAST(NULL AS Nullable(UUID))                    AS org_unit_id,
     supervisorEId                                   AS manager_person_id,
     CASE
         WHEN status = 'Active' THEN 'active'
@@ -41,7 +41,7 @@ SELECT
     parseDateTimeBestEffortOrNull(terminationDate)   AS termination_date,
     location                                        AS location,
     country                                         AS country,
-    NULL                                            AS fte,
+    CAST(NULL AS Nullable(Float64))                 AS fte,
     CAST(map('division', coalesce(division, '')) AS Map(String, String))
                                                     AS custom_str_attrs,
     CAST(map() AS Map(String, Float64))             AS custom_num_attrs,

--- a/src/ingestion/dbt/macros/identity_inputs_from_history.sql
+++ b/src/ingestion/dbt/macros/identity_inputs_from_history.sql
@@ -130,7 +130,7 @@ id_upserts AS (
             coalesce(entity_id, ''), '-',
             'id-',
             'UPSERT-',
-            toString(toUnixTimestamp64Milli(updated_at))
+            toString(toUnixTimestamp64Milli(toDateTime64(updated_at, 3)))
         ) AS String) AS unique_key,
         tenant_id AS insight_tenant_id,
         source_id AS insight_source_id,
@@ -141,7 +141,7 @@ id_upserts AS (
         '{{ source_type }}.entity_id' AS value_field_name,
         'UPSERT' AS operation_type,
         updated_at AS _synced_at,
-        toUnixTimestamp64Milli(updated_at) AS _version
+        toUnixTimestamp64Milli(toDateTime64(updated_at, 3)) AS _version
     FROM history
     WHERE entity_id IS NOT NULL AND entity_id != ''
 ),
@@ -155,7 +155,7 @@ id_deletes AS (
             coalesce(d.entity_id, ''), '-',
             'id-',
             'DELETE-',
-            toString(toUnixTimestamp64Milli(d.updated_at))
+            toString(toUnixTimestamp64Milli(toDateTime64(d.updated_at, 3)))
         ) AS String) AS unique_key,
         d.tenant_id AS insight_tenant_id,
         d.source_id AS insight_source_id,
@@ -166,7 +166,7 @@ id_deletes AS (
         '{{ source_type }}.entity_id' AS value_field_name,
         'DELETE' AS operation_type,
         d.updated_at AS _synced_at,
-        toUnixTimestamp64Milli(d.updated_at) AS _version
+        toUnixTimestamp64Milli(toDateTime64(d.updated_at, 3)) AS _version
     FROM deactivation_events d
 )
 

--- a/src/ingestion/silver/_shared/identity_inputs.sql
+++ b/src/ingestion/silver/_shared/identity_inputs.sql
@@ -11,6 +11,8 @@
 
 -- depends_on: {{ ref('bamboohr__identity_inputs') }}
 -- depends_on: {{ ref('zoom__identity_inputs') }}
+-- depends_on: {{ ref('seed_identity_inputs_from_cursor') }}
+-- depends_on: {{ ref('seed_identity_inputs_from_claude_admin') }}
 
 SELECT * FROM (
     {{ union_by_tag('silver:identity_inputs') }}


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#277](https://github.com/cyberfabric/cyber-insight/pull/277) | **Author:** mitasovr | **Opened:** 2026-05-04T18:51:09Z | **Status:** merged on 2026-05-05T11:53:46Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

Follow-up to #1099. Found by re-running the same end-to-end rehearsal against the new toolbox image (\`2026.05.04.18.16-f568cb2\`). Three fresh first-run errors that #1099 didn't catch — two are interactions between #1137 and #1106 that surface only after both merged, the third is a missing depends_on hint added by #1137.

## Bug 1 — \`identity_inputs_from_history\` \`id_upserts\` / \`id_deletes\` CTEs miss the \`toDateTime64\` wrap

[\`src/ingestion/dbt/macros/identity_inputs_from_history.sql\`](https://github.com/constructorfabric/insight/blob/main/src/ingestion/dbt/macros/identity_inputs_from_history.sql)

#1137 added two new CTEs in this macro (canonical \`value_type='id'\` binding row per ADR-0002). Both call \`toUnixTimestamp64Milli(updated_at)\` directly. The \`*__users_fields_history\` / \`*__employees_fields_history\` columns are \`DateTime\` (second precision); \`toUnixTimestamp64Milli\` requires \`DateTime64\` and rejects:

\`\`\`
Code: 43. DB::Exception: A value of illegal type was provided as 1st
argument 'value' to function 'toUnixTimestamp64Milli'.
Expected: DateTime64, got: DateTime
\`\`\`

Same shape as the bug #1099 fixed in the \`upserts\` / \`deletes\` CTEs. The \`id_*\` CTEs landed in a separate PR (#1137) so #1099's diff didn't reach them. Wrap with \`toDateTime64(_, 3)\` the same way.

Hits \`bamboohr__identity_inputs\`, \`zoom__identity_inputs\`, slack/jira variants on the very first run.

## Bug 2 — \`to_class_people.sql\` writes plain \`NULL\` for three columns

[\`src/ingestion/connectors/hr-directory/bamboohr/dbt/to_class_people.sql\`](https://github.com/constructorfabric/insight/blob/main/src/ingestion/connectors/hr-directory/bamboohr/dbt/to_class_people.sql)

\`person_id\`, \`org_unit_id\`, and \`fte\` are written as bare \`NULL\` (no \`CAST\`). Until #1106 the downstream \`silver.class_people\` was \`materialized='view'\`, where \`Nullable(Nothing)\` is fine — views don't store data. #1106 changed \`class_people\` to \`materialized='table'\` for full-refresh dimension semantics (per ADR-0001), and ClickHouse rejects on materialise:

\`\`\`
Code: 370. DB::Exception: Data type Nullable(Nothing) of column
'person_id' cannot be used in tables.
\`\`\`

Cast each \`NULL\` to its real type — \`Nullable(UUID)\` for the two id columns, \`Nullable(Float64)\` for \`fte\` (matches the column types in \`person.persons\` from \`scripts/migrations/20260408000000_init-identity.sql\`).

## Bug 3 — \`silver/_shared/identity_inputs.sql\` missing \`depends_on\` hints

[\`src/ingestion/silver/_shared/identity_inputs.sql\`](https://github.com/constructorfabric/insight/blob/main/src/ingestion/silver/_shared/identity_inputs.sql)

The model uses \`union_by_tag('silver:identity_inputs')\` but its \`-- depends_on:\` block only lists bamboohr and zoom. \`seed_identity_inputs_from_cursor\` and \`seed_identity_inputs_from_claude_admin\` carry the same tag and dbt's static parser can't see them through the macro's \`for\` loop:

\`\`\`
Compilation Error in model identity_inputs (../silver/_shared/identity_inputs.sql)
  dbt was unable to infer all dependencies for the model \"identity_inputs\".
  This typically happens when ref() is placed within a conditional block.

  To fix this, add the following hint to the top of the model \"identity_inputs\":
  -- depends_on: {{ ref('seed_identity_inputs_from_cursor') }}
\`\`\`

Add the two missing hints. dbt now resolves the DAG; \`union_by_tag\` already handles the existence check at compile time, so missing-bronze cases for \`claude_admin\` are skipped cleanly.

## Test plan

- [x] Re-restored the same 9-connector dump (159 tables) used for #1099, applied the three patches on top of \`upstream/main\` (\`f568cb2\`).
- [x] \`dbt run --select bamboohr__identity_inputs zoom__identity_inputs +class_people\` — without patches: Code 43 + Code 370. With patches: \`Done. PASS=3 ERROR=0\`.
- [x] \`dbt run --select +silver.identity_inputs\` — without patch: Compilation Error. With patch: resolves DAG, materialises with what's tagged.
- [x] Full \`dbt run --target local --exclude jira__changelog_items jira__issue_field_snapshot\` against staging+silver from scratch: \`Done. PASS=66 ERROR=25 SKIP=21\`. All 25 errors are pre-existing missing-bronze cascades for connectors not deployed on this tenant (\`github\`, \`hubspot\`, \`salesforce\`, \`claude_admin\`, \`openai\`) plus the pre-existing \`seed_persons_from_cursor\` correlated-subquery issue. None introduced by #1106 or this PR.
- [x] \`dbt parse\` clean.

## Out of scope

- The two excluded models in the test plan (\`jira__changelog_items\`, \`jira__issue_field_snapshot\`) hit \`MEMORY_LIMIT_EXCEEDED\` at ~7 GiB on a small kind cluster. Not investigated here — production CH on the target tenant has more memory and does not hit the limit.
- \`seed_persons_from_cursor\` Code 1 \`UNSUPPORTED_METHOD\` (correlated subquery rejected by CH 25.3 query analyzer). Predates #1106 / #1137 and is independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#277 -->