### PR TITLE
[PR #242] feat(insight): slack metrics — rename mislabeled keys + add consistency metrics

### DIFF
--- a/src/backend/services/analytics-api/src/migration/m20260428_000001_slack_metrics_update.rs
+++ b/src/backend/services/analytics-api/src/migration/m20260428_000001_slack_metrics_update.rs
@@ -1,0 +1,73 @@
+//! Slack metrics update — rename mislabeled keys + add consistency metrics
+//! in the TEAM_BULLET_COLLAB (UUID …05) and IC_BULLET_COLLAB (UUID …12)
+//! bullet aggregation queries.
+//!
+//! Renames:
+//!   slack_message_engagement   → slack_messages_sent
+//!   slack_thread_participation → slack_channel_posts
+//!
+//! New metrics added to the inner-aggregation `sum`-list:
+//!   slack_active_days          (per-day 1/0 → period total = active days)
+//!
+//! New metric using default `avg`-aggregation (emitted as NULL on inactive
+//! days so CH avg() yields mean intensity over active days):
+//!   slack_msgs_per_active_day
+//!
+//! Paired with CH migration `20260428000000_slack-metrics-update.sql` which
+//! redefines `insight.collab_bullet_rows` to emit the renamed keys and the
+//! two new metrics.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const TEAM_BULLET_COLLAB_ID: &str = "00000000000000000001000000000005";
+const IC_BULLET_COLLAB_ID: &str = "00000000000000000001000000000012";
+
+const TEAM_BULLET_COLLAB_QUERY: &str = "SELECT p.metric_key AS metric_key, avg(p.v_period) AS value, any(c.company_median) AS median, any(c.company_min) AS range_min, any(c.company_max) AS range_max FROM (SELECT metric_key, person_id, any(org_unit_id) AS org_unit_id, multiIf(metric_key IN ('m365_emails_sent', 'zoom_calls', 'meeting_hours', 'm365_teams_messages', 'm365_files_shared', 'meeting_free', 'slack_channel_posts', 'slack_messages_sent', 'slack_active_days'), sum(metric_value), avg(metric_value)) AS v_period FROM insight.collab_bullet_rows GROUP BY metric_key, person_id) p LEFT JOIN (SELECT metric_key, quantileExact(0.5)(v_period) AS company_median, min(v_period) AS company_min, max(v_period) AS company_max FROM (SELECT metric_key, person_id, multiIf(metric_key IN ('m365_emails_sent', 'zoom_calls', 'meeting_hours', 'm365_teams_messages', 'm365_files_shared', 'meeting_free', 'slack_channel_posts', 'slack_messages_sent', 'slack_active_days'), sum(metric_value), avg(metric_value)) AS v_period FROM insight.collab_bullet_rows GROUP BY metric_key, person_id) inner_c GROUP BY metric_key) c ON c.metric_key = p.metric_key GROUP BY p.metric_key";
+
+const IC_BULLET_COLLAB_QUERY: &str = "SELECT p.metric_key AS metric_key, avg(p.v_period) AS value, any(c.team_median) AS median, any(c.team_min) AS range_min, any(c.team_max) AS range_max FROM (SELECT metric_key, person_id, any(org_unit_id) AS org_unit_id, multiIf(metric_key IN ('m365_emails_sent', 'zoom_calls', 'meeting_hours', 'm365_teams_messages', 'm365_files_shared', 'meeting_free', 'slack_channel_posts', 'slack_messages_sent', 'slack_active_days'), sum(metric_value), avg(metric_value)) AS v_period FROM insight.collab_bullet_rows GROUP BY metric_key, person_id) p LEFT JOIN (SELECT metric_key, org_unit_id, quantileExact(0.5)(v_period) AS team_median, min(v_period) AS team_min, max(v_period) AS team_max FROM (SELECT metric_key, person_id, any(org_unit_id) AS org_unit_id, multiIf(metric_key IN ('m365_emails_sent', 'zoom_calls', 'meeting_hours', 'm365_teams_messages', 'm365_files_shared', 'meeting_free', 'slack_channel_posts', 'slack_messages_sent', 'slack_active_days'), sum(metric_value), avg(metric_value)) AS v_period FROM insight.collab_bullet_rows GROUP BY metric_key, person_id) inner_c GROUP BY metric_key, org_unit_id) c ON c.metric_key = p.metric_key AND c.org_unit_id = p.org_unit_id GROUP BY p.metric_key";
+
+// Snapshotted from m20260422_000001_seed_metrics so `down()` can restore
+// the exact pre-rename text on rollback.
+const TEAM_BULLET_COLLAB_QUERY_OLD: &str = "SELECT p.metric_key AS metric_key, avg(p.v_period) AS value, any(c.company_median) AS median, any(c.company_min) AS range_min, any(c.company_max) AS range_max FROM (SELECT metric_key, person_id, any(org_unit_id) AS org_unit_id, multiIf(metric_key IN ('m365_emails_sent', 'zoom_calls', 'meeting_hours', 'm365_teams_messages', 'm365_files_shared', 'meeting_free', 'slack_thread_participation', 'slack_message_engagement'), sum(metric_value), avg(metric_value)) AS v_period FROM insight.collab_bullet_rows GROUP BY metric_key, person_id) p LEFT JOIN (SELECT metric_key, quantileExact(0.5)(v_period) AS company_median, min(v_period) AS company_min, max(v_period) AS company_max FROM (SELECT metric_key, person_id, multiIf(metric_key IN ('m365_emails_sent', 'zoom_calls', 'meeting_hours', 'm365_teams_messages', 'm365_files_shared', 'meeting_free', 'slack_thread_participation', 'slack_message_engagement'), sum(metric_value), avg(metric_value)) AS v_period FROM insight.collab_bullet_rows GROUP BY metric_key, person_id) inner_c GROUP BY metric_key) c ON c.metric_key = p.metric_key GROUP BY p.metric_key";
+
+const IC_BULLET_COLLAB_QUERY_OLD: &str = "SELECT p.metric_key AS metric_key, avg(p.v_period) AS value, any(c.team_median) AS median, any(c.team_min) AS range_min, any(c.team_max) AS range_max FROM (SELECT metric_key, person_id, any(org_unit_id) AS org_unit_id, multiIf(metric_key IN ('m365_emails_sent', 'zoom_calls', 'meeting_hours', 'm365_teams_messages', 'm365_files_shared', 'meeting_free', 'slack_thread_participation', 'slack_message_engagement'), sum(metric_value), avg(metric_value)) AS v_period FROM insight.collab_bullet_rows GROUP BY metric_key, person_id) p LEFT JOIN (SELECT metric_key, org_unit_id, quantileExact(0.5)(v_period) AS team_median, min(v_period) AS team_min, max(v_period) AS team_max FROM (SELECT metric_key, person_id, any(org_unit_id) AS org_unit_id, multiIf(metric_key IN ('m365_emails_sent', 'zoom_calls', 'meeting_hours', 'm365_teams_messages', 'm365_files_shared', 'meeting_free', 'slack_thread_participation', 'slack_message_engagement'), sum(metric_value), avg(metric_value)) AS v_period FROM insight.collab_bullet_rows GROUP BY metric_key, person_id) inner_c GROUP BY metric_key, org_unit_id) c ON c.metric_key = p.metric_key AND c.org_unit_id = p.org_unit_id GROUP BY p.metric_key";
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        for (hex_id, query) in [
+            (TEAM_BULLET_COLLAB_ID, TEAM_BULLET_COLLAB_QUERY),
+            (IC_BULLET_COLLAB_ID, IC_BULLET_COLLAB_QUERY),
+        ] {
+            db.execute_unprepared(&format!(
+                "UPDATE metrics SET query_ref = '{qr}' WHERE id = UNHEX('{hex_id}')",
+                qr = query.replace('\'', "''"),
+            ))
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        for (hex_id, query) in [
+            (TEAM_BULLET_COLLAB_ID, TEAM_BULLET_COLLAB_QUERY_OLD),
+            (IC_BULLET_COLLAB_ID, IC_BULLET_COLLAB_QUERY_OLD),
+        ] {
+            db.execute_unprepared(&format!(
+                "UPDATE metrics SET query_ref = '{qr}' WHERE id = UNHEX('{hex_id}')",
+                qr = query.replace('\'', "''"),
+            ))
+            .await?;
+        }
+
+        Ok(())
+    }
+}

