### PR TITLE
BFF Phase 1: OIDC login + server-side sessions

### DIFF
--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -2836,6 +2836,7 @@ dependencies = [
  "cf-grpc-hub",
  "cf-modkit",
  "cf-modkit-auth",
+ "cf-modkit-canonical-errors",
  "cf-modkit-macros",
  "cf-modkit-security 0.6.2",
  "cf-module-orchestrator",

--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -430,6 +430,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-extra"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "cookie",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "serde_core",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "axum-macros"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,6 +1596,17 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
 
 [[package]]
 name = "core-foundation"
@@ -2769,11 +2803,14 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "axum-extra",
+ "base64",
  "cf-api-gateway",
  "cf-authn-resolver",
  "cf-authz-resolver",
  "cf-grpc-hub",
  "cf-modkit",
+ "cf-modkit-auth",
  "cf-modkit-macros",
  "cf-modkit-security 0.6.2",
  "cf-module-orchestrator",
@@ -2783,14 +2820,21 @@ dependencies = [
  "cf-types-registry",
  "cf-types-registry-sdk",
  "clap",
+ "hex",
  "oidc-authn-plugin",
+ "rand 0.8.5",
+ "redis",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
+ "subtle",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -71,7 +71,7 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9d87771969112cbfb21574d11935c2cc37b961b7b1e8e0f146bc1f327d175f4"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde",
 ]
 
@@ -474,6 +474,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +611,15 @@ checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -750,7 +771,7 @@ dependencies = [
  "cf-modkit-security 0.6.2",
  "gts",
  "gts-macros",
- "schemars",
+ "schemars 1.2.1",
  "secrecy",
  "serde",
  "serde_json",
@@ -791,7 +812,7 @@ dependencies = [
  "cf-modkit-security 0.6.2",
  "gts",
  "gts-macros",
- "schemars",
+ "schemars 1.2.1",
  "secrecy",
  "serde",
  "serde_json",
@@ -858,7 +879,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "parking_lot",
- "schemars",
+ "schemars 1.2.1",
  "sea-orm-migration",
  "serde",
  "serde-saphyr 0.0.16",
@@ -891,7 +912,7 @@ dependencies = [
  "aliri_tokens",
  "arc-swap",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "cf-modkit-http",
  "cf-modkit-security 0.6.2",
  "cf-modkit-utils",
@@ -1067,7 +1088,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67e82c56a885ac7f037a4adb43eb86b01068cb2ea525eeb3e360d16c28ac8be3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bigdecimal",
  "cf-modkit-errors 0.6.2",
  "cf-modkit-errors-macro",
@@ -1089,7 +1110,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1edda2d6bbe1f9b8504a00785cf774e7a3787369a41b3511e23136155007846f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bigdecimal",
  "cf-modkit-errors 0.7.0",
  "cf-modkit-errors-macro",
@@ -1111,7 +1132,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d88116ec506d129a3b8ca109443f464ea3528002a187d797576064d8632407fc"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bigdecimal",
  "cf-modkit-errors 0.7.0",
  "cf-modkit-errors-macro",
@@ -1320,7 +1341,7 @@ dependencies = [
  "cf-modkit-security 0.6.2",
  "gts",
  "gts-macros",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1702,6 +1723,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1712,13 +1745,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -1735,12 +1805,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -1891,12 +1985,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2001,6 +2154,22 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "figment"
@@ -2247,6 +2416,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2256,8 +2426,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2318,6 +2490,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "gts"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2325,7 +2508,7 @@ checksum = "3cf70de49935aad158ecc91b335a5e1361757a7048417a26e19bd72b2d5bb44d"
 dependencies = [
  "gts-id",
  "jsonschema",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde-saphyr 0.0.10",
  "serde_json",
@@ -2370,7 +2553,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2435,7 +2618,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "headers-core",
  "http",
@@ -2634,7 +2817,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -2794,6 +2977,17 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
@@ -2829,7 +3023,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-extra",
- "base64",
+ "base64 0.22.1",
  "cf-api-gateway",
  "cf-authn-resolver",
  "cf-authz-resolver",
@@ -2848,6 +3042,7 @@ dependencies = [
  "clap",
  "hex",
  "oidc-authn-plugin",
+ "openidconnect",
  "rand 0.8.6",
  "redis",
  "reqwest",
@@ -2904,6 +3099,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2985,7 +3189,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
  "getrandom 0.2.17",
  "js-sys",
  "pem",
@@ -3071,6 +3275,12 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
@@ -3362,6 +3572,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand 0.8.6",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "oidc-authn-plugin"
 version = "0.1.0"
 dependencies = [
@@ -3394,6 +3624,37 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "openidconnect"
+version = "4.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c6709ba2ea764bbed26bce1adf3c10517113ddea6f2d4196e4851757ef2b2"
+dependencies = [
+ "base64 0.21.7",
+ "chrono",
+ "dyn-clone",
+ "ed25519-dalek",
+ "hmac",
+ "http",
+ "itertools 0.10.5",
+ "log",
+ "oauth2",
+ "p256",
+ "p384",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_plain",
+ "serde_with",
+ "sha2",
+ "subtle",
+ "thiserror 1.0.69",
+ "url",
+]
 
 [[package]]
 name = "openssl"
@@ -3522,6 +3783,15 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
@@ -3558,6 +3828,30 @@ name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
 
 [[package]]
 name = "parking"
@@ -3659,7 +3953,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -3686,7 +3980,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -3876,6 +4170,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4034,6 +4337,61 @@ dependencies = [
  "wasi",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2 0.6.3",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2 0.6.3",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4282,7 +4640,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-channel",
@@ -4302,6 +4660,8 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4309,6 +4669,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -4316,6 +4677,17 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -4433,6 +4805,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4488,6 +4866,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -4552,6 +4931,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4688,7 +5079,7 @@ dependencies = [
  "bigdecimal",
  "chrono",
  "inherent",
- "ordered-float",
+ "ordered-float 4.6.0",
  "rust_decimal",
  "sea-query-derive",
  "serde_json",
@@ -4718,7 +5109,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bae0cbad6ab996955664982739354128c58d16e126114fe88c2a493642502aab"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "heck 0.4.1",
  "proc-macro2",
  "quote",
@@ -4756,6 +5147,20 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "secrecy"
@@ -4813,7 +5218,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b9e06cddad47cc6214c0c456cf209b99a58b54223e7af2f6d4b88a5a9968499"
 dependencies = [
  "ahash 0.8.12",
- "base64",
+ "base64 0.22.1",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",
@@ -4832,7 +5237,7 @@ checksum = "4db5a4a562bcc0017c34cd0efbabf447be783f00576a2a516947f884e6a7ed57"
 dependencies = [
  "ahash 0.8.12",
  "annotate-snippets",
- "base64",
+ "base64 0.22.1",
  "encoding_rs_io",
  "nohash-hasher",
  "num-traits",
@@ -4842,6 +5247,16 @@ dependencies = [
  "serde_json",
  "smallvec 2.0.0-alpha.12",
  "zmij",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
+ "serde",
 ]
 
 [[package]]
@@ -4881,7 +5296,7 @@ version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -4901,6 +5316,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_plain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1fc6db65a611022b23a0dec6975d63fb80a302cb3388835ff02c097258d50"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4913,12 +5337,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -5115,7 +5571,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bigdecimal",
  "bytes",
  "chrono",
@@ -5129,7 +5585,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "memchr",
  "once_cell",
@@ -5193,7 +5649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bigdecimal",
  "bitflags",
  "byteorder",
@@ -5240,7 +5696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.22.1",
  "bigdecimal",
  "bitflags",
  "byteorder",
@@ -5637,7 +6093,7 @@ version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -5660,7 +6116,7 @@ checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "h2",
  "http",
@@ -5728,7 +6184,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -5977,7 +6433,7 @@ version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "log",
  "once_cell",
@@ -5997,6 +6453,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -6023,7 +6480,7 @@ version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -6210,7 +6667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -6223,7 +6680,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -6624,7 +7081,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -6655,7 +7112,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -6674,7 +7131,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -6839,7 +7296,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap",
+ "indexmap 2.14.0",
  "memchr",
  "thiserror 2.0.18",
  "zopfli",

--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -2830,6 +2830,7 @@ dependencies = [
  "sha2",
  "subtle",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tower",
  "tracing",

--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -2822,7 +2822,7 @@ dependencies = [
  "clap",
  "hex",
  "oidc-authn-plugin",
- "rand 0.8.5",
+ "rand 0.8.6",
  "redis",
  "reqwest",
  "serde",

--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -440,6 +440,7 @@ dependencies = [
  "bytes",
  "cookie",
  "futures-util",
+ "headers",
  "http",
  "http-body",
  "http-body-util",
@@ -2426,6 +2427,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64",
+ "bytes",
+ "headers-core",
+ "http",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http",
 ]
 
 [[package]]

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -72,6 +72,21 @@ reqwest = { version = "0.12", features = ["json"] }
 # Caching
 redis = { version = "0.27", features = ["tokio-comp", "connection-manager"] }
 
+# Cookie typed helpers (BFF)
+axum-extra = { version = "0.10", features = ["cookie"] }
+
+# Crypto / random (BFF: CSPRNG for session IDs, CSRF tokens)
+rand = "0.8"
+base64 = "0.22"
+sha2 = "0.10"
+hex = "0.4"
+
+# JWT (back-channel logout token validation, ID token verification fallback)
+jsonwebtoken = { version = "9.3", default-features = false, features = ["use_pem"] }
+
+# Constant-time comparison for CSRF
+subtle = "2.6"
+
 # CLI
 clap = { version = "4.5", features = ["derive"] }
 

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -73,7 +73,7 @@ reqwest = { version = "0.12", features = ["json"] }
 redis = { version = "0.27", features = ["tokio-comp", "connection-manager"] }
 
 # Cookie typed helpers (BFF)
-axum-extra = { version = "0.10", features = ["cookie"] }
+axum-extra = { version = "0.10", features = ["cookie", "typed-header"] }
 
 # Crypto / random (BFF: CSPRNG for session IDs, CSRF tokens)
 rand = "0.8"

--- a/src/backend/services/api-gateway/Cargo.toml
+++ b/src/backend/services/api-gateway/Cargo.toml
@@ -63,6 +63,8 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 anyhow = { workspace = true }
 clap = { workspace = true }
+# OIDC (discovery, code-with-PKCE, ID-token validation) used by the BFF.
+openidconnect = "4"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/src/backend/services/api-gateway/Cargo.toml
+++ b/src/backend/services/api-gateway/Cargo.toml
@@ -37,11 +37,23 @@ oidc-authn-plugin = { path = "../../plugins/oidc-authn-plugin" }
 # Auth info + proxy modules
 modkit-macros = { workspace = true }
 modkit-security = { workspace = true }
+modkit-auth = { workspace = true }
 async-trait = { workspace = true }
 axum = "0.8"
+axum-extra = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+thiserror = { workspace = true }
+
+# BFF: session store + OIDC + crypto
+redis = { workspace = true }
+rand = { workspace = true }
+base64 = { workspace = true }
+sha2 = { workspace = true }
+hex = { workspace = true }
+subtle = { workspace = true }
+url = "2.5"
 
 # Runtime
 tokio = { workspace = true }

--- a/src/backend/services/api-gateway/Cargo.toml
+++ b/src/backend/services/api-gateway/Cargo.toml
@@ -38,6 +38,7 @@ oidc-authn-plugin = { path = "../../plugins/oidc-authn-plugin" }
 modkit-macros = { workspace = true }
 modkit-security = { workspace = true }
 modkit-auth = { workspace = true }
+modkit-canonical-errors = { workspace = true }
 async-trait = { workspace = true }
 axum = "0.8"
 axum-extra = { workspace = true }

--- a/src/backend/services/api-gateway/Cargo.toml
+++ b/src/backend/services/api-gateway/Cargo.toml
@@ -41,6 +41,7 @@ modkit-auth = { workspace = true }
 async-trait = { workspace = true }
 axum = "0.8"
 axum-extra = { workspace = true }
+time = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/backend/services/api-gateway/src/bff/audit.rs
+++ b/src/backend/services/api-gateway/src/bff/audit.rs
@@ -1,0 +1,120 @@
+//! Auth-event audit emitter (`cpt-insightspec-nfr-bff-audit`).
+//!
+//! v1 emits structured tracing events. A future iteration will wire a
+//! Redpanda producer behind the same `emit` call so consumers don't need
+//! to change.
+
+use serde::Serialize;
+
+/// Auth event kind. Stable strings; renaming a variant means breaking the
+/// audit topic, which we want to know about explicitly.
+///
+/// Variants beyond `LoginStart`/`LoginOk`/`LoginFail` are reserved for
+/// Phase 2/3 (refresh, logout, sessions, back-channel). They're declared
+/// here so the audit envelope shape doesn't shift when those handlers
+/// land.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)]
+pub enum AuthEventKind {
+    LoginStart,
+    LoginOk,
+    LoginFail,
+    SessionRefresh,
+    Logout,
+    RevokeSingle,
+    RevokeAll,
+    RevokeAdmin,
+    BackChannelLogout,
+}
+
+impl AuthEventKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::LoginStart => "login_start",
+            Self::LoginOk => "login_ok",
+            Self::LoginFail => "login_fail",
+            Self::SessionRefresh => "session_refresh",
+            Self::Logout => "logout",
+            Self::RevokeSingle => "revoke_single",
+            Self::RevokeAll => "revoke_all",
+            Self::RevokeAdmin => "revoke_admin",
+            Self::BackChannelLogout => "back_channel_logout",
+        }
+    }
+}
+
+/// Optional context for an audit event. All fields are optional so a
+/// caller can include only what it knows.
+#[derive(Debug, Default, Clone, Serialize)]
+pub struct AuthEvent<'a> {
+    pub user_id: Option<&'a str>,
+    pub tenant_id: Option<&'a str>,
+    pub session_id_hash: Option<&'a str>,
+    pub idp_iss: Option<&'a str>,
+    pub idp_sub: Option<&'a str>,
+    pub ip: Option<&'a str>,
+    pub user_agent: Option<&'a str>,
+    pub correlation_id: Option<&'a str>,
+    pub reason: Option<&'a str>,
+}
+
+/// Emit a structured audit event.
+///
+/// Never log raw cookies, tokens, or session IDs — pass the SHA-256 hex
+/// prefix via `session_id_hash` instead.
+pub fn emit(kind: AuthEventKind, ev: &AuthEvent<'_>) {
+    tracing::info!(
+        target: "audit.auth",
+        event = kind.as_str(),
+        user_id = ev.user_id.unwrap_or(""),
+        tenant_id = ev.tenant_id.unwrap_or(""),
+        session_id_hash = ev.session_id_hash.unwrap_or(""),
+        idp_iss = ev.idp_iss.unwrap_or(""),
+        idp_sub = ev.idp_sub.unwrap_or(""),
+        ip = ev.ip.unwrap_or(""),
+        user_agent = ev.user_agent.unwrap_or(""),
+        correlation_id = ev.correlation_id.unwrap_or(""),
+        reason = ev.reason.unwrap_or(""),
+        "auth event",
+    );
+}
+
+/// Hash a session ID for audit logs. Truncated SHA-256 hex (16 chars,
+/// 64 bits) — enough to correlate events for the same session, far short
+/// of being a usable cookie.
+#[must_use]
+pub fn hash_session_id(sid: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(sid.as_bytes());
+    let digest = h.finalize();
+    hex::encode(&digest[..8])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_session_id_is_stable_and_short() {
+        let a = hash_session_id("opaque-abc");
+        let b = hash_session_id("opaque-abc");
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 16);
+    }
+
+    #[test]
+    fn hash_session_id_distinguishes_inputs() {
+        assert_ne!(hash_session_id("a"), hash_session_id("b"));
+    }
+
+    #[test]
+    fn event_kind_strings_are_snake_case() {
+        assert_eq!(AuthEventKind::LoginOk.as_str(), "login_ok");
+        assert_eq!(
+            AuthEventKind::BackChannelLogout.as_str(),
+            "back_channel_logout"
+        );
+    }
+}

--- a/src/backend/services/api-gateway/src/bff/config.rs
+++ b/src/backend/services/api-gateway/src/bff/config.rs
@@ -1,0 +1,249 @@
+//! BFF module configuration.
+//!
+//! All knobs live under `modules.bff.config` in the api-gateway YAML.
+//! Defaults match `cpt-insightspec-fr-bff-*` requirements unless explicitly
+//! noted; production values should be set via Helm.
+
+use serde::Deserialize;
+
+/// BFF module configuration.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct BffConfig {
+    /// OIDC settings.
+    pub oidc: OidcConfig,
+    /// Session lifecycle settings.
+    pub session: SessionConfig,
+    /// CSRF settings.
+    pub csrf: CsrfConfig,
+    /// Public origin where the BFF serves the SPA's redirect target.
+    /// Used to build absolute callback URLs and the post-login redirect.
+    /// Required.
+    pub public_origin: String,
+    /// Default tenant assigned to every authenticated user until the
+    /// Identity Service mapping lands. Single-tenant deployments only.
+    pub default_tenant_id: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct OidcConfig {
+    /// OIDC issuer URL — `<issuer>/.well-known/openid-configuration` is
+    /// fetched at module init.
+    pub issuer_url: String,
+    /// Confidential client ID.
+    pub client_id: String,
+    /// Confidential client secret.
+    pub client_secret: String,
+    /// Scopes to request (`openid` is appended automatically if missing).
+    pub scopes: Vec<String>,
+    /// Optional override for the OIDC `audience` claim validation. Defaults
+    /// to `client_id`.
+    pub audience: Option<String>,
+}
+
+impl Default for OidcConfig {
+    fn default() -> Self {
+        Self {
+            issuer_url: String::new(),
+            client_id: String::new(),
+            client_secret: String::new(),
+            scopes: vec![
+                "openid".to_owned(),
+                "profile".to_owned(),
+                "email".to_owned(),
+            ],
+            audience: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct SessionConfig {
+    /// Session cookie TTL. Spec range: 30 s – 1 h. Default 120 s.
+    pub ttl_seconds: u64,
+    /// Hard cap on session lifetime across refreshes. Spec range:
+    /// 1 h – 24 h. Default 8 h.
+    pub absolute_lifetime_seconds: u64,
+    /// `refresh_at = expires_at - safety_margin + jitter`. Default 30 s.
+    pub refresh_safety_margin_seconds: u64,
+    /// Total jitter window applied to `refresh_at` (uniform in `±half/2`).
+    /// Default 10 s.
+    pub refresh_jitter_seconds: u64,
+    /// Grace TTL for `bff:swap:{old_sid}` after a refresh-rotation. Default
+    /// 250 ms.
+    pub refresh_grace_ms: u64,
+}
+
+impl Default for SessionConfig {
+    fn default() -> Self {
+        Self {
+            ttl_seconds: 120,
+            absolute_lifetime_seconds: 8 * 3600,
+            refresh_safety_margin_seconds: 30,
+            refresh_jitter_seconds: 10,
+            refresh_grace_ms: 250,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct CsrfConfig {
+    /// Allowlist of `Origin` values accepted as the secondary CSRF defense.
+    /// Empty means fail-closed: every state-changing `/auth/*` request must
+    /// carry a valid `X-CSRF-Token`.
+    pub origins: Vec<String>,
+}
+
+impl BffConfig {
+    /// Validate the loaded config against spec ranges. Called once at
+    /// module init.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if self.public_origin.is_empty() {
+            anyhow::bail!("bff: public_origin is required");
+        }
+        url::Url::parse(&self.public_origin)
+            .map_err(|e| anyhow::anyhow!("bff: public_origin is not a valid URL: {e}"))?;
+
+        if self.oidc.issuer_url.is_empty() {
+            anyhow::bail!("bff: oidc.issuer_url is required");
+        }
+        if self.oidc.client_id.is_empty() {
+            anyhow::bail!("bff: oidc.client_id is required");
+        }
+        if self.oidc.client_secret.is_empty() {
+            anyhow::bail!("bff: oidc.client_secret is required");
+        }
+
+        // cpt-insightspec-nfr-bff-session-ttl
+        if !(30..=3600).contains(&self.session.ttl_seconds) {
+            anyhow::bail!(
+                "bff: session.ttl_seconds must be in [30, 3600], got {}",
+                self.session.ttl_seconds
+            );
+        }
+        if !(3600..=86_400).contains(&self.session.absolute_lifetime_seconds) {
+            anyhow::bail!(
+                "bff: session.absolute_lifetime_seconds must be in [3600, 86400], got {}",
+                self.session.absolute_lifetime_seconds
+            );
+        }
+        if self.session.refresh_safety_margin_seconds >= self.session.ttl_seconds {
+            anyhow::bail!(
+                "bff: session.refresh_safety_margin_seconds ({}) must be < session.ttl_seconds ({})",
+                self.session.refresh_safety_margin_seconds,
+                self.session.ttl_seconds
+            );
+        }
+        if self.session.refresh_jitter_seconds >= self.session.ttl_seconds {
+            anyhow::bail!(
+                "bff: session.refresh_jitter_seconds ({}) must be < session.ttl_seconds ({})",
+                self.session.refresh_jitter_seconds,
+                self.session.ttl_seconds
+            );
+        }
+        if self.session.refresh_grace_ms == 0 || self.session.refresh_grace_ms > 5_000 {
+            anyhow::bail!(
+                "bff: session.refresh_grace_ms must be in (0, 5000], got {}",
+                self.session.refresh_grace_ms
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Final list of OIDC scopes with `openid` guaranteed present.
+    #[must_use]
+    pub fn effective_scopes(&self) -> Vec<String> {
+        let mut scopes = self.oidc.scopes.clone();
+        if !scopes.iter().any(|s| s == "openid") {
+            scopes.insert(0, "openid".to_owned());
+        }
+        scopes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn good_cfg() -> BffConfig {
+        BffConfig {
+            public_origin: "https://insight.example.com".to_owned(),
+            default_tenant_id: "00000000-0000-0000-0000-000000000001".to_owned(),
+            oidc: OidcConfig {
+                issuer_url: "https://idp.example.com".to_owned(),
+                client_id: "insight-bff".to_owned(),
+                client_secret: "secret".to_owned(),
+                ..OidcConfig::default()
+            },
+            ..BffConfig::default()
+        }
+    }
+
+    #[test]
+    fn validate_accepts_good_config() {
+        good_cfg().validate().expect("should pass");
+    }
+
+    #[test]
+    fn validate_rejects_short_session_ttl() {
+        let mut c = good_cfg();
+        c.session.ttl_seconds = 10;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_long_session_ttl() {
+        let mut c = good_cfg();
+        c.session.ttl_seconds = 7200;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_short_absolute_lifetime() {
+        let mut c = good_cfg();
+        c.session.absolute_lifetime_seconds = 300;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_safety_margin_geq_ttl() {
+        let mut c = good_cfg();
+        c.session.refresh_safety_margin_seconds = 120;
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn effective_scopes_inserts_openid_when_missing() {
+        let mut c = good_cfg();
+        c.oidc.scopes = vec!["profile".to_owned()];
+        assert_eq!(
+            c.effective_scopes(),
+            vec!["openid".to_owned(), "profile".to_owned()]
+        );
+    }
+
+    #[test]
+    fn effective_scopes_keeps_openid_when_present() {
+        let c = good_cfg();
+        let s = c.effective_scopes();
+        assert_eq!(s.iter().filter(|x| x.as_str() == "openid").count(), 1);
+    }
+
+    #[test]
+    fn validate_rejects_empty_public_origin() {
+        let mut c = good_cfg();
+        c.public_origin = String::new();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_empty_issuer() {
+        let mut c = good_cfg();
+        c.oidc.issuer_url = String::new();
+        assert!(c.validate().is_err());
+    }
+}

--- a/src/backend/services/api-gateway/src/bff/config.rs
+++ b/src/backend/services/api-gateway/src/bff/config.rs
@@ -62,18 +62,18 @@ impl Default for OidcConfig {
 #[serde(default, deny_unknown_fields)]
 pub struct SessionConfig {
     /// Session cookie TTL. Spec range: 30 s – 1 h. Default 120 s.
-    pub ttl_seconds: u64,
+    pub ttl_seconds: u32,
     /// Hard cap on session lifetime across refreshes. Spec range:
     /// 1 h – 24 h. Default 8 h.
-    pub absolute_lifetime_seconds: u64,
+    pub absolute_lifetime_seconds: u32,
     /// `refresh_at = expires_at - safety_margin + jitter`. Default 30 s.
-    pub refresh_safety_margin_seconds: u64,
+    pub refresh_safety_margin_seconds: u16,
     /// Total jitter window applied to `refresh_at` (uniform in `±half/2`).
     /// Default 10 s.
-    pub refresh_jitter_seconds: u64,
+    pub refresh_jitter_seconds: u16,
     /// Grace TTL for `bff:swap:{old_sid}` after a refresh-rotation. Default
     /// 250 ms.
-    pub refresh_grace_ms: u64,
+    pub refresh_grace_ms: u32,
 }
 
 impl Default for SessionConfig {
@@ -104,8 +104,9 @@ impl BffConfig {
         if self.public_origin.is_empty() {
             anyhow::bail!("bff: public_origin is required");
         }
-        url::Url::parse(&self.public_origin)
+        let parsed = url::Url::parse(&self.public_origin)
             .map_err(|e| anyhow::anyhow!("bff: public_origin is not a valid URL: {e}"))?;
+        validate_public_origin(&parsed)?;
 
         if self.oidc.issuer_url.is_empty() {
             anyhow::bail!("bff: oidc.issuer_url is required");
@@ -115,6 +116,9 @@ impl BffConfig {
         }
         if self.oidc.client_secret.is_empty() {
             anyhow::bail!("bff: oidc.client_secret is required");
+        }
+        if self.default_tenant_id.trim().is_empty() {
+            anyhow::bail!("bff: default_tenant_id is required");
         }
 
         // cpt-insightspec-nfr-bff-session-ttl
@@ -130,14 +134,14 @@ impl BffConfig {
                 self.session.absolute_lifetime_seconds
             );
         }
-        if self.session.refresh_safety_margin_seconds >= self.session.ttl_seconds {
+        if u32::from(self.session.refresh_safety_margin_seconds) >= self.session.ttl_seconds {
             anyhow::bail!(
                 "bff: session.refresh_safety_margin_seconds ({}) must be < session.ttl_seconds ({})",
                 self.session.refresh_safety_margin_seconds,
                 self.session.ttl_seconds
             );
         }
-        if self.session.refresh_jitter_seconds >= self.session.ttl_seconds {
+        if u32::from(self.session.refresh_jitter_seconds) >= self.session.ttl_seconds {
             anyhow::bail!(
                 "bff: session.refresh_jitter_seconds ({}) must be < session.ttl_seconds ({})",
                 self.session.refresh_jitter_seconds,
@@ -163,6 +167,37 @@ impl BffConfig {
         }
         scopes
     }
+}
+
+/// Defense-in-depth validation for `public_origin`: HTTPS only, except for
+/// local-dev hosts (`localhost`, `127.0.0.1`). Reject query/fragment/userinfo
+/// and any path beyond `/` since the value is concatenated with `"/auth/..."`
+/// at the call site. Runtime traffic is still enforced HTTPS-only at the
+/// ingress (NFR `cpt-insightspec-nfr-bff-https-only`); this guards the config.
+fn validate_public_origin(u: &url::Url) -> anyhow::Result<()> {
+    let host = u.host_str().unwrap_or("");
+    let is_local = host == "localhost" || host == "127.0.0.1";
+    match u.scheme() {
+        "https" => {}
+        "http" if is_local => {}
+        s => anyhow::bail!(
+            "bff: public_origin must use https (got `{s}://{host}`); http allowed only for localhost"
+        ),
+    }
+    if !u.username().is_empty() || u.password().is_some() {
+        anyhow::bail!("bff: public_origin must not include userinfo");
+    }
+    if u.query().is_some() {
+        anyhow::bail!("bff: public_origin must not include a query string");
+    }
+    if u.fragment().is_some() {
+        anyhow::bail!("bff: public_origin must not include a fragment");
+    }
+    let path = u.path();
+    if !(path.is_empty() || path == "/") {
+        anyhow::bail!("bff: public_origin must not include a path (got `{path}`)");
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -244,6 +279,69 @@ mod tests {
     fn validate_rejects_empty_issuer() {
         let mut c = good_cfg();
         c.oidc.issuer_url = String::new();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_empty_default_tenant_id() {
+        let mut c = good_cfg();
+        c.default_tenant_id = String::new();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_blank_default_tenant_id() {
+        let mut c = good_cfg();
+        c.default_tenant_id = "   ".to_owned();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_accepts_localhost_http_public_origin() {
+        let mut c = good_cfg();
+        c.public_origin = "http://localhost:8080".to_owned();
+        c.validate().expect("localhost http should pass");
+    }
+
+    #[test]
+    fn validate_accepts_loopback_http_public_origin() {
+        let mut c = good_cfg();
+        c.public_origin = "http://127.0.0.1:8080".to_owned();
+        c.validate().expect("127.0.0.1 http should pass");
+    }
+
+    #[test]
+    fn validate_rejects_non_localhost_http_public_origin() {
+        let mut c = good_cfg();
+        c.public_origin = "http://insight.example.com".to_owned();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_https_with_userinfo_public_origin() {
+        let mut c = good_cfg();
+        c.public_origin = "https://user:pass@insight.example.com".to_owned();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_public_origin_with_query() {
+        let mut c = good_cfg();
+        c.public_origin = "https://insight.example.com/?x=1".to_owned();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_public_origin_with_fragment() {
+        let mut c = good_cfg();
+        c.public_origin = "https://insight.example.com/#f".to_owned();
+        assert!(c.validate().is_err());
+    }
+
+    #[test]
+    fn validate_rejects_public_origin_with_path() {
+        let mut c = good_cfg();
+        c.public_origin = "https://insight.example.com/app".to_owned();
         assert!(c.validate().is_err());
     }
 }

--- a/src/backend/services/api-gateway/src/bff/cookies.rs
+++ b/src/backend/services/api-gateway/src/bff/cookies.rs
@@ -36,7 +36,13 @@ pub const SESSION_COOKIE_NAME: &str = "__Host-sid";
 #[must_use]
 pub struct SessionCookie<'a> {
     value: &'a str,
-    max_age_seconds: i64,
+    /// Residual cookie lifetime, clamped to `[0, u32::MAX]` at the
+    /// construction boundary. The session's `expires_at - now`
+    /// subtraction is naturally `i64`, but the stored result is always
+    /// non-negative and bounded above by the absolute session lifetime
+    /// (≤ 24h per spec), so `u32` is the right shape — it eliminates the
+    /// "is this negative?" question downstream.
+    max_age_seconds: u32,
 }
 
 impl<'a> SessionCookie<'a> {
@@ -46,9 +52,11 @@ impl<'a> SessionCookie<'a> {
     /// session record's `expires_at` directly without restating the
     /// subtraction.
     pub fn set(sid: &'a str, expires_at: i64, now: i64) -> Self {
+        let residual_signed = expires_at.saturating_sub(now).max(0);
+        let max_age_seconds = u32::try_from(residual_signed).unwrap_or(u32::MAX);
         Self {
             value: sid,
-            max_age_seconds: expires_at.saturating_sub(now).max(0),
+            max_age_seconds,
         }
     }
 
@@ -115,13 +123,13 @@ fn unquote(s: &str) -> &str {
 /// Construct a `Cookie` carrying the full attribute set mandated by
 /// `cpt-insightspec-nfr-bff-cookie-attrs`. Single source of truth for
 /// what makes a session cookie valid.
-fn build_cookie(value: &str, max_age_seconds: i64) -> Cookie<'static> {
+fn build_cookie(value: &str, max_age_seconds: u32) -> Cookie<'static> {
     Cookie::build((SESSION_COOKIE_NAME, value.to_owned()))
         .http_only(true)
         .secure(true)
         .same_site(SameSite::Strict)
         .path("/")
-        .max_age(Duration::seconds(max_age_seconds))
+        .max_age(Duration::seconds(i64::from(max_age_seconds)))
         .build()
 }
 

--- a/src/backend/services/api-gateway/src/bff/cookies.rs
+++ b/src/backend/services/api-gateway/src/bff/cookies.rs
@@ -1,0 +1,181 @@
+//! Single source of truth for the BFF session cookie.
+//!
+//! Per `cpt-insightspec-nfr-bff-cookie-attrs` every session-cookie response
+//! MUST carry `__Host-` prefix, `HttpOnly`, `Secure`, `SameSite=Strict`,
+//! `Path=/`, no `Domain`. We hard-code those attributes here so any other
+//! call site has to go through these helpers.
+
+use axum::http::HeaderValue;
+
+/// Name of the BFF session cookie. The `__Host-` prefix tells the browser to:
+///   * require Secure
+///   * require Path=/
+///   * forbid Domain — pinning the cookie to one host
+pub const SESSION_COOKIE_NAME: &str = "__Host-sid";
+
+/// Build a `Set-Cookie` header value that establishes a fresh session.
+#[must_use]
+pub fn build_set_session(value: &str, max_age_seconds: i64) -> HeaderValue {
+    cookie_header(value, max_age_seconds)
+}
+
+/// Build a `Set-Cookie` header value that clears the session.
+#[must_use]
+pub fn build_clear_session() -> HeaderValue {
+    // Empty value + Max-Age=0 evicts the cookie. We still set every other
+    // attribute identically to the live cookie so a buggy browser never
+    // ends up with a cookie that has weaker attrs than the original.
+    cookie_header("", 0)
+}
+
+/// Read the BFF session cookie value from a single `Cookie` header.
+///
+/// Returns `None` when:
+///   * no header is present;
+///   * no `__Host-sid` cookie is found;
+///   * **more than one** `__Host-sid` cookie is present (RFC 6265bis
+///     leaves duplicate handling undefined — we reject to avoid an
+///     attacker-set duplicate masking the real cookie).
+///
+/// Strips an optional pair of surrounding double-quotes so a quoted
+/// cookie value `"abc"` matches the unquoted SID we generated.
+#[must_use]
+pub fn read_session_cookie(cookie_header: Option<&HeaderValue>) -> Option<String> {
+    let raw = cookie_header?.to_str().ok()?;
+    let mut found: Option<String> = None;
+    for pair in raw.split(';') {
+        let trimmed = pair.trim();
+        let Some((name, value)) = trimmed.split_once('=') else {
+            continue;
+        };
+        if name.trim() != SESSION_COOKIE_NAME {
+            continue;
+        }
+        let v = unquote(value.trim()).to_owned();
+        if found.is_some() {
+            // Duplicate __Host-sid in the same Cookie header — refuse
+            // rather than guess which one is genuine.
+            return None;
+        }
+        found = Some(v);
+    }
+    found
+}
+
+fn unquote(s: &str) -> &str {
+    if s.len() >= 2 && s.starts_with('"') && s.ends_with('"') {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
+fn cookie_header(value: &str, max_age_seconds: i64) -> HeaderValue {
+    // RFC 6265 cookie attributes. Order is convention; all attributes are
+    // mandatory to keep `cpt-insightspec-nfr-bff-cookie-attrs` honest.
+    let raw = format!(
+        "{SESSION_COOKIE_NAME}={value}; Max-Age={max_age_seconds}; Path=/; Secure; HttpOnly; SameSite=Strict",
+    );
+    // Inputs are: a fixed ASCII cookie name, an opaque base64url session
+    // value (alphanumeric + `-_`) we generate ourselves in `secrets.rs`,
+    // and a signed integer. None can introduce non-ASCII bytes; the
+    // expect can never fire unless the program is rewritten to pass an
+    // attacker-controlled value here.
+    #[allow(clippy::expect_used)]
+    HeaderValue::from_str(&raw).expect("session cookie header must be ASCII by construction")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_session_header_carries_all_required_attrs() {
+        let v = build_set_session("opaque-value", 120);
+        let s = v.to_str().expect("ascii");
+
+        assert!(s.starts_with("__Host-sid=opaque-value"), "name and value");
+        assert!(s.contains("Max-Age=120"));
+        assert!(s.contains("Path=/"));
+        assert!(s.contains("Secure"));
+        assert!(s.contains("HttpOnly"));
+        assert!(s.contains("SameSite=Strict"));
+        assert!(!s.contains("Domain="), "no Domain attribute");
+    }
+
+    #[test]
+    fn clear_header_uses_max_age_zero_with_full_attrs() {
+        let v = build_clear_session();
+        let s = v.to_str().expect("ascii");
+
+        assert!(s.starts_with("__Host-sid="));
+        assert!(s.contains("Max-Age=0"));
+        assert!(s.contains("Path=/"));
+        assert!(s.contains("Secure"));
+        assert!(s.contains("HttpOnly"));
+        assert!(s.contains("SameSite=Strict"));
+        assert!(!s.contains("Domain="));
+    }
+
+    #[test]
+    fn snapshot_set_session_120s() {
+        // Hard snapshot — if this changes, somebody touched cookie hardening.
+        // Anyone updating this needs to re-run the security review.
+        let v = build_set_session("AAAA", 120);
+        let s = v.to_str().expect("ascii");
+        assert_eq!(
+            s,
+            "__Host-sid=AAAA; Max-Age=120; Path=/; Secure; HttpOnly; SameSite=Strict"
+        );
+    }
+
+    #[test]
+    fn snapshot_clear_session() {
+        let v = build_clear_session();
+        let s = v.to_str().expect("ascii");
+        assert_eq!(
+            s,
+            "__Host-sid=; Max-Age=0; Path=/; Secure; HttpOnly; SameSite=Strict"
+        );
+    }
+
+    #[test]
+    fn read_session_cookie_finds_value() {
+        let h = HeaderValue::from_static("foo=bar; __Host-sid=abc; baz=qux");
+        assert_eq!(read_session_cookie(Some(&h)), Some("abc".to_owned()));
+    }
+
+    #[test]
+    fn read_session_cookie_returns_none_when_absent() {
+        let h = HeaderValue::from_static("foo=bar; baz=qux");
+        assert_eq!(read_session_cookie(Some(&h)), None);
+        assert_eq!(read_session_cookie(None), None);
+    }
+
+    #[test]
+    fn read_session_cookie_handles_only_cookie() {
+        let h = HeaderValue::from_static("__Host-sid=alone");
+        assert_eq!(read_session_cookie(Some(&h)), Some("alone".to_owned()));
+    }
+
+    #[test]
+    fn read_session_cookie_strips_quoted_value() {
+        let h = HeaderValue::from_static("__Host-sid=\"quoted-val\"");
+        assert_eq!(read_session_cookie(Some(&h)), Some("quoted-val".to_owned()));
+    }
+
+    #[test]
+    fn read_session_cookie_rejects_duplicate_session_cookies() {
+        // Two `__Host-sid` cookies in the same header — refuse to guess.
+        let h = HeaderValue::from_static("__Host-sid=first; __Host-sid=second");
+        assert_eq!(read_session_cookie(Some(&h)), None);
+    }
+
+    #[test]
+    fn read_session_cookie_does_not_match_substring_of_other_cookie() {
+        // A cookie whose value mentions `__Host-sid=...` must not be
+        // treated as the session cookie.
+        let h = HeaderValue::from_static("foo=__Host-sid=evil; bar=baz");
+        assert_eq!(read_session_cookie(Some(&h)), None);
+    }
+}

--- a/src/backend/services/api-gateway/src/bff/cookies.rs
+++ b/src/backend/services/api-gateway/src/bff/cookies.rs
@@ -4,12 +4,17 @@
 //! MUST carry `__Host-` prefix, `HttpOnly`, `Secure`, `SameSite=Strict`,
 //! `Path=/`, no `Domain`. We build every `Set-Cookie` here via the typed
 //! `cookie` crate (re-exported by `axum-extra`) so the attribute set is
-//! constructed structurally rather than concatenated by hand. The
-//! snapshot tests below pin the exact rendered string so any
-//! crate-version drift fails CI explicitly instead of silently changing
-//! header bytes that browsers consume.
+//! constructed structurally rather than concatenated by hand.
+//!
+//! Handlers don't touch any of that. They compose a tuple response with
+//! [`SessionCookie::set`] (after login or refresh) or
+//! [`SessionCookie::clear`] (logout, 401 paths), and `IntoResponseParts`
+//! does the encoding and `Set-Cookie` insertion.
 
-use axum::http::HeaderValue;
+use std::convert::Infallible;
+
+use axum::http::{HeaderValue, header};
+use axum::response::{IntoResponseParts, ResponseParts};
 use axum_extra::extract::cookie::{Cookie, SameSite};
 use time::Duration;
 
@@ -19,20 +24,53 @@ use time::Duration;
 ///   * forbid Domain — pinning the cookie to one host
 pub const SESSION_COOKIE_NAME: &str = "__Host-sid";
 
-/// Build a `Set-Cookie` header value that establishes a fresh session.
+/// Typed response-part for the BFF session cookie. Constructed by
+/// handlers and composed into a tuple response; `IntoResponseParts`
+/// renders the full attribute set and appends a single `Set-Cookie`
+/// header. Callers never see `Max-Age` arithmetic or `HeaderName`s.
+///
+/// ```ignore
+/// (StatusCode::OK, no_store(), SessionCookie::set(&sid, expires_at, now), Json(view))
+///     .into_response()
+/// ```
 #[must_use]
-pub fn build_set_session(value: &str, max_age_seconds: i64) -> HeaderValue {
-    render(&session_cookie(value, max_age_seconds))
+pub struct SessionCookie<'a> {
+    value: &'a str,
+    max_age_seconds: i64,
 }
 
-/// Build a `Set-Cookie` header value that clears the session.
-///
-/// Empty value + `Max-Age=0` evicts the cookie. We still emit every
-/// other attribute identically to the live cookie so a buggy browser
-/// never ends up with a cookie carrying weaker attrs than the original.
-#[must_use]
-pub fn build_clear_session() -> HeaderValue {
-    render(&session_cookie("", 0))
+impl<'a> SessionCookie<'a> {
+    /// Set the cookie to `sid` with `Max-Age = max(expires_at - now, 0)`.
+    /// `expires_at` and `now` are both absolute epoch seconds; the helper
+    /// turns them into the residual lifetime so callers can pass the
+    /// session record's `expires_at` directly without restating the
+    /// subtraction.
+    pub fn set(sid: &'a str, expires_at: i64, now: i64) -> Self {
+        Self {
+            value: sid,
+            max_age_seconds: expires_at.saturating_sub(now).max(0),
+        }
+    }
+
+    /// Clear the cookie. Empty value + `Max-Age=0`, every other attribute
+    /// identical to the live cookie so a buggy browser never ends up with
+    /// weaker attrs than the original.
+    pub fn clear() -> SessionCookie<'static> {
+        SessionCookie {
+            value: "",
+            max_age_seconds: 0,
+        }
+    }
+}
+
+impl IntoResponseParts for SessionCookie<'_> {
+    type Error = Infallible;
+
+    fn into_response_parts(self, mut res: ResponseParts) -> Result<ResponseParts, Self::Error> {
+        let value = render(&build_cookie(self.value, self.max_age_seconds));
+        res.headers_mut().append(header::SET_COOKIE, value);
+        Ok(res)
+    }
 }
 
 /// Read the BFF session cookie value from a single `Cookie` header.
@@ -75,10 +113,9 @@ fn unquote(s: &str) -> &str {
 }
 
 /// Construct a `Cookie` carrying the full attribute set mandated by
-/// `cpt-insightspec-nfr-bff-cookie-attrs`. Owned here as the only path
-/// that builds session cookies — every caller goes through
-/// `build_set_session` / `build_clear_session`.
-fn session_cookie(value: &str, max_age_seconds: i64) -> Cookie<'static> {
+/// `cpt-insightspec-nfr-bff-cookie-attrs`. Single source of truth for
+/// what makes a session cookie valid.
+fn build_cookie(value: &str, max_age_seconds: i64) -> Cookie<'static> {
     Cookie::build((SESSION_COOKIE_NAME, value.to_owned()))
         .http_only(true)
         .secure(true)
@@ -104,14 +141,31 @@ fn render(c: &Cookie<'_>) -> HeaderValue {
 mod tests {
     use super::*;
 
-    #[test]
-    fn set_session_header_carries_all_required_attrs() {
-        let v = build_set_session("opaque-value", 120);
-        let s = v.to_str().expect("ascii");
+    /// Round-trip a `SessionCookie` through the axum tuple-response
+    /// machinery and return the rendered `Set-Cookie` header string —
+    /// exactly what a handler's `(StatusCode, …, SessionCookie::…)`
+    /// would emit on the wire.
+    fn emit(c: SessionCookie<'_>) -> String {
+        use axum::http::StatusCode;
+        use axum::response::IntoResponse;
+        // `(StatusCode, IntoResponseParts, IntoResponse)` is axum's
+        // canonical "status + headers + body" shape; the `()` body keeps
+        // the test tight without bringing `Body::empty()` into scope.
+        let resp = (StatusCode::OK, c, ()).into_response();
+        resp.headers()
+            .get(header::SET_COOKIE)
+            .expect("set-cookie present")
+            .to_str()
+            .expect("ascii")
+            .to_owned()
+    }
 
+    #[test]
+    fn set_carries_all_required_attrs() {
+        let s = emit(SessionCookie::set("opaque-value", 220, 100));
         assert!(
             s.starts_with("__Host-sid=opaque-value"),
-            "name and value first",
+            "name + value first"
         );
         assert!(s.contains("Max-Age=120"));
         assert!(s.contains("Path=/"));
@@ -122,10 +176,8 @@ mod tests {
     }
 
     #[test]
-    fn clear_header_uses_max_age_zero_with_full_attrs() {
-        let v = build_clear_session();
-        let s = v.to_str().expect("ascii");
-
+    fn clear_uses_max_age_zero_with_full_attrs() {
+        let s = emit(SessionCookie::clear());
         assert!(s.starts_with("__Host-sid="));
         assert!(s.contains("Max-Age=0"));
         assert!(s.contains("Path=/"));
@@ -141,8 +193,7 @@ mod tests {
         // (or bumped the `cookie` crate to a version that emits attributes
         // in a different order). Either path needs a fresh security review
         // before the snapshot is updated.
-        let v = build_set_session("AAAA", 120);
-        let s = v.to_str().expect("ascii");
+        let s = emit(SessionCookie::set("AAAA", 220, 100));
         assert_eq!(
             s,
             "__Host-sid=AAAA; HttpOnly; SameSite=Strict; Secure; Path=/; Max-Age=120",
@@ -151,12 +202,20 @@ mod tests {
 
     #[test]
     fn snapshot_clear_session() {
-        let v = build_clear_session();
-        let s = v.to_str().expect("ascii");
+        let s = emit(SessionCookie::clear());
         assert_eq!(
             s,
             "__Host-sid=; HttpOnly; SameSite=Strict; Secure; Path=/; Max-Age=0",
         );
+    }
+
+    #[test]
+    fn set_clamps_negative_residual_to_zero() {
+        // `now` past `expires_at` — without the clamp, `Max-Age=-N` would
+        // be rendered (cookie crate accepts negative). We floor to 0 so the
+        // browser evicts immediately rather than holding a confused cookie.
+        let s = emit(SessionCookie::set("AAAA", 100, 500));
+        assert!(s.contains("Max-Age=0"));
     }
 
     #[test]

--- a/src/backend/services/api-gateway/src/bff/cookies.rs
+++ b/src/backend/services/api-gateway/src/bff/cookies.rs
@@ -2,10 +2,16 @@
 //!
 //! Per `cpt-insightspec-nfr-bff-cookie-attrs` every session-cookie response
 //! MUST carry `__Host-` prefix, `HttpOnly`, `Secure`, `SameSite=Strict`,
-//! `Path=/`, no `Domain`. We hard-code those attributes here so any other
-//! call site has to go through these helpers.
+//! `Path=/`, no `Domain`. We build every `Set-Cookie` here via the typed
+//! `cookie` crate (re-exported by `axum-extra`) so the attribute set is
+//! constructed structurally rather than concatenated by hand. The
+//! snapshot tests below pin the exact rendered string so any
+//! crate-version drift fails CI explicitly instead of silently changing
+//! header bytes that browsers consume.
 
 use axum::http::HeaderValue;
+use axum_extra::extract::cookie::{Cookie, SameSite};
+use time::Duration;
 
 /// Name of the BFF session cookie. The `__Host-` prefix tells the browser to:
 ///   * require Secure
@@ -16,16 +22,17 @@ pub const SESSION_COOKIE_NAME: &str = "__Host-sid";
 /// Build a `Set-Cookie` header value that establishes a fresh session.
 #[must_use]
 pub fn build_set_session(value: &str, max_age_seconds: i64) -> HeaderValue {
-    cookie_header(value, max_age_seconds)
+    render(&session_cookie(value, max_age_seconds))
 }
 
 /// Build a `Set-Cookie` header value that clears the session.
+///
+/// Empty value + `Max-Age=0` evicts the cookie. We still emit every
+/// other attribute identically to the live cookie so a buggy browser
+/// never ends up with a cookie carrying weaker attrs than the original.
 #[must_use]
 pub fn build_clear_session() -> HeaderValue {
-    // Empty value + Max-Age=0 evicts the cookie. We still set every other
-    // attribute identically to the live cookie so a buggy browser never
-    // ends up with a cookie that has weaker attrs than the original.
-    cookie_header("", 0)
+    render(&session_cookie("", 0))
 }
 
 /// Read the BFF session cookie value from a single `Cookie` header.
@@ -36,28 +43,25 @@ pub fn build_clear_session() -> HeaderValue {
 ///   * **more than one** `__Host-sid` cookie is present (RFC 6265bis
 ///     leaves duplicate handling undefined — we reject to avoid an
 ///     attacker-set duplicate masking the real cookie).
-///
-/// Strips an optional pair of surrounding double-quotes so a quoted
-/// cookie value `"abc"` matches the unquoted SID we generated.
 #[must_use]
 pub fn read_session_cookie(cookie_header: Option<&HeaderValue>) -> Option<String> {
     let raw = cookie_header?.to_str().ok()?;
     let mut found: Option<String> = None;
-    for pair in raw.split(';') {
-        let trimmed = pair.trim();
-        let Some((name, value)) = trimmed.split_once('=') else {
-            continue;
-        };
-        if name.trim() != SESSION_COOKIE_NAME {
+    for parsed in Cookie::split_parse(raw) {
+        let Ok(c) = parsed else { continue };
+        if c.name() != SESSION_COOKIE_NAME {
             continue;
         }
-        let v = unquote(value.trim()).to_owned();
         if found.is_some() {
-            // Duplicate __Host-sid in the same Cookie header — refuse
+            // Duplicate `__Host-sid` in the same Cookie header — refuse
             // rather than guess which one is genuine.
             return None;
         }
-        found = Some(v);
+        // RFC 6265 allows a cookie value to be wrapped in double quotes;
+        // the `cookie` crate's parser preserves them verbatim. The
+        // SIDs we mint never contain quotes, so stripping a matching
+        // outer pair is a safe normalization.
+        found = Some(unquote(c.value()).to_owned());
     }
     found
 }
@@ -70,19 +74,30 @@ fn unquote(s: &str) -> &str {
     }
 }
 
-fn cookie_header(value: &str, max_age_seconds: i64) -> HeaderValue {
-    // RFC 6265 cookie attributes. Order is convention; all attributes are
-    // mandatory to keep `cpt-insightspec-nfr-bff-cookie-attrs` honest.
-    let raw = format!(
-        "{SESSION_COOKIE_NAME}={value}; Max-Age={max_age_seconds}; Path=/; Secure; HttpOnly; SameSite=Strict",
-    );
+/// Construct a `Cookie` carrying the full attribute set mandated by
+/// `cpt-insightspec-nfr-bff-cookie-attrs`. Owned here as the only path
+/// that builds session cookies — every caller goes through
+/// `build_set_session` / `build_clear_session`.
+fn session_cookie(value: &str, max_age_seconds: i64) -> Cookie<'static> {
+    Cookie::build((SESSION_COOKIE_NAME, value.to_owned()))
+        .http_only(true)
+        .secure(true)
+        .same_site(SameSite::Strict)
+        .path("/")
+        .max_age(Duration::seconds(max_age_seconds))
+        .build()
+}
+
+fn render(c: &Cookie<'_>) -> HeaderValue {
     // Inputs are: a fixed ASCII cookie name, an opaque base64url session
     // value (alphanumeric + `-_`) we generate ourselves in `secrets.rs`,
-    // and a signed integer. None can introduce non-ASCII bytes; the
-    // expect can never fire unless the program is rewritten to pass an
-    // attacker-controlled value here.
+    // and a signed integer Max-Age. None can introduce non-ASCII bytes,
+    // and the cookie crate's encoder rejects control characters at parse
+    // time, so this expect can only fire if the program is rewritten to
+    // pass an attacker-controlled value here.
     #[allow(clippy::expect_used)]
-    HeaderValue::from_str(&raw).expect("session cookie header must be ASCII by construction")
+    HeaderValue::from_str(&c.to_string())
+        .expect("session cookie header must be ASCII by construction")
 }
 
 #[cfg(test)]
@@ -94,7 +109,10 @@ mod tests {
         let v = build_set_session("opaque-value", 120);
         let s = v.to_str().expect("ascii");
 
-        assert!(s.starts_with("__Host-sid=opaque-value"), "name and value");
+        assert!(
+            s.starts_with("__Host-sid=opaque-value"),
+            "name and value first",
+        );
         assert!(s.contains("Max-Age=120"));
         assert!(s.contains("Path=/"));
         assert!(s.contains("Secure"));
@@ -119,13 +137,15 @@ mod tests {
 
     #[test]
     fn snapshot_set_session_120s() {
-        // Hard snapshot — if this changes, somebody touched cookie hardening.
-        // Anyone updating this needs to re-run the security review.
+        // Hard snapshot — if this changes, somebody touched cookie hardening
+        // (or bumped the `cookie` crate to a version that emits attributes
+        // in a different order). Either path needs a fresh security review
+        // before the snapshot is updated.
         let v = build_set_session("AAAA", 120);
         let s = v.to_str().expect("ascii");
         assert_eq!(
             s,
-            "__Host-sid=AAAA; Max-Age=120; Path=/; Secure; HttpOnly; SameSite=Strict"
+            "__Host-sid=AAAA; HttpOnly; SameSite=Strict; Secure; Path=/; Max-Age=120",
         );
     }
 
@@ -135,7 +155,7 @@ mod tests {
         let s = v.to_str().expect("ascii");
         assert_eq!(
             s,
-            "__Host-sid=; Max-Age=0; Path=/; Secure; HttpOnly; SameSite=Strict"
+            "__Host-sid=; HttpOnly; SameSite=Strict; Secure; Path=/; Max-Age=0",
         );
     }
 

--- a/src/backend/services/api-gateway/src/bff/errors.rs
+++ b/src/backend/services/api-gateway/src/bff/errors.rs
@@ -1,38 +1,64 @@
-//! Typed errors for the BFF, with RFC 9457 Problem conversion.
+//! BFF errors, rendered through the constructor-fabric canonical error
+//! envelope (`modkit-canonical-errors`).
 //!
-//! Public-facing handler errors all flow through the `IntoResponse` impl on
-//! `BffError`, which renders a `application/problem+json` body. Internal
-//! callers can pattern-match on the variant.
+//! Internal callers pattern-match on `BffError` variants. The wire shape
+//! is the same RFC 9457 `application/problem+json` envelope the rest of
+//! the Insight backend emits — `type` is a `gts://…/cf.core.err.*` URI,
+//! `context.resource_type` scopes BFF-owned resources, and structured
+//! `field_violations` / `quota_violations` carry the failure reason.
+//!
+//! Mapping (`BffError` → canonical):
+//!
+//! | Variant            | Canonical                  | HTTP |
+//! |--------------------|----------------------------|------|
+//! | `Unauthorized`     | `unauthenticated` + reason | 401  |
+//! | `BadRequest`       | `invalid_argument`         | 400  |
+//! | `Idp`              | `service_unavailable`      | 503  |
+//! | `StoreUnavailable` | `service_unavailable`      | 503  |
+//! | `Internal`         | `internal` + diagnostic    | 500  |
+//! | `RateLimited`      | `resource_exhausted`       | 429  |
+//!
+//! `Idp` used to map to HTTP 502, but the canonical-error standard set
+//! has no 502 slot. 503 is the closest semantic match (external IdP
+//! unreachable from the BFF's perspective) and keeps the wire envelope
+//! consistent with the rest of the platform.
 
-use axum::Json;
-use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use serde_json::json;
+use modkit_canonical_errors::{CanonicalError, resource_error};
 use thiserror::Error;
+
+/// Resource namespace for every BFF-emitted canonical error. Same scheme
+/// as the analytics-api namespaces — `gts.cf.<repo>.<service>.<area>.v1~`.
+#[resource_error("gts.cf.insight.api_gateway.bff.v1~")]
+pub struct BffResource;
 
 #[derive(Debug, Error)]
 #[allow(dead_code)]
 pub enum BffError {
-    /// Generic 401 — used for missing/expired/invalid session cookies and
-    /// for OIDC state/nonce mismatches.
+    /// 401 — missing/expired/invalid session cookie, or OIDC state/nonce
+    /// mismatch. The static `&str` is the wire-facing reason.
     #[error("unauthorized: {0}")]
     Unauthorized(&'static str),
 
     /// 400 — malformed request shape that wasn't caught by extractor
-    /// validation.
+    /// validation. The static `&str` becomes a field-violation `reason`
+    /// scoped to the synthetic `request` field.
     #[error("bad request: {0}")]
     BadRequest(&'static str),
 
-    /// 502 — IdP unreachable or returned a non-OK status.
+    /// 503 — IdP unreachable or returned a non-OK status. The diagnostic
+    /// string is logged server-side but never echoed in the wire body.
     #[error("upstream IdP error: {0}")]
     Idp(String),
 
-    /// 503 — Redis unreachable (DD-BFF-06: fail closed).
+    /// 503 — Redis unreachable (DD-BFF-06: fail closed). Diagnostic
+    /// logged server-side only.
     #[error("session store unavailable: {0}")]
     StoreUnavailable(String),
 
-    /// 500 — anything we did not categorize. Detail is intentionally
-    /// generic in the response body; the source error is logged.
+    /// 500 — uncategorized internal failure. Diagnostic surfaces through
+    /// `CanonicalError::diagnostic()` for server-side logs but stays out
+    /// of the response body.
     #[error("internal: {0}")]
     Internal(#[from] anyhow::Error),
 
@@ -42,74 +68,48 @@ pub enum BffError {
 }
 
 impl BffError {
-    fn problem_parts(&self) -> (StatusCode, &'static str, &'static str, String) {
+    fn to_canonical(&self) -> CanonicalError {
         match self {
-            Self::Unauthorized(msg) => (
-                StatusCode::UNAUTHORIZED,
-                "Unauthorized",
-                "urn:insight:error:unauthorized",
-                (*msg).to_string(),
-            ),
-            Self::BadRequest(msg) => (
-                StatusCode::BAD_REQUEST,
-                "Bad Request",
-                "urn:insight:error:bad_request",
-                (*msg).to_string(),
-            ),
-            Self::Idp(detail) => (
-                StatusCode::BAD_GATEWAY,
-                "Bad Gateway",
-                "urn:insight:error:idp_unreachable",
-                detail.clone(),
-            ),
-            Self::StoreUnavailable(detail) => (
-                StatusCode::SERVICE_UNAVAILABLE,
-                "Service Unavailable",
-                "urn:insight:error:session_store_unavailable",
-                detail.clone(),
-            ),
-            Self::Internal(_) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Internal Server Error",
-                "urn:insight:error:internal",
-                "internal error".to_owned(),
-            ),
-            Self::RateLimited => (
-                StatusCode::TOO_MANY_REQUESTS,
-                "Too Many Requests",
-                "urn:insight:error:rate_limited",
-                "rate limited".to_owned(),
-            ),
+            Self::Unauthorized(reason) => CanonicalError::unauthenticated()
+                .with_reason((*reason).to_owned())
+                .create(),
+            Self::BadRequest(reason) => BffResource::invalid_argument()
+                .with_field_violation("request", (*reason).to_owned(), "INVALID")
+                .create(),
+            // `service_unavailable` collapses both "IdP unreachable" and
+            // "Redis unreachable" — wire-side they both mean "an upstream
+            // the BFF depends on is currently down; try again later".
+            // The variant-specific diagnostic is captured in the trace
+            // log emitted by `into_response`.
+            Self::Idp(_) | Self::StoreUnavailable(_) => {
+                CanonicalError::service_unavailable().create()
+            }
+            Self::Internal(err) => CanonicalError::internal(err.to_string()).create(),
+            Self::RateLimited => BffResource::resource_exhausted("rate limit exceeded on /auth/*")
+                .with_quota_violation("auth_rate", "per-IP / per-pod auth rate limit hit")
+                .create(),
         }
     }
 }
 
 impl IntoResponse for BffError {
     fn into_response(self) -> Response {
-        let (status, title, type_uri, detail) = self.problem_parts();
-
-        // Log the full error chain for Internal errors — never put it in
-        // the body.
-        if matches!(self, Self::Internal(_)) {
-            tracing::error!(error = %self, "BFF internal error");
-        } else {
-            tracing::warn!(error = %self, status = %status.as_u16(), "BFF error");
+        // Log the full error chain before erasing it. The canonical
+        // envelope intentionally hides diagnostic text from clients for
+        // `Internal` / `ServiceUnavailable`; we keep that visible
+        // server-side for operators correlating with `trace_id`.
+        match &self {
+            Self::Internal(_) => {
+                tracing::error!(error = %self, "BFF internal error");
+            }
+            Self::Idp(_) | Self::StoreUnavailable(_) => {
+                tracing::warn!(error = %self, "BFF upstream error");
+            }
+            _ => {
+                tracing::warn!(error = %self, "BFF error");
+            }
         }
-
-        let body = json!({
-            "type": type_uri,
-            "title": title,
-            "status": status.as_u16(),
-            "detail": detail,
-        });
-
-        let mut resp = (status, Json(body)).into_response();
-        // RFC 9457 §3 mandates application/problem+json
-        resp.headers_mut().insert(
-            axum::http::header::CONTENT_TYPE,
-            axum::http::HeaderValue::from_static("application/problem+json"),
-        );
-        resp
+        self.to_canonical().into_response()
     }
 }
 
@@ -117,27 +117,133 @@ impl IntoResponse for BffError {
 mod tests {
     use super::*;
     use axum::body::to_bytes;
+    use axum::http::header::CONTENT_TYPE;
 
-    #[tokio::test]
-    async fn unauthorized_renders_problem_json() {
-        let r = BffError::Unauthorized("no session").into_response();
-        assert_eq!(r.status(), StatusCode::UNAUTHORIZED);
-        let ct = r
+    async fn problem_body(err: BffError) -> (u16, serde_json::Value) {
+        let resp = err.into_response();
+        let status = resp.status().as_u16();
+        let ct = resp
             .headers()
-            .get(axum::http::header::CONTENT_TYPE)
-            .expect("ct");
-        assert_eq!(ct, "application/problem+json");
-        let bytes = to_bytes(r.into_body(), 4096).await.expect("body");
-        let v: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
-        assert_eq!(v["status"], 401);
-        assert_eq!(v["type"], "urn:insight:error:unauthorized");
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .expect("content-type present")
+            .to_owned();
+        assert_eq!(
+            ct, "application/problem+json",
+            "RFC 9457 mandates problem+json",
+        );
+        let bytes = to_bytes(resp.into_body(), 8192).await.expect("body");
+        (
+            status,
+            serde_json::from_slice(&bytes).expect("problem json"),
+        )
     }
 
     #[tokio::test]
-    async fn internal_response_does_not_leak_detail() {
-        let r = BffError::Internal(anyhow::anyhow!("secret-implementation-detail")).into_response();
-        let bytes = to_bytes(r.into_body(), 4096).await.expect("body");
-        let v: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
-        assert_eq!(v["detail"], "internal error");
+    async fn unauthorized_maps_to_canonical_unauthenticated() {
+        let (status, p) = problem_body(BffError::Unauthorized("no session")).await;
+        assert_eq!(status, 401);
+        assert_eq!(
+            p["type"],
+            "gts://gts.cf.core.errors.err.v1~cf.core.err.unauthenticated.v1~",
+        );
+        assert_eq!(p["title"], "Unauthenticated");
+        assert_eq!(p["context"]["reason"], "no session");
+    }
+
+    #[tokio::test]
+    async fn bad_request_maps_to_invalid_argument_with_field_violation() {
+        let (status, p) = problem_body(BffError::BadRequest("state mismatch or expired")).await;
+        assert_eq!(status, 400);
+        assert_eq!(
+            p["type"],
+            "gts://gts.cf.core.errors.err.v1~cf.core.err.invalid_argument.v1~",
+        );
+        assert_eq!(
+            p["context"]["resource_type"],
+            "gts.cf.insight.api_gateway.bff.v1~",
+        );
+        let violations = p["context"]["field_violations"]
+            .as_array()
+            .expect("field violations present");
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0]["field"], "request");
+        assert_eq!(violations[0]["description"], "state mismatch or expired");
+        assert_eq!(violations[0]["reason"], "INVALID");
+    }
+
+    #[tokio::test]
+    async fn idp_maps_to_service_unavailable() {
+        let (status, p) = problem_body(BffError::Idp("token endpoint: timeout".into())).await;
+        assert_eq!(status, 503);
+        assert_eq!(
+            p["type"],
+            "gts://gts.cf.core.errors.err.v1~cf.core.err.service_unavailable.v1~",
+        );
+        // Diagnostic stays in tracing logs; never in the wire body.
+        let body_str = p.to_string();
+        assert!(
+            !body_str.contains("token endpoint: timeout"),
+            "diagnostic must not leak to the wire response",
+        );
+    }
+
+    #[tokio::test]
+    async fn store_unavailable_maps_to_service_unavailable() {
+        let (status, p) = problem_body(BffError::StoreUnavailable(
+            "redis connection refused".into(),
+        ))
+        .await;
+        assert_eq!(status, 503);
+        assert_eq!(
+            p["type"],
+            "gts://gts.cf.core.errors.err.v1~cf.core.err.service_unavailable.v1~",
+        );
+        let body_str = p.to_string();
+        assert!(
+            !body_str.contains("redis connection refused"),
+            "diagnostic must not leak to the wire response",
+        );
+    }
+
+    #[tokio::test]
+    async fn internal_renders_as_canonical_internal_without_leaking_detail() {
+        let (status, p) = problem_body(BffError::Internal(anyhow::anyhow!("secret-detail"))).await;
+        assert_eq!(status, 500);
+        assert_eq!(
+            p["type"],
+            "gts://gts.cf.core.errors.err.v1~cf.core.err.internal.v1~",
+        );
+        let body_str = p.to_string();
+        assert!(
+            !body_str.contains("secret-detail"),
+            "anyhow detail must not leak to the wire response",
+        );
+    }
+
+    #[tokio::test]
+    async fn rate_limited_maps_to_resource_exhausted_with_quota_violation() {
+        let (status, p) = problem_body(BffError::RateLimited).await;
+        assert_eq!(status, 429);
+        assert_eq!(
+            p["type"],
+            "gts://gts.cf.core.errors.err.v1~cf.core.err.resource_exhausted.v1~",
+        );
+        assert_eq!(
+            p["context"]["resource_type"],
+            "gts.cf.insight.api_gateway.bff.v1~",
+        );
+        // The canonical envelope flattens quota-category violations under
+        // `context.violations`. Pin both the subject (machine-readable
+        // throttle id) and the description.
+        let violations = p["context"]["violations"]
+            .as_array()
+            .expect("quota violations present");
+        assert_eq!(violations.len(), 1);
+        assert_eq!(violations[0]["subject"], "auth_rate");
+        assert_eq!(
+            violations[0]["description"],
+            "per-IP / per-pod auth rate limit hit",
+        );
     }
 }

--- a/src/backend/services/api-gateway/src/bff/errors.rs
+++ b/src/backend/services/api-gateway/src/bff/errors.rs
@@ -1,0 +1,143 @@
+//! Typed errors for the BFF, with RFC 9457 Problem conversion.
+//!
+//! Public-facing handler errors all flow through the `IntoResponse` impl on
+//! `BffError`, which renders a `application/problem+json` body. Internal
+//! callers can pattern-match on the variant.
+
+use axum::Json;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde_json::json;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[allow(dead_code)]
+pub enum BffError {
+    /// Generic 401 — used for missing/expired/invalid session cookies and
+    /// for OIDC state/nonce mismatches.
+    #[error("unauthorized: {0}")]
+    Unauthorized(&'static str),
+
+    /// 400 — malformed request shape that wasn't caught by extractor
+    /// validation.
+    #[error("bad request: {0}")]
+    BadRequest(&'static str),
+
+    /// 502 — IdP unreachable or returned a non-OK status.
+    #[error("upstream IdP error: {0}")]
+    Idp(String),
+
+    /// 503 — Redis unreachable (DD-BFF-06: fail closed).
+    #[error("session store unavailable: {0}")]
+    StoreUnavailable(String),
+
+    /// 500 — anything we did not categorize. Detail is intentionally
+    /// generic in the response body; the source error is logged.
+    #[error("internal: {0}")]
+    Internal(#[from] anyhow::Error),
+
+    /// 429 — login-state cap or per-IP rate limit hit.
+    #[error("rate limited")]
+    RateLimited,
+}
+
+impl BffError {
+    fn problem_parts(&self) -> (StatusCode, &'static str, &'static str, String) {
+        match self {
+            Self::Unauthorized(msg) => (
+                StatusCode::UNAUTHORIZED,
+                "Unauthorized",
+                "urn:insight:error:unauthorized",
+                (*msg).to_string(),
+            ),
+            Self::BadRequest(msg) => (
+                StatusCode::BAD_REQUEST,
+                "Bad Request",
+                "urn:insight:error:bad_request",
+                (*msg).to_string(),
+            ),
+            Self::Idp(detail) => (
+                StatusCode::BAD_GATEWAY,
+                "Bad Gateway",
+                "urn:insight:error:idp_unreachable",
+                detail.clone(),
+            ),
+            Self::StoreUnavailable(detail) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Service Unavailable",
+                "urn:insight:error:session_store_unavailable",
+                detail.clone(),
+            ),
+            Self::Internal(_) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal Server Error",
+                "urn:insight:error:internal",
+                "internal error".to_owned(),
+            ),
+            Self::RateLimited => (
+                StatusCode::TOO_MANY_REQUESTS,
+                "Too Many Requests",
+                "urn:insight:error:rate_limited",
+                "rate limited".to_owned(),
+            ),
+        }
+    }
+}
+
+impl IntoResponse for BffError {
+    fn into_response(self) -> Response {
+        let (status, title, type_uri, detail) = self.problem_parts();
+
+        // Log the full error chain for Internal errors — never put it in
+        // the body.
+        if matches!(self, Self::Internal(_)) {
+            tracing::error!(error = %self, "BFF internal error");
+        } else {
+            tracing::warn!(error = %self, status = %status.as_u16(), "BFF error");
+        }
+
+        let body = json!({
+            "type": type_uri,
+            "title": title,
+            "status": status.as_u16(),
+            "detail": detail,
+        });
+
+        let mut resp = (status, Json(body)).into_response();
+        // RFC 9457 §3 mandates application/problem+json
+        resp.headers_mut().insert(
+            axum::http::header::CONTENT_TYPE,
+            axum::http::HeaderValue::from_static("application/problem+json"),
+        );
+        resp
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+
+    #[tokio::test]
+    async fn unauthorized_renders_problem_json() {
+        let r = BffError::Unauthorized("no session").into_response();
+        assert_eq!(r.status(), StatusCode::UNAUTHORIZED);
+        let ct = r
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .expect("ct");
+        assert_eq!(ct, "application/problem+json");
+        let bytes = to_bytes(r.into_body(), 4096).await.expect("body");
+        let v: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        assert_eq!(v["status"], 401);
+        assert_eq!(v["type"], "urn:insight:error:unauthorized");
+    }
+
+    #[tokio::test]
+    async fn internal_response_does_not_leak_detail() {
+        let r = BffError::Internal(anyhow::anyhow!("secret-implementation-detail")).into_response();
+        let bytes = to_bytes(r.into_body(), 4096).await.expect("body");
+        let v: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        assert_eq!(v["detail"], "internal error");
+    }
+}

--- a/src/backend/services/api-gateway/src/bff/handlers/callback.rs
+++ b/src/backend/services/api-gateway/src/bff/handlers/callback.rs
@@ -19,7 +19,7 @@ use axum::response::{IntoResponse, Response};
 use serde::Deserialize;
 
 use crate::bff::audit::{AuthEvent, AuthEventKind, hash_session_id};
-use crate::bff::cookies::{build_set_session, read_session_cookie};
+use crate::bff::cookies::{SessionCookie, read_session_cookie};
 use crate::bff::errors::BffError;
 use crate::bff::handlers::{BffState, no_store};
 use crate::bff::identity;
@@ -141,17 +141,13 @@ pub async fn callback(
     // login-state records.
     let return_to = super::login::sanitize_return_to(Some(&ls.return_to));
 
-    let max_age = i64::try_from(st.cfg.session.ttl_seconds).unwrap_or(i64::MAX);
-    let set_cookie = build_set_session(&outcome.session_id, max_age);
     let location = HeaderValue::from_str(&return_to)
         .map_err(|e| BffError::Internal(anyhow::anyhow!("return_to not ASCII: {e}")))?;
     Ok((
         StatusCode::FOUND,
         no_store(),
-        [
-            (header::LOCATION, location),
-            (header::SET_COOKIE, set_cookie),
-        ],
+        SessionCookie::set(&outcome.session_id, outcome.record.expires_at, now),
+        [(header::LOCATION, location)],
     )
         .into_response())
 }

--- a/src/backend/services/api-gateway/src/bff/handlers/callback.rs
+++ b/src/backend/services/api-gateway/src/bff/handlers/callback.rs
@@ -1,0 +1,268 @@
+//! `GET /auth/callback` — finishes the OIDC handshake.
+//!
+//! 1. Look up `bff:login_state:{state}` (atomic GET+DEL).
+//! 2. If absent → 400. State mismatch / replay / TTL expired all collapse here.
+//! 3. Exchange `code` + `verifier` at the IdP token endpoint.
+//! 4. Validate ID token signature + iss/aud/nonce/exp.
+//! 5. Resolve internal identity (deterministic user_id from iss+sub,
+//!    tenant from config, email/name from validated claims).
+//! 6. Read incoming `__Host-sid` cookie — fixation guard revokes it.
+//! 7. Create session in Redis (atomic MULTI/EXEC).
+//! 8. Set `__Host-sid` cookie + 302 to `return_to`.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::extract::{Query, State};
+use axum::http::{HeaderMap, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+use serde::Deserialize;
+
+use crate::bff::audit::{AuthEvent, AuthEventKind, hash_session_id};
+use crate::bff::cookies::{build_set_session, read_session_cookie};
+use crate::bff::errors::BffError;
+use crate::bff::handlers::BffState;
+use crate::bff::identity;
+use crate::bff::session_store::{CreateSessionRequest, login_state};
+
+#[derive(Debug, Deserialize)]
+pub struct CallbackQuery {
+    pub code: Option<String>,
+    pub state: Option<String>,
+    /// Set by the IdP if the user denied consent or the IdP errored out.
+    pub error: Option<String>,
+    pub error_description: Option<String>,
+}
+
+pub async fn callback(
+    State(state): State<Arc<BffState>>,
+    headers: HeaderMap,
+    Query(q): Query<CallbackQuery>,
+) -> Result<Response, BffError> {
+    let st = state;
+
+    if let Some(err) = q.error.as_deref() {
+        // Log the raw values for debugging, but only echo a normalized
+        // OAuth error code back to the user — the IdP-supplied query is
+        // attacker-influenceable.
+        tracing::warn!(
+            err = %err,
+            err_desc = %q.error_description.as_deref().unwrap_or(""),
+            "OIDC callback returned error",
+        );
+        let safe = sanitize_oauth_error_code(err);
+        crate::bff::audit::emit(
+            AuthEventKind::LoginFail,
+            &AuthEvent {
+                reason: Some(&safe),
+                ..Default::default()
+            },
+        );
+        return Err(BffError::Idp(format!("idp error: {safe}")));
+    }
+
+    let oauth_state = q
+        .state
+        .as_deref()
+        .ok_or(BffError::BadRequest("missing state"))?;
+    let code = q
+        .code
+        .as_deref()
+        .ok_or(BffError::BadRequest("missing code"))?;
+
+    // Atomic take of the login-state record.
+    let ls = login_state::take(&st.redis, oauth_state)
+        .await?
+        .ok_or(BffError::BadRequest("state mismatch or expired"))?;
+
+    let exch = st
+        .oidc
+        .exchange_code(code, &ls.pkce_verifier, &ls.nonce)
+        .await?;
+
+    // Resolve internal identity. user_id == OIDC sub (single issuer per
+    // installation). Tenant comes from config (single-tenant). Identity
+    // Service mapping lands in a separate scope.
+    let resolved = identity::resolve(
+        &exch.claims.sub,
+        exch.claims.email.as_deref(),
+        exch.claims.name.as_deref(),
+        &st.cfg.default_tenant_id,
+    );
+
+    // Fixation guard input: any incoming __Host-sid is treated as
+    // attacker-controlled. We never reuse it.
+    let incoming_sid = read_session_cookie(headers.get(header::COOKIE));
+    let user_agent = headers
+        .get(header::USER_AGENT)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_owned();
+    let ip = client_ip_from_headers(&headers);
+
+    let now = unix_now();
+    let outcome = st
+        .store
+        .create_session(CreateSessionRequest {
+            user_id: &resolved.user_id,
+            tenant_id: &resolved.tenant_id,
+            idp_iss: &exch.claims.iss,
+            idp_sub: &exch.claims.sub,
+            idp_sid: exch.claims.sid.as_deref().unwrap_or(""),
+            id_token: &exch.id_token,
+            email: &resolved.email,
+            display_name: &resolved.display_name,
+            user_agent: &user_agent,
+            ip: &ip,
+            now,
+            session_ttl_seconds: st.cfg.session.ttl_seconds,
+            absolute_lifetime_seconds: st.cfg.session.absolute_lifetime_seconds,
+            incoming_sid: incoming_sid.as_deref(),
+        })
+        .await?;
+
+    crate::bff::audit::emit(
+        AuthEventKind::LoginOk,
+        &AuthEvent {
+            user_id: Some(&resolved.user_id),
+            tenant_id: Some(&resolved.tenant_id),
+            session_id_hash: Some(&hash_session_id(&outcome.session_id)),
+            idp_iss: Some(&exch.claims.iss),
+            idp_sub: Some(&exch.claims.sub),
+            ip: Some(&ip),
+            user_agent: Some(&user_agent),
+            ..Default::default()
+        },
+    );
+
+    // 302 to return_to + Set-Cookie. Even though /auth/login already
+    // sanitized return_to before storing it in Redis, we re-sanitize here
+    // — single source of truth, and defense-in-depth against tampered
+    // login-state records.
+    let return_to = super::login::sanitize_return_to(Some(&ls.return_to));
+
+    let max_age = i64::try_from(st.cfg.session.ttl_seconds).unwrap_or(i64::MAX);
+    let set_cookie = build_set_session(&outcome.session_id, max_age);
+
+    let mut resp = Response::builder()
+        .status(StatusCode::FOUND)
+        .header(header::LOCATION, return_to)
+        .body(axum::body::Body::empty())
+        .map_err(|e| BffError::Internal(anyhow::anyhow!("response builder: {e}")))?;
+    resp.headers_mut().append(header::SET_COOKIE, set_cookie);
+    resp.headers_mut().insert(
+        header::CACHE_CONTROL,
+        axum::http::HeaderValue::from_static("no-store"),
+    );
+
+    Ok(resp.into_response())
+}
+
+/// Sanitize an OAuth error code echoed from the IdP. RFC 6749 §4.1.2.1
+/// defines the error code as `*VSCHAR (%x20-7E)`, but in practice all
+/// real codes are short identifiers (`access_denied`, `invalid_request`).
+/// We keep only `[a-zA-Z0-9_-]` and cap at 64 chars; anything else
+/// collapses to `unknown`.
+fn sanitize_oauth_error_code(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return "unknown".to_owned();
+    }
+    let cleaned: String = trimmed
+        .chars()
+        .take(64)
+        .filter(|c| c.is_ascii_alphanumeric() || *c == '_' || *c == '-')
+        .collect();
+    if cleaned.is_empty() {
+        "unknown".to_owned()
+    } else {
+        cleaned
+    }
+}
+
+/// Best-effort source IP. Honors `X-Forwarded-For` (first hop) when the
+/// gateway is behind a trusted proxy — the ingress in our deployment.
+fn client_ip_from_headers(headers: &HeaderMap) -> String {
+    if let Some(v) = headers.get("x-forwarded-for").and_then(|v| v.to_str().ok())
+        && let Some(first) = v.split(',').next()
+    {
+        let trimmed = first.trim();
+        if !trimmed.is_empty() {
+            return trimmed.to_owned();
+        }
+    }
+    headers
+        .get("x-real-ip")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("")
+        .to_owned()
+}
+
+fn unix_now() -> i64 {
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+    )
+    .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn client_ip_prefers_xff_first_hop() {
+        let mut h = HeaderMap::new();
+        h.insert(
+            "x-forwarded-for",
+            "203.0.113.5, 10.0.0.1".parse().expect("hv"),
+        );
+        assert_eq!(client_ip_from_headers(&h), "203.0.113.5");
+    }
+
+    #[test]
+    fn client_ip_falls_back_to_x_real_ip() {
+        let mut h = HeaderMap::new();
+        h.insert("x-real-ip", "203.0.113.7".parse().expect("hv"));
+        assert_eq!(client_ip_from_headers(&h), "203.0.113.7");
+    }
+
+    #[test]
+    fn client_ip_empty_when_no_headers() {
+        let h = HeaderMap::new();
+        assert_eq!(client_ip_from_headers(&h), "");
+    }
+
+    #[test]
+    fn sanitize_oauth_error_code_keeps_legit_identifiers() {
+        assert_eq!(sanitize_oauth_error_code("access_denied"), "access_denied");
+        assert_eq!(
+            sanitize_oauth_error_code("invalid_request"),
+            "invalid_request"
+        );
+    }
+
+    #[test]
+    fn sanitize_oauth_error_code_strips_suspicious_chars() {
+        assert_eq!(
+            sanitize_oauth_error_code("invalid_request<script>alert(1)</script>"),
+            "invalid_requestscriptalert1script"
+        );
+    }
+
+    #[test]
+    fn sanitize_oauth_error_code_caps_length() {
+        let long = "a".repeat(200);
+        let s = sanitize_oauth_error_code(&long);
+        assert_eq!(s.len(), 64);
+    }
+
+    #[test]
+    fn sanitize_oauth_error_code_handles_empty_and_blank() {
+        assert_eq!(sanitize_oauth_error_code(""), "unknown");
+        assert_eq!(sanitize_oauth_error_code("   "), "unknown");
+        assert_eq!(sanitize_oauth_error_code("@@@"), "unknown");
+    }
+}

--- a/src/backend/services/api-gateway/src/bff/handlers/callback.rs
+++ b/src/backend/services/api-gateway/src/bff/handlers/callback.rs
@@ -202,8 +202,7 @@ fn unix_now() -> i64 {
     i64::try_from(
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0),
+            .map_or(0, |d| d.as_secs()),
     )
     .unwrap_or(0)
 }

--- a/src/backend/services/api-gateway/src/bff/handlers/callback.rs
+++ b/src/backend/services/api-gateway/src/bff/handlers/callback.rs
@@ -11,7 +11,6 @@
 //! 8. Set `__Host-sid` cookie + 302 to `return_to`.
 
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::extract::{Query, State};
 use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
@@ -21,7 +20,7 @@ use serde::Deserialize;
 use crate::bff::audit::{AuthEvent, AuthEventKind, hash_session_id};
 use crate::bff::cookies::{SessionCookie, read_session_cookie};
 use crate::bff::errors::BffError;
-use crate::bff::handlers::{BffState, no_store};
+use crate::bff::handlers::{BffState, no_store, unix_now};
 use crate::bff::identity;
 use crate::bff::session_store::{CreateSessionRequest, login_state};
 
@@ -50,6 +49,15 @@ pub async fn callback(
             err_desc = %q.error_description.as_deref().unwrap_or(""),
             "OIDC callback returned error",
         );
+        // Best-effort burn of the login_state record so the one-shot
+        // CSRF contract is honored even when the IdP rejected the
+        // request. We log on failure but do not block the user-facing
+        // response; the caller cannot complete the flow anyway.
+        if let Some(s) = q.state.as_deref()
+            && let Err(e) = login_state::take(&st.redis, s).await
+        {
+            tracing::warn!(error = %e, "best-effort login_state burn on error callback failed");
+        }
         let safe = sanitize_oauth_error_code(err);
         crate::bff::audit::emit(
             AuthEventKind::LoginFail,
@@ -190,15 +198,6 @@ fn client_ip_from_headers(headers: &HeaderMap) -> String {
         .and_then(|v| v.to_str().ok())
         .unwrap_or("")
         .to_owned()
-}
-
-fn unix_now() -> i64 {
-    i64::try_from(
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_or(0, |d| d.as_secs()),
-    )
-    .unwrap_or(0)
 }
 
 #[cfg(test)]

--- a/src/backend/services/api-gateway/src/bff/handlers/callback.rs
+++ b/src/backend/services/api-gateway/src/bff/handlers/callback.rs
@@ -14,14 +14,14 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::extract::{Query, State};
-use axum::http::{HeaderMap, StatusCode, header};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use serde::Deserialize;
 
 use crate::bff::audit::{AuthEvent, AuthEventKind, hash_session_id};
 use crate::bff::cookies::{build_set_session, read_session_cookie};
 use crate::bff::errors::BffError;
-use crate::bff::handlers::BffState;
+use crate::bff::handlers::{BffState, no_store};
 use crate::bff::identity;
 use crate::bff::session_store::{CreateSessionRequest, login_state};
 
@@ -143,19 +143,17 @@ pub async fn callback(
 
     let max_age = i64::try_from(st.cfg.session.ttl_seconds).unwrap_or(i64::MAX);
     let set_cookie = build_set_session(&outcome.session_id, max_age);
-
-    let mut resp = Response::builder()
-        .status(StatusCode::FOUND)
-        .header(header::LOCATION, return_to)
-        .body(axum::body::Body::empty())
-        .map_err(|e| BffError::Internal(anyhow::anyhow!("response builder: {e}")))?;
-    resp.headers_mut().append(header::SET_COOKIE, set_cookie);
-    resp.headers_mut().insert(
-        header::CACHE_CONTROL,
-        axum::http::HeaderValue::from_static("no-store"),
-    );
-
-    Ok(resp.into_response())
+    let location = HeaderValue::from_str(&return_to)
+        .map_err(|e| BffError::Internal(anyhow::anyhow!("return_to not ASCII: {e}")))?;
+    Ok((
+        StatusCode::FOUND,
+        no_store(),
+        [
+            (header::LOCATION, location),
+            (header::SET_COOKIE, set_cookie),
+        ],
+    )
+        .into_response())
 }
 
 /// Sanitize an OAuth error code echoed from the IdP. RFC 6749 §4.1.2.1

--- a/src/backend/services/api-gateway/src/bff/handlers/login.rs
+++ b/src/backend/services/api-gateway/src/bff/handlers/login.rs
@@ -41,9 +41,7 @@ pub async fn login(
     let oauth_nonce = new_nonce();
     let pkce = PkcePair::generate();
 
-    let auth_url = st
-        .oidc
-        .authorize_url(&oauth_state, &oauth_nonce, &pkce.challenge)?;
+    let auth_url = st.oidc.authorize_url(&oauth_state, &oauth_nonce, &pkce.verifier);
 
     login_state::store(
         &st.redis,

--- a/src/backend/services/api-gateway/src/bff/handlers/login.rs
+++ b/src/backend/services/api-gateway/src/bff/handlers/login.rs
@@ -1,0 +1,183 @@
+//! `GET /auth/login` — kicks off the OIDC handshake.
+//!
+//! Generates `state`, `nonce`, and a fresh PKCE pair; persists them in
+//! `bff:login_state:{state}` with a 5-minute TTL; redirects the browser
+//! to the IdP authorize endpoint.
+
+use std::sync::Arc;
+
+use axum::extract::Query;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::Deserialize;
+
+use crate::bff::audit::{AuthEvent, AuthEventKind};
+use crate::bff::errors::BffError;
+use crate::bff::handlers::BffState;
+use crate::bff::oidc_client::PkcePair;
+use crate::bff::secrets::{new_nonce, new_state};
+use crate::bff::session_store::login_state;
+
+#[derive(Debug, Deserialize)]
+pub struct LoginQuery {
+    /// Path-only target inside the SPA to land on after callback.
+    /// Validated for path-only-ness; absolute URLs are rejected.
+    #[serde(default)]
+    pub return_to: Option<String>,
+}
+
+pub async fn login(
+    state: axum::extract::State<Arc<BffState>>,
+    Query(q): Query<LoginQuery>,
+) -> Result<Response, BffError> {
+    let st = state.0;
+
+    let return_to = sanitize_return_to(q.return_to.as_deref());
+    let oauth_state = new_state();
+    let oauth_nonce = new_nonce();
+    let pkce = PkcePair::generate();
+
+    let auth_url = st
+        .oidc
+        .authorize_url(&oauth_state, &oauth_nonce, &pkce.challenge)?;
+
+    login_state::store(
+        &st.redis,
+        &oauth_state,
+        &login_state::LoginState {
+            pkce_verifier: pkce.verifier,
+            nonce: oauth_nonce,
+            return_to,
+        },
+    )
+    .await?;
+
+    // Bump the global per-pod login-state counter. Phase 3 will check it
+    // against the cap; for now we just maintain it.
+    let _ = login_state::touch(&st.redis).await;
+
+    crate::bff::audit::emit(
+        AuthEventKind::LoginStart,
+        &AuthEvent {
+            ..Default::default()
+        },
+    );
+
+    let mut resp = Response::builder()
+        .status(StatusCode::FOUND)
+        .header(axum::http::header::LOCATION, auth_url)
+        .body(axum::body::Body::empty())
+        .map_err(|e| BffError::Internal(anyhow::anyhow!("response builder: {e}")))?;
+
+    // Defensive: explicitly disable caching of the redirect.
+    resp.headers_mut().insert(
+        axum::http::header::CACHE_CONTROL,
+        axum::http::HeaderValue::from_static("no-store"),
+    );
+
+    Ok(resp.into_response())
+}
+
+/// Reject anything that could turn into an absolute URL when the browser
+/// resolves a `Location:` header. Accepts only path-and-query starting
+/// with `/`. Rejects:
+///   * absolute URLs (`http://…`, `https://…`)
+///   * protocol-relative (`//host/…`)
+///   * backslash variants (`/\evil`, `\/evil`) — WHATWG URL parsing
+///     normalizes `\` to `/` against special schemes
+///   * percent-encoded slash/backslash (`/%2f%2fhost`, `/%5cevil`)
+///   * any control character (CR/LF/TAB/etc) — defense in depth
+///   * anything above the length cap
+///
+/// On rejection or absence we fall back to `/`.
+pub(super) fn sanitize_return_to(raw: Option<&str>) -> String {
+    let raw = raw.unwrap_or("/").trim();
+    if raw.is_empty() || !raw.starts_with('/') {
+        return "/".to_owned();
+    }
+    if raw.len() > 1024 {
+        return "/".to_owned();
+    }
+    // First two raw chars must be `/` followed by something other than
+    // `/` or `\`. Catches `//evil`, `/\evil`, `/\\evil`.
+    if let Some(c) = raw.chars().nth(1)
+        && (c == '/' || c == '\\')
+    {
+        return "/".to_owned();
+    }
+    // Reject any control char or backslash anywhere in the value. A `\`
+    // mid-path can still mislead URL parsers; if a real SPA path needs
+    // a backslash, it can be percent-encoded *and* we reject `%5c` below.
+    if raw.contains('\\') || raw.chars().any(|c| (c as u32) < 0x20) {
+        return "/".to_owned();
+    }
+    // Reject percent-encoded slashes/backslashes that some browsers
+    // decode before resolving Location. Case-insensitive match.
+    let lower = raw.to_ascii_lowercase();
+    if lower.contains("%2f") || lower.contains("%5c") {
+        return "/".to_owned();
+    }
+    raw.to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_return_to_accepts_paths() {
+        assert_eq!(sanitize_return_to(Some("/dashboard")), "/dashboard");
+        assert_eq!(
+            sanitize_return_to(Some("/connectors?id=1")),
+            "/connectors?id=1"
+        );
+    }
+
+    #[test]
+    fn sanitize_return_to_rejects_absolute_urls() {
+        assert_eq!(sanitize_return_to(Some("https://evil.example/")), "/");
+        assert_eq!(sanitize_return_to(Some("http://evil/")), "/");
+    }
+
+    #[test]
+    fn sanitize_return_to_rejects_protocol_relative() {
+        assert_eq!(sanitize_return_to(Some("//evil/path")), "/");
+    }
+
+    #[test]
+    fn sanitize_return_to_handles_empty_and_none() {
+        assert_eq!(sanitize_return_to(None), "/");
+        assert_eq!(sanitize_return_to(Some("")), "/");
+        assert_eq!(sanitize_return_to(Some("   ")), "/");
+    }
+
+    #[test]
+    fn sanitize_return_to_caps_length() {
+        let long = format!("/{}", "a".repeat(2000));
+        assert_eq!(sanitize_return_to(Some(&long)), "/");
+    }
+
+    #[test]
+    fn sanitize_return_to_rejects_backslash_variants() {
+        // `/\evil.com` — browser may resolve as https://evil.com/
+        assert_eq!(sanitize_return_to(Some("/\\evil.com")), "/");
+        assert_eq!(sanitize_return_to(Some("/\\\\evil.com")), "/");
+        // backslash mid-path is also rejected
+        assert_eq!(sanitize_return_to(Some("/path\\evil")), "/");
+    }
+
+    #[test]
+    fn sanitize_return_to_rejects_percent_encoded_slash() {
+        assert_eq!(sanitize_return_to(Some("/%2f%2fevil.com")), "/");
+        assert_eq!(sanitize_return_to(Some("/%2F%2Fevil.com")), "/");
+        assert_eq!(sanitize_return_to(Some("/%5cevil.com")), "/");
+        assert_eq!(sanitize_return_to(Some("/%5Cevil.com")), "/");
+    }
+
+    #[test]
+    fn sanitize_return_to_rejects_control_chars() {
+        assert_eq!(sanitize_return_to(Some("/foo\r\nLocation: x")), "/");
+        assert_eq!(sanitize_return_to(Some("/foo\tbar")), "/");
+        assert_eq!(sanitize_return_to(Some("/foo\u{0000}")), "/");
+    }
+}

--- a/src/backend/services/api-gateway/src/bff/handlers/login.rs
+++ b/src/backend/services/api-gateway/src/bff/handlers/login.rs
@@ -41,7 +41,9 @@ pub async fn login(
     let oauth_nonce = new_nonce();
     let pkce = PkcePair::generate();
 
-    let auth_url = st.oidc.authorize_url(&oauth_state, &oauth_nonce, &pkce.verifier);
+    let auth_url = st
+        .oidc
+        .authorize_url(&oauth_state, &oauth_nonce, &pkce.verifier);
 
     login_state::store(
         &st.redis,

--- a/src/backend/services/api-gateway/src/bff/handlers/login.rs
+++ b/src/backend/services/api-gateway/src/bff/handlers/login.rs
@@ -7,13 +7,13 @@
 use std::sync::Arc;
 
 use axum::extract::Query;
-use axum::http::StatusCode;
+use axum::http::{HeaderValue, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 use serde::Deserialize;
 
 use crate::bff::audit::{AuthEvent, AuthEventKind};
 use crate::bff::errors::BffError;
-use crate::bff::handlers::BffState;
+use crate::bff::handlers::{BffState, no_store};
 use crate::bff::oidc_client::PkcePair;
 use crate::bff::secrets::{new_nonce, new_state};
 use crate::bff::session_store::login_state;
@@ -63,19 +63,14 @@ pub async fn login(
         },
     );
 
-    let mut resp = Response::builder()
-        .status(StatusCode::FOUND)
-        .header(axum::http::header::LOCATION, auth_url)
-        .body(axum::body::Body::empty())
-        .map_err(|e| BffError::Internal(anyhow::anyhow!("response builder: {e}")))?;
-
-    // Defensive: explicitly disable caching of the redirect.
-    resp.headers_mut().insert(
-        axum::http::header::CACHE_CONTROL,
-        axum::http::HeaderValue::from_static("no-store"),
-    );
-
-    Ok(resp.into_response())
+    let location = HeaderValue::from_str(&auth_url)
+        .map_err(|e| BffError::Internal(anyhow::anyhow!("authorize url not ASCII: {e}")))?;
+    Ok((
+        StatusCode::FOUND,
+        no_store(),
+        [(header::LOCATION, location)],
+    )
+        .into_response())
 }
 
 /// Reject anything that could turn into an absolute URL when the browser

--- a/src/backend/services/api-gateway/src/bff/handlers/login.rs
+++ b/src/backend/services/api-gateway/src/bff/handlers/login.rs
@@ -18,6 +18,10 @@ use crate::bff::oidc_client::PkcePair;
 use crate::bff::secrets::{new_nonce, new_state};
 use crate::bff::session_store::login_state;
 
+/// Cap on `return_to` length. Aligns with typical browser URL length caps;
+/// not operator-tunable — purely defense in depth.
+const RETURN_TO_MAX_LEN: usize = 1024;
+
 #[derive(Debug, Deserialize)]
 pub struct LoginQuery {
     /// Path-only target inside the SPA to land on after callback.
@@ -90,7 +94,7 @@ pub(super) fn sanitize_return_to(raw: Option<&str>) -> String {
     if raw.is_empty() || !raw.starts_with('/') {
         return "/".to_owned();
     }
-    if raw.len() > 1024 {
+    if raw.len() > RETURN_TO_MAX_LEN {
         return "/".to_owned();
     }
     // First two raw chars must be `/` followed by something other than
@@ -103,7 +107,9 @@ pub(super) fn sanitize_return_to(raw: Option<&str>) -> String {
     // Reject any control char or backslash anywhere in the value. A `\`
     // mid-path can still mislead URL parsers; if a real SPA path needs
     // a backslash, it can be percent-encoded *and* we reject `%5c` below.
-    if raw.contains('\\') || raw.chars().any(|c| (c as u32) < 0x20) {
+    // `char::is_control` covers the full Unicode Cc category (C0
+    // U+0000–U+001F, DEL U+007F, and C1 U+0080–U+009F).
+    if raw.contains('\\') || raw.chars().any(char::is_control) {
         return "/".to_owned();
     }
     // Reject percent-encoded slashes/backslashes that some browsers
@@ -148,7 +154,7 @@ mod tests {
 
     #[test]
     fn sanitize_return_to_caps_length() {
-        let long = format!("/{}", "a".repeat(2000));
+        let long = format!("/{}", "a".repeat(RETURN_TO_MAX_LEN));
         assert_eq!(sanitize_return_to(Some(&long)), "/");
     }
 
@@ -174,5 +180,15 @@ mod tests {
         assert_eq!(sanitize_return_to(Some("/foo\r\nLocation: x")), "/");
         assert_eq!(sanitize_return_to(Some("/foo\tbar")), "/");
         assert_eq!(sanitize_return_to(Some("/foo\u{0000}")), "/");
+    }
+
+    #[test]
+    fn sanitize_return_to_rejects_del_and_c1_controls() {
+        // DEL (U+007F) was missed by the prior `(c as u32) < 0x20` check.
+        assert_eq!(sanitize_return_to(Some("/foo\u{007f}bar")), "/");
+        // NEL (U+0085), a C1 control.
+        assert_eq!(sanitize_return_to(Some("/foo\u{0085}bar")), "/");
+        // APC (U+009F), C1.
+        assert_eq!(sanitize_return_to(Some("/foo\u{009f}bar")), "/");
     }
 }

--- a/src/backend/services/api-gateway/src/bff/handlers/me.rs
+++ b/src/backend/services/api-gateway/src/bff/handlers/me.rs
@@ -21,14 +21,17 @@ use crate::bff::errors::BffError;
 use crate::bff::handlers::{BffState, jittered_refresh_at, no_store};
 use crate::bff::session::{SessionView, TenantView, UserView};
 
+const NO_SESSION_REASON: &str = "no session";
+
 pub async fn me(
     State(state): State<Arc<BffState>>,
     headers: HeaderMap,
 ) -> Result<Response, BffError> {
     let st = state;
 
-    let sid = read_session_cookie(headers.get(header::COOKIE))
-        .ok_or(BffError::Unauthorized("no session cookie"))?;
+    let Some(sid) = read_session_cookie(headers.get(header::COOKIE)) else {
+        return Ok(unauthorized_clear_cookie());
+    };
 
     let Some(record) = st.store.get_session(&sid).await? else {
         return Ok(unauthorized_clear_cookie());
@@ -75,25 +78,16 @@ pub async fn me(
 }
 
 fn unauthorized_clear_cookie() -> Response {
-    let mut resp = (
-        StatusCode::UNAUTHORIZED,
+    // Compose: canonical `unauthenticated` envelope (status, problem+json
+    // body, type URI, reason) from `BffError`; layered with `no_store()`
+    // and `SessionCookie::clear()` so the browser drops the (possibly
+    // stale) `__Host-sid` cookie before the SPA redirects to /auth/login.
+    (
         no_store(),
         SessionCookie::clear(),
-        Json(serde_json::json!({
-            "type": "urn:insight:error:unauthorized",
-            "title": "Unauthorized",
-            "status": 401,
-            "detail": "no session"
-        })),
+        BffError::Unauthorized(NO_SESSION_REASON),
     )
-        .into_response();
-    // RFC 9457: problem+json content type. Override the `Content-Type:
-    // application/json` that `Json` set.
-    resp.headers_mut().insert(
-        header::CONTENT_TYPE,
-        axum::http::HeaderValue::from_static("application/problem+json"),
-    );
-    resp
+        .into_response()
 }
 
 #[cfg(test)]
@@ -102,12 +96,12 @@ mod tests {
     use axum::body::to_bytes;
 
     #[tokio::test]
-    async fn unauthorized_clear_cookie_carries_clear_set_cookie_and_problem_ct() {
+    async fn unauthorized_clear_cookie_carries_clear_set_cookie_and_canonical_envelope() {
         let resp = unauthorized_clear_cookie();
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
         assert_eq!(
             resp.headers().get(header::CONTENT_TYPE).expect("ct"),
-            "application/problem+json"
+            "application/problem+json",
         );
         let sc = resp
             .headers()
@@ -116,9 +110,15 @@ mod tests {
             .expect("set-cookie");
         assert!(sc.contains("Max-Age=0"));
         assert!(sc.contains("__Host-sid="));
+        assert!(sc.contains("SameSite=Strict"));
 
         let bytes = to_bytes(resp.into_body(), 4096).await.expect("body");
         let v: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
         assert_eq!(v["status"], 401);
+        assert_eq!(
+            v["type"], "gts://gts.cf.core.errors.err.v1~cf.core.err.unauthenticated.v1~",
+            "must use the constructorfabric canonical envelope",
+        );
+        assert_eq!(v["context"]["reason"], NO_SESSION_REASON);
     }
 }

--- a/src/backend/services/api-gateway/src/bff/handlers/me.rs
+++ b/src/backend/services/api-gateway/src/bff/handlers/me.rs
@@ -16,7 +16,7 @@ use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 
-use crate::bff::cookies::{build_clear_session, read_session_cookie};
+use crate::bff::cookies::{SessionCookie, read_session_cookie};
 use crate::bff::errors::BffError;
 use crate::bff::handlers::{BffState, jittered_refresh_at, no_store};
 use crate::bff::session::{SessionView, TenantView, UserView};
@@ -78,6 +78,7 @@ fn unauthorized_clear_cookie() -> Response {
     let mut resp = (
         StatusCode::UNAUTHORIZED,
         no_store(),
+        SessionCookie::clear(),
         Json(serde_json::json!({
             "type": "urn:insight:error:unauthorized",
             "title": "Unauthorized",
@@ -86,12 +87,12 @@ fn unauthorized_clear_cookie() -> Response {
         })),
     )
         .into_response();
+    // RFC 9457: problem+json content type. Override the `Content-Type:
+    // application/json` that `Json` set.
     resp.headers_mut().insert(
         header::CONTENT_TYPE,
         axum::http::HeaderValue::from_static("application/problem+json"),
     );
-    resp.headers_mut()
-        .append(header::SET_COOKIE, build_clear_session());
     resp
 }
 

--- a/src/backend/services/api-gateway/src/bff/handlers/me.rs
+++ b/src/backend/services/api-gateway/src/bff/handlers/me.rs
@@ -1,0 +1,135 @@
+//! `GET /auth/me` — bootstrap endpoint for the SPA.
+//!
+//! Returns `{user, tenant, expires_at, refresh_at, csrf_token}` so the SPA
+//! can prime its refresh timer and CSRF cache without an extra round-trip.
+//!
+//! Returns 401 + clear cookie when:
+//!   * no `__Host-sid` cookie is present
+//!   * the session is missing in Redis (expired / revoked)
+//!   * the session has expired but Redis has not yet evicted it (race)
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode, header};
+use axum::response::{IntoResponse, Response};
+
+use crate::bff::cookies::{build_clear_session, read_session_cookie};
+use crate::bff::errors::BffError;
+use crate::bff::handlers::{BffState, jittered_refresh_at};
+use crate::bff::session::{SessionView, TenantView, UserView};
+
+pub async fn me(
+    State(state): State<Arc<BffState>>,
+    headers: HeaderMap,
+) -> Result<Response, BffError> {
+    let st = state;
+
+    let sid = read_session_cookie(headers.get(header::COOKIE))
+        .ok_or(BffError::Unauthorized("no session cookie"))?;
+
+    let Some(record) = st.store.get_session(&sid).await? else {
+        return Ok(unauthorized_clear_cookie());
+    };
+
+    let now = i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+    )
+    .unwrap_or(0);
+    if record.expires_at <= now {
+        return Ok(unauthorized_clear_cookie());
+    }
+    // Hard cap on session lifetime — even if `expires_at` is fine, a
+    // session past `absolute_expires_at` MUST NOT be served. Phase 2's
+    // /auth/refresh enforces the same cap; mirror it here so /auth/me
+    // doesn't silently outlive a refresh boundary.
+    if record.absolute_expires_at <= now {
+        return Ok(unauthorized_clear_cookie());
+    }
+
+    let refresh_at = jittered_refresh_at(
+        record.expires_at,
+        st.cfg.session.refresh_safety_margin_seconds,
+        st.cfg.session.refresh_jitter_seconds,
+    );
+
+    let view = SessionView {
+        user: UserView {
+            user_id: record.user_id,
+            email: record.email,
+            display_name: record.display_name,
+        },
+        tenant: TenantView {
+            tenant_id: record.tenant_id,
+        },
+        expires_at: record.expires_at,
+        refresh_at,
+        csrf_token: record.csrf_token,
+    };
+
+    let body = serde_json::to_vec(&view)
+        .map_err(|e| BffError::Internal(anyhow::anyhow!("serialize: {e}")))?;
+    let resp = Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::CACHE_CONTROL, "no-store")
+        .body(axum::body::Body::from(body))
+        .map_err(|e| BffError::Internal(anyhow::anyhow!("response builder: {e}")))?;
+
+    Ok(resp.into_response())
+}
+
+fn unauthorized_clear_cookie() -> Response {
+    let mut resp = (
+        StatusCode::UNAUTHORIZED,
+        axum::Json(serde_json::json!({
+            "type": "urn:insight:error:unauthorized",
+            "title": "Unauthorized",
+            "status": 401,
+            "detail": "no session"
+        })),
+    )
+        .into_response();
+    resp.headers_mut().insert(
+        header::CONTENT_TYPE,
+        axum::http::HeaderValue::from_static("application/problem+json"),
+    );
+    resp.headers_mut()
+        .append(header::SET_COOKIE, build_clear_session());
+    resp.headers_mut().insert(
+        header::CACHE_CONTROL,
+        axum::http::HeaderValue::from_static("no-store"),
+    );
+    resp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+
+    #[tokio::test]
+    async fn unauthorized_clear_cookie_carries_clear_set_cookie_and_problem_ct() {
+        let resp = unauthorized_clear_cookie();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).expect("ct"),
+            "application/problem+json"
+        );
+        let sc = resp
+            .headers()
+            .get(header::SET_COOKIE)
+            .and_then(|v| v.to_str().ok())
+            .expect("set-cookie");
+        assert!(sc.contains("Max-Age=0"));
+        assert!(sc.contains("__Host-sid="));
+
+        let bytes = to_bytes(resp.into_body(), 4096).await.expect("body");
+        let v: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        assert_eq!(v["status"], 401);
+    }
+}

--- a/src/backend/services/api-gateway/src/bff/handlers/me.rs
+++ b/src/backend/services/api-gateway/src/bff/handlers/me.rs
@@ -36,8 +36,7 @@ pub async fn me(
     let now = i64::try_from(
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0),
+            .map_or(0, |d| d.as_secs()),
     )
     .unwrap_or(0);
     if record.expires_at <= now {

--- a/src/backend/services/api-gateway/src/bff/handlers/me.rs
+++ b/src/backend/services/api-gateway/src/bff/handlers/me.rs
@@ -11,13 +11,14 @@
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use axum::Json;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode, header};
 use axum::response::{IntoResponse, Response};
 
 use crate::bff::cookies::{build_clear_session, read_session_cookie};
 use crate::bff::errors::BffError;
-use crate::bff::handlers::{BffState, jittered_refresh_at};
+use crate::bff::handlers::{BffState, jittered_refresh_at, no_store};
 use crate::bff::session::{SessionView, TenantView, UserView};
 
 pub async fn me(
@@ -70,22 +71,14 @@ pub async fn me(
         csrf_token: record.csrf_token,
     };
 
-    let body = serde_json::to_vec(&view)
-        .map_err(|e| BffError::Internal(anyhow::anyhow!("serialize: {e}")))?;
-    let resp = Response::builder()
-        .status(StatusCode::OK)
-        .header(header::CONTENT_TYPE, "application/json")
-        .header(header::CACHE_CONTROL, "no-store")
-        .body(axum::body::Body::from(body))
-        .map_err(|e| BffError::Internal(anyhow::anyhow!("response builder: {e}")))?;
-
-    Ok(resp.into_response())
+    Ok((StatusCode::OK, no_store(), Json(view)).into_response())
 }
 
 fn unauthorized_clear_cookie() -> Response {
     let mut resp = (
         StatusCode::UNAUTHORIZED,
-        axum::Json(serde_json::json!({
+        no_store(),
+        Json(serde_json::json!({
             "type": "urn:insight:error:unauthorized",
             "title": "Unauthorized",
             "status": 401,
@@ -99,10 +92,6 @@ fn unauthorized_clear_cookie() -> Response {
     );
     resp.headers_mut()
         .append(header::SET_COOKIE, build_clear_session());
-    resp.headers_mut().insert(
-        header::CACHE_CONTROL,
-        axum::http::HeaderValue::from_static("no-store"),
-    );
     resp
 }
 

--- a/src/backend/services/api-gateway/src/bff/handlers/me.rs
+++ b/src/backend/services/api-gateway/src/bff/handlers/me.rs
@@ -9,7 +9,6 @@
 //!   * the session has expired but Redis has not yet evicted it (race)
 
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::Json;
 use axum::extract::State;
@@ -18,7 +17,7 @@ use axum::response::{IntoResponse, Response};
 
 use crate::bff::cookies::{SessionCookie, read_session_cookie};
 use crate::bff::errors::BffError;
-use crate::bff::handlers::{BffState, jittered_refresh_at, no_store};
+use crate::bff::handlers::{BffState, jittered_refresh_at, no_store, unix_now};
 use crate::bff::session::{SessionView, TenantView, UserView};
 
 const NO_SESSION_REASON: &str = "no session";
@@ -37,12 +36,7 @@ pub async fn me(
         return Ok(unauthorized_clear_cookie());
     };
 
-    let now = i64::try_from(
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_or(0, |d| d.as_secs()),
-    )
-    .unwrap_or(0);
+    let now = unix_now();
     if record.expires_at <= now {
         return Ok(unauthorized_clear_cookie());
     }

--- a/src/backend/services/api-gateway/src/bff/handlers/mod.rs
+++ b/src/backend/services/api-gateway/src/bff/handlers/mod.rs
@@ -1,0 +1,75 @@
+//! HTTP handlers for `/auth/*`. Each handler is sync-thin: it pulls
+//! request-scoped data, calls the BFF service layer, and returns a
+//! `Response`. Long-lived state (Redis client, OIDC client, config)
+//! flows in via `Arc<BffState>`.
+
+pub mod callback;
+pub mod login;
+pub mod me;
+
+use std::sync::Arc;
+
+use crate::bff::config::BffConfig;
+use crate::bff::oidc_client::OidcClient;
+use crate::bff::session_store::SessionStore;
+use crate::redis_client::RedisShared;
+
+/// Shared service state passed into handlers. Cheap to clone — every
+/// field is `Arc` or `Clone`.
+#[derive(Clone)]
+pub struct BffState {
+    pub cfg: Arc<BffConfig>,
+    pub oidc: Arc<OidcClient>,
+    pub store: SessionStore,
+    pub redis: Arc<RedisShared>,
+}
+
+/// Compute jittered `refresh_at = expires_at - safety_margin + uniform(±jitter/2)`.
+///
+/// Pulled out so handlers and tests can call it without dragging in the
+/// rest of the state.
+#[must_use]
+pub fn jittered_refresh_at(
+    expires_at: i64,
+    safety_margin_seconds: u64,
+    jitter_window_seconds: u64,
+) -> i64 {
+    use rand::Rng;
+
+    let base = expires_at.saturating_sub(i64::try_from(safety_margin_seconds).unwrap_or(i64::MAX));
+    if jitter_window_seconds == 0 {
+        return base;
+    }
+    let half = i64::try_from(jitter_window_seconds / 2).unwrap_or(i64::MAX);
+    let offset = rand::thread_rng().gen_range(-half..=half);
+    base.saturating_add(offset)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jitter_zero_window_returns_base() {
+        assert_eq!(jittered_refresh_at(1000, 30, 0), 970);
+    }
+
+    #[test]
+    fn jitter_stays_within_window() {
+        for _ in 0..200 {
+            let r = jittered_refresh_at(1000, 30, 10);
+            // base = 970, half = 5 → range [965, 975]
+            assert!((965..=975).contains(&r), "got {r}");
+        }
+    }
+
+    #[test]
+    fn jitter_clamps_overflowing_safety_margin_without_panic() {
+        // Safety margin > i64::MAX is clamped to i64::MAX before subtraction;
+        // the saturating subtraction never overflows, never panics. We
+        // don't care about the exact value — only that it's far in the
+        // past so the SPA refreshes immediately.
+        let r = jittered_refresh_at(10, u64::MAX, 0);
+        assert!(r < 0, "expected far-past refresh_at, got {r}");
+    }
+}

--- a/src/backend/services/api-gateway/src/bff/handlers/mod.rs
+++ b/src/backend/services/api-gateway/src/bff/handlers/mod.rs
@@ -9,6 +9,9 @@ pub mod me;
 
 use std::sync::Arc;
 
+use axum_extra::TypedHeader;
+use axum_extra::headers::CacheControl;
+
 use crate::bff::config::BffConfig;
 use crate::bff::oidc_client::OidcClient;
 use crate::bff::session_store::SessionStore;
@@ -22,6 +25,16 @@ pub struct BffState {
     pub oidc: Arc<OidcClient>,
     pub store: SessionStore,
     pub redis: Arc<RedisShared>,
+}
+
+/// `Cache-Control: no-store` for every `/auth/*` response.
+///
+/// All BFF responses carry auth-sensitive payloads (cookies, user data,
+/// id_token-hint URLs) that browsers, proxies, and shared caches must
+/// never store. Typed via `axum-extra` so the header value is built by
+/// the `headers` crate rather than hand-formatted in every handler.
+pub fn no_store() -> TypedHeader<CacheControl> {
+    TypedHeader(CacheControl::new().with_no_store())
 }
 
 /// Compute jittered `refresh_at = expires_at - safety_margin + uniform(±jitter/2)`.
@@ -71,5 +84,18 @@ mod tests {
         // past so the SPA refreshes immediately.
         let r = jittered_refresh_at(10, u64::MAX, 0);
         assert!(r < 0, "expected far-past refresh_at, got {r}");
+    }
+
+    #[test]
+    fn no_store_helper_encodes_to_cache_control_no_store() {
+        // Lock the helper's rendered value so any future bump of
+        // `axum-extra` / `headers` that changes encoding fails CI
+        // before it can silently change `Cache-Control` semantics.
+        use axum_extra::headers::Header;
+        let tv = no_store();
+        let mut values: Vec<axum::http::HeaderValue> = Vec::new();
+        tv.0.encode(&mut values);
+        assert_eq!(values.len(), 1);
+        assert_eq!(values[0].to_str().expect("ascii"), "no-store");
     }
 }

--- a/src/backend/services/api-gateway/src/bff/handlers/mod.rs
+++ b/src/backend/services/api-gateway/src/bff/handlers/mod.rs
@@ -8,6 +8,7 @@ pub mod login;
 pub mod me;
 
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum_extra::TypedHeader;
 use axum_extra::headers::CacheControl;
@@ -35,6 +36,22 @@ pub struct BffState {
 /// the `headers` crate rather than hand-formatted in every handler.
 pub fn no_store() -> TypedHeader<CacheControl> {
     TypedHeader(CacheControl::new().with_no_store())
+}
+
+/// Current UNIX time in seconds, as `i64` for direct use against the
+/// `i64` epoch fields stored on `SessionRecord`.
+///
+/// Panics if the system clock is before `UNIX_EPOCH` (operator-grade
+/// invariant violation — JWTs/TLS/cookies are already broken in that
+/// state, so loud failure is correct) or after `i64::MAX` seconds
+/// (~year 292 billion; not reachable). Bare `panic!` keeps the
+/// workspace-wide `unwrap_used`/`expect_used` denies satisfied.
+#[must_use]
+pub(crate) fn unix_now() -> i64 {
+    let d = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_else(|_| panic!("system clock is before UNIX_EPOCH"));
+    i64::try_from(d.as_secs()).unwrap_or_else(|_| panic!("system clock past i64::MAX seconds"))
 }
 
 /// Compute jittered `refresh_at = expires_at - safety_margin + uniform(±jitter/2)`.
@@ -74,6 +91,16 @@ mod tests {
             // base = 970, half = 5 → range [965, 975]
             assert!((965..=975).contains(&r), "got {r}");
         }
+    }
+
+    #[test]
+    fn unix_now_returns_recent_epoch_seconds() {
+        // Loosely sanity-check that we're returning seconds, not millis or
+        // a stale constant. Anchor against 2024-01-01 (1_704_067_200) so
+        // the test stays valid for as long as the CI clock advances.
+        let n = unix_now();
+        assert!(n > 1_704_067_200, "got {n}");
+        assert!(n < 32_503_680_000, "got {n}");
     }
 
     #[test]

--- a/src/backend/services/api-gateway/src/bff/handlers/mod.rs
+++ b/src/backend/services/api-gateway/src/bff/handlers/mod.rs
@@ -44,16 +44,16 @@ pub fn no_store() -> TypedHeader<CacheControl> {
 #[must_use]
 pub fn jittered_refresh_at(
     expires_at: i64,
-    safety_margin_seconds: u64,
-    jitter_window_seconds: u64,
+    safety_margin_seconds: u16,
+    jitter_window_seconds: u16,
 ) -> i64 {
     use rand::Rng;
 
-    let base = expires_at.saturating_sub(i64::try_from(safety_margin_seconds).unwrap_or(i64::MAX));
+    let base = expires_at.saturating_sub(i64::from(safety_margin_seconds));
     if jitter_window_seconds == 0 {
         return base;
     }
-    let half = i64::try_from(jitter_window_seconds / 2).unwrap_or(i64::MAX);
+    let half = i64::from(jitter_window_seconds / 2);
     let offset = rand::thread_rng().gen_range(-half..=half);
     base.saturating_add(offset)
 }
@@ -74,16 +74,6 @@ mod tests {
             // base = 970, half = 5 → range [965, 975]
             assert!((965..=975).contains(&r), "got {r}");
         }
-    }
-
-    #[test]
-    fn jitter_clamps_overflowing_safety_margin_without_panic() {
-        // Safety margin > i64::MAX is clamped to i64::MAX before subtraction;
-        // the saturating subtraction never overflows, never panics. We
-        // don't care about the exact value — only that it's far in the
-        // past so the SPA refreshes immediately.
-        let r = jittered_refresh_at(10, u64::MAX, 0);
-        assert!(r < 0, "expected far-past refresh_at, got {r}");
     }
 
     #[test]

--- a/src/backend/services/api-gateway/src/bff/identity.rs
+++ b/src/backend/services/api-gateway/src/bff/identity.rs
@@ -1,0 +1,73 @@
+//! Map a validated ID token to the internal identity fields the BFF
+//! stores on the session.
+//!
+//! ## Model
+//!
+//! - **One OIDC issuer per installation.** No cross-issuer collisions are
+//!   possible by deployment design, so we treat the OIDC `sub` claim as
+//!   the internal `user_id` directly. No hashing, no derivation.
+//! - **Identity Service is out of scope for this milestone.** When it
+//!   lands, it will accept queries shaped like `(scope="oidc", id=<sub>)`
+//!   and return cross-references to other identity sources. At that
+//!   point we'll add a resolver call here; the persisted `idp_iss` and
+//!   `idp_sub` on every session record give us everything we need.
+//! - `tenant_id` comes from config (single-tenant).
+//! - `email` and `display_name` come from the validated ID token claims.
+
+/// Identity payload stitched onto a session at login.
+#[derive(Debug, Clone)]
+pub struct ResolvedIdentity {
+    pub user_id: String,
+    pub email: String,
+    pub display_name: String,
+    pub tenant_id: String,
+}
+
+/// Build a `ResolvedIdentity` from validated OIDC claims plus a tenant
+/// pulled from config. `user_id` is the OIDC `sub` verbatim.
+#[must_use]
+pub fn resolve(
+    sub: &str,
+    email: Option<&str>,
+    display_name: Option<&str>,
+    tenant_id: &str,
+) -> ResolvedIdentity {
+    ResolvedIdentity {
+        user_id: sub.to_owned(),
+        email: email.unwrap_or("").to_owned(),
+        display_name: display_name.unwrap_or("").to_owned(),
+        tenant_id: tenant_id.to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_id_is_the_oidc_sub_verbatim() {
+        let r = resolve("00uA1b2C3d", None, None, "t-1");
+        assert_eq!(r.user_id, "00uA1b2C3d");
+    }
+
+    #[test]
+    fn resolve_carries_through_tenant_and_claims() {
+        let r = resolve(
+            "sub-1",
+            Some("alice@example.com"),
+            Some("Alice"),
+            "tenant-1",
+        );
+        assert_eq!(r.user_id, "sub-1");
+        assert_eq!(r.email, "alice@example.com");
+        assert_eq!(r.display_name, "Alice");
+        assert_eq!(r.tenant_id, "tenant-1");
+    }
+
+    #[test]
+    fn resolve_handles_missing_claims() {
+        let r = resolve("sub", None, None, "tenant-1");
+        assert_eq!(r.email, "");
+        assert_eq!(r.display_name, "");
+    }
+}

--- a/src/backend/services/api-gateway/src/bff/mod.rs
+++ b/src/backend/services/api-gateway/src/bff/mod.rs
@@ -1,0 +1,22 @@
+//! Backend-for-Frontend (BFF) module.
+//!
+//! Owns the OIDC handshake, server-side session lifecycle, and `/auth/*`
+//! API consumed by the SPA. See
+//! `docs/components/backend/api-gateway/bff/{PRD,DESIGN}.md`.
+
+pub mod audit;
+pub mod config;
+pub mod cookies;
+pub mod errors;
+pub mod handlers;
+pub mod identity;
+pub mod module;
+pub mod oidc_client;
+pub mod redis_keys;
+pub mod routes;
+pub mod secrets;
+pub mod session;
+pub mod session_store;
+
+// `BffModule` is registered into the inventory by `#[modkit::module]` —
+// no explicit re-export needed here.

--- a/src/backend/services/api-gateway/src/bff/module.rs
+++ b/src/backend/services/api-gateway/src/bff/module.rs
@@ -1,0 +1,96 @@
+//! BFF ModKit module.
+//!
+//! Loads config, builds the OIDC client (discovery + JWKS), wires the
+//! Redis-backed session store, and registers `/auth/*` routes.
+
+use std::sync::{Arc, OnceLock};
+
+use async_trait::async_trait;
+use axum::Router;
+use modkit::api::OpenApiRegistry;
+use modkit::context::ModuleCtx;
+use modkit::contracts::{Module, RestApiCapability};
+use tracing::info;
+
+use crate::bff::config::BffConfig;
+use crate::bff::handlers::BffState;
+use crate::bff::oidc_client::OidcClient;
+use crate::bff::session_store::SessionStore;
+use crate::redis_client::RedisShared;
+
+/// BFF module — owns `/auth/*` and the session lifecycle.
+#[modkit::module(
+    name = "bff",
+    deps = ["redis-client"],
+    capabilities = [rest]
+)]
+pub struct BffModule {
+    state: OnceLock<Arc<BffState>>,
+}
+
+impl Default for BffModule {
+    fn default() -> Self {
+        Self {
+            state: OnceLock::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl Module for BffModule {
+    async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
+        let cfg: BffConfig = ctx.config()?;
+        cfg.validate()?;
+
+        // Pull the shared Redis client published by the redis-client module.
+        let redis = ctx
+            .client_hub()
+            .get::<RedisShared>()
+            .map_err(|e| anyhow::anyhow!("bff: redis-client not available: {e}"))?;
+
+        // Build the OIDC client: discovery + JWKS.
+        let redirect_uri = format!("{}/auth/callback", cfg.public_origin.trim_end_matches('/'));
+        let oidc = OidcClient::new(
+            &cfg.oidc.issuer_url,
+            &cfg.oidc.client_id,
+            &cfg.oidc.client_secret,
+            &redirect_uri,
+            cfg.effective_scopes(),
+            cfg.oidc.audience.as_deref(),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("bff: oidc client init failed: {e}"))?;
+
+        let store = SessionStore::new(redis.clone());
+
+        let state = Arc::new(BffState {
+            cfg: Arc::new(cfg),
+            oidc: Arc::new(oidc),
+            store,
+            redis,
+        });
+
+        self.state
+            .set(state)
+            .map_err(|_| anyhow::anyhow!("bff module already initialized"))?;
+
+        info!("bff: initialized");
+        Ok(())
+    }
+}
+
+impl RestApiCapability for BffModule {
+    fn register_rest(
+        &self,
+        _ctx: &ModuleCtx,
+        router: Router,
+        openapi: &dyn OpenApiRegistry,
+    ) -> anyhow::Result<Router> {
+        let state = self
+            .state
+            .get()
+            .ok_or_else(|| anyhow::anyhow!("bff module not initialized"))?
+            .clone();
+        Ok(crate::bff::routes::register(router, openapi, state))
+    }
+}

--- a/src/backend/services/api-gateway/src/bff/oidc_client.rs
+++ b/src/backend/services/api-gateway/src/bff/oidc_client.rs
@@ -36,6 +36,20 @@ const ALLOWED_ALGS: &[&str] = &["RS256", "RS384", "RS512", "ES256", "ES384", "Ed
 /// Matches the default leeway in upstream JWT libraries.
 const CLOCK_SKEW_SECONDS: i64 = 60;
 
+/// OIDC Core §3.1.2.2: the RP MUST validate that the discovery document's
+/// `issuer` matches the URL it was fetched from. Both sides are normalized
+/// by trimming a single trailing `/` before comparison.
+fn check_issuer_match(configured: &str, advertised: &str) -> Result<(), BffError> {
+    let expected = configured.trim_end_matches('/');
+    let got = advertised.trim_end_matches('/');
+    if expected != got {
+        return Err(BffError::Idp(format!(
+            "discovery issuer mismatch: expected `{expected}`, got `{got}`",
+        )));
+    }
+    Ok(())
+}
+
 /// Subset of the OIDC discovery document we consume.
 #[derive(Debug, Clone, Deserialize)]
 #[allow(dead_code)]
@@ -85,6 +99,7 @@ impl DiscoveryDoc {
                 "discovery doc missing required fields".into(),
             ));
         }
+        check_issuer_match(issuer_url, &doc.issuer)?;
         Ok(doc)
     }
 }
@@ -156,12 +171,20 @@ impl IdTokenClaims {
                 .and_then(serde_json::Value::as_i64)
                 .ok_or_else(|| BffError::Idp(format!("id_token claim `{k}` missing or not int")))
         };
-        let aud = match v.get("aud") {
+        let aud: Vec<String> = match v.get("aud") {
             Some(serde_json::Value::String(s)) => vec![s.clone()],
-            Some(serde_json::Value::Array(arr)) => arr
-                .iter()
-                .filter_map(|x| x.as_str().map(str::to_owned))
-                .collect(),
+            Some(serde_json::Value::Array(arr)) => {
+                if arr.is_empty() {
+                    return Err(BffError::Idp("id_token `aud` claim missing".into()));
+                }
+                arr.iter()
+                    .map(|x| {
+                        x.as_str().map(str::to_owned).ok_or_else(|| {
+                            BffError::Idp("id_token `aud` entry is not a string".into())
+                        })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?
+            }
             _ => return Err(BffError::Idp("id_token `aud` claim missing".into())),
         };
         let opt_int = |k: &str| -> Option<i64> { v.get(k).and_then(serde_json::Value::as_i64) };
@@ -551,6 +574,53 @@ mod tests {
     fn id_token_claims_reject_missing_aud() {
         let v = serde_json::json!({"iss": "i", "sub": "s", "exp": 1});
         assert!(IdTokenClaims::from_value(&v).is_err());
+    }
+
+    #[test]
+    fn id_token_claims_reject_aud_array_with_non_string_entry() {
+        let v = serde_json::json!({
+            "iss": "i", "sub": "s", "exp": 1,
+            "aud": ["client-id", 123],
+        });
+        let err = IdTokenClaims::from_value(&v).expect_err("must reject");
+        match err {
+            BffError::Idp(msg) => {
+                assert!(msg.contains("aud"), "got `{msg}`");
+                assert!(msg.contains("not a string"), "got `{msg}`");
+            }
+            _ => panic!("expected BffError::Idp, got {err:?}"),
+        }
+    }
+
+    #[test]
+    fn id_token_claims_reject_empty_aud_array() {
+        let v = serde_json::json!({"iss": "i", "sub": "s", "aud": [], "exp": 1});
+        assert!(IdTokenClaims::from_value(&v).is_err());
+    }
+
+    #[test]
+    fn check_issuer_match_accepts_equal_normalized() {
+        check_issuer_match("https://idp.example.com", "https://idp.example.com")
+            .expect("equal must pass");
+        // Trailing slash tolerated on either side.
+        check_issuer_match("https://idp.example.com/", "https://idp.example.com")
+            .expect("trailing slash on configured must pass");
+        check_issuer_match("https://idp.example.com", "https://idp.example.com/")
+            .expect("trailing slash on advertised must pass");
+    }
+
+    #[test]
+    fn check_issuer_match_rejects_foreign_issuer() {
+        let err = check_issuer_match("https://idp.example.com", "https://attacker.example.com")
+            .expect_err("must reject");
+        match err {
+            BffError::Idp(msg) => {
+                assert!(msg.contains("issuer mismatch"), "got `{msg}`");
+                assert!(msg.contains("idp.example.com"), "got `{msg}`");
+                assert!(msg.contains("attacker.example.com"), "got `{msg}`");
+            }
+            _ => panic!("expected BffError::Idp, got {err:?}"),
+        }
     }
 
     #[test]

--- a/src/backend/services/api-gateway/src/bff/oidc_client.rs
+++ b/src/backend/services/api-gateway/src/bff/oidc_client.rs
@@ -1,397 +1,133 @@
-//! Minimal OIDC confidential client.
+//! OIDC confidential client, backed by the `openidconnect` crate.
 //!
-//! Drives the authorization-code-with-PKCE flow without depending on the
-//! `openidconnect` crate, which pins reqwest versions that conflict with
-//! the rest of the workspace. We only need:
-//!   * discovery doc fetch (cached at module init)
-//!   * authorize URL builder (state, nonce, PKCE)
-//!   * token exchange (POST `token_endpoint`)
-//!   * ID token validation, delegated to `modkit_auth::JwksKeyProvider`
-//!     (signature) plus our own `iss`/`aud`/`nonce`/`exp` checks.
+//! Thin adapter around `openidconnect 4`: discovery, authorize-URL
+//! builder, code-with-PKCE exchange, and ID-token verification
+//! (signature + `iss`/`aud`/`nonce`/`exp`/`nbf` + alg allow-list) all
+//! live in the upstream crate. The local surface mirrors what the
+//! previous hand-rolled module exposed so callers
+//! (`handlers::login`, `handlers::callback`, `module`) didn't change.
 //!
-//! Anything beyond that — refresh-token use, dynamic client registration,
-//! UserInfo, etc. — is out of scope for v1.
+//! Anything beyond the authorization-code-with-PKCE flow — refresh
+//! tokens, dynamic client registration, UserInfo — is out of scope
+//! for Phase 1. RP-initiated logout will be wired through the crate's
+//! `ProviderMetadataWithLogout` extension when the `/auth/logout`
+//! handler lands.
 
 use std::sync::Arc;
 use std::time::Duration;
 
-use base64::Engine;
-use base64::engine::general_purpose::URL_SAFE_NO_PAD;
-use modkit_auth::JwksKeyProvider;
-use modkit_auth::traits::KeyProvider;
-use rand::RngCore;
-use rand::rngs::OsRng;
-use serde::Deserialize;
-use sha2::{Digest, Sha256};
+use openidconnect::core::{
+    CoreAuthDisplay, CoreAuthPrompt, CoreAuthenticationFlow, CoreErrorResponseType,
+    CoreGenderClaim, CoreJsonWebKey, CoreJweContentEncryptionAlgorithm, CoreJwsSigningAlgorithm,
+    CoreProviderMetadata, CoreRevocableToken, CoreTokenIntrospectionResponse, CoreTokenType,
+};
+use openidconnect::{
+    AdditionalClaims, AuthorizationCode, ClientId, ClientSecret, CsrfToken, EmptyExtraTokenFields,
+    EndpointMaybeSet, EndpointNotSet, EndpointSet, IdTokenFields, IssuerUrl, Nonce,
+    PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, RevocationErrorResponseType, Scope,
+    StandardErrorResponse, StandardTokenResponse, TokenResponse, reqwest,
+};
+use serde::{Deserialize, Serialize};
 
 use crate::bff::errors::BffError;
-use crate::bff::handlers::unix_now;
 
-/// Algorithms accepted on the ID token JWT header. Locked down to the
-/// asymmetric set OIDC providers actually use; rejecting `HS*` closes
-/// the JWKS-as-HMAC-secret confusion vector, rejecting `none` is
-/// belt-and-braces (the JWT crate already rejects it on parse).
-const ALLOWED_ALGS: &[&str] = &["RS256", "RS384", "RS512", "ES256", "ES384", "EdDSA"];
-
-/// Clock skew tolerance for `exp` / `nbf` checks on the ID token.
-/// Matches the default leeway in upstream JWT libraries.
-const CLOCK_SKEW_SECONDS: i64 = 60;
-
-/// OIDC Core §3.1.2.2: the RP MUST validate that the discovery document's
-/// `issuer` matches the URL it was fetched from. Both sides are normalized
-/// by trimming a single trailing `/` before comparison.
-fn check_issuer_match(configured: &str, advertised: &str) -> Result<(), BffError> {
-    let expected = configured.trim_end_matches('/');
-    let got = advertised.trim_end_matches('/');
-    if expected != got {
-        return Err(BffError::Idp(format!(
-            "discovery issuer mismatch: expected `{expected}`, got `{got}`",
-        )));
-    }
-    Ok(())
+/// Asymmetric signing algorithms the BFF accepts on ID tokens. HMAC
+/// (`HS*`) is excluded to close the JWKS-as-shared-secret confusion
+/// vector; `none` is excluded for the obvious reason. Enforced via the
+/// verifier's `set_allowed_algs` knob inside `exchange_code`.
+fn allowed_signing_algs() -> Vec<CoreJwsSigningAlgorithm> {
+    vec![
+        CoreJwsSigningAlgorithm::RsaSsaPkcs1V15Sha256,
+        CoreJwsSigningAlgorithm::RsaSsaPkcs1V15Sha384,
+        CoreJwsSigningAlgorithm::RsaSsaPkcs1V15Sha512,
+        CoreJwsSigningAlgorithm::EcdsaP256Sha256,
+        CoreJwsSigningAlgorithm::EcdsaP384Sha384,
+        CoreJwsSigningAlgorithm::EdDsa,
+    ]
 }
 
-/// Subset of the OIDC discovery document we consume.
-#[derive(Debug, Clone, Deserialize)]
-#[allow(dead_code)]
-pub struct DiscoveryDoc {
-    pub issuer: String,
-    pub authorization_endpoint: String,
-    pub token_endpoint: String,
-    pub jwks_uri: String,
-    /// Optional: present iff the IdP supports RP-initiated logout.
-    /// Used by Phase 2's `/auth/logout`.
-    #[serde(default)]
-    pub end_session_endpoint: Option<String>,
+/// Extra ID-token claims the BFF cares about beyond the OIDC standard
+/// set — namely `sid`, used by back-channel logout to map IdP sessions
+/// to local ones.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct BffAdditionalClaims {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sid: Option<String>,
 }
 
-impl DiscoveryDoc {
-    /// Fetch the discovery doc. Used once at module init; not on the hot path.
-    pub async fn fetch(issuer_url: &str, http_timeout: Duration) -> Result<Self, BffError> {
-        let url = format!(
-            "{}/.well-known/openid-configuration",
-            issuer_url.trim_end_matches('/')
-        );
-        let client = reqwest::Client::builder()
-            .timeout(http_timeout)
-            .build()
-            .map_err(|e| BffError::Internal(anyhow::anyhow!("reqwest builder: {e}")))?;
-        let resp = client
-            .get(&url)
-            .send()
-            .await
-            .map_err(|e| BffError::Idp(format!("discovery fetch: {e}")))?;
-        if !resp.status().is_success() {
-            return Err(BffError::Idp(format!(
-                "discovery doc returned status {}",
-                resp.status()
-            )));
-        }
-        let doc: DiscoveryDoc = resp
-            .json()
-            .await
-            .map_err(|e| BffError::Idp(format!("discovery parse: {e}")))?;
-        if doc.issuer.is_empty()
-            || doc.authorization_endpoint.is_empty()
-            || doc.token_endpoint.is_empty()
-            || doc.jwks_uri.is_empty()
-        {
-            return Err(BffError::Idp(
-                "discovery doc missing required fields".into(),
-            ));
-        }
-        check_issuer_match(issuer_url, &doc.issuer)?;
-        Ok(doc)
-    }
-}
+impl AdditionalClaims for BffAdditionalClaims {}
 
-/// PKCE verifier + challenge pair.
+type BffIdTokenFields = IdTokenFields<
+    BffAdditionalClaims,
+    EmptyExtraTokenFields,
+    CoreGenderClaim,
+    CoreJweContentEncryptionAlgorithm,
+    CoreJwsSigningAlgorithm,
+>;
+
+type BffTokenResponse = StandardTokenResponse<BffIdTokenFields, CoreTokenType>;
+
+/// Concrete client type after discovery + redirect URI are set. The
+/// typestate parameters mirror what `from_provider_metadata` produces:
+/// auth URL is always supplied by discovery (`EndpointSet`), token and
+/// userinfo URLs may or may not be (`EndpointMaybeSet`), and the rest
+/// stay `NotSet` since the BFF never speaks device-flow, introspection,
+/// or revocation.
+type BffOidcClient = openidconnect::Client<
+    BffAdditionalClaims,
+    CoreAuthDisplay,
+    CoreGenderClaim,
+    CoreJweContentEncryptionAlgorithm,
+    CoreJsonWebKey,
+    CoreAuthPrompt,
+    StandardErrorResponse<CoreErrorResponseType>,
+    BffTokenResponse,
+    CoreTokenIntrospectionResponse,
+    CoreRevocableToken,
+    StandardErrorResponse<RevocationErrorResponseType>,
+    EndpointSet,
+    EndpointNotSet,
+    EndpointNotSet,
+    EndpointNotSet,
+    EndpointMaybeSet,
+    EndpointMaybeSet,
+>;
+
+/// PKCE verifier. The crate deliberately makes
+/// `PkceCodeChallenge` non-`Clone` and constructible only from a
+/// verifier, so the BFF persists the verifier (in
+/// `bff:login_state:{state}`) and re-derives the challenge inside
+/// `authorize_url` each time. Two-field shape is gone; the public
+/// field is now `verifier` only.
 pub struct PkcePair {
     pub verifier: String,
-    pub challenge: String,
 }
 
 impl PkcePair {
-    /// Generate a fresh verifier (32 random bytes → 43-char base64url) and
-    /// derive its S256 challenge.
     #[must_use]
     pub fn generate() -> Self {
-        let mut buf = [0u8; 32];
-        OsRng.fill_bytes(&mut buf);
-        let verifier = URL_SAFE_NO_PAD.encode(buf);
-        let mut h = Sha256::new();
-        h.update(verifier.as_bytes());
-        let challenge = URL_SAFE_NO_PAD.encode(h.finalize());
+        let (_challenge, verifier) = PkceCodeChallenge::new_random_sha256();
         Self {
-            verifier,
-            challenge,
+            verifier: verifier.secret().clone(),
         }
     }
 }
 
 /// Validated ID token claims surfaced to the rest of the BFF.
+///
+/// Projection over `openidconnect::IdTokenClaims<BffAdditionalClaims,
+/// CoreGenderClaim>`: the crate's claims type is verbose (locale-
+/// aware names, generic over key/alg/claim types) and verifier-bound,
+/// so we collapse it to the small set of values the handlers actually
+/// consume. Every value here has already cleared the crate's verifier
+/// (signature + iss + aud + nonce + exp/nbf + alg allow-list).
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct IdTokenClaims {
     pub iss: String,
     pub sub: String,
-    pub aud: Vec<String>,
-    pub exp: i64,
-    /// Optional per RFC 7519. We stop short of treating absence as an
-    /// error (some IdPs really don't emit it) but never substitute zero
-    /// for missing — `None` means "unknown".
-    pub iat: Option<i64>,
-    pub nbf: Option<i64>,
-    pub nonce: Option<String>,
     pub sid: Option<String>,
-    /// Authorized party (OIDC Core §3.1.3.7 step 5). Required when `aud`
-    /// is multi-valued.
-    pub azp: Option<String>,
     pub email: Option<String>,
     pub name: Option<String>,
-}
-
-impl IdTokenClaims {
-    fn from_value(value: &serde_json::Value) -> Result<Self, BffError> {
-        let v = value
-            .as_object()
-            .ok_or_else(|| BffError::Idp("id_token claims is not an object".into()))?;
-        let str_field = |k: &str| -> Result<String, BffError> {
-            v.get(k)
-                .and_then(serde_json::Value::as_str)
-                .map(str::to_owned)
-                .ok_or_else(|| BffError::Idp(format!("id_token claim `{k}` missing")))
-        };
-        let opt_str = |k: &str| -> Option<String> {
-            v.get(k)
-                .and_then(serde_json::Value::as_str)
-                .map(str::to_owned)
-        };
-        let int_field = |k: &str| -> Result<i64, BffError> {
-            v.get(k)
-                .and_then(serde_json::Value::as_i64)
-                .ok_or_else(|| BffError::Idp(format!("id_token claim `{k}` missing or not int")))
-        };
-        let aud: Vec<String> = match v.get("aud") {
-            Some(serde_json::Value::String(s)) => vec![s.clone()],
-            Some(serde_json::Value::Array(arr)) => {
-                if arr.is_empty() {
-                    return Err(BffError::Idp("id_token `aud` claim missing".into()));
-                }
-                arr.iter()
-                    .map(|x| {
-                        x.as_str().map(str::to_owned).ok_or_else(|| {
-                            BffError::Idp("id_token `aud` entry is not a string".into())
-                        })
-                    })
-                    .collect::<Result<Vec<_>, _>>()?
-            }
-            _ => return Err(BffError::Idp("id_token `aud` claim missing".into())),
-        };
-        let opt_int = |k: &str| -> Option<i64> { v.get(k).and_then(serde_json::Value::as_i64) };
-        Ok(Self {
-            iss: str_field("iss")?,
-            sub: str_field("sub")?,
-            aud,
-            exp: int_field("exp")?,
-            iat: opt_int("iat"),
-            nbf: opt_int("nbf"),
-            nonce: opt_str("nonce"),
-            sid: opt_str("sid"),
-            azp: opt_str("azp"),
-            email: opt_str("email"),
-            name: opt_str("name").or_else(|| opt_str("preferred_username")),
-        })
-    }
-}
-
-/// Confidential OIDC client.
-#[derive(Clone)]
-pub struct OidcClient {
-    discovery: DiscoveryDoc,
-    client_id: String,
-    client_secret: String,
-    redirect_uri: String,
-    expected_audience: String,
-    scopes: Vec<String>,
-    http: reqwest::Client,
-    jwks: Arc<JwksKeyProvider>,
-}
-
-impl OidcClient {
-    /// Build a new client. Performs discovery + initial JWKS fetch.
-    pub async fn new(
-        issuer_url: &str,
-        client_id: &str,
-        client_secret: &str,
-        redirect_uri: &str,
-        scopes: Vec<String>,
-        audience: Option<&str>,
-    ) -> Result<Self, BffError> {
-        let discovery = DiscoveryDoc::fetch(issuer_url, Duration::from_secs(10)).await?;
-        let jwks = Arc::new(
-            JwksKeyProvider::new(discovery.jwks_uri.clone())
-                .map_err(|e| BffError::Internal(anyhow::anyhow!("jwks provider: {e}")))?
-                .with_refresh_interval(Duration::from_hours(1)),
-        );
-        // Initial fetch — not fatal if it fails (the IdP may be briefly
-        // unreachable at boot); on-demand refresh will retry.
-        if let Err(e) = jwks.refresh_keys().await {
-            tracing::warn!(error = %e, "initial JWKS fetch failed; will retry on demand");
-        }
-
-        let http = reqwest::Client::builder()
-            .timeout(Duration::from_secs(15))
-            .build()
-            .map_err(|e| BffError::Internal(anyhow::anyhow!("reqwest builder: {e}")))?;
-
-        Ok(Self {
-            discovery,
-            client_id: client_id.to_owned(),
-            client_secret: client_secret.to_owned(),
-            redirect_uri: redirect_uri.to_owned(),
-            expected_audience: audience.unwrap_or(client_id).to_owned(),
-            scopes,
-            http,
-            jwks,
-        })
-    }
-
-    /// Phase-2 access for `/auth/logout` (id_token_hint, end_session_url).
-    #[must_use]
-    #[allow(dead_code)]
-    pub fn discovery(&self) -> &DiscoveryDoc {
-        &self.discovery
-    }
-
-    /// Build the authorize URL the browser is redirected to.
-    pub fn authorize_url(
-        &self,
-        state: &str,
-        nonce: &str,
-        pkce_challenge: &str,
-    ) -> Result<String, BffError> {
-        let mut url = url::Url::parse(&self.discovery.authorization_endpoint)
-            .map_err(|e| BffError::Internal(anyhow::anyhow!("invalid auth endpoint: {e}")))?;
-        url.query_pairs_mut()
-            .append_pair("response_type", "code")
-            .append_pair("client_id", &self.client_id)
-            .append_pair("redirect_uri", &self.redirect_uri)
-            .append_pair("scope", &self.scopes.join(" "))
-            .append_pair("state", state)
-            .append_pair("nonce", nonce)
-            .append_pair("code_challenge", pkce_challenge)
-            .append_pair("code_challenge_method", "S256");
-        Ok(url.to_string())
-    }
-
-    /// Exchange a callback `code` for tokens. Returns the raw `id_token`
-    /// (so we can keep it for `id_token_hint` later) plus the validated
-    /// claims.
-    pub async fn exchange_code(
-        &self,
-        code: &str,
-        verifier: &str,
-        expected_nonce: &str,
-    ) -> Result<TokenExchange, BffError> {
-        let resp = self
-            .http
-            .post(&self.discovery.token_endpoint)
-            .basic_auth(&self.client_id, Some(&self.client_secret))
-            .form(&[
-                ("grant_type", "authorization_code"),
-                ("code", code),
-                ("redirect_uri", self.redirect_uri.as_str()),
-                ("code_verifier", verifier),
-                // client_id repeated in body for IdPs that demand it even
-                // alongside Basic auth (Keycloak, some Auth0 setups).
-                ("client_id", self.client_id.as_str()),
-            ])
-            .send()
-            .await
-            .map_err(|e| BffError::Idp(format!("token endpoint: {e}")))?;
-
-        if !resp.status().is_success() {
-            let status = resp.status();
-            // Pull `error` / `error_description` out of a JSON body if the
-            // IdP supplied them — that's the actionable signal. Don't echo
-            // the raw body into the response or logs (could carry user
-            // input or partial grant data).
-            let body_text = resp.text().await.unwrap_or_default();
-            let parsed = serde_json::from_str::<TokenError>(&body_text).ok();
-            let summary = parsed.as_ref().map_or_else(
-                || status.to_string(),
-                |e| {
-                    format!(
-                        "{} ({})",
-                        e.error,
-                        e.error_description.as_deref().unwrap_or("")
-                    )
-                },
-            );
-            tracing::warn!(
-                status = %status,
-                error = %parsed.as_ref().map_or("", |e| e.error.as_str()),
-                "token endpoint non-success",
-            );
-            return Err(BffError::Idp(format!("token endpoint: {summary}")));
-        }
-
-        let body: TokenResponse = resp
-            .json()
-            .await
-            .map_err(|e| BffError::Idp(format!("token response parse: {e}")))?;
-
-        let id_token = body
-            .id_token
-            .ok_or_else(|| BffError::Idp("token response missing id_token".into()))?;
-
-        // Algorithm allow-list — guard against alg-confusion / `none`. We
-        // peek at the JWT header before delegating signature verification
-        // to the JWKS provider, since the provider does not enforce an
-        // allow-list itself.
-        verify_alg_against_allowlist(&id_token)?;
-
-        // Signature check via JWKS provider. The provider validates the
-        // signature only — `exp`/`nbf`/`iss`/`aud`/`nonce` are this BFF's
-        // responsibility (see `validate_id_token_claims`).
-        let (_header, claims_value) = self
-            .jwks
-            .validate_and_decode(&id_token)
-            .await
-            .map_err(|e| BffError::Idp(format!("id_token validate: {e}")))?;
-
-        let claims = IdTokenClaims::from_value(&claims_value)?;
-        let now = unix_now();
-        validate_id_token_claims(
-            &claims,
-            &self.discovery.issuer,
-            &self.expected_audience,
-            &self.client_id,
-            expected_nonce,
-            now,
-        )?;
-
-        Ok(TokenExchange { id_token, claims })
-    }
-
-    /// Build the RP-initiated logout URL. Returns `None` if the IdP did
-    /// not advertise an `end_session_endpoint`. Phase 2's `/auth/logout`.
-    #[must_use]
-    #[allow(dead_code)]
-    pub fn end_session_url(
-        &self,
-        id_token_hint: &str,
-        post_logout_redirect: &str,
-    ) -> Option<String> {
-        let endpoint = self.discovery.end_session_endpoint.as_ref()?;
-        let mut url = url::Url::parse(endpoint).ok()?;
-        url.query_pairs_mut()
-            .append_pair("id_token_hint", id_token_hint)
-            .append_pair("post_logout_redirect_uri", post_logout_redirect)
-            .append_pair("client_id", &self.client_id);
-        Some(url.to_string())
-    }
 }
 
 /// Successful token-exchange result.
@@ -400,100 +136,164 @@ pub struct TokenExchange {
     pub claims: IdTokenClaims,
 }
 
-#[derive(Debug, Deserialize)]
-struct TokenResponse {
-    #[serde(default)]
-    id_token: Option<String>,
+/// Confidential OIDC client.
+#[derive(Clone)]
+pub struct OidcClient {
+    client: Arc<BffOidcClient>,
+    http: reqwest::Client,
+    metadata: CoreProviderMetadata,
+    /// Optional explicit audience override. `None` falls back to the
+    /// crate verifier's default (matches `client_id`).
+    expected_audience: Option<String>,
+    scopes: Vec<Scope>,
 }
 
-/// OAuth 2.0 / OIDC error response shape (RFC 6749 §5.2).
-#[derive(Debug, Deserialize)]
-struct TokenError {
-    error: String,
-    #[serde(default)]
-    error_description: Option<String>,
-}
+impl OidcClient {
+    /// Build a new client. Performs discovery; the JWKS arrives as
+    /// part of the provider metadata and stays cached inside the
+    /// crate's client for the duration of the process.
+    pub async fn new(
+        issuer_url: &str,
+        client_id: &str,
+        client_secret: &str,
+        redirect_uri: &str,
+        scopes: Vec<String>,
+        audience: Option<&str>,
+    ) -> Result<Self, BffError> {
+        let http = reqwest::ClientBuilder::new()
+            .timeout(Duration::from_secs(15))
+            // Mitigation called out by the openidconnect docs: following
+            // 3xx redirects on token/userinfo/jwks fetches opens SSRF
+            // against the provider's hostname.
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .map_err(|e| BffError::Internal(anyhow::anyhow!("reqwest builder: {e}")))?;
 
-/// Decode the JWT header without verifying signature, and reject any
-/// algorithm not in `ALLOWED_ALGS`. This closes the alg-confusion family:
-/// `none`, `HS256`-with-RSA-pubkey-as-shared-secret, downgrade games.
-fn verify_alg_against_allowlist(token: &str) -> Result<(), BffError> {
-    // header is the first dot-separated segment, base64url-encoded JSON.
-    let header_b64 = token
-        .split('.')
-        .next()
-        .ok_or_else(|| BffError::Idp("id_token has no header".into()))?;
-    let raw = URL_SAFE_NO_PAD
-        .decode(header_b64)
-        .map_err(|e| BffError::Idp(format!("id_token header decode: {e}")))?;
-    let header: serde_json::Value = serde_json::from_slice(&raw)
-        .map_err(|e| BffError::Idp(format!("id_token header parse: {e}")))?;
-    let alg = header
-        .get("alg")
-        .and_then(serde_json::Value::as_str)
-        .ok_or_else(|| BffError::Idp("id_token header missing alg".into()))?;
-    if !ALLOWED_ALGS.contains(&alg) {
-        return Err(BffError::Idp(format!(
-            "id_token alg `{alg}` not in allow-list"
-        )));
-    }
-    Ok(())
-}
+        let issuer = IssuerUrl::new(issuer_url.to_owned())
+            .map_err(|e| BffError::Idp(format!("invalid issuer_url: {e}")))?;
+        let metadata = CoreProviderMetadata::discover_async(issuer, &http)
+            .await
+            .map_err(|e| BffError::Idp(format!("discovery failed: {e}")))?;
 
-/// Validate iss/aud/nonce/exp/nbf/azp on a parsed `IdTokenClaims`.
-///
-/// Pulled out of `exchange_code` so it's directly testable with a fake
-/// `IdTokenClaims` and a fixed `now`, no IdP needed.
-///
-/// Per OIDC Core §3.1.3.7:
-///   * `iss` must match the configured issuer exactly.
-///   * `aud` must contain the expected audience.
-///   * If `aud` is multi-valued AND `azp` is present, `azp` must equal
-///     the client_id.
-///   * `nonce` must match what the BFF stored at /auth/login time.
-///   * `exp` must be in the future (with clock skew leeway).
-///   * `nbf`, if present, must not be in the future (with leeway).
-fn validate_id_token_claims(
-    claims: &IdTokenClaims,
-    expected_issuer: &str,
-    expected_audience: &str,
-    client_id: &str,
-    expected_nonce: &str,
-    now: i64,
-) -> Result<(), BffError> {
-    if claims.iss != expected_issuer {
-        return Err(BffError::Idp("id_token iss mismatch".into()));
+        let redirect = RedirectUrl::new(redirect_uri.to_owned())
+            .map_err(|e| BffError::Internal(anyhow::anyhow!("invalid redirect_uri: {e}")))?;
+
+        let client: BffOidcClient = openidconnect::Client::from_provider_metadata(
+            metadata.clone(),
+            ClientId::new(client_id.to_owned()),
+            Some(ClientSecret::new(client_secret.to_owned())),
+        )
+        .set_redirect_uri(redirect);
+
+        Ok(Self {
+            client: Arc::new(client),
+            http,
+            metadata,
+            expected_audience: audience.map(str::to_owned),
+            scopes: scopes.into_iter().map(Scope::new).collect(),
+        })
     }
-    if !claims.aud.iter().any(|a| a == expected_audience) {
-        return Err(BffError::Idp("id_token aud mismatch".into()));
+
+    /// Phase-2 access for `/auth/logout` (id_token_hint, end_session_url).
+    #[must_use]
+    #[allow(dead_code)]
+    pub fn metadata(&self) -> &CoreProviderMetadata {
+        &self.metadata
     }
-    // §3.1.3.7 step 5: if multiple audiences, azp MUST be present and equal client_id.
-    if claims.aud.len() > 1 {
-        match claims.azp.as_deref() {
-            Some(azp) if azp == client_id => {}
-            Some(_) => {
-                return Err(BffError::Idp("id_token azp mismatch".into()));
-            }
-            None => {
-                return Err(BffError::Idp(
-                    "id_token has multiple audiences but no azp".into(),
-                ));
-            }
+
+    /// Build the authorize URL the browser is redirected to. State and
+    /// nonce are generated by the BFF (so they can be persisted
+    /// alongside the PKCE verifier in Redis) and supplied here; the
+    /// crate wraps them in `CsrfToken` / `Nonce` newtypes and stitches
+    /// them onto the URL. The PKCE challenge is derived from the
+    /// verifier per `from_code_verifier_sha256`.
+    #[must_use]
+    pub fn authorize_url(&self, state: &str, nonce: &str, pkce_verifier: &str) -> String {
+        let state_owned = state.to_owned();
+        let nonce_owned = nonce.to_owned();
+        let verifier = PkceCodeVerifier::new(pkce_verifier.to_owned());
+        let challenge = PkceCodeChallenge::from_code_verifier_sha256(&verifier);
+
+        let mut builder = self.client.authorize_url(
+            CoreAuthenticationFlow::AuthorizationCode,
+            move || CsrfToken::new(state_owned.clone()),
+            move || Nonce::new(nonce_owned.clone()),
+        );
+        for scope in &self.scopes {
+            builder = builder.add_scope(scope.clone());
         }
+        let (url, _csrf, _nonce) = builder.set_pkce_challenge(challenge).url();
+        url.to_string()
     }
-    match claims.nonce.as_deref() {
-        Some(n) if n == expected_nonce => {}
-        _ => return Err(BffError::Idp("id_token nonce mismatch".into())),
+
+    /// Exchange a callback `code` for tokens. Returns the raw
+    /// `id_token` (so callers can keep it for `id_token_hint` in
+    /// RP-initiated logout) plus the verified claims.
+    pub async fn exchange_code(
+        &self,
+        code: &str,
+        verifier: &str,
+        expected_nonce: &str,
+    ) -> Result<TokenExchange, BffError> {
+        let token_response = self
+            .client
+            .exchange_code(AuthorizationCode::new(code.to_owned()))
+            .map_err(|e| BffError::Idp(format!("exchange_code build: {e}")))?
+            .set_pkce_verifier(PkceCodeVerifier::new(verifier.to_owned()))
+            .request_async(&self.http)
+            .await
+            .map_err(|e| BffError::Idp(format!("token endpoint: {e}")))?;
+
+        let id_token = token_response
+            .id_token()
+            .ok_or_else(|| BffError::Idp("token response missing id_token".into()))?
+            .clone();
+
+        let mut verifier_cfg = self
+            .client
+            .id_token_verifier()
+            .set_allowed_algs(allowed_signing_algs());
+        if let Some(aud) = self.expected_audience.clone() {
+            verifier_cfg = verifier_cfg.set_other_audience_verifier_fn(move |a| a.as_str() == aud);
+        }
+
+        let nonce = Nonce::new(expected_nonce.to_owned());
+        let claims = id_token
+            .claims(&verifier_cfg, &nonce)
+            .map_err(|e| BffError::Idp(format!("id_token validate: {e}")))?;
+
+        let projected = project_claims(claims);
+
+        Ok(TokenExchange {
+            id_token: id_token.to_string(),
+            claims: projected,
+        })
     }
-    if claims.exp <= now.saturating_sub(CLOCK_SKEW_SECONDS) {
-        return Err(BffError::Idp("id_token expired".into()));
+}
+
+fn project_claims(
+    c: &openidconnect::IdTokenClaims<BffAdditionalClaims, CoreGenderClaim>,
+) -> IdTokenClaims {
+    // Prefer the unlocalized `name`, fall back to the first localized
+    // entry, then to `preferred_username`. The session record only ever
+    // stores one display string, so flattening here keeps callers
+    // unaware of `LocalizedClaim`.
+    let name = c
+        .name()
+        .and_then(|lc| {
+            lc.get(None)
+                .map(|n| n.as_str().to_owned())
+                .or_else(|| lc.iter().next().map(|(_, n)| n.as_str().to_owned()))
+        })
+        .or_else(|| c.preferred_username().map(|p| p.as_str().to_owned()));
+
+    IdTokenClaims {
+        iss: c.issuer().as_str().to_owned(),
+        sub: c.subject().as_str().to_owned(),
+        sid: c.additional_claims().sid.clone(),
+        email: c.email().map(|e| e.as_str().to_owned()),
+        name,
     }
-    if let Some(nbf) = claims.nbf
-        && nbf > now.saturating_add(CLOCK_SKEW_SECONDS)
-    {
-        return Err(BffError::Idp("id_token not yet valid (nbf)".into()));
-    }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -501,326 +301,36 @@ mod tests {
     use super::*;
 
     #[test]
-    fn pkce_pair_uses_url_safe_no_pad() {
+    fn pkce_verifier_is_url_safe_no_pad() {
         let p = PkcePair::generate();
-        assert_eq!(p.verifier.len(), 43);
-        assert_eq!(p.challenge.len(), 43);
+        assert!(!p.verifier.is_empty());
         assert!(!p.verifier.contains('='));
-        assert!(!p.challenge.contains('='));
-        assert!(!p.challenge.contains('+'));
-        assert!(!p.challenge.contains('/'));
+        assert!(!p.verifier.contains('+'));
+        assert!(!p.verifier.contains('/'));
     }
 
     #[test]
-    fn pkce_pair_challenge_matches_s256_of_verifier() {
-        let p = PkcePair::generate();
-        let mut h = Sha256::new();
-        h.update(p.verifier.as_bytes());
-        let expected = URL_SAFE_NO_PAD.encode(h.finalize());
-        assert_eq!(p.challenge, expected);
-    }
-
-    #[test]
-    fn pkce_pair_verifier_is_random() {
+    fn pkce_verifier_is_random() {
         let a = PkcePair::generate();
         let b = PkcePair::generate();
         assert_ne!(a.verifier, b.verifier);
     }
 
     #[test]
-    fn id_token_claims_parse_minimal() {
-        let v = serde_json::json!({
-            "iss": "https://idp/",
-            "sub": "sub-1",
-            "aud": "client-id",
-            "exp": 1_700_000_000_i64,
-            "nonce": "abc",
-        });
-        let c = IdTokenClaims::from_value(&v).expect("parse");
-        assert_eq!(c.iss, "https://idp/");
-        assert_eq!(c.sub, "sub-1");
-        assert_eq!(c.aud, vec!["client-id".to_owned()]);
-        assert_eq!(c.exp, 1_700_000_000);
-        assert_eq!(c.nonce.as_deref(), Some("abc"));
+    fn additional_claims_round_trips_sid() {
+        let json = serde_json::json!({"sid": "abc123"});
+        let parsed: BffAdditionalClaims = serde_json::from_value(json).expect("parse");
+        assert_eq!(parsed.sid.as_deref(), Some("abc123"));
+        let rendered = serde_json::to_value(&parsed).expect("ser");
+        assert_eq!(rendered, serde_json::json!({"sid": "abc123"}));
     }
 
     #[test]
-    fn id_token_claims_parse_aud_array() {
-        let v = serde_json::json!({
-            "iss": "i",
-            "sub": "s",
-            "aud": ["a", "b"],
-            "exp": 1_i64,
-        });
-        let c = IdTokenClaims::from_value(&v).expect("parse");
-        assert_eq!(c.aud, vec!["a".to_owned(), "b".to_owned()]);
-    }
-
-    #[test]
-    fn id_token_claims_reject_missing_iss() {
-        let v = serde_json::json!({"sub": "s", "aud": "x", "exp": 1});
-        assert!(IdTokenClaims::from_value(&v).is_err());
-    }
-
-    #[test]
-    fn id_token_claims_reject_missing_aud() {
-        let v = serde_json::json!({"iss": "i", "sub": "s", "exp": 1});
-        assert!(IdTokenClaims::from_value(&v).is_err());
-    }
-
-    #[test]
-    fn id_token_claims_reject_aud_array_with_non_string_entry() {
-        let v = serde_json::json!({
-            "iss": "i", "sub": "s", "exp": 1,
-            "aud": ["client-id", 123],
-        });
-        let err = IdTokenClaims::from_value(&v).expect_err("must reject");
-        match err {
-            BffError::Idp(msg) => {
-                assert!(msg.contains("aud"), "got `{msg}`");
-                assert!(msg.contains("not a string"), "got `{msg}`");
-            }
-            _ => panic!("expected BffError::Idp, got {err:?}"),
-        }
-    }
-
-    #[test]
-    fn id_token_claims_reject_empty_aud_array() {
-        let v = serde_json::json!({"iss": "i", "sub": "s", "aud": [], "exp": 1});
-        assert!(IdTokenClaims::from_value(&v).is_err());
-    }
-
-    #[test]
-    fn check_issuer_match_accepts_equal_normalized() {
-        check_issuer_match("https://idp.example.com", "https://idp.example.com")
-            .expect("equal must pass");
-        // Trailing slash tolerated on either side.
-        check_issuer_match("https://idp.example.com/", "https://idp.example.com")
-            .expect("trailing slash on configured must pass");
-        check_issuer_match("https://idp.example.com", "https://idp.example.com/")
-            .expect("trailing slash on advertised must pass");
-    }
-
-    #[test]
-    fn check_issuer_match_rejects_foreign_issuer() {
-        let err = check_issuer_match("https://idp.example.com", "https://attacker.example.com")
-            .expect_err("must reject");
-        match err {
-            BffError::Idp(msg) => {
-                assert!(msg.contains("issuer mismatch"), "got `{msg}`");
-                assert!(msg.contains("idp.example.com"), "got `{msg}`");
-                assert!(msg.contains("attacker.example.com"), "got `{msg}`");
-            }
-            _ => panic!("expected BffError::Idp, got {err:?}"),
-        }
-    }
-
-    #[test]
-    fn id_token_claims_extract_email_and_name() {
-        let v = serde_json::json!({
-            "iss": "i", "sub": "s", "aud": "x", "exp": 1,
-            "email": "a@b.com", "name": "Alice",
-        });
-        let c = IdTokenClaims::from_value(&v).expect("parse");
-        assert_eq!(c.email.as_deref(), Some("a@b.com"));
-        assert_eq!(c.name.as_deref(), Some("Alice"));
-    }
-
-    #[test]
-    fn id_token_claims_falls_back_to_preferred_username() {
-        let v = serde_json::json!({
-            "iss": "i", "sub": "s", "aud": "x", "exp": 1,
-            "preferred_username": "alice",
-        });
-        let c = IdTokenClaims::from_value(&v).expect("parse");
-        assert_eq!(c.name.as_deref(), Some("alice"));
-    }
-
-    #[test]
-    fn id_token_claims_iat_is_none_when_missing() {
-        let v = serde_json::json!({"iss": "i", "sub": "s", "aud": "x", "exp": 1});
-        let c = IdTokenClaims::from_value(&v).expect("parse");
-        assert_eq!(c.iat, None);
-        assert_eq!(c.nbf, None);
-        assert_eq!(c.azp, None);
-    }
-
-    fn good_claims(now: i64, nonce: &str) -> IdTokenClaims {
-        IdTokenClaims {
-            iss: "https://idp/".into(),
-            sub: "sub".into(),
-            aud: vec!["client-id".into()],
-            exp: now + 300,
-            iat: Some(now),
-            nbf: None,
-            nonce: Some(nonce.into()),
-            sid: None,
-            azp: None,
-            email: Some("a@b.com".into()),
-            name: Some("Alice".into()),
-        }
-    }
-
-    #[test]
-    fn validate_claims_accepts_good_token() {
-        let c = good_claims(1_000_000, "n");
-        validate_id_token_claims(&c, "https://idp/", "client-id", "client-id", "n", 1_000_000)
-            .expect("ok");
-    }
-
-    #[test]
-    fn validate_claims_rejects_iss_mismatch() {
-        let c = good_claims(1_000_000, "n");
-        let r = validate_id_token_claims(
-            &c,
-            "https://other/",
-            "client-id",
-            "client-id",
-            "n",
-            1_000_000,
-        );
-        assert!(r.is_err());
-    }
-
-    #[test]
-    fn validate_claims_rejects_aud_mismatch() {
-        let c = good_claims(1_000_000, "n");
-        let r =
-            validate_id_token_claims(&c, "https://idp/", "other-aud", "client-id", "n", 1_000_000);
-        assert!(r.is_err());
-    }
-
-    #[test]
-    fn validate_claims_rejects_nonce_mismatch() {
-        let c = good_claims(1_000_000, "n");
-        let r = validate_id_token_claims(
-            &c,
-            "https://idp/",
-            "client-id",
-            "client-id",
-            "wrong",
-            1_000_000,
-        );
-        assert!(r.is_err());
-    }
-
-    #[test]
-    fn validate_claims_rejects_missing_nonce() {
-        let mut c = good_claims(1_000_000, "n");
-        c.nonce = None;
-        let r =
-            validate_id_token_claims(&c, "https://idp/", "client-id", "client-id", "n", 1_000_000);
-        assert!(r.is_err());
-    }
-
-    #[test]
-    fn validate_claims_rejects_expired_token() {
-        let c = good_claims(1_000_000, "n");
-        // now is past exp + leeway
-        let r =
-            validate_id_token_claims(&c, "https://idp/", "client-id", "client-id", "n", 1_000_400);
-        assert!(r.is_err());
-    }
-
-    #[test]
-    fn validate_claims_accepts_token_within_clock_skew_after_exp() {
-        let mut c = good_claims(1_000_000, "n");
-        c.exp = 1_000_000;
-        // now is 30s past exp — within 60s leeway
-        let r =
-            validate_id_token_claims(&c, "https://idp/", "client-id", "client-id", "n", 1_000_030);
-        assert!(r.is_ok(), "30s past exp should be in leeway");
-    }
-
-    #[test]
-    fn validate_claims_rejects_future_nbf() {
-        let mut c = good_claims(1_000_000, "n");
-        c.nbf = Some(1_000_500); // 500s in future, past leeway
-        let r =
-            validate_id_token_claims(&c, "https://idp/", "client-id", "client-id", "n", 1_000_000);
-        assert!(r.is_err());
-    }
-
-    #[test]
-    fn validate_claims_accepts_nbf_within_leeway() {
-        let mut c = good_claims(1_000_000, "n");
-        c.nbf = Some(1_000_030); // 30s in future — within 60s leeway
-        let r =
-            validate_id_token_claims(&c, "https://idp/", "client-id", "client-id", "n", 1_000_000);
-        assert!(r.is_ok());
-    }
-
-    #[test]
-    fn validate_claims_requires_azp_when_aud_is_multi() {
-        let mut c = good_claims(1_000_000, "n");
-        c.aud = vec!["client-id".into(), "other-aud".into()];
-        let r =
-            validate_id_token_claims(&c, "https://idp/", "client-id", "client-id", "n", 1_000_000);
-        assert!(r.is_err(), "multi-aud without azp must fail");
-    }
-
-    #[test]
-    fn validate_claims_accepts_multi_aud_with_correct_azp() {
-        let mut c = good_claims(1_000_000, "n");
-        c.aud = vec!["client-id".into(), "other-aud".into()];
-        c.azp = Some("client-id".into());
-        validate_id_token_claims(&c, "https://idp/", "client-id", "client-id", "n", 1_000_000)
-            .expect("ok");
-    }
-
-    #[test]
-    fn validate_claims_rejects_multi_aud_with_wrong_azp() {
-        let mut c = good_claims(1_000_000, "n");
-        c.aud = vec!["client-id".into(), "other-aud".into()];
-        c.azp = Some("attacker".into());
-        let r =
-            validate_id_token_claims(&c, "https://idp/", "client-id", "client-id", "n", 1_000_000);
-        assert!(r.is_err());
-    }
-
-    fn header_b64(alg: &str) -> String {
-        let json = serde_json::json!({"alg": alg, "typ": "JWT"});
-        URL_SAFE_NO_PAD.encode(serde_json::to_vec(&json).expect("ser"))
-    }
-
-    fn jwt_with_alg(alg: &str) -> String {
-        let header = header_b64(alg);
-        let payload = URL_SAFE_NO_PAD.encode(b"{}");
-        let sig = URL_SAFE_NO_PAD.encode(b"x");
-        format!("{header}.{payload}.{sig}")
-    }
-
-    #[test]
-    fn alg_allowlist_accepts_rs256() {
-        verify_alg_against_allowlist(&jwt_with_alg("RS256")).expect("ok");
-    }
-
-    #[test]
-    fn alg_allowlist_rejects_none() {
-        let r = verify_alg_against_allowlist(&jwt_with_alg("none"));
-        assert!(r.is_err());
-    }
-
-    #[test]
-    fn alg_allowlist_rejects_hs256() {
-        // HMAC family is what enables key-confusion; must reject.
-        let r = verify_alg_against_allowlist(&jwt_with_alg("HS256"));
-        assert!(r.is_err());
-    }
-
-    #[test]
-    fn alg_allowlist_rejects_unknown() {
-        let r = verify_alg_against_allowlist(&jwt_with_alg("PS256")); // PS family not in list
-        assert!(r.is_err());
-    }
-
-    #[test]
-    fn alg_allowlist_rejects_missing_alg_field() {
-        // header without alg
-        let header = URL_SAFE_NO_PAD.encode(b"{\"typ\":\"JWT\"}");
-        let payload = URL_SAFE_NO_PAD.encode(b"{}");
-        let sig = URL_SAFE_NO_PAD.encode(b"x");
-        let r = verify_alg_against_allowlist(&format!("{header}.{payload}.{sig}"));
-        assert!(r.is_err());
+    fn additional_claims_omits_sid_when_absent() {
+        let parsed: BffAdditionalClaims =
+            serde_json::from_value(serde_json::json!({})).expect("parse");
+        assert!(parsed.sid.is_none());
+        let rendered = serde_json::to_value(&parsed).expect("ser");
+        assert_eq!(rendered, serde_json::json!({}));
     }
 }

--- a/src/backend/services/api-gateway/src/bff/oidc_client.rs
+++ b/src/backend/services/api-gateway/src/bff/oidc_client.rs
@@ -1,0 +1,765 @@
+//! Minimal OIDC confidential client.
+//!
+//! Drives the authorization-code-with-PKCE flow without depending on the
+//! `openidconnect` crate, which pins reqwest versions that conflict with
+//! the rest of the workspace. We only need:
+//!   * discovery doc fetch (cached at module init)
+//!   * authorize URL builder (state, nonce, PKCE)
+//!   * token exchange (POST `token_endpoint`)
+//!   * ID token validation, delegated to `modkit_auth::JwksKeyProvider`
+//!     (signature) plus our own `iss`/`aud`/`nonce`/`exp` checks.
+//!
+//! Anything beyond that — refresh-token use, dynamic client registration,
+//! UserInfo, etc. — is out of scope for v1.
+
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use modkit_auth::JwksKeyProvider;
+use modkit_auth::traits::KeyProvider;
+use rand::RngCore;
+use rand::rngs::OsRng;
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+use crate::bff::errors::BffError;
+
+/// Algorithms accepted on the ID token JWT header. Locked down to the
+/// asymmetric set OIDC providers actually use; rejecting `HS*` closes
+/// the JWKS-as-HMAC-secret confusion vector, rejecting `none` is
+/// belt-and-braces (the JWT crate already rejects it on parse).
+const ALLOWED_ALGS: &[&str] = &["RS256", "RS384", "RS512", "ES256", "ES384", "EdDSA"];
+
+/// Clock skew tolerance for `exp` / `nbf` checks on the ID token.
+/// Matches the default leeway in upstream JWT libraries.
+const CLOCK_SKEW_SECONDS: i64 = 60;
+
+/// Subset of the OIDC discovery document we consume.
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub struct DiscoveryDoc {
+    pub issuer: String,
+    pub authorization_endpoint: String,
+    pub token_endpoint: String,
+    pub jwks_uri: String,
+    /// Optional: present iff the IdP supports RP-initiated logout.
+    /// Used by Phase 2's `/auth/logout`.
+    #[serde(default)]
+    pub end_session_endpoint: Option<String>,
+}
+
+impl DiscoveryDoc {
+    /// Fetch the discovery doc. Used once at module init; not on the hot path.
+    pub async fn fetch(issuer_url: &str, http_timeout: Duration) -> Result<Self, BffError> {
+        let url = format!(
+            "{}/.well-known/openid-configuration",
+            issuer_url.trim_end_matches('/')
+        );
+        let client = reqwest::Client::builder()
+            .timeout(http_timeout)
+            .build()
+            .map_err(|e| BffError::Internal(anyhow::anyhow!("reqwest builder: {e}")))?;
+        let resp = client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| BffError::Idp(format!("discovery fetch: {e}")))?;
+        if !resp.status().is_success() {
+            return Err(BffError::Idp(format!(
+                "discovery doc returned status {}",
+                resp.status()
+            )));
+        }
+        let doc: DiscoveryDoc = resp
+            .json()
+            .await
+            .map_err(|e| BffError::Idp(format!("discovery parse: {e}")))?;
+        if doc.issuer.is_empty()
+            || doc.authorization_endpoint.is_empty()
+            || doc.token_endpoint.is_empty()
+            || doc.jwks_uri.is_empty()
+        {
+            return Err(BffError::Idp(
+                "discovery doc missing required fields".into(),
+            ));
+        }
+        Ok(doc)
+    }
+}
+
+/// PKCE verifier + challenge pair.
+pub struct PkcePair {
+    pub verifier: String,
+    pub challenge: String,
+}
+
+impl PkcePair {
+    /// Generate a fresh verifier (32 random bytes → 43-char base64url) and
+    /// derive its S256 challenge.
+    #[must_use]
+    pub fn generate() -> Self {
+        let mut buf = [0u8; 32];
+        OsRng.fill_bytes(&mut buf);
+        let verifier = URL_SAFE_NO_PAD.encode(buf);
+        let mut h = Sha256::new();
+        h.update(verifier.as_bytes());
+        let challenge = URL_SAFE_NO_PAD.encode(h.finalize());
+        Self {
+            verifier,
+            challenge,
+        }
+    }
+}
+
+/// Validated ID token claims surfaced to the rest of the BFF.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct IdTokenClaims {
+    pub iss: String,
+    pub sub: String,
+    pub aud: Vec<String>,
+    pub exp: i64,
+    /// Optional per RFC 7519. We stop short of treating absence as an
+    /// error (some IdPs really don't emit it) but never substitute zero
+    /// for missing — `None` means "unknown".
+    pub iat: Option<i64>,
+    pub nbf: Option<i64>,
+    pub nonce: Option<String>,
+    pub sid: Option<String>,
+    /// Authorized party (OIDC Core §3.1.3.7 step 5). Required when `aud`
+    /// is multi-valued.
+    pub azp: Option<String>,
+    pub email: Option<String>,
+    pub name: Option<String>,
+}
+
+impl IdTokenClaims {
+    fn from_value(value: &serde_json::Value) -> Result<Self, BffError> {
+        let v = value
+            .as_object()
+            .ok_or_else(|| BffError::Idp("id_token claims is not an object".into()))?;
+        let str_field = |k: &str| -> Result<String, BffError> {
+            v.get(k)
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+                .ok_or_else(|| BffError::Idp(format!("id_token claim `{k}` missing")))
+        };
+        let opt_str = |k: &str| -> Option<String> {
+            v.get(k)
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        };
+        let int_field = |k: &str| -> Result<i64, BffError> {
+            v.get(k)
+                .and_then(serde_json::Value::as_i64)
+                .ok_or_else(|| BffError::Idp(format!("id_token claim `{k}` missing or not int")))
+        };
+        let aud = match v.get("aud") {
+            Some(serde_json::Value::String(s)) => vec![s.clone()],
+            Some(serde_json::Value::Array(arr)) => arr
+                .iter()
+                .filter_map(|x| x.as_str().map(str::to_owned))
+                .collect(),
+            _ => return Err(BffError::Idp("id_token `aud` claim missing".into())),
+        };
+        let opt_int = |k: &str| -> Option<i64> { v.get(k).and_then(serde_json::Value::as_i64) };
+        Ok(Self {
+            iss: str_field("iss")?,
+            sub: str_field("sub")?,
+            aud,
+            exp: int_field("exp")?,
+            iat: opt_int("iat"),
+            nbf: opt_int("nbf"),
+            nonce: opt_str("nonce"),
+            sid: opt_str("sid"),
+            azp: opt_str("azp"),
+            email: opt_str("email"),
+            name: opt_str("name").or_else(|| opt_str("preferred_username")),
+        })
+    }
+}
+
+/// Confidential OIDC client.
+#[derive(Clone)]
+pub struct OidcClient {
+    discovery: DiscoveryDoc,
+    client_id: String,
+    client_secret: String,
+    redirect_uri: String,
+    expected_audience: String,
+    scopes: Vec<String>,
+    http: reqwest::Client,
+    jwks: Arc<JwksKeyProvider>,
+}
+
+impl OidcClient {
+    /// Build a new client. Performs discovery + initial JWKS fetch.
+    pub async fn new(
+        issuer_url: &str,
+        client_id: &str,
+        client_secret: &str,
+        redirect_uri: &str,
+        scopes: Vec<String>,
+        audience: Option<&str>,
+    ) -> Result<Self, BffError> {
+        let discovery = DiscoveryDoc::fetch(issuer_url, Duration::from_secs(10)).await?;
+        let jwks = Arc::new(
+            JwksKeyProvider::new(discovery.jwks_uri.clone())
+                .map_err(|e| BffError::Internal(anyhow::anyhow!("jwks provider: {e}")))?
+                .with_refresh_interval(Duration::from_secs(3600)),
+        );
+        // Initial fetch — not fatal if it fails (the IdP may be briefly
+        // unreachable at boot); on-demand refresh will retry.
+        if let Err(e) = jwks.refresh_keys().await {
+            tracing::warn!(error = %e, "initial JWKS fetch failed; will retry on demand");
+        }
+
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(15))
+            .build()
+            .map_err(|e| BffError::Internal(anyhow::anyhow!("reqwest builder: {e}")))?;
+
+        Ok(Self {
+            discovery,
+            client_id: client_id.to_owned(),
+            client_secret: client_secret.to_owned(),
+            redirect_uri: redirect_uri.to_owned(),
+            expected_audience: audience.unwrap_or(client_id).to_owned(),
+            scopes,
+            http,
+            jwks,
+        })
+    }
+
+    /// Phase-2 access for `/auth/logout` (id_token_hint, end_session_url).
+    #[must_use]
+    #[allow(dead_code)]
+    pub fn discovery(&self) -> &DiscoveryDoc {
+        &self.discovery
+    }
+
+    /// Build the authorize URL the browser is redirected to.
+    pub fn authorize_url(
+        &self,
+        state: &str,
+        nonce: &str,
+        pkce_challenge: &str,
+    ) -> Result<String, BffError> {
+        let mut url = url::Url::parse(&self.discovery.authorization_endpoint)
+            .map_err(|e| BffError::Internal(anyhow::anyhow!("invalid auth endpoint: {e}")))?;
+        url.query_pairs_mut()
+            .append_pair("response_type", "code")
+            .append_pair("client_id", &self.client_id)
+            .append_pair("redirect_uri", &self.redirect_uri)
+            .append_pair("scope", &self.scopes.join(" "))
+            .append_pair("state", state)
+            .append_pair("nonce", nonce)
+            .append_pair("code_challenge", pkce_challenge)
+            .append_pair("code_challenge_method", "S256");
+        Ok(url.to_string())
+    }
+
+    /// Exchange a callback `code` for tokens. Returns the raw `id_token`
+    /// (so we can keep it for `id_token_hint` later) plus the validated
+    /// claims.
+    pub async fn exchange_code(
+        &self,
+        code: &str,
+        verifier: &str,
+        expected_nonce: &str,
+    ) -> Result<TokenExchange, BffError> {
+        let resp = self
+            .http
+            .post(&self.discovery.token_endpoint)
+            .basic_auth(&self.client_id, Some(&self.client_secret))
+            .form(&[
+                ("grant_type", "authorization_code"),
+                ("code", code),
+                ("redirect_uri", self.redirect_uri.as_str()),
+                ("code_verifier", verifier),
+                // client_id repeated in body for IdPs that demand it even
+                // alongside Basic auth (Keycloak, some Auth0 setups).
+                ("client_id", self.client_id.as_str()),
+            ])
+            .send()
+            .await
+            .map_err(|e| BffError::Idp(format!("token endpoint: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            // Pull `error` / `error_description` out of a JSON body if the
+            // IdP supplied them — that's the actionable signal. Don't echo
+            // the raw body into the response or logs (could carry user
+            // input or partial grant data).
+            let body_text = resp.text().await.unwrap_or_default();
+            let parsed = serde_json::from_str::<TokenError>(&body_text).ok();
+            let summary = parsed.as_ref().map_or_else(
+                || status.to_string(),
+                |e| {
+                    format!(
+                        "{} ({})",
+                        e.error,
+                        e.error_description.as_deref().unwrap_or("")
+                    )
+                },
+            );
+            tracing::warn!(
+                status = %status,
+                error = %parsed.as_ref().map_or("", |e| e.error.as_str()),
+                "token endpoint non-success",
+            );
+            return Err(BffError::Idp(format!("token endpoint: {summary}")));
+        }
+
+        let body: TokenResponse = resp
+            .json()
+            .await
+            .map_err(|e| BffError::Idp(format!("token response parse: {e}")))?;
+
+        let id_token = body
+            .id_token
+            .ok_or_else(|| BffError::Idp("token response missing id_token".into()))?;
+
+        // Algorithm allow-list — guard against alg-confusion / `none`. We
+        // peek at the JWT header before delegating signature verification
+        // to the JWKS provider, since the provider does not enforce an
+        // allow-list itself.
+        verify_alg_against_allowlist(&id_token)?;
+
+        // Signature check via JWKS provider. The provider validates the
+        // signature only — `exp`/`nbf`/`iss`/`aud`/`nonce` are this BFF's
+        // responsibility (see `validate_id_token_claims`).
+        let (_header, claims_value) = self
+            .jwks
+            .validate_and_decode(&id_token)
+            .await
+            .map_err(|e| BffError::Idp(format!("id_token validate: {e}")))?;
+
+        let claims = IdTokenClaims::from_value(&claims_value)?;
+        let now = unix_now();
+        validate_id_token_claims(
+            &claims,
+            &self.discovery.issuer,
+            &self.expected_audience,
+            &self.client_id,
+            expected_nonce,
+            now,
+        )?;
+
+        Ok(TokenExchange { id_token, claims })
+    }
+
+    /// Build the RP-initiated logout URL. Returns `None` if the IdP did
+    /// not advertise an `end_session_endpoint`. Phase 2's `/auth/logout`.
+    #[must_use]
+    #[allow(dead_code)]
+    pub fn end_session_url(
+        &self,
+        id_token_hint: &str,
+        post_logout_redirect: &str,
+    ) -> Option<String> {
+        let endpoint = self.discovery.end_session_endpoint.as_ref()?;
+        let mut url = url::Url::parse(endpoint).ok()?;
+        url.query_pairs_mut()
+            .append_pair("id_token_hint", id_token_hint)
+            .append_pair("post_logout_redirect_uri", post_logout_redirect)
+            .append_pair("client_id", &self.client_id);
+        Some(url.to_string())
+    }
+}
+
+/// Successful token-exchange result.
+pub struct TokenExchange {
+    pub id_token: String,
+    pub claims: IdTokenClaims,
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    #[serde(default)]
+    id_token: Option<String>,
+}
+
+/// OAuth 2.0 / OIDC error response shape (RFC 6749 §5.2).
+#[derive(Debug, Deserialize)]
+struct TokenError {
+    error: String,
+    #[serde(default)]
+    error_description: Option<String>,
+}
+
+fn unix_now() -> i64 {
+    i64::try_from(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0),
+    )
+    .unwrap_or(0)
+}
+
+/// Decode the JWT header without verifying signature, and reject any
+/// algorithm not in `ALLOWED_ALGS`. This closes the alg-confusion family:
+/// `none`, `HS256`-with-RSA-pubkey-as-shared-secret, downgrade games.
+fn verify_alg_against_allowlist(token: &str) -> Result<(), BffError> {
+    // header is the first dot-separated segment, base64url-encoded JSON.
+    let header_b64 = token
+        .split('.')
+        .next()
+        .ok_or_else(|| BffError::Idp("id_token has no header".into()))?;
+    let raw = URL_SAFE_NO_PAD
+        .decode(header_b64)
+        .map_err(|e| BffError::Idp(format!("id_token header decode: {e}")))?;
+    let header: serde_json::Value = serde_json::from_slice(&raw)
+        .map_err(|e| BffError::Idp(format!("id_token header parse: {e}")))?;
+    let alg = header
+        .get("alg")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| BffError::Idp("id_token header missing alg".into()))?;
+    if !ALLOWED_ALGS.contains(&alg) {
+        return Err(BffError::Idp(format!(
+            "id_token alg `{alg}` not in allow-list"
+        )));
+    }
+    Ok(())
+}
+
+/// Validate iss/aud/nonce/exp/nbf/azp on a parsed `IdTokenClaims`.
+///
+/// Pulled out of `exchange_code` so it's directly testable with a fake
+/// `IdTokenClaims` and a fixed `now`, no IdP needed.
+///
+/// Per OIDC Core §3.1.3.7:
+///   * `iss` must match the configured issuer exactly.
+///   * `aud` must contain the expected audience.
+///   * If `aud` is multi-valued AND `azp` is present, `azp` must equal
+///     the client_id.
+///   * `nonce` must match what the BFF stored at /auth/login time.
+///   * `exp` must be in the future (with clock skew leeway).
+///   * `nbf`, if present, must not be in the future (with leeway).
+fn validate_id_token_claims(
+    claims: &IdTokenClaims,
+    expected_issuer: &str,
+    expected_audience: &str,
+    client_id: &str,
+    expected_nonce: &str,
+    now: i64,
+) -> Result<(), BffError> {
+    if claims.iss != expected_issuer {
+        return Err(BffError::Idp("id_token iss mismatch".into()));
+    }
+    if !claims.aud.iter().any(|a| a == expected_audience) {
+        return Err(BffError::Idp("id_token aud mismatch".into()));
+    }
+    // §3.1.3.7 step 5: if multiple audiences, azp MUST be present and equal client_id.
+    if claims.aud.len() > 1 {
+        match claims.azp.as_deref() {
+            Some(azp) if azp == client_id => {}
+            Some(_) => {
+                return Err(BffError::Idp("id_token azp mismatch".into()));
+            }
+            None => {
+                return Err(BffError::Idp(
+                    "id_token has multiple audiences but no azp".into(),
+                ));
+            }
+        }
+    }
+    match claims.nonce.as_deref() {
+        Some(n) if n == expected_nonce => {}
+        _ => return Err(BffError::Idp("id_token nonce mismatch".into())),
+    }
+    if claims.exp <= now.saturating_sub(CLOCK_SKEW_SECONDS) {
+        return Err(BffError::Idp("id_token expired".into()));
+    }
+    if let Some(nbf) = claims.nbf
+        && nbf > now.saturating_add(CLOCK_SKEW_SECONDS)
+    {
+        return Err(BffError::Idp("id_token not yet valid (nbf)".into()));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pkce_pair_uses_url_safe_no_pad() {
+        let p = PkcePair::generate();
+        assert_eq!(p.verifier.len(), 43);
+        assert_eq!(p.challenge.len(), 43);
+        assert!(!p.verifier.contains('='));
+        assert!(!p.challenge.contains('='));
+        assert!(!p.challenge.contains('+'));
+        assert!(!p.challenge.contains('/'));
+    }
+
+    #[test]
+    fn pkce_pair_challenge_matches_s256_of_verifier() {
+        let p = PkcePair::generate();
+        let mut h = Sha256::new();
+        h.update(p.verifier.as_bytes());
+        let expected = URL_SAFE_NO_PAD.encode(h.finalize());
+        assert_eq!(p.challenge, expected);
+    }
+
+    #[test]
+    fn pkce_pair_verifier_is_random() {
+        let a = PkcePair::generate();
+        let b = PkcePair::generate();
+        assert_ne!(a.verifier, b.verifier);
+    }
+
+    #[test]
+    fn id_token_claims_parse_minimal() {
+        let v = serde_json::json!({
+            "iss": "https://idp/",
+            "sub": "sub-1",
+            "aud": "client-id",
+            "exp": 1_700_000_000_i64,
+            "nonce": "abc",
+        });
+        let c = IdTokenClaims::from_value(&v).expect("parse");
+        assert_eq!(c.iss, "https://idp/");
+        assert_eq!(c.sub, "sub-1");
+        assert_eq!(c.aud, vec!["client-id".to_owned()]);
+        assert_eq!(c.exp, 1_700_000_000);
+        assert_eq!(c.nonce.as_deref(), Some("abc"));
+    }
+
+    #[test]
+    fn id_token_claims_parse_aud_array() {
+        let v = serde_json::json!({
+            "iss": "i",
+            "sub": "s",
+            "aud": ["a", "b"],
+            "exp": 1_i64,
+        });
+        let c = IdTokenClaims::from_value(&v).expect("parse");
+        assert_eq!(c.aud, vec!["a".to_owned(), "b".to_owned()]);
+    }
+
+    #[test]
+    fn id_token_claims_reject_missing_iss() {
+        let v = serde_json::json!({"sub": "s", "aud": "x", "exp": 1});
+        assert!(IdTokenClaims::from_value(&v).is_err());
+    }
+
+    #[test]
+    fn id_token_claims_reject_missing_aud() {
+        let v = serde_json::json!({"iss": "i", "sub": "s", "exp": 1});
+        assert!(IdTokenClaims::from_value(&v).is_err());
+    }
+
+    #[test]
+    fn id_token_claims_extract_email_and_name() {
+        let v = serde_json::json!({
+            "iss": "i", "sub": "s", "aud": "x", "exp": 1,
+            "email": "a@b.com", "name": "Alice",
+        });
+        let c = IdTokenClaims::from_value(&v).expect("parse");
+        assert_eq!(c.email.as_deref(), Some("a@b.com"));
+        assert_eq!(c.name.as_deref(), Some("Alice"));
+    }
+
+    #[test]
+    fn id_token_claims_falls_back_to_preferred_username() {
+        let v = serde_json::json!({
+            "iss": "i", "sub": "s", "aud": "x", "exp": 1,
+            "preferred_username": "alice",
+        });
+        let c = IdTokenClaims::from_value(&v).expect("parse");
+        assert_eq!(c.name.as_deref(), Some("alice"));
+    }
+
+    #[test]
+    fn id_token_claims_iat_is_none_when_missing() {
+        let v = serde_json::json!({"iss": "i", "sub": "s", "aud": "x", "exp": 1});
+        let c = IdTokenClaims::from_value(&v).expect("parse");
+        assert_eq!(c.iat, None);
+        assert_eq!(c.nbf, None);
+        assert_eq!(c.azp, None);
+    }
+
+    fn good_claims(now: i64, nonce: &str) -> IdTokenClaims {
+        IdTokenClaims {
+            iss: "https://idp/".into(),
+            sub: "sub".into(),
+            aud: vec!["client-id".into()],
+            exp: now + 300,
+            iat: Some(now),
+            nbf: None,
+            nonce: Some(nonce.into()),
+            sid: None,
+            azp: None,
+            email: Some("a@b.com".into()),
+            name: Some("Alice".into()),
+        }
+    }
+
+    #[test]
+    fn validate_claims_accepts_good_token() {
+        let c = good_claims(1_000_000, "n");
+        validate_id_token_claims(&c, "https://idp/", "client-id", "client-id", "n", 1_000_000)
+            .expect("ok");
+    }
+
+    #[test]
+    fn validate_claims_rejects_iss_mismatch() {
+        let c = good_claims(1_000_000, "n");
+        let r = validate_id_token_claims(
+            &c,
+            "https://other/",
+            "client-id",
+            "client-id",
+            "n",
+            1_000_000,
+        );
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn validate_claims_rejects_aud_mismatch() {
+        let c = good_claims(1_000_000, "n");
+        let r =
+            validate_id_token_claims(&c, "https://idp/", "other-aud", "client-id", "n", 1_000_000);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn validate_claims_rejects_nonce_mismatch() {
+        let c = good_claims(1_000_000, "n");
+        let r = validate_id_token_claims(
+            &c,
+            "https://idp/",
+            "client-id",
+            "client-id",
+            "wrong",
+            1_000_000,
+        );
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn validate_claims_rejects_missing_nonce() {
+        let mut c = good_claims(1_000_000, "n");
+        c.nonce = None;
+        let r =
+            validate_id_token_claims(&c, "https://idp/", "client-id", "client-id", "n", 1_000_000);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn validate_claims_rejects_expired_token() {
+        let c = good_claims(1_000_000, "n");
+        // now is past exp + leeway
+        let r =
+            validate_id_token_claims(&c, "https://idp/", "client-id", "client-id", "n", 1_000_400);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn validate_claims_accepts_token_within_clock_skew_after_exp() {
+        let mut c = good_claims(1_000_000, "n");
+        c.exp = 1_000_000;
+        // now is 30s past exp — within 60s leeway
+        let r =
+            validate_id_token_claims(&c, "https://idp/", "client-id", "client-id", "n", 1_000_030);
+        assert!(r.is_ok(), "30s past exp should be in leeway");
+    }
+
+    #[test]
+    fn validate_claims_rejects_future_nbf() {
+        let mut c = good_claims(1_000_000, "n");
+        c.nbf = Some(1_000_500); // 500s in future, past leeway
+        let r =
+            validate_id_token_claims(&c, "https://idp/", "client-id", "client-id", "n", 1_000_000);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn validate_claims_accepts_nbf_within_leeway() {
+        let mut c = good_claims(1_000_000, "n");
+        c.nbf = Some(1_000_030); // 30s in future — within 60s leeway
+        let r =
+            validate_id_token_claims(&c, "https://idp/", "client-id", "client-id", "n", 1_000_000);
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn validate_claims_requires_azp_when_aud_is_multi() {
+        let mut c = good_claims(1_000_000, "n");
+        c.aud = vec!["client-id".into(), "other-aud".into()];
+        let r =
+            validate_id_token_claims(&c, "https://idp/", "client-id", "client-id", "n", 1_000_000);
+        assert!(r.is_err(), "multi-aud without azp must fail");
+    }
+
+    #[test]
+    fn validate_claims_accepts_multi_aud_with_correct_azp() {
+        let mut c = good_claims(1_000_000, "n");
+        c.aud = vec!["client-id".into(), "other-aud".into()];
+        c.azp = Some("client-id".into());
+        validate_id_token_claims(&c, "https://idp/", "client-id", "client-id", "n", 1_000_000)
+            .expect("ok");
+    }
+
+    #[test]
+    fn validate_claims_rejects_multi_aud_with_wrong_azp() {
+        let mut c = good_claims(1_000_000, "n");
+        c.aud = vec!["client-id".into(), "other-aud".into()];
+        c.azp = Some("attacker".into());
+        let r =
+            validate_id_token_claims(&c, "https://idp/", "client-id", "client-id", "n", 1_000_000);
+        assert!(r.is_err());
+    }
+
+    fn header_b64(alg: &str) -> String {
+        let json = serde_json::json!({"alg": alg, "typ": "JWT"});
+        URL_SAFE_NO_PAD.encode(serde_json::to_vec(&json).expect("ser"))
+    }
+
+    fn jwt_with_alg(alg: &str) -> String {
+        let header = header_b64(alg);
+        let payload = URL_SAFE_NO_PAD.encode(b"{}");
+        let sig = URL_SAFE_NO_PAD.encode(b"x");
+        format!("{header}.{payload}.{sig}")
+    }
+
+    #[test]
+    fn alg_allowlist_accepts_rs256() {
+        verify_alg_against_allowlist(&jwt_with_alg("RS256")).expect("ok");
+    }
+
+    #[test]
+    fn alg_allowlist_rejects_none() {
+        let r = verify_alg_against_allowlist(&jwt_with_alg("none"));
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn alg_allowlist_rejects_hs256() {
+        // HMAC family is what enables key-confusion; must reject.
+        let r = verify_alg_against_allowlist(&jwt_with_alg("HS256"));
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn alg_allowlist_rejects_unknown() {
+        let r = verify_alg_against_allowlist(&jwt_with_alg("PS256")); // PS family not in list
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn alg_allowlist_rejects_missing_alg_field() {
+        // header without alg
+        let header = URL_SAFE_NO_PAD.encode(b"{\"typ\":\"JWT\"}");
+        let payload = URL_SAFE_NO_PAD.encode(b"{}");
+        let sig = URL_SAFE_NO_PAD.encode(b"x");
+        let r = verify_alg_against_allowlist(&format!("{header}.{payload}.{sig}"));
+        assert!(r.is_err());
+    }
+}

--- a/src/backend/services/api-gateway/src/bff/oidc_client.rs
+++ b/src/backend/services/api-gateway/src/bff/oidc_client.rs
@@ -208,7 +208,7 @@ impl OidcClient {
         let jwks = Arc::new(
             JwksKeyProvider::new(discovery.jwks_uri.clone())
                 .map_err(|e| BffError::Internal(anyhow::anyhow!("jwks provider: {e}")))?
-                .with_refresh_interval(Duration::from_secs(3600)),
+                .with_refresh_interval(Duration::from_hours(1)),
         );
         // Initial fetch — not fatal if it fails (the IdP may be briefly
         // unreachable at boot); on-demand refresh will retry.
@@ -394,8 +394,7 @@ fn unix_now() -> i64 {
     i64::try_from(
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0),
+            .map_or(0, |d| d.as_secs()),
     )
     .unwrap_or(0)
 }

--- a/src/backend/services/api-gateway/src/bff/oidc_client.rs
+++ b/src/backend/services/api-gateway/src/bff/oidc_client.rs
@@ -13,7 +13,7 @@
 //! UserInfo, etc. — is out of scope for v1.
 
 use std::sync::Arc;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
@@ -25,6 +25,7 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
 use crate::bff::errors::BffError;
+use crate::bff::handlers::unix_now;
 
 /// Algorithms accepted on the ID token JWT header. Locked down to the
 /// asymmetric set OIDC providers actually use; rejecting `HS*` closes
@@ -411,15 +412,6 @@ struct TokenError {
     error: String,
     #[serde(default)]
     error_description: Option<String>,
-}
-
-fn unix_now() -> i64 {
-    i64::try_from(
-        SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .map_or(0, |d| d.as_secs()),
-    )
-    .unwrap_or(0)
 }
 
 /// Decode the JWT header without verifying signature, and reject any

--- a/src/backend/services/api-gateway/src/bff/redis_keys.rs
+++ b/src/backend/services/api-gateway/src/bff/redis_keys.rs
@@ -1,0 +1,85 @@
+//! Centralized Redis key builders for the BFF.
+//!
+//! Every key starts with `bff:` (DD-BFF-04). The Router owns `router:` and
+//! the BFF only writes to `router:jwt_cache:*` to invalidate cached JWTs on
+//! revoke.
+//!
+//! Key builders for Phase 2/3 surfaces (`bff:swap:*`, `bff:logout_jti:*`,
+//! `bff:lock:janitor`) are declared here so the schema is one place; they
+//! aren't called from Phase 1 handlers yet.
+
+#![allow(dead_code)]
+
+/// `bff:session:{sid}` — HASH, full session record.
+#[must_use]
+pub fn session(sid: &str) -> String {
+    format!("bff:session:{sid}")
+}
+
+/// `bff:user_sessions:{user_id}` — ZSET, score = `expires_at`.
+#[must_use]
+pub fn user_sessions(user_id: &str) -> String {
+    format!("bff:user_sessions:{user_id}")
+}
+
+/// `bff:sid_index:{iss}:{idp_sid}` — SET of local `session_id`s, used to
+/// resolve back-channel `logout_token` (iss, sid) → local sessions.
+#[must_use]
+pub fn sid_index(iss: &str, idp_sid: &str) -> String {
+    format!("bff:sid_index:{iss}:{idp_sid}")
+}
+
+/// `bff:login_state:{state}` — HASH, PKCE verifier + nonce + return_to.
+/// One-shot, 5 min TTL.
+#[must_use]
+pub fn login_state(state: &str) -> String {
+    format!("bff:login_state:{state}")
+}
+
+/// `bff:swap:{old_sid}` — STRING → new_sid; refresh grace window
+/// (DD-BFF-10), default 250 ms TTL.
+#[must_use]
+pub fn swap(old_sid: &str) -> String {
+    format!("bff:swap:{old_sid}")
+}
+
+/// `bff:logout_jti:{iss}:{jti}` — STRING `1`, replay guard for OIDC
+/// back-channel logout.
+#[must_use]
+pub fn logout_jti(iss: &str, jti: &str) -> String {
+    format!("bff:logout_jti:{iss}:{jti}")
+}
+
+/// `router:jwt_cache:{sid}` — owned by the Router; the BFF only deletes
+/// these on revoke / rotate to invalidate cached JWTs.
+#[must_use]
+pub fn router_jwt_cache(sid: &str) -> String {
+    format!("router:jwt_cache:{sid}")
+}
+
+/// `bff:lock:janitor` — leader-election lock for the expired-session
+/// janitor (Phase 3).
+#[must_use]
+pub fn janitor_lock() -> &'static str {
+    "bff:lock:janitor"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keys_use_bff_prefix() {
+        assert!(session("abc").starts_with("bff:session:"));
+        assert!(user_sessions("u1").starts_with("bff:user_sessions:"));
+        assert!(sid_index("https://idp/", "s1").starts_with("bff:sid_index:"));
+        assert!(login_state("st").starts_with("bff:login_state:"));
+        assert!(swap("old").starts_with("bff:swap:"));
+        assert!(logout_jti("iss", "j1").starts_with("bff:logout_jti:"));
+    }
+
+    #[test]
+    fn router_key_uses_router_prefix() {
+        assert!(router_jwt_cache("sid").starts_with("router:"));
+    }
+}

--- a/src/backend/services/api-gateway/src/bff/redis_keys.rs
+++ b/src/backend/services/api-gateway/src/bff/redis_keys.rs
@@ -64,6 +64,20 @@ pub fn janitor_lock() -> &'static str {
     "bff:lock:janitor"
 }
 
+/// `bff:rl:auth:{ip}` — per-IP token-bucket counter for `/auth/*` rate
+/// limiting (DESIGN §4.4, Phase 3).
+#[must_use]
+pub fn bff_rl_auth(ip: &str) -> String {
+    format!("bff:rl:auth:{ip}")
+}
+
+/// `bff:rl:login_state_count` — process-wide live `bff:login_state:*` cap
+/// counter (DESIGN §4.4, Phase 3).
+#[must_use]
+pub fn bff_rl_login_state_count() -> &'static str {
+    "bff:rl:login_state_count"
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -76,6 +90,8 @@ mod tests {
         assert!(login_state("st").starts_with("bff:login_state:"));
         assert!(swap("old").starts_with("bff:swap:"));
         assert!(logout_jti("iss", "j1").starts_with("bff:logout_jti:"));
+        assert_eq!(bff_rl_auth("10.0.0.1"), "bff:rl:auth:10.0.0.1");
+        assert_eq!(bff_rl_login_state_count(), "bff:rl:login_state_count");
     }
 
     #[test]

--- a/src/backend/services/api-gateway/src/bff/routes.rs
+++ b/src/backend/services/api-gateway/src/bff/routes.rs
@@ -1,0 +1,83 @@
+//! Route registration for `/auth/*` endpoints.
+//!
+//! All routes register as `.public()`. The BFF handles its own auth: every
+//! protected endpoint reads the `__Host-sid` cookie, validates against
+//! Redis, and returns 401 itself. We do NOT delegate cookie validation to
+//! the existing `oidc-authn-plugin` (Bearer-JWT validator) — that plugin
+//! is for upstream `/api/*` calls.
+
+use std::sync::Arc;
+
+use axum::Router;
+use axum::extract::{Query, State};
+use axum::http::{HeaderMap, Method, StatusCode};
+use axum::response::IntoResponse;
+use modkit::api::{OpenApiRegistry, OperationBuilder};
+
+use crate::bff::errors::BffError;
+use crate::bff::handlers::{BffState, callback, login, me};
+
+pub fn register(mut router: Router, openapi: &dyn OpenApiRegistry, state: Arc<BffState>) -> Router {
+    let s = state.clone();
+    router = OperationBuilder::new(Method::GET, "/auth/login")
+        .summary("Start OIDC login flow")
+        .description(
+            "Redirects the browser to the configured OIDC provider's authorize endpoint. \
+             Public, no auth required. Pass `?return_to=/<path>` to land back on a \
+             specific SPA page after callback.",
+        )
+        .public()
+        .json_response(StatusCode::FOUND, "Redirect to IdP")
+        .handler(move |q: Query<login::LoginQuery>| {
+            let s = s.clone();
+            async move { unify(login::login(State(s), q).await) }
+        })
+        .register(router, openapi);
+
+    let s = state.clone();
+    router = OperationBuilder::new(Method::GET, "/auth/callback")
+        .summary("OIDC callback handler")
+        .description(
+            "Receives the authorization code from the IdP, exchanges it for an ID token, \
+             validates the token, creates a session, sets the __Host-sid cookie, and \
+             redirects to the SPA's target page.",
+        )
+        .public()
+        .json_response(StatusCode::FOUND, "Redirect to SPA with session cookie")
+        .handler(
+            move |headers: HeaderMap, q: Query<callback::CallbackQuery>| {
+                let s = s.clone();
+                async move { unify(callback::callback(State(s), headers, q).await) }
+            },
+        )
+        .register(router, openapi);
+
+    let s = state;
+    router = OperationBuilder::new(Method::GET, "/auth/me")
+        .summary("Current session info")
+        .description(
+            "Returns the current user, tenant, expires_at, refresh_at, and csrf_token. \
+             SPA calls this on boot to know whether the user is logged in and to schedule \
+             the next /auth/refresh.",
+        )
+        .public()
+        .json_response(StatusCode::OK, "Session view")
+        .json_response(StatusCode::UNAUTHORIZED, "No or invalid session")
+        .handler(move |headers: HeaderMap| {
+            let s = s.clone();
+            async move { unify(me::me(State(s), headers).await) }
+        })
+        .register(router, openapi);
+
+    tracing::info!("BFF: registered /auth/login, /auth/callback, /auth/me");
+    router
+}
+
+/// Collapse a handler `Result` into the unified `Response` shape that
+/// axum / OperationBuilder expects.
+fn unify(r: Result<axum::response::Response, BffError>) -> axum::response::Response {
+    match r {
+        Ok(resp) => resp,
+        Err(e) => e.into_response(),
+    }
+}

--- a/src/backend/services/api-gateway/src/bff/secrets.rs
+++ b/src/backend/services/api-gateway/src/bff/secrets.rs
@@ -1,0 +1,104 @@
+//! CSPRNG helpers for opaque session IDs and CSRF tokens.
+
+#![allow(dead_code)]
+// `ct_eq` lands in Phase 3 with the CSRF middleware; defined here so the
+// crypto primitives live next to the random tokens they protect.
+//!
+//! All values are URL-safe base64 (no padding) of 32 random bytes — 256 bits
+//! of entropy, well above the 128-bit minimum required by
+//! `cpt-insightspec-fr-bff-session-cookie`.
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use rand::RngCore;
+use rand::rngs::OsRng;
+
+const TOKEN_BYTES: usize = 32;
+
+/// Generate a fresh session ID (CSPRNG, 256 bits entropy).
+///
+/// Returned string is URL-safe base64 with no padding.
+#[must_use]
+pub fn new_session_id() -> String {
+    new_token(TOKEN_BYTES)
+}
+
+/// Generate a fresh CSRF token (CSPRNG, 256 bits entropy).
+#[must_use]
+pub fn new_csrf_token() -> String {
+    new_token(TOKEN_BYTES)
+}
+
+/// Generate a fresh OIDC `state` parameter (CSPRNG, 256 bits entropy).
+#[must_use]
+pub fn new_state() -> String {
+    new_token(TOKEN_BYTES)
+}
+
+/// Generate a fresh OIDC `nonce` parameter (CSPRNG, 256 bits entropy).
+#[must_use]
+pub fn new_nonce() -> String {
+    new_token(TOKEN_BYTES)
+}
+
+fn new_token(bytes: usize) -> String {
+    let mut buf = vec![0u8; bytes];
+    OsRng.fill_bytes(&mut buf);
+    URL_SAFE_NO_PAD.encode(buf)
+}
+
+/// Constant-time comparison of two CSRF tokens. Both inputs are treated as
+/// opaque ASCII strings; equal-length-and-bytes is the only acceptance
+/// criterion.
+#[must_use]
+pub fn ct_eq(a: &str, b: &str) -> bool {
+    use subtle::ConstantTimeEq;
+    if a.len() != b.len() {
+        return false;
+    }
+    a.as_bytes().ct_eq(b.as_bytes()).into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn session_id_is_url_safe_base64_no_pad() {
+        let s = new_session_id();
+        // 32 bytes → 43 base64 chars (no padding)
+        assert_eq!(s.len(), 43);
+        assert!(
+            s.chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        );
+        assert!(!s.contains('='), "URL_SAFE_NO_PAD must not include padding");
+    }
+
+    #[test]
+    fn ids_are_unique() {
+        let ids: HashSet<String> = (0..256).map(|_| new_session_id()).collect();
+        assert_eq!(ids.len(), 256, "256 generated IDs must all be distinct");
+    }
+
+    #[test]
+    fn ct_eq_matches_only_equal_strings() {
+        assert!(ct_eq("foo", "foo"));
+        assert!(!ct_eq("foo", "fop"));
+        assert!(!ct_eq("foo", "fooo"));
+        assert!(!ct_eq("", "x"));
+        assert!(ct_eq("", ""));
+    }
+
+    #[test]
+    fn token_kinds_are_independent() {
+        let a = new_session_id();
+        let b = new_csrf_token();
+        let c = new_state();
+        let d = new_nonce();
+        assert_ne!(a, b);
+        assert_ne!(b, c);
+        assert_ne!(c, d);
+    }
+}

--- a/src/backend/services/api-gateway/src/bff/session.rs
+++ b/src/backend/services/api-gateway/src/bff/session.rs
@@ -1,0 +1,141 @@
+//! Session record domain types.
+//!
+//! See DESIGN §3.7 for the canonical Redis HASH layout. We keep the
+//! field names and types tight against the spec so other modules (Router,
+//! janitor) can decode without surprises.
+
+use serde::{Deserialize, Serialize};
+
+/// Full session record stored under `bff:session:{sid}` (HASH).
+///
+/// Field names mirror the DESIGN doc one-for-one.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionRecord {
+    pub user_id: String,
+    pub tenant_id: String,
+    pub idp_iss: String,
+    pub idp_sub: String,
+    /// OIDC `sid` claim — empty if the IdP did not supply one.
+    pub idp_sid: String,
+    /// Stored only for use as `id_token_hint` on RP-initiated logout.
+    pub id_token: String,
+    /// Email pulled from the OIDC `email` claim, surfaced via `/auth/me`.
+    pub email: String,
+    /// Display name from `name` / `preferred_username` if present.
+    pub display_name: String,
+    pub created_at: i64,
+    pub expires_at: i64,
+    pub absolute_expires_at: i64,
+    pub user_agent: String,
+    pub ip: String,
+    pub csrf_token: String,
+}
+
+impl SessionRecord {
+    /// Encode the record as Redis HASH field/value pairs in stable order.
+    /// The order matches the read path in `from_redis_pairs`.
+    #[must_use]
+    pub fn to_redis_pairs(&self) -> Vec<(&'static str, String)> {
+        vec![
+            ("user_id", self.user_id.clone()),
+            ("tenant_id", self.tenant_id.clone()),
+            ("idp_iss", self.idp_iss.clone()),
+            ("idp_sub", self.idp_sub.clone()),
+            ("idp_sid", self.idp_sid.clone()),
+            ("id_token", self.id_token.clone()),
+            ("email", self.email.clone()),
+            ("display_name", self.display_name.clone()),
+            ("created_at", self.created_at.to_string()),
+            ("expires_at", self.expires_at.to_string()),
+            ("absolute_expires_at", self.absolute_expires_at.to_string()),
+            ("user_agent", self.user_agent.clone()),
+            ("ip", self.ip.clone()),
+            ("csrf_token", self.csrf_token.clone()),
+        ]
+    }
+}
+
+/// Compact summary for `GET /auth/sessions` listings (Phase 2). Defined
+/// here so future code shares one struct across the controller and audit.
+#[derive(Debug, Clone, Serialize)]
+#[allow(dead_code)]
+pub struct SessionSummary {
+    pub session_id: String,
+    pub created_at: i64,
+    pub expires_at: i64,
+    pub user_agent: String,
+    pub ip: String,
+    pub current: bool,
+}
+
+/// Result of a successful `/auth/me` or `/auth/refresh` call. The SPA
+/// schedules its next refresh from `refresh_at`.
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionView {
+    pub user: UserView,
+    pub tenant: TenantView,
+    pub expires_at: i64,
+    pub refresh_at: i64,
+    pub csrf_token: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UserView {
+    pub user_id: String,
+    pub email: String,
+    pub display_name: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TenantView {
+    pub tenant_id: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> SessionRecord {
+        SessionRecord {
+            user_id: "u-1".into(),
+            tenant_id: "t-1".into(),
+            idp_iss: "https://idp/".into(),
+            idp_sub: "sub-1".into(),
+            idp_sid: "sid-1".into(),
+            id_token: "jwt".into(),
+            email: "alice@example.com".into(),
+            display_name: "Alice".into(),
+            created_at: 1,
+            expires_at: 121,
+            absolute_expires_at: 28_801,
+            user_agent: "ua".into(),
+            ip: "1.2.3.4".into(),
+            csrf_token: "csrf".into(),
+        }
+    }
+
+    #[test]
+    fn pairs_have_stable_field_order() {
+        let pairs = sample().to_redis_pairs();
+        let names: Vec<&str> = pairs.iter().map(|(k, _)| *k).collect();
+        assert_eq!(
+            names,
+            vec![
+                "user_id",
+                "tenant_id",
+                "idp_iss",
+                "idp_sub",
+                "idp_sid",
+                "id_token",
+                "email",
+                "display_name",
+                "created_at",
+                "expires_at",
+                "absolute_expires_at",
+                "user_agent",
+                "ip",
+                "csrf_token",
+            ]
+        );
+    }
+}

--- a/src/backend/services/api-gateway/src/bff/session_store.rs
+++ b/src/backend/services/api-gateway/src/bff/session_store.rs
@@ -1,0 +1,475 @@
+//! Session store — the only writer/reader of `bff:*` keys.
+//!
+//! Phase 1 surface:
+//!   * `create_session` — new login, atomic MULTI/EXEC, with session-
+//!     fixation guard on an incoming cookie value.
+//!   * `get_session` — HGETALL of a session record.
+//!   * `revoke_session` — atomic delete + ZREM + SREM + cache invalidation.
+//!
+//! Refresh + revoke-all + back-channel revocation land in Phase 2/3.
+
+use std::sync::Arc;
+
+use redis::AsyncCommands;
+use redis::aio::ConnectionManager;
+use tracing::warn;
+
+use crate::bff::errors::BffError;
+use crate::bff::redis_keys;
+use crate::bff::secrets::{new_csrf_token, new_session_id};
+use crate::bff::session::SessionRecord;
+use crate::redis_client::RedisShared;
+
+/// Inputs to `create_session`.
+pub struct CreateSessionRequest<'a> {
+    pub user_id: &'a str,
+    pub tenant_id: &'a str,
+    pub idp_iss: &'a str,
+    pub idp_sub: &'a str,
+    /// Empty string means "IdP did not supply a sid claim". Empty values
+    /// skip the sid_index write.
+    pub idp_sid: &'a str,
+    pub id_token: &'a str,
+    pub email: &'a str,
+    pub display_name: &'a str,
+    pub user_agent: &'a str,
+    pub ip: &'a str,
+    pub now: i64,
+    pub session_ttl_seconds: u64,
+    pub absolute_lifetime_seconds: u64,
+    /// Cookie value present on the callback request. We never reuse it;
+    /// if it maps to a live session we revoke it before creating the new
+    /// one (DESIGN §3.6 fixation guard).
+    pub incoming_sid: Option<&'a str>,
+}
+
+pub struct CreateSessionOutcome {
+    pub session_id: String,
+    /// The full record we just persisted. Phase 1 callers only need
+    /// `session_id`, but Phase 2 (refresh/sessions endpoints) will read
+    /// from this without touching Redis again.
+    #[allow(dead_code)]
+    pub record: SessionRecord,
+}
+
+/// Concrete session-store implementation backed by Redis.
+#[derive(Clone)]
+pub struct SessionStore {
+    redis: Arc<RedisShared>,
+}
+
+impl SessionStore {
+    #[must_use]
+    pub fn new(redis: Arc<RedisShared>) -> Self {
+        Self { redis }
+    }
+
+    fn conn(&self) -> ConnectionManager {
+        self.redis.manager()
+    }
+
+    /// Look up a live session record by SID. Returns `None` if the key
+    /// does not exist (expired or never existed). Surfaces a
+    /// `StoreUnavailable` error when Redis cannot be reached.
+    pub async fn get_session(&self, sid: &str) -> Result<Option<SessionRecord>, BffError> {
+        let mut conn = self.conn();
+        let key = redis_keys::session(sid);
+        let pairs: Vec<(String, String)> = conn
+            .hgetall(&key)
+            .await
+            .map_err(|e| BffError::StoreUnavailable(e.to_string()))?;
+        if pairs.is_empty() {
+            return Ok(None);
+        }
+        decode_session(&pairs)
+    }
+
+    /// Create a fresh session, optionally revoking an incoming attacker-
+    /// planted SID first. Returns the new opaque `session_id` and the
+    /// stored record.
+    pub async fn create_session(
+        &self,
+        req: CreateSessionRequest<'_>,
+    ) -> Result<CreateSessionOutcome, BffError> {
+        let mut conn = self.conn();
+
+        // 1. Fixation guard: revoke incoming SID if it resolved to a live
+        //    session. We do NOT propagate any cookie state into the new
+        //    session. A revoke failure on a stale/unknown SID isn't fatal —
+        //    log and continue. A real Redis outage would also fail step 2
+        //    below and bail there.
+        if let Some(incoming) = req.incoming_sid
+            && !incoming.is_empty()
+            && let Err(e) = self.revoke_session(incoming).await
+        {
+            warn!(
+                error = %e,
+                "failed to revoke incoming SID during fixation guard; continuing",
+            );
+        }
+
+        // 2. Mint fresh session_id + CSRF token (server-side CSPRNG).
+        let session_id = new_session_id();
+        let csrf_token = new_csrf_token();
+
+        let expires_at = req
+            .now
+            .saturating_add(i64::try_from(req.session_ttl_seconds).unwrap_or(i64::MAX));
+        let absolute_expires_at = req
+            .now
+            .saturating_add(i64::try_from(req.absolute_lifetime_seconds).unwrap_or(i64::MAX));
+
+        let record = SessionRecord {
+            user_id: req.user_id.to_owned(),
+            tenant_id: req.tenant_id.to_owned(),
+            idp_iss: req.idp_iss.to_owned(),
+            idp_sub: req.idp_sub.to_owned(),
+            idp_sid: req.idp_sid.to_owned(),
+            id_token: req.id_token.to_owned(),
+            email: req.email.to_owned(),
+            display_name: req.display_name.to_owned(),
+            created_at: req.now,
+            expires_at,
+            absolute_expires_at,
+            user_agent: req.user_agent.to_owned(),
+            ip: req.ip.to_owned(),
+            csrf_token,
+        };
+
+        // 3. Atomic write: HSET + EXPIREAT + ZADD (+ SADD when sid).
+        let pairs = record.to_redis_pairs();
+        let session_key = redis_keys::session(&session_id);
+        let user_key = redis_keys::user_sessions(&record.user_id);
+
+        let mut pipe = redis::pipe();
+        pipe.atomic();
+        pipe.hset_multiple(&session_key, &pairs).ignore();
+        pipe.expire_at(&session_key, expires_at).ignore();
+        pipe.zadd(&user_key, &session_id, expires_at).ignore();
+        if !record.idp_sid.is_empty() {
+            let sid_idx = redis_keys::sid_index(&record.idp_iss, &record.idp_sid);
+            pipe.sadd(&sid_idx, &session_id).ignore();
+        }
+
+        let _: () = pipe
+            .query_async(&mut conn)
+            .await
+            .map_err(|e| BffError::StoreUnavailable(e.to_string()))?;
+
+        Ok(CreateSessionOutcome { session_id, record })
+    }
+
+    /// Revoke a session by SID. Idempotent: revoking a missing session is
+    /// a successful no-op.
+    pub async fn revoke_session(&self, sid: &str) -> Result<(), BffError> {
+        let mut conn = self.conn();
+
+        // Read the three index pointers we need to drop. Explicit HMGET
+        // with a positional tuple, so we never have to second-guess
+        // whether redis-rs flattened nils into a shorter Vec.
+        let session_key = redis_keys::session(sid);
+        let (user_id_opt, idp_iss_opt, idp_sid_opt): (
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        ) = redis::cmd("HMGET")
+            .arg(&session_key)
+            .arg("user_id")
+            .arg("idp_iss")
+            .arg("idp_sid")
+            .query_async(&mut conn)
+            .await
+            .map_err(|e| BffError::StoreUnavailable(e.to_string()))?;
+
+        // Missing session → all three nils → no-op.
+        if user_id_opt.is_none() && idp_iss_opt.is_none() && idp_sid_opt.is_none() {
+            return Ok(());
+        }
+
+        let user_id = user_id_opt.unwrap_or_default();
+        let idp_iss = idp_iss_opt.unwrap_or_default();
+        let idp_sid = idp_sid_opt.unwrap_or_default();
+
+        let mut pipe = redis::pipe();
+        pipe.atomic();
+        pipe.del(&session_key).ignore();
+        if !user_id.is_empty() {
+            pipe.zrem(redis_keys::user_sessions(&user_id), sid).ignore();
+        }
+        if !idp_iss.is_empty() && !idp_sid.is_empty() {
+            pipe.srem(redis_keys::sid_index(&idp_iss, &idp_sid), sid)
+                .ignore();
+        }
+        pipe.del(redis_keys::router_jwt_cache(sid)).ignore();
+
+        let _: () = pipe
+            .query_async(&mut conn)
+            .await
+            .map_err(|e| BffError::StoreUnavailable(e.to_string()))?;
+
+        Ok(())
+    }
+}
+
+/// PKCE login state stored at `bff:login_state:{state}` for 5 minutes.
+///
+/// Phase 1: this is read once on `/auth/callback` and deleted. Step-up
+/// to a typed Redis HASH read happens via `HGETALL`; the spec only requires
+/// us to keep PKCE verifier + nonce + return URL.
+pub mod login_state {
+    use std::sync::Arc;
+
+    use redis::AsyncCommands;
+    use serde::{Deserialize, Serialize};
+
+    use crate::bff::errors::BffError;
+    use crate::bff::redis_keys;
+    use crate::redis_client::RedisShared;
+
+    pub const TTL_SECONDS: u64 = 300; // 5 min, per DESIGN §3.7
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct LoginState {
+        pub pkce_verifier: String,
+        pub nonce: String,
+        pub return_to: String,
+    }
+
+    pub async fn store(
+        redis: &Arc<RedisShared>,
+        state: &str,
+        ls: &LoginState,
+    ) -> Result<(), BffError> {
+        let mut conn = redis.manager();
+        let key = redis_keys::login_state(state);
+        let pairs: [(&'static str, String); 3] = [
+            ("pkce_verifier", ls.pkce_verifier.clone()),
+            ("nonce", ls.nonce.clone()),
+            ("return_to", ls.return_to.clone()),
+        ];
+        let mut pipe = redis::pipe();
+        pipe.atomic();
+        pipe.hset_multiple(&key, &pairs).ignore();
+        pipe.expire(&key, i64::try_from(TTL_SECONDS).unwrap_or(i64::MAX))
+            .ignore();
+        let _: () = pipe
+            .query_async(&mut conn)
+            .await
+            .map_err(|e| BffError::StoreUnavailable(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Read and delete the login-state record in one round-trip. Returns
+    /// `None` if the state has expired, was already consumed, or never
+    /// existed (state mismatch).
+    pub async fn take(
+        redis: &Arc<RedisShared>,
+        state: &str,
+    ) -> Result<Option<LoginState>, BffError> {
+        let mut conn = redis.manager();
+        let key = redis_keys::login_state(state);
+        // Pipeline: HGETALL + DEL — atomic enough for a single-shot consumption.
+        let mut pipe = redis::pipe();
+        pipe.atomic();
+        pipe.hgetall(&key);
+        pipe.del(&key).ignore();
+        let pairs: Vec<(String, String)> = pipe
+            .query_async(&mut conn)
+            .await
+            .map_err(|e| BffError::StoreUnavailable(e.to_string()))?;
+        if pairs.is_empty() {
+            return Ok(None);
+        }
+        let mut verifier = String::new();
+        let mut nonce = String::new();
+        let mut return_to = String::new();
+        for (k, v) in pairs {
+            match k.as_str() {
+                "pkce_verifier" => verifier = v,
+                "nonce" => nonce = v,
+                "return_to" => return_to = v,
+                _ => {}
+            }
+        }
+        if verifier.is_empty() || nonce.is_empty() {
+            return Ok(None);
+        }
+        Ok(Some(LoginState {
+            pkce_verifier: verifier,
+            nonce,
+            return_to,
+        }))
+    }
+
+    /// Increment the per-pod login-state cap counter and return the new
+    /// value. The caller compares against `auth_login_state_max` and
+    /// rejects with 429 if exceeded.
+    ///
+    /// Phase 1 stub — we increment but the cap check lives in Phase 3
+    /// (`cpt-insightspec-nfr-bff-rate-limit-auth`). Plumbed in now so the
+    /// counter exists before the rate-limit middleware lands.
+    pub async fn touch(redis: &Arc<RedisShared>) -> Result<i64, BffError> {
+        let mut conn = redis.manager();
+        let v: i64 = conn
+            .incr("bff:rl:login_state_count", 1)
+            .await
+            .map_err(|e| BffError::StoreUnavailable(e.to_string()))?;
+        Ok(v)
+    }
+}
+
+fn decode_session(pairs: &[(String, String)]) -> Result<Option<SessionRecord>, BffError> {
+    let get = |name: &str| -> String {
+        pairs
+            .iter()
+            .find(|(k, _)| k == name)
+            .map(|(_, v)| v.clone())
+            .unwrap_or_default()
+    };
+    let parse_i64 = |name: &str| -> Result<i64, BffError> {
+        let raw = get(name);
+        if raw.is_empty() {
+            return Ok(0);
+        }
+        raw.parse::<i64>().map_err(|_| {
+            BffError::Internal(anyhow::anyhow!("session field {name} is not i64: {raw}"))
+        })
+    };
+
+    Ok(Some(SessionRecord {
+        user_id: get("user_id"),
+        tenant_id: get("tenant_id"),
+        idp_iss: get("idp_iss"),
+        idp_sub: get("idp_sub"),
+        idp_sid: get("idp_sid"),
+        id_token: get("id_token"),
+        email: get("email"),
+        display_name: get("display_name"),
+        created_at: parse_i64("created_at")?,
+        expires_at: parse_i64("expires_at")?,
+        absolute_expires_at: parse_i64("absolute_expires_at")?,
+        user_agent: get("user_agent"),
+        ip: get("ip"),
+        csrf_token: get("csrf_token"),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_session_round_trips_through_pairs() {
+        let original = SessionRecord {
+            user_id: "u-1".into(),
+            tenant_id: "t-1".into(),
+            idp_iss: "iss".into(),
+            idp_sub: "sub".into(),
+            idp_sid: "isid".into(),
+            id_token: "jwt".into(),
+            email: "alice@example.com".into(),
+            display_name: "Alice".into(),
+            created_at: 100,
+            expires_at: 220,
+            absolute_expires_at: 28_900,
+            user_agent: "ua".into(),
+            ip: "1.2.3.4".into(),
+            csrf_token: "csrf".into(),
+        };
+        let pairs: Vec<(String, String)> = original
+            .to_redis_pairs()
+            .into_iter()
+            .map(|(k, v)| (k.to_owned(), v))
+            .collect();
+        let decoded = decode_session(&pairs).expect("ok").expect("present");
+        assert_eq!(decoded.user_id, original.user_id);
+        assert_eq!(decoded.expires_at, original.expires_at);
+        assert_eq!(decoded.absolute_expires_at, original.absolute_expires_at);
+        assert_eq!(decoded.csrf_token, original.csrf_token);
+        assert_eq!(decoded.email, original.email);
+    }
+
+    #[test]
+    fn decode_session_handles_missing_optional_fields() {
+        let pairs = vec![
+            ("user_id".to_owned(), "u-1".to_owned()),
+            ("expires_at".to_owned(), "220".to_owned()),
+        ];
+        let decoded = decode_session(&pairs).expect("ok").expect("present");
+        assert_eq!(decoded.user_id, "u-1");
+        assert_eq!(decoded.expires_at, 220);
+        assert_eq!(decoded.email, "");
+        assert_eq!(decoded.created_at, 0);
+    }
+
+    #[test]
+    fn decode_session_rejects_non_numeric_int_fields() {
+        let pairs = vec![
+            ("user_id".to_owned(), "u-1".to_owned()),
+            ("expires_at".to_owned(), "not-a-number".to_owned()),
+        ];
+        assert!(decode_session(&pairs).is_err());
+    }
+
+    /// End-to-end SessionStore round-trip against a real Redis. Skipped
+    /// unless `BFF_TEST_REDIS_URL` is set, so CI / local `cargo test`
+    /// without Redis stays green. Run with:
+    ///
+    /// ```ignore
+    /// BFF_TEST_REDIS_URL=redis://localhost:6379/15 cargo test \
+    ///     -p insight-api-gateway --bin insight-api-gateway \
+    ///     -- --ignored session_store_round_trip
+    /// ```
+    ///
+    /// Use a dedicated DB (e.g. `/15`) — the test wipes its own keys
+    /// but does not flush the DB, and a stray collision could break a
+    /// shared dev instance.
+    #[tokio::test]
+    #[ignore = "requires a running Redis; opt in via BFF_TEST_REDIS_URL"]
+    async fn session_store_round_trip_against_real_redis() {
+        let Ok(url) = std::env::var("BFF_TEST_REDIS_URL") else {
+            eprintln!("BFF_TEST_REDIS_URL not set; skipping");
+            return;
+        };
+        let client = redis::Client::open(url).expect("open client");
+        let manager = redis::aio::ConnectionManager::new(client)
+            .await
+            .expect("connect");
+        let shared = std::sync::Arc::new(crate::redis_client::RedisShared::__test_from_manager(
+            manager,
+        ));
+        let store = SessionStore::new(shared);
+
+        let req = CreateSessionRequest {
+            user_id: "test-user-zzz",
+            tenant_id: "test-tenant",
+            idp_iss: "https://test-idp/",
+            idp_sub: "test-sub-zzz",
+            idp_sid: "test-isid-zzz",
+            id_token: "irrelevant",
+            email: "test@example.com",
+            display_name: "Test",
+            user_agent: "ua",
+            ip: "127.0.0.1",
+            now: 1,
+            session_ttl_seconds: 60,
+            absolute_lifetime_seconds: 3600,
+            incoming_sid: None,
+        };
+        let outcome = store.create_session(req).await.expect("create");
+        let sid = outcome.session_id.clone();
+
+        let read = store
+            .get_session(&sid)
+            .await
+            .expect("get")
+            .expect("present");
+        assert_eq!(read.user_id, "test-user-zzz");
+        assert_eq!(read.email, "test@example.com");
+        assert_eq!(read.expires_at, 61);
+
+        store.revoke_session(&sid).await.expect("revoke");
+        let after = store.get_session(&sid).await.expect("get");
+        assert!(after.is_none(), "session should be gone after revoke");
+    }
+}

--- a/src/backend/services/api-gateway/src/bff/session_store.rs
+++ b/src/backend/services/api-gateway/src/bff/session_store.rs
@@ -45,10 +45,8 @@ pub struct CreateSessionRequest<'a> {
 
 pub struct CreateSessionOutcome {
     pub session_id: String,
-    /// The full record we just persisted. Phase 1 callers only need
-    /// `session_id`, but Phase 2 (refresh/sessions endpoints) will read
-    /// from this without touching Redis again.
-    #[allow(dead_code)]
+    /// The full record we just persisted. Callers use it to set the
+    /// rotation cookie's `Max-Age` without an extra Redis read.
     pub record: SessionRecord,
 }
 

--- a/src/backend/services/api-gateway/src/bff/session_store.rs
+++ b/src/backend/services/api-gateway/src/bff/session_store.rs
@@ -307,7 +307,7 @@ pub mod login_state {
     pub async fn touch(redis: &Arc<RedisShared>) -> Result<i64, BffError> {
         let mut conn = redis.manager();
         let v: i64 = conn
-            .incr("bff:rl:login_state_count", 1)
+            .incr(redis_keys::bff_rl_login_state_count(), 1)
             .await
             .map_err(|e| BffError::StoreUnavailable(e.to_string()))?;
         Ok(v)

--- a/src/backend/services/api-gateway/src/bff/session_store.rs
+++ b/src/backend/services/api-gateway/src/bff/session_store.rs
@@ -440,18 +440,29 @@ mod tests {
         ));
         let store = SessionStore::new(shared);
 
+        // Use a fixed future epoch (2099-01-01) so EXPIREAT lands ahead
+        // of Redis's wall clock. With `now: 1` the key would be evicted
+        // immediately, making the round-trip read return None.
+        // Per-test random suffix so parallel `cargo test` runs don't
+        // collide on shared keys.
+        let suffix: String = crate::bff::secrets::new_session_id()
+            .chars()
+            .take(6)
+            .collect();
+        let user_id = format!("test-user-{suffix}");
+        let now: i64 = 4_070_908_800;
         let req = CreateSessionRequest {
-            user_id: "test-user-zzz",
+            user_id: &user_id,
             tenant_id: "test-tenant",
             idp_iss: "https://test-idp/",
-            idp_sub: "test-sub-zzz",
-            idp_sid: "test-isid-zzz",
+            idp_sub: &format!("test-sub-{suffix}"),
+            idp_sid: &format!("test-isid-{suffix}"),
             id_token: "irrelevant",
             email: "test@example.com",
             display_name: "Test",
             user_agent: "ua",
             ip: "127.0.0.1",
-            now: 1,
+            now,
             session_ttl_seconds: 60,
             absolute_lifetime_seconds: 3600,
             incoming_sid: None,
@@ -464,9 +475,9 @@ mod tests {
             .await
             .expect("get")
             .expect("present");
-        assert_eq!(read.user_id, "test-user-zzz");
+        assert_eq!(read.user_id, user_id);
         assert_eq!(read.email, "test@example.com");
-        assert_eq!(read.expires_at, 61);
+        assert_eq!(read.expires_at, now + 60);
 
         store.revoke_session(&sid).await.expect("revoke");
         let after = store.get_session(&sid).await.expect("get");

--- a/src/backend/services/api-gateway/src/bff/session_store.rs
+++ b/src/backend/services/api-gateway/src/bff/session_store.rs
@@ -35,8 +35,8 @@ pub struct CreateSessionRequest<'a> {
     pub user_agent: &'a str,
     pub ip: &'a str,
     pub now: i64,
-    pub session_ttl_seconds: u64,
-    pub absolute_lifetime_seconds: u64,
+    pub session_ttl_seconds: u32,
+    pub absolute_lifetime_seconds: u32,
     /// Cookie value present on the callback request. We never reuse it;
     /// if it maps to a live session we revoke it before creating the new
     /// one (DESIGN §3.6 fixation guard).
@@ -110,12 +110,10 @@ impl SessionStore {
         let session_id = new_session_id();
         let csrf_token = new_csrf_token();
 
-        let expires_at = req
-            .now
-            .saturating_add(i64::try_from(req.session_ttl_seconds).unwrap_or(i64::MAX));
+        let expires_at = req.now.saturating_add(i64::from(req.session_ttl_seconds));
         let absolute_expires_at = req
             .now
-            .saturating_add(i64::try_from(req.absolute_lifetime_seconds).unwrap_or(i64::MAX));
+            .saturating_add(i64::from(req.absolute_lifetime_seconds));
 
         let record = SessionRecord {
             user_id: req.user_id.to_owned(),

--- a/src/backend/services/api-gateway/src/main.rs
+++ b/src/backend/services/api-gateway/src/main.rs
@@ -5,6 +5,8 @@
 //! - OIDC `AuthN` plugin (JWT validation against Okta/Keycloak/Auth0)
 //! - `AuthZ` resolver (static plugin for now, custom org-tree plugin later)
 //! - Tenant resolver (single-tenant plugin)
+//! - BFF (server-side OIDC + cookie sessions)
+//! - Reverse proxy
 //!
 //! # Configuration
 //!
@@ -14,10 +16,18 @@
 //!   insight-api-gateway run -c config/insight.yaml
 //!   insight-api-gateway check -c config/insight.yaml
 
+#![cfg_attr(test, allow(clippy::expect_used, clippy::unwrap_used))]
+// IdP, ModKit, ClientHub, OperationBuilder, UserInfo etc. are standard
+// industry/framework terms — wrapping every occurrence in backticks adds
+// noise without improving readability.
+#![allow(clippy::doc_markdown)]
+
 // Insight modules (compiled into the binary, registered via inventory).
 mod auth_info;
+mod bff;
 mod core_types;
 mod proxy;
+mod redis_client;
 
 // Link external modules via inventory — runtime discovers them automatically.
 use api_gateway_module as _;

--- a/src/backend/services/api-gateway/src/redis_client.rs
+++ b/src/backend/services/api-gateway/src/redis_client.rs
@@ -1,0 +1,154 @@
+//! Shared Redis client for the API Gateway pod.
+//!
+//! Initializes a single `redis::aio::ConnectionManager` from config and
+//! publishes it on the ClientHub as `Arc<RedisShared>` so other ModKit
+//! modules in the same binary (BFF today, Router tomorrow) can consume it
+//! without re-opening a connection pool.
+//!
+//! # Configuration
+//!
+//! ```yaml
+//! modules:
+//!   redis-client:
+//!     config:
+//!       url: "redis://redis:6379/0"
+//! ```
+
+use std::sync::{Arc, OnceLock};
+
+use async_trait::async_trait;
+use modkit::context::ModuleCtx;
+use modkit::contracts::Module;
+use redis::aio::ConnectionManager;
+use serde::Deserialize;
+use tracing::info;
+
+/// Module configuration.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct RedisClientConfig {
+    /// Redis connection URL (e.g. `redis://localhost:6379/0`). Empty means
+    /// "no Redis configured" — modules that depend on this client will fail
+    /// at their own init when they call `client_hub.get::<RedisShared>()`.
+    pub url: String,
+}
+
+/// Shared Redis handle. Cheap to clone — wraps `ConnectionManager` which
+/// itself is a `Clone` reference into a multiplexed connection pool.
+#[derive(Clone)]
+pub struct RedisShared {
+    manager: ConnectionManager,
+}
+
+impl std::fmt::Debug for RedisShared {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RedisShared").finish_non_exhaustive()
+    }
+}
+
+impl RedisShared {
+    /// Borrow the underlying multiplexed connection manager.
+    ///
+    /// Callers clone this to obtain an owned `ConnectionManager` that can be
+    /// passed by value to `redis::pipe()` / `cmd().query_async(&mut conn)`.
+    #[must_use]
+    pub fn manager(&self) -> ConnectionManager {
+        self.manager.clone()
+    }
+
+    /// Test-only constructor — wraps an externally-built `ConnectionManager`
+    /// without going through the module init path. Lets integration tests
+    /// drive `SessionStore` against a real Redis from `cargo test`.
+    #[cfg(test)]
+    #[must_use]
+    #[doc(hidden)]
+    pub fn __test_from_manager(manager: ConnectionManager) -> Self {
+        Self { manager }
+    }
+}
+
+/// Redis client module. Has no capabilities — its only job is to initialize
+/// a connection manager and register it with the ClientHub.
+#[modkit::module(name = "redis-client")]
+pub struct RedisClientModule {
+    shared: OnceLock<Arc<RedisShared>>,
+}
+
+impl Default for RedisClientModule {
+    fn default() -> Self {
+        Self {
+            shared: OnceLock::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl Module for RedisClientModule {
+    async fn init(&self, ctx: &ModuleCtx) -> anyhow::Result<()> {
+        let cfg: RedisClientConfig = ctx.config()?;
+
+        if cfg.url.is_empty() {
+            anyhow::bail!(
+                "redis-client: url is required. \
+                 Set modules.redis-client.config.url in your config."
+            );
+        }
+
+        info!(url = redacted_url(&cfg.url).as_str(), "connecting to Redis");
+
+        let client = redis::Client::open(cfg.url.clone())
+            .map_err(|e| anyhow::anyhow!("invalid redis url: {e}"))?;
+        let manager = ConnectionManager::new(client)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to open redis connection manager: {e}"))?;
+
+        let shared = Arc::new(RedisShared { manager });
+        self.shared
+            .set(shared.clone())
+            .map_err(|_| anyhow::anyhow!("redis-client already initialized"))?;
+
+        ctx.client_hub().register::<RedisShared>(shared);
+        info!("redis-client: registered RedisShared on ClientHub");
+
+        Ok(())
+    }
+}
+
+/// Strip credentials and query string from a Redis URL for safe logging.
+fn redacted_url(url: &str) -> String {
+    match url::Url::parse(url) {
+        Ok(mut u) => {
+            let _ = u.set_password(None);
+            let _ = u.set_username("");
+            u.set_query(None);
+            u.set_fragment(None);
+            u.to_string()
+        }
+        Err(_) => "<unparseable redis url>".to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacted_url_strips_credentials() {
+        assert_eq!(
+            redacted_url("redis://user:secret@host:6379/0"),
+            "redis://host:6379/0"
+        );
+        assert_eq!(
+            redacted_url("redis://host:6379/0?foo=bar"),
+            "redis://host:6379/0"
+        );
+        assert_eq!(redacted_url("redis://host:6379"), "redis://host:6379");
+        assert_eq!(redacted_url("not a url"), "<unparseable redis url>");
+    }
+
+    #[test]
+    fn config_default_has_empty_url() {
+        let c = RedisClientConfig::default();
+        assert!(c.url.is_empty());
+    }
+}

--- a/src/backend/services/api-gateway/src/redis_client.rs
+++ b/src/backend/services/api-gateway/src/redis_client.rs
@@ -27,9 +27,8 @@ use tracing::info;
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct RedisClientConfig {
-    /// Redis connection URL (e.g. `redis://localhost:6379/0`). Empty means
-    /// "no Redis configured" — modules that depend on this client will fail
-    /// at their own init when they call `client_hub.get::<RedisShared>()`.
+    /// Redis connection URL (e.g. `redis://localhost:6379/0`). Required:
+    /// module initialization fails fast if this is empty.
     pub url: String,
 }
 


### PR DESCRIPTION
## Summary

Phase 1 of the BFF cookie-auth migration (issue #1260 EPIC). Adds a new BFF (Backend-for-Frontend) ModKit module to the api-gateway binary plus a shared `redis-client` module that publishes a `RedisShared` handle on the ClientHub.

Specs: [`docs/components/backend/api-gateway/bff/PRD.md`](docs/components/backend/api-gateway/bff/PRD.md) §5.1, §5.2, §5.4 and [`bff/DESIGN.md`](docs/components/backend/api-gateway/bff/DESIGN.md) §3.6 (Login). FR IDs: `cpt-insightspec-fr-bff-oidc-login`, `cpt-insightspec-fr-bff-session-cookie`, `cpt-insightspec-fr-bff-session-store`.

### Endpoints (all public; BFF owns its own cookie-based auth)

- **GET /auth/login** — kicks off OIDC code+PKCE; stores state/nonce/PKCE verifier in `bff:login_state:{state}` (5 min TTL); 302 to the IdP authorize endpoint.
- **GET /auth/callback** — atomic GET+DEL of login state; exchanges code at the IdP token endpoint; validates the ID token (signature via `modkit_auth::JwksKeyProvider`, then our own iss/aud/nonce/exp/nbf/azp checks plus an algorithm allow-list); revokes any attacker-planted incoming cookie (fixation guard); creates a session in Redis under one atomic MULTI/EXEC; sets `__Host-sid` and 302s the browser to a sanitized `return_to`.
- **GET /auth/me** — reads cookie, looks up session, enforces both `expires_at` and `absolute_expires_at`; returns `{user, tenant, expires_at, refresh_at, csrf_token}`; 401 + clear-cookie otherwise.

### Cookie hardening (`cpt-insightspec-nfr-bff-cookie-attrs`)

Single helper emits `__Host-sid`, `HttpOnly`, `Secure`, `SameSite=Strict`, `Path=/`, no `Domain`. Snapshot tests pin the exact `Set-Cookie` string. Reader rejects duplicate `__Host-sid` cookies and strips RFC 6265 quoted values.

### Redis schema (DD-BFF-04, prefix `bff:`)

- `session:{sid}` HASH
- `user_sessions:{user_id}` ZSET (score = `expires_at`)
- `sid_index:{iss}:{idp_sid}` SET
- `login_state:{state}` HASH

Phase 2/3 keys (`swap`, `logout_jti`, `lock:janitor`) declared in the same builder file for schema unity but not used yet.

### Identity

`user_id = OIDC sub` verbatim (single OIDC issuer per installation by deployment design). Identity Service mapping is a separate scope; `idp_iss` and `idp_sub` are persisted on every session so the future `(scope="oidc", id=sub)` resolver call has its data.

### Out of scope (intentional, follow-ups)

`/auth/refresh`, `/auth/logout`, `/auth/sessions`, `/auth/csrf`, `/auth/oidc/back-channel-logout`, CSRF middleware, janitor, rate-limit middleware, dev-fake-OIDC stub, Helm + config example.

### Side fix-up (second commit)

Two trivial clippy-1.95 lints (`map(f).unwrap_or(x)` → `map_or(x, f)`, `Duration::from_secs(3600)` → `Duration::from_hours(1)`) plus the Phase 1 integration test's `now: 1` → fixed future epoch so EXPIREAT lands ahead of Redis's wall clock instead of evicting immediately. No behavioural change.

## Test plan

- [x] `cargo fmt -p insight-api-gateway` clean
- [x] `cargo clippy --workspace --all-targets` clean (workspace-pedantic config, `pedantic = deny`, `unwrap_used = deny`, `expect_used = deny`)
- [x] `cargo test -p insight-api-gateway` — 87 / 87 pass
- [x] `BFF_TEST_REDIS_URL=redis://localhost:16379/15 cargo test -p insight-api-gateway -- --include-ignored` — 88 / 88 pass against Redis 7
- [ ] Reviewer: cookie attributes verified via snapshot tests in `cookies.rs`
- [ ] Reviewer: grep diff for `id_token` and confirm it never reaches logs or response bodies (only Redis HASH field + future Phase 2 `id_token_hint`)

Phase 2 (`/auth/refresh` + `/auth/logout`) follows as a stacked PR (#1278) once this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backend-for-Frontend (BFF) auth: /auth/login, /auth/callback, /auth/me with OIDC (PKCE), discovery, token exchange and session refresh.
  * Server-side Redis sessions, secure __Host-sid cookie handling, CSRF tokens, login-state lifecycle, jittered refresh scheduling, and audit-event emission.
  * Centralized canonical API error responses, Redis key namespace, and a Redis client module.

* **Tests**
  * Extensive unit tests for config, crypto/secrets, cookies, session store, OIDC flows, audit, routing, and helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->