### PR TITLE
[PR #276] fix(dbt): unblock first run after #251 on CH 25.3 (allow_nullable_key + DateTime cast)

### DIFF
--- a/src/ingestion/dbt/macros/identity_inputs_from_history.sql
+++ b/src/ingestion/dbt/macros/identity_inputs_from_history.sql
@@ -54,7 +54,7 @@ upserts AS (
             coalesce(entity_id, ''), '-',
             '{{ f.alias_type }}', '-',
             'UPSERT-',
-            toString(toUnixTimestamp64Milli(updated_at))
+            toString(toUnixTimestamp64Milli(toDateTime64(updated_at, 3)))
         ) AS String) AS unique_key,
         tenant_id AS insight_tenant_id,
         source_id AS insight_source_id,
@@ -65,7 +65,7 @@ upserts AS (
         '{{ f.alias_field_name }}' AS alias_field_name,
         'UPSERT' AS operation_type,
         updated_at AS _synced_at,
-        toUnixTimestamp64Milli(updated_at) AS _version
+        toUnixTimestamp64Milli(toDateTime64(updated_at, 3)) AS _version
     FROM history
     WHERE field_name = '{{ f.field }}'
       AND new_value != ''
@@ -93,7 +93,7 @@ deletes AS (
             coalesce(d.entity_id, ''), '-',
             '{{ f.alias_type }}', '-',
             'DELETE-',
-            toString(toUnixTimestamp64Milli(d.updated_at))
+            toString(toUnixTimestamp64Milli(toDateTime64(d.updated_at, 3)))
         ) AS String) AS unique_key,
         d.tenant_id AS insight_tenant_id,
         d.source_id AS insight_source_id,