--- a/src/backend/services/analytics-api/src/migration/mod.rs
+++ b/src/backend/services/analytics-api/src/migration/mod.rs
@@ -3,6 +3,7 @@
 mod m20260414_000001_init;
 mod m20260422_000001_seed_metrics;
 mod m20260423_000001_seed_metrics_honest_nulls;
+mod m20260428_000001_slack_metrics_update;
 
 use sea_orm_migration::prelude::*;
 
@@ -15,6 +16,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260414_000001_init::Migration),
             Box::new(m20260422_000001_seed_metrics::Migration),
             Box::new(m20260423_000001_seed_metrics_honest_nulls::Migration),
+            Box::new(m20260428_000001_slack_metrics_update::Migration),
         ]
     }
 }

--- a/src/ingestion/scripts/migrations/20260428000000_slack-metrics-update.sql
+++ b/src/ingestion/scripts/migrations/20260428000000_slack-metrics-update.sql
@@ -1,0 +1,135 @@
+-- =====================================================================
+-- Slack metrics update — rename mislabeled keys + add consistency metrics
+-- =====================================================================
+--
+-- Two of the existing Slack bullet metrics misrepresented their underlying
+-- data, and two new metrics are added to surface engagement consistency
+-- (not just raw volume).
+--
+-- Renames
+--   slack_message_engagement   → slack_messages_sent
+--     was computed from silver.class_collab_chat_activity.total_chat_messages,
+--     i.e. raw messages a user posted on Slack that day. The label "Message
+--     Engagement (avg replies per thread)" implied reply-level data, which
+--     Slack's analytics endpoint does not split out.
+--   slack_thread_participation → slack_channel_posts
+--     was computed from channel_messages_posted_count, i.e. all messages in
+--     public channels — not just replies to others' threads. Bronze does not
+--     separate post vs reply.
+--
+-- New metrics (both from total_chat_messages)
+--   slack_active_days          per-day = 1 if user sent any messages, else 0.
+--                              Aggregates to count of active days in period
+--                              (sum). Higher = more consistent presence.
+--   slack_msgs_per_active_day  per-day = total_chat_messages on active days,
+--                              NULL otherwise. Aggregates as avg (default),
+--                              which CH avg() computes over non-NULL values
+--                              → mean intensity when active. Avoids the
+--                              "100 messages on Monday, silent the rest" /
+--                              "20 messages every day" being indistinguishable
+--                              by raw period total.
+--
+-- Supersedes the slack branch of insight.collab_bullet_rows defined in
+-- 20260427120000_views-from-silver.sql. View is DROP+CREATE.
+-- =====================================================================
+
+DROP VIEW IF EXISTS insight.collab_bullet_rows;
+CREATE VIEW insight.collab_bullet_rows AS
+SELECT
+    lower(e.email)                                AS person_id,
+    p.org_unit_id,
+    toString(e.date)                              AS metric_date,
+    'm365_emails_sent'                            AS metric_key,
+    toFloat64(ifNull(e.sent_count, 0))            AS metric_value
+FROM silver.class_collab_email_activity AS e
+LEFT JOIN insight.people AS p ON lower(e.email) = p.person_id
+WHERE e.data_source = 'insight_m365'
+
+UNION ALL
+SELECT
+    lower(m.email), p.org_unit_id, toString(m.date), 'zoom_calls',
+    toFloat64(ifNull(m.calls_count, 0))
+FROM silver.class_collab_meeting_activity AS m
+LEFT JOIN insight.people AS p ON lower(m.email) = p.person_id
+WHERE m.data_source = 'insight_zoom'
+
+UNION ALL
+SELECT
+    f.email, p.org_unit_id, toString(f.day), 'meeting_hours',
+    least(toFloat64(ifNull(f.meeting_hours, 0)), f.working_hours_per_day)
+FROM silver.class_focus_metrics AS f
+LEFT JOIN insight.people AS p ON f.email = p.person_id
+
+UNION ALL
+SELECT
+    lower(c.email), p.org_unit_id, toString(c.date), 'm365_teams_messages',
+    toFloat64(c.total_chat_messages)
+FROM silver.class_collab_chat_activity AS c
+LEFT JOIN insight.people AS p ON lower(c.email) = p.person_id
+WHERE c.data_source = 'insight_m365'
+
+UNION ALL
+SELECT
+    lower(d.email), p.org_unit_id, toString(d.date), 'm365_files_shared',
+    toFloat64(ifNull(d.shared_internally_count, 0)) +
+    toFloat64(ifNull(d.shared_externally_count, 0))
+FROM silver.class_collab_document_activity AS d
+LEFT JOIN insight.people AS p ON lower(d.email) = p.person_id
+WHERE d.data_source = 'insight_m365'
+
+UNION ALL
+SELECT
+    f.email, p.org_unit_id, toString(f.day), 'meeting_free',
+    if(ifNull(f.meeting_hours, 0) = 0, toFloat64(1), toFloat64(0))
+FROM silver.class_focus_metrics AS f
+LEFT JOIN insight.people AS p ON f.email = p.person_id
+
+-- Slack ----------------------------------------------------------------
+UNION ALL
+SELECT
+    lower(s.email), p.org_unit_id, toString(s.date), 'slack_messages_sent',
+    toFloat64(ifNull(s.total_chat_messages, 0))
+FROM silver.class_collab_chat_activity AS s
+LEFT JOIN insight.people AS p ON lower(s.email) = p.person_id
+WHERE s.data_source = 'insight_slack'
+
+UNION ALL
+SELECT
+    lower(s.email), p.org_unit_id, toString(s.date), 'slack_channel_posts',
+    toFloat64(ifNull(s.channel_posts, 0))
+FROM silver.class_collab_chat_activity AS s
+LEFT JOIN insight.people AS p ON lower(s.email) = p.person_id
+WHERE s.data_source = 'insight_slack'
+
+UNION ALL
+SELECT
+    lower(s.email), p.org_unit_id, toString(s.date), 'slack_active_days',
+    if(ifNull(s.total_chat_messages, 0) > 0, toFloat64(1), toFloat64(0))
+FROM silver.class_collab_chat_activity AS s
+LEFT JOIN insight.people AS p ON lower(s.email) = p.person_id
+WHERE s.data_source = 'insight_slack'
+
+UNION ALL
+SELECT
+    lower(s.email), p.org_unit_id, toString(s.date), 'slack_msgs_per_active_day',
+    -- Emit msgs only on active days; NULL otherwise so avg() aggregates
+    -- to mean intensity over active days (CH avg ignores NULLs).
+    if(ifNull(s.total_chat_messages, 0) > 0,
+       toFloat64(s.total_chat_messages),
+       CAST(NULL AS Nullable(Float64)))
+FROM silver.class_collab_chat_activity AS s
+LEFT JOIN insight.people AS p ON lower(s.email) = p.person_id
+WHERE s.data_source = 'insight_slack'
+
+UNION ALL
+SELECT
+    lower(s.email), p.org_unit_id, toString(s.date), 'slack_dm_ratio',
+    -- 0 messages → no rate to compute; return NULL not 0.
+    if(ifNull(s.total_chat_messages, 0) > 0,
+       round(((toFloat64(ifNull(s.total_chat_messages, 0)) -
+               toFloat64(ifNull(s.channel_posts, 0))) /
+              toFloat64(s.total_chat_messages)) * 100, 1),
+       CAST(NULL AS Nullable(Float64)))
+FROM silver.class_collab_chat_activity AS s
+LEFT JOIN insight.people AS p ON lower(s.email) = p.person_id
+WHERE s.data_source = 'insight_slack';


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#242](https://github.com/cyberfabric/cyber-insight/pull/242) | **Author:** dzarlax | **Opened:** 2026-04-28T13:43:01Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

