### PR TITLE
[PR #184] feat(deploy): parametrize up.sh for remote envs + K8s Secret-backed OIDC/CH creds

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,49 @@
+# Insight — local (Kind) environment.
+#
+# Copy to .env.local (gitignored) and adjust as needed.
+# Run:   ./up.sh --env local       # (default when --env is omitted)
+
+# ── Cluster ────────────────────────────────────────────────────
+CLUSTER_MODE=local                 # local | remote
+CLUSTER_NAME=insight
+NAMESPACE=insight
+
+# ── Images ─────────────────────────────────────────────────────
+# Empty IMAGE_REGISTRY → images are built locally and loaded into Kind.
+IMAGE_REGISTRY=
+IMAGE_TAG=local
+IMAGE_PULL_POLICY=IfNotPresent
+BUILD_IMAGES=true
+BUILD_AND_PUSH=false
+
+# Frontend is pulled from a public registry by default.
+FE_IMAGE_REPOSITORY=ghcr.io/cyberfabric/insight-front
+FE_IMAGE_TAG=latest
+
+# ── Ingress ────────────────────────────────────────────────────
+INGRESS_INSTALL=true                # install ingress-nginx helm release
+INGRESS_MODE=hostPort               # hostPort | nodePort
+INGRESS_HTTP_PORT=8000              # Kind maps 8000 → container 80 (see k8s/kind-config.yaml)
+INGRESS_HTTPS_PORT=8443
+INGRESS_ENABLED=false               # chart-level Ingress resources (off for local, use port-forward)
+INGRESS_CLASS=nginx
+
+# ── Auth ───────────────────────────────────────────────────────
+AUTH_DISABLED=true                  # disable OIDC locally
+
+# ── Service wiring (defaults work for local Kind) ──────────────
+# Leave CLICKHOUSE_CREDENTIALS_SECRET empty for local — chart will use inline
+# CLICKHOUSE_USER / CLICKHOUSE_PASSWORD values instead.
+CLICKHOUSE_CREDENTIALS_SECRET=
+# CLICKHOUSE_USER=insight
+# CLICKHOUSE_PASSWORD=insight-local
+
+# When AUTH_DISABLED=false AND OIDC_EXISTING_SECRET is empty,
+# the api-gateway chart creates its own Secret from these values.
+OIDC_ISSUER=https://integrator-4985807.okta.com/oauth2/default
+OIDC_CLIENT_ID=0oa11o77z8qysGwEK698
+OIDC_REDIRECT_URI=http://localhost:8000/callback
+OIDC_AUDIENCE=api://default
+
+# When set, chart skips inline Secret creation and points envFrom at this existing Secret.
+OIDC_EXISTING_SECRET=

--- a/.env.virtuozzo.example
+++ b/.env.virtuozzo.example
@@ -1,0 +1,81 @@
+# Insight — Virtuozzo (remote OpenStack-Magnum cluster).
+#
+# Copy to .env.virtuozzo (gitignored) and fill in real values.
+#
+# One-time setup:
+#   1. Build & push images to a public registry (ghcr.io/cyberfabric/*).
+#      Re-run with BUILD_AND_PUSH=true, or run a CI job.
+#   2. Create Okta SPA application (PKCE, no client_secret), register redirect URI:
+#        http://<vpn-node-ip>/callback    e.g. http://192.168.44.36/callback
+#   3. Apply insight-oidc Secret (see src/backend/services/api-gateway/secrets/oidc.yaml.example)
+#
+# Typical deploy — додеплой недостающего без переразвертывания существующего:
+#   ./up.sh --env virtuozzo app
+# This deploys: ingress-nginx, redis, api-gateway, analytics-api, identity, frontend.
+# It does NOT touch existing: mariadb, clickhouse, airbyte, argo, metabase.
+
+# ── Cluster ────────────────────────────────────────────────────
+CLUSTER_MODE=remote
+NAMESPACE=insight
+KUBECONFIG=access/virtuozzo/cyber-insight/cyber-insight-k8s-31_03_2026_18_03.kubeconfig
+
+# ── Images ─────────────────────────────────────────────────────
+IMAGE_REGISTRY=ghcr.io/cyberfabric
+IMAGE_TAG=virtuozzo
+IMAGE_PULL_POLICY=Always
+# Target platform for the cluster. On an Apple Silicon workstation this
+# triggers buildx + QEMU emulation (slow but needed because Virtuozzo nodes
+# are amd64). When IMAGE_PLATFORM is set, buildx pushes directly (no local load).
+IMAGE_PLATFORM=linux/amd64
+
+# For routine deploys when image is already published, set both to false.
+# For first push (or after code change) set to true.
+BUILD_IMAGES=true
+BUILD_AND_PUSH=true
+
+FE_IMAGE_REPOSITORY=ghcr.io/cyberfabric/insight-front
+FE_IMAGE_TAG=latest
+
+# ── Ingress ────────────────────────────────────────────────────
+INGRESS_INSTALL=true
+INGRESS_MODE=hostPort               # binds controller pod directly to node:80/:443
+INGRESS_HTTP_PORT=80
+INGRESS_HTTPS_PORT=443
+INGRESS_ENABLED=true                # turn on chart-level Ingress resources
+INGRESS_CLASS=nginx
+
+# ── Infra: додеплой недостающего ───────────────────────────────
+# mariadb, clickhouse, airbyte, argo already exist — DO NOT re-deploy.
+# Redis is missing in the cluster but required by analytics-api.
+DEPLOY_REDIS=true
+
+# ── Auth ───────────────────────────────────────────────────────
+AUTH_DISABLED=false
+# All Okta values live in K8s Secret `insight-oidc` (apply via oidc.yaml.example).
+OIDC_EXISTING_SECRET=insight-oidc
+
+# ── Service wiring — match existing services in the cluster ────
+#
+# ClickHouse lives in `data` namespace. Credentials are NOT passed via env here —
+# the analytics-api and identity-resolution charts load them directly from the
+# existing `clickhouse-credentials` K8s Secret at pod runtime via secretKeyRef.
+# Rotate the password = update the secret + restart pods (no helm upgrade needed).
+CLICKHOUSE_URL=http://clickhouse.data.svc.cluster.local:8123
+CLICKHOUSE_DB=insight
+CLICKHOUSE_CREDENTIALS_SECRET=clickhouse-credentials
+CLICKHOUSE_CREDENTIALS_USER_KEY=username
+CLICKHOUSE_CREDENTIALS_PASSWORD_KEY=password
+
+# MariaDB: Bitnami release name is `mariadb`, service `mariadb`, database `analytics`.
+# Credentials come from `mariadb-credentials` secret (keys: mariadb-password, mariadb-root-password).
+# Get password:
+#   KUBECONFIG=... kubectl get secret mariadb-credentials -n insight \
+#     -o jsonpath='{.data.mariadb-password}' | base64 -d
+ANALYTICS_DB_URL=mysql://insight:CHANGE_ME@mariadb:3306/analytics
+
+# Redis — we deploy it as release `insight-redis` (Bitnami) in the insight namespace.
+# Default service: insight-redis-master.insight.svc.cluster.local:6379 (no auth)
+REDIS_URL=redis://insight-redis-master:6379
+
+# Identity Resolution — deployed by this script as release `insight-identity`.
+IDENTITY_URL=http://insight-identity-identity-resolution:8082

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+.env
 .env.local
+.env.*
+!.env.*.example
 up-orb.sh
 __pycache__/
 *.pyc

--- a/src/backend/services/analytics-api/helm/templates/deployment.yaml
+++ b/src/backend/services/analytics-api/helm/templates/deployment.yaml
@@ -35,6 +35,19 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ .Values.existingSecret | default (printf "%s-config" (include "insight-analytics-api.fullname" .)) }}
+          {{- if .Values.clickhouse.credentialsSecret.name }}
+          env:
+            - name: ANALYTICS__clickhouse_user
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.clickhouse.credentialsSecret.name | quote }}
+                  key: {{ .Values.clickhouse.credentialsSecret.userKey | quote }}
+            - name: ANALYTICS__clickhouse_password
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.clickhouse.credentialsSecret.name | quote }}
+                  key: {{ .Values.clickhouse.credentialsSecret.passwordKey | quote }}
+          {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
           {{- with .Values.livenessProbe }}
@@ -55,5 +68,18 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ .Values.existingSecret | default (printf "%s-config" (include "insight-analytics-api.fullname" .)) }}
+          {{- if .Values.clickhouse.credentialsSecret.name }}
+          env:
+            - name: ANALYTICS__clickhouse_user
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.clickhouse.credentialsSecret.name | quote }}
+                  key: {{ .Values.clickhouse.credentialsSecret.userKey | quote }}
+            - name: ANALYTICS__clickhouse_password
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.clickhouse.credentialsSecret.name | quote }}
+                  key: {{ .Values.clickhouse.credentialsSecret.passwordKey | quote }}
+          {{- end }}
           securityContext:
             allowPrivilegeEscalation: false

