### PR TITLE
[PR #203] fix(ingestion): align comms events schema and include upstream dbt deps

### DIFF
--- a/src/ingestion/connectors/ai-dev/cursor/dbt/cursor__ai_dev_usage.sql
+++ b/src/ingestion/connectors/ai-dev/cursor/dbt/cursor__ai_dev_usage.sql
@@ -9,6 +9,8 @@
     tags=['cursor', 'silver:class_ai_dev_usage']
 ) }}
 
+{{ skip_if_no_source("bronze_cursor") }}
+
 WITH resync AS (
     -- Authoritative data for completed days (yesterday and earlier)
     SELECT

--- a/src/ingestion/connectors/ai-dev/cursor/dbt/cursor__members_history.sql
+++ b/src/ingestion/connectors/ai-dev/cursor/dbt/cursor__members_history.sql
@@ -7,6 +7,8 @@
     inserts_only=true
 ) }}
 
+{{ skip_if_no_source("bronze_cursor") }}
+
 {{ fields_history(
     snapshot_ref=ref('cursor__members_snapshot'),
     entity_id_col='id',

--- a/src/ingestion/connectors/ai-dev/cursor/dbt/cursor__members_snapshot.sql
+++ b/src/ingestion/connectors/ai-dev/cursor/dbt/cursor__members_snapshot.sql
@@ -7,6 +7,8 @@
     tags=['cursor']
 ) }}
 
+{{ skip_if_no_source("bronze_cursor") }}
+
 {{ snapshot(
     source_ref=source('bronze_cursor', 'cursor_members'),
     unique_key_col='unique_key',

--- a/src/ingestion/connectors/ai/claude-api/dbt/to_ai_api_usage.sql
+++ b/src/ingestion/connectors/ai/claude-api/dbt/to_ai_api_usage.sql
@@ -2,6 +2,8 @@
 -- Joins with keys and workspaces for dimension name enrichment.
 {{ config(materialized='incremental', unique_key='unique_id') }}
 
+{{ skip_if_no_source("bronze_claude_api") }}
+
 WITH usage AS (
     SELECT
         tenant_id,

--- a/src/ingestion/connectors/ai/claude-team/dbt/to_ai_dev_usage.sql
+++ b/src/ingestion/connectors/ai/claude-team/dbt/to_ai_dev_usage.sql
@@ -4,6 +4,8 @@
 -- This model handles Claude Code sessions — developer AI tool usage alongside Cursor/Windsurf.
 {{ config(materialized='incremental', unique_key='unique_id') }}
 
+{{ skip_if_no_source("bronze_claude_team") }}
+
 SELECT
     tenant_id,
     source_instance_id,

--- a/src/ingestion/connectors/ai/claude-team/dbt/to_ai_tool_usage.sql
+++ b/src/ingestion/connectors/ai/claude-team/dbt/to_ai_tool_usage.sql
@@ -27,4 +27,6 @@
 
 {{ config(enabled=false) }}
 
+{{ skip_if_no_source("bronze_claude_team") }}
+
 SELECT 1 AS placeholder

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_chat_activity.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_chat_activity.sql
@@ -5,6 +5,8 @@
     tags=['m365', 'silver:class_collab_chat_activity']
 ) }}
 
+{{ skip_if_no_source("bronze_m365") }}
+
 SELECT
     tenant_id,
     source_id AS insight_source_id,

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_document_activity_onedrive.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_document_activity_onedrive.sql
@@ -5,6 +5,8 @@
     tags=['m365', 'silver:class_collab_document_activity']
 ) }}
 
+{{ skip_if_no_source("bronze_m365") }}
+
 -- OneDrive half of document activity.
 -- Split from SharePoint (see m365__collab_document_activity_sharepoint) so each
 -- product has its own incremental watermark. Unioned at silver by tag.

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_document_activity_sharepoint.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_document_activity_sharepoint.sql
@@ -5,6 +5,8 @@
     tags=['m365', 'silver:class_collab_document_activity']
 ) }}
 
+{{ skip_if_no_source("bronze_m365") }}
+
 -- SharePoint half of document activity.
 -- Split from OneDrive (see m365__collab_document_activity_onedrive) so each
 -- product has its own incremental watermark. Unioned at silver by tag.

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_email_activity.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_email_activity.sql
@@ -5,6 +5,8 @@
     tags=['m365', 'silver:class_collab_email_activity']
 ) }}
 