Slack bullet metrics were misrepresenting their underlying data. The `admin.analytics.getFile?type=member` endpoint we ingest into `silver.class_collab_chat_activity` exposes only daily counts of total messages and channel posts — no post-vs-reply split, no DM-vs-group breakdown, no thread depth. Two existing metrics had labels implying finer-grained data than the source provides; this PR renames them to match reality and adds two consistency metrics built from the same raw column.

### Renames

- `slack_message_engagement` → `slack_messages_sent`
  Was `total_chat_messages` labelled "Message Engagement (avg replies per thread)". Renamed to plain "Messages Sent".
- `slack_thread_participation` → `slack_channel_posts`
  Was `channel_messages_posted_count` labelled "Thread Participation (replies to others' threads)". Bronze does not separate post vs reply — renamed to "Channel Posts".

### New metrics

- `slack_active_days` — per-day 1/0, period total = days the user sent any messages. Distinguishes "regular but quiet" from "silent then burst", which raw period totals can't.
- `slack_msgs_per_active_day` — per-day = `total_chat_messages` on active days, `NULL` otherwise. Aggregates as avg (CH `avg()` ignores NULL) → mean intensity over active days.

## Files

- `src/ingestion/scripts/migrations/20260428000000_slack-metrics-update.sql` — `DROP+CREATE insight.collab_bullet_rows` with renamed keys + two new metrics. Idempotent.
- `src/backend/services/analytics-api/src/migration/m20260428_000001_slack_metrics_update.rs` — `UPDATE metrics.query_ref` for `TEAM_BULLET_COLLAB` (UUID `…05`) and `IC_BULLET_COLLAB` (UUID `…12`) to include the new metric_keys in the inner-aggregation sum-list. Snapshots pre-rename strings for `down()`.
- `src/backend/services/analytics-api/src/migration/mod.rs` — registers the new migration.