--- a/src/backend/services/analytics-api/helm/templates/secret.yaml
+++ b/src/backend/services/analytics-api/helm/templates/secret.yaml
@@ -10,11 +10,13 @@ stringData:
   ANALYTICS__database_url: {{ required "database.url is required" .Values.database.url | quote }}
   ANALYTICS__clickhouse_url: {{ required "clickhouse.url is required" .Values.clickhouse.url | quote }}
   ANALYTICS__clickhouse_database: {{ .Values.clickhouse.database | quote }}
+  {{- if not .Values.clickhouse.credentialsSecret.name }}
   {{- if .Values.clickhouse.user }}
   ANALYTICS__clickhouse_user: {{ .Values.clickhouse.user | quote }}
   {{- end }}
   {{- if .Values.clickhouse.password }}
   ANALYTICS__clickhouse_password: {{ .Values.clickhouse.password | quote }}
+  {{- end }}
   {{- end }}
   ANALYTICS__identity_resolution_url: {{ .Values.identityResolution.url | quote }}
   ANALYTICS__redis_url: {{ .Values.redis.url | quote }}

--- a/src/backend/services/analytics-api/helm/values.yaml
+++ b/src/backend/services/analytics-api/helm/values.yaml
@@ -31,6 +31,14 @@ database:
 clickhouse:
   url: "http://insight-clickhouse:8123"
   database: "insight"
+  # Credentials: prefer a pre-existing K8s Secret (set credentialsSecret.name).
+  # When credentialsSecret.name is set, user/password below are ignored and
+  # values are injected via env: secretKeyRef at pod level.
+  credentialsSecret:
+    name: ""                  # e.g., clickhouse-credentials
+    userKey: "username"
+    passwordKey: "password"
+  # Inline fallback (used only when credentialsSecret.name is empty).
   user: "insight"
   password: "insight-pass"
 

