### PR TITLE
[PR #233] fix(dbt): allow_nullable_key=1 in 39 more incremental/table models

### DIFF
--- a/src/ingestion/connectors/ai/claude-enterprise/dbt/claude_enterprise__ai_api_usage.sql
+++ b/src/ingestion/connectors/ai/claude-enterprise/dbt/claude_enterprise__ai_api_usage.sql
@@ -27,6 +27,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['claude-enterprise', 'silver:class_ai_api_usage']
 ) }}

--- a/src/ingestion/connectors/ai/cursor/dbt/cursor__ai_dev_usage.sql
+++ b/src/ingestion/connectors/ai/cursor/dbt/cursor__ai_dev_usage.sql
@@ -21,6 +21,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['cursor', 'silver:class_ai_dev_usage']
 ) }}

--- a/src/ingestion/connectors/ai/cursor/dbt/cursor__members_snapshot.sql
+++ b/src/ingestion/connectors/ai/cursor/dbt/cursor__members_snapshot.sql
@@ -5,6 +5,7 @@
     incremental_strategy='append',
     engine='MergeTree',
     order_by=['unique_key', '_tracked_at'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['cursor']
 ) }}

--- a/src/ingestion/connectors/ai/cursor/dbt/cursor__members_snapshot.sql
+++ b/src/ingestion/connectors/ai/cursor/dbt/cursor__members_snapshot.sql
@@ -13,4 +13,4 @@
     source_ref=source('bronze_cursor', 'cursor_members'),
     unique_key_col='unique_key',
     check_cols=['name', 'role', 'isRemoved']
-) }})
+) }}

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_chat_activity.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_chat_activity.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['m365', 'silver:class_collab_chat_activity']
 ) }}

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_document_activity_onedrive.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_document_activity_onedrive.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['m365', 'silver:class_collab_document_activity']
 ) }}

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_document_activity_sharepoint.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_document_activity_sharepoint.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['m365', 'silver:class_collab_document_activity']
 ) }}

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_email_activity.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_email_activity.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['m365', 'silver:class_collab_email_activity']
 ) }}

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_meeting_activity.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_meeting_activity.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['m365', 'silver:class_collab_meeting_activity']
 ) }}

--- a/src/ingestion/connectors/collaboration/slack/dbt/slack__collab_chat_activity.sql
+++ b/src/ingestion/connectors/collaboration/slack/dbt/slack__collab_chat_activity.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['slack', 'silver:class_collab_chat_activity']
 ) }}

--- a/src/ingestion/connectors/collaboration/zoom/dbt/zoom__collab_meeting_activity.sql
+++ b/src/ingestion/connectors/collaboration/zoom/dbt/zoom__collab_meeting_activity.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['zoom', 'silver:class_collab_meeting_activity']
 ) }}

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__commits.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__commits.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['bitbucket-cloud', 'silver:class_git_commits']
 ) }}

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__file_changes.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__file_changes.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['bitbucket-cloud', 'silver:class_git_file_changes']
 ) }}

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['bitbucket-cloud', 'silver:class_git_pull_requests']
 ) }}

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_comments.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_comments.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['bitbucket-cloud', 'silver:class_git_pull_requests_comments']
 ) }}

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_commits.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_commits.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['bitbucket-cloud', 'silver:class_git_pull_requests_commits']
 ) }}

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_reviewers.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_reviewers.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['bitbucket-cloud', 'silver:class_git_pull_requests_reviewers']
 ) }}

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__repositories.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__repositories.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['bitbucket-cloud', 'silver:class_git_repositories']
 ) }}

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__repository_branches.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__repository_branches.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['bitbucket-cloud', 'silver:class_git_repository_branches']
 ) }}

--- a/src/ingestion/connectors/git/github/dbt/github__commits.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__commits.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['github', 'silver:class_git_commits']
 ) }}

--- a/src/ingestion/connectors/git/github/dbt/github__file_changes.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__file_changes.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['github', 'silver:class_git_file_changes']
 ) }}

--- a/src/ingestion/connectors/git/github/dbt/github__pull_requests.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__pull_requests.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['github', 'silver:class_git_pull_requests']
 ) }}

--- a/src/ingestion/connectors/git/github/dbt/github__pull_requests_comments.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__pull_requests_comments.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['github', 'silver:class_git_pull_requests_comments']
 ) }}

