### PR TITLE
[PR #139] Add GitHub v2 connector (CDK, GraphQL)

### DIFF
--- a/src/ingestion/connectors/git/github-v2/Dockerfile
+++ b/src/ingestion/connectors/git/github-v2/Dockerfile
@@ -1,0 +1,10 @@
+FROM airbyte/python-connector-base:2.0.0
+
+COPY . /airbyte/integration_code
+RUN pip install /airbyte/integration_code
+
+RUN useradd --create-home --no-log-init --shell /bin/bash airbyte_user
+USER airbyte_user
+
+ENV AIRBYTE_ENTRYPOINT="python /airbyte/integration_code/source_github_v2/source.py"
+ENTRYPOINT ["python", "/airbyte/integration_code/source_github_v2/source.py"]

--- a/src/ingestion/connectors/git/github-v2/descriptor.yaml
+++ b/src/ingestion/connectors/git/github-v2/descriptor.yaml
@@ -1,0 +1,51 @@
+name: github-v2
+version: "1.0"
+type: cdk
+schedule: "0 2 * * *"
+workflow: sync
+dbt_select: "tag:github+"
+
+connection:
+  namespace: "bronze_github"
+
+silver_targets:
+  - class_git_repositories
+  - class_git_repository_branches
+  - class_git_commits
+  - class_git_file_changes
+  - class_git_pull_requests
+  - class_git_pull_requests_reviewers
+  - class_git_pull_requests_comments
+  - class_git_pull_requests_commits
+
+streams:
+  - name: repositories
+    bronze_table: repositories
+    primary_key: [unique_key]
+    cursor_field: updated_at
+  - name: branches
+    bronze_table: branches
+    primary_key: [unique_key]
+  - name: commits
+    bronze_table: commits
+    primary_key: [unique_key]
+    cursor_field: committed_date
+  - name: file_changes
+    bronze_table: file_changes
+    primary_key: [unique_key]
+  - name: pull_requests
+    bronze_table: pull_requests
+    primary_key: [unique_key]
+    cursor_field: updated_at
+  - name: pull_request_reviews
+    bronze_table: pull_request_reviews
+    primary_key: [unique_key]
+  - name: pull_request_comments
+    bronze_table: pull_request_comments
+    primary_key: [unique_key]
+  - name: pull_request_review_comments
+    bronze_table: pull_request_review_comments
+    primary_key: [unique_key]
+  - name: pull_request_commits
+    bronze_table: pull_request_commits
+    primary_key: [unique_key]

--- a/src/ingestion/connectors/git/github-v2/pyproject.toml
+++ b/src/ingestion/connectors/git/github-v2/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=68.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "source-github-insight-v2"
+version = "0.1.0"
+description = "Airbyte source connector for GitHub (CDK-native, ConcurrentSource)"
+requires-python = ">=3.10"
+dependencies = [
+    "airbyte-cdk>=7.16.0",
+    "requests>=2.31.0",
+]
+
+[project.scripts]
+source-github-insight-v2 = "source_github_v2.source:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["source_github_v2*"]

--- a/src/ingestion/connectors/git/github-v2/source_github_v2/auth.py
+++ b/src/ingestion/connectors/git/github-v2/source_github_v2/auth.py
@@ -1,0 +1,20 @@
+"""GitHub authentication helpers."""
+
+
+def auth_headers(token: str) -> dict:
+    """Build authentication headers for GitHub API requests."""
+    return {
+        "Authorization": f"Bearer {token}",
+        "User-Agent": "insight-github-connector/1.0",
+    }
+
+
+def rest_headers(token: str) -> dict:
+    headers = auth_headers(token)
+    headers["Accept"] = "application/vnd.github+json"
+    headers["X-GitHub-Api-Version"] = "2022-11-28"
+    return headers
+
+
+def graphql_headers(token: str) -> dict:
+    return auth_headers(token)

--- a/src/ingestion/connectors/git/github-v2/source_github_v2/queries.py
+++ b/src/ingestion/connectors/git/github-v2/source_github_v2/queries.py
@@ -1,0 +1,373 @@
+"""GraphQL query templates for GitHub API v4.
+
+GraphQL for bulk listing (commits, PRs) and PR commit linkage.
+REST for reviews, comments (simpler pagination).
+"""
+
+BULK_COMMIT_QUERY = """
+query($owner: String!, $repo: String!, $branch: String!, $first: Int!, $after: String, $since: GitTimestamp) {
+  repository(owner: $owner, name: $repo) {
+    ref(qualifiedName: $branch) {
+      target {
+        ... on Commit {
+          history(first: $first, after: $after, since: $since) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              oid
+              message
+              committedDate
+              authoredDate
+              additions
+              deletions
+              changedFilesIfAvailable
+              author {
+                name
+                email
+                user {
+                  login
+                  databaseId
+                }
+              }
+              committer {
+                name
+                email
+                user {
+                  login
+                  databaseId
+                }
+              }
+              parents(first: 10) {
+                nodes {
+                  oid
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  rateLimit {
+    cost
+    remaining
+    resetAt
+  }
+}
+"""
+
+BULK_PR_QUERY = """
+query($owner: String!, $repo: String!, $first: Int!, $after: String, $orderBy: IssueOrder!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequests(first: $first, after: $after, orderBy: $orderBy, states: [OPEN, CLOSED, MERGED]) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      nodes {
+        databaseId
+        number
+        title
+        body
+        state
+        merged
+        isDraft
+        createdAt
+        updatedAt
+        closedAt
+        mergedAt
+        headRefName
+        baseRefName
+        additions
+        deletions
+        changedFiles
+        author {
+          login
+          ... on User {
+            databaseId
+            email
+          }
+        }
+        reviewDecision
+        labels(first: 20) {
+          nodes {
+            name
+          }
+        }
+        milestone {
+          title
+        }
+        mergeCommit {
+          oid
+        }
+        mergedBy {
+          login
+          ... on User {
+            databaseId
+          }
+        }
+        commits(first: __COMMITS_PAGE_SIZE__) {
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          nodes { commit { oid committedDate } }
+        }
+        comments(first: __COMMENTS_PAGE_SIZE__) {
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            databaseId
+            body
+            createdAt
+            updatedAt
+            author {
+              login
+              ... on User { databaseId }
+            }
+            authorAssociation
+          }
+        }
+        reviews(first: __REVIEWS_PAGE_SIZE__) {
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            databaseId
+            state
+            body
+            submittedAt
+            authorAssociation
+            commit { oid }
+            author {
+              login
+              ... on User { databaseId }
+            }
+          }
+        }
+        reviewThreads(first: __RT_PAGE_SIZE__) {
+          totalCount
+          pageInfo { hasNextPage endCursor }
+          nodes {
+            id
+            isResolved
+            comments(first: __RTC_PAGE_SIZE__) {
+              pageInfo { hasNextPage endCursor }
+              nodes {
+                databaseId
+                body
+                path
+                line
+                startLine
+                diffHunk
+                createdAt
+                updatedAt
+                author {
+                  login
+                  ... on User { databaseId }
+                }
+                authorAssociation
+                commit { oid }
+                originalCommit { oid }
+                replyTo { databaseId }
+              }
+            }
+          }
+        }
+        reviewRequests(first: 20) {
+          nodes {
+            requestedReviewer {
+              ... on User {
+                login
+                databaseId
+              }
+              ... on Team {
+                name
+                slug
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  rateLimit {
+    cost
+    remaining
+    resetAt
+  }
+}
+"""
+
+PR_REVIEWS_QUERY = """
+query($owner: String!, $repo: String!, $prNumber: Int!, $first: Int!, $after: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $prNumber) {
+      reviews(first: $first, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          databaseId
+          state
+          body
+          submittedAt
+          authorAssociation
+          commit { oid }
+          author {
+            login
+            ... on User { databaseId }
+          }
+        }
+      }
+    }
+  }
+  rateLimit {
+    cost
+    remaining
+    resetAt
+  }
+}
+"""
+
+PR_COMMENTS_QUERY = """
+query($owner: String!, $repo: String!, $prNumber: Int!, $first: Int!, $after: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $prNumber) {
+      comments(first: $first, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          databaseId
+          body
+          createdAt
+          updatedAt
+          author {
+            login
+            ... on User { databaseId }
+          }
+          authorAssociation
+        }
+      }
+    }
+  }
+  rateLimit {
+    cost
+    remaining
+    resetAt
+  }
+}
+"""
+
+PR_COMMITS_QUERY = """
+query($owner: String!, $repo: String!, $prNumber: Int!, $first: Int!, $after: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $prNumber) {
+      commits(first: $first, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          commit {
+            oid
+            committedDate
+          }
+        }
+      }
+    }
+  }
+  rateLimit {
+    cost
+    remaining
+    resetAt
+  }
+}
+"""
+
+PR_REVIEW_THREADS_QUERY = """
+query($owner: String!, $repo: String!, $prNumber: Int!, $first: Int!, $after: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $prNumber) {
+      reviewThreads(first: $first, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          isResolved
+          comments(first: 100) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              databaseId
+              body
+              path
+              line
+              startLine
+              diffHunk
+              createdAt
+              updatedAt
+              author {
+                login
+                ... on User { databaseId }
+              }
+              authorAssociation
+              commit { oid }
+              originalCommit { oid }
+              replyTo { databaseId }
+            }
+          }
+        }
+      }
+    }
+  }
+  rateLimit {
+    cost
+    remaining
+    resetAt
+  }
+}
+"""
+
+PR_THREAD_COMMENTS_QUERY = """
+query($threadId: ID!, $first: Int!, $after: String) {
+  node(id: $threadId) {
+    ... on PullRequestReviewThread {
+      isResolved
+      comments(first: $first, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          databaseId
+          body
+          path
+          line
+          startLine
+          diffHunk
+          createdAt
+          updatedAt
+          author {
+            login
+            ... on User { databaseId }
+          }
+          authorAssociation
+          commit { oid }
+          originalCommit { oid }
+          replyTo { databaseId }
+        }
+      }
+    }
+  }
+  rateLimit {
+    cost
+    remaining
+    resetAt
+  }
+}
+"""
+

--- a/src/ingestion/connectors/git/github-v2/source_github_v2/source.py
+++ b/src/ingestion/connectors/git/github-v2/source_github_v2/source.py
@@ -1,0 +1,170 @@
+"""GitHub Airbyte source connector v2 (CDK-native, ConcurrentSource-ready).
+
+For now this is a standard ``AbstractSource`` that returns ``HttpStream``
+instances.  ``ConcurrentSource`` + ``StreamFacade`` wrapping will be added
+once all streams work correctly in sequential mode.
+"""
+
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any, List, Mapping, Optional, Tuple
+
+import requests
+from airbyte_cdk.sources import AbstractSource
+from airbyte_cdk.sources.streams import Stream
+
+from source_github_v2.auth import rest_headers
+
+logger = logging.getLogger("airbyte")
+
+
+class SourceGitHubV2(AbstractSource):
+    """Entry-point for the GitHub v2 Airbyte source connector."""
+
+    def spec(self, logger: Any) -> Mapping[str, Any]:
+        from airbyte_cdk.models import ConnectorSpecification
+
+        spec_path = Path(__file__).parent / "spec.json"
+        return ConnectorSpecification(**json.loads(spec_path.read_text()))
+
+    def check_connection(
+        self, logger: Any, config: Mapping[str, Any]
+    ) -> Tuple[bool, Optional[Any]]:
+        """Validate auth token and access to each configured organization."""
+        token = config["github_token"]
+        organizations = config.get("github_organizations", [])
+        headers = rest_headers(token)
+
+        try:
+            # Validate the token itself
+            resp = requests.get(
+                "https://api.github.com/rate_limit",
+                headers=headers,
+                timeout=10,
+            )
+            if resp.status_code != 200:
+                return False, (
+                    f"Token validation failed ({resp.status_code}): "
+                    f"{resp.text[:200]}"
+                )
+
+            # Verify access to each organization
+            for org in organizations:
+                resp = requests.get(
+                    f"https://api.github.com/orgs/{org}/repos?per_page=1",
+                    headers=headers,
+                    timeout=10,
+                )
+                if resp.status_code == 404:
+                    return False, (
+                        f"Organization '{org}' not found or not accessible "
+                        f"with this token"
+                    )
+                if resp.status_code == 403:
+                    return False, (
+                        f"Token lacks permission to access organization '{org}'"
+                    )
+                if resp.status_code != 200:
+                    return False, (
+                        f"Failed to access org '{org}' ({resp.status_code}): "
+                        f"{resp.text[:200]}"
+                    )
+
+            return True, None
+        except Exception as exc:
+            return False, str(exc)
+
+    def streams(self, config: Mapping[str, Any]) -> List[Stream]:
+        """Build the stream dependency graph.
+
+        Stream hierarchy::
+
+            repos
+            +-- branches
+            |   +-- commits
+            |       +-- file_changes
+            +-- prs
+                +-- reviews
+                +-- comments
+                +-- pr_commits
+        """
+        token = config["github_token"]
+        tenant_id = config["insight_tenant_id"]
+        source_id = config["insight_source_id"]
+        organizations = config["github_organizations"]
+        start_date = config.get("github_start_date")
+        skip_archived = config.get("github_skip_archived", True)
+        skip_forks = config.get("github_skip_forks", True)
+        pr_page_size = config.get("github_pr_page_size", 25)
+        embedded_page_sizes = {
+            "commits": config.get("github_embedded_commits_per_pr", 10),
+            "reviews": config.get("github_embedded_reviews_per_pr", 10),
+            "comments": config.get("github_embedded_comments_per_pr", 10),
+            "review_threads": config.get("github_embedded_review_threads_per_pr", 15),
+            "thread_comments": config.get("github_embedded_thread_comments", 2),
+        }
+
+        shared = {
+            "token": token,
+            "tenant_id": tenant_id,
+            "source_id": source_id,
+        }
+
+        # -- Lazy imports to avoid circular dependencies at module level ----
+        from source_github_v2.streams.repositories import RepositoriesStream
+        from source_github_v2.streams.branches import BranchesStream
+        from source_github_v2.streams.commits import CommitsStream
+        from source_github_v2.streams.pull_requests import PullRequestsStream
+        from source_github_v2.streams.reviews import ReviewsStream
+        from source_github_v2.streams.comments import CommentsStream
+        from source_github_v2.streams.pr_commits import PRCommitsStream
+        from source_github_v2.streams.file_changes import FileChangesStream
+        from source_github_v2.streams.review_comments import ReviewCommentsStream
+
+        repos = RepositoriesStream(
+            organizations=organizations,
+            skip_archived=skip_archived,
+            skip_forks=skip_forks,
+            **shared,
+        )
+        branches = BranchesStream(parent=repos, **shared)
+        commits = CommitsStream(parent=branches, start_date=start_date, **shared)
+        prs = PullRequestsStream(
+            parent=repos, start_date=start_date, page_size=pr_page_size,
+            embedded_page_sizes=embedded_page_sizes,
+            **shared,
+        )
+        reviews = ReviewsStream(parent=prs, **shared)
+        comments = CommentsStream(parent=prs, **shared)
+        pr_commits = PRCommitsStream(parent=prs, **shared)
+        review_comments = ReviewCommentsStream(parent=prs, **shared)
+        file_changes = FileChangesStream(
+            parent=commits,
+            **shared,
+        )
+
+        return [
+            repos,
+            branches,
+            prs,
+            reviews,
+            comments,
+            review_comments,
+            pr_commits,
+            commits,        # slow — GraphQL pagination across all branches
+            file_changes,   # slowest — one REST call per commit
+        ]
+
+
+def main() -> None:
+    """CLI entry-point (``source-github-insight-v2``)."""
+    source = SourceGitHubV2()
+    from airbyte_cdk.entrypoint import launch
+
+    launch(source, sys.argv[1:])
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ingestion/connectors/git/github-v2/source_github_v2/spec.json
+++ b/src/ingestion/connectors/git/github-v2/source_github_v2/spec.json
@@ -1,0 +1,117 @@
+{
+  "documentationUrl": "https://docs.github.com/en/rest",
+  "connectionSpecification": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "GitHub Source v2",
+    "type": "object",
+    "required": ["insight_tenant_id", "insight_source_id", "github_token", "github_organizations"],
+    "additionalProperties": true,
+    "properties": {
+      "insight_tenant_id": {
+        "type": "string",
+        "title": "Tenant ID",
+        "description": "Tenant isolation identifier (UUID).",
+        "order": 0
+      },
+      "insight_source_id": {
+        "type": "string",
+        "title": "Source ID",
+        "description": "Stable identifier for this GitHub instance (e.g., 'github-acme-prod').",
+        "examples": ["github-acme-prod"],
+        "order": 1
+      },
+      "github_token": {
+        "type": "string",
+        "title": "Access Token",
+        "description": "GitHub Personal Access Token or GitHub App installation token. Required scopes: repo, read:org, read:user.",
+        "airbyte_secret": true,
+        "order": 2
+      },
+      "github_organizations": {
+        "type": "array",
+        "items": { "type": "string" },
+        "title": "Organizations",
+        "description": "List of GitHub organization logins to collect.",
+        "minItems": 1,
+        "order": 3
+      },
+      "github_start_date": {
+        "type": "string",
+        "title": "Start Date",
+        "description": "Start date for initial collection (YYYY-MM-DD). Commits and PRs before this date are skipped on the first run.",
+        "format": "date",
+        "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+        "examples": ["2024-01-01"],
+        "order": 4
+      },
+      "github_pr_page_size": {
+        "type": "integer",
+        "title": "PR Page Size",
+        "description": "Number of pull requests per GraphQL page. Lower values reduce risk of GitHub 504 timeouts. Range: 10-100.",
+        "default": 25,
+        "minimum": 10,
+        "maximum": 100,
+        "order": 5
+      },
+      "github_embedded_commits_per_pr": {
+        "type": "integer",
+        "title": "Embedded Commits per PR",
+        "description": "Max commits embedded per PR in the bulk query. Overflow is fetched separately.",
+        "default": 10,
+        "minimum": 1,
+        "maximum": 100,
+        "order": 6
+      },
+      "github_embedded_reviews_per_pr": {
+        "type": "integer",
+        "title": "Embedded Reviews per PR",
+        "description": "Max reviews embedded per PR in the bulk query. Overflow is fetched separately.",
+        "default": 10,
+        "minimum": 1,
+        "maximum": 100,
+        "order": 7
+      },
+      "github_embedded_comments_per_pr": {
+        "type": "integer",
+        "title": "Embedded Comments per PR",
+        "description": "Max comments embedded per PR in the bulk query. Overflow is fetched separately.",
+        "default": 10,
+        "minimum": 1,
+        "maximum": 100,
+        "order": 8
+      },
+      "github_embedded_review_threads_per_pr": {
+        "type": "integer",
+        "title": "Embedded Review Threads per PR",
+        "description": "Max review threads embedded per PR in the bulk query. Overflow is fetched separately.",
+        "default": 15,
+        "minimum": 1,
+        "maximum": 100,
+        "order": 9
+      },
+      "github_embedded_thread_comments": {
+        "type": "integer",
+        "title": "Embedded Comments per Review Thread",
+        "description": "Max comments per review thread embedded in the bulk query. Overflow is fetched separately.",
+        "default": 2,
+        "minimum": 1,
+        "maximum": 100,
+        "order": 10
+      },
+      "github_skip_archived": {
+        "type": "boolean",
+        "title": "Skip Archived Repos",
+        "description": "Skip archived repositories during collection.",
+        "default": true,
+        "order": 11
+      },
+      "github_skip_forks": {
+        "type": "boolean",
+        "title": "Skip Forked Repos",
+        "description": "Skip forked repositories during collection.",
+        "default": true,
+        "order": 12
+      }
+    }
+  }
+}

--- a/src/ingestion/connectors/git/github-v2/source_github_v2/streams/__init__.py
+++ b/src/ingestion/connectors/git/github-v2/source_github_v2/streams/__init__.py
@@ -1,0 +1,13 @@
+"""GitHub v2 connector streams."""
+
+from source_github_v2.streams.branches import BranchesStream
+from source_github_v2.streams.commits import CommitsStream
+from source_github_v2.streams.pull_requests import PullRequestsStream
+from source_github_v2.streams.repositories import RepositoriesStream
+
+__all__ = [
+    "BranchesStream",
+    "CommitsStream",
+    "PullRequestsStream",
+    "RepositoriesStream",
+]

