### PR TITLE
[PR #232] fix(dbt): cursor typo + bitbucket-cloud nullable-key settings

### DIFF
--- a/src/ingestion/connectors/ai/cursor/dbt/cursor__members_snapshot.sql
+++ b/src/ingestion/connectors/ai/cursor/dbt/cursor__members_snapshot.sql
@@ -13,4 +13,4 @@
     source_ref=source('bronze_cursor', 'cursor_members'),
     unique_key_col='unique_key',
     check_cols=['name', 'role', 'isRemoved']
-) }})
+) }}

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__commits.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__commits.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['bitbucket-cloud', 'silver:class_git_commits']
 ) }}

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__file_changes.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__file_changes.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['bitbucket-cloud', 'silver:class_git_file_changes']
 ) }}

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['bitbucket-cloud', 'silver:class_git_pull_requests']
 ) }}

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_comments.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_comments.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['bitbucket-cloud', 'silver:class_git_pull_requests_comments']
 ) }}

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_commits.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_commits.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['bitbucket-cloud', 'silver:class_git_pull_requests_commits']
 ) }}

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_reviewers.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_reviewers.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['bitbucket-cloud', 'silver:class_git_pull_requests_reviewers']
 ) }}

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__repositories.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__repositories.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['bitbucket-cloud', 'silver:class_git_repositories']
 ) }}

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__repository_branches.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__repository_branches.sql
@@ -2,6 +2,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['bitbucket-cloud', 'silver:class_git_repository_branches']
 ) }}


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#232](https://github.com/cyberfabric/cyber-insight/pull/232) | **Author:** mitasovr | **Opened:** 2026-04-24T14:45:44Z | **Status:** merged on 2026-04-24T14:48:16Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

Two CH 25.3 compile-time errors missed by #1134 that block most nightly cron runs on deployed clusters:

- `cursor__members_snapshot.sql`: stray `)` after the `snapshot()` Jinja call (introduced in `cd1a1a9`). SQL compile fails with `Code: 62 Syntax error "Unmatched parentheses: )"`.
- All `bitbucket_cloud__*.sql` staging models use `order_by=['unique_key']`, but `unique_key` is inherited as `Nullable(String)` from Airbyte bronze (even though the connector manifest declares it `"type": "string"`). CH 25.3 rejects this with `ILLEGAL_COLUMN: Sorting key contains nullable columns`. Each model now sets `settings={'allow_nullable_key': 1}` explicitly — matching the pattern `jira__*.sql` already uses (profile-level default isn't applied to table DDL).

Verified `dbt parse --target=k8s` succeeds; 0 NULL unique_key rows in live bronze so the setting is safe in practice.

## Test plan

- [x] `dbt parse --target=k8s` — no errors
- [x] `grep ') }})'` — clean
- [x] All 8 bitbucket_cloud models have `allow_nullable_key` setting
- [ ] Build toolbox image and run on virtuozzo cron

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#232 -->