--- a/src/backend/services/api-gateway/helm/templates/deployment.yaml
+++ b/src/backend/services/api-gateway/helm/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         {{- include "insight-api-gateway.selectorLabels" . | nindent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- if not .Values.authDisabled }}
+        {{- if and (not .Values.authDisabled) (not .Values.oidc.existingSecret) }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
         {{- with .Values.podAnnotations }}
@@ -47,21 +47,8 @@ spec:
                 name: {{ include "insight-api-gateway.fullname" . }}-config
             {{- if not .Values.authDisabled }}
             - secretRef:
-                name: {{ include "insight-api-gateway.fullname" . }}-oidc
+                name: {{ .Values.oidc.existingSecret | default (printf "%s-oidc" (include "insight-api-gateway.fullname" .)) }}
             {{- end }}
-          env:
-            - name: CLICKHOUSE_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: clickhouse-credentials
-                  key: password
-                  optional: true
-            - name: CLICKHOUSE_USER
-              valueFrom:
-                secretKeyRef:
-                  name: clickhouse-credentials
-                  key: username
-                  optional: true
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false

--- a/src/backend/services/api-gateway/helm/templates/secret.yaml
+++ b/src/backend/services/api-gateway/helm/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.authDisabled }}
+{{- if and (not .Values.authDisabled) (not .Values.oidc.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,11 +7,11 @@ metadata:
     {{- include "insight-api-gateway.labels" . | nindent 4 }}
 type: Opaque
 stringData:
-  APP__modules__oidc-authn-plugin__config__issuer_url: {{ required "oidc.issuer is required when auth is enabled" .Values.oidc.issuer | quote }}
+  APP__modules__oidc-authn-plugin__config__issuer_url: {{ required "oidc.issuer is required when auth is enabled and oidc.existingSecret is not set" .Values.oidc.issuer | quote }}
   APP__modules__oidc-authn-plugin__config__audience: {{ .Values.oidc.audience | quote }}
-  APP__modules__auth-info__config__issuer_url: {{ required "oidc.issuer is required when auth is enabled" .Values.oidc.issuer | quote }}
-  APP__modules__auth-info__config__client_id: {{ required "oidc.clientId is required when auth is enabled" .Values.oidc.clientId | quote }}
-  APP__modules__auth-info__config__redirect_uri: {{ required "oidc.redirectUri is required when auth is enabled" .Values.oidc.redirectUri | quote }}
+  APP__modules__auth-info__config__issuer_url: {{ required "oidc.issuer is required when auth is enabled and oidc.existingSecret is not set" .Values.oidc.issuer | quote }}
+  APP__modules__auth-info__config__client_id: {{ required "oidc.clientId is required when auth is enabled and oidc.existingSecret is not set" .Values.oidc.clientId | quote }}
+  APP__modules__auth-info__config__redirect_uri: {{ required "oidc.redirectUri is required when auth is enabled and oidc.existingSecret is not set" .Values.oidc.redirectUri | quote }}
   {{- if .Values.oidc.jwksUrl }}
   APP__modules__oidc-authn-plugin__config__jwks_url: {{ .Values.oidc.jwksUrl | quote }}
   {{- end }}

--- a/src/backend/services/api-gateway/helm/values.yaml
+++ b/src/backend/services/api-gateway/helm/values.yaml
@@ -29,7 +29,15 @@ resources:
     memory: 256Mi
 
 # OIDC configuration (required for production)
+#
+# Two modes:
+#   1. Pre-provisioned Secret (recommended): set oidc.existingSecret to the
+#      name of a K8s Secret containing all OIDC env vars (see secrets/oidc.yaml.example).
+#      Values below are ignored.
+#   2. Inline values: set oidc.issuer / clientId / redirectUri / audience directly.
+#      The chart will create its own Secret from these values. Suitable for local dev.
 oidc:
+  existingSecret: ""      # Name of pre-provisioned Secret. When set, inline values below are ignored.
   issuer: ""              # e.g., https://dev-12345.okta.com/oauth2/default
   audience: ""            # e.g., api://insight
   clientId: ""            # Frontend (public) OIDC client ID

--- a/src/backend/services/api-gateway/secrets/.gitignore
+++ b/src/backend/services/api-gateway/secrets/.gitignore
@@ -1,0 +1,4 @@
+# Real secrets — never commit
+*.yaml
+!*.yaml.example
+!.gitignore

--- a/src/backend/services/api-gateway/secrets/oidc.yaml.example
+++ b/src/backend/services/api-gateway/secrets/oidc.yaml.example
@@ -1,0 +1,35 @@
+# Insight API Gateway — OIDC Secret (Okta, Authorization Code + PKCE)
+#
+# Keys are API Gateway env-var overrides (APP__<module>__config__<key>).
+# They are consumed via `envFrom: secretRef` in the Helm chart when
+# `oidc.existingSecret` points to this Secret.
+#
+# Usage:
+#   1. Copy this file to oidc.yaml (gitignored):
+#        cp oidc.yaml.example oidc.yaml
+#   2. Fill in real Okta values.
+#   3. Apply:
+#        kubectl apply -n insight -f oidc.yaml
+#   4. Reference in Helm:
+#        --set oidc.existingSecret=insight-oidc
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-oidc
+  labels:
+    app.kubernetes.io/part-of: insight
+    app.kubernetes.io/component: api-gateway
+  annotations:
+    insight.cyberfabric.com/component: api-gateway
+type: Opaque
+stringData:
+  # ─── oidc-authn-plugin (validates bearer tokens) ───────────────
+  APP__modules__oidc-authn-plugin__config__issuer_url: "https://integrator-4985807.okta.com/oauth2/default"
+  APP__modules__oidc-authn-plugin__config__audience: "api://default"
+
+  # ─── auth-info (public GET /api/v1/auth/config for the SPA) ────
+  # issuer_url MUST match the one above.
+  APP__modules__auth-info__config__issuer_url: "https://integrator-4985807.okta.com/oauth2/default"
+  APP__modules__auth-info__config__client_id: "CHANGE_ME"                         # Okta SPA app client ID (PKCE, no secret)
+  APP__modules__auth-info__config__redirect_uri: "http://CHANGE_ME/callback"      # e.g., http://192.168.44.36/callback

--- a/src/backend/services/identity/helm/templates/deployment.yaml
+++ b/src/backend/services/identity/helm/templates/deployment.yaml
@@ -30,6 +30,19 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ .Values.existingSecret | default (printf "%s-config" (include "insight-identity-resolution.fullname" .)) }}
+          {{- if .Values.clickhouse.credentialsSecret.name }}
+          env:
+            - name: IDENTITY__clickhouse_user
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.clickhouse.credentialsSecret.name | quote }}
+                  key: {{ .Values.clickhouse.credentialsSecret.userKey | quote }}
+            - name: IDENTITY__clickhouse_password
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.clickhouse.credentialsSecret.name | quote }}
+                  key: {{ .Values.clickhouse.credentialsSecret.passwordKey | quote }}
+          {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/src/backend/services/identity/helm/templates/secret.yaml
+++ b/src/backend/services/identity/helm/templates/secret.yaml
@@ -9,11 +9,13 @@ type: Opaque
 stringData:
   IDENTITY__clickhouse_url: {{ required "clickhouse.url is required" .Values.clickhouse.url | quote }}
   IDENTITY__clickhouse_database: {{ .Values.clickhouse.database | quote }}
+  {{- if not .Values.clickhouse.credentialsSecret.name }}
   {{- if .Values.clickhouse.user }}
   IDENTITY__clickhouse_user: {{ .Values.clickhouse.user | quote }}
   {{- end }}
   {{- if .Values.clickhouse.password }}
   IDENTITY__clickhouse_password: {{ .Values.clickhouse.password | quote }}
+  {{- end }}
   {{- end }}
   IDENTITY__bind_addr: "0.0.0.0:{{ .Values.service.port }}"
 {{- end }}

--- a/src/backend/services/identity/helm/values.yaml
+++ b/src/backend/services/identity/helm/values.yaml
@@ -25,6 +25,14 @@ existingSecret: ""
 clickhouse:
   url: "http://insight-clickhouse:8123"
   database: "insight"
+  # Credentials: prefer a pre-existing K8s Secret (set credentialsSecret.name).
+  # When set, user/password below are ignored and values are injected via
+  # env: secretKeyRef at pod level.
+  credentialsSecret:
+    name: ""                  # e.g., clickhouse-credentials
+    userKey: "username"
+    passwordKey: "password"
+  # Inline fallback (used only when credentialsSecret.name is empty).
   user: "insight"
   password: ""
 

--- a/up.sh
+++ b/up.sh
@@ -1,166 +1,358 @@
 #!/usr/bin/env bash
-# Insight platform — bring up all services in a local Kind cluster.
+# Insight platform — bring up all services in a Kubernetes cluster.
+#
+# Environment is selected with --env <name>. Configuration for each environment
+# lives in .env.<name> at the repo root. See .env.local.example for the full
+# contract.
 #
 # Components:
-#   1. Kind cluster + ingress-nginx
-#   2. Ingestion (Airbyte, ClickHouse, Argo)
-#   3. Backend  (Analytics API, Identity Resolution, API Gateway)
-#   4. Frontend (SPA)
+#   1. Cluster bootstrap (Kind create / external kubeconfig)
+#   2. Ingress controller (optional, driven by INGRESS_INSTALL)
+#   3. Ingestion (Airbyte, ClickHouse, Argo)
+#   4. Backend (Analytics API, Identity Resolution, API Gateway)
+#   5. Frontend (SPA)
 #
 # Usage:
-#   ./up.sh              # full stack
-#   ./up.sh ingestion    # only ingestion services
-#   ./up.sh app          # only backend + frontend
+#   ./up.sh                         # --env local, all components
+#   ./up.sh --env virtuozzo         # remote cluster, all components
+#   ./up.sh --env virtuozzo app     # backend + frontend only
+#   ./up.sh ingestion               # only ingestion (default env=local)
+#
+# Valid components: all | ingestion | app | backend | frontend
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$ROOT_DIR"
 
-ENV="${ENV:-local}"
-CLUSTER_NAME="insight"
-KUBECONFIG_PATH="${KUBECONFIG:-${HOME}/.kube/insight.kubeconfig}"
-COMPONENT="${1:-all}"
-
-# ─── Load .env.local (OIDC credentials, overrides) ─────────────────────────
-ENV_FILE="$ROOT_DIR/.env.local"
-if [[ -f "$ENV_FILE" ]]; then
-  # shellcheck source=/dev/null
-  source "$ENV_FILE"
-fi
-
-: "${OIDC_ISSUER:?ERROR: OIDC_ISSUER is required — set it in .env.local}"
-: "${OIDC_CLIENT_ID:?ERROR: OIDC_CLIENT_ID is required — set it in .env.local}"
-OIDC_REDIRECT_URI="${OIDC_REDIRECT_URI:-http://localhost:8000/callback}"
-OIDC_AUDIENCE="${OIDC_AUDIENCE:-api://default}"
-
-# Timestamp to force pod restarts when image tag doesn't change
-DEPLOY_TS="$(date +%s)"
-
-echo "=== Insight Platform — Environment: ${ENV} ==="
-
-# --- Prerequisites ---
-for cmd in kubectl helm docker; do
-  if ! command -v "$cmd" &>/dev/null; then
-    echo "ERROR: $cmd is required but not found" >&2
-    exit 1
-  fi
+# ─── Argument parsing ─────────────────────────────────────────────────────
+ENV_NAME="local"
+COMPONENT="all"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env)
+      ENV_NAME="$2"
+      shift 2
+      ;;
+    --env=*)
+      ENV_NAME="${1#*=}"
+      shift
+      ;;
+    -h|--help)
+      grep -E '^#( |$)' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      COMPONENT="$1"
+      shift
+      ;;
+  esac
 done
 
