### PR TITLE
[PR #142] feat(connectors): align cursor, claude-api, claude-team with project conventions

### DIFF
--- a/docs/components/connectors/ai-dev/cursor/cursor.md
+++ b/docs/components/connectors/ai-dev/cursor/cursor.md
@@ -97,7 +97,7 @@ Standalone specification for the Cursor (AI Dev Tool) connector. Expands Source 
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `event_unique` | String | Parent event reference — joins to `cursor_events.unique` |
+| `event_unique` | String | Parent event reference — joins to `cursor_events.unique_key` |
 | `inputTokens` | Float64 | Tokens in the prompt |
 | `outputTokens` | Float64 | Tokens in the model response |
 | `cacheReadTokens` | Float64 | Tokens served from prompt cache |

--- a/docs/components/connectors/ai-dev/cursor/cursor.md
+++ b/docs/components/connectors/ai-dev/cursor/cursor.md
@@ -45,7 +45,7 @@ Standalone specification for the Cursor (AI Dev Tool) connector. Expands Source 
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `unique` | String | Primary key |
+| `unique_key` | String | Primary key (`{tenant_id}-{source_id}-{natural_key}`) |
 | `day` | String | Day label |
 | `date` | Int64 | Unix timestamp in milliseconds |
 | `email` | String | User email — identity key |
@@ -79,7 +79,7 @@ Standalone specification for the Cursor (AI Dev Tool) connector. Expands Source 
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `unique` | String | Primary key |
+| `unique_key` | String | Primary key (`{tenant_id}-{source_id}-{natural_key}`) |
 | `userEmail` | String | User email — identity key |
 | `timestamp` | DateTime64(3) | Event timestamp |
 | `kind` | String | Event type: `chat`, `completion`, `agent`, `cmd-k`, etc. |

--- a/docs/components/connectors/ai-dev/cursor/specs/DESIGN.md
+++ b/docs/components/connectors/ai-dev/cursor/specs/DESIGN.md
@@ -246,12 +246,12 @@ streams:
 
   - name: cursor_usage_events
     bronze_table: cursor_usage_events
-    primary_key: [unique]
+    primary_key: [unique_key]
     cursor_field: timestamp
 
   - name: cursor_daily_usage
     bronze_table: cursor_daily_usage
-    primary_key: [unique]
+    primary_key: [unique_key]
     cursor_field: date
 
   - name: cursor_collection_runs
@@ -299,7 +299,7 @@ check:
 streams:
   - type: DeclarativeStream
     name: cursor_usage_events
-    primary_key: [unique]
+    primary_key: [unique_key]
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -343,7 +343,7 @@ streams:
           - path: [tenant_id]
             value: "{{ config['insight_tenant_id'] }}"
           - path: [source_id]
-            value: "{{ config.get('insight_source_id', '') }}"
+            value: "{{ config['insight_source_id'] }}"
           - path: [unique]
             value: "{{ record['userEmail'] }}{{ record['timestamp'] }}"
     incremental_sync:
@@ -476,7 +476,7 @@ transformations:
       - path: [tenant_id]
         value: "{{ config['insight_tenant_id'] }}"
       - path: [source_id]
-        value: "{{ config.get('insight_source_id', '') }}"
+        value: "{{ config['insight_source_id'] }}"
 ```
 
 This transformation is applied to **every stream** in the manifest, ensuring `tenant_id`, `source_id`, `collected_at`, and `data_source` are present in every record before it reaches the destination.

--- a/docs/components/connectors/ai-dev/cursor/specs/DESIGN.md
+++ b/docs/components/connectors/ai-dev/cursor/specs/DESIGN.md
@@ -217,7 +217,7 @@ src/ingestion/connectors/ai-dev/cursor/
     └── schema.yml          # Column documentation + dbt tests (tenant_id not_null)
 ```
 
-The dbt model `to_ai_dev_usage.sql` transforms `cursor_daily_usage` and `cursor_usage_events` Bronze tables into the unified `class_ai_dev_usage` Silver table. `tenant_id` MUST be preserved and tested with a `not_null` dbt test. The `data_source` column (already present in Bronze tables as `'insight_cursor'`) MUST be carried through to Silver as the canonical source discriminator — no separate `source` column is needed.
+The dbt model `to_cursor_ai_dev_usage.sql` transforms `cursor_daily_usage` and `cursor_usage_events` Bronze tables into the unified `class_ai_dev_usage` Silver table. Bronze `tenant_id` is mapped to Silver `insight_tenant_id`, `source_id` to `insight_source_id`, and `insight_source_type` is set to `'cursor'` (per glossary §3). Both `insight_tenant_id` and `insight_source_id` MUST be tested with `not_null` dbt tests. The `data_source` column (already present in Bronze tables as `'insight_cursor'`) MUST be carried through to Silver as the canonical source discriminator.
 
 #### Connector Package Descriptor
 

--- a/docs/components/connectors/ai-dev/cursor/specs/DESIGN.md
+++ b/docs/components/connectors/ai-dev/cursor/specs/DESIGN.md
@@ -167,8 +167,8 @@ The `POST /teams/daily-usage-data` endpoint returns rows for all team members fo
 |--------|-------------|
 | `TeamMember` | A user account in the Cursor team. Key: `email`. Contains name, role, removal status. |
 | `AuditEvent` | An administrative/security event. Key: `event_id`. Contains event type, user email, event data (JSON), IP address. |
-| `UsageEvent` | A single AI invocation. Key: `unique_key` (email + timestamp). Contains model, kind, cost, billing flags, and optional `tokenUsage` nested object. |
-| `DailyUsage` | One user's aggregated AI activity for one date. Key: `unique_key` (email + date). Contains request counts, tab metrics, code metrics, model/extension metadata. |
+| `UsageEvent` | A single AI invocation. Key: `unique_key` (`{tenant_id}-{source_id}-{userEmail}\|{timestamp}`). Contains model, kind, cost, billing flags, and optional `tokenUsage` nested object. |
+| `DailyUsage` | One user's aggregated AI activity for one date. Key: `unique_key` (`{tenant_id}-{source_id}-{email}\|{date}`). Contains request counts, tab metrics, code metrics, model/extension metadata. |
 
 **Relationships**:
 
@@ -361,10 +361,12 @@ spec:
       insight_tenant_id:
         type: string
         title: Insight Tenant ID
+        minLength: 1
         order: 0
       insight_source_id:
         type: string
         title: Insight Source ID
+        minLength: 1
         order: 1
       api_key:
         type: string
@@ -457,11 +459,13 @@ properties:
     type: string
     title: Insight Tenant ID
     description: Insight tenant isolation identifier
+    minLength: 1
     order: 0
   insight_source_id:
     type: string
     title: Insight Source ID
     description: Connector instance identifier
+    minLength: 1
     order: 1
   api_key:
     type: string
@@ -598,7 +602,7 @@ These columns are not defined in the manifest schema but are present in all Bron
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key — framework-injected |
-| `source_id` | String | Connector instance identifier — framework-injected, DEFAULT '' |
+| `source_id` | String | Connector instance identifier — framework-injected (from config `insight_source_id`, required) |
 | `id` | String | Cursor internal member ID |
 | `name` | String | Member display name |
 | `email` | String | Member email — primary identity key → `person_id` |
@@ -617,7 +621,7 @@ These columns are not defined in the manifest schema but are present in all Bron
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key — framework-injected |
-| `source_id` | String | Connector instance identifier — framework-injected, DEFAULT '' |
+| `source_id` | String | Connector instance identifier — framework-injected (from config `insight_source_id`, required) |
 | `event_id` | String | Unique audit event identifier — primary key |
 | `timestamp` | String | Event timestamp (ISO 8601) |
 | `user_email` | String | User email — identity key |
@@ -639,7 +643,7 @@ These columns are not defined in the manifest schema but are present in all Bron
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key — framework-injected |
-| `source_id` | String | Connector instance identifier — framework-injected, DEFAULT '' |
+| `source_id` | String | Connector instance identifier — framework-injected (from config `insight_source_id`, required) |
 | `unique_key` | String | Primary key — computed as `userEmail + timestamp` |
 | `userEmail` | String | User email — identity key |
 | `timestamp` | String | Event timestamp (ISO 8601 or epoch ms) |
@@ -678,7 +682,7 @@ Same schema as `cursor_usage_events` (same API endpoint, same fields, same prima
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key — framework-injected |
-| `source_id` | String | Connector instance identifier — framework-injected, DEFAULT '' |
+| `source_id` | String | Connector instance identifier — framework-injected (from config `insight_source_id`, required) |
 | `unique_key` | String | Primary key — computed as `email + date` |
 | `userId` | String | Cursor platform user ID |
 | `email` | String | User email — identity key |
@@ -722,7 +726,7 @@ Same schema as `cursor_usage_events` (same API endpoint, same fields, same prima
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key — framework-injected |
-| `source_id` | String | Connector instance identifier — framework-injected, DEFAULT '' |
+| `source_id` | String | Connector instance identifier — framework-injected (from config `insight_source_id`, required) |
 | `run_id` | String | Unique run identifier |
 | `started_at` | DateTime | Run start time |
 | `completed_at` | DateTime | Run end time |

--- a/docs/components/connectors/ai-dev/cursor/specs/DESIGN.md
+++ b/docs/components/connectors/ai-dev/cursor/specs/DESIGN.md
@@ -86,7 +86,7 @@ graph LR
 | `cpt-insightspec-fr-cursor-dual-sync` | Stream `cursor_usage_events_daily_resync` → same endpoint, daily after 12:08 UTC, re-fetches previous day |
 | `cpt-insightspec-fr-cursor-daily-usage` | Stream `cursor_daily_usage` → `POST /teams/daily-usage-data` (incremental) |
 | `cpt-insightspec-fr-cursor-collection-runs` | Stream `cursor_collection_runs` — connector execution log |
-| `cpt-insightspec-fr-cursor-deduplication` | Primary keys: `email` (members), `event_id` (audit), `unique` (events/daily) |
+| `cpt-insightspec-fr-cursor-deduplication` | Primary keys: `email` (members), `event_id` (audit), `unique_key` (events/daily) |
 | `cpt-insightspec-fr-cursor-identity-key` | `email`/`userEmail` present in all streams |
 
 #### NFR Allocation
@@ -167,8 +167,8 @@ The `POST /teams/daily-usage-data` endpoint returns rows for all team members fo
 |--------|-------------|
 | `TeamMember` | A user account in the Cursor team. Key: `email`. Contains name, role, removal status. |
 | `AuditEvent` | An administrative/security event. Key: `event_id`. Contains event type, user email, event data (JSON), IP address. |
-| `UsageEvent` | A single AI invocation. Key: `unique` (email + timestamp). Contains model, kind, cost, billing flags, and optional `tokenUsage` nested object. |
-| `DailyUsage` | One user's aggregated AI activity for one date. Key: `unique` (email + date). Contains request counts, tab metrics, code metrics, model/extension metadata. |
+| `UsageEvent` | A single AI invocation. Key: `unique_key` (email + timestamp). Contains model, kind, cost, billing flags, and optional `tokenUsage` nested object. |
+| `DailyUsage` | One user's aggregated AI activity for one date. Key: `unique_key` (email + date). Contains request counts, tab metrics, code metrics, model/extension metadata. |
 
 **Relationships**:
 
@@ -341,7 +341,9 @@ streams:
       - type: AddFields
         fields:
           - path: [tenant_id]
-            value: "{{ config['tenant_id'] }}"
+            value: "{{ config['insight_tenant_id'] }}"
+          - path: [source_id]
+            value: "{{ config.get('insight_source_id', '') }}"
           - path: [unique]
             value: "{{ record['userEmail'] }}{{ record['timestamp'] }}"
     incremental_sync:
@@ -354,17 +356,21 @@ spec:
   type: Spec
   connection_specification:
     type: object
-    required: [tenant_id, api_key]
+    required: [insight_tenant_id, insight_source_id, api_key]
     properties:
-      tenant_id:
+      insight_tenant_id:
         type: string
-        title: Tenant ID
+        title: Insight Tenant ID
         order: 0
+      insight_source_id:
+        type: string
+        title: Insight Source ID
+        order: 1
       api_key:
         type: string
         title: API Key
         airbyte_secret: true
-        order: 1
+        order: 2
 ```
 
 This is a structural skeleton — the full manifest is in `src/ingestion/connectors/ai-dev/cursor/connector.yaml`.
@@ -381,7 +387,7 @@ Orchestration, scheduling, and state storage are handled by the Airbyte platform
 
 - [ ] `p1` - **ID**: `cpt-insightspec-component-cursor-tenant-id-injection`
 
-Ensures every record emitted by all streams contains `tenant_id` from the connector config. Implemented as an `AddFields` transformation in the manifest, applied to every stream. See §3.3 Source Config Schema for the injection pattern.
+Ensures every record emitted by all streams contains `tenant_id` and `source_id` from the connector config (`insight_tenant_id` → `tenant_id`, `insight_source_id` → `source_id`). Implemented as an `AddFields` transformation in the manifest, applied to every stream. See §3.3 Source Config Schema for the injection pattern.
 
 ### 3.3 API Contracts
 
@@ -431,41 +437,49 @@ The source config (credentials) for the Cursor connector:
 
 ```json
 {
-  "tenant_id": "Tenant isolation identifier (UUID)",
+  "insight_tenant_id": "Insight tenant isolation identifier (UUID)",
+  "insight_source_id": "Connector instance identifier",
   "api_key": "Cursor team API key"
 }
 ```
 
-Both fields are required. `tenant_id` is a platform invariant — every connector must accept it. `api_key` is marked `airbyte_secret: true` — it is never logged or displayed.
+All three fields are required. `insight_tenant_id` is a platform invariant — every connector must accept it. `api_key` is marked `airbyte_secret: true` — it is never logged or displayed.
 
 #### tenant_id Injection
 
-Per the ingestion layer tenant isolation principle (see [Ingestion Layer DESIGN](../../../../domain/ingestion/specs/DESIGN.md)), every record emitted by the connector MUST contain `tenant_id`. This is achieved via an `AddFields` transformation in the manifest:
+Per the ingestion layer tenant isolation principle (see [Ingestion Layer DESIGN](../../../../domain/ingestion/specs/DESIGN.md)), every record emitted by the connector MUST contain `tenant_id`. The config parameter `insight_tenant_id` is mapped to Bronze column `tenant_id`; `insight_source_id` is mapped to Bronze column `source_id`. This is achieved via an `AddFields` transformation in the manifest:
 
 ```yaml
 # In spec.connection_specification:
-required: [tenant_id, api_key]
+required: [insight_tenant_id, insight_source_id, api_key]
 properties:
-  tenant_id:
+  insight_tenant_id:
     type: string
-    title: Tenant ID
-    description: Tenant isolation identifier
+    title: Insight Tenant ID
+    description: Insight tenant isolation identifier
     order: 0
+  insight_source_id:
+    type: string
+    title: Insight Source ID
+    description: Connector instance identifier
+    order: 1
   api_key:
     type: string
     title: API Key
     airbyte_secret: true
-    order: 1
+    order: 2
 
 # In each stream's transformations:
 transformations:
   - type: AddFields
     fields:
       - path: [tenant_id]
-        value: "{{ config['tenant_id'] }}"
+        value: "{{ config['insight_tenant_id'] }}"
+      - path: [source_id]
+        value: "{{ config.get('insight_source_id', '') }}"
 ```
 
-This transformation is applied to **every stream** in the manifest, ensuring `tenant_id` is present in every record before it reaches the destination.
+This transformation is applied to **every stream** in the manifest, ensuring `tenant_id`, `source_id`, `collected_at`, and `data_source` are present in every record before it reaches the destination.
 
 ### 3.4 Internal Dependencies
 
@@ -584,7 +598,7 @@ These columns are not defined in the manifest schema but are present in all Bron
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key — framework-injected |
-| `source_instance_id` | String | Connector instance identifier — framework-injected, DEFAULT '' |
+| `source_id` | String | Connector instance identifier — framework-injected, DEFAULT '' |
 | `id` | String | Cursor internal member ID |
 | `name` | String | Member display name |
 | `email` | String | Member email — primary identity key → `person_id` |
@@ -603,7 +617,7 @@ These columns are not defined in the manifest schema but are present in all Bron
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key — framework-injected |
-| `source_instance_id` | String | Connector instance identifier — framework-injected, DEFAULT '' |
+| `source_id` | String | Connector instance identifier — framework-injected, DEFAULT '' |
 | `event_id` | String | Unique audit event identifier — primary key |
 | `timestamp` | String | Event timestamp (ISO 8601) |
 | `user_email` | String | User email — identity key |
@@ -625,8 +639,8 @@ These columns are not defined in the manifest schema but are present in all Bron
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key — framework-injected |
-| `source_instance_id` | String | Connector instance identifier — framework-injected, DEFAULT '' |
-| `unique` | String | Primary key — computed as `userEmail + timestamp` |
+| `source_id` | String | Connector instance identifier — framework-injected, DEFAULT '' |
+| `unique_key` | String | Primary key — computed as `userEmail + timestamp` |
 | `userEmail` | String | User email — identity key |
 | `timestamp` | String | Event timestamp (ISO 8601 or epoch ms) |
 | `kind` | String | Event type: `chat`, `completion`, `agent`, `cmd-k`, etc. |
@@ -650,7 +664,7 @@ These columns are not defined in the manifest schema but are present in all Bron
 **Notes**:
 
 - `tokenUsage` is preserved as a nested JSON object at Bronze level. The Silver layer is responsible for flattening `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheWriteTokens`, `totalCents` into separate columns. When `tokenUsage` is `null`, the event has no token-level detail — this is **not** the same as zero-cost and must not be treated as such.
-- The `unique` key is computed as a simple concatenation of `userEmail` and `timestamp`. See [ADR-0001](ADR/0001-usage-events-dedup-key.md) for the rationale, accepted collision risk, and Silver-layer mitigation path.
+- The `unique_key` key is computed as a simple concatenation of `userEmail` and `timestamp`. See [ADR-0001](ADR/0001-usage-events-dedup-key.md) for the rationale, accepted collision risk, and Silver-layer mitigation path.
 - The field `isFreeBugbot` is present in the actual API but was absent from the original connector specification (`cursor.md`). Fields `isChargeable` and `isHeadless` appear in the original specification but are **not** returned by the current API — see [API Discrepancies Log](#api-discrepancies-log).
 
 #### Table: `cursor_usage_events_daily_resync`
@@ -664,8 +678,8 @@ Same schema as `cursor_usage_events` (same API endpoint, same fields, same prima
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key — framework-injected |
-| `source_instance_id` | String | Connector instance identifier — framework-injected, DEFAULT '' |
-| `unique` | String | Primary key — computed as `email + date` |
+| `source_id` | String | Connector instance identifier — framework-injected, DEFAULT '' |
+| `unique_key` | String | Primary key — computed as `email + date` |
 | `userId` | String | Cursor platform user ID |
 | `email` | String | User email — identity key |
 | `day` | String | Day label (human-readable) |
@@ -708,7 +722,7 @@ Same schema as `cursor_usage_events` (same API endpoint, same fields, same prima
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key — framework-injected |
-| `source_instance_id` | String | Connector instance identifier — framework-injected, DEFAULT '' |
+| `source_id` | String | Connector instance identifier — framework-injected, DEFAULT '' |
 | `run_id` | String | Unique run identifier |
 | `started_at` | DateTime | Run start time |
 | `completed_at` | DateTime | Run end time |
@@ -950,7 +964,7 @@ The following checklist domains have been evaluated and are not applicable for t
 |--------|--------|
 | **PERF (Performance)** | Batch data pipeline with native API pagination. No caching, connection pooling, or latency optimization needed. Rate limit handling (HTTP 429 → 60s retry) is the only performance-related concern, documented in Constraints §2.2. |
 | **SEC (Security)** | Authentication is delegated to the Airbyte framework: the API key is stored as `airbyte_secret`, never logged or exposed. The declarative manifest contains no custom security logic. No user-facing endpoints, no authorization model, no data encryption beyond what the destination provides. |
-| **REL (Reliability)** | Idempotent extraction via deduplication keys (`unique`, `event_id`, `email`). No distributed state, no transactions, no saga patterns. Recovery = re-run the sync; the Airbyte framework manages cursor state and retry. |
+| **REL (Reliability)** | Idempotent extraction via deduplication keys (`unique_key`, `event_id`, `email`). No distributed state, no transactions, no saga patterns. Recovery = re-run the sync; the Airbyte framework manages cursor state and retry. |
 | **OPS (Operations)** | Deployed as a standard Airbyte connection — no custom infrastructure, no IaC, no observability beyond what the Airbyte platform provides (job logs, sync metrics, alerting). Deployment topology documented in §3.8. |
 | **MAINT (Maintainability)** | Declarative YAML manifest with no custom code. Maintenance consists of updating field definitions when the API schema changes. No module structure, dependency injection, or layering needed. |
 | **TEST (Testing)** | Declarative connector validated by the Airbyte framework's built-in checks (connection check, schema validation). No custom code to unit-test. Integration testing = run a sync against the live API. |

--- a/docs/components/connectors/ai-dev/cursor/specs/DESIGN.md
+++ b/docs/components/connectors/ai-dev/cursor/specs/DESIGN.md
@@ -752,7 +752,7 @@ Package: src/ingestion/connectors/ai-dev/cursor/
 Connection A: cursor-{team_name}-hourly
 ├── Schedule: hourly (via Kestra cron)
 ├── Source image: airbyte/source-declarative-manifest
-├── Source config: {tenant_id, api_key}
+├── Source config: {insight_tenant_id, insight_source_id, api_key}
 ├── Streams: cursor_members, cursor_audit_logs, cursor_usage_events,
 │            cursor_daily_usage, cursor_collection_runs
 ├── Destination: ClickHouse (Bronze)
@@ -761,11 +761,21 @@ Connection A: cursor-{team_name}-hourly
 Connection B: cursor-{team_name}-daily-resync
 ├── Schedule: daily after 12:08 UTC (via Kestra cron)
 ├── Source image: airbyte/source-declarative-manifest
-├── Source config: {tenant_id, api_key}
+├── Source config: {insight_tenant_id, insight_source_id, api_key}
 ├── Streams: cursor_usage_events_daily_resync (only)
 ├── Destination: ClickHouse (Bronze)
 └── State: n/a (always fetches previous day)
 ```
+
+#### Migration: `tenant_id` → `insight_tenant_id` (PR #142)
+
+The config spec renamed `tenant_id` → `insight_tenant_id` and added `insight_source_id` as required. This is a breaking change for existing Airbyte sources. Deployment procedure:
+
+1. **K8s Secrets**: ensure each Secret has annotation `insight.cyberfabric.com/source-id` (see `secrets/connectors/cursor.yaml.example`)
+2. **Register**: run `register.sh` (or `upload-manifests.sh`) to update the Airbyte source definition with the new manifest
+3. **Connect**: run `connect.sh` (or `apply-connections.sh`) to update existing source configs — this auto-injects `insight_tenant_id` and `insight_source_id` from tenant YAML and Secret annotation
+
+Steps must run before the next scheduled sync (`0 2 * * *`). Without step 3, existing sources will fail Airbyte validation.
 
 ## 4. Additional context
 

--- a/docs/components/connectors/ai-dev/cursor/specs/PRD.md
+++ b/docs/components/connectors/ai-dev/cursor/specs/PRD.md
@@ -240,9 +240,9 @@ Each stream **MUST** use a primary key to ensure that re-running the connector f
 
 - `cursor_members`: key = `email`
 - `cursor_audit_logs`: key = `event_id`
-- `cursor_usage_events`: key = `unique` (computed as `userEmail + timestamp`)
-- `cursor_usage_events_daily_resync`: key = `unique` (same schema as `cursor_usage_events`)
-- `cursor_daily_usage`: key = `unique` (computed as `email + date`)
+- `cursor_usage_events`: key = `unique_key` (computed as `userEmail + timestamp`)
+- `cursor_usage_events_daily_resync`: key = `unique_key` (same schema as `cursor_usage_events`)
+- `cursor_daily_usage`: key = `unique_key` (computed as `email + date`)
 
 **Rationale**: The incremental sync window may overlap with previously fetched dates. Usage events within the billing period are re-fetched on each sync to capture retroactive adjustments. Deduplication ensures idempotent extraction.
 
@@ -412,7 +412,7 @@ Usage event cost fields (`requestsCosts`, `cursorTokenFee`, `totalCents`) **MUST
 - `email`/`userEmail` is present in every record across all data streams except the monitoring stream (`cursor_collection_runs`), which does not carry user identity fields
 - Pagination is exhausted for all paginated endpoints (no truncated results)
 - Basic authentication works correctly with the team API key
-- `tenant_id` is present in every record emitted by the connector (injected via `AddFields` transformation in the manifest `spec.connection_specification`)
+- `tenant_id` is present in every record (mapped from config `insight_tenant_id` via `AddFields` transformation)
 
 ## 10. Dependencies
 
@@ -474,4 +474,4 @@ The following checklist domains have been evaluated and determined not applicabl
 | **Usability (UX)** | No user-facing interface. Configuration is a single API key field in the Airbyte UI. |
 | **Compliance (COMPL)** | Work emails are personal data under GDPR. Retention, deletion, and access controls are delegated to the Airbyte platform and destination operator. The connector must not store credentials outside the platform's secret management. Data residency is a platform responsibility. |
 | **Maintainability (MAINT)** | Declarative YAML manifest — no custom code to maintain. Schema changes are handled by updating field definitions in the manifest. |
-| **Testing (TEST)** | Connector behaviour must satisfy PRD acceptance criteria (§9). Validation includes: Airbyte framework connection check, schema validation, and connector-specific acceptance tests (verify `tenant_id` presence, stream completeness, pagination exhaustion). No custom unit tests required — the declarative manifest is validated by the framework. |
+| **Testing (TEST)** | Connector behaviour must satisfy PRD acceptance criteria (§9). Validation includes: Airbyte framework connection check, schema validation, and connector-specific acceptance tests (verify `tenant_id` presence (mapped from config `insight_tenant_id`), stream completeness, pagination exhaustion). No custom unit tests required — the declarative manifest is validated by the framework. |

--- a/docs/components/connectors/ai-dev/cursor/specs/PRD.md
+++ b/docs/components/connectors/ai-dev/cursor/specs/PRD.md
@@ -317,6 +317,8 @@ Usage event cost fields (`requestsCosts`, `cursorTokenFee`, `totalCents`) **MUST
 
 **Breaking Change Policy**: Adding new fields is non-breaking. Removing or renaming fields requires a migration.
 
+**Migration (PR #142)**: The config spec renamed `tenant_id` → `insight_tenant_id` and added `insight_source_id` as required. This is a breaking change for existing Airbyte sources. Deployment procedure: (1) ensure K8s Secrets have `insight.cyberfabric.com/source-id` annotation, (2) run `register.sh` to update the Airbyte definition, (3) run `connect.sh` to update existing source configs. Step 3 auto-injects `insight_tenant_id` and `insight_source_id` from tenant YAML and Secret annotation. Without step 3, existing sources will fail validation on next sync.
+
 ### 7.2 External Integration Contracts
 
 #### Cursor Admin API

--- a/docs/components/connectors/ai/claude-api/specs/ADR/ADR-003-cursor-granularity-boundary-fix.md
+++ b/docs/components/connectors/ai/claude-api/specs/ADR/ADR-003-cursor-granularity-boundary-fix.md
@@ -16,9 +16,9 @@ date: 2026-04-08
   - [Consequences](#consequences)
   - [Confirmation](#confirmation)
 - [Pros and Cons of the Options](#pros-and-cons-of-the-options)
-  - [Option 1: cursor\_granularity: PT1S](#option-1-cursor_granularity-pt1s)
-  - [Option 2: Remove end\_time\_option and let API default ending\_at](#option-2-remove-end_time_option-and-let-api-default-ending_at)
-  - [Option 3: Set end\_datetime to day\_delta(1) to push past today](#option-3-set-end_datetime-to-day_delta1-to-push-past-today)
+  - [Option 1: cursor_granularity: PT1S](#option-1-cursorgranularity-pt1s)
+  - [Option 2: Remove end_time_option and let API default ending_at](#option-2-remove-endtimeoption-and-let-api-default-endingat)
+  - [Option 3: Set end_datetime to day_delta(1) to push past today](#option-3-set-enddatetime-to-daydelta1-to-push-past-today)
 - [More Information](#more-information)
 - [Traceability](#traceability)
 

--- a/docs/components/connectors/ai/claude-api/specs/DESIGN.md
+++ b/docs/components/connectors/ai/claude-api/specs/DESIGN.md
@@ -443,8 +443,8 @@ sequenceDiagram
 | Column | Type | Description |
 |--------|------|-------------|
 | `tenant_id` | String | Tenant isolation identifier (UUID) -- framework-injected |
-| `source_instance_id` | String | Source instance discriminator -- framework-injected, DEFAULT '' |
-| `unique_key` | String | Composite key: `{date}\|{model}\|{api_key_id}\|{workspace_id}\|{service_tier}\|{context_window}` |
+| `source_id` | String | Source instance discriminator -- framework-injected, DEFAULT '' |
+| `unique_key` | String | Composite key: `{tenant_id}-{source_id}-{date}\|{model}\|{api_key_id}\|{workspace_id}\|{service_tier}\|{context_window}` |
 | `date` | String | Usage date (ISO 8601 date) |
 | `model` | String | Model ID (e.g., `claude-opus-4-6`, `claude-sonnet-4-6`) |
 | `api_key_id` | String | API key identifier |
@@ -478,7 +478,7 @@ sequenceDiagram
 |--------|------|-------------|
 | `tenant_id` | String | Tenant isolation identifier (UUID) -- framework-injected |
 | `source_id` | String | Source instance discriminator -- framework-injected, DEFAULT '' |
-| `unique_key` | String | Composite key: `{date}\|{workspace_id}\|{description}` |
+| `unique_key` | String | Composite key: `{tenant_id}-{source_id}-{date}\|{workspace_id}\|{description}` |
 | `date` | String | Cost date (ISO 8601 date) |
 | `workspace_id` | String | Workspace identifier |
 | `description` | String | Cost category description |

--- a/docs/components/connectors/ai/claude-api/specs/DESIGN.md
+++ b/docs/components/connectors/ai/claude-api/specs/DESIGN.md
@@ -76,7 +76,7 @@ graph LR
 | `cpt-insightspec-fr-claude-api-workspaces` | `claude_api_workspaces` stream with offset-based pagination, full refresh |
 | `cpt-insightspec-fr-claude-api-invites` | `claude_api_invites` stream with offset-based pagination, full refresh |
 | `cpt-insightspec-fr-claude-api-collection-runs` | `claude_api_collection_runs` monitoring stream (framework-managed) |
-| `cpt-insightspec-fr-claude-api-framework-fields` | `AddFields` transformation injects `tenant_id`, `source_id`, `data_source`, `collected_at`, `_version` |
+| `cpt-insightspec-fr-claude-api-framework-fields` | `AddFields` transformation injects `tenant_id`, `source_id`, `data_source`, `collected_at` |
 | `cpt-insightspec-fr-claude-api-usage-unique-key` | `AddFields` generates composite `unique_key` key from dimensional columns |
 | `cpt-insightspec-fr-claude-api-cost-unique-key` | `AddFields` generates composite `unique_key` key from `(date, workspace_id, description)` |
 
@@ -443,7 +443,7 @@ sequenceDiagram
 | Column | Type | Description |
 |--------|------|-------------|
 | `tenant_id` | String | Tenant isolation identifier (UUID) -- framework-injected |
-| `source_id` | String | Source instance discriminator -- framework-injected, DEFAULT '' |
+| `source_id` | String | Source instance discriminator -- framework-injected (from config `insight_source_id`, required) |
 | `unique_key` | String | Composite key: `{tenant_id}-{source_id}-{date}\|{model}\|{api_key_id}\|{workspace_id}\|{service_tier}\|{context_window}` |
 | `date` | String | Usage date (ISO 8601 date) |
 | `model` | String | Model ID (e.g., `claude-opus-4-6`, `claude-sonnet-4-6`) |
@@ -477,7 +477,7 @@ sequenceDiagram
 | Column | Type | Description |
 |--------|------|-------------|
 | `tenant_id` | String | Tenant isolation identifier (UUID) -- framework-injected |
-| `source_id` | String | Source instance discriminator -- framework-injected, DEFAULT '' |
+| `source_id` | String | Source instance discriminator -- framework-injected (from config `insight_source_id`, required) |
 | `unique_key` | String | Composite key: `{tenant_id}-{source_id}-{date}\|{workspace_id}\|{description}` |
 | `date` | String | Cost date (ISO 8601 date) |
 | `workspace_id` | String | Workspace identifier |
@@ -508,7 +508,7 @@ sequenceDiagram
 | Column | Type | Description |
 |--------|------|-------------|
 | `tenant_id` | String | Tenant isolation identifier (UUID) -- framework-injected |
-| `source_id` | String | Source instance discriminator -- framework-injected, DEFAULT '' |
+| `source_id` | String | Source instance discriminator -- framework-injected (from config `insight_source_id`, required) |
 | `id` | String | API key identifier |
 | `name` | String | API key name |
 | `status` | String | Key status (e.g., `active`, `disabled`) |
@@ -532,7 +532,7 @@ sequenceDiagram
 | Column | Type | Description |
 |--------|------|-------------|
 | `tenant_id` | String | Tenant isolation identifier (UUID) -- framework-injected |
-| `source_id` | String | Source instance discriminator -- framework-injected, DEFAULT '' |
+| `source_id` | String | Source instance discriminator -- framework-injected (from config `insight_source_id`, required) |
 | `id` | String | Workspace identifier |
 | `name` | String | Workspace name |
 | `display_name` | String | Workspace display name |
@@ -555,7 +555,7 @@ sequenceDiagram
 | Column | Type | Description |
 |--------|------|-------------|
 | `tenant_id` | String | Tenant isolation identifier (UUID) -- framework-injected |
-| `source_id` | String | Source instance discriminator -- framework-injected, DEFAULT '' |
+| `source_id` | String | Source instance discriminator -- framework-injected (from config `insight_source_id`, required) |
 | `id` | String | Invite identifier |
 | `email` | String | Invitee email address |
 | `role` | String | Organization role assigned |
@@ -579,7 +579,7 @@ sequenceDiagram
 | Column | Type | Description |
 |--------|------|-------------|
 | `tenant_id` | String | Tenant isolation identifier (UUID) -- framework-injected |
-| `source_id` | String | Source instance discriminator -- framework-injected, DEFAULT '' |
+| `source_id` | String | Source instance discriminator -- framework-injected (from config `insight_source_id`, required) |
 | `run_id` | String | Unique run identifier |
 | `started_at` | String | Run start time (ISO 8601) |
 | `completed_at` | String | Run end time (ISO 8601) |

--- a/docs/components/connectors/ai/claude-api/specs/DESIGN.md
+++ b/docs/components/connectors/ai/claude-api/specs/DESIGN.md
@@ -76,9 +76,9 @@ graph LR
 | `cpt-insightspec-fr-claude-api-workspaces` | `claude_api_workspaces` stream with offset-based pagination, full refresh |
 | `cpt-insightspec-fr-claude-api-invites` | `claude_api_invites` stream with offset-based pagination, full refresh |
 | `cpt-insightspec-fr-claude-api-collection-runs` | `claude_api_collection_runs` monitoring stream (framework-managed) |
-| `cpt-insightspec-fr-claude-api-framework-fields` | `AddFields` transformation injects `tenant_id`, `insight_source_id`, `data_source`, `collected_at`, `_version` |
-| `cpt-insightspec-fr-claude-api-usage-unique-key` | `AddFields` generates composite `unique` key from dimensional columns |
-| `cpt-insightspec-fr-claude-api-cost-unique-key` | `AddFields` generates composite `unique` key from `(date, workspace_id, description)` |
+| `cpt-insightspec-fr-claude-api-framework-fields` | `AddFields` transformation injects `tenant_id`, `source_id`, `data_source`, `collected_at`, `_version` |
+| `cpt-insightspec-fr-claude-api-usage-unique-key` | `AddFields` generates composite `unique_key` key from dimensional columns |
+| `cpt-insightspec-fr-claude-api-cost-unique-key` | `AddFields` generates composite `unique_key` key from `(date, workspace_id, description)` |
 
 #### NFR Allocation
 
@@ -87,7 +87,7 @@ graph LR
 | `cpt-insightspec-nfr-claude-api-auth` | Admin API key auth + version header | `base_requester` | `ApiKeyAuthenticator` with `header: x-api-key`; `request_headers` with `anthropic-version` | Integration test with valid/invalid keys |
 | `cpt-insightspec-nfr-claude-api-rate-limiting` | Exponential backoff on 429 | `error_handler` | `DefaultErrorHandler` with `ExponentialBackoffStrategy` | Unit test retry logic |
 | `cpt-insightspec-nfr-claude-api-data-source` | `data_source = 'insight_claude_api'` on all rows | `AddFields` transformation | Hard-coded constant injected into every stream | Row-level assertion in integration tests |
-| `cpt-insightspec-nfr-claude-api-idempotent` | No duplicates on re-sync | Primary key definitions | `unique` composite key for usage/cost; `id` for dimension tables | Run sync twice; verify row counts unchanged |
+| `cpt-insightspec-nfr-claude-api-idempotent` | No duplicates on re-sync | Primary key definitions | `unique_key` composite key for usage/cost; `id` for dimension tables | Run sync twice; verify row counts unchanged |
 | `cpt-insightspec-nfr-claude-api-freshness` | 48h latency | Scheduler config | Daily schedule; lookback window covers D-2 | SLA monitoring dashboard |
 
 #### Architecture Decision Records
@@ -167,7 +167,7 @@ API keys, workspaces, and invites are small, slowly-changing dimension tables. F
 
 - [ ] `p1` - **ID**: `cpt-insightspec-principle-claude-api-framework-fields`
 
-All streams inject `tenant_id`, `source_instance_id`, `data_source`, and `collected_at` via `AddFields` transformations. This is consistent across all Insight connectors and enables multi-tenant operation. Note: `_version` and `metadata` (full API response JSON) are documented in Bronze table schemas for forward compatibility but are **not implemented** in the declarative manifest — the Airbyte `AddFields` transformation cannot capture the full response payload or generate deduplication versions. These fields may be added by a destination-side post-processing step if needed.
+All streams inject `tenant_id`, `source_id`, `data_source`, and `collected_at` via `AddFields` transformations. The config parameter `insight_tenant_id` is written to Bronze column `tenant_id`; `insight_source_id` is written to Bronze column `source_id`. This is consistent across all Insight connectors and enables multi-tenant operation. Note: `_version` and `metadata` (full API response JSON) are documented in Bronze table schemas for forward compatibility but are **not implemented** in the declarative manifest — the Airbyte `AddFields` transformation cannot capture the full response payload or generate deduplication versions. These fields may be added by a destination-side post-processing step if needed.
 
 ### 2.2 Constraints
 
@@ -318,9 +318,9 @@ SQL transformation that maps `claude_api_messages_usage` Bronze data to the `cla
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `tenant_id` | string | Yes | Tenant isolation identifier (UUID) |
+| `insight_tenant_id` | string | Yes | Insight tenant isolation identifier (UUID) |
+| `insight_source_id` | string | Yes | Connector instance identifier |
 | `admin_api_key` | string (secret) | Yes | Anthropic Admin API key |
-| `insight_source_id` | string | No | Source instance discriminator (default: empty) |
 | `start_date` | string | No | Earliest date to collect (ISO 8601, default: 90 days ago) |
 
 ### 3.4 Internal Dependencies
@@ -444,7 +444,7 @@ sequenceDiagram
 |--------|------|-------------|
 | `tenant_id` | String | Tenant isolation identifier (UUID) -- framework-injected |
 | `source_instance_id` | String | Source instance discriminator -- framework-injected, DEFAULT '' |
-| `unique` | String | Composite key: `{date}\|{model}\|{api_key_id}\|{workspace_id}\|{service_tier}\|{context_window}` |
+| `unique_key` | String | Composite key: `{date}\|{model}\|{api_key_id}\|{workspace_id}\|{service_tier}\|{context_window}` |
 | `date` | String | Usage date (ISO 8601 date) |
 | `model` | String | Model ID (e.g., `claude-opus-4-6`, `claude-sonnet-4-6`) |
 | `api_key_id` | String | API key identifier |
@@ -464,7 +464,7 @@ sequenceDiagram
 | `_version` | String | Deduplication version |
 | `metadata` | String | Full API response as JSON |
 
-**PK**: `unique`
+**PK**: `unique_key`
 
 **Granularity**: One row per `(date, model, api_key_id, workspace_id, service_tier, context_window)`.
 
@@ -477,8 +477,8 @@ sequenceDiagram
 | Column | Type | Description |
 |--------|------|-------------|
 | `tenant_id` | String | Tenant isolation identifier (UUID) -- framework-injected |
-| `insight_source_id` | String | Source instance discriminator -- framework-injected, DEFAULT '' |
-| `unique` | String | Composite key: `{date}\|{workspace_id}\|{description}` |
+| `source_id` | String | Source instance discriminator -- framework-injected, DEFAULT '' |
+| `unique_key` | String | Composite key: `{date}\|{workspace_id}\|{description}` |
 | `date` | String | Cost date (ISO 8601 date) |
 | `workspace_id` | String | Workspace identifier |
 | `description` | String | Cost category description |
@@ -495,7 +495,7 @@ sequenceDiagram
 | `_version` | String | Deduplication version |
 | `metadata` | String | Full API response as JSON |
 
-**PK**: `unique`
+**PK**: `unique_key`
 
 **Granularity**: One row per `(date, workspace_id, description)`.
 
@@ -508,7 +508,7 @@ sequenceDiagram
 | Column | Type | Description |
 |--------|------|-------------|
 | `tenant_id` | String | Tenant isolation identifier (UUID) -- framework-injected |
-| `insight_source_id` | String | Source instance discriminator -- framework-injected, DEFAULT '' |
+| `source_id` | String | Source instance discriminator -- framework-injected, DEFAULT '' |
 | `id` | String | API key identifier |
 | `name` | String | API key name |
 | `status` | String | Key status (e.g., `active`, `disabled`) |
@@ -532,7 +532,7 @@ sequenceDiagram
 | Column | Type | Description |
 |--------|------|-------------|
 | `tenant_id` | String | Tenant isolation identifier (UUID) -- framework-injected |
-| `insight_source_id` | String | Source instance discriminator -- framework-injected, DEFAULT '' |
+| `source_id` | String | Source instance discriminator -- framework-injected, DEFAULT '' |
 | `id` | String | Workspace identifier |
 | `name` | String | Workspace name |
 | `display_name` | String | Workspace display name |
@@ -555,7 +555,7 @@ sequenceDiagram
 | Column | Type | Description |
 |--------|------|-------------|
 | `tenant_id` | String | Tenant isolation identifier (UUID) -- framework-injected |
-| `insight_source_id` | String | Source instance discriminator -- framework-injected, DEFAULT '' |
+| `source_id` | String | Source instance discriminator -- framework-injected, DEFAULT '' |
 | `id` | String | Invite identifier |
 | `email` | String | Invitee email address |
 | `role` | String | Organization role assigned |
@@ -579,7 +579,7 @@ sequenceDiagram
 | Column | Type | Description |
 |--------|------|-------------|
 | `tenant_id` | String | Tenant isolation identifier (UUID) -- framework-injected |
-| `insight_source_id` | String | Source instance discriminator -- framework-injected, DEFAULT '' |
+| `source_id` | String | Source instance discriminator -- framework-injected, DEFAULT '' |
 | `run_id` | String | Unique run identifier |
 | `started_at` | String | Run start time (ISO 8601) |
 | `completed_at` | String | Run end time (ISO 8601) |

--- a/docs/components/connectors/ai/claude-api/specs/DESIGN.md
+++ b/docs/components/connectors/ai/claude-api/specs/DESIGN.md
@@ -613,6 +613,17 @@ The connector is deployed as a standard Airbyte source connector. The YAML manif
 | `descriptor.yaml` | Platform registry | Connector metadata |
 | `dbt/to_ai_api_usage.sql` | dbt project | Silver transformation |
 | `dbt/schema.yml` | dbt project | Source and model definitions |
+| `secrets/connectors/claude-api.yaml.example` | K8s Secret template | Credential + `insight_source_id` annotation |
+
+#### Migration: `tenant_id` → `insight_tenant_id` (PR #142)
+
+The config spec renamed `tenant_id` → `insight_tenant_id` and added `insight_source_id` as required. This is a breaking change for existing Airbyte sources. Deployment procedure:
+
+1. **K8s Secrets**: ensure each Secret has annotation `insight.cyberfabric.com/source-id` (see `secrets/connectors/claude-api.yaml.example`)
+2. **Register**: run `register.sh` (or `upload-manifests.sh`) to update the Airbyte source definition with the new manifest
+3. **Connect**: run `connect.sh` (or `apply-connections.sh`) to update existing source configs — this auto-injects `insight_tenant_id` and `insight_source_id` from tenant YAML and Secret annotation
+
+Steps must run before the next scheduled sync (`0 2 * * *`). Without step 3, existing sources will fail Airbyte validation.
 
 ---
 

--- a/docs/components/connectors/ai/claude-api/specs/DESIGN.md
+++ b/docs/components/connectors/ai/claude-api/specs/DESIGN.md
@@ -253,6 +253,59 @@ Single YAML file that defines all streams, authentication, pagination strategies
 - Implements `AddFields` transformations for framework fields and composite unique keys.
 - Declares inline JSON Schema for each stream.
 
+##### Manifest skeleton (structural overview)
+
+```yaml
+definitions:
+  api_key_authenticator:
+    type: ApiKeyAuthenticator
+    api_token: "{{ config['admin_api_key'] }}"
+    header: x-api-key
+
+  tenant_id_injection:
+    type: AddFields
+    fields:
+      - path: [tenant_id]
+        value: "{{ config['insight_tenant_id'] }}"
+      - path: [source_id]
+        value: "{{ config['insight_source_id'] }}"
+      - path: [collected_at]
+        value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+      - path: [data_source]
+        value: insight_claude_api
+
+streams:
+  - type: DeclarativeStream
+    name: claude_api_messages_usage
+    primary_key: [unique_key]
+    # ... schema, retriever, incremental_sync
+  # ... remaining streams follow same pattern
+
+spec:
+  type: Spec
+  connection_specification:
+    type: object
+    required: [insight_tenant_id, insight_source_id, admin_api_key]
+    properties:
+      insight_tenant_id:
+        type: string
+        title: Insight Tenant ID
+        minLength: 1
+        order: 0
+      insight_source_id:
+        type: string
+        title: Insight Source ID
+        minLength: 1
+        order: 1
+      admin_api_key:
+        type: string
+        title: Admin API Key
+        airbyte_secret: true
+        order: 2
+```
+
+This is a structural skeleton -- the full manifest is in `src/ingestion/connectors/ai/claude-api/connector.yaml`.
+
 ##### Responsibility boundaries
 
 - Does NOT implement Silver/Gold transformations (owned by dbt models).
@@ -318,8 +371,8 @@ SQL transformation that maps `claude_api_messages_usage` Bronze data to the `cla
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `insight_tenant_id` | string | Yes | Insight tenant isolation identifier (UUID) |
-| `insight_source_id` | string | Yes | Connector instance identifier |
+| `insight_tenant_id` | string (minLength: 1) | Yes | Insight tenant isolation identifier (UUID) |
+| `insight_source_id` | string (minLength: 1) | Yes | Connector instance identifier |
 | `admin_api_key` | string (secret) | Yes | Anthropic Admin API key |
 | `start_date` | string | No | Earliest date to collect (ISO 8601, default: 90 days ago) |
 

--- a/docs/components/connectors/ai/claude-api/specs/DESIGN.md
+++ b/docs/components/connectors/ai/claude-api/specs/DESIGN.md
@@ -636,7 +636,9 @@ The mapping from `created_by` fields and invite emails to `person_id` is handled
 
 | Bronze Field (`claude_api_messages_usage`) | Silver Field (`class_ai_api_usage`) | Transformation |
 |--------------------------------------------|-------------------------------------|---------------|
-| `tenant_id` | `tenant_id` | Pass through |
+| `tenant_id` | `insight_tenant_id` | Rename (Bronze → Silver convention per glossary §3) |
+| `source_id` | `insight_source_id` | Rename (Bronze → Silver convention per glossary §3) |
+| -- | `insight_source_type` | Constant `'claude-api'` |
 | `date` | `report_date` | Rename |
 | `model` | `model` | Pass through |
 | `api_key_id` | `api_key_id` | Pass through |
@@ -656,7 +658,6 @@ The mapping from `created_by` fields and invite emails to `person_id` is handled
 | `data_source` | `data_source` | `'insight_claude_api'` |
 | -- | `provider` | `'anthropic'` (constant) |
 | -- | `person_id` | NULL (no user attribution at API level) |
-| `source_instance_id` | `source_instance_id` | Pass through |
 
 #### Silver/Gold Summary
 

--- a/docs/components/connectors/ai/claude-api/specs/PRD.md
+++ b/docs/components/connectors/ai/claude-api/specs/PRD.md
@@ -390,6 +390,8 @@ Repeated collection of the same date range **MUST NOT** create duplicate rows. T
 
 **Breaking Change Policy**: Configuration schema changes require a version bump.
 
+**Migration (PR #142)**: The config spec renamed `tenant_id` → `insight_tenant_id` and added `insight_source_id` as required. This is a breaking change for existing Airbyte sources. Deployment procedure: (1) ensure K8s Secrets have `insight.cyberfabric.com/source-id` annotation, (2) run `register.sh` to update the Airbyte definition, (3) run `connect.sh` to update existing source configs. Step 3 auto-injects `insight_tenant_id` and `insight_source_id` from tenant YAML and Secret annotation. Without step 3, existing sources will fail validation on next sync.
+
 ### 7.2 External Integration Contracts
 
 #### Anthropic Admin API Contract

--- a/docs/components/connectors/ai/claude-team/specs/ADR/ADR-001-cursor-granularity-boundary-fix.md
+++ b/docs/components/connectors/ai/claude-team/specs/ADR/ADR-001-cursor-granularity-boundary-fix.md
@@ -16,8 +16,8 @@ date: 2026-04-08
   - [Consequences](#consequences)
   - [Confirmation](#confirmation)
 - [Pros and Cons of the Options](#pros-and-cons-of-the-options)
-  - [Option 1: cursor\_granularity: PT1S (chosen)](#option-1-cursor_granularity-pt1s-chosen)
-  - [Option 2: Keep cursor\_granularity: P1D](#option-2-keep-cursor_granularity-p1d)
+  - [Option 1: cursor_granularity: PT1S (chosen)](#option-1-cursorgranularity-pt1s-chosen)
+  - [Option 2: Keep cursor_granularity: P1D](#option-2-keep-cursorgranularity-p1d)
 - [More Information](#more-information)
 - [Traceability](#traceability)
 

--- a/docs/components/connectors/ai/claude-team/specs/DESIGN.md
+++ b/docs/components/connectors/ai/claude-team/specs/DESIGN.md
@@ -374,7 +374,7 @@ spec:
   type: Spec
   connection_specification:
     type: object
-    required: [tenant_id, admin_api_key]
+    required: [insight_tenant_id, insight_source_id, admin_api_key]
     properties:
       tenant_id:
         type: string
@@ -455,7 +455,8 @@ The source config (credentials) for the Claude Team connector:
 
 ```json
 {
-  "tenant_id": "Tenant isolation identifier (UUID)",
+  "insight_tenant_id": "Insight tenant isolation identifier (UUID)",
+  "insight_source_id": "Connector instance identifier",
   "admin_api_key": "Anthropic Admin API key (Team/Enterprise workspace)"
 }
 ```
@@ -888,7 +889,7 @@ The following checklist domains have been evaluated and are not applicable for t
 | **MAINT (Maintainability)** | Declarative YAML manifest with no custom code. Maintenance consists of updating field definitions when the API schema changes. |
 | **TEST (Testing)** | Declarative connector validated by the Airbyte framework's built-in checks (connection check, schema validation). No custom code to unit-test. |
 | **COMPL (Compliance)** | The connector extracts work emails and AI activity metrics -- personal/work-linked data under GDPR. Retention, deletion, and access controls are delegated to the Airbyte platform and destination operator. |
-| **UX (Usability)** | No user-facing interface. The only UX surface is the Airbyte connection configuration form (two required fields: `tenant_id` and `admin_api_key`). |
+| **UX (Usability)** | No user-facing interface. The only UX surface is the Airbyte connection configuration form (three required fields: `insight_tenant_id`, `insight_source_id`, and `admin_api_key`). |
 
 ### Architecture Decision Records
 

--- a/docs/components/connectors/ai/claude-team/specs/DESIGN.md
+++ b/docs/components/connectors/ai/claude-team/specs/DESIGN.md
@@ -83,7 +83,7 @@ graph LR
 | `cpt-insightspec-fr-claude-team-workspace-members-collect` | Stream `claude_team_workspace_members` -> `GET /v1/organizations/workspaces/{id}/members` (substream) |
 | `cpt-insightspec-fr-claude-team-invites-collect` | Stream `claude_team_invites` -> `GET /v1/organizations/invites` (full refresh) |
 | `cpt-insightspec-fr-claude-team-collection-runs` | Stream `claude_team_collection_runs` -- connector execution log |
-| `cpt-insightspec-fr-claude-team-deduplication` | Primary keys: `id` (users/workspaces/invites), `unique` (code_usage/workspace_members), `run_id` (collection_runs) |
+| `cpt-insightspec-fr-claude-team-deduplication` | Primary keys: `id` (users/workspaces/invites), `unique_key` (code_usage/workspace_members), `run_id` (collection_runs) |
 | `cpt-insightspec-fr-claude-team-identity-key` | `email`/`actor_identifier` present in user-facing streams |
 
 #### NFR Allocation
@@ -126,7 +126,7 @@ Each Anthropic Admin API endpoint maps to exactly one stream. `GET /v1/organizat
 
 - [ ] `p2` - **ID**: `cpt-insightspec-principle-claude-team-source-native-schema`
 
-Bronze tables preserve the original Anthropic Admin API field names in their native casing (snake_case) where possible. Framework fields (`tenant_id`, `source_instance_id`, `collected_at`, `data_source`) are injected via `AddFields`. Additionally, the `code_usage` stream derives several flattened fields from nested API objects: `actor_type` and `actor_identifier` (from `actor`), `session_count`, `lines_added`, `lines_removed` (from `core_metrics`), `tool_use_accepted`, `tool_use_rejected` (summed from `tool_actions`), and serializes `core_metrics_json`, `tool_actions_json`, `model_breakdown_json` as JSON strings. All streams compute a `unique` composite key. Nested objects like `data_residency` (workspaces) are serialized to JSON strings via `tojson`. Note: `_version` and `metadata` are documented in Bronze table schemas for forward compatibility but are **not implemented** in the declarative manifest.
+Bronze tables preserve the original Anthropic Admin API field names in their native casing (snake_case) where possible. Framework fields (`tenant_id`, `source_id`, `collected_at`, `data_source`) are injected via `AddFields`. The config parameter `insight_tenant_id` is written to Bronze column `tenant_id`; `insight_source_id` is written to Bronze column `source_id`. Additionally, the `code_usage` stream derives several flattened fields from nested API objects: `actor_type` and `actor_identifier` (from `actor`), `session_count`, `lines_added`, `lines_removed` (from `core_metrics`), `tool_use_accepted`, `tool_use_rejected` (summed from `tool_actions`), and serializes `core_metrics_json`, `tool_actions_json`, `model_breakdown_json` as JSON strings. All streams compute a `unique_key` composite key. Nested objects like `data_residency` (workspaces) are serialized to JSON strings via `tojson`. Note: `_version` and `metadata` are documented in Bronze table schemas for forward compatibility but are **not implemented** in the declarative manifest.
 
 ### 2.2 Constraints
 
@@ -362,7 +362,7 @@ streams:
         fields:
           - path: [tenant_id]
             value: "{{ config['tenant_id'] }}"
-          - path: [insight_source_id]
+          - path: [source_id]
             value: "{{ config.get('insight_source_id', '') }}"
           - path: [collected_at]
             value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
@@ -460,34 +460,39 @@ The source config (credentials) for the Claude Team connector:
 }
 ```
 
-Both fields are required. `tenant_id` is a platform invariant -- every connector must accept it. `admin_api_key` is marked `airbyte_secret: true` -- it is never logged or displayed.
+Both fields are required. `insight_tenant_id` is a platform invariant -- every connector must accept it. `admin_api_key` is marked `airbyte_secret: true` -- it is never logged or displayed.
 
 #### tenant_id Injection
 
-Per the ingestion layer tenant isolation principle, every record emitted by the connector MUST contain `tenant_id`. This is achieved via an `AddFields` transformation in the manifest:
+Per the ingestion layer tenant isolation principle, every record emitted by the connector MUST contain `tenant_id`. The config parameter `insight_tenant_id` is mapped to Bronze column `tenant_id`; `insight_source_id` is mapped to Bronze column `source_id`. This is achieved via an `AddFields` transformation in the manifest:
 
 ```yaml
 # In spec.connection_specification:
-required: [tenant_id, admin_api_key]
+required: [insight_tenant_id, insight_source_id, admin_api_key]
 properties:
-  tenant_id:
+  insight_tenant_id:
     type: string
-    title: Tenant ID
-    description: Tenant isolation identifier
+    title: Insight Tenant ID
+    description: Insight tenant isolation identifier
     order: 0
+  insight_source_id:
+    type: string
+    title: Insight Source ID
+    description: Connector instance identifier
+    order: 1
   admin_api_key:
     type: string
     title: Admin API Key
     airbyte_secret: true
-    order: 1
+    order: 2
 
 # In each stream's transformations:
 transformations:
   - type: AddFields
     fields:
       - path: [tenant_id]
-        value: "{{ config['tenant_id'] }}"
-      - path: [insight_source_id]
+        value: "{{ config['insight_tenant_id'] }}"
+      - path: [source_id]
         value: "{{ config.get('insight_source_id', '') }}"
       - path: [collected_at]
         value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
@@ -495,7 +500,7 @@ transformations:
         value: "insight_claude_team"
 ```
 
-This transformation is applied to **every stream** in the manifest, ensuring `tenant_id`, `insight_source_id`, `collected_at`, and `data_source` are present in every record before it reaches the destination.
+This transformation is applied to **every stream** in the manifest, ensuring `tenant_id`, `source_id`, `collected_at`, and `data_source` are present in every record before it reaches the destination.
 
 ### 3.4 Internal Dependencies
 
@@ -605,7 +610,7 @@ These columns are not defined in the manifest schema but are present in all Bron
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key -- framework-injected |
-| `insight_source_id` | String | Connector instance identifier -- framework-injected, DEFAULT '' |
+| `source_id` | String | Connector instance identifier -- framework-injected, DEFAULT '' |
 | `id` | String | Anthropic platform user ID -- primary key |
 | `type` | String (nullable) | Record type (e.g., `user`) |
 | `email` | String | User email -- primary identity key -> `person_id` |
@@ -626,8 +631,8 @@ One row per user. Current-state only -- no versioning.
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key -- framework-injected |
-| `insight_source_id` | String | Connector instance identifier -- framework-injected, DEFAULT '' |
-| `unique` | String | Primary key -- computed composite of date + actor fields + terminal_type |
+| `source_id` | String | Connector instance identifier -- framework-injected, DEFAULT '' |
+| `unique_key` | String | Primary key -- computed composite of date + actor fields + terminal_type |
 | `date` | String | Activity date (`YYYY-MM-DD`) -- cursor for incremental sync |
 | `actor_type` | String (nullable) | Actor type: `api_actor` or `user` -- flattened from `actor.type` |
 | `actor_identifier` | String (nullable) | API key name (for `api_actor`) or email (for `user`) -- flattened from `actor.api_key_name` or `actor.email` |
@@ -659,7 +664,7 @@ One row per `(date, actor_type, actor_identifier, terminal_type)`. Incremental s
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key -- framework-injected |
-| `insight_source_id` | String | Connector instance identifier -- framework-injected, DEFAULT '' |
+| `source_id` | String | Connector instance identifier -- framework-injected, DEFAULT '' |
 | `id` | String | Workspace ID -- primary key |
 | `name` | String | Workspace slug name |
 | `display_name` | String | Human-readable workspace name |
@@ -678,8 +683,8 @@ Full refresh -- one row per workspace.
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key -- framework-injected |
-| `insight_source_id` | String | Connector instance identifier -- framework-injected, DEFAULT '' |
-| `unique` | String | Primary key -- computed as `{user_id}:{workspace_id}` |
+| `source_id` | String | Connector instance identifier -- framework-injected, DEFAULT '' |
+| `unique_key` | String | Primary key -- computed as `{user_id}:{workspace_id}` |
 | `type` | String (nullable) | Record type (e.g., `workspace_member`) |
 | `user_id` | String | Anthropic user ID |
 | `workspace_id` | String | Workspace ID (from parent stream partition) |
@@ -696,7 +701,7 @@ Full refresh -- one row per user-workspace pair.
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key -- framework-injected |
-| `insight_source_id` | String | Connector instance identifier -- framework-injected, DEFAULT '' |
+| `source_id` | String | Connector instance identifier -- framework-injected, DEFAULT '' |
 | `id` | String | Invite ID -- primary key |
 | `email` | String | Invited user's email |
 | `role` | String | Invited role |
@@ -716,7 +721,7 @@ Full refresh -- one row per invite.
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key -- framework-injected |
-| `insight_source_id` | String | Connector instance identifier -- framework-injected, DEFAULT '' |
+| `source_id` | String | Connector instance identifier -- framework-injected, DEFAULT '' |
 | `run_id` | String | Unique run identifier -- primary key |
 | `started_at` | DateTime | Run start time |
 | `completed_at` | DateTime | Run end time |
@@ -782,7 +787,7 @@ The Identity Manager resolves `email`/`actor_identifier` -> canonical `person_id
 | Unified field | Claude Team source | Notes |
 |---------------|-------------------|-------|
 | `tenant_id` | `tenant_id` | Framework-injected |
-| `source_instance_id` | `source_instance_id` | Connector instance |
+| `source_id` | `source_id` | Connector instance (Bronze column, mapped from config `insight_source_id`) |
 | `data_source` | `data_source` | Always `insight_claude_team` |
 | `unique_id` | -- | Computed: `concat(date, '\|', actor_identifier, '\|', terminal_type)`. Note: `actor_type` is omitted because the model filters to `actor_type = 'user'` (always constant); Bronze key includes it but Silver does not. |
 | `report_date` | `date` | Rename from `date` |

--- a/docs/components/connectors/ai/claude-team/specs/DESIGN.md
+++ b/docs/components/connectors/ai/claude-team/specs/DESIGN.md
@@ -250,7 +250,7 @@ streams:
 
   - name: claude_team_code_usage
     bronze_table: claude_team_code_usage
-    primary_key: [unique]
+    primary_key: [unique_key]
     cursor_field: date
 
   - name: claude_team_workspaces
@@ -260,7 +260,7 @@ streams:
 
   - name: claude_team_workspace_members
     bronze_table: claude_team_workspace_members
-    primary_key: [unique]
+    primary_key: [unique_key]
     cursor_field: null
 
   - name: claude_team_invites
@@ -361,9 +361,9 @@ streams:
       - type: AddFields
         fields:
           - path: [tenant_id]
-            value: "{{ config['tenant_id'] }}"
+            value: "{{ config['insight_tenant_id'] }}"
           - path: [source_id]
-            value: "{{ config.get('insight_source_id', '') }}"
+            value: "{{ config['insight_source_id'] }}"
           - path: [collected_at]
             value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
           - path: [data_source]
@@ -494,7 +494,7 @@ transformations:
       - path: [tenant_id]
         value: "{{ config['insight_tenant_id'] }}"
       - path: [source_id]
-        value: "{{ config.get('insight_source_id', '') }}"
+        value: "{{ config['insight_source_id'] }}"
       - path: [collected_at]
         value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
       - path: [data_source]
@@ -611,7 +611,7 @@ These columns are not defined in the manifest schema but are present in all Bron
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key -- framework-injected |
-| `source_id` | String | Connector instance identifier -- framework-injected, DEFAULT '' |
+| `source_id` | String | Connector instance identifier -- framework-injected (from config `insight_source_id`, required) |
 | `id` | String | Anthropic platform user ID -- primary key |
 | `type` | String (nullable) | Record type (e.g., `user`) |
 | `email` | String | User email -- primary identity key -> `person_id` |
@@ -632,7 +632,7 @@ One row per user. Current-state only -- no versioning.
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key -- framework-injected |
-| `source_id` | String | Connector instance identifier -- framework-injected, DEFAULT '' |
+| `source_id` | String | Connector instance identifier -- framework-injected (from config `insight_source_id`, required) |
 | `unique_key` | String | Primary key -- computed composite of date + actor fields + terminal_type |
 | `date` | String | Activity date (`YYYY-MM-DD`) -- cursor for incremental sync |
 | `actor_type` | String (nullable) | Actor type: `api_actor` or `user` -- flattened from `actor.type` |
@@ -665,7 +665,7 @@ One row per `(date, actor_type, actor_identifier, terminal_type)`. Incremental s
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key -- framework-injected |
-| `source_id` | String | Connector instance identifier -- framework-injected, DEFAULT '' |
+| `source_id` | String | Connector instance identifier -- framework-injected (from config `insight_source_id`, required) |
 | `id` | String | Workspace ID -- primary key |
 | `name` | String | Workspace slug name |
 | `display_name` | String | Human-readable workspace name |
@@ -684,7 +684,7 @@ Full refresh -- one row per workspace.
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key -- framework-injected |
-| `source_id` | String | Connector instance identifier -- framework-injected, DEFAULT '' |
+| `source_id` | String | Connector instance identifier -- framework-injected (from config `insight_source_id`, required) |
 | `unique_key` | String | Primary key -- computed as `{user_id}:{workspace_id}` |
 | `type` | String (nullable) | Record type (e.g., `workspace_member`) |
 | `user_id` | String | Anthropic user ID |
@@ -702,7 +702,7 @@ Full refresh -- one row per user-workspace pair.
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key -- framework-injected |
-| `source_id` | String | Connector instance identifier -- framework-injected, DEFAULT '' |
+| `source_id` | String | Connector instance identifier -- framework-injected (from config `insight_source_id`, required) |
 | `id` | String | Invite ID -- primary key |
 | `email` | String | Invited user's email |
 | `role` | String | Invited role |
@@ -722,7 +722,7 @@ Full refresh -- one row per invite.
 | Field | Type | Description |
 |-------|------|-------------|
 | `tenant_id` | UUID | Workspace isolation key -- framework-injected |
-| `source_id` | String | Connector instance identifier -- framework-injected, DEFAULT '' |
+| `source_id` | String | Connector instance identifier -- framework-injected (from config `insight_source_id`, required) |
 | `run_id` | String | Unique run identifier -- primary key |
 | `started_at` | DateTime | Run start time |
 | `completed_at` | DateTime | Run end time |
@@ -797,9 +797,9 @@ The Identity Manager resolves `email`/`actor_identifier` -> canonical `person_id
 
 | Unified field | Claude Team source | Notes |
 |---------------|-------------------|-------|
-| `tenant_id` | `insight_tenant_id` | Rename (Bronze → Silver convention per glossary §3) |
-| `source_id` | `insight_source_id` | Rename (Bronze → Silver convention per glossary §3) |
-| -- | `insight_source_type` | Constant `'claude-team'` |
+| `insight_tenant_id` | `tenant_id` | Rename (Bronze → Silver convention per glossary §3) |
+| `insight_source_id` | `source_id` | Rename (Bronze → Silver convention per glossary §3) |
+| `insight_source_type` | -- | Constant `'claude-team'` |
 | `data_source` | `data_source` | Always `insight_claude_team` |
 | `unique_id` | -- | Computed: `concat(date, '\|', actor_identifier, '\|', terminal_type)`. Note: `actor_type` is omitted because the model filters to `actor_type = 'user'` (always constant); Bronze key includes it but Silver does not. |
 | `report_date` | `date` | Rename from `date` |

--- a/docs/components/connectors/ai/claude-team/specs/DESIGN.md
+++ b/docs/components/connectors/ai/claude-team/specs/DESIGN.md
@@ -753,13 +753,23 @@ Package: src/ingestion/connectors/ai/claude-team/
 Connection: claude-team-{org_name}-daily
 +-- Schedule: daily (via Kestra cron)
 +-- Source image: airbyte/source-declarative-manifest
-+-- Source config: {tenant_id, admin_api_key}
++-- Source config: {insight_tenant_id, insight_source_id, admin_api_key}
 +-- Streams: claude_team_users, claude_team_code_usage,
 |            claude_team_workspaces, claude_team_workspace_members,
 |            claude_team_invites, claude_team_collection_runs
 +-- Destination: ClickHouse (Bronze)
 +-- State: per-stream cursors (code_usage date cursor)
 ```
+
+#### Migration: `tenant_id` → `insight_tenant_id` (PR #142)
+
+The config spec renamed `tenant_id` → `insight_tenant_id` and added `insight_source_id` as required. This is a breaking change for existing Airbyte sources. Deployment procedure:
+
+1. **K8s Secrets**: ensure each Secret has annotation `insight.cyberfabric.com/source-id` (see `secrets/connectors/claude-team.yaml.example`)
+2. **Register**: run `register.sh` (or `upload-manifests.sh`) to update the Airbyte source definition with the new manifest
+3. **Connect**: run `connect.sh` (or `apply-connections.sh`) to update existing source configs — this auto-injects `insight_tenant_id` and `insight_source_id` from tenant YAML and Secret annotation
+
+Steps must run before the next scheduled sync (`0 2 * * *`). Without step 3, existing sources will fail Airbyte validation.
 
 ## 4. Additional context
 

--- a/docs/components/connectors/ai/claude-team/specs/DESIGN.md
+++ b/docs/components/connectors/ai/claude-team/specs/DESIGN.md
@@ -223,7 +223,7 @@ src/ingestion/connectors/ai/claude-team/
     +-- schema.yml          # Column documentation + dbt tests
 ```
 
-The dbt model `to_ai_dev_usage.sql` transforms `claude_team_code_usage` Bronze table into the unified `class_ai_dev_usage` Silver table. `tenant_id` MUST be preserved and tested with a `not_null` dbt test. The `data_source` column (set to `'insight_claude_team'` in Bronze) MUST be carried through to Silver as the canonical source discriminator.
+The dbt model `to_ai_dev_usage.sql` transforms `claude_team_code_usage` Bronze table into the unified `class_ai_dev_usage` Silver table. Bronze `tenant_id` is mapped to Silver `insight_tenant_id`, `source_id` to `insight_source_id`, and `insight_source_type` is set to `'claude-team'` (per glossary §3). Both `insight_tenant_id` and `insight_source_id` MUST be tested with `not_null` dbt tests. The `data_source` column (set to `'insight_claude_team'` in Bronze) MUST be carried through to Silver as the canonical source discriminator.
 
 The dbt model `to_ai_tool_usage.sql` is a placeholder -- the Anthropic Admin API does not currently expose web/mobile activity data through a separate endpoint. This model documents the architectural gap and will be implemented when the data becomes available.
 
@@ -786,8 +786,9 @@ The Identity Manager resolves `email`/`actor_identifier` -> canonical `person_id
 
 | Unified field | Claude Team source | Notes |
 |---------------|-------------------|-------|
-| `tenant_id` | `tenant_id` | Framework-injected |
-| `source_id` | `source_id` | Connector instance (Bronze column, mapped from config `insight_source_id`) |
+| `tenant_id` | `insight_tenant_id` | Rename (Bronze → Silver convention per glossary §3) |
+| `source_id` | `insight_source_id` | Rename (Bronze → Silver convention per glossary §3) |
+| -- | `insight_source_type` | Constant `'claude-team'` |
 | `data_source` | `data_source` | Always `insight_claude_team` |
 | `unique_id` | -- | Computed: `concat(date, '\|', actor_identifier, '\|', terminal_type)`. Note: `actor_type` is omitted because the model filters to `actor_type = 'user'` (always constant); Bronze key includes it but Silver does not. |
 | `report_date` | `date` | Rename from `date` |

--- a/docs/components/connectors/ai/claude-team/specs/DESIGN.md
+++ b/docs/components/connectors/ai/claude-team/specs/DESIGN.md
@@ -376,15 +376,21 @@ spec:
     type: object
     required: [insight_tenant_id, insight_source_id, admin_api_key]
     properties:
-      tenant_id:
+      insight_tenant_id:
         type: string
-        title: Tenant ID
+        title: Insight Tenant ID
+        minLength: 1
         order: 0
+      insight_source_id:
+        type: string
+        title: Insight Source ID
+        minLength: 1
+        order: 1
       admin_api_key:
         type: string
         title: Admin API Key
         airbyte_secret: true
-        order: 1
+        order: 2
 ```
 
 This is a structural skeleton -- the full manifest is in `src/ingestion/connectors/ai/claude-team/connector.yaml`.
@@ -475,11 +481,13 @@ properties:
     type: string
     title: Insight Tenant ID
     description: Insight tenant isolation identifier
+    minLength: 1
     order: 0
   insight_source_id:
     type: string
     title: Insight Source ID
     description: Connector instance identifier
+    minLength: 1
     order: 1
   admin_api_key:
     type: string

--- a/docs/components/connectors/ai/claude-team/specs/PRD.md
+++ b/docs/components/connectors/ai/claude-team/specs/PRD.md
@@ -392,7 +392,7 @@ Bronze table schemas **MUST** remain stable across connector versions. Breaking 
 
 **Authentication**: API key via `x-api-key` header, with required `anthropic-version: 2023-06-01` header.
 
-**Compatibility**: Anthropic Admin API. Response format is JSON with cursor-based pagination. Field additions are non-breaking. Pagination parameter details are documented in [DESIGN.md](./DESIGN.md) §3.3.
+**Compatibility**: Anthropic Admin API. Response format is JSON; pagination varies by stream (cursor-based for users, next-page token for code_usage, offset for workspaces/invites). See [DESIGN.md](./DESIGN.md) §3.3 for details. Field additions are non-breaking. Pagination parameter details are documented in [DESIGN.md](./DESIGN.md) §3.3.
 
 ## 8. Use Cases
 
@@ -489,7 +489,7 @@ Bronze table schemas **MUST** remain stable across connector versions. Breaking 
 - The Anthropic Admin API response format remains stable across minor versions
 - `email` in the users endpoint and `actor_identifier` in the code usage endpoint are stable, non-null fields for user-type actors
 - Code usage data granularity is one row per `(date, actor_type, actor_identifier, terminal_type)`
-- All endpoints use cursor-based pagination (exact parameter names are configured in the connector manifest)
+- Endpoints use mixed pagination: cursor-based (`after_id`) for users, next-page token for code_usage, offset for workspaces/workspace_members/invites. Parameter names are configured in the connector manifest
 - The `anthropic-version: 2023-06-01` header is required on all requests and will remain stable
 - Workspace members can be fetched by iterating over workspace IDs from the workspaces endpoint
 - Daily usage data is available with D+1 lag (same day or next day)

--- a/docs/components/connectors/ai/claude-team/specs/PRD.md
+++ b/docs/components/connectors/ai/claude-team/specs/PRD.md
@@ -372,6 +372,8 @@ Bronze table schemas **MUST** remain stable across connector versions. Breaking 
 
 **Breaking Change Policy**: Adding new fields is non-breaking. Removing or renaming fields requires a migration.
 
+**Migration (PR #142)**: The config spec renamed `tenant_id` → `insight_tenant_id` and added `insight_source_id` as required. This is a breaking change for existing Airbyte sources. Deployment procedure: (1) ensure K8s Secrets have `insight.cyberfabric.com/source-id` annotation, (2) run `register.sh` to update the Airbyte definition, (3) run `connect.sh` to update existing source configs. Step 3 auto-injects `insight_tenant_id` and `insight_source_id` from tenant YAML and Secret annotation. Without step 3, existing sources will fail validation on next sync.
+
 ### 7.2 External Integration Contracts
 
 #### Anthropic Admin API

--- a/docs/domain/identity-resolution/specs/DESIGN.md
+++ b/docs/domain/identity-resolution/specs/DESIGN.md
@@ -1211,7 +1211,7 @@ Phase 1 seed models derive `insight_tenant_id` (UUID) from the Bronze string `te
 - `seed_persons_from_cursor.sql`, `seed_persons_from_claude_team.sql` — compute the hash
 - `seed_aliases_from_cursor.sql`, `seed_aliases_from_claude_team.sql` — use it in tenant-scoped JOINs
 - `seed_bootstrap_inputs_from_cursor.sql`, `seed_bootstrap_inputs_from_claude_team.sql` — compute the hash
-- `scripts/adhoc/seed_from_cursor_manual.sql`, `scripts/adhoc/seed_from_claude_team_manual.sql` — ad-hoc Play UI testing SQL (point-in-time snapshots, not kept in sync with dbt models)
+- `src/ingestion/scripts/adhoc/seed_from_cursor_manual.sql`, `src/ingestion/scripts/adhoc/seed_from_claude_team_manual.sql` — ad-hoc Play UI testing SQL (point-in-time snapshots, not kept in sync with dbt models)
 
 ## 6. Traceability
 

--- a/src/ingestion/connectors/ai-dev/cursor/README.md
+++ b/src/ingestion/connectors/ai-dev/cursor/README.md
@@ -57,6 +57,18 @@ kubectl apply -f src/ingestion/secrets/connectors/cursor.yaml
 | `cursor_usage_events_daily_resync` | Per-request usage events (daily resync, finalized costs) | Incremental |
 | `cursor_daily_usage` | Aggregated daily usage per user | Incremental |
 
+## Migration
+
+**From `tenant_id` to `insight_tenant_id` spec (PR #142):**
+
+The connector spec changed `tenant_id` → `insight_tenant_id` and added `insight_source_id` as required. After merging:
+
+1. Ensure K8s Secret exists with `insight.cyberfabric.com/source-id` annotation
+2. Run `register.sh` (or `upload-manifests.sh`) to update the Airbyte definition
+3. Run `connect.sh` (or `apply-connections.sh`) to update existing source configs — this auto-injects `insight_tenant_id` and `insight_source_id` from tenant YAML and Secret annotation
+
+Without step 3, existing Airbyte sources will fail validation on next sync.
+
 ## Silver Targets
 
 - `class_ai_dev_usage` -- unified AI developer tool usage

--- a/src/ingestion/connectors/ai-dev/cursor/README.md
+++ b/src/ingestion/connectors/ai-dev/cursor/README.md
@@ -1,0 +1,62 @@
+# Cursor Connector
+
+Team member roster, audit logs, usage events, and daily usage from Cursor via API Key authentication.
+
+## Prerequisites
+
+1. Log in to the Cursor dashboard as a team admin
+2. Go to **Settings > API** and generate or copy the team API key
+
+## K8s Secret
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-cursor-main
+  labels:
+    app.kubernetes.io/part-of: insight
+  annotations:
+    insight.cyberfabric.com/connector: cursor
+    insight.cyberfabric.com/source-id: cursor-main
+type: Opaque
+stringData:
+  api_key: ""                           # Cursor team API key
+```
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `api_key` | Yes | Cursor team API key (Settings > API) |
+
+### Automatically injected
+
+| Field | Source |
+|-------|--------|
+| `insight_tenant_id` | `tenant_id` from tenant YAML |
+| `insight_source_id` | `insight.cyberfabric.com/source-id` annotation |
+
+### Local development
+
+Create `src/ingestion/secrets/connectors/cursor.yaml` (gitignored) from the example:
+
+```bash
+cp src/ingestion/secrets/connectors/cursor.yaml.example src/ingestion/secrets/connectors/cursor.yaml
+# Fill in real values, then apply:
+kubectl apply -f src/ingestion/secrets/connectors/cursor.yaml
+```
+
+## Streams
+
+| Stream | Description | Sync Mode |
+|--------|-------------|-----------|
+| `cursor_members` | Team member roster (email, name, role) | Full refresh |
+| `cursor_audit_logs` | Audit events (user actions) | Incremental |
+| `cursor_usage_events` | Per-request usage events (hourly) | Incremental |
+| `cursor_usage_events_daily_resync` | Per-request usage events (daily resync, finalized costs) | Incremental |
+| `cursor_daily_usage` | Aggregated daily usage per user | Incremental |
+
+## Silver Targets
+
+- `class_ai_dev_usage` -- unified AI developer tool usage

--- a/src/ingestion/connectors/ai-dev/cursor/connector.yaml
+++ b/src/ingestion/connectors/ai-dev/cursor/connector.yaml
@@ -493,6 +493,7 @@ spec:
     type: object
     required:
       - insight_tenant_id
+      - insight_source_id
       - api_key
     properties:
       insight_tenant_id:
@@ -504,7 +505,6 @@ spec:
         type: string
         title: Insight Source ID
         description: Connector instance identifier for multi-instance deployments
-        default: ""
         order: 1
       api_key:
         type: string

--- a/src/ingestion/connectors/ai-dev/cursor/connector.yaml
+++ b/src/ingestion/connectors/ai-dev/cursor/connector.yaml
@@ -54,7 +54,7 @@ streams:
   - type: DeclarativeStream
     name: cursor_members
     primary_key:
-      - email
+      - unique_key
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -64,6 +64,8 @@ streams:
           tenant_id:
             type: string
           source_id:
+            type: string
+          unique_key:
             type: string
           id:
             type: string
@@ -97,6 +99,10 @@ streams:
         type: NoPagination
     transformations:
       - $ref: "#/definitions/tenant_id_injection"
+      - type: AddFields
+        fields:
+          - path: [unique_key]
+            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ record['email'] }}"
 
   # ── Stream 2: cursor_audit_logs (incremental, GET) ──
   - type: DeclarativeStream
@@ -250,7 +256,7 @@ streams:
         fields:
           - path:
               - unique_key
-            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ record['userEmail'] }}{{ record['timestamp'] }}"
+            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ record['userEmail'] }}|{{ record['timestamp'] }}"
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: timestamp
@@ -341,7 +347,7 @@ streams:
         fields:
           - path:
               - unique_key
-            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ record['userEmail'] }}{{ record['timestamp'] }}"
+            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ record['userEmail'] }}|{{ record['timestamp'] }}"
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: timestamp
@@ -460,7 +466,7 @@ streams:
         fields:
           - path:
               - unique_key
-            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ record['email'] }}{{ record['date'] }}"
+            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ record['email'] }}|{{ record['date'] }}"
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: date

--- a/src/ingestion/connectors/ai-dev/cursor/connector.yaml
+++ b/src/ingestion/connectors/ai-dev/cursor/connector.yaml
@@ -17,7 +17,7 @@ definitions:
       - path: [tenant_id]
         value: "{{ config['insight_tenant_id'] }}"
       - path: [source_id]
-        value: "{{ config.get('insight_source_id', '') }}"
+        value: "{{ config['insight_source_id'] }}"
 
   post_paginator:
     type: DefaultPaginator
@@ -102,7 +102,7 @@ streams:
       - type: AddFields
         fields:
           - path: [unique_key]
-            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ record['email'] }}"
+            value: "{{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['email'] }}"
 
   # ── Stream 2: cursor_audit_logs (incremental, GET) ──
   - type: DeclarativeStream
@@ -256,7 +256,7 @@ streams:
         fields:
           - path:
               - unique_key
-            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ record['userEmail'] }}|{{ record['timestamp'] }}"
+            value: "{{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['userEmail'] }}|{{ record['timestamp'] }}"
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: timestamp
@@ -347,7 +347,7 @@ streams:
         fields:
           - path:
               - unique_key
-            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ record['userEmail'] }}|{{ record['timestamp'] }}"
+            value: "{{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['userEmail'] }}|{{ record['timestamp'] }}"
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: timestamp
@@ -466,7 +466,7 @@ streams:
         fields:
           - path:
               - unique_key
-            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ record['email'] }}|{{ record['date'] }}"
+            value: "{{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['email'] }}|{{ record['date'] }}"
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: date

--- a/src/ingestion/connectors/ai-dev/cursor/connector.yaml
+++ b/src/ingestion/connectors/ai-dev/cursor/connector.yaml
@@ -493,7 +493,6 @@ spec:
     type: object
     required:
       - insight_tenant_id
-      - insight_source_id
       - api_key
     properties:
       insight_tenant_id:
@@ -505,6 +504,7 @@ spec:
         type: string
         title: Insight Source ID
         description: Connector instance identifier for multi-instance deployments
+        default: ""
         order: 1
       api_key:
         type: string

--- a/src/ingestion/connectors/ai-dev/cursor/connector.yaml
+++ b/src/ingestion/connectors/ai-dev/cursor/connector.yaml
@@ -500,11 +500,13 @@ spec:
         type: string
         title: Insight Tenant ID
         description: Insight tenant isolation identifier (UUID)
+        minLength: 1
         order: 0
       insight_source_id:
         type: string
         title: Insight Source ID
         description: Connector instance identifier for multi-instance deployments
+        minLength: 1
         order: 1
       api_key:
         type: string

--- a/src/ingestion/connectors/ai-dev/cursor/connector.yaml
+++ b/src/ingestion/connectors/ai-dev/cursor/connector.yaml
@@ -15,7 +15,9 @@ definitions:
     type: AddFields
     fields:
       - path: [tenant_id]
-        value: "{{ config['tenant_id'] }}"
+        value: "{{ config['insight_tenant_id'] }}"
+      - path: [source_id]
+        value: "{{ config.get('insight_source_id', '') }}"
 
   post_paginator:
     type: DefaultPaginator
@@ -61,6 +63,8 @@ streams:
         properties:
           tenant_id:
             type: string
+          source_id:
+            type: string
           id:
             type: string
           name:
@@ -71,6 +75,7 @@ streams:
             type: string
           isRemoved:
             type: boolean
+        additionalProperties: true
     retriever:
       type: SimpleRetriever
       requester:
@@ -106,6 +111,8 @@ streams:
         properties:
           tenant_id:
             type: string
+          source_id:
+            type: string
           event_id:
             type: string
           timestamp:
@@ -122,6 +129,7 @@ streams:
             type:
               - string
               - "null"
+        additionalProperties: true
     retriever:
       type: SimpleRetriever
       requester:
@@ -167,7 +175,7 @@ streams:
   - type: DeclarativeStream
     name: cursor_usage_events
     primary_key:
-      - unique
+      - unique_key
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -176,7 +184,9 @@ streams:
         properties:
           tenant_id:
             type: string
-          unique:
+          source_id:
+            type: string
+          unique_key:
             type: string
           userEmail:
             type: string
@@ -211,6 +221,7 @@ streams:
                 type: number
               totalCents:
                 type: number
+        additionalProperties: true
     retriever:
       type: SimpleRetriever
       requester:
@@ -238,8 +249,8 @@ streams:
       - type: AddFields
         fields:
           - path:
-              - unique
-            value: "{{ record['userEmail'] }}{{ record['timestamp'] }}"
+              - unique_key
+            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ record['userEmail'] }}{{ record['timestamp'] }}"
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: timestamp
@@ -255,7 +266,7 @@ streams:
   - type: DeclarativeStream
     name: cursor_usage_events_daily_resync
     primary_key:
-      - unique
+      - unique_key
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -264,7 +275,9 @@ streams:
         properties:
           tenant_id:
             type: string
-          unique:
+          source_id:
+            type: string
+          unique_key:
             type: string
           userEmail:
             type: string
@@ -299,6 +312,7 @@ streams:
                 type: number
               totalCents:
                 type: number
+        additionalProperties: true
     retriever:
       type: SimpleRetriever
       requester:
@@ -326,8 +340,8 @@ streams:
       - type: AddFields
         fields:
           - path:
-              - unique
-            value: "{{ record['userEmail'] }}{{ record['timestamp'] }}"
+              - unique_key
+            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ record['userEmail'] }}{{ record['timestamp'] }}"
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: timestamp
@@ -347,7 +361,7 @@ streams:
   - type: DeclarativeStream
     name: cursor_daily_usage
     primary_key:
