### PR TITLE
[PR #229] feat(silver): add class_wiki_pages and class_wiki_activity for Confluence

### DIFF
--- a/src/ingestion/connectors/wiki/confluence/dbt/confluence__wiki_activity.sql
+++ b/src/ingestion/connectors/wiki/confluence/dbt/confluence__wiki_activity.sql
@@ -70,12 +70,12 @@ agg AS (
 SELECT
     a.tenant_id,
     a.source_id,
-    concat(
+    CAST(concat(
         coalesce(a.tenant_id, ''), '-',
         coalesce(a.source_id, ''), '-',
         a.author_id, '-',
         toString(a.day)
-    )                                                                       AS unique_key,
+    ) AS String)                                                            AS unique_key,
     a.author_id,
     {% if jira_user %}u.email{% else %}CAST(NULL AS Nullable(String)){% endif %}                                                     AS author_email,
     a.day,

--- a/src/ingestion/connectors/wiki/confluence/dbt/confluence__wiki_activity.sql
+++ b/src/ingestion/connectors/wiki/confluence/dbt/confluence__wiki_activity.sql
@@ -1,0 +1,87 @@
+-- Bronze → Silver step 1: Confluence page versions → class_wiki_activity
+--
+-- Per-user per-day edit activity rolled up from wiki_page_versions. One row
+-- per (tenant, source, author, day) with counts of pages edited, total edits,
+-- pages created (version_number = 1), major edits, minor edits.
+--
+-- Identity resolution: same pattern as confluence__wiki_pages — LEFT JOIN
+-- with bronze_jira.jira_user on accountId. Skipped at compile-time if Jira
+-- is not provisioned; author_email falls back to NULL.
+{{ config(
+    materialized='view',
+    schema='staging',
+    tags=['confluence', 'silver:class_wiki_activity']
+) }}
+
+{%- set jira_user = adapter.get_relation(database=none, schema='bronze_jira', identifier='jira_user') -%}
+
+WITH versions AS (
+    SELECT
+        tenant_id,
+        source_id,
+        page_id,
+        author_id,
+        toUInt32(coalesce(version_number, 0))                               AS version_number,
+        coalesce(minor_edit, false)                                         AS minor_edit,
+        toDate(parseDateTime64BestEffortOrNull(coalesce(created_at, ''), 3)) AS day,
+        parseDateTime64BestEffortOrNull(coalesce(collected_at, ''), 3)      AS collected_at
+    FROM {{ source('bronze_confluence', 'wiki_page_versions') }}
+    WHERE author_id IS NOT NULL AND author_id != ''
+    QUALIFY row_number() OVER (PARTITION BY unique_key ORDER BY _airbyte_extracted_at DESC) = 1
+),
+
+agg AS (
+    SELECT
+        tenant_id,
+        source_id,
+        author_id,
+        day,
+        uniq(page_id)                                                       AS pages_edited,
+        count()                                                             AS total_edits,
+        countIf(version_number = 1)                                         AS pages_created,
+        countIf(not minor_edit)                                             AS major_edits,
+        countIf(minor_edit)                                                 AS minor_edits,
+        max(collected_at)                                                   AS collected_at_max
+    FROM versions
+    WHERE day IS NOT NULL
+    GROUP BY tenant_id, source_id, author_id, day
+)
+
+{%- if jira_user %}
+, users AS (
+    SELECT
+        tenant_id,
+        account_id,
+        lower(trim(email))                                                  AS email
+    FROM {{ source('bronze_jira', 'jira_user') }}
+    WHERE email IS NOT NULL AND trim(email) != ''
+    QUALIFY row_number() OVER (PARTITION BY tenant_id, account_id ORDER BY _airbyte_extracted_at DESC) = 1
+)
+{%- endif %}
+
+SELECT
+    a.tenant_id,
+    a.source_id,
+    concat(
+        coalesce(a.tenant_id, ''), '-',
+        coalesce(a.source_id, ''), '-',
+        a.author_id, '-',
+        toString(a.day)
+    )                                                                       AS unique_key,
+    a.author_id,
+    {% if jira_user %}u.email{% else %}CAST(NULL AS Nullable(String)){% endif %}                                                     AS author_email,
+    a.day,
+    toUInt32(a.pages_edited)                                                AS pages_edited,
+    toUInt32(a.total_edits)                                                 AS total_edits,
+    toUInt32(a.pages_created)                                               AS pages_created,
+    toUInt32(a.major_edits)                                                 AS major_edits,
+    toUInt32(a.minor_edits)                                                 AS minor_edits,
+    'confluence'                                                            AS source,
+    'insight_confluence'                                                    AS data_source,
+    CAST(a.collected_at_max AS Nullable(DateTime64(3)))                     AS collected_at
+FROM agg a
+{%- if jira_user %}
+LEFT JOIN users u
+    ON a.tenant_id = u.tenant_id
+   AND a.author_id = u.account_id
+{%- endif %}

--- a/src/ingestion/connectors/wiki/confluence/dbt/confluence__wiki_activity.sql
+++ b/src/ingestion/connectors/wiki/confluence/dbt/confluence__wiki_activity.sql
@@ -7,6 +7,11 @@
 -- Identity resolution: same pattern as confluence__wiki_pages — LEFT JOIN
 -- with bronze_jira.jira_user on accountId. Skipped at compile-time if Jira
 -- is not provisioned; author_email falls back to NULL.
+--
+-- Scaling note: materialized as view, which recomputes the versions → agg
+-- pipeline on every downstream query. Fine for MVP (tens of thousands of
+-- versions). Promote to materialized='incremental' keyed on (author_id, day)
+-- once wiki_page_versions grows past ~1M rows or Gold query latency rises.
 {{ config(
     materialized='view',
     schema='staging',
@@ -36,7 +41,10 @@ agg AS (
         source_id,
         author_id,
         day,
-        uniq(page_id)                                                       AS pages_edited,
+        -- uniqExact (not uniq): uniq is HyperLogLog and can miscount by a
+        -- full unit for small per-day page counts, directly skewing the
+        -- pages_edited metric. uniqExact is correct at this scale.
+        uniqExact(page_id)                                                  AS pages_edited,
         count()                                                             AS total_edits,
         countIf(version_number = 1)                                         AS pages_created,
         countIf(not minor_edit)                                             AS major_edits,

--- a/src/ingestion/connectors/wiki/confluence/dbt/confluence__wiki_pages.sql
+++ b/src/ingestion/connectors/wiki/confluence/dbt/confluence__wiki_pages.sql
@@ -1,0 +1,97 @@
+-- Bronze → Silver step 1: Confluence pages → class_wiki_pages
+--
+-- One row per (tenant, source, page). Dedupe by taking the latest extraction
+-- per unique_key via QUALIFY row_number() (ReplacingMergeTree parts may not
+-- yet be merged at read time).
+--
+-- Identity resolution: Confluence v2 API returns `authorId` (Atlassian
+-- accountId) but not email. Resolved in Silver Step 1 via LEFT JOIN with
+-- bronze_jira.jira_user on the same accountId namespace. If Jira is not
+-- provisioned for the tenant, the JOIN is skipped at compile-time and
+-- author_email / last_editor_email fall back to NULL — Silver Step 2
+-- (Identity Resolution) maps author_id → person_id directly.
+{{ config(
+    materialized='view',
+    schema='staging',
+    tags=['confluence', 'silver:class_wiki_pages']
+) }}
+
+{%- set jira_user = adapter.get_relation(database=none, schema='bronze_jira', identifier='jira_user') -%}
+
+WITH pages AS (
+    SELECT
+        tenant_id,
+        source_id,
+        unique_key,
+        page_id,
+        space_id,
+        title,
+        status,
+        author_id,
+        last_editor_id,
+        parent_page_id,
+        toUInt32(coalesce(version_number, 0))                              AS version_count,
+        parseDateTime64BestEffortOrNull(coalesce(created_at, ''), 3)        AS created_at,
+        parseDateTime64BestEffortOrNull(coalesce(updated_at, ''), 3)        AS updated_at,
+        parseDateTime64BestEffortOrNull(coalesce(collected_at, ''), 3)      AS collected_at
+    FROM {{ source('bronze_confluence', 'wiki_pages') }}
+    QUALIFY row_number() OVER (PARTITION BY unique_key ORDER BY _airbyte_extracted_at DESC) = 1
+),
+
+spaces AS (
+    SELECT
+        tenant_id,
+        source_id,
+        space_id,
+        name                                                                AS space_name,
+        url                                                                 AS space_url
+    FROM {{ source('bronze_confluence', 'wiki_spaces') }}
+    QUALIFY row_number() OVER (PARTITION BY unique_key ORDER BY _airbyte_extracted_at DESC) = 1
+)
+
+{%- if jira_user %}
+, users AS (
+    SELECT
+        tenant_id,
+        account_id,
+        lower(trim(email))                                                  AS email
+    FROM {{ source('bronze_jira', 'jira_user') }}
+    WHERE email IS NOT NULL AND trim(email) != ''
+    QUALIFY row_number() OVER (PARTITION BY tenant_id, account_id ORDER BY _airbyte_extracted_at DESC) = 1
+)
+{%- endif %}
+
+SELECT
+    p.tenant_id,
+    p.source_id,
+    p.unique_key,
+    p.page_id,
+    p.space_id,
+    s.space_name,
+    p.title,
+    p.status,
+    p.author_id,
+    {% if jira_user %}ua.email{% else %}CAST(NULL AS Nullable(String)){% endif %}                                                    AS author_email,
+    p.last_editor_id,
+    {% if jira_user %}ue.email{% else %}CAST(NULL AS Nullable(String)){% endif %}                                                    AS last_editor_email,
+    p.parent_page_id,
+    p.version_count,
+    p.created_at,
+    p.updated_at,
+    s.space_url                                                             AS space_url,
+    'confluence'                                                            AS source,
+    'insight_confluence'                                                    AS data_source,
+    p.collected_at
+FROM pages p
+LEFT JOIN spaces s
+    ON p.tenant_id = s.tenant_id
+   AND p.source_id = s.source_id
+   AND p.space_id  = s.space_id
+{%- if jira_user %}
+LEFT JOIN users ua
+    ON p.tenant_id = ua.tenant_id
+   AND p.author_id = ua.account_id
+LEFT JOIN users ue
+    ON p.tenant_id = ue.tenant_id
+   AND p.last_editor_id = ue.account_id
+{%- endif %}

--- a/src/ingestion/connectors/wiki/confluence/dbt/confluence__wiki_pages.sql
+++ b/src/ingestion/connectors/wiki/confluence/dbt/confluence__wiki_pages.sql
@@ -10,6 +10,10 @@
 -- provisioned for the tenant, the JOIN is skipped at compile-time and
 -- author_email / last_editor_email fall back to NULL — Silver Step 2
 -- (Identity Resolution) maps author_id → person_id directly.
+--
+-- Scaling note: materialized as view with LEFT JOINs to spaces and users.
+-- Fine for MVP (thousands of pages). Promote to materialized='table' or
+-- 'incremental' once wiki_pages crosses ~100K rows per tenant.
 {{ config(
     materialized='view',
     schema='staging',
@@ -27,10 +31,14 @@ WITH pages AS (
         space_id,
         title,
         status,
-        author_id,
-        last_editor_id,
-        parent_page_id,
-        toUInt32(coalesce(version_number, 0))                              AS version_count,
+        -- Confluence connector.yaml emits '' when a field is absent from
+        -- the API response (authorId, parentId, etc). Normalise to NULL so
+        -- downstream "IS NULL" filters (e.g. top-level pages with no parent)
+        -- behave correctly and empty identifiers never reach Silver Step 2.
+        nullIf(author_id, '')                                               AS author_id,
+        nullIf(last_editor_id, '')                                          AS last_editor_id,
+        nullIf(parent_page_id, '')                                          AS parent_page_id,
+        toUInt32(coalesce(version_number, 0))                               AS version_count,
         parseDateTime64BestEffortOrNull(coalesce(created_at, ''), 3)        AS created_at,
         parseDateTime64BestEffortOrNull(coalesce(updated_at, ''), 3)        AS updated_at,
         parseDateTime64BestEffortOrNull(coalesce(collected_at, ''), 3)      AS collected_at

--- a/src/ingestion/connectors/wiki/confluence/dbt/schema.yml
+++ b/src/ingestion/connectors/wiki/confluence/dbt/schema.yml
@@ -7,3 +7,98 @@ sources:
       - name: wiki_spaces
       - name: wiki_pages
       - name: wiki_page_versions
+
+  # bronze_jira.jira_user is declared by the Jira connector
+  # (connectors/task-tracking/jira/dbt/schema.yml). Staging models below
+  # reference it via source('bronze_jira', 'jira_user') for author email
+  # resolution, guarded with adapter.get_relation() so dbt still compiles
+  # if Jira is not provisioned for the tenant.
+
+models:
+  - name: confluence__wiki_pages
+    description: >
+      Bronze → Silver step 1: Confluence pages → class_wiki_pages. One row
+      per (tenant, source, page) with space/author/editor dimensions and
+      version count. author_email / last_editor_email resolved via LEFT JOIN
+      with bronze_jira.jira_user on accountId (NULL fallback when Jira is
+      not provisioned).
+    columns:
+      - name: tenant_id
+        tests:
+          - not_null
+      - name: source_id
+        tests:
+          - not_null
+      - name: unique_key
+        tests:
+          - not_null
+          - unique
+      - name: page_id
+        tests:
+          - not_null
+      - name: version_count
+        tests:
+          - not_null
+      - name: source
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['confluence']
+      - name: data_source
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['insight_confluence']
+
+  - name: confluence__wiki_activity
+    description: >
+      Bronze → Silver step 1: Confluence page versions → class_wiki_activity.
+      Per-user per-day edit activity with counts of pages_edited, total_edits,
+      pages_created, major_edits, minor_edits. author_email resolved via
+      bronze_jira.jira_user JOIN with NULL fallback.
+    columns:
+      - name: tenant_id
+        tests:
+          - not_null
+      - name: source_id
+        tests:
+          - not_null
+      - name: unique_key
+        tests:
+          - not_null
+          - unique
+      - name: author_id
+        tests:
+          - not_null
+      - name: day
+        tests:
+          - not_null
+      - name: pages_edited
+        tests:
+          - not_null
+      - name: total_edits
+        tests:
+          - not_null
+      - name: pages_created
+        tests:
+          - not_null
+      - name: major_edits
+        tests:
+          - not_null
+      - name: minor_edits
+        tests:
+          - not_null
+      - name: source
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['confluence']
+      - name: data_source
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['insight_confluence']

--- a/src/ingestion/connectors/wiki/confluence/descriptor.yaml
+++ b/src/ingestion/connectors/wiki/confluence/descriptor.yaml
@@ -4,10 +4,10 @@ version: "1.0"
 schedule: "0 4 * * *"
 workflow: sync
 
-# Phase 1 scope: Bronze-only. Silver routing (class_wiki_pages, class_wiki_activity)
-# is deferred to Phase 2 per DESIGN §1.1 and §3.7.
+# Silver routing (class_wiki_pages, class_wiki_activity) enabled via dbt tags
+# on the staging models (silver:class_wiki_pages, silver:class_wiki_activity).
 # silver_targets prohibited per Connector Spec §4.10 — Silver determined by dbt_select tags.
-dbt_select: ""
+dbt_select: "tag:confluence+"
 
 connection:
   namespace: bronze_confluence

--- a/src/ingestion/silver/wiki/class_wiki_activity.sql
+++ b/src/ingestion/silver/wiki/class_wiki_activity.sql
@@ -1,0 +1,9 @@
+{{ config(
+    materialized='view',
+    schema='silver',
+    tags=['silver']
+) }}
+
+-- depends_on: {{ ref('confluence__wiki_activity') }}
+
+{{ union_by_tag('silver:class_wiki_activity') }}

--- a/src/ingestion/silver/wiki/class_wiki_pages.sql
+++ b/src/ingestion/silver/wiki/class_wiki_pages.sql
@@ -1,0 +1,9 @@
+{{ config(
+    materialized='view',
+    schema='silver',
+    tags=['silver']
+) }}
+
+-- depends_on: {{ ref('confluence__wiki_pages') }}
+
+{{ union_by_tag('silver:class_wiki_pages') }}

--- a/src/ingestion/silver/wiki/schema.yml
+++ b/src/ingestion/silver/wiki/schema.yml
@@ -1,0 +1,153 @@
+version: 2
+
+models:
+  - name: class_wiki_pages
+    description: >
+      Unified per-page snapshot across wiki sources. One row per
+      (tenant, source, page) with latest metadata: space, title, status,
+      author, last editor, version count, timestamps. Feeds future wiki
+      metrics (pages_by_author, pages_per_space) — currently no dashboard
+      metrics consume this model.
+
+      Identity resolution: Confluence v2 API returns only `author_id`
+      (Atlassian accountId). `author_email` is resolved via LEFT JOIN with
+      bronze_jira.jira_user on the same accountId namespace. If Jira is not
+      provisioned, the JOIN is skipped at compile-time and author_email /
+      last_editor_email are NULL — Silver Step 2 maps author_id → person_id.
+    columns:
+      - name: tenant_id
+        description: "Tenant isolation field"
+        tests:
+          - not_null
+      - name: source_id
+        description: "Connector instance identifier"
+        tests:
+          - not_null
+      - name: unique_key
+        description: "Composite dedup key: tenant-source-page_id"
+        tests:
+          - not_null
+          - unique
+      - name: page_id
+        description: "Wiki page identifier (stable across the source)"
+        tests:
+          - not_null
+      - name: space_id
+        description: "Wiki space identifier"
+      - name: space_name
+        description: "Space display name (from wiki_spaces.name)"
+      - name: title
+        description: "Page title"
+      - name: status
+        description: "Page status (current, archived, trashed for Confluence)"
+      - name: author_id
+        description: "Original author identifier as reported by the source (Atlassian accountId for Confluence)"
+      - name: author_email
+        description: >
+          Work email of original author. Resolved via LEFT JOIN with
+          bronze_jira.jira_user on accountId. NULL when Jira is not
+          provisioned or the account is deactivated/external.
+      - name: last_editor_id
+        description: "Identifier of the author of the latest version"
+      - name: last_editor_email
+        description: "Resolved email of the last editor. NULL if Jira not provisioned."
+      - name: parent_page_id
+        description: "Parent page identifier (hierarchy). NULL for top-level pages."
+      - name: version_count
+        description: "Current revision count. For Confluence: wiki_pages.version.number."
+        tests:
+          - not_null
+      - name: created_at
+        description: "Page creation timestamp (UTC)"
+      - name: updated_at
+        description: "Latest version timestamp (UTC)"
+      - name: space_url
+        description: "Space web URL"
+      - name: source
+        description: "Staging-model discriminator"
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['confluence']
+      - name: data_source
+        description: "Framework source discriminator"
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['insight_confluence']
+      - name: collected_at
+        description: "When the record was collected"
+
+  - name: class_wiki_activity
+    description: >
+      Unified per-user per-day edit activity across wiki sources. One row per
+      (tenant, source, author, day) with counts of pages edited, total edits,
+      pages created, major edits, minor edits. Derived from page-version
+      history (Confluence: wiki_page_versions).
+
+      Identity: `author_id` is the source-side identifier (Atlassian accountId
+      for Confluence). `author_email` is resolved via LEFT JOIN with
+      bronze_jira.jira_user. Silver Step 2 (Identity Resolution) maps
+      author_id → person_id.
+    columns:
+      - name: tenant_id
+        description: "Tenant isolation field"
+        tests:
+          - not_null
+      - name: source_id
+        description: "Connector instance identifier"
+        tests:
+          - not_null
+      - name: unique_key
+        description: "Composite dedup key: tenant-source-author_id-day"
+        tests:
+          - not_null
+          - unique
+      - name: author_id
+        description: "Source-side author identifier"
+        tests:
+          - not_null
+      - name: author_email
+        description: "Resolved email via jira_user JOIN. NULL if Jira not provisioned."
+      - name: day
+        description: "Activity date (UTC)"
+        tests:
+          - not_null
+      - name: pages_edited
+        description: "Distinct pages edited on this day"
+        tests:
+          - not_null
+      - name: total_edits
+        description: "Total version rows authored on this day (multiple edits on one page count separately)"
+        tests:
+          - not_null
+      - name: pages_created
+        description: "Pages created on this day (version_number = 1)"
+        tests:
+          - not_null
+      - name: major_edits
+        description: "Edits where minor_edit = false"
+        tests:
+          - not_null
+      - name: minor_edits
+        description: "Edits where minor_edit = true"
+        tests:
+          - not_null
+      - name: source
+        description: "Staging-model discriminator"
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['confluence']
+      - name: data_source
+        description: "Framework source discriminator"
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['insight_confluence']
+      - name: collected_at
+        description: "When the record was collected"


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#229](https://github.com/cyberfabric/cyber-insight/pull/229) | **Author:** mozhaev-dev | **Opened:** 2026-04-24T07:18:19Z | **Status:** merged on 2026-04-24T12:40:31Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

Introduces the Silver layer for Confluence wiki data per issue #709.

- **`class_wiki_pages`** — one row per (tenant, source, page) with space, author/editor, version count, timestamps. View built via `union_by_tag('silver:class_wiki_pages')`.
- **`class_wiki_activity`** — per-(tenant, source, author, day) edit rollups (`pages_edited`, `total_edits`, `pages_created`, `major_edits`, `minor_edits`) derived from `wiki_page_versions`.

Staging models live under the connector (`connectors/wiki/confluence/dbt`) and feed Silver via `silver:class_wiki_*` tags consumed by `union_by_tag`. `descriptor.yaml` switched from `dbt_select=""` to `"tag:confluence+"` so the sync workflow materialises both staging and Silver.

## Identity resolution

Confluence v2 returns only Atlassian `accountId`. `author_email` / `last_editor_email` resolved via LEFT JOIN with `bronze_jira.jira_user` on the same accountId namespace. The JOIN is guarded with `adapter.get_relation()` so the project still compiles when Jira is not provisioned — emails fall back to NULL, and Silver Step 2 (Identity Resolution) maps `author_id` → `person_id`.

## Scope — intentional omissions

- `view_count` / `content_length` (mentioned in #709) — the current Confluence Bronze does not extract them. Deferred to Phase 2 (Bronze extension required).
- `space_key` — replaced with `space_id` + `space_name`. The connector doesn't extract the space key slug today; trivially addable as a follow-up.
- Outline source — no connector exists yet. Schema designed to accept it through the same `union_by_tag` pattern.

## Validation

Local dbt run against Virtuozzo Confluence Bronze (2 332 pages, 20 713 versions):

| Model | Rows | Unique authors | Dups on unique_key |
|---|---|---|---|
| `class_wiki_pages` | 2 332 | 272 | 0 |
| `class_wiki_activity` | 6 657 | 347 | 0 |

- JOIN path without `bronze_jira.jira_user`: all emails NULL (conditional branch works).
- JOIN path with seeded `jira_user` (2 accounts): 455 activity rows got `author_email` populated — cross-connector JOIN confirmed.
- After review fixes: `parent_page_id = ''` → 0 rows, `parent_page_id IS NULL` → 343 top-level pages correctly surfaced.

## Review fixes already applied

- `uniq(page_id)` → `uniqExact(page_id)` — HyperLogLog was miscounting per-day distinct pages by a full unit on small totals.
- `nullIf('', …)` for `author_id`, `last_editor_id`, `parent_page_id` — the connector emits `''` when the API field is absent; without normalisation `WHERE parent_page_id IS NULL` silently missed top-level pages.
- Scaling notes in both staging models flagging when to promote `materialized='view'` → `incremental` (pages > ~100K; versions > ~1M per tenant).

## Test plan

- [ ] dbt parse / compile passes
- [ ] `dbt run --select tag:confluence+` creates both staging and Silver
- [ ] dbt tests pass (not_null, unique, accepted_values)
- [ ] End-to-end Argo workflow materialises Silver after Confluence sync
- [ ] Cross-check `pages_created` aggregate vs `wiki_page_versions WHERE version_number = 1` count

Closes #709.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wiki activity tracking with per-user, per-day edit metrics including pages edited, total edits, pages created, and major/minor edit counts
  * Added wiki pages model with normalized page information including space details, author information, and revision tracking
  * Integrated author email resolution from Jira user data when available
  * Implemented comprehensive data quality validations for wiki models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#229 -->