### PR TITLE
[PR #235] fix(dbt): align silver union types — meeting_activity Int64, bootstrap_inputs source_id String

### DIFF
--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_meeting_activity.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_meeting_activity.sql
@@ -18,18 +18,22 @@ SELECT
        lower(userPrincipalName),
        '') AS person_key,
     toDate(reportRefreshDate) AS date,
-    callCount AS calls_count,
-    meetingsOrganizedCount AS meetings_organized,
-    meetingsAttendedCount AS meetings_attended,
-    adHocMeetingsOrganizedCount AS adhoc_meetings_organized,
-    adHocMeetingsAttendedCount AS adhoc_meetings_attended,
-    COALESCE(scheduledOneTimeMeetingsOrganizedCount, 0)
-        + COALESCE(scheduledRecurringMeetingsOrganizedCount, 0) AS scheduled_meetings_organized,
-    COALESCE(scheduledOneTimeMeetingsAttendedCount, 0)
-        + COALESCE(scheduledRecurringMeetingsAttendedCount, 0) AS scheduled_meetings_attended,
-    {{ iso8601_duration_seconds("ifNull(audioDuration, 'PT0S')") }} AS audio_duration_seconds,
-    {{ iso8601_duration_seconds("ifNull(videoDuration, 'PT0S')") }} AS video_duration_seconds,
-    {{ iso8601_duration_seconds("ifNull(screenShareDuration, 'PT0S')") }} AS screen_share_duration_seconds,
+    -- Cast counts and durations to Int64 to match zoom__collab_meeting_activity
+    -- when both feeders UNION ALL into silver.class_collab_meeting_activity.
+    -- Bronze stores them as Decimal(38, 9) / Float64; CH 25.3 refuses
+    -- Int64 ∪ Decimal/Float with NO_COMMON_TYPE.
+    toInt64(coalesce(callCount, 0)) AS calls_count,
+    toInt64(coalesce(meetingsOrganizedCount, 0)) AS meetings_organized,
+    toInt64(coalesce(meetingsAttendedCount, 0)) AS meetings_attended,
+    toInt64(coalesce(adHocMeetingsOrganizedCount, 0)) AS adhoc_meetings_organized,
+    toInt64(coalesce(adHocMeetingsAttendedCount, 0)) AS adhoc_meetings_attended,
+    toInt64(COALESCE(scheduledOneTimeMeetingsOrganizedCount, 0)
+        + COALESCE(scheduledRecurringMeetingsOrganizedCount, 0)) AS scheduled_meetings_organized,
+    toInt64(COALESCE(scheduledOneTimeMeetingsAttendedCount, 0)
+        + COALESCE(scheduledRecurringMeetingsAttendedCount, 0)) AS scheduled_meetings_attended,
+    toInt64({{ iso8601_duration_seconds("ifNull(audioDuration, 'PT0S')") }}) AS audio_duration_seconds,
+    toInt64({{ iso8601_duration_seconds("ifNull(videoDuration, 'PT0S')") }}) AS video_duration_seconds,
+    toInt64({{ iso8601_duration_seconds("ifNull(screenShareDuration, 'PT0S')") }}) AS screen_share_duration_seconds,
     reportPeriod AS report_period,
     now() AS collected_at,
     'insight_m365' AS data_source,