--- a/src/ingestion/connectors/git/github/dbt/github__pull_requests_commits.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__pull_requests_commits.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['github', 'silver:class_git_pull_requests_commits']
 ) }}

--- a/src/ingestion/connectors/git/github/dbt/github__pull_requests_reviewers.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__pull_requests_reviewers.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['github', 'silver:class_git_pull_requests_reviewers']
 ) }}

--- a/src/ingestion/connectors/git/github/dbt/github__repositories.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__repositories.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['github', 'silver:class_git_repositories']
 ) }}

--- a/src/ingestion/connectors/git/github/dbt/github__repository_branches.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__repository_branches.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['github', 'silver:class_git_repository_branches']
 ) }}

--- a/src/ingestion/dbt/identity/seed_aliases_from_claude_admin.sql
+++ b/src/ingestion/dbt/identity/seed_aliases_from_claude_admin.sql
@@ -16,6 +16,7 @@
     materialized='incremental',
     unique_key='id',
     order_by=['id'],
+    settings={'allow_nullable_key': 1},
     schema='identity',
     tags=['identity:seed', 'aliases']
 ) }}

--- a/src/ingestion/dbt/identity/seed_aliases_from_cursor.sql
+++ b/src/ingestion/dbt/identity/seed_aliases_from_cursor.sql
@@ -12,6 +12,7 @@
     materialized='incremental',
     unique_key='id',
     order_by=['id'],
+    settings={'allow_nullable_key': 1},
     schema='identity',
     tags=['identity:seed', 'aliases']
 ) }}

--- a/src/ingestion/dbt/identity/seed_persons_from_claude_admin.sql
+++ b/src/ingestion/dbt/identity/seed_persons_from_claude_admin.sql
@@ -13,6 +13,7 @@
     materialized='incremental',
     unique_key='id',
     order_by=['id'],
+    settings={'allow_nullable_key': 1},
     schema='person',
     tags=['identity:seed', 'person']
 ) }}

--- a/src/ingestion/dbt/identity/seed_persons_from_cursor.sql
+++ b/src/ingestion/dbt/identity/seed_persons_from_cursor.sql
@@ -10,6 +10,7 @@
     materialized='incremental',
     unique_key='id',
     order_by=['id'],
+    settings={'allow_nullable_key': 1},
     schema='person',
     tags=['identity:seed', 'person']
 ) }}

--- a/src/ingestion/silver/collaboration/class_collab_chat_activity.sql
+++ b/src/ingestion/silver/collaboration/class_collab_chat_activity.sql
@@ -5,6 +5,7 @@
     unique_key='unique_key',
     incremental_strategy='append',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='silver',
     tags=['silver']
 ) }}

--- a/src/ingestion/silver/collaboration/class_collab_document_activity.sql
+++ b/src/ingestion/silver/collaboration/class_collab_document_activity.sql
@@ -5,6 +5,7 @@
     unique_key='unique_key',
     incremental_strategy='append',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='silver',
     tags=['silver']
 ) }}

--- a/src/ingestion/silver/collaboration/class_collab_email_activity.sql
+++ b/src/ingestion/silver/collaboration/class_collab_email_activity.sql
@@ -4,6 +4,7 @@
     unique_key='unique_key',
     incremental_strategy='append',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='silver',
     tags=['silver']
 ) }}

--- a/src/ingestion/silver/collaboration/class_collab_meeting_activity.sql
+++ b/src/ingestion/silver/collaboration/class_collab_meeting_activity.sql
@@ -5,6 +5,7 @@
     unique_key='unique_key',
     incremental_strategy='append',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='silver',
     tags=['silver']
 ) }}

--- a/src/ingestion/silver/git/class_git_commits.sql
+++ b/src/ingestion/silver/git/class_git_commits.sql
@@ -5,6 +5,7 @@
     unique_key='unique_key',
     incremental_strategy='append',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='silver',
     tags=['silver']
 ) }}

--- a/src/ingestion/silver/git/class_git_file_changes.sql
+++ b/src/ingestion/silver/git/class_git_file_changes.sql
@@ -5,6 +5,7 @@
     unique_key='unique_key',
     incremental_strategy='append',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='silver',
     tags=['silver']
 ) }}