## Frontend

Paired with cyberfabric/insight-front#__FE_PR__ which renames the metric keys, sublabels, units, and adds the new metrics to the IC and Team collaboration views.

## Test plan

Verified end-to-end on local stack (kind cluster + restored CH dump):
- [x] `clickhouse-client` shows all 5 slack keys emitted from `insight.collab_bullet_rows` over real bronze_slack data (17046 person-day rows each)
- [x] `POST /api/analytics/v1/metrics/00000000-0000-0000-0001-000000000012/query` returns all 5 keys with sane `value` / `median` / `range_min` / `range_max` (no `unavailable` statuses)
- [x] `cargo check -p analytics-api` passes
- [ ] Reviewer to verify thresholds (`good` / `warn`) calibrate to your data

## Rollout note

CH migration and Rust migration must be applied together: until both land, `collab_bullet_rows` and `metrics.query_ref` will reference different keys for the slack metrics, and the collab bullet section will render `ComingSoon` placeholders for the affected slots (no crash, just empty cells).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected Slack metric key names for improved data consistency and report accuracy.

* **New Features**
  * Added Slack active days tracking to measure daily engagement levels.
  * Added messages per active day metric to analyze engagement patterns on active days.
  * Added direct message ratio calculation to understand communication channel distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#242 -->