### PR TITLE
[PR #240] fix(silver-git): mtr_git_person_* — work around CH 25.3 FOJ default-fill bug

### DIFF
--- a/src/ingestion/silver/git/mtr_git_person_totals.sql
+++ b/src/ingestion/silver/git/mtr_git_person_totals.sql
@@ -8,8 +8,31 @@
 -- the reviewer-login namespace (GitHub login, Bitbucket display_name), which
 -- does not match the email-based person_key used by commits/PRs. Returns
 -- once identity resolution bridges the two namespaces.
+--
+-- Why anchor + LEFT JOINs instead of FULL OUTER JOIN ... USING:
+-- ClickHouse 25.3 fills unmatched per-side columns with the column's default
+-- value (empty string for non-Nullable String) instead of NULL after FOJ.
+-- A subsequent `coalesce(prs.person_key, commits.person_key, …)` then picks
+-- the empty string and the joining key is lost. We anchor on the union of
+-- all (tenant_id, person_key) tuples and LEFT JOIN each metric CTE onto it,
+-- which keeps the join key authoritative on the anchor side.
 
-WITH prs AS (
+WITH all_keys AS (
+    SELECT tenant_id, person_key
+    FROM {{ ref('fct_git_pr') }}
+    WHERE person_key != ''
+    UNION DISTINCT
+    SELECT tenant_id, person_key
+    FROM {{ ref('fct_git_commit') }}
+    WHERE is_merge_commit = 0 AND person_key != ''
+    UNION DISTINCT
+    SELECT tenant_id, person_key
+    FROM {{ ref('fct_git_file_change') }}
+    WHERE is_merge_commit = 0
+      AND file_category = 'code'
+      AND person_key != ''
+),
+prs AS (
     SELECT
         tenant_id,
         person_key,
@@ -43,19 +66,16 @@ clean AS (
     GROUP BY tenant_id, person_key
 )
 SELECT
-    coalesce(prs.tenant_id, commits.tenant_id, clean.tenant_id)    AS tenant_id,
-    coalesce(prs.person_key, commits.person_key, clean.person_key) AS person_key,
-    concat(
-        coalesce(prs.tenant_id, commits.tenant_id, clean.tenant_id),
-        '|',
-        coalesce(prs.person_key, commits.person_key, clean.person_key)
-    ) AS unique_key,
+    ak.tenant_id                          AS tenant_id,
+    ak.person_key                         AS person_key,
+    concat(coalesce(ak.tenant_id, ''), '|', ak.person_key) AS unique_key,
     coalesce(prs.prs_created, 0)          AS prs_created,
     coalesce(prs.prs_merged, 0)           AS prs_merged,
     prs.avg_pr_cycle_time_h               AS avg_pr_cycle_time_h,
     coalesce(commits.commits, 0)          AS commits,
     coalesce(commits.loc, 0)              AS loc,
     coalesce(clean.clean_loc, 0)          AS clean_loc
-FROM prs
-FULL OUTER JOIN commits USING (tenant_id, person_key)
-FULL OUTER JOIN clean   USING (tenant_id, person_key)
+FROM all_keys ak
+LEFT JOIN prs     USING (tenant_id, person_key)
+LEFT JOIN commits USING (tenant_id, person_key)
+LEFT JOIN clean   USING (tenant_id, person_key)

--- a/src/ingestion/silver/git/mtr_git_person_weekly.sql
+++ b/src/ingestion/silver/git/mtr_git_person_weekly.sql
@@ -5,10 +5,18 @@
 ) }}
 
 -- All CTEs bucket by commit-date week (toStartOfWeek(commit.date, 1)) so the
--- FULL OUTER JOIN on `week` aligns rows from the same activity window.
+-- LEFT JOINs on `week` align rows from the same activity window.
 -- For prs_merged the week is taken from the merge commit's date (when the
 -- merge_commit_hash resolves to a commit row), falling back to the PR
 -- closed_on week. This avoids commit-week vs PR-close-week drift.