-# ─── Kind cluster (local only) ───────────────────────────────────────────────
-if [[ "$ENV" == "local" ]]; then
-  if ! command -v kind &>/dev/null; then
-    echo "ERROR: kind is required for local development" >&2
-    exit 1
-  fi
+# ─── Load environment config ──────────────────────────────────────────────
+ENV_FILE="$ROOT_DIR/.env.${ENV_NAME}"
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "ERROR: env file not found: $ENV_FILE" >&2
+  echo "       Copy .env.${ENV_NAME}.example to .env.${ENV_NAME} and fill it in." >&2
+  exit 1
+fi
+# shellcheck source=/dev/null
+set -a
+source "$ENV_FILE"
+set +a
 
+# ─── Defaults (env file may override) ─────────────────────────────────────
+CLUSTER_MODE="${CLUSTER_MODE:-local}"           # local | remote
+CLUSTER_NAME="${CLUSTER_NAME:-insight}"
+NAMESPACE="${NAMESPACE:-insight}"
+
+IMAGE_REGISTRY="${IMAGE_REGISTRY:-}"            # empty = local-only images
+IMAGE_TAG="${IMAGE_TAG:-local}"
+IMAGE_PULL_POLICY="${IMAGE_PULL_POLICY:-IfNotPresent}"
+IMAGE_PULL_SECRET="${IMAGE_PULL_SECRET:-}"
+IMAGE_PLATFORM="${IMAGE_PLATFORM:-}"            # e.g., linux/amd64. Empty = native.
+BUILD_IMAGES="${BUILD_IMAGES:-true}"
+BUILD_AND_PUSH="${BUILD_AND_PUSH:-false}"
+LOAD_IMAGES_INTO_KIND="${LOAD_IMAGES_INTO_KIND:-auto}"   # auto = yes iff CLUSTER_MODE=local
+
+INGRESS_INSTALL="${INGRESS_INSTALL:-false}"
+INGRESS_CLASS="${INGRESS_CLASS:-nginx}"
+INGRESS_ENABLED="${INGRESS_ENABLED:-false}"     # chart-level ingress resource
+INGRESS_MODE="${INGRESS_MODE:-hostPort}"        # hostPort | nodePort
+INGRESS_HTTP_PORT="${INGRESS_HTTP_PORT:-80}"
+INGRESS_HTTPS_PORT="${INGRESS_HTTPS_PORT:-443}"
+
+AUTH_DISABLED="${AUTH_DISABLED:-false}"
+OIDC_EXISTING_SECRET="${OIDC_EXISTING_SECRET:-}"
+OIDC_ISSUER="${OIDC_ISSUER:-}"
+OIDC_CLIENT_ID="${OIDC_CLIENT_ID:-}"
+OIDC_REDIRECT_URI="${OIDC_REDIRECT_URI:-}"
+OIDC_AUDIENCE="${OIDC_AUDIENCE:-api://default}"
+
+DEPLOY_TS="$(date +%s)"
+
+# ─── Sanity ───────────────────────────────────────────────────────────────
+if [[ "$AUTH_DISABLED" != "true" && -z "$OIDC_EXISTING_SECRET" ]]; then
+  : "${OIDC_ISSUER:?ERROR: OIDC_ISSUER is required — set it in $ENV_FILE or use OIDC_EXISTING_SECRET}"
+  : "${OIDC_CLIENT_ID:?ERROR: OIDC_CLIENT_ID is required — set it in $ENV_FILE or use OIDC_EXISTING_SECRET}"
+  OIDC_REDIRECT_URI="${OIDC_REDIRECT_URI:-http://localhost:8000/callback}"
+fi
+
+echo "═══════════════════════════════════════════════════════════════"
+echo "  Insight Platform"
+echo "  Environment: ${ENV_NAME}   (${CLUSTER_MODE})"
+echo "  Component:   ${COMPONENT}"
+echo "  Namespace:   ${NAMESPACE}"
+echo "  Image:       ${IMAGE_REGISTRY:-<local>}/insight-*:${IMAGE_TAG}"
+echo "═══════════════════════════════════════════════════════════════"
+
+for cmd in kubectl helm docker; do
+  command -v "$cmd" &>/dev/null || { echo "ERROR: $cmd required" >&2; exit 1; }
+done
+
+# ─── Cluster bootstrap ────────────────────────────────────────────────────
+if [[ "$CLUSTER_MODE" == "local" ]]; then
+  command -v kind &>/dev/null || { echo "ERROR: kind required for CLUSTER_MODE=local" >&2; exit 1; }
+  KUBECONFIG_PATH="${KUBECONFIG:-${HOME}/.kube/insight.kubeconfig}"
   if ! kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
     echo "=== Creating Kind cluster '${CLUSTER_NAME}' ==="
     kind create cluster --config k8s/kind-config.yaml
