### PR TITLE
chore(ci): retarget build/deploy from cyberfabric to constructorfabric

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-.github/CODEOWNERS @cyberfabric/security
-* @cyberfabric/insight-app-maintainers
+.github/CODEOWNERS @constructorfabric/security
+* @constructorfabric/insight-app-maintainers

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: "1.92.0"
+          toolchain: "1.95.0"
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -19,7 +19,7 @@ on:
       - ".github/workflows/scripts/discover-image-matrix.py"
   workflow_dispatch:
     inputs:
-      # Cross-repo dispatch hook: cyberfabric/cyber-insight-front's CI sends
+      # Cross-repo dispatch hook: constructorfabric/insight-front's CI sends
       # the just-published frontend image tag here so the umbrella chart
       # bumps the frontend subchart appVersion to match. When set, ALL
       # backend image-build jobs are skipped (the dispatch carries no
@@ -40,7 +40,7 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_PREFIX: ghcr.io/cyberfabric
+  IMAGE_PREFIX: ghcr.io/constructorfabric
 
 permissions:
   contents: write   # publish-chart auto-commits Chart.yaml bumps back to main
@@ -498,7 +498,7 @@ jobs:
           BUILD_TAG: ${{ needs.changes.outputs.build_tag }}
         run: |
           set -euo pipefail
-          git config user.email "ci@cyberfabric.local"
+          git config user.email "ci@constructorfabric.local"
           git config user.name  "insight-ci"
 
           # Stage every descriptor.yaml that was patched. `sort -u` because
@@ -544,7 +544,7 @@ jobs:
   # ─── Umbrella chart publish ────────────────────────────────────────────────
   # Per merge to main: bump subchart appVersions for whichever services were
   # rebuilt in this run, patch-bump the umbrella version, regenerate
-  # Chart.lock, package, push to oci://ghcr.io/cyberfabric/charts/insight,
+  # Chart.lock, package, push to oci://ghcr.io/constructorfabric/charts/insight,
   # and commit the bumps back to main with [skip ci] so we don't recurse.
   #
   # Skipped in this run when bump-descriptors committed (`committed=true`):
@@ -639,7 +639,7 @@ jobs:
           fi
 
       # Cross-repo frontend bump. The frontend lives in
-      # cyberfabric/cyber-insight-front and builds its own image; on
+      # constructorfabric/insight-front and builds its own image; on
       # publish-to-main its CI dispatches THIS workflow with frontend_tag
       # set to the just-built tag. We mirror that into the frontend
       # subchart's appVersion so the deploy path resolves the right image.
@@ -717,7 +717,7 @@ jobs:
       - name: Helm push
         run: |
           helm push "dist/insight-${{ steps.umbrella.outputs.version }}.tgz" \
-            oci://ghcr.io/cyberfabric/charts
+            oci://ghcr.io/constructorfabric/charts
 
       - name: Commit version bumps back to main
         env:
@@ -725,7 +725,7 @@ jobs:
           BUILD_TAG: ${{ needs.changes.outputs.build_tag }}
         run: |
           set -euo pipefail
-          git config user.email "ci@cyberfabric.local"
+          git config user.email "ci@constructorfabric.local"
           git config user.name  "insight-ci"
 
           git add charts/insight/Chart.yaml \

--- a/charts/insight/Chart.yaml
+++ b/charts/insight/Chart.yaml
@@ -25,12 +25,12 @@ type: application
 version: 0.1.47
 appVersion: "2026.06.04.19.35-89ba5bf"
 kubeVersion: ">=1.27.0-0"
-home: https://github.com/cyberfabric/insight
+home: https://github.com/constructorfabric/insight
 sources:
-  - https://github.com/cyberfabric/insight
+  - https://github.com/constructorfabric/insight
 maintainers:
-  - name: Cyberfabric
-    url: https://github.com/cyberfabric
+  - name: Constructorfabric
+    url: https://github.com/constructorfabric
 # Dependencies — the heart of the umbrella.
 #
 # Fields:

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -162,7 +162,7 @@ ingestion:
   # `serviceaccount "argo-workflow" not found`.
   templates:
     enabled: true
-  toolboxImage: "ghcr.io/cyberfabric/insight-toolbox:2026.06.04.19.35-89ba5bf" # e.g. "ghcr.io/cyberfabric/insight-toolbox:2026.04.28.10.34-b08b460"
+  toolboxImage: "ghcr.io/constructorfabric/insight-toolbox:2026.06.04.19.35-89ba5bf" # e.g. "ghcr.io/constructorfabric/insight-toolbox:2026.04.28.10.34-b08b460"
   # airbyte-sync poll-job tunables — see templates/ingestion/airbyte-sync.yaml.
   # The poll loop replaces a wall-clock deadline with a progress watchdog:
   # it tracks (status, bytesEmitted, recordsEmitted, stateMessagesEmitted)