+--
+-- Why anchor + LEFT JOINs instead of FULL OUTER JOIN ... USING:
+-- ClickHouse 25.3 fills unmatched per-side columns with the column's default
+-- value (empty string for non-Nullable String, 1970-01-01 for Date) instead
+-- of NULL after FOJ. A subsequent `coalesce(commits.person_key, …)` then
+-- picks the default and the joining key is lost. We anchor on the union of
+-- all (tenant_id, person_key, week) tuples and LEFT JOIN each metric CTE
+-- onto it, which keeps the join key authoritative on the anchor side.
 
 WITH commits AS (
     SELECT
@@ -52,22 +60,30 @@ prs AS (
       AND pr.closed_on IS NOT NULL
       AND pr.person_key != ''
     GROUP BY pr.tenant_id, pr.person_key, week
+),
+all_keys AS (
+    SELECT tenant_id, person_key, week FROM commits
+    UNION DISTINCT
+    SELECT tenant_id, person_key, week FROM loc
+    UNION DISTINCT
+    SELECT tenant_id, person_key, week FROM prs
 )
 SELECT
-    coalesce(commits.tenant_id, loc.tenant_id, prs.tenant_id)    AS tenant_id,
-    coalesce(commits.person_key, loc.person_key, prs.person_key) AS person_key,
-    coalesce(commits.week, loc.week, prs.week)                   AS week,
+    ak.tenant_id                                                 AS tenant_id,
+    ak.person_key                                                AS person_key,
+    ak.week                                                      AS week,
     concat(
-        coalesce(commits.tenant_id, loc.tenant_id, prs.tenant_id),
+        coalesce(ak.tenant_id, ''),
         '|',
-        coalesce(commits.person_key, loc.person_key, prs.person_key),
+        ak.person_key,
         '|',
-        toString(coalesce(commits.week, loc.week, prs.week))
-    ) AS unique_key,
+        toString(ak.week)
+    )                                                            AS unique_key,
     coalesce(commits.commits, 0)                                 AS commits,
     coalesce(prs.prs_merged, 0)                                  AS prs_merged,
     coalesce(loc.code_loc, 0)                                    AS code_loc,
     coalesce(loc.spec_lines, 0)                                  AS spec_lines
-FROM commits
-FULL OUTER JOIN loc USING (tenant_id, person_key, week)
-FULL OUTER JOIN prs USING (tenant_id, person_key, week)
+FROM all_keys ak
+LEFT JOIN commits USING (tenant_id, person_key, week)
+LEFT JOIN loc     USING (tenant_id, person_key, week)
+LEFT JOIN prs     USING (tenant_id, person_key, week)


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#240](https://github.com/cyberfabric/cyber-insight/pull/240) | **Author:** mitasovr | **Opened:** 2026-04-27T20:06:23Z | **Status:** merged on 2026-04-28T07:48:16Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

`silver.mtr_git_person_totals` and `silver.mtr_git_person_weekly` lose their join key on ClickHouse 25.3, causing all downstream git-metric gold views to surface 0 instead of real values. Rewrite both models to use an anchor-CTE + LEFT JOIN pattern that avoids the bug.

## Live impact (virtuozzo, before this PR)

| Table | rows | rows with empty `person_key` |
|---|---:|---:|
| `silver.mtr_git_person_totals` | 365 | **271** |
| `silver.mtr_git_person_weekly` | 305 | **99** |

Downstream gold views (`insight.ic_kpis.{loc, prs_merged, pr_cycle_time_h}`, `insight.ic_chart_loc.spec_lines`, `insight.ic_chart_delivery.prs_merged`) join `mtr_git_person_*.person_key` to user emails. With most rows holding empty keys, all those columns surfaced as 0 in the dashboard — the recently-merged #1116 wired them up correctly, but the underlying data was already broken.

