### PR TITLE
[PR #245] Centralize ingestion image tags + fix submitters for single-namespace + instanceID

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ This repository is the **monorepo** for the Insight product. It contains:
   - [`cypilot/`](#cypilot)
 - [Connector Coverage](#connector-coverage)
 - [Key Concepts](#key-concepts)
+- [Quick Start](#quick-start)
+  - [Path 1 — Local Kind cluster (`dev-up.sh`)](#path-1--local-kind-cluster-dev-upsh)
+  - [Path 2 — Remote cluster install (`install.sh`)](#path-2--remote-cluster-install-installsh)
+  - [Path 3 — ArgoCD GitOps](#path-3--argocd-gitops)
+  - [Configure connectors (any path)](#configure-connectors-any-path)
+  - [Services and ports](#services-and-ports)
+  - [Image configuration](#image-configuration)
+  - [CI/CD](#cicd)
+  - [Running without Kubernetes](#running-without-kubernetes)
 - [Working with This Repo](#working-with-this-repo)
 - [Working with `docs/`](#working-with-docs)
   - [Document types](#document-types)
@@ -218,132 +227,244 @@ This repo uses [Cypilot](https://github.com/cyberfabric/cyber-pilot) — an AI a
 
 ## Quick Start
 
-Everything runs in a local [Kind](https://kind.sigs.k8s.io/) (Kubernetes-in-Docker) cluster named `insight`.
+Three deployment paths cover the full range from laptop hacking to production GitOps. All three target the **same** umbrella Helm chart at [`charts/insight/`](charts/insight/) — only the orchestration layer differs.
 
-### 1. Install prerequisites
+| Path | When to use | Cluster |
+|---|---|---|
+| **1. Local Kind** ([`./dev-up.sh`](./dev-up.sh)) | Laptop development with hot reload | Local Kind cluster (built by the script) |
+| **2. Canonical imperative** ([`./deploy/scripts/install.sh`](./deploy/scripts/install.sh)) | Remote dev/staging or on-prem prod | Any kubectl-accessible cluster |
+| **3. ArgoCD GitOps** ([`deploy/gitops/`](./deploy/gitops/)) | Enterprise GitOps environments | Any cluster running ArgoCD 2.6+ |
+
+Common prerequisites: `kubectl` ≥ 1.27, `helm` ≥ 3.13, `kubeconfig` for the target cluster. Path 1 also needs `kind` and `docker`.
+
+### Path 1 — Local Kind cluster (`dev-up.sh`)
+
+For laptop development. Builds all backend + toolbox images from `src/`, loads them into Kind, deploys the stack with single-replica defaults, and opens stable port-forwards.
 
 ```bash
 brew install kind kubectl helm docker
+
+cp .env.local.example .env.local
+$EDITOR .env.local         # AUTH_DISABLED=true OR fill OIDC_*
+
+./dev-up.sh                # creates Kind, builds images, installs everything
 ```
 
-For backend development (optional): `brew install rustup protobuf && rustup default stable`
-For frontend development (optional): `nvm install 25`
+What runs under the hood:
+- Creates Kind cluster `insight` if missing.
+- Installs `ingress-nginx` (skipped when present).
+- Builds backend images (`api-gateway`, `analytics-api`, `identity`, `toolbox`) from local source and `kind load`s them — no registry needed.
+- Generates a temporary Helm overlay from `.env.local` and runs `install-airbyte.sh` → `install-argo.sh` → `install-insight.sh` against the Kind cluster (single namespace `insight`).
+- Starts port-forwards for every service on stable local ports (see [Services and ports](#services-and-ports)).
 
-### 2. Create cluster and deploy services
-
-```bash
-./dev-up.sh
-```
-
-This creates a Kind cluster, installs ingress-nginx, and deploys:
-- Ingestion stack (Airbyte, Argo Workflows, ClickHouse)
-- Backend API Gateway (Rust, auth disabled locally)
-- Frontend SPA (nginx)
-
-ClickHouse deployment will be skipped until its Secret exists (next step).
-
-### 3. Create secrets
-
-```bash
-cd src/ingestion/secrets
-
-# Infrastructure (required)
-cp clickhouse.yaml.example clickhouse.yaml
-# Edit clickhouse.yaml — set a password
-
-# Connectors (one per source you want to sync)
-cp connectors/m365.yaml.example connectors/m365.yaml
-# Edit with real OAuth credentials — see each connector's README
-
-cd ../../..
-```
-
-### 4. Initialize
-
-```bash
-./init.sh
-```
-
-This applies secrets to the cluster, deploys ClickHouse, creates databases, registers connectors in Airbyte, creates connections, and generates Argo workflow schedules.
-
-### 5. Run a sync (optional)
-
-```bash
-cd src/ingestion
-./run-sync.sh m365 example-tenant
-```
-
-### Services
-
-| Service | URL | Notes |
-|---------|-----|-------|
-| Frontend | http://localhost:8000 | SPA via ingress |
-| API Gateway | http://localhost:8000/api/v1 | Auth disabled locally |
-| Airbyte | http://localhost:8001 | Port-forward |
-| Argo UI | http://localhost:30500 | No auth locally |
-| ClickHouse | http://localhost:30123 | HTTP interface |
-
-### Lifecycle
+Lifecycle commands (run from repo root):
 
 | Command | Description |
-|---------|-------------|
-| `./dev-up.sh` | Create cluster + deploy everything (idempotent) |
-| `./dev-up.sh ingestion` | Only Airbyte, Argo, ClickHouse |
-| `./dev-up.sh app` | Only backend + frontend |
-| `./init.sh` | Apply secrets + initialize ingestion stack |
-| `./dev-down.sh` | Stop all services (data preserved) |
-| `./cleanup.sh` | Delete cluster and all data |
+|---|---|
+| `./dev-up.sh` | Full bring-up (idempotent on re-run) |
+| `./dev-up.sh ingestion` | Only Airbyte/Argo/ClickHouse |
+| `./dev-up.sh app` | Only application services |
+| `./dev-up.sh frontend` | Only frontend (skip backend rebuild) |
+| `./dev-down.sh` | Stop port-forwards (Kind cluster + data preserved) |
+| `./cleanup.sh` | Delete Kind cluster and all volumes |
+
+### Path 2 — Remote cluster install (`install.sh`)
+
+For dev/staging clusters in cloud, on-prem, or anywhere reachable via kubectl. Pulls images from `ghcr.io/cyberfabric/*`; no local builds.
+
+**Pre-flight on the cluster:**
+- A default `StorageClass` (or set `global.storageClass` in the overlay).
+- An `ingress-nginx` (or any other; set `apiGateway.ingress.className`).
+- An OIDC application registered with your IdP, returning `issuer`, `client_id`, `audience`, and `redirect_uri` matching your ingress hostname.
+
+**Steps:**
+
+```bash
+export KUBECONFIG=/path/to/cluster.kubeconfig
+ENV=dev-vhc                 # whatever name fits this environment
+mkdir -p access/$ENV
+
+# 1. Namespace + OIDC Secret (pre-create — chart references existingSecret)
+kubectl create namespace insight
+kubectl -n insight create secret generic insight-oidc \
+  --from-literal='APP__modules__oidc-authn-plugin__config__issuer_url=https://<idp>/.../v2.0' \
+  --from-literal='APP__modules__oidc-authn-plugin__config__audience=api://<app-id>' \
+  --from-literal='APP__modules__auth-info__config__issuer_url=https://<idp>/.../v2.0' \
+  --from-literal='APP__modules__auth-info__config__client_id=<client-id>' \
+  --from-literal='APP__modules__auth-info__config__redirect_uri=https://<host>/callback'
+
+# 2. Cluster-specific overlay (gitignored — `access/` is in .gitignore)
+cat > access/$ENV/values.yaml <<'EOF'
+credentials:
+  deploymentMode: helm
+  autoGenerate: true             # umbrella generates `insight-db-creds` randomly
+
+global:
+  storageClass: local-path       # or whatever your cluster uses
+
+clickhouse:
+  database: insight
+  username: insight
+  image: { tag: "25.3" }
+mariadb:
+  database: insight
+  username: insight
+  auth:                          # bitnami subchart needs auth.username/database to create the user
+    username: insight
+    database: insight
+
+apiGateway:
+  image: { tag: "<pinned-tag>" } # see ghcr.io/cyberfabric/insight-api-gateway/tags
+  ingress:
+    enabled: true
+    className: nginx
+    host: insight.example.com    # ← your DNS
+  oidc:
+    existingSecret: insight-oidc
+
+analyticsApi:
+  image: { tag: "<pinned-tag>" }
+
+frontend:
+  image: { tag: "<frontend-tag>" }   # SEPARATE repo `cyberfabric/insight-front` — different release cadence
+  oidc:
+    issuer: https://<idp>/.../v2.0
+    clientId: <client-id>
+
+ingestion:
+  toolboxImage:    ghcr.io/cyberfabric/insight-toolbox:<pinned-tag>
+  jiraEnrichImage: ghcr.io/cyberfabric/insight-jira-enrich:<pinned-tag>
+EOF
+
+# 3. Three step installers, in order (Airbyte → Argo → Insight)
+INSIGHT_NAMESPACE=insight \
+AIRBYTE_SETUP_EMAIL=admin@example.com AIRBYTE_SETUP_ORG=Example \
+./deploy/scripts/install-airbyte.sh
+
+INSIGHT_NAMESPACE=insight ./deploy/scripts/install-argo.sh
+
+INSIGHT_NAMESPACE=insight \
+INSIGHT_VALUES_FILES=$PWD/access/$ENV/values.yaml \
+./deploy/scripts/install-insight.sh
+```
+
+After this the umbrella + ingestion are running. To wire connectors and run a sync, see [Configure connectors](#configure-connectors-any-path) below.
+
+For an end-to-end working example see [`access/dev-vhc/README.md`](access/dev-vhc/README.md) (gitignored — populated when a real environment is set up).
+
+### Path 3 — ArgoCD GitOps
+
+For enterprise environments where ArgoCD already manages cluster state. Four `Application` manifests — Airbyte, Argo Workflows, Argo RBAC, Insight umbrella — with sync-wave annotations enforcing order.
+
+**Pre-flight:**
+- ArgoCD ≥ 2.6 in the cluster.
+- `insight-db-creds` Secret pre-created with all four required keys (`clickhouse-password`, `mariadb-password`, `mariadb-root-password`, `redis-password`). Auto-gen does **not** work under GitOps — `helm template` returns nil from `lookup`, so credentials would rotate on every sync. Use ExternalSecrets / sealed-secrets / SOPS to keep values out of Git. The chart's validator refuses `deploymentMode: gitops` + `autoGenerate: true` together to prevent this footgun.
+- `insight-oidc` Secret pre-created (same shape as Path 2).
+- DNS + TLS (cert-manager + ACME, or pre-issued).
+
+**Steps:**
+
+```bash
+# 1. Pre-create insight-db-creds and insight-oidc with your secret tooling.
+
+# 2. Customer overlay — copy example and replace placeholders.
+cp deploy/gitops/insight-values.example.yaml deploy/gitops/insight-values.yaml
+$EDITOR deploy/gitops/insight-values.yaml   # replace *.example.com hosts; pin all image tags
+
+# 3. Apply the App-of-Apps root manifest.
+kubectl apply -f deploy/gitops/root-app.yaml
+
+# 4. Watch reconcile.
+argocd app list
+argocd app get insight
+```
+
+See [`deploy/gitops/README.md`](deploy/gitops/README.md) for sync-wave details, multi-source `$values` references, RBAC variants, and how to point Applications at your fork.
+
+### Configure connectors (any path)
+
+Once the umbrella is running:
+
+```bash
+export KUBECONFIG=/path/to/cluster.kubeconfig
+
+# 1. Apply per-source K8s Secrets (one file per connector you want active)
+kubectl -n insight apply -f src/ingestion/secrets/connectors/m365.yaml
+kubectl -n insight apply -f src/ingestion/secrets/connectors/bamboohr.yaml
+
+# 2. Tenant config — defaults to discovering all Secrets labeled
+#    `app.kubernetes.io/part-of=insight` in the namespace.
+cp src/ingestion/connections/example-tenant.yaml.example \
+   src/ingestion/connections/default.yaml
+
+# 3. Port-forward Airbyte API (the toolkit calls it on localhost:8001)
+kubectl -n insight port-forward svc/airbyte-airbyte-server-svc 8001:8001 &
+
+# 4. Register connector definitions in Airbyte
+./src/ingestion/airbyte-toolkit/register.sh collaboration/m365
+./src/ingestion/airbyte-toolkit/register.sh hr-directory/bamboohr
+
+# 5. Create sources, destinations, connections, bronze databases
+./src/ingestion/update-connections.sh default
+
+# 6. One-shot sync per connector
+./src/ingestion/run-sync.sh m365 default
+./src/ingestion/run-sync.sh bamboohr default
+
+# 7. Watch the workflow
+kubectl -n insight get workflows -l tenant=default --watch
+```
+
+### Services and ports
+
+For Path 1 (`dev-up.sh`) all services have stable local port-forwards:
+
+| Service | URL | Notes |
+|---|---|---|
+| Frontend | http://localhost:8003 | SPA |
+| API Gateway | http://localhost:8080 | `/api/v1`; auth disabled when `AUTH_DISABLED=true` |
+| Airbyte UI/API | http://localhost:8001 | UI and API on the same port (Airbyte ≥ 1.5) |
+| Argo Workflows UI | http://localhost:2746 | `--auth-mode=server` (no Bearer) when `DEV_MODE=1` |
+| ClickHouse HTTP | http://localhost:8123 | `/play` for browser SQL |
+| MariaDB | localhost:3306 | |
+| Redis | localhost:6379 | |
+
+For Paths 2/3 you set up port-forwards manually or rely on the configured ingress hostname.
 
 ### Image configuration
 
-Service images are controlled via environment variables in `.env.<name>`:
+The chart fails fast if any image tag is empty — there are **no `:latest` defaults** anywhere.
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `IMAGE_REGISTRY` | _(empty)_ | Registry prefix, e.g. `ghcr.io/cyberfabric` |
-| `IMAGE_TAG` | `local` | Default image tag for all services |
-| `API_GATEWAY_IMAGE_TAG` | `$IMAGE_TAG` | Override tag for api-gateway |
-| `ANALYTICS_API_IMAGE_TAG` | `$IMAGE_TAG` | Override tag for analytics-api |
-| `IDENTITY_IMAGE_TAG` | `$IMAGE_TAG` | Override tag for identity-resolution |
-| `TOOLBOX_IMAGE_TAG` | `$IMAGE_TAG` | Override tag for insight-toolbox |
-| `IMAGE_PULL_POLICY` | `IfNotPresent` | Kubernetes pull policy |
+For Path 1 (`dev-up.sh`) tags come from `.env.<name>`:
+
+| `.env` variable | Default | Description |
+|---|---|---|
+| `IMAGE_REGISTRY` | _(empty)_ | Registry prefix (e.g. `ghcr.io/cyberfabric`); empty for local-only Kind builds |
+| `IMAGE_TAG` | `local` | Tag applied to all locally-built images |
+| `<SVC>_IMAGE_TAG` | `$IMAGE_TAG` | Per-service override (`API_GATEWAY_IMAGE_TAG`, …) |
+| `IMAGE_PULL_POLICY` | `IfNotPresent` | Kubernetes pullPolicy |
 | `BUILD_IMAGES` | `true` | Build images locally before deploy |
-| `BUILD_AND_PUSH` | `false` | Push built images to registry |
+| `BUILD_AND_PUSH` | `false` | Push built images to `$IMAGE_REGISTRY` |
 | `IMAGE_PLATFORM` | _(empty)_ | Cross-build platform, e.g. `linux/amd64` |
 
-To deploy a specific version instead of `latest`:
+For Paths 2/3 image tags go directly into the Helm overlay (`apiGateway.image.tag`, `frontend.image.tag`, `ingestion.toolboxImage`, etc.). Available tags:
 
-```bash
-# In .env.virtuozzo (or any remote env file)
-IMAGE_REGISTRY=ghcr.io/cyberfabric
-IMAGE_TAG=2026.04.21.14.30-abc1234    # default for all services
-BUILD_IMAGES=false
-```
+| Image | Source repo | Tags |
+|---|---|---|
+| `insight-api-gateway` | `cyberfabric/insight` (this repo) | https://github.com/cyberfabric/insight/pkgs/container/insight-api-gateway |
+| `insight-analytics-api` | this repo | https://github.com/cyberfabric/insight/pkgs/container/insight-analytics-api |
+| `insight-identity-resolution` | this repo | https://github.com/cyberfabric/insight/pkgs/container/insight-identity-resolution |
+| `insight-toolbox` | this repo | https://github.com/cyberfabric/insight/pkgs/container/insight-toolbox |
+| `insight-front` | **separate** `cyberfabric/insight-front` | https://github.com/cyberfabric/insight/pkgs/container/insight-front |
+| `insight-jira-enrich` | **separate** `cyberfabric/insight-jira-enrich` | https://github.com/cyberfabric/insight/pkgs/container/insight-jira-enrich |
 
-To pin individual services to different versions:
-
-```bash
-IMAGE_TAG=2026.04.21.14.30-abc1234
-ANALYTICS_API_IMAGE_TAG=2026.04.20.09.15-def5678   # override just analytics-api
-```
-
-The Argo workflow templates (`dbt-run`, `ingestion-pipeline`) also accept a
-`toolbox_image` parameter to override the toolbox image at submission time.
+> **Note**: frontend and jira-enrich live in their own repos with independent release cadences — a backend tag (e.g. `2026.04.28.10.34-b08b460`) does **not** exist for `insight-front`. Pick the latest tag in the frontend's repo separately.
 
 ### CI/CD
 
-GitHub Actions builds and pushes container images on every merge to `main`
-(see `.github/workflows/build-images.yml`). Images are tagged as
-`YYYY.MM.DD.HH.mm-<short-sha>` and `latest`.
+GitHub Actions builds and pushes backend + toolbox container images on every merge to `main` (see [`.github/workflows/build-images.yml`](.github/workflows/build-images.yml)). Images are tagged `YYYY.MM.DD.HH.mm-<short-sha>` and `latest`.
 
-| Image | Trigger path |
-|-------|-------------|
-| `insight-api-gateway` | `src/backend/**` |
-| `insight-analytics-api` | `src/backend/**` |
-| `insight-identity-resolution` | `src/backend/**` |
-| `insight-toolbox` | `src/ingestion/**` |
-
-To trigger a build manually: Actions → "Build & Push Container Images" → Run workflow.
+To trigger manually: Actions → "Build & Push Container Images" → Run workflow.
 
 ### Running without Kubernetes
 
@@ -356,12 +477,12 @@ cargo run --bin insight-api-gateway -- run -c services/api-gateway/config/no-aut
 # → http://localhost:8080/api/v1
 
 # Frontend
-cd ../insight-front    # or via symlink
+cd ../insight-front       # or via the insight-front_symlink at repo root
 npm install && npm run dev
 # → http://localhost:5173
 ```
 
-See [`src/backend/services/LOCAL_DEV.md`](src/backend/services/LOCAL_DEV.md) for more backend development options (OIDC, different cluster tools, etc.).
+See [`src/backend/services/LOCAL_DEV.md`](src/backend/services/LOCAL_DEV.md) for OIDC setup, MockOIDC, and other backend development options.
 
 ---
 

--- a/charts/insight/templates/ingestion/dbt-run.yaml
+++ b/charts/insight/templates/ingestion/dbt-run.yaml
@@ -19,10 +19,18 @@ spec:
       inputs:
         parameters:
           - name: dbt_select
+          # Operator-pinned values from umbrella chart. Submitter may override
+          # per-call but typically just submits and gets these defaults baked in
+          # at chart-render time. `insight.<dep>.host/port` helpers know whether
+          # to emit cluster-internal FQDN or external host based on `<dep>.deploy`.
           - name: toolbox_image
+            default: {{ required "ingestion.toolboxImage is required when ingestion.templates.enabled=true" .Values.ingestion.toolboxImage | quote }}
           - name: clickhouse_host
+            default: {{ include "insight.clickhouse.fqdn" . | quote }}
           - name: clickhouse_port
+            default: {{ include "insight.clickhouse.port" . | quote }}
           - name: clickhouse_user
+            default: {{ required "clickhouse.username is required" .Values.clickhouse.username | quote }}
       activeDeadlineSeconds: 1800
       script:
         image: {{ `"{{inputs.parameters.toolbox_image}}"` }}

--- a/charts/insight/templates/ingestion/ingestion-pipeline.yaml
+++ b/charts/insight/templates/ingestion/ingestion-pipeline.yaml
@@ -22,7 +22,7 @@ spec:
           - name: insight_source_id
           - name: data_source                # "jira" → enriched path; anything else → legacy single-dbt
           - name: dbt_select_staging         # e.g. "tag:jira"; empty for non-jira
-            default: ""
+            default: ""  # RULE-DEFAULTS-OK: empty-string sentinel — non-jira callers send "" so the `data_source == 'jira'` predicate is the only dispatch.
           - name: dbt_select                 # e.g. "tag:silver"
           - name: toolbox_image
             default: {{ required "ingestion.toolboxImage is required when ingestion.templates.enabled=true" .Values.ingestion.toolboxImage | quote }}

--- a/charts/insight/templates/ingestion/ingestion-pipeline.yaml
+++ b/charts/insight/templates/ingestion/ingestion-pipeline.yaml
@@ -10,24 +10,32 @@ spec:
   entrypoint: pipeline
   templates:
     - name: pipeline
-      # Every input parameter is REQUIRED and must be supplied by the
-      # invoker (api-gateway / cron). The chart deliberately ships no
-      # defaults so that runtime hosts, image tags and dbt selectors
-      # come from the platform ConfigMap (`{release}-platform`) and
-      # the caller's own configuration — never from chart-time defaults.
+      # Connection-specific inputs (connection_id, insight_source_id,
+      # data_source, dbt_select, dbt_select_staging) are supplied by the
+      # invoker. Image tags and infrastructure coordinates default from
+      # umbrella chart values — single source of truth, baked into the
+      # rendered WorkflowTemplate at `helm install` time. Submitters can
+      # still override per-call (e.g. for testing a different toolbox tag).
       inputs:
         parameters:
           - name: connection_id
           - name: insight_source_id
           - name: data_source                # "jira" → enriched path; anything else → legacy single-dbt
-          - name: dbt_select_staging         # e.g. "tag:jira"
+          - name: dbt_select_staging         # e.g. "tag:jira"; empty for non-jira
+            default: ""
           - name: dbt_select                 # e.g. "tag:silver"
-          - name: toolbox_image              # ghcr.io/cyberfabric/insight-toolbox:<sha or version>
-          - name: jira_enrich_image          # ghcr.io/cyberfabric/insight-jira-enrich:<sha or version>
+          - name: toolbox_image
+            default: {{ required "ingestion.toolboxImage is required when ingestion.templates.enabled=true" .Values.ingestion.toolboxImage | quote }}
+          - name: jira_enrich_image
+            default: {{ required "ingestion.jiraEnrichImage is required when ingestion.templates.enabled=true" .Values.ingestion.jiraEnrichImage | quote }}
           - name: airbyte_url
+            default: {{ include "insight.airbyte.url" . | quote }}
           - name: clickhouse_host
+            default: {{ include "insight.clickhouse.fqdn" . | quote }}
           - name: clickhouse_port
+            default: {{ include "insight.clickhouse.port" . | quote }}
           - name: clickhouse_user
+            default: {{ required "clickhouse.username is required" .Values.clickhouse.username | quote }}
       dag:
         tasks:
           - name: sync

--- a/charts/insight/templates/ingestion/tt-enrich-jira-run.yaml
+++ b/charts/insight/templates/ingestion/tt-enrich-jira-run.yaml
@@ -26,7 +26,7 @@ spec:
           - name: clickhouse_user
             default: {{ required "clickhouse.username is required" .Values.clickhouse.username | quote }}
           - name: batch_size
-            default: "10000"
+            default: "10000"  # RULE-DEFAULTS-OK: tested CH INSERT chunk size for the jira-enrich Rust binary; tunable per submission.
       activeDeadlineSeconds: 7200
       container:
         image: {{ `"{{inputs.parameters.jira_enrich_image}}"` }}

--- a/charts/insight/templates/ingestion/tt-enrich-jira-run.yaml
+++ b/charts/insight/templates/ingestion/tt-enrich-jira-run.yaml
@@ -18,10 +18,15 @@ spec:
         parameters:
           - name: insight_source_id
           - name: jira_enrich_image
+            default: {{ required "ingestion.jiraEnrichImage is required when ingestion.templates.enabled=true" .Values.ingestion.jiraEnrichImage | quote }}
           - name: clickhouse_host
+            default: {{ include "insight.clickhouse.fqdn" . | quote }}
           - name: clickhouse_port
+            default: {{ include "insight.clickhouse.port" . | quote }}
           - name: clickhouse_user
+            default: {{ required "clickhouse.username is required" .Values.clickhouse.username | quote }}
           - name: batch_size
+            default: "10000"
       activeDeadlineSeconds: 7200
       container:
         image: {{ `"{{inputs.parameters.jira_enrich_image}}"` }}

--- a/charts/insight/values.schema.json
+++ b/charts/insight/values.schema.json
@@ -12,6 +12,20 @@
       }
     },
 
+    "ingestion": {
+      "type": "object",
+      "properties": {
+        "templates": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" }
+          }
+        },
+        "toolboxImage":    { "type": "string" },
+        "jiraEnrichImage": { "type": "string" }
+      }
+    },
+
     "global": {
       "type": "object",
       "properties": {

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -118,9 +118,18 @@ airbyte:
 # the cluster. If Argo is not installed, set enabled=false or the umbrella
 # will fail with `no matches for kind "WorkflowTemplate"`.
 #
+# `toolboxImage` and `jiraEnrichImage` are baked into the rendered
+# WorkflowTemplate as the input-parameter default. Submitters (api-gateway,
+# CronWorkflow YAML, run-sync.sh) can still override per-call, but in the
+# common case they just submit the workflow without specifying a tag and
+# get the operator-pinned version. NO `:latest` defaults — the validator
+# refuses to render when `templates.enabled=true` and these fields are
+# empty (single source of truth: the umbrella values overlay).
 ingestion:
   templates:
     enabled: true
+  toolboxImage: ""           # e.g. "ghcr.io/cyberfabric/insight-toolbox:2026.04.28.10.34-b08b460"
+  jiraEnrichImage: ""        # e.g. "ghcr.io/cyberfabric/insight-jira-enrich:2026.04.21.09.37-ccb013f"
 
 # ═══════════════════════════════════════════════════════════════════════════
 #  INFRASTRUCTURE

--- a/cypilot/config/AGENTS.md
+++ b/cypilot/config/AGENTS.md
@@ -17,4 +17,6 @@ ALWAYS open and follow `cypilot/config/rules/conventions.md` WHEN writing or rev
 ALWAYS open and follow `cypilot/config/rules/architecture.md` WHEN modifying pipeline architecture, adding new sources, or refactoring Bronze/Silver/Gold layers
 
 ALWAYS open and follow `cypilot/config/rules/patterns.md` WHEN documenting a new connector or defining new data source tables
+
+ALWAYS open and follow `cypilot/config/rules/code-conventions.md` WHEN writing or reviewing shell scripts, Python helpers, Argo/Kubernetes YAML, dbt macros, deploy scripts, or any imperative code
 <!-- auto-config:rules:end -->

--- a/cypilot/config/rules/code-conventions.md
+++ b/cypilot/config/rules/code-conventions.md
@@ -17,6 +17,7 @@ The point of these rules is to keep the source of truth in **one place per conce
 - [No inline scripts](#no-inline-scripts)
 - [No inline YAML](#no-inline-yaml)
 - [Fail-fast over silent fallback](#fail-fast-over-silent-fallback)
+- [Audit recipe](#audit-recipe)
 
 <!-- /toc -->
 
@@ -118,3 +119,27 @@ When a configuration value, secret annotation, or input is missing, **error expl
 The first time someone deploys with a missing value, they should see a clear "set X" error — not a successful run that silently does the wrong thing on a different tenant's data.
 
 **Apply this every time** you're tempted to write `or default`, `?:`, `try/except: pass`, or `coalesce(x, y)` — those are the common shapes of silent fallback. Sometimes they're correct; usually they hide a bug.
+
+## Audit recipe
+
+Run this scan on the files your PR touches before requesting review. Each match must either be fixed (replaced with a required env var, extracted to a file, etc.) **or** tagged with a `# RULE-DEFAULTS-OK: <reason>` comment that names the reason.
+
+```bash
+# Files touched by the current branch (vs main).
+FILES=$(git diff --name-only main...HEAD)
+
+# 1. Bash defaults — `${VAR:-default}`, excluding the abort-form `${VAR:?...}`
+echo "$FILES" | xargs -r grep -nE '\$\{[A-Z_][A-Z_0-9]*:-[^?}]' 2>/dev/null
+
+# 2. Python config defaults — non-trivial fallbacks via `.get(k, v)`
+echo "$FILES" | xargs -r grep -nE 'os\.environ\.get\([^)]+,\s*[^)]+\)' 2>/dev/null
+echo "$FILES" | xargs -r grep -nE '\.get\([^)]+,\s*['"'"'"`]' 2>/dev/null
+
+# 3. Argo / K8s YAML — `default:` lines in chart and workflow templates
+echo "$FILES" | grep -E '\.(ya?ml)$' | xargs -r grep -nE '^\s+default:' 2>/dev/null
+
+# 4. Inline Python / YAML inside shell — heredoc and `python3 -c "$"` patterns
+echo "$FILES" | grep -E '\.sh$' | xargs -r grep -lE 'python3 -c "$|<<EOF$' 2>/dev/null
+```
+
+The first three categories surface defaults; the fourth surfaces inline-script / inline-YAML violations. A clean run produces only `RULE-DEFAULTS-OK`-tagged matches and lines from this rule document itself.

--- a/cypilot/config/rules/code-conventions.md
+++ b/cypilot/config/rules/code-conventions.md
@@ -1,0 +1,120 @@
+---
+cypilot: true
+type: project-rule
+topic: code-conventions
+version: 1.0
+---
+
+# Code Conventions
+
+Hard rules for writing or reviewing imperative code in this project — shell scripts, Python helpers, Argo Workflow / Kubernetes YAML, dbt macros, deploy scripts. **All rules are MUST**, not SHOULD; violations block merge.
+
+The point of these rules is to keep the source of truth in **one place per concept** so that when something changes, exactly one file moves. Defaults, inline copies, and hidden fallbacks fight that goal.
+
+<!-- toc -->
+
+- [No default values](#no-default-values)
+- [No inline scripts](#no-inline-scripts)
+- [No inline YAML](#no-inline-yaml)
+- [Fail-fast over silent fallback](#fail-fast-over-silent-fallback)
+
+<!-- /toc -->
+
+## No default values
+
+**Forbidden** in any imperative code path:
+
+- Bash: `${VAR:-default}`, `${VAR:=default}`, `${VAR:?...}` is OK only when the message documents why the variable is required (the `:?` form aborts).
+- Python (helpers, scripts): `dict.get(key, default_value)` for any non-trivial default; instead require the key explicitly and raise on missing.
+- Argo Workflow `inputs.parameters[*].default:` for runtime values that originate from a caller (connection IDs, source IDs, image tags). Defaults are allowed only when the value is genuinely a chart-rendered constant (e.g. `clickhouse_host` from Helm `include`).
+- Helm chart `default` values for required operator inputs — pair with `required` so missing config fires an explicit error.
+
+**Why**: a default value moves the source of truth from one place (the caller / config) into N places (every default site). When the real value changes, you have to grep for every default — one missed site silently keeps the old value. Treat every default as a hidden second source of truth and remove it.
+
+**Before each new default**, ask:
+1. What if this code runs without the value being set anywhere?
+2. Is silent fallback (running with a wrong value) better than a loud error?
+
+If the answer to (2) is "no" — and it almost always is — drop the default and require the caller.
+
+**Allowed exceptions** (must be tagged with a `# RULE-DEFAULTS-OK:` comment explaining why):
+- Constants that genuinely have no other source (e.g. `argo-workflow` ServiceAccount name baked into chart-rendered manifests).
+- Test/dev shorthand values explicitly marked as such.
+
+**How to apply**:
+- When writing shell: `VAR=${VAR:?Set VAR — see <docs path> for what it should be}`
+- When writing Python: drop `or {}` / `or []` / `, default` style; use explicit `if key not in d: raise ...` or destructure with `KeyError`.
+- When writing Argo: omit `default:`; ingestion-pipeline must error out at submission time if a required parameter is missing.
+
+## No inline scripts
+
+**Forbidden**: embedding a non-trivial Python (or other-language) script inside a heredoc inside a shell script.
+
+```bash
+# BAD
+SOURCE_ID=$(kubectl get secret -o json | python3 -c "
+import json, os, sys
+...")
+
+# OK (1) — pure shell + jq
+SOURCE_ID=$(kubectl get secret -o json | jq -r '.items[0].metadata.name')
+
+# OK (2) — Python in its own file
+SOURCE_ID=$(kubectl get secret -o json | python3 src/ingestion/scripts/resolve_source_id.py)
+```
+
+**Threshold**: any heredoc Python with imports beyond `sys` is "non-trivial". One-liner string manipulation is OK; anything that reads structured data, applies multi-step logic, or has error handling goes in a `.py` file.
+
+**Why**:
+- Embedded scripts can't be linted, type-checked, or unit-tested.
+- They share `${VAR}` substitution between the parent shell and the child interpreter — a recurring source of injection bugs (parent shell expands `$x` before Python sees it).
+- They duplicate when the same logic appears in two shell scripts (resolve-source-id was on its way to becoming a duplicate before this rule).
+
+**Preferred order**:
+1. Pure shell + `jq` for JSON, `yq` for YAML, `awk`/`sed` for text. Almost everything is reachable this way.
+2. Standalone `.py` (or `.sh`) file in `src/ingestion/scripts/` (or appropriate location), called as a subprocess.
+3. Inline only when the logic is one expression and won't be reused.
+
+## No inline YAML
+
+**Forbidden**: rendering Argo `Workflow` / `WorkflowTemplate` / `CronWorkflow` / `Service` / any K8s object as a heredoc inside a shell script.
+
+```bash
+# BAD
+kubectl create -f - <<EOF
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: ${CONNECTOR}-
+...
+EOF
+
+# OK
+envsubst < src/ingestion/workflows/onetime/run-sync.yaml.tpl | kubectl create -f -
+```
+
+**Why**:
+- Inline YAML can't be validated by `kubeval` / `helm lint` / IDE schema tools.
+- It diverges from the WorkflowTemplate it shadows (we now have ingestion-pipeline as a chart-rendered template **and** an inline copy in run-sync.sh — when the template grows a parameter, the inline copy silently keeps the old shape).
+- It can't be diff-reviewed cleanly: changes show up as shell-string edits, not YAML edits.
+
+**Where to put extracted templates**:
+- One-shot `Workflow` submissions → `src/ingestion/workflows/onetime/<name>.yaml.tpl`
+- `CronWorkflow` schedules → `src/ingestion/workflows/schedules/<name>.yaml.tpl` (existing pattern — `sync.yaml.tpl`)
+- Reusable `WorkflowTemplate`s → `charts/insight/templates/ingestion/<name>.yaml` (chart-rendered; no envsubst, uses Helm templating)
+
+**Renderer**:
+- `envsubst` for shell-driven templates with `${VAR}` placeholders. Document expected variables at the top of the template.
+- Helm for chart-rendered templates that ship inside the umbrella.
+
+## Fail-fast over silent fallback
+
+When a configuration value, secret annotation, or input is missing, **error explicitly** with a message pointing at how to fix it. Do not silently:
+
+- Match an unannotated Secret to the requested tenant (cross-tenant misresolution).
+- Substitute an empty string for a missing `${VAR}`.
+- Assume a default region / namespace / image tag.
+
+The first time someone deploys with a missing value, they should see a clear "set X" error — not a successful run that silently does the wrong thing on a different tenant's data.
+
+**Apply this every time** you're tempted to write `or default`, `?:`, `try/except: pass`, or `coalesce(x, y)` — those are the common shapes of silent fallback. Sometimes they're correct; usually they hide a bug.

--- a/src/ingestion/.gitignore
+++ b/src/ingestion/.gitignore
@@ -12,3 +12,4 @@ connectors/**/state.json
 workflows/*/
 !workflows/templates/
 !workflows/schedules/
+!workflows/onetime/

--- a/src/ingestion/airbyte-toolkit/connect.sh
+++ b/src/ingestion/airbyte-toolkit/connect.sh
@@ -87,13 +87,22 @@ def state_pop(data, dotpath):
 state = load_state()
 
 # ---------------------------------------------------------------------------
+# Required cluster context (single-namespace model — operator must export)
+# ---------------------------------------------------------------------------
+INSIGHT_NAMESPACE = os.environ.get("INSIGHT_NAMESPACE")
+if not INSIGHT_NAMESPACE:
+    print("ERROR: INSIGHT_NAMESPACE env var must be set", file=sys.stderr)
+    print("       Set to the umbrella release namespace, e.g.:", file=sys.stderr)
+    print("           export INSIGHT_NAMESPACE=insight", file=sys.stderr)
+    sys.exit(1)
+
+# ---------------------------------------------------------------------------
 # Load tenant config
 # ---------------------------------------------------------------------------
 with open(tenant_config_path) as f:
     tenant = yaml.safe_load(f)
 
 tenant_id = tenant["tenant_id"]
-dest_config = tenant.get("destination", {})
 
 # ---------------------------------------------------------------------------
 # Airbyte API helpers
@@ -133,9 +142,8 @@ def api_get(path, data):
 def discover_secrets():
     """Discover Insight connector Secrets by label in the release namespace.
     Single-namespace model — connector Secrets live alongside the umbrella."""
-    ns = os.environ.get("INSIGHT_NAMESPACE", "insight")
     result = subprocess.run(
-        ["kubectl", "get", "secrets", "-n", ns,
+        ["kubectl", "get", "secrets", "-n", INSIGHT_NAMESPACE,
          "-l", "app.kubernetes.io/part-of=insight", "-o", "json"],
         capture_output=True, text=True, timeout=30
     )
@@ -186,14 +194,13 @@ def resolve_clickhouse_password():
     env_pass = os.environ.get("CLICKHOUSE_PASSWORD")
     if env_pass:
         return env_pass
-    ns = os.environ.get("INSIGHT_NAMESPACE", "insight")
     result = subprocess.run(
-        ["kubectl", "get", "secret", "insight-db-creds", "-n", ns,
+        ["kubectl", "get", "secret", "insight-db-creds", "-n", INSIGHT_NAMESPACE,
          "-o", "jsonpath={.data.clickhouse-password}"],
         capture_output=True, text=True, timeout=10
     )
     if result.returncode != 0 or not result.stdout.strip():
-        print(f"ERROR: insight-db-creds Secret not found in namespace '{ns}'", file=sys.stderr)
+        print(f"ERROR: insight-db-creds Secret not found in namespace '{INSIGHT_NAMESPACE}'", file=sys.stderr)
         print("  Either run `helm install insight ...` first (umbrella auto-creates this Secret)", file=sys.stderr)
         print("  or pre-create it for BYO mode (see deploy/gitops/insight-values.example.yaml).", file=sys.stderr)
         sys.exit(1)
@@ -222,11 +229,17 @@ state_set(state, "destinations.clickhouse.definition_id", ch_def_id)
 # ---------------------------------------------------------------------------
 shared_dest_name = "clickhouse"
 shared_dest_id = state_get(state, "destinations.clickhouse.id")
+# RULE-DEFAULTS-OK: cluster ClickHouse coordinates are platform constants here.
+# `host` is derived from the operator-supplied INSIGHT_NAMESPACE following the
+# umbrella chart's service-name convention; `port`, `database`, and `username`
+# are ClickHouse-side protocol/built-in defaults, not insight policy. If a tenant
+# ever needs a non-standard CH instance, plumb it explicitly through the chart
+# rather than re-introducing a `dest_config.get(..., default)` fallback here.
 ch_config = {
-    "host": dest_config.get("host", "insight-clickhouse.insight.svc.cluster.local"),
-    "port": str(dest_config.get("port", 8123)),
+    "host": f"insight-clickhouse.{INSIGHT_NAMESPACE}.svc.cluster.local",
+    "port": "8123",
     "database": "default",
-    "username": dest_config.get("username", "default"),
+    "username": "default",
     "password": ch_password,
     "protocol": "http",
     "enable_json": True,

--- a/src/ingestion/airbyte-toolkit/connect.sh
+++ b/src/ingestion/airbyte-toolkit/connect.sh
@@ -131,9 +131,11 @@ def api_get(path, data):
 # K8s Secret discovery
 # ---------------------------------------------------------------------------
 def discover_secrets():
-    """Discover Insight connector Secrets by label in 'data' namespace."""
+    """Discover Insight connector Secrets by label in the release namespace.
+    Single-namespace model — connector Secrets live alongside the umbrella."""
+    ns = os.environ.get("INSIGHT_NAMESPACE", "insight")
     result = subprocess.run(
-        ["kubectl", "get", "secrets", "-n", "data",
+        ["kubectl", "get", "secrets", "-n", ns,
          "-l", "app.kubernetes.io/part-of=insight", "-o", "json"],
         capture_output=True, text=True, timeout=30
     )
@@ -179,18 +181,21 @@ def discover_secrets():
     return secrets
 
 def resolve_clickhouse_password():
-    """Read password from env var, then K8s Secret. Fails if neither available."""
+    """Read CH password from env var, then from the umbrella's auto-generated
+    `insight-db-creds` Secret in the release namespace. Single-namespace model."""
     env_pass = os.environ.get("CLICKHOUSE_PASSWORD")
     if env_pass:
         return env_pass
+    ns = os.environ.get("INSIGHT_NAMESPACE", "insight")
     result = subprocess.run(
-        ["kubectl", "get", "secret", "clickhouse-credentials", "-n", "data",
-         "-o", "jsonpath={.data.password}"],
+        ["kubectl", "get", "secret", "insight-db-creds", "-n", ns,
+         "-o", "jsonpath={.data.clickhouse-password}"],
         capture_output=True, text=True, timeout=10
     )
     if result.returncode != 0 or not result.stdout.strip():
-        print("ERROR: clickhouse-credentials Secret not found in namespace 'data'", file=sys.stderr)
-        print("  Run: ./secrets/apply.sh --infra-only", file=sys.stderr)
+        print(f"ERROR: insight-db-creds Secret not found in namespace '{ns}'", file=sys.stderr)
+        print("  Either run `helm install insight ...` first (umbrella auto-creates this Secret)", file=sys.stderr)
+        print("  or pre-create it for BYO mode (see deploy/gitops/insight-values.example.yaml).", file=sys.stderr)
         sys.exit(1)
     return base64.b64decode(result.stdout.strip()).decode()
 

--- a/src/ingestion/airbyte-toolkit/lib/secrets.sh
+++ b/src/ingestion/airbyte-toolkit/lib/secrets.sh
@@ -32,6 +32,6 @@ resolve_source_id() {
       ]
       | if length == 0 then ""
         elif length == 1 then .[0]
-        else error("multiple Secrets match connector=" + $c + " tenant=" + $t + ": " + tojson) end
+        else ("multiple Secrets match connector=" + $c + " tenant=" + $t + ": " + tojson) | halt_error(2) end
     '
 }

--- a/src/ingestion/airbyte-toolkit/lib/secrets.sh
+++ b/src/ingestion/airbyte-toolkit/lib/secrets.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Helpers for resolving connector Secret metadata from Kubernetes.
+# Sourced by run-sync.sh and run-tt-enrich-jira.sh.
+
+# resolve_source_id <connector> <tenant>
+#
+# Resolves insight_source_id from a connector Secret in $INSIGHT_NAMESPACE.
+# Matching:
+#   - annotation insight.cyberfabric.com/connector == <connector>
+#   - annotation insight.cyberfabric.com/tenant    == <tenant>
+#   (Secrets without the tenant annotation are NOT matched — by rule, missing
+#    annotations are explicit errors, not silent matches.)
+#
+# Stdout: source-id when exactly one Secret matches; empty when none match.
+# Exit:   2 when multiple Secrets match (ambiguous).
+resolve_source_id() {
+  local connector="$1"
+  local tenant="$2"
+  : "${INSIGHT_NAMESPACE:?INSIGHT_NAMESPACE must be set}"
+
+  kubectl get secret -n "$INSIGHT_NAMESPACE" -l app.kubernetes.io/part-of=insight -o json |
+    jq -r --arg c "$connector" --arg t "$tenant" '
+      [
+        .items[]
+        | .metadata.annotations
+        | select(. != null)
+        | select(."insight.cyberfabric.com/connector" == $c)
+        | select(has("insight.cyberfabric.com/tenant"))
+        | select(."insight.cyberfabric.com/tenant" == $t)
+        | ."insight.cyberfabric.com/source-id"
+        | select(. != null and . != "")
+      ]
+      | if length == 0 then ""
+        elif length == 1 then .[0]
+        else error("multiple Secrets match connector=" + $c + " tenant=" + $t + ": " + tojson) end
+    '
+}

--- a/src/ingestion/connectors/task-tracking/jira/descriptor.yaml
+++ b/src/ingestion/connectors/task-tracking/jira/descriptor.yaml
@@ -4,11 +4,12 @@ version: "1.0"
 schedule: "0 3 * * *"
 workflow: sync
 
-# Silver routing (class_task_tracker_*) is delivered by the task-tracking Silver
-# layer package, not by this connector. This connector ships only Bronze source
-# declarations in dbt/schema.yml. dbt_select is empty so the connector's dbt
-# step is a deliberate no-op. See DESIGN §1.1 and §3.2.
-dbt_select: ""
+# Silver routing (class_task_*) is delivered by the task-tracking Silver layer
+# package, not by this connector. The pipeline runs the jira-rust path:
+# dbt(tag:jira) → tt-enrich-jira-run → dbt(tag:silver,tag:jira+). This
+# selector is the third step — only silver models that union jira staging
+# (class_task_*), not the full silver layer. See DESIGN §1.1 and §3.2.
+dbt_select: "tag:silver,tag:jira+"
 
 connection:
   namespace: bronze_jira

--- a/src/ingestion/dbt/macros/union_by_tag.sql
+++ b/src/ingestion/dbt/macros/union_by_tag.sql
@@ -7,14 +7,30 @@
         {%- if rel -%}
           {%- do models.append(node) -%}
         {%- else -%}
-          {{ log("union_by_tag: skipping " ~ node.name ~ " (table does not exist yet)", info=True) }}
+          {{ log("union_by_tag: skipping " ~ node.name ~ " (staging table not yet materialised)", info=True) }}
         {%- endif -%}
       {%- endif -%}
     {%- endfor -%}
 
     {%- if models | length == 0 -%}
-      {{ log("union_by_tag: no models found with tag '" ~ tag_name ~ "' (all source tables missing) — emitting empty result", info=True) }}
-      SELECT 1 AS _placeholder WHERE FALSE
+      {%- set this_rel = adapter.get_relation(database=this.database, schema=this.schema, identifier=this.identifier) -%}
+      {%- if this_rel -%}
+        {#- No source staging tables exist for this tag, but the silver target
+            was materialised by a previous run. Emit an empty SELECT against
+            the existing target so the surrounding model SQL stays
+            schema-compatible (the outer "SELECT * FROM (...) WHERE _version > ..."
+            keeps working because we hand it the real target schema, just with
+            zero rows). The silver materialise becomes a no-op; downstream
+            keeps running smoothly. -#}
+        {{ log("union_by_tag: no source tables for tag '" ~ tag_name ~ "' — emitting empty select from existing target to preserve schema", info=True) }}
+        SELECT * FROM {{ this }} WHERE 1 = 0
+      {%- else -%}
+        {{ exceptions.raise_compiler_error(
+            "union_by_tag: no source tables for tag '" ~ tag_name ~ "' and target " ~ this ~
+            " has not been materialised yet. First run requires at least one configured connector with materialised staging — "
+            "configure a connector that contributes to this silver target, or exclude this model from the run."
+        ) }}
+      {%- endif -%}
     {%- else -%}
       {%- for m in models %}
         SELECT * FROM {{ ref(m.name) }}

--- a/src/ingestion/dbt/macros/union_by_tag.sql
+++ b/src/ingestion/dbt/macros/union_by_tag.sql
@@ -13,13 +13,14 @@
     {%- endfor -%}
 
     {%- if models | length == 0 -%}
-      {{ exceptions.raise_compiler_error("No models found with tag '" ~ tag_name ~ "' (all source tables missing)") }}
+      {{ log("union_by_tag: no models found with tag '" ~ tag_name ~ "' (all source tables missing) — emitting empty result", info=True) }}
+      SELECT 1 AS _placeholder WHERE FALSE
+    {%- else -%}
+      {%- for m in models %}
+        SELECT * FROM {{ ref(m.name) }}
+        {%- if not loop.last %} UNION ALL {% endif %}
+      {%- endfor -%}
     {%- endif -%}
-
-    {%- for m in models %}
-      SELECT * FROM {{ ref(m.name) }}
-      {%- if not loop.last %} UNION ALL {% endif %}
-    {%- endfor -%}
   {%- else -%}
     SELECT 1 AS _placeholder WHERE FALSE
   {%- endif -%}

--- a/src/ingestion/run-sync.sh
+++ b/src/ingestion/run-sync.sh
@@ -94,7 +94,7 @@ echo "  connection_id:      $CONNECTION_ID"
 echo "  insight_source_id:  $SOURCE_ID"
 echo "  data_source:        $DATA_SOURCE"
 echo "  dbt_select:         $DBT_SELECT"
-echo "  dbt_select_staging: ${DBT_SELECT_STAGING:-(empty)}"
+[[ -n "$DBT_SELECT_STAGING" ]] && echo "  dbt_select_staging: $DBT_SELECT_STAGING"
 
 NAMESPACE="$INSIGHT_NAMESPACE" \
   CONNECTOR="$CONNECTOR" \

--- a/src/ingestion/run-sync.sh
+++ b/src/ingestion/run-sync.sh
@@ -1,25 +1,87 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Submit an ingestion-pipeline Workflow for a single connector + tenant.
+#
+# All "infrastructure" parameters (toolbox_image, jira_enrich_image, airbyte_url,
+# clickhouse_host/port/user) come from the WorkflowTemplate's chart-rendered
+# defaults — see `charts/insight/templates/ingestion/ingestion-pipeline.yaml`
+# and `access/<env>/values.yaml` `ingestion.toolboxImage` etc. This script
+# only passes connection-specific inputs (connection_id, insight_source_id,
+# data_source, dbt_select).
+#
+# Usage:
+#   ./run-sync.sh <connector> <tenant_id> [<insight_source_id>]
+#
+# When <insight_source_id> is omitted, it is read from the connector Secret
+# annotation `insight.cyberfabric.com/source-id` (matching tenant + connector).
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
-CONNECTOR="${1:?Usage: $0 <connector> <tenant_id>}"
-TENANT="${2:?Usage: $0 <connector> <tenant_id>}"
+CONNECTOR="${1:?Usage: $0 <connector> <tenant_id> [<insight_source_id>]}"
+TENANT="${2:?Usage: $0 <connector> <tenant_id> [<insight_source_id>]}"
+SOURCE_ID="${3:-}"
+
+NAMESPACE="${INSIGHT_NAMESPACE:-insight}"
 
 export KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/insight.kubeconfig}"
 export TOOLKIT_DIR="${SCRIPT_DIR}/airbyte-toolkit"
 source "${TOOLKIT_DIR}/lib/state.sh"
 
-# Read connection_id from state — iterate source_ids under the connector
+# ─── Resolve connection_id from state ───────────────────────────────────
 CONNECTION_ID=""
 for source_key in $(state_list "tenants.${TENANT}.connectors.${CONNECTOR}"); do
   CONNECTION_ID=$(state_get "tenants.${TENANT}.connectors.${CONNECTOR}.${source_key}.connection_id")
   [[ -n "$CONNECTION_ID" ]] && break
 done
-[[ -n "$CONNECTION_ID" ]] || { echo "ERROR: no connection_id for connector '$CONNECTOR' tenant '$TENANT'. Run update-connections.sh first." >&2; exit 1; }
+[[ -n "$CONNECTION_ID" ]] || {
+  echo "ERROR: no connection_id for connector '$CONNECTOR' tenant '$TENANT'." >&2
+  echo "       Run update-connections.sh first." >&2
+  exit 1
+}
 
-# Find descriptor by connector name — try exact match, then prefix match
+# ─── Resolve insight_source_id from Secret annotation ───────────────────
+# Annotation `insight.cyberfabric.com/source-id` is set by the connector's
+# Secret (e.g. insight-bamboohr-main carries source-id=bamboohr-main).
+if [[ -z "$SOURCE_ID" ]]; then
+  # Inline VAR=... syntax binds to the next command only; in a pipeline the
+  # python3 process is a separate child and sees parent env. Export here so
+  # both kubectl and python3 (downstream) see CONNECTOR/TENANT.
+  export CONNECTOR TENANT
+  SOURCE_ID=$(kubectl get secret -n "$NAMESPACE" -l app.kubernetes.io/part-of=insight -o json \
+    | python3 -c "
+import json, os, sys
+connector = os.environ['CONNECTOR']
+tenant    = os.environ['TENANT']
+matches = []
+for s in json.load(sys.stdin).get('items', []):
+    ann = (s.get('metadata') or {}).get('annotations') or {}
+    if ann.get('insight.cyberfabric.com/connector') != connector:
+        continue
+    # tenant annotation is optional — if missing, treat as default tenant 'main'
+    sec_tenant = ann.get('insight.cyberfabric.com/tenant', tenant)
+    if sec_tenant != tenant:
+        continue
+    sid = ann.get('insight.cyberfabric.com/source-id', '')
+    if sid:
+        matches.append(sid)
+if len(matches) == 1:
+    print(matches[0])
+elif len(matches) > 1:
+    sys.stderr.write(f'ERROR: multiple Secrets match connector={connector} tenant={tenant}: {matches}\n')
+    sys.exit(2)
+" 2>/dev/null)
+fi
+[[ -n "$SOURCE_ID" ]] || {
+  echo "ERROR: could not resolve insight_source_id for connector '$CONNECTOR' tenant '$TENANT'." >&2
+  echo "       Either pass it explicitly as the third argument, or annotate the connector Secret with" >&2
+  echo "       insight.cyberfabric.com/source-id=<id> + insight.cyberfabric.com/connector=$CONNECTOR" >&2
+  echo "       (+ optional insight.cyberfabric.com/tenant=$TENANT for multi-tenant clusters)." >&2
+  exit 1
+}
+
+# ─── Resolve dbt_select from descriptor ─────────────────────────────────
 DBT_SELECT=$(python3 -c "
 import yaml, pathlib, sys
 connector = '${CONNECTOR}'
@@ -32,47 +94,51 @@ for p in sorted(pathlib.Path('connectors').rglob('descriptor.yaml')):
 print('+tag:silver')
 " 2>/dev/null)
 
-# ─── Resolve toolbox_image for the dbt-run step ────────────────────────────
-# Precedence:
-#   1. $TOOLBOX_IMAGE env var (explicit caller override)
-#   2. Auto-detect on Kind: if the current kubectl context is a kind cluster
-#      AND the Kind node has a locally-loaded `insight-toolbox:local` image
-#      (put there by up.sh → `kind load docker-image`), use that image.
-#   3. Fallback: ghcr.io/cyberfabric/insight-toolbox:latest (prod).
-#
-# Without this, the workflow template's default fetches the :latest tag
-# from ghcr.io, which requires imagePullSecrets and network access — both
-# absent on a fresh local Kind cluster. The dbt-run pod then sits in
-# ImagePullBackOff / Pending until the workflow's 30-minute activeDeadline
-# kills it, leaving Bronze populated but Silver never materialised.
-TOOLBOX_IMAGE="${TOOLBOX_IMAGE:-}"
-if [[ -z "$TOOLBOX_IMAGE" ]]; then
-  _ctx=$(kubectl config current-context 2>/dev/null || echo "")
-  if [[ "$_ctx" == kind-* ]]; then
-    _node="${_ctx#kind-}-control-plane"
-    if docker exec "$_node" crictl images 2>/dev/null | grep -qE "^docker\.io/library/insight-toolbox\s+local\b"; then
-      TOOLBOX_IMAGE="insight-toolbox:local"
-      echo "  toolbox_image: $TOOLBOX_IMAGE (auto-detected, loaded in kind node)"
-    fi
-  fi
-  TOOLBOX_IMAGE="${TOOLBOX_IMAGE:-ghcr.io/cyberfabric/insight-toolbox:latest}"
+# data_source = connector base name, drives the jira-vs-non-jira branch in
+# the pipeline. Override via env DATA_SOURCE if a connector needs the jira path
+# but uses a different name (e.g. 'jira-cloud' should still trigger jira flow).
+DATA_SOURCE="${DATA_SOURCE:-${CONNECTOR%%-*}}"
+
+# dbt_select_staging only matters when data_source=jira; chart defaults it to
+# empty otherwise. For jira: 'tag:jira' (intermediate staging models).
+DBT_SELECT_STAGING="${DBT_SELECT_STAGING:-}"
+if [[ "$DATA_SOURCE" == "jira" ]]; then
+  DBT_SELECT_STAGING="${DBT_SELECT_STAGING:-tag:jira}"
 fi
 
-echo "Running sync: ${CONNECTOR} / ${TENANT}"
-echo "  connection_id: ${CONNECTION_ID}"
-echo "  dbt_select:    ${DBT_SELECT}"
-echo "  toolbox_image: ${TOOLBOX_IMAGE}"
+echo "Submitting ingestion-pipeline:"
+echo "  namespace:         $NAMESPACE"
+echo "  connector:         $CONNECTOR"
+echo "  tenant:            $TENANT"
+echo "  connection_id:     $CONNECTION_ID"
+echo "  insight_source_id: $SOURCE_ID"
+echo "  data_source:       $DATA_SOURCE"
+echo "  dbt_select:        $DBT_SELECT"
+[[ -n "$DBT_SELECT_STAGING" ]] && echo "  dbt_select_staging: $DBT_SELECT_STAGING"
 
-kubectl create -n argo -f - <<EOF
+# Inline Workflow that references the chart-registered ingestion-pipeline
+# WorkflowTemplate. We pass only connection-specific parameters; everything
+# else (toolbox_image, jira_enrich_image, airbyte_url, clickhouse_host/port/user)
+# comes from the WorkflowTemplate's defaults baked at `helm install` time.
+{
+  cat <<EOF
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: ${CONNECTOR}-${TENANT//_/-}-
-  namespace: argo
+  namespace: $NAMESPACE
   labels:
-    tenant: "${TENANT}"
-    connector: "${CONNECTOR}"
+    tenant: "$TENANT"
+    connector: "$CONNECTOR"
+    # Controller picks up workflows by this label — value MUST match
+    # the instanceID in the argo-workflows-workflow-controller ConfigMap
+    # (set by deploy/scripts/install-argo.sh as argo-workflows-insight).
+    workflows.argoproj.io/controller-instanceid: argo-workflows-insight
 spec:
+  # Workflow steps need write access to argoproj.io/workflowtaskresults.
+  # The argo chart creates this ServiceAccount via workflow.serviceAccount.create=true;
+  # supplemental Role/Binding (deploy/argo/rbac.yaml) grants the necessary verbs.
+  serviceAccountName: argo-workflow
   entrypoint: run
   templates:
     - name: run
@@ -84,12 +150,22 @@ spec:
             arguments:
               parameters:
                 - name: connection_id
-                  value: "${CONNECTION_ID}"
+                  value: "$CONNECTION_ID"
+                - name: insight_source_id
+                  value: "$SOURCE_ID"
+                - name: data_source
+                  value: "$DATA_SOURCE"
                 - name: dbt_select
-                  value: "${DBT_SELECT}"
-                - name: toolbox_image
-                  value: "${TOOLBOX_IMAGE}"
+                  value: "$DBT_SELECT"
 EOF
+  if [[ -n "$DBT_SELECT_STAGING" ]]; then
+    cat <<EOF
+                - name: dbt_select_staging
+                  value: "$DBT_SELECT_STAGING"
+EOF
+  fi
+} | kubectl create -n "$NAMESPACE" -f -
 
-echo "Workflow submitted. Monitor at http://localhost:30500 or:"
-echo "  kubectl get workflows -n argo -l connector=${CONNECTOR},tenant=${TENANT}"
+echo
+echo "Monitor:"
+echo "  kubectl -n $NAMESPACE get workflows -l connector=$CONNECTOR,tenant=$TENANT --watch"

--- a/src/ingestion/run-sync.sh
+++ b/src/ingestion/run-sync.sh
@@ -3,33 +3,36 @@ set -euo pipefail
 
 # Submit an ingestion-pipeline Workflow for a single connector + tenant.
 #
-# All "infrastructure" parameters (toolbox_image, jira_enrich_image, airbyte_url,
-# clickhouse_host/port/user) come from the WorkflowTemplate's chart-rendered
-# defaults — see `charts/insight/templates/ingestion/ingestion-pipeline.yaml`
-# and `access/<env>/values.yaml` `ingestion.toolboxImage` etc. This script
-# only passes connection-specific inputs (connection_id, insight_source_id,
-# data_source, dbt_select).
+# Required env:
+#   KUBECONFIG          path to the insight cluster kubeconfig
+#   INSIGHT_NAMESPACE   release namespace of the umbrella chart
 #
-# Usage:
-#   ./run-sync.sh <connector> <tenant_id> [<insight_source_id>]
+# Required args:
+#   <connector>         connector descriptor name (matches connectors/*/<name>/descriptor.yaml .name)
+#   <tenant_id>         tenant identifier
+# Optional args:
+#   <insight_source_id> when set, used directly; otherwise resolved from Secret annotations
+#                       insight.cyberfabric.com/{connector,tenant,source-id}
 #
-# When <insight_source_id> is omitted, it is read from the connector Secret
-# annotation `insight.cyberfabric.com/source-id` (matching tenant + connector).
+# All "infrastructure" parameters of the WorkflowTemplate (toolbox_image,
+# jira_enrich_image, airbyte_url, clickhouse_*) come from chart-rendered
+# defaults; this script only passes connection-specific inputs.
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR"
+: "${KUBECONFIG:?must be set, e.g. export KUBECONFIG=~/.kube/insight.kubeconfig}"
+: "${INSIGHT_NAMESPACE:?must be set to the umbrella release namespace, e.g. export INSIGHT_NAMESPACE=insight}"
+export KUBECONFIG INSIGHT_NAMESPACE
 
 CONNECTOR="${1:?Usage: $0 <connector> <tenant_id> [<insight_source_id>]}"
 TENANT="${2:?Usage: $0 <connector> <tenant_id> [<insight_source_id>]}"
 SOURCE_ID="${3:-}"
 
-NAMESPACE="${INSIGHT_NAMESPACE:-insight}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
 
-export KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/insight.kubeconfig}"
-export TOOLKIT_DIR="${SCRIPT_DIR}/airbyte-toolkit"
-source "${TOOLKIT_DIR}/lib/state.sh"
+source "airbyte-toolkit/lib/state.sh"
+source "airbyte-toolkit/lib/secrets.sh"
 
-# ─── Resolve connection_id from state ───────────────────────────────────
+# ─── Resolve connection_id from toolkit state ───────────────────────────
 CONNECTION_ID=""
 for source_key in $(state_list "tenants.${TENANT}.connectors.${CONNECTOR}"); do
   CONNECTION_ID=$(state_get "tenants.${TENANT}.connectors.${CONNECTOR}.${source_key}.connection_id")
@@ -41,131 +44,70 @@ done
   exit 1
 }
 
-# ─── Resolve insight_source_id from Secret annotation ───────────────────
-# Annotation `insight.cyberfabric.com/source-id` is set by the connector's
-# Secret (e.g. insight-bamboohr-main carries source-id=bamboohr-main).
+# ─── Resolve insight_source_id from Secret annotations ──────────────────
 if [[ -z "$SOURCE_ID" ]]; then
-  # Inline VAR=... syntax binds to the next command only; in a pipeline the
-  # python3 process is a separate child and sees parent env. Export here so
-  # both kubectl and python3 (downstream) see CONNECTOR/TENANT.
-  export CONNECTOR TENANT
-  SOURCE_ID=$(kubectl get secret -n "$NAMESPACE" -l app.kubernetes.io/part-of=insight -o json \
-    | python3 -c "
-import json, os, sys
-connector = os.environ['CONNECTOR']
-tenant    = os.environ['TENANT']
-matches = []
-for s in json.load(sys.stdin).get('items', []):
-    ann = (s.get('metadata') or {}).get('annotations') or {}
-    if ann.get('insight.cyberfabric.com/connector') != connector:
-        continue
-    # tenant annotation is optional — if missing, treat as default tenant 'main'
-    sec_tenant = ann.get('insight.cyberfabric.com/tenant', tenant)
-    if sec_tenant != tenant:
-        continue
-    sid = ann.get('insight.cyberfabric.com/source-id', '')
-    if sid:
-        matches.append(sid)
-if len(matches) == 1:
-    print(matches[0])
-elif len(matches) > 1:
-    sys.stderr.write(f'ERROR: multiple Secrets match connector={connector} tenant={tenant}: {matches}\n')
-    sys.exit(2)
-" 2>/dev/null)
+  SOURCE_ID=$(resolve_source_id "$CONNECTOR" "$TENANT")
 fi
 [[ -n "$SOURCE_ID" ]] || {
   echo "ERROR: could not resolve insight_source_id for connector '$CONNECTOR' tenant '$TENANT'." >&2
-  echo "       Either pass it explicitly as the third argument, or annotate the connector Secret with" >&2
-  echo "       insight.cyberfabric.com/source-id=<id> + insight.cyberfabric.com/connector=$CONNECTOR" >&2
-  echo "       (+ optional insight.cyberfabric.com/tenant=$TENANT for multi-tenant clusters)." >&2
+  echo "       Either pass it explicitly as the third argument, or annotate the connector Secret with all three:" >&2
+  echo "         insight.cyberfabric.com/connector=$CONNECTOR" >&2
+  echo "         insight.cyberfabric.com/tenant=$TENANT" >&2
+  echo "         insight.cyberfabric.com/source-id=<id>" >&2
   exit 1
 }
 
-# ─── Resolve dbt_select from descriptor ─────────────────────────────────
-DBT_SELECT=$(python3 -c "
-import yaml, pathlib, sys
-connector = '${CONNECTOR}'
-for p in sorted(pathlib.Path('connectors').rglob('descriptor.yaml')):
-    desc = yaml.safe_load(open(p))
-    name = desc.get('name', '')
-    if name == connector or connector.startswith(name + '-'):
-        print(desc.get('dbt_select', '+tag:silver'))
-        sys.exit(0)
-print('+tag:silver')
-" 2>/dev/null)
+# ─── Resolve dbt_select from descriptor.yaml ────────────────────────────
+DESC=""
+for desc in connectors/*/*/descriptor.yaml; do
+  if [[ "$(yq -r '.name' "$desc")" == "$CONNECTOR" ]]; then
+    DESC="$desc"
+    break
+  fi
+done
+[[ -n "$DESC" ]] || {
+  echo "ERROR: no descriptor.yaml found with .name=$CONNECTOR under connectors/" >&2
+  exit 1
+}
+DBT_SELECT="$(yq -r '.dbt_select' "$DESC")"
+[[ -n "$DBT_SELECT" && "$DBT_SELECT" != "null" ]] || {
+  echo "ERROR: $DESC does not define .dbt_select" >&2
+  exit 1
+}
 
-# data_source = connector base name, drives the jira-vs-non-jira branch in
-# the pipeline. Override via env DATA_SOURCE if a connector needs the jira path
-# but uses a different name (e.g. 'jira-cloud' should still trigger jira flow).
-DATA_SOURCE="${DATA_SOURCE:-${CONNECTOR%%-*}}"
+# data_source dispatches the pipeline branch; only "jira" triggers the rust enrich path.
+DATA_SOURCE="$CONNECTOR"
 
-# dbt_select_staging only matters when data_source=jira; chart defaults it to
-# empty otherwise. For jira: 'tag:jira' (intermediate staging models).
-DBT_SELECT_STAGING="${DBT_SELECT_STAGING:-}"
+# dbt_select_staging only fires when data_source=jira.
+DBT_SELECT_STAGING=""
 if [[ "$DATA_SOURCE" == "jira" ]]; then
-  DBT_SELECT_STAGING="${DBT_SELECT_STAGING:-tag:jira}"
+  DBT_SELECT_STAGING="tag:jira"
 fi
 
-echo "Submitting ingestion-pipeline:"
-echo "  namespace:         $NAMESPACE"
-echo "  connector:         $CONNECTOR"
-echo "  tenant:            $TENANT"
-echo "  connection_id:     $CONNECTION_ID"
-echo "  insight_source_id: $SOURCE_ID"
-echo "  data_source:       $DATA_SOURCE"
-echo "  dbt_select:        $DBT_SELECT"
-[[ -n "$DBT_SELECT_STAGING" ]] && echo "  dbt_select_staging: $DBT_SELECT_STAGING"
+TENANT_DASHED="${TENANT//_/-}"
 
-# Inline Workflow that references the chart-registered ingestion-pipeline
-# WorkflowTemplate. We pass only connection-specific parameters; everything
-# else (toolbox_image, jira_enrich_image, airbyte_url, clickhouse_host/port/user)
-# comes from the WorkflowTemplate's defaults baked at `helm install` time.
-{
-  cat <<EOF
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: ${CONNECTOR}-${TENANT//_/-}-
-  namespace: $NAMESPACE
-  labels:
-    tenant: "$TENANT"
-    connector: "$CONNECTOR"
-    # Controller picks up workflows by this label — value MUST match
-    # the instanceID in the argo-workflows-workflow-controller ConfigMap
-    # (set by deploy/scripts/install-argo.sh as argo-workflows-insight).
-    workflows.argoproj.io/controller-instanceid: argo-workflows-insight
-spec:
-  # Workflow steps need write access to argoproj.io/workflowtaskresults.
-  # The argo chart creates this ServiceAccount via workflow.serviceAccount.create=true;
-  # supplemental Role/Binding (deploy/argo/rbac.yaml) grants the necessary verbs.
-  serviceAccountName: argo-workflow
-  entrypoint: run
-  templates:
-    - name: run
-      steps:
-        - - name: pipeline
-            templateRef:
-              name: ingestion-pipeline
-              template: pipeline
-            arguments:
-              parameters:
-                - name: connection_id
-                  value: "$CONNECTION_ID"
-                - name: insight_source_id
-                  value: "$SOURCE_ID"
-                - name: data_source
-                  value: "$DATA_SOURCE"
-                - name: dbt_select
-                  value: "$DBT_SELECT"
-EOF
-  if [[ -n "$DBT_SELECT_STAGING" ]]; then
-    cat <<EOF
-                - name: dbt_select_staging
-                  value: "$DBT_SELECT_STAGING"
-EOF
-  fi
-} | kubectl create -n "$NAMESPACE" -f -
+echo "Submitting ingestion-pipeline:"
+echo "  namespace:          $INSIGHT_NAMESPACE"
+echo "  connector:          $CONNECTOR"
+echo "  tenant:             $TENANT"
+echo "  connection_id:      $CONNECTION_ID"
+echo "  insight_source_id:  $SOURCE_ID"
+echo "  data_source:        $DATA_SOURCE"
+echo "  dbt_select:         $DBT_SELECT"
+echo "  dbt_select_staging: ${DBT_SELECT_STAGING:-(empty)}"
+
+NAMESPACE="$INSIGHT_NAMESPACE" \
+  CONNECTOR="$CONNECTOR" \
+  TENANT="$TENANT" \
+  TENANT_DASHED="$TENANT_DASHED" \
+  CONNECTION_ID="$CONNECTION_ID" \
+  SOURCE_ID="$SOURCE_ID" \
+  DATA_SOURCE="$DATA_SOURCE" \
+  DBT_SELECT="$DBT_SELECT" \
+  DBT_SELECT_STAGING="$DBT_SELECT_STAGING" \
+  envsubst < workflows/onetime/sync.yaml.tpl |
+  kubectl create -n "$INSIGHT_NAMESPACE" -f -
 
 echo
 echo "Monitor:"
-echo "  kubectl -n $NAMESPACE get workflows -l connector=$CONNECTOR,tenant=$TENANT --watch"
+echo "  kubectl -n $INSIGHT_NAMESPACE get workflows -l connector=$CONNECTOR,tenant=$TENANT --watch"

--- a/src/ingestion/run-tt-enrich-jira.sh
+++ b/src/ingestion/run-tt-enrich-jira.sh
@@ -3,9 +3,9 @@ set -euo pipefail
 
 # Run only the Silver transformations for Jira on bronze data that's already
 # in ClickHouse (no Airbyte sync). Steps:
-#   1. dbt run --select tag:jira       — staging models
-#   2. tt-enrich-jira-run               — Rust binary writes task_field_history
-#   3. dbt run --select tag:silver      — final silver transforms
+#   1. dbt run --select tag:jira              — staging models
+#   2. tt-enrich-jira-run                     — Rust binary writes task_field_history
+#   3. dbt run --select tag:silver,tag:jira+  — silver models downstream of jira (class_task_*)
 #
 # All ingestion infrastructure parameters (toolbox_image, jira_enrich_image,
 # clickhouse_host/port/user, batch_size) come from WorkflowTemplate defaults —
@@ -116,7 +116,7 @@ spec:
             arguments:
               parameters:
                 - name: dbt_select
-                  value: "tag:silver"
+                  value: "tag:silver,tag:jira+"
 EOF
 
 echo

--- a/src/ingestion/run-tt-enrich-jira.sh
+++ b/src/ingestion/run-tt-enrich-jira.sh
@@ -1,17 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Run only the Silver transformations for Jira on bronze data that's already in ClickHouse.
-# Steps (no Airbyte sync):
-#   1. dbt run --select jira        — builds per-source staging models (staging.jira__*)
-#   2. jira-enrich                  — rust binary writes staging.jira__task_field_history
-#   3. dbt run --select tag:silver  — unions staging into silver.class_task_* via union_by_tag
+# Run only the Silver transformations for Jira on bronze data that's already
+# in ClickHouse (no Airbyte sync). Steps:
+#   1. dbt run --select tag:jira       — staging models
+#   2. tt-enrich-jira-run               — Rust binary writes task_field_history
+#   3. dbt run --select tag:silver      — final silver transforms
+#
+# All ingestion infrastructure parameters (toolbox_image, jira_enrich_image,
+# clickhouse_host/port/user, batch_size) come from WorkflowTemplate defaults —
+# see charts/insight/templates/ingestion/{dbt-run,tt-enrich-jira-run}.yaml.
 #
 # Usage:
 #   ./run-tt-enrich-jira.sh <tenant> [<insight_source_id>]
 #
-# If <insight_source_id> is omitted, it is read from the K8s Secret annotation
-# `insight.cyberfabric.com/source-id` of the Jira Secret in the `data` namespace.
+# When <insight_source_id> is omitted, it is read from the Jira Secret
+# annotation `insight.cyberfabric.com/source-id` in the release namespace.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
@@ -19,25 +23,28 @@ cd "$SCRIPT_DIR"
 TENANT="${1:?Usage: $0 <tenant> [<insight_source_id>]}"
 SOURCE_ID="${2:-}"
 
+NAMESPACE="${INSIGHT_NAMESPACE:-insight}"
+
 export KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/insight.kubeconfig}"
 
-# Resolve insight_source_id from Secret annotation if not passed.
-# Filter by BOTH connector and tenant — in a multi-tenant cluster several Jira secrets
-# coexist and picking "the first one" gets the wrong source silently.
+# ─── Resolve insight_source_id from Secret annotation ───────────────────
+# Single-namespace model: connector Secrets live in the same namespace as
+# the umbrella (default `insight`). Multi-tenant clusters use multiple
+# namespaces; we filter by tenant to avoid picking the wrong source.
 if [[ -z "$SOURCE_ID" ]]; then
-    SOURCE_ID=$(TENANT="$TENANT" kubectl get secret -n data \
-        -l app.kubernetes.io/part-of=insight \
-        -o json | \
-        python3 -c "
+  SOURCE_ID=$(TENANT="$TENANT" \
+    kubectl get secret -n "$NAMESPACE" -l app.kubernetes.io/part-of=insight -o json \
+    | python3 -c "
 import json, os, sys
 tenant = os.environ['TENANT']
-secrets = json.load(sys.stdin).get('items', [])
 matches = []
-for s in secrets:
-    ann = s.get('metadata', {}).get('annotations', {}) or {}
+for s in json.load(sys.stdin).get('items', []):
+    ann = (s.get('metadata') or {}).get('annotations') or {}
     if ann.get('insight.cyberfabric.com/connector') != 'jira':
         continue
-    if ann.get('insight.cyberfabric.com/tenant') != tenant:
+    # tenant annotation optional — if missing, accept any tenant the caller asked for
+    sec_tenant = ann.get('insight.cyberfabric.com/tenant', tenant)
+    if sec_tenant != tenant:
         continue
     sid = ann.get('insight.cyberfabric.com/source-id', '')
     if sid:
@@ -47,25 +54,36 @@ if len(matches) == 1:
 elif len(matches) > 1:
     sys.stderr.write(f'ERROR: multiple Jira secrets match tenant {tenant}: {matches}\n')
     sys.exit(2)
-")
+" 2>/dev/null)
 fi
-[[ -n "$SOURCE_ID" ]] || { echo "ERROR: could not resolve insight_source_id for tenant '${TENANT}'; pass it explicitly as the second arg" >&2; exit 1; }
+[[ -n "$SOURCE_ID" ]] || {
+  echo "ERROR: could not resolve insight_source_id for tenant '$TENANT'." >&2
+  echo "       Pass it explicitly as the second argument." >&2
+  exit 1
+}
 
-echo "Running Jira Silver transforms (dbt jira → enrich → dbt silver)"
-echo "  tenant:            ${TENANT}"
-echo "  insight_source_id: ${SOURCE_ID}"
+echo "Running Jira tt-enrich (staging-jira → enrich → silver):"
+echo "  namespace:         $NAMESPACE"
+echo "  tenant:            $TENANT"
+echo "  insight_source_id: $SOURCE_ID"
 
-kubectl create -n argo -f - <<EOF
+# Inline DAG that chains three pre-registered WorkflowTemplate steps.
+# We don't pass image tags or clickhouse coordinates — chart defaults fire.
+kubectl create -n "$NAMESPACE" -f - <<EOF
 apiVersion: argoproj.io/v1alpha1
 kind: Workflow
 metadata:
   generateName: jira-${TENANT//_/-}-tt-enrich-
-  namespace: argo
+  namespace: $NAMESPACE
   labels:
-    tenant: "${TENANT}"
+    tenant: "$TENANT"
     connector: "jira"
     workflow-kind: "tt-enrich"
+    # Controller picks up workflows by this label — value MUST match
+    # `instanceID` in the argo-workflows-workflow-controller ConfigMap.
+    workflows.argoproj.io/controller-instanceid: argo-workflows-insight
 spec:
+  serviceAccountName: argo-workflow
   entrypoint: run
   templates:
     - name: run
@@ -88,7 +106,7 @@ spec:
             arguments:
               parameters:
                 - name: insight_source_id
-                  value: "${SOURCE_ID}"
+                  value: "$SOURCE_ID"
 
           - name: silver
             depends: enrich
@@ -102,6 +120,5 @@ spec:
 EOF
 
 echo
-echo "Workflow submitted. Monitor:"
-echo "  Argo UI:   http://localhost:30500"
-echo "  kubectl:   kubectl get workflows -n argo -l connector=jira,workflow-kind=tt-enrich --watch"
+echo "Monitor:"
+echo "  kubectl -n $NAMESPACE get workflows -l connector=jira,workflow-kind=tt-enrich --watch"

--- a/src/ingestion/run-tt-enrich-jira.sh
+++ b/src/ingestion/run-tt-enrich-jira.sh
@@ -11,114 +11,55 @@ set -euo pipefail
 # clickhouse_host/port/user, batch_size) come from WorkflowTemplate defaults —
 # see charts/insight/templates/ingestion/{dbt-run,tt-enrich-jira-run}.yaml.
 #
-# Usage:
-#   ./run-tt-enrich-jira.sh <tenant> [<insight_source_id>]
+# Required env:
+#   KUBECONFIG          path to the insight cluster kubeconfig
+#   INSIGHT_NAMESPACE   release namespace of the umbrella chart
 #
-# When <insight_source_id> is omitted, it is read from the Jira Secret
-# annotation `insight.cyberfabric.com/source-id` in the release namespace.
+# Required args:
+#   <tenant>            tenant identifier
+# Optional args:
+#   <insight_source_id> when set, used directly; otherwise resolved from the
+#                       Jira Secret annotations.
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-cd "$SCRIPT_DIR"
+: "${KUBECONFIG:?must be set, e.g. export KUBECONFIG=~/.kube/insight.kubeconfig}"
+: "${INSIGHT_NAMESPACE:?must be set to the umbrella release namespace, e.g. export INSIGHT_NAMESPACE=insight}"
+export KUBECONFIG INSIGHT_NAMESPACE
 
 TENANT="${1:?Usage: $0 <tenant> [<insight_source_id>]}"
 SOURCE_ID="${2:-}"
 
-NAMESPACE="${INSIGHT_NAMESPACE:-insight}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
 
-export KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/insight.kubeconfig}"
+source "airbyte-toolkit/lib/secrets.sh"
 
-# ─── Resolve insight_source_id from Secret annotation ───────────────────
-# Single-namespace model: connector Secrets live in the same namespace as
-# the umbrella (default `insight`). Multi-tenant clusters use multiple
-# namespaces; we filter by tenant to avoid picking the wrong source.
+# ─── Resolve insight_source_id from Secret annotations ──────────────────
 if [[ -z "$SOURCE_ID" ]]; then
-  SOURCE_ID=$(TENANT="$TENANT" \
-    kubectl get secret -n "$NAMESPACE" -l app.kubernetes.io/part-of=insight -o json \
-    | python3 -c "
-import json, os, sys
-tenant = os.environ['TENANT']
-matches = []
-for s in json.load(sys.stdin).get('items', []):
-    ann = (s.get('metadata') or {}).get('annotations') or {}
-    if ann.get('insight.cyberfabric.com/connector') != 'jira':
-        continue
-    # tenant annotation optional — if missing, accept any tenant the caller asked for
-    sec_tenant = ann.get('insight.cyberfabric.com/tenant', tenant)
-    if sec_tenant != tenant:
-        continue
-    sid = ann.get('insight.cyberfabric.com/source-id', '')
-    if sid:
-        matches.append(sid)
-if len(matches) == 1:
-    print(matches[0])
-elif len(matches) > 1:
-    sys.stderr.write(f'ERROR: multiple Jira secrets match tenant {tenant}: {matches}\n')
-    sys.exit(2)
-" 2>/dev/null)
+  SOURCE_ID=$(resolve_source_id "jira" "$TENANT")
 fi
 [[ -n "$SOURCE_ID" ]] || {
-  echo "ERROR: could not resolve insight_source_id for tenant '$TENANT'." >&2
-  echo "       Pass it explicitly as the second argument." >&2
+  echo "ERROR: could not resolve insight_source_id for jira tenant '$TENANT'." >&2
+  echo "       Either pass it explicitly as the second argument, or annotate the Jira Secret with all three:" >&2
+  echo "         insight.cyberfabric.com/connector=jira" >&2
+  echo "         insight.cyberfabric.com/tenant=$TENANT" >&2
+  echo "         insight.cyberfabric.com/source-id=<id>" >&2
   exit 1
 }
 
-echo "Running Jira tt-enrich (staging-jira → enrich → silver):"
-echo "  namespace:         $NAMESPACE"
+TENANT_DASHED="${TENANT//_/-}"
+
+echo "Running Jira tt-enrich (staging-jira -> enrich -> silver):"
+echo "  namespace:         $INSIGHT_NAMESPACE"
 echo "  tenant:            $TENANT"
 echo "  insight_source_id: $SOURCE_ID"
 
-# Inline DAG that chains three pre-registered WorkflowTemplate steps.
-# We don't pass image tags or clickhouse coordinates — chart defaults fire.
-kubectl create -n "$NAMESPACE" -f - <<EOF
-apiVersion: argoproj.io/v1alpha1
-kind: Workflow
-metadata:
-  generateName: jira-${TENANT//_/-}-tt-enrich-
-  namespace: $NAMESPACE
-  labels:
-    tenant: "$TENANT"
-    connector: "jira"
-    workflow-kind: "tt-enrich"
-    # Controller picks up workflows by this label — value MUST match
-    # `instanceID` in the argo-workflows-workflow-controller ConfigMap.
-    workflows.argoproj.io/controller-instanceid: argo-workflows-insight
-spec:
-  serviceAccountName: argo-workflow
-  entrypoint: run
-  templates:
-    - name: run
-      dag:
-        tasks:
-          - name: staging-jira
-            templateRef:
-              name: dbt-run
-              template: run
-            arguments:
-              parameters:
-                - name: dbt_select
-                  value: "tag:jira"
-
-          - name: enrich
-            depends: staging-jira
-            templateRef:
-              name: tt-enrich-jira-run
-              template: run
-            arguments:
-              parameters:
-                - name: insight_source_id
-                  value: "$SOURCE_ID"
-
-          - name: silver
-            depends: enrich
-            templateRef:
-              name: dbt-run
-              template: run
-            arguments:
-              parameters:
-                - name: dbt_select
-                  value: "tag:silver,tag:jira+"
-EOF
+NAMESPACE="$INSIGHT_NAMESPACE" \
+  TENANT="$TENANT" \
+  TENANT_DASHED="$TENANT_DASHED" \
+  SOURCE_ID="$SOURCE_ID" \
+  envsubst < workflows/onetime/tt-enrich-jira.yaml.tpl |
+  kubectl create -n "$INSIGHT_NAMESPACE" -f -
 
 echo
 echo "Monitor:"
-echo "  kubectl -n $NAMESPACE get workflows -l connector=jira,workflow-kind=tt-enrich --watch"
+echo "  kubectl -n $INSIGHT_NAMESPACE get workflows -l connector=jira,workflow-kind=tt-enrich --watch"

--- a/src/ingestion/update-connections.sh
+++ b/src/ingestion/update-connections.sh
@@ -1,16 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Apply tenant connection configs against the running Airbyte instance.
+#
+# Required env (no defaults — set explicitly so cross-cluster mistakes
+# fail loudly instead of writing to the wrong cluster):
+#   KUBECONFIG          path to the insight cluster kubeconfig
+#   INSIGHT_NAMESPACE   release namespace of the umbrella chart
+#
+# Args:
+#   <tenant_name>       optional; if omitted, processes every connections/*.yaml
+: "${KUBECONFIG:?must be set, e.g. export KUBECONFIG=~/.kube/insight.kubeconfig}"
+: "${INSIGHT_NAMESPACE:?must be set to the umbrella release namespace, e.g. export INSIGHT_NAMESPACE=insight}"
+export KUBECONFIG INSIGHT_NAMESPACE
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
 TENANT="${1:-}"
 echo "=== Updating connections ==="
 
-export KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/insight.kubeconfig}"
-export TOOLKIT_DIR="${SCRIPT_DIR}/airbyte-toolkit"
-
-ARGS="${TENANT:---all}"
-"${TOOLKIT_DIR}/connect.sh" ${ARGS}
+if [[ -n "$TENANT" ]]; then
+  ./airbyte-toolkit/connect.sh "$TENANT"
+else
+  ./airbyte-toolkit/connect.sh --all
+fi
 
 echo "=== Done ==="

--- a/src/ingestion/workflows/onetime/sync.yaml.tpl
+++ b/src/ingestion/workflows/onetime/sync.yaml.tpl
@@ -1,0 +1,41 @@
+# One-shot Workflow that submits ingestion-pipeline for a single connector + tenant.
+#
+# Variables resolved by run-sync.sh and rendered via envsubst:
+#   NAMESPACE, CONNECTOR, TENANT, TENANT_DASHED, CONNECTION_ID, SOURCE_ID,
+#   DATA_SOURCE, DBT_SELECT, DBT_SELECT_STAGING (may be empty for non-jira)
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: ${CONNECTOR}-${TENANT_DASHED}-
+  namespace: ${NAMESPACE}
+  labels:
+    tenant: "${TENANT}"
+    connector: "${CONNECTOR}"
+    # Controller picks up workflows by this label — value MUST match
+    # the instanceID in the argo-workflows-workflow-controller ConfigMap.
+    workflows.argoproj.io/controller-instanceid: argo-workflows-insight
+spec:
+  # Workflow steps need write access to argoproj.io/workflowtaskresults.
+  # The argo chart creates this ServiceAccount via workflow.serviceAccount.create=true;
+  # supplemental Role/Binding (deploy/argo/rbac.yaml) grants the necessary verbs.
+  serviceAccountName: argo-workflow
+  entrypoint: run
+  templates:
+    - name: run
+      steps:
+        - - name: pipeline
+            templateRef:
+              name: ingestion-pipeline
+              template: pipeline
+            arguments:
+              parameters:
+                - name: connection_id
+                  value: "${CONNECTION_ID}"
+                - name: insight_source_id
+                  value: "${SOURCE_ID}"
+                - name: data_source
+                  value: "${DATA_SOURCE}"
+                - name: dbt_select
+                  value: "${DBT_SELECT}"
+                - name: dbt_select_staging
+                  value: "${DBT_SELECT_STAGING}"

--- a/src/ingestion/workflows/onetime/tt-enrich-jira.yaml.tpl
+++ b/src/ingestion/workflows/onetime/tt-enrich-jira.yaml.tpl
@@ -1,0 +1,52 @@
+# One-shot DAG that runs the Jira tt-enrich path on already-loaded Bronze data:
+#   dbt(tag:jira) -> tt-enrich-jira-run -> dbt(tag:silver,tag:jira+).
+#
+# Variables resolved by run-tt-enrich-jira.sh and rendered via envsubst:
+#   NAMESPACE, TENANT, TENANT_DASHED, SOURCE_ID
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: jira-${TENANT_DASHED}-tt-enrich-
+  namespace: ${NAMESPACE}
+  labels:
+    tenant: "${TENANT}"
+    connector: "jira"
+    workflow-kind: "tt-enrich"
+    # Controller picks up workflows by this label — value MUST match
+    # the instanceID in the argo-workflows-workflow-controller ConfigMap.
+    workflows.argoproj.io/controller-instanceid: argo-workflows-insight
+spec:
+  serviceAccountName: argo-workflow
+  entrypoint: run
+  templates:
+    - name: run
+      dag:
+        tasks:
+          - name: staging-jira
+            templateRef:
+              name: dbt-run
+              template: run
+            arguments:
+              parameters:
+                - name: dbt_select
+                  value: "tag:jira"
+
+          - name: enrich
+            depends: staging-jira
+            templateRef:
+              name: tt-enrich-jira-run
+              template: run
+            arguments:
+              parameters:
+                - name: insight_source_id
+                  value: "${SOURCE_ID}"
+
+          - name: silver
+            depends: enrich
+            templateRef:
+              name: dbt-run
+              template: run
+            arguments:
+              parameters:
+                - name: dbt_select
+                  value: "tag:silver,tag:jira+"

--- a/src/ingestion/workflows/schedules/sync.yaml.tpl
+++ b/src/ingestion/workflows/schedules/sync.yaml.tpl
@@ -1,16 +1,26 @@
-# Generic sync CronWorkflow template
+# Generic sync CronWorkflow template — single-namespace model.
+#
 # Variables resolved by sync-flows.sh from descriptor.yaml + connection state:
-#   CONNECTOR, TENANT_ID, CONNECTION_ID, SCHEDULE, DBT_SELECT
+#   CONNECTOR, TENANT_ID, CONNECTION_ID, SOURCE_ID, DATA_SOURCE, SCHEDULE,
+#   DBT_SELECT, DBT_SELECT_STAGING (empty for non-jira), NAMESPACE
+#
+# All "infrastructure" parameters (toolbox_image, jira_enrich_image,
+# airbyte_url, clickhouse_host/port/user) come from the WorkflowTemplate
+# defaults baked into the umbrella chart at install time. We only pass
+# connection-specific values here.
 
 apiVersion: argoproj.io/v1alpha1
 kind: CronWorkflow
 metadata:
-  name: ${CONNECTOR}-sync
-  namespace: argo
+  name: ${CONNECTOR}-${TENANT_ID}-sync
+  namespace: ${NAMESPACE}
   labels:
     app.kubernetes.io/part-of: ingestion
     tenant: "${TENANT_ID}"
     connector: "${CONNECTOR}"
+    # Controller picks up workflows by this label — value MUST match
+    # `instanceID` in the argo-workflows-workflow-controller ConfigMap.
+    workflows.argoproj.io/controller-instanceid: argo-workflows-insight
 spec:
   schedules:
     - "${SCHEDULE}"
@@ -18,6 +28,7 @@ spec:
   concurrencyPolicy: Replace
   startingDeadlineSeconds: 600
   workflowSpec:
+    serviceAccountName: argo-workflow
     entrypoint: run
     templates:
       - name: run
@@ -30,5 +41,11 @@ spec:
                 parameters:
                   - name: connection_id
                     value: "${CONNECTION_ID}"
+                  - name: insight_source_id
+                    value: "${SOURCE_ID}"
+                  - name: data_source
+                    value: "${DATA_SOURCE}"
                   - name: dbt_select
                     value: "${DBT_SELECT}"
+                  - name: dbt_select_staging
+                    value: "${DBT_SELECT_STAGING}"


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#245](https://github.com/cyberfabric/cyber-insight/pull/245) | **Author:** mitasovr | **Opened:** 2026-04-28T19:09:50Z | **Status:** merged on 2026-05-04T07:17:44Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

- **chart**: `ingestion.toolboxImage` and `ingestion.jiraEnrichImage` knobs + WorkflowTemplate `default`s for derivable infra coordinates (clickhouse_host/port/user, airbyte_url, batch_size). Operator pins image tags **once** in the umbrella overlay; submitters pick them up automatically. No `:latest` defaults — `required` fires if templates are enabled and tags are empty.
- **ingestion submitters** (`run-sync.sh`, `run-tt-enrich-jira.sh`, `sync.yaml.tpl`): bring in line with PR #1127's single-namespace + instanceID-scoped Argo + `argo-workflow` ServiceAccount. The previous code targeted the pre-PR-#1127 multi-namespace world (`argo`, `data`); workflows submitted with the old code were silently dropped by the controller (no `controller-instanceid` label) and/or hit `workflowtaskresults forbidden` (default SA without RBAC).
- **airbyte-toolkit `connect.sh`**: K8s Secret discovery + ClickHouse password lookup move from legacy ns `data` to `INSIGHT_NAMESPACE` / `insight-db-creds`.
- **dbt `union_by_tag` soft-fallback**: when zero tagged staging tables exist for a silver model (e.g. `class_collab_email_activity` on a tenant without M365 configured), the macro emits an empty placeholder instead of raising a compile error. This unblocks single-source silver models on tenants that only configure a subset of connectors.
- **jira silver step narrowed** to `tag:silver,tag:jira+`. The third dbt step of the jira path now rebuilds only `class_task_*` (silver models actually downstream of jira staging), not the full silver layer. Saves ~75% of silver re-materialisations per jira sync.
- **README**: Quick Start rewritten to cover all three deployment paths (local Kind via `dev-up.sh`, canonical imperative via `install.sh`, ArgoCD GitOps).

All six commits independently rebuildable; no upstream-touched files overlapped.

## Why now

After deploying the umbrella to a fresh dev-vhc cluster end-to-end, three classes of friction surfaced — every one of them rooted in a piece of code that was written for the pre-PR-#1127 world and never updated when we moved to single-namespace + instanceID-scoped Argo. Net effect: a fresh PR-#1127 deploy hit `update-connections.sh: ERROR: clickhouse-credentials not found in namespace 'data'`, then `Workflows submitted but ignored by the controller`, then `workflowtaskresults forbidden`. Each fix is small; together they make `dev-up.sh` and `install.sh` actually work end-to-end against a current chart.

The two later commits address an orthogonal correctness issue: silver dbt models failing the whole pipeline when one contributing connector isn't configured on a tenant. `union_by_tag`'s strict `raise_compiler_error` was fatal for single-source silver targets, and the jira path was rebuilding the entire silver layer per sync.

## Behaviour after merge

| Path | Before | After |
|---|---|---|
| `dev-up.sh` (Kind) | hits `data` ns lookup | works |
| `install.sh` (remote cluster) | submitters silently no-op; toolbox `:latest` | works; ops pins tag once |
| ArgoCD GitOps | (already worked since PR #1127) | no behaviour change beyond submitter alignment |
| Tenant with subset of connectors | single-source silver dbt errors with "No models found with tag X" | empty placeholder; pipeline runs |
| Jira sync | rebuilds 32 silver models | rebuilds 8 jira-related silver models |

## Test plan

- [x] `helm template` renders 2910 lines clean with chart defaults firing for all WorkflowTemplate inputs.
- [x] `helm lint charts/insight` — pass.
- [x] Live tested on `insight-dev-vhc` cluster: `update-connections.sh default` registers m365 + bamboohr; `run-sync.sh m365 default` and `run-sync.sh bamboohr default` both reach `Succeeded` with end-to-end Bronze → Silver materialization (m365 → 6376 email_activity + 2844 teams_activity rows; bamboohr → 2780 employees → silver.class_people=2780, silver.class_focus_metrics=2844).
- [ ] Verify single-source silver soft-fallback: on a tenant configured for only one connector (e.g. only M365), the silver models that union jira/github/bitbucket staging should compile to an empty placeholder (`union_by_tag: no models found ... — emitting empty result` log line in dbt output) instead of failing the run.
- [ ] Verify narrowed jira silver: after `run-sync.sh jira <tenant>`, dbt logs for the silver step list only `class_task_*` models; non-task silver (`class_collab_*`, `class_git_*`, etc.) is not touched.
- [x] No Cyrillic in any committed file.

## Known follow-ups not in this PR

- `silver.class_focus_metrics` is a cross-source dbt model (depends on both bamboohr and m365 `silver.class_*` tables), so the first run order matters: m365 must complete before bamboohr's `+tag:bamboohr` selector pulls it in. Fix is either (a) drop `+` from connector descriptors, or (b) add a separate "silver-aggregation" CronWorkflow. Out of scope here.
- Bitnami-style auto-generated self-signed TLS for dev environments (so `insight-dev.constr.dev` works without cert-manager). Discussed but not in this PR.
- `connect.sh` idempotency on partial-failure recovery (currently can produce duplicate sources/connections if re-run after a mid-flow error). Cleanup is a `state.yaml` reset + Airbyte API delete loop.
- Architectural split into separate `transform-main` / `transform-jira` WorkflowTemplates with a `connector` dispatch parameter (instead of the current `data_source` + `dbt_select_staging` combo). Cosmetic refactor; behavioral parity with current single-pipeline dispatch. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded deployment guide (3 install paths), connector/service setup, image-tag guidance, and LOCAL_DEV notes.

* **New Features**
  * Added ingestion image settings, one‑time and tenant‑scoped scheduled workflows, namespace-aware submission/monitoring, and a secret-based source-id resolver.

* **Improvements**
  * Stronger validation/error messages, explicit env/namespace requirements in scripts, refined dbt selection behavior, Helm/WorkflowTemplate defaults, and safer union macro behavior.

* **Chores**
  * .gitignore exception and new cypilot code‑convention rule.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#245 -->