### PR TITLE
fix(ingestion): watermark collaboration staging on extract time, not business date

### DIFF
--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_chat_activity.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_chat_activity.sql
@@ -68,8 +68,16 @@ FROM {{ source('bronze_m365', 'teams_activity') }}
 WHERE userPrincipalName IS NOT NULL
   AND userPrincipalName != ''
 {% if is_incremental() %}
+  -- Watermark on the source EXTRACT time, not the business date (see zoom model header
+  -- for the backfill-strand failure mode this fixes). Re-pulled rows carry a fresh
+  -- `_airbyte_extracted_at`, so reprocess every business date touched by a recent extract.
   AND (
-    (SELECT max(date) FROM {{ this }}) IS NULL
-    OR toDate(reportRefreshDate) > (SELECT max(date) - INTERVAL 3 DAY FROM {{ this }})
+    (SELECT count() FROM {{ this }}) = 0
+    OR toDate(reportRefreshDate) IN (
+      SELECT DISTINCT toDate(reportRefreshDate)
+      FROM {{ source('bronze_m365', 'teams_activity') }}
+      WHERE _airbyte_extracted_at
+            > (SELECT max(_airbyte_extracted_at) FROM {{ source('bronze_m365', 'teams_activity') }}) - INTERVAL 3 DAY
+    )
   )
 {% endif %}

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_document_activity_onedrive.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_document_activity_onedrive.sql
@@ -37,8 +37,16 @@ FROM {{ source('bronze_m365', 'onedrive_activity') }}
 WHERE userPrincipalName IS NOT NULL
   AND userPrincipalName != ''
 {% if is_incremental() %}
+  -- Watermark on the source EXTRACT time, not the business date (see zoom model header
+  -- for the backfill-strand failure mode this fixes). Re-pulled rows carry a fresh
+  -- `_airbyte_extracted_at`, so reprocess every business date touched by a recent extract.
   AND (
-    (SELECT max(date) FROM {{ this }}) IS NULL
-    OR toDate(reportRefreshDate) > (SELECT max(date) - INTERVAL 3 DAY FROM {{ this }})
+    (SELECT count() FROM {{ this }}) = 0
+    OR toDate(reportRefreshDate) IN (
+      SELECT DISTINCT toDate(reportRefreshDate)
+      FROM {{ source('bronze_m365', 'onedrive_activity') }}
+      WHERE _airbyte_extracted_at
+            > (SELECT max(_airbyte_extracted_at) FROM {{ source('bronze_m365', 'onedrive_activity') }}) - INTERVAL 3 DAY
+    )
   )
 {% endif %}

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_document_activity_sharepoint.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_document_activity_sharepoint.sql
@@ -37,8 +37,16 @@ FROM {{ source('bronze_m365', 'sharepoint_activity') }}
 WHERE userPrincipalName IS NOT NULL
   AND userPrincipalName != ''
 {% if is_incremental() %}
+  -- Watermark on the source EXTRACT time, not the business date (see zoom model header
+  -- for the backfill-strand failure mode this fixes). Re-pulled rows carry a fresh
+  -- `_airbyte_extracted_at`, so reprocess every business date touched by a recent extract.
   AND (
-    (SELECT max(date) FROM {{ this }}) IS NULL
-    OR toDate(reportRefreshDate) > (SELECT max(date) - INTERVAL 3 DAY FROM {{ this }})
+    (SELECT count() FROM {{ this }}) = 0
+    OR toDate(reportRefreshDate) IN (
+      SELECT DISTINCT toDate(reportRefreshDate)
+      FROM {{ source('bronze_m365', 'sharepoint_activity') }}
+      WHERE _airbyte_extracted_at
+            > (SELECT max(_airbyte_extracted_at) FROM {{ source('bronze_m365', 'sharepoint_activity') }}) - INTERVAL 3 DAY
+    )
   )
 {% endif %}

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_email_activity.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_email_activity.sql
@@ -32,8 +32,16 @@ FROM {{ source('bronze_m365', 'email_activity') }}
 WHERE userPrincipalName IS NOT NULL
   AND userPrincipalName != ''
 {% if is_incremental() %}