-      - unique
+      - unique_key
     schema_loader:
       type: InlineSchemaLoader
       schema:
@@ -356,7 +370,9 @@ streams:
         properties:
           tenant_id:
             type: string
-          unique:
+          source_id:
+            type: string
+          unique_key:
             type: string
           userId:
             type: string
@@ -418,6 +434,7 @@ streams:
             type: number
           apiKeyReqs:
             type: number
+        additionalProperties: true
     retriever:
       type: SimpleRetriever
       requester:
@@ -442,8 +459,8 @@ streams:
       - type: AddFields
         fields:
           - path:
-              - unique
-            value: "{{ record['email'] }}{{ record['date'] }}"
+              - unique_key
+            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ record['email'] }}{{ record['date'] }}"
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: date
@@ -469,20 +486,26 @@ spec:
     $schema: http://json-schema.org/draft-07/schema#
     type: object
     required:
-      - tenant_id
+      - insight_tenant_id
+      - insight_source_id
       - api_key
     properties:
-      tenant_id:
+      insight_tenant_id:
         type: string
-        title: Tenant ID
-        description: Tenant isolation identifier (UUID)
+        title: Insight Tenant ID
+        description: Insight tenant isolation identifier (UUID)
         order: 0
+      insight_source_id:
+        type: string
+        title: Insight Source ID
+        description: Connector instance identifier for multi-instance deployments
+        order: 1
       api_key:
         type: string
         title: API Key
         description: Cursor team API key
         airbyte_secret: true
