### PR TITLE
[PR #254] fix(analytics-api): accept OData 'le' (inclusive upper bound) on metric_date

### DIFF
--- a/src/backend/services/analytics-api/src/api/handlers.rs
+++ b/src/backend/services/analytics-api/src/api/handlers.rs
@@ -293,14 +293,28 @@ pub async fn query_metric(
     // selected period. Outer person_id/org_unit_id filters still apply post-aggregate.
     let (effective_from, date_pushed) = if let Some(ref filter) = req.filter {
         let date_from = extract_odata_value(filter, "metric_date", "ge");
-        let date_to = extract_odata_value(filter, "metric_date", "lt");
+        // Accept both `lt` (exclusive) and `le` (inclusive) — the FE's
+        // `odataDateFilter` emits `le`, OData spec also allows `lt`. Without
+        // both, the upper bound is silently dropped and the period extends
+        // to "today" — which is exactly the bug we're fixing here.
+        let (date_to, date_to_op) = match extract_odata_value(filter, "metric_date", "lt") {
+            Some(v) => (Some(v), "<"),
+            None => match extract_odata_value(filter, "metric_date", "le") {
+                Some(v) => (Some(v), "<="),
+                None => (None, "<"),
+            },
+        };
         if (date_from.is_some() || date_to.is_some()) && from_clause.trim_start().starts_with('(') {
             let mut clauses: Vec<String> = vec![];
             if let Some(ref v) = date_from {
                 clauses.push(format!("metric_date >= '{}'", v.replace('\'', "''")));
             }
             if let Some(ref v) = date_to {
-                clauses.push(format!("metric_date < '{}'", v.replace('\'', "''")));
+                clauses.push(format!(
+                    "metric_date {} '{}'",
+                    date_to_op,
+                    v.replace('\'', "''"),
+                ));
             }
             let where_inner = format!(" WHERE {}", clauses.join(" AND "));
             (
@@ -327,6 +341,9 @@ pub async fn query_metric(
             }
             if let Some(date_to) = extract_odata_value(filter, "metric_date", "lt") {
                 sql.push_str(" AND metric_date < ?");
+                params.push(date_to);
+            } else if let Some(date_to) = extract_odata_value(filter, "metric_date", "le") {
+                sql.push_str(" AND metric_date <= ?");
                 params.push(date_to);
             }
         }


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#254](https://github.com/cyberfabric/cyber-insight/pull/254) | **Author:** dzarlax | **Opened:** 2026-04-30T17:28:22Z | **Status:** merged on 2026-04-30T18:00:04Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

The FE's `odataDateFilter()` emits `metric_date le '<to>'` (OData inclusive less-or-equal), but `extract_odata_value()` in `handlers.rs` only looked for `lt` (exclusive less-than). The upper bound was silently dropped and every dashboard query effectively ran with an open-ended period extending to "today".

## Concrete impact

A user-selected window of "Apr 19–20" returned data through Apr 28 (today) because the lower bound (`ge '2026-04-19'`) was the only clause that survived parsing. All bullet/KPI/chart numbers across IC / Team / Executive views were wrong by varying amounts depending on how far the viewer's "today" was from their selected `to`.

Reproducer:

```
$ curl ... -d '{"$filter": "person_id eq '\''vakos@virtuozzo.com'\'' and metric_date ge '\''2026-04-19'\'' and metric_date le '\''2026-04-20'\''"}'
# before fix: meeting_hours = 15.56  (sum across Apr 19 .. today)
# after fix:  no meeting rows         (correct — vakos had no meetings on Apr 19-20)
```

Verified empirically end-to-end on local kind cluster.

## Fix

Both the subquery-pushdown branch (`l. 295-310`) and the top-level `WHERE` fallback (`l. 338-348`) now:

1. **Prefer `lt`** (exclusive `<`) — kept for backwards compat with any caller using strict less-than.
2. **Fall back to `le`** (inclusive `<=`) — emits `metric_date <= '<to>'` in SQL.

Logic preserves original `lt` semantics; only adds handling for `le` callers that previously got dropped on the floor.

No CH migration needed — the fix is purely in the request parser.

## Why this slipped past tests

There are no end-to-end tests for the FE→BE→CH date-filter pipeline. `extract_odata_value` is a substring-based parser — adding new ops on the FE side silently widens windows on the BE side. Follow-up safety PR planned (whitelist parser + integration test) — see CLAUDE.md / known issues.

## Test plan

- [x] `cargo build` / `cargo clippy --all-features` pass
- [x] Local kind cluster: API call with `metric_date le '2026-04-20'` now returns only rows with `metric_date <= 2026-04-20` (verified with direct ClickHouse `SELECT` for parity)
- [x] Backwards compat: API call with `metric_date lt '2026-04-21'` still emits `metric_date < ...` (exclusive)
- [ ] FE dashboards (paired with `constructorfabric/insight-front#50`) show period-correct numbers for week / month / custom ranges after merge

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#254 -->