### PR TITLE
[PR #157] feat(connector): add OpenAI Admin API connector

### DIFF
--- a/src/ingestion/connectors/ai/openai/README.md
+++ b/src/ingestion/connectors/ai/openai/README.md
@@ -1,0 +1,73 @@
+# OpenAI Connector
+
+Extracts organization users, per-endpoint API usage metrics, and cost data from the OpenAI Admin API using a Bearer token (Admin API key).
+
+## Prerequisites
+
+1. Go to [platform.openai.com/settings/organization/admin-keys](https://platform.openai.com/settings/organization/admin-keys)
+2. Create an Admin API key with read access to organization data
+3. The key must have permissions for: Users, Usage, and Costs endpoints
+
+## K8s Secret
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-openai-main
+  labels:
+    app.kubernetes.io/part-of: insight
+  annotations:
+    insight.cyberfabric.com/connector: openai
+    insight.cyberfabric.com/source-id: openai-main
+type: Opaque
+stringData:
+  openai_admin_api_key: "CHANGE_ME"
+  openai_start_date: "2026-01-01"
+```
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `openai_admin_api_key` | Yes | OpenAI Admin API key (from platform.openai.com) |
+| `openai_start_date` | No | Earliest date to collect usage/costs (YYYY-MM-DD). Defaults to 90 days ago |
+
+### Automatically injected
+
+| Field | Source |
+|-------|--------|
+| `insight_tenant_id` | `tenant_id` from tenant YAML |
+| `insight_source_id` | `insight.cyberfabric.com/source-id` annotation |
+
+### Local development
+
+Create `src/ingestion/secrets/connectors/openai.yaml` (gitignored) from the example:
+
+```bash
+cp src/ingestion/secrets/connectors/openai.yaml.example src/ingestion/secrets/connectors/openai.yaml
+# Fill in real values, then apply:
+kubectl apply -f src/ingestion/secrets/connectors/openai.yaml
+```
+
+## Streams
+
+| Stream | Description | Sync Mode |
+|--------|-------------|-----------|
+| `users` | Organization user roster (id, email, name, role) | Full Refresh |
+| `usage_completions` | Chat/API completion usage (input/output/cached/audio tokens) | Incremental |
+| `usage_embeddings` | Embedding usage (input tokens) | Incremental |
+| `usage_moderations` | Moderation usage (input tokens) | Incremental |
+| `usage_images` | Image generation usage (image count) | Incremental |
+| `usage_audio_speeches` | Text-to-speech usage (characters) | Incremental |
+| `usage_audio_transcriptions` | Speech-to-text usage (seconds) | Incremental |
+| `usage_vector_stores` | Vector store usage (bytes) | Incremental |
+| `usage_code_interpreter` | Code interpreter sessions | Incremental |
+| `costs` | Organization costs by line item and project | Incremental |
+
+All usage streams are grouped by `project_id`, `model`, and `user_id` (where supported) at daily bucket granularity.
+
+## Silver Targets
+
+- `class_ai_tool_usage` — Completions usage mapped to unified AI tool usage schema (provider=openai)
+- `class_ai_cost` — Organization costs mapped to unified AI cost schema (provider=openai)

--- a/src/ingestion/connectors/ai/openai/connector.yaml
+++ b/src/ingestion/connectors/ai/openai/connector.yaml
@@ -1,0 +1,1365 @@
+version: 7.0.4
+type: DeclarativeSource
+
+check:
+  type: CheckStream
+  stream_names:
+    - users
+
+definitions:
+  linked:
+    HttpRequester:
+      url_base: https://api.openai.com/v1
+      authenticator:
+        type: BearerAuthenticator
+        api_token: "{{ config['openai_admin_api_key'] }}"
+      request_headers:
+        Content-Type: application/json
+    UsagePaginator:
+      type: DefaultPaginator
+      page_token_option:
+        type: RequestOption
+        inject_into: request_parameter
+        field_name: page
+      pagination_strategy:
+        type: CursorPagination
+        cursor_value: "{{ response.get('next_page', '') }}"
+        stop_condition: "{{ not response.get('has_more', false) }}"
+    UsersPaginator:
+      type: DefaultPaginator
+      page_token_option:
+        type: RequestOption
+        inject_into: request_parameter
+        field_name: after
+      pagination_strategy:
+        type: CursorPagination
+        cursor_value: "{{ response.get('last_id', '') }}"
+        stop_condition: "{{ not response.get('has_more', false) }}"
+
+streams:
+  # ── Stream 1: users (full refresh) ──
+  - type: DeclarativeStream
+    name: users
+    primary_key: unique_key
+    retriever:
+      type: SimpleRetriever
+      decoder:
+        type: JsonDecoder
+      requester:
+        type: HttpRequester
+        url_base:
+          $ref: "#/definitions/linked/HttpRequester/url_base"
+        authenticator:
+          $ref: "#/definitions/linked/HttpRequester/authenticator"
+        request_headers:
+          $ref: "#/definitions/linked/HttpRequester/request_headers"
+        http_method: GET
+        path: organization/users
+        request_parameters:
+          limit: "100"
+      paginator:
+        $ref: "#/definitions/linked/UsersPaginator"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - data
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key:
+            type: string
+          tenant_id:
+            type:
+              - string
+              - "null"
+          source_id:
+            type:
+              - string
+              - "null"
+          id:
+            type:
+              - string
+              - "null"
+          object:
+            type:
+              - string
+              - "null"
+          email:
+            type:
+              - string
+              - "null"
+          name:
+            type:
+              - string
+              - "null"
+          role:
+            type:
+              - string
+              - "null"
+          added_at:
+            type:
+              - number
+              - "null"
+        required:
+          - unique_key
+        additionalProperties: true
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - tenant_id
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - source_id
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - unique_key
+            value: >-
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
+              }}-{{ record['id'] }}
+
+  # ── Stream 2: usage_completions (incremental) ──
+  - type: DeclarativeStream
+    name: usage_completions
+    primary_key: unique_key
+    retriever:
+      type: SimpleRetriever
+      decoder:
+        type: JsonDecoder
+      requester:
+        type: HttpRequester
+        url_base:
+          $ref: "#/definitions/linked/HttpRequester/url_base"
+        authenticator:
+          $ref: "#/definitions/linked/HttpRequester/authenticator"
+        request_headers:
+          $ref: "#/definitions/linked/HttpRequester/request_headers"
+        http_method: GET
+        path: organization/usage/completions?group_by=project_id&group_by=model&group_by=user_id
+        request_parameters:
+          bucket_width: 1d
+          limit: "31"
+      paginator:
+        $ref: "#/definitions/linked/UsagePaginator"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - data
+            - "*"
+            - results
+            - "*"
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: bucket_start_time
+      cursor_datetime_formats:
+        - "%s"
+      datetime_format: "%s"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('openai_start_date', day_delta(-90, format='%Y-%m-%d')) }}"
+        datetime_format: "%Y-%m-%d"
+      end_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ now_utc().strftime('%Y-%m-%d') }}"
+        datetime_format: "%Y-%m-%d"
+      step: P31D
+      cursor_granularity: P1D
+      start_time_option:
+        type: RequestOption
+        field_name: start_time
+        inject_into: request_parameter
+      end_time_option:
+        type: RequestOption
+        field_name: end_time
+        inject_into: request_parameter
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key:
+            type: string
+          tenant_id:
+            type:
+              - string
+              - "null"
+          source_id:
+            type:
+              - string
+              - "null"
+          bucket_start_time:
+            type:
+              - number
+              - "null"
+          bucket_end_time:
+            type:
+              - number
+              - "null"
+          input_tokens:
+            type:
+              - number
+              - "null"
+          output_tokens:
+            type:
+              - number
+              - "null"
+          input_cached_tokens:
+            type:
+              - number
+              - "null"
+          input_audio_tokens:
+            type:
+              - number
+              - "null"
+          output_audio_tokens:
+            type:
+              - number
+              - "null"
+          num_model_requests:
+            type:
+              - number
+              - "null"
+          project_id:
+            type:
+              - string
+              - "null"
+          user_id:
+            type:
+              - string
+              - "null"
+          model:
+            type:
+              - string
+              - "null"
+          batch:
+            type:
+              - boolean
+              - "null"
+          service_tier:
+            type:
+              - string
+              - "null"
+        required:
+          - unique_key
+        additionalProperties: true
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - tenant_id
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - source_id
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - bucket_start_time
+            value: "{{ record.get('start_time', '') }}"
+          - type: AddedFieldDefinition
+            path:
+              - bucket_end_time
+            value: "{{ record.get('end_time', '') }}"
+          - type: AddedFieldDefinition
+            path:
+              - unique_key
+            value: >-
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
+              }}-{{ record.get('start_time', '') }}-{{ record.get('project_id',
+              '') }}-{{ record.get('model', '') }}-{{ record.get('user_id', '') }}
+
+  # ── Stream 3: usage_embeddings (incremental) ──
+  - type: DeclarativeStream
+    name: usage_embeddings
+    primary_key: unique_key
+    retriever:
+      type: SimpleRetriever
+      decoder:
+        type: JsonDecoder
+      requester:
+        type: HttpRequester
+        url_base:
+          $ref: "#/definitions/linked/HttpRequester/url_base"
+        authenticator:
+          $ref: "#/definitions/linked/HttpRequester/authenticator"
+        request_headers:
+          $ref: "#/definitions/linked/HttpRequester/request_headers"
+        http_method: GET
+        path: organization/usage/embeddings?group_by=project_id&group_by=model&group_by=user_id
+        request_parameters:
+          bucket_width: 1d
+          limit: "31"
+      paginator:
+        $ref: "#/definitions/linked/UsagePaginator"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - data
+            - "*"
+            - results
+            - "*"
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: bucket_start_time
+      cursor_datetime_formats:
+        - "%s"
+      datetime_format: "%s"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('openai_start_date', day_delta(-90, format='%Y-%m-%d')) }}"
+        datetime_format: "%Y-%m-%d"
+      end_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ now_utc().strftime('%Y-%m-%d') }}"
+        datetime_format: "%Y-%m-%d"
+      step: P31D
+      cursor_granularity: P1D
+      start_time_option:
+        type: RequestOption
+        field_name: start_time
+        inject_into: request_parameter
+      end_time_option:
+        type: RequestOption
+        field_name: end_time
+        inject_into: request_parameter
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key:
+            type: string
+          tenant_id:
+            type:
+              - string
+              - "null"
+          source_id:
+            type:
+              - string
+              - "null"
+          bucket_start_time:
+            type:
+              - number
+              - "null"
+          bucket_end_time:
+            type:
+              - number
+              - "null"
+          input_tokens:
+            type:
+              - number
+              - "null"
+          num_model_requests:
+            type:
+              - number
+              - "null"
+          project_id:
+            type:
+              - string
+              - "null"
+          user_id:
+            type:
+              - string
+              - "null"
+          model:
+            type:
+              - string
+              - "null"
+        required:
+          - unique_key
+        additionalProperties: true
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - tenant_id
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - source_id
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - bucket_start_time
+            value: "{{ record.get('start_time', '') }}"
+          - type: AddedFieldDefinition
+            path:
+              - bucket_end_time
+            value: "{{ record.get('end_time', '') }}"
+          - type: AddedFieldDefinition
+            path:
+              - unique_key
+            value: >-
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
+              }}-{{ record.get('start_time', '') }}-{{ record.get('project_id',
+              '') }}-{{ record.get('model', '') }}-{{ record.get('user_id', '') }}
+
+  # ── Stream 4: usage_moderations (incremental) ──
+  - type: DeclarativeStream
+    name: usage_moderations
+    primary_key: unique_key
+    retriever:
+      type: SimpleRetriever
+      decoder:
+        type: JsonDecoder
+      requester:
+        type: HttpRequester
+        url_base:
+          $ref: "#/definitions/linked/HttpRequester/url_base"
+        authenticator:
+          $ref: "#/definitions/linked/HttpRequester/authenticator"
+        request_headers:
+          $ref: "#/definitions/linked/HttpRequester/request_headers"
+        http_method: GET
+        path: organization/usage/moderations?group_by=project_id&group_by=model&group_by=user_id
+        request_parameters:
+          bucket_width: 1d
+          limit: "31"
+      paginator:
+        $ref: "#/definitions/linked/UsagePaginator"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - data
+            - "*"
+            - results
+            - "*"
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: bucket_start_time
+      cursor_datetime_formats:
+        - "%s"
+      datetime_format: "%s"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('openai_start_date', day_delta(-90, format='%Y-%m-%d')) }}"
+        datetime_format: "%Y-%m-%d"
+      end_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ now_utc().strftime('%Y-%m-%d') }}"
+        datetime_format: "%Y-%m-%d"
+      step: P31D
+      cursor_granularity: P1D
+      start_time_option:
+        type: RequestOption
+        field_name: start_time
+        inject_into: request_parameter
+      end_time_option:
+        type: RequestOption
+        field_name: end_time
+        inject_into: request_parameter
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key:
+            type: string
+          tenant_id:
+            type:
+              - string
+              - "null"
+          source_id:
+            type:
+              - string
+              - "null"
+          bucket_start_time:
+            type:
+              - number
+              - "null"
+          bucket_end_time:
+            type:
+              - number
+              - "null"
+          input_tokens:
+            type:
+              - number
+              - "null"
+          num_model_requests:
+            type:
+              - number
+              - "null"
+          project_id:
+            type:
+              - string
+              - "null"
+          user_id:
+            type:
+              - string
+              - "null"
+          model:
+            type:
+              - string
+              - "null"
+        required:
+          - unique_key
+        additionalProperties: true
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - tenant_id
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - source_id
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - bucket_start_time
+            value: "{{ record.get('start_time', '') }}"
+          - type: AddedFieldDefinition
+            path:
+              - bucket_end_time
+            value: "{{ record.get('end_time', '') }}"
+          - type: AddedFieldDefinition
+            path:
+              - unique_key
+            value: >-
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
+              }}-{{ record.get('start_time', '') }}-{{ record.get('project_id',
+              '') }}-{{ record.get('model', '') }}-{{ record.get('user_id', '') }}
+
+  # ── Stream 5: usage_images (incremental) ──
+  - type: DeclarativeStream
+    name: usage_images
+    primary_key: unique_key
+    retriever:
+      type: SimpleRetriever
+      decoder:
+        type: JsonDecoder
+      requester:
+        type: HttpRequester
+        url_base:
+          $ref: "#/definitions/linked/HttpRequester/url_base"
+        authenticator:
+          $ref: "#/definitions/linked/HttpRequester/authenticator"
+        request_headers:
+          $ref: "#/definitions/linked/HttpRequester/request_headers"
+        http_method: GET
+        path: organization/usage/images?group_by=project_id&group_by=model&group_by=user_id
+        request_parameters:
+          bucket_width: 1d
+          limit: "31"
+      paginator:
+        $ref: "#/definitions/linked/UsagePaginator"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - data
+            - "*"
+            - results
+            - "*"
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: bucket_start_time
+      cursor_datetime_formats:
+        - "%s"
+      datetime_format: "%s"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('openai_start_date', day_delta(-90, format='%Y-%m-%d')) }}"
+        datetime_format: "%Y-%m-%d"
+      end_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ now_utc().strftime('%Y-%m-%d') }}"
+        datetime_format: "%Y-%m-%d"
+      step: P31D
+      cursor_granularity: P1D
+      start_time_option:
+        type: RequestOption
+        field_name: start_time
+        inject_into: request_parameter
+      end_time_option:
+        type: RequestOption
+        field_name: end_time
+        inject_into: request_parameter
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key:
+            type: string
+          tenant_id:
+            type:
+              - string
+              - "null"
+          source_id:
+            type:
+              - string
+              - "null"
+          bucket_start_time:
+            type:
+              - number
+              - "null"
+          bucket_end_time:
+            type:
+              - number
+              - "null"
+          images:
+            type:
+              - number
+              - "null"
+          num_model_requests:
+            type:
+              - number
+              - "null"
+          project_id:
+            type:
+              - string
+              - "null"
+          user_id:
+            type:
+              - string
+              - "null"
+          model:
+            type:
+              - string
+              - "null"
+          size:
+            type:
+              - string
+              - "null"
+          source:
+            type:
+              - string
+              - "null"
+        required:
+          - unique_key
+        additionalProperties: true
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - tenant_id
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - source_id
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - bucket_start_time
+            value: "{{ record.get('start_time', '') }}"
+          - type: AddedFieldDefinition
+            path:
+              - bucket_end_time
+            value: "{{ record.get('end_time', '') }}"
+          - type: AddedFieldDefinition
+            path:
+              - unique_key
+            value: >-
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
+              }}-{{ record.get('start_time', '') }}-{{ record.get('project_id',
+              '') }}-{{ record.get('model', '') }}-{{ record.get('user_id', '') }}
+
+  # ── Stream 6: usage_audio_speeches (incremental) ──
+  - type: DeclarativeStream
+    name: usage_audio_speeches
+    primary_key: unique_key
+    retriever:
+      type: SimpleRetriever
+      decoder:
+        type: JsonDecoder
+      requester:
+        type: HttpRequester
+        url_base:
+          $ref: "#/definitions/linked/HttpRequester/url_base"
+        authenticator:
+          $ref: "#/definitions/linked/HttpRequester/authenticator"
+        request_headers:
+          $ref: "#/definitions/linked/HttpRequester/request_headers"
+        http_method: GET
+        path: organization/usage/audio_speeches?group_by=project_id&group_by=model&group_by=user_id
+        request_parameters:
+          bucket_width: 1d
+          limit: "31"
+      paginator:
+        $ref: "#/definitions/linked/UsagePaginator"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - data
+            - "*"
+            - results
+            - "*"
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: bucket_start_time
+      cursor_datetime_formats:
+        - "%s"
+      datetime_format: "%s"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('openai_start_date', day_delta(-90, format='%Y-%m-%d')) }}"
+        datetime_format: "%Y-%m-%d"
+      end_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ now_utc().strftime('%Y-%m-%d') }}"
+        datetime_format: "%Y-%m-%d"
+      step: P31D
+      cursor_granularity: P1D
+      start_time_option:
+        type: RequestOption
+        field_name: start_time
+        inject_into: request_parameter
+      end_time_option:
+        type: RequestOption
+        field_name: end_time
+        inject_into: request_parameter
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key:
+            type: string
+          tenant_id:
+            type:
+              - string
+              - "null"
+          source_id:
+            type:
+              - string
+              - "null"
+          bucket_start_time:
+            type:
+              - number
+              - "null"
+          bucket_end_time:
+            type:
+              - number
+              - "null"
+          characters:
+            type:
+              - number
+              - "null"
+          num_model_requests:
+            type:
+              - number
+              - "null"
+          project_id:
+            type:
+              - string
+              - "null"
+          user_id:
+            type:
+              - string
+              - "null"
+          model:
+            type:
+              - string
+              - "null"
+        required:
+          - unique_key
+        additionalProperties: true
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - tenant_id
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - source_id
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - bucket_start_time
+            value: "{{ record.get('start_time', '') }}"
+          - type: AddedFieldDefinition
+            path:
+              - bucket_end_time
+            value: "{{ record.get('end_time', '') }}"
+          - type: AddedFieldDefinition
+            path:
+              - unique_key
+            value: >-
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
+              }}-{{ record.get('start_time', '') }}-{{ record.get('project_id',
+              '') }}-{{ record.get('model', '') }}-{{ record.get('user_id', '') }}
+
+  # ── Stream 7: usage_audio_transcriptions (incremental) ──
+  - type: DeclarativeStream
+    name: usage_audio_transcriptions
+    primary_key: unique_key
+    retriever:
+      type: SimpleRetriever
+      decoder:
+        type: JsonDecoder
+      requester:
+        type: HttpRequester
+        url_base:
+          $ref: "#/definitions/linked/HttpRequester/url_base"
+        authenticator:
+          $ref: "#/definitions/linked/HttpRequester/authenticator"
+        request_headers:
+          $ref: "#/definitions/linked/HttpRequester/request_headers"
+        http_method: GET
+        path: organization/usage/audio_transcriptions?group_by=project_id&group_by=model&group_by=user_id
+        request_parameters:
+          bucket_width: 1d
+          limit: "31"
+      paginator:
+        $ref: "#/definitions/linked/UsagePaginator"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - data
+            - "*"
+            - results
+            - "*"
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: bucket_start_time
+      cursor_datetime_formats:
+        - "%s"
+      datetime_format: "%s"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('openai_start_date', day_delta(-90, format='%Y-%m-%d')) }}"
+        datetime_format: "%Y-%m-%d"
+      end_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ now_utc().strftime('%Y-%m-%d') }}"
+        datetime_format: "%Y-%m-%d"
+      step: P31D
+      cursor_granularity: P1D
+      start_time_option:
+        type: RequestOption
+        field_name: start_time
+        inject_into: request_parameter
+      end_time_option:
+        type: RequestOption
+        field_name: end_time
+        inject_into: request_parameter
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key:
+            type: string
+          tenant_id:
+            type:
+              - string
+              - "null"
+          source_id:
+            type:
+              - string
+              - "null"
+          bucket_start_time:
+            type:
+              - number
+              - "null"
+          bucket_end_time:
+            type:
+              - number
+              - "null"
+          seconds:
+            type:
+              - number
+              - "null"
+          num_model_requests:
+            type:
+              - number
+              - "null"
+          project_id:
+            type:
+              - string
+              - "null"
+          user_id:
+            type:
+              - string
+              - "null"
+          model:
+            type:
+              - string
+              - "null"
+        required:
+          - unique_key
+        additionalProperties: true
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - tenant_id
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - source_id
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - bucket_start_time
+            value: "{{ record.get('start_time', '') }}"
+          - type: AddedFieldDefinition
+            path:
+              - bucket_end_time
+            value: "{{ record.get('end_time', '') }}"
+          - type: AddedFieldDefinition
+            path:
+              - unique_key
+            value: >-
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
+              }}-{{ record.get('start_time', '') }}-{{ record.get('project_id',
+              '') }}-{{ record.get('model', '') }}-{{ record.get('user_id', '') }}
+
+  # ── Stream 8: usage_vector_stores (incremental) ──
+  - type: DeclarativeStream
+    name: usage_vector_stores
+    primary_key: unique_key
+    retriever:
+      type: SimpleRetriever
+      decoder:
+        type: JsonDecoder
+      requester:
+        type: HttpRequester
+        url_base:
+          $ref: "#/definitions/linked/HttpRequester/url_base"
+        authenticator:
+          $ref: "#/definitions/linked/HttpRequester/authenticator"
+        request_headers:
+          $ref: "#/definitions/linked/HttpRequester/request_headers"
+        http_method: GET
+        path: organization/usage/vector_stores?group_by=project_id
+        request_parameters:
+          bucket_width: 1d
+          limit: "31"
+      paginator:
+        $ref: "#/definitions/linked/UsagePaginator"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - data
+            - "*"
+            - results
+            - "*"
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: bucket_start_time
+      cursor_datetime_formats:
+        - "%s"
+      datetime_format: "%s"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('openai_start_date', day_delta(-90, format='%Y-%m-%d')) }}"
+        datetime_format: "%Y-%m-%d"
+      end_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ now_utc().strftime('%Y-%m-%d') }}"
+        datetime_format: "%Y-%m-%d"
+      step: P31D
+      cursor_granularity: P1D
+      start_time_option:
+        type: RequestOption
+        field_name: start_time
+        inject_into: request_parameter
+      end_time_option:
+        type: RequestOption
+        field_name: end_time
+        inject_into: request_parameter
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key:
+            type: string
+          tenant_id:
+            type:
+              - string
+              - "null"
+          source_id:
+            type:
+              - string
+              - "null"
+          bucket_start_time:
+            type:
+              - number
+              - "null"
+          bucket_end_time:
+            type:
+              - number
+              - "null"
+          usage_bytes:
+            type:
+              - number
+              - "null"
+          project_id:
+            type:
+              - string
+              - "null"
+        required:
+          - unique_key
+        additionalProperties: true
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - tenant_id
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - source_id
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - bucket_start_time
+            value: "{{ record.get('start_time', '') }}"
+          - type: AddedFieldDefinition
+            path:
+              - bucket_end_time
+            value: "{{ record.get('end_time', '') }}"
+          - type: AddedFieldDefinition
+            path:
+              - unique_key
+            value: >-
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
+              }}-{{ record.get('start_time', '') }}-{{ record.get('project_id',
+              '') }}
+
+  # ── Stream 9: usage_code_interpreter (incremental) ──
+  - type: DeclarativeStream
+    name: usage_code_interpreter
+    primary_key: unique_key
+    retriever:
+      type: SimpleRetriever
+      decoder:
+        type: JsonDecoder
+      requester:
+        type: HttpRequester
+        url_base:
+          $ref: "#/definitions/linked/HttpRequester/url_base"
+        authenticator:
+          $ref: "#/definitions/linked/HttpRequester/authenticator"
+        request_headers:
+          $ref: "#/definitions/linked/HttpRequester/request_headers"
+        http_method: GET
+        path: organization/usage/code_interpreter_sessions?group_by=project_id
+        request_parameters:
+          bucket_width: 1d
+          limit: "31"
+      paginator:
+        $ref: "#/definitions/linked/UsagePaginator"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - data
+            - "*"
+            - results
+            - "*"
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: bucket_start_time
+      cursor_datetime_formats:
+        - "%s"
+      datetime_format: "%s"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('openai_start_date', day_delta(-90, format='%Y-%m-%d')) }}"
+        datetime_format: "%Y-%m-%d"
+      end_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ now_utc().strftime('%Y-%m-%d') }}"
+        datetime_format: "%Y-%m-%d"
+      step: P31D
+      cursor_granularity: P1D
+      start_time_option:
+        type: RequestOption
+        field_name: start_time
+        inject_into: request_parameter
+      end_time_option:
+        type: RequestOption
+        field_name: end_time
+        inject_into: request_parameter
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key:
+            type: string
+          tenant_id:
+            type:
+              - string
+              - "null"
+          source_id:
+            type:
+              - string
+              - "null"
+          bucket_start_time:
+            type:
+              - number
+              - "null"
+          bucket_end_time:
+            type:
+              - number
+              - "null"
+          num_sessions:
+            type:
+              - number
+              - "null"
+          project_id:
+            type:
+              - string
+              - "null"
+        required:
+          - unique_key
+        additionalProperties: true
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - tenant_id
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - source_id
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - bucket_start_time
+            value: "{{ record.get('start_time', '') }}"
+          - type: AddedFieldDefinition
+            path:
+              - bucket_end_time
+            value: "{{ record.get('end_time', '') }}"
+          - type: AddedFieldDefinition
+            path:
+              - unique_key
+            value: >-
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
+              }}-{{ record.get('start_time', '') }}-{{ record.get('project_id',
+              '') }}
+
+  # ── Stream 10: costs (incremental) ──
+  - type: DeclarativeStream
+    name: costs
+    primary_key: unique_key
+    retriever:
+      type: SimpleRetriever
+      decoder:
+        type: JsonDecoder
+      requester:
+        type: HttpRequester
+        url_base:
+          $ref: "#/definitions/linked/HttpRequester/url_base"
+        authenticator:
+          $ref: "#/definitions/linked/HttpRequester/authenticator"
+        request_headers:
+          $ref: "#/definitions/linked/HttpRequester/request_headers"
+        http_method: GET
+        path: organization/costs?group_by=line_item&group_by=project_id
+        request_parameters:
+          bucket_width: 1d
+          limit: "31"
+      paginator:
+        $ref: "#/definitions/linked/UsagePaginator"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - data
+            - "*"
+            - results
+            - "*"
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: bucket_start_time
+      cursor_datetime_formats:
+        - "%s"
+      datetime_format: "%s"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('openai_start_date', day_delta(-90, format='%Y-%m-%d')) }}"
+        datetime_format: "%Y-%m-%d"
+      end_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ now_utc().strftime('%Y-%m-%d') }}"
+        datetime_format: "%Y-%m-%d"
+      step: P31D
+      cursor_granularity: P1D
+      start_time_option:
+        type: RequestOption
+        field_name: start_time
+        inject_into: request_parameter
+      end_time_option:
+        type: RequestOption
+        field_name: end_time
+        inject_into: request_parameter
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key:
+            type: string
+          tenant_id:
+            type:
+              - string
+              - "null"
+          source_id:
+            type:
+              - string
+              - "null"
+          bucket_start_time:
+            type:
+              - number
+              - "null"
+          bucket_end_time:
+            type:
+              - number
+              - "null"
+          amount_value:
+            type:
+              - number
+              - "null"
+          amount_currency:
+            type:
+              - string
+              - "null"
+          line_item:
+            type:
+              - string
+              - "null"
+          project_id:
+            type:
+              - string
+              - "null"
+        required:
+          - unique_key
+        additionalProperties: true
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - tenant_id
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - source_id
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - bucket_start_time
+            value: "{{ record.get('start_time', '') }}"
+          - type: AddedFieldDefinition
+            path:
+              - bucket_end_time
+            value: "{{ record.get('end_time', '') }}"
+          - type: AddedFieldDefinition
+            path:
+              - amount_value
+            value: "{{ record.get('amount', {}).get('value', '') }}"
+          - type: AddedFieldDefinition
+            path:
+              - amount_currency
+            value: "{{ record.get('amount', {}).get('currency', '') }}"
+          - type: AddedFieldDefinition
+            path:
+              - unique_key
+            value: >-
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
+              }}-{{ record.get('start_time', '') }}-{{ record.get('line_item',
+              '') }}-{{ record.get('project_id', '') }}
+
+concurrency_level:
+  type: ConcurrencyLevel
+  default_concurrency: 1
+
+spec:
+  type: Spec
+  connection_specification:
+    type: object
+    $schema: http://json-schema.org/draft-07/schema#
+    required:
+      - insight_tenant_id
+      - insight_source_id
+      - openai_admin_api_key
+    properties:
+      insight_tenant_id:
+        type: string
+        description: Insight tenant identifier stamped onto every emitted record.
+        title: Insight Tenant ID
+        order: 0
+      insight_source_id:
+        type: string
+        description: Connector instance identifier for multi-instance deployments.
+        title: Insight Source ID
+        order: 1
+      openai_admin_api_key:
+        type: string
+        description: >-
+          OpenAI Admin API key. Create at
+          https://platform.openai.com/settings/organization/admin-keys
+          (Organization Owner only). Regular API keys will not work.
+        title: OpenAI Admin API Key
+        airbyte_secret: true
+        order: 2
+      openai_start_date:
+        type: string
+        description: >-
+          Earliest date to collect usage from (YYYY-MM-DD). Defaults to 90 days
+          ago.
+        title: Start Date
+        format: date
+        order: 3
+    additionalProperties: true
+
+metadata:
+  autoImportSchema:
+    users: true
+    usage_completions: true
+    usage_embeddings: true
+    usage_moderations: true
+    usage_images: true
+    usage_audio_speeches: true
+    usage_audio_transcriptions: true
+    usage_vector_stores: true
+    usage_code_interpreter: true
+    costs: true

--- a/src/ingestion/connectors/ai/openai/connector.yaml
+++ b/src/ingestion/connectors/ai/openai/connector.yaml
@@ -147,6 +147,8 @@ streams:
         request_parameters:
           bucket_width: 1d
           limit: "31"
+          start_time: "{{ stream_slice['start_time'] }}"
+          end_time: "{{ stream_slice['start_time'] | int + 86400 }}"
       paginator:
         $ref: "#/definitions/linked/UsagePaginator"
       record_selector:
@@ -172,16 +174,8 @@ streams:
         type: MinMaxDatetime
         datetime: "{{ now_utc().strftime('%Y-%m-%d') }}"
         datetime_format: "%Y-%m-%d"
-      step: P31D
-      cursor_granularity: P1D
-      start_time_option:
-        type: RequestOption
-        field_name: start_time
-        inject_into: request_parameter
-      end_time_option:
-        type: RequestOption
-        field_name: end_time
-        inject_into: request_parameter
+      step: P1D
+      cursor_granularity: PT1S
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -267,17 +261,17 @@ streams:
           - type: AddedFieldDefinition
             path:
               - bucket_start_time
-            value: "{{ record.get('start_time', '') }}"
+            value: "{{ stream_slice['start_time'] }}"
           - type: AddedFieldDefinition
             path:
               - bucket_end_time
-            value: "{{ record.get('end_time', '') }}"
+            value: "{{ stream_slice['end_time'] }}"
           - type: AddedFieldDefinition
             path:
               - unique_key
             value: >-
               {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record.get('start_time', '') }}-{{ record.get('project_id',
+              }}-{{ stream_slice['start_time'] }}-{{ record.get('project_id',
               '') }}-{{ record.get('model', '') }}-{{ record.get('user_id', '') }}
 
   # ── Stream 3: usage_embeddings (incremental) ──
@@ -301,6 +295,8 @@ streams:
         request_parameters:
           bucket_width: 1d
           limit: "31"
+          start_time: "{{ stream_slice['start_time'] }}"
+          end_time: "{{ stream_slice['start_time'] | int + 86400 }}"
       paginator:
         $ref: "#/definitions/linked/UsagePaginator"
       record_selector:
@@ -326,16 +322,8 @@ streams:
         type: MinMaxDatetime
         datetime: "{{ now_utc().strftime('%Y-%m-%d') }}"
         datetime_format: "%Y-%m-%d"
-      step: P31D
-      cursor_granularity: P1D
-      start_time_option:
-        type: RequestOption
-        field_name: start_time
-        inject_into: request_parameter
-      end_time_option:
-        type: RequestOption
-        field_name: end_time
-        inject_into: request_parameter
+      step: P1D
+      cursor_granularity: PT1S
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -397,17 +385,17 @@ streams:
           - type: AddedFieldDefinition
             path:
               - bucket_start_time
-            value: "{{ record.get('start_time', '') }}"
+            value: "{{ stream_slice['start_time'] }}"
           - type: AddedFieldDefinition
             path:
               - bucket_end_time
-            value: "{{ record.get('end_time', '') }}"
+            value: "{{ stream_slice['end_time'] }}"
           - type: AddedFieldDefinition
             path:
               - unique_key
             value: >-
               {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record.get('start_time', '') }}-{{ record.get('project_id',
+              }}-{{ stream_slice['start_time'] }}-{{ record.get('project_id',
               '') }}-{{ record.get('model', '') }}-{{ record.get('user_id', '') }}
 
   # ── Stream 4: usage_moderations (incremental) ──
@@ -431,6 +419,8 @@ streams:
         request_parameters:
           bucket_width: 1d
           limit: "31"
+          start_time: "{{ stream_slice['start_time'] }}"
+          end_time: "{{ stream_slice['start_time'] | int + 86400 }}"
       paginator:
         $ref: "#/definitions/linked/UsagePaginator"
       record_selector:
@@ -456,16 +446,8 @@ streams:
         type: MinMaxDatetime
         datetime: "{{ now_utc().strftime('%Y-%m-%d') }}"
         datetime_format: "%Y-%m-%d"
-      step: P31D
-      cursor_granularity: P1D
-      start_time_option:
-        type: RequestOption
-        field_name: start_time
-        inject_into: request_parameter
-      end_time_option:
-        type: RequestOption
-        field_name: end_time
-        inject_into: request_parameter
+      step: P1D
+      cursor_granularity: PT1S
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -527,17 +509,17 @@ streams:
           - type: AddedFieldDefinition
             path:
               - bucket_start_time
-            value: "{{ record.get('start_time', '') }}"
+            value: "{{ stream_slice['start_time'] }}"
           - type: AddedFieldDefinition
             path:
               - bucket_end_time
-            value: "{{ record.get('end_time', '') }}"
+            value: "{{ stream_slice['end_time'] }}"
           - type: AddedFieldDefinition
             path:
               - unique_key
             value: >-
               {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record.get('start_time', '') }}-{{ record.get('project_id',
+              }}-{{ stream_slice['start_time'] }}-{{ record.get('project_id',
               '') }}-{{ record.get('model', '') }}-{{ record.get('user_id', '') }}
 
   # ── Stream 5: usage_images (incremental) ──
@@ -561,6 +543,8 @@ streams:
         request_parameters:
           bucket_width: 1d
           limit: "31"
+          start_time: "{{ stream_slice['start_time'] }}"
+          end_time: "{{ stream_slice['start_time'] | int + 86400 }}"
       paginator:
         $ref: "#/definitions/linked/UsagePaginator"
       record_selector:
@@ -586,16 +570,8 @@ streams:
         type: MinMaxDatetime
         datetime: "{{ now_utc().strftime('%Y-%m-%d') }}"
         datetime_format: "%Y-%m-%d"
-      step: P31D
-      cursor_granularity: P1D
-      start_time_option:
-        type: RequestOption
-        field_name: start_time
-        inject_into: request_parameter
-      end_time_option:
-        type: RequestOption
-        field_name: end_time
-        inject_into: request_parameter
+      step: P1D
+      cursor_granularity: PT1S
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -665,17 +641,17 @@ streams:
           - type: AddedFieldDefinition
             path:
               - bucket_start_time
-            value: "{{ record.get('start_time', '') }}"
+            value: "{{ stream_slice['start_time'] }}"
           - type: AddedFieldDefinition
             path:
               - bucket_end_time
-            value: "{{ record.get('end_time', '') }}"
+            value: "{{ stream_slice['end_time'] }}"
           - type: AddedFieldDefinition
             path:
               - unique_key
             value: >-
               {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record.get('start_time', '') }}-{{ record.get('project_id',
+              }}-{{ stream_slice['start_time'] }}-{{ record.get('project_id',
               '') }}-{{ record.get('model', '') }}-{{ record.get('user_id', '') }}
 
   # ── Stream 6: usage_audio_speeches (incremental) ──
@@ -699,6 +675,8 @@ streams:
         request_parameters:
           bucket_width: 1d
           limit: "31"
+          start_time: "{{ stream_slice['start_time'] }}"
+          end_time: "{{ stream_slice['start_time'] | int + 86400 }}"
       paginator:
         $ref: "#/definitions/linked/UsagePaginator"
       record_selector:
@@ -724,16 +702,8 @@ streams:
         type: MinMaxDatetime
         datetime: "{{ now_utc().strftime('%Y-%m-%d') }}"
         datetime_format: "%Y-%m-%d"
-      step: P31D
-      cursor_granularity: P1D
-      start_time_option:
-        type: RequestOption
-        field_name: start_time
-        inject_into: request_parameter
-      end_time_option:
-        type: RequestOption
-        field_name: end_time
-        inject_into: request_parameter
+      step: P1D
+      cursor_granularity: PT1S
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -795,17 +765,17 @@ streams:
           - type: AddedFieldDefinition
             path:
               - bucket_start_time
-            value: "{{ record.get('start_time', '') }}"
+            value: "{{ stream_slice['start_time'] }}"
           - type: AddedFieldDefinition
             path:
               - bucket_end_time
-            value: "{{ record.get('end_time', '') }}"
+            value: "{{ stream_slice['end_time'] }}"
           - type: AddedFieldDefinition
             path:
               - unique_key
             value: >-
               {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record.get('start_time', '') }}-{{ record.get('project_id',
+              }}-{{ stream_slice['start_time'] }}-{{ record.get('project_id',
               '') }}-{{ record.get('model', '') }}-{{ record.get('user_id', '') }}
 
   # ── Stream 7: usage_audio_transcriptions (incremental) ──
@@ -829,6 +799,8 @@ streams:
         request_parameters:
           bucket_width: 1d
           limit: "31"
+          start_time: "{{ stream_slice['start_time'] }}"
+          end_time: "{{ stream_slice['start_time'] | int + 86400 }}"
       paginator:
         $ref: "#/definitions/linked/UsagePaginator"
       record_selector:
@@ -854,16 +826,8 @@ streams:
         type: MinMaxDatetime
         datetime: "{{ now_utc().strftime('%Y-%m-%d') }}"
         datetime_format: "%Y-%m-%d"
-      step: P31D
-      cursor_granularity: P1D
-      start_time_option:
-        type: RequestOption
-        field_name: start_time
-        inject_into: request_parameter
-      end_time_option:
-        type: RequestOption
-        field_name: end_time
-        inject_into: request_parameter
+      step: P1D
+      cursor_granularity: PT1S
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -925,17 +889,17 @@ streams:
           - type: AddedFieldDefinition
             path:
               - bucket_start_time
-            value: "{{ record.get('start_time', '') }}"
+            value: "{{ stream_slice['start_time'] }}"
           - type: AddedFieldDefinition
             path:
               - bucket_end_time
-            value: "{{ record.get('end_time', '') }}"
+            value: "{{ stream_slice['end_time'] }}"
           - type: AddedFieldDefinition
             path:
               - unique_key
             value: >-
               {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record.get('start_time', '') }}-{{ record.get('project_id',
+              }}-{{ stream_slice['start_time'] }}-{{ record.get('project_id',
               '') }}-{{ record.get('model', '') }}-{{ record.get('user_id', '') }}
 
   # ── Stream 8: usage_vector_stores (incremental) ──
@@ -959,6 +923,8 @@ streams:
         request_parameters:
           bucket_width: 1d
           limit: "31"
+          start_time: "{{ stream_slice['start_time'] }}"
+          end_time: "{{ stream_slice['start_time'] | int + 86400 }}"
       paginator:
         $ref: "#/definitions/linked/UsagePaginator"
       record_selector:
@@ -984,16 +950,8 @@ streams:
         type: MinMaxDatetime
         datetime: "{{ now_utc().strftime('%Y-%m-%d') }}"
         datetime_format: "%Y-%m-%d"
-      step: P31D
-      cursor_granularity: P1D
-      start_time_option:
-        type: RequestOption
-        field_name: start_time
-        inject_into: request_parameter
-      end_time_option:
-        type: RequestOption
-        field_name: end_time
-        inject_into: request_parameter
+      step: P1D
+      cursor_granularity: PT1S
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -1043,17 +1001,17 @@ streams:
           - type: AddedFieldDefinition
             path:
               - bucket_start_time
-            value: "{{ record.get('start_time', '') }}"
+            value: "{{ stream_slice['start_time'] }}"
           - type: AddedFieldDefinition
             path:
               - bucket_end_time
-            value: "{{ record.get('end_time', '') }}"
+            value: "{{ stream_slice['end_time'] }}"
           - type: AddedFieldDefinition
             path:
               - unique_key
             value: >-
               {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record.get('start_time', '') }}-{{ record.get('project_id',
+              }}-{{ stream_slice['start_time'] }}-{{ record.get('project_id',
               '') }}
 
   # ── Stream 9: usage_code_interpreter (incremental) ──
@@ -1077,6 +1035,8 @@ streams:
         request_parameters:
           bucket_width: 1d
           limit: "31"
+          start_time: "{{ stream_slice['start_time'] }}"
+          end_time: "{{ stream_slice['start_time'] | int + 86400 }}"
       paginator:
         $ref: "#/definitions/linked/UsagePaginator"
       record_selector:
@@ -1102,16 +1062,8 @@ streams:
         type: MinMaxDatetime
         datetime: "{{ now_utc().strftime('%Y-%m-%d') }}"
         datetime_format: "%Y-%m-%d"
-      step: P31D
-      cursor_granularity: P1D
-      start_time_option:
-        type: RequestOption
-        field_name: start_time
-        inject_into: request_parameter
-      end_time_option:
-        type: RequestOption
-        field_name: end_time
-        inject_into: request_parameter
+      step: P1D
+      cursor_granularity: PT1S
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -1161,17 +1113,17 @@ streams:
           - type: AddedFieldDefinition
             path:
               - bucket_start_time
-            value: "{{ record.get('start_time', '') }}"
+            value: "{{ stream_slice['start_time'] }}"
           - type: AddedFieldDefinition
             path:
               - bucket_end_time
-            value: "{{ record.get('end_time', '') }}"
+            value: "{{ stream_slice['end_time'] }}"
           - type: AddedFieldDefinition
             path:
               - unique_key
             value: >-
               {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record.get('start_time', '') }}-{{ record.get('project_id',
+              }}-{{ stream_slice['start_time'] }}-{{ record.get('project_id',
               '') }}
 
   # ── Stream 10: costs (incremental) ──
@@ -1195,6 +1147,8 @@ streams:
         request_parameters:
           bucket_width: 1d
           limit: "31"
+          start_time: "{{ stream_slice['start_time'] }}"
+          end_time: "{{ stream_slice['start_time'] | int + 86400 }}"
       paginator:
         $ref: "#/definitions/linked/UsagePaginator"
       record_selector:
@@ -1220,16 +1174,8 @@ streams:
         type: MinMaxDatetime
         datetime: "{{ now_utc().strftime('%Y-%m-%d') }}"
         datetime_format: "%Y-%m-%d"
-      step: P31D
-      cursor_granularity: P1D
-      start_time_option:
-        type: RequestOption
-        field_name: start_time
-        inject_into: request_parameter
-      end_time_option:
-        type: RequestOption
-        field_name: end_time
-        inject_into: request_parameter
+      step: P1D
+      cursor_granularity: PT1S
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -1287,11 +1233,11 @@ streams:
           - type: AddedFieldDefinition
             path:
               - bucket_start_time
-            value: "{{ record.get('start_time', '') }}"
+            value: "{{ stream_slice['start_time'] }}"
           - type: AddedFieldDefinition
             path:
               - bucket_end_time
-            value: "{{ record.get('end_time', '') }}"
+            value: "{{ stream_slice['end_time'] }}"
           - type: AddedFieldDefinition
             path:
               - amount_value
@@ -1305,7 +1251,7 @@ streams:
               - unique_key
             value: >-
               {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record.get('start_time', '') }}-{{ record.get('line_item',
+              }}-{{ stream_slice['start_time'] }}-{{ record.get('line_item',
               '') }}-{{ record.get('project_id', '') }}
 
 concurrency_level:

--- a/src/ingestion/connectors/ai/openai/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/openai/dbt/schema.yml
@@ -1,0 +1,109 @@
+version: 2
+
+sources:
+  - name: bronze
+    schema: raw
+    tables:
+      - name: users
+      - name: usage_completions
+      - name: usage_embeddings
+      - name: usage_moderations
+      - name: usage_images
+      - name: usage_audio_speeches
+      - name: usage_audio_transcriptions
+      - name: usage_vector_stores
+      - name: usage_code_interpreter
+      - name: costs
+
+models:
+  - name: to_ai_tool_usage
+    description: >
+      OpenAI completions usage from Admin API.
+      Maps per-user, per-model, per-project daily completion metrics
+      to class_ai_tool_usage Silver schema. Provider=openai.
+    columns:
+      - name: tenant_id
+        description: "Tenant isolation field — framework-injected"
+        tests:
+          - not_null
+      - name: insight_source_id
+        description: "Connector instance identifier"
+      - name: unique_id
+        description: "Composite dedup key: bucket_start_time|project_id|model|user_id"
+        tests:
+          - not_null
+      - name: report_date
+        description: "Usage date derived from bucket_start_time"
+        tests:
+          - not_null
+      - name: user_id
+        description: "OpenAI user ID — identity key for Silver step 2"
+      - name: project_id
+        description: "OpenAI project ID"
+      - name: model
+        description: "Model name (e.g. gpt-4o, gpt-4o-mini)"
+      - name: input_tokens
+        description: "Input tokens consumed"
+      - name: output_tokens
+        description: "Output tokens generated"
+      - name: input_cached_tokens
+        description: "Input tokens served from prompt cache"
+      - name: input_audio_tokens
+        description: "Input audio tokens"
+      - name: output_audio_tokens
+        description: "Output audio tokens"
+      - name: num_model_requests
+        description: "Number of API requests"
+      - name: is_batch
+        description: "Whether request was a batch API call"
+      - name: service_tier
+        description: "Service tier used for the request"
+      - name: person_id
+        description: "NULL at Silver step 1 — resolved in step 2 via Identity Manager"
+      - name: provider
+        description: "Always 'openai'"
+      - name: client
+        description: "Always 'openai_api'"
+      - name: data_source
+        description: "Always 'insight_openai' — source discriminator"
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['insight_openai']
+
+  - name: to_ai_cost
+    description: >
+      OpenAI costs from Admin API.
+      Maps per-line-item, per-project daily cost data
+      to class_ai_cost Silver schema. Provider=openai.
+    columns:
+      - name: tenant_id
+        description: "Tenant isolation field — framework-injected"
+        tests:
+          - not_null
+      - name: insight_source_id
+        description: "Connector instance identifier"
+      - name: unique_id
+        description: "Composite dedup key: bucket_start_time|line_item|project_id"
+        tests:
+          - not_null
+      - name: report_date
+        description: "Cost date derived from bucket_start_time"
+        tests:
+          - not_null
+      - name: line_item
+        description: "Cost line item (e.g. completions, embeddings, images)"
+      - name: project_id
+        description: "OpenAI project ID"
+      - name: amount_value
+        description: "Cost amount in currency units"
+      - name: amount_currency
+        description: "Currency code (e.g. usd)"
+      - name: provider
+        description: "Always 'openai'"
+      - name: data_source
+        description: "Always 'insight_openai' — source discriminator"
+        tests:
+          - not_null
+          - accepted_values:
+              values: ['insight_openai']

--- a/src/ingestion/connectors/ai/openai/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/openai/dbt/schema.yml
@@ -1,8 +1,8 @@
 version: 2
 
 sources:
-  - name: bronze
-    schema: raw
+  - name: bronze_openai
+    schema: bronze_openai
     tables:
       - name: users
       - name: usage_completions

--- a/src/ingestion/connectors/ai/openai/dbt/to_ai_cost.sql
+++ b/src/ingestion/connectors/ai/openai/dbt/to_ai_cost.sql
@@ -1,0 +1,27 @@
+-- Bronze → Silver step 1: OpenAI costs → class_ai_cost
+-- Maps per-line-item, per-project daily cost data.
+-- bucket_start_time is Unix seconds — converted to date for report_date.
+{{ config(materialized='incremental', unique_key='unique_id') }}
+
+SELECT
+    tenant_id,
+    source_id                                       AS insight_source_id,
+    concat(
+        toString(bucket_start_time), '|',
+        coalesce(line_item, ''), '|',
+        coalesce(project_id, '')
+    )                                               AS unique_id,
+    toDate(fromUnixTimestamp(
+        CAST(bucket_start_time AS UInt32)
+    ))                                              AS report_date,
+    line_item,
+    project_id,
+    amount_value,
+    amount_currency,
+    'openai'                                        AS provider,
+    'insight_openai'                                AS data_source
+FROM {{ source('bronze', 'costs') }}
+{% if is_incremental() %}
+WHERE toDate(fromUnixTimestamp(CAST(bucket_start_time AS UInt32)))
+    > (SELECT max(report_date) FROM {{ this }})
+{% endif %}

--- a/src/ingestion/connectors/ai/openai/dbt/to_ai_cost.sql
+++ b/src/ingestion/connectors/ai/openai/dbt/to_ai_cost.sql
@@ -1,7 +1,7 @@
 -- Bronze → Silver step 1: OpenAI costs → class_ai_cost
 -- Maps per-line-item, per-project daily cost data.
 -- bucket_start_time is Unix seconds — converted to date for report_date.
-{{ config(materialized='incremental', unique_key='unique_id') }}
+{{ config(materialized='incremental', unique_key='unique_id', tags=['openai']) }}
 
 SELECT
     tenant_id,
@@ -20,7 +20,7 @@ SELECT
     amount_currency,
     'openai'                                        AS provider,
     'insight_openai'                                AS data_source
-FROM {{ source('bronze', 'costs') }}
+FROM {{ source('bronze_openai', 'costs') }}
 {% if is_incremental() %}
 WHERE toDate(fromUnixTimestamp(CAST(bucket_start_time AS UInt32)))
     > (SELECT max(report_date) FROM {{ this }})

--- a/src/ingestion/connectors/ai/openai/dbt/to_ai_tool_usage.sql
+++ b/src/ingestion/connectors/ai/openai/dbt/to_ai_tool_usage.sql
@@ -1,0 +1,37 @@
+-- Bronze → Silver step 1: OpenAI completions usage → class_ai_tool_usage
+-- Maps per-user, per-model, per-project daily completion metrics.
+-- bucket_start_time is Unix seconds — converted to date for report_date.
+{{ config(materialized='incremental', unique_key='unique_id') }}
+
+SELECT
+    tenant_id,
+    source_id                                       AS insight_source_id,
+    concat(
+        toString(bucket_start_time), '|',
+        coalesce(project_id, ''), '|',
+        coalesce(model, ''), '|',
+        coalesce(user_id, '')
+    )                                               AS unique_id,
+    toDate(fromUnixTimestamp(
+        CAST(bucket_start_time AS UInt32)
+    ))                                              AS report_date,
+    user_id,
+    project_id,
+    model,
+    input_tokens,
+    output_tokens,
+    input_cached_tokens,
+    input_audio_tokens,
+    output_audio_tokens,
+    num_model_requests,
+    coalesce(batch, false)                          AS is_batch,
+    service_tier,
+    NULL                                            AS person_id,
+    'openai'                                        AS provider,
+    'openai_api'                                    AS client,
+    'insight_openai'                                AS data_source
+FROM {{ source('bronze', 'usage_completions') }}
+{% if is_incremental() %}
+WHERE toDate(fromUnixTimestamp(CAST(bucket_start_time AS UInt32)))
+    > (SELECT max(report_date) FROM {{ this }})
+{% endif %}

--- a/src/ingestion/connectors/ai/openai/dbt/to_ai_tool_usage.sql
+++ b/src/ingestion/connectors/ai/openai/dbt/to_ai_tool_usage.sql
@@ -1,7 +1,7 @@
 -- Bronze → Silver step 1: OpenAI completions usage → class_ai_tool_usage
 -- Maps per-user, per-model, per-project daily completion metrics.
 -- bucket_start_time is Unix seconds — converted to date for report_date.
-{{ config(materialized='incremental', unique_key='unique_id') }}
+{{ config(materialized='incremental', unique_key='unique_id', tags=['openai']) }}
 
 SELECT
     tenant_id,
@@ -30,7 +30,7 @@ SELECT
     'openai'                                        AS provider,
     'openai_api'                                    AS client,
     'insight_openai'                                AS data_source
-FROM {{ source('bronze', 'usage_completions') }}
+FROM {{ source('bronze_openai', 'usage_completions') }}
 {% if is_incremental() %}
 WHERE toDate(fromUnixTimestamp(CAST(bucket_start_time AS UInt32)))
     > (SELECT max(report_date) FROM {{ this }})

--- a/src/ingestion/connectors/ai/openai/descriptor.yaml
+++ b/src/ingestion/connectors/ai/openai/descriptor.yaml
@@ -1,0 +1,7 @@
+name: openai
+version: '1.0'
+schedule: 0 2 * * *
+dbt_select: tag:openai+
+workflow: sync
+connection:
+  namespace: bronze_openai

--- a/src/ingestion/secrets/connectors/openai.yaml.example
+++ b/src/ingestion/secrets/connectors/openai.yaml.example
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-openai-main
+  labels:
+    app.kubernetes.io/part-of: insight
+  annotations:
+    insight.cyberfabric.com/connector: openai
+    insight.cyberfabric.com/source-id: openai-main
+type: Opaque
+stringData:
+  openai_admin_api_key: "CHANGE_ME"
+  openai_start_date: "2026-01-01"


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#157](https://github.com/cyberfabric/cyber-insight/pull/157) | **Author:** aleksdotbar | **Opened:** 2026-04-15T12:51:47Z | **Status:** merged on 2026-04-24T12:20:24Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

- New declarative connector (v7.0.4) for OpenAI Admin API — extracts org users, per-endpoint API usage metrics (completions, embeddings, moderations, images, audio, vector stores, code interpreter), and costs
- 10 streams with incremental sync on daily buckets, per-user/model/project attribution via `group_by`
- dbt models for Bronze→Silver: `to_ai_tool_usage` (completions) and `to_ai_cost`
- K8s Secret example, descriptor, README

## Test plan

- [x] `source.sh validate ai/openai` — manifest valid
- [x] `source.sh check ai/openai <tenant>` — auth check with real Admin API key
- [x] `source.sh discover ai/openai <tenant>` — verify all 10 streams discovered
- [x] `source.sh read ai/openai <tenant>` — pull actual records, verify tenant_id/source_id/unique_key
- [ ] E2E sync via Argo — Bronze tables populated, dbt Silver models run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New OpenAI connector integrates organizational data including users, usage metrics by operation type (completions, embeddings, moderations, images, audio, vector stores, code interpreter), and costs data
  * Supports incremental syncing for efficient updates
  * Standardized data transformation into usage and cost reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#157 -->