-        order: 1
+        order: 2
     additionalProperties: true
 
 metadata:

--- a/src/ingestion/connectors/ai-dev/cursor/dbt/schema.yml
+++ b/src/ingestion/connectors/ai-dev/cursor/dbt/schema.yml
@@ -22,6 +22,10 @@ models:
         description: "Tenant isolation field — framework-injected"
         tests:
           - not_null
+      - name: source_id
+        description: "Connector instance identifier — framework-injected"
+        tests:
+          - not_null
       - name: user_email
         description: "User email (identity key for Silver step 2 resolution)"
         tests:

--- a/src/ingestion/connectors/ai-dev/cursor/dbt/schema.yml
+++ b/src/ingestion/connectors/ai-dev/cursor/dbt/schema.yml
@@ -18,12 +18,16 @@ models:
       Deduplication: yesterday and earlier from daily_resync (finalized costs),
       today from hourly stream (near-real-time).
     columns:
-      - name: tenant_id
-        description: "Tenant isolation field — framework-injected"
+      - name: insight_tenant_id
+        description: "Insight tenant isolation identifier (mapped from Bronze tenant_id)"
         tests:
           - not_null
-      - name: source_id
-        description: "Connector instance identifier — framework-injected"
+      - name: insight_source_id
+        description: "Connector instance identifier (mapped from Bronze source_id)"
+        tests:
+          - not_null
+      - name: insight_source_type
+        description: "Source system type (always 'cursor')"
         tests:
           - not_null
       - name: user_email

