### PR TITLE
feat(jira): auto-discover projects — drop the jira_project_keys allowlist

### DIFF
--- a/src/ingestion/connectors/task-tracking/jira/README.md
+++ b/src/ingestion/connectors/task-tracking/jira/README.md
@@ -31,7 +31,6 @@ stringData:
   jira_instance_url: "https://myorg.atlassian.net"
   jira_email: "user@example.com"
   jira_api_token: "CHANGE_ME"
-  jira_project_keys: "PROJ1,PROJ2"
   # jira_start_date: "2024-01-01"   # optional, default = 2020-01-01
 ```
 
@@ -42,7 +41,6 @@ stringData:
 | `jira_instance_url` | Yes | Jira Cloud URL, no trailing slash (e.g. `https://myorg.atlassian.net`) |
 | `jira_email` | Yes | Atlassian account email for Basic Auth |
 | `jira_api_token` | Yes | Atlassian API token. Marked `airbyte_secret: true` — never logged |
-| `jira_project_keys` | Yes | Comma-separated project keys (e.g. `TC,TNG`). Jira Cloud rejects unbounded JQL queries |
 | `jira_start_date` | No | Earliest date to sync issues from, `YYYY-MM-DD`. Default `2020-01-01` |
 
 ### Automatically injected
@@ -94,7 +92,7 @@ The `jira_boards` stream (`GET /rest/agile/1.0/board`) is the substream parent f
 
 - **Auth**: Basic Auth with email + API token. Missing/invalid token → HTTP 401; Jira project-level permission failures → 403. Both halt the run.
 - **Rate limits**: Atlassian caps per-user and per-IP API calls. The connector honours `Retry-After` on HTTP 429 and 503 (both used by Atlassian for throttling) with backoff.
-- **JQL scope**: `jira_project_keys` is required; Jira Cloud rejects unbounded queries (`project != EMPTY`) with an error.
+- **Project scope**: projects are auto-discovered each sync via `/rest/api/3/project/search` (every project visible to the API token) and scanned per project (`project = "<KEY>"` JQL — Jira Cloud rejects unbounded queries). An incremental gate on `insight.lastIssueUpdateTime` (with a 3-day lookback) skips projects with no issue changes since the previous sync, so idle projects cost zero requests. New projects are picked up automatically on the next scheduled sync.
 - **Custom fields**: all custom fields are preserved in `jira_issue.custom_fields_json` for downstream dbt extraction.
 
 ## Related

--- a/src/ingestion/connectors/task-tracking/jira/connector.yaml
+++ b/src/ingestion/connectors/task-tracking/jira/connector.yaml
@@ -36,8 +36,11 @@ definitions:
               - 400
               - 404
       request_parameters:
+        # Per-project JQL: the project scope comes from the
+        # jira_project_discovery partition router (see definitions), not from
+        # config — the manual jira_project_keys allowlist is gone.
         jql: >-
-          project IN ({{ config['jira_project_keys'] }}) AND updated >= "{{
+          project = "{{ stream_partition.project_key }}" AND updated >= "{{
           stream_slice.start_time }}" AND updated <= "{{ stream_slice.end_time
           }}" ORDER BY updated ASC
         expand: names
@@ -56,6 +59,103 @@ definitions:
         pagination_strategy:
           type: OffsetIncrement
           page_size: 50
+
+  # ─── Project auto-discovery parent (supersedes the jira_project_keys
+  # allowlist; idea from PR #941/#616, reworked) ──────────────────────────
+  # Inline-only parent for jira_issue and jira_issue_keys: enumerates every
+  # project visible to the API token via /project/search and partitions the
+  # issue scans per project (JQL `project = "<KEY>"`). Defined under
+  # `definitions`, NOT `streams`, so discover() never sees it and reconcile
+  # (ADR-0015) cannot auto-select it as a bronze table.
+  #
+  # Incremental gate: `expand=insight` adds per-project
+  # insight.lastIssueUpdateTime (a denormalized Atlassian aggregate; observed
+  # second-fresh on live Jira Cloud). With the client-side cursor on the
+  # hoisted last_issue_update_time, the first sync emits every project while
+  # later syncs emit only projects whose issues changed since the previous
+  # run — idle projects cost zero child requests. Projects with no issues
+  # carry no insight block; they default to epoch and stay filtered until
+  # their first issue stamps a fresh lastIssueUpdateTime. Comments/worklogs
+  # bump the issue's `updated`, which bumps the project aggregate
+  # transitively, so this one gate covers all issue substreams.
+  #
+  # Residual risk (verified empirically): the client-side record filter
+  # compares strictly against the stored cursor — lookback_window does NOT
+  # widen the gate on resume (observed: 3/211 projects re-emitted, only those
+  # updated after the cursor). If the insight aggregate ever lags behind the
+  # source of truth, that project's data is delayed until its next issue
+  # update pushes the aggregate past the cursor. Accepted: the aggregate was
+  # observed second-fresh on live Jira Cloud, and a periodic full refresh
+  # (major version bump / connection reset) re-covers everything.
+  jira_project_discovery:
+    type: DeclarativeStream
+    name: jira_project_discovery
+    primary_key:
+      - project_key
+    retriever:
+      type: SimpleRetriever
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - values
+      paginator:
+        $ref: "#/definitions/linked/SimpleRetriever/paginator"
+      requester:
+        type: HttpRequester
+        http_method: GET
+        authenticator:
+          $ref: "#/definitions/linked/HttpRequester/authenticator"
+        error_handler:
+          $ref: "#/definitions/linked/HttpRequester/error_handler"
+        request_parameters:
+          expand: insight
+        url: "{{ config['jira_instance_url'] }}/rest/api/3/project/search"
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - project_key
+            value: "{{ record['key'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - last_issue_update_time
+            value: >-
+              {{ (record.get('insight') or {}).get('lastIssueUpdateTime') or
+              '1970-01-01T00:00:00.000+0000' }}
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: last_issue_update_time
+      is_client_side_incremental: true
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S.%f%z"
+      datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "1970-01-01"
+        datetime_format: "%Y-%m-%d"
+      end_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S.%f%z') }}"
+        datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
+      lookback_window: P3D
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          project_key:
+            type:
+              - string
+              - "null"
+          last_issue_update_time:
+            type:
+              - string
+              - "null"
+        additionalProperties: true
 
 streams:
   - type: DeclarativeStream
