### PR TITLE
[PR #148] feat(frontend): use GHCR image instead of local build

### DIFF
--- a/src/frontend/helm/values.yaml
+++ b/src/frontend/helm/values.yaml
@@ -1,9 +1,9 @@
 replicaCount: 1
 
 image:
-  repository: insight-frontend
-  tag: "local"
-  pullPolicy: IfNotPresent
+  repository: ghcr.io/cyberfabric/insight-front
+  tag: "latest"
+  pullPolicy: Always
 
 service:
   type: ClusterIP

--- a/src/ingestion/.gitignore
+++ b/src/ingestion/.gitignore
@@ -2,9 +2,6 @@
 connections/*.yaml
 !connections/*.yaml.example
 
-# Airbyte toolkit state (generated, instance-specific)
-airbyte-toolkit/state.yaml
-
 # Generated schemas and catalogs (can be regenerated)
 connectors/**/schemas/
 connectors/**/configured_catalog.json

--- a/src/ingestion/airbyte-toolkit/.gitignore
+++ b/src/ingestion/airbyte-toolkit/.gitignore
@@ -1,0 +1,2 @@
+state.*.yaml
+state.yaml

--- a/src/ingestion/airbyte-toolkit/lib/state.sh
+++ b/src/ingestion/airbyte-toolkit/lib/state.sh
@@ -15,7 +15,7 @@
 # ---------------------------------------------------------------------------
 
 TOOLKIT_DIR="${TOOLKIT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
-STATE_FILE="${TOOLKIT_DIR}/state.yaml"
+STATE_FILE="${STATE_FILE:-${TOOLKIT_DIR}/state.yaml}"
 STATE_CM_NAME="airbyte-state"
 STATE_CM_NS="data"
 

--- a/src/ingestion/connectors/collaboration/zoom/README.md
+++ b/src/ingestion/connectors/collaboration/zoom/README.md
@@ -5,7 +5,7 @@ Zoom meeting, webinar, and user activity data via Server-to-Server OAuth.
 ## Prerequisites
 
 1. Create a Server-to-Server OAuth app at https://marketplace.zoom.us/
-2. Grant scopes: `dashboard:read:chat:admin`, `dashboard:read:list_meetings:admin`, `dashboard:read:list_meeting_participants:admin`
+2. Grant scopes: `dashboard:read:chat:admin`, `dashboard:read:list_meetings:admin`, `dashboard:read:list_meeting_participants:admin`, `user:read:list_users:admin`
 
 
 ## K8s Secret

--- a/src/ingestion/workflows/templates/dbt-run.yaml
+++ b/src/ingestion/workflows/templates/dbt-run.yaml
@@ -19,8 +19,7 @@ spec:
             default: "8123"
       activeDeadlineSeconds: 1800
       script:
-        image: insight-toolbox:local
-        imagePullPolicy: IfNotPresent
+        image: ghcr.io/cyberfabric/insight-toolbox:latest
         command: [bash]
         env:
           - name: CLICKHOUSE_PASSWORD

--- a/up.sh
+++ b/up.sh
@@ -105,25 +105,18 @@ fi
 
 # ─── Frontend ────────────────────────────────────────────────────────────────
 if [[ "$COMPONENT" == "all" || "$COMPONENT" == "app" || "$COMPONENT" == "frontend" ]]; then
-  FRONTEND_DIR="$ROOT_DIR/insight-front_symlink"
-  if [[ ! -d "$FRONTEND_DIR" ]]; then
-    echo "WARNING: Frontend directory not found at $FRONTEND_DIR — skipping"
-  else
-    echo "=== Building Frontend ==="
-    docker build -t insight-frontend:local \
-      -f src/frontend/Dockerfile \
-      "$FRONTEND_DIR"
-
-    if [[ "$ENV" == "local" ]]; then
-      kind load docker-image insight-frontend:local --name "${CLUSTER_NAME}"
-    fi
-
-    echo "=== Deploying Frontend ==="
-    helm upgrade --install insight-fe src/frontend/helm/ \
-      --namespace insight \
-      --set image.pullPolicy=IfNotPresent \
-      --wait --timeout 3m
+  FE_IMAGE="ghcr.io/cyberfabric/insight-front:latest"
+  echo "=== Pulling Frontend image ==="
+  docker pull "$FE_IMAGE"
+  if [[ "$ENV" == "local" ]]; then
+    kind load docker-image "$FE_IMAGE" --name "${CLUSTER_NAME}"
   fi
+
+  echo "=== Deploying Frontend ==="
+  helm upgrade --install insight-fe src/frontend/helm/ \
+    --namespace insight \
+    --set image.pullPolicy=IfNotPresent \
+    --wait --timeout 3m
 fi
 
 # ─── Airbyte port-forward (local only) ──────────────────────────────────────


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#148](https://github.com/cyberfabric/cyber-insight/pull/148) | **Author:** mitasovr | **Opened:** 2026-04-14T11:42:43Z | **Status:** merged on 2026-04-15T12:43:35Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

- Frontend image pulled from `ghcr.io/cyberfabric/insight-front:latest` instead of local build from symlink
- `up.sh`: `docker pull` → `kind load` → `helm install` (no more local Docker build)
- Removes dependency on `insight-front` repo being cloned alongside `insight`

## Test plan

- [ ] `./up.sh` pulls frontend image from GHCR
- [ ] Frontend accessible at http://localhost:8000
- [ ] Works without `insight-front_symlink` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployments now pull prebuilt container images from the remote registry and use the latest image by default (frontend and tooling).
  * Local cluster setup loads the pulled frontend image for local environments.

* **Bug Fixes**
  * Improved handling of local state file path via environment override.
  * Added ignores to prevent Airbyte state YAML files from being tracked.

* **Documentation**
  * Zoom connector setup updated with an additional OAuth scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Part of #658

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#148 -->