--- a/src/ingestion/connectors/ai-dev/cursor/dbt/to_cursor_ai_dev_usage.sql
+++ b/src/ingestion/connectors/ai-dev/cursor/dbt/to_cursor_ai_dev_usage.sql
@@ -7,8 +7,9 @@
 WITH resync AS (
     -- Authoritative data for completed days (yesterday and earlier)
     SELECT
-        tenant_id,
-        source_id,
+        tenant_id AS insight_tenant_id,
+        source_id AS insight_source_id,
+        'cursor' AS insight_source_type,
         userEmail                   AS user_email,
         timestamp                   AS event_timestamp,
         kind                        AS event_kind,
@@ -31,8 +32,9 @@ WITH resync AS (
 realtime AS (
     -- Near-real-time data for today only
     SELECT
-        tenant_id,
-        source_id,
+        tenant_id AS insight_tenant_id,
+        source_id AS insight_source_id,
+        'cursor' AS insight_source_type,
         userEmail                   AS user_email,
         timestamp                   AS event_timestamp,
         kind                        AS event_kind,

--- a/src/ingestion/connectors/ai-dev/cursor/dbt/to_cursor_ai_dev_usage.sql
+++ b/src/ingestion/connectors/ai-dev/cursor/dbt/to_cursor_ai_dev_usage.sql
@@ -8,6 +8,7 @@ WITH resync AS (
     -- Authoritative data for completed days (yesterday and earlier)
     SELECT
         tenant_id,
+        source_id,
         userEmail                   AS user_email,
         timestamp                   AS event_timestamp,
         kind                        AS event_kind,
@@ -31,6 +32,7 @@ realtime AS (
     -- Near-real-time data for today only
     SELECT
         tenant_id,
+        source_id,
         userEmail                   AS user_email,
         timestamp                   AS event_timestamp,
         kind                        AS event_kind,

--- a/src/ingestion/connectors/ai-dev/cursor/descriptor.yaml
+++ b/src/ingestion/connectors/ai-dev/cursor/descriptor.yaml
@@ -1,5 +1,6 @@
 name: cursor
 version: '1.0'
+type: nocode
 schedule: 0 2 * * *
 dbt_select: tag:cursor+
 workflow: sync

--- a/src/ingestion/connectors/ai/claude-api/README.md
+++ b/src/ingestion/connectors/ai/claude-api/README.md
@@ -58,6 +58,18 @@ kubectl apply -f src/ingestion/secrets/connectors/claude-api.yaml
 | `claude_api_workspaces` | Organization workspaces | Full refresh |
 | `claude_api_invites` | Pending invitations | Full refresh |
 
+## Migration
+
+**From `tenant_id` to `insight_tenant_id` spec (PR #142):**
+
+The connector spec changed `tenant_id` → `insight_tenant_id` and added `insight_source_id` as required. After merging:
+
+1. Ensure K8s Secret exists with `insight.cyberfabric.com/source-id` annotation
+2. Run `register.sh` (or `upload-manifests.sh`) to update the Airbyte definition
+3. Run `connect.sh` (or `apply-connections.sh`) to update existing source configs — this auto-injects `insight_tenant_id` and `insight_source_id` from tenant YAML and Secret annotation
+
+Without step 3, existing Airbyte sources will fail validation on next sync.
+
 ## Silver Targets
 
 - `class_ai_api_usage` -- unified AI API usage metrics

--- a/src/ingestion/connectors/ai/claude-api/README.md
+++ b/src/ingestion/connectors/ai/claude-api/README.md
@@ -1,0 +1,63 @@
+# Claude API Connector
+
+API usage reports, cost reports, API keys, workspaces, and invites from the Anthropic Admin API.
+
+## Prerequisites
+
+1. Log in to the Anthropic Console as an organization admin
+2. Go to **Settings > Admin API Keys** and generate a new admin API key
+3. The key must have organization-level read permissions
+
+## K8s Secret
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-claude-api-main
+  labels:
+    app.kubernetes.io/part-of: insight
+  annotations:
+    insight.cyberfabric.com/connector: claude-api
+    insight.cyberfabric.com/source-id: claude-api-main
+type: Opaque
+stringData:
+  admin_api_key: ""                     # Anthropic Admin API key
+```
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `admin_api_key` | Yes | Anthropic Admin API key (Console > Settings > Admin API Keys) |
+
+### Automatically injected
+
+| Field | Source |
+|-------|--------|
+| `insight_tenant_id` | `tenant_id` from tenant YAML |
+| `insight_source_id` | `insight.cyberfabric.com/source-id` annotation |
+
+### Local development
+
+Create `src/ingestion/secrets/connectors/claude-api.yaml` (gitignored) from the example:
+
+```bash
+cp src/ingestion/secrets/connectors/claude-api.yaml.example src/ingestion/secrets/connectors/claude-api.yaml
+# Fill in real values, then apply:
+kubectl apply -f src/ingestion/secrets/connectors/claude-api.yaml
+```
+
+## Streams
+
+| Stream | Description | Sync Mode |
+|--------|-------------|-----------|
+| `claude_api_messages_usage` | Token usage per model/key/workspace/day | Incremental |
+| `claude_api_cost_report` | Cost breakdown per workspace/day | Incremental |
+| `claude_api_keys` | Organization API keys | Full refresh |
+| `claude_api_workspaces` | Organization workspaces | Full refresh |
+| `claude_api_invites` | Pending invitations | Full refresh |
+
+## Silver Targets
+
+- `class_ai_api_usage` -- unified AI API usage metrics

--- a/src/ingestion/connectors/ai/claude-api/connector.yaml
+++ b/src/ingestion/connectors/ai/claude-api/connector.yaml
@@ -512,6 +512,7 @@ spec:
     type: object
     required:
       - insight_tenant_id
+      - insight_source_id
       - admin_api_key
     properties:
       insight_tenant_id:
@@ -523,7 +524,6 @@ spec:
         type: string
         title: Insight Source ID
         description: Connector instance identifier for multi-instance deployments
-        default: ""
         order: 1
       admin_api_key:
         type: string

--- a/src/ingestion/connectors/ai/claude-api/connector.yaml
+++ b/src/ingestion/connectors/ai/claude-api/connector.yaml
@@ -519,11 +519,13 @@ spec:
         type: string
         title: Insight Tenant ID
         description: Insight tenant isolation identifier (UUID)
+        minLength: 1
         order: 0
       insight_source_id:
         type: string
         title: Insight Source ID
         description: Connector instance identifier for multi-instance deployments
+        minLength: 1
         order: 1
       admin_api_key:
         type: string

--- a/src/ingestion/connectors/ai/claude-api/connector.yaml
+++ b/src/ingestion/connectors/ai/claude-api/connector.yaml
@@ -23,7 +23,7 @@ definitions:
       - path: [tenant_id]
         value: "{{ config['insight_tenant_id'] }}"
       - path: [source_id]
-        value: "{{ config.get('insight_source_id', '') }}"
+        value: "{{ config['insight_source_id'] }}"
       - path: [collected_at]
         value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
       - path: [data_source]
@@ -157,7 +157,7 @@ streams:
           - path: [web_search_requests]
             value: "{{ record.get('server_tool_use', {}).get('web_search_requests', 0) }}"
           - path: [unique_key]
-            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ stream_interval['start_time'][:10] }}|{{ record.get('model') or '' }}|{{ record.get('api_key_id') or '' }}|{{ record.get('workspace_id') or '' }}|{{ record.get('service_tier') or '' }}|{{ record.get('context_window') or '' }}"
+            value: "{{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ stream_interval['start_time'][:10] }}|{{ record.get('model') or '' }}|{{ record.get('api_key_id') or '' }}|{{ record.get('workspace_id') or '' }}|{{ record.get('service_tier') or '' }}|{{ record.get('context_window') or '' }}"
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: date
@@ -274,7 +274,7 @@ streams:
           - path: [date]
             value: "{{ stream_interval['start_time'][:10] }}"
           - path: [unique_key]
-            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ stream_interval['start_time'][:10] }}|{{ record.get('workspace_id') or '' }}|{{ record.get('description') or '' }}"
+            value: "{{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ stream_interval['start_time'][:10] }}|{{ record.get('workspace_id') or '' }}|{{ record.get('description') or '' }}"
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: date

--- a/src/ingestion/connectors/ai/claude-api/connector.yaml
+++ b/src/ingestion/connectors/ai/claude-api/connector.yaml
@@ -512,7 +512,6 @@ spec:
     type: object
     required:
       - insight_tenant_id
-      - insight_source_id
       - admin_api_key
     properties:
       insight_tenant_id:
@@ -524,6 +523,7 @@ spec:
         type: string
         title: Insight Source ID
         description: Connector instance identifier for multi-instance deployments
+        default: ""
         order: 1
       admin_api_key:
         type: string

--- a/src/ingestion/connectors/ai/claude-api/connector.yaml
+++ b/src/ingestion/connectors/ai/claude-api/connector.yaml
@@ -21,8 +21,8 @@ definitions:
     type: AddFields
     fields:
       - path: [tenant_id]
-        value: "{{ config['tenant_id'] }}"
-      - path: [insight_source_id]
+        value: "{{ config['insight_tenant_id'] }}"
+      - path: [source_id]
         value: "{{ config.get('insight_source_id', '') }}"
       - path: [collected_at]
         value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
@@ -59,18 +59,19 @@ streams:
   - type: DeclarativeStream
     name: claude_api_messages_usage
     primary_key:
-      - unique
+      - unique_key
     schema_loader:
       type: InlineSchemaLoader
       schema:
         $schema: http://json-schema.org/schema#
         type: object
+        additionalProperties: true
         properties:
           tenant_id:
             type: string
-          insight_source_id:
+          source_id:
             type: string
-          unique:
+          unique_key:
             type: string
           date:
             type: string
@@ -155,8 +156,8 @@ streams:
             value: "{{ record.get('cache_creation', {}).get('ephemeral_1h_input_tokens', 0) }}"
           - path: [web_search_requests]
             value: "{{ record.get('server_tool_use', {}).get('web_search_requests', 0) }}"
-          - path: [unique]
-            value: "{{ stream_interval['start_time'][:10] }}|{{ record.get('model') or '' }}|{{ record.get('api_key_id') or '' }}|{{ record.get('workspace_id') or '' }}|{{ record.get('service_tier') or '' }}|{{ record.get('context_window') or '' }}"
+          - path: [unique_key]
+            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ stream_interval['start_time'][:10] }}|{{ record.get('model') or '' }}|{{ record.get('api_key_id') or '' }}|{{ record.get('workspace_id') or '' }}|{{ record.get('service_tier') or '' }}|{{ record.get('context_window') or '' }}"
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: date
@@ -183,18 +184,19 @@ streams:
   - type: DeclarativeStream
     name: claude_api_cost_report
     primary_key:
-      - unique
+      - unique_key
     schema_loader:
       type: InlineSchemaLoader
       schema:
         $schema: http://json-schema.org/schema#
         type: object
+        additionalProperties: true
         properties:
           tenant_id:
             type: string
-          insight_source_id:
+          source_id:
             type: string
-          unique:
+          unique_key:
             type: string
           date:
             type: string
@@ -271,8 +273,8 @@ streams:
         fields:
           - path: [date]
             value: "{{ stream_interval['start_time'][:10] }}"
-          - path: [unique]
-            value: "{{ stream_interval['start_time'][:10] }}|{{ record.get('workspace_id') or '' }}|{{ record.get('description') or '' }}"
+          - path: [unique_key]
+            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ stream_interval['start_time'][:10] }}|{{ record.get('workspace_id') or '' }}|{{ record.get('description') or '' }}"
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: date
@@ -305,10 +307,11 @@ streams:
       schema:
         $schema: http://json-schema.org/schema#
         type: object
+        additionalProperties: true
         properties:
           tenant_id:
             type: string
-          insight_source_id:
+          source_id:
             type: string
           id:
             type: string
@@ -384,10 +387,11 @@ streams:
       schema:
         $schema: http://json-schema.org/schema#
         type: object
+        additionalProperties: true
         properties:
           tenant_id:
             type: string
-          insight_source_id:
+          source_id:
             type: string
           id:
             type: string
@@ -449,10 +453,11 @@ streams:
       schema:
         $schema: http://json-schema.org/schema#
         type: object
+        additionalProperties: true
         properties:
           tenant_id:
             type: string
-          insight_source_id:
+          source_id:
             type: string
           id:
             type: string
@@ -506,25 +511,25 @@ spec:
     $schema: http://json-schema.org/draft-07/schema#
     type: object
     required:
-      - tenant_id
+      - insight_tenant_id
+      - insight_source_id
       - admin_api_key
     properties:
-      tenant_id:
+      insight_tenant_id:
         type: string
-        title: Tenant ID
-        description: Tenant isolation identifier (UUID)
+        title: Insight Tenant ID
+        description: Insight tenant isolation identifier (UUID)
         order: 0
+      insight_source_id:
+        type: string
+        title: Insight Source ID
+        description: Connector instance identifier for multi-instance deployments
+        order: 1
       admin_api_key:
         type: string
         title: Admin API Key
         description: Anthropic Admin API key (from Anthropic Console)
         airbyte_secret: true
-        order: 1
-      insight_source_id:
-        type: string
-        title: Source Instance ID
-        description: Optional connector instance identifier for multi-instance deployments
-        default: ""
         order: 2
       start_date:
         type: string

--- a/src/ingestion/connectors/ai/claude-api/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/claude-api/dbt/schema.yml
@@ -18,12 +18,16 @@ models:
       Joins messages_usage with keys and workspaces for dimension enrichment.
       person_id is always NULL (API usage has no direct user attribution).
     columns:
-      - name: tenant_id
-        description: "Tenant isolation field — framework-injected"
+      - name: insight_tenant_id
+        description: "Insight tenant isolation identifier (mapped from Bronze tenant_id)"
         tests:
           - not_null
-      - name: source_id
-        description: "Connector instance identifier — framework-injected"
+      - name: insight_source_id
+        description: "Connector instance identifier (mapped from Bronze source_id)"
+        tests:
+          - not_null
+      - name: insight_source_type
+        description: "Source system type (always 'claude-api')"
         tests:
           - not_null
       - name: unique_id

--- a/src/ingestion/connectors/ai/claude-api/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/claude-api/dbt/schema.yml
@@ -22,8 +22,10 @@ models:
         description: "Tenant isolation field — framework-injected"
         tests:
           - not_null
-      - name: insight_source_id
-        description: "Connector instance identifier"
+      - name: source_id
+        description: "Connector instance identifier — framework-injected"
+        tests:
+          - not_null
       - name: unique_id
         description: "Composite dedup key: date|model|api_key_id|workspace_id|service_tier|context_window"
         tests:

--- a/src/ingestion/connectors/ai/claude-api/dbt/to_ai_api_usage.sql
+++ b/src/ingestion/connectors/ai/claude-api/dbt/to_ai_api_usage.sql
@@ -53,7 +53,8 @@ SELECT
     u.insight_source_id,
     u.insight_source_type,
     -- composite unique id for incremental
-    concat(u.report_date, '|', u.model, '|', u.api_key_id, '|',
+    concat(u.insight_tenant_id, '-', u.insight_source_id, '-',
+           u.report_date, '|', u.model, '|', u.api_key_id, '|',
            u.workspace_id, '|', u.service_tier, '|',
            u.context_window)                        AS unique_id,
     u.report_date,

--- a/src/ingestion/connectors/ai/claude-api/dbt/to_ai_api_usage.sql
+++ b/src/ingestion/connectors/ai/claude-api/dbt/to_ai_api_usage.sql
@@ -4,8 +4,9 @@
 
 WITH usage AS (
     SELECT
-        tenant_id,
-        source_id,
+        tenant_id AS insight_tenant_id,
+        source_id AS insight_source_id,
+        'claude-api' AS insight_source_type,
         date                                        AS report_date,
         model,
         api_key_id,
@@ -48,8 +49,9 @@ workspaces AS (
 )
 
 SELECT
-    u.tenant_id,
-    u.source_id,
+    u.insight_tenant_id,
+    u.insight_source_id,
+    u.insight_source_type,
     -- composite unique id for incremental
     concat(u.report_date, '|', u.model, '|', u.api_key_id, '|',
            u.workspace_id, '|', u.service_tier, '|',
@@ -78,5 +80,5 @@ SELECT
     u.data_source,
     u.collected_at
 FROM usage u
-LEFT JOIN keys k ON u.tenant_id = k.tenant_id AND u.api_key_id = k.id
-LEFT JOIN workspaces w ON u.tenant_id = w.tenant_id AND u.workspace_id = w.id
+LEFT JOIN keys k ON u.insight_tenant_id = k.tenant_id AND u.api_key_id = k.id
+LEFT JOIN workspaces w ON u.insight_tenant_id = w.tenant_id AND u.workspace_id = w.id

--- a/src/ingestion/connectors/ai/claude-api/dbt/to_ai_api_usage.sql
+++ b/src/ingestion/connectors/ai/claude-api/dbt/to_ai_api_usage.sql
@@ -5,7 +5,7 @@
 WITH usage AS (
     SELECT
         tenant_id,
-        insight_source_id,
+        source_id,
         date                                        AS report_date,
         model,
         api_key_id,
@@ -49,7 +49,7 @@ workspaces AS (
 
 SELECT
     u.tenant_id,
-    u.insight_source_id,
+    u.source_id,
     -- composite unique id for incremental
     concat(u.report_date, '|', u.model, '|', u.api_key_id, '|',
            u.workspace_id, '|', u.service_tier, '|',

--- a/src/ingestion/connectors/ai/claude-api/descriptor.yaml
+++ b/src/ingestion/connectors/ai/claude-api/descriptor.yaml
@@ -1,5 +1,6 @@
 name: claude-api
 version: '1.0'
+type: nocode
 schedule: 0 2 * * *
 dbt_select: tag:claude-api+
 workflow: sync

--- a/src/ingestion/connectors/ai/claude-team/README.md
+++ b/src/ingestion/connectors/ai/claude-team/README.md
@@ -58,6 +58,18 @@ kubectl apply -f src/ingestion/secrets/connectors/claude-team.yaml
 | `claude_team_workspace_members` | Per-workspace membership | Full refresh |
 | `claude_team_invites` | Pending invitations | Full refresh |
 
+## Migration
+
+**From `tenant_id` to `insight_tenant_id` spec (PR #142):**
+
+The connector spec changed `tenant_id` → `insight_tenant_id` and added `insight_source_id` as required. After merging:
+
+1. Ensure K8s Secret exists with `insight.cyberfabric.com/source-id` annotation
+2. Run `register.sh` (or `upload-manifests.sh`) to update the Airbyte definition
+3. Run `connect.sh` (or `apply-connections.sh`) to update existing source configs — this auto-injects `insight_tenant_id` and `insight_source_id` from tenant YAML and Secret annotation
+
+Without step 3, existing Airbyte sources will fail validation on next sync.
+
 ## Silver Targets
 
 - `class_ai_dev_usage` -- unified AI developer tool usage (from Claude Code)

--- a/src/ingestion/connectors/ai/claude-team/README.md
+++ b/src/ingestion/connectors/ai/claude-team/README.md
@@ -1,0 +1,64 @@
+# Claude Team Connector
+
+Team users, Claude Code usage, workspaces, workspace members, and invites from the Anthropic Admin API.
+
+## Prerequisites
+
+1. Log in to the Anthropic Console as a team/enterprise admin
+2. Go to **Settings > Admin API Keys** and generate a new admin API key
+3. The key must have organization-level read permissions
+
+## K8s Secret
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-claude-team-main
+  labels:
+    app.kubernetes.io/part-of: insight
+  annotations:
+    insight.cyberfabric.com/connector: claude-team
+    insight.cyberfabric.com/source-id: claude-team-main
+type: Opaque
+stringData:
+  admin_api_key: ""                     # Anthropic Admin API key
+```
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `admin_api_key` | Yes | Anthropic Admin API key (Console > Settings > Admin API Keys) |
+
+### Automatically injected
+
+| Field | Source |
+|-------|--------|
+| `insight_tenant_id` | `tenant_id` from tenant YAML |
+| `insight_source_id` | `insight.cyberfabric.com/source-id` annotation |
+
+### Local development
+
+Create `src/ingestion/secrets/connectors/claude-team.yaml` (gitignored) from the example:
+
+```bash
+cp src/ingestion/secrets/connectors/claude-team.yaml.example src/ingestion/secrets/connectors/claude-team.yaml
+# Fill in real values, then apply:
+kubectl apply -f src/ingestion/secrets/connectors/claude-team.yaml
+```
+
+## Streams
+
+| Stream | Description | Sync Mode |
+|--------|-------------|-----------|
+| `claude_team_users` | Team seat roster (email, name, role) | Full refresh |
+| `claude_team_code_usage` | Daily Claude Code usage per user | Incremental |
+| `claude_team_workspaces` | Workspace structure | Full refresh |
+| `claude_team_workspace_members` | Per-workspace membership | Full refresh |
+| `claude_team_invites` | Pending invitations | Full refresh |
+
+## Silver Targets
+
+- `class_ai_dev_usage` -- unified AI developer tool usage (from Claude Code)
+- `class_ai_tool_usage` -- Claude conversational usage (planned)

--- a/src/ingestion/connectors/ai/claude-team/connector.yaml
+++ b/src/ingestion/connectors/ai/claude-team/connector.yaml
@@ -508,6 +508,7 @@ spec:
     type: object
     required:
       - insight_tenant_id
+      - insight_source_id
       - admin_api_key
     properties:
       insight_tenant_id:
@@ -519,7 +520,6 @@ spec:
         type: string
         title: Insight Source ID
         description: Connector instance identifier for multi-instance deployments
-        default: ""
         order: 1
       admin_api_key:
         type: string

--- a/src/ingestion/connectors/ai/claude-team/connector.yaml
+++ b/src/ingestion/connectors/ai/claude-team/connector.yaml
@@ -21,8 +21,8 @@ definitions:
     type: AddFields
     fields:
       - path: [tenant_id]
-        value: "{{ config['tenant_id'] }}"
-      - path: [insight_source_id]
+        value: "{{ config['insight_tenant_id'] }}"
+      - path: [source_id]
         value: "{{ config.get('insight_source_id', '') }}"
       - path: [collected_at]
         value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
@@ -76,10 +76,11 @@ streams:
       schema:
         $schema: http://json-schema.org/schema#
         type: object
+        additionalProperties: true
         properties:
           tenant_id:
             type: string
-          insight_source_id:
+          source_id:
             type: string
           id:
             type: string
@@ -139,18 +140,19 @@ streams:
   - type: DeclarativeStream
     name: claude_team_code_usage
     primary_key:
-      - unique
+      - unique_key
     schema_loader:
       type: InlineSchemaLoader
       schema:
         $schema: http://json-schema.org/schema#
         type: object
+        additionalProperties: true
         properties:
           tenant_id:
             type: string
-          insight_source_id:
+          source_id:
             type: string
-          unique:
+          unique_key:
             type: string
           date:
             type: string
@@ -251,8 +253,8 @@ streams:
             value: "{{ record.get('tool_actions', {}) | tojson }}"
           - path: [model_breakdown_json]
             value: "{{ record.get('model_breakdown', []) | tojson }}"
-          - path: [unique]
-            value: "{{ record.get('date', '')[:10] }}|{{ record.get('actor', {}).get('type') or '' }}|{{ record.get('actor', {}).get('api_key_name') or record.get('actor', {}).get('email') or '' }}|{{ record.get('terminal_type') or '' }}"
+          - path: [unique_key]
+            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ record.get('date', '')[:10] }}|{{ record.get('actor', {}).get('type') or '' }}|{{ record.get('actor', {}).get('api_key_name') or record.get('actor', {}).get('email') or '' }}|{{ record.get('terminal_type') or '' }}"
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: date
@@ -281,10 +283,11 @@ streams:
       schema:
         $schema: http://json-schema.org/schema#
         type: object
+        additionalProperties: true
         properties:
           tenant_id:
             type: string
-          insight_source_id:
+          source_id:
             type: string
           id:
             type: string
@@ -340,18 +343,19 @@ streams:
   - type: DeclarativeStream
     name: claude_team_workspace_members
     primary_key:
-      - unique
+      - unique_key
     schema_loader:
       type: InlineSchemaLoader
       schema:
         $schema: http://json-schema.org/schema#
         type: object
+        additionalProperties: true
         properties:
           tenant_id:
             type: string
-          insight_source_id:
+          source_id:
             type: string
-          unique:
+          unique_key:
             type: string
           type:
             type:
@@ -432,8 +436,8 @@ streams:
         fields:
           - path: [workspace_id]
             value: "{{ stream_partition['workspace_id'] }}"
-          - path: [unique]
-            value: "{{ record.get('user_id', '') }}:{{ stream_partition['workspace_id'] }}"
+          - path: [unique_key]
+            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ record.get('user_id', '') }}:{{ stream_partition['workspace_id'] }}"
 
   # ── Stream 5: claude_team_invites (full refresh) ──
   - type: DeclarativeStream
@@ -445,10 +449,11 @@ streams:
       schema:
         $schema: http://json-schema.org/schema#
         type: object
+        additionalProperties: true
         properties:
           tenant_id:
             type: string
-          insight_source_id:
+          source_id:
             type: string
           id:
             type: string
@@ -502,25 +507,25 @@ spec:
     $schema: http://json-schema.org/draft-07/schema#
     type: object
     required:
-      - tenant_id
+      - insight_tenant_id
+      - insight_source_id
       - admin_api_key
     properties:
-      tenant_id:
+      insight_tenant_id:
         type: string
-        title: Tenant ID
-        description: Tenant isolation identifier (UUID)
+        title: Insight Tenant ID
+        description: Insight tenant isolation identifier (UUID)
         order: 0
+      insight_source_id:
+        type: string
+        title: Insight Source ID
+        description: Connector instance identifier for multi-instance deployments
+        order: 1
       admin_api_key:
         type: string
         title: Admin API Key
         description: Anthropic Admin API key for Team/Enterprise workspace
         airbyte_secret: true
-        order: 1
-      insight_source_id:
-        type: string
-        title: Source Instance ID
-        description: Optional connector instance identifier for multi-instance deployments
-        default: ""
         order: 2
       start_date:
         type: string

--- a/src/ingestion/connectors/ai/claude-team/connector.yaml
+++ b/src/ingestion/connectors/ai/claude-team/connector.yaml
@@ -508,7 +508,6 @@ spec:
     type: object
     required:
       - insight_tenant_id
-      - insight_source_id
       - admin_api_key
     properties:
       insight_tenant_id:
@@ -520,6 +519,7 @@ spec:
         type: string
         title: Insight Source ID
         description: Connector instance identifier for multi-instance deployments
+        default: ""
         order: 1
       admin_api_key:
         type: string

--- a/src/ingestion/connectors/ai/claude-team/connector.yaml
+++ b/src/ingestion/connectors/ai/claude-team/connector.yaml
@@ -23,7 +23,7 @@ definitions:
       - path: [tenant_id]
         value: "{{ config['insight_tenant_id'] }}"
       - path: [source_id]
-        value: "{{ config.get('insight_source_id', '') }}"
+        value: "{{ config['insight_source_id'] }}"
       - path: [collected_at]
         value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
       - path: [data_source]
@@ -254,7 +254,7 @@ streams:
           - path: [model_breakdown_json]
             value: "{{ record.get('model_breakdown', []) | tojson }}"
           - path: [unique_key]
-            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ record.get('date', '')[:10] }}|{{ record.get('actor', {}).get('type') or '' }}|{{ record.get('actor', {}).get('api_key_name') or record.get('actor', {}).get('email') or '' }}|{{ record.get('terminal_type') or '' }}"
+            value: "{{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record.get('date', '')[:10] }}|{{ record.get('actor', {}).get('type') or '' }}|{{ record.get('actor', {}).get('api_key_name') or record.get('actor', {}).get('email') or '' }}|{{ record.get('terminal_type') or '' }}"
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: date
@@ -437,7 +437,7 @@ streams:
           - path: [workspace_id]
             value: "{{ stream_partition['workspace_id'] }}"
           - path: [unique_key]
