### PR TITLE
fix(ci): drop main-push triggers from backend-checks and e2e (PR-only)

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -1,11 +1,12 @@
 name: Backend Lint & Test
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "src/backend/**"
-      - ".github/workflows/backend-checks.yml"
+  # PR-only: every change touching the backend must pass these checks before
+  # it lands. Re-running the same suite on the merge commit just burns minutes
+  # — the PR already proved the tree is green, and branch protection ensures
+  # nothing reaches `main` without that PR. Use workflow_dispatch for an
+  # explicit manual rerun against `main` (e.g. after a runner-image rollover
+  # that might shift behaviour).
   pull_request:
     branches: [main]
     paths:

--- a/.github/workflows/e2e-bronze-to-api.yml
+++ b/.github/workflows/e2e-bronze-to-api.yml
@@ -11,15 +11,11 @@ name: E2E — Bronze to API
 # Code:  src/ingestion/tests/e2e/
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "src/ingestion/**"
-      - "src/backend/services/analytics-api/**"
-      - "src/backend/libs/insight-clickhouse/**"
-      - "src/backend/Cargo.toml"
-      - "src/backend/Cargo.lock"
-      - ".github/workflows/e2e-bronze-to-api.yml"
+  # PR-only — same reasoning as backend-checks: branch protection gates
+  # merge on PR success, and re-running the full bronze→API stack
+  # (clickhouse + mariadb + dbt + pytest) on the merge commit just burns
+  # ~30 minutes for an outcome we already proved. workflow_dispatch
+  # remains for manual reruns against main.
   pull_request:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary

Two workflows currently run twice for every change — once on the PR (where they correctly gate the merge) and again on the resulting merge commit on `main`:

- `Backend Lint & Test` (`.github/workflows/backend-checks.yml`) — Rust + .NET Identity build, including testcontainers MariaDB integration tests.
- `E2E — Bronze to API` (`.github/workflows/e2e-bronze-to-api.yml`) — full clickhouse + mariadb + dbt + pytest stack, ~30 minutes per run.

The second run is wasted: branch protection guarantees nothing reaches `main` without the PR run passing first, so the post-merge rerun on the same commit just burns minutes without producing new signal. The user flagged the `.NET — Identity Service Build & Test` job specifically as the most visible offender.

## Change

Drop `push: branches: [main]` from both workflows. Keep `pull_request: branches: [main]` (still the gate) and `workflow_dispatch` (manual reruns against `main` — e.g. after a runner-image rollover that might shift behaviour).

```diff
 on:
-  push:
-    branches: [main]
-    paths: [...]
   pull_request:
     branches: [main]
     paths: [...]
   workflow_dispatch:
```

## Out of scope

- `build-images.yml` still needs `push: branches: [main]` — that's the *image-publishing* pipeline, not a check; it has to run on the merge commit so the new images get tagged + pushed.
- Per-stack splitting (Rust vs .NET inside `backend-checks.yml`) was considered but isn't this PR — the user's specific ask is to stop the post-merge rerun. Each job still runs on every PR that flags the workflow.

## Test plan

- [ ] Open a no-op backend PR on top of this branch. Confirm `Backend Lint & Test` (both jobs) and `E2E — Bronze to API` run during the PR.
- [ ] Merge the PR. Confirm neither workflow runs on the resulting `main` commit (only `Build & Push Container Images` should fire, as today).
- [ ] Run `gh workflow run backend-checks.yml --ref main` and confirm the manual dispatch path still works.