### PR TITLE
docs(deploy): grafana as-code (no persistence) + per-code error panels

### DIFF
--- a/docs/deploy/system/grafana/values.yaml
+++ b/docs/deploy/system/grafana/values.yaml
@@ -119,8 +119,24 @@ dashboards:
              "targets": [
                {"refId": "A", "expr": "{namespace=\"insight\", container=\"api-gateway\"} |= \"access_log\" | logfmt | status=~\"[45]..\""}
              ]},
+            {"id": 6, "type": "timeseries", "title": "4xx by status code (count)",
+             "gridPos": {"h": 8, "w": 12, "x": 0, "y": 16},
+             "datasource": {"type": "loki", "uid": "loki"},
+             "fieldConfig": {"defaults": {"unit": "short", "custom": {"drawStyle": "bars", "fillOpacity": 60, "stacking": {"mode": "normal"}}}, "overrides": []},
+             "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["sum"]}},
+             "targets": [
+               {"refId": "A", "legendFormat": "{{status}}", "expr": "sum by (status) (count_over_time({namespace=\"insight\", container=\"api-gateway\"} |= \"access_log\" | logfmt | status=~\"4..\" [$__auto]))"}
+             ]},
+            {"id": 7, "type": "timeseries", "title": "5xx by status code (count)",
+             "gridPos": {"h": 8, "w": 12, "x": 12, "y": 16},
+             "datasource": {"type": "loki", "uid": "loki"},
+             "fieldConfig": {"defaults": {"unit": "short", "custom": {"drawStyle": "bars", "fillOpacity": 60, "stacking": {"mode": "normal"}}}, "overrides": []},
+             "options": {"legend": {"displayMode": "table", "placement": "right", "calcs": ["sum"]}},
+             "targets": [
+               {"refId": "A", "legendFormat": "{{status}}", "expr": "sum by (status) (count_over_time({namespace=\"insight\", container=\"api-gateway\"} |= \"access_log\" | logfmt | status=~\"5..\" [$__auto]))"}
+             ]},
             {"id": 5, "type": "logs", "title": "Service errors (gateway / analytics / identity)",
-             "gridPos": {"h": 8, "w": 24, "x": 0, "y": 16},
+             "gridPos": {"h": 8, "w": 24, "x": 0, "y": 24},
              "datasource": {"type": "loki", "uid": "loki"},
              "options": {"showTime": true, "wrapLogMessage": true, "sortOrder": "Descending"},
              "targets": [

--- a/docs/deploy/system/grafana/values.yaml
+++ b/docs/deploy/system/grafana/values.yaml
@@ -13,9 +13,25 @@
 ## Then Explore → Loki, or the provisioned dashboards in the Insight folder.
 ##
 
+# No persistence: this Grafana is fully as-code — the Loki datasource and
+# the dashboards below are provisioned from this values file, so an
+# ephemeral grafana.db is the source-of-truth-friendly choice. It also
+# avoids two problems a PVC caused on the reference cluster:
+#   1. RWO PVC + RollingUpdate deadlock — a new pod can't mount the volume
+#      the old one holds, so every dashboard change wedged the rollout.
+#   2. "Datasource provisioning error: data source not found" — a persisted
+#      datasource (provisioned before it had a uid) collides with the
+#      uid-bearing provisioning on restart and crash-loops grafana.
+# Anything worth keeping lives in git, not in grafana.db. The admin
+# password is re-applied from the Secret on each start, so it stays stable.
 persistence:
-  enabled: true
-  size: 5Gi
+  enabled: false
+
+# init-chown-data is moot without a PVC, but keep it off: some clusters'
+# runtimes strip CAP_CHOWN from uid-0 containers, so the chart's chown init
+# fails with EPERM and would wedge the rollout if ever re-enabled.
+initChownData:
+  enabled: false
 
 # Loki wired as the default datasource so Explore works out of the box.
 # Fixed uid so provisioned dashboards can reference it. Tempo/Mimir get


### PR DESCRIPTION
Mirror of gitops grafana `system/grafana/values.yaml` changes into the public deploy sample.

**1. As-code, no persistence.** The provisioned Grafana (Loki datasource + dashboards from values) doesn't need a persistent `grafana.db`; a PVC caused two failures on the reference cluster:
- RWO PVC + RollingUpdate deadlock on every dashboard-change rollout (`Pending termination`);
- `Datasource provisioning error: data source not found` crash-loop when uid-bearing provisioning hit a pre-uid persisted datasource.
`persistence.enabled: false` fixes both (admin pw re-applied from the Secret on start). `initChownData.enabled: false` stays (some runtimes strip CAP_CHOWN from uid-0 containers).

**2. Per-status-code error panels** on Insight · HTTP: 4xx and 5xx split by status code (`sum by (status)` over the gateway access_log), one stacked-bar series per code, count (errors are sparse, so count reads better than rate). The aggregate status-class panel and the 4xx/5xx log tail stay.

Verified on dev: grafana 1/1, both dashboards provisioned with all 7 HTTP panels, live data.