-            value: "{{ config['insight_tenant_id'] }}-{{ config.get('insight_source_id', '') }}-{{ record.get('user_id', '') }}:{{ stream_partition['workspace_id'] }}"
+            value: "{{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record.get('user_id', '') }}:{{ stream_partition['workspace_id'] }}"
 
   # ── Stream 5: claude_team_invites (full refresh) ──
   - type: DeclarativeStream

--- a/src/ingestion/connectors/ai/claude-team/connector.yaml
+++ b/src/ingestion/connectors/ai/claude-team/connector.yaml
@@ -515,11 +515,13 @@ spec:
         type: string
         title: Insight Tenant ID
         description: Insight tenant isolation identifier (UUID)
+        minLength: 1
         order: 0
       insight_source_id:
         type: string
         title: Insight Source ID
         description: Connector instance identifier for multi-instance deployments
+        minLength: 1
         order: 1
       admin_api_key:
         type: string

--- a/src/ingestion/connectors/ai/claude-team/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/claude-team/dbt/schema.yml
@@ -22,8 +22,10 @@ models:
         description: "Tenant isolation field — framework-injected"
         tests:
           - not_null
-      - name: insight_source_id
-        description: "Connector instance identifier"
+      - name: source_id
+        description: "Connector instance identifier — framework-injected"
+        tests:
+          - not_null
       - name: unique_id
         description: "Composite dedup key: date|actor_identifier|terminal_type"
         tests:

