### PR TITLE
fix(ci): block bump-descriptors until backend services + toolbox finish

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -420,13 +420,30 @@ jobs:
   #
   # See ADR-0016 (descriptor.images: schema) and ADR-0001 (chart-publishing).
   bump-descriptors:
-    needs: [changes, discover-images, build-image]
+    needs:
+      - changes
+      - discover-images
+      - backend-api-gateway
+      - backend-analytics-api
+      - backend-identity
+      - toolbox
+      - build-image
+    # All siblings must finish first — bump-descriptors auto-commits to main
+    # and that push retriggers the workflow, so we must NOT pin descriptors
+    # while a backend service or toolbox is still building or has just failed
+    # tests. The `success || skipped` shape mirrors publish-chart: any of
+    # the backend/toolbox jobs may legitimately be `skipped` when `changes`
+    # didn't flag them, but they must never be `failure` or `cancelled`.
     if: |
       always()
       && github.event_name == 'push'
       && github.ref == 'refs/heads/main'
       && needs.discover-images.outputs.any == 'true'
       && needs.build-image.result == 'success'
+      && (needs.backend-api-gateway.result   == 'success' || needs.backend-api-gateway.result   == 'skipped')
+      && (needs.backend-analytics-api.result == 'success' || needs.backend-analytics-api.result == 'skipped')
+      && (needs.backend-identity.result      == 'success' || needs.backend-identity.result      == 'skipped')
+      && (needs.toolbox.result               == 'success' || needs.toolbox.result               == 'skipped')
     runs-on: ubuntu-latest
     outputs:
       # `committed` is set to 'true' when this job actually pushed a


### PR DESCRIPTION
## Summary

`bump-descriptors` previously only declared `needs: [changes, discover-images, build-image]`, so on a push to `main` it could fire as soon as the connector image matrix completed — while `backend-api-gateway`, `backend-analytics-api`, `backend-identity`, or `toolbox` were still building or had just failed tests.

Observed in the wild on a recent `main` push: `bump-descriptors` auto-committed a descriptor bump back to `main` while `backend-identity` tests had failed and `backend-api-gateway` was still building. That commit re-triggered the workflow with descriptor refs pointing at images the broken sibling never produced.

## Fix

Mirror `publish-chart`'s already-correct guard pattern (L558-L576):

- Add `backend-api-gateway`, `backend-analytics-api`, `backend-identity`, `toolbox` to `bump-descriptors.needs`.
- Gate the `if:` on `success || skipped` for each of the four. `skipped` is preserved because `changes` legitimately short-circuits service jobs that didn't change — `bump-descriptors` only needs to know they didn't *fail*.

`publish-chart` was already safe; only the descriptor auto-commit was escaping the safety net.

## Test plan

- [ ] Open a no-op push to `main` with the change merged — verify `bump-descriptors` waits for the backend matrix instead of racing it.
- [ ] Force a failing backend test on a follow-up `main` push (e.g. via a `--no-verify` style merge) and confirm `bump-descriptors` is **not** queued for execution — should resolve as `skipped` because the `if:` evaluates to false.
- [ ] On a clean `main` push, confirm both `bump-descriptors` and `publish-chart` still run end-to-end with the same overall wall-clock as before (parallelism between connector matrix and backend services is preserved; only the final gate moves).