### PR TITLE
fix(reconcile): stop IFS=$'\t' read from collapsing empty TSV fields

### DIFF
--- a/src/ingestion/reconcile-connectors/lib/reconcile.sh
+++ b/src/ingestion/reconcile-connectors/lib/reconcile.sh
@@ -872,7 +872,10 @@ reconcile_gc_orphans() {
   # @cpt-end:cpt-insightspec-algo-reconcile-gc-orphans:p2:inst-gc-conn-orphan
 
   # @cpt-begin:cpt-insightspec-algo-reconcile-gc-orphans:p2:inst-gc-src-loop
-  while IFS=$'\t' read -r conn_id src_id conn_name; do
+  # Re-delimit on US (\037) before reading: `IFS=$'\t' read` would coalesce empty
+  # fields (TAB is IFS-whitespace), so an orphan row with an empty conn_name (or
+  # any empty middle field) would shift columns and mis-target the deletion.
+  while IFS=$'\037' read -r conn_id src_id conn_name; do
     [[ -n "${conn_id}" ]] || continue
     if [[ "${RECONCILE_DRY_RUN:-0}" -eq 1 ]]; then  # RULE-DEFAULTS-OK: feature flag — OFF when caller doesn't opt in
       reconcile__log CHANGE "${conn_name}" \
@@ -885,7 +888,7 @@ reconcile_gc_orphans() {
         "garbage-collected orphan connection ${conn_id} and source ${src_id}"
       _RECONCILE_CHANGED=$((_RECONCILE_CHANGED + 1))
     fi
-  done <<<"${orphan_lines}"
+  done < <(printf '%s\n' "${orphan_lines}" | tr '\t' '\037')
   # @cpt-end:cpt-insightspec-algo-reconcile-gc-orphans:p2:inst-gc-src-loop
 }
 
@@ -1160,14 +1163,25 @@ reconcile_run() {
   local descriptors_tsv
   descriptors_tsv="$(disc_load_descriptors)"
 
-  while IFS=$'\t' read -r name connector_dir version type cdk_image enrich_image dbt_select; do
+  # NOTE: `IFS=$'\t' read` is WRONG for this TSV. TAB is IFS-whitespace, so bash
+  # COALESCES runs of tabs into a single delimiter and trims leading/trailing ones
+  # — i.e. empty fields silently disappear and every later column shifts left.
+  # The descriptor TSV has empty fields by design (cdk_image is empty for every
+  # nocode connector; enrich_image is empty for all but jira), so a row like
+  #   jira\t<dir>\t<ver>\tnocode\t<EMPTY cdk>\t<enrich>\t<dbt_select>
+  # would parse as cdk_image=<enrich>, enrich_image=<dbt_select>, dbt_select=''.
+  # That mis-feeds argo_apply_cronworkflow (enrich image := dbt selector) and
+  # bricks the jira enrich step. Re-delimit on US (\037, non-whitespace → no
+  # coalescing) so empty fields are preserved. Process substitution (not a pipe)
+  # keeps the loop in the current shell so _RECONCILE_* counters persist.
+  while IFS=$'\037' read -r name connector_dir version type cdk_image enrich_image dbt_select; do
     [[ -n "${name}" ]] || continue
     if ! _reconcile_one_connector "${name}" "${connector_dir}" "${version}" "${type}" "${cdk_image}" "${enrich_image}" "${dbt_select}" \
          "${opt_dry_run}" "${opt_no_sync_trigger}" "${opt_connector}"; then
       log_line ERROR "${name}: reconcile failed (continuing with next)"
       _RECONCILE_FAILED=$((_RECONCILE_FAILED + 1))
     fi
-  done <<<"${descriptors_tsv}"
+  done < <(printf '%s\n' "${descriptors_tsv}" | tr '\t' '\037')
   # shellcheck disable=SC2034
   : "${connector_dir:=}"  # silence unused-variable warning when no descriptors
 


### PR DESCRIPTION
## Problem

The jira nightly sync on the virtuozzo cluster has been failing at the **enrich** step on every run (2h `activeDeadlineSeconds` timeout, zero ClickHouse queries → the enrich pod never ran the binary). The deployed `jira-virtuozzo-sync` CronWorkflow had crossed parameters:

| param | actual | expected |
|---|---|---|
| `jira_enrich_image` | `tag:silver,tag:jira+` (a dbt selector!) | `ghcr.io/constructorfabric/insight-jira-enrich:…` |
| `dbt_select` | `` (empty) | `tag:silver,tag:jira+` |

With the enrich container's `image:` set to `tag:silver,tag:jira+` (an invalid image reference), the pod can never start the binary — it sits unschedulable until the workflow deadline fires.

## Root cause

`reconcile_run` reads the descriptor TSV with `IFS=$'\t' read`:

```bash
while IFS=$'\t' read -r name connector_dir version type cdk_image enrich_image dbt_select; do
```

TAB is **IFS-whitespace**, so bash *coalesces* runs of tabs into a single delimiter (and trims leading/trailing ones) — empty fields silently disappear and every later column shifts left. The descriptor TSV has empty fields by design:

- `cdk_image` is empty for **every** nocode connector (sourced from `images.cdk.image`, absent for nocode),
- `enrich_image` is empty for all connectors except jira.

So jira's row

```
jira<TAB><dir><TAB><ver><TAB>nocode<TAB><EMPTY cdk><TAB><enrich><TAB><dbt_select>
```

parsed as `cdk_image=<enrich image>`, `enrich_image=<dbt_select>`, `dbt_select=''`, and `argo_apply_cronworkflow … "$dbt_select" "$enrich_image"` rendered the broken CronWorkflow above.

Minimal repro:

```bash
$ printf 'jira\t/d\t2.0.0\tnocode\t\tENRICH\tDBT\n' \
  | while IFS=$'\t' read -r n d v t cdk en sel; do echo "cdk=[$cdk] enrich=[$en] dbt=[$sel]"; done
cdk=[ENRICH] enrich=[DBT] dbt=[]      # ← shifted
```

This affects **all** nocode connectors (every one has an empty `cdk_image`); jira is the one where it's fatal, because the enrich container image becomes a dbt selector.

## Fix

Re-delimit each TSV row on US (`\037`, a non-whitespace control char → no coalescing) before reading, so empty fields are preserved. Applied to the descriptor loop and the structurally identical GC orphan loop. Process substitution (not a pipe) keeps the loops in the current shell so the `_RECONCILE_*` counters still persist.

After the fix, the same input parses correctly:

```bash
$ printf 'jira\t/d\t2.0.0\tnocode\t\tENRICH\tDBT\n' | tr '\t' '\037' \
  | while IFS=$'\037' read -r n d v t cdk en sel; do echo "cdk=[$cdk] enrich=[$en] dbt=[$sel]"; done
cdk=[] enrich=[ENRICH] dbt=[DBT]
```

## Test plan

- [x] Re-ran `disc_load_descriptors` logic + the patched read over real descriptors (jira/slack/hubspot): `cdk_image`, `enrich_image`, `dbt_select` now land in the correct columns for nocode, nocode+enrich, and cdk connectors.
- [x] `shellcheck -S warning` clean on `reconcile.sh`.
- [ ] After a toolbox image rebuild + reconcile run: confirm `jira-virtuozzo-sync` re-renders with `jira_enrich_image=ghcr.io/…/insight-jira-enrich:…` and `dbt_select=tag:silver,tag:jira+`, and the jira enrich step completes.

## Related follow-up (not in this PR)

`reconcile_gc_orphans` passes the full Airbyte connections+sources JSON as **argv** to `find_orphan_connections.py`, which hits `ARG_MAX` (`Argument list too long`) once enough connectors exist — GC silently no-ops. Should be switched to stdin in a separate change.

Signed-off-by: Roman Mitasov <Roman.Mitasov@constructor.tech>