--- a/src/ingestion/connectors/ai/claude-team/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/claude-team/dbt/schema.yml
@@ -18,12 +18,16 @@ models:
       Filters code_usage to actor_type='user', maps actor_identifier as email.
       Feeds class_ai_dev_usage alongside Cursor and Windsurf.
     columns:
-      - name: tenant_id
-        description: "Tenant isolation field — framework-injected"
+      - name: insight_tenant_id
+        description: "Insight tenant isolation identifier (mapped from Bronze tenant_id)"
         tests:
           - not_null
-      - name: source_id
-        description: "Connector instance identifier — framework-injected"
+      - name: insight_source_id
+        description: "Connector instance identifier (mapped from Bronze source_id)"
+        tests:
+          - not_null
+      - name: insight_source_type
+        description: "Source system type (always 'claude-team')"
         tests:
           - not_null
       - name: unique_id

--- a/src/ingestion/connectors/ai/claude-team/dbt/to_ai_dev_usage.sql
+++ b/src/ingestion/connectors/ai/claude-team/dbt/to_ai_dev_usage.sql
@@ -10,7 +10,8 @@ SELECT
     'claude-team' AS insight_source_type,
     -- actor_type omitted from key: model filters to actor_type='user' so it's
     -- always constant; Bronze unique key includes it (see connector.yaml)