+{{ skip_if_no_source("bronze_m365") }}
+
 SELECT
     tenant_id,
     source_id AS insight_source_id,

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_meeting_activity.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_meeting_activity.sql
@@ -5,6 +5,8 @@
     tags=['m365', 'silver:class_collab_meeting_activity']
 ) }}
 
+{{ skip_if_no_source("bronze_m365") }}
+
 SELECT
     tenant_id,
     source_id AS insight_source_id,

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__comms_events.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__comms_events.sql
@@ -5,6 +5,8 @@
     tags=['m365', 'silver:class_comms_events']
 ) }}
 
+{{ skip_if_no_source("bronze_m365") }}
+
 SELECT
     tenant_id,
     source_id,

--- a/src/ingestion/connectors/collaboration/slack/dbt/slack__collab_chat_activity.sql
+++ b/src/ingestion/connectors/collaboration/slack/dbt/slack__collab_chat_activity.sql
@@ -5,6 +5,8 @@
     tags=['slack', 'silver:class_collab_chat_activity']
 ) }}
 
+{{ skip_if_no_source("bronze_slack") }}
+
 -- Slack chat activity aggregated per user per day.
 -- Email can be NULL when Slack workspace policy hides it — we keep the row and
 -- fall back to display_name for person_key (matches the git-plugin convention:

--- a/src/ingestion/connectors/collaboration/slack/dbt/slack__comms_events.sql
+++ b/src/ingestion/connectors/collaboration/slack/dbt/slack__comms_events.sql
@@ -5,6 +5,8 @@
     tags=['slack', 'silver:class_comms_events']
 ) }}
 
+{{ skip_if_no_source("bronze_slack") }}
+
 SELECT
     m.tenant_id,
     m.source_id,

--- a/src/ingestion/connectors/collaboration/slack/dbt/slack__users_fields_history.sql
+++ b/src/ingestion/connectors/collaboration/slack/dbt/slack__users_fields_history.sql
@@ -4,6 +4,8 @@
     tags=['slack', 'silver']
 ) }}
 
+{{ skip_if_no_source("bronze_slack") }}
+
 {{ fields_history(
     snapshot_ref=ref('slack__users_snapshot'),
     entity_id_col='unique_key',

--- a/src/ingestion/connectors/collaboration/slack/dbt/slack__users_snapshot.sql
+++ b/src/ingestion/connectors/collaboration/slack/dbt/slack__users_snapshot.sql
@@ -5,6 +5,8 @@
     tags=['slack']
 ) }}
 
+{{ skip_if_no_source("bronze_slack") }}
+
 {{ snapshot(
     source_ref=source('bronze_slack', 'users'),
     unique_key_col='unique_key',

--- a/src/ingestion/connectors/collaboration/zoom/dbt/zoom__bootstrap_inputs.sql
+++ b/src/ingestion/connectors/collaboration/zoom/dbt/zoom__bootstrap_inputs.sql
@@ -5,6 +5,8 @@
     tags=['zoom', 'silver', 'silver:bootstrap_inputs']
 ) }}
 
+{{ skip_if_no_source("bronze_zoom") }}
+
 {{ bootstrap_inputs_from_history(
     fields_history_ref=ref('zoom__users_fields_history'),
     source_type='zoom',

--- a/src/ingestion/connectors/collaboration/zoom/dbt/zoom__collab_meeting_activity.sql
+++ b/src/ingestion/connectors/collaboration/zoom/dbt/zoom__collab_meeting_activity.sql
@@ -5,6 +5,8 @@
     tags=['zoom', 'silver:class_collab_meeting_activity']
 ) }}
 
+{{ skip_if_no_source("bronze_zoom") }}
+
 -- Zoom meeting activity aggregated per user per day.
 --
 -- Grain: (tenant, source, email, date). We intentionally filter out participants

--- a/src/ingestion/connectors/collaboration/zoom/dbt/zoom__comms_events.sql
+++ b/src/ingestion/connectors/collaboration/zoom/dbt/zoom__comms_events.sql
@@ -5,6 +5,8 @@
     tags=['zoom', 'silver:class_comms_events']
 ) }}
 
+{{ skip_if_no_source("bronze_zoom") }}
+
 SELECT
     p.tenant_id,
     p.source_id,