@@ -380,7 +380,7 @@ redpanda:
 apiGateway:
   replicaCount: 2
   image:
-    repository: ghcr.io/cyberfabric/insight-api-gateway
+    repository: ghcr.io/constructorfabric/insight-api-gateway
     tag: "" # MUST be set (e.g. "0.1.0")
     pullPolicy: IfNotPresent
   resources:
@@ -426,7 +426,7 @@ apiGateway:
 analyticsApi:
   replicaCount: 2
   image:
-    repository: ghcr.io/cyberfabric/insight-analytics-api
+    repository: ghcr.io/constructorfabric/insight-analytics-api
     tag: "" # MUST be set (e.g. "0.1.0")
     pullPolicy: IfNotPresent
   resources:
@@ -451,7 +451,7 @@ identity:
   deploy: false
   replicaCount: 1
   image:
-    repository: ghcr.io/cyberfabric/insight-identity
+    repository: ghcr.io/constructorfabric/insight-identity
     tag: "" # MUST be set (e.g. "0.1.0")
     pullPolicy: IfNotPresent
   resources:
@@ -491,7 +491,7 @@ identity:
 frontend:
   replicaCount: 1
   image:
-    repository: ghcr.io/cyberfabric/cyber-insight-front
+    repository: ghcr.io/constructorfabric/insight-front
     tag: "" # MUST be set (e.g. "0.1.0")
     pullPolicy: IfNotPresent
   resources:

--- a/deploy/scripts/install-insight.sh
+++ b/deploy/scripts/install-insight.sh
@@ -13,7 +13,7 @@
 #   INSIGHT_VALUES       single extra -f values.yaml (back-compat)
 #   INSIGHT_VALUES_FILES colon-separated list of -f values files, applied in order
 #   CHART_SOURCE         local | oci   (default: local — path to charts/insight)
-#   OCI_REF              OCI reference for the chart (default: oci://ghcr.io/cyberfabric/charts/insight)
+#   OCI_REF              OCI reference for the chart (default: oci://ghcr.io/constructorfabric/charts/insight)
 #
 # Usage:
 #   ./deploy/scripts/install-insight.sh
@@ -28,7 +28,7 @@ cd "$ROOT_DIR"
 NAMESPACE="${INSIGHT_NAMESPACE:-insight}"
 RELEASE="${INSIGHT_RELEASE:-insight}"
 CHART_SOURCE="${CHART_SOURCE:-local}"
-OCI_REF="${OCI_REF:-oci://ghcr.io/cyberfabric/charts/insight}"
+OCI_REF="${OCI_REF:-oci://ghcr.io/constructorfabric/charts/insight}"
 EXTRA_VALUES="${INSIGHT_VALUES:-}"
 EXTRA_VALUES_FILES="${INSIGHT_VALUES_FILES:-}"
 