+  -- Watermark on the source EXTRACT time, not the business date (see zoom model header
+  -- for the backfill-strand failure mode this fixes). Re-pulled rows carry a fresh
+  -- `_airbyte_extracted_at`, so reprocess every business date touched by a recent extract.
   AND (
-    (SELECT max(date) FROM {{ this }}) IS NULL
-    OR toDate(reportRefreshDate) > (SELECT max(date) - INTERVAL 3 DAY FROM {{ this }})
+    (SELECT count() FROM {{ this }}) = 0
+    OR toDate(reportRefreshDate) IN (
+      SELECT DISTINCT toDate(reportRefreshDate)
+      FROM {{ source('bronze_m365', 'email_activity') }}
+      WHERE _airbyte_extracted_at
+            > (SELECT max(_airbyte_extracted_at) FROM {{ source('bronze_m365', 'email_activity') }}) - INTERVAL 3 DAY
+    )
   )
 {% endif %}

--- a/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_meeting_activity.sql
+++ b/src/ingestion/connectors/collaboration/m365/dbt/m365__collab_meeting_activity.sql
@@ -43,8 +43,18 @@ FROM {{ source('bronze_m365', 'teams_activity') }}
 WHERE userPrincipalName IS NOT NULL
   AND userPrincipalName != ''
 {% if is_incremental() %}
+  -- Watermark on the source EXTRACT time, not the business date: a forward-only
+  -- `reportRefreshDate > max(date) - 3d` filter permanently strands backfilled /
+  -- late-arriving history (older business dates never re-enter the model — see the
+  -- zoom model header). Re-pulled rows carry a fresh `_airbyte_extracted_at`, so we
+  -- reprocess every business date touched by a recent extract; cheap in steady state.
   AND (
-    (SELECT max(date) FROM {{ this }}) IS NULL
-    OR toDate(reportRefreshDate) > (SELECT max(date) - INTERVAL 3 DAY FROM {{ this }})
+    (SELECT count() FROM {{ this }}) = 0
+    OR toDate(reportRefreshDate) IN (
+      SELECT DISTINCT toDate(reportRefreshDate)
+      FROM {{ source('bronze_m365', 'teams_activity') }}
+      WHERE _airbyte_extracted_at
+            > (SELECT max(_airbyte_extracted_at) FROM {{ source('bronze_m365', 'teams_activity') }}) - INTERVAL 3 DAY
+    )
   )
 {% endif %}

--- a/src/ingestion/connectors/collaboration/slack/dbt/slack__collab_chat_activity.sql
+++ b/src/ingestion/connectors/collaboration/slack/dbt/slack__collab_chat_activity.sql
@@ -64,8 +64,17 @@ WHERE u.user_id IS NOT NULL
   AND u.user_id != ''
   AND parseDateTimeBestEffortOrNull(u.date) IS NOT NULL
 {% if is_incremental() %}
+  -- Watermark on the source EXTRACT time, not the business date (see zoom model header for
+  -- the backfill-strand failure mode this fixes — Slack chat had the same gap on virtuozzo,
+  -- bronze from Jan but staging only from late Mar). Re-pulled rows carry a fresh
+  -- `_airbyte_extracted_at`, so reprocess every business date touched by a recent extract.
   AND (
-    (SELECT max(date) FROM {{ this }}) IS NULL
-    OR toDate(parseDateTimeBestEffortOrNull(u.date)) > (SELECT max(date) - INTERVAL 3 DAY FROM {{ this }})
+    (SELECT count() FROM {{ this }}) = 0
+    OR toDate(parseDateTimeBestEffortOrNull(u.date)) IN (
+      SELECT DISTINCT toDate(parseDateTimeBestEffortOrNull(date))
+      FROM {{ source('bronze_slack', 'users_details') }}
+      WHERE _airbyte_extracted_at
+            > (SELECT max(_airbyte_extracted_at) FROM {{ source('bronze_slack', 'users_details') }}) - INTERVAL 3 DAY
+    )
   )
 {% endif %}

