### PR TITLE
fix(ci): registry login for chart attestation; tolerate gha cache export errors

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -212,7 +212,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
       # Keyless SLSA provenance: attests "this digest was built by THIS
       # workflow at THIS commit" via the runner's short-lived OIDC identity —
       # no stored signing keys. push-to-registry stores the attestation next
@@ -258,7 +258,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
       # Keyless SLSA provenance — see backend-api-gateway for the contract.
       - name: Attest build provenance
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
@@ -301,7 +301,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
       # Keyless SLSA provenance — see backend-api-gateway for the contract.
       - name: Attest build provenance
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
@@ -357,7 +357,7 @@ jobs:
           push: false
           tags: insight-toolbox:ci-validate
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-to: type=gha,mode=max,ignore-error=true
 
       - name: Validate dbt project (dbt parse)
         # `dbt parse` exercises the dbt manifest: duplicate model/test
@@ -448,7 +448,7 @@ jobs:
           # Scope cache per image name so unrelated connectors don't evict
           # each other's layer cache.
           cache-from: type=gha,scope=${{ matrix.entry.name }}
-          cache-to:   type=gha,mode=max,scope=${{ matrix.entry.name }}
+          cache-to:   type=gha,mode=max,scope=${{ matrix.entry.name }},ignore-error=true
       # Keyless SLSA provenance — see backend-api-gateway for the contract.
       - name: Attest build provenance
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
@@ -799,6 +799,16 @@ jobs:
             exit 1
           fi
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+
+      # attest-build-provenance with push-to-registry reads DOCKER credentials
+      # (~/.docker/config.json) — `helm registry login` above writes to helm's
+      # own config, which the attest action cannot see. Without this login the
+      # attest step dies with "No credentials found for registry ghcr.io".
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # Keyless SLSA provenance for the umbrella chart OCI artifact — same
       # contract as the image attestations (see backend-api-gateway). Verify:

--- a/src/backend/services/analytics-api/Dockerfile
+++ b/src/backend/services/analytics-api/Dockerfile
@@ -1,6 +1,8 @@
-# Rebuild marker (2026-06-11): republish so the chart-pinned tag advances to
+# Rebuild marker (2026-06-11, take 2): republish so the chart-pinned tag advances to
 # an SLSA-attested image — current appVersion predates the provenance
 # attestation steps in build-images.yml.
+# Take 2: the first publish-chart attempt failed before committing the
+# appVersion bumps back to main (chart attest step lacked registry login).
 # Multi-stage build for Insight Analytics API
 #
 # Build context: src/backend/

--- a/src/backend/services/api-gateway/Dockerfile
+++ b/src/backend/services/api-gateway/Dockerfile
@@ -1,6 +1,8 @@
-# Rebuild marker (2026-06-11): republish so the chart-pinned tag advances to
+# Rebuild marker (2026-06-11, take 2): republish so the chart-pinned tag advances to
 # an SLSA-attested image — current appVersion predates the provenance
 # attestation steps in build-images.yml.
+# Take 2: the first publish-chart attempt failed before committing the
+# appVersion bumps back to main (chart attest step lacked registry login).
 # Multi-stage build for Insight API Gateway
 #
 # Build context: src/backend/

--- a/src/backend/services/identity/Dockerfile
+++ b/src/backend/services/identity/Dockerfile
@@ -1,6 +1,8 @@
-# Rebuild marker (2026-06-11): republish so the chart-pinned tag advances to
+# Rebuild marker (2026-06-11, take 2): republish so the chart-pinned tag advances to
 # an SLSA-attested image — current appVersion predates the provenance
 # attestation steps in build-images.yml.
+# Take 2: the first publish-chart attempt failed before committing the
+# appVersion bumps back to main (chart attest step lacked registry login).
 # Identity Resolution — .NET 9 service.
 #
 # Build context: src/backend/services/identity/


### PR DESCRIPTION
## What broke

The merge run of #1298 ([run 27353068335](https://github.com/constructorfabric/insight/actions/runs/27353068335)) failed twice:

1. **`backend-analytics-api`** — GHA cache backend 504 during layer-blob write (third spurious cache failure in three days). Recovered by re-run.
2. **`publish-chart` → Attest chart provenance** — `No credentials found for registry ghcr.io`. `helm registry login` writes to helm's own config; `attest-build-provenance` with `push-to-registry: true` reads **Docker** credentials, which nothing in that job ever provided. Image jobs were unaffected (they run `docker/login-action`).

Fallout of (2): the job aborted **before** "Commit version bumps back to main" — chart `0.1.53` was pushed **unattested**, and main still pins all backend appVersions to the pre-attestation tag `2026.06.09.10.55-9ef2224`.

## Fix

- `docker/login-action` in `publish-chart` before the attest step.
- Refreshed rebuild markers in the three backend Dockerfiles → merging this PR rebuilds + attests `api-gateway`/`analytics-api`/`identity`, and `publish-chart` re-publishes `0.1.53` (recomputed from main's `0.1.52`) with attested backend pins, attests the chart digest, and commits the bumps back.
- `ignore-error=true` on every `cache-to: type=gha` export — cache export is an optimization; by that point the image is already built and pushed. A flaky cache service must not fail the job (and with it the whole publish chain). `cache-from` already tolerates cache unavailability.

## Verify after merge

```
gh attestation verify oci://ghcr.io/constructorfabric/charts/insight:0.1.53 --repo constructorfabric/insight
gh attestation verify oci://ghcr.io/constructorfabric/insight-api-gateway:<new-tag> --repo constructorfabric/insight
```

Known-red: **Run E2E suite** (pre-existing `cost_cents` migration mismatch, tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD build resilience by tolerating cache layer failures during image builds.
  * Fixed chart publication workflow by adding required Docker registry authentication for provenance attestation steps.
  * Updated build metadata comments across service images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->