### PR TITLE
[PR #628] fix(gold): correct peer-median kpi_key to ai_loc_share_pct

### DIFF
--- a/src/ingestion/scripts/migrations/20260527000000_metrics-gold-views.sql
+++ b/src/ingestion/scripts/migrations/20260527000000_metrics-gold-views.sql
@@ -307,7 +307,7 @@ ARRAY JOIN [
     ('bugs_fixed',      toFloat64(k.bugs_fixed)),
     ('tasks_closed',    toFloat64(k.tasks_closed)),
     ('prs_merged',      toFloat64(coalesce(k.prs_merged, 0))),
-    ('ai_loc_share',    toFloat64(k.ai_loc_share_pct)),
+    ('ai_loc_share_pct', toFloat64(k.ai_loc_share_pct)),
     ('focus_time_pct',  toFloat64(k.focus_time_pct)),
     ('pr_cycle_time_h', toFloat64(coalesce(k.pr_cycle_time_h, 0))),
     ('ai_sessions',     toFloat64(k.ai_sessions))


### PR DESCRIPTION
> 🔗 **Mirrored PR** [cyberfabric/cyber-insight#628](https://github.com/cyberfabric/cyber-insight/pull/628) | **Author:** aleksdotbar | **Opened:** 2026-06-04T10:48:48Z | **Status:** closed (not merged)
> *GitHub API does not allow setting PR author or timestamps — attribution preserved here.*

---

ic_kpi_peer_median emitted kpi_key 'ai_loc_share' while the column rename landed on ai_loc_share_pct — catalog, IC aggregate and FE all look up ai_loc_share_pct, so the AI Code Acceptance tile found no median.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated KPI metric identifier for lines-of-code share percentage in peer-median reporting to improve consistency in metric naming conventions and ensure accurate metric identification in analytics and reporting outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
<!-- cf-mirror-pr: cyberfabric/cyber-insight#628 -->