--- a/src/ingestion/connectors/collaboration/zoom/dbt/zoom__collab_meeting_activity.sql
+++ b/src/ingestion/connectors/collaboration/zoom/dbt/zoom__collab_meeting_activity.sql
@@ -147,9 +147,22 @@ LEFT JOIN {{ ref('zoom__meeting_sessions') }} AS ml FINAL
     AND p.tenant_id = ml.tenant_id
     AND p.source_id = ml.source_id
 {% if is_incremental() %}
+-- Watermark on the source EXTRACT time, not the meeting date. A forward-only
+-- `join_time > max(date) - 3d` filter permanently strands backfilled / late-arriving
+-- history: this is exactly how the Zoom meeting_hours undercount happened on virtuozzo —
+-- bronze held the full history but staging kept only the last few days, so the monthly
+-- total collapsed to ~one week. Re-pulled rows always carry a fresh `_airbyte_extracted_at`,
+-- so we reprocess every meeting date touched by a recent extract. The whole date is
+-- re-aggregated from full bronze, so per-day SUMs stay correct even when a day's
+-- participants arrive across several sync batches.
 WHERE (
-    (SELECT max(date) FROM {{ this }}) IS NULL
-    OR toDate(parseDateTimeBestEffortOrNull(p.join_time)) > (SELECT max(date) - INTERVAL 3 DAY FROM {{ this }})
+    (SELECT count() FROM {{ this }}) = 0
+    OR toDate(parseDateTimeBestEffortOrNull(p.join_time)) IN (
+        SELECT DISTINCT toDate(parseDateTimeBestEffortOrNull(join_time))
+        FROM {{ source('bronze_zoom', 'participants') }}
+        WHERE _airbyte_extracted_at
+              > (SELECT max(_airbyte_extracted_at) FROM {{ source('bronze_zoom', 'participants') }}) - INTERVAL 3 DAY
+    )
 )
 {% endif %}
 GROUP BY

--- a/src/ingestion/connectors/collaboration/zulip-proxy/dbt/zulip_proxy__collab_chat_activity.sql
+++ b/src/ingestion/connectors/collaboration/zulip-proxy/dbt/zulip_proxy__collab_chat_activity.sql
@@ -73,9 +73,17 @@ LEFT JOIN {{ source('bronze_zulip_proxy', 'users') }} AS u FINAL
     AND u.id = m.sender_id
 WHERE u.email IS NOT NULL AND u.email != ''
 {% if is_incremental() %}
+  -- Watermark on the source EXTRACT time, not the business date (see zoom model header
+  -- for the backfill-strand failure mode this fixes). Re-pulled rows carry a fresh
+  -- `_airbyte_extracted_at`, so reprocess every business date touched by a recent extract.
   AND (
-    (SELECT max(date) FROM {{ this }}) IS NULL
-    OR toDate(parseDateTimeBestEffortOrNull(m.created_at)) > (SELECT max(date) - INTERVAL 3 DAY FROM {{ this }})
+    (SELECT count() FROM {{ this }}) = 0
+    OR toDate(parseDateTimeBestEffortOrNull(m.created_at)) IN (
+      SELECT DISTINCT toDate(parseDateTimeBestEffortOrNull(created_at))
+      FROM {{ source('bronze_zulip_proxy', 'messages') }}
+      WHERE _airbyte_extracted_at
+            > (SELECT max(_airbyte_extracted_at) FROM {{ source('bronze_zulip_proxy', 'messages') }}) - INTERVAL 3 DAY
+    )
   )
 {% endif %}
 GROUP BY