--- a/dev-up.sh
+++ b/dev-up.sh
@@ -261,7 +261,7 @@ build_and_load_image() {
 # would otherwise crash with `FE_REPO: unbound variable` after the
 # toolbox/jira-enrich builds succeed but before the values file is
 # generated.
-FE_REPO="${FE_IMAGE_REPOSITORY:-ghcr.io/cyberfabric/insight-front}"
+FE_REPO="${FE_IMAGE_REPOSITORY:-ghcr.io/constructorfabric/insight-front}"
 FE_TAG="${FE_IMAGE_TAG:-$(image_tag_for frontend)}"
 FE_IMAGE="${FE_REPO}:${FE_TAG}"
 

--- a/docs/components/backend/specs/DESIGN.md
+++ b/docs/components/backend/specs/DESIGN.md
@@ -737,7 +737,7 @@ All responses use RFC 9457 Problem Details for errors. All list endpoints suppor
 | modkit-db / modkit-db-macros | Analytics, Connector, Identity, Identity Resolution, Alerts, Transform, Email | MariaDB access via SeaORM |
 | modkit-auth | Analytics, Connector, Identity, Identity Resolution, Alerts, Transform, Audit | OIDC/JWT authentication |
 | modkit-odata / modkit-odata-macros | Analytics API, Audit | Query filtering, sorting, pagination |
-| modkit-errors | Analytics, Connector, Identity, Identity Resolution, Alerts, Transform, Audit | RFC 9457 error responses |
+| modkit-canonical-errors | Analytics, Connector, Identity, Identity Resolution, Alerts, Transform, Audit | RFC 9457 error responses (Problem+JSON via `modkit_canonical_errors::Problem`) |
 | modkit-macros | All services | Domain model macros |
 | modkit-sdk | All services | SDK pattern for inter-module contracts |
 | modkit-security | Analytics, Connector, Identity, Identity Resolution, Alerts, Transform, Audit | Security context |

--- a/docs/deploy/Makefile
+++ b/docs/deploy/Makefile
@@ -4,7 +4,7 @@
 #
 # This is a SAMPLE gitops layout intended to be copied into your own
 # private repo and adapted (cluster names, hostnames, image tags, secret
-# backend, CI). The umbrella chart it pulls (oci://ghcr.io/cyberfabric/
+# backend, CI). The umbrella chart it pulls (oci://ghcr.io/constructorfabric/
 # charts/insight) is published from the public Insight repo per merge to
 # main, so this directory plus an actual cluster is enough to deploy.
 #
@@ -30,7 +30,7 @@
 #       password manager). Or use VALUE_FILE=… for one-off seals.
 #
 # This repo is settings-only. The umbrella chart is published per merge
-# to oci://ghcr.io/cyberfabric/charts/insight; INSIGHT_VERSION pins one
+# to oci://ghcr.io/constructorfabric/charts/insight; INSIGHT_VERSION pins one
 # semver from .insight-version.
 
 ENV              ?= local
@@ -49,7 +49,7 @@ RELEASE          ?= $(shell yq -r '.release             // "insight"'        $(I
 
 # Back-compat alias for older targets still referencing NAMESPACE.
 NAMESPACE        ?= $(NS_APP)
-CHART            ?= oci://ghcr.io/cyberfabric/charts/insight
+CHART            ?= oci://ghcr.io/constructorfabric/charts/insight
 INSIGHT_VERSION  ?= $(shell cat .insight-version 2>/dev/null)
 VALUES           ?= environments/$(ENV)/values.yaml
 TIMEOUT          ?= 10m

--- a/docs/deploy/environments/local/values.yaml
+++ b/docs/deploy/environments/local/values.yaml
@@ -77,7 +77,7 @@ ingestion:
 # Pin `image.tag` to a concrete tag published to GHCR by the upstream
 # CI. The published tag format is `YYYY.MM.DD.HH.MM-<short-sha>`; pick
 # the latest one from the chart appVersion in
-# https://github.com/cyberfabric/cyber-insight (or whichever umbrella
+# https://github.com/constructorfabric/insight (or whichever umbrella
 # you're tracking) and update on bumps.
 #
 # The example tags below are illustrative — replace them with whatever
@@ -116,7 +116,7 @@ analyticsApi:
 identity:
   deploy: true
   image:
-    repository: ghcr.io/cyberfabric/insight-identity
+    repository: ghcr.io/constructorfabric/insight-identity
     tag: "REPLACE_WITH_LATEST_BACKEND_TAG"
   databaseName: "identity"
   # Optional. When set (must be a valid GUID), identity-resolution
@@ -134,7 +134,7 @@ frontend:
   # The frontend image is built from a separate repo (insight-front)
   # with its own publish-chart workflow; its tag is decoupled from the
   # backend services above. Pin the latest tag from
-  # https://github.com/orgs/cyberfabric/packages?q=cyber-insight-front
+  # https://github.com/orgs/constructorfabric/packages?q=insight-front
   # (or whichever upstream you're tracking).
   image:
     tag: "REPLACE_WITH_LATEST_FRONTEND_TAG"

--- a/docs/deploy/scripts/render-diff.sh
+++ b/docs/deploy/scripts/render-diff.sh
@@ -10,7 +10,7 @@
 #   $1  ENV
 #   $2  NAMESPACE
 #   $3  RELEASE
-#   $4  CHART (OCI ref, e.g. oci://ghcr.io/cyberfabric/charts/insight)
+#   $4  CHART (OCI ref, e.g. oci://ghcr.io/constructorfabric/charts/insight)
 #   $5  VALUES file
 #   $6  RENDER_DIR (typically .deploy)
 #   $7  INSIGHT_VERSION (umbrella semver from .insight-version)

--- a/scripts/bootstrap-connector-images.sh
+++ b/scripts/bootstrap-connector-images.sh
@@ -12,7 +12,7 @@
 # Effect: every connector with an `images.<key>` entry under
 # `src/ingestion/connectors/*/*/descriptor.yaml` gets:
 #   1. its image built from the declared `context` + `dockerfile`
-#   2. its image pushed to `ghcr.io/cyberfabric/<images.<key>.name>:<BUILD_TAG>`
+#   2. its image pushed to `ghcr.io/constructorfabric/<images.<key>.name>:<BUILD_TAG>`
 #   3. its `descriptor.yaml.images.<key>.image` patched with the new ref
 #
 # The script DOES NOT commit, push, or create a PR — it leaves the working
@@ -112,7 +112,7 @@ echo "GitHub user: ${GH_USER}"
 # ─── GHCR login (no-op if already logged in with the same token) ──────────
 
 REGISTRY="ghcr.io"
-IMAGE_PREFIX="ghcr.io/cyberfabric"
+IMAGE_PREFIX="ghcr.io/constructorfabric"
 
 if [[ "${PUSH}" == "true" && "${DRY_RUN}" == "false" ]]; then
   echo "Logging into ${REGISTRY} via gh auth token..."

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -10,8 +10,8 @@ resolver = "3"
 [workspace.package]
 edition = "2024"
 license = "Apache-2.0"
-authors = ["Cyber Fabric"]
-repository = "https://github.com/cyberfabric/insight"
+authors = ["Constructor Fabric"]
+repository = "https://github.com/constructorfabric/insight"
 rust-version = "1.95.0"
 
 [workspace.lints.rust]
@@ -75,7 +75,7 @@ redis = { version = "0.27", features = ["tokio-comp", "connection-manager"] }
 # CLI
 clap = { version = "4.5", features = ["derive"] }
 
-# cyberfabric-core (crates.io)
+# gears-rust (crates.io)
 modkit = { package = "cf-modkit", version = "=0.6.2" }
 modkit-auth = { package = "cf-modkit-auth", version = "=0.6.1" }
 modkit-http = { package = "cf-modkit-http", version = "=0.6.2" }
@@ -84,12 +84,12 @@ modkit-macros = { package = "cf-modkit-macros", version = "=0.6.2" }
 modkit-errors = { package = "cf-modkit-errors", version = "=0.6.2" }
 modkit-canonical-errors = { package = "cf-modkit-canonical-errors", version = "=0.7.3", features = ["axum", "sea-orm"] }
 
-# cyberfabric-core SDKs (crates.io)
+# gears-rust SDKs (crates.io)
 authn-resolver-sdk = { package = "cf-authn-resolver-sdk", version = "0.3.8" }
 authz-resolver-sdk = { package = "cf-authz-resolver-sdk", version = "0.2.17" }
 types-registry-sdk = { package = "cf-types-registry-sdk", version = "0.1.5" }
 
-# cyberfabric-core system modules (crates.io)
+# gears-rust system modules (crates.io)
 api-gateway-module = { package = "cf-api-gateway", version = "0.1.22" }
 authn-resolver = { package = "cf-authn-resolver", version = "0.2.8" }
 authz-resolver = { package = "cf-authz-resolver", version = "0.1.15" }

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -75,13 +75,17 @@ redis = { version = "0.27", features = ["tokio-comp", "connection-manager"] }
 # CLI
 clap = { version = "4.5", features = ["derive"] }
 
-# gears-rust (crates.io)
+# gears-rust toolkit (crates.io)
+#
+# Still published under the legacy `cf-modkit-*` / `cf-*` names. The
+# gears-rust workspace renamed the local packages to `cf-gears-toolkit-*`
+# but the renamed crates have not been pushed to crates.io yet; flip the
+# `package = "..."` strings here when they appear.
 modkit = { package = "cf-modkit", version = "=0.6.2" }
 modkit-auth = { package = "cf-modkit-auth", version = "=0.6.1" }
 modkit-http = { package = "cf-modkit-http", version = "=0.6.2" }
 modkit-security = { package = "cf-modkit-security", version = "=0.6.2" }
 modkit-macros = { package = "cf-modkit-macros", version = "=0.6.2" }
-modkit-errors = { package = "cf-modkit-errors", version = "=0.6.2" }
 modkit-canonical-errors = { package = "cf-modkit-canonical-errors", version = "=0.7.3", features = ["axum", "sea-orm"] }
 
 # gears-rust SDKs (crates.io)

--- a/src/backend/libs/insight-clickhouse/src/config.rs
+++ b/src/backend/libs/insight-clickhouse/src/config.rs
@@ -96,9 +96,9 @@ mod tests {
     #[test]
     fn custom_timeout() {
         let cfg =
-            Config::new("http://ch:8123", "insight").with_query_timeout(Duration::from_secs(60));
+            Config::new("http://ch:8123", "insight").with_query_timeout(Duration::from_mins(1));
 
-        assert_eq!(cfg.query_timeout, Some(Duration::from_secs(60)));
+        assert_eq!(cfg.query_timeout, Some(Duration::from_mins(1)));
     }
 
     #[test]

--- a/src/backend/plugins/oidc-authn-plugin/Cargo.toml
+++ b/src/backend/plugins/oidc-authn-plugin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oidc-authn-plugin"
 version = "0.1.0"
-description = "OIDC/JWT authentication plugin for cyberfabric authn-resolver"
+description = "OIDC/JWT authentication plugin for gears-rust authn-resolver"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -12,7 +12,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-# cyberfabric
+# gears-rust
 modkit = { workspace = true }
 modkit-auth = { workspace = true }
 modkit-http = { workspace = true }

--- a/src/backend/services/analytics-api/helm/values.yaml
+++ b/src/backend/services/analytics-api/helm/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 podAnnotations: {}
 
 image:
-  repository: ghcr.io/cyberfabric/insight-analytics-api
+  repository: ghcr.io/constructorfabric/insight-analytics-api
   tag: ""                  # MUST be set by the operator. No `:latest` default.
   pullPolicy: IfNotPresent
 

--- a/src/backend/services/analytics-api/src/api/handlers.rs
+++ b/src/backend/services/analytics-api/src/api/handlers.rs
@@ -1438,8 +1438,7 @@ mod tests {
     }
 
     #[test]
-    fn inject_skips_bare_bronze_table_without_metric_date()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn inject_skips_bare_bronze_table_without_metric_date() {
         let from = "bronze_bamboohr.employees e \
                     LEFT JOIN insight.people p ON e.workEmail = p.email";
         let where_clause = " WHERE metric_date >= '2026-04-01'";
@@ -1449,12 +1448,11 @@ mod tests {
             inject_date_filter_into_subqueries(&normalised, where_clause).is_none(),
             "bronze leaf must be skipped (no metric_date column)"
         );
-        Ok(())
     }
 
     #[test]
-    fn inject_after_prewrap_injects_into_bare_fact_table()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn inject_after_prewrap_injects_into_bare_fact_table() -> Result<(), Box<dyn std::error::Error>>
+    {
         let from = "insight.team_member m \
                     LEFT JOIN insight.people p ON m.person_id = p.person_id";
         let where_clause = " WHERE metric_date >= '2026-04-01'";
@@ -1541,7 +1539,10 @@ mod tests {
     #[test]
     fn ensure_subquery_from_wraps_bare_single_table() {
         let from = "insight.ic_kpis";
-        assert_eq!(ensure_subquery_from(from), "(SELECT * FROM insight.ic_kpis)");
+        assert_eq!(
+            ensure_subquery_from(from),
+            "(SELECT * FROM insight.ic_kpis)"
+        );
     }
 
     #[test]

--- a/src/backend/services/analytics-api/src/domain/schema_validator/probe.rs
+++ b/src/backend/services/analytics-api/src/domain/schema_validator/probe.rs
@@ -47,6 +47,7 @@ pub enum ProbeOutcome {
 }
 
 #[derive(Row, Deserialize)]
+#[allow(clippy::struct_field_names)] // fields ARE counts of distinct column kinds; postfix is semantic
 struct ProbeRow {
     total_columns: u64,
     matching_columns: u64,

--- a/src/backend/services/analytics-api/src/migration/m20260529_000001_metric_query_catalog_link.rs
+++ b/src/backend/services/analytics-api/src/migration/m20260529_000001_metric_query_catalog_link.rs
@@ -199,10 +199,7 @@ impl MigrationTrait for Migration {
                     .foreign_key(
                         ForeignKey::create()
                             .name("fk_metric_query_catalog_metrics")
-                            .from(
-                                MetricQueryCatalog::Table,
-                                MetricQueryCatalog::MetricsId,
-                            )
+                            .from(MetricQueryCatalog::Table, MetricQueryCatalog::MetricsId)
                             .to(Metrics::Table, Metrics::Id)
                             .on_delete(ForeignKeyAction::Cascade),
                     )

--- a/src/backend/services/analytics-api/src/migration/m20260601_000001_ai_claude_team_metrics.rs
+++ b/src/backend/services/analytics-api/src/migration/m20260601_000001_ai_claude_team_metrics.rs
@@ -268,7 +268,7 @@ mod tests {
         "cursor_total_lines",
     ];
 
-    /// Dropped metric_keys from m20260519 that must NOT be read via sumIf.
+    /// Dropped `metric_keys` from m20260519 that must NOT be read via sumIf.
     const FORBIDDEN_RAW_KEY_READS: &[&str] = &[
         "cursor_acceptance",
         "cc_tool_acceptance",
@@ -278,7 +278,7 @@ mod tests {
         "claude_web",
     ];
 
-    /// New Claude Team metric_keys must NOT appear in ACTIVE_LIST
+    /// New Claude Team `metric_keys` must NOT appear in `ACTIVE_LIST`
     /// (they are counters, not active-person markers).
     const CLAUDE_TEAM_KEYS: &[&str] = &["cc_cost", "prs_with_cc", "prs_total"];
 

--- a/src/backend/services/analytics-api/src/migration/m20260601_000002_seed_claude_team_metrics_catalog.rs
+++ b/src/backend/services/analytics-api/src/migration/m20260601_000002_seed_claude_team_metrics_catalog.rs
@@ -1,5 +1,5 @@
 //! Seed `metric_catalog` + `product-default` `metric_threshold` rows for
-//! the three new Claude Team metric_keys introduced in
+//! the three new Claude Team `metric_keys` introduced in
 //! `m20260601_000001_ai_claude_team_metrics` (INSIGHT-458).
 //!
 //! New keys (all routed through `insight.ai_bullet_rows`):
@@ -22,11 +22,11 @@
 //! Threshold placeholders: initial `good` / `warn` values are estimates for
 //! an active developer. Adjust per-tenant via the admin CRUD API (#525).
 //!
-//!   cc_cost      — good ≤ 5000 ¢ ($50) / warn ≤ 10000 ¢ ($100) per period.
-//!   prs_with_cc  — good ≥ 3 / warn ≥ 1 PRs with CC attribution per period.
-//!   prs_total    — good ≥ 5 / warn ≥ 2 PRs per period (context denominator).
+//!   `cc_cost`      — good ≤ 5000 ¢ ($50) / warn ≤ 10000 ¢ ($100) per period.
+//!   `prs_with_cc`  — good ≥ 3 / warn ≥ 1 PRs with CC attribution per period.
+//!   `prs_total`    — good ≥ 5 / warn ≥ 2 PRs per period (context denominator).
 //!
-//! Three FE-visible metric_keys from m20260527 remain at 69 rows. This
+//! Three FE-visible `metric_keys` from m20260527 remain at 69 rows. This
 //! migration adds 3 more for a running catalog total of 72.
 
 use sea_orm::{ConnectionTrait, Statement, Value};
@@ -93,9 +93,7 @@ const SEEDS: &[SeedRow] = &[
     SeedRow {
         metric_key: "ai_bullet_rows.prs_with_cc",
         label: "PRs with Claude Code",
-        sublabel: Some(
-            "Claude Team GitHub-app \u{b7} PRs with CC attribution \u{b7} period total",
-        ),
+        sublabel: Some("Claude Team GitHub-app \u{b7} PRs with CC attribution \u{b7} period total"),
         description: Some(
             "Number of pull requests where Claude Code was active at least once \
              in the measurement window. Populated only on tenants with the \
@@ -112,9 +110,7 @@ const SEEDS: &[SeedRow] = &[
     SeedRow {
         metric_key: "ai_bullet_rows.prs_total",
         label: "Total PRs (CC window)",
-        sublabel: Some(
-            "Claude Team GitHub-app \u{b7} total PRs in window \u{b7} period total",
-        ),
+        sublabel: Some("Claude Team GitHub-app \u{b7} total PRs in window \u{b7} period total"),
         description: Some(
             "Total pull requests opened in the measurement window — denominator \
              for the prs_with_cc_pct ratio metric. Same availability caveat as \
@@ -225,7 +221,7 @@ mod tests {
     use super::*;
 
     /// Pins the number of new catalog rows shipped by this migration.
-    /// Update if Claude Team gains new metric_keys in a future migration.
+    /// Update if Claude Team gains new `metric_keys` in a future migration.
     #[test]
     fn seed_count_is_three() {
         assert_eq!(
@@ -235,7 +231,7 @@ mod tests {
         );
     }
 
-    /// All three metric_keys must route to `ai_bullet_rows` (not a typo
+    /// All three `metric_keys` must route to `ai_bullet_rows` (not a typo
     /// like `ai_bullet_row` or a different table segment).
     #[test]
     fn all_keys_route_to_ai_bullet_rows() {
@@ -248,21 +244,21 @@ mod tests {
         }
     }
 
-    /// cc_cost is a spending signal — higher values mean more cost.
+    /// `cc_cost` is a spending signal — higher values mean more cost.
     /// `higher_is_better` must be `false`.
     #[test]
     fn cc_cost_is_lower_is_better() {
         let row = SEEDS
             .iter()
             .find(|r| r.metric_key == "ai_bullet_rows.cc_cost")
-            .expect("cc_cost row must be in SEEDS");
+            .unwrap_or_else(|| panic!("cc_cost row must be in SEEDS"));
         assert!(
             !row.higher_is_better,
             "cc_cost is a cost metric — higher_is_better must be false"
         );
     }
 
-    /// prs_with_cc and prs_total are activity counters — more is better.
+    /// `prs_with_cc` and `prs_total` are activity counters — more is better.
     #[test]
     fn prs_keys_are_higher_is_better() {
         for key in ["ai_bullet_rows.prs_with_cc", "ai_bullet_rows.prs_total"] {
@@ -291,7 +287,7 @@ mod tests {
         }
     }
 
-    /// No duplicate metric_keys within this migration's SEEDS slice.
+    /// No duplicate `metric_keys` within this migration's SEEDS slice.
     #[test]
     fn no_duplicate_metric_keys() {
         use std::collections::HashSet;
@@ -305,7 +301,7 @@ mod tests {
         }
     }
 
-    /// source_tags JSON must be a well-formed JSON array string.
+    /// `source_tags` JSON must be a well-formed JSON array string.
     #[test]
     fn source_tags_json_is_well_formed() {
         for row in SEEDS {

--- a/src/backend/services/analytics-api/src/migration/m20260603_000001_seed_crm_metric_catalog.rs
+++ b/src/backend/services/analytics-api/src/migration/m20260603_000001_seed_crm_metric_catalog.rs
@@ -195,9 +195,7 @@ const SEEDS: &[SeedRow] = &[
     SeedRow {
         metric_key: "crm_bullet_rows.comms_per_won",
         label: "Comms / Won Deal",
-        sublabel: Some(
-            "Total comms \u{f7} deals won \u{b7} efficiency \u{b7} lower = better",
-        ),
+        sublabel: Some("Total comms \u{f7} deals won \u{b7} efficiency \u{b7} lower = better"),
         description: None,
         unit: None,
         format: None,
@@ -336,7 +334,10 @@ mod tests {
     /// `higher_is_better` must be `false` on both.
     #[test]
     fn lower_is_better_keys_are_marked() {
-        let lower_better = ["crm_bullet_rows.cycle_days", "crm_bullet_rows.comms_per_won"];
+        let lower_better = [
+            "crm_bullet_rows.cycle_days",
+            "crm_bullet_rows.comms_per_won",
+        ];
         for key in lower_better {
             let row = SEEDS
                 .iter()

--- a/src/backend/services/api-gateway/Cargo.toml
+++ b/src/backend/services/api-gateway/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-# cyberfabric core
+# gears-rust
 modkit = { workspace = true, features = ["bootstrap"] }
 
 # System modules (linked via inventory for runtime discovery)

--- a/src/backend/services/api-gateway/helm/values.yaml
+++ b/src/backend/services/api-gateway/helm/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 podAnnotations: {}
 
 image:
-  repository: ghcr.io/cyberfabric/insight-api-gateway
+  repository: ghcr.io/constructorfabric/insight-api-gateway
   tag: ""                # MUST be set by the operator. No `:latest` default.
   pullPolicy: IfNotPresent
 
@@ -70,7 +70,7 @@ proxy:
   routes: []
 
 # Health probes
-# Provided by cyberfabric api-gateway module:
+# Provided by gears-rust api-gateway module:
 #   GET /health  → {"status":"healthy","timestamp":"..."} (public, no auth)
 #   GET /healthz → "ok" (public, no auth)
 # No separate /ready endpoint — gateway is stateless, healthy = ready.

--- a/src/backend/services/identity/helm/values.yaml
+++ b/src/backend/services/identity/helm/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 podAnnotations: {}
 
 image:
-  repository: ghcr.io/cyberfabric/insight-identity
+  repository: ghcr.io/constructorfabric/insight-identity
   tag: ""
   pullPolicy: IfNotPresent
 

--- a/src/frontend/helm/values.yaml
+++ b/src/frontend/helm/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 podAnnotations: {}
 
 image:
-  repository: ghcr.io/cyberfabric/cyber-insight-front
+  repository: ghcr.io/constructorfabric/insight-front
   tag: ""                # MUST be set by the operator. No `:latest` default.
   pullPolicy: IfNotPresent
 

--- a/src/ingestion/connectors/task-tracking/jira/enrich/Cargo.toml
+++ b/src/ingestion/connectors/task-tracking/jira/enrich/Cargo.toml
@@ -3,8 +3,8 @@ name = "jira-enrich"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-authors = ["Cyber Fabric"]
-repository = "https://github.com/cyberfabric/insight"
+authors = ["Constructor Fabric"]
+repository = "https://github.com/constructorfabric/insight"
 rust-version = "1.80"
 description = "Jira Silver enrich — materializes silver.task_tracker_field_history from bronze_jira."
 

--- a/src/ingestion/reconcile-connectors/lib/cdk-build.sh
+++ b/src/ingestion/reconcile-connectors/lib/cdk-build.sh
@@ -15,7 +15,7 @@
 # Image reference:
 #   The full Docker image reference is read verbatim from
 #   descriptor.images.cdk.image per ADR-0016
-#   (e.g. `ghcr.io/cyberfabric/source-foo-insight:v1.2.3` for push, or
+#   (e.g. `ghcr.io/constructorfabric/source-foo-insight:v1.2.3` for push, or
 #   `source-foo-insight:dev` for local-only). No registry derivation.
 #
 # Function naming: cdk_*

--- a/src/ingestion/tests/e2e/compose/Dockerfile.runner
+++ b/src/ingestion/tests/e2e/compose/Dockerfile.runner
@@ -2,7 +2,7 @@
 #
 # Bakes in:
 #   - Python 3.12 + e2e_lib deps (pytest, clickhouse-connect, pandas, dbt-clickhouse, …)
-#   - Rust 1.92 (cargo+rustc — edition2024 required by src/backend)
+#   - Rust 1.95 (cargo+rustc — matches `rust-version` in src/backend/Cargo.toml)
 #   - protobuf-compiler (used by some src/backend crates)
 #
 # The repo is bind-mounted at /workspace; the cargo target dir + cargo registry
@@ -19,7 +19,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH \
-    RUST_VERSION=1.92.0
+    RUST_VERSION=1.95.0
 
 # ── System tooling ──────────────────────────────────────────────────────
 # build-essential + pkg-config: cargo needs a linker and pkg-config for native

--- a/src/ingestion/tools/toolbox/build.sh
+++ b/src/ingestion/tools/toolbox/build.sh
@@ -20,7 +20,7 @@ Env:
 
 Examples:
   $0
-  TOOLBOX_IMAGE=ghcr.io/cyberfabric/insight-toolbox:latest $0 --push --platform=linux/amd64
+  TOOLBOX_IMAGE=ghcr.io/constructorfabric/insight-toolbox:latest $0 --push --platform=linux/amd64
 USAGE
       exit 0 ;;
   esac


### PR DESCRIPTION
## Summary

- Flip every CI / chart / helm-values / helper-script reference from `ghcr.io/cyberfabric` (and `github.com/cyberfabric`) to the new `constructorfabric` namespace after the GitHub org rename.
- Rename the frontend Docker image `cyber-insight-front` → `insight-front` in both the umbrella chart (`charts/insight/values.yaml`) and the frontend subchart (`src/frontend/helm/values.yaml`) to match what `insight-front` now publishes.
- Cross-repo dispatch comments + CI git-author email updated for parity with the new org.

15 files changed, 35 insertions / 35 deletions.

## Out of scope (tracked separately)

- Runtime K8s annotation namespace `insight.cyberfabric.com/*` — renaming requires re-annotating already-deployed Secrets in lockstep, so it's its own change with a deploy playbook.
- Connector `descriptor.yaml` image refs — left for the next CI auto-bump (`build-images.yml`'s descriptor-bump job rewrites them on the next push).

## Test plan

- [ ] Trigger `build-images.yml` on this branch and confirm images push to `ghcr.io/constructorfabric/...`
- [ ] Confirm umbrella chart pushes to `oci://ghcr.io/constructorfabric/charts/insight`
- [ ] `helm template charts/insight` renders without unresolved repos
- [ ] Verify `dev-up.sh` pulls FE from `ghcr.io/constructorfabric/insight-front` when `FE_IMAGE_REPOSITORY` is unset

Co-companion PR: constructorfabric/insight-front#<TBD>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched container image repositories and Helm/OCI chart references to a new registry namespace across deployment configs, scripts, and service Helm values.
  * Updated local/dev defaults, install/bootstrap scripts, and documentation examples to reflect the new image/chart locations.
  * Updated CI/workflow comments and commit-author metadata to the new namespace.
  * Updated repository/package metadata, CODEOWNERS, and incidental doc/test formatting/comments to reflect the new organization names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->