### PR TITLE
[PR #162] Add Slack connector

### DIFF
--- a/src/ingestion/connectors/collaboration/slack/README.md
+++ b/src/ingestion/connectors/collaboration/slack/README.md
@@ -1,0 +1,85 @@
+# Slack Connector
+
+Slack workspace data: users, channels, and message activity via Bot Token.
+
+## Prerequisites
+
+### Creating a Bot Token
+
+1. Go to https://api.slack.com/apps and click **Create New App** -> **From scratch**
+2. Enter app name (e.g. `Insight`) and select your workspace
+3. In the left sidebar, go to **OAuth & Permissions**
+4. Scroll to **Bot Token Scopes** and add the following scopes:
+   - `channels:history`, `channels:read`
+   - `groups:history`, `groups:read`
+   - `im:history`, `im:read`
+   - `mpim:history`, `mpim:read`
+   - `users:read`, `users:read.email`
+5. Scroll up and click **Install to Workspace** -> **Allow**
+6. Copy the **Bot User OAuth Token** (`xoxb-...`) from the OAuth & Permissions page
+
+## Streams
+
+| Stream | Sync Mode | Primary Key | Description |
+|--------|-----------|-------------|-------------|
+| `users` | Full Refresh | `unique_key` | Slack user directory (id, email, display name, role flags) |
+| `channels` | Full Refresh | `unique_key` | Channel directory with type classification |
+| `messages` | Incremental (cursor: `ts`) | `unique_key` | Messages partitioned by channel, daily slices |
+
+## K8s Secret
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-slack-main
+  labels:
+    app.kubernetes.io/part-of: insight
+  annotations:
+    insight.cyberfabric.com/connector: slack
+    insight.cyberfabric.com/source-id: main
+type: Opaque
+stringData:
+  slack_bot_token: "xoxb-..."       # Bot User OAuth Token
+  slack_start_date: "2026-01-01"    # Earliest date for message sync (YYYY-MM-DD)
+```
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `slack_bot_token` | Yes | Bot User OAuth Token (`xoxb-*`) with scopes listed above |
+| `slack_start_date` | Yes | Earliest date for incremental message sync (YYYY-MM-DD) |
+
+### Optional fields
+
+| Field | Default | Description |
+|-------|---------|-------------|
+| `slack_page_size` | `200` | Records per API page (1-999) |
+| `slack_lookback_days` | `7` | Days to re-scan on incremental sync |
+| `slack_channel_types` | `public_channel,private_channel,mpim,im` | Channel types to scan |
+
+### Automatically injected
+
+| Field | Source |
+|-------|--------|
+| `insight_tenant_id` | `tenant_id` from tenant YAML |
+| `insight_source_id` | `insight.cyberfabric.com/source-id` annotation |
+
+### Multi-instance example
+
+To connect multiple Slack workspaces, create separate Secrets with different `source-id`:
+
+```yaml
+# Workspace 1
+metadata:
+  name: insight-slack-acme
+  annotations:
+    insight.cyberfabric.com/source-id: slack-acme
+
+# Workspace 2
+metadata:
+  name: insight-slack-partner
+  annotations:
+    insight.cyberfabric.com/source-id: slack-partner
+```

--- a/src/ingestion/connectors/collaboration/slack/README.md
+++ b/src/ingestion/connectors/collaboration/slack/README.md
@@ -37,7 +37,7 @@ metadata:
     app.kubernetes.io/part-of: insight
   annotations:
     insight.cyberfabric.com/connector: slack
-    insight.cyberfabric.com/source-id: main
+    insight.cyberfabric.com/source-id: slack-main
 type: Opaque
 stringData:
   slack_bot_token: "xoxb-..."       # Bot User OAuth Token

--- a/src/ingestion/connectors/collaboration/slack/connector.yaml
+++ b/src/ingestion/connectors/collaboration/slack/connector.yaml
@@ -7,6 +7,10 @@ check:
   stream_names:
     - users
 
+concurrency_level:
+  type: ConcurrencyLevel
+  default_concurrency: 1
+
 definitions:
   base_error_handler:
     type: CompositeErrorHandler
@@ -47,7 +51,7 @@ definitions:
     url_base: https://slack.com/api/
     authenticator:
       type: BearerAuthenticator
-      api_token: "{{ config['bot_token'] }}"
+      api_token: "{{ config['slack_bot_token'] }}"
     request_headers:
       Accept: application/json
 
@@ -65,10 +69,9 @@ definitions:
       condition: "{{ not response.get('response_metadata', {}).get('next_cursor') }}"
 
   streams:
-    # ── users ─────────────────────────────────────────────────────────
+    # -- users ---------------------------------------------------------------
     # Root stream: Slack user directory from users.list
-    # Full refresh — small dataset, no incremental sync needed
-    # PRD: cpt-insightspec-fr-slack-user-directory
+    # Full refresh -- small dataset, no incremental sync needed
     users:
       type: DeclarativeStream
       name: users
@@ -83,7 +86,7 @@ definitions:
           error_handler:
             $ref: "#/definitions/base_error_handler"
           request_parameters:
-            limit: "{{ config.get('page_size', 200) }}"
+            limit: "{{ config.get('slack_page_size', 200) }}"
         paginator:
           $ref: "#/definitions/slack_paginator"
         record_selector:
@@ -93,7 +96,7 @@ definitions:
             field_path:
               - members
       primary_key:
-        - slack_user_id
+        - unique_key
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -128,21 +131,16 @@ definitions:
               value: "{{ config['insight_tenant_id'] }}"
             - type: AddedFieldDefinition
               path:
-                - source_instance_id
-              value: "{{ config['source_instance_id'] }}"
+                - source_id
+              value: "{{ config['insight_source_id'] }}"
             - type: AddedFieldDefinition
               path:
-                - _airbyte_data_source
-              value: insight_slack
-            - type: AddedFieldDefinition
-              path:
-                - _airbyte_collected_at
-              value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+                - unique_key
+              value: "{{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}"
 
-    # ── channels ──────────────────────────────────────────────────────
+    # -- channels ------------------------------------------------------------
     # Root stream: Slack channel directory from conversations.list
-    # Full refresh — provides authoritative channel_type for message attribution
-    # PRD: cpt-insightspec-fr-slack-channel-type-cache
+    # Full refresh -- provides authoritative channel_type for message attribution
     channels:
       type: DeclarativeStream
       name: channels
@@ -157,8 +155,8 @@ definitions:
           error_handler:
             $ref: "#/definitions/base_error_handler"
           request_parameters:
-            types: "{{ config.get('channel_types', 'public_channel,private_channel,mpim,im') }}"
-            limit: "{{ config.get('page_size', 200) }}"
+            types: "{{ config.get('slack_channel_types', 'public_channel,private_channel,mpim,im') }}"
+            limit: "{{ config.get('slack_page_size', 200) }}"
             exclude_archived: "true"
         paginator:
           $ref: "#/definitions/slack_paginator"
@@ -169,7 +167,7 @@ definitions:
             field_path:
               - channels
       primary_key:
-        - channel_id
+        - unique_key
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -197,21 +195,16 @@ definitions:
               value: "{{ config['insight_tenant_id'] }}"
             - type: AddedFieldDefinition
               path:
-                - source_instance_id
-              value: "{{ config['source_instance_id'] }}"
+                - source_id
+              value: "{{ config['insight_source_id'] }}"
             - type: AddedFieldDefinition
               path:
-                - _airbyte_data_source
-              value: insight_slack
-            - type: AddedFieldDefinition
-              path:
-                - _airbyte_collected_at
-              value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+                - unique_key
+              value: "{{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}"
 
-    # ── messages ──────────────────────────────────────────────────────
+    # -- messages ------------------------------------------------------------
     # Child stream of channels: raw messages from conversations.history
     # Partitioned by channel_id; incremental via DatetimeBasedCursor on ts
-    # PRD: cpt-insightspec-fr-slack-chat-standard
     messages:
       type: DeclarativeStream
       name: messages
@@ -225,11 +218,6 @@ definitions:
               partition_field: channel_id
               stream:
                 $ref: "#/definitions/streams/channels"
-            - type: ParentStreamConfig
-              parent_key: channel_type
-              partition_field: channel_type
-              stream:
-                $ref: "#/definitions/streams/channels"
         decoder:
           type: JsonDecoder
         requester:
@@ -240,7 +228,7 @@ definitions:
             $ref: "#/definitions/base_error_handler"
           request_parameters:
             channel: "{{ stream_partition.channel_id }}"
-            limit: "{{ config.get('page_size', 200) }}"
+            limit: "{{ config.get('slack_page_size', 200) }}"
         paginator:
           $ref: "#/definitions/slack_paginator"
         record_selector:
@@ -253,16 +241,15 @@ definitions:
         type: DatetimeBasedCursor
         cursor_field: ts
         cursor_datetime_formats:
-          - "%s.%f"
           - "%s"
         datetime_format: "%s"
         start_datetime:
           type: MinMaxDatetime
-          datetime: "{{ config['start_date'] }}"
+          datetime: "{{ config['slack_start_date'] }}"
           datetime_format: "%Y-%m-%d"
         end_datetime:
           type: MinMaxDatetime
-          datetime: "{{ now_utc().strftime('%Y-%m-%d') }}"
+          datetime: "{{ (now_utc() + duration('P1D')).strftime('%Y-%m-%d') }}"
           datetime_format: "%Y-%m-%d"
         start_time_option:
           type: RequestOption
@@ -272,11 +259,11 @@ definitions:
           type: RequestOption
           field_name: latest
           inject_into: request_parameter
-        lookback_window: "P{{ config.get('lookback_days', 7) }}D"
+        lookback_window: "P{{ config.get('slack_lookback_days', 7) }}D"
         step: "P1D"
         cursor_granularity: "PT1S"
       primary_key:
-        - message_key
+        - unique_key
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -286,16 +273,16 @@ definitions:
           fields:
             - type: AddedFieldDefinition
               path:
-                - message_key
-              value: "{{ stream_partition.channel_id ~ ':' ~ record['ts'] }}"
+                - ts_raw
+              value: "{{ record['ts'] }}"
+            - type: AddedFieldDefinition
+              path:
+                - ts
+              value: "{{ record['ts'].split('.')[0] }}"
             - type: AddedFieldDefinition
               path:
                 - channel_id
               value: "{{ stream_partition.channel_id }}"
-            - type: AddedFieldDefinition
-              path:
-                - channel_type
-              value: "{{ stream_partition.channel_type }}"
         - type: AddFields
           fields:
             - type: AddedFieldDefinition
@@ -304,16 +291,12 @@ definitions:
               value: "{{ config['insight_tenant_id'] }}"
             - type: AddedFieldDefinition
               path:
-                - source_instance_id
-              value: "{{ config['source_instance_id'] }}"
+                - source_id
+              value: "{{ config['insight_source_id'] }}"
             - type: AddedFieldDefinition
               path:
-                - _airbyte_data_source
-              value: insight_slack
-            - type: AddedFieldDefinition
-              path:
-                - _airbyte_collected_at
-              value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+                - unique_key
+              value: "{{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ stream_partition.channel_id }}-{{ record['ts_raw'] }}"
 
 streams:
   - $ref: "#/definitions/streams/users"
@@ -326,12 +309,24 @@ spec:
     type: object
     $schema: http://json-schema.org/draft-07/schema#
     required:
-      - bot_token
       - insight_tenant_id
-      - source_instance_id
-      - start_date
+      - insight_source_id
+      - slack_bot_token
+      - slack_start_date
     properties:
-      bot_token:
+      insight_tenant_id:
+        type: string
+        title: Insight Tenant ID
+        description: Tenant isolation identifier stamped onto every emitted record.
+        order: 0
+      insight_source_id:
+        type: string
+        title: Insight Source ID
+        description: >-
+          Unique identifier for this connector instance (e.g., slack-acme).
+          Disambiguates workspaces in multi-workspace setups.
+        order: 1
+      slack_bot_token:
         type: string
         title: Slack Bot Token
         description: >-
@@ -339,20 +334,8 @@ spec:
           channels:read, groups:history, groups:read, im:history,
           im:read, mpim:history, mpim:read, users:read, users:read.email.
         airbyte_secret: true
-        order: 0
-      insight_tenant_id:
-        type: string
-        title: Insight Tenant ID
-        description: Insight tenant identifier stamped onto every emitted record.
-        order: 1
-      source_instance_id:
-        type: string
-        title: Source Instance ID
-        description: >-
-          Slack workspace identifier (e.g., slack-acme).
-          Disambiguates workspaces in multi-workspace setups.
         order: 2
-      start_date:
+      slack_start_date:
         type: string
         title: Start Date
         description: >-
@@ -360,7 +343,7 @@ spec:
           Subsequent syncs use the incremental cursor with a 7-day lookback window.
         format: date
         order: 3
-      page_size:
+      slack_page_size:
         type: integer
         title: Page Size
         description: Records per API page for paginated Slack endpoints.
@@ -368,7 +351,7 @@ spec:
         minimum: 1
         maximum: 999
         order: 4
-      lookback_days:
+      slack_lookback_days:
         type: integer
         title: Lookback Days
         description: >-
@@ -378,7 +361,7 @@ spec:
         minimum: 1
         maximum: 30
         order: 5
-      channel_types:
+      slack_channel_types:
         type: string
         title: Channel Types
         description: >-
@@ -400,6 +383,12 @@ schemas:
     type: object
     $schema: http://json-schema.org/draft-07/schema#
     properties:
+      unique_key:
+        type: string
+      tenant_id:
+        type: string
+      source_id:
+        type: string
       slack_user_id:
         type: string
       email:
@@ -446,28 +435,22 @@ schemas:
         type:
           - integer
           - "null"
-      tenant_id:
-        type:
-          - string
-          - "null"
-      source_instance_id:
-        type:
-          - string
-          - "null"
-      _airbyte_data_source:
-        type:
-          - string
-          - "null"
-      _airbyte_collected_at:
-        type:
-          - string
-          - "null"
-        format: date-time
+    required:
+      - unique_key
+      - tenant_id
+      - source_id
+      - slack_user_id
     additionalProperties: true
   channels:
     type: object
     $schema: http://json-schema.org/draft-07/schema#
     properties:
+      unique_key:
+        type: string
+      tenant_id:
+        type: string
+      source_id:
+        type: string
       channel_id:
         type: string
       name:
@@ -514,39 +497,31 @@ schemas:
         type:
           - string
           - "null"
-      tenant_id:
-        type:
-          - string
-          - "null"
-      source_instance_id:
-        type:
-          - string
-          - "null"
-      _airbyte_data_source:
-        type:
-          - string
-          - "null"
-      _airbyte_collected_at:
-        type:
-          - string
-          - "null"
-        format: date-time
+    required:
+      - unique_key
+      - tenant_id
+      - source_id
+      - channel_id
     additionalProperties: true
   messages:
     type: object
     $schema: http://json-schema.org/draft-07/schema#
     properties:
-      message_key:
+      unique_key:
+        type: string
+      tenant_id:
+        type: string
+      source_id:
         type: string
       channel_id:
         type:
           - string
           - "null"
-      channel_type:
+      ts:
         type:
           - string
           - "null"
-      ts:
+      ts_raw:
         type:
           - string
           - "null"
@@ -574,21 +549,8 @@ schemas:
         type:
           - integer
           - "null"
-      tenant_id:
-        type:
-          - string
-          - "null"
-      source_instance_id:
-        type:
-          - string
-          - "null"
-      _airbyte_data_source:
-        type:
-          - string
-          - "null"
-      _airbyte_collected_at:
-        type:
-          - string
-          - "null"
-        format: date-time
+    required:
+      - unique_key
+      - tenant_id
+      - source_id
     additionalProperties: true

--- a/src/ingestion/connectors/collaboration/slack/connector.yaml
+++ b/src/ingestion/connectors/collaboration/slack/connector.yaml
@@ -157,7 +157,7 @@ definitions:
           request_parameters:
             types: "{{ config.get('slack_channel_types', 'public_channel,private_channel,mpim,im') }}"
             limit: "{{ config.get('slack_page_size', 200) }}"
-            exclude_archived: "true"
+            exclude_archived: "false"
         paginator:
           $ref: "#/definitions/slack_paginator"
         record_selector:

--- a/src/ingestion/connectors/collaboration/slack/dbt/schema.yml
+++ b/src/ingestion/connectors/collaboration/slack/dbt/schema.yml
@@ -1,0 +1,50 @@
+version: 2
+
+sources:
+  - name: bronze_slack
+    schema: bronze_slack
+    tables:
+      - name: users
+      - name: channels
+      - name: messages
+
+models:
+  - name: slack__comms_events
+    description: "Slack message events -> staging, feeds class_comms_events"
+    columns:
+      - name: tenant_id
+        tests:
+          - not_null
+      - name: source_id
+        tests:
+          - not_null
+      - name: unique_key
+        tests:
+          - not_null
+          - unique
+      - name: activity_date
+        tests:
+          - not_null
+
+  - name: slack__users_snapshot
+    description: "Slack users snapshot — tracks field changes over time"
+    columns:
+      - name: tenant_id
+        tests:
+          - not_null
+      - name: source_id
+        tests:
+          - not_null
+      - name: unique_key
+        tests:
+          - not_null
+
+  - name: slack__users_fields_history
+    description: "Slack users field-level change history"
+    columns:
+      - name: tenant_id
+        tests:
+          - not_null
+      - name: source_id
+        tests:
+          - not_null

--- a/src/ingestion/connectors/collaboration/slack/dbt/slack__comms_events.sql
+++ b/src/ingestion/connectors/collaboration/slack/dbt/slack__comms_events.sql
@@ -26,5 +26,5 @@ LEFT JOIN {{ source('bronze_slack', 'channels') }} c
 WHERE m.user IS NOT NULL
   AND m.subtype IS NULL
 {% if is_incremental() %}
-  AND toDateTime(toFloat64(m.ts)) > (SELECT max(activity_date) FROM {{ this }})
+  AND toDateTime(toFloat64(m.ts)) > (SELECT max(activity_date) - INTERVAL 7 DAY FROM {{ this }})
 {% endif %}

--- a/src/ingestion/connectors/collaboration/slack/dbt/slack__comms_events.sql
+++ b/src/ingestion/connectors/collaboration/slack/dbt/slack__comms_events.sql
@@ -1,0 +1,30 @@
+{{ config(
+    materialized='incremental',
+    unique_key='unique_key',
+    schema='staging',
+    tags=['slack', 'silver:class_comms_events']
+) }}
+
+SELECT
+    m.tenant_id,
+    m.source_id,
+    m.unique_key,
+    m.user AS slack_user_id,
+    m.channel_id,
+    c.channel_type,
+    toDateTime(toFloat64(m.ts)) AS activity_date,
+    m.type AS event_type,
+    m.subtype,
+    m.thread_ts IS NOT NULL AS is_thread_reply,
+    COALESCE(m.reply_count, 0) AS reply_count,
+    'slack' AS source
+FROM {{ source('bronze_slack', 'messages') }} m
+LEFT JOIN {{ source('bronze_slack', 'channels') }} c
+    ON m.channel_id = c.channel_id
+    AND m.tenant_id = c.tenant_id
+    AND m.source_id = c.source_id
+WHERE m.user IS NOT NULL
+  AND m.subtype IS NULL
+{% if is_incremental() %}
+  AND toDateTime(toFloat64(m.ts)) > (SELECT max(activity_date) FROM {{ this }})
+{% endif %}

--- a/src/ingestion/connectors/collaboration/slack/dbt/slack__users_fields_history.sql
+++ b/src/ingestion/connectors/collaboration/slack/dbt/slack__users_fields_history.sql
@@ -6,7 +6,7 @@
 
 {{ fields_history(
     snapshot_ref=ref('slack__users_snapshot'),
-    entity_id_col='slack_user_id',
+    entity_id_col='unique_key',
     fields=[
         'email', 'display_name', 'real_name',
         'is_admin', 'is_owner', 'is_restricted', 'is_ultra_restricted',

--- a/src/ingestion/connectors/collaboration/slack/dbt/slack__users_fields_history.sql
+++ b/src/ingestion/connectors/collaboration/slack/dbt/slack__users_fields_history.sql
@@ -1,0 +1,15 @@
+{{ config(
+    materialized='table',
+    schema='staging',
+    tags=['slack', 'silver']
+) }}
+
+{{ fields_history(
+    snapshot_ref=ref('slack__users_snapshot'),
+    entity_id_col='slack_user_id',
+    fields=[
+        'email', 'display_name', 'real_name',
+        'is_admin', 'is_owner', 'is_restricted', 'is_ultra_restricted',
+        'is_bot', 'deleted', 'tz'
+    ]
+) }}

--- a/src/ingestion/connectors/collaboration/slack/dbt/slack__users_snapshot.sql
+++ b/src/ingestion/connectors/collaboration/slack/dbt/slack__users_snapshot.sql
@@ -1,0 +1,16 @@
+{{ config(
+    materialized='incremental',
+    incremental_strategy='append',
+    schema='staging',
+    tags=['slack']
+) }}
+
+{{ snapshot(
+    source_ref=source('bronze_slack', 'users'),
+    unique_key_col='unique_key',
+    check_cols=[
+        'email', 'display_name', 'real_name',
+        'is_admin', 'is_owner', 'is_restricted', 'is_ultra_restricted',
+        'is_bot', 'deleted', 'tz'
+    ]
+) }}

--- a/src/ingestion/connectors/collaboration/slack/descriptor.yaml
+++ b/src/ingestion/connectors/collaboration/slack/descriptor.yaml
@@ -1,0 +1,7 @@
+name: slack
+version: '1.0'
+schedule: 0 4 * * *
+dbt_select: tag:slack+
+workflow: sync
+connection:
+  namespace: bronze_slack

--- a/src/ingestion/secrets/connectors/slack.yaml.example
+++ b/src/ingestion/secrets/connectors/slack.yaml.example
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-slack-main
+  labels:
+    app.kubernetes.io/part-of: insight
+  annotations:
+    insight.cyberfabric.com/connector: slack
+    insight.cyberfabric.com/source-id: slack-main
+type: Opaque
+stringData:
+  slack_bot_token: "CHANGE_ME"
+  slack_start_date: "2026-01-01"


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#162](https://github.com/cyberfabric/cyber-insight/pull/162) | **Author:** mitasovr | **Opened:** 2026-04-16T07:58:05Z | **Status:** merged on 2026-04-16T09:41:54Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary
- New declarative nocode connector for Slack workspace data (Bot Token auth)
- Streams: `users` (full refresh), `channels` (full refresh), `messages` (incremental, daily cursor on `ts`)
- dbt models: `slack__comms_events` (messages → staging), `slack__users_snapshot` (SCD), `slack__users_fields_history` (field-level change log)
- K8s Secret template + README with token creation guide

## Key decisions
- `concurrency_level: 1` to avoid CDK concurrent reader bug with `%s` timestamp format
- `ts` truncated to integer seconds for cursor compatibility; `ts_raw` preserves full precision for `unique_key`
- `channel_type` enrichment via dbt JOIN (not available through SubstreamPartitionRouter)
- `end_datetime: now_utc() + P1D` to include same-day messages

## Test plan
- [x] `source.sh validate` — manifest valid
- [x] `source.sh check` — CONNECTION_STATUS: SUCCEEDED
- [x] `source.sh discover` — 3 streams discovered
- [x] `source.sh read` — 14 records (3 users, 4 channels, 7 messages)
- [x] All records have `tenant_id`, `source_id`, `unique_key`
- [x] E2E sync via Argo: Bronze + Staging populated
- [x] `/connector validate slack` — PASS (40/40)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Slack connector with support for users, channels, and messages data streams.
  * Enabled multi-instance Slack workspace connectivity.
  * Introduced incremental data models for communication events and user tracking with historical change detection.

* **Documentation**
  * Added comprehensive setup guide for Slack connector including OAuth scope requirements and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

Closes #772

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#162 -->