-    concat(date, '|', actor_identifier, '|', terminal_type)
+    concat(insight_tenant_id, '-', insight_source_id, '-',
+           date, '|', actor_identifier, '|', terminal_type)
                                                     AS unique_id,
     date                                            AS report_date,
     actor_identifier                                AS email,

--- a/src/ingestion/connectors/ai/claude-team/dbt/to_ai_dev_usage.sql
+++ b/src/ingestion/connectors/ai/claude-team/dbt/to_ai_dev_usage.sql
@@ -5,8 +5,9 @@
 {{ config(materialized='incremental', unique_key='unique_id') }}
 
 SELECT
-    tenant_id,
-    source_id,
+    tenant_id AS insight_tenant_id,
+    source_id AS insight_source_id,
+    'claude-team' AS insight_source_type,
     -- actor_type omitted from key: model filters to actor_type='user' so it's
     -- always constant; Bronze unique key includes it (see connector.yaml)
     concat(date, '|', actor_identifier, '|', terminal_type)

--- a/src/ingestion/connectors/ai/claude-team/dbt/to_ai_dev_usage.sql
+++ b/src/ingestion/connectors/ai/claude-team/dbt/to_ai_dev_usage.sql
@@ -6,7 +6,7 @@
 
 SELECT
     tenant_id,