--- a/src/ingestion/connectors/collaboration/zoom/dbt/zoom__users_fields_history.sql
+++ b/src/ingestion/connectors/collaboration/zoom/dbt/zoom__users_fields_history.sql
@@ -4,6 +4,8 @@
     tags=['zoom', 'silver']
 ) }}
 
+{{ skip_if_no_source("bronze_zoom") }}
+
 {{ fields_history(
     snapshot_ref=ref('zoom__users_snapshot'),
     entity_id_col='id',

--- a/src/ingestion/connectors/collaboration/zoom/dbt/zoom__users_snapshot.sql
+++ b/src/ingestion/connectors/collaboration/zoom/dbt/zoom__users_snapshot.sql
@@ -5,6 +5,8 @@
     tags=['zoom']
 ) }}
 
+{{ skip_if_no_source("bronze_zoom") }}
+
 {{ snapshot(
     source_ref=source('bronze_zoom', 'users'),
     unique_key_col='unique_key',

--- a/src/ingestion/connectors/crm/salesforce/dbt/to_crm_accounts.sql
+++ b/src/ingestion/connectors/crm/salesforce/dbt/to_crm_accounts.sql
@@ -6,6 +6,8 @@
     tags=['silver:class_crm_accounts']
 ) }}
 
+{{ skip_if_no_source("bronze_salesforce") }}
+
 SELECT
     Id                                              AS account_id,
     Name                                            AS name,

--- a/src/ingestion/connectors/crm/salesforce/dbt/to_crm_activities.sql
+++ b/src/ingestion/connectors/crm/salesforce/dbt/to_crm_activities.sql
@@ -4,6 +4,8 @@
 -- Duration: CallDurationInSeconds (tasks), DurationInMinutes*60 (events).
 {{ config(materialized='incremental', unique_key='activity_id', schema='salesforce', tags=['silver:class_crm_activities']) }}
 
+{{ skip_if_no_source("bronze_salesforce") }}
+
 WITH tasks AS (
     SELECT
         Id                                          AS activity_id,

--- a/src/ingestion/connectors/crm/salesforce/dbt/to_crm_contacts.sql
+++ b/src/ingestion/connectors/crm/salesforce/dbt/to_crm_contacts.sql
@@ -6,6 +6,8 @@
     tags=['silver:class_crm_contacts']
 ) }}
 
+{{ skip_if_no_source("bronze_salesforce") }}
+
 SELECT
     Id                                              AS contact_id,
     Email                                           AS email,

--- a/src/ingestion/connectors/crm/salesforce/dbt/to_crm_deals.sql
+++ b/src/ingestion/connectors/crm/salesforce/dbt/to_crm_deals.sql
@@ -2,6 +2,8 @@
 -- Incremental via SystemModstamp. IsClosed/IsWon are native Salesforce fields.
 {{ config(materialized='incremental', unique_key='deal_id', schema='salesforce', tags=['silver:class_crm_deals']) }}
 
+{{ skip_if_no_source("bronze_salesforce") }}
+
 SELECT
     Id                                              AS deal_id,
     Name                                            AS name,

--- a/src/ingestion/connectors/crm/salesforce/dbt/to_crm_users.sql
+++ b/src/ingestion/connectors/crm/salesforce/dbt/to_crm_users.sql
@@ -6,6 +6,8 @@
     tags=['silver:class_crm_users']
 ) }}
 
+{{ skip_if_no_source("bronze_salesforce") }}
+
 SELECT
     Id                                              AS user_id,
     Email                                           AS email,

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__commits.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__commits.sql
@@ -5,6 +5,8 @@
     tags=['bitbucket-cloud', 'silver:class_git_commits']
 ) }}
 
+{{ skip_if_no_source("bronze_bitbucket_cloud") }}
+
 SELECT
     c.tenant_id,
     c.source_id,

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__file_changes.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__file_changes.sql
@@ -5,6 +5,8 @@
     tags=['bitbucket-cloud', 'silver:class_git_file_changes']
 ) }}
 
+{{ skip_if_no_source("bronze_bitbucket_cloud") }}
+
 SELECT
     tenant_id,
     source_id,

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests.sql
@@ -5,6 +5,8 @@
     tags=['bitbucket-cloud', 'silver:class_git_pull_requests']
 ) }}
 
+{{ skip_if_no_source("bronze_bitbucket_cloud") }}
+
 SELECT
     pr.tenant_id,
     pr.source_id,

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_comments.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_comments.sql
@@ -5,6 +5,8 @@
     tags=['bitbucket-cloud', 'silver:class_git_pull_requests_comments']
 ) }}
 