@@ -776,6 +876,15 @@ streams:
         request_parameters:
           $ref: "#/definitions/linked/HttpRequester/request_parameters"
         url: "{{ config['jira_instance_url'] }}/rest/api/3/search/jql"
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: project_key
+            partition_field: project_key
+            incremental_dependency: true
+            stream:
+              $ref: "#/definitions/jira_project_discovery"
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: updated
@@ -794,7 +903,14 @@ streams:
         datetime: "{{ now_utc().strftime('%Y-%m-%d %H:%M') }}"
         datetime_format: "%Y-%m-%d %H:%M"
       step: P30D
-      lookback_window: PT1H
+      # 14h lookback (was 1h): JQL bare datetimes are evaluated in the API
+      # user's local timezone, so an `updated <= <now-as-UTC-string>` upper
+      # bound silently excludes up to 14h of fresh updates for users in
+      # positive UTC offsets (max UTC+14). Rewinding the next window start by
+      # 14h re-covers that tail. Do NOT fix this by pushing end_datetime into
+      # the future instead — that advances the cursor past the actual query
+      # time and permanently skips records updated in between.
+      lookback_window: PT14H
     transformations:
       - type: AddFields
         fields:
@@ -7943,11 +8059,20 @@ streams:
           $ref: "#/definitions/linked/HttpRequester/error_handler"
         request_parameters:
           jql: >-
-            project IN ({{ config['jira_project_keys'] }}) AND updated >= "{{
+            project = "{{ stream_partition.project_key }}" AND updated >= "{{
             stream_slice.start_time }}" AND updated <= "{{ stream_slice.end_time
             }}" ORDER BY updated ASC
           fields: updated
         url: "{{ config['jira_instance_url'] }}/rest/api/3/search/jql"
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: project_key
+            partition_field: project_key
+            incremental_dependency: true
+            stream:
+              $ref: "#/definitions/jira_project_discovery"
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: updated
@@ -7966,7 +8091,14 @@ streams:
         datetime: "{{ now_utc().strftime('%Y-%m-%d %H:%M') }}"
         datetime_format: "%Y-%m-%d %H:%M"
       step: P30D
-      lookback_window: PT1H
+      # 14h lookback (was 1h): JQL bare datetimes are evaluated in the API
+      # user's local timezone, so an `updated <= <now-as-UTC-string>` upper
+      # bound silently excludes up to 14h of fresh updates for users in
+      # positive UTC offsets (max UTC+14). Rewinding the next window start by
+      # 14h re-covers that tail. Do NOT fix this by pushing end_datetime into
+      # the future instead — that advances the cursor past the actual query
+      # time and permanently skips records updated in between.
+      lookback_window: PT14H
     transformations:
       - type: AddFields
         fields:
@@ -8059,7 +8191,6 @@ spec:
       - jira_api_token
       - insight_tenant_id
       - insight_source_id
-      - jira_project_keys
     properties:
       jira_instance_url:
         type: string
@@ -8086,13 +8217,6 @@ spec:
         description: Instance discriminator (e.g., jira-team-alpha)
         title: Source Instance ID
         order: 4
-      jira_project_keys:
-        type: string
-        description: >-
-          Comma-separated project keys to sync (e.g., TC,TNG). Required — Jira
-          Cloud does not allow unbounded queries.
-        title: Project Keys
-        order: 5
       jira_start_date:
         type: string
         description: "Earliest date to sync issues from (YYYY-MM-DD). Default: 2020-01-01"

