### PR TITLE
chore(ci): trigger backend image rebuild on constructorfabric namespace

### DIFF
--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -109,3 +109,7 @@ figment = { version = "0.10", features = ["yaml", "env"] }
 
 # Internal crates
 insight-clickhouse = { path = "libs/insight-clickhouse" }
+
+# CI rebuild marker — bumped to retrigger the api-gateway + analytics-api
+# image builds on the constructorfabric/* namespace flip (2026-06-09).
+

--- a/src/backend/services/identity/Directory.Build.props
+++ b/src/backend/services/identity/Directory.Build.props
@@ -1,4 +1,6 @@
 <Project>
+  <!-- CI rebuild marker — bumped to retrigger the identity image build on
+       the constructorfabric/* namespace flip (2026-06-09). -->
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
## Summary

The cyberfabric → constructorfabric namespace migration merged earlier today, but no backend code has changed since, so the per-service paths-filter in `build-images.yml` (job `changes`) hasn't flagged any of the three backend services for a rebuild. The old `ghcr.io/cyberfabric/insight-*` tags are stranded; nothing has published under `ghcr.io/constructorfabric/insight-*` yet.

This PR is a deliberate no-op touch to make the filter fire for every backend service:

| File touched | Triggers filter | Job that runs |
|---|---|---|
| `src/backend/Cargo.toml` | `api_gateway`, `analytics_api` | `backend-api-gateway`, `backend-analytics-api` |
| `src/backend/services/identity/Directory.Build.props` | `identity` | `backend-identity` |

Both edits are comment-only.

## Out of scope (intentionally NOT touched)

- `src/ingestion/**` — would fire the `toolbox` filter and the connector image matrix. Those images are already pinned via descriptor.yaml refs and don't need a rebuild from this PR.

## Test plan

- [ ] Merge to main and confirm `backend-api-gateway`, `backend-analytics-api`, and `backend-identity` all run and push to `ghcr.io/constructorfabric/*`.
- [ ] Confirm the connector `build-image` matrix is empty (`any=false`) and `toolbox` is `skipped` — neither should run.
- [ ] Confirm `publish-chart` runs after all three backend builds finish and bumps each subchart's `appVersion` to the new build tag.