### PR DESCRIPTION
## Problem

The incremental connector-staging models for **collaboration** gated incrementality on a forward-only **business-date** watermark:

```sql
{% if is_incremental() %}
  WHERE business_date > (SELECT max(business_date) - INTERVAL 3 DAY FROM {{ this }})
{% endif %}
```

This permanently **strands backfilled / late-arriving bronze history**: once the target's max business date advances, any source rows whose business date is older than that max never re-enter the model — even though they are present in bronze.

### Observed impact (virtuozzo)
A user's **Meeting Hours** read **~19h/month ≈ ~17h/week** — month ≈ week — for someone whose true month was **~67h**.

Root cause traced layer by layer:

| layer | Zoom meeting coverage |
|---|---|
| `bronze_zoom.participants` | 128 days (2026-01 … 06-08) |
| `staging.zoom__collab_meeting_activity` | **8 days (2026-06-01 … 06-08)** |

So the monthly metric was effectively *M365 (full) + Zoom (last week only)*. Slack chat had the same gap (bronze from Jan, staging from late-Mar). M365/Cursor/Claude happened **not** to manifest only because their bronze never gained pre-existing history after the watermark advanced — the code is equally fragile.

## Fix

Gate on the source **extract time** instead of the business date. Re-pulled / late rows always carry a fresh `_airbyte_extracted_at`, so we reprocess every business date that has any bronze row extracted within 3 days of the newest extract:

```sql
{% if is_incremental() %}
  AND (
    (SELECT count() FROM {{ this }}) = 0
    OR business_date IN (
      SELECT DISTINCT business_date
      FROM {{ source(...) }}
      WHERE _airbyte_extracted_at
            > (SELECT max(_airbyte_extracted_at) FROM {{ source(...) }}) - INTERVAL 3 DAY
    )
  )
{% endif %}
```

- The **whole date** is re-derived from full bronze, so the Zoom per-day aggregate (`GROUP BY email, date`) stays correct even when a day's participants arrive across several sync batches — a plain `_airbyte_extracted_at > max` row-watermark (as used by the 1:1 git/CRM staging models) would undercount aggregates here, which is why this uses a date-reprocess form.
- **Pure `WHERE` change** — no new output columns, so `union_by_tag` feeders stay schema-aligned and **no `--full-refresh` redeploy is required**.

## Files (8 collaboration staging models)
- `zoom__collab_meeting_activity`
- `m365__collab_meeting_activity`, `m365__collab_chat_activity`, `m365__collab_email_activity`, `m365__collab_document_activity_onedrive`, `m365__collab_document_activity_sharepoint`
- `slack__collab_chat_activity`
- `zulip_proxy__collab_chat_activity`

## Already remediated on virtuozzo
A one-off `dbt run --full-refresh` over the affected staging + silver chain has been applied: `staging.zoom__collab_meeting_activity` went 8 → 127 days, and the user's monthly Meeting Hours corrected **19.82h → 66.77h** with **no duplicates** (silver `union_by_tag` QUALIFY-dedup + gold view).

## Follow-up (same anti-pattern, not in this PR)
The AI usage models carry the identical business-date watermark and should get the same fix: `cursor__ai_dev_usage`, `claude_admin__ai_{api,dev}_usage`, `claude_enterprise__ai_{assistant,dev}_usage`, `claude_team__ai_dev_usage`, `copilot__ai_{dev,org}_usage`, the OpenAI `to_ai_*` models (`max(report_date)`, no interval), and silver `class_focus_metrics` (`max(day) - 3`). They are not currently manifesting on virtuozzo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated incremental data refresh logic for collaboration data models (Microsoft 365, Slack, Zoom, Zulip). Data reprocessing now uses source extraction timestamps with a 3-day lookback window instead of previously stored business dates, improving consistency in data updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->