### PR TITLE
[PR #236] fix(ingestion): use JSONExtract for issue_type in gold-views migration

### DIFF
--- a/src/ingestion/scripts/migrations/20260422000000_gold-views.sql
+++ b/src/ingestion/scripts/migrations/20260422000000_gold-views.sql
@@ -85,7 +85,7 @@ CREATE VIEW insight.jira_person_daily
 AS SELECT
     lower(JSONExtractString(custom_fields_json, 'assignee', 'emailAddress')) AS person_id,
     toDate(parseDateTimeBestEffort(updated)) AS metric_date,
-    issue_type,
+    JSONExtractString(custom_fields_json, 'issuetype', 'name') AS issue_type,
     JSONExtractString(custom_fields_json, 'status', 'name') AS status_name,
     JSONExtractString(custom_fields_json, 'resolution', 'name') AS resolution,
     due_date,
@@ -121,7 +121,7 @@ SELECT
     lower(JSONExtractString(custom_fields_json, 'assignee', 'emailAddress')) AS person_id,
     toDate(parseDateTimeBestEffort(updated)) AS metric_date,
     count() AS tasks_closed,
-    countIf(issue_type = 'Bug') AS bugs_fixed,
+    countIf(JSONExtractString(custom_fields_json, 'issuetype', 'name') = 'Bug') AS bugs_fixed,
     countIf(due_date IS NOT NULL AND due_date != ''
             AND toDate(parseDateTimeBestEffort(updated)) <= toDate(due_date)) AS on_time_count,
     countIf(due_date IS NOT NULL AND due_date != '') AS has_due_date_count,


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#236](https://github.com/cyberfabric/cyber-insight/pull/236) | **Author:** mitasovr | **Opened:** 2026-04-27T11:07:24Z | **Status:** merged on 2026-04-27T11:26:32Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

- `init.sh` fails on a fresh cluster with `Unknown identifier: issue_type` because the squashed gold-views migration ([#1135](https://github.com/constructorfabric/insight/issues/216)) still expects a top-level `issue_type` column on `bronze_jira.jira_issue`.
- That column was removed in [#1145](https://github.com/constructorfabric/insight/issues/205) (jira silver pipeline rewrite). The connector now writes only `issuetype_id` (numeric ID) and serialises the full `issuetype` object into `custom_fields_json`.
- Both broken call sites in `src/ingestion/scripts/migrations/20260422000000_gold-views.sql` now extract the name via `JSONExtractString(custom_fields_json, 'issuetype', 'name')`, matching the style already used in the same file for `status.name` / `resolution.name`.

### Changed call sites

| Object | Line | Before | After |
|---|---|---|---|
| `insight.jira_person_daily` view | 88 | `issue_type,` | `JSONExtractString(custom_fields_json, 'issuetype', 'name') AS issue_type,` |
| `insight.jira_closed_tasks` INSERT | 124 | `countIf(issue_type = 'Bug')` | `countIf(JSONExtractString(custom_fields_json, 'issuetype', 'name') = 'Bug')` |

Downstream views (`insight.team_member`, `insight.ic_kpis`, `insight.exec_summary`, the bullet views) read `tasks_closed` / `bugs_fixed` from `insight.jira_closed_tasks` and are unaffected by the change in extraction expression — only the populating INSERT needed updating.

### Why JSONExtract (not a JOIN to `bronze_jira.jira_issuetypes`)

- One-character change keeps the migration idempotent for existing dumps.
- `custom_fields_json` is already the canonical source for `status.name` / `resolution.name` in the same view — keeps the file consistent.
- A JOIN-based alternative would require `issuetype_id` to be present in older bronze data; pre-#1145 dumps don't have it.

## Test plan

- [ ] On a clean ClickHouse, `bash src/ingestion/scripts/init.sh` runs to completion without `Unknown identifier: issue_type`.
- [ ] `SELECT count(), countIf(issue_type = 'Bug') FROM insight.jira_person_daily` returns sensible numbers.
- [ ] `SELECT sum(tasks_closed), sum(bugs_fixed) FROM insight.jira_closed_tasks` matches expected order of magnitude vs raw `bronze_jira.jira_issue`.
- [ ] Frontend KPIs `tasks_closed` / `bugs_fixed` render non-zero on the IC dashboard for active assignees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Bug tracking calculations have been updated to improve accuracy and consistency across reporting systems.
  * Daily metrics and closed task analytics now use enhanced data sourcing for more precise bug categorization and counting.
  * Internal data aggregation logic has been refined to ensure reliable metrics throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#236 -->