+{{ skip_if_no_source("bronze_bitbucket_cloud") }}
+
 SELECT
     tenant_id,
     source_id,

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_commits.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_commits.sql
@@ -5,6 +5,8 @@
     tags=['bitbucket-cloud', 'silver:class_git_pull_requests_commits']
 ) }}
 
+{{ skip_if_no_source("bronze_bitbucket_cloud") }}
+
 SELECT
     tenant_id,
     source_id,

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_reviewers.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests_reviewers.sql
@@ -5,6 +5,8 @@
     tags=['bitbucket-cloud', 'silver:class_git_pull_requests_reviewers']
 ) }}
 
+{{ skip_if_no_source("bronze_bitbucket_cloud") }}
+
 SELECT
     pr.tenant_id,
     pr.source_id,

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__repositories.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__repositories.sql
@@ -5,6 +5,8 @@
     tags=['bitbucket-cloud', 'silver:class_git_repositories']
 ) }}
 
+{{ skip_if_no_source("bronze_bitbucket_cloud") }}
+
 SELECT
     tenant_id,
     source_id,

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__repository_branches.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__repository_branches.sql
@@ -5,6 +5,8 @@
     tags=['bitbucket-cloud', 'silver:class_git_repository_branches']
 ) }}
 
+{{ skip_if_no_source("bronze_bitbucket_cloud") }}
+
 SELECT
     tenant_id,
     source_id,

--- a/src/ingestion/connectors/git/github/dbt/github__commits.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__commits.sql
@@ -5,6 +5,8 @@
     tags=['github', 'silver:class_git_commits']
 ) }}
 
+{{ skip_if_no_source("bronze_github") }}
+
 SELECT
     tenant_id,
     source_id,

--- a/src/ingestion/connectors/git/github/dbt/github__file_changes.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__file_changes.sql
@@ -5,6 +5,8 @@
     tags=['github', 'silver:class_git_file_changes']
 ) }}
 
+{{ skip_if_no_source("bronze_github") }}
+
 SELECT
     tenant_id,
     source_id,

--- a/src/ingestion/connectors/git/github/dbt/github__pull_requests.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__pull_requests.sql
@@ -5,6 +5,8 @@
     tags=['github', 'silver:class_git_pull_requests']
 ) }}
 
+{{ skip_if_no_source("bronze_github") }}
+
 SELECT
     tenant_id,
     source_id,

--- a/src/ingestion/connectors/git/github/dbt/github__pull_requests_comments.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__pull_requests_comments.sql
@@ -5,6 +5,8 @@
     tags=['github', 'silver:class_git_pull_requests_comments']
 ) }}
 
+{{ skip_if_no_source("bronze_github") }}
+
 SELECT
     tenant_id,
     source_id,

--- a/src/ingestion/connectors/git/github/dbt/github__pull_requests_commits.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__pull_requests_commits.sql
@@ -5,6 +5,8 @@
     tags=['github', 'silver:class_git_pull_requests_commits']
 ) }}
 
+{{ skip_if_no_source("bronze_github") }}
+
 SELECT
     tenant_id,
     source_id,

--- a/src/ingestion/connectors/git/github/dbt/github__pull_requests_reviewers.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__pull_requests_reviewers.sql
@@ -5,6 +5,8 @@
     tags=['github', 'silver:class_git_pull_requests_reviewers']
 ) }}
 
+{{ skip_if_no_source("bronze_github") }}
+
 SELECT
     tenant_id,
     source_id,

--- a/src/ingestion/connectors/git/github/dbt/github__repositories.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__repositories.sql
@@ -5,6 +5,8 @@
     tags=['github', 'silver:class_git_repositories']
 ) }}
 
+{{ skip_if_no_source("bronze_github") }}
+
 SELECT
     tenant_id,
     source_id,

--- a/src/ingestion/connectors/git/github/dbt/github__repository_branches.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__repository_branches.sql
@@ -5,6 +5,8 @@
     tags=['github', 'silver:class_git_repository_branches']
 ) }}
 
+{{ skip_if_no_source("bronze_github") }}
+
 SELECT
     tenant_id,
     source_id,

--- a/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__bootstrap_inputs.sql
+++ b/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__bootstrap_inputs.sql
@@ -5,6 +5,8 @@
     tags=['bamboohr', 'silver', 'silver:bootstrap_inputs']
 ) }}
 
