### PR TITLE
fix(silver): add zulip_proxy depends_on to shared identity_inputs

### DIFF
--- a/src/ingestion/silver/_shared/identity_inputs.sql
+++ b/src/ingestion/silver/_shared/identity_inputs.sql
@@ -13,6 +13,7 @@
 -- depends_on: {{ ref('bamboohr__identity_inputs') }}
 -- depends_on: {{ ref('zoom__identity_inputs') }}
 -- depends_on: {{ ref('ms_entra__identity_inputs') }}
+-- depends_on: {{ ref('zulip_proxy__identity_inputs') }}
 -- depends_on: {{ ref('seed_identity_inputs_from_cursor') }}
 -- depends_on: {{ ref('seed_identity_inputs_from_claude_admin') }}
 


### PR DESCRIPTION
## Summary

The shared `identity_inputs` union (`src/ingestion/silver/_shared/identity_inputs.sql`) lists explicit `-- depends_on:` hints for every model tagged `silver:identity_inputs` (bamboohr, zoom, ms_entra, both seeds), but `zulip_proxy__identity_inputs` was missing.

Without the hint, dbt does not know about the dependency edge and may build the shared union before the zulip staging model on a first run — `union_by_tag` then silently skips the not-yet-materialised table, dropping zulip identities from the union.

## Changes

- Add `-- depends_on: {{ ref('zulip_proxy__identity_inputs') }}` to the header block of `src/ingestion/silver/_shared/identity_inputs.sql`.

## Verification

- Repo-wide grep confirms `zulip_proxy__identity_inputs` was the only `silver:identity_inputs`-tagged model missing from the header on this branch (`outline__identity_inputs` will need the same treatment once #1312 merges).
- `dbt parse` passes with no errors.
- `dbt ls -s +identity_inputs` now shows `zulip_proxy__identity_inputs` as an upstream of the shared union.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated data pipeline dependencies to ensure proper data lineage tracking and consistency across ingestion processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->