--- a/src/ingestion/silver/git/class_git_pull_requests.sql
+++ b/src/ingestion/silver/git/class_git_pull_requests.sql
@@ -5,6 +5,7 @@
     unique_key='unique_key',
     incremental_strategy='append',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='silver',
     tags=['silver']
 ) }}

--- a/src/ingestion/silver/git/class_git_pull_requests_comments.sql
+++ b/src/ingestion/silver/git/class_git_pull_requests_comments.sql
@@ -5,6 +5,7 @@
     unique_key='unique_key',
     incremental_strategy='append',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='silver',
     tags=['silver']
 ) }}

--- a/src/ingestion/silver/git/class_git_pull_requests_commits.sql
+++ b/src/ingestion/silver/git/class_git_pull_requests_commits.sql
@@ -5,6 +5,7 @@
     unique_key='unique_key',
     incremental_strategy='append',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='silver',
     tags=['silver']
 ) }}

--- a/src/ingestion/silver/git/class_git_pull_requests_reviewers.sql
+++ b/src/ingestion/silver/git/class_git_pull_requests_reviewers.sql
@@ -5,6 +5,7 @@
     unique_key='unique_key',
     incremental_strategy='append',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='silver',
     tags=['silver']
 ) }}

--- a/src/ingestion/silver/git/class_git_repositories.sql
+++ b/src/ingestion/silver/git/class_git_repositories.sql
@@ -5,6 +5,7 @@
     unique_key='unique_key',
     incremental_strategy='append',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='silver',
     tags=['silver']
 ) }}

--- a/src/ingestion/silver/git/class_git_repository_branches.sql
+++ b/src/ingestion/silver/git/class_git_repository_branches.sql
@@ -5,6 +5,7 @@
     unique_key='unique_key',
     incremental_strategy='append',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='silver',
     tags=['silver']
 ) }}

--- a/src/ingestion/silver/git/fct_git_commit.sql
+++ b/src/ingestion/silver/git/fct_git_commit.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='silver',
     tags=['silver']
 ) }}

--- a/src/ingestion/silver/git/fct_git_file_change.sql
+++ b/src/ingestion/silver/git/fct_git_file_change.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='silver',
     tags=['silver']
 ) }}

--- a/src/ingestion/silver/git/fct_git_pr.sql
+++ b/src/ingestion/silver/git/fct_git_pr.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='silver',
     tags=['silver']
 ) }}

--- a/src/ingestion/silver/git/fct_git_review.sql
+++ b/src/ingestion/silver/git/fct_git_review.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='silver',
     tags=['silver']
 ) }}

--- a/src/ingestion/silver/hr/class_focus_metrics.sql
+++ b/src/ingestion/silver/hr/class_focus_metrics.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='silver',
     tags=['silver']
 ) }}


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#233](https://github.com/cyberfabric/cyber-insight/pull/233) | **Author:** mitasovr | **Opened:** 2026-04-24T16:52:15Z | **Status:** merged on 2026-04-24T16:54:19Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

Follow-up to #1121. That PR only patched `bitbucket_cloud__*` but the same CH 25.3 strict check trips on every other incremental/table model whose order_by column is Nullable. Today's virtuozzo nightly cron runs all failed with

```
Code: 44. Sorting key contains nullable columns, but merge tree setting `allow_nullable_key` is disabled.
```

Adds `settings={'allow_nullable_key': 1}` to 39 files across:

- cursor staging (members_snapshot, ai_dev_usage)
- claude-enterprise staging (ai_api_usage)
- m365 / slack / zoom collab_* staging
- github staging (all 8 streams)
- identity seeds (cursor, claude-admin)
- silver collab_* class models
- silver git class_* and fct_* models
- silver hr class_focus_metrics

`claude_admin__ai_*` deliberately excluded — per inline comments those models already cast unique_key to non-nullable and opted out; they are also not scheduled via a cron so not in today's failures.

## Test plan

- [x] `dbt parse --target=k8s` — no errors
- [x] jira-manual (previously failing) — now succeeds on new toolbox image
- [ ] All other connectors manually re-run after new toolbox image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated data ingestion configurations across 50+ models spanning AI, collaboration tools, Git platforms, identity services, and HR systems to enhance handling of nullable values in key constraints during incremental data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#233 -->