-    source_instance_id,
+    source_id,
     -- actor_type omitted from key: model filters to actor_type='user' so it's
     -- always constant; Bronze unique key includes it (see connector.yaml)
     concat(date, '|', actor_identifier, '|', terminal_type)

--- a/src/ingestion/connectors/ai/claude-team/dbt/to_ai_tool_usage.sql
+++ b/src/ingestion/connectors/ai/claude-team/dbt/to_ai_tool_usage.sql
@@ -20,7 +20,7 @@
 --   5. Set data_source = 'insight_claude_team'
 --
 -- Expected Silver schema (class_ai_tool_usage):
---   tenant_id, insight_source_id, unique_id, report_date, email,
+--   tenant_id, source_id, unique_id, report_date, email,
 --   client (web/mobile), model, message_count, conversation_count,
 --   input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
 --   person_id (NULL until Silver step 2), provider, data_source, collected_at

--- a/src/ingestion/connectors/ai/claude-team/descriptor.yaml
+++ b/src/ingestion/connectors/ai/claude-team/descriptor.yaml
@@ -1,5 +1,6 @@
 name: claude-team
 version: '1.0'
+type: nocode
 schedule: 0 2 * * *
 dbt_select: tag:claude-team+
 workflow: sync

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__comms_events.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__comms_events.sql
@@ -6,8 +6,9 @@
 ) }}
 
 SELECT
-    tenant_id,
-    source_id,
+    tenant_id AS insight_tenant_id,
+    source_id AS insight_source_id,
+    'm365' AS insight_source_type,
     unique_key,
     userPrincipalName AS user_email,
     sendCount AS emails_sent,

--- a/src/ingestion/connectors/collaboration/m365/dbt/schema.yml
+++ b/src/ingestion/connectors/collaboration/m365/dbt/schema.yml
@@ -11,10 +11,13 @@ models:
   - name: m365__comms_events
     description: "M365 communication events → staging, feeds class_comms_events"
     columns:
-      - name: tenant_id
+      - name: insight_tenant_id
         tests:
           - not_null
-      - name: source_id
+      - name: insight_source_id
+        tests:
+          - not_null
+      - name: insight_source_type
         tests:
           - not_null
       - name: unique_key

--- a/src/ingestion/connectors/collaboration/zoom/dbt/schema.yml
+++ b/src/ingestion/connectors/collaboration/zoom/dbt/schema.yml
@@ -12,10 +12,13 @@ models:
   - name: zoom__comms_events
     description: "Zoom communication events (meetings + chat) -> staging, feeds class_comms_events"
     columns:
-      - name: tenant_id
+      - name: insight_tenant_id
         tests:
           - not_null
-      - name: source_id
+      - name: insight_source_id
+        tests:
+          - not_null
+      - name: insight_source_type
         tests:
           - not_null
       - name: unique_key

--- a/src/ingestion/connectors/collaboration/zoom/dbt/zoom__comms_events.sql
+++ b/src/ingestion/connectors/collaboration/zoom/dbt/zoom__comms_events.sql
@@ -6,8 +6,9 @@
 ) }}
 
 SELECT
-    p.tenant_id,
-    p.source_id,
+    p.tenant_id AS insight_tenant_id,
+    p.source_id AS insight_source_id,
+    'zoom' AS insight_source_type,
     p.unique_key,
     p.user_name,
     COALESCE(p.email, '') AS user_email,

--- a/src/ingestion/connectors/hr-directory/bamboohr/dbt/schema.yml
+++ b/src/ingestion/connectors/hr-directory/bamboohr/dbt/schema.yml
@@ -17,12 +17,16 @@ models:
       SCD Type 2 fields (valid_from/valid_to) are set as current-state snapshot
       (valid_from = lastChanged, valid_to = NULL).
     columns:
-      - name: tenant_id
-        description: "Tenant isolation identifier"
+      - name: insight_tenant_id
+        description: "Insight tenant isolation identifier (mapped from Bronze tenant_id)"
         tests:
           - not_null
-      - name: source_id
-        description: "Connector instance identifier"
+      - name: insight_source_id
+        description: "Connector instance identifier (mapped from Bronze source_id)"
+        tests:
+          - not_null
+      - name: insight_source_type
+        description: "Source system type (always 'bamboohr')"
         tests:
           - not_null
       - name: unique_key

--- a/src/ingestion/connectors/hr-directory/bamboohr/dbt/to_class_people.sql
+++ b/src/ingestion/connectors/hr-directory/bamboohr/dbt/to_class_people.sql
@@ -9,8 +9,9 @@
 ) }}
 
 SELECT
-    tenant_id,
-    source_id,
+    tenant_id AS insight_tenant_id,
+    source_id AS insight_source_id,
+    'bamboohr' AS insight_source_type,
     unique_key,
     coalesce(tenant_id, '')                         AS workspace_id,
     -- person_id resolved in Silver Step 2 via Identity Manager

--- a/src/ingestion/dbt/silver/schema.yml
+++ b/src/ingestion/dbt/silver/schema.yml
@@ -4,12 +4,16 @@ models:
   - name: class_comms_events
     description: "Unified communication events from all sources"
     columns:
-      - name: tenant_id
-        description: "Tenant isolation field"
+      - name: insight_tenant_id
+        description: "Insight tenant isolation field (mapped from Bronze tenant_id)"
         tests:
           - not_null
-      - name: source_id
-        description: "Source instance identifier"
+      - name: insight_source_id
+        description: "Connector instance identifier (mapped from Bronze source_id)"
+        tests:
+          - not_null
+      - name: insight_source_type
+        description: "Source system type (e.g. zoom, m365)"
         tests:
           - not_null
       - name: unique_key

--- a/src/ingestion/secrets/connectors/claude-api.yaml.example
+++ b/src/ingestion/secrets/connectors/claude-api.yaml.example
@@ -10,3 +10,4 @@ metadata:
 type: Opaque
 stringData:
   admin_api_key: "CHANGE_ME"
+  start_date: "2026-01-01T00:00:00Z"          # Optional: earliest date to collect (default: 90 days ago)

--- a/src/ingestion/secrets/connectors/claude-api.yaml.example
+++ b/src/ingestion/secrets/connectors/claude-api.yaml.example
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-claude-api-main
+  labels:
+    app.kubernetes.io/part-of: insight
+  annotations:
+    insight.cyberfabric.com/connector: claude-api
+    insight.cyberfabric.com/source-id: claude-api-main
+type: Opaque
+stringData:
+  admin_api_key: "CHANGE_ME"

--- a/src/ingestion/secrets/connectors/claude-team.yaml.example
+++ b/src/ingestion/secrets/connectors/claude-team.yaml.example
@@ -10,3 +10,4 @@ metadata:
 type: Opaque
 stringData:
   admin_api_key: "CHANGE_ME"
+  start_date: "2026-01-01"                     # Optional: earliest date for code usage (default: 90 days ago)

--- a/src/ingestion/secrets/connectors/claude-team.yaml.example
+++ b/src/ingestion/secrets/connectors/claude-team.yaml.example
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-claude-team-main
+  labels:
+    app.kubernetes.io/part-of: insight
+  annotations:
+    insight.cyberfabric.com/connector: claude-team
+    insight.cyberfabric.com/source-id: claude-team-main
+type: Opaque
+stringData:
+  admin_api_key: "CHANGE_ME"

--- a/src/ingestion/secrets/connectors/cursor.yaml.example
+++ b/src/ingestion/secrets/connectors/cursor.yaml.example
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-cursor-main
+  labels:
+    app.kubernetes.io/part-of: insight
+  annotations:
+    insight.cyberfabric.com/connector: cursor
+    insight.cyberfabric.com/source-id: cursor-main
+type: Opaque
+stringData:
+  api_key: "CHANGE_ME"


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#142](https://github.com/cyberfabric/cyber-insight/pull/142) | **Author:** Gregory91G | **Opened:** 2026-04-09T14:54:58Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

> **Depends on**: #1184 — must be merged first. This branch is based on `identity-init` and will conflict if merged before #1184.

## Summary

- Align cursor, claude-api, and claude-team connectors with project conventions and PR #1182 connector checklist
- Migrate config spec to `insight_tenant_id` / `insight_source_id` (ADR-0003); Bronze output columns use short names `tenant_id` / `source_id` (convention: Bronze preserves short names, Silver applies `insight_` prefix)
- Rename composite dedup field `unique` → `unique_key` with `{tenant_id}-{source_id}-{natural_key}` pattern for global uniqueness (consistent with reference connectors bamboohr, m365, zoom)
- Add `additionalProperties: true` to all 15 inline stream schemas (forward-compatible with API changes)
- Fix `cursor_granularity: P1D` → `PT1S` in claude-api incremental streams (prevents `ending_at == starting_at` on current-day partition — ADR-003)
- Apply same fix defensively to claude-team (ADR-001)
- Fix claude-team pagination: `after_id` → `next_page` for code_usage stream
- Add `type: nocode`, `workflow: sync` to descriptors; remove `streams` / `silver_targets` blocks per PR #1182 convention
- Add `source_id` to cursor/claude-team dbt model SELECT and all three dbt schema.yml with `not_null` test
- Create README.md with K8s Secret documentation for each connector
- Create K8s Secret `.yaml.example` templates for cursor, claude-api, claude-team
- Update DESIGN specs to reflect all changes (config params, Bronze schemas, unique_key, ADR references)

## Test plan

- [x] `cpt validate` passes for all modified DESIGN and ADR artifacts (claude-api DESIGN: 6 pre-existing errors unrelated to this PR)
- [x] `/connector validate cursor claude-api claude-team` — all checks pass per PR #1182 checklist
- [x] Airbyte connection catalog confirmed: `unique_key`, `source_id`, `tenant_id` in discovered schema (verified via API)
- [x] Reference connector bamboohr: sync + dbt succeeded, schema unchanged (`tenant_id` + `source_id` + `unique_key`)
- [ ] Airbyte sync for cursor, claude-api, claude-team — Bronze tables will be recreated with correct schema on next sync (old tables dropped; connection catalogs verified correct)
- [ ] dbt models compile and run for connector-specific tags (blocked by sync completion)

## Migration required

`insight_source_id` is now **required** in all three connector specs (was optional/absent). Existing Airbyte sources will fail validation unless updated.

**Deployment order** (before next scheduled sync at `0 2 * * *`):

1. **K8s Secrets**: ensure each Secret has annotation `insight.cyberfabric.com/source-id` (see `secrets/connectors/*.yaml.example`)
2. **Register**: `register.sh --all` (or `upload-manifests.sh --all`) — updates Airbyte definitions
3. **Connect**: `connect.sh test-local` (or `apply-connections.sh test-local`) — updates existing source configs, auto-injects `insight_tenant_id` and `insight_source_id`

Step 3 patches existing Airbyte sources via API — no manual Airbyte config editing needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cursor, Claude Team, and Claude API connector documentation and READMEs.

* **Improvements**
  * Standardized tenant/source naming (tenant_id → insight_tenant_id) and made insight_source_id required; added insight_source_type tagging.

* **Connector Updates**
  * Switched deduplication primary keys from `unique` to `unique_key` and prefixed keys with tenant/source.

* **Documentation**
  * Added secret examples, migration guidance for the breaking config rename, and deployment/update procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#142 -->