@@ -104,7 +104,7 @@ deletes AS (
         '{{ f.alias_field_name }}' AS alias_field_name,
         'DELETE' AS operation_type,
         d.updated_at AS _synced_at,
-        toUnixTimestamp64Milli(d.updated_at) AS _version
+        toUnixTimestamp64Milli(toDateTime64(d.updated_at, 3)) AS _version
     FROM deactivation_events d
     {{ 'UNION ALL' if not loop.last }}
     {% endfor %}

--- a/src/ingestion/dbt/macros/promote_bronze_to_rmt.sql
+++ b/src/ingestion/dbt/macros/promote_bronze_to_rmt.sql
@@ -111,6 +111,7 @@
         ENGINE = {{ engine_decl }}
         {{ partition_clause }}
         ORDER BY {{ order_by }}
+        SETTINGS allow_nullable_key = 1
         AS SELECT * FROM `{{ db }}`.`{{ tbl }}`
     {% endset %}
     {% do run_query(ctas) %}


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#276](https://github.com/cyberfabric/cyber-insight/pull/276) | **Author:** mitasovr | **Opened:** 2026-05-04T18:08:25Z | **Status:** merged on 2026-05-04T18:15:52Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

Two minimal post-merge fixes for #1106. Both block the **first dbt run** of the new toolbox on any tenant running CH 25.3.14 and surface only at runtime — the PR's test plan listed _\"dbt build against a tenant ClickHouse\"_ as unchecked, so they slipped through.

Found via local rehearsal of an upcoming virtuozzo deploy: restored a fresh CH dump (159 tables, 9M rows across 9 connectors) into a kind cluster, then ran the new toolbox dbt code end-to-end. Hit both errors below in sequence.

## Bug 1 — \`promote_bronze_to_rmt\` swap CTAS missing \`allow_nullable_key=1\`

[\`src/ingestion/dbt/macros/promote_bronze_to_rmt.sql\`](https://github.com/constructorfabric/insight/blob/main/src/ingestion/dbt/macros/promote_bronze_to_rmt.sql) creates the \`__rmt_swap\` table with \`ORDER BY <unique_key>\` but does not set \`SETTINGS allow_nullable_key = 1\` on the engine.

All Airbyte-written bronze tables have \`unique_key Nullable(String)\` — Airbyte appends it via the AddFields transformation without a NOT NULL constraint. CH 25.3.14 hard-rejects:

\`\`\`
Code: 44. DB::Exception: Sorting key contains nullable columns,
but merge tree setting \`allow_nullable_key\` is disabled.
\`\`\`

Confirmed against \`bronze_jira.*\` (\`unique_key\` is \`Nullable(String)\` for all 12 tables in our tenant). The very first \`jira__bronze_promoted\` invocation errors out, and every dependent jira staging/silver model is SKIP'd.

Other RMT tables in this project already declare \`allow_nullable_key=1\` (silver \`class_*\`, staging \`*__users_fields_history\`, the \`local\` and \`k8s\` dbt profiles via \`custom_settings\`); the swap-table CTAS in this macro just missed it.

## Bug 2 — \`identity_inputs_from_history\` calls \`toUnixTimestamp64Milli\` on \`DateTime\`

[\`src/ingestion/dbt/macros/identity_inputs_from_history.sql\`](https://github.com/constructorfabric/insight/blob/main/src/ingestion/dbt/macros/identity_inputs_from_history.sql) calls \`toUnixTimestamp64Milli(updated_at)\` in four places (UPSERT \`unique_key\`, UPSERT \`_version\`, DELETE \`unique_key\`, DELETE \`_version\`).

The upstream \`*__users_fields_history\` / \`*__employees_fields_history\` staging columns are \`DateTime\` (second precision), not \`DateTime64(3)\`. \`toUnixTimestamp64Milli\` requires \`DateTime64\` and rejects \`DateTime\` outright:

\`\`\`
Code: 43. DB::Exception: A value of illegal type was provided as 1st
argument 'value' to function 'toUnixTimestamp64Milli'.
Expected: DateTime64, got: DateTime
\`\`\`

Confirmed: \`bamboohr__employees_fields_history.updated_at\`, \`jira__users_fields_history.updated_at\`, \`slack__users_fields_history.updated_at\`, \`zoom__users_fields_history.updated_at\` — all \`DateTime\`.

Wrapping with \`toDateTime64(..., 3)\` is the smallest fix and avoids touching the upstream column types (a wider migration). Without this, four staging \`*__identity_inputs\` models fail and cascade into silver \`class_people\` and other identity consumers.

## Diff

\`\`\`diff
- toUnixTimestamp64Milli(updated_at)
+ toUnixTimestamp64Milli(toDateTime64(updated_at, 3))
\`\`\`

\`\`\`diff
  ORDER BY {{ order_by }}
+ SETTINGS allow_nullable_key = 1
  AS SELECT * FROM \`{{ db }}\`.\`{{ tbl }}\`
\`\`\`

5 insertions, 4 deletions, two files.

## Test plan

- [x] Restore tenant dump into kind CH 25.3.14 (159 tables, 9 connectors).
- [x] \`dbt run --select jira__bronze_promoted\` — without patch fails Code 44; with patch all 8 jira bronze tables migrate \`MergeTree → ReplacingMergeTree(_airbyte_extracted_at) ORDER BY unique_key\` in one pass; second run is no-op (idempotency preserved).
- [x] \`dbt run --select bamboohr__identity_inputs zoom__identity_inputs slack__users_fields_history jira__users_fields_history\` — without patch fails Code 43; with patch \`Done. PASS=5 ERROR=0\`.
- [x] \`dbt parse\` clean (only pre-existing deprecation warnings).
- [ ] Apply on the cluster that the dump came from and confirm the silver-from-bronze rebuild proceeds past these two checkpoints. (Blocked on this PR + new toolbox build.)

## Out of scope (separate follow-ups)

- \`jira__changelog_items\` / \`jira__issue_field_snapshot\` hit \`MEMORY_LIMIT_EXCEEDED\` at ~7 GiB on the local cluster (small CH pod). Not investigated in this PR — production CH has more memory and may not hit the limit; if it does, the JSON-extract pattern needs revisiting separately.
- \`seed_persons_from_cursor\` fails Code 1 \`UNSUPPORTED_METHOD\` (correlated subquery rejected by CH 25.3 query analyzer). Predates this PR and is independent of #1106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved timestamp precision handling in identity data processing for accurate version tracking
  * Enhanced database table creation settings for improved data pipeline reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#276 -->