## Root cause

The model uses

```sql
FROM prs
FULL OUTER JOIN commits USING (tenant_id, person_key)
FULL OUTER JOIN clean   USING (tenant_id, person_key)

SELECT coalesce(prs.person_key, commits.person_key, clean.person_key) AS person_key, ...
```

to recover the joining key for outer rows. This depended on the per-side reference (`prs.person_key`) being **NULL** for unmatched rows, so COALESCE would fall through to the matched side.

Behavior change in ClickHouse 25.3:
- The per-CTE `person_key` columns are non-Nullable `String` (inherited from `fct_git_*`).
- After `FULL OUTER JOIN ... USING`, CH 25.3 fills the unmatched per-side reference with the column's **default value** (empty string for non-Nullable String) instead of NULL.
- COALESCE only treats NULL as missing — empty string is a valid value, so it gets picked, and the real key (still living in the merged USING column or in the matched-side reference) is lost.

Reproduction on virtuozzo:

```sql
WITH prs AS (...), c2 AS (...)  -- both filtered WHERE person_key != ''
SELECT
  countIf(prs.person_key = '')   AS prs_pk_empty,    -- 137
  countIf(c2.person_key  = '')   AS c2_pk_empty,     --  94
  countIf(prs.person_key IS NULL) AS prs_pk_null,    --   0
  countIf(c2.person_key  IS NULL) AS c2_pk_null      --   0
FROM prs FULL OUTER JOIN c2 USING (tenant_id, person_key);
```

— per-side references are empty strings, never NULL.

## Fix

Build an `all_keys` anchor CTE that UNIONs `(tenant_id, person_key[, week])` across all sources, then LEFT JOIN each metric CTE onto the anchor:

```sql
WITH
  all_keys AS (
    SELECT tenant_id, person_key FROM fct_git_pr WHERE person_key != ''
    UNION DISTINCT
    SELECT tenant_id, person_key FROM fct_git_commit
      WHERE is_merge_commit = 0 AND person_key != ''
    UNION DISTINCT
    SELECT tenant_id, person_key FROM fct_git_file_change
      WHERE is_merge_commit = 0 AND file_category = 'code' AND person_key != ''
  ),
  prs AS (...), commits AS (...), clean AS (...)
SELECT
  ak.tenant_id, ak.person_key,
  coalesce(prs.prs_created, 0) AS prs_created, ...
FROM all_keys ak
LEFT JOIN prs     USING (tenant_id, person_key)
LEFT JOIN commits USING (tenant_id, person_key)
LEFT JOIN clean   USING (tenant_id, person_key);
```

`ak.person_key` is authoritative — never empty, never NULL. Same fix in both `_totals` and `_weekly` (the latter unions a 3-tuple including `week`).

## Verification (live virtuozzo)

|   | total rows | empty `person_key` | top user by commits |
|---|---:|---:|---|
| Before fix | 365 | 271 | (empty key, 360 commits) |
| After fix  | 231 |   0 | `vzbuild@virtuozzo.com` (360 commits / 7538 LOC) |

Per-row aggregate values for matched data are unchanged — only the previously-broken outer rows are fixed.

## Test plan

- [ ] `dbt run --select mtr_git_person_totals mtr_git_person_weekly --full-refresh` on a CH 25.3 instance with non-empty `fct_git_*`.
- [ ] Verify `SELECT countIf(person_key = '') FROM silver.mtr_git_person_*` returns 0.
- [ ] Spot-check a few rows: top users by commits should match independent counts from `silver.fct_git_commit GROUP BY person_key`.
- [ ] Confirm dashboard surfaces real values in `ic_kpis.loc`, `ic_chart_loc.spec_lines`, `ic_chart_delivery.prs_merged`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved data aggregation logic for git metrics calculations. Restructured how person-level totals and weekly metrics are computed to enhance reliability and consistency of metric reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#240 -->