+{{ skip_if_no_source("bronze_bamboohr") }}
+
 {{ bootstrap_inputs_from_history(
     fields_history_ref=ref('bamboohr__employees_fields_history'),
     source_type='bamboohr',

--- a/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__employees_fields_history.sql
+++ b/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__employees_fields_history.sql
@@ -4,6 +4,8 @@
     tags=['bamboohr', 'silver']
 ) }}
 
+{{ skip_if_no_source("bronze_bamboohr") }}
+
 {{ fields_history(
     snapshot_ref=ref('bamboohr__employees_snapshot'),
     entity_id_col='id',

--- a/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__employees_snapshot.sql
+++ b/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__employees_snapshot.sql
@@ -5,6 +5,8 @@
     tags=['bamboohr']
 ) }}
 
+{{ skip_if_no_source("bronze_bamboohr") }}
+
 {{ snapshot(
     source_ref=source('bamboohr', 'employees'),
     unique_key_col='unique_key',

--- a/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__hr_events.sql
+++ b/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__hr_events.sql
@@ -4,6 +4,8 @@
     tags=['bamboohr', 'silver:class_hr_events']
 ) }}
 
+{{ skip_if_no_source("bronze_bamboohr") }}
+
 SELECT
     lr.tenant_id                                            AS insight_tenant_id,
     lr.source_id,

--- a/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__working_hours.sql
+++ b/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__working_hours.sql
@@ -4,6 +4,8 @@
     tags=['bamboohr', 'silver:class_hr_working_hours']
 ) }}
 
+{{ skip_if_no_source("bronze_bamboohr") }}
+
 SELECT
     tenant_id                 AS insight_tenant_id,
     source_id,

--- a/src/ingestion/connectors/hr-directory/bamboohr/dbt/to_class_people.sql
+++ b/src/ingestion/connectors/hr-directory/bamboohr/dbt/to_class_people.sql
@@ -8,6 +8,8 @@
     tags=['bamboohr', 'silver:class_people']
 ) }}
 
+{{ skip_if_no_source("bronze_bamboohr") }}
+
 SELECT
     tenant_id,
     source_id,

--- a/src/ingestion/dbt/identity/seed_aliases_from_claude_team.sql
+++ b/src/ingestion/dbt/identity/seed_aliases_from_claude_team.sql
@@ -19,6 +19,8 @@
     tags=['identity:seed', 'aliases']
 ) }}
 
+{{ skip_if_no_source("bronze_claude_team") }}
+
 WITH latest AS (
     SELECT id AS source_id, email, name, tenant_id
     FROM {{ source('bronze_claude_team', 'claude_team_users') }}

--- a/src/ingestion/dbt/identity/seed_aliases_from_cursor.sql
+++ b/src/ingestion/dbt/identity/seed_aliases_from_cursor.sql
@@ -15,6 +15,8 @@
     tags=['identity:seed', 'aliases']
 ) }}
 
+{{ skip_if_no_source("bronze_cursor") }}
+
 -- Each cursor member emits up to 3 alias rows: email, platform_id, display_name.
 -- Join on email to resolve person_id from the seed_persons_from_cursor output.
 

--- a/src/ingestion/dbt/identity/seed_bootstrap_inputs_from_claude_team.sql
+++ b/src/ingestion/dbt/identity/seed_bootstrap_inputs_from_claude_team.sql
@@ -23,6 +23,8 @@
     tags=['identity:seed', 'silver', 'silver:bootstrap_inputs']
 ) }}
 
+{{ skip_if_no_source("bronze_claude_team") }}
+
 -- Column set matches bootstrap_inputs_from_history macro output.
 -- TEMPORARY: insight_tenant_id derived via sipHash128 until tenants table exists.
 

--- a/src/ingestion/dbt/identity/seed_bootstrap_inputs_from_cursor.sql
+++ b/src/ingestion/dbt/identity/seed_bootstrap_inputs_from_cursor.sql
@@ -19,6 +19,8 @@
     tags=['identity:seed', 'silver', 'silver:bootstrap_inputs']
 ) }}
 
+{{ skip_if_no_source("bronze_cursor") }}
+
 -- Each cursor member emits up to 3 observation rows: email, platform_id, display_name.
 -- Column set matches bootstrap_inputs_from_history macro output.
 -- TEMPORARY: insight_tenant_id derived via sipHash128 until tenants table exists.

