### PR TITLE
[PR #181] feat(ingestion): collaboration Silver dbt transformations

### DIFF
--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_chat_activity.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_chat_activity.sql
@@ -1,0 +1,37 @@
+{{ config(
+    materialized='incremental',
+    unique_key='unique_key',
+    schema='staging',
+    tags=['m365', 'silver:class_collab_chat_activity']
+) }}
+
+SELECT
+    tenant_id,
+    source_id AS insight_source_id,
+    MD5(concat(tenant_id, '-', source_id, '-', coalesce(userPrincipalName, ''), '-', toString(reportRefreshDate))) AS unique_key,
+    userPrincipalName AS user_id,
+    userPrincipalName AS user_name,
+    userPrincipalName AS email,
+    if(userPrincipalName IS NOT NULL AND userPrincipalName != '',
+       lower(userPrincipalName),
+       '') AS person_key,
+    toDate(reportRefreshDate) AS date,
+    privateChatMessageCount AS direct_messages,
+    teamChatMessageCount AS group_chat_messages,
+    COALESCE(privateChatMessageCount, 0) + COALESCE(teamChatMessageCount, 0) AS total_chat_messages,
+    postMessages AS channel_posts,
+    replyMessages AS channel_replies,
+    urgentMessages AS urgent_messages,
+    reportPeriod AS report_period,
+    now() AS collected_at,
+    'insight_m365' AS data_source,
+    toUnixTimestamp64Milli(now()) AS _version
+FROM {{ source('bronze_m365', 'teams_activity') }}
+WHERE userPrincipalName IS NOT NULL
+  AND userPrincipalName != ''
+{% if is_incremental() %}
+  AND (
+    (SELECT max(date) FROM {{ this }}) IS NULL
+    OR toDate(reportRefreshDate) > (SELECT max(date) - INTERVAL 3 DAY FROM {{ this }})
+  )
+{% endif %}

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_document_activity_onedrive.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_document_activity_onedrive.sql
@@ -1,0 +1,41 @@
+{{ config(
+    materialized='incremental',
+    unique_key='unique_key',
+    schema='staging',
+    tags=['m365', 'silver:class_collab_document_activity']
+) }}
+
+-- OneDrive half of document activity.
+-- Split from SharePoint (see m365__collab_document_activity_sharepoint) so each
+-- product has its own incremental watermark. Unioned at silver by tag.
+
+SELECT
+    tenant_id,
+    source_id AS insight_source_id,
+    MD5(concat(tenant_id, '-', source_id, '-', coalesce(userPrincipalName, ''), '-', toString(reportRefreshDate), '-', 'onedrive')) AS unique_key,
+    userPrincipalName AS user_id,
+    userPrincipalName AS user_name,
+    userPrincipalName AS email,
+    if(userPrincipalName IS NOT NULL AND userPrincipalName != '',
+       lower(userPrincipalName),
+       '') AS person_key,
+    toDate(reportRefreshDate) AS date,
+    'onedrive' AS product,
+    viewedOrEditedFileCount AS viewed_or_edited_count,
+    syncedFileCount AS synced_count,
+    sharedInternallyFileCount AS shared_internally_count,
+    sharedExternallyFileCount AS shared_externally_count,
+    CAST(NULL AS Nullable(Int64)) AS visited_page_count,
+    reportPeriod AS report_period,
+    now() AS collected_at,
+    'insight_m365' AS data_source,
+    toUnixTimestamp64Milli(now()) AS _version
+FROM {{ source('bronze_m365', 'onedrive_activity') }}
+WHERE userPrincipalName IS NOT NULL
+  AND userPrincipalName != ''
+{% if is_incremental() %}
+  AND (
+    (SELECT max(date) FROM {{ this }}) IS NULL
+    OR toDate(reportRefreshDate) > (SELECT max(date) - INTERVAL 3 DAY FROM {{ this }})
+  )
+{% endif %}

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_document_activity_sharepoint.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_document_activity_sharepoint.sql
@@ -1,0 +1,41 @@
+{{ config(
+    materialized='incremental',
+    unique_key='unique_key',
+    schema='staging',
+    tags=['m365', 'silver:class_collab_document_activity']
+) }}
+
+-- SharePoint half of document activity.
+-- Split from OneDrive (see m365__collab_document_activity_onedrive) so each
+-- product has its own incremental watermark. Unioned at silver by tag.
+
+SELECT
+    tenant_id,
+    source_id AS insight_source_id,
+    MD5(concat(tenant_id, '-', source_id, '-', coalesce(userPrincipalName, ''), '-', toString(reportRefreshDate), '-', 'sharepoint')) AS unique_key,
+    userPrincipalName AS user_id,
+    userPrincipalName AS user_name,
+    userPrincipalName AS email,
+    if(userPrincipalName IS NOT NULL AND userPrincipalName != '',
+       lower(userPrincipalName),
+       '') AS person_key,
+    toDate(reportRefreshDate) AS date,
+    'sharepoint' AS product,
+    viewedOrEditedFileCount AS viewed_or_edited_count,
+    syncedFileCount AS synced_count,
+    sharedInternallyFileCount AS shared_internally_count,
+    sharedExternallyFileCount AS shared_externally_count,
+    visitedPageCount AS visited_page_count,
+    reportPeriod AS report_period,
+    now() AS collected_at,
+    'insight_m365' AS data_source,
+    toUnixTimestamp64Milli(now()) AS _version
+FROM {{ source('bronze_m365', 'sharepoint_activity') }}
+WHERE userPrincipalName IS NOT NULL
+  AND userPrincipalName != ''
+{% if is_incremental() %}
+  AND (
+    (SELECT max(date) FROM {{ this }}) IS NULL
+    OR toDate(reportRefreshDate) > (SELECT max(date) - INTERVAL 3 DAY FROM {{ this }})
+  )
+{% endif %}

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_email_activity.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_email_activity.sql
@@ -1,0 +1,36 @@
+{{ config(
+    materialized='incremental',
+    unique_key='unique_key',
+    schema='staging',
+    tags=['m365', 'silver:class_collab_email_activity']
+) }}
+
+SELECT
+    tenant_id,
+    source_id AS insight_source_id,
+    MD5(concat(tenant_id, '-', source_id, '-', coalesce(userPrincipalName, ''), '-', toString(reportRefreshDate))) AS unique_key,
+    userPrincipalName AS user_id,
+    userPrincipalName AS user_name,
+    userPrincipalName AS email,
+    if(userPrincipalName IS NOT NULL AND userPrincipalName != '',
+       lower(userPrincipalName),
+       '') AS person_key,
+    toDate(reportRefreshDate) AS date,
+    sendCount AS sent_count,
+    receiveCount AS received_count,
+    readCount AS read_count,
+    meetingCreatedCount AS meetings_created,
+    meetingInteractedCount AS meetings_interacted,
+    reportPeriod AS report_period,
+    now() AS collected_at,
+    'insight_m365' AS data_source,
+    toUnixTimestamp64Milli(now()) AS _version
+FROM {{ source('bronze_m365', 'email_activity') }}
+WHERE userPrincipalName IS NOT NULL
+  AND userPrincipalName != ''
+{% if is_incremental() %}
+  AND (
+    (SELECT max(date) FROM {{ this }}) IS NULL
+    OR toDate(reportRefreshDate) > (SELECT max(date) - INTERVAL 3 DAY FROM {{ this }})
+  )
+{% endif %}

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_meeting_activity.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_meeting_activity.sql
@@ -1,0 +1,43 @@
+{{ config(
+    materialized='incremental',
+    unique_key='unique_key',
+    schema='staging',
+    tags=['m365', 'silver:class_collab_meeting_activity']
+) }}
+
+SELECT
+    tenant_id,
+    source_id AS insight_source_id,
+    MD5(concat(tenant_id, '-', source_id, '-', coalesce(userPrincipalName, ''), '-', toString(reportRefreshDate))) AS unique_key,
+    userPrincipalName AS user_id,
+    userPrincipalName AS user_name,
+    userPrincipalName AS email,
+    if(userPrincipalName IS NOT NULL AND userPrincipalName != '',
+       lower(userPrincipalName),
+       '') AS person_key,
+    toDate(reportRefreshDate) AS date,
+    callCount AS calls_count,
+    meetingsOrganizedCount AS meetings_organized,
+    meetingsAttendedCount AS meetings_attended,
+    adHocMeetingsOrganizedCount AS adhoc_meetings_organized,
+    adHocMeetingsAttendedCount AS adhoc_meetings_attended,
+    COALESCE(scheduledOneTimeMeetingsOrganizedCount, 0)
+        + COALESCE(scheduledRecurringMeetingsOrganizedCount, 0) AS scheduled_meetings_organized,
+    COALESCE(scheduledOneTimeMeetingsAttendedCount, 0)
+        + COALESCE(scheduledRecurringMeetingsAttendedCount, 0) AS scheduled_meetings_attended,
+    toInt64(toSeconds(parseTimeDelta(ifNull(audioDuration, 'PT0S')))) AS audio_duration_seconds,
+    toInt64(toSeconds(parseTimeDelta(ifNull(videoDuration, 'PT0S')))) AS video_duration_seconds,
+    toInt64(toSeconds(parseTimeDelta(ifNull(screenShareDuration, 'PT0S')))) AS screen_share_duration_seconds,
+    reportPeriod AS report_period,
+    now() AS collected_at,
+    'insight_m365' AS data_source,
+    toUnixTimestamp64Milli(now()) AS _version
+FROM {{ source('bronze_m365', 'teams_activity') }}
+WHERE userPrincipalName IS NOT NULL
+  AND userPrincipalName != ''
+{% if is_incremental() %}
+  AND (
+    (SELECT max(date) FROM {{ this }}) IS NULL
+    OR toDate(reportRefreshDate) > (SELECT max(date) - INTERVAL 3 DAY FROM {{ this }})
+  )
+{% endif %}

--- a/src/ingestion/connectors/collaboration/m365/dbt/schema.yml
+++ b/src/ingestion/connectors/collaboration/m365/dbt/schema.yml
@@ -6,6 +6,8 @@ sources:
     tables:
       - name: email_activity
       - name: teams_activity
+      - name: onedrive_activity
+      - name: sharepoint_activity
 
 models:
   - name: m365__comms_events
@@ -26,3 +28,113 @@ models:
       - name: activity_date
         tests:
           - not_null
+
+  - name: m365__collab_chat_activity
+    description: "M365 Teams chat activity → staging, feeds class_collab_chat_activity"
+    columns:
+      - name: tenant_id
+        tests:
+          - not_null
+      - name: insight_source_id
+        tests:
+          - not_null
+      - name: unique_key
+        tests:
+          - not_null
+          - unique
+      - name: person_key
+        tests:
+          - not_null
+      - name: date
+        tests:
+          - not_null
+
+  - name: m365__collab_meeting_activity
+    description: "M365 Teams meeting activity → staging, feeds class_collab_meeting_activity"
+    columns:
+      - name: tenant_id
+        tests:
+          - not_null
+      - name: insight_source_id
+        tests:
+          - not_null
+      - name: unique_key
+        tests:
+          - not_null
+          - unique
+      - name: person_key
+        tests:
+          - not_null
+      - name: date
+        tests:
+          - not_null
+
+  - name: m365__collab_email_activity
+    description: "M365 Outlook email activity → staging, feeds class_collab_email_activity"
+    columns:
+      - name: tenant_id
+        tests:
+          - not_null
+      - name: insight_source_id
+        tests:
+          - not_null
+      - name: unique_key
+        tests:
+          - not_null
+          - unique
+      - name: person_key
+        tests:
+          - not_null
+      - name: date
+        tests:
+          - not_null
+
+  - name: m365__collab_document_activity_onedrive
+    description: "M365 OneDrive document activity → staging, unioned into class_collab_document_activity"
+    columns:
+      - name: tenant_id
+        tests:
+          - not_null
+      - name: insight_source_id
+        tests:
+          - not_null
+      - name: unique_key
+        tests:
+          - not_null
+          - unique
+      - name: person_key
+        tests:
+          - not_null
+      - name: date
+        tests:
+          - not_null
+      - name: product
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['onedrive']
+
+  - name: m365__collab_document_activity_sharepoint
+    description: "M365 SharePoint document activity → staging, unioned into class_collab_document_activity"
+    columns:
+      - name: tenant_id
+        tests:
+          - not_null
+      - name: insight_source_id
+        tests:
+          - not_null
+      - name: unique_key
+        tests:
+          - not_null
+          - unique
+      - name: person_key
+        tests:
+          - not_null
+      - name: date
+        tests:
+          - not_null
+      - name: product
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['sharepoint']

--- a/src/ingestion/connectors/collaboration/slack/dbt/schema.yml
+++ b/src/ingestion/connectors/collaboration/slack/dbt/schema.yml
@@ -48,3 +48,23 @@ models:
       - name: source_id
         tests:
           - not_null
+
+  - name: slack__collab_chat_activity
+    description: "Slack chat activity aggregated per user per day → staging, feeds class_collab_chat_activity"
+    columns:
+      - name: tenant_id
+        tests:
+          - not_null
+      - name: insight_source_id
+        tests:
+          - not_null
+      - name: unique_key
+        tests:
+          - not_null
+          - unique
+      - name: person_key
+        tests:
+          - not_null
+      - name: date
+        tests:
+          - not_null

--- a/src/ingestion/connectors/collaboration/slack/dbt/slack__collab_chat_activity.sql
+++ b/src/ingestion/connectors/collaboration/slack/dbt/slack__collab_chat_activity.sql
@@ -1,0 +1,64 @@
+{{ config(
+    materialized='incremental',
+    unique_key='unique_key',
+    schema='staging',
+    tags=['slack', 'silver:class_collab_chat_activity']
+) }}
+
+-- Slack chat activity aggregated per user per day.
+-- Email can be NULL when Slack workspace policy hides it — we keep the row and
+-- fall back to display_name for person_key (matches the git-plugin convention:
+--   if(email != '', lower(email), lower(user_name))).
+
+SELECT
+    m.tenant_id,
+    m.source_id AS insight_source_id,
+    MD5(concat(
+        m.tenant_id, '-',
+        m.source_id, '-',
+        coalesce(m.user, ''), '-',
+        toString(toDate(toDateTime(toFloat64(m.ts))))
+    )) AS unique_key,
+    m.user AS user_id,
+    coalesce(u.display_name, u.real_name, '') AS user_name,
+    coalesce(u.email, '') AS email,
+    if(coalesce(u.email, '') != '',
+       lower(u.email),
+       lower(coalesce(u.display_name, u.real_name, m.user))) AS person_key,
+    toDate(toDateTime(toFloat64(m.ts))) AS date,
+    countIf(c.is_im = true OR c.is_mpim = true) AS direct_messages,
+    countIf(c.is_channel = true OR c.is_group = true) AS group_chat_messages,
+    count(*) AS total_chat_messages,
+    CAST(NULL AS Nullable(Int64)) AS channel_posts,
+    CAST(NULL AS Nullable(Int64)) AS channel_replies,
+    CAST(NULL AS Nullable(Int64)) AS urgent_messages,
+    CAST(NULL AS Nullable(String)) AS report_period,
+    now() AS collected_at,
+    'insight_slack' AS data_source,
+    toUnixTimestamp64Milli(now()) AS _version
+FROM {{ source('bronze_slack', 'messages') }} m
+LEFT JOIN {{ source('bronze_slack', 'channels') }} c
+    ON m.channel_id = c.channel_id
+    AND m.tenant_id = c.tenant_id
+    AND m.source_id = c.source_id
+LEFT JOIN {{ source('bronze_slack', 'users') }} u
+    ON m.user = u.slack_user_id
+    AND m.tenant_id = u.tenant_id
+    AND m.source_id = u.source_id
+WHERE m.user IS NOT NULL
+  AND m.user != ''
+  AND m.subtype IS NULL
+{% if is_incremental() %}
+  AND (
+    (SELECT max(date) FROM {{ this }}) IS NULL
+    OR toDate(toDateTime(toFloat64(m.ts))) > (SELECT max(date) - INTERVAL 7 DAY FROM {{ this }})
+  )
+{% endif %}
+GROUP BY
+    m.tenant_id,
+    m.source_id,
+    m.user,
+    u.email,
+    u.display_name,
+    u.real_name,
+    toDate(toDateTime(toFloat64(m.ts)))

--- a/src/ingestion/connectors/collaboration/zoom/dbt/schema.yml
+++ b/src/ingestion/connectors/collaboration/zoom/dbt/schema.yml
@@ -25,3 +25,23 @@ models:
       - name: activity_date
         tests:
           - not_null
+
+  - name: zoom__collab_meeting_activity
+    description: "Zoom meeting activity aggregated per user per day → staging, feeds class_collab_meeting_activity"
+    columns:
+      - name: tenant_id
+        tests:
+          - not_null
+      - name: insight_source_id
+        tests:
+          - not_null
+      - name: unique_key
+        tests:
+          - not_null
+          - unique
+      - name: person_key
+        tests:
+          - not_null
+      - name: date
+        tests:
+          - not_null

--- a/src/ingestion/connectors/collaboration/zoom/dbt/zoom__collab_meeting_activity.sql
+++ b/src/ingestion/connectors/collaboration/zoom/dbt/zoom__collab_meeting_activity.sql
@@ -1,0 +1,80 @@
+{{ config(
+    materialized='incremental',
+    unique_key='unique_key',
+    schema='staging',
+    tags=['zoom', 'silver:class_collab_meeting_activity']
+) }}
+
+-- Zoom meeting activity aggregated per user per day.
+--
+-- Grain: (tenant, source, email, date). We intentionally filter out participants
+-- without an email (guests / anonymous joiners) because:
+--   1. Without a stable user identifier, a COALESCE(email, user_name) key is
+--      unstable — the same person can flip keys between batches depending on
+--      whether Zoom returns their email that run.
+--   2. Anonymous participants can't be joined to identity at the Silver layer
+--      anyway, so they add noise without enabling any downstream use case.
+-- If Zoom ever starts exposing a stable participant_id/user_id, switch to that.
+
+SELECT
+    p.tenant_id,
+    p.source_id AS insight_source_id,
+    MD5(concat(
+        p.tenant_id, '-',
+        p.source_id, '-',
+        lower(p.email), '-',
+        toString(toDate(parseDateTimeBestEffort(p.join_time)))
+    )) AS unique_key,
+    p.email AS user_id,
+    coalesce(p.user_name, '') AS user_name,
+    p.email AS email,
+    lower(p.email) AS person_key,
+    toDate(parseDateTimeBestEffort(p.join_time)) AS date,
+    CAST(NULL AS Nullable(Int64)) AS calls_count,
+    CAST(NULL AS Nullable(Int64)) AS meetings_organized,
+    toInt64(count(*)) AS meetings_attended,
+    CAST(NULL AS Nullable(Int64)) AS adhoc_meetings_organized,
+    CAST(NULL AS Nullable(Int64)) AS adhoc_meetings_attended,
+    CAST(NULL AS Nullable(Int64)) AS scheduled_meetings_organized,
+    CAST(NULL AS Nullable(Int64)) AS scheduled_meetings_attended,
+    toInt64(sum(
+        if(p.join_time IS NOT NULL AND p.leave_time IS NOT NULL,
+           dateDiff('second', parseDateTimeBestEffort(p.join_time), parseDateTimeBestEffort(p.leave_time)),
+           0)
+    )) AS audio_duration_seconds,
+    toInt64(sumIf(
+        if(p.join_time IS NOT NULL AND p.leave_time IS NOT NULL,
+           dateDiff('second', parseDateTimeBestEffort(p.join_time), parseDateTimeBestEffort(p.leave_time)),
+           0),
+        m.has_video = true
+    )) AS video_duration_seconds,
+    toInt64(sumIf(
+        if(p.join_time IS NOT NULL AND p.leave_time IS NOT NULL,
+           dateDiff('second', parseDateTimeBestEffort(p.join_time), parseDateTimeBestEffort(p.leave_time)),
+           0),
+        m.has_screen_share = true
+    )) AS screen_share_duration_seconds,
+    CAST(NULL AS Nullable(String)) AS report_period,
+    now() AS collected_at,
+    'insight_zoom' AS data_source,
+    toUnixTimestamp64Milli(now()) AS _version
+FROM {{ source('bronze_zoom', 'participants') }} p
+LEFT JOIN {{ source('bronze_zoom', 'meetings') }} m
+    ON p.meeting_uuid = m.uuid
+    AND p.tenant_id = m.tenant_id
+    AND p.source_id = m.source_id
+WHERE p.join_time IS NOT NULL
+  AND p.email IS NOT NULL
+  AND p.email != ''
+{% if is_incremental() %}
+  AND (
+    (SELECT max(date) FROM {{ this }}) IS NULL
+    OR toDate(parseDateTimeBestEffort(p.join_time)) > (SELECT max(date) - INTERVAL 3 DAY FROM {{ this }})
+  )
+{% endif %}
+GROUP BY
+    p.tenant_id,
+    p.source_id,
+    p.email,
+    p.user_name,
+    toDate(parseDateTimeBestEffort(p.join_time))

--- a/src/ingestion/silver/collaboration/class_collab_chat_activity.sql
+++ b/src/ingestion/silver/collaboration/class_collab_chat_activity.sql
@@ -1,0 +1,12 @@
+{{ config(
+    materialized='incremental',
+    unique_key='unique_key',
+    schema='silver',
+    tags=['silver']
+) }}
+
+-- explicit dependency so dbt knows to run staging models first
+-- depends_on: {{ ref('m365__collab_chat_activity') }}
+-- depends_on: {{ ref('slack__collab_chat_activity') }}
+
+{{ union_by_tag('silver:class_collab_chat_activity') }}

--- a/src/ingestion/silver/collaboration/class_collab_document_activity.sql
+++ b/src/ingestion/silver/collaboration/class_collab_document_activity.sql
@@ -1,0 +1,12 @@
+{{ config(
+    materialized='incremental',
+    unique_key='unique_key',
+    schema='silver',
+    tags=['silver']
+) }}
+
+-- explicit dependency so dbt knows to run staging models first
+-- depends_on: {{ ref('m365__collab_document_activity_onedrive') }}
+-- depends_on: {{ ref('m365__collab_document_activity_sharepoint') }}
+
+{{ union_by_tag('silver:class_collab_document_activity') }}

--- a/src/ingestion/silver/collaboration/class_collab_email_activity.sql
+++ b/src/ingestion/silver/collaboration/class_collab_email_activity.sql
@@ -1,0 +1,11 @@
+{{ config(
+    materialized='incremental',
+    unique_key='unique_key',
+    schema='silver',
+    tags=['silver']
+) }}
+
+-- explicit dependency so dbt knows to run staging models first
+-- depends_on: {{ ref('m365__collab_email_activity') }}
+
+{{ union_by_tag('silver:class_collab_email_activity') }}

--- a/src/ingestion/silver/collaboration/class_collab_meeting_activity.sql
+++ b/src/ingestion/silver/collaboration/class_collab_meeting_activity.sql
@@ -1,0 +1,12 @@
+{{ config(
+    materialized='incremental',
+    unique_key='unique_key',
+    schema='silver',
+    tags=['silver']
+) }}
+
+-- explicit dependency so dbt knows to run staging models first
+-- depends_on: {{ ref('m365__collab_meeting_activity') }}
+-- depends_on: {{ ref('zoom__collab_meeting_activity') }}
+
+{{ union_by_tag('silver:class_collab_meeting_activity') }}

--- a/src/ingestion/silver/collaboration/schema.yml
+++ b/src/ingestion/silver/collaboration/schema.yml
@@ -17,3 +17,125 @@ models:
         tests:
           - not_null
           - unique
+
+  - name: class_collab_chat_activity
+    description: "Unified daily chat activity per user from all collaboration sources (M365 Teams, Slack)"
+    columns:
+      - name: tenant_id
+        description: "Tenant isolation field"
+        tests:
+          - not_null
+      - name: insight_source_id
+        description: "Source instance identifier"
+        tests:
+          - not_null
+      - name: unique_key
+        description: "Composite deduplication key"
+        tests:
+          - not_null
+          - unique
+      - name: person_key
+        description: "lower(email) with lower(user_name) fallback — cross-source identity join key"
+        tests:
+          - not_null
+      - name: date
+        description: "Activity date (UTC)"
+        tests:
+          - not_null
+      - name: data_source
+        description: "Source discriminator: insight_m365 | insight_slack"
+        tests:
+          - not_null
+
+  - name: class_collab_meeting_activity
+    description: "Unified daily meeting activity per user from all collaboration sources (M365 Teams, Zoom)"
+    columns:
+      - name: tenant_id
+        description: "Tenant isolation field"
+        tests:
+          - not_null
+      - name: insight_source_id
+        description: "Source instance identifier"
+        tests:
+          - not_null
+      - name: unique_key
+        description: "Composite deduplication key"
+        tests:
+          - not_null
+          - unique
+      - name: person_key
+        description: "lower(email) with lower(user_name) fallback — cross-source identity join key"
+        tests:
+          - not_null
+      - name: date
+        description: "Activity date (UTC)"
+        tests:
+          - not_null
+      - name: data_source
+        description: "Source discriminator: insight_m365 | insight_zoom"
+        tests:
+          - not_null
+
+  - name: class_collab_email_activity
+    description: "Unified daily email activity per user (M365 Outlook)"
+    columns:
+      - name: tenant_id
+        description: "Tenant isolation field"
+        tests:
+          - not_null
+      - name: insight_source_id
+        description: "Source instance identifier"
+        tests:
+          - not_null
+      - name: unique_key
+        description: "Composite deduplication key"
+        tests:
+          - not_null
+          - unique
+      - name: person_key
+        description: "lower(email) with lower(user_name) fallback — cross-source identity join key"
+        tests:
+          - not_null
+      - name: date
+        description: "Activity date (UTC)"
+        tests:
+          - not_null
+      - name: data_source
+        description: "Source discriminator: insight_m365"
+        tests:
+          - not_null
+
+  - name: class_collab_document_activity
+    description: "Unified daily document activity per user (M365 OneDrive + SharePoint)"
+    columns:
+      - name: tenant_id
+        description: "Tenant isolation field"
+        tests:
+          - not_null
+      - name: insight_source_id
+        description: "Source instance identifier"
+        tests:
+          - not_null
+      - name: unique_key
+        description: "Composite deduplication key"
+        tests:
+          - not_null
+          - unique
+      - name: person_key
+        description: "lower(email) with lower(user_name) fallback — cross-source identity join key"
+        tests:
+          - not_null
+      - name: date
+        description: "Activity date (UTC)"
+        tests:
+          - not_null
+      - name: product
+        description: "onedrive | sharepoint"
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['onedrive', 'sharepoint']
+      - name: data_source
+        description: "Source discriminator: insight_m365"
+        tests:
+          - not_null


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#181](https://github.com/cyberfabric/cyber-insight/pull/181) | **Author:** mitasovr | **Opened:** 2026-04-16T16:12:31Z | **Status:** merged on 2026-04-20T08:18:49Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

- Add Bronze → staging → Silver dbt pipeline for 4 collaboration tables: `collab_chat_activity`, `collab_meeting_activity`, `collab_email_activity`, `collab_document_activity`
- M365 (chat, meetings, email, documents), Slack (chat), Zoom (meetings) produce per-connector staging models unified via `union_by_tag`
- Incremental, tag-based selectors (`tag:m365+`, `tag:slack+`, `tag:zoom+`) run each connector's full pipeline through Silver

## Details

**10 new staging models:**
- `m365__collab_chat_activity` — Teams chat from `bronze_m365.teams_activity`
- `m365__collab_meeting_activity` — Teams meetings from `bronze_m365.teams_activity` (ISO 8601 durations → seconds)
- `m365__collab_email_activity` — Outlook from `bronze_m365.email_activity`
- `m365__collab_document_activity` — OneDrive + SharePoint UNION from `bronze_m365.onedrive_activity` / `sharepoint_activity`
- `slack__collab_chat_activity` — Messages aggregated per user/day with channel type classification
- `zoom__collab_meeting_activity` — Participants + meetings aggregated per user/day

**4 Silver union models** in `dbt/silver/`:
- `collab_chat_activity` (M365 + Slack)
- `collab_meeting_activity` (M365 + Zoom)
- `collab_email_activity` (M365 only)
- `collab_document_activity` (M365 only)

**Schema aligned with spec** (`docs/components/connectors/collaboration/README.md`): `insight_source_id`, `_version`, duration conversion validated.

## Test plan

- [ ] `dbt run --select tag:m365+` runs 4 M365 staging + 4 Silver union models
- [ ] `dbt run --select tag:slack+` runs Slack staging + collab_chat_activity Silver
- [ ] `dbt run --select tag:zoom+` runs Zoom staging + collab_meeting_activity Silver
- [ ] `silver.collab_chat_activity` contains rows from M365 and Slack with correct `data_source`
- [ ] `silver.collab_meeting_activity` contains rows from M365 and Zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added collaboration activity tracking for Microsoft 365, Slack, and Zoom
  * Enables monitoring of chat, email, meeting, and document interactions across platforms
  * Unified multi-source collaboration data with standardized metrics and quality assurance
  * Supports incremental data processing with automatic deduplication
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#181 -->