### PR TITLE
[PR #202] docs(deploy): deploy domain spec + dev-vhc environment

### DIFF
--- a/docs/domain/README.md
+++ b/docs/domain/README.md
@@ -9,3 +9,4 @@ Domain-level specifications for the Insight platform. Each domain represents a b
 | [`ingestion/`](ingestion/) | Data pipeline from source APIs to Silver step 1 (Airbyte + Argo Workflows + dbt) | Accepted |
 | [`connector/`](connector/) | Connector development: Insight Connector packages, nocode and CDK patterns, packaging, debugging | Accepted |
 | [`identity-resolution/`](identity-resolution/) | Person identity matching and resolution across sources | Proposed |
+| [`deploy/`](deploy/) | Deployment architecture: Helm packaging, environment configuration, multi-environment orchestration | Proposed |

--- a/docs/domain/deploy/README.md
+++ b/docs/domain/deploy/README.md
@@ -1,0 +1,39 @@
+# Deploy Domain
+
+Deployment architecture for the Insight platform: Helm packaging, environment configuration, and multi-environment orchestration (local Kind, dev k3s, Virtuozzo, any managed K8s).
+
+## Status
+
+**Proposed** — spec captures target state (umbrella Helm chart). Current state is three independent per-service charts plus raw manifests, orchestrated by `up.sh`. Migration tracked in DESIGN §5.
+
+## Quick Map
+
+| Environment | Cluster | Dependencies | How |
+|---|---|---|---|
+| `local` | Kind (single-node, Docker) | all bundled | `./up.sh` |
+| `dev-vhc` | k3s on VM `10.21.14.101` | all bundled | `./up.sh --env dev-vhc` |
+| `virtuozzo` | managed K8s (OpenStack Magnum) | external MariaDB, external ClickHouse | `./up.sh --env virtuozzo` |
+
+## Known Workarounds (to clean up)
+
+Discovered during dev-vhc bring-up (2026-04-20). Full context and fixes in [DESIGN.md §6](specs/DESIGN.md#6-known-issues--tech-debt).
+
+- **`toolbox/build.sh` hardcoded to Kind** — on `CLUSTER_MODE=remote`, the `insight-toolbox:local` image (used by `dbt-run` WorkflowTemplate) is never shipped to the remote cluster. Worked around manually with `docker save | ssh k3s-node k3s ctr images import -`. [§6.1](specs/DESIGN.md#61-upsh-orchestration-gaps)
+- **`.env.<env>` overrides shell env** — `BUILD_IMAGES=false ./up.sh` silently rebuilds because the env file re-sets it. [§6.1](specs/DESIGN.md#61-upsh-orchestration-gaps)
+- **No remote buildx executor** — Rust cross-compile arm64→amd64 via local QEMU is ~30 min/service; native on the VM is ~2 min. `up.sh` has no way to point buildx at a remote builder. [§6.1](specs/DESIGN.md#61-upsh-orchestration-gaps)
+- **Identity service crashes on a fresh cluster** — `services/identity` unconditionally queries `bronze_bamboohr.employees` at startup; missing database → `CrashLoopBackOff`. Worked around by creating an empty table. [§6.2](specs/DESIGN.md#62-missing-bootstrap-steps)
+- **No bootstrap for ClickHouse `insight` DB + schema** — fresh cluster has no `insight` database; queries fail until dbt runs. [§6.2](specs/DESIGN.md#62-missing-bootstrap-steps)
+- **MariaDB not in any chart** — deployed ad-hoc via inline `kubectl apply -f -` on dev-vhc; not versioned. [§6.2](specs/DESIGN.md#62-missing-bootstrap-steps)
+- **GHCR PAT plaintext on the VM** — required to build images natively; lives in `~/.docker/config.json` base64-encoded. [§6.3](specs/DESIGN.md#63-secrets--credentials)
+- **`ghcr-creds` imagePullSecret created manually** — not owned by any chart, undocumented for ops handoff. [§6.3](specs/DESIGN.md#63-secrets--credentials)
+- **`ANALYTICS_DB_URL` plaintext in `.env.dev-vhc`** — duplicates `mariadb-credentials` secret contents. [§6.3](specs/DESIGN.md#63-secrets--credentials)
+- **Connector K8s Secrets absent on dev-vhc** — per ADR-0003, every connector needs `insight-<connector>-<source-id>`; none provisioned yet, all syncs will be skipped. [§6.3](specs/DESIGN.md#63-secrets--credentials)
+- **ClickHouse still in ns `data`, Redis still inline YAML in `up.sh`** — deviations from target (§3.2); corrected by the umbrella refactor. [§6.4](specs/DESIGN.md#64-dev-vhc-deviations-from-target)
+- **Per-env Airbyte/Argo values files duplicate** — `values-dev-vhc.yaml` was created as a copy of `values-local.yaml`; should be consolidated into sized profiles. [§6.4](specs/DESIGN.md#64-dev-vhc-deviations-from-target)
+
+## Documents
+
+| Document | Description |
+|---|---|
+| [specs/DESIGN.md](specs/DESIGN.md) | Target deployment architecture and migration plan |
+| [specs/ADR/0001-umbrella-helm-chart.md](specs/ADR/0001-umbrella-helm-chart.md) | Decision: umbrella Helm chart over per-service charts |

--- a/docs/domain/deploy/specs/ADR/0001-umbrella-helm-chart.md
+++ b/docs/domain/deploy/specs/ADR/0001-umbrella-helm-chart.md
@@ -1,0 +1,137 @@
+---
+status: proposed
+date: 2026-04-20
+---
+
+# ADR-0001: Umbrella Helm Chart for the Insight Application Bundle
+
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [Umbrella Helm Chart (backend bundle only)](#umbrella-helm-chart-backend-bundle-only)
+  - [Single umbrella covering all platform components](#single-umbrella-covering-all-platform-components)
+  - [Status quo (per-service charts + bash orchestrator)](#status-quo-per-service-charts--bash-orchestrator)
+  - [Kustomize overlays](#kustomize-overlays)
+- [More Information](#more-information)
+- [Traceability](#traceability)
+
+<!-- /toc -->
+
+## Context and Problem Statement
+
+The Insight platform currently deploys via three independent Helm releases (`analytics-api`, `identity`, `api-gateway`) plus a frontend release, raw Kubernetes manifests for ClickHouse (`src/ingestion/k8s/clickhouse/`), an inline Deployment/Service embedded in `up.sh` for Redis, and upstream charts for Airbyte and Argo Workflows. A bash orchestrator (`up.sh`) wires all of them together, sourcing per-environment `.env.<env>` files.
+
+SRE review (April 2026) flagged three structural issues:
+
+1. The application bundle lacks a single Helm artifact. Operators cannot install the platform with one `helm install` or one ArgoCD Application — they must run the bash orchestrator or manually replicate its `kubectl`/`helm` sequence.
+2. Stateful dependencies (ClickHouse, MariaDB, Redis) are deployed inconsistently — raw manifests, inline YAML, or expected to pre-exist externally — with no unified `enabled: true/false` toggle to switch between bundled and external modes.
+3. Repeated values (ClickHouse URL, credential Secret name, database name) are passed as `--set` flags to each chart from `up.sh`. A rename or URL change requires editing multiple places.
+
+The platform needs a packaging model that: (a) enables single-command or GitOps-driven deployment of the application bundle, (b) cleanly supports both bundled-dependencies (local, dev) and external-dependencies (managed clusters) modes, and (c) keeps shared configuration DRY.
+
+## Decision Drivers
+
+- SRE guidance: bundle service + its dependencies in one namespace, expose enable/disable toggles for third-party subcharts, extract repeated values into variables
+- GitOps compatibility — deploy via ArgoCD Application or Flux HelmRelease without a bootstrap script
+- Dev/prod parity — same chart installs on local Kind, dev k3s, and managed Virtuozzo K8s
+- Minimize orchestration code in `up.sh` — replace three `helm upgrade` calls plus raw `kubectl apply` with one `helm upgrade`
+- Support external dependencies on managed environments (MariaDB, ClickHouse already exist on Virtuozzo)
+- Preserve independent lifecycle for platform-level infra (Airbyte, Argo Workflows, ingress controller) — their security updates and chart versions should not be coupled to application release cadence
+
+## Considered Options
+
+- **Umbrella Helm chart (backend bundle only)** — one chart covering analytics-api, identity, api-gateway, frontend, and bundled stateful deps (ClickHouse, MariaDB, Redis) as conditional subcharts; Airbyte/Argo/ingress remain separate releases
+- **Single umbrella covering all platform components** — one chart owning backend, stateful deps, Airbyte, Argo, and ingress
+- **Status quo (per-service charts + bash orchestrator)** — no refactor; iterate on `up.sh`
+- **Kustomize overlays** — replace Helm with Kustomize base + per-environment overlays
+
+## Decision Outcome
+
+Chosen option: **Umbrella Helm chart (backend bundle only)**.
+
+The bundle (`src/backend/helm/insight/`) is a single Helm chart with the backend services as local subcharts and the stateful dependencies (ClickHouse, MariaDB, Redis) as conditional subcharts. A `global.*` values section carries shared configuration (URLs, credential Secret references, database names) consumed uniformly by all subcharts. Platform infrastructure — Airbyte, Argo Workflows, ingress controller — remains outside the umbrella as independent Helm releases with their own upgrade cadence.
+
+Selected because it matches the SRE recommendation precisely (bundle + toggles + DRY) while preserving lifecycle independence for platform components whose updates should not be gated on application releases. A single `helm upgrade --install insight ./src/backend/helm/insight -f values-<env>.yaml` replaces the three chart installs and raw-manifest applies currently in `up.sh`, making the bundle directly consumable by ArgoCD or Flux.
+
+### Consequences
+
+- Good, because operators can install the application bundle with one Helm command or one ArgoCD Application manifest
+- Good, because `<dep>.enabled` toggles give a clean boundary between bundled-dev and external-dep modes
+- Good, because `global.*` centralizes shared configuration — one change updates all consumers
+- Good, because independent Airbyte/Argo/ingress releases retain upgrade flexibility for security patches
+- Good, because removing raw `kubectl apply -f k8s/clickhouse/` eliminates the only non-Helm step in the backend deployment path
+- Bad, because the refactor is ~1 week of engineering effort plus ~1–2 days for Virtuozzo data migration (ClickHouse moves from ns `data` to ns `insight`)
+- Bad, because introducing Bitnami subcharts adds an external dependency (registry availability, version compatibility)
+- Bad, because `helm dependency update` becomes a build-time prerequisite (offline installs need a vendored `charts/` tarball)
+
+### Confirmation
+
+Confirmed when:
+
+- `helm upgrade --install insight ./src/backend/helm/insight -f values.yaml` succeeds on a fresh Kind cluster with all subcharts enabled
+- `helm upgrade --install insight ./src/backend/helm/insight -f values-virtuozzo.yaml` succeeds on Virtuozzo with `mariadb.enabled=false` and `clickhouse.enabled=false`, connecting to external services via `global.*` URLs
+- `up.sh` contains one `helm upgrade` call for the bundle instead of three plus a raw `kubectl apply`
+- `src/backend/services/*/helm/`, `src/ingestion/k8s/clickhouse/`, and the inline Redis YAML in `up.sh` are deleted
+- Virtuozzo migration completed with no data loss (ClickHouse restore succeeds, MariaDB restore succeeds, Airbyte connections continue incremental sync)
+
+## Pros and Cons of the Options
+
+### Umbrella Helm Chart (backend bundle only)
+
+Chart depends on local subcharts for application services (analytics-api, identity, api-gateway, frontend, clickhouse) and on Bitnami subcharts for mariadb and redis, all gated by `condition: <dep>.enabled`. Shared configuration (URLs, Secret names) lives under `values.global.*` and is consumed by each subchart via `{{ .Values.global.clickhouse.url }}`. Airbyte, Argo, and ingress stay as independent releases managed by `up.sh` or an operator.
+
+- Good, because it directly implements the SRE recommendation
+- Good, because bundle-vs-external is a single values toggle
+- Good, because `global.*` removes `--set` duplication from `up.sh`
+- Good, because ArgoCD-compatible without additional wrapping
+- Neutral, because `up.sh` still exists (orchestrates bundle + Airbyte + Argo + ingress)
+- Bad, because Bitnami chart dependency adds external version-compatibility surface
+
+### Single umbrella covering all platform components
+
+One chart depending on the backend bundle plus Airbyte, Argo, and ingress as subcharts. Entire platform installs with one `helm install`.
+
+- Good, because truly one-command platform install
+- Bad, because Airbyte/Argo security updates require a platform-release version bump
+- Bad, because upstream charts have deep namespace-coupling that conflicts with umbrella release-name conventions
+- Bad, because failure in any subchart blocks upgrade of unrelated components
+- Bad, because ingress lifecycle is cluster-scoped (shared across tenants) and belongs outside a tenant-level bundle
+
+### Status quo (per-service charts + bash orchestrator)
+
+No refactor. Each service remains an independent chart; `up.sh` orchestrates them with `--set` flags and raw `kubectl apply`.
+
+- Good, because zero migration work
+- Bad, because operators cannot install the platform without the bash orchestrator
+- Bad, because bundle-vs-external is mixed across chart toggles, env vars, and `up.sh` conditionals
+- Bad, because repeated values (ClickHouse URL, Secret names) are maintained in multiple places
+- Bad, because ArgoCD / Flux adoption requires re-engineering anyway
+
+### Kustomize overlays
+
+Replace Helm with Kustomize: a base manifest directory plus per-environment overlays patching images, replicas, and config.
+
+- Good, because pure Kubernetes manifests with no templating language
+- Good, because overlays compose explicitly
+- Bad, because Kustomize has no native support for conditional third-party charts (Bitnami MariaDB/Redis ship as Helm charts only)
+- Bad, because the ecosystem around third-party charts (ArgoCD, Renovate, chart-testing) is Helm-centric
+- Bad, because Secret templating and value interpolation are weaker than Helm
+
+## More Information
+
+- Chart lives at `src/backend/helm/insight/` in the repository.
+- Bitnami charts pulled from `oci://registry-1.docker.io/bitnamicharts` (no Helm repo `helm repo add` required).
+- Wrapping existing ClickHouse manifests as a subchart (vs. adopting `altinity/clickhouse-operator`) is deferred — tracked as OQ-DEPLOY-02 in `DESIGN.md`.
+- Airbyte/Argo inclusion as subcharts is out of scope — tracked as OQ-DEPLOY-01.
+- GitOps (ArgoCD / Flux) adoption is out of scope for the refactor — tracked as OQ-DEPLOY-03. Chart must be GitOps-compatible when that work is picked up.
+
+## Traceability
+
+- **DESIGN**: [../DESIGN.md](../DESIGN.md)
+- **Related ADRs**: `docs/domain/ingestion/specs/ADR/0003-k8s-secrets-credentials.md` — K8s Secrets as credential source (consumed by this chart's subcharts)

--- a/docs/domain/deploy/specs/DESIGN.md
+++ b/docs/domain/deploy/specs/DESIGN.md
@@ -1,0 +1,408 @@
+---
+status: proposed
+date: 2026-04-20
+---
+
+# DESIGN -- Deployment Architecture
+
+<!-- toc -->
+
+- [1. Architecture Overview](#1-architecture-overview)
+  - [1.1 Vision](#11-vision)
+  - [1.2 Drivers](#12-drivers)
+- [2. Principles & Constraints](#2-principles--constraints)
+- [3. Target Architecture](#3-target-architecture)
+  - [3.1 Umbrella Helm Chart](#31-umbrella-helm-chart)
+  - [3.2 Namespace Layout](#32-namespace-layout)
+  - [3.3 Values Hierarchy](#33-values-hierarchy)
+  - [3.4 Dependency Toggles](#34-dependency-toggles)
+  - [3.5 Global Values](#35-global-values)
+  - [3.6 Secrets](#36-secrets)
+- [4. Environment Matrix](#4-environment-matrix)
+- [5. Migration Plan](#5-migration-plan)
+  - [5.1 Current State (as of 2026-04-20)](#51-current-state-as-of-2026-04-20)
+  - [5.2 Refactor Steps](#52-refactor-steps)
+  - [5.3 Virtuozzo Data Migration](#53-virtuozzo-data-migration)
+- [6. Known Issues & Tech Debt](#6-known-issues--tech-debt)
+  - [6.1 up.sh orchestration gaps](#61-upsh-orchestration-gaps)
+  - [6.2 Missing bootstrap steps](#62-missing-bootstrap-steps)
+  - [6.3 Secrets & credentials](#63-secrets--credentials)
+  - [6.4 dev-vhc deviations from target](#64-dev-vhc-deviations-from-target)
+- [7. Open Questions](#7-open-questions)
+- [8. Traceability](#8-traceability)
+
+<!-- /toc -->
+
+---
+
+## 1. Architecture Overview
+
+### 1.1 Vision
+
+A single Helm release deploys the entire Insight platform (backend services + stateful dependencies) into one Kubernetes namespace. Each stateful dependency (ClickHouse, MariaDB, Redis) can be toggled on (bundled, for local/dev) or off (external, for managed environments). Infrastructure-level components with their own lifecycle (Airbyte, Argo Workflows, ingress controller) remain independent Helm releases in dedicated namespaces.
+
+### 1.2 Drivers
+
+- SRE guidance: bundle service + dependencies in one namespace, expose enable/disable toggles for 3rd-party subcharts, keep repeated values DRY
+- Single `helm upgrade --install` replaces three separate releases orchestrated by bash
+- Values files per environment replace `.env.*` shell-sourced config
+- GitOps compatibility — chart is installable by ArgoCD / Flux without a bootstrap script
+- Local development parity with managed deployments (same chart, different values)
+
+## 2. Principles & Constraints
+
+1. **One chart, one release** for backend bundle. Infra (Airbyte, Argo, ingress-nginx) stays separate — their own lifecycles.
+2. **Conditional subcharts** for stateful deps (`condition: <dep>.enabled`) so the same chart deploys in both bundled and external-dep modes.
+3. **DRY via `global.*`** — URLs, credential secret refs, connection params live once in `values.global.*` and are consumed by every subchart.
+4. **Secrets never in values** — templates reference existing K8s Secrets by name. Values only contain Secret **names** and **key names**.
+5. **Backwards compatible** — `up.sh` remains the orchestration entrypoint during transition; internally it calls `helm upgrade --install` once per environment.
+6. **No data loss during migration** — stateful PVCs adopted into the new chart or data restored from dumps.
+
+## 3. Target Architecture
+
+### 3.1 Umbrella Helm Chart
+
+```
+src/backend/helm/insight/
+  Chart.yaml                        # umbrella, depends on subcharts
+  Chart.lock
+  values.yaml                       # defaults (everything bundled, for local)
+  values-dev-vhc.yaml               # k3s dev VM
+  values-virtuozzo.yaml             # managed, external deps
+  charts/
+    analytics-api/                  # local subchart (moved from services/*/helm)
+    identity/
+    api-gateway/
+    frontend/
+    clickhouse/                     # wrap k8s/clickhouse/*.yaml
+  # External subcharts pulled via dependencies:
+  #   bitnami/mariadb  (condition: mariadb.enabled)
+  #   bitnami/redis    (condition: redis.enabled)
+```
+
+`Chart.yaml` dependencies:
+
+```yaml
+dependencies:
+  - name: mariadb
+    version: ~18.0.0
+    repository: oci://registry-1.docker.io/bitnamicharts
+    condition: mariadb.enabled
+  - name: redis
+    version: ~19.0.0
+    repository: oci://registry-1.docker.io/bitnamicharts
+    condition: redis.enabled
+  - name: clickhouse
+    version: 0.1.0
+    repository: "file://charts/clickhouse"
+    condition: clickhouse.enabled
+  - name: analytics-api
+    version: 0.1.0
+    repository: "file://charts/analytics-api"
+  - name: identity
+    version: 0.1.0
+    repository: "file://charts/identity"
+  - name: api-gateway
+    version: 0.1.0
+    repository: "file://charts/api-gateway"
+  - name: frontend
+    version: 0.1.0
+    repository: "file://charts/frontend"
+```
+
+### 3.2 Namespace Layout
+
+| Namespace | Contents | Lifecycle |
+|---|---|---|
+| `insight` | analytics-api, identity, api-gateway, frontend, redis, mariadb, clickhouse (when bundled) | Umbrella chart (`helm upgrade --install insight`) |
+| `airbyte` | Airbyte (upstream chart) | Separate release (`helm upgrade --install airbyte airbyte/airbyte`) |
+| `argo` | Argo Workflows, WorkflowTemplates | Separate release (`helm upgrade --install argo-workflows argo/argo-workflows`) |
+| `ingress-nginx` | Ingress controller | Separate release (when `INGRESS_INSTALL=true`) |
+
+Rationale for not putting Airbyte and Argo into `insight` namespace:
+- Upstream charts create many sub-resources with hardcoded namespace assumptions
+- Different upgrade cadences (security updates for Airbyte don't belong in bundle versioning)
+- SRE feedback targets the **application bundle**, not platform-level infra
+
+### 3.3 Values Hierarchy
+
+1. `values.yaml` — defaults (all subcharts enabled, for local Kind)
+2. `values-<env>.yaml` — per-environment overrides
+3. `--set` flags from `up.sh` — image tags, one-off deploys
+
+Precedence: `--set` > `values-<env>.yaml` > `values.yaml`.
+
+### 3.4 Dependency Toggles
+
+```yaml
+# values.yaml (defaults — local)
+mariadb:
+  enabled: true
+redis:
+  enabled: true
+clickhouse:
+  enabled: true
+```
+
+```yaml
+# values-virtuozzo.yaml (external deps)
+mariadb:
+  enabled: false
+redis:
+  enabled: true    # redis is missing on virtuozzo, bundle it
+clickhouse:
+  enabled: false
+
+global:
+  mariadb:
+    host: mariadb.insight.svc.cluster.local
+    credentialsSecret: mariadb-credentials
+  clickhouse:
+    url: http://clickhouse.data.svc.cluster.local:8123
+    database: insight
+    credentialsSecret: clickhouse-credentials
+```
+
+### 3.5 Global Values
+
+Repeated values live under `global.*` and are consumed by all subcharts:
+
+```yaml
+global:
+  namespace: insight
+  clickhouse:
+    url: ""                      # computed if clickhouse.enabled=true
+    database: insight
+    credentialsSecret: clickhouse-credentials
+    credentialsUserKey: username
+    credentialsPasswordKey: password
+  mariadb:
+    host: ""                     # computed if mariadb.enabled=true
+    database: analytics
+    credentialsSecret: mariadb-credentials
+  redis:
+    url: ""                      # computed if redis.enabled=true
+  oidc:
+    existingSecret: insight-oidc
+```
+
+Computed defaults (in `values.yaml` via `tpl`):
+
+```yaml
+global:
+  clickhouse:
+    url: |-
+      {{- if .Values.clickhouse.enabled -}}
+        http://{{ .Release.Name }}-clickhouse:8123
+      {{- end -}}
+```
+
+### 3.6 Secrets
+
+No secret values in charts or values files. Convention:
+
+| Secret | Namespace | Keys | Consumed by |
+|---|---|---|---|
+| `clickhouse-credentials` | `insight` | `username`, `password` | analytics-api, identity, clickhouse subchart |
+| `mariadb-credentials` | `insight` | `mariadb-password`, `mariadb-root-password` | analytics-api, mariadb subchart |
+| `insight-oidc` | `insight` | `issuer`, `client-id`, `audience`, `redirect-uri` | api-gateway |
+| `insight-<connector>-<source-id>` | `airbyte` | per-connector fields | `airbyte-toolkit/connect.sh` (ADR-0003) |
+
+Secrets are created out-of-band:
+- Local: `./secrets/apply.sh` with files in `src/ingestion/secrets/` (gitignored)
+- Managed: cluster admin provisions via Vault + ESO / Sealed Secrets / manual
+
+## 4. Environment Matrix
+
+| | local (Kind) | dev-vhc (k3s) | virtuozzo |
+|---|---|---|---|
+| `CLUSTER_MODE` | local | remote | remote |
+| Image source | build + `kind load` | build + push to ghcr.io | build + push to ghcr.io |
+| `IMAGE_PLATFORM` | native | `linux/amd64` | `linux/amd64` |
+| `mariadb.enabled` | true | true | false (external) |
+| `redis.enabled` | true | true | true |
+| `clickhouse.enabled` | true | true | false (external `data` ns) |
+| Airbyte | bundled release in `airbyte` ns | bundled release in `airbyte` ns | pre-existing |
+| Argo | bundled release in `argo` ns | bundled release in `argo` ns | pre-existing |
+| Ingress | optional | hostPort 80/443 | hostPort 80/443 |
+| OIDC | disabled (`AUTH_DISABLED=true`) | Okta SPA | Okta SPA |
+
+## 5. Migration Plan
+
+### 5.1 Current State (as of 2026-04-20)
+
+| | Current | Target |
+|---|---|---|
+| Backend charts | 3 separate: `analytics-api/helm`, `identity/helm`, `api-gateway/helm` | Subcharts in `src/backend/helm/insight/charts/` |
+| Frontend | `src/frontend/helm/` | Subchart in umbrella |
+| ClickHouse | raw manifests `src/ingestion/k8s/clickhouse/*.yaml`, ns `data` | Subchart in umbrella, ns `insight` |
+| MariaDB | not deployed (expected pre-existing on virtuozzo) | Bitnami subchart, ns `insight`, toggled |
+| Redis | inline YAML in `up.sh` when `DEPLOY_REDIS=true` | Bitnami subchart, ns `insight`, toggled |
+| Airbyte | upstream chart, ns `airbyte` | Unchanged |
+| Argo | upstream chart, ns `argo` | Unchanged |
+| Orchestration | `up.sh` with three `helm upgrade` calls + inline Redis YAML + `kubectl apply -f k8s/clickhouse/` | `up.sh` with one `helm upgrade insight ./src/backend/helm/insight -f values-<env>.yaml` + Airbyte + Argo |
+| Config | `.env.<env>` | `values-<env>.yaml` (env still used for image/auth flags) |
+| ClickHouse namespace | `data` | `insight` |
+
+### 5.2 Refactor Steps
+
+1. **Scaffold umbrella chart** `src/backend/helm/insight/` with `Chart.yaml`, `values.yaml`, `global.*` section, empty `charts/` directory.
+2. **Wrap ClickHouse** as subchart `charts/clickhouse/` from existing `src/ingestion/k8s/clickhouse/*.yaml`. Parameterize storage, resources, credentials secret name.
+3. **Move service charts** from `src/backend/services/*/helm/` to `charts/*/`. Adjust `image.repository`, `image.tag`, and DB references to read from `.Values.global.*`.
+4. **Add bitnami subcharts** (`mariadb`, `redis`) with `condition: <dep>.enabled`. Run `helm dependency update`.
+5. **Write per-env values**: `values.yaml` (local defaults), `values-dev-vhc.yaml`, `values-virtuozzo.yaml`.
+6. **Rewrite `up.sh`** — replace three `helm upgrade` blocks with one, keep Airbyte/Argo blocks untouched.
+7. **Test on Kind** — verify fresh install + upgrade idempotency.
+8. **Test on dev-vhc** — fresh install on k3s, end-to-end ingestion through ClickHouse.
+9. **Migrate virtuozzo** — see §5.3.
+10. **Delete** `src/backend/services/*/helm/`, `src/ingestion/k8s/clickhouse/`, inline Redis YAML from `up.sh`.
+
+Estimated effort: ~1 week for the refactor, ~1–2 days for Virtuozzo migration.
+
+### 5.3 Virtuozzo Data Migration
+
+Virtuozzo already has ClickHouse in ns `data` with data, plus MariaDB, Airbyte, Argo. Refactor moves ClickHouse to ns `insight`, so data migration is required.
+
+**Preconditions**:
+- Check `reclaimPolicy` on all PVCs: `kubectl get pv -o jsonpath='{.items[*].spec.persistentVolumeReclaimPolicy}'`. If `Delete`, patch to `Retain` before `helm uninstall`.
+
+**Backup**:
+```bash
+./dump-clickhouse.sh                                    # script already exists
+kubectl exec -n insight mariadb-0 -- mysqldump \
+  --all-databases -p"$MARIADB_ROOT_PASS" > mariadb.sql
+kubectl exec -n airbyte airbyte-db-0 -- pg_dumpall \
+  -U postgres > airbyte-pg.sql
+kubectl get secrets -n insight -n data -n airbyte -o yaml > secrets.yaml
+```
+
+**Cutover**:
+```bash
+helm uninstall insight-analytics insight-identity insight-gw insight-fe -n insight
+helm uninstall insight-redis -n insight 2>/dev/null || true
+kubectl delete -f src/ingestion/k8s/clickhouse/ -n data
+kubectl delete namespace data
+# Airbyte, Argo stay
+./up.sh --env virtuozzo                                 # deploys new chart
+```
+
+**Restore**:
+```bash
+# ClickHouse: for db in bronze_*, silver, identity: INSERT ... FORMAT Native
+# MariaDB: mysql < mariadb.sql
+# Airbyte PG: restore only if Airbyte version matches (same chart version)
+```
+
+**Risks**:
+1. `reclaimPolicy: Delete` → data loss before backup completes. **Mitigation**: patch to Retain first.
+2. Airbyte PG schema mismatch if Airbyte version changes. **Mitigation**: pin Airbyte chart version; skip PG restore and recreate connections via `connect.sh` (triggers full re-sync).
+3. Incremental sync state loss (Airbyte connection cursors) → full re-sync of all sources. **Mitigation**: dump/restore Airbyte PG with matching version.
+4. Secret `resourceVersion`/`uid` fields on reapply → strip via `jq` before apply.
+
+## 6. Known Issues & Tech Debt
+
+Everything in this section is a real bug or missing piece uncovered during the dev-vhc bring-up (2026-04-20). Each item is a concrete fix that should land before or as part of the umbrella-chart refactor (§5).
+
+### 6.1 `up.sh` orchestration gaps
+
+**`toolbox/build.sh` hardcoded to Kind**
+
+`src/ingestion/tools/toolbox/build.sh` detects a local Kind cluster named `insight` and runs `kind load docker-image`. In `CLUSTER_MODE=remote`, the toolbox image (`insight-toolbox:local`, used by the `dbt-run` Argo WorkflowTemplate) never reaches the remote cluster's containerd. On dev-vhc this was worked around manually with `docker save | ssh r.mitasov@10.21.14.101 'sudo k3s ctr images import -'`, which is neither idempotent nor reproducible.
+
+Fix: teach `build.sh` the `CLUSTER_MODE` contract. For `remote`, either (a) push the image to `${IMAGE_REGISTRY}/insight-toolbox:${IMAGE_TAG}` and update `dbt-run.yaml` to use the parameterized ref, or (b) `docker save | ssh k3s-node k3s ctr images import -` when a VM host is known. Option (a) is cleaner and aligns with how backend images are shipped.
+
+**`.env.<env>` overrides shell environment**
+
+`up.sh` does `set -a; source "$ENV_FILE"; set +a`, which replaces any variables already set in the invoking shell. Running `BUILD_IMAGES=false ./up.sh --env dev-vhc app` silently rebuilds images because the env file sets `BUILD_IMAGES=true`. Discovered after killing a 30-minute QEMU buildx round-trip that should have been skipped.
+
+Fix: source the env file first, then let shell-exported variables win. Practically: in `up.sh`, replace direct `source` with a loop that only sets keys not already exported, or use `${VAR:-<env_file_value>}` pattern throughout.
+
+**Fallback image build path is single-executor**
+
+When `IMAGE_PLATFORM=linux/amd64` on an arm64 workstation, `up.sh` runs `docker buildx build --push` against the local BuildKit (QEMU-emulated Rust ~30 min per service). There is no built-in way to point buildx at a remote amd64 builder (the VM itself) for 10–15× speedup. On dev-vhc this was unblocked by building directly on the VM via SSH, bypassing `up.sh`.
+
+Fix: support `BUILDER_CONTEXT` / `DOCKER_HOST` override, or auto-detect a remote buildx node from the kubeconfig server URL for `CLUSTER_MODE=remote`.
+
+### 6.2 Missing bootstrap steps
+
+**Identity service crashes on fresh cluster**
+
+`services/identity/src/people.rs` unconditionally queries `bronze_bamboohr.employees` at startup. If the database or table does not exist (fresh cluster with no completed sync), the pod enters `CrashLoopBackOff` with `UNKNOWN_DATABASE`. On dev-vhc this was unblocked by manually creating an empty `bronze_bamboohr.employees` table with the expected schema.
+
+Fix — pick one:
+1. Make the identity stub tolerant of missing databases/tables (treat as empty) and retry on a timer.
+2. Add a startup init container that ensures all expected bronze databases/tables exist (no-op if populated).
+3. Stop treating identity as a zero-data service — it needs at least one successful ingestion pipeline pass before it can claim Ready.
+
+**No bootstrap for ClickHouse `insight` database and schema**
+
+`src/ingestion/k8s/clickhouse/*.yaml` creates the ClickHouse Deployment + Service + PVC but does not initialize the `insight` database or any schema. Analytics queries targeting `insight.*` tables fail until dbt models run at least once. This is hidden on virtuozzo because the cluster has historical data.
+
+Fix: subchart should include an `initContainers` or `postInstall` Job that creates `insight` database and any required baseline DDL. Same Job can own the empty `bronze_*` placeholders needed by the identity stub until Issue 6.2.1 is resolved.
+
+**MariaDB not deployed by any chart**
+
+`up.sh` does not deploy MariaDB. `analytics-api` expects it at `mysql://insight:...@mariadb:3306/analytics`. On virtuozzo it pre-exists; on dev-vhc it was deployed ad-hoc via `kubectl apply -f -` of an inline manifest. Not reproducible, not versioned.
+
+Fix: add Bitnami MariaDB as a conditional subchart of the umbrella (§3.1). Until then, add a `MARIADB_DEPLOY=true` path in `up.sh` mirroring the Redis inline YAML, or keep a versioned manifest under `src/backend/k8s/mariadb/`.
+
+### 6.3 Secrets & credentials
+
+**GHCR PAT plaintext on VM**
+
+To build images natively on the dev-vhc VM, `docker login ghcr.io` was run with a GitHub PAT. The token lands in `~/.docker/config.json` base64-encoded (not encrypted). Anyone with VM access can read it and push to `ghcr.io/cyberfabric`. Token has `write:packages` scope and does not expire automatically.
+
+Fix: rotate PAT after refactor; for the long term, use a GitHub App deploy key scoped to the specific repository, or issue short-lived tokens via OIDC federation. Do not commit the PAT or leave it on any long-lived shared host.
+
+**`ghcr-creds` imagePullSecret manually created**
+
+k3s on dev-vhc pulls private images from `ghcr.io/cyberfabric/insight-*:dev-vhc` using a `ghcr-creds` Secret in namespace `insight`, created manually with the same PAT as above. The secret is not owned by any chart and not documented anywhere that CI or a future operator would discover.
+
+Fix: in the umbrella chart, accept `global.imagePullSecret` as the value and either (a) expect it to pre-exist (document how to create), or (b) template the Secret from `global.imagePullCredentials` when provided. Prefer (a) with External Secrets Operator integration for managed environments.
+
+**`ANALYTICS_DB_URL` with plaintext password in `.env.dev-vhc`**
+
+`.env.dev-vhc` contains `ANALYTICS_DB_URL=mysql://insight:insight-dev-pass@mariadb:3306/analytics`. The value is duplicated in the ad-hoc MariaDB manifest's `mariadb-credentials` secret. Two sources of truth, neither scoped per-deployment.
+
+Fix: once analytics-api chart reads MariaDB creds from a Secret (like it does for ClickHouse with `credentialsSecret`), drop the inline URL from `.env.*` and `up.sh`. Chart composes URL from `global.mariadb.host` + Secret keys.
+
+**Connector K8s Secrets not provisioned on dev-vhc**
+
+Connectors (Jira, M365, BambooHR, etc.) require `insight-{connector}-{source-id}` Secrets per ADR-0003 (`docs/domain/ingestion/specs/ADR/0003-k8s-secrets-credentials.md`). None exist on dev-vhc yet; all syncs will be skipped. Required before smoke-testing the ingestion pipeline on dev-vhc.
+
+Fix: document per-connector required fields in a dev-only `src/ingestion/secrets/connectors/*.yaml.example` set and run `./src/ingestion/secrets/apply.sh` as part of the dev bring-up playbook.
+
+### 6.4 dev-vhc deviations from target
+
+**ClickHouse still in namespace `data`**
+
+Target architecture (§3.2) places ClickHouse in namespace `insight` as a bundled subchart. dev-vhc inherited the current layout (`data` namespace, raw manifests). Will be corrected during the refactor (§5.2 step 3). Until then, `global.clickhouse.url` must explicitly reference `clickhouse.data.svc.cluster.local`.
+
+**Redis still inline YAML in `up.sh`**
+
+`up.sh` embeds Redis Deployment+Service YAML directly. Functional but not versioned as a chart. Target state (§3.1) makes it a Bitnami subchart. Remove the inline YAML in refactor step 10 (§5.2).
+
+**Airbyte/Argo values files must exist per environment**
+
+`src/ingestion/up.sh` loads `k8s/airbyte/values-${ENV}.yaml` and `k8s/argo/values-${ENV}.yaml`. On dev-vhc these were created as copies of `values-local.yaml`. Adding a new environment currently requires two file copies plus touching `.env.<env>`. Low priority but a source of cognitive overhead.
+
+Fix: collapse values files to `values-small.yaml` / `values-prod.yaml` (sized profiles) and select via an env var, not env name.
+
+## 7. Open Questions
+
+### OQ-DEPLOY-01: Airbyte/Argo ownership
+
+Should Airbyte and Argo Workflows become subcharts of the umbrella to achieve single-release deployment, or stay as independent releases? Independent keeps lifecycle separation (security updates, chart version pinning) at the cost of multiple `helm upgrade` calls. Current direction: **stay independent**.
+
+### OQ-DEPLOY-02: ClickHouse operator vs. raw chart
+
+Wrap existing raw manifests as a subchart, or switch to `altinity/clickhouse-operator`? Operator provides cluster macros, backup automation, and schema sync — aligned with production needs. Cost: new dependency, learning curve. Current direction: **wrap existing manifests now**, evaluate operator after migration.
+
+### OQ-DEPLOY-03: GitOps adoption
+
+Once umbrella chart exists, is ArgoCD / Flux in scope? Enables pull-based deployment and drift detection. Requires secret management integration (Sealed Secrets or ESO). Current direction: **out of scope for this refactor**, but chart must be ArgoCD-compatible.
+
+## 8. Traceability
+
+- **ADR-0001**: [ADR/0001-umbrella-helm-chart.md](ADR/0001-umbrella-helm-chart.md)
+- **Related**: `ingestion/specs/ADR/0003-k8s-secrets-credentials.md` — credential resolution via K8s Secrets (consumed by this chart)

--- a/src/ingestion/k8s/airbyte/values-dev-vhc.yaml
+++ b/src/ingestion/k8s/airbyte/values-dev-vhc.yaml
@@ -1,0 +1,58 @@
+# Airbyte Helm values — local Kind cluster
+# Uses latest version from airbyte/airbyte Helm chart
+
+# Disable connector builder to save resources locally
+connectorBuilderServer:
+  enabled: false
+
+server:
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 100m
+
+worker:
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 100m
+
+workloadLauncher:
+  resources:
+    requests:
+      memory: 128Mi
+      cpu: 50m
+
+workloadApiServer:
+  resources:
+    requests:
+      memory: 128Mi
+      cpu: 50m
+
+cron:
+  resources:
+    requests:
+      memory: 128Mi
+      cpu: 50m
+
+temporal:
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 100m
+
+# Airbyte's internal Postgres (managed by the chart)
+postgresql:
+  resources:
+    requests:
+      memory: 256Mi
+      cpu: 100m
+
+# Default admin account for local dev
+global:
+  auth:
+    instanceAdmin:
+      firstName: Admin
+      lastName: Local
+      email: admin@example.com
+      password: admin123

--- a/src/ingestion/k8s/argo/values-dev-vhc.yaml
+++ b/src/ingestion/k8s/argo/values-dev-vhc.yaml
@@ -1,0 +1,31 @@
+# Helm values for argo/argo-workflows chart
+# Local Kind cluster — minimal resources, server auth mode
+
+server:
+  extraArgs:
+    - "--auth-mode=server"
+  serviceType: NodePort
+  serviceNodePort: 30500
+  resources:
+    requests:
+      memory: 128Mi
+      cpu: 100m
+
+controller:
+  workflowNamespaces:
+    - argo
+  resources:
+    requests:
+      memory: 128Mi
+      cpu: 100m
+
+workflow:
+  serviceAccount:
+    create: true
+    name: argo-workflow
+
+executor:
+  resources:
+    requests:
+      memory: 64Mi
+      cpu: 50m


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#202](https://github.com/cyberfabric/cyber-insight/pull/202) | **Author:** mitasovr | **Opened:** 2026-04-20T14:57:08Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary
- Add new `deploy` domain spec (`docs/domain/deploy/`) — DESIGN with target umbrella Helm chart, namespace layout, `global.*` values hierarchy, `<dep>.enabled` toggles, environment matrix (local Kind / dev-vhc k3s / Virtuozzo), migration plan, and a **§6 Known Workarounds** section capturing tech debt discovered during bring-up.
- Add ADR-0001 — decision record for umbrella Helm chart over per-service charts / bash orchestrator.
- Add dev-vhc environment profile for Airbyte and Argo (`src/ingestion/k8s/{airbyte,argo}/values-dev-vhc.yaml`) used on k3s single-node dev VM `10.21.14.101`.
- Register the `deploy` domain in `docs/domain/README.md`.

This PR is documentation + one new environment config profile. No code or chart changes. Umbrella-chart refactor itself is tracked in the spec's §5 migration plan and not landed here.

## Test plan
- [ ] Specs render on GitHub with working TOCs and cross-links
- [ ] `./up.sh --env dev-vhc ingestion` consumes `values-dev-vhc.yaml` on k3s (verified manually during authoring)
- [ ] No conflicts with any open PR that touches `docs/domain/` or `src/ingestion/k8s/{airbyte,argo}/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive deployment architecture documentation covering deployment strategies, environment configurations, and known constraints
  * Provided detailed environment setup guides for local development with cluster types and dependency configuration details

* **Chores**
  * Added environment-specific configuration files for local development of platform components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#202 -->