### PR TITLE
ci: attest umbrella chart provenance; advance backend images to attested tags

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -785,9 +785,31 @@ jobs:
             | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Helm push
+        id: helm_push
         run: |
-          helm push "dist/insight-${{ steps.umbrella.outputs.version }}.tgz" \
-            oci://ghcr.io/constructorfabric/charts
+          set -euo pipefail
+          OUT="$(helm push "dist/insight-${{ steps.umbrella.outputs.version }}.tgz" \
+            oci://ghcr.io/constructorfabric/charts 2>&1)"
+          echo "$OUT"
+          # helm push prints "Digest: sha256:..." — that digest is the chart's
+          # OCI manifest identity, which the attestation below binds to.
+          DIGEST="$(echo "$OUT" | sed -n 's/^Digest: //p')"
+          if [ -z "$DIGEST" ]; then
+            echo "ERROR: could not parse chart digest from helm push output" >&2
+            exit 1
+          fi
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      # Keyless SLSA provenance for the umbrella chart OCI artifact — same
+      # contract as the image attestations (see backend-api-gateway). Verify:
+      #   gh attestation verify oci://ghcr.io/constructorfabric/charts/insight:<ver> \
+      #     --repo constructorfabric/insight
+      - name: Attest chart provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/constructorfabric/charts/insight
+          subject-digest: ${{ steps.helm_push.outputs.digest }}
+          push-to-registry: true
 
       - name: Commit version bumps back to main
         env:

--- a/src/backend/services/analytics-api/Dockerfile
+++ b/src/backend/services/analytics-api/Dockerfile
@@ -1,3 +1,6 @@
+# Rebuild marker (2026-06-11): republish so the chart-pinned tag advances to
+# an SLSA-attested image — current appVersion predates the provenance
+# attestation steps in build-images.yml.
 # Multi-stage build for Insight Analytics API
 #
 # Build context: src/backend/

--- a/src/backend/services/api-gateway/Dockerfile
+++ b/src/backend/services/api-gateway/Dockerfile
@@ -1,3 +1,6 @@
+# Rebuild marker (2026-06-11): republish so the chart-pinned tag advances to
+# an SLSA-attested image — current appVersion predates the provenance
+# attestation steps in build-images.yml.
 # Multi-stage build for Insight API Gateway
 #
 # Build context: src/backend/

--- a/src/backend/services/identity/Dockerfile
+++ b/src/backend/services/identity/Dockerfile
@@ -1,3 +1,6 @@
+# Rebuild marker (2026-06-11): republish so the chart-pinned tag advances to
+# an SLSA-attested image — current appVersion predates the provenance
+# attestation steps in build-images.yml.
 # Identity Resolution — .NET 9 service.
 #
 # Build context: src/backend/services/identity/


### PR DESCRIPTION
## Summary

Follow-up to #1280 closing the two remaining provenance gaps.

### 1. Umbrella chart attestation
`publish-chart` now parses the chart's OCI digest from `helm push` output and attests it with `actions/attest-build-provenance@v2` (`push-to-registry: true`) — the same keyless SLSA contract as the container images:

```
gh attestation verify oci://ghcr.io/constructorfabric/charts/insight:<version> \
  --repo constructorfabric/insight
```

### 2. Backend images: chart pins predate attestation
The chart currently pins all three backend services (`api-gateway`, `analytics-api`, `identity`) to `2026.06.09.10.55-9ef2224` — built **before** the attestation steps landed, so `gh attestation verify` fails for every chart-referenced backend image. The attested rebuilds from #1280 were never promoted into the chart: `bump-descriptors` committed in that run (which skips `publish-chart`), and the follow-up run no longer matched the backend path filters.

Rebuild markers in the three service Dockerfiles make the merge of this PR rebuild + attest all three images; `publish-chart` then advances their `appVersion`s and publishes an umbrella whose pinned backend tags are all attested — and the chart artifact itself now carries provenance too.

## Expected CI flow on merge (single run)

`changes` flags all three backend services → rebuild + push + attest ×3 → connector matrix empty → `bump-descriptors` skipped → `publish-chart` runs in the same run: bumps three subchart appVersions, patch-bumps umbrella, pushes the chart, **attests the chart digest**.

## Known-red check

**Run E2E suite** is red on every PR (pre-existing `cost_cents` migration mismatch on the e2e rig) — unrelated, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline to capture and validate artifact metadata during chart publishing.
  * Updated Docker image build configurations to support improved artifact tracking and provenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->