### PR TITLE
[PR #219] refactor(silver): ReplacingMergeTree for collab + git union models

### DIFF
--- a/src/ingestion/silver/collaboration/class_collab_chat_activity.sql
+++ b/src/ingestion/silver/collaboration/class_collab_chat_activity.sql
@@ -1,12 +1,18 @@
+-- depends_on: {{ ref('m365__collab_chat_activity') }}
+-- depends_on: {{ ref('slack__collab_chat_activity') }}
 {{ config(
     materialized='incremental',
-    unique_key='unique_key',
+    incremental_strategy='append',
     schema='silver',
+    engine='ReplacingMergeTree(_version)',
+    order_by='(unique_key)',
+    settings={'allow_nullable_key': 1},
     tags=['silver']
 ) }}
 
--- explicit dependency so dbt knows to run staging models first
--- depends_on: {{ ref('m365__collab_chat_activity') }}
--- depends_on: {{ ref('slack__collab_chat_activity') }}
-
-{{ union_by_tag('silver:class_collab_chat_activity') }}
+SELECT * FROM (
+    {{ union_by_tag('silver:class_collab_chat_activity') }}
+)
+{% if is_incremental() %}
+WHERE _version > (SELECT max(_version) FROM {{ this }})
+{% endif %}

--- a/src/ingestion/silver/collaboration/class_collab_document_activity.sql
+++ b/src/ingestion/silver/collaboration/class_collab_document_activity.sql
@@ -1,12 +1,18 @@
+-- depends_on: {{ ref('m365__collab_document_activity_onedrive') }}
+-- depends_on: {{ ref('m365__collab_document_activity_sharepoint') }}
 {{ config(
     materialized='incremental',
-    unique_key='unique_key',
+    incremental_strategy='append',
     schema='silver',
+    engine='ReplacingMergeTree(_version)',
+    order_by='(unique_key)',
+    settings={'allow_nullable_key': 1},
     tags=['silver']
 ) }}
 
--- explicit dependency so dbt knows to run staging models first
--- depends_on: {{ ref('m365__collab_document_activity_onedrive') }}
--- depends_on: {{ ref('m365__collab_document_activity_sharepoint') }}
-
-{{ union_by_tag('silver:class_collab_document_activity') }}
+SELECT * FROM (
+    {{ union_by_tag('silver:class_collab_document_activity') }}
+)
+{% if is_incremental() %}
+WHERE _version > (SELECT max(_version) FROM {{ this }})
+{% endif %}

--- a/src/ingestion/silver/collaboration/class_collab_email_activity.sql
+++ b/src/ingestion/silver/collaboration/class_collab_email_activity.sql
@@ -1,11 +1,17 @@
+-- depends_on: {{ ref('m365__collab_email_activity') }}
 {{ config(
     materialized='incremental',
-    unique_key='unique_key',
+    incremental_strategy='append',
     schema='silver',
+    engine='ReplacingMergeTree(_version)',
+    order_by='(unique_key)',
+    settings={'allow_nullable_key': 1},
     tags=['silver']
 ) }}
 
--- explicit dependency so dbt knows to run staging models first
--- depends_on: {{ ref('m365__collab_email_activity') }}
-
-{{ union_by_tag('silver:class_collab_email_activity') }}
+SELECT * FROM (
+    {{ union_by_tag('silver:class_collab_email_activity') }}
+)
+{% if is_incremental() %}
+WHERE _version > (SELECT max(_version) FROM {{ this }})
+{% endif %}

--- a/src/ingestion/silver/collaboration/class_collab_meeting_activity.sql
+++ b/src/ingestion/silver/collaboration/class_collab_meeting_activity.sql
@@ -1,12 +1,18 @@
+-- depends_on: {{ ref('m365__collab_meeting_activity') }}
+-- depends_on: {{ ref('zoom__collab_meeting_activity') }}
 {{ config(
     materialized='incremental',
-    unique_key='unique_key',
+    incremental_strategy='append',
     schema='silver',
+    engine='ReplacingMergeTree(_version)',
+    order_by='(unique_key)',
+    settings={'allow_nullable_key': 1},
     tags=['silver']
 ) }}
 
--- explicit dependency so dbt knows to run staging models first
--- depends_on: {{ ref('m365__collab_meeting_activity') }}
--- depends_on: {{ ref('zoom__collab_meeting_activity') }}
-
-{{ union_by_tag('silver:class_collab_meeting_activity') }}
+SELECT * FROM (
+    {{ union_by_tag('silver:class_collab_meeting_activity') }}
+)
+{% if is_incremental() %}
+WHERE _version > (SELECT max(_version) FROM {{ this }})
+{% endif %}

--- a/src/ingestion/silver/git/class_git_commits.sql
+++ b/src/ingestion/silver/git/class_git_commits.sql
@@ -2,9 +2,17 @@
 -- depends_on: {{ ref('bitbucket_cloud__commits') }}
 {{ config(
     materialized='incremental',
-    unique_key='unique_key',
+    incremental_strategy='append',
     schema='silver',
+    engine='ReplacingMergeTree(_version)',
+    order_by='(unique_key)',
+    settings={'allow_nullable_key': 1},
     tags=['silver']
 ) }}
 
-{{ union_by_tag('silver:class_git_commits') }}
+SELECT * FROM (
+    {{ union_by_tag('silver:class_git_commits') }}
+)
+{% if is_incremental() %}
+WHERE _version > (SELECT max(_version) FROM {{ this }})
+{% endif %}

--- a/src/ingestion/silver/git/class_git_file_changes.sql
+++ b/src/ingestion/silver/git/class_git_file_changes.sql
@@ -2,9 +2,17 @@
 -- depends_on: {{ ref('bitbucket_cloud__file_changes') }}
 {{ config(
     materialized='incremental',
-    unique_key='unique_key',
+    incremental_strategy='append',
     schema='silver',
+    engine='ReplacingMergeTree(_version)',
+    order_by='(unique_key)',
+    settings={'allow_nullable_key': 1},
     tags=['silver']
 ) }}
 
-{{ union_by_tag('silver:class_git_file_changes') }}
+SELECT * FROM (
+    {{ union_by_tag('silver:class_git_file_changes') }}
+)
+{% if is_incremental() %}
+WHERE _version > (SELECT max(_version) FROM {{ this }})
+{% endif %}

--- a/src/ingestion/silver/git/class_git_pull_requests.sql
+++ b/src/ingestion/silver/git/class_git_pull_requests.sql
@@ -2,9 +2,17 @@
 -- depends_on: {{ ref('bitbucket_cloud__pull_requests') }}
 {{ config(
     materialized='incremental',
-    unique_key='unique_key',
+    incremental_strategy='append',
     schema='silver',
+    engine='ReplacingMergeTree(_version)',
+    order_by='(unique_key)',
+    settings={'allow_nullable_key': 1},
     tags=['silver']
 ) }}
 
-{{ union_by_tag('silver:class_git_pull_requests') }}
+SELECT * FROM (
+    {{ union_by_tag('silver:class_git_pull_requests') }}
+)
+{% if is_incremental() %}
+WHERE _version > (SELECT max(_version) FROM {{ this }})
+{% endif %}

--- a/src/ingestion/silver/git/class_git_pull_requests_comments.sql
+++ b/src/ingestion/silver/git/class_git_pull_requests_comments.sql
@@ -2,9 +2,17 @@
 -- depends_on: {{ ref('bitbucket_cloud__pull_requests_comments') }}
 {{ config(
     materialized='incremental',
-    unique_key='unique_key',
+    incremental_strategy='append',
     schema='silver',
+    engine='ReplacingMergeTree(_version)',
+    order_by='(unique_key)',
+    settings={'allow_nullable_key': 1},
     tags=['silver']
 ) }}
 
-{{ union_by_tag('silver:class_git_pull_requests_comments') }}
+SELECT * FROM (
+    {{ union_by_tag('silver:class_git_pull_requests_comments') }}
+)
+{% if is_incremental() %}
+WHERE _version > (SELECT max(_version) FROM {{ this }})
+{% endif %}

--- a/src/ingestion/silver/git/class_git_pull_requests_commits.sql
+++ b/src/ingestion/silver/git/class_git_pull_requests_commits.sql
@@ -2,9 +2,17 @@
 -- depends_on: {{ ref('bitbucket_cloud__pull_requests_commits') }}
 {{ config(
     materialized='incremental',
-    unique_key='unique_key',
+    incremental_strategy='append',
     schema='silver',
+    engine='ReplacingMergeTree(_version)',
+    order_by='(unique_key)',
+    settings={'allow_nullable_key': 1},
     tags=['silver']
 ) }}
 
-{{ union_by_tag('silver:class_git_pull_requests_commits') }}
+SELECT * FROM (
+    {{ union_by_tag('silver:class_git_pull_requests_commits') }}
+)
+{% if is_incremental() %}
+WHERE _version > (SELECT max(_version) FROM {{ this }})
+{% endif %}

--- a/src/ingestion/silver/git/class_git_pull_requests_reviewers.sql
+++ b/src/ingestion/silver/git/class_git_pull_requests_reviewers.sql
@@ -2,9 +2,17 @@
 -- depends_on: {{ ref('bitbucket_cloud__pull_requests_reviewers') }}
 {{ config(
     materialized='incremental',
-    unique_key='unique_key',
+    incremental_strategy='append',
     schema='silver',
+    engine='ReplacingMergeTree(_version)',
+    order_by='(unique_key)',
+    settings={'allow_nullable_key': 1},
     tags=['silver']
 ) }}
 
-{{ union_by_tag('silver:class_git_pull_requests_reviewers') }}
+SELECT * FROM (
+    {{ union_by_tag('silver:class_git_pull_requests_reviewers') }}
+)
+{% if is_incremental() %}
+WHERE _version > (SELECT max(_version) FROM {{ this }})
+{% endif %}

--- a/src/ingestion/silver/git/class_git_repositories.sql
+++ b/src/ingestion/silver/git/class_git_repositories.sql
@@ -2,9 +2,17 @@
 -- depends_on: {{ ref('bitbucket_cloud__repositories') }}
 {{ config(
     materialized='incremental',
-    unique_key='unique_key',
+    incremental_strategy='append',
     schema='silver',
+    engine='ReplacingMergeTree(_version)',
+    order_by='(unique_key)',
+    settings={'allow_nullable_key': 1},
     tags=['silver']
 ) }}
 
-{{ union_by_tag('silver:class_git_repositories') }}
+SELECT * FROM (
+    {{ union_by_tag('silver:class_git_repositories') }}
+)
+{% if is_incremental() %}
+WHERE _version > (SELECT max(_version) FROM {{ this }})
+{% endif %}

--- a/src/ingestion/silver/git/class_git_repository_branches.sql
+++ b/src/ingestion/silver/git/class_git_repository_branches.sql
@@ -2,9 +2,17 @@
 -- depends_on: {{ ref('bitbucket_cloud__repository_branches') }}
 {{ config(
     materialized='incremental',
-    unique_key='unique_key',
+    incremental_strategy='append',
     schema='silver',
+    engine='ReplacingMergeTree(_version)',
+    order_by='(unique_key)',
+    settings={'allow_nullable_key': 1},
     tags=['silver']
 ) }}
 
-{{ union_by_tag('silver:class_git_repository_branches') }}
+SELECT * FROM (
+    {{ union_by_tag('silver:class_git_repository_branches') }}
+)
+{% if is_incremental() %}
+WHERE _version > (SELECT max(_version) FROM {{ this }})
+{% endif %}


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#219](https://github.com/cyberfabric/cyber-insight/pull/219) | **Author:** mitasovr | **Opened:** 2026-04-22T10:23:23Z | **Status:** merged on 2026-04-22T13:59:07Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

Switch 12 union-by-tag silver models (collaboration + git) from the default `unique_key`-based incremental to `ReplacingMergeTree(_version)` + append strategy. Same pattern applied to all 12 files.

## Why

- `unique_key` with default MergeTree requires full-table scan on every incremental run to dedup. Large unions (git commits, PR events) got impractically slow as history grew.
- `ReplacingMergeTree(_version)` moves dedup to merge time — bronze-side append writes stay cheap, silver reads stay correct, and re-runs after partial failures are idempotent.
- The `WHERE _version > (SELECT max(_version) FROM {{ this }})` guard in incremental mode avoids re-scanning already-ingested staging batches.

## Pattern applied

```diff
 {{ config(
     materialized='incremental',
-    unique_key='unique_key',
+    incremental_strategy='append',
     schema='silver',
+    engine='ReplacingMergeTree(_version)',
+    order_by='(unique_key)',
+    settings={'allow_nullable_key': 1},
     tags=['silver']
 ) }}

-{{ union_by_tag('silver:...') }}
+SELECT * FROM (
+    {{ union_by_tag('silver:...') }}
+)
+{% if is_incremental() %}
+WHERE _version > (SELECT max(_version) FROM {{ this }})
+{% endif %}
```

## Scope

**Included (12 files):**
- `silver/collaboration/class_collab_{chat,document,email,meeting}_activity.sql`
- `silver/git/class_git_{commits,file_changes,pull_requests,pull_requests_comments,pull_requests_commits,pull_requests_reviewers,repositories,repository_branches}.sql`

**Not in this PR:**
- Task-tracking silver models — same pattern, but the models live on `feat/jira-ingestion` (PR #1145). Applied there in that PR.

## Test plan

- [ ] `dbt compile` passes on all 12 models
- [ ] First-run `dbt run --select tag:silver` creates tables as ReplacingMergeTree(_version)
- [ ] Incremental run reads only rows where `_version > max(_version)` — check EXPLAIN or CH query log
- [ ] Re-run after partial failure produces no duplicates (dedup at merge time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#219 -->