--- a/src/ingestion/connectors/git/github-v2/source_github_v2/streams/base.py
+++ b/src/ingestion/connectors/git/github-v2/source_github_v2/streams/base.py
@@ -1,0 +1,309 @@
+"""Base stream classes for GitHub REST and GraphQL APIs (v2 connector).
+
+Designed for ConcurrentSource compatibility:
+- No shared mutable state between stream instances
+- Proper stream_slices / next_page_token contracts
+- Rate-limit back-off handled via CDK retry (no external RateLimiter)
+"""
+
+import logging
+import time
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping, MutableMapping, Optional
+
+import requests
+from airbyte_cdk.sources.streams.http import HttpStream
+
+from source_github_v2.auth import graphql_headers, rest_headers
+
+logger = logging.getLogger("airbyte")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class GitHubAuthError(RuntimeError):
+    """Raised on 401/403 (non-rate-limit) to prevent silent swallowing by child streams."""
+    pass
+
+
+def _is_rate_limit_403(resp) -> bool:
+    """Return True if a 403 response is due to rate limit exhaustion, not auth failure."""
+    if resp.status_code != 403:
+        return False
+    if resp.headers.get("Retry-After"):
+        return True
+    if resp.headers.get("X-RateLimit-Remaining") == "0":
+        return True
+    try:
+        body_text = resp.text.lower()
+        if "secondary rate limit" in body_text or "rate limit" in body_text:
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def _make_unique_key(tenant_id: str, source_id: str, *natural_key_parts: str) -> str:
+    return f"{tenant_id}-{source_id}-{'-'.join(natural_key_parts)}"
+
+
+class GitHubRestStream(HttpStream, ABC):
+    """Base for GitHub REST API v3 streams.
+
+    No external ``RateLimiter`` -- back-off is handled entirely through the
+    CDK retry mechanism (``should_retry`` / ``backoff_time``).
+    """
+
+    url_base = "https://api.github.com/"
+    primary_key = "unique_key"
+
+    @property
+    def request_timeout(self) -> Optional[int]:
+        return 60
+
+    def __init__(
+        self,
+        token: str,
+        tenant_id: str,
+        source_id: str,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._token = token
+        self._tenant_id = tenant_id
+        self._source_id = source_id
+
+    def request_headers(self, **kwargs) -> Mapping[str, Any]:
+        return rest_headers(self._token)
+
+    def request_params(self, **kwargs) -> MutableMapping[str, Any]:
+        return {"per_page": "100"}
+
+    def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
+        links = response.links
+        if "next" in links:
+            return {"next_url": links["next"]["url"]}
+        return None
+
+    def path(self, *, next_page_token: Optional[Mapping[str, Any]] = None, **kwargs) -> str:
+        if next_page_token and "next_url" in next_page_token:
+            return next_page_token["next_url"].replace(self.url_base, "")
+        return self._path(**kwargs)
+
+    @abstractmethod
+    def _path(self, **kwargs) -> str:
+        ...
+
+    def should_retry(self, response: requests.Response) -> bool:
+        if not isinstance(response, requests.Response):
+            return True  # connection error — always retry
+        if response.status_code == 403 and _is_rate_limit_403(response):
+            return True
+        if response.status_code in (401, 403, 404, 409):
+            return False
+        return response.status_code in (429, 500, 502, 503, 504)
+
+    def backoff_time(self, response: requests.Response) -> Optional[float]:
+        if not isinstance(response, requests.Response):
+            return 60.0  # connection error — retry after 60s
+        if response.status_code == 429 or (response.status_code == 403 and _is_rate_limit_403(response)):
+            retry_after = response.headers.get("Retry-After")
+            if retry_after:
+                return max(float(retry_after), 1.0)
+            reset = response.headers.get("X-RateLimit-Reset")
+            if reset:
+                wait = float(reset) - time.time() + 1
+                return max(wait, 1.0)
+        if response.status_code in (502, 503):
+            return 60.0
+        return None
+
+    def parse_response(self, response: requests.Response, **kwargs) -> Iterable[Mapping[str, Any]]:
+        if response.status_code == 404:
+            logger.warning(f"Resource not found (404): {response.url}")
+            return
+        if response.status_code == 409:
+            logger.warning(f"Empty repository (409): {response.url}")
+            return
+        data = response.json()
+        records = data if isinstance(data, list) else [data]
+        for record in records:
+            yield self._add_envelope(record)
+
+    def _add_envelope(self, record: dict, pk_parts: Optional[list] = None) -> dict:
+        record = dict(record)  # shallow copy — prevent mutating cached dicts
+        record["tenant_id"] = self._tenant_id
+        record["source_id"] = self._source_id
+        record["data_source"] = "insight_github"
+        record["collected_at"] = _now_iso()
+        if pk_parts:
+            record["unique_key"] = _make_unique_key(self._tenant_id, self._source_id, *pk_parts)
+        return record
+
+
+class GitHubGraphQLStream(HttpStream, ABC):
+    """Base for GitHub GraphQL API v4 streams.
+
+    Uses POST to ``/graphql``.  Back-off handled via CDK retry.
+    """
+
+    url_base = "https://api.github.com/"
+    primary_key = "unique_key"
+    http_method = "POST"
+
+    @property
+    def request_timeout(self) -> Optional[int]:
+        return 120
+
+    def __init__(
+        self,
+        token: str,
+        tenant_id: str,
+        source_id: str,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._token = token
+        self._tenant_id = tenant_id
+        self._source_id = source_id
+
+    @staticmethod
+    def _safe_get(data, *keys):
+        """Navigate nested dicts safely, treating None as empty dict."""
+        for key in keys:
+            data = (data or {}).get(key)
+        return data
+
+    def path(self, **kwargs) -> str:
+        return "graphql"
+
+    def request_headers(self, **kwargs) -> Mapping[str, Any]:
+        return graphql_headers(self._token)
+
+    @abstractmethod
+    def _query(self) -> str:
+        ...
+
+    @abstractmethod
+    def _variables(
+        self,
+        stream_slice: Optional[Mapping[str, Any]] = None,
+        next_page_token: Optional[Mapping[str, Any]] = None,
+    ) -> dict:
+        ...
+
+    @abstractmethod
+    def _extract_nodes(self, data: dict) -> list:
+        ...
+
+    @abstractmethod
+    def _extract_page_info(self, data: dict) -> dict:
+        ...
+
+    def request_body_json(
+        self,
+        stream_slice: Optional[Mapping[str, Any]] = None,
+        next_page_token: Optional[Mapping[str, Any]] = None,
+        **kwargs,
+    ) -> Optional[Mapping[str, Any]]:
+        return {
+            "query": self._query(),
+            "variables": self._variables(stream_slice, next_page_token),
+        }
+
+    def next_page_token(self, response: requests.Response) -> Optional[Mapping[str, Any]]:
+        data = response.json().get("data", {})
+        page_info = self._extract_page_info(data)
+        if page_info.get("hasNextPage"):
+            return {"after": page_info["endCursor"]}
+        return None
+
+    def _is_graphql_rate_limited(self, response: requests.Response) -> bool:
+        """Check if a 200 response contains a GraphQL rate-limit error in the body."""
+        if response.status_code != 200:
+            return False
+        try:
+            body = response.json()
+            for error in body.get("errors", []):
+                err_type = (error.get("type") or "").upper()
+                err_msg = (error.get("message") or "").lower()
+                if err_type == "RATE_LIMITED" or "rate limit" in err_msg:
+                    return True
+        except Exception:
+            pass
+        return False
+
+    def should_retry(self, response: requests.Response) -> bool:
+        if not isinstance(response, requests.Response):
+            return True  # connection error — always retry
+        if self._is_graphql_rate_limited(response):
+            return True
+        if response.status_code == 403 and _is_rate_limit_403(response):
+            return True
+        if response.status_code in (401, 403):
+            return False
+        return response.status_code in (429, 500, 502, 503, 504)
+
+    def backoff_time(self, response: requests.Response) -> Optional[float]:
+        if not isinstance(response, requests.Response):
+            return 60.0  # connection error — retry after 60s
+        if self._is_graphql_rate_limited(response):
+            reset = response.headers.get("x-ratelimit-reset")
+            if reset:
+                wait = float(reset) - time.time() + 1
+                return max(wait, 1.0)
+            return 60.0
+        if response.status_code == 429 or (response.status_code == 403 and _is_rate_limit_403(response)):
+            retry_after = response.headers.get("Retry-After")
+            if retry_after:
+                return max(float(retry_after), 1.0)
+            reset = response.headers.get("x-ratelimit-reset")
+            if reset:
+                wait = float(reset) - time.time() + 1
+                return max(wait, 1.0)
+            return 60.0
+        if response.status_code in (502, 503):
+            return 60.0
+        return None
+
+    def parse_response(
+        self,
+        response: requests.Response,
+        stream_slice: Optional[Mapping[str, Any]] = None,
+        **kwargs,
+    ) -> Iterable[Mapping[str, Any]]:
+        body = response.json()
+        self._update_graphql_rate_limit(body, response)
+
+        if "errors" in body:
+            if "data" not in body or body.get("data") is None:
+                raise RuntimeError(f"GraphQL query failed: {body['errors']}")
+            logger.warning(f"GraphQL partial errors (continuing with data): {body['errors']}")
+
+        data = body.get("data", {})
+        nodes = self._extract_nodes(data)
+        for node in nodes:
+            yield self._add_envelope(node)
+
+    def _update_graphql_rate_limit(self, body: dict, response: requests.Response = None):
+        """Log GraphQL rate limit info from response body or headers."""
+        rate_limit = body.get("data", {}).get("rateLimit", {})
+        remaining = rate_limit.get("remaining")
+        cost = rate_limit.get("cost")
+        if cost is not None:
+            logger.debug(f"GraphQL rate limit: cost={cost}, remaining={remaining}")
+        if remaining is not None and remaining < 100:
+            logger.warning(f"GraphQL rate limit low: {remaining} remaining")
+
+    def _add_envelope(self, record: dict, pk_parts: Optional[list] = None) -> dict:
+        record = dict(record)  # shallow copy — prevent mutating cached dicts
+        record["tenant_id"] = self._tenant_id
+        record["source_id"] = self._source_id
+        record["data_source"] = "insight_github"
+        record["collected_at"] = _now_iso()
+        if pk_parts:
+            record["unique_key"] = _make_unique_key(self._tenant_id, self._source_id, *pk_parts)
+        return record

--- a/src/ingestion/connectors/git/github-v2/source_github_v2/streams/branches.py
+++ b/src/ingestion/connectors/git/github-v2/source_github_v2/streams/branches.py
@@ -1,0 +1,112 @@
+"""GitHub branches stream (REST, full refresh, child of repositories)."""
+
+import json
+import logging
+import os
+import tempfile
+from typing import Any, Iterable, Mapping, Optional
+
+from source_github_v2.streams.base import GitHubRestStream, _make_unique_key
+from source_github_v2.streams.repositories import RepositoriesStream
+
+logger = logging.getLogger("airbyte")
+
+
+class BranchesStream(GitHubRestStream):
+    """Fetches branches for each repository."""
+
+    name = "branches"
+    use_cache = True
+
+    def __init__(self, parent: RepositoriesStream, **kwargs):
+        super().__init__(**kwargs)
+        self._parent = parent
+        self._child_records_path = os.path.join(tempfile.gettempdir(), "insight_branches.jsonl")
+        self._child_records_file: Any = None
+
+    def _path(self, stream_slice: Optional[Mapping[str, Any]] = None, **kwargs) -> str:
+        s = stream_slice or {}
+        owner = s.get("owner", "")
+        repo = s.get("repo", "")
+        if not owner or not repo:
+            raise ValueError("BranchesStream._path() called without owner/repo in stream_slice")
+        return f"repos/{owner}/{repo}/branches"
+
+    def stream_slices(self, **kwargs) -> Iterable[Optional[Mapping[str, Any]]]:
+        for record in self._parent.get_child_records():
+            owner = record.get("owner", "")
+            repo = record.get("name", "")
+            default_branch = record.get("default_branch", "")
+            pushed_at = record.get("pushed_at", "")
+            if owner and repo:
+                yield {
+                    "owner": owner,
+                    "repo": repo,
+                    "default_branch": default_branch,
+                    "pushed_at": pushed_at,
+                }
+
+    def parse_response(self, response, stream_slice=None, **kwargs):
+        s = stream_slice or {}
+        owner = s.get("owner", "")
+        repo = s.get("repo", "")
+        if response.status_code in (404, 409):
+            logger.warning(f"Skipping branches for {owner}/{repo} ({response.status_code})")
+            return
+        branches = response.json()
+        if not isinstance(branches, list):
+            branches = [branches]
+        # Open child records file on first parse_response call
+        if self._child_records_file is None:
+            self._child_records_file = open(self._child_records_path, "w")
+        for branch in branches:
+            branch_name = branch.get("name", "")
+            branch["unique_key"] = _make_unique_key(
+                self._tenant_id, self._source_id, owner, repo, branch_name,
+            )
+            branch["repo_owner"] = owner
+            branch["repo_name"] = repo
+            branch["default_branch_name"] = s.get("default_branch", "")
+            branch["pushed_at"] = s.get("pushed_at", "")
+            # Write minimal child data to disk for commits stream
+            head_sha = (branch.get("commit") or {}).get("sha", "")
+            self._child_records_file.write(json.dumps({
+                "name": branch_name,
+                "repo_owner": owner,
+                "repo_name": repo,
+                "default_branch": s.get("default_branch", ""),
+                "pushed_at": s.get("pushed_at", ""),
+                "commit": {"sha": head_sha},
+            }, separators=(",", ":")) + "\n")
+            yield self._add_envelope(branch)
+
+    def get_child_records(self) -> Iterable:
+        """Yield branch records from disk. Zero memory, zero API calls."""
+        if self._child_records_file and not self._child_records_file.closed:
+            self._child_records_file.close()
+        with open(self._child_records_path, "r") as f:
+            for line in f:
+                line = line.rstrip("\n")
+                if line:
+                    yield json.loads(line)
+
+    def get_json_schema(self) -> Mapping[str, Any]:
+        return {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": True,
+            "properties": {
+                "tenant_id": {"type": "string"},
+                "source_id": {"type": "string"},
+                "unique_key": {"type": "string"},
+                "data_source": {"type": "string"},
+                "collected_at": {"type": "string"},
+                "name": {"type": ["null", "string"]},
+                "commit": {"type": ["null", "object"]},
+                "protected": {"type": ["null", "boolean"]},
+                "repo_owner": {"type": "string"},
+                "repo_name": {"type": "string"},
+                "default_branch_name": {"type": ["null", "string"]},
+                "pushed_at": {"type": ["null", "string"]},
+            },
+        }

--- a/src/ingestion/connectors/git/github-v2/source_github_v2/streams/comments.py
+++ b/src/ingestion/connectors/git/github-v2/source_github_v2/streams/comments.py
@@ -1,0 +1,251 @@
+"""GitHub PR comments stream (GraphQL, per-PR sequential, incremental).
+
+Follows the same pattern as PRCommitsStream:
+- Embedded comments from the parent PR query are yielded first
+- If the PR has <= 100 comments (comments_complete=True), no additional
+  API call is needed
+- Otherwise, pagination continues from the embedded end_cursor
+
+Only fetches general discussion comments (IssueComment on PRs).
+Inline review comments are covered by the reviews stream.
+"""
+
+import logging
+from typing import Any, Iterable, Mapping, MutableMapping, Optional
+
+from source_github_v2.queries import PR_COMMENTS_QUERY
+from source_github_v2.streams.base import (
+    GitHubAuthError,
+    GitHubGraphQLStream,
+    _make_unique_key,
+    _now_iso,
+)
+
+logger = logging.getLogger("airbyte")
+
+
+class CommentsStream(GitHubGraphQLStream):
+    """Fetches discussion comments for each PR via GraphQL.
+
+    Uses per-PR incremental state keyed by owner/repo/pr_number
+    with synced_at = parent PR updated_at.
+    """
+
+    name = "pull_request_comments"
+    cursor_field = "pull_request_updated_at"
+
+    def __init__(self, parent, **kwargs):
+        super().__init__(**kwargs)
+        self._parent = parent
+
+    def _query(self) -> str:
+        return PR_COMMENTS_QUERY
+
+    def stream_slices(
+        self,
+        stream_state: Optional[Mapping[str, Any]] = None,
+        **kwargs,
+    ) -> Iterable[Optional[Mapping[str, Any]]]:
+        state = stream_state or {}
+        total = 0
+        skipped = 0
+        skipped_no_comments = 0
+        for pr in self._parent.get_child_slices():
+            owner = pr.get("repo_owner", "")
+            repo = pr.get("repo_name", "")
+            pr_number = pr.get("number")
+            pr_database_id = pr.get("database_id")
+            pr_updated_at = pr.get("updated_at", "")
+            comment_count = pr.get("comment_count")
+            if not (owner and repo and pr_number):
+                continue
+            total += 1
+            if comment_count == 0:
+                skipped_no_comments += 1
+                continue
+            partition_key = f"{owner}/{repo}/{pr_number}"
+            child_cursor = state.get(partition_key, {}).get("synced_at", "")
+            if pr_updated_at and child_cursor and pr_updated_at <= child_cursor:
+                skipped += 1
+                continue
+            yield {
+                "owner": owner,
+                "repo": repo,
+                "pr_number": pr_number,
+                "pr_database_id": pr_database_id,
+                "pr_updated_at": pr_updated_at,
+                "partition_key": partition_key,
+                "embedded_offset": pr.get("embedded_offset", 0),
+                "comments_complete": pr.get("comments_complete", False),
+                "comments_end_cursor": pr.get("comments_end_cursor"),
+            }
+        fetched = total - skipped - skipped_no_comments
+        if skipped or skipped_no_comments:
+            logger.info(
+                f"Comments: {fetched}/{total} PRs need comment sync "
+                f"({skipped} unchanged, {skipped_no_comments} zero comments)"
+            )
+
+    def _variables(self, stream_slice=None, next_page_token=None) -> dict:
+        s = stream_slice or {}
+        variables: dict = {
+            "owner": s.get("owner", ""),
+            "repo": s.get("repo", ""),
+            "prNumber": s.get("pr_number"),
+            "first": 100,
+        }
+        if next_page_token and "after" in next_page_token:
+            variables["after"] = next_page_token["after"]
+        elif s.get("_overflow_after"):
+            variables["after"] = s["_overflow_after"]
+        return variables
+
+    def _extract_nodes(self, data: dict) -> list:
+        return self._safe_get(data, "repository", "pullRequest", "comments", "nodes") or []
+
+    def _extract_page_info(self, data: dict) -> dict:
+        return self._safe_get(data, "repository", "pullRequest", "comments", "pageInfo") or {}
+
+    def _make_record(self, node: dict, stream_slice: dict) -> dict:
+        """Build an output record from a GraphQL comment node."""
+        s = stream_slice or {}
+        owner = s.get("owner", "")
+        repo = s.get("repo", "")
+        pr_number = s.get("pr_number")
+        pr_database_id = s.get("pr_database_id")
+        pr_id = str(pr_database_id) if pr_database_id is not None else ""
+
+        database_id = node.get("databaseId")
+        comment_id = str(database_id) if database_id is not None else ""
+        author = node.get("author") or {}
+
+        return {
+            "unique_key": _make_unique_key(
+                self._tenant_id, self._source_id, owner, repo, pr_id, comment_id,
+            ),
+            "tenant_id": self._tenant_id,
+            "source_id": self._source_id,
+            "data_source": "insight_github",
+            "collected_at": _now_iso(),
+            "database_id": database_id,
+            "pr_number": pr_number,
+            "pull_request_id": pr_database_id,
+            "body": node.get("body"),
+            "created_at": node.get("createdAt"),
+            "updated_at": node.get("updatedAt"),
+            "author_login": author.get("login"),
+            "author_id": author.get("databaseId"),
+            "author_association": node.get("authorAssociation"),
+            "pull_request_updated_at": s.get("pr_updated_at"),
+            "repo_owner": owner,
+            "repo_name": repo,
+        }
+
+    def parse_response(self, response, stream_slice=None, **kwargs):
+        """CDK calls this for each overflow page."""
+        s = stream_slice or {}
+        owner = s.get("owner", "")
+        repo = s.get("repo", "")
+        pr_number = s.get("pr_number")
+
+        body = response.json()
+        self._update_graphql_rate_limit(body, response)
+
+        if "errors" in body:
+            if "data" not in body or body.get("data") is None:
+                raise RuntimeError(
+                    f"GraphQL errors for {owner}/{repo} PR#{pr_number} comments: {body['errors']}"
+                )
+            logger.warning(f"GraphQL partial errors (continuing with data): {body['errors']}")
+
+        data = body.get("data", {})
+        nodes = self._extract_nodes(data)
+
+        for node in nodes:
+            yield self._make_record(node, s)
+
+    def read_records(self, sync_mode=None, stream_slice=None, stream_state=None, **kwargs):
+        """Yield embedded records first, then overflow-paginate if needed."""
+        s = stream_slice or {}
+        owner = s.get("owner", "")
+        repo = s.get("repo", "")
+        pr_number = s.get("pr_number")
+
+        try:
+            # Step 1: read embedded records from disk
+            comments_data = self._parent.read_embedded_data(s.get("embedded_offset", 0), "comments")
+            embedded_nodes = comments_data.get("nodes") or []
+            embedded_count = 0
+            for node in embedded_nodes:
+                embedded_count += 1
+                yield self._make_record(node, s)
+
+            # Step 2: if embedded data was read successfully, check completeness
+            embedded_data_available = bool(comments_data)
+            if embedded_data_available and s.get("comments_complete", False):
+                logger.debug(f"Comments {owner}/{repo} PR#{pr_number}: {embedded_count} embedded (complete)")
+                return
+
+            # Step 3: overflow or full fetch if embedded data was missing/incomplete
+            if not embedded_data_available:
+                logger.debug(f"Comments {owner}/{repo} PR#{pr_number}: no embedded data, full fetch")
+            else:
+                logger.debug(f"Comments {owner}/{repo} PR#{pr_number}: {embedded_count} embedded, overflow needed")
+            end_cursor = s.get("comments_end_cursor") if embedded_data_available else None
+            if end_cursor:
+                overflow_slice = dict(s)
+                overflow_slice["_overflow_after"] = end_cursor
+                yield from super().read_records(
+                    sync_mode=sync_mode, stream_slice=overflow_slice,
+                    stream_state=stream_state, **kwargs,
+                )
+            else:
+                yield from super().read_records(
+                    sync_mode=sync_mode, stream_slice=stream_slice,
+                    stream_state=stream_state, **kwargs,
+                )
+        except GitHubAuthError:
+            raise
+        except Exception as exc:
+            pk = s.get("partition_key", "?")
+            logger.warning(f"Skipping comments slice {pk}: {exc}")
+
+    def get_updated_state(
+        self,
+        current_stream_state: MutableMapping[str, Any],
+        latest_record: Mapping[str, Any],
+    ) -> MutableMapping[str, Any]:
+        owner = latest_record.get("repo_owner", "")
+        repo = latest_record.get("repo_name", "")
+        pr_number = latest_record.get("pr_number")
+        partition_key = f"{owner}/{repo}/{pr_number}" if (owner and repo and pr_number) else ""
+        pr_updated_at = latest_record.get("pull_request_updated_at", "")
+        if partition_key and pr_updated_at:
+            current_stream_state[partition_key] = {"synced_at": pr_updated_at}
+        return current_stream_state
+
+    def get_json_schema(self) -> Mapping[str, Any]:
+        return {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": True,
+            "properties": {
+                "tenant_id": {"type": "string"},
+                "source_id": {"type": "string"},
+                "unique_key": {"type": "string"},
+                "data_source": {"type": "string"},
+                "collected_at": {"type": "string"},
+                "database_id": {"type": ["null", "integer"]},
+                "pr_number": {"type": ["null", "integer"]},
+                "pull_request_id": {"type": ["null", "integer"]},
+                "body": {"type": ["null", "string"]},
+                "created_at": {"type": ["null", "string"]},
+                "updated_at": {"type": ["null", "string"]},
+                "author_login": {"type": ["null", "string"]},
+                "author_id": {"type": ["null", "integer"]},
+                "author_association": {"type": ["null", "string"]},
+                "pull_request_updated_at": {"type": ["null", "string"]},
+                "repo_owner": {"type": "string"},
+                "repo_name": {"type": "string"},
+            },
+        }

--- a/src/ingestion/connectors/git/github-v2/source_github_v2/streams/commits.py
+++ b/src/ingestion/connectors/git/github-v2/source_github_v2/streams/commits.py
@@ -1,0 +1,461 @@
+"""GitHub commits stream (GraphQL, incremental, partitioned by repo+branch)."""
+
+import logging
+import os
+import tempfile
+from typing import Any, Iterable, Mapping, MutableMapping, Optional
+
+from source_github_v2.queries import BULK_COMMIT_QUERY
+from source_github_v2.streams.base import GitHubGraphQLStream, _make_unique_key
+from source_github_v2.streams.branches import BranchesStream
+
+logger = logging.getLogger("airbyte")
+
+
+class CommitsStream(GitHubGraphQLStream):
+    """Fetches commits via GraphQL bulk query, partitioned by repo+branch.
+
+    Performance optimizations (all in stream_slices, single-threaded):
+    1. Repo freshness gate: skip repos where pushed_at hasn't changed
+    2. Branch HEAD SHA dedup: skip sibling branches with same HEAD SHA
+    3. HEAD SHA unchanged: skip branches where HEAD hasn't moved
+    4. Seen-hash skip: skip non-default branches whose HEAD is in main's history
+    5. Force-push detection: reset cursor when HEAD changes
+    """
+
+    name = "commits"
+    cursor_field = "committed_date"
+
+    def __init__(
+        self,
+        parent: BranchesStream,
+        start_date: Optional[str] = None,
+        page_size: int = 100,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._parent = parent
+        self._start_date = start_date
+        self._page_size = page_size
+        self._partitions_with_errors: set = set()
+        self._current_skipped_siblings: list = []
+        self._current_stop_at_sha: Optional[str] = None
+        self._last_partition_key: Optional[str] = None
+        self._stop_pagination: bool = False
+        self._seen_hashes: dict[str, str] = {}  # sha → "owner/repo"
+        self._deferred_state_updates: dict[str, dict] = {}  # partition_key → state entry
+        # Fixed-path temp file for passing commit metadata to file_changes.
+        # Overwritten on each sync — no accumulation across runs.
+        self._commit_meta_path = os.path.join(tempfile.gettempdir(), "insight_commits_meta.tsv")
+        self._commit_meta_file = open(self._commit_meta_path, "w")
+        self._commit_meta_count: int = 0
+        logger.info(f"Commit metadata temp file: {self._commit_meta_path}")
+
+    def _query(self) -> str:
+        return BULK_COMMIT_QUERY
+
+    def read_records(self, sync_mode=None, stream_slice=None, stream_state=None, **kwargs):
+        if stream_slice is None:
+            for branch_slice in self.stream_slices(stream_state=stream_state):
+                yield from super().read_records(
+                    sync_mode=sync_mode, stream_slice=branch_slice,
+                    stream_state=stream_state, **kwargs,
+                )
+        else:
+            yield from super().read_records(
+                sync_mode=sync_mode, stream_slice=stream_slice,
+                stream_state=stream_state, **kwargs,
+            )
+
+    def _variables(self, stream_slice=None, next_page_token=None) -> dict:
+        s = stream_slice or {}
+        owner = s.get("owner", "")
+        repo = s.get("repo", "")
+        branch = s.get("branch", "")
+        if not owner or not repo or not branch:
+            raise ValueError(
+                f"CommitsStream._variables() called with incomplete slice: "
+                f"owner={owner}, repo={repo}, branch={branch}"
+            )
+        variables: dict[str, Any] = {
+            "owner": owner,
+            "repo": repo,
+            "branch": f"refs/heads/{branch}",
+            "first": self._page_size,
+        }
+        if next_page_token and "after" in next_page_token:
+            variables["after"] = next_page_token["after"]
+        since = s.get("cursor_value") or self._start_date
+        if since:
+            if len(since) == 10:
+                since = f"{since}T00:00:00Z"
+            variables["since"] = since
+        return variables
+
+    def _extract_nodes(self, data: dict) -> list:
+        return self._safe_get(data, "repository", "ref", "target", "history", "nodes") or []
+
+    def _extract_page_info(self, data: dict) -> dict:
+        return self._safe_get(data, "repository", "ref", "target", "history", "pageInfo") or {}
+
+    def next_page_token(self, response, **kwargs):
+        """Override to stop pagination on dedup exit or previously-seen HEAD."""
+        # parse_response signals stop via this flag (dedup exit, stop_at_sha hit)
+        if self._stop_pagination:
+            self._stop_pagination = False
+            return None
+
+        if self._current_stop_at_sha:
+            body = response.json()
+            data = body.get("data", {})
+            nodes = self._extract_nodes(data)
+            for node in nodes:
+                if node.get("oid") == self._current_stop_at_sha:
+                    logger.debug(f"Early exit: reached known HEAD {self._current_stop_at_sha[:8]}")
+                    return None
+
+        return super().next_page_token(response, **kwargs)
+
+    # ------------------------------------------------------------------
+    # stream_slices: all branch-level optimizations live here
+    # ------------------------------------------------------------------
+
+    def stream_slices(
+        self,
+        stream_state: Optional[Mapping[str, Any]] = None,
+        **kwargs,
+    ) -> Iterable[Optional[Mapping[str, Any]]]:
+        state = stream_state or {}
+
+        # Group all branches by repo
+        repo_branches: dict[tuple, list] = {}
+        for record in self._parent.get_child_records():
+            owner = record.get("repo_owner", "")
+            repo = record.get("repo_name", "")
+            if owner and repo:
+                repo_branches.setdefault((owner, repo), []).append(record)
+
+        repos_skipped_fresh = 0
+        branches_skipped_head = 0
+
+        for (owner, repo), branches in repo_branches.items():
+            # Bound memory: dedup is per-repo (cross-branch), not cross-repo
+            self._seen_hashes.clear()
+
+            # --- Optimization 1: Repo freshness gate ---
+            repo_pushed_at = ""
+            for record in branches:
+                pa = record.get("pushed_at", "")
+                if pa:
+                    repo_pushed_at = pa
+                    break
+
+            repo_state_key = f"_repo:{owner}/{repo}"
+            stored_pushed_at = state.get(repo_state_key, {}).get("pushed_at", "")
+            if repo_pushed_at and stored_pushed_at and repo_pushed_at <= stored_pushed_at:
+                repos_skipped_fresh += 1
+                logger.info(f"Repo freshness: skipping {owner}/{repo} (pushed_at unchanged: {repo_pushed_at})")
+                continue
+
+            # --- Find default branch ---
+            default_branch = ""
+            for record in branches:
+                db = record.get("default_branch", "")
+                if db:
+                    default_branch = db
+                    break
+
+            # --- Optimization 2: Branch HEAD SHA dedup ---
+            def _sort_key(r, db=default_branch):
+                return 0 if r.get("name") == db else 1
+
+            seen_heads: dict[str, str] = {}
+            skipped_map: dict[str, str] = {}
+            selected: list = []
+            for record in sorted(branches, key=_sort_key):
+                branch_name = record.get("name", "")
+                head_sha = (record.get("commit") or {}).get("sha", "")
+
+                if not head_sha:
+                    selected.append(record)
+                    continue
+
+                if head_sha in seen_heads:
+                    skipped_map[branch_name] = seen_heads[head_sha]
+                    continue
+
+                seen_heads[head_sha] = branch_name
+                selected.append(record)
+
+            if skipped_map:
+                logger.info(
+                    f"Branch dedup: {owner}/{repo} - {len(selected)} of {len(branches)} branches "
+                    f"selected, {len(skipped_map)} skipped (duplicate HEAD SHAs)"
+                )
+
+            # --- Optimization 3: HEAD SHA unchanged -> skip branch ---
+            final_selected: list[tuple] = []
+            for record in selected:
+                branch_name = record.get("name", "")
+                head_sha = (record.get("commit") or {}).get("sha", "")
+                partition_key = f"{owner}/{repo}/{branch_name}"
+                stored = state.get(partition_key, {})
+                stored_head = stored.get("head_sha", "")
+
+                # HEAD SHA unchanged -> skip entirely
+                if head_sha and stored_head and head_sha == stored_head:
+                    branches_skipped_head += 1
+                    logger.debug(f"HEAD unchanged: skipping {partition_key} (HEAD {head_sha[:8]})")
+                    continue
+
+                final_selected.append((record, head_sha, stored_head))
+
+            if branches_skipped_head:
+                logger.info(
+                    f"Branch optimization: {owner}/{repo} - {len(final_selected)} branches to fetch, "
+                    f"{branches_skipped_head} skipped (HEAD unchanged)"
+                )
+                branches_skipped_head = 0
+
+            # --- Optimization 4: Seen-hash skip for non-default branches ---
+            branches_skipped_seen = 0
+            for record, head_sha, stored_head in final_selected:
+                branch_name = record.get("name", "")
+
+                # After default branch is processed, _seen_hashes is populated.
+                # Skip non-default branches whose HEAD is already in main's history.
+                if branch_name != default_branch and head_sha and head_sha in self._seen_hashes:
+                    branches_skipped_seen += 1
+                    # Defer head_sha update — applied in get_updated_state (don't mutate state dict)
+                    partition_key = f"{owner}/{repo}/{branch_name}"
+                    if head_sha:
+                        self._deferred_state_updates[partition_key] = {
+                            **state.get(partition_key, {}),
+                            "head_sha": head_sha,
+                        }
+                    continue
+
+                partition_key = f"{owner}/{repo}/{branch_name}"
+                cursor_value = state.get(partition_key, {}).get(self.cursor_field)
+
+                # Optimization 5: Force-push detection
+                head_changed = stored_head and head_sha and head_sha != stored_head
+                if head_changed and cursor_value:
+                    logger.info(
+                        f"HEAD changed on {partition_key} "
+                        f"({stored_head[:8]}->{head_sha[:8]}): resetting cursor for re-fetch"
+                    )
+                    cursor_value = None  # falls back to start_date in _variables()
+
+                yield {
+                    "owner": owner,
+                    "repo": repo,
+                    "branch": branch_name,
+                    "default_branch": default_branch,
+                    "partition_key": partition_key,
+                    "cursor_value": cursor_value,
+                    "head_sha": head_sha,
+                    "stop_at_sha": stored_head,
+                    "repo_pushed_at": repo_pushed_at,
+                    "_skipped_siblings": [
+                        f"{owner}/{repo}/{sb}"
+                        for sb, chosen in skipped_map.items()
+                        if chosen == branch_name
+                    ],
+                }
+
+            if branches_skipped_seen:
+                logger.info(
+                    f"Seen-hash skip: {owner}/{repo} - {branches_skipped_seen} non-default branches "
+                    f"skipped (HEAD already in default branch history)"
+                )
+
+    # ------------------------------------------------------------------
+    # parse_response
+    # ------------------------------------------------------------------
+
+    def parse_response(self, response, stream_slice=None, **kwargs):
+        s = stream_slice or {}
+        self._current_skipped_siblings = s.get("_skipped_siblings", [])
+        self._current_stop_at_sha = s.get("stop_at_sha")
+        head_sha = s.get("head_sha", "")
+        repo_pushed_at = s.get("repo_pushed_at", "")
+        default_branch = s.get("default_branch", "")
+
+        partition_key = f"{s.get('owner', '')}/{s.get('repo', '')}/{s.get('branch', '')}"
+        if partition_key != self._last_partition_key:
+            self._partitions_with_errors.discard(self._last_partition_key)
+            self._last_partition_key = partition_key
+
+        body = response.json()
+        self._update_graphql_rate_limit(body, response)
+
+        if "errors" in body:
+            if "data" not in body or body.get("data") is None:
+                raise RuntimeError(f"GraphQL query failed: {body['errors']}")
+            logger.warning(f"GraphQL partial errors (emitting data, freezing cursor): {body['errors']}")
+            self._partitions_with_errors.add(partition_key)
+
+        data = body.get("data", {})
+        nodes = self._extract_nodes(data)
+        owner = s.get("owner", "")
+        repo = s.get("repo", "")
+        branch = s.get("branch", "")
+
+        hit_seen = False
+        for node in nodes:
+            commit_hash = node.get("oid", "")
+
+            # Early exit: stop at previously-seen HEAD
+            if self._current_stop_at_sha and commit_hash == self._current_stop_at_sha:
+                logger.debug(f"Early exit: reached known commit {commit_hash[:8]} on {owner}/{repo}/{branch}")
+                self._stop_pagination = True
+                return
+
+            # Dedup: skip commits already seen from earlier branches
+            if commit_hash in self._seen_hashes:
+                hit_seen = True
+                continue
+            self._seen_hashes[commit_hash] = f"{owner}/{repo}"
+
+            author = node.get("author") or {}
+            author_user = author.get("user") or {}
+            committer = node.get("committer") or {}
+            committer_user = committer.get("user") or {}
+
+            record = {
+                "unique_key": _make_unique_key(self._tenant_id, self._source_id, owner, repo, commit_hash),
+                "sha": commit_hash,
+                "message": node.get("message"),
+                "committed_date": node.get("committedDate"),
+                "authored_date": node.get("authoredDate"),
+                "additions": node.get("additions"),
+                "deletions": node.get("deletions"),
+                "changed_files": node.get("changedFilesIfAvailable"),
+                "author_name": author.get("name"),
+                "author_email": author.get("email"),
+                "author_login": author_user.get("login"),
+                "author_id": author_user.get("databaseId"),
+                "committer_name": committer.get("name"),
+                "committer_email": committer.get("email"),
+                "committer_login": committer_user.get("login"),
+                "committer_id": committer_user.get("databaseId"),
+                "parent_hashes": [p["oid"] for p in (node.get("parents", {}).get("nodes") or [])],
+                "repo_owner": owner,
+                "repo_name": repo,
+                "branch_name": branch,
+                "default_branch_name": default_branch,
+                "head_sha": head_sha,
+                "repo_pushed_at": repo_pushed_at,
+            }
+            yield self._add_envelope(record)
+
+            # Write metadata row for file_changes stream (TSV, disk-backed)
+            parent_count = len(record["parent_hashes"]) if record.get("parent_hashes") else 0
+            self._commit_meta_file.write(
+                f"{commit_hash}\t{owner}\t{repo}\t{node.get('committedDate', '')}\t{parent_count}\n"
+            )
+            self._commit_meta_count += 1
+
+        # If we hit any already-seen commit, the rest of this branch is shared
+        # history (commits are newest-first). Stop paginating.
+        if hit_seen and nodes:
+            logger.debug(f"Dedup exit: hit seen commit on {owner}/{repo}/{branch}, stopping pagination")
+            self._stop_pagination = True
+            return
+
+    # ------------------------------------------------------------------
+    # get_updated_state: per-partition cursor with head_sha + pushed_at
+    # ------------------------------------------------------------------
+
+    def get_updated_state(
+        self,
+        current_stream_state: MutableMapping[str, Any],
+        latest_record: Mapping[str, Any],
+    ) -> MutableMapping[str, Any]:
+        partition_key = (
+            f"{latest_record.get('repository_owner', '')}/"
+            f"{latest_record.get('repository_name', '')}/"
+            f"{latest_record.get('branch_name', '')}"
+        )
+        if partition_key in self._partitions_with_errors:
+            return current_stream_state
+
+        record_cursor = latest_record.get(self.cursor_field, "")
+        current_cursor = current_stream_state.get(partition_key, {}).get(self.cursor_field, "")
+        if record_cursor > current_cursor:
+            head_sha = latest_record.get("head_sha", "")
+            cursor_entry: dict[str, str] = {self.cursor_field: record_cursor}
+            if head_sha:
+                cursor_entry["head_sha"] = head_sha
+            current_stream_state[partition_key] = cursor_entry
+
+            # Mirror cursor to skipped siblings (same HEAD SHA)
+            for sibling_key in self._current_skipped_siblings:
+                sibling_cursor = current_stream_state.get(sibling_key, {}).get(self.cursor_field, "")
+                if record_cursor > sibling_cursor:
+                    current_stream_state[sibling_key] = dict(cursor_entry)
+
+        # Store repo pushed_at for freshness gate
+        repo_pushed_at = latest_record.get("repo_pushed_at", "")
+        if repo_pushed_at:
+            owner = latest_record.get("repo_owner", "")
+            repo_name = latest_record.get("repo_name", "")
+            repo_state_key = f"_repo:{owner}/{repo_name}"
+            current_stream_state[repo_state_key] = {"pushed_at": repo_pushed_at}
+
+        # Apply deferred state updates (from seen-hash skipped branches in stream_slices)
+        if self._deferred_state_updates:
+            for key, entry in self._deferred_state_updates.items():
+                if key not in current_stream_state:
+                    current_stream_state[key] = entry
+                else:
+                    current_stream_state[key] = {**current_stream_state[key], **entry}
+            self._deferred_state_updates.clear()
+
+        return current_stream_state
+
+    def get_commit_meta_path(self) -> str:
+        """Return path to temp file with commit metadata for file_changes.
+
+        Format: TSV with columns sha, owner, repo, committed_at, parent_count.
+        Must be called after the commits stream has been fully driven by the CDK.
+        """
+        if not self._commit_meta_file.closed:
+            self._commit_meta_file.close()
+        logger.info(f"Commit metadata: {self._commit_meta_count} rows written to {self._commit_meta_path}")
+        return self._commit_meta_path
+
+    def get_json_schema(self) -> Mapping[str, Any]:
+        return {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": True,
+            "properties": {
+                "tenant_id": {"type": "string"},
+                "source_id": {"type": "string"},
+                "unique_key": {"type": "string"},
+                "data_source": {"type": "string"},
+                "collected_at": {"type": "string"},
+                "sha": {"type": "string"},
+                "message": {"type": ["null", "string"]},
+                "committed_date": {"type": ["null", "string"]},
+                "authored_date": {"type": ["null", "string"]},
+                "additions": {"type": ["null", "integer"]},
+                "deletions": {"type": ["null", "integer"]},
+                "changed_files": {"type": ["null", "integer"]},
+                "author_name": {"type": ["null", "string"]},
+                "author_email": {"type": ["null", "string"]},
+                "author_login": {"type": ["null", "string"]},
+                "author_id": {"type": ["null", "integer"]},
+                "committer_name": {"type": ["null", "string"]},
+                "committer_email": {"type": ["null", "string"]},
+                "committer_login": {"type": ["null", "string"]},
+                "committer_id": {"type": ["null", "integer"]},
+                "parent_hashes": {"type": ["null", "array"], "items": {"type": "string"}},
+                "repo_owner": {"type": "string"},
+                "repo_name": {"type": "string"},
+                "branch_name": {"type": "string"},
+                "default_branch_name": {"type": ["null", "string"]},
+            },
+        }

--- a/src/ingestion/connectors/git/github-v2/source_github_v2/streams/file_changes.py
+++ b/src/ingestion/connectors/git/github-v2/source_github_v2/streams/file_changes.py
@@ -1,0 +1,168 @@
+"""GitHub file changes stream -- per-commit file changes.
+
+CDK-native: stream_slices yields one slice per commit (non-merge only,
+deduplicated). Commit metadata is read from a temp file written by the
+commits stream — zero extra API calls, near-zero memory.
+CDK handles pagination (Link header), retry, and backoff for each slice.
+"""
+
+import logging
+from typing import Any, Iterable, Mapping, MutableMapping, Optional
+
+from source_github_v2.streams.base import (
+    GitHubAuthError,
+    GitHubRestStream,
+    _make_unique_key,
+    _now_iso,
+)
+
+logger = logging.getLogger("airbyte")
+
+
+class FileChangesStream(GitHubRestStream):
+    """File changes per commit (all branches, non-merge only, deduplicated).
+
+    Data source: GET /repos/{owner}/{repo}/commits/{sha} -> files array.
+    Commit list comes from a temp TSV written by CommitsStream during its
+    parse_response — no re-read, no extra API calls, near-zero memory.
+    """
+
+    name = "file_changes"
+
+    def __init__(self, parent, **kwargs):
+        super().__init__(**kwargs)
+        self._parent = parent
+
+    def _path(self, stream_slice=None, **kwargs) -> str:
+        s = stream_slice or {}
+        owner = s.get("owner", "")
+        repo = s.get("repo", "")
+        sha = s.get("sha", "")
+        return f"repos/{owner}/{repo}/commits/{sha}"
+
+    def stream_slices(
+        self,
+        stream_state: Optional[Mapping[str, Any]] = None,
+        **kwargs,
+    ) -> Iterable[Optional[Mapping[str, Any]]]:
+        meta_path = self._parent.get_commit_meta_path()
+        total = 0
+        skipped_merge = 0
+
+        # The TSV only contains commits the commits stream emitted this sync
+        # (already incremental, already deduplicated). No additional cursor
+        # filtering here — that would break force-push scenarios where the
+        # commits stream re-emits old commits with older committed_at.
+        with open(meta_path, "r") as f:
+            for line in f:
+                line = line.rstrip("\n")
+                if not line:
+                    continue
+                parts = line.split("\t", 4)
+                if len(parts) < 5:
+                    continue
+                sha, owner, repo, committed_at, parent_count_str = parts
+                parent_count = int(parent_count_str) if parent_count_str.isdigit() else 0
+
+                # Skip merge commits
+                if parent_count > 1:
+                    skipped_merge += 1
+                    continue
+
+                total += 1
+                yield {
+                    "owner": owner,
+                    "repo": repo,
+                    "sha": sha,
+                    "committed_date": committed_at,
+                }
+
+        logger.info(f"File changes: {total} commits to fetch ({skipped_merge} merge skipped)")
+
+    def request_params(
+        self,
+        next_page_token: Optional[Mapping[str, Any]] = None,
+        **kwargs,
+    ) -> MutableMapping[str, Any]:
+        if next_page_token:
+            return {}
+        return {"per_page": "100"}
+
+    def parse_response(self, response, stream_slice=None, **kwargs):
+        """CDK calls this per page. Extract files from commit response."""
+        s = stream_slice or {}
+        owner = s.get("owner", "")
+        repo = s.get("repo", "")
+
+        if response.status_code in (404, 409):
+            logger.warning(
+                f"Skipping {owner}/{repo} file_changes ({response.status_code}): "
+                f"sha={s.get('sha', '?')[:8]}"
+            )
+            return
+
+        data = response.json()
+        files = data.get("files", [])
+        sha = s.get("sha", "")
+        committed_at = s.get("committed_date", "")
+
+        for f in files:
+            filename = f.get("filename", "")
+            pk_parts = [owner, repo, sha, filename]
+            yield {
+                "unique_key": _make_unique_key(self._tenant_id, self._source_id, *pk_parts),
+                "tenant_id": self._tenant_id,
+                "source_id": self._source_id,
+                "data_source": "insight_github",
+                "collected_at": _now_iso(),
+                "source_type": "commit",
+                "sha": sha,
+                "filename": filename,
+                "status": f.get("status"),
+                "additions": f.get("additions"),
+                "deletions": f.get("deletions"),
+                "changes": f.get("changes"),
+                "previous_filename": f.get("previous_filename"),
+                "patch": f.get("patch"),
+                "committed_date": committed_at,
+                "repo_owner": owner,
+                "repo_name": repo,
+            }
+
+    def read_records(self, sync_mode=None, stream_slice=None, stream_state=None, **kwargs):
+        try:
+            yield from super().read_records(
+                sync_mode=sync_mode, stream_slice=stream_slice,
+                stream_state=stream_state, **kwargs,
+            )
+        except GitHubAuthError:
+            raise
+        except Exception as exc:
+            s = stream_slice or {}
+            logger.warning(f"Skipping file_changes for {s.get('owner')}/{s.get('repo')}/{s.get('sha', '?')[:8]}: {exc}")
+
+    def get_json_schema(self) -> Mapping[str, Any]:
+        return {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": True,
+            "properties": {
+                "tenant_id": {"type": "string"},
+                "source_id": {"type": "string"},
+                "unique_key": {"type": "string"},
+                "data_source": {"type": "string"},
+                "collected_at": {"type": "string"},
+                "source_type": {"type": "string"},
+                "sha": {"type": ["null", "string"]},
+                "filename": {"type": ["null", "string"]},
+                "status": {"type": ["null", "string"]},
+                "additions": {"type": ["null", "integer"]},
+                "deletions": {"type": ["null", "integer"]},
+                "changes": {"type": ["null", "integer"]},
+                "previous_filename": {"type": ["null", "string"]},
+                "patch": {"type": ["null", "string"]},
+                "committed_date": {"type": ["null", "string"]},
+                "repo_owner": {"type": "string"},
+                "repo_name": {"type": "string"},
+            },
+        }

--- a/src/ingestion/connectors/git/github-v2/source_github_v2/streams/pr_commits.py
+++ b/src/ingestion/connectors/git/github-v2/source_github_v2/streams/pr_commits.py
@@ -1,0 +1,257 @@
+"""GitHub PR commits stream (GraphQL, per-PR sequential, incremental).
+
+CDK-native: extends GitHubGraphQLStream. stream_slices yields one slice
+per PR, CDK handles pagination (pageInfo), retry, and backoff via the
+base class. Zero manual HTTP code.
+
+Optimization: embedded commits from the parent PR query are yielded first.
+If the PR has <= 100 commits (commits_complete=True), no additional API
+call is needed. Otherwise, pagination continues from the embedded end_cursor.
+"""
+
+import logging
+from typing import Any, Iterable, Mapping, MutableMapping, Optional
+
+from source_github_v2.queries import PR_COMMITS_QUERY
+from source_github_v2.streams.base import (
+    GitHubAuthError,
+    GitHubGraphQLStream,
+    _make_unique_key,
+    _now_iso,
+)
+
+logger = logging.getLogger("airbyte")
+
+
+class PRCommitsStream(GitHubGraphQLStream):
+    """Fetches commits linked to each PR via GraphQL with CDK-managed pagination.
+
+    No 250-commit cap (unlike REST endpoint). Uses per-PR incremental state
+    keyed by owner/repo/pr_number with synced_at = parent PR updated_at.
+    """
+
+    name = "pull_request_commits"
+    cursor_field = "pull_request_updated_at"
+
+    def __init__(self, parent, **kwargs):
+        super().__init__(**kwargs)
+        self._parent = parent
+
+    def _query(self) -> str:
+        return PR_COMMITS_QUERY
+
+    def stream_slices(
+        self,
+        stream_state: Optional[Mapping[str, Any]] = None,
+        **kwargs,
+    ) -> Iterable[Optional[Mapping[str, Any]]]:
+        state = stream_state or {}
+        total = 0
+        skipped = 0
+        for pr in self._parent.get_child_slices():
+            owner = pr.get("repo_owner", "")
+            repo = pr.get("repo_name", "")
+            pr_number = pr.get("number")
+            pr_database_id = pr.get("database_id")
+            pr_updated_at = pr.get("updated_at", "")
+            pr_commit_count = pr.get("commit_count")
+            if not (owner and repo and pr_number):
+                continue
+            total += 1
+            partition_key = f"{owner}/{repo}/{pr_number}"
+            child_cursor = state.get(partition_key, {}).get("synced_at", "")
+            if pr_updated_at and child_cursor and pr_updated_at <= child_cursor:
+                skipped += 1
+                continue
+            yield {
+                "owner": owner,
+                "repo": repo,
+                "pr_number": pr_number,
+                "pr_database_id": pr_database_id,
+                "pr_updated_at": pr_updated_at,
+                "pr_commit_count": pr_commit_count,
+                "partition_key": partition_key,
+                "embedded_offset": pr.get("embedded_offset", 0),
+                "commits_complete": pr.get("commits_complete", False),
+                "commits_end_cursor": pr.get("commits_end_cursor"),
+            }
+        if skipped:
+            logger.info(
+                f"PR commits: {total - skipped}/{total} PRs need commit sync ({skipped} skipped, unchanged)"
+            )
+
+    def _variables(self, stream_slice=None, next_page_token=None) -> dict:
+        s = stream_slice or {}
+        variables: dict = {
+            "owner": s.get("owner", ""),
+            "repo": s.get("repo", ""),
+            "prNumber": s.get("pr_number"),
+            "first": 100,
+        }
+        if next_page_token and "after" in next_page_token:
+            variables["after"] = next_page_token["after"]
+        elif s.get("_overflow_after"):
+            variables["after"] = s["_overflow_after"]
+        return variables
+
+    def _extract_nodes(self, data: dict) -> list:
+        return self._safe_get(data, "repository", "pullRequest", "commits", "nodes") or []
+
+    def _extract_page_info(self, data: dict) -> dict:
+        return self._safe_get(data, "repository", "pullRequest", "commits", "pageInfo") or {}
+
+    def parse_response(self, response, stream_slice=None, **kwargs):
+        """CDK calls this for each page. Extract commits from GraphQL nodes."""
+        s = stream_slice or {}
+        owner = s.get("owner", "")
+        repo = s.get("repo", "")
+        pr_number = s.get("pr_number")
+        pr_database_id = s.get("pr_database_id")
+        pr_updated_at = s.get("pr_updated_at", "")
+        pr_id = str(pr_database_id) if pr_database_id is not None else ""
+
+        body = response.json()
+        self._update_graphql_rate_limit(body, response)
+
+        if "errors" in body:
+            if "data" not in body or body.get("data") is None:
+                raise RuntimeError(
+                    f"GraphQL errors for {owner}/{repo} PR#{pr_number} commits: {body['errors']}"
+                )
+            logger.warning(
+                f"GraphQL partial errors (continuing with data): {body['errors']}"
+            )
+
+        data = body.get("data", {})
+        nodes = self._extract_nodes(data)
+
+        for node in nodes:
+            commit = node.get("commit") or {}
+            sha = commit.get("oid", "")
+            if not sha:
+                continue
+            yield {
+                "unique_key": _make_unique_key(self._tenant_id, self._source_id, owner, repo, pr_id, sha),
+                "tenant_id": self._tenant_id,
+                "source_id": self._source_id,
+                "data_source": "insight_github",
+                "collected_at": _now_iso(),
+                "pull_request_id": pr_database_id,
+                "pr_number": pr_number,
+                "sha": sha,
+                "committed_date": commit.get("committedDate"),
+                "pull_request_updated_at": pr_updated_at,
+                "repo_owner": owner,
+                "repo_name": repo,
+            }
+
+    def _records_from_embedded_commits(self, commits_data, stream_slice):
+        """Produce output records from embedded commit nodes (same format as parse_response)."""
+        s = stream_slice or {}
+        owner = s.get("owner", "")
+        repo = s.get("repo", "")
+        pr_number = s.get("pr_number")
+        pr_database_id = s.get("pr_database_id")
+        pr_updated_at = s.get("pr_updated_at", "")
+        pr_id = str(pr_database_id) if pr_database_id is not None else ""
+
+        nodes = commits_data.get("nodes") or []
+        for node in nodes:
+            commit = node.get("commit") or {}
+            sha = commit.get("oid", "")
+            if not sha:
+                continue
+            yield {
+                "unique_key": _make_unique_key(self._tenant_id, self._source_id, owner, repo, pr_id, sha),
+                "tenant_id": self._tenant_id,
+                "source_id": self._source_id,
+                "data_source": "insight_github",
+                "collected_at": _now_iso(),
+                "pull_request_id": pr_database_id,
+                "pr_number": pr_number,
+                "sha": sha,
+                "committed_date": commit.get("committedDate"),
+                "pull_request_updated_at": pr_updated_at,
+                "repo_owner": owner,
+                "repo_name": repo,
+            }
+
+    def read_records(self, sync_mode=None, stream_slice=None, stream_state=None, **kwargs):
+        """Yield embedded records first, then overflow-paginate if needed."""
+        s = stream_slice or {}
+        owner = s.get("owner", "")
+        repo = s.get("repo", "")
+        pr_number = s.get("pr_number")
+
+        try:
+            # Step 1: read embedded records from disk
+            commits_data = self._parent.read_embedded_data(s.get("embedded_offset", 0), "commits")
+            embedded_data_available = bool(commits_data)
+            embedded_count = 0
+            for record in self._records_from_embedded_commits(commits_data, stream_slice):
+                embedded_count += 1
+                yield record
+
+            # Step 2: if embedded data was read successfully, check completeness
+            if embedded_data_available and s.get("commits_complete", False):
+                logger.debug(f"PR commits {owner}/{repo} PR#{pr_number}: {embedded_count} embedded (complete)")
+                return
+
+            # Step 3: overflow or full fetch if embedded data was missing/incomplete
+            if not embedded_data_available:
+                logger.debug(f"PR commits {owner}/{repo} PR#{pr_number}: no embedded data, full fetch")
+            else:
+                logger.debug(f"PR commits {owner}/{repo} PR#{pr_number}: {embedded_count} embedded, overflow needed")
+            end_cursor = s.get("commits_end_cursor") if embedded_data_available else None
+            if end_cursor:
+                overflow_slice = dict(s)
+                overflow_slice["_overflow_after"] = end_cursor
+                yield from super().read_records(
+                    sync_mode=sync_mode, stream_slice=overflow_slice,
+                    stream_state=stream_state, **kwargs,
+                )
+            else:
+                yield from super().read_records(
+                    sync_mode=sync_mode, stream_slice=stream_slice,
+                    stream_state=stream_state, **kwargs,
+                )
+        except GitHubAuthError:
+            raise
+        except Exception as exc:
+            pk = s.get("partition_key", "?")
+            logger.warning(f"Skipping pr_commits slice {pk}: {exc}")
+
+    def get_updated_state(
+        self,
+        current_stream_state: MutableMapping[str, Any],
+        latest_record: Mapping[str, Any],
+    ) -> MutableMapping[str, Any]:
+        owner = latest_record.get("repo_owner", "")
+        repo = latest_record.get("repo_name", "")
+        pr_number = latest_record.get("pr_number")
+        partition_key = f"{owner}/{repo}/{pr_number}" if (owner and repo and pr_number) else ""
+        pr_updated_at = latest_record.get("pull_request_updated_at", "")
+        if partition_key and pr_updated_at:
+            current_stream_state[partition_key] = {"synced_at": pr_updated_at}
+        return current_stream_state
+
+    def get_json_schema(self) -> Mapping[str, Any]:
+        return {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": True,
+            "properties": {
+                "tenant_id": {"type": "string"},
+                "source_id": {"type": "string"},
+                "unique_key": {"type": "string"},
+                "data_source": {"type": "string"},
+                "collected_at": {"type": "string"},
+                "pull_request_id": {"type": ["null", "integer"]},
+                "pr_number": {"type": ["null", "integer"]},
+                "sha": {"type": ["null", "string"]},
+                "committed_date": {"type": ["null", "string"]},
+                "pull_request_updated_at": {"type": ["null", "string"]},
+                "repo_owner": {"type": "string"},
+                "repo_name": {"type": "string"},
+            },
+        }

--- a/src/ingestion/connectors/git/github-v2/source_github_v2/streams/pull_requests.py
+++ b/src/ingestion/connectors/git/github-v2/source_github_v2/streams/pull_requests.py
@@ -1,0 +1,423 @@
+"""GitHub pull requests stream (GraphQL, incremental, child of repos)."""
+
+import json
+import logging
+import os
+import tempfile
+from typing import Any, Iterable, Mapping, MutableMapping, Optional
+
+from source_github_v2.queries import BULK_PR_QUERY
+from source_github_v2.streams.base import GitHubGraphQLStream, _make_unique_key
+from source_github_v2.streams.repositories import RepositoriesStream
+
+logger = logging.getLogger("airbyte")
+
+
+class PullRequestsStream(GitHubGraphQLStream):
+    """Fetches PRs via GraphQL bulk query, incremental by updated_at.
+
+    Reviews, comments, and PR commits are fetched by separate child streams
+    that consume get_child_slices() for slice construction.
+    """
+
+    name = "pull_requests"
+    cursor_field = "updated_at"
+    # NOTE: use_cache=True does NOT work for POST requests in the CDK.
+    # requests_cache defaults to allowable_methods=('GET', 'HEAD') only.
+    # Child streams use embedded data + overflow pagination instead.
+
+    def __init__(
+        self,
+        parent: RepositoriesStream,
+        start_date: Optional[str] = None,
+        page_size: int = 25,
+        embedded_page_sizes: Optional[dict] = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._parent = parent
+        self._start_date = start_date
+        self._page_size = page_size
+        # Build the PR query with configured embedded page sizes
+        eps = embedded_page_sizes or {}
+        self._pr_query = (
+            BULK_PR_QUERY
+            .replace("__COMMITS_PAGE_SIZE__", str(eps.get("commits")))
+            .replace("__REVIEWS_PAGE_SIZE__", str(eps.get("reviews")))
+            .replace("__COMMENTS_PAGE_SIZE__", str(eps.get("comments")))
+            .replace("__RT_PAGE_SIZE__", str(eps.get("review_threads")))
+            .replace("__RTC_PAGE_SIZE__", str(eps.get("thread_comments")))
+        )
+        self._partitions_with_errors: set = set()
+        self._child_slice_cache: dict[tuple, dict] = {}
+        self._current_cursor_value: Optional[str] = None
+        # Disk-backed embedded child data — near-zero memory.
+        # Each line is JSON: {commits: {...}, reviews: {...}, comments: {...}, review_threads: {...}}
+        # Child streams seek to byte offset stored in child_slice_cache.
+        self._embedded_data_path = os.path.join(tempfile.gettempdir(), "insight_pr_embedded.jsonl")
+        self._embedded_data_file = open(self._embedded_data_path, "w")
+
+    def _query(self) -> str:
+        return self._pr_query
+
+    # ------------------------------------------------------------------
+    # read_records: delegate to slices when called without a slice
+    # ------------------------------------------------------------------
+
+    def read_records(self, sync_mode=None, stream_slice=None, stream_state=None, **kwargs):
+        if stream_slice is None:
+            for repo_slice in self.stream_slices(stream_state=stream_state):
+                self._current_cursor_value = None  # reset between slices
+                yield from super().read_records(
+                    sync_mode=sync_mode, stream_slice=repo_slice,
+                    stream_state=stream_state, **kwargs,
+                )
+        else:
+            yield from super().read_records(
+                sync_mode=sync_mode, stream_slice=stream_slice,
+                stream_state=stream_state, **kwargs,
+            )
+
+    # ------------------------------------------------------------------
+    # _variables
+    # ------------------------------------------------------------------
+
+    def _variables(self, stream_slice=None, next_page_token=None) -> dict:
+        s = stream_slice or {}
+        owner = s.get("owner", "")
+        repo = s.get("repo", "")
+        if not owner or not repo:
+            raise ValueError(
+                f"PullRequestsStream._variables() called with incomplete slice: "
+                f"owner={owner}, repo={repo}"
+            )
+        variables: dict[str, Any] = {
+            "owner": owner,
+            "repo": repo,
+            "first": self._page_size,
+            "orderBy": {"field": "UPDATED_AT", "direction": "DESC"},
+        }
+        if next_page_token and "after" in next_page_token:
+            variables["after"] = next_page_token["after"]
+        return variables
+
+    def _extract_nodes(self, data: dict) -> list:
+        return self._safe_get(data, "repository", "pullRequests", "nodes") or []
+
+    def _extract_page_info(self, data: dict) -> dict:
+        return self._safe_get(data, "repository", "pullRequests", "pageInfo") or {}
+
+    # ------------------------------------------------------------------
+    # stream_slices: repo freshness gate + eager pushed_at persist
+    # ------------------------------------------------------------------
+
+    def stream_slices(
+        self,
+        stream_state: Optional[Mapping[str, Any]] = None,
+        **kwargs,
+    ) -> Iterable[Optional[Mapping[str, Any]]]:
+        state = stream_state or {}
+        repos_skipped = 0
+        repos_total = 0
+
+        for record in self._parent.get_child_records():
+            owner = record.get("owner", "")
+            repo = record.get("name", "")
+            if not (owner and repo):
+                continue
+            repos_total += 1
+
+            # No pushed_at gate here — PR metadata (labels, reviews, merges,
+            # comments) can change without a push. The per-repo updated_at
+            # cursor + early exit in next_page_token handles incrementality.
+
+            partition_key = f"{owner}/{repo}"
+            cursor_value = state.get(partition_key, {}).get(self.cursor_field)
+            yield {
+                "owner": owner,
+                "repo": repo,
+                "partition_key": partition_key,
+                "cursor_value": cursor_value,
+            }
+
+    # ------------------------------------------------------------------
+    # next_page_token: early exit on incremental cursor
+    # ------------------------------------------------------------------
+
+    def next_page_token(self, response, **kwargs):
+        """Override to implement early exit on incremental cursor."""
+        body = response.json()
+        data = body.get("data", {})
+        page_info = self._extract_page_info(data)
+
+        nodes = self._extract_nodes(data)
+        if nodes:
+            last_updated = nodes[-1].get("updatedAt", "")
+            if last_updated:
+                if self._current_cursor_value and last_updated < self._current_cursor_value:
+                    return None
+                if self._start_date and last_updated[:10] < self._start_date:
+                    return None
+
+        if page_info.get("hasNextPage"):
+            return {"after": page_info["endCursor"]}
+        return None
+
+    # ------------------------------------------------------------------
+    # parse_response
+    # ------------------------------------------------------------------
+
+    def parse_response(self, response, stream_slice=None, **kwargs):
+        body = response.json()
+        self._update_graphql_rate_limit(body, response)
+
+        if "errors" in body:
+            if "data" not in body or body.get("data") is None:
+                raise RuntimeError(f"GraphQL query failed: {body['errors']}")
+            logger.warning(f"GraphQL partial errors (emitting data, freezing cursor): {body['errors']}")
+            s = stream_slice or {}
+            partition_key = f"{s.get('owner', '')}/{s.get('repo', '')}"
+            self._partitions_with_errors.add(partition_key)
+
+        data = body.get("data", {})
+        nodes = self._extract_nodes(data)
+        s = stream_slice or {}
+        owner = s.get("owner", "")
+        repo = s.get("repo", "")
+        cursor_value = s.get("cursor_value")
+        self._current_cursor_value = cursor_value
+
+        for pr_node in nodes:
+            pr_database_id = pr_node.get("databaseId")
+            pr_id = str(pr_database_id) if pr_database_id is not None else ""
+            pr_number = pr_node.get("number")
+            updated_at = pr_node.get("updatedAt", "")
+
+            # Skip records older than cursor for incremental
+            if cursor_value and updated_at and updated_at <= cursor_value:
+                continue
+            # Skip records older than start_date on first sync
+            if self._start_date and updated_at and updated_at[:10] < self._start_date:
+                continue
+
+            # Write embedded child data to disk (JSONL) — near-zero memory
+            commits_conn = pr_node.get("commits") or {}
+            reviews_conn = pr_node.get("reviews") or {}
+            comments_conn = pr_node.get("comments") or {}
+            review_threads_conn = pr_node.get("reviewThreads") or {}
+            rt_nodes = review_threads_conn.get("nodes") or []
+            embedded_offset = self._embedded_data_file.tell()
+            embedded_data = {
+                "commits": {
+                    "nodes": commits_conn.get("nodes") or [],
+                    "has_next_page": (commits_conn.get("pageInfo") or {}).get("hasNextPage", False),
+                    "end_cursor": (commits_conn.get("pageInfo") or {}).get("endCursor"),
+                },
+                "reviews": {
+                    "nodes": reviews_conn.get("nodes") or [],
+                    "has_next_page": (reviews_conn.get("pageInfo") or {}).get("hasNextPage", False),
+                    "end_cursor": (reviews_conn.get("pageInfo") or {}).get("endCursor"),
+                },
+                "comments": {
+                    "nodes": comments_conn.get("nodes") or [],
+                    "has_next_page": (comments_conn.get("pageInfo") or {}).get("hasNextPage", False),
+                    "end_cursor": (comments_conn.get("pageInfo") or {}).get("endCursor"),
+                },
+                "review_threads": {
+                    "nodes": rt_nodes,
+                    "threads_has_next_page": (review_threads_conn.get("pageInfo") or {}).get("hasNextPage", False),
+                    "threads_end_cursor": (review_threads_conn.get("pageInfo") or {}).get("endCursor"),
+                },
+            }
+            self._embedded_data_file.write(json.dumps(embedded_data, separators=(",", ":")) + "\n")
+
+            # Normalize state: MERGED / CLOSED / OPEN
+            if pr_node.get("merged"):
+                pr_state = "MERGED"
+            elif pr_node.get("state") == "CLOSED":
+                pr_state = "CLOSED"
+            else:
+                pr_state = "OPEN"
+
+            author = pr_node.get("author") or {}
+            merged_by = pr_node.get("mergedBy") or {}
+
+            labels_nodes = (pr_node.get("labels") or {}).get("nodes") or []
+            labels = [label.get("name") for label in labels_nodes if label.get("name")]
+
+            milestone = pr_node.get("milestone") or {}
+            merge_commit = pr_node.get("mergeCommit") or {}
+
+            # Requested reviewers (users) and teams
+            review_requests = (pr_node.get("reviewRequests") or {}).get("nodes") or []
+            requested_reviewers: list[str] = []
+            requested_teams: list[str] = []
+            for rr in review_requests:
+                reviewer = rr.get("requestedReviewer") or {}
+                if "login" in reviewer:
+                    requested_reviewers.append(reviewer["login"])
+                elif "slug" in reviewer:
+                    requested_teams.append(reviewer["slug"])
+
+            record = {
+                "unique_key": _make_unique_key(self._tenant_id, self._source_id, owner, repo, pr_id),
+                "database_id": pr_database_id,
+                "number": pr_number,
+                "title": pr_node.get("title"),
+                "body": pr_node.get("body"),
+                "state": pr_state,
+                "is_draft": pr_node.get("isDraft"),
+                "review_decision": pr_node.get("reviewDecision"),
+                "labels": labels,
+                "milestone_title": milestone.get("title"),
+                "merge_commit_sha": merge_commit.get("oid"),
+                "created_at": pr_node.get("createdAt"),
+                "updated_at": updated_at,
+                "closed_at": pr_node.get("closedAt"),
+                "merged_at": pr_node.get("mergedAt"),
+                "head_ref": pr_node.get("headRefName"),
+                "base_ref": pr_node.get("baseRefName"),
+                "additions": pr_node.get("additions"),
+                "deletions": pr_node.get("deletions"),
+                "changed_files": pr_node.get("changedFiles"),
+                "author_login": author.get("login"),
+                "author_id": author.get("databaseId"),
+                "author_email": author.get("email"),
+                "merged_by_login": merged_by.get("login"),
+                "merged_by_id": merged_by.get("databaseId"),
+                "commit_count": commits_conn.get("totalCount"),
+                "comment_count": comments_conn.get("totalCount"),
+                "review_count": reviews_conn.get("totalCount"),
+                "requested_reviewers": requested_reviewers,
+                "requested_teams": requested_teams,
+                "repo_owner": owner,
+                "repo_name": repo,
+            }
+            yield self._add_envelope(record)
+
+            # Build child slice cache incrementally (dict-keyed to dedup on retry)
+            cache_key = (owner, repo, pr_number)
+            self._child_slice_cache[cache_key] = {
+                "number": pr_number,
+                "database_id": pr_database_id,
+                "updated_at": updated_at,
+                "commit_count": commits_conn.get("totalCount"),
+                "comment_count": comments_conn.get("totalCount"),
+                "review_count": reviews_conn.get("totalCount"),
+                "repo_owner": owner,
+                "repo_name": repo,
+                "embedded_offset": embedded_offset,
+                "commits_complete": not embedded_data["commits"]["has_next_page"],
+                "commits_end_cursor": embedded_data["commits"]["end_cursor"],
+                "reviews_complete": not embedded_data["reviews"]["has_next_page"],
+                "reviews_end_cursor": embedded_data["reviews"]["end_cursor"],
+                "comments_complete": not embedded_data["comments"]["has_next_page"],
+                "comments_end_cursor": embedded_data["comments"]["end_cursor"],
+                "review_threads_has_next_page": embedded_data["review_threads"]["threads_has_next_page"],
+                "review_threads_end_cursor": embedded_data["review_threads"]["threads_end_cursor"],
+            }
+
+    # ------------------------------------------------------------------
+    # get_child_slices: minimal PR metadata for child streams
+    # ------------------------------------------------------------------
+
+    def read_embedded_data(self, offset: int, field: str) -> dict:
+        """Read embedded child data for a PR from the JSONL file at the given byte offset.
+
+        Args:
+            offset: byte offset in the JSONL file (from child slice's embedded_offset)
+            field: which child data to extract ("commits", "reviews", "comments", "review_threads")
+
+        Returns:
+            The embedded data dict for that field, or {} if not found.
+        """
+        if not self._embedded_data_file.closed:
+            self._embedded_data_file.close()
+        with open(self._embedded_data_path, "r") as f:
+            f.seek(offset)
+            line = f.readline()
+            if not line:
+                return {}
+            try:
+                data = json.loads(line)
+                return data.get(field, {})
+            except (json.JSONDecodeError, ValueError):
+                return {}
+
+    def get_child_slices(self) -> list:
+        """Return minimal PR metadata for child streams to build slices from.
+
+        Populated during parse_response (no re-read). If called before
+        parse_response has run, triggers a full read to populate.
+        """
+        if self._child_slice_cache:
+            return list(self._child_slice_cache.values())
+        # Fallback: trigger read if not yet populated (e.g., CDK hasn't driven this stream yet)
+        list(self.read_records(sync_mode=None))
+        logger.info(f"PR child-slice cache: {len(self._child_slice_cache)} PRs")
+        return list(self._child_slice_cache.values())
+
+    # ------------------------------------------------------------------
+    # get_updated_state: per-repo cursor
+    # ------------------------------------------------------------------
+
+    def get_updated_state(
+        self,
+        current_stream_state: MutableMapping[str, Any],
+        latest_record: Mapping[str, Any],
+    ) -> MutableMapping[str, Any]:
+        partition_key = f"{latest_record.get('repository_owner', '')}/{latest_record.get('repository_name', '')}"
+        if partition_key in self._partitions_with_errors:
+            return current_stream_state
+
+        record_cursor = latest_record.get(self.cursor_field, "")
+        current_cursor = current_stream_state.get(partition_key, {}).get(self.cursor_field, "")
+        if record_cursor > current_cursor:
+            current_stream_state[partition_key] = {self.cursor_field: record_cursor}
+
+        return current_stream_state
+
+    def get_json_schema(self) -> Mapping[str, Any]:
+        return {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": True,
+            "properties": {
+                "tenant_id": {"type": "string"},
+                "source_id": {"type": "string"},
+                "unique_key": {"type": "string"},
+                "data_source": {"type": "string"},
+                "collected_at": {"type": "string"},
+                "database_id": {"type": ["null", "integer"]},
+                "number": {"type": ["null", "integer"]},
+                "title": {"type": ["null", "string"]},
+                "body": {"type": ["null", "string"]},
+                "state": {"type": ["null", "string"]},
+                "is_draft": {"type": ["null", "boolean"]},
+                "review_decision": {"type": ["null", "string"]},
+                "labels": {"type": ["null", "array"], "items": {"type": "string"}},
+                "milestone_title": {"type": ["null", "string"]},
+                "merge_commit_sha": {"type": ["null", "string"]},
+                "created_at": {"type": ["null", "string"]},
+                "updated_at": {"type": ["null", "string"]},
+                "closed_at": {"type": ["null", "string"]},
+                "merged_at": {"type": ["null", "string"]},
+                "head_ref": {"type": ["null", "string"]},
+                "base_ref": {"type": ["null", "string"]},
+                "additions": {"type": ["null", "integer"]},
+                "deletions": {"type": ["null", "integer"]},
+                "changed_files": {"type": ["null", "integer"]},
+                "author_login": {"type": ["null", "string"]},
+                "author_id": {"type": ["null", "integer"]},
+                "author_email": {"type": ["null", "string"]},
+                "merged_by_login": {"type": ["null", "string"]},
+                "merged_by_id": {"type": ["null", "integer"]},
+                "commit_count": {"type": ["null", "integer"]},
+                "comment_count": {"type": ["null", "integer"]},
+                "review_count": {"type": ["null", "integer"]},
+                "requested_reviewers": {"type": ["null", "array"], "items": {"type": "string"}},
+                "requested_teams": {"type": ["null", "array"], "items": {"type": "string"}},
+                "repo_owner": {"type": "string"},
+                "repo_name": {"type": "string"},
+            },
+        }

--- a/src/ingestion/connectors/git/github-v2/source_github_v2/streams/repositories.py
+++ b/src/ingestion/connectors/git/github-v2/source_github_v2/streams/repositories.py
@@ -1,0 +1,122 @@
+"""GitHub repositories stream (REST, full refresh)."""
+
+import json
+import logging
+import os
+import tempfile
+from typing import Any, Iterable, Mapping, Optional
+
+from source_github_v2.streams.base import GitHubRestStream, _make_unique_key
+
+logger = logging.getLogger("airbyte")
+
+
+class RepositoriesStream(GitHubRestStream):
+    """Fetches all repositories for configured organizations via REST API."""
+
+    name = "repositories"
+    use_cache = True
+
+    def __init__(
+        self,
+        organizations: list[str],
+        skip_archived: bool = True,
+        skip_forks: bool = True,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._organizations = organizations
+        self._skip_archived = skip_archived
+        self._skip_forks = skip_forks
+        self._child_records_path = os.path.join(tempfile.gettempdir(), "insight_repos.jsonl")
+        self._child_records_file: Any = None
+
+    def _path(self, stream_slice: Optional[Mapping[str, Any]] = None, **kwargs) -> str:
+        org = (stream_slice or {}).get("org", "")
+        if not org:
+            raise ValueError("RepositoriesStream._path() called without org in stream_slice")
+        return f"orgs/{org}/repos"
+
+    def request_params(self, **kwargs) -> dict:
+        return {"per_page": "100", "type": "all"}
+
+    def stream_slices(self, **kwargs) -> Iterable[Optional[Mapping[str, Any]]]:
+        for org in self._organizations:
+            yield {"org": org}
+
+    def parse_response(self, response, stream_slice=None, **kwargs):
+        org = (stream_slice or {}).get("org", "")
+        if response.status_code in (404, 409):
+            logger.warning(f"Skipping repos for org {org} ({response.status_code})")
+            return
+        repos = response.json()
+        if not isinstance(repos, list):
+            repos = [repos]
+        # Open child records file on first parse_response call
+        if self._child_records_file is None:
+            self._child_records_file = open(self._child_records_path, "w")
+        skipped = 0
+        for repo in repos:
+            if self._skip_archived and repo.get("archived"):
+                skipped += 1
+                continue
+            if self._skip_forks and repo.get("fork"):
+                skipped += 1
+                continue
+
+            owner = repo.get("owner", {}).get("login", "")
+            repo_name = repo.get("name", "")
+            repo["unique_key"] = _make_unique_key(
+                self._tenant_id, self._source_id, owner, repo_name,
+            )
+            repo["repo_owner"] = owner
+            record = self._add_envelope(repo)
+            # Write minimal child data to disk for child streams
+            self._child_records_file.write(json.dumps({
+                "owner": owner,
+                "name": repo_name,
+                "default_branch": repo.get("default_branch"),
+                "pushed_at": repo.get("pushed_at"),
+            }, separators=(",", ":")) + "\n")
+            yield record
+        if skipped:
+            logger.info(f"Repo filter: skipped {skipped} repos (archived/fork) in org {org}")
+
+    def get_child_records(self) -> Iterable:
+        """Yield repo records from disk. Zero memory, zero API calls."""
+        if self._child_records_file and not self._child_records_file.closed:
+            self._child_records_file.close()
+        with open(self._child_records_path, "r") as f:
+            for line in f:
+                line = line.rstrip("\n")
+                if line:
+                    yield json.loads(line)
+
+    def get_json_schema(self) -> Mapping[str, Any]:
+        return {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": True,
+            "properties": {
+                "tenant_id": {"type": "string"},
+                "source_id": {"type": "string"},
+                "unique_key": {"type": "string"},
+                "data_source": {"type": "string"},
+                "collected_at": {"type": "string"},
+                "repo_owner": {"type": "string"},
+                "name": {"type": ["null", "string"]},
+                "full_name": {"type": ["null", "string"]},
+                "private": {"type": ["null", "boolean"]},
+                "description": {"type": ["null", "string"]},
+                "language": {"type": ["null", "string"]},
+                "created_at": {"type": ["null", "string"]},
+                "updated_at": {"type": ["null", "string"]},
+                "pushed_at": {"type": ["null", "string"]},
+                "size": {"type": ["null", "integer"]},
+                "default_branch": {"type": ["null", "string"]},
+                "has_issues": {"type": ["null", "boolean"]},
+                "has_wiki": {"type": ["null", "boolean"]},
+                "fork": {"type": ["null", "boolean"]},
+                "archived": {"type": ["null", "boolean"]},
+            },
+        }

--- a/src/ingestion/connectors/git/github-v2/source_github_v2/streams/review_comments.py
+++ b/src/ingestion/connectors/git/github-v2/source_github_v2/streams/review_comments.py
@@ -1,0 +1,344 @@
+"""GitHub PR inline review comments stream (GraphQL embedded + overflow).
+
+Review thread comments are embedded in the bulk PR query with configurable
+page sizes (default: 20 threads, 20 comments per thread). This covers
+the vast majority of PRs with zero additional API calls.
+
+Overflow handling (all GraphQL):
+1. >N threads (configurable): paginate via PR_REVIEW_THREADS_QUERY
+2. >M comments in a thread (configurable): paginate via PR_THREAD_COMMENTS_QUERY
+3. Embedded data missing/corrupt: full fetch via PR_REVIEW_THREADS_QUERY
+"""
+
+import logging
+from typing import Any, Iterable, Mapping, MutableMapping, Optional
+
+import requests
+
+from source_github_v2.auth import graphql_headers
+from source_github_v2.queries import PR_REVIEW_THREADS_QUERY, PR_THREAD_COMMENTS_QUERY
+from source_github_v2.streams.base import (
+    GitHubAuthError,
+    GitHubGraphQLStream,
+    _make_unique_key,
+    _now_iso,
+)
+
+logger = logging.getLogger("airbyte")
+
+
+class ReviewCommentsStream(GitHubGraphQLStream):
+    """Fetches inline review comments for each PR via embedded GraphQL data.
+
+    Primary path: embedded reviewThreads from parent PR query (zero API calls).
+    Overflow path 1: PR_REVIEW_THREADS_QUERY for >100 threads.
+    Overflow path 2: PR_THREAD_COMMENTS_QUERY for threads with >100 comments.
+
+    Uses per-PR incremental state keyed by owner/repo/pr_number
+    with synced_at = parent PR updated_at.
+    """
+
+    name = "pull_request_review_comments"
+    cursor_field = "pull_request_updated_at"
+
+    def __init__(self, parent, **kwargs):
+        super().__init__(**kwargs)
+        self._parent = parent
+
+    def _query(self) -> str:
+        return PR_REVIEW_THREADS_QUERY
+
+    def _variables(self, stream_slice=None, next_page_token=None) -> dict:
+        s = stream_slice or {}
+        variables: dict = {
+            "owner": s.get("owner", ""),
+            "repo": s.get("repo", ""),
+            "prNumber": s.get("pr_number"),
+            "first": 100,
+        }
+        if next_page_token and "after" in next_page_token:
+            variables["after"] = next_page_token["after"]
+        elif s.get("_overflow_after"):
+            variables["after"] = s["_overflow_after"]
+        return variables
+
+    def _extract_nodes(self, data: dict) -> list:
+        return self._safe_get(data, "repository", "pullRequest", "reviewThreads", "nodes") or []
+
+    def _extract_page_info(self, data: dict) -> dict:
+        return self._safe_get(data, "repository", "pullRequest", "reviewThreads", "pageInfo") or {}
+
+    def stream_slices(
+        self,
+        stream_state: Optional[Mapping[str, Any]] = None,
+        **kwargs,
+    ) -> Iterable[Optional[Mapping[str, Any]]]:
+        state = stream_state or {}
+        total = 0
+        skipped = 0
+        skipped_no_reviews = 0
+        for pr in self._parent.get_child_slices():
+            owner = pr.get("repo_owner", "")
+            repo = pr.get("repo_name", "")
+            pr_number = pr.get("number")
+            pr_database_id = pr.get("database_id")
+            pr_updated_at = pr.get("updated_at", "")
+            review_count = pr.get("review_count")
+            if not (owner and repo and pr_number):
+                continue
+            total += 1
+            if review_count == 0:
+                skipped_no_reviews += 1
+                continue
+            partition_key = f"{owner}/{repo}/{pr_number}"
+            child_cursor = state.get(partition_key, {}).get("synced_at", "")
+            if pr_updated_at and child_cursor and pr_updated_at <= child_cursor:
+                skipped += 1
+                continue
+            yield {
+                "owner": owner,
+                "repo": repo,
+                "pr_number": pr_number,
+                "pr_database_id": pr_database_id,
+                "pr_updated_at": pr_updated_at,
+                "partition_key": partition_key,
+                "embedded_offset": pr.get("embedded_offset", 0),
+                "review_threads_has_next_page": pr.get("review_threads_has_next_page", False),
+                "review_threads_end_cursor": pr.get("review_threads_end_cursor"),
+            }
+        fetched = total - skipped - skipped_no_reviews
+        if skipped or skipped_no_reviews:
+            logger.info(
+                f"Review comments: {fetched}/{total} PRs need sync "
+                f"({skipped} unchanged, {skipped_no_reviews} zero reviews)"
+            )
+
+    def _make_record(self, comment_node: dict, thread_node: dict, stream_slice: dict) -> dict:
+        """Build output record from a GraphQL review thread comment node."""
+        s = stream_slice or {}
+        owner = s.get("owner", "")
+        repo = s.get("repo", "")
+        pr_number = s.get("pr_number")
+        pr_database_id = s.get("pr_database_id")
+        pr_id = str(pr_database_id) if pr_database_id is not None else ""
+
+        database_id = comment_node.get("databaseId")
+        comment_id = str(database_id) if database_id is not None else ""
+        author = comment_node.get("author") or {}
+
+        return {
+            "unique_key": _make_unique_key(
+                self._tenant_id, self._source_id, owner, repo, pr_id, "rc", comment_id,
+            ),
+            "tenant_id": self._tenant_id,
+            "source_id": self._source_id,
+            "data_source": "insight_github",
+            "collected_at": _now_iso(),
+            "database_id": database_id,
+            "pr_number": pr_number,
+            "pull_request_id": pr_database_id,
+            "body": comment_node.get("body"),
+            "filename": comment_node.get("filename"),
+            "line": comment_node.get("line"),
+            "start_line": comment_node.get("startLine"),
+            "diff_hunk": comment_node.get("diffHunk"),
+            "commit_id": (comment_node.get("commit") or {}).get("oid"),
+            "original_commit_id": (comment_node.get("originalCommit") or {}).get("oid"),
+            "in_reply_to_id": (comment_node.get("replyTo") or {}).get("databaseId"),
+            "thread_resolved": thread_node.get("isResolved"),
+            "created_at": comment_node.get("createdAt"),
+            "updated_at": comment_node.get("updatedAt"),
+            "author_login": author.get("login"),
+            "author_id": author.get("databaseId"),
+            "author_association": comment_node.get("authorAssociation"),
+            "pull_request_updated_at": s.get("pr_updated_at"),
+            "repo_owner": owner,
+            "repo_name": repo,
+        }
+
+    def _yield_thread_comments(self, thread: dict, stream_slice: dict):
+        """Yield all comments from a thread, paginating if >100 comments."""
+        comments_conn = thread.get("comments") or {}
+        comment_nodes = comments_conn.get("nodes") or []
+        page_info = comments_conn.get("pageInfo") or {}
+
+        # Yield embedded comments
+        for node in comment_nodes:
+            yield self._make_record(node, thread, stream_slice)
+
+        # Overflow: paginate this thread's comments if >100
+        if not page_info.get("hasNextPage"):
+            return
+
+        thread_id = thread.get("id")
+        if not thread_id:
+            return
+
+        logger.debug(
+            f"Review thread {thread_id[:20]}... has >100 comments, "
+            f"paginating from {page_info.get('endCursor')}"
+        )
+        after = page_info.get("endCursor")
+        headers = graphql_headers(self._token)
+
+        while after:
+            body = {
+                "query": PR_THREAD_COMMENTS_QUERY,
+                "variables": {"threadId": thread_id, "first": 100, "after": after},
+            }
+            resp = requests.post(
+                "https://api.github.com/graphql",
+                json=body,
+                headers=headers,
+                timeout=120,
+            )
+            if resp.status_code != 200:
+                logger.warning(f"Thread comment overflow failed ({resp.status_code}), skipping remaining")
+                return
+
+            data = resp.json()
+            if "errors" in data and not data.get("data"):
+                logger.warning(f"Thread comment overflow GraphQL error: {data['errors']}")
+                return
+
+            node_data = self._safe_get(data, "node") or {}
+            thread_info = {"isResolved": node_data.get("isResolved", thread.get("isResolved"))}
+            overflow_comments = self._safe_get(node_data, "comments", "nodes") or []
+            overflow_page = self._safe_get(node_data, "comments", "pageInfo") or {}
+
+            for node in overflow_comments:
+                yield self._make_record(node, thread_info, stream_slice)
+
+            if overflow_page.get("hasNextPage"):
+                after = overflow_page.get("endCursor")
+            else:
+                after = None
+
+    def parse_response(self, response, stream_slice=None, **kwargs):
+        """CDK calls this for thread overflow pages. Each thread's comments are yielded inline."""
+        s = stream_slice or {}
+        owner = s.get("owner", "")
+        repo = s.get("repo", "")
+        pr_number = s.get("pr_number")
+
+        body = response.json()
+        self._update_graphql_rate_limit(body, response)
+
+        if "errors" in body:
+            if "data" not in body or body.get("data") is None:
+                raise RuntimeError(
+                    f"GraphQL errors for {owner}/{repo} PR#{pr_number} review threads: {body['errors']}"
+                )
+            logger.warning(f"GraphQL partial errors (continuing with data): {body['errors']}")
+
+        data = body.get("data", {})
+        thread_nodes = self._extract_nodes(data)
+
+        for thread in thread_nodes:
+            yield from self._yield_thread_comments(thread, s)
+
+    def read_records(self, sync_mode=None, stream_slice=None, stream_state=None, **kwargs):
+        """Yield embedded review thread comments, then overflow-paginate if needed."""
+        s = stream_slice or {}
+        owner = s.get("owner", "")
+        repo = s.get("repo", "")
+        pr_number = s.get("pr_number")
+
+        try:
+            # Step 1: read embedded review threads from disk
+            rt_data = self._parent.read_embedded_data(s.get("embedded_offset", 0), "review_threads")
+            thread_nodes = rt_data.get("nodes") or []
+            embedded_count = 0
+
+            for thread in thread_nodes:
+                for record in self._yield_thread_comments(thread, s):
+                    embedded_count += 1
+                    yield record
+
+            # Step 2: if embedded data was read successfully (even if zero comments), check completeness
+            embedded_data_available = bool(rt_data)  # non-empty dict means file read succeeded
+            if embedded_data_available and not s.get("review_threads_has_next_page", False):
+                logger.debug(
+                    f"Review comments {owner}/{repo} PR#{pr_number}: "
+                    f"{embedded_count} from {len(thread_nodes)} threads (complete)"
+                )
+                return
+
+            # Step 3: overflow or full fetch if embedded data was missing/incomplete
+            if not embedded_data_available:
+                logger.debug(
+                    f"Review comments {owner}/{repo} PR#{pr_number}: "
+                    f"no embedded data, full fetch"
+                )
+            else:
+                logger.debug(
+                    f"Review comments {owner}/{repo} PR#{pr_number}: "
+                    f"{embedded_count} embedded, thread overflow needed"
+                )
+            end_cursor = s.get("review_threads_end_cursor") if embedded_data_available else None
+            if end_cursor:
+                overflow_slice = dict(s)
+                overflow_slice["_overflow_after"] = end_cursor
+                yield from super().read_records(
+                    sync_mode=sync_mode, stream_slice=overflow_slice,
+                    stream_state=stream_state, **kwargs,
+                )
+            else:
+                yield from super().read_records(
+                    sync_mode=sync_mode, stream_slice=stream_slice,
+                    stream_state=stream_state, **kwargs,
+                )
+
+        except GitHubAuthError:
+            raise
+        except Exception as exc:
+            pk = s.get("partition_key", "?")
+            logger.warning(f"Skipping review_comments slice {pk}: {exc}")
+
+    def get_updated_state(
+        self,
+        current_stream_state: MutableMapping[str, Any],
+        latest_record: Mapping[str, Any],
+    ) -> MutableMapping[str, Any]:
+        owner = latest_record.get("repo_owner", "")
+        repo = latest_record.get("repo_name", "")
+        pr_number = latest_record.get("pr_number")
+        partition_key = f"{owner}/{repo}/{pr_number}" if (owner and repo and pr_number) else ""
+        pr_updated_at = latest_record.get("pull_request_updated_at", "")
+        if partition_key and pr_updated_at:
+            current_stream_state[partition_key] = {"synced_at": pr_updated_at}
+        return current_stream_state
+
+    def get_json_schema(self) -> Mapping[str, Any]:
+        return {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": True,
+            "properties": {
+                "tenant_id": {"type": "string"},
+                "source_id": {"type": "string"},
+                "unique_key": {"type": "string"},
+                "data_source": {"type": "string"},
+                "collected_at": {"type": "string"},
+                "database_id": {"type": ["null", "integer"]},
+                "pr_number": {"type": ["null", "integer"]},
+                "pull_request_id": {"type": ["null", "integer"]},
+                "body": {"type": ["null", "string"]},
+                "filename": {"type": ["null", "string"]},
+                "line": {"type": ["null", "integer"]},
+                "start_line": {"type": ["null", "integer"]},
+                "diff_hunk": {"type": ["null", "string"]},
+                "commit_id": {"type": ["null", "string"]},
+                "original_commit_id": {"type": ["null", "string"]},
+                "in_reply_to_id": {"type": ["null", "integer"]},
+                "thread_resolved": {"type": ["null", "boolean"]},
+                "created_at": {"type": ["null", "string"]},
+                "updated_at": {"type": ["null", "string"]},
+                "author_login": {"type": ["null", "string"]},
+                "author_id": {"type": ["null", "integer"]},
+                "author_association": {"type": ["null", "string"]},
+                "pull_request_updated_at": {"type": ["null", "string"]},
+                "repo_owner": {"type": "string"},
+                "repo_name": {"type": "string"},
+            },
+        }

--- a/src/ingestion/connectors/git/github-v2/source_github_v2/streams/reviews.py
+++ b/src/ingestion/connectors/git/github-v2/source_github_v2/streams/reviews.py
@@ -1,0 +1,258 @@
+"""GitHub PR reviews stream (GraphQL, per-PR sequential, incremental).
+
+Follows the same pattern as PRCommitsStream and CommentsStream:
+- Embedded reviews from the parent PR query are yielded first
+- If the PR has <= 100 reviews (reviews_complete=True), no additional
+  API call is needed
+- Otherwise, pagination continues from the embedded end_cursor
+"""
+
+import logging
+from typing import Any, Iterable, Mapping, MutableMapping, Optional
+
+from source_github_v2.queries import PR_REVIEWS_QUERY
+from source_github_v2.streams.base import (
+    GitHubAuthError,
+    GitHubGraphQLStream,
+    _make_unique_key,
+    _now_iso,
+)
+
+logger = logging.getLogger("airbyte")
+
+
+class ReviewsStream(GitHubGraphQLStream):
+    """Fetches reviews for each PR via GraphQL.
+
+    Uses per-PR incremental state keyed by owner/repo/pr_number
+    with synced_at = parent PR updated_at.
+    """
+
+    name = "pull_request_reviews"
+    cursor_field = "pull_request_updated_at"
+
+    def __init__(self, parent, **kwargs):
+        super().__init__(**kwargs)
+        self._parent = parent
+
+    def _query(self) -> str:
+        return PR_REVIEWS_QUERY
+
+    def stream_slices(
+        self,
+        stream_state: Optional[Mapping[str, Any]] = None,
+        **kwargs,
+    ) -> Iterable[Optional[Mapping[str, Any]]]:
+        state = stream_state or {}
+        total = 0
+        skipped = 0
+        skipped_no_reviews = 0
+        for pr in self._parent.get_child_slices():
+            owner = pr.get("repo_owner", "")
+            repo = pr.get("repo_name", "")
+            pr_number = pr.get("number")
+            pr_database_id = pr.get("database_id")
+            pr_updated_at = pr.get("updated_at", "")
+            review_count = pr.get("review_count")
+            if not (owner and repo and pr_number):
+                continue
+            total += 1
+            if review_count == 0:
+                skipped_no_reviews += 1
+                continue
+            partition_key = f"{owner}/{repo}/{pr_number}"
+            child_cursor = state.get(partition_key, {}).get("synced_at", "")
+            if pr_updated_at and child_cursor and pr_updated_at <= child_cursor:
+                skipped += 1
+                continue
+            yield {
+                "owner": owner,
+                "repo": repo,
+                "pr_number": pr_number,
+                "pr_database_id": pr_database_id,
+                "pr_updated_at": pr_updated_at,
+                "partition_key": partition_key,
+                "embedded_offset": pr.get("embedded_offset", 0),
+                "reviews_complete": pr.get("reviews_complete", False),
+                "reviews_end_cursor": pr.get("reviews_end_cursor"),
+            }
+        fetched = total - skipped - skipped_no_reviews
+        if skipped or skipped_no_reviews:
+            logger.info(
+                f"Reviews: {fetched}/{total} PRs need review sync "
+                f"({skipped} unchanged, {skipped_no_reviews} zero reviews)"
+            )
+
+    def _variables(self, stream_slice=None, next_page_token=None) -> dict:
+        s = stream_slice or {}
+        variables: dict = {
+            "owner": s.get("owner", ""),
+            "repo": s.get("repo", ""),
+            "prNumber": s.get("pr_number"),
+            "first": 100,
+        }
+        if next_page_token and "after" in next_page_token:
+            variables["after"] = next_page_token["after"]
+        elif s.get("_overflow_after"):
+            variables["after"] = s["_overflow_after"]
+        return variables
+
+    def _extract_nodes(self, data: dict) -> list:
+        return self._safe_get(data, "repository", "pullRequest", "reviews", "nodes") or []
+
+    def _extract_page_info(self, data: dict) -> dict:
+        return self._safe_get(data, "repository", "pullRequest", "reviews", "pageInfo") or {}
+
+    def _make_record(self, node: dict, stream_slice: dict) -> Optional[dict]:
+        """Build an output record from a GraphQL review node. Returns None for PENDING reviews."""
+        state_val = node.get("state")
+        if state_val == "PENDING":
+            return None
+
+        s = stream_slice or {}
+        owner = s.get("owner", "")
+        repo = s.get("repo", "")
+        pr_number = s.get("pr_number")
+        pr_database_id = s.get("pr_database_id")
+        pr_id = str(pr_database_id) if pr_database_id is not None else ""
+
+        database_id = node.get("databaseId")
+        review_id = str(database_id) if database_id is not None else ""
+        author = node.get("author") or {}
+
+        return {
+            "unique_key": _make_unique_key(
+                self._tenant_id, self._source_id, owner, repo, pr_id, review_id,
+            ),
+            "tenant_id": self._tenant_id,
+            "source_id": self._source_id,
+            "data_source": "insight_github",
+            "collected_at": _now_iso(),
+            "database_id": database_id,
+            "pr_number": pr_number,
+            "pull_request_id": pr_database_id,
+            "state": state_val,
+            "body": node.get("body"),
+            "submitted_at": node.get("submittedAt"),
+            "author_login": author.get("login"),
+            "author_id": author.get("databaseId"),
+            "author_association": node.get("authorAssociation"),
+            "commit_id": (node.get("commit") or {}).get("oid"),
+            "pull_request_updated_at": s.get("pr_updated_at"),
+            "repo_owner": owner,
+            "repo_name": repo,
+        }
+
+    def parse_response(self, response, stream_slice=None, **kwargs):
+        """CDK calls this for each overflow page."""
+        s = stream_slice or {}
+        owner = s.get("owner", "")
+        repo = s.get("repo", "")
+        pr_number = s.get("pr_number")
+
+        body = response.json()
+        self._update_graphql_rate_limit(body, response)
+
+        if "errors" in body:
+            if "data" not in body or body.get("data") is None:
+                raise RuntimeError(
+                    f"GraphQL errors for {owner}/{repo} PR#{pr_number} reviews: {body['errors']}"
+                )
+            logger.warning(f"GraphQL partial errors (continuing with data): {body['errors']}")
+
+        data = body.get("data", {})
+        nodes = self._extract_nodes(data)
+
+        for node in nodes:
+            record = self._make_record(node, s)
+            if record is not None:
+                yield record
+
+    def read_records(self, sync_mode=None, stream_slice=None, stream_state=None, **kwargs):
+        """Yield embedded records first, then overflow-paginate if needed."""
+        s = stream_slice or {}
+        owner = s.get("owner", "")
+        repo = s.get("repo", "")
+        pr_number = s.get("pr_number")
+
+        try:
+            # Step 1: read embedded records from disk
+            reviews_data = self._parent.read_embedded_data(s.get("embedded_offset", 0), "reviews")
+            embedded_nodes = reviews_data.get("nodes") or []
+            embedded_count = 0
+            for node in embedded_nodes:
+                record = self._make_record(node, s)
+                if record is not None:
+                    embedded_count += 1
+                    yield record
+
+            # Step 2: if embedded data was read successfully, check completeness
+            embedded_data_available = bool(reviews_data)
+            if embedded_data_available and s.get("reviews_complete", False):
+                logger.debug(f"Reviews {owner}/{repo} PR#{pr_number}: {embedded_count} embedded (complete)")
+                return
+
+            # Step 3: overflow or full fetch if embedded data was missing/incomplete
+            if not embedded_data_available:
+                logger.debug(f"Reviews {owner}/{repo} PR#{pr_number}: no embedded data, full fetch")
+            else:
+                logger.debug(f"Reviews {owner}/{repo} PR#{pr_number}: {embedded_count} embedded, overflow needed")
+            end_cursor = s.get("reviews_end_cursor") if embedded_data_available else None
+            if end_cursor:
+                overflow_slice = dict(s)
+                overflow_slice["_overflow_after"] = end_cursor
+                yield from super().read_records(
+                    sync_mode=sync_mode, stream_slice=overflow_slice,
+                    stream_state=stream_state, **kwargs,
+                )
+            else:
+                yield from super().read_records(
+                    sync_mode=sync_mode, stream_slice=stream_slice,
+                    stream_state=stream_state, **kwargs,
+                )
+        except GitHubAuthError:
+            raise
+        except Exception as exc:
+            pk = s.get("partition_key", "?")
+            logger.warning(f"Skipping reviews slice {pk}: {exc}")
+
+    def get_updated_state(
+        self,
+        current_stream_state: MutableMapping[str, Any],
+        latest_record: Mapping[str, Any],
+    ) -> MutableMapping[str, Any]:
+        owner = latest_record.get("repo_owner", "")
+        repo = latest_record.get("repo_name", "")
+        pr_number = latest_record.get("pr_number")
+        partition_key = f"{owner}/{repo}/{pr_number}" if (owner and repo and pr_number) else ""
+        pr_updated_at = latest_record.get("pull_request_updated_at", "")
+        if partition_key and pr_updated_at:
+            current_stream_state[partition_key] = {"synced_at": pr_updated_at}
+        return current_stream_state
+
+    def get_json_schema(self) -> Mapping[str, Any]:
+        return {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "additionalProperties": True,
+            "properties": {
+                "tenant_id": {"type": "string"},
+                "source_id": {"type": "string"},
+                "unique_key": {"type": "string"},
+                "data_source": {"type": "string"},
+                "collected_at": {"type": "string"},
+                "database_id": {"type": ["null", "integer"]},
+                "pr_number": {"type": ["null", "integer"]},
+                "pull_request_id": {"type": ["null", "integer"]},
+                "state": {"type": ["null", "string"]},
+                "body": {"type": ["null", "string"]},
+                "submitted_at": {"type": ["null", "string"]},
+                "author_login": {"type": ["null", "string"]},
+                "author_id": {"type": ["null", "integer"]},
+                "author_association": {"type": ["null", "string"]},
+                "commit_id": {"type": ["null", "string"]},
+                "pull_request_updated_at": {"type": ["null", "string"]},
+                "repo_owner": {"type": "string"},
+                "repo_name": {"type": "string"},
+            },
+        }

--- a/src/ingestion/connectors/git/github/descriptor.yaml
+++ b/src/ingestion/connectors/git/github/descriptor.yaml
@@ -21,27 +21,27 @@ silver_targets:
 streams:
   - name: repositories
     bronze_table: repositories
-    primary_key: [pk]
+    primary_key: [unique_key]
   - name: branches
     bronze_table: branches
-    primary_key: [pk]
+    primary_key: [unique_key]
   - name: commits
     bronze_table: commits
-    primary_key: [pk]
+    primary_key: [unique_key]
     cursor_field: committed_date
   - name: file_changes
     bronze_table: file_changes
-    primary_key: [pk]
+    primary_key: [unique_key]
   - name: pull_requests
     bronze_table: pull_requests
-    primary_key: [pk]
+    primary_key: [unique_key]
     cursor_field: updated_at
   - name: pull_request_reviews
     bronze_table: pull_request_reviews
-    primary_key: [pk]
+    primary_key: [unique_key]
   - name: pull_request_comments
     bronze_table: pull_request_comments
-    primary_key: [pk]
+    primary_key: [unique_key]
   - name: pull_request_commits
     bronze_table: pull_request_commits
-    primary_key: [pk]
+    primary_key: [unique_key]

--- a/src/ingestion/connectors/git/github/source_github/source.py
+++ b/src/ingestion/connectors/git/github/source_github/source.py
@@ -35,8 +35,8 @@ class SourceGitHub(AbstractSource):
         import requests
         from source_github.clients.auth import rest_headers
 
-        token = config["token"]
-        organizations = config.get("organizations", [])
+        token = config["github_token"]
+        organizations = config.get("github_organizations", [])
         headers = rest_headers(token)
 
         try:
@@ -60,18 +60,15 @@ class SourceGitHub(AbstractSource):
             return False, str(e)
 
     def streams(self, config: Mapping[str, Any]) -> List[Stream]:
-        token = config["token"]
+        token = config["github_token"]
         tenant_id = config["insight_tenant_id"]
         source_id = config["insight_source_id"]
-        organizations = config["organizations"]
-        start_date = config.get("start_date")
-        page_size_commits = config.get("page_size_graphql_commits", 100)
-        page_size_prs = config.get("page_size_graphql_prs", 50)
-        rate_limit_threshold = config.get("rate_limit_threshold", 200)
+        organizations = config["github_organizations"]
+        start_date = config.get("github_start_date")
         skip_archived = config.get("skip_archived", True)
         skip_forks = config.get("skip_forks", True)
         max_workers = config.get("max_workers", 5)
-        rate_limiter = RateLimiter(threshold=rate_limit_threshold)
+        rate_limiter = RateLimiter(threshold=200)
 
         shared_kwargs = {
             "token": token,
@@ -90,13 +87,13 @@ class SourceGitHub(AbstractSource):
         branches = BranchesStream(parent=repos, **shared_kwargs)
         commits = CommitsStream(
             parent=branches,
-            page_size=page_size_commits,
+            page_size=100,
             start_date=start_date,
             **shared_kwargs,
         )
         prs = PullRequestsStream(
             parent=repos,
-            page_size=page_size_prs,
+            page_size=100,
             **shared_kwargs,
         )
 

--- a/src/ingestion/connectors/git/github/source_github/source.py
+++ b/src/ingestion/connectors/git/github/source_github/source.py
@@ -93,7 +93,7 @@ class SourceGitHub(AbstractSource):
         )
         prs = PullRequestsStream(
             parent=repos,
-            page_size=100,
+            page_size=50,
             **shared_kwargs,
         )
 

--- a/src/ingestion/connectors/git/github/source_github/source.py
+++ b/src/ingestion/connectors/git/github/source_github/source.py
@@ -94,6 +94,7 @@ class SourceGitHub(AbstractSource):
         prs = PullRequestsStream(
             parent=repos,
             page_size=50,
+            start_date=start_date,
             **shared_kwargs,
         )
 

--- a/src/ingestion/connectors/git/github/source_github/spec.json
+++ b/src/ingestion/connectors/git/github/source_github/spec.json
@@ -38,9 +38,10 @@
       "start_date": {
         "type": "string",
         "title": "Start Date",
-        "description": "UTC date for initial collection (ISO 8601). Commits before this date are skipped on the first run. Default: no limit.",
-        "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
-        "examples": ["2024-01-01T00:00:00Z"],
+        "description": "Start date for initial collection (YYYY-MM-DD). Commits before this date are skipped on the first run. Default: no limit.",
+        "format": "date",
+        "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+        "examples": ["2024-01-01"],
         "order": 4
       },
       "page_size_graphql_commits": {

--- a/src/ingestion/connectors/git/github/source_github/spec.json
+++ b/src/ingestion/connectors/git/github/source_github/spec.json
@@ -4,7 +4,7 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "GitHub Source",
     "type": "object",
-    "required": ["insight_tenant_id", "insight_source_id", "token", "organizations"],
+    "required": ["insight_tenant_id", "insight_source_id", "github_token", "github_organizations"],
     "additionalProperties": true,
     "properties": {
       "insight_tenant_id": {
@@ -20,14 +20,14 @@
         "examples": ["github-acme-prod"],
         "order": 1
       },
-      "token": {
+      "github_token": {
         "type": "string",
         "title": "Access Token",
         "description": "GitHub Personal Access Token or GitHub App installation token. Required scopes: repo, read:org, read:user.",
         "airbyte_secret": true,
         "order": 2
       },
-      "organizations": {
+      "github_organizations": {
         "type": "array",
         "items": { "type": "string" },
         "title": "Organizations",
@@ -35,7 +35,7 @@
         "minItems": 1,
         "order": 3
       },
-      "start_date": {
+      "github_start_date": {
         "type": "string",
         "title": "Start Date",
         "description": "Start date for initial collection (YYYY-MM-DD). Commits before this date are skipped on the first run. Default: no limit.",
@@ -44,44 +44,19 @@
         "examples": ["2024-01-01"],
         "order": 4
       },
-      "page_size_graphql_commits": {
-        "type": "integer",
-        "title": "GraphQL Commits Page Size",
-        "description": "Number of commits per GraphQL request (max 100).",
-        "default": 100,
-        "minimum": 1,
-        "maximum": 100,
-        "order": 5
-      },
-      "page_size_graphql_prs": {
-        "type": "integer",
-        "title": "GraphQL PRs Page Size",
-        "description": "Number of PRs per GraphQL request (max 100).",
-        "default": 100,
-        "minimum": 1,
-        "maximum": 100,
-        "order": 6
-      },
-      "rate_limit_threshold": {
-        "type": "integer",
-        "title": "Rate Limit Threshold",
-        "description": "Proactive backoff when remaining API budget drops below this value.",
-        "default": 200,
-        "order": 7
-      },
       "skip_archived": {
         "type": "boolean",
         "title": "Skip Archived Repos",
         "description": "Skip archived repositories during collection.",
         "default": true,
-        "order": 8
+        "order": 5
       },
       "skip_forks": {
         "type": "boolean",
         "title": "Skip Forked Repos",
         "description": "Skip forked repositories during collection.",
         "default": true,
-        "order": 9
+        "order": 6
       },
       "max_workers": {
         "type": "integer",
@@ -90,7 +65,7 @@
         "default": 5,
         "minimum": 1,
         "maximum": 20,
-        "order": 10
+        "order": 7
       }
     }
   }

--- a/src/ingestion/connectors/git/github/source_github/spec.json
+++ b/src/ingestion/connectors/git/github/source_github/spec.json
@@ -56,10 +56,10 @@
       "page_size_graphql_prs": {
         "type": "integer",
         "title": "GraphQL PRs Page Size",
-        "description": "Number of PRs per GraphQL request (max 50).",
-        "default": 50,
+        "description": "Number of PRs per GraphQL request (max 100).",
+        "default": 100,
         "minimum": 1,
-        "maximum": 50,
+        "maximum": 100,
         "order": 6
       },
       "rate_limit_threshold": {

--- a/src/ingestion/connectors/git/github/source_github/streams/base.py
+++ b/src/ingestion/connectors/git/github/source_github/streams/base.py
@@ -89,6 +89,8 @@ class GitHubRestStream(HttpStream, ABC):
         self._rate_limiter = rate_limiter
 
     def request_headers(self, **kwargs) -> Mapping[str, Any]:
+        # Check shared rate limiter before every CDK-managed request
+        self._rate_limiter.wait_if_needed("rest")
         return rest_headers(self._token)
 
     def request_params(self, **kwargs) -> MutableMapping[str, Any]:
@@ -189,6 +191,8 @@ class GitHubGraphQLStream(HttpStream, ABC):
         return "graphql"
 
     def request_headers(self, **kwargs) -> Mapping[str, Any]:
+        # Check shared rate limiter before every CDK-managed request
+        self._rate_limiter.wait_if_needed("graphql")
         return graphql_headers(self._token)
 
     @abstractmethod
@@ -239,6 +243,22 @@ class GitHubGraphQLStream(HttpStream, ABC):
         if response.status_code in (401, 403):
             return False
         return response.status_code in (429, 500, 502, 503, 504)
+
+    def backoff_time(self, response: requests.Response) -> Optional[float]:
+        if response.status_code == 429 or (response.status_code == 403 and _is_rate_limit_403(response)):
+            retry_after = response.headers.get("Retry-After")
+            if retry_after:
+                return max(float(retry_after), 1.0)
+            reset = response.headers.get("x-ratelimit-reset")
+            if reset:
+                import time
+                wait = float(reset) - time.time() + 1
+                return max(wait, 1.0)
+            return 60.0
+        if response.status_code in (502, 503):
+            self._rate_limiter.on_secondary_limit()
+            return 60.0
+        return None
 
     def parse_response(
         self,

--- a/src/ingestion/connectors/git/github/source_github/streams/base.py
+++ b/src/ingestion/connectors/git/github/source_github/streams/base.py
@@ -64,11 +64,6 @@ def _is_fatal(exc: Exception) -> bool:
     return False
 
 
-def _make_pk(tenant_id: str, source_id: str, *parts: str) -> str:
-    suffix = ":".join(parts)
-    return f"urn:github:{tenant_id}:{source_id}:{suffix}"
-
-
 def _make_unique_key(tenant_id: str, source_id: str, *natural_key_parts: str) -> str:
     return f"{tenant_id}-{source_id}-{'-'.join(natural_key_parts)}"
 
@@ -77,7 +72,7 @@ class GitHubRestStream(HttpStream, ABC):
     """Base for GitHub REST API v3 streams."""
 
     url_base = "https://api.github.com/"
-    primary_key = "pk"
+    primary_key = "unique_key"
 
     def __init__(
         self,
@@ -165,7 +160,6 @@ class GitHubRestStream(HttpStream, ABC):
         record["data_source"] = "insight_github"
         record["collected_at"] = _now_iso()
         if pk_parts:
-            record["pk"] = _make_pk(self._tenant_id, self._source_id, *pk_parts)
             record["unique_key"] = _make_unique_key(self._tenant_id, self._source_id, *pk_parts)
         return record
 
@@ -174,7 +168,7 @@ class GitHubGraphQLStream(HttpStream, ABC):
     """Base for GitHub GraphQL API v4 streams."""
 
     url_base = "https://api.github.com/"
-    primary_key = "pk"
+    primary_key = "unique_key"
     http_method = "POST"
 
     def __init__(
@@ -287,6 +281,5 @@ class GitHubGraphQLStream(HttpStream, ABC):
         record["data_source"] = "insight_github"
         record["collected_at"] = _now_iso()
         if pk_parts:
-            record["pk"] = _make_pk(self._tenant_id, self._source_id, *pk_parts)
             record["unique_key"] = _make_unique_key(self._tenant_id, self._source_id, *pk_parts)
         return record

--- a/src/ingestion/connectors/git/github/source_github/streams/branches.py
+++ b/src/ingestion/connectors/git/github/source_github/streams/branches.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Iterable, List, Mapping, Optional
 
-from source_github.streams.base import GitHubRestStream, _make_pk, _make_unique_key, check_rest_response
+from source_github.streams.base import GitHubRestStream, _make_unique_key, check_rest_response
 from source_github.streams.repositories import RepositoriesStream
 
 
@@ -61,10 +61,6 @@ class BranchesStream(GitHubRestStream):
         repo = stream_slice["repo"]
         for branch in branches:
             branch_name = branch.get("name", "")
-            branch["pk"] = _make_pk(
-                self._tenant_id, self._source_id,
-                owner, repo, branch_name,
-            )
             branch["unique_key"] = _make_unique_key(
                 self._tenant_id, self._source_id,
                 owner, repo, branch_name,
@@ -81,7 +77,6 @@ class BranchesStream(GitHubRestStream):
             "type": "object",
             "additionalProperties": True,
             "properties": {
-                "pk": {"type": "string"},
                 "tenant_id": {"type": "string"},
                 "source_id": {"type": "string"},
                 "unique_key": {"type": "string"},

--- a/src/ingestion/connectors/git/github/source_github/streams/comments.py
+++ b/src/ingestion/connectors/git/github/source_github/streams/comments.py
@@ -7,7 +7,7 @@ import requests as req
 
 from source_github.clients.auth import rest_headers
 from source_github.clients.concurrent import fetch_parallel_with_slices, retry_request
-from source_github.streams.base import GitHubRestStream, _is_fatal, _make_pk, _make_unique_key, _now_iso, check_rest_response, _is_rate_limit_403
+from source_github.streams.base import GitHubRestStream, _is_fatal, _make_unique_key, _now_iso, check_rest_response, _is_rate_limit_403
 from source_github.streams.pull_requests import PullRequestsStream
 
 logger = logging.getLogger("airbyte")
@@ -236,7 +236,6 @@ class CommentsStream(GitHubRestStream):
                 comment_id = str(comment.get("id", ""))
                 user = comment.get("user") or {}
                 record = {
-                    "pk": _make_pk(self._tenant_id, self._source_id, owner, repo, pk_prefix, comment_id),
                     "unique_key": _make_unique_key(self._tenant_id, self._source_id, owner, repo, pk_prefix, comment_id),
                     "tenant_id": self._tenant_id,
                     "source_id": self._source_id,
@@ -313,7 +312,6 @@ class CommentsStream(GitHubRestStream):
             "type": "object",
             "additionalProperties": True,
             "properties": {
-                "pk": {"type": "string"},
                 "tenant_id": {"type": "string"},
                 "source_id": {"type": "string"},
                 "unique_key": {"type": "string"},

--- a/src/ingestion/connectors/git/github/source_github/streams/comments.py
+++ b/src/ingestion/connectors/git/github/source_github/streams/comments.py
@@ -102,9 +102,9 @@ class CommentsStream(GitHubRestStream):
             self._state = stream_state
 
         if stream_slice is not None:
-            records = self._fetch_repo_comments(stream_slice)
+            records, general_page_max, inline_page_max = self._fetch_repo_comments(stream_slice)
             yield from records
-            self._advance_state(stream_slice, records)
+            self._advance_state(stream_slice, records, general_page_max, inline_page_max)
         else:
             slices = self.stream_slices(stream_state=stream_state)
             for result in fetch_parallel_with_slices(self._fetch_repo_comments, slices, self._max_workers):
@@ -113,18 +113,20 @@ class CommentsStream(GitHubRestStream):
                         raise result.error
                     logger.warning(f"Skipping comment slice {result.slice.get('repo_key', '?')}: {result.error}")
                     continue
-                yield from result.records
-                self._advance_state(result.slice, result.records)
+                records, general_page_max, inline_page_max = result.records
+                yield from records
+                self._advance_state(result.slice, records, general_page_max, inline_page_max)
 
-    def _advance_state(self, stream_slice: Mapping[str, Any], records: List[Mapping[str, Any]]):
+    def _advance_state(self, stream_slice: Mapping[str, Any], records: List[Mapping[str, Any]],
+                        general_page_max: str = "", inline_page_max: str = ""):
         repo_key = stream_slice.get("repo_key", "")
         if not repo_key:
             return
         # Use page-level max timestamps (covers ALL items on the page, including
         # non-PR issue comments that were filtered out). This ensures the cursor
         # advances past active issue comments so they don't replay forever.
-        max_general = stream_slice.get("_general_page_max", "") or stream_slice.get("general_since", "")
-        max_inline = stream_slice.get("_inline_page_max", "") or stream_slice.get("inline_since", "")
+        max_general = general_page_max or stream_slice.get("general_since", "")
+        max_inline = inline_page_max or stream_slice.get("inline_since", "")
         # Also check emitted records in case page-level max wasn't set
         for r in records:
             updated = r.get("updated_at", "")
@@ -141,17 +143,18 @@ class CommentsStream(GitHubRestStream):
         if max_inline:
             self._state[f"{repo_key}/inline"] = {"since": max_inline}
 
-    def _fetch_repo_comments(self, stream_slice: dict) -> List[Mapping[str, Any]]:
-        """Fetch both general and inline comments for one repo. Thread-safe."""
+    def _fetch_repo_comments(self, stream_slice: dict) -> tuple:
+        """Fetch both general and inline comments for one repo. Thread-safe.
+
+        Returns (records, general_page_max, inline_page_max) to avoid mutating
+        the input stream_slice which may be shared across concurrent workers.
+        """
         records = []
         general_records, general_page_max = self._fetch_paginated(stream_slice, comment_type="general")
         inline_records, inline_page_max = self._fetch_paginated(stream_slice, comment_type="inline")
         records.extend(general_records)
         records.extend(inline_records)
-        # Stash page-level max timestamps on the slice for _advance_state
-        stream_slice["_general_page_max"] = general_page_max
-        stream_slice["_inline_page_max"] = inline_page_max
-        return records
+        return records, general_page_max, inline_page_max
 
     def _do_rest_get(self, url: str, params: dict = None) -> req.Response:
         """REST GET with page-level retry. Thread-safe."""

--- a/src/ingestion/connectors/git/github/source_github/streams/commits.py
+++ b/src/ingestion/connectors/git/github/source_github/streams/commits.py
@@ -8,7 +8,7 @@ import requests as req
 
 from source_github.clients.auth import rest_headers
 from source_github.graphql.queries import BULK_COMMIT_QUERY
-from source_github.streams.base import GitHubGraphQLStream, _make_pk, _make_unique_key
+from source_github.streams.base import GitHubGraphQLStream, _make_unique_key
 from source_github.streams.branches import BranchesStream
 
 logger = logging.getLogger("airbyte")
@@ -364,7 +364,6 @@ class CommitsStream(GitHubGraphQLStream):
             committer_user = committer.get("user") or {}
 
             record = {
-                "pk": _make_pk(self._tenant_id, self._source_id, owner, repo, commit_hash),
                 "unique_key": _make_unique_key(self._tenant_id, self._source_id, owner, repo, commit_hash),
                 "oid": commit_hash,
                 "message": node.get("message"),
@@ -397,7 +396,6 @@ class CommitsStream(GitHubGraphQLStream):
             "type": "object",
             "additionalProperties": True,
             "properties": {
-                "pk": {"type": "string"},
                 "tenant_id": {"type": "string"},
                 "source_id": {"type": "string"},
                 "unique_key": {"type": "string"},

--- a/src/ingestion/connectors/git/github/source_github/streams/commits.py
+++ b/src/ingestion/connectors/git/github/source_github/streams/commits.py
@@ -77,6 +77,9 @@ class CommitsStream(GitHubGraphQLStream):
         # Use cursor from state or start_date for initial run
         since = s.get("cursor_value") or self._start_date
         if since:
+            # GitTimestamp requires full ISO 8601; bare YYYY-MM-DD needs T00:00:00Z
+            if len(since) == 10:
+                since = f"{since}T00:00:00Z"
             variables["since"] = since
         return variables
 

--- a/src/ingestion/connectors/git/github/source_github/streams/commits.py
+++ b/src/ingestion/connectors/git/github/source_github/streams/commits.py
@@ -43,6 +43,7 @@ class CommitsStream(GitHubGraphQLStream):
         self._partitions_with_errors: set = set()
         self._current_skipped_siblings: list = []
         self._current_stop_at_sha: Optional[str] = None
+        self._last_partition_key: Optional[str] = None
 
     def _query(self) -> str:
         return BULK_COMMIT_QUERY
@@ -152,7 +153,7 @@ class CommitsStream(GitHubGraphQLStream):
 
             repo_state_key = f"_repo:{owner}/{repo}"
             stored_pushed_at = state.get(repo_state_key, {}).get("pushed_at", "")
-            if repo_pushed_at and stored_pushed_at and repo_pushed_at <= stored_pushed_at:
+            if repo_pushed_at and stored_pushed_at and repo_pushed_at < stored_pushed_at:
                 repos_skipped_fresh += 1
                 logger.info(f"Repo freshness: skipping {owner}/{repo} (pushed_at unchanged: {repo_pushed_at})")
                 continue
@@ -335,6 +336,14 @@ class CommitsStream(GitHubGraphQLStream):
         head_sha = s.get("head_sha", "")
         repo_pushed_at = s.get("repo_pushed_at", "")
         default_branch = s.get("default_branch", "")
+
+        # Clear error tracking when we move to a new partition — a transient
+        # error on an earlier page should not freeze the cursor if subsequent
+        # pages succeed.
+        partition_key = f"{s.get('owner', '')}/{s.get('repo', '')}/{s.get('branch', '')}"
+        if partition_key != self._last_partition_key:
+            self._partitions_with_errors.discard(self._last_partition_key)
+            self._last_partition_key = partition_key
 
         body = response.json()
         self._update_graphql_rate_limit(body, response)

--- a/src/ingestion/connectors/git/github/source_github/streams/file_changes.py
+++ b/src/ingestion/connectors/git/github/source_github/streams/file_changes.py
@@ -7,7 +7,7 @@ import requests as req
 
 from source_github.clients.auth import rest_headers
 from source_github.clients.concurrent import fetch_parallel_with_slices, retry_request
-from source_github.streams.base import GitHubRestStream, _is_fatal, _make_pk, _make_unique_key, _now_iso, check_rest_response
+from source_github.streams.base import GitHubRestStream, _is_fatal, _make_unique_key, _now_iso, check_rest_response
 from source_github.streams.commits import CommitsStream
 from source_github.streams.pull_requests import PullRequestsStream
 
@@ -226,7 +226,6 @@ class FileChangesStream(GitHubRestStream):
             for f in files:
                 filename = f.get("filename", "")
                 records.append({
-                    "pk": _make_pk(self._tenant_id, self._source_id, owner, repo, f"pr{pr_number}", filename),
                     "unique_key": _make_unique_key(self._tenant_id, self._source_id, owner, repo, f"pr{pr_number}", filename),
                     "tenant_id": self._tenant_id,
                     "source_id": self._source_id,
@@ -284,7 +283,6 @@ class FileChangesStream(GitHubRestStream):
             for f in files:
                 filename = f.get("filename", "")
                 records.append({
-                    "pk": _make_pk(self._tenant_id, self._source_id, owner, repo, sha, filename),
                     "unique_key": _make_unique_key(self._tenant_id, self._source_id, owner, repo, sha, filename),
                     "tenant_id": self._tenant_id,
                     "source_id": self._source_id,
@@ -334,7 +332,6 @@ class FileChangesStream(GitHubRestStream):
             "type": "object",
             "additionalProperties": True,
             "properties": {
-                "pk": {"type": "string"},
                 "tenant_id": {"type": "string"},
                 "source_id": {"type": "string"},
                 "unique_key": {"type": "string"},

--- a/src/ingestion/connectors/git/github/source_github/streams/file_changes.py
+++ b/src/ingestion/connectors/git/github/source_github/streams/file_changes.py
@@ -57,7 +57,10 @@ class FileChangesStream(GitHubRestStream):
         current_stream_state: MutableMapping[str, Any],
         latest_record: Mapping[str, Any],
     ) -> MutableMapping[str, Any]:
-        return self._state
+        # Only persist pr: entries (bounded by active PRs). commit: entries are
+        # transient within a single sync to avoid re-fetching, but don't need
+        # to persist across syncs — they would grow unboundedly otherwise.
+        return {k: v for k, v in self._state.items() if not k.startswith("commit:")}
 
     def read_records(self, sync_mode=None, stream_slice=None, stream_state=None, **kwargs) -> Iterable[Mapping[str, Any]]:
         if stream_state:

--- a/src/ingestion/connectors/git/github/source_github/streams/pr_commits.py
+++ b/src/ingestion/connectors/git/github/source_github/streams/pr_commits.py
@@ -8,7 +8,7 @@ import requests as req
 from source_github.clients.auth import graphql_headers
 from source_github.clients.concurrent import fetch_parallel_with_slices
 from source_github.graphql.queries import PR_COMMITS_QUERY
-from source_github.streams.base import GitHubRestStream, _is_fatal, _make_pk, _make_unique_key, _now_iso
+from source_github.streams.base import GitHubRestStream, _is_fatal, _make_unique_key, _now_iso
 from source_github.streams.pull_requests import PullRequestsStream
 
 logger = logging.getLogger("airbyte")
@@ -179,7 +179,6 @@ class PRCommitsStream(GitHubRestStream):
                 if not sha:
                     continue
                 records.append({
-                    "pk": _make_pk(self._tenant_id, self._source_id, owner, repo, pr_id, sha),
                     "unique_key": _make_unique_key(self._tenant_id, self._source_id, owner, repo, pr_id, sha),
                     "tenant_id": self._tenant_id,
                     "source_id": self._source_id,
@@ -223,7 +222,6 @@ class PRCommitsStream(GitHubRestStream):
             "type": "object",
             "additionalProperties": True,
             "properties": {
-                "pk": {"type": "string"},
                 "tenant_id": {"type": "string"},
                 "source_id": {"type": "string"},
                 "unique_key": {"type": "string"},

--- a/src/ingestion/connectors/git/github/source_github/streams/pull_requests.py
+++ b/src/ingestion/connectors/git/github/source_github/streams/pull_requests.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any, Iterable, List, Mapping, MutableMapping, Optional
 
 from source_github.graphql.queries import BULK_PR_QUERY
-from source_github.streams.base import GitHubGraphQLStream, _make_pk, _make_unique_key
+from source_github.streams.base import GitHubGraphQLStream, _make_unique_key
 from source_github.streams.repositories import RepositoriesStream
 
 logger = logging.getLogger("airbyte")
@@ -258,7 +258,6 @@ class PullRequestsStream(GitHubGraphQLStream):
                     requested_teams.append(reviewer["slug"])
 
             record = {
-                "pk": _make_pk(self._tenant_id, self._source_id, owner, repo, pr_id),
                 "unique_key": _make_unique_key(self._tenant_id, self._source_id, owner, repo, pr_id),
                 "database_id": pr_database_id,
                 "number": pr_number,
@@ -301,7 +300,6 @@ class PullRequestsStream(GitHubGraphQLStream):
             "type": "object",
             "additionalProperties": True,
             "properties": {
-                "pk": {"type": "string"},
                 "tenant_id": {"type": "string"},
                 "source_id": {"type": "string"},
                 "unique_key": {"type": "string"},

--- a/src/ingestion/connectors/git/github/source_github/streams/pull_requests.py
+++ b/src/ingestion/connectors/git/github/source_github/streams/pull_requests.py
@@ -25,11 +25,13 @@ class PullRequestsStream(GitHubGraphQLStream):
         self,
         parent: RepositoriesStream,
         page_size: int = 50,
+        start_date: Optional[str] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self._parent = parent
         self._page_size = page_size
+        self._start_date = start_date
         self._partitions_with_errors: set = set()
         # Minimal child-slice cache: only fields children need for slice building
         self._child_slice_cache: Optional[list] = None
@@ -186,12 +188,15 @@ class PullRequestsStream(GitHubGraphQLStream):
         data = body.get("data", {})
         page_info = self._extract_page_info(data)
 
-        # Early exit: if last node on this page is older than cursor
+        # Early exit: if last node on this page is older than cursor or start_date
         nodes = self._extract_nodes(data)
-        if nodes and hasattr(self, "_current_cursor_value") and self._current_cursor_value:
+        if nodes:
             last_updated = nodes[-1].get("updatedAt", "")
-            if last_updated and last_updated < self._current_cursor_value:
-                return None
+            if last_updated:
+                if hasattr(self, "_current_cursor_value") and self._current_cursor_value and last_updated < self._current_cursor_value:
+                    return None
+                if self._start_date and last_updated[:10] < self._start_date:
+                    return None
 
         if page_info.get("hasNextPage"):
             return {"after": page_info["endCursor"]}
@@ -226,6 +231,9 @@ class PullRequestsStream(GitHubGraphQLStream):
 
             # Skip records older than cursor for incremental
             if cursor_value and updated_at and updated_at <= cursor_value:
+                continue
+            # Skip records older than start_date on first sync
+            if self._start_date and updated_at and updated_at[:10] < self._start_date:
                 continue
 
             # Normalize state

--- a/src/ingestion/connectors/git/github/source_github/streams/pull_requests.py
+++ b/src/ingestion/connectors/git/github/source_github/streams/pull_requests.py
@@ -19,7 +19,7 @@ class PullRequestsStream(GitHubGraphQLStream):
 
     name = "pull_requests"
     cursor_field = "updated_at"
-    use_cache = True  # Reviews/comments streams use this as parent
+    # Caching managed by _child_slice_cache — no CDK use_cache needed
 
     def __init__(
         self,
@@ -134,7 +134,7 @@ class PullRequestsStream(GitHubGraphQLStream):
             pushed_at = record.get("pushed_at", "")
             repo_state_key = f"_repo:{owner}/{repo}"
             stored_pushed_at = state.get(repo_state_key, {}).get("pushed_at", "")
-            if pushed_at and stored_pushed_at and pushed_at <= stored_pushed_at:
+            if pushed_at and stored_pushed_at and pushed_at < stored_pushed_at:
                 repos_skipped += 1
                 logger.debug(f"PR freshness: skipping {owner}/{repo} (pushed_at unchanged)")
                 continue

--- a/src/ingestion/connectors/git/github/source_github/streams/repositories.py
+++ b/src/ingestion/connectors/git/github/source_github/streams/repositories.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Any, Iterable, List, Mapping, Optional
 
-from source_github.streams.base import GitHubRestStream, _make_pk, _make_unique_key, check_rest_response
+from source_github.streams.base import GitHubRestStream, _make_unique_key, check_rest_response
 
 logger = logging.getLogger("airbyte")
 
@@ -73,7 +73,6 @@ class RepositoriesStream(GitHubRestStream):
             if self._skip_forks and repo.get("fork"):
                 skipped += 1
                 continue
-            repo["pk"] = _make_pk(self._tenant_id, self._source_id, owner, name)
             repo["unique_key"] = _make_unique_key(self._tenant_id, self._source_id, owner, name)
             yield self._add_envelope(repo)
         if skipped:
@@ -85,7 +84,6 @@ class RepositoriesStream(GitHubRestStream):
             "type": "object",
             "additionalProperties": True,
             "properties": {
-                "pk": {"type": "string"},
                 "tenant_id": {"type": "string"},
                 "source_id": {"type": "string"},
                 "unique_key": {"type": "string"},

--- a/src/ingestion/connectors/git/github/source_github/streams/repositories.py
+++ b/src/ingestion/connectors/git/github/source_github/streams/repositories.py
@@ -12,7 +12,7 @@ class RepositoriesStream(GitHubRestStream):
     """Fetches all repositories for configured organizations via REST API."""
 
     name = "repositories"
-    use_cache = True  # Other streams use this as parent
+    # Caching managed by _cached_records — no CDK use_cache needed
 
     def __init__(
         self,

--- a/src/ingestion/connectors/git/github/source_github/streams/reviews.py
+++ b/src/ingestion/connectors/git/github/source_github/streams/reviews.py
@@ -7,7 +7,7 @@ import requests as req
 
 from source_github.clients.auth import rest_headers
 from source_github.clients.concurrent import fetch_parallel_with_slices, retry_request
-from source_github.streams.base import GitHubRestStream, _is_fatal, _make_pk, _make_unique_key, _now_iso, check_rest_response, _is_rate_limit_403
+from source_github.streams.base import GitHubRestStream, _is_fatal, _make_unique_key, _now_iso, check_rest_response, _is_rate_limit_403
 from source_github.streams.pull_requests import PullRequestsStream
 
 logger = logging.getLogger("airbyte")
@@ -168,7 +168,6 @@ class ReviewsStream(GitHubRestStream):
                 review_id = str(review.get("id", ""))
                 user = review.get("user") or {}
                 records.append({
-                    "pk": _make_pk(self._tenant_id, self._source_id, owner, repo, pr_id, review_id),
                     "unique_key": _make_unique_key(self._tenant_id, self._source_id, owner, repo, pr_id, review_id),
                     "tenant_id": self._tenant_id,
                     "source_id": self._source_id,
@@ -207,7 +206,6 @@ class ReviewsStream(GitHubRestStream):
             "type": "object",
             "additionalProperties": True,
             "properties": {
-                "pk": {"type": "string"},
                 "tenant_id": {"type": "string"},
                 "source_id": {"type": "string"},
                 "unique_key": {"type": "string"},

--- a/src/ingestion/connectors/git/github/source_github/streams/reviews.py
+++ b/src/ingestion/connectors/git/github/source_github/streams/reviews.py
@@ -149,10 +149,6 @@ class ReviewsStream(GitHubRestStream):
             resp = retry_request(_call, context=f"{owner}/{repo} PR#{pr_number} reviews")
             params = {}
 
-            remaining = resp.headers.get("X-RateLimit-Remaining")
-            reset = resp.headers.get("X-RateLimit-Reset")
-            if remaining and reset:
-                self._rate_limiter.update_rest(int(remaining), float(reset))
             self._rate_limiter.wait_if_needed("rest")
 
             if not check_rest_response(resp, f"{owner}/{repo} PR#{pr_number} reviews"):


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#139](https://github.com/cyberfabric/cyber-insight/pull/139) | **Author:** aleksdotbar | **Opened:** 2026-04-09T13:07:27Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary
- New GitHub connector using Airbyte CDK with GraphQL bulk queries for PRs and commits
- REST endpoints for repositories, branches, and per-commit file changes
- Embedded PR children (reviews, comments, review threads, pr_commits) in bulk PR query with overflow pagination
- Disk-backed parent-child data passing via temp files (JSONL/TSV)
- Configurable page sizes for all embedded data
- Inline review comments via GraphQL reviewThreads with per-thread comment overflow

## Test plan
- [x] Full sync — all 9 streams, validated in ClickHouse (zero dupes, zero orphans)
- [x] Incremental sync — only updated PRs re-fetched
- [x] Date-range sync with start_date filtering
- [x] 504/502 retry recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#139 -->