### PR TITLE
[PR #183] fix(ingestion): improve CDK connector setup resilience

### DIFF
--- a/src/ingestion/airbyte-toolkit/connect.sh
+++ b/src/ingestion/airbyte-toolkit/connect.sh
@@ -158,10 +158,11 @@ def discover_secrets():
                 raw = base64.b64decode(v).decode()
             except Exception:
                 raw = v
-            # Parse JSON arrays/objects stored as strings in K8s Secrets
+            # Parse JSON values stored as strings in K8s Secrets
+            # (arrays, objects, booleans, numbers)
             try:
                 parsed = json.loads(raw)
-                if isinstance(parsed, (list, dict)):
+                if isinstance(parsed, (list, dict, bool, int, float)):
                     data[k] = parsed
                 else:
                     data[k] = raw
@@ -346,20 +347,28 @@ for connector_name, source_id_label, config in connector_instances:
             state_pop(state, f"{tenant_connector_path}.connection_id")
         else:
             # Update source config (credentials may have changed)
-            api("POST", "/api/v1/sources/update", {
-                "sourceId": source_id,
-                "name": source_name,
-                "connectionConfiguration": config,
-            })
-            print(f"    Source updated: {source_id}")
+            try:
+                api("POST", "/api/v1/sources/update", {
+                    "sourceId": source_id,
+                    "name": source_name,
+                    "connectionConfiguration": config,
+                })
+                print(f"    Source updated: {source_id}")
+            except ApiError as e:
+                print(f"    ERROR: could not update source for {connector_name}: {e.code} {e.message[:200]}", file=sys.stderr)
+                continue
 
     if not source_id:
-        result = api("POST", "/api/v1/sources/create", {
-            "workspaceId": workspace_id,
-            "name": source_name,
-            "sourceDefinitionId": def_id,
-            "connectionConfiguration": config,
-        })
+        try:
+            result = api("POST", "/api/v1/sources/create", {
+                "workspaceId": workspace_id,
+                "name": source_name,
+                "sourceDefinitionId": def_id,
+                "connectionConfiguration": config,
+            })
+        except ApiError as e:
+            print(f"    ERROR: could not create source for {connector_name}: {e.code} {e.message[:200]}", file=sys.stderr)
+            continue
         if result and "sourceId" in result:
             source_id = result["sourceId"]
             print(f"    Source created: {source_id}")

--- a/src/ingestion/connectors/git/bitbucket-cloud/source_bitbucket_cloud/auth.py
+++ b/src/ingestion/connectors/git/bitbucket-cloud/source_bitbucket_cloud/auth.py
@@ -6,14 +6,15 @@ import base64
 def auth_headers(token: str, username: str = "") -> dict:
     """Build authentication headers for Bitbucket Cloud API requests.
 
-    Both personal API tokens and workspace access tokens use Basic Auth.
-    Personal tokens require username:token. Workspace tokens use
-    an arbitrary username (defaults to "x-token-auth") with the token as password.
+    Personal API tokens require Basic Auth (username:token).
+    Workspace/Repository/Project access tokens use Bearer auth.
+    When username is empty, Bearer is used (workspace access token).
     """
-    if not username:
-        username = "x-token-auth"
-    credentials = base64.b64encode(f"{username}:{token}".encode()).decode()
-    auth_value = f"Basic {credentials}"
+    if username:
+        credentials = base64.b64encode(f"{username}:{token}".encode()).decode()
+        auth_value = f"Basic {credentials}"
+    else:
+        auth_value = f"Bearer {token}"
 
     return {
         "Authorization": auth_value,


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#183](https://github.com/cyberfabric/cyber-insight/pull/183) | **Author:** mitasovr | **Opened:** 2026-04-16T18:04:00Z | **Status:** merged on 2026-04-16T18:54:23Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

- **connect.sh**: Wrap source create/update API calls in try/except so one failing connector doesn't abort the entire setup. Also parse all JSON value types from K8s secrets (bool, int, float), not just arrays/objects.
- **bitbucket-cloud auth.py**: Use Bearer auth for workspace/repository access tokens (when no username provided). Keep Basic auth only for personal API tokens.

## Test plan

- [ ] `connect.sh` with a mix of valid and invalid connectors — valid ones should succeed, invalid should log error and continue
- [ ] Bitbucket Cloud connector with workspace access token — should authenticate via Bearer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#183 -->