### PR TITLE
chore(helm): disable enableServiceLinks across all owned PodSpecs

### DIFF
--- a/charts/insight/templates/clickhouse-init-svcdbs-job.yaml
+++ b/charts/insight/templates/clickhouse-init-svcdbs-job.yaml
@@ -71,6 +71,10 @@ spec:
         app.kubernetes.io/name: {{ include "insight.fullname" . }}-clickhouse-init
         app.kubernetes.io/component: clickhouse-init
     spec:
+      # Suppress the legacy `<SVC>_SERVICE_HOST/PORT/…` Docker-link env-vars
+      # kubelet auto-injects for every Service in the namespace at pod-start
+      # (see apiGateway deployment for the longer explanation).
+      enableServiceLinks: false
       restartPolicy: OnFailure
       containers:
         - name: db-init

--- a/charts/insight/templates/mariadb-init-svcdbs-job.yaml
+++ b/charts/insight/templates/mariadb-init-svcdbs-job.yaml
@@ -61,6 +61,10 @@ spec:
         app.kubernetes.io/name: {{ include "insight.fullname" . }}-mariadb-init
         app.kubernetes.io/component: mariadb-init
     spec:
+      # Suppress the legacy `<SVC>_SERVICE_HOST/PORT/…` Docker-link env-vars
+      # kubelet auto-injects for every Service in the namespace at pod-start
+      # (see apiGateway deployment for the longer explanation).
+      enableServiceLinks: false
       restartPolicy: OnFailure
       containers:
         - name: db-init

--- a/helmfile/charts/clickhouse/templates/statefulset.yaml
+++ b/helmfile/charts/clickhouse/templates/statefulset.yaml
@@ -21,6 +21,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- end }}
+      # Suppress the legacy `<SVC>_SERVICE_HOST/PORT/…` Docker-link env-vars
+      # kubelet auto-injects for every Service in the namespace at pod-start
+      # (see api-gateway deployment for the longer explanation).
+      enableServiceLinks: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 101

--- a/src/backend/services/analytics-api/helm/templates/deployment.yaml
+++ b/src/backend/services/analytics-api/helm/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- end }}
+      # Suppress the legacy `<SVC>_SERVICE_HOST/PORT/…` Docker-link env-vars
+      # kubelet auto-injects for every Service in the namespace at pod-start
+      # (see api-gateway deployment for the longer explanation).
+      enableServiceLinks: false
       terminationGracePeriodSeconds: 30
       securityContext:
         runAsNonRoot: true

--- a/src/backend/services/api-gateway/helm/templates/deployment.yaml
+++ b/src/backend/services/api-gateway/helm/templates/deployment.yaml
@@ -28,6 +28,13 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- end }}
+      # Suppress the legacy `<SVC>_SERVICE_HOST/PORT/…` Docker-link env-vars
+      # kubelet auto-injects for every Service in the namespace at pod-start.
+      # We discover dependencies via DNS (`*.svc.cluster.local`); the env-var
+      # mechanism only adds noise (~100+ vars in this namespace), creates
+      # startup-ordering coupling, and confuses `env` output by colliding
+      # with our own `APP__*` config-prefix scheme.
+      enableServiceLinks: false
       terminationGracePeriodSeconds: 60
       securityContext:
         runAsNonRoot: true

--- a/src/backend/services/identity/helm/templates/deployment.yaml
+++ b/src/backend/services/identity/helm/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- end }}
+      # Suppress the legacy `<SVC>_SERVICE_HOST/PORT/…` Docker-link env-vars
+      # kubelet auto-injects for every Service in the namespace at pod-start
+      # (see api-gateway deployment for the longer explanation).
+      enableServiceLinks: false
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/src/frontend/helm/templates/deployment.yaml
+++ b/src/frontend/helm/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- end }}
+      # Suppress the legacy `<SVC>_SERVICE_HOST/PORT/…` Docker-link env-vars
+      # kubelet auto-injects for every Service in the namespace at pod-start
+      # (see api-gateway deployment for the longer explanation).
+      enableServiceLinks: false
       containers:
         - name: frontend
           image: "{{ required "image.repository is required" .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
kubelet auto-injects the legacy Docker-link env-vars (one batch per Service in the namespace: `<SVC>_SERVICE_HOST`, `<SVC>_SERVICE_PORT`, `<SVC>_PORT_<num>_TCP_*`, …) into every container by default. In a namespace with ~20 Services that's ~100+ extra env-vars per container. For the api-gateway specifically they swamp the `env` output, get confused with our own `APP__*`-prefixed config schema, and create startup-ordering coupling (only Services that exist at pod-start get the env-vars). We discover dependencies via DNS anyway (`*.svc.cluster.local`), so the env-var path adds noise with zero benefit.

The off-switch is `pod.spec.enableServiceLinks: false`, set per PodSpec. Setting it on every Deployment / StatefulSet / Job we own in the umbrella:

  - charts/insight/templates/{clickhouse,mariadb}-init-svcdbs-job.yaml
  - helmfile/charts/clickhouse/templates/statefulset.yaml
  - src/backend/services/api-gateway/helm/templates/deployment.yaml
  - src/backend/services/analytics-api/helm/templates/deployment.yaml
  - src/backend/services/identity/helm/templates/deployment.yaml
  - src/frontend/helm/templates/deployment.yaml

Verified with `helm template charts/insight -f
…/insight-gitops/environments/dev/values.yaml`: all six owned PodSpecs now render with `enableServiceLinks: false`. The upstream subcharts we depend on (mariadb / redis / redpanda / airbyte) don't expose the toggle as a values key — their pods still carry the default-on behavior, but those pods aren't where the noise hurts debug-time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic Kubernetes service environment variable injection in pod specifications across multiple services including ClickHouse, MariaDB, Analytics API, API Gateway, Identity, and Frontend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->