-  else
-    if ! docker ps --format '{{.Names}}' | grep -q "^${CLUSTER_NAME}-control-plane$"; then
-      echo "=== Starting Kind cluster ==="
-      docker start "${CLUSTER_NAME}-control-plane"
-      sleep 5
-    else
-      echo "=== Kind cluster '${CLUSTER_NAME}' already running ==="
-    fi
+  elif ! docker ps --format '{{.Names}}' | grep -q "^${CLUSTER_NAME}-control-plane$"; then
+    echo "=== Starting Kind cluster ==="
+    docker start "${CLUSTER_NAME}-control-plane"
+    sleep 5
   fi
-
-  KUBECONFIG_PATH="$(kind get kubeconfig-path --name "${CLUSTER_NAME}" 2>/dev/null || echo "${HOME}/.kube/insight.kubeconfig")"
   kind export kubeconfig --name "${CLUSTER_NAME}" --kubeconfig "${KUBECONFIG_PATH}" 2>/dev/null || true
+  export KUBECONFIG="${KUBECONFIG_PATH}"
+else
+  # remote: KUBECONFIG must already be set via env file or shell
+  : "${KUBECONFIG:?ERROR: KUBECONFIG must be set for CLUSTER_MODE=remote (set it in $ENV_FILE)}"
+  if [[ "$KUBECONFIG" != /* ]]; then
+    KUBECONFIG="$ROOT_DIR/$KUBECONFIG"
+  fi
+  [[ -f "$KUBECONFIG" ]] || { echo "ERROR: kubeconfig not found: $KUBECONFIG" >&2; exit 1; }
+  export KUBECONFIG
 fi
-
-export KUBECONFIG="${KUBECONFIG_PATH}"
 echo "  KUBECONFIG=${KUBECONFIG}"
 
-# ─── Ingress controller (local only) ─────────────────────────────────────────
-if [[ "$ENV" == "local" ]]; then
-  echo "=== Installing ingress-nginx ==="
+# Resolve whether to load images into Kind
+if [[ "$LOAD_IMAGES_INTO_KIND" == "auto" ]]; then
+  [[ "$CLUSTER_MODE" == "local" ]] && LOAD_IMAGES_INTO_KIND=true || LOAD_IMAGES_INTO_KIND=false
+fi
+
+# ─── Ingress controller ───────────────────────────────────────────────────
+if [[ "$INGRESS_INSTALL" == "true" ]]; then
+  echo "=== Installing ingress-nginx (${INGRESS_MODE}) ==="
   helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx 2>/dev/null || true
+  helm repo update ingress-nginx >/dev/null
+  INGRESS_ARGS=(
+    --namespace ingress-nginx --create-namespace
+    --set controller.watchIngressWithoutClass=true
+    --set controller.ingressClassResource.default=true
+  )
+  case "$INGRESS_MODE" in
+    hostPort)
+      INGRESS_ARGS+=(
+        --set controller.kind=DaemonSet
+        --set controller.hostPort.enabled=true
+        --set controller.hostPort.ports.http="$INGRESS_HTTP_PORT"
+        --set controller.hostPort.ports.https="$INGRESS_HTTPS_PORT"
+        --set controller.service.type=ClusterIP
+      )
+      ;;
+    nodePort)
+      INGRESS_ARGS+=(
+        --set controller.service.type=NodePort
+        --set controller.service.nodePorts.http="$INGRESS_HTTP_PORT"
+        --set controller.service.nodePorts.https="$INGRESS_HTTPS_PORT"
+      )
+      ;;
+    *)
+      echo "ERROR: unknown INGRESS_MODE: $INGRESS_MODE (hostPort|nodePort)" >&2
+      exit 1
+      ;;
+  esac
   helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
-    --namespace ingress-nginx --create-namespace \
-    --set controller.hostPort.enabled=true \
-    --set controller.service.type=ClusterIP \
-    --set controller.watchIngressWithoutClass=true \
-    --wait --timeout 3m
+    "${INGRESS_ARGS[@]}" --wait --timeout 5m
 fi
 
-# ─── Namespace for app services ──────────────────────────────────────────────
-kubectl create namespace insight --dry-run=client -o yaml | kubectl apply -f -
+# ─── Namespace ────────────────────────────────────────────────────────────
+kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
 
-# ─── Ingestion ───────────────────────────────────────────────────────────────
+# ─── Ingestion ────────────────────────────────────────────────────────────
 if [[ "$COMPONENT" == "all" || "$COMPONENT" == "ingestion" ]]; then
-  "$ROOT_DIR/src/ingestion/up.sh"
+  ENV="$ENV_NAME" "$ROOT_DIR/src/ingestion/up.sh"
 fi
 
-# ─── Backend (API Gateway) ───────────────────────────────────────────────────
-if [[ "$COMPONENT" == "all" || "$COMPONENT" == "app" || "$COMPONENT" == "backend" ]]; then
-  echo "=== Building API Gateway ==="
-  docker build -t insight-api-gateway:local \
-    -f src/backend/services/api-gateway/Dockerfile \
-    src/backend/
-
-  if [[ "$ENV" == "local" ]]; then
-    kind load docker-image insight-api-gateway:local --name "${CLUSTER_NAME}"
+# ─── App-level infra (redis) ──────────────────────────────────────────────
+# Plain Deployment + Service. Cache only — no persistence, no auth.
+# (Using redis:7-alpine from Docker Hub; bitnami/redis chart images moved
+# behind a paywall in 2025 and no longer pull freely.)
+if [[ "$COMPONENT" == "all" || "$COMPONENT" == "app" || "$COMPONENT" == "infra" ]]; then
+  if [[ "${DEPLOY_REDIS:-false}" == "true" ]]; then
+    echo "=== Deploying Redis ==="
+    kubectl apply -n "$NAMESPACE" -f - <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: insight-redis-master
+  labels: {app.kubernetes.io/name: redis, app.kubernetes.io/instance: insight-redis}
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app.kubernetes.io/name: redis, app.kubernetes.io/instance: insight-redis}
+  template:
+    metadata:
+      labels: {app.kubernetes.io/name: redis, app.kubernetes.io/instance: insight-redis}
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          args: ["redis-server", "--appendonly", "no", "--save", ""]
+          ports:
+            - name: tcp-redis
+              containerPort: 6379
+          readinessProbe:
+            tcpSocket: {port: tcp-redis}
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          resources:
+            requests: {cpu: 50m, memory: 32Mi}
+            limits:   {cpu: 200m, memory: 128Mi}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: insight-redis-master
+  labels: {app.kubernetes.io/name: redis, app.kubernetes.io/instance: insight-redis}
+spec:
+  type: ClusterIP
+  selector: {app.kubernetes.io/name: redis, app.kubernetes.io/instance: insight-redis}
+  ports:
+    - name: tcp-redis
+      port: 6379
+      targetPort: tcp-redis
+EOF
+    kubectl rollout status deployment/insight-redis-master -n "$NAMESPACE" --timeout=2m
   fi
+fi
 
-  echo "=== Building Analytics API ==="
-  docker build -t insight-analytics-api:local \
-    -f src/backend/services/analytics-api/Dockerfile \
-    src/backend/
+# ─── Backend ──────────────────────────────────────────────────────────────
+image_ref() {
+  local svc="$1"
+  echo "${IMAGE_REGISTRY:+$IMAGE_REGISTRY/}insight-${svc}:${IMAGE_TAG}"
+}
 
-  if [[ "$ENV" == "local" ]]; then
-    kind load docker-image insight-analytics-api:local --name "${CLUSTER_NAME}"
+build_and_load_image() {
+  local svc="$1" dockerfile="$2"
+  local full; full=$(image_ref "$svc")
+
+  if [[ "$BUILD_IMAGES" == "true" ]]; then
+    if [[ -n "$IMAGE_PLATFORM" ]]; then
+      # Cross-platform build via buildx. For non-native platforms, buildx cannot
+      # load the result into the local docker image store — we push directly.
+      if [[ -z "$IMAGE_REGISTRY" ]]; then
+        echo "ERROR: IMAGE_PLATFORM set but IMAGE_REGISTRY is empty — cross-platform build needs a registry to push to" >&2
+        exit 1
+      fi
+      echo "  Building ${full} for ${IMAGE_PLATFORM} (buildx + push)..."
+      docker buildx build --platform "$IMAGE_PLATFORM" \
+        -t "$full" -f "$dockerfile" --push src/backend/
+    else
+      echo "  Building ${full}..."
+      docker build -t "$full" -f "$dockerfile" src/backend/
+      if [[ -n "$IMAGE_REGISTRY" && "$BUILD_AND_PUSH" == "true" ]]; then
+        echo "  Pushing ${full}..."
+        docker push "$full"
+      fi
+    fi
+  fi
+  if [[ "$LOAD_IMAGES_INTO_KIND" == "true" ]]; then
+    echo "  Loading ${full} into Kind..."
+    kind load docker-image "$full" --name "${CLUSTER_NAME}"
+  fi
+}
+
+helm_image_args() {
+  local full="$1"
+  local repo="${full%:*}"
+  local tag="${full##*:}"
+  printf -- '--set image.repository=%s --set image.tag=%s --set image.pullPolicy=%s' \
+    "$repo" "$tag" "$IMAGE_PULL_POLICY"
+  if [[ -n "$IMAGE_PULL_SECRET" ]]; then
+    printf -- ' --set imagePullSecrets[0].name=%s' "$IMAGE_PULL_SECRET"
+  fi
+}
+
+if [[ "$COMPONENT" == "all" || "$COMPONENT" == "app" || "$COMPONENT" == "backend" ]]; then
+  build_and_load_image analytics-api src/backend/services/analytics-api/Dockerfile
+  build_and_load_image identity       src/backend/services/identity/Dockerfile
+  build_and_load_image api-gateway    src/backend/services/api-gateway/Dockerfile
+  ANALYTICS_IMG=$(image_ref analytics-api)
+  IDENTITY_IMG=$(image_ref identity)
+  GATEWAY_IMG=$(image_ref api-gateway)
+
+  # ── Service wiring (env-configurable) ───────────────────────────────
+  ANALYTICS_DB_URL="${ANALYTICS_DB_URL:-mysql://insight:insight-pass@insight-mariadb:3306/analytics}"
+  CLICKHOUSE_URL="${CLICKHOUSE_URL:-http://clickhouse.data.svc.cluster.local:8123}"
+  CLICKHOUSE_DB="${CLICKHOUSE_DB:-insight}"
+  CLICKHOUSE_CREDENTIALS_SECRET="${CLICKHOUSE_CREDENTIALS_SECRET:-}"
+  CLICKHOUSE_CREDENTIALS_USER_KEY="${CLICKHOUSE_CREDENTIALS_USER_KEY:-username}"
+  CLICKHOUSE_CREDENTIALS_PASSWORD_KEY="${CLICKHOUSE_CREDENTIALS_PASSWORD_KEY:-password}"
+  # Inline fallback: only used when CLICKHOUSE_CREDENTIALS_SECRET is empty
+  CLICKHOUSE_USER="${CLICKHOUSE_USER:-default}"
+  CLICKHOUSE_PASSWORD="${CLICKHOUSE_PASSWORD:-}"
+  REDIS_URL="${REDIS_URL:-redis://insight-redis-master:6379}"
+  IDENTITY_URL="${IDENTITY_URL:-http://insight-identity-identity-resolution:8082}"
+
+  # Build --set args for ClickHouse credentials: prefer secretRef
+  CH_CREDS_ARGS=()
+  if [[ -n "$CLICKHOUSE_CREDENTIALS_SECRET" ]]; then
+    CH_CREDS_ARGS+=(
+      --set clickhouse.credentialsSecret.name="$CLICKHOUSE_CREDENTIALS_SECRET"
+      --set clickhouse.credentialsSecret.userKey="$CLICKHOUSE_CREDENTIALS_USER_KEY"
+      --set clickhouse.credentialsSecret.passwordKey="$CLICKHOUSE_CREDENTIALS_PASSWORD_KEY"
+      --set clickhouse.user=
+      --set clickhouse.password=
+    )
+  else
+    CH_CREDS_ARGS+=(
+      --set clickhouse.user="$CLICKHOUSE_USER"
+      --set clickhouse.password="$CLICKHOUSE_PASSWORD"
+    )
   fi
 
   echo "=== Deploying Analytics API ==="
+  # shellcheck disable=SC2046
   helm upgrade --install insight-analytics src/backend/services/analytics-api/helm/ \
-    --namespace insight \
-    --set image.repository=insight-analytics-api \
-    --set image.tag=local \
-    --set image.pullPolicy=IfNotPresent \
-    --set database.url="mysql://insight:insight-pass@insight-mariadb:3306/analytics" \
-    --set clickhouse.url="http://clickhouse.data.svc.cluster.local:8123" \
-    --set clickhouse.database=insight \
-    --set redis.url="redis://insight-redis-master:6379" \
-    --set identityResolution.url="http://insight-identity-identity-resolution:8082" \
+    --namespace "$NAMESPACE" \
+    $(helm_image_args "$ANALYTICS_IMG") \
+    --set database.url="$ANALYTICS_DB_URL" \
+    --set clickhouse.url="$CLICKHOUSE_URL" \
+    --set clickhouse.database="$CLICKHOUSE_DB" \
+    "${CH_CREDS_ARGS[@]}" \
+    --set redis.url="$REDIS_URL" \
+    --set identityResolution.url="$IDENTITY_URL" \
     --set-string podAnnotations.deployedAt="$DEPLOY_TS" \
     --wait --timeout 3m
 
-  echo "=== Building Identity Resolution ==="
-  docker build -t insight-identity:local \
-    -f src/backend/services/identity/Dockerfile \
-    src/backend/
-
-  if [[ "$ENV" == "local" ]]; then
-    kind load docker-image insight-identity:local --name "${CLUSTER_NAME}"
-  fi
-
   echo "=== Deploying Identity Resolution ==="
+  # shellcheck disable=SC2046
   helm upgrade --install insight-identity src/backend/services/identity/helm/ \
-    --namespace insight \
-    --set image.repository=insight-identity \
-    --set image.tag=local \
-    --set image.pullPolicy=IfNotPresent \
-    --set clickhouse.url="http://clickhouse.data.svc.cluster.local:8123" \
-    --set clickhouse.database=insight \
-    --set clickhouse.user="${CLICKHOUSE_USER:-insight}" \
-    --set clickhouse.password="${CLICKHOUSE_PASSWORD:-}" \
+    --namespace "$NAMESPACE" \
+    $(helm_image_args "$IDENTITY_IMG") \
+    --set clickhouse.url="$CLICKHOUSE_URL" \
+    --set clickhouse.database="$CLICKHOUSE_DB" \
+    "${CH_CREDS_ARGS[@]}" \
     --set-string podAnnotations.deployedAt="$DEPLOY_TS" \
     --wait --timeout 3m
 
   echo "=== Deploying API Gateway ==="
-  GW_HELM_ARGS=(
-    --namespace insight
-    --set image.repository=insight-api-gateway
-    --set image.tag=local
-    --set image.pullPolicy=IfNotPresent
-    --set ingress.enabled=false
+  GW_ARGS=(
+    --namespace "$NAMESPACE"
+    --set ingress.enabled="$INGRESS_ENABLED"
+    --set ingress.className="$INGRESS_CLASS"
     --set gateway.enableDocs=true
-    --set oidc.issuer="$OIDC_ISSUER"
-    --set oidc.audience="$OIDC_AUDIENCE"
-    --set oidc.clientId="$OIDC_CLIENT_ID"
-    --set oidc.redirectUri="$OIDC_REDIRECT_URI"
+    --set authDisabled="$AUTH_DISABLED"
     --set proxy.routes[0].prefix=/analytics
     --set proxy.routes[0].upstream=http://insight-analytics-analytics-api:8081
     --set proxy.routes[0].public=false
@@ -168,62 +360,76 @@ if [[ "$COMPONENT" == "all" || "$COMPONENT" == "app" || "$COMPONENT" == "backend
     --set proxy.routes[1].upstream=http://insight-identity-identity-resolution:8082
     --set proxy.routes[1].public=false
     --set-string podAnnotations.deployedAt="$DEPLOY_TS"
-    --wait --timeout 3m
   )
-  if [[ "$ENV" == "local" ]]; then
-    GW_HELM_ARGS+=(--set authDisabled=true)
+  # shellcheck disable=SC2206
+  GW_ARGS+=( $(helm_image_args "$GATEWAY_IMG") )
+  if [[ "$AUTH_DISABLED" != "true" ]]; then
+    if [[ -n "$OIDC_EXISTING_SECRET" ]]; then
+      GW_ARGS+=( --set oidc.existingSecret="$OIDC_EXISTING_SECRET" )
+    else
+      GW_ARGS+=(
+        --set oidc.issuer="$OIDC_ISSUER"
+        --set oidc.audience="$OIDC_AUDIENCE"
+        --set oidc.clientId="$OIDC_CLIENT_ID"
+        --set oidc.redirectUri="$OIDC_REDIRECT_URI"
+      )
+    fi
   fi
-  helm upgrade --install insight-gw src/backend/services/api-gateway/helm/ "${GW_HELM_ARGS[@]}"
+  helm upgrade --install insight-gw src/backend/services/api-gateway/helm/ "${GW_ARGS[@]}" --wait --timeout 3m
 fi
 
-# ─── Frontend ────────────────────────────────────────────────────────────────
+# ─── Frontend ─────────────────────────────────────────────────────────────
 if [[ "$COMPONENT" == "all" || "$COMPONENT" == "app" || "$COMPONENT" == "frontend" ]]; then
-  FE_IMAGE="ghcr.io/cyberfabric/insight-front:latest"
+  FE_REPO="${FE_IMAGE_REPOSITORY:-ghcr.io/cyberfabric/insight-front}"
+  FE_TAG="${FE_IMAGE_TAG:-latest}"
+  FE_IMAGE="${FE_REPO}:${FE_TAG}"
+
   echo "=== Pulling Frontend image ==="
   docker pull "$FE_IMAGE"
-  if [[ "$ENV" == "local" ]]; then
+  if [[ "$LOAD_IMAGES_INTO_KIND" == "true" ]]; then
     kind load docker-image "$FE_IMAGE" --name "${CLUSTER_NAME}"
   fi
 
   echo "=== Deploying Frontend ==="
-  helm upgrade --install insight-fe src/frontend/helm/ \
-    --namespace insight \
-    --set image.pullPolicy=IfNotPresent \
-    --set ingress.enabled=false \
-    --set oidc.issuer="$OIDC_ISSUER" \
-    --set oidc.clientId="$OIDC_CLIENT_ID" \
-    --set-string podAnnotations.deployedAt="$DEPLOY_TS" \
-    --wait --timeout 3m
+  FE_ARGS=(
+    --namespace "$NAMESPACE"
+    --set image.repository="$FE_REPO"
+    --set image.tag="$FE_TAG"
+    --set image.pullPolicy="$IMAGE_PULL_POLICY"
+    --set ingress.enabled="$INGRESS_ENABLED"
+    --set ingress.className="$INGRESS_CLASS"
+    --set-string podAnnotations.deployedAt="$DEPLOY_TS"
+  )
+  if [[ -n "$IMAGE_PULL_SECRET" ]]; then
+    FE_ARGS+=( --set "imagePullSecrets[0].name=$IMAGE_PULL_SECRET" )
+  fi
+  helm upgrade --install insight-fe src/frontend/helm/ "${FE_ARGS[@]}" --wait --timeout 3m
 fi
 
-# ─── Airbyte port-forward (local only) ──────────────────────────────────────
-if [[ "$ENV" == "local" && ("$COMPONENT" == "all" || "$COMPONENT" == "ingestion") ]]; then
+# ─── Airbyte port-forward (local only) ────────────────────────────────────
+if [[ "$CLUSTER_MODE" == "local" && ("$COMPONENT" == "all" || "$COMPONENT" == "ingestion") ]]; then
   echo "=== Starting Airbyte port-forward ==="
   pkill -f 'port-forward.*airbyte' 2>/dev/null || true
   kubectl -n airbyte port-forward svc/airbyte-airbyte-server-svc 8001:8001 >/dev/null 2>&1 &
 fi
 
-# ─── Summary ─────────────────────────────────────────────────────────────────
+# ─── Summary ──────────────────────────────────────────────────────────────
 echo ""
-echo "════════════════════════════════════════════════"
+echo "═══════════════════════════════════════════════════════════════"
 echo "  KUBECONFIG: ${KUBECONFIG}"
-echo "  To use:     export KUBECONFIG=${KUBECONFIG}"
-echo ""
-echo "  Services:"
-echo "    Frontend:   http://localhost:8000"
-echo "    API:        http://localhost:8000/api"
-echo "    Analytics:  http://localhost:8000/api/analytics/v1/metrics (via gateway)"
-echo "    Airbyte:    http://localhost:8001"
-echo "    Argo UI:    http://localhost:30500"
-echo "    ClickHouse: http://localhost:30123"
-# Show Airbyte UI credentials hint (don't print password to logs)
+if [[ "$CLUSTER_MODE" == "local" ]]; then
+  echo "  Frontend:   http://localhost:${INGRESS_HTTP_PORT:-8000}"
+  echo "  API:        http://localhost:${INGRESS_HTTP_PORT:-8000}/api"
+  echo "  Airbyte:    http://localhost:8001"
+  echo "  Argo UI:    http://localhost:30500"
+  echo "  ClickHouse: http://localhost:30123"
+else
+  echo "  Access via VPN-reachable node IP on port ${INGRESS_HTTP_PORT}"
+fi
 if kubectl get secret airbyte-auth-secrets -n airbyte &>/dev/null; then
   echo ""
   echo "  Airbyte UI login:"
   echo "    Email:    admin@example.com"
   echo "    Password: kubectl get secret airbyte-auth-secrets -n airbyte -o jsonpath='{.data.instance-admin-password}' | base64 -d"
 fi
-echo ""
-echo "  Next steps:"
-echo "    cd src/ingestion && ./run-init.sh"
-echo "════════════════════════════════════════════════"
+echo "═══════════════════════════════════════════════════════════════"


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#184](https://github.com/cyberfabric/cyber-insight/pull/184) | **Author:** mitasovr | **Opened:** 2026-04-16T21:51:01Z | **Status:** merged on 2026-04-17T08:57:55Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

- `up.sh` accepts `--env <name>` and loads `.env.<name>` — same script drives local Kind and remote (Virtuozzo) deploys without branching logic.
- Backend Helm charts (api-gateway, analytics-api, identity) gain support for pre-provisioned K8s Secrets: ClickHouse user/password are loaded via `env: secretKeyRef` from the existing `clickhouse-credentials` Secret, and api-gateway OIDC config comes from a new `insight-oidc` Secret via `envFrom`. Inline helm values remain as fallback for local dev.
- New image-pipeline knobs: `IMAGE_REGISTRY`, `IMAGE_TAG`, `IMAGE_PLATFORM`, `BUILD_AND_PUSH` — support buildx cross-platform push (needed to target amd64 cluster from Apple Silicon).
- Ingress install is opt-in via `INGRESS_INSTALL`, mode is `hostPort` (IP-only access behind VPN) or `NodePort`.
- Redis dependency uses a plain `redis:7-alpine` Deployment + Service (Bitnami Redis chart dropped after their image-hosting change).
- `.env.local.example`, `.env.virtuozzo.example`, and `src/backend/services/api-gateway/secrets/oidc.yaml.example` document every knob; `.env.*` and `*.yaml` under `secrets/` are gitignored.

## Test plan

- [ ] Local: `cp .env.local.example .env.local && ./up.sh` — Kind-based stack brings up ingestion + backend + frontend as before.
- [ ] Remote: `cp .env.virtuozzo.example .env.virtuozzo`, fill MariaDB creds and kubeconfig path, apply `src/backend/services/api-gateway/secrets/oidc.yaml` to cluster, run `./up.sh --env virtuozzo app` — ingress-nginx + redis + analytics-api + identity + api-gateway + frontend deploy into an existing cluster without touching mariadb/clickhouse/airbyte/argo.
- [ ] `helm template` renders correctly for both existingSecret and inline-values paths for each of the three charts.
- [ ] `GET /api/v1/auth/config` on the cluster returns the Okta config loaded from the `insight-oidc` Secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for multi-environment deployments with configuration templates for local and remote clusters
  * Introduced external Kubernetes secret support for ClickHouse credential management
  * Added OIDC authentication configuration example

* **Documentation**
  * Provided environment configuration templates for local and Virtuozzo deployments
  * Added OIDC configuration manifest example with setup instructions

* **Chores**
  * Enhanced bootstrap process to support multiple cluster types and configurations
  * Updated git ignore patterns for environment files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

Closes #840

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#184 -->