--- a/src/ingestion/connectors/task-tracking/jira/descriptor.yaml
+++ b/src/ingestion/connectors/task-tracking/jira/descriptor.yaml
@@ -1,5 +1,9 @@
 name: jira
-version: "1.2.1"
+# 2.0.0 (major): project scope moved from the jira_project_keys allowlist to
+# runtime auto-discovery; per-project partitioning resets incremental state —
+# reconcile dispatches a full refresh on major bumps (ADR-0015), which is the
+# intended migration.
+version: "2.0.0"
 schedule: "0 3 * * *"
 workflow: sync
 # CI build metadata + runtime image refs (ADR-0016). The `images:` block is
@@ -28,4 +32,3 @@ secret:
     - jira_instance_url
     - jira_email
     - jira_api_token
-    - jira_project_keys

--- a/src/ingestion/secrets/connectors/jira.yaml.example
+++ b/src/ingestion/secrets/connectors/jira.yaml.example
@@ -18,8 +18,5 @@ stringData:
   # Required — Atlassian API token (https://id.atlassian.com/manage-profile/security/api-tokens)
   jira_api_token: "CHANGE_ME"
 
-  # Required — comma-separated project keys to sync (Jira Cloud rejects unbounded queries)
-  jira_project_keys: "PROJ1,PROJ2"
-
   # Optional — earliest date to sync issues from (YYYY-MM-DD). Default: 2020-01-01.
   # jira_start_date: "2024-01-01"


### PR DESCRIPTION
Supersedes #941 (original idea and per-project JQL by **mozhaev-dev**, mirrored from cyberfabric/cyber-insight#616) — reworked from scratch against the current manifest, since #941 predates #1283/#1308/#1310 and can no longer apply cleanly.

## What

- **`jira_project_discovery`** — inline-only parent under `definitions` (invisible to `discover()`, so reconcile/ADR-0015 cannot auto-select it as a bronze table): `GET /rest/api/3/project/search?expand=insight` enumerates every project visible to the API token.
- **Both** `jira_issue` **and** `jira_issue_keys` are partitioned per project (`project = "<KEY>"` JQL). This is the critical delta vs #941: it predates `jira_issue_keys` (#1283) and, by deleting the config key its JQL still references, would have silently zeroed out `jira_issue_history`/`jira_comments`/`jira_worklogs`.
- **Incremental discovery gate**: client-side cursor on the hoisted `insight.lastIssueUpdateTime` — first sync emits all projects; subsequent syncs only projects whose issues changed since the previous run. Comments/worklogs bump the issue's `updated` → the project aggregate, so one gate covers all substreams.
- **Timezone tail fixed safely**: `lookback_window PT1H → PT14H` on the issue scans (JQL bare datetimes are evaluated in the API user's local TZ). #941 instead pushed `end_datetime` 14h into the future — that advances the cursor past the actual query time and **permanently skips** records updated in between.
- `jira_project_keys` removed everywhere (spec, descriptor `required_fields`, secret example, README).
- descriptor `1.2.1 → 2.0.0` (major → reconcile dispatches full refresh; the per-project partitioning resets incremental state anyway — intended migration, per the #1310 lesson the bump ships in the same PR as the manifest change).

## Verified live (virtuozzo Jira, isolated `read` runs)

| Check | Result |
|---|---|
| First read, no `jira_project_keys` in config | ✅ Succeeded, **211 projects** enumerated |
| Coverage vs old allowlist (4 projects) | **25 projects** had fresh issues; 2478 records — the allowlist would have missed 538 of them across 21 projects |
| Identity stamp | `unique_key = virtuozzo-jira-main-<KEY>` intact |
| Parent gate state | `parent_state.jira_project_discovery.last_issue_update_time` advances |
| Resume read with state | ✅ only **3/211** project partitions touched (just those updated after the cursor) — idle projects cost zero requests |
| CDK runtime `validate` | ✅ manifest valid |
| `validate-strict` | 14 pre-existing errors on main (jira is the known whole-object-`$ref` anti-template) — count and nature unchanged by this diff |

## Known costs (documented in-manifest)

- **First sync after rollout = full re-sync of all visible projects** since `jira_start_date` — plan for a long first run.
- The client-side gate compares strictly against the stored cursor (empirically, `lookback_window` does not widen it on resume). If Atlassian's `insight` aggregate ever lags, that project's data is delayed until its next issue update pushes the aggregate past the cursor. Accepted: the aggregate was observed second-fresh on live Cloud; any full refresh re-covers everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Jira projects are now automatically discovered during each sync operation rather than requiring manual configuration.

* **Breaking Changes**
  * Removed the `jira_project_keys` configuration parameter; projects are now auto-discovered based on available access.

* **Documentation**
  * Updated documentation and configuration examples to reflect the new auto-discovery behavior and connector version 2.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->