### PR TITLE
chore(connectors): bump jira/confluence descriptor versions to publish #1308

### DIFF
--- a/cypilot/.core/skills/connector/workflows/deploy.md
+++ b/cypilot/.core/skills/connector/workflows/deploy.md
@@ -15,6 +15,7 @@ Registers connector in Airbyte, creates connections, and sets up Argo workflows.
 - **All cursor fields exist in schema** (prevents ClickHouse destination NPE)
 - Tenant config (`connections/<tenant>.yaml` with `tenant_id`) and K8s Secrets with credentials
 - Cluster running (`./up.sh` completed)
+- **`descriptor.yaml` `version` bumped whenever `connector.yaml` changed.** On reconcile-managed clusters the nocode manifest is republished ONLY on descriptor-version drift (reconcile compares descriptor `version` against the version stored on the Airbyte definition; equal → noop, ADR-0015). A manifest-only PR without a version bump silently never reaches Airbyte — the deploy "succeeds" with the old manifest still active. CI auto-bumps descriptors only for image ref changes, NOT for manifest edits.
 
 ## Phase 1: Register Connector
 

--- a/cypilot/.core/skills/connector/workflows/validate.md
+++ b/cypilot/.core/skills/connector/workflows/validate.md
@@ -91,6 +91,7 @@ Read connector package files and verify each item:
 
 ### Descriptor
 - [ ] `name` matches directory name
+- [ ] `version` is bumped in the SAME PR as any `connector.yaml` change — reconcile republishes the nocode manifest only on descriptor-version drift (equal versions → noop), so a manifest edit without a bump silently never reaches Airbyte
 - [ ] `connection.namespace` = `bronze_<name>`
 - [ ] `dbt_select` includes connector tag with `+` suffix (e.g., `tag:m365+`)
 - [ ] `schedule` is valid cron expression

--- a/src/ingestion/connectors/task-tracking/jira/descriptor.yaml
+++ b/src/ingestion/connectors/task-tracking/jira/descriptor.yaml
@@ -1,5 +1,5 @@
 name: jira
-version: "1.2.0"
+version: "1.2.1"
 schedule: "0 3 * * *"
 workflow: sync
 # CI build metadata + runtime image refs (ADR-0016). The `images:` block is

--- a/src/ingestion/connectors/wiki/confluence/descriptor.yaml
+++ b/src/ingestion/connectors/wiki/confluence/descriptor.yaml
@@ -1,5 +1,5 @@
 name: confluence
-version: "1.1.0"
+version: "1.1.1"
 schedule: "0 4 * * *"
 workflow: sync
 


### PR DESCRIPTION
## Why

#1308 (jira/confluence `default_concurrency: 1 → 4`, the CDK partition-deadlock fix) changed `connector.yaml` **without bumping the descriptor versions** — and reconcile republishes a nocode declarative manifest **only on descriptor-version drift** (descriptor `version` vs the version stored on the Airbyte definition; equal → noop per ADR-0015).

Verified on virtuozzo after deploying umbrella 0.1.59 (toolbox `2a575de`, contains #1308): reconcile ran clean but no-op'd both connectors — the active manifests in Airbyte (`declarative_manifest` v3 for jira, v2 for confluence) still carry `default_concurrency: 1`, so the deadlock fix never shipped. (#1283 only got through because an unrelated image-ref bump had already moved jira's descriptor to 1.2.0, creating accidental drift.)

## What

- jira descriptor: `1.2.0 → 1.2.1`
- confluence descriptor: `1.1.0 → 1.1.1`

Patch bump → reconcile classifies it as non-breaking: republish manifest + re-discover catalog, no full-refresh dispatch.

Also encodes the lesson into the `/connector` skill (deploy prerequisites + validate descriptor checklist): **bump `descriptor.yaml` `version` in the same PR as any `connector.yaml` change** — a manifest-only PR silently never reaches Airbyte (CI auto-bumps descriptors only for image-ref changes, not manifest edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Jira connector to v1.2.1 and Confluence connector to v1.1.1.

* **Documentation**
  * Enhanced deployment and validation documentation with clarifications on descriptor version management and republish behavior on reconcile-managed clusters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->