--- a/src/ingestion/dbt/identity/seed_bootstrap_inputs_from_claude_admin.sql
+++ b/src/ingestion/dbt/identity/seed_bootstrap_inputs_from_claude_admin.sql
@@ -37,7 +37,7 @@ observations AS (
     -- email
     SELECT
         UUIDNumToString(sipHash128(coalesce(tenant_id, '')))        AS insight_tenant_id,
-        toUUID('00000000-0000-0000-0000-000000000000')              AS insight_source_id,
+        '00000000-0000-0000-0000-000000000000'::Nullable(String)              AS insight_source_id,
         'claude_admin'                                              AS insight_source_type,
         source_id                                                   AS source_account_id,
         'email'                                                     AS alias_type,
@@ -52,7 +52,7 @@ observations AS (
     -- platform_id (Claude Admin user ID)
     SELECT
         UUIDNumToString(sipHash128(coalesce(tenant_id, ''))),
-        toUUID('00000000-0000-0000-0000-000000000000'),
+        '00000000-0000-0000-0000-000000000000'::Nullable(String),
         'claude_admin',
         source_id,
         'platform_id',
@@ -68,7 +68,7 @@ observations AS (
     -- display_name
     SELECT
         UUIDNumToString(sipHash128(coalesce(tenant_id, ''))),
-        toUUID('00000000-0000-0000-0000-000000000000'),
+        '00000000-0000-0000-0000-000000000000'::Nullable(String),
         'claude_admin',
         source_id,
         'display_name',

--- a/src/ingestion/dbt/identity/seed_bootstrap_inputs_from_cursor.sql
+++ b/src/ingestion/dbt/identity/seed_bootstrap_inputs_from_cursor.sql
@@ -36,7 +36,7 @@ observations AS (
     -- email
     SELECT
         UUIDNumToString(sipHash128(coalesce(tenant_id, '')))        AS insight_tenant_id,
-        toUUID('00000000-0000-0000-0000-000000000000')              AS insight_source_id,
+        '00000000-0000-0000-0000-000000000000'::Nullable(String)              AS insight_source_id,
         'cursor'                                                    AS insight_source_type,
         source_account_id,
         'email'                                                     AS alias_type,
@@ -52,7 +52,7 @@ observations AS (
     -- platform_id (cursor user ID)
     SELECT
         UUIDNumToString(sipHash128(coalesce(tenant_id, ''))),
-        toUUID('00000000-0000-0000-0000-000000000000'),
+        '00000000-0000-0000-0000-000000000000'::Nullable(String),
         'cursor',
         source_account_id,
         'platform_id',
@@ -68,7 +68,7 @@ observations AS (
     -- display_name
     SELECT
         UUIDNumToString(sipHash128(coalesce(tenant_id, ''))),
-        toUUID('00000000-0000-0000-0000-000000000000'),
+        '00000000-0000-0000-0000-000000000000'::Nullable(String),
         'cursor',
         source_account_id,
         'display_name',


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#235](https://github.com/cyberfabric/cyber-insight/pull/235) | **Author:** mitasovr | **Opened:** 2026-04-27T10:12:45Z | **Status:** merged on 2026-04-27T10:14:15Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

Two CH 25.3 `NO_COMMON_TYPE` failures in silver UNION ALL views — they're what's keeping m365 / zoom / bamboohr crons red on virtuozzo today (the latter via `class_focus_metrics` cascading off `silver.class_collab_meeting_activity`).

### 1. `silver.class_collab_meeting_activity` — Int64 vs Float64/Decimal

`m365__collab_meeting_activity` emitted bronze `Decimal(38, 9)` counts and `iso8601_duration_seconds()` `Float64` durations; `zoom__collab_meeting_activity` already used `toInt64()`. CH 25.3 refuses `Int64 ∪ Decimal/Float64` with `Code: 386. NO_COMMON_TYPE`.

Wrap every count and duration on the m365 side with `toInt64()` so both branches yield `Int64`. Counts are integer-valued in source data; no loss. Durations were already integer seconds (cast through `Float64` only for arithmetic).

### 2. `silver.bootstrap_inputs` — UUID vs Nullable(String)

`seed_bootstrap_inputs_from_{cursor,claude_admin}` declared `toUUID('00000000-...')` for `insight_source_id`, while `bamboohr__bootstrap_inputs` and `zoom__bootstrap_inputs` emit `Nullable(String)`. UNION ALL refuses `UUID ∪ String`.

Replace `toUUID(...)` with the literal string cast to `Nullable(String)` so all four feeders share the column type.

## Test plan

- [x] `dbt parse --target=k8s` succeeds
- [x] Inspected current bronze schemas (Decimal/Float on m365, Int64 on zoom; UUID vs Nullable(String) on insight_source_id)
- [ ] Run nightly cron on virtuozzo after merge; expect bamboohr / m365 / zoom transforms to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#235 -->