### PR TITLE
fix(ingestion): ai_dev_usage placeholder missing cost_cents / PR-attribution columns — E2E red on main since Jun 4

### DIFF
--- a/src/ingestion/scripts/create-bronze-placeholders.sh
+++ b/src/ingestion/scripts/create-bronze-placeholders.sh
@@ -221,6 +221,9 @@ CREATE TABLE IF NOT EXISTS silver.class_ai_dev_usage (
     spec_lines           Nullable(Float64),
     session_count        Nullable(Float64),
     total_chat_messages  Nullable(Float64),
+    cost_cents           Nullable(UInt32),
+    prs_with_cc_count    Nullable(UInt32),
+    prs_total_count      Nullable(UInt32),
     _version             UInt64
 ) ENGINE = ReplacingMergeTree(_version) ORDER BY (email, day) COMMENT 'INSIGHT_PLACEHOLDER_v1';
 SQL


### PR DESCRIPTION
## Problem

The E2E suite (`E2E — Bronze to API`) has been failing on `main` since 2026-06-04 (last 4 runs red). Root cause:

- Migration `20260601000000_ai-claude-team-metrics.sql` creates a gold view selecting `c.cost_cents`, `c.prs_with_cc_count`, `c.prs_total_count` from `silver.class_ai_dev_usage`.
- Those columns were added to the dbt model / connector staging projections, but the bootstrap placeholder in `scripts/create-bronze-placeholders.sh` was **not** extended.
- On a fresh cluster (and in the e2e rig, which bootstraps placeholders + migrations from scratch), ClickHouse validates the `CREATE VIEW` SELECT against the placeholder and aborts:

```
Code: 47. DB::Exception: Identifier 'c.cost_cents' cannot be resolved from table with name c.
```

All subsequent migrations are skipped, so the whole session setup collapses and every e2e test errors.

## Fix

Add the three columns to the `class_ai_dev_usage` placeholder as `Nullable(UInt32)` — matching the connector staging models (`claude_team__ai_dev_usage`, `claude_enterprise__ai_dev_usage`, `cursor__ai_dev_usage`, `copilot__ai_dev_usage` all emit them as `Nullable(UInt32)`). The placeholder is dropped and replaced by dbt with the real schema on first run; minimum-viable parity with the migrations is all that's needed.

Verified the migration references nothing else that's missing: it reads only `silver.class_ai_dev_usage` (all 12 referenced columns now covered) and `insight.people`.

## Note

This is another instance of the "schema updated in one place, forgotten in another" drift class — same family as cross-connector silver drift. A follow-up PR will propose a contract/parity gate for exactly this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal data schema with three new fields to improve type-checking validation on fresh instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->