### PR TITLE
[PR #55] docs(shared): add database field naming conventions and ADRs

### DIFF
--- a/cypilot/config/artifacts.toml
+++ b/cypilot/config/artifacts.toml
@@ -348,6 +348,11 @@ kind = "ADR"
 path = "docs/shared/glossary/ADR/0002-database-field-conventions.md"
 name = "ADR-0002: Database Field Naming and Type Conventions"
 
+[[systems.artifacts]]
+kind = "ADR"
+path = "docs/shared/glossary/ADR/0003-insight-prefixed-tenant-id.md"
+name = "ADR-0003: Use insight_tenant_id Instead of tenant_id"
+
 [[systems]]
 name = "Orchestrator"
 slug = "orch"

--- a/cypilot/config/artifacts.toml
+++ b/cypilot/config/artifacts.toml
@@ -338,6 +338,16 @@ path = "docs/domain/airbyte-connector/specs/DESIGN.md"
 name = "Airbyte Connector Development Guide"
 traceability = "DOCS-ONLY"
 
+[[systems.artifacts]]
+kind = "ADR"
+path = "docs/shared/glossary/ADR/0001-uuidv7-primary-key.md"
+name = "ADR-0001: UUIDv7 as Universal Primary Key"
+
+[[systems.artifacts]]
+kind = "ADR"
+path = "docs/shared/glossary/ADR/0002-database-field-conventions.md"
+name = "ADR-0002: Database Field Naming and Type Conventions"
+
 [[systems]]
 name = "Orchestrator"
 slug = "orch"

--- a/docs/shared/glossary/ADR/0001-uuidv7-primary-key.md
+++ b/docs/shared/glossary/ADR/0001-uuidv7-primary-key.md
@@ -116,7 +116,7 @@ Primary key composed of business-meaningful columns (e.g., `(tenant_id, email, s
 
 ## More Information
 
-**SCD Type 2 exception**: For versioned/historical tables (e.g., person version history, org unit history), each row still has `id UUID` as PK, plus a logical entity reference (`person_id UUID` FK to the entity table). This is not the INT+UUID anti-pattern -- both columns are UUIDs, and they serve different purposes (row identity vs entity identity). See [README.md section 2.2](../README.md#22-scd-type-2--versioned-tables).
+**SCD Type 2 note**: SCD2 versioning in Insight is handled by dbt-macros in ClickHouse, not in MariaDB. See [README.md section 14](../README.md#14-proposals-with-known-contradictions) for details. If a MariaDB table does reference the same logical entity across multiple rows (e.g., temporal validity), each row still has `id UUID` as PK, plus a logical entity reference (`person_id UUID` FK). This is not the INT+UUID anti-pattern -- both columns are UUIDs, and they serve different purposes (row identity vs entity identity).
 
 **ClickHouse tables** do not use UUID as PK in the RDBMS sense. ClickHouse uses composite `ORDER BY` keys optimised for analytical queries. UUID columns exist for filtering and joining but are placed last in ORDER BY (if at all).
 

--- a/docs/shared/glossary/ADR/0001-uuidv7-primary-key.md
+++ b/docs/shared/glossary/ADR/0001-uuidv7-primary-key.md
@@ -74,7 +74,7 @@ Single `id UUID DEFAULT uuid_v7()` column serves as both PK and external identif
 * Good, because single identifier everywhere -- zero mapping complexity
 * Good, because UUIDv7 is time-ordered -- near-sequential inserts, ~90% InnoDB page fill
 * Good, because MariaDB 10.7+ native `UUID` type stores 16 bytes internally (not 36-byte CHAR)
-* Good, because `uuid_v7()` built into MariaDB 11.4+ (or application-generated for earlier versions)
+* Good, because `uuid_v7()` built into MariaDB 11.7+ (or application-generated for earlier versions)
 * Good, because globally unique without central authority -- safe for cross-service, cross-tenant references
 * Neutral, because 16-byte PK is larger than 4-byte INT but smaller than 36-byte CHAR(36)
 * Bad, because secondary indexes carry 16-byte PK values (4x larger than INT per index entry)
@@ -120,7 +120,7 @@ Primary key composed of business-meaningful columns (e.g., `(tenant_id, email, s
 
 **ClickHouse tables** do not use UUID as PK in the RDBMS sense. ClickHouse uses composite `ORDER BY` keys optimised for analytical queries. UUID columns exist for filtering and joining but are placed last in ORDER BY (if at all).
 
-**MariaDB version**: native `UUID` type requires MariaDB 10.7+. `uuid_v7()` function requires MariaDB 11.4+ (or application-side generation with the `uuid` Rust crate).
+**MariaDB version**: native `UUID` type requires MariaDB 10.7+. `uuid_v7()` function requires MariaDB 11.7+ (or application-side generation with the `uuid` Rust crate).
 
 **References**:
 - [RFC 9562 -- UUIDs](https://www.rfc-editor.org/rfc/rfc9562) -- UUIDv7 specification

--- a/docs/shared/glossary/ADR/0001-uuidv7-primary-key.md
+++ b/docs/shared/glossary/ADR/0001-uuidv7-primary-key.md
@@ -1,0 +1,139 @@
+---
+status: proposed
+date: 2026-04-03
+---
+
+# ADR-0001: UUIDv7 as Universal Primary Key Strategy
+
+- [ ] `p1` - **ID**: `cpt-insightspec-adr-db-uuidv7-primary-key`
+
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [UUID-only PK (UUIDv7)](#uuid-only-pk-uuidv7)
+  - [INT Surrogate PK + Separate UUID Column](#int-surrogate-pk--separate-uuid-column)
+  - [INT Auto-Increment PK Only](#int-auto-increment-pk-only)
+  - [Composite Natural Keys](#composite-natural-keys)
+- [More Information](#more-information)
+- [Traceability](#traceability)
+
+<!-- /toc -->
+
+## Context and Problem Statement
+
+Insight is a multi-service platform (8 Rust microservices) where entities are referenced across services via HTTP SDK clients, Redpanda events, REST APIs, logs, and audit trails. The primary key strategy must work consistently across MariaDB (OLTP metadata), ClickHouse (OLAP analytics/audit), and the JSON API surface. Which primary key type and pattern should all internal MariaDB tables use?
+
+## Decision Drivers
+
+* Cross-service identity -- the same entity ID appears in API responses, Redpanda events, audit logs, inter-service SDK calls, and database rows; mapping between internal and external IDs adds complexity
+* API Guideline alignment -- the project [API Guideline](../../api-guideline/README.md) already mandates `uuidv7` for all resource identifiers in JSON responses
+* InnoDB clustered index performance -- MariaDB/InnoDB clusters rows by PK; random UUIDs cause page splits; time-ordered UUIDs (v7) mitigate this
+* Schema simplicity -- fewer columns and indexes reduce cognitive load and migration complexity across 8 services
+* Metadata workload scale -- Insight MariaDB tables hold configuration, org trees, roles, alerts, and templates (thousands to low millions of rows per tenant), not high-volume transactional data
+
+## Considered Options
+
+* UUID-only PK (UUIDv7)
+* INT Surrogate PK + Separate UUID Column
+* INT Auto-Increment PK Only
+* Composite Natural Keys
+
+## Decision Outcome
+
+Chosen option: "UUID-only PK (UUIDv7)", because it provides the simplest schema while satisfying cross-service identity requirements, aligns with the existing API Guideline, and has negligible performance trade-offs at Insight's metadata workload scale.
+
+### Consequences
+
+* Good, because one identifier per entity works everywhere -- API, DB, events, logs, inter-service calls
+* Good, because aligns with existing API Guideline (`uuidv7` already mandated for JSON responses)
+* Good, because no mapping layer between internal INT and external UUID
+* Good, because UUIDv7 is time-ordered, achieving ~90% InnoDB page fill (vs ~94% for sequential INT)
+* Good, because globally unique without coordination -- safe for future distributed scenarios
+* Bad, because 16-byte PK bloats secondary indexes (4x vs INT) -- acceptable for metadata tables with few indexes
+* Bad, because JOINs on 16-byte UUID are marginally slower than 4-byte INT -- not measurable at Insight scale
+
+### Confirmation
+
+* All MariaDB `CREATE TABLE` statements in DESIGN documents use `id UUID NOT NULL DEFAULT uuid_v7() PRIMARY KEY`
+* No `AUTO_INCREMENT` PKs in any service schema
+* API responses use the same UUID value as the database PK -- no ID translation layer exists
+* Code review: verify no service stores two ID columns for the same entity
+
+## Pros and Cons of the Options
+
+### UUID-only PK (UUIDv7)
+
+Single `id UUID DEFAULT uuid_v7()` column serves as both PK and external identifier. UUIDv7 (RFC 9562) embeds a Unix millisecond timestamp in the high bits, producing time-ordered values.
+
+* Good, because single identifier everywhere -- zero mapping complexity
+* Good, because UUIDv7 is time-ordered -- near-sequential inserts, ~90% InnoDB page fill
+* Good, because MariaDB 10.7+ native `UUID` type stores 16 bytes internally (not 36-byte CHAR)
+* Good, because `uuid_v7()` built into MariaDB 11.4+ (or application-generated for earlier versions)
+* Good, because globally unique without central authority -- safe for cross-service, cross-tenant references
+* Neutral, because 16-byte PK is larger than 4-byte INT but smaller than 36-byte CHAR(36)
+* Bad, because secondary indexes carry 16-byte PK values (4x larger than INT per index entry)
+* Bad, because within-millisecond ordering has random lower bits (minor, only affects bulk inserts of identical entities)
+
+### INT Surrogate PK + Separate UUID Column
+
+`id INT AUTO_INCREMENT PRIMARY KEY` for internal use, plus `external_id UUID UNIQUE` for API/event exposure. Used in the Identity Resolution DESIGN (PR #54) for SCD Type 2 tables.
+
+* Good, because smallest possible PK (4 bytes) -- optimal InnoDB page fill (~94%) and secondary index size
+* Good, because JOINs on INT are marginally faster (smaller comparisons, better cache utilization)
+* Good, because well-established pattern in high-write OLTP systems
+* Bad, because two ID columns per table -- which one to use in events? In logs? In SDK calls?
+* Bad, because requires additional UNIQUE index on UUID column (storage overhead partially negates INT savings)
+* Bad, because application must generate UUID on insert (additional logic)
+* Bad, because cross-service references must always use UUID but internal FKs might use INT -- inconsistency risk
+* Bad, because the performance benefit is negligible for Insight's metadata workload (not a high-write OLTP system)
+
+### INT Auto-Increment PK Only
+
+`id INT AUTO_INCREMENT PRIMARY KEY` with no UUID column. Internal-only identifiers.
+
+* Good, because simplest schema, smallest storage, fastest JOINs
+* Bad, because sequential INTs are guessable -- information disclosure risk (entity count enumeration)
+* Bad, because not globally unique -- collisions when merging data from multiple services or tenants
+* Bad, because API Guideline mandates UUIDv7 for JSON responses -- would need a separate ID for the API layer anyway
+* Bad, because Redpanda events and audit logs would use different identifiers than the database
+
+### Composite Natural Keys
+
+Primary key composed of business-meaningful columns (e.g., `(tenant_id, email, source_system)`).
+
+* Good, because no surrogate IDs needed -- data is self-describing
+* Good, because enforces uniqueness at the business level
+* Bad, because natural keys change (email changes, username changes) -- cascading FK updates
+* Bad, because composite keys complicate JOINs and API references
+* Bad, because not compatible with API Guideline's `id` field convention
+* Bad, because ClickHouse uses composite ORDER BY keys for analytics -- conflating OLTP PKs with OLAP ordering
+
+## More Information
+
+**SCD Type 2 exception**: For versioned/historical tables (e.g., person version history, org unit history), each row still has `id UUID` as PK, plus a logical entity reference (`person_id UUID` FK to the entity table). This is not the INT+UUID anti-pattern -- both columns are UUIDs, and they serve different purposes (row identity vs entity identity). See [README.md section 2.2](../README.md#22-scd-type-2--versioned-tables).
+
+**ClickHouse tables** do not use UUID as PK in the RDBMS sense. ClickHouse uses composite `ORDER BY` keys optimised for analytical queries. UUID columns exist for filtering and joining but are placed last in ORDER BY (if at all).
+
+**MariaDB version**: native `UUID` type requires MariaDB 10.7+. `uuid_v7()` function requires MariaDB 11.4+ (or application-side generation with the `uuid` Rust crate).
+
+**References**:
+- [RFC 9562 -- UUIDs](https://www.rfc-editor.org/rfc/rfc9562) -- UUIDv7 specification
+- [MariaDB UUID Data Type](https://mariadb.com/docs/server/reference/data-types/string-data-types/uuid-data-type/)
+- [PlanetScale: The Problem with UUID PKs in MySQL](https://planetscale.com/blog/the-problem-with-using-a-uuid-primary-key-in-mysql) -- UUIDv7 mitigates most issues
+- [Bytebase: UUID vs Auto-Increment](https://www.bytebase.com/blog/choose-primary-key-uuid-or-auto-increment/)
+
+## Traceability
+
+This decision directly addresses the following requirements or design elements:
+
+* `cpt-insightspec-nfr-be-tenant-isolation` -- UUID tenant_id is part of the universal UUID convention; consistent type across all tables and services
+* `cpt-insightspec-nfr-be-query-safety` -- Parameterized UUID bind parameters eliminate injection vectors in ID-based queries
+* `cpt-insightspec-principle-be-service-owns-data` -- UUID PKs are globally unique, enabling safe cross-service references without coordination
+* `cpt-insightspec-principle-be-api-versioned` -- API Guideline mandates UUIDv7; using the same value as PK ensures zero-translation API versioning
+* `cpt-insightspec-fr-be-audit-trail` -- Audit events reference entity UUIDs; same value in DB and audit log simplifies correlation

--- a/docs/shared/glossary/ADR/0002-database-field-conventions.md
+++ b/docs/shared/glossary/ADR/0002-database-field-conventions.md
@@ -17,7 +17,7 @@ date: 2026-04-03
   - [Confirmation](#confirmation)
 - [Decisions](#decisions)
   - [D1: Temporal Range Naming -- effective_from / effective_to](#d1-temporal-range-naming----effectivefrom--effectiveto)
-  - [D2: tenant_id Type -- UUID](#d2-tenantid-type----uuid)
+  - [D2: Tenant Identifier -- insight_tenant_id UUID](#d2-tenant-identifier----insighttenantid-uuid)
   - [D3: Actor Attribution -- UUID Foreign Key](#d3-actor-attribution----uuid-foreign-key)
   - [D4: MariaDB Timestamp Type -- DATETIME(3)](#d4-mariadb-timestamp-type----datetime3)
   - [D5: ClickHouse Enum Strategy -- LowCardinality(String)](#d5-clickhouse-enum-strategy----lowcardinalitystring)
@@ -53,7 +53,8 @@ Adopt the six conventions documented below as mandatory for all internal Insight
 * Good, because resolves all known conflicts between PR #49 and PR #54
 * Good, because aligns with existing API Guideline and ClickHouse/MariaDB best practices
 * Good, because new services can follow the convention document without reading every existing schema
-* Bad, because PR #54 (identity-resolution DESIGN) requires updates to comply -- `valid_from/valid_to` renamed, `tenant_id` type changed, `performed_by` replaced with UUID FK
+* Bad, because PR #54 (identity-resolution DESIGN) requires updates to comply -- `valid_from/valid_to` renamed, `tenant_id` → `insight_tenant_id`, `performed_by` replaced with UUID FK
+* Bad, because PR #49 (backend DESIGN) requires updates -- `tenant_id` → `insight_tenant_id` across all table definitions
 * Bad, because conventions add constraints that may feel rigid for edge cases -- exceptions must be documented
 
 ### Confirmation
@@ -85,18 +86,19 @@ Adopt the six conventions documented below as mandatory for all internal Insight
 - Use `DATE` when business granularity is days; `DATETIME(3)` when sub-day precision is needed
 - Never use `BETWEEN` for temporal queries
 
-### D2: tenant_id Type -- UUID
+### D2: Tenant Identifier -- insight_tenant_id UUID
 
-**Problem**: PR #49 uses `UUID` for `tenant_id`; PR #54 uses `VARCHAR(100)`.
+**Problem**: PR #49 uses `tenant_id UUID`; PR #54 uses `tenant_id VARCHAR(100)`. Additionally, external systems (Azure, Salesforce) use `tenant_id` as their own field name, creating ambiguity.
 
-| Option | Storage (MariaDB) | Joinability | Consistency |
-|--------|-------------------|-------------|-------------|
-| `UUID` | 16 bytes (native) | Direct JOIN with tenant.id | Matches all-UUID convention |
-| `VARCHAR(100)` | Up to 100 bytes + length prefix | Requires type cast or inconsistent schema | Breaks UUID-everywhere convention |
+| Option | Type | Collision risk | Consistency |
+|--------|------|---------------|-------------|
+| `insight_tenant_id UUID` | UUID (16 bytes) | None -- `insight_` prefix is unambiguous | Matches connector config convention |
+| `tenant_id UUID` | UUID (16 bytes) | Collides with Azure `tenant_id`, etc. | Breaks in Bronze/Silver context |
+| `tenant_id VARCHAR(100)` | VARCHAR (up to 100 bytes) | Same collision + type inconsistency | Breaks UUID-everywhere convention |
 
-**Decision**: `tenant_id` is always `UUID NOT NULL`.
+**Decision**: `insight_tenant_id` is always `UUID NOT NULL`. See [ADR-0003](0003-insight-prefixed-tenant-id.md) for full rationale.
 
-**Rationale**: The project uses UUID for all identifiers (ADR-0001). `tenant_id` references `tenant.id` which is UUID. Using VARCHAR would break type consistency, waste storage, and require casts in JOINs.
+**Rationale**: The `insight_` prefix eliminates name collisions with source systems, aligns with the existing connector config convention (`insight_tenant_id`, `insight_source_id`), and the UUID type is consistent with ADR-0001.
 
 ### D3: Actor Attribution -- UUID Foreign Key
 

--- a/docs/shared/glossary/ADR/0002-database-field-conventions.md
+++ b/docs/shared/glossary/ADR/0002-database-field-conventions.md
@@ -102,16 +102,16 @@ Adopt the six conventions documented below as mandatory for all internal Insight
 
 ### D3: Actor Attribution -- UUID Foreign Key
 
-**Problem**: PR #49 uses `actor_person_id UUID` (FK to person.id) for audit attribution; PR #54 uses `performed_by VARCHAR(100)` storing a username string.
+**Problem**: PR #49 uses `actor_person_id UUID` (FK to persons.id) for audit attribution; PR #54 uses `performed_by VARCHAR(100)` storing a username string.
 
 | Option | Joinability | Resilience to rename | Storage |
 |--------|-------------|---------------------|---------|
-| `actor_person_id UUID` (FK) | Direct JOIN to person | Immune -- UUID is stable | 16 bytes |
+| `actor_person_id UUID` (FK) | Direct JOIN to persons | Immune -- UUID is stable | 16 bytes |
 | `performed_by VARCHAR(100)` | Requires lookup by username | Breaks if username changes | Up to 100 bytes |
 
 **Decision**: Always use UUID FK to `person.id` for actor attribution.
 
-**Rationale**: Usernames and emails change. A UUID FK is stable, joinable, and consistent with the all-UUID convention. Column name follows the `{role}_{entity}_id` pattern: `actor_person_id`, `granted_by`, `resolved_by` (all UUID FKs to person.id).
+**Rationale**: Usernames and emails change. A UUID FK is stable, joinable, and consistent with the all-UUID convention. Column name follows the `{role}_{entity}_id` pattern: `actor_person_id`, `granted_by`, `resolved_by` (all UUID FKs to persons.id).
 
 **Naming**:
 - `actor_person_id` -- who performed the action (audit events)

--- a/docs/shared/glossary/ADR/0002-database-field-conventions.md
+++ b/docs/shared/glossary/ADR/0002-database-field-conventions.md
@@ -54,7 +54,7 @@ Adopt the six conventions documented below as mandatory for all internal Insight
 * Good, because aligns with existing API Guideline and ClickHouse/MariaDB best practices
 * Good, because new services can follow the convention document without reading every existing schema
 * Bad, because PR #54 (identity-resolution DESIGN) requires updates to comply -- `valid_from/valid_to` renamed, `tenant_id` → `insight_tenant_id`, `performed_by` replaced with UUID FK
-* Bad, because PR #49 (backend DESIGN) requires updates -- `tenant_id` → `insight_tenant_id` across all table definitions
+* Bad, because existing DESIGN documents across the project (backend, ingestion, connector, individual connectors) require `tenant_id` → `insight_tenant_id` renaming -- see [Known Convention Violations](../README.md#15-known-convention-violations)
 * Bad, because conventions add constraints that may feel rigid for edge cases -- exceptions must be documented
 
 ### Confirmation

--- a/docs/shared/glossary/ADR/0002-database-field-conventions.md
+++ b/docs/shared/glossary/ADR/0002-database-field-conventions.md
@@ -1,0 +1,188 @@
+---
+status: proposed
+date: 2026-04-03
+---
+
+# ADR-0002: Database Field Naming and Type Conventions
+
+- [ ] `p1` - **ID**: `cpt-insightspec-adr-db-field-conventions`
+
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Decisions](#decisions)
+  - [D1: Temporal Range Naming -- effective_from / effective_to](#d1-temporal-range-naming----effectivefrom--effectiveto)
+  - [D2: tenant_id Type -- UUID](#d2-tenantid-type----uuid)
+  - [D3: Actor Attribution -- UUID Foreign Key](#d3-actor-attribution----uuid-foreign-key)
+  - [D4: MariaDB Timestamp Type -- DATETIME(3)](#d4-mariadb-timestamp-type----datetime3)
+  - [D5: ClickHouse Enum Strategy -- LowCardinality(String)](#d5-clickhouse-enum-strategy----lowcardinalitystring)
+  - [D6: ClickHouse Nullable Avoidance](#d6-clickhouse-nullable-avoidance)
+- [More Information](#more-information)
+- [Traceability](#traceability)
+
+<!-- /toc -->
+
+## Context and Problem Statement
+
+Insight has 8 microservices writing to MariaDB and ClickHouse. Early specs (PR #49 backend, PR #54 identity-resolution) introduced inconsistent conventions for the same concepts: different names for temporal ranges, different types for `tenant_id`, different patterns for audit attribution. Without a shared standard, each new service will invent its own column names and types, making cross-service queries, event correlation, and onboarding harder over time. Which conventions should all services follow?
+
+## Decision Drivers
+
+* Consistency across 8+ services -- a developer moving between services should recognise column semantics instantly by name
+* Existing project decisions -- the [API Guideline](../../api-guideline/API.md) already mandates `snake_case`, `created_at`/`updated_at`, ISO-8601 UTC timestamps
+* Conflict resolution -- PR #49 and PR #54 diverge on temporal naming, tenant_id type, and actor attribution; one convention must win
+* Database engine best practices -- ClickHouse and MariaDB have documented recommendations for types and patterns
+* Joinability -- audit logs, events, and API responses reference the same entities; types must be compatible
+
+## Considered Options
+
+Each decision below lists its specific alternatives. This ADR bundles six related naming/type conventions because they are interdependent (e.g., choosing UUID for tenant_id depends on choosing UUID for PKs) and too granular for individual ADRs.
+
+## Decision Outcome
+
+Adopt the six conventions documented below as mandatory for all internal Insight tables. See the full specification in the [Database Field Naming & Type Conventions](../README.md) document.
+
+### Consequences
+
+* Good, because all services use identical column names and types for the same concepts
+* Good, because resolves all known conflicts between PR #49 and PR #54
+* Good, because aligns with existing API Guideline and ClickHouse/MariaDB best practices
+* Good, because new services can follow the convention document without reading every existing schema
+* Bad, because PR #54 (identity-resolution DESIGN) requires updates to comply -- `valid_from/valid_to` renamed, `tenant_id` type changed, `performed_by` replaced with UUID FK
+* Bad, because conventions add constraints that may feel rigid for edge cases -- exceptions must be documented
+
+### Confirmation
+
+* Code review: all `CREATE TABLE` statements in DESIGN documents use the mandated column names and types
+* `cypilot validate` checks cross-reference consistency for traceability IDs
+* Grep for anti-patterns: `valid_from`, `owned_from`, `performed_by VARCHAR`, `TIMESTAMP` (MariaDB), `Enum8`, `Nullable(String)` (ClickHouse)
+* Each service's integration tests use real databases (testcontainers) -- schema mismatches surface as test failures
+
+## Decisions
+
+### D1: Temporal Range Naming -- effective_from / effective_to
+
+**Problem**: Three competing naming patterns exist across specs.
+
+| Option | Used in | Convention |
+|--------|---------|------------|
+| `effective_from` / `effective_to` | Backend DESIGN (PR #49) | Majority (7 services) |
+| `valid_from` / `valid_to` | Identity Resolution DESIGN (PR #54) | 1 service |
+| `owned_from` / `owned_until` | Identity Resolution alias table (PR #54) | 1 table |
+
+**Decision**: Use `effective_from` / `effective_to` everywhere.
+
+**Rationale**: Backend DESIGN (PR #49) covers 7 of 8 services and establishes the majority convention. One consistent pair eliminates ambiguity. The suffix `_to` (not `_until`) matches the `_from` / `_to` symmetry.
+
+**Rules**:
+- All temporal ranges use half-open intervals: `[effective_from, effective_to)`
+- `effective_to IS NULL` means "currently active"
+- Use `DATE` when business granularity is days; `DATETIME(3)` when sub-day precision is needed
+- Never use `BETWEEN` for temporal queries
+
+### D2: tenant_id Type -- UUID
+
+**Problem**: PR #49 uses `UUID` for `tenant_id`; PR #54 uses `VARCHAR(100)`.
+
+| Option | Storage (MariaDB) | Joinability | Consistency |
+|--------|-------------------|-------------|-------------|
+| `UUID` | 16 bytes (native) | Direct JOIN with tenant.id | Matches all-UUID convention |
+| `VARCHAR(100)` | Up to 100 bytes + length prefix | Requires type cast or inconsistent schema | Breaks UUID-everywhere convention |
+
+**Decision**: `tenant_id` is always `UUID NOT NULL`.
+
+**Rationale**: The project uses UUID for all identifiers (ADR-0001). `tenant_id` references `tenant.id` which is UUID. Using VARCHAR would break type consistency, waste storage, and require casts in JOINs.
+
+### D3: Actor Attribution -- UUID Foreign Key
+
+**Problem**: PR #49 uses `actor_person_id UUID` (FK to person.id) for audit attribution; PR #54 uses `performed_by VARCHAR(100)` storing a username string.
+
+| Option | Joinability | Resilience to rename | Storage |
+|--------|-------------|---------------------|---------|
+| `actor_person_id UUID` (FK) | Direct JOIN to person | Immune -- UUID is stable | 16 bytes |
+| `performed_by VARCHAR(100)` | Requires lookup by username | Breaks if username changes | Up to 100 bytes |
+
+**Decision**: Always use UUID FK to `person.id` for actor attribution.
+
+**Rationale**: Usernames and emails change. A UUID FK is stable, joinable, and consistent with the all-UUID convention. Column name follows the `{role}_{entity}_id` pattern: `actor_person_id`, `granted_by`, `resolved_by` (all UUID FKs to person.id).
+
+**Naming**:
+- `actor_person_id` -- who performed the action (audit events)
+- `granted_by` -- who granted a role/permission
+- `resolved_by` -- who resolved a conflict/alert
+
+### D4: MariaDB Timestamp Type -- DATETIME(3)
+
+**Problem**: MariaDB offers both `TIMESTAMP` and `DATETIME`. The API Guideline mandates ISO-8601 with milliseconds (`.SSS`).
+
+| Option | Precision | Range | Timezone behaviour | Size |
+|--------|-----------|-------|--------------------|------|
+| `TIMESTAMP` | seconds (or fsp) | 1970-2038 | Implicit UTC conversion | 4 bytes |
+| `DATETIME` | seconds (or fsp) | 1000-9999 | Stored as-is, no conversion | 8 bytes |
+| `DATETIME(3)` | milliseconds | 1000-9999 | Stored as-is, no conversion | 8 bytes |
+
+**Decision**: Use `DATETIME(3)` for all timestamp columns in MariaDB.
+
+**Rationale**:
+- Millisecond precision matches the API's ISO-8601 `.SSS` format -- no precision loss on round-trip
+- No 2038 problem (TIMESTAMP wraps; DATETIME does not)
+- No implicit timezone conversion -- application controls UTC explicitly
+- Standard defaults: `DEFAULT CURRENT_TIMESTAMP(3)` and `ON UPDATE CURRENT_TIMESTAMP(3)` for `created_at`/`updated_at`
+
+### D5: ClickHouse Enum Strategy -- LowCardinality(String)
+
+**Problem**: ClickHouse offers `Enum8`/`Enum16` and `LowCardinality(String)` for categorical columns.
+
+| Option | Schema evolution | Storage | Query syntax |
+|--------|-----------------|---------|-------------|
+| `Enum8('a'=1, 'b'=2)` | `ALTER TABLE` required to add values | Compact (1-2 bytes) | Must use exact string values |
+| `LowCardinality(String)` | No schema change needed | Dictionary-encoded, similarly compact for <10K values | Standard string comparison |
+
+**Decision**: Use `LowCardinality(String)` for all categorical/enum columns in ClickHouse.
+
+**Rationale**: Adding a new status value or action type should not require a ClickHouse `ALTER TABLE`. `LowCardinality(String)` achieves comparable compression via dictionary encoding for columns with fewer than ~10,000 distinct values (all Insight categorical columns qualify). This is the approach recommended by ClickHouse documentation.
+
+### D6: ClickHouse Nullable Avoidance
+
+**Problem**: ClickHouse stores an additional `UInt8` null-mask column for every `Nullable` column, adding storage and processing overhead.
+
+| Option | Storage overhead | Query complexity |
+|--------|-----------------|-----------------|
+| `Nullable(T)` | +1 byte per row per column | `IS NULL` checks in every query |
+| Default/sentinel values | None | Simpler predicates |
+
+**Decision**: Avoid `Nullable` in ClickHouse unless null carries distinct semantic meaning that cannot be represented by a sentinel value.
+
+**Rationale**: ClickHouse best practice. Use empty string `''` for text, `0` for counts, `'1970-01-01'` for dates, `toUUID('00000000-...')` for UUIDs. Reserve `Nullable` for cases where "unknown/not applicable" is semantically different from "empty" (e.g., `Nullable(UUID)` for optional FK references where the zero UUID would be misleading).
+
+## More Information
+
+The full specification with examples and anti-patterns is in [Database Field Naming & Type Conventions](../README.md).
+
+**Existing project standards referenced**:
+- [API Guideline](../../api-guideline/API.md) -- `snake_case`, `created_at`/`updated_at`, ISO-8601 UTC `.SSS`, UUIDv7
+- [ADR-0001: UUIDv7 Primary Key](0001-uuidv7-primary-key.md) -- UUID-only PK strategy
+
+**ClickHouse best practices**:
+- [Avoid Nullable Columns](https://clickhouse.com/docs/en/cloud/bestpractices/avoid-nullable-columns)
+- [LowCardinality Optimization](https://clickhouse.com/docs/en/sql-reference/data-types/lowcardinality)
+
+**MariaDB documentation**:
+- [DATETIME vs TIMESTAMP](https://mariadb.com/docs/server/reference/data-types/date-and-time-data-types/timestamp/)
+- [UUID Data Type](https://mariadb.com/docs/server/reference/data-types/string-data-types/uuid-data-type/)
+
+## Traceability
+
+This decision directly addresses the following requirements or design elements:
+
+* `cpt-insightspec-nfr-be-tenant-isolation` -- D2 (UUID tenant_id) ensures consistent tenant isolation type across all storage systems
+* `cpt-insightspec-fr-be-audit-trail` -- D3 (UUID actor attribution) ensures audit events can be joined to person records without fragile string matching
+* `cpt-insightspec-fr-be-visibility-policy` -- D1 (effective_from/effective_to) standardises the temporal range fields that implement follow-the-unit-strict policy
+* `cpt-insightspec-fr-be-org-tree-sync` -- D1 (effective_from/effective_to) applies to person_org_membership temporal fields
+* `cpt-insightspec-principle-be-secure-by-default` -- D4 (DATETIME(3)) avoids implicit timezone conversions that could cause time-based access control errors
+* `cpt-insightspec-fr-be-forward-only-migrations` -- D5 (LowCardinality over Enum) avoids ALTER TABLE for ClickHouse enum evolution, simplifying forward-only migrations

--- a/docs/shared/glossary/ADR/0002-database-field-conventions.md
+++ b/docs/shared/glossary/ADR/0002-database-field-conventions.md
@@ -134,6 +134,7 @@ Adopt the six conventions documented below as mandatory for all internal Insight
 - Millisecond precision matches the API's ISO-8601 `.SSS` format -- no precision loss on round-trip
 - No 2038 problem (TIMESTAMP wraps; DATETIME does not)
 - No implicit timezone conversion -- application controls UTC explicitly
+- All `DATETIME(3)` values **MUST** be stored in UTC -- this is an application-level responsibility since `DATETIME` has no built-in timezone semantics. MariaDB connection string should include `SET time_zone = '+00:00'` to ensure `CURRENT_TIMESTAMP` and `NOW()` return UTC
 - Standard defaults: `DEFAULT CURRENT_TIMESTAMP(3)` and `ON UPDATE CURRENT_TIMESTAMP(3)` for `created_at`/`updated_at`
 
 ### D5: ClickHouse Enum Strategy -- LowCardinality(String)

--- a/docs/shared/glossary/ADR/0003-insight-prefixed-tenant-id.md
+++ b/docs/shared/glossary/ADR/0003-insight-prefixed-tenant-id.md
@@ -50,7 +50,7 @@ Chosen option: "`insight_tenant_id` (prefixed)", because it eliminates name coll
 * Good, because grep for `insight_tenant_id` returns only platform references; grep for `azure_tenant_id` returns only Azure references
 * Good, because eliminates the need for per-context disambiguation rules (which `tenant_id` is this?)
 * Bad, because longer column name (19 chars vs 9) -- minor ergonomic cost
-* Bad, because all existing DESIGN documents (backend PR #49, identity-resolution PR #54) must be updated -- `tenant_id` → `insight_tenant_id` across ~50 column definitions
+* Bad, because existing DESIGN documents across the project require `tenant_id` → `insight_tenant_id` renaming -- see [Known Convention Violations](../README.md#15-known-convention-violations) for the full list
 * Bad, because deviates from the common `{entity}_id` naming pattern -- but this is intentional, as `insight_tenant_id` is a platform-level qualifier, not a simple FK
 
 ### Confirmation
@@ -58,7 +58,7 @@ Chosen option: "`insight_tenant_id` (prefixed)", because it eliminates name coll
 * All MariaDB `CREATE TABLE` statements use `insight_tenant_id`, not `tenant_id`
 * All ClickHouse table definitions use `insight_tenant_id`
 * All Redpanda message schemas include `insight_tenant_id`
-* Code search: `grep -r "tenant_id" --include="*.rs"` should return only `insight_tenant_id` (no bare `tenant_id`)
+* Code search: `grep -r "tenant_id" --include="*.rs" --include="*.sql" --include="*.yml" --include="*.yaml" --include="*.md" --include="*.toml"` should return only `insight_tenant_id` (no bare `tenant_id`)
 * Connector config fields: `insight_tenant_id` in `connection_specification`, `azure_tenant_id` for Azure -- no collision
 
 ## Pros and Cons of the Options

--- a/docs/shared/glossary/ADR/0003-insight-prefixed-tenant-id.md
+++ b/docs/shared/glossary/ADR/0003-insight-prefixed-tenant-id.md
@@ -1,0 +1,106 @@
+---
+status: proposed
+date: 2026-04-03
+---
+
+# ADR-0003: Use insight_tenant_id Instead of tenant_id
+
+- [ ] `p1` - **ID**: `cpt-insightspec-adr-db-insight-tenant-id`
+
+<!-- toc -->
+
+- [Context and Problem Statement](#context-and-problem-statement)
+- [Decision Drivers](#decision-drivers)
+- [Considered Options](#considered-options)
+- [Decision Outcome](#decision-outcome)
+  - [Consequences](#consequences)
+  - [Confirmation](#confirmation)
+- [Pros and Cons of the Options](#pros-and-cons-of-the-options)
+  - [insight_tenant_id (prefixed)](#insighttenantid-prefixed)
+  - [tenant_id (bare)](#tenantid-bare)
+- [More Information](#more-information)
+- [Traceability](#traceability)
+
+<!-- /toc -->
+
+## Context and Problem Statement
+
+Insight ingests data from external systems (Azure, Salesforce, GitHub, Jira, etc.) that have their own `tenant_id` fields. When Bronze tables preserve source-native schemas and Silver/Gold tables unify them, the name `tenant_id` becomes ambiguous: does it refer to the Insight platform tenant or the source system's tenant? This ambiguity extends to connector configs, Redpanda events, and API payloads where both Insight and source-system fields may coexist. What naming convention should Insight use for its own tenant identifier?
+
+## Decision Drivers
+
+* Name collision avoidance -- Azure APIs return `tenant_id` (Azure AD tenant); Salesforce uses `org_id`; bare `tenant_id` in Insight tables is ambiguous when source fields are present in the same row or payload
+* Cross-layer consistency -- the same tenant identifier appears in Bronze, Silver, Gold, MariaDB, Redpanda, Redis, and S3; one name everywhere eliminates per-layer disambiguation
+* Existing connector convention -- the connector framework already uses `insight_tenant_id` and `insight_source_id` in `connection_specification` to avoid collisions with source-specific config fields (e.g., `azure_tenant_id`)
+* Grep-ability -- searching for `insight_tenant_id` returns only Insight platform references; searching for `tenant_id` returns both platform and source-system results
+
+## Considered Options
+
+* `insight_tenant_id` (prefixed)
+* `tenant_id` (bare)
+
+## Decision Outcome
+
+Chosen option: "`insight_tenant_id` (prefixed)", because it eliminates name collisions with source systems, aligns with the existing connector config convention, and provides unambiguous grep-ability across the entire codebase.
+
+### Consequences
+
+* Good, because zero ambiguity -- `insight_tenant_id` is always the Insight platform tenant, in every table, event, and API payload
+* Good, because aligns with existing connector convention (`insight_tenant_id`, `insight_source_id` in connection specs)
+* Good, because grep for `insight_tenant_id` returns only platform references; grep for `azure_tenant_id` returns only Azure references
+* Good, because eliminates the need for per-context disambiguation rules (which `tenant_id` is this?)
+* Bad, because longer column name (19 chars vs 9) -- minor ergonomic cost
+* Bad, because all existing DESIGN documents (backend PR #49, identity-resolution PR #54) must be updated -- `tenant_id` → `insight_tenant_id` across ~50 column definitions
+* Bad, because deviates from the common `{entity}_id` naming pattern -- but this is intentional, as `insight_tenant_id` is a platform-level qualifier, not a simple FK
+
+### Confirmation
+
+* All MariaDB `CREATE TABLE` statements use `insight_tenant_id`, not `tenant_id`
+* All ClickHouse table definitions use `insight_tenant_id`
+* All Redpanda message schemas include `insight_tenant_id`
+* Code search: `grep -r "tenant_id" --include="*.rs"` should return only `insight_tenant_id` (no bare `tenant_id`)
+* Connector config fields: `insight_tenant_id` in `connection_specification`, `azure_tenant_id` for Azure -- no collision
+
+## Pros and Cons of the Options
+
+### insight_tenant_id (prefixed)
+
+All Insight platform tables and events use `insight_tenant_id` as the tenant isolation column. The `insight_` prefix is reserved for platform-injected fields.
+
+* Good, because unambiguous across all layers (Bronze through Gold, MariaDB, events)
+* Good, because already established in connector framework config convention
+* Good, because enables mechanical validation -- any bare `tenant_id` in Insight-owned code is a bug
+* Neutral, because longer name adds minor typing overhead
+* Bad, because requires updating all existing spec documents
+
+### tenant_id (bare)
+
+Standard convention used by most multi-tenant SaaS systems. Short, familiar, widely understood.
+
+* Good, because shortest possible name -- less typing, less visual noise
+* Good, because follows the standard `{entity}_id` FK pattern
+* Good, because universally recognised as "the tenant column" in multi-tenant systems
+* Bad, because collides with `tenant_id` in Azure AD, Azure APIs, and potentially other source systems
+* Bad, because in Bronze/Silver tables, requires disambiguation (which `tenant_id` is this row's?)
+* Bad, because connector configs already had to work around this with `insight_tenant_id` prefix -- bare name was insufficient
+
+## More Information
+
+The connector framework established the `insight_*` prefix convention to prevent config field collisions. This ADR extends that convention from connector configs to all platform tables and events.
+
+**Related fields using the same `insight_` prefix:**
+- `insight_source_id` -- connector instance identifier
+- `insight_source_type` -- source system type (e.g., `github`, `bamboohr`)
+
+**Fields that do NOT use the prefix:**
+- `source_account_id` -- this is a source-native identifier, not platform-injected
+
+See the full field conventions in [Database Field Naming & Type Conventions](../README.md).
+
+## Traceability
+
+This decision directly addresses the following requirements or design elements:
+
+* `cpt-insightspec-nfr-be-tenant-isolation` -- `insight_tenant_id` is the universal tenant isolation column across all storage systems
+* `cpt-insightspec-nfr-be-query-safety` -- Unambiguous column name prevents accidental joins on wrong `tenant_id` when source-system fields are present
+* `cpt-insightspec-principle-be-secure-by-default` -- Eliminates a class of bugs where platform tenant_id is confused with source-system tenant_id

--- a/docs/shared/glossary/ADR/0003-insight-prefixed-tenant-id.md
+++ b/docs/shared/glossary/ADR/0003-insight-prefixed-tenant-id.md
@@ -55,10 +55,12 @@ Chosen option: "`insight_tenant_id` (prefixed)", because it eliminates name coll
 
 ### Confirmation
 
+Post-migration target state (existing violations documented in [Known Convention Violations](../README.md#15-known-convention-violations)):
+
 * All MariaDB `CREATE TABLE` statements use `insight_tenant_id`, not `tenant_id`
 * All ClickHouse table definitions use `insight_tenant_id`
 * All Redpanda message schemas include `insight_tenant_id`
-* Code search: `grep -r "tenant_id" --include="*.rs" --include="*.sql" --include="*.yml" --include="*.yaml" --include="*.md" --include="*.toml"` should return only `insight_tenant_id` (no bare `tenant_id`)
+* Code search: `grep -r "tenant_id" --include="*.rs" --include="*.sql" --include="*.yml" --include="*.yaml" --include="*.md" --include="*.toml"` will return only `insight_tenant_id` (no bare `tenant_id`) after migration of existing code and specs is complete
 * Connector config fields: `insight_tenant_id` in `connection_specification`, `azure_tenant_id` for Azure -- no collision
 
 ## Pros and Cons of the Options

--- a/docs/shared/glossary/README.md
+++ b/docs/shared/glossary/README.md
@@ -57,6 +57,9 @@ This document defines mandatory naming patterns and data types for columns that 
 - [14. Proposals with Known Contradictions](#14-proposals-with-known-contradictions)
   - [SCD Type 2 in MariaDB](#scd-type-2-in-mariadb)
   - [MariaDB Partial Index Workaround](#mariadb-partial-index-workaround)
+- [15. Known Convention Violations](#15-known-convention-violations)
+  - [Code](#code)
+  - [Spec documents](#spec-documents)
 
 <!-- /toc -->
 
@@ -94,11 +97,11 @@ id UUID NOT NULL DEFAULT uuid_v7() PRIMARY KEY
 id UUID DEFAULT generateUUIDv7()
 ```
 
-> In ClickHouse `id` is a column, not a PK in the RDBMS sense. It should appear **last** in the `ORDER BY` key (if at all) — never first. See [section 11](#11-clickhouse-specific-conventions).
+> In ClickHouse `id` is a column, not a PK in the RDBMS sense. It should appear **last** in the `ORDER BY` key (if at all) — never first. See [section 6](#6-clickhouse-specific-conventions).
 
 **Foreign key references** use the pattern `{entity}_id`:
 
-```
+```sql
 person_id       UUID    -- FK to person.id
 org_unit_id     UUID    -- FK to org_unit.id
 metric_id       UUID    -- FK to metric.id
@@ -120,7 +123,7 @@ The identity-resolution DESIGN (PR #54) proposed `id INT AUTO_INCREMENT` as PK w
 
 **Decision**: the marginal InnoDB performance benefit of INT surrogates does not justify the complexity for Insight's metadata workloads (thousands to low millions of rows per tenant). UUIDv7 provides near-sequential ordering. All services, events, logs, and APIs use one identifier per entity.
 
-**Exception**: ClickHouse Bronze/Silver tables do NOT use UUID PKs — they use composite `ORDER BY` keys optimised for analytical queries. See [section 11](#11-clickhouse-specific-conventions).
+**Exception**: ClickHouse Bronze/Silver tables do NOT use UUID PKs — they use composite `ORDER BY` keys optimised for analytical queries. See [section 6](#6-clickhouse-specific-conventions).
 
 ---
 
@@ -490,3 +493,21 @@ An earlier draft proposed SCD2 versioning directly in MariaDB tables (entity anc
 ### MariaDB Partial Index Workaround
 
 An earlier draft proposed a generated column `is_current` to emulate PostgreSQL partial unique indexes in MariaDB (`WHERE effective_to IS NULL`). This workaround is unnecessary if SCD2 versioning is not in MariaDB. For **business temporal validity** tables (e.g., org memberships with `effective_from`/`effective_to`), the uniqueness constraint will be defined when the org-chart module is designed.
+
+---
+
+## 15. Known Convention Violations
+
+Existing code and specs that conflict with the adopted conventions. To be updated as part of follow-up work.
+
+### Code
+
+| File | Violation | Convention |
+|------|-----------|------------|
+| `src/ingestion/connectors/hr-directory/bamboohr/dbt/to_class_people.sql:16` | `CAST(NULL AS Nullable(DateTime))` for `valid_to` | ClickHouse Nullable avoidance (section 6); use sentinel value (e.g., `'1970-01-01'`) instead of `Nullable` |
+| `src/ingestion/connectors/hr-directory/bamboohr/dbt/to_class_people.sql:12` | bare `tenant_id` | `insight_tenant_id` (section 3.1) |
+| `src/ingestion/connectors/hr-directory/bamboohr/dbt/to_class_people.sql:15` | `valid_from` / `valid_to` | `effective_from` / `effective_to` (section 4.2) |
+
+### Spec documents
+
+See PR #55 summary for the full list of spec-level violations across ~25 documents (~270+ bare `tenant_id` references, `valid_from/valid_to`, `performed_by VARCHAR`, `INT` PKs, `TIMESTAMP` types).

--- a/docs/shared/glossary/README.md
+++ b/docs/shared/glossary/README.md
@@ -31,30 +31,30 @@ This document defines mandatory naming patterns and data types for columns that 
   - [4.3 Job / Processing Timestamps](#43-job--processing-timestamps)
   - [4.4 Event Timestamps](#44-event-timestamps)
 - [5. Foreign Key References](#5-foreign-key-references)
-- [6. Hash & Change Detection](#6-hash--change-detection)
-- [7. ClickHouse-Specific Conventions](#7-clickhouse-specific-conventions)
+- [6. ClickHouse-Specific Conventions](#6-clickhouse-specific-conventions)
   - [ORDER BY Key Design](#order-by-key-design)
   - [Nullable](#nullable)
   - [LowCardinality](#lowcardinality)
   - [Partitioning](#partitioning)
   - [TTL](#ttl)
-- [8. MariaDB-Specific Conventions](#8-mariadb-specific-conventions)
+- [7. MariaDB-Specific Conventions](#7-mariadb-specific-conventions)
   - [UUID Type](#uuid-type)
   - [DATETIME Precision](#datetime-precision)
   - [Character Sets](#character-sets)
-- [9. Boolean Fields](#9-boolean-fields)
-- [10. Soft-Delete](#10-soft-delete)
-- [11. Observation Timestamps](#11-observation-timestamps)
-- [12. String Length Tiers](#12-string-length-tiers)
-- [13. Anti-Patterns](#13-anti-patterns)
-- [14. Proposals](#14-proposals)
+- [8. Boolean Fields](#8-boolean-fields)
+- [9. Soft-Delete](#9-soft-delete)
+- [10. Observation Timestamps](#10-observation-timestamps)
+- [11. String Length Tiers](#11-string-length-tiers)
+- [12. Anti-Patterns](#12-anti-patterns)
+- [13. Proposals](#13-proposals)
   - [P1: Hierarchy & Tree Fields](#p1-hierarchy--tree-fields)
   - [P2: Status & Enum Fields](#p2-status--enum-fields)
   - [P3: Actor / Audit Attribution](#p3-actor--audit-attribution)
   - [P4: Confidence & Scoring Fields](#p4-confidence--scoring-fields)
   - [P5: JSON / Flexible Storage](#p5-json--flexible-storage)
-  - [P6: Business Temporal Validity in MariaDB](#p6-business-temporal-validity-in-mariadb)
-- [15. Proposals with Known Contradictions](#15-proposals-with-known-contradictions)
+  - [P6: Hash & Change Detection](#p6-hash--change-detection)
+  - [P7: Business Temporal Validity in MariaDB](#p7-business-temporal-validity-in-mariadb)
+- [14. Proposals with Known Contradictions](#14-proposals-with-known-contradictions)
   - [SCD Type 2 in MariaDB](#scd-type-2-in-mariadb)
   - [MariaDB Partial Index Workaround](#mariadb-partial-index-workaround)
 
@@ -227,22 +227,13 @@ For ClickHouse event tables (audit log, analytics):
 - FK column name matches the referenced table's logical entity: `person_id`, `org_unit_id`, `metric_id`
 - `insight_tenant_id` is a special case (see [section 3](#3-tenant--source-isolation))
 - When the same entity is referenced twice in one table, prefix with role: `source_person_id`, `target_person_id`, `manager_person_id`
-- Self-referential FK for hierarchies: `parent_id UUID NULL` — `NULL` means root node. Application must prevent circular references. Materialised path fields (`path`, `depth`) are proposed in [section 14](#14-proposals)
+- Self-referential FK for hierarchies: `parent_id UUID NULL` — `NULL` means root node. Application must prevent circular references. Materialised path fields (`path`, `depth`) are proposed in [section 13](#13-proposals)
 
 Concrete FK lists per domain will be defined in corresponding DESIGN documents.
 
 ---
 
-## 6. Hash & Change Detection
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `record_hash` | `VARCHAR(64)` | SHA-256 hex of canonical attribute set for change detection |
-| `version` | `INT NOT NULL DEFAULT 1` | Monotonic counter for optimistic locking |
-
----
-
-## 7. ClickHouse-Specific Conventions
+## 6. ClickHouse-Specific Conventions
 
 ### ORDER BY Key Design
 
@@ -295,7 +286,7 @@ Always define TTL on event tables. Configurable per tenant via application logic
 
 ---
 
-## 8. MariaDB-Specific Conventions
+## 7. MariaDB-Specific Conventions
 
 ### UUID Type
 
@@ -316,7 +307,7 @@ Use `utf8mb4` character set and `utf8mb4_unicode_ci` collation for all string co
 
 ---
 
-## 9. Boolean Fields
+## 8. Boolean Fields
 
 Use `BOOL` (MariaDB alias for `TINYINT(1)`) with `is_` prefix:
 
@@ -341,7 +332,7 @@ is_deleted  UInt8 DEFAULT 0
 
 ---
 
-## 10. Soft-Delete
+## 9. Soft-Delete
 
 Use `deleted_at` timestamp (not boolean flag) for soft-delete:
 
@@ -360,7 +351,7 @@ deleted_at DATETIME(3) NULL DEFAULT NULL
 
 ---
 
-## 11. Observation Timestamps
+## 10. Observation Timestamps
 
 For records that track when something was first/last observed (e.g., unmapped aliases, sync status):
 
@@ -377,7 +368,7 @@ For records that track when something was first/last observed (e.g., unmapped al
 
 ---
 
-## 12. String Length Tiers
+## 11. String Length Tiers
 
 Use consistent `VARCHAR` lengths based on content type:
 
@@ -397,7 +388,7 @@ Use consistent `VARCHAR` lengths based on content type:
 
 ---
 
-## 13. Anti-Patterns
+## 12. Anti-Patterns
 
 | Anti-pattern | Why | Do instead |
 |-------------|-----|-----------|
@@ -416,7 +407,7 @@ Use consistent `VARCHAR` lengths based on content type:
 
 ---
 
-## 14. Proposals
+## 13. Proposals
 
 Conventions proposed but not yet confirmed. Will be finalized when the corresponding domain modules are designed.
 
@@ -469,7 +460,16 @@ Rules: always UUID FK, never username strings. For grant/revoke: `granted_by UUI
 
 Use JSON columns sparingly for genuinely dynamic data (`config`, `parameters`, `snapshot_before`, `snapshot_after`). JSON field names follow `snake_case`. Do NOT store queryable data in JSON. ClickHouse: use `String` type.
 
-### P6: Business Temporal Validity in MariaDB
+### P6: Hash & Change Detection
+
+> **Scope**: identity-resolution, connector sync
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `record_hash` | `VARCHAR(64)` | SHA-256 hex of canonical attribute set for change detection |
+| `version` | `INT NOT NULL DEFAULT 1` | Monotonic counter for optimistic locking |
+
+### P7: Business Temporal Validity in MariaDB
 
 > **Scope**: org-chart module (future)
 
@@ -479,7 +479,7 @@ Use JSON columns sparingly for genuinely dynamic data (`config`, `parameters`, `
 
 ---
 
-## 15. Proposals with Known Contradictions
+## 14. Proposals with Known Contradictions
 
 Patterns that were initially considered but contradict the adopted SCD mechanism (dbt-macros with `*_snapshot` and `fields_history` tables in ClickHouse). Documented for context — not to be implemented.
 

--- a/docs/shared/glossary/README.md
+++ b/docs/shared/glossary/README.md
@@ -514,6 +514,8 @@ Existing code and specs that conflict with the adopted conventions. To be update
 | `src/ingestion/connectors/hr-directory/bamboohr/dbt/to_class_people.sql:16` | `CAST(NULL AS Nullable(DateTime))` for `valid_to` | ClickHouse Nullable avoidance (section 6); use sentinel value (e.g., `'1970-01-01'`) instead of `Nullable` |
 | `src/ingestion/connectors/hr-directory/bamboohr/dbt/to_class_people.sql:12` | bare `tenant_id` | `insight_tenant_id` (section 3.1) |
 | `src/ingestion/connectors/hr-directory/bamboohr/dbt/to_class_people.sql:15` | `valid_from` / `valid_to` | `effective_from` / `effective_to` (section 4.2) |
+| `src/ingestion/connectors/ai/claude-api/dbt/to_ai_api_usage.sql:8` | `insight_source_id` without `insight_source_type` | Source tracking fields must co-occur (section 3.2) |
+| `src/ingestion/connectors/ai/claude-api/dbt/to_ai_api_usage.sql:7` | bare `tenant_id` | `insight_tenant_id` (section 3.1) |
 
 ### Spec documents
 

--- a/docs/shared/glossary/README.md
+++ b/docs/shared/glossary/README.md
@@ -11,6 +11,7 @@ This document defines mandatory naming patterns and data types for columns that 
 |-----|----------|--------|
 | [ADR-0001](ADR/0001-uuidv7-primary-key.md) | UUIDv7 as universal primary key -- single UUID PK per table, no INT surrogates | proposed |
 | [ADR-0002](ADR/0002-database-field-conventions.md) | Database field naming and type conventions -- temporal naming, tenant_id type, actor attribution, DATETIME(3), ClickHouse patterns | proposed |
+| [ADR-0003](ADR/0003-insight-prefixed-tenant-id.md) | Use `insight_tenant_id` instead of `tenant_id` -- avoid name collision with source systems | proposed |
 
 ---
 
@@ -22,13 +23,16 @@ This document defines mandatory naming patterns and data types for columns that 
   - [2.1 Standard Tables (No Versioning)](#21-standard-tables-no-versioning)
   - [2.2 SCD Type 2 / Versioned Tables](#22-scd-type-2--versioned-tables)
   - [2.3 Why UUID-Only, Not INT Surrogate + UUID](#23-why-uuid-only-not-int-surrogate--uuid)
-- [3. Tenant Isolation](#3-tenant-isolation)
+- [3. Tenant & Source Isolation](#3-tenant--source-isolation)
+  - [3.1 Tenant Identifier -- insight_tenant_id](#31-tenant-identifier----insighttenantid)
+  - [3.2 Source Tracking Fields](#32-source-tracking-fields)
 - [4. Timestamp Fields](#4-timestamp-fields)
   - [4.1 Record Lifecycle Timestamps](#41-record-lifecycle-timestamps)
   - [4.2 Temporal Validity (Effective Ranges)](#42-temporal-validity-effective-ranges)
   - [4.3 Job / Processing Timestamps](#43-job--processing-timestamps)
   - [4.4 Event Timestamps](#44-event-timestamps)
 - [5. Foreign Key References](#5-foreign-key-references)
+  - [5.1 Self-Referential Foreign Keys (Hierarchies)](#51-self-referential-foreign-keys-hierarchies)
 - [6. Status & Enum Fields](#6-status--enum-fields)
 - [7. Actor / Audit Attribution](#7-actor--audit-attribution)
 - [8. Confidence & Scoring Fields](#8-confidence--scoring-fields)
@@ -44,7 +48,13 @@ This document defines mandatory naming patterns and data types for columns that 
   - [UUID Type](#uuid-type)
   - [DATETIME Precision](#datetime-precision)
   - [Character Sets](#character-sets)
-- [13. Anti-Patterns](#13-anti-patterns)
+- [13. Boolean Fields](#13-boolean-fields)
+- [14. Hierarchy & Tree Fields](#14-hierarchy--tree-fields)
+- [15. Soft-Delete](#15-soft-delete)
+- [16. Observation Timestamps](#16-observation-timestamps)
+- [17. String Length Tiers](#17-string-length-tiers)
+- [18. MariaDB Partial Index Workaround](#18-mariadb-partial-index-workaround)
+- [19. Anti-Patterns](#19-anti-patterns)
 
 <!-- /toc -->
 
@@ -90,7 +100,7 @@ id UUID DEFAULT generateUUIDv7()
 person_id       UUID    -- FK to person.id
 org_unit_id     UUID    -- FK to org_unit.id
 metric_id       UUID    -- FK to metric.id
-tenant_id       UUID    -- FK to tenant.id (see section 3)
+insight_tenant_id UUID   -- FK to tenant.id (see section 3)
 ```
 
 ### 2.2 SCD Type 2 / Versioned Tables
@@ -142,19 +152,40 @@ The identity-resolution DESIGN (PR #54) proposed `id INT AUTO_INCREMENT` as PK w
 
 ---
 
-## 3. Tenant Isolation
+## 3. Tenant & Source Isolation
 
-Every table in every storage system includes `tenant_id`:
+### 3.1 Tenant Identifier -- insight_tenant_id
+
+Every table in every storage system includes `insight_tenant_id`:
 
 | Storage | Column | Type | Enforcement |
 |---------|--------|------|-------------|
-| MariaDB | `tenant_id` | `UUID NOT NULL` | `SecureConn` + `AccessScope` (modkit-db) |
-| ClickHouse | `tenant_id` | `UUID` | Row-level filter on all queries |
-| Redis | key prefix | `{tenant_id}:` | Application convention |
+| MariaDB | `insight_tenant_id` | `UUID NOT NULL` | `SecureConn` + `AccessScope` (modkit-db) |
+| ClickHouse | `insight_tenant_id` | `UUID` | Row-level filter on all queries |
+| Redis | key prefix | `{insight_tenant_id}:` | Application convention |
 | Redpanda | message field | UUID (JSON) | Consumer-side filter |
-| S3 / MinIO | object prefix | `{tenant_id}/` | Application convention |
+| S3 / MinIO | object prefix | `{insight_tenant_id}/` | Application convention |
 
-`tenant_id` is always `UUID`, consistent with the project-wide ID convention. Never `VARCHAR` or `String`.
+**Why `insight_tenant_id`, not `tenant_id`?** Many external systems use `tenant_id` as their own field name (e.g., Azure `tenant_id`, Salesforce `org_id`). The `insight_` prefix eliminates ambiguity across all layers -- Bronze tables, Silver tables, internal metadata, connector configs, and API payloads. One name, zero collisions. See [ADR-0003](ADR/0003-insight-prefixed-tenant-id.md).
+
+`insight_tenant_id` is always `UUID`, consistent with the project-wide ID convention. Never `VARCHAR` or `String`.
+
+### 3.2 Source Tracking Fields
+
+Tables that contain or reference data from external source systems include source tracking fields:
+
+| Column | Type | Required | Description |
+|--------|------|----------|-------------|
+| `insight_source_id` | `UUID NOT NULL` | When source-specific | Connector instance identifier -- distinguishes between two GitLab instances for the same tenant. Propagated from Bronze layer |
+| `insight_source_type` | `VARCHAR(100) NOT NULL` | When source-specific | Source system type (e.g., `github`, `gitlab`, `bamboohr`, `jira`, `slack`). Replaces `source_system` / `source` |
+| `source_account_id` | `VARCHAR(500) NOT NULL` | When source-specific | Unique account/user ID within the source system (e.g., GitHub user ID, Jira account ID). Source-native format, not normalised |
+
+**Rules:**
+- `insight_source_id` and `insight_source_type` always appear together -- a source type without an instance ID is ambiguous when a tenant has multiple instances of the same system
+- `source_account_id` is the raw identifier from the external system -- not a UUID, not normalised. Format varies by source
+- These fields are NOT present on purely internal tables (e.g., `alert_rule`, `dashboard`, `user_role`) that have no relationship to external source data
+
+**Naming convention:** `insight_` prefix for platform-injected fields; no prefix for source-native fields (`source_account_id`).
 
 ---
 
@@ -223,14 +254,28 @@ Pattern: `{referenced_entity}_id`
 ```
 person_id           UUID        -- FK to person.id
 org_unit_id         UUID        -- FK to org_unit.id
-tenant_id           UUID        -- FK to tenant.id
+insight_tenant_id   UUID        -- FK to tenant.id (see section 3)
 metric_id           UUID        -- FK to metric.id
 connector_id        UUID        -- FK to connector_config.id
 granted_by          UUID        -- FK to person.id (actor who granted)
 manager_person_id   UUID        -- FK to person.id (with role qualifier)
+parent_id           UUID NULL   -- Self-referential FK (see section 5.1)
 ```
 
 When the same entity is referenced twice in one table, prefix with role: `source_person_id`, `target_person_id`, `manager_person_id`.
+
+### 5.1 Self-Referential Foreign Keys (Hierarchies)
+
+For tree/hierarchy structures (org units, categories):
+
+```sql
+parent_id UUID NULL   -- FK to same table's id; NULL = root node
+```
+
+**Rules:**
+- `NULL` means root of the hierarchy (no parent)
+- Application must prevent circular references -- database cannot enforce this via FK alone
+- For efficient subtree queries, consider a materialised `path` column (see [section 14](#14-hierarchy--tree-fields))
 
 ---
 
@@ -314,10 +359,10 @@ Use JSON columns sparingly for genuinely dynamic data:
 ### ORDER BY Key Design
 
 ```sql
-ORDER BY (tenant_id, event_date, entity_type, id)
+ORDER BY (insight_tenant_id, event_date, entity_type, id)
 ```
 
-- **First**: `tenant_id` — always filtered, lowest cardinality
+- **First**: `insight_tenant_id` — always filtered, lowest cardinality
 - **Middle**: date/category columns — filtered frequently, medium cardinality
 - **Last** (if needed): UUID — highest cardinality, only for deduplication
 
@@ -383,15 +428,135 @@ Use `utf8mb4` character set and `utf8mb4_unicode_ci` collation for all string co
 
 ---
 
-## 13. Anti-Patterns
+## 13. Boolean Fields
+
+Use `BOOL` (MariaDB alias for `TINYINT(1)`) with `is_` prefix:
+
+**MariaDB:**
+
+```sql
+is_enabled  BOOL NOT NULL DEFAULT TRUE,
+is_deleted  BOOL NOT NULL DEFAULT FALSE
+```
+
+**ClickHouse:**
+
+```sql
+is_deleted  UInt8 DEFAULT 0
+```
+
+**Rules:**
+- Always prefix with `is_` — `is_enabled`, `is_deleted`, `is_bot`, `is_active`
+- Always `NOT NULL` with an explicit `DEFAULT` — a boolean should never be unknown
+- ClickHouse: use `UInt8` (0/1), not `LowCardinality(String)` — booleans are not categorical strings
+- Never use `ENUM('yes','no')` or string representations
+
+---
+
+## 14. Hierarchy & Tree Fields
+
+For materialized path hierarchies (org units, categories):
+
+| Column | Type (MariaDB) | Description |
+|--------|----------------|-------------|
+| `parent_id` | `UUID NULL` | FK to same table's `id`; `NULL` = root node |
+| `path` | `TEXT NOT NULL` | Materialised path (e.g., `/company/engineering/platform`) |
+| `depth` | `INT NOT NULL DEFAULT 0` | Nesting level (root = 0) |
+
+**Rules:**
+- `path` uses `/`-delimited segments, always starts with `/`
+- `depth` is derived from `path` (number of segments - 1) — keep in sync on writes
+- Application must prevent circular references
+- Index `path` for prefix queries (`LIKE '/company/engineering/%'`)
+
+---
+
+## 15. Soft-Delete
+
+Use `deleted_at` timestamp (not boolean flag) for soft-delete:
+
+**MariaDB:**
+
+```sql
+deleted_at DATETIME(3) NULL DEFAULT NULL
+```
+
+**Rules:**
+- `NULL` means active/not deleted; non-NULL means deleted at that timestamp
+- Aligns with [API Guideline](../api-guideline/API.md) §3 which specifies `deleted_at` as optional standard field
+- Application queries add `WHERE deleted_at IS NULL` for active records
+- Prefer `deleted_at` over `is_deleted BOOL` — the timestamp provides audit value (when was it deleted?)
+- For ClickHouse, use `is_deleted UInt8 DEFAULT 0` — ClickHouse does not benefit from nullable timestamps for filtering, and `ReplacingMergeTree` uses `is_deleted` for tombstone semantics
+
+---
+
+## 16. Observation Timestamps
+
+For records that track when something was first/last observed (e.g., unmapped aliases, sync status):
+
+| Column | Type (MariaDB) | Nullable | Description |
+|--------|----------------|----------|-------------|
+| `first_observed_at` | `DATETIME(3) NOT NULL` | No | When the record was first seen |
+| `last_observed_at` | `DATETIME(3) NOT NULL` | No | When the record was most recently seen |
+
+**Rules:**
+- `first_observed_at` is immutable after insert (like `created_at`)
+- `last_observed_at` updates on every observation
+- These differ from `created_at`/`updated_at` — a record may be created once but observed many times without being "updated" (no attribute change)
+- Follow the `_at` suffix convention — not `first_seen` / `last_seen`
+
+---
+
+## 17. String Length Tiers
+
+Use consistent `VARCHAR` lengths based on content type:
+
+| Tier | Length | Use for | Examples |
+|------|--------|---------|----------|
+| **Short** | `VARCHAR(50)` | Type codes, enum-like values, short identifiers | `alias_type`, `assignment_type`, `source` |
+| **Medium** | `VARCHAR(100)` | System names, rule names, attribute names | `insight_source_type`, `attribute_name`, `condition_type` |
+| **Standard** | `VARCHAR(255)` | Human-readable names, display values | `display_name`, `name`, `role`, `location` |
+| **Long** | `VARCHAR(500)` | Emails, URLs, external identifiers, user agents | `alias_value`, `email`, `source_account_id`, `actor_user_agent` |
+| **Unbounded** | `TEXT` | Paths, free-form text, reasons, descriptions | `path`, `reason`, `description` |
+
+**Rules:**
+- Pick the tier that fits the content, not the "maximum possible length"
+- `TEXT` should only be used when length is genuinely unpredictable
+- Do NOT use `VARCHAR(500)` for a field that will always be under 50 characters
+- ClickHouse: always use `String` (no length limit) or `FixedString(N)` for fixed-width codes
+
+---
+
+## 18. MariaDB Partial Index Workaround
+
+MariaDB does not support PostgreSQL-style partial unique indexes (`WHERE valid_to IS NULL`). Use a generated column:
+
+```sql
+-- Add to SCD2 / versioned tables
+is_current TINYINT(1) GENERATED ALWAYS AS (
+    CASE WHEN effective_to IS NULL THEN 1 ELSE NULL END
+) STORED,
+
+UNIQUE KEY idx_person_current (person_id, is_current)
+```
+
+This ensures only one row per `person_id` can have `effective_to IS NULL`. When `effective_to` is set, `is_current` becomes `NULL`, and `UNIQUE` ignores NULLs.
+
+---
+
+## 19. Anti-Patterns
 
 | Anti-pattern | Why | Do instead |
 |-------------|-----|-----------|
 | `INT AUTO_INCREMENT` PK + separate UUID column | Unnecessary complexity at Insight scale; two IDs to manage | `id UUID DEFAULT uuid_v7() PRIMARY KEY` |
-| `tenant_id VARCHAR(100)` | Inconsistent with project UUID convention; larger storage | `tenant_id UUID NOT NULL` |
+| Bare `tenant_id` | Collides with source system field names (e.g., Azure `tenant_id`) | `insight_tenant_id UUID NOT NULL` |
+| `tenant_id VARCHAR(100)` | Inconsistent with project UUID convention; larger storage | `insight_tenant_id UUID NOT NULL` |
+| `source_system VARCHAR` / bare `source` | Ambiguous naming; no instance-level granularity | `insight_source_type` + `insight_source_id` pair |
 | `performed_by VARCHAR(100)` (username string) | Breaks on rename; cannot join to person table | `actor_person_id UUID` (FK to person.id) |
 | `valid_from` / `valid_to` or `owned_from` / `owned_until` | Multiple naming conventions for the same concept | `effective_from` / `effective_to` everywhere |
+| `first_seen` / `last_seen` (no `_at` suffix) | Breaks timestamp naming convention | `first_observed_at` / `last_observed_at` |
+| `is_deleted BOOL` in MariaDB | Loses "when deleted" information | `deleted_at DATETIME(3) NULL` |
 | `TIMESTAMP` for MariaDB columns | Implicit timezone conversion; 2038 limit | `DATETIME(3)` |
-| UUID first in ClickHouse `ORDER BY` | Destroys data skipping and compression | `tenant_id` first, UUID last |
+| UUID first in ClickHouse `ORDER BY` | Destroys data skipping and compression | `insight_tenant_id` first, UUID last |
 | `Nullable(String)` in ClickHouse | Storage overhead from null-mask column | Empty string `''` as default |
 | `Enum8`/`Enum16` in ClickHouse | Hard to evolve (adding values requires ALTER) | `LowCardinality(String)` |

--- a/docs/shared/glossary/README.md
+++ b/docs/shared/glossary/README.md
@@ -20,7 +20,7 @@ This document defines mandatory naming patterns and data types for columns that 
 - [Architecture Decision Records](#architecture-decision-records)
 - [1. General Rules](#1-general-rules)
 - [2. Identifiers & Primary Keys](#2-identifiers--primary-keys)
-  - [2.1 Standard Tables (No Versioning)](#21-standard-tables-no-versioning)
+  - [2.1 Internal Entity Tables](#21-internal-entity-tables)
   - [2.2 Why UUID-Only, Not INT Surrogate + UUID](#22-why-uuid-only-not-int-surrogate--uuid)
 - [3. Tenant & Source Isolation](#3-tenant--source-isolation)
   - [3.1 Tenant Identifier -- insight_tenant_id](#31-tenant-identifier----insighttenantid)
@@ -70,7 +70,7 @@ This document defines mandatory naming patterns and data types for columns that 
 | Rule | Convention | Source |
 |------|-----------|--------|
 | Column naming | `snake_case`, lowercase | [API Guideline](../api-guideline/API.md) §4 |
-| Table naming | `snake_case`, lowercase, singular (`person`, `alert_rule`) | Project convention |
+| Table naming | `snake_case`, lowercase, **plural** (`persons`, `alert_rules`, `org_units`) | Project convention |
 | ID format | UUIDv7 (time-ordered) | [API Guideline](../api-guideline/README.md) §3 |
 | Timestamp format | ISO-8601 UTC with milliseconds in JSON; DB-native types in storage | [API Guideline](../api-guideline/API.md) §3 |
 | Nullability | Avoid unless null carries distinct semantic meaning | ClickHouse best practice; MariaDB convention |
@@ -79,9 +79,9 @@ This document defines mandatory naming patterns and data types for columns that 
 
 ## 2. Identifiers & Primary Keys
 
-### 2.1 Standard Tables (No Versioning)
+### 2.1 Internal Entity Tables
 
-Every table has a single `id` column as primary key:
+Every **internal entity table** (MariaDB or ClickHouse) has a single `id` column as primary key or unique identifier:
 
 **MariaDB:**
 
@@ -91,21 +91,28 @@ id UUID NOT NULL DEFAULT uuid_v7() PRIMARY KEY
 
 > MariaDB 10.7+ native `UUID` type stores 16 bytes internally. Always use `uuid_v7()` (time-ordered) to preserve insert ordering and minimise InnoDB page splits.
 
-**ClickHouse:**
+**ClickHouse (internal tables, e.g., audit events):**
 
 ```sql
 id UUID DEFAULT generateUUIDv7()
 ```
 
-> In ClickHouse `id` is a column, not a PK in the RDBMS sense. It should appear **last** in the `ORDER BY` key (if at all) — never first. See [section 6](#6-clickhouse-specific-conventions).
+> In ClickHouse `id` is not a PK in the RDBMS sense — it serves as a unique row identifier for filtering and joining. It should appear **last** in the `ORDER BY` key (if at all). See [section 6](#6-clickhouse-specific-conventions).
+
+**This applies to**: all tables that represent Insight's own domain entities and internal data — `persons`, `aliases`, `org_units`, `alert_rules`, `dashboards`, `metrics`, `connector_configs`, `tenant_keys`, `secrets`, audit events, email delivery logs, etc. This includes both MariaDB and ClickHouse tables owned by Insight services.
+
+**This does NOT apply to**:
+- **Bronze tables** — raw data from external sources via Airbyte; schema is source-native, no UUID PK
+- **Silver tables** — unified analytical tables in ClickHouse (`class_commits`, `class_people`, etc.); use composite `ORDER BY` keys, not UUID PKs
+- **Gold tables** — aggregated metrics in ClickHouse; same as Silver
 
 **Foreign key references** use the pattern `{entity}_id`:
 
 ```sql
-person_id       UUID    -- FK to person.id
-org_unit_id     UUID    -- FK to org_unit.id
-metric_id       UUID    -- FK to metric.id
-insight_tenant_id UUID   -- FK to tenant.id (see section 3)
+person_id         UUID    -- FK to persons.id
+org_unit_id       UUID    -- FK to org_units.id
+metric_id         UUID    -- FK to metrics.id
+insight_tenant_id UUID    -- FK to tenants.id (see section 3)
 ```
 
 ### 2.2 Why UUID-Only, Not INT Surrogate + UUID
@@ -158,7 +165,7 @@ Tables that contain or reference data from external source systems include sourc
 **Rules:**
 - `insight_source_id` and `insight_source_type` always appear together -- a source type without an instance ID is ambiguous when a tenant has multiple instances of the same system
 - `source_account_id` is the raw identifier from the external system -- not a UUID, not normalised. Format varies by source
-- These fields are NOT present on purely internal tables (e.g., `alert_rule`, `dashboard`, `user_role`) that have no relationship to external source data
+- These fields are NOT present on purely internal tables (e.g., `alert_rules`, `dashboards`, `user_roles`) that have no relationship to external source data
 
 **Naming convention:** `insight_` prefix for platform-injected fields; no prefix for source-native fields (`source_account_id`).
 
@@ -399,7 +406,7 @@ Use consistent `VARCHAR` lengths based on content type:
 | Bare `tenant_id` | Collides with source system field names (e.g., Azure `tenant_id`) | `insight_tenant_id UUID NOT NULL` |
 | `tenant_id VARCHAR(100)` | Inconsistent with project UUID convention; larger storage | `insight_tenant_id UUID NOT NULL` |
 | `source_system VARCHAR` / bare `source` | Ambiguous naming; no instance-level granularity | `insight_source_type` + `insight_source_id` pair |
-| `performed_by VARCHAR(100)` (username string) | Breaks on rename; cannot join to person table | `actor_person_id UUID` (FK to person.id) |
+| `performed_by VARCHAR(100)` (username string) | Breaks on rename; cannot join to persons table | `actor_person_id UUID` (FK to persons.id) |
 | `valid_from` / `valid_to` or `owned_from` / `owned_until` | Multiple naming conventions for the same concept | `effective_from` / `effective_to` everywhere |
 | `first_seen` / `last_seen` (no `_at` suffix) | Breaks timestamp naming convention | `first_observed_at` / `last_observed_at` |
 | `is_deleted BOOL` in MariaDB | Loses "when deleted" information | `deleted_at DATETIME(3) NULL` |
@@ -442,7 +449,7 @@ Concrete enum values will be defined per domain.
 
 | Column | Type (MariaDB) | Description |
 |--------|----------------|-------------|
-| `actor_person_id` | `UUID NOT NULL` | FK to person.id -- who performed the action |
+| `actor_person_id` | `UUID NOT NULL` | FK to persons.id -- who performed the action |
 | `actor_ip` | `VARCHAR(45)` | Client IP (IPv4 or IPv6) |
 | `actor_user_agent` | `VARCHAR(500)` | Client User-Agent |
 

--- a/docs/shared/glossary/README.md
+++ b/docs/shared/glossary/README.md
@@ -40,6 +40,7 @@ This document defines mandatory naming patterns and data types for columns that 
 - [7. MariaDB-Specific Conventions](#7-mariadb-specific-conventions)
   - [UUID Type](#uuid-type)
   - [DATETIME Precision](#datetime-precision)
+  - [Timezone](#timezone)
   - [Character Sets](#character-sets)
 - [8. Boolean Fields](#8-boolean-fields)
 - [9. Soft-Delete](#9-soft-delete)
@@ -184,6 +185,7 @@ Present on virtually every MariaDB table:
 
 - Always `DATETIME(3)` (millisecond precision) to match the API's ISO-8601 `.SSS` format.
 - `DATETIME` over `TIMESTAMP` — wider range (no 2038 problem), no implicit timezone conversion, predictable behaviour.
+- All `DATETIME(3)` values are stored in **UTC**. MariaDB `DATETIME` has no timezone semantics — application code is responsible for converting to UTC before write and from UTC after read. Set `time_zone = '+00:00'` in the MariaDB connection string to ensure `CURRENT_TIMESTAMP` and `NOW()` return UTC.
 - `created_at` is immutable after insert.
 
 ### 4.2 Temporal Validity (Effective Ranges)
@@ -310,6 +312,10 @@ Use `DATETIME(3)` (millisecond precision) for all timestamp columns to match the
 created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)
 ```
+
+### Timezone
+
+All connections **MUST** set `time_zone = '+00:00'` to ensure `CURRENT_TIMESTAMP`, `NOW()`, and default values produce UTC. `DATETIME` has no timezone semantics — without this setting, server-local time is used.
 
 ### Character Sets
 

--- a/docs/shared/glossary/README.md
+++ b/docs/shared/glossary/README.md
@@ -21,8 +21,7 @@ This document defines mandatory naming patterns and data types for columns that 
 - [1. General Rules](#1-general-rules)
 - [2. Identifiers & Primary Keys](#2-identifiers--primary-keys)
   - [2.1 Standard Tables (No Versioning)](#21-standard-tables-no-versioning)
-  - [2.2 SCD Type 2 / Versioned Tables](#22-scd-type-2--versioned-tables)
-  - [2.3 Why UUID-Only, Not INT Surrogate + UUID](#23-why-uuid-only-not-int-surrogate--uuid)
+  - [2.2 Why UUID-Only, Not INT Surrogate + UUID](#22-why-uuid-only-not-int-surrogate--uuid)
 - [3. Tenant & Source Isolation](#3-tenant--source-isolation)
   - [3.1 Tenant Identifier -- insight_tenant_id](#31-tenant-identifier----insighttenantid)
   - [3.2 Source Tracking Fields](#32-source-tracking-fields)
@@ -32,29 +31,32 @@ This document defines mandatory naming patterns and data types for columns that 
   - [4.3 Job / Processing Timestamps](#43-job--processing-timestamps)
   - [4.4 Event Timestamps](#44-event-timestamps)
 - [5. Foreign Key References](#5-foreign-key-references)
-  - [5.1 Self-Referential Foreign Keys (Hierarchies)](#51-self-referential-foreign-keys-hierarchies)
-- [6. Status & Enum Fields](#6-status--enum-fields)
-- [7. Actor / Audit Attribution](#7-actor--audit-attribution)
-- [8. Confidence & Scoring Fields](#8-confidence--scoring-fields)
-- [9. Hash & Change Detection](#9-hash--change-detection)
-- [10. JSON / Flexible Storage](#10-json--flexible-storage)
-- [11. ClickHouse-Specific Conventions](#11-clickhouse-specific-conventions)
+- [6. Hash & Change Detection](#6-hash--change-detection)
+- [7. ClickHouse-Specific Conventions](#7-clickhouse-specific-conventions)
   - [ORDER BY Key Design](#order-by-key-design)
   - [Nullable](#nullable)
   - [LowCardinality](#lowcardinality)
   - [Partitioning](#partitioning)
   - [TTL](#ttl)
-- [12. MariaDB-Specific Conventions](#12-mariadb-specific-conventions)
+- [8. MariaDB-Specific Conventions](#8-mariadb-specific-conventions)
   - [UUID Type](#uuid-type)
   - [DATETIME Precision](#datetime-precision)
   - [Character Sets](#character-sets)
-- [13. Boolean Fields](#13-boolean-fields)
-- [14. Hierarchy & Tree Fields](#14-hierarchy--tree-fields)
-- [15. Soft-Delete](#15-soft-delete)
-- [16. Observation Timestamps](#16-observation-timestamps)
-- [17. String Length Tiers](#17-string-length-tiers)
-- [18. MariaDB Partial Index Workaround](#18-mariadb-partial-index-workaround)
-- [19. Anti-Patterns](#19-anti-patterns)
+- [9. Boolean Fields](#9-boolean-fields)
+- [10. Soft-Delete](#10-soft-delete)
+- [11. Observation Timestamps](#11-observation-timestamps)
+- [12. String Length Tiers](#12-string-length-tiers)
+- [13. Anti-Patterns](#13-anti-patterns)
+- [14. Proposals](#14-proposals)
+  - [P1: Hierarchy & Tree Fields](#p1-hierarchy--tree-fields)
+  - [P2: Status & Enum Fields](#p2-status--enum-fields)
+  - [P3: Actor / Audit Attribution](#p3-actor--audit-attribution)
+  - [P4: Confidence & Scoring Fields](#p4-confidence--scoring-fields)
+  - [P5: JSON / Flexible Storage](#p5-json--flexible-storage)
+  - [P6: Business Temporal Validity in MariaDB](#p6-business-temporal-validity-in-mariadb)
+- [15. Proposals with Known Contradictions](#15-proposals-with-known-contradictions)
+  - [SCD Type 2 in MariaDB](#scd-type-2-in-mariadb)
+  - [MariaDB Partial Index Workaround](#mariadb-partial-index-workaround)
 
 <!-- /toc -->
 
@@ -103,37 +105,7 @@ metric_id       UUID    -- FK to metric.id
 insight_tenant_id UUID   -- FK to tenant.id (see section 3)
 ```
 
-### 2.2 SCD Type 2 / Versioned Tables
-
-For tables that track historical versions of the same logical entity (e.g., person transfers, org restructures), use a **composite primary key**:
-
-```sql
--- Row-level identity
-id          UUID NOT NULL DEFAULT uuid_v7(),
--- Logical entity identity (same across all versions)
-person_id   UUID NOT NULL,
--- Version tracking
-version     INT  NOT NULL DEFAULT 1,
-
-PRIMARY KEY (id),
-UNIQUE (person_id, version)
-```
-
-- `id` — unique row identifier (UUIDv7), serves as PK
-- `person_id` — logical entity FK, remains constant across versions
-- `version` — monotonically incrementing per logical entity
-
-Current version is identified by:
-
-```sql
--- Option A: partial unique index (preferred)
-CREATE UNIQUE INDEX idx_person_current ON person (person_id) WHERE valid_to IS NULL;
-
--- Option B: query filter
-WHERE valid_to IS NULL
-```
-
-### 2.3 Why UUID-Only, Not INT Surrogate + UUID
+### 2.2 Why UUID-Only, Not INT Surrogate + UUID
 
 The identity-resolution DESIGN (PR #54) proposed `id INT AUTO_INCREMENT` as PK with a separate `person_id UUID` column. We standardise on **UUID-only** for the following reasons:
 
@@ -249,112 +221,28 @@ For ClickHouse event tables (audit log, analytics):
 
 ## 5. Foreign Key References
 
-Pattern: `{referenced_entity}_id`
-
-```
-person_id           UUID        -- FK to person.id
-org_unit_id         UUID        -- FK to org_unit.id
-insight_tenant_id   UUID        -- FK to tenant.id (see section 3)
-metric_id           UUID        -- FK to metric.id
-connector_id        UUID        -- FK to connector_config.id
-granted_by          UUID        -- FK to person.id (actor who granted)
-manager_person_id   UUID        -- FK to person.id (with role qualifier)
-parent_id           UUID NULL   -- Self-referential FK (see section 5.1)
-```
-
-When the same entity is referenced twice in one table, prefix with role: `source_person_id`, `target_person_id`, `manager_person_id`.
-
-### 5.1 Self-Referential Foreign Keys (Hierarchies)
-
-For tree/hierarchy structures (org units, categories):
-
-```sql
-parent_id UUID NULL   -- FK to same table's id; NULL = root node
-```
+**General pattern:** `{referenced_entity}_id UUID`
 
 **Rules:**
-- `NULL` means root of the hierarchy (no parent)
-- Application must prevent circular references -- database cannot enforce this via FK alone
-- For efficient subtree queries, consider a materialised `path` column (see [section 14](#14-hierarchy--tree-fields))
+- FK column name matches the referenced table's logical entity: `person_id`, `org_unit_id`, `metric_id`
+- `insight_tenant_id` is a special case (see [section 3](#3-tenant--source-isolation))
+- When the same entity is referenced twice in one table, prefix with role: `source_person_id`, `target_person_id`, `manager_person_id`
+- Self-referential FK for hierarchies: `parent_id UUID NULL` — `NULL` means root node. Application must prevent circular references. Materialised path fields (`path`, `depth`) are proposed in [section 14](#14-proposals)
+
+Concrete FK lists per domain will be defined in corresponding DESIGN documents.
 
 ---
 
-## 6. Status & Enum Fields
-
-Use MariaDB `ENUM` for fixed, small value sets. Name the column by what it represents:
-
-| Column | Typical values | Notes |
-|--------|---------------|-------|
-| `status` | `active`, `inactive`, `deleted` | Generic record lifecycle |
-| `role` | `member`, `manager` | Role within a relationship |
-| `outcome` | `success`, `failure`, `denied` | Result of an operation |
-| `priority` | `p1`, `p2`, `p3` | Requirement priority |
-
-**Rules:**
-- Values are `snake_case`, lowercase
-- Prefer short, unambiguous strings
-- ClickHouse equivalent: `LowCardinality(String)` — never ClickHouse `Enum8/Enum16` (hard to evolve)
-- Do NOT encode business logic in enum names (no `auto_approved_by_admin`)
-
----
-
-## 7. Actor / Audit Attribution
-
-For tracking who performed an action:
-
-| Column | Type (MariaDB) | Description |
-|--------|----------------|-------------|
-| `actor_person_id` | `UUID NOT NULL` | FK to person.id — who performed the action |
-| `actor_ip` | `VARCHAR(45)` | Client IP (IPv4 or IPv6) |
-| `actor_user_agent` | `VARCHAR(500)` | Client User-Agent |
-
-**Rules:**
-- Always reference persons by `UUID` FK, never by username or email string.
-- For grant/revoke patterns: `granted_by UUID` / `revoked_by UUID`.
-- For resolution patterns: `resolved_by UUID` (FK to person.id).
-- The `performed_by VARCHAR` anti-pattern (storing a username string instead of person FK) should not be used — it breaks when usernames change and cannot be joined.
-
----
-
-## 8. Confidence & Scoring Fields
-
-For match quality and completeness:
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `confidence` | `DECIMAL(3,2)` | Score 0.00–1.00 |
-| `completeness_score` | `FLOAT` | Fraction of non-null attributes (0.0–1.0) |
-
----
-
-## 9. Hash & Change Detection
+## 6. Hash & Change Detection
 
 | Column | Type | Description |
 |--------|------|-------------|
 | `record_hash` | `VARCHAR(64)` | SHA-256 hex of canonical attribute set for change detection |
-| `version` | `INT NOT NULL DEFAULT 1` | Monotonic counter for SCD2 / optimistic locking |
+| `version` | `INT NOT NULL DEFAULT 1` | Monotonic counter for optimistic locking |
 
 ---
 
-## 10. JSON / Flexible Storage
-
-Use JSON columns sparingly for genuinely dynamic data:
-
-| Column | Type (MariaDB) | Description |
-|--------|----------------|-------------|
-| `config` | `JSON` | Rule-specific parameters, plugin configs |
-| `parameters` | `JSON` | Connector-specific parameters |
-| `snapshot_before` | `JSON` | Full state snapshot for audit rollback |
-| `snapshot_after` | `JSON` | State after change |
-
-**Rules:**
-- JSON field names inside the value also follow `snake_case`
-- Do NOT store data in JSON that is queried with `WHERE` — extract it into a proper column
-- ClickHouse equivalent: `String` (store JSON string, parse with JSON functions)
-
----
-
-## 11. ClickHouse-Specific Conventions
+## 7. ClickHouse-Specific Conventions
 
 ### ORDER BY Key Design
 
@@ -407,7 +295,7 @@ Always define TTL on event tables. Configurable per tenant via application logic
 
 ---
 
-## 12. MariaDB-Specific Conventions
+## 8. MariaDB-Specific Conventions
 
 ### UUID Type
 
@@ -428,7 +316,7 @@ Use `utf8mb4` character set and `utf8mb4_unicode_ci` collation for all string co
 
 ---
 
-## 13. Boolean Fields
+## 9. Boolean Fields
 
 Use `BOOL` (MariaDB alias for `TINYINT(1)`) with `is_` prefix:
 
@@ -453,25 +341,7 @@ is_deleted  UInt8 DEFAULT 0
 
 ---
 
-## 14. Hierarchy & Tree Fields
-
-For materialized path hierarchies (org units, categories):
-
-| Column | Type (MariaDB) | Description |
-|--------|----------------|-------------|
-| `parent_id` | `UUID NULL` | FK to same table's `id`; `NULL` = root node |
-| `path` | `TEXT NOT NULL` | Materialised path (e.g., `/company/engineering/platform`) |
-| `depth` | `INT NOT NULL DEFAULT 0` | Nesting level (root = 0) |
-
-**Rules:**
-- `path` uses `/`-delimited segments, always starts with `/`
-- `depth` is derived from `path` (number of segments - 1) — keep in sync on writes
-- Application must prevent circular references
-- Index `path` for prefix queries (`LIKE '/company/engineering/%'`)
-
----
-
-## 15. Soft-Delete
+## 10. Soft-Delete
 
 Use `deleted_at` timestamp (not boolean flag) for soft-delete:
 
@@ -490,7 +360,7 @@ deleted_at DATETIME(3) NULL DEFAULT NULL
 
 ---
 
-## 16. Observation Timestamps
+## 11. Observation Timestamps
 
 For records that track when something was first/last observed (e.g., unmapped aliases, sync status):
 
@@ -507,7 +377,7 @@ For records that track when something was first/last observed (e.g., unmapped al
 
 ---
 
-## 17. String Length Tiers
+## 12. String Length Tiers
 
 Use consistent `VARCHAR` lengths based on content type:
 
@@ -527,24 +397,7 @@ Use consistent `VARCHAR` lengths based on content type:
 
 ---
 
-## 18. MariaDB Partial Index Workaround
-
-MariaDB does not support PostgreSQL-style partial unique indexes (`WHERE valid_to IS NULL`). Use a generated column:
-
-```sql
--- Add to SCD2 / versioned tables
-is_current TINYINT(1) GENERATED ALWAYS AS (
-    CASE WHEN effective_to IS NULL THEN 1 ELSE NULL END
-) STORED,
-
-UNIQUE KEY idx_person_current (person_id, is_current)
-```
-
-This ensures only one row per `person_id` can have `effective_to IS NULL`. When `effective_to` is set, `is_current` becomes `NULL`, and `UNIQUE` ignores NULLs.
-
----
-
-## 19. Anti-Patterns
+## 13. Anti-Patterns
 
 | Anti-pattern | Why | Do instead |
 |-------------|-----|-----------|
@@ -560,3 +413,80 @@ This ensures only one row per `person_id` can have `effective_to IS NULL`. When 
 | UUID first in ClickHouse `ORDER BY` | Destroys data skipping and compression | `insight_tenant_id` first, UUID last |
 | `Nullable(String)` in ClickHouse | Storage overhead from null-mask column | Empty string `''` as default |
 | `Enum8`/`Enum16` in ClickHouse | Hard to evolve (adding values requires ALTER) | `LowCardinality(String)` |
+
+---
+
+## 14. Proposals
+
+Conventions proposed but not yet confirmed. Will be finalized when the corresponding domain modules are designed.
+
+### P1: Hierarchy & Tree Fields
+
+> **Scope**: org-chart module (future)
+
+For materialized path hierarchies (org units, categories):
+
+| Column | Type (MariaDB) | Description |
+|--------|----------------|-------------|
+| `parent_id` | `UUID NULL` | FK to same table's `id`; `NULL` = root node |
+| `path` | `TEXT NOT NULL` | Materialised path (e.g., `/company/engineering/platform`) |
+| `depth` | `INT NOT NULL DEFAULT 0` | Nesting level (root = 0) |
+
+Rules: `path` uses `/`-delimited segments; `depth` derived from path; application prevents circular references; index `path` for prefix queries.
+
+### P2: Status & Enum Fields
+
+> **Scope**: per-domain DESIGN documents
+
+Use MariaDB `ENUM` for fixed, small value sets. Name the column by what it represents (e.g., `status`, `role`, `outcome`). Values are `snake_case`, lowercase. ClickHouse equivalent: `LowCardinality(String)`.
+
+Concrete enum values will be defined per domain.
+
+### P3: Actor / Audit Attribution
+
+> **Scope**: audit service, identity service
+
+| Column | Type (MariaDB) | Description |
+|--------|----------------|-------------|
+| `actor_person_id` | `UUID NOT NULL` | FK to person.id -- who performed the action |
+| `actor_ip` | `VARCHAR(45)` | Client IP (IPv4 or IPv6) |
+| `actor_user_agent` | `VARCHAR(500)` | Client User-Agent |
+
+Rules: always UUID FK, never username strings. For grant/revoke: `granted_by UUID`, `revoked_by UUID`. For resolution: `resolved_by UUID`.
+
+### P4: Confidence & Scoring Fields
+
+> **Scope**: identity-resolution module
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `confidence` | `DECIMAL(3,2)` | Score 0.00-1.00 |
+| `completeness_score` | `FLOAT` | Fraction of non-null attributes (0.0-1.0) |
+
+### P5: JSON / Flexible Storage
+
+> **Scope**: per-domain DESIGN documents
+
+Use JSON columns sparingly for genuinely dynamic data (`config`, `parameters`, `snapshot_before`, `snapshot_after`). JSON field names follow `snake_case`. Do NOT store queryable data in JSON. ClickHouse: use `String` type.
+
+### P6: Business Temporal Validity in MariaDB
+
+> **Scope**: org-chart module (future)
+
+**Question**: How should org membership periods (`effective_from`/`effective_to`) be managed in MariaDB? Specifically: uniqueness enforcement (only one active membership per person+org_unit), query patterns for "who was in this unit on date X", and indexing strategy.
+
+**Context**: The `effective_from`/`effective_to` naming convention is adopted (section 4.2), but the concrete schema design for temporal tables in MariaDB will depend on the org-chart module architecture.
+
+---
+
+## 15. Proposals with Known Contradictions
+
+Patterns that were initially considered but contradict the adopted SCD mechanism (dbt-macros with `*_snapshot` and `fields_history` tables in ClickHouse). Documented for context — not to be implemented.
+
+### SCD Type 2 in MariaDB
+
+An earlier draft proposed SCD2 versioning directly in MariaDB tables (entity anchor table + versioned rows with `version INT`, composite PK `(entity_id, version)`). This contradicts the adopted approach where SCD2/SCD3 is implemented via **dbt-macros** that populate `*_snapshot` and `fields_history` tables in ClickHouse. MariaDB stores only the **current state** of each entity; historical versions are managed by the analytics pipeline.
+
+### MariaDB Partial Index Workaround
+
+An earlier draft proposed a generated column `is_current` to emulate PostgreSQL partial unique indexes in MariaDB (`WHERE effective_to IS NULL`). This workaround is unnecessary if SCD2 versioning is not in MariaDB. For **business temporal validity** tables (e.g., org memberships with `effective_from`/`effective_to`), the uniqueness constraint will be defined when the org-chart module is designed.

--- a/docs/shared/glossary/README.md
+++ b/docs/shared/glossary/README.md
@@ -1,0 +1,397 @@
+# Database Field Naming & Type Conventions
+
+> Applies to all **internal Insight tables** (MariaDB metadata, ClickHouse analytics/audit).
+> Does NOT apply to Bronze tables ingested from external sources via Airbyte connectors — those preserve source-native schemas.
+
+This document defines mandatory naming patterns and data types for columns that appear across multiple services and layers. The goal is consistency: any engineer reading any table in any service should immediately recognise the role of a column by its name.
+
+## Architecture Decision Records
+
+| ADR | Decision | Status |
+|-----|----------|--------|
+| [ADR-0001](ADR/0001-uuidv7-primary-key.md) | UUIDv7 as universal primary key -- single UUID PK per table, no INT surrogates | proposed |
+| [ADR-0002](ADR/0002-database-field-conventions.md) | Database field naming and type conventions -- temporal naming, tenant_id type, actor attribution, DATETIME(3), ClickHouse patterns | proposed |
+
+---
+
+<!-- toc -->
+
+- [Architecture Decision Records](#architecture-decision-records)
+- [1. General Rules](#1-general-rules)
+- [2. Identifiers & Primary Keys](#2-identifiers--primary-keys)
+  - [2.1 Standard Tables (No Versioning)](#21-standard-tables-no-versioning)
+  - [2.2 SCD Type 2 / Versioned Tables](#22-scd-type-2--versioned-tables)
+  - [2.3 Why UUID-Only, Not INT Surrogate + UUID](#23-why-uuid-only-not-int-surrogate--uuid)
+- [3. Tenant Isolation](#3-tenant-isolation)
+- [4. Timestamp Fields](#4-timestamp-fields)
+  - [4.1 Record Lifecycle Timestamps](#41-record-lifecycle-timestamps)
+  - [4.2 Temporal Validity (Effective Ranges)](#42-temporal-validity-effective-ranges)
+  - [4.3 Job / Processing Timestamps](#43-job--processing-timestamps)
+  - [4.4 Event Timestamps](#44-event-timestamps)
+- [5. Foreign Key References](#5-foreign-key-references)
+- [6. Status & Enum Fields](#6-status--enum-fields)
+- [7. Actor / Audit Attribution](#7-actor--audit-attribution)
+- [8. Confidence & Scoring Fields](#8-confidence--scoring-fields)
+- [9. Hash & Change Detection](#9-hash--change-detection)
+- [10. JSON / Flexible Storage](#10-json--flexible-storage)
+- [11. ClickHouse-Specific Conventions](#11-clickhouse-specific-conventions)
+  - [ORDER BY Key Design](#order-by-key-design)
+  - [Nullable](#nullable)
+  - [LowCardinality](#lowcardinality)
+  - [Partitioning](#partitioning)
+  - [TTL](#ttl)
+- [12. MariaDB-Specific Conventions](#12-mariadb-specific-conventions)
+  - [UUID Type](#uuid-type)
+  - [DATETIME Precision](#datetime-precision)
+  - [Character Sets](#character-sets)
+- [13. Anti-Patterns](#13-anti-patterns)
+
+<!-- /toc -->
+
+---
+
+## 1. General Rules
+
+| Rule | Convention | Source |
+|------|-----------|--------|
+| Column naming | `snake_case`, lowercase | [API Guideline](../api-guideline/API.md) §4 |
+| Table naming | `snake_case`, lowercase, singular (`person`, `alert_rule`) | Project convention |
+| ID format | UUIDv7 (time-ordered) | [API Guideline](../api-guideline/README.md) §3 |
+| Timestamp format | ISO-8601 UTC with milliseconds in JSON; DB-native types in storage | [API Guideline](../api-guideline/API.md) §3 |
+| Nullability | Avoid unless null carries distinct semantic meaning | ClickHouse best practice; MariaDB convention |
+
+---
+
+## 2. Identifiers & Primary Keys
+
+### 2.1 Standard Tables (No Versioning)
+
+Every table has a single `id` column as primary key:
+
+**MariaDB:**
+
+```sql
+id UUID NOT NULL DEFAULT uuid_v7() PRIMARY KEY
+```
+
+> MariaDB 10.7+ native `UUID` type stores 16 bytes internally. Always use `uuid_v7()` (time-ordered) to preserve insert ordering and minimise InnoDB page splits.
+
+**ClickHouse:**
+
+```sql
+id UUID DEFAULT generateUUIDv7()
+```
+
+> In ClickHouse `id` is a column, not a PK in the RDBMS sense. It should appear **last** in the `ORDER BY` key (if at all) — never first. See [section 11](#11-clickhouse-specific-conventions).
+
+**Foreign key references** use the pattern `{entity}_id`:
+
+```
+person_id       UUID    -- FK to person.id
+org_unit_id     UUID    -- FK to org_unit.id
+metric_id       UUID    -- FK to metric.id
+tenant_id       UUID    -- FK to tenant.id (see section 3)
+```
+
+### 2.2 SCD Type 2 / Versioned Tables
+
+For tables that track historical versions of the same logical entity (e.g., person transfers, org restructures), use a **composite primary key**:
+
+```sql
+-- Row-level identity
+id          UUID NOT NULL DEFAULT uuid_v7(),
+-- Logical entity identity (same across all versions)
+person_id   UUID NOT NULL,
+-- Version tracking
+version     INT  NOT NULL DEFAULT 1,
+
+PRIMARY KEY (id),
+UNIQUE (person_id, version)
+```
+
+- `id` — unique row identifier (UUIDv7), serves as PK
+- `person_id` — logical entity FK, remains constant across versions
+- `version` — monotonically incrementing per logical entity
+
+Current version is identified by:
+
+```sql
+-- Option A: partial unique index (preferred)
+CREATE UNIQUE INDEX idx_person_current ON person (person_id) WHERE valid_to IS NULL;
+
+-- Option B: query filter
+WHERE valid_to IS NULL
+```
+
+### 2.3 Why UUID-Only, Not INT Surrogate + UUID
+
+The identity-resolution DESIGN (PR #54) proposed `id INT AUTO_INCREMENT` as PK with a separate `person_id UUID` column. We standardise on **UUID-only** for the following reasons:
+
+| Factor | INT surrogate + UUID | UUID-only (UUIDv7) |
+|--------|---------------------|---------------------|
+| Schema complexity | Two ID columns to manage, two indexes | One column, one index |
+| Cross-service references | Services must know both IDs or always join | Single ID works everywhere (API, DB, events, logs) |
+| InnoDB page fill (UUIDv7) | ~94% (sequential INT) | ~90% (time-ordered, minor random suffix) |
+| Secondary index overhead | 4 bytes per entry | 16 bytes per entry |
+| Practical impact at Insight scale | Negligible — metadata tables, not billions of rows | Negligible |
+| API consistency | API exposes UUID, DB uses INT — mapping layer needed | API and DB use the same value |
+
+**Decision**: the marginal InnoDB performance benefit of INT surrogates does not justify the complexity for Insight's metadata workloads (thousands to low millions of rows per tenant). UUIDv7 provides near-sequential ordering. All services, events, logs, and APIs use one identifier per entity.
+
+**Exception**: ClickHouse Bronze/Silver tables do NOT use UUID PKs — they use composite `ORDER BY` keys optimised for analytical queries. See [section 11](#11-clickhouse-specific-conventions).
+
+---
+
+## 3. Tenant Isolation
+
+Every table in every storage system includes `tenant_id`:
+
+| Storage | Column | Type | Enforcement |
+|---------|--------|------|-------------|
+| MariaDB | `tenant_id` | `UUID NOT NULL` | `SecureConn` + `AccessScope` (modkit-db) |
+| ClickHouse | `tenant_id` | `UUID` | Row-level filter on all queries |
+| Redis | key prefix | `{tenant_id}:` | Application convention |
+| Redpanda | message field | UUID (JSON) | Consumer-side filter |
+| S3 / MinIO | object prefix | `{tenant_id}/` | Application convention |
+
+`tenant_id` is always `UUID`, consistent with the project-wide ID convention. Never `VARCHAR` or `String`.
+
+---
+
+## 4. Timestamp Fields
+
+### 4.1 Record Lifecycle Timestamps
+
+Present on virtually every MariaDB table:
+
+| Column | Type (MariaDB) | Nullable | Default | Description |
+|--------|----------------|----------|---------|-------------|
+| `created_at` | `DATETIME(3) NOT NULL` | No | `CURRENT_TIMESTAMP(3)` | When the record was first inserted |
+| `updated_at` | `DATETIME(3) NOT NULL` | No | `CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)` | When the record was last modified |
+
+- Always `DATETIME(3)` (millisecond precision) to match the API's ISO-8601 `.SSS` format.
+- `DATETIME` over `TIMESTAMP` — wider range (no 2038 problem), no implicit timezone conversion, predictable behaviour.
+- `created_at` is immutable after insert.
+
+### 4.2 Temporal Validity (Effective Ranges)
+
+For records with a period of validity (org memberships, SCD2 versions, alias ownership):
+
+| Column | Type (MariaDB) | Nullable | Description |
+|--------|----------------|----------|-------------|
+| `effective_from` | `DATE NOT NULL` | No | Start of validity (inclusive) |
+| `effective_to` | `DATE NULL` | Yes | End of validity (exclusive); `NULL` = currently active |
+
+**Rules:**
+- All temporal ranges use **half-open intervals**: `[effective_from, effective_to)`
+- `NULL` in `effective_to` means "currently active / no known end"
+- Never use `BETWEEN` for temporal queries — use `effective_from <= @date AND (effective_to IS NULL OR effective_to > @date)`
+- Use `DATE` (not `DATETIME`) when the business granularity is days (org memberships, role assignments)
+- Use `DATETIME(3)` when sub-day precision matters (SCD2 version ranges in identity resolution)
+
+**Naming convention**: always `effective_from` / `effective_to`. Not `valid_from/valid_to`, not `owned_from/owned_until` — one consistent pair across all services.
+
+### 4.3 Job / Processing Timestamps
+
+For records that are periodically re-evaluated by background jobs:
+
+| Column | Type (MariaDB) | Nullable | Description |
+|--------|----------------|----------|-------------|
+| `last_analyzed_at` | `DATETIME(3) NULL` | Yes | When a job last processed this record (e.g., bootstrap, identity resolution) |
+| `resolved_at` | `DATETIME(3) NULL` | Yes | When a conflict / unmapped alias was resolved |
+
+`NULL` means "never processed" or "never resolved".
+
+### 4.4 Event Timestamps
+
+For ClickHouse event tables (audit log, analytics):
+
+| Column | Type (ClickHouse) | Description |
+|--------|-------------------|-------------|
+| `timestamp` | `DateTime64(3, 'UTC')` | When the event occurred |
+
+- Use `DateTime64(3, 'UTC')` (millisecond precision) for event tables where sub-second ordering matters.
+- Use `DateTime` (second precision) for analytical aggregates where milliseconds add no value.
+- Always specify `'UTC'` timezone explicitly.
+
+---
+
+## 5. Foreign Key References
+
+Pattern: `{referenced_entity}_id`
+
+```
+person_id           UUID        -- FK to person.id
+org_unit_id         UUID        -- FK to org_unit.id
+tenant_id           UUID        -- FK to tenant.id
+metric_id           UUID        -- FK to metric.id
+connector_id        UUID        -- FK to connector_config.id
+granted_by          UUID        -- FK to person.id (actor who granted)
+manager_person_id   UUID        -- FK to person.id (with role qualifier)
+```
+
+When the same entity is referenced twice in one table, prefix with role: `source_person_id`, `target_person_id`, `manager_person_id`.
+
+---
+
+## 6. Status & Enum Fields
+
+Use MariaDB `ENUM` for fixed, small value sets. Name the column by what it represents:
+
+| Column | Typical values | Notes |
+|--------|---------------|-------|
+| `status` | `active`, `inactive`, `deleted` | Generic record lifecycle |
+| `role` | `member`, `manager` | Role within a relationship |
+| `outcome` | `success`, `failure`, `denied` | Result of an operation |
+| `priority` | `p1`, `p2`, `p3` | Requirement priority |
+
+**Rules:**
+- Values are `snake_case`, lowercase
+- Prefer short, unambiguous strings
+- ClickHouse equivalent: `LowCardinality(String)` — never ClickHouse `Enum8/Enum16` (hard to evolve)
+- Do NOT encode business logic in enum names (no `auto_approved_by_admin`)
+
+---
+
+## 7. Actor / Audit Attribution
+
+For tracking who performed an action:
+
+| Column | Type (MariaDB) | Description |
+|--------|----------------|-------------|
+| `actor_person_id` | `UUID NOT NULL` | FK to person.id — who performed the action |
+| `actor_ip` | `VARCHAR(45)` | Client IP (IPv4 or IPv6) |
+| `actor_user_agent` | `VARCHAR(500)` | Client User-Agent |
+
+**Rules:**
+- Always reference persons by `UUID` FK, never by username or email string.
+- For grant/revoke patterns: `granted_by UUID` / `revoked_by UUID`.
+- For resolution patterns: `resolved_by UUID` (FK to person.id).
+- The `performed_by VARCHAR` anti-pattern (storing a username string instead of person FK) should not be used — it breaks when usernames change and cannot be joined.
+
+---
+
+## 8. Confidence & Scoring Fields
+
+For match quality and completeness:
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `confidence` | `DECIMAL(3,2)` | Score 0.00–1.00 |
+| `completeness_score` | `FLOAT` | Fraction of non-null attributes (0.0–1.0) |
+
+---
+
+## 9. Hash & Change Detection
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `record_hash` | `VARCHAR(64)` | SHA-256 hex of canonical attribute set for change detection |
+| `version` | `INT NOT NULL DEFAULT 1` | Monotonic counter for SCD2 / optimistic locking |
+
+---
+
+## 10. JSON / Flexible Storage
+
+Use JSON columns sparingly for genuinely dynamic data:
+
+| Column | Type (MariaDB) | Description |
+|--------|----------------|-------------|
+| `config` | `JSON` | Rule-specific parameters, plugin configs |
+| `parameters` | `JSON` | Connector-specific parameters |
+| `snapshot_before` | `JSON` | Full state snapshot for audit rollback |
+| `snapshot_after` | `JSON` | State after change |
+
+**Rules:**
+- JSON field names inside the value also follow `snake_case`
+- Do NOT store data in JSON that is queried with `WHERE` — extract it into a proper column
+- ClickHouse equivalent: `String` (store JSON string, parse with JSON functions)
+
+---
+
+## 11. ClickHouse-Specific Conventions
+
+### ORDER BY Key Design
+
+```sql
+ORDER BY (tenant_id, event_date, entity_type, id)
+```
+
+- **First**: `tenant_id` — always filtered, lowest cardinality
+- **Middle**: date/category columns — filtered frequently, medium cardinality
+- **Last** (if needed): UUID — highest cardinality, only for deduplication
+
+Never place UUID first — it destroys granule-level data skipping and compression.
+
+### Nullable
+
+Avoid `Nullable` unless null is semantically meaningful. Prefer:
+- Empty string `''` for text
+- `0` for counts
+- Sentinel `'1970-01-01'` for dates
+- `toUUID('00000000-0000-0000-0000-000000000000')` for UUIDs
+
+Each `Nullable` column adds a UInt8 null-mask column (storage + processing overhead).
+
+### LowCardinality
+
+Use `LowCardinality(String)` for string columns with fewer than ~10,000 distinct values:
+
+```sql
+service         LowCardinality(String),    -- ~8 services
+action          LowCardinality(String),    -- ~50 actions
+category        LowCardinality(String),    -- ~6 categories
+outcome         LowCardinality(String),    -- success/failure/denied
+```
+
+### Partitioning
+
+```sql
+PARTITION BY toYYYYMM(timestamp)
+```
+
+Use month-based partitioning for time-series data. Ensures efficient TTL expiry and partition pruning.
+
+### TTL
+
+```sql
+TTL timestamp + INTERVAL 1 YEAR
+```
+
+Always define TTL on event tables. Configurable per tenant via application logic.
+
+---
+
+## 12. MariaDB-Specific Conventions
+
+### UUID Type
+
+Use the native `UUID` type (MariaDB 10.7+). It stores 16 bytes internally and displays as `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`. Always generate with `uuid_v7()`.
+
+### DATETIME Precision
+
+Use `DATETIME(3)` (millisecond precision) for all timestamp columns to match the API's ISO-8601 `.SSS` format:
+
+```sql
+created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)
+```
+
+### Character Sets
+
+Use `utf8mb4` character set and `utf8mb4_unicode_ci` collation for all string columns.
+
+---
+
+## 13. Anti-Patterns
+
+| Anti-pattern | Why | Do instead |
+|-------------|-----|-----------|
+| `INT AUTO_INCREMENT` PK + separate UUID column | Unnecessary complexity at Insight scale; two IDs to manage | `id UUID DEFAULT uuid_v7() PRIMARY KEY` |
+| `tenant_id VARCHAR(100)` | Inconsistent with project UUID convention; larger storage | `tenant_id UUID NOT NULL` |
+| `performed_by VARCHAR(100)` (username string) | Breaks on rename; cannot join to person table | `actor_person_id UUID` (FK to person.id) |
+| `valid_from` / `valid_to` or `owned_from` / `owned_until` | Multiple naming conventions for the same concept | `effective_from` / `effective_to` everywhere |
+| `TIMESTAMP` for MariaDB columns | Implicit timezone conversion; 2038 limit | `DATETIME(3)` |
+| UUID first in ClickHouse `ORDER BY` | Destroys data skipping and compression | `tenant_id` first, UUID last |
+| `Nullable(String)` in ClickHouse | Storage overhead from null-mask column | Empty string `''` as default |
+| `Enum8`/`Enum16` in ClickHouse | Hard to evolve (adding values requires ALTER) | `LowCardinality(String)` |


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#55](https://github.com/cyberfabric/cyber-insight/pull/55) | **Author:** Gregory91G | **Opened:** 2026-04-03T11:15:33Z | **Status:** merged on 2026-04-07T10:23:52Z
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

## Summary

- Add `docs/shared/glossary/README.md` — cross-service database field naming and type conventions for all internal Insight tables (MariaDB + ClickHouse)
- Add `ADR-0001: UUIDv7 as Universal Primary Key` — standardise on single UUID PK (no INT surrogates)
- Add `ADR-0002: Database Field Naming and Type Conventions` — 6 sub-decisions: temporal naming, `insight_tenant_id`, actor attribution, `DATETIME(3)`, ClickHouse patterns
- Add `ADR-0003: Use insight_tenant_id Instead of tenant_id` — `insight_` prefix eliminates name collision with source systems

## Motivation

PR #1203 (backend) and PR #1198 (identity-resolution) introduced conflicting conventions for the same concepts:
- `tenant_id`: UUID vs VARCHAR(100), and bare name collides with source systems
- PK pattern: UUID-only vs INT surrogate + UUID
- Temporal ranges: `effective_from/to` vs `valid_from/to` vs `owned_from/until`
- Audit attribution: `actor_person_id` UUID vs `performed_by` VARCHAR

This PR resolves all conflicts by establishing a single convention document with ADR-backed rationale.

## Document structure

| Tier | Sections | Status |
|------|----------|--------|
| **Adopted conventions** (sections 1–12) | General rules, identifiers, tenant/source isolation, timestamps, FK references, ClickHouse, MariaDB, booleans, soft-delete, observation timestamps, string length tiers, anti-patterns | Ready for implementation |
| **Proposals** (section 13, P1–P7) | Hierarchy fields, status/enum fields, actor attribution, confidence/scoring, JSON storage, hash/change detection, business temporal validity in MariaDB | Awaiting domain DESIGN phase |
| **Proposals with known contradictions** (section 14) | SCD2 in MariaDB, partial index workaround — contradict adopted dbt-macro SCD approach | Documented for context, not to be implemented |
| **Known convention violations** (section 15) | Code violations (bamboohr dbt) + pointer to spec violations in PR summary | Tracking for follow-up |

## Key decisions

| Decision | Chosen | Rejected | ADR |
|----------|--------|----------|-----|
| PK strategy | `id UUID DEFAULT uuid_v7()` for all internal entity tables | INT AUTO_INCREMENT + UUID | ADR-0001 |
| PK scope | Internal entity tables only; Bronze/Silver/Gold exempt | UUID PK everywhere | ADR-0001 |
| Table naming | **Plural** (`persons`, `alert_rules`, `org_units`) | Singular (`person`, `alert_rule`) | — |
| Tenant column | `insight_tenant_id UUID` | bare `tenant_id` | ADR-0003 |
| Source tracking | `insight_source_id` + `insight_source_type` pair | bare `source_system` | ADR-0002 |
| Temporal ranges | `effective_from` / `effective_to` | `valid_from/to`, `owned_from/until` | ADR-0002 |
| Actor attribution | UUID FK (`actor_person_id`) | VARCHAR username (`performed_by`) | ADR-0002 |
| MariaDB timestamps | `DATETIME(3)` | `TIMESTAMP` | ADR-0002 |
| ClickHouse enums | `LowCardinality(String)` | `Enum8/Enum16` | ADR-0002 |
| Soft-delete (MariaDB) | `deleted_at DATETIME(3) NULL` | `is_deleted BOOL` | — |
| Observation timestamps | `first_observed_at` / `last_observed_at` | `first_seen` / `last_seen` | — |

## Files changed

| File | Action |
|------|--------|
| `docs/shared/glossary/README.md` | **New** — conventions document (15 sections) |
| `docs/shared/glossary/ADR/0001-uuidv7-primary-key.md` | **New** — ADR |
| `docs/shared/glossary/ADR/0002-database-field-conventions.md` | **New** — ADR |
| `docs/shared/glossary/ADR/0003-insight-prefixed-tenant-id.md` | **New** — ADR |
| `cypilot/config/artifacts.toml` | **Modified** — register 3 new ADRs |

## Convention violations in existing specs

The following documents use patterns that conflict with the new conventions.

### `docs/domain/identity-resolution/specs/DESIGN.md` (PR #1198) — 46 violations

| Violation | Count | Tables affected |
|-----------|-------|----------------|
| `INT` PK instead of `UUID` | 9 | person, alias, org_unit, person_assignment, person_source_contribution, match_rule, unmapped, merge_audit, conflict |
| `TIMESTAMP` instead of `DATETIME(3)` | 13 | All tables |
| Bare `tenant_id` instead of `insight_tenant_id` | 7 | person_entity, alias, org_unit_entity, person_source_contribution, person_golden, unmapped, conflict |
| `valid_from`/`valid_to` instead of `effective_from`/`effective_to` | 6 | person, org_unit, person_assignment |
| `owned_from`/`owned_until` instead of `effective_from`/`effective_to` | 2 | alias |
| `performed_by`/`created_by`/`resolved_by` VARCHAR instead of UUID FK | 6 | alias, match_rule, unmapped, merge_audit, conflict |
| `source_system` instead of `insight_source_type` | 4 | person_assignment, person_source_contribution, unmapped |
| `first_seen`/`last_seen` instead of `first_observed_at`/`last_observed_at` | 2 | unmapped |
| Singular table names | all | All tables need renaming to plural |

### Code violations

| File | Violation |
|------|-----------|
| `src/ingestion/connectors/hr-directory/bamboohr/dbt/to_class_people.sql` | `CAST(NULL AS Nullable(DateTime))`, bare `tenant_id`, `valid_from`/`valid_to` |

### `docs/components/backend/specs/DESIGN.md` (PR #1203, separate branch)

All table definitions use bare `tenant_id` (~30 column definitions) and singular table names.

### Other spec violations

| Scope | Violation | Count |
|-------|-----------|-------|
| `docs/domain/connector/specs/DESIGN.md` | Bare `tenant_id` | 51 |
| `docs/domain/ingestion/specs/DESIGN.md` | Bare `tenant_id` | 15 |
| 10 individual connector DESIGNs | Bare `tenant_id` | ~150 |
| `docs/components/connectors/hr-directory/README.md` | `valid_from`/`valid_to` | 30 |
| `docs/components/connectors/git/README.md` | `first_seen` | 1 |
| Various connector PRDs | `valid_from`/`valid_to` | ~13 |

## Test plan

- [x] `cypilot validate-toc` — PASS on all 4 documents
- [x] Manual structural validation against ADR template — PASS (all 3 ADRs)
- [x] ID uniqueness verified via grep — no duplicates
- [x] Cross-reference integrity — all internal anchors and file links resolve correctly
- [x] No stale section numbers, no TODO/TBD/FIXME, no unlabeled code blocks
- [x] Conventions completeness review — gaps identified and addressed
- [x] Convention violations scan — all existing specs and code checked, violations catalogued above
- [ ] Review: confirm ADR decisions align with team consensus

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#55 -->