### PR TITLE
fix(ci): umbrella appVersion computed as "---" since runner yq update

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -754,12 +754,25 @@ jobs:
           set -euo pipefail
           CURRENT="$(yq '.version' charts/insight/Chart.yaml)"
           NEXT="$(echo "$CURRENT" | awk -F. '{ printf "%d.%d.%d", $1, $2, $3+1 }')"
+          # yq v4 emits a `---` document separator between results when given
+          # multiple files (behaviour appeared with a runner yq update,
+          # 2026-06-08): without the filter below, `sort -V | tail -1` picks
+          # the separator and `appVersion: "---"` ships in the published
+          # chart — an invalid `app.kubernetes.io/version` label value that
+          # breaks every install (charts 0.1.48–0.1.55 were affected).
           NEW_APP=$(yq -r '.appVersion' \
             src/backend/services/api-gateway/helm/Chart.yaml \
             src/backend/services/analytics-api/helm/Chart.yaml \
             src/backend/services/identity/helm/Chart.yaml \
             src/frontend/helm/Chart.yaml \
+            | grep -Ev '^(---|null)$' \
             | sort -V | tail -1)
+          # Fail loud unless the result is a build tag (YYYY.MM.DD.HH.MM-sha):
+          # a malformed appVersion must never reach a published chart again.
+          if ! echo "$NEW_APP" | grep -Eq '^[0-9]{4}(\.[0-9]{2}){4}-[0-9a-f]{7}$'; then
+            echo "ERROR: computed umbrella appVersion '$NEW_APP' is not a valid build tag" >&2
+            exit 1
+          fi
           echo "Umbrella version $CURRENT → $NEXT (appVersion → $NEW_APP)"
           yq -i ".version = \"$NEXT\""        charts/insight/Chart.yaml
           yq -i ".appVersion = \"$NEW_APP\""  charts/insight/Chart.yaml

--- a/charts/insight/Chart.yaml
+++ b/charts/insight/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # appVersion — product version. Matches the image tag of all insight-* images.
 # Release pipeline: git tag v0.1.0 → version=0.1.0, appVersion="0.1.0".
 version: 0.1.56
-appVersion: "---"
+appVersion: "2026.06.11.15.07-672d487"
 kubeVersion: ">=1.27.0-0"
 home: https://github.com/constructorfabric/insight
 sources:


### PR DESCRIPTION
## What broke

Every umbrella chart published since 2026-06-08 (**0.1.48 → 0.1.55**) carries `appVersion: "---"`:

```
0.1.47 (06-04): appVersion "2026.06.04.19.35-89ba5bf"   ← last healthy
0.1.48 (06-08): appVersion "---"                         ← first broken
```

The runner's yq v4 update started emitting `---` **document separators** between results when given multiple files. `publish-chart`'s computation

```bash
NEW_APP=$(yq -r '.appVersion' <4 Chart.yaml files> | sort -V | tail -1)
```

then picks the separator (`sort -V` orders `---` after date-prefixed tags). The value lands in the `app.kubernetes.io/version` label of every rendered resource → **invalid label value** → every install of the published chart fails at the pre-upgrade hook. First real-world hit: today's dev gitops deploy of 0.1.54/0.1.55 (helm release went to `failed`, see run history in insight-gitops).

Nobody noticed for three days because dev hadn't been deployed since June 4.

## Fix

1. Filter `---`/`null` lines before `sort -V`.
2. **Fail-fast guard**: abort publish if the computed appVersion doesn't match the `YYYY.MM.DD.HH.MM-shortsha` build-tag shape — a malformed appVersion must never ship again.
3. Restore the committed umbrella `appVersion` (`"---"` → current max of subchart appVersions). This also makes the merge fire `publish-chart` (`charts/insight/**` path filter), so the next chart (0.1.57) publishes healthy + attested immediately.

Verified locally on yq v4.53.2: old expression → `---`, fixed expression → `2026.06.11.15.07-672d487`, guard passes; guard rejects `---`/`null`/garbage.

## Relation to #1290

#1290's `_helpers.tpl` hunk treats the committed `"---"` as an *intentional placeholder* and omits the version label when seen. Git history shows `"---"` is the **output of this bug**, not a design: it first appeared with the 0.1.48 release commit. If only #1290 merged, CI would keep publishing `appVersion: "---"` forever and the `app.kubernetes.io/version` label would silently vanish from all published charts. With this PR merged, real tags return and that guard becomes dead code (harmless; its comment should be updated or the hunk dropped).

Known-red: **Run E2E suite** (pre-existing `cost_cents` migration mismatch, tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build workflow to improve chart version extraction and validation with filtering and format verification
  * Updated umbrella chart metadata with latest version identifier

<!-- end of auto-generated comment: release notes by coderabbit.ai -->