--- a/src/ingestion/dbt/identity/seed_persons_from_claude_team.sql
+++ b/src/ingestion/dbt/identity/seed_persons_from_claude_team.sql
@@ -16,6 +16,8 @@
     tags=['identity:seed', 'person']
 ) }}
 
+{{ skip_if_no_source("bronze_claude_team") }}
+
 WITH latest AS (
     SELECT email, name, role, type, tenant_id
     FROM {{ source('bronze_claude_team', 'claude_team_users') }}

--- a/src/ingestion/dbt/identity/seed_persons_from_cursor.sql
+++ b/src/ingestion/dbt/identity/seed_persons_from_cursor.sql
@@ -13,6 +13,8 @@
     tags=['identity:seed', 'person']
 ) }}
 
+{{ skip_if_no_source("bronze_cursor") }}
+
 SELECT
     generateUUIDv7()                                        AS id,
     -- TEMPORARY: sipHash128 derives UUID from string tenant_id until tenants table exists

--- a/src/ingestion/dbt/macros/skip_if_no_source.sql
+++ b/src/ingestion/dbt/macros/skip_if_no_source.sql
@@ -1,0 +1,7 @@
+{% macro skip_if_no_source(db_name) %}
+  {%- set dbs = var('available_dbs', none) -%}
+  {%- if dbs is not none and db_name not in dbs -%}
+    {{ log(model.name ~ ": skipping — " ~ db_name ~ " not available", info=True) }}
+    {{ config(materialized='ephemeral') }}
+  {%- endif -%}
+{% endmacro %}

--- a/src/ingestion/workflows/templates/dbt-run.yaml
+++ b/src/ingestion/workflows/templates/dbt-run.yaml
@@ -12,7 +12,7 @@ spec:
       inputs:
         parameters:
           - name: dbt_select
-            default: "tag:silver"
+            default: "+tag:silver"
           - name: clickhouse_host
             default: "clickhouse.data.svc.cluster.local"
           - name: clickhouse_port

--- a/src/ingestion/workflows/templates/dbt-run.yaml
+++ b/src/ingestion/workflows/templates/dbt-run.yaml
@@ -43,4 +43,12 @@ spec:
                 password: "${CH_PASS}"
                 secure: false
           PROFILES
-          dbt run --profiles-dir . --select "{{inputs.parameters.dbt_select}}"
+          # Discover which bronze databases exist so connector models can skip missing ones
+          AVAILABLE_DBS=$(curl -sf "http://{{inputs.parameters.clickhouse_host}}:{{inputs.parameters.clickhouse_port}}" \
+            --data-urlencode "query=SELECT name FROM system.databases WHERE name LIKE 'bronze_%'" \
+            --data-urlencode "user=default" \
+            --data-urlencode "password=${CH_PASS}" \
+            | tr '\n' ',' | sed 's/,$//')
+          VARS="{available_dbs: [${AVAILABLE_DBS}]}"
+          echo "Available bronze databases: ${AVAILABLE_DBS}"
+          dbt run --profiles-dir . --select "{{inputs.parameters.dbt_select}}" --vars "${VARS}"

--- a/src/ingestion/workflows/templates/ingestion-pipeline.yaml
+++ b/src/ingestion/workflows/templates/ingestion-pipeline.yaml
@@ -13,7 +13,7 @@ spec:
         parameters:
           - name: connection_id
           - name: dbt_select
-            default: "tag:silver"
+            default: "+tag:silver"
           - name: airbyte_url
             default: "http://airbyte-airbyte-server-svc.airbyte.svc.cluster.local:8001"
           - name: clickhouse_host


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#203](https://github.com/cyberfabric/cyber-insight/pull/203) | **Author:** cyberantonz | **Opened:** 2026-04-20T15:27:01Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

Unify m365, zoom, and slack comms_events models to a common 7-column schema (tenant_id, source_id, unique_key, user_email, activity_date, event_type, source) so the silver union_by_tag macro can UNION ALL them. Change dbt-run selector from tag:silver to +tag:silver to include upstream connector staging models in the run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ingestion now conditionally skips connector models when their upstream data source is unavailable, reducing noisy failures and unnecessary runs.
  * Workflow runs now detect available upstream databases and pass them into dbt, and the default dbt selection behavior was adjusted for broader inclusion.

* **Chores**
  * Added a lightweight runtime guard to centralize source-availability checks for reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#203 -->