### PR TITLE
test(data): source freshness on all bronze connectors (#1322)

### DIFF
--- a/src/ingestion/connectors/ai/chatgpt-team/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/chatgpt-team/dbt/schema.yml
@@ -2,6 +2,12 @@ version: 2
 
 sources:
   - name: bronze_chatgpt_team
+    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
+    # else the sync silently stopped and dashboards go stale with no error.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
     schema: bronze_chatgpt_team
     tables:
       - name: chatgpt_team_seats

--- a/src/ingestion/connectors/ai/chatgpt-team/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/chatgpt-team/dbt/schema.yml
@@ -2,19 +2,39 @@ version: 2
 
 sources:
   - name: bronze_chatgpt_team
-    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
-    # else the sync silently stopped and dashboards go stale with no error.
+    # Source freshness (TAF #1322). Source-level default = _airbyte_extracted_at
+    # (sync-liveness) for the roster table; the WINDOWED daily/snapshot tables
+    # override below to anchor on their business date. ChatGPT Team re-emits a
+    # fixed window every sync, so extracted_at is false-green for them — VERIFIED
+    # on live data (extracted_at ~8.6h fresh while `date` 60–85h stale). Report
+    # tier absorbs the vendor publish lag.
     freshness:
       warn_after: {count: 36, period: hour}
       error_after: {count: 72, period: hour}
     loaded_at_field: _airbyte_extracted_at
     schema: bronze_chatgpt_team
     tables:
-      - name: chatgpt_team_seats
-      - name: chatgpt_team_chat_activity
-      - name: chatgpt_team_codex_user_daily
-      - name: chatgpt_team_subscription_usage
-      - name: chatgpt_team_subscription_balance
+      - name: chatgpt_team_seats   # roster — sync-liveness default is correct
+      - name: chatgpt_team_chat_activity      # VERIFIED windowed
+        loaded_at_field: parseDateTimeBestEffortOrNull(date)
+        freshness:
+          warn_after: {count: 72, period: hour}
+          error_after: {count: 120, period: hour}
+      - name: chatgpt_team_codex_user_daily   # VERIFIED windowed
+        loaded_at_field: parseDateTimeBestEffortOrNull(date)
+        freshness:
+          warn_after: {count: 72, period: hour}
+          error_after: {count: 120, period: hour}
+      - name: chatgpt_team_subscription_usage    # inferred windowed (snapshot_date)
+        loaded_at_field: parseDateTimeBestEffortOrNull(snapshot_date)
+        freshness:
+          warn_after: {count: 72, period: hour}
+          error_after: {count: 120, period: hour}
+      - name: chatgpt_team_subscription_balance  # inferred windowed (snapshot_date)
+        loaded_at_field: parseDateTimeBestEffortOrNull(snapshot_date)
+        freshness:
+          warn_after: {count: 72, period: hour}
+          error_after: {count: 120, period: hour}
 
 models:
   - name: chatgpt_team__ai_dev_usage

--- a/src/ingestion/connectors/ai/claude-admin/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/claude-admin/dbt/schema.yml
@@ -2,6 +2,12 @@ version: 2
 
 sources:
   - name: bronze_claude_admin
+    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
+    # else the sync silently stopped and dashboards go stale with no error.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
     schema: bronze_claude_admin
     tables:
       - name: claude_admin_users

--- a/src/ingestion/connectors/ai/claude-admin/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/claude-admin/dbt/schema.yml
@@ -2,8 +2,12 @@ version: 2
 
 sources:
   - name: bronze_claude_admin
-    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
-    # else the sync silently stopped and dashboards go stale with no error.
+    # Source freshness (TAF #1322). INFERRED, NOT live-verified — bronze_claude_admin
+    # has no rows in any reachable install (config is not a reliable signal, cf.
+    # M365). Source-level default = _airbyte_extracted_at (sync-liveness) for the
+    # roster/lookup tables (full-refresh → extracted_at stays fresh, so it still
+    # catches a stopped sync). The daily usage tables are WINDOWED (incremental on
+    # `date`) and override below. Confirm against live data once ingested.
     freshness:
       warn_after: {count: 36, period: hour}
       error_after: {count: 72, period: hour}
@@ -11,9 +15,21 @@ sources:
     schema: bronze_claude_admin
     tables:
       - name: claude_admin_users
-      - name: claude_admin_messages_usage
-      - name: claude_admin_cost_report
-      - name: claude_admin_code_usage
+      - name: claude_admin_messages_usage   # inferred windowed (date)
+        loaded_at_field: parseDateTimeBestEffortOrNull(date)
+        freshness:
+          warn_after: {count: 72, period: hour}
+          error_after: {count: 120, period: hour}
+      - name: claude_admin_cost_report   # inferred windowed (date)
+        loaded_at_field: parseDateTimeBestEffortOrNull(date)
+        freshness:
+          warn_after: {count: 72, period: hour}
+          error_after: {count: 120, period: hour}
+      - name: claude_admin_code_usage   # inferred windowed (date)
+        loaded_at_field: parseDateTimeBestEffortOrNull(date)
+        freshness:
+          warn_after: {count: 72, period: hour}
+          error_after: {count: 120, period: hour}
       - name: claude_admin_api_keys
       - name: claude_admin_workspaces
       - name: claude_admin_workspace_members

--- a/src/ingestion/connectors/ai/claude-enterprise/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/claude-enterprise/dbt/schema.yml
@@ -2,6 +2,12 @@ version: 2
 
 sources:
   - name: bronze_claude_enterprise
+    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
+    # else the sync silently stopped and dashboards go stale with no error.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
     schema: bronze_claude_enterprise
     tables:
       - name: claude_enterprise_summaries

--- a/src/ingestion/connectors/ai/claude-enterprise/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/claude-enterprise/dbt/schema.yml
@@ -2,15 +2,23 @@ version: 2
 
 sources:
   - name: bronze_claude_enterprise
-    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
-    # else the sync silently stopped and dashboards go stale with no error.
+    # Source freshness (TAF #1322). INFERRED, NOT live-verified — bronze_claude_enterprise
+    # has no rows in any reachable install (config is not a reliable signal, cf.
+    # M365). Source-level default = _airbyte_extracted_at (sync-liveness) for the
+    # roster/lookup tables. The daily usage summaries table is WINDOWED
+    # (incremental on `date`) and overrides below. Confirm against live data
+    # once Claude Enterprise is ingested.
     freshness:
       warn_after: {count: 36, period: hour}
       error_after: {count: 72, period: hour}
     loaded_at_field: _airbyte_extracted_at
     schema: bronze_claude_enterprise
     tables:
-      - name: claude_enterprise_summaries
+      - name: claude_enterprise_summaries   # inferred windowed (date)
+        loaded_at_field: parseDateTimeBestEffortOrNull(date)
+        freshness:
+          warn_after: {count: 72, period: hour}
+          error_after: {count: 120, period: hour}
       - name: claude_enterprise_users
       - name: claude_enterprise_chat_projects
       - name: claude_enterprise_skills

--- a/src/ingestion/connectors/ai/claude-team/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/claude-team/dbt/schema.yml
@@ -2,6 +2,12 @@ version: 2
 
 sources:
   - name: bronze_claude_team
+    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
+    # else the sync silently stopped and dashboards go stale with no error.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
     schema: bronze_claude_team
     tables:
       - name: claude_team_members

--- a/src/ingestion/connectors/ai/claude-team/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/claude-team/dbt/schema.yml
@@ -2,16 +2,24 @@ version: 2
 
 sources:
   - name: bronze_claude_team
-    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
-    # else the sync silently stopped and dashboards go stale with no error.
+    # Source freshness (TAF #1322). Source-level default = _airbyte_extracted_at
+    # (sync-liveness) for the roster table; the WINDOWED daily metrics table
+    # overrides below. Claude Team re-emits a fixed window every sync, so
+    # extracted_at is false-green for code_metrics — VERIFIED on live data
+    # (extracted_at ~8.6h fresh while metric_date 60.7h stale). Report tier
+    # absorbs the vendor publish lag.
     freshness:
       warn_after: {count: 36, period: hour}
       error_after: {count: 72, period: hour}
     loaded_at_field: _airbyte_extracted_at
     schema: bronze_claude_team
     tables:
-      - name: claude_team_members
-      - name: claude_team_code_metrics
+      - name: claude_team_members   # roster — sync-liveness default is correct
+      - name: claude_team_code_metrics   # VERIFIED windowed
+        loaded_at_field: parseDateTimeBestEffortOrNull(metric_date)
+        freshness:
+          warn_after: {count: 72, period: hour}
+          error_after: {count: 120, period: hour}
 
 models:
   - name: claude_team__ai_dev_usage

--- a/src/ingestion/connectors/ai/cursor/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/cursor/dbt/schema.yml
@@ -2,6 +2,12 @@ version: 2
 
 sources:
   - name: bronze_cursor
+    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
+    # else the sync silently stopped and dashboards go stale with no error.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
     schema: bronze_cursor
     tables:
       - name: cursor_members

--- a/src/ingestion/connectors/ai/cursor/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/cursor/dbt/schema.yml
@@ -2,8 +2,13 @@ version: 2
 
 sources:
   - name: bronze_cursor
-    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
-    # else the sync silently stopped and dashboards go stale with no error.
+    # Source freshness (TAF #1322). Source-level default = _airbyte_extracted_at
+    # (sync-liveness) for the roster + event-stream tables (members, audit_logs,
+    # usage_events — incremental on an event cursor, where extracted_at tracks
+    # reality). The aggregated daily table is WINDOWED (the connector re-fetches
+    # yesterday on every run — `cursor_usage_events_daily_resync: true`), so its
+    # extracted_at is false-green; it overrides below to anchor on `day` (column
+    # name verified in ClickHouse; behavior inferred — no live rows in Eternal).
     freshness:
       warn_after: {count: 36, period: hour}
       error_after: {count: 72, period: hour}
@@ -14,7 +19,11 @@ sources:
       - name: cursor_audit_logs
       - name: cursor_usage_events
       - name: cursor_usage_events_daily_resync
-      - name: cursor_daily_usage
+      - name: cursor_daily_usage   # inferred windowed (daily resync re-fetch)
+        loaded_at_field: parseDateTimeBestEffortOrNull(day)
+        freshness:
+          warn_after: {count: 72, period: hour}
+          error_after: {count: 120, period: hour}
 
 models:
   - name: cursor__ai_dev_usage

--- a/src/ingestion/connectors/ai/github-copilot/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/github-copilot/dbt/schema.yml
@@ -2,6 +2,12 @@ version: 2
 
 sources:
   - name: bronze_github_copilot
+    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
+    # else the sync silently stopped and dashboards go stale with no error.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
     schema: bronze_github_copilot
     tables:
       - name: copilot_seats

--- a/src/ingestion/connectors/ai/github-copilot/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/github-copilot/dbt/schema.yml
@@ -2,17 +2,29 @@ version: 2
 
 sources:
   - name: bronze_github_copilot
-    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
-    # else the sync silently stopped and dashboards go stale with no error.
+    # Source freshness (TAF #1322). INFERRED, NOT live-verified — bronze_github_copilot
+    # has no rows in any reachable install. The metrics streams are per-day
+    # reports with a documented ~24h+ publish lag (cursor `day`, confirmed in
+    # README + bronze schema); anchoring on `day` with the report tier is correct
+    # if the API re-emits a window and harmless if it is strictly incremental.
+    # `copilot_seats` is a roster → sync-liveness default. Confirm against live data.
     freshness:
       warn_after: {count: 36, period: hour}
       error_after: {count: 72, period: hour}
     loaded_at_field: _airbyte_extracted_at
     schema: bronze_github_copilot
     tables:
-      - name: copilot_seats
-      - name: copilot_user_metrics
-      - name: copilot_org_metrics
+      - name: copilot_seats   # roster — sync-liveness default
+      - name: copilot_user_metrics   # inferred windowed (day, ~24h+ report lag)
+        loaded_at_field: parseDateTimeBestEffortOrNull(day)
+        freshness:
+          warn_after: {count: 72, period: hour}
+          error_after: {count: 120, period: hour}
+      - name: copilot_org_metrics   # inferred windowed (day, ~24h+ report lag)
+        loaded_at_field: parseDateTimeBestEffortOrNull(day)
+        freshness:
+          warn_after: {count: 72, period: hour}
+          error_after: {count: 120, period: hour}
 
 models:
   - name: copilot__ai_dev_usage

--- a/src/ingestion/connectors/ai/openai/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/openai/dbt/schema.yml
@@ -2,6 +2,12 @@ version: 2
 
 sources:
   - name: bronze_openai
+    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
+    # else the sync silently stopped and dashboards go stale with no error.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
     schema: bronze_openai
     tables:
       - name: users

--- a/src/ingestion/connectors/ai/openai/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/openai/dbt/schema.yml
@@ -10,10 +10,16 @@ sources:
     # business bucket), so anchor source-level on it with the report tier;
     # `users` is a full-refresh roster with no bucket column, overridden to the
     # sync-liveness default. Confirm against live data once OpenAI is ingested.
+    #
+    # `bucket_start_time` is Unix **seconds** (an integer), not a date string —
+    # see the connector's own dbt models (to_ai_cost.sql / to_ai_tool_usage.sql:
+    # `toDate(fromUnixTimestamp(CAST(bucket_start_time AS UInt32)))`). Use the
+    # matching epoch conversion here; `parseDateTimeBestEffortOrNull` would fail
+    # on an integer.
     freshness:
       warn_after: {count: 72, period: hour}
       error_after: {count: 120, period: hour}
-    loaded_at_field: parseDateTimeBestEffortOrNull(bucket_start_time)
+    loaded_at_field: fromUnixTimestamp(CAST(bucket_start_time AS UInt32))
     schema: bronze_openai
     tables:
       - name: users   # roster — no bucket column; sync-liveness default

--- a/src/ingestion/connectors/ai/openai/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/openai/dbt/schema.yml
@@ -2,15 +2,25 @@ version: 2
 
 sources:
   - name: bronze_openai
-    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
-    # else the sync silently stopped and dashboards go stale with no error.
+    # Source freshness (TAF #1322). INFERRED, NOT live-verified — bronze_openai
+    # has no rows in any reachable install, and connector config is not a
+    # reliable windowed/incremental signal (cf. M365, which declared
+    # lookback_window: P0D yet re-fetches a 24-day window). The usage/cost
+    # streams are incremental on `bucket_start_time` (the OpenAI usage API's
+    # business bucket), so anchor source-level on it with the report tier;
+    # `users` is a full-refresh roster with no bucket column, overridden to the
+    # sync-liveness default. Confirm against live data once OpenAI is ingested.
     freshness:
-      warn_after: {count: 36, period: hour}
-      error_after: {count: 72, period: hour}
-    loaded_at_field: _airbyte_extracted_at
+      warn_after: {count: 72, period: hour}
+      error_after: {count: 120, period: hour}
+    loaded_at_field: parseDateTimeBestEffortOrNull(bucket_start_time)
     schema: bronze_openai
     tables:
-      - name: users
+      - name: users   # roster — no bucket column; sync-liveness default
+        loaded_at_field: _airbyte_extracted_at
+        freshness:
+          warn_after: {count: 36, period: hour}
+          error_after: {count: 72, period: hour}
       - name: usage_completions
       - name: usage_embeddings
       - name: usage_moderations

--- a/src/ingestion/connectors/collaboration/m365/dbt/schema.yml
+++ b/src/ingestion/connectors/collaboration/m365/dbt/schema.yml
@@ -2,6 +2,12 @@ version: 2
 
 sources:
   - name: bronze_m365
+    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
+    # else the sync silently stopped and dashboards go stale with no error.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
     schema: bronze_m365
     tables:
       - name: email_activity

--- a/src/ingestion/connectors/collaboration/m365/dbt/schema.yml
+++ b/src/ingestion/connectors/collaboration/m365/dbt/schema.yml
@@ -2,12 +2,19 @@ version: 2
 
 sources:
   - name: bronze_m365
-    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
-    # else the sync silently stopped and dashboards go stale with no error.
+    # Source freshness (TAF #1322). WINDOWED connector — verified on live data:
+    # the Graph getReport endpoint re-emits the whole `reportPeriod` window
+    # every sync, so `_airbyte_extracted_at` is re-stamped each run and tracks
+    # sync liveness, NOT data freshness (measured: extracted_at 10.6h fresh
+    # while reportRefreshDate 108.7h / 4.5d stale; 24 business dates re-emitted
+    # in the last extraction batch). Anchor on the report's own business date
+    # and use the report tier to absorb Graph's 24–48h publish lag.
     freshness:
-      warn_after: {count: 36, period: hour}
-      error_after: {count: 72, period: hour}
-    loaded_at_field: _airbyte_extracted_at
+      warn_after: {count: 72, period: hour}
+      error_after: {count: 120, period: hour}
+    # reportRefreshDate is Nullable(String) 'YYYY-MM-DD'; dbt freshness needs a
+    # timestamp expression, so parse it (verified against live ClickHouse).
+    loaded_at_field: parseDateTimeBestEffortOrNull(reportRefreshDate)
     schema: bronze_m365
     tables:
       - name: email_activity

--- a/src/ingestion/connectors/collaboration/slack/dbt/schema.yml
+++ b/src/ingestion/connectors/collaboration/slack/dbt/schema.yml
@@ -2,6 +2,12 @@ version: 2
 
 sources:
   - name: bronze_slack
+    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
+    # else the sync silently stopped and dashboards go stale with no error.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
     schema: bronze_slack
     tables:
       - name: users_details

--- a/src/ingestion/connectors/collaboration/slack/dbt/schema.yml
+++ b/src/ingestion/connectors/collaboration/slack/dbt/schema.yml
@@ -2,12 +2,17 @@ version: 2
 
 sources:
   - name: bronze_slack
-    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
-    # else the sync silently stopped and dashboards go stale with no error.
+    # Source freshness (TAF #1322). WINDOWED connector — Slack
+    # admin.analytics.getFile re-emits a fixed window each sync, so
+    # _airbyte_extracted_at tracks sync liveness, not data freshness. Anchor on
+    # the report's `date` (column verified in ClickHouse; windowed behavior
+    # inferred — no live rows in Eternal). report_extended tier: Slack analytics
+    # has a documented ~3-day publish lag (up to 5 during Slack maintenance).
     freshness:
-      warn_after: {count: 36, period: hour}
-      error_after: {count: 72, period: hour}
-    loaded_at_field: _airbyte_extracted_at
+      warn_after: {count: 120, period: hour}
+      error_after: {count: 168, period: hour}
+    # `date` is String 'YYYY-MM-DD'; parse for the freshness timestamp compare.
+    loaded_at_field: parseDateTimeBestEffortOrNull(date)
     schema: bronze_slack
     tables:
       - name: users_details

--- a/src/ingestion/connectors/collaboration/zoom/dbt/schema.yml
+++ b/src/ingestion/connectors/collaboration/zoom/dbt/schema.yml
@@ -2,6 +2,12 @@ version: 2
 
 sources:
   - name: bronze_zoom
+    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
+    # else the sync silently stopped and dashboards go stale with no error.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
     schema: bronze_zoom
     tables:
       - name: users

--- a/src/ingestion/connectors/collaboration/zoom/dbt/schema.yml
+++ b/src/ingestion/connectors/collaboration/zoom/dbt/schema.yml
@@ -2,17 +2,30 @@ version: 2
 
 sources:
   - name: bronze_zoom
-    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
-    # else the sync silently stopped and dashboards go stale with no error.
+    # Source freshness (TAF #1322). Source-level default = _airbyte_extracted_at
+    # (sync-liveness) for the roster table. The event tables are WINDOWED — the
+    # connector re-fetches a 30-day window (lookback_window: P7D, step: P30D), so
+    # extracted_at is false-green; they override below to anchor on the event
+    # time. event tier (96h/168h) absorbs legitimately quiet weekends/holidays
+    # where zero meetings is normal. (columns from connector.yaml / participants
+    # verified in ClickHouse; windowed behavior inferred — meetings empty in Eternal.)
     freshness:
       warn_after: {count: 36, period: hour}
       error_after: {count: 72, period: hour}
     loaded_at_field: _airbyte_extracted_at
     schema: bronze_zoom
     tables:
-      - name: users
-      - name: meetings
-      - name: participants
+      - name: users   # roster — sync-liveness default is correct
+      - name: meetings   # inferred windowed (event)
+        loaded_at_field: parseDateTimeBestEffortOrNull(end_time)
+        freshness:
+          warn_after: {count: 96, period: hour}
+          error_after: {count: 168, period: hour}
+      - name: participants   # inferred windowed (event)
+        loaded_at_field: parseDateTimeBestEffortOrNull(join_time)
+        freshness:
+          warn_after: {count: 96, period: hour}
+          error_after: {count: 168, period: hour}
 
 models:
   - name: zoom__meeting_sessions

--- a/src/ingestion/connectors/collaboration/zulip-proxy/dbt/schema.yml
+++ b/src/ingestion/connectors/collaboration/zulip-proxy/dbt/schema.yml
@@ -2,6 +2,12 @@ version: 2
 
 sources:
   - name: bronze_zulip_proxy
+    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
+    # else the sync silently stopped and dashboards go stale with no error.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
     schema: bronze_zulip_proxy
     tables:
       - name: users

--- a/src/ingestion/connectors/crm/hubspot/dbt/schema.yml
+++ b/src/ingestion/connectors/crm/hubspot/dbt/schema.yml
@@ -9,6 +9,12 @@ version: 2
 
 sources:
   - name: bronze_hubspot
+    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
+    # else the sync silently stopped and dashboards go stale with no error.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
     schema: bronze_hubspot
     tables:
       # Core CRM entities feeding Silver — live (search) + archived (list)

--- a/src/ingestion/connectors/crm/salesforce/dbt/schema.yml
+++ b/src/ingestion/connectors/crm/salesforce/dbt/schema.yml
@@ -8,6 +8,12 @@ version: 2
 
 sources:
   - name: bronze_salesforce
+    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
+    # else the sync silently stopped and dashboards go stale with no error.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
     schema: bronze_salesforce
     tables:
       # Core deal lifecycle

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/schema.yml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/schema.yml
@@ -2,6 +2,12 @@ version: 2
 
 sources:
   - name: bronze_bitbucket_cloud
+    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
+    # else the sync silently stopped and dashboards go stale with no error.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
     schema: bronze_bitbucket_cloud
     tables:
       - name: repositories

--- a/src/ingestion/connectors/git/github/dbt/schema.yml
+++ b/src/ingestion/connectors/git/github/dbt/schema.yml
@@ -2,6 +2,12 @@ version: 2
 
 sources:
   - name: bronze_github
+    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
+    # else the sync silently stopped and dashboards go stale with no error.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
     schema: bronze_github
     tables:
       - name: repositories

--- a/src/ingestion/connectors/hr-directory/ms-entra/dbt/schema.yml
+++ b/src/ingestion/connectors/hr-directory/ms-entra/dbt/schema.yml
@@ -2,6 +2,12 @@ version: 2
 
 sources:
   - name: bronze_ms_entra
+    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
+    # else the sync silently stopped and dashboards go stale with no error.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
     schema: bronze_ms_entra
     tables:
       - name: users

--- a/src/ingestion/connectors/task-tracking/jira/dbt/schema.yml
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/schema.yml
@@ -6,6 +6,12 @@ version: 2
 
 sources:
   - name: bronze_jira
+    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
+    # else the sync silently stopped and dashboards go stale with no error.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
     schema: bronze_jira
     tables:
       - name: jira_fields

--- a/src/ingestion/connectors/task-tracking/youtrack/dbt/schema.yml
+++ b/src/ingestion/connectors/task-tracking/youtrack/dbt/schema.yml
@@ -9,6 +9,12 @@ version: 2
 
 sources:
   - name: bronze_youtrack
+    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
+    # else the sync silently stopped and dashboards go stale with no error.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
     schema: bronze_youtrack
     tables:
       - name: youtrack_projects

--- a/src/ingestion/connectors/ui-design/figma/dbt/schema.yml
+++ b/src/ingestion/connectors/ui-design/figma/dbt/schema.yml
@@ -2,6 +2,12 @@ version: 2
 
 sources:
   - name: bronze_figma
+    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
+    # else the sync silently stopped and dashboards go stale with no error.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
     schema: bronze_figma
     tables:
       - name: design_projects

--- a/src/ingestion/connectors/wiki/confluence/dbt/schema.yml
+++ b/src/ingestion/connectors/wiki/confluence/dbt/schema.yml
@@ -2,6 +2,12 @@ version: 2
 
 sources:
   - name: bronze_confluence
+    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
+    # else the sync silently stopped and dashboards go stale with no error.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
     schema: bronze_confluence
     tables:
       - name: wiki_spaces

--- a/src/ingestion/connectors/wiki/confluence/dbt/schema.yml
+++ b/src/ingestion/connectors/wiki/confluence/dbt/schema.yml
@@ -17,7 +17,9 @@ sources:
     tables:
       - name: wiki_spaces
       - name: wiki_pages   # inferred windowed/event (updated_at)
-        loaded_at_field: parseDateTimeBestEffortOrNull(updated_at)
+        # ms-precision parse to match the connector's own model convention
+        # (confluence__wiki_pages: parseDateTime64BestEffortOrNull(updated_at, 3)).
+        loaded_at_field: parseDateTime64BestEffortOrNull(updated_at, 3)
         freshness:
           warn_after: {count: 96, period: hour}
           error_after: {count: 168, period: hour}

--- a/src/ingestion/connectors/wiki/confluence/dbt/schema.yml
+++ b/src/ingestion/connectors/wiki/confluence/dbt/schema.yml
@@ -2,8 +2,13 @@ version: 2
 
 sources:
   - name: bronze_confluence
-    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
-    # else the sync silently stopped and dashboards go stale with no error.
+    # Source freshness (TAF #1322). INFERRED, NOT live-verified — bronze_confluence
+    # has no rows in any reachable install. Edit activity is event-style: a quiet
+    # weekend/holiday with zero page edits is normal, so flat _airbyte_extracted_at
+    # would false-alarm and the event tier (96h/168h) is the right band. The
+    # content table anchors on `updated_at` (cursor-confirmed); the remaining
+    # version/comment/space tables stay on the sync-liveness default rather than
+    # guess per-table edit-time columns without data. Confirm once ingested.
     freshness:
       warn_after: {count: 36, period: hour}
       error_after: {count: 72, period: hour}
@@ -11,7 +16,11 @@ sources:
     schema: bronze_confluence
     tables:
       - name: wiki_spaces
-      - name: wiki_pages
+      - name: wiki_pages   # inferred windowed/event (updated_at)
+        loaded_at_field: parseDateTimeBestEffortOrNull(updated_at)
+        freshness:
+          warn_after: {count: 96, period: hour}
+          error_after: {count: 168, period: hour}
       - name: wiki_page_versions
       - name: wiki_footer_comments
       - name: wiki_footer_comment_replies

--- a/src/ingestion/connectors/wiki/outline/dbt/schema.yml
+++ b/src/ingestion/connectors/wiki/outline/dbt/schema.yml
@@ -2,6 +2,12 @@ version: 2
 
 sources:
   - name: bronze_outline
+    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
+    # else the sync silently stopped and dashboards go stale with no error.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
     schema: bronze_outline
     tables:
       - name: wiki_spaces

--- a/src/ingestion/connectors/wiki/outline/dbt/schema.yml
+++ b/src/ingestion/connectors/wiki/outline/dbt/schema.yml
@@ -2,8 +2,11 @@ version: 2
 
 sources:
   - name: bronze_outline
-    # Source freshness (TAF #1322): the newest Airbyte row must be recent,
-    # else the sync silently stopped and dashboards go stale with no error.
+    # Source freshness (TAF #1322). INFERRED, NOT live-verified — bronze_outline
+    # has no rows in any reachable install. Edit activity is event-style (quiet
+    # periods are normal), so the content table anchors on `updated_at`
+    # (cursor-confirmed) with the event tier (96h/168h); the rest stay on the
+    # sync-liveness default. Confirm once ingested.
     freshness:
       warn_after: {count: 36, period: hour}
       error_after: {count: 72, period: hour}
@@ -11,7 +14,11 @@ sources:
     schema: bronze_outline
     tables:
       - name: wiki_spaces
-      - name: wiki_pages
+      - name: wiki_pages   # inferred windowed/event (updated_at)
+        loaded_at_field: parseDateTimeBestEffortOrNull(updated_at)
+        freshness:
+          warn_after: {count: 96, period: hour}
+          error_after: {count: 168, period: hour}
       - name: wiki_page_versions
       - name: wiki_comments
       - name: wiki_users

--- a/src/ingestion/connectors/wiki/outline/dbt/schema.yml
+++ b/src/ingestion/connectors/wiki/outline/dbt/schema.yml
@@ -15,7 +15,9 @@ sources:
     tables:
       - name: wiki_spaces
       - name: wiki_pages   # inferred windowed/event (updated_at)
-        loaded_at_field: parseDateTimeBestEffortOrNull(updated_at)
+        # ms-precision parse to match the connector's own model convention
+        # (outline__wiki_pages: parseDateTime64BestEffortOrNull(updated_at, 3)).
+        loaded_at_field: parseDateTime64BestEffortOrNull(updated_at, 3)
         freshness:
           warn_after: {count: 96, period: hour}
           error_after: {count: 168, period: hour}


### PR DESCRIPTION
## What
Adds dbt **source freshness** to all 21 `bronze_*` connector sources — `warn_after: 36h`, `error_after: 72h`, `loaded_at_field: _airbyte_extracted_at`.

## Why
A stopped/slow sync is currently invisible: the dashboard just shows stale numbers with no error. `dbt source freshness` turns that into a signal. Implements the bronze half of [#1322](https://github.com/constructorfabric/insight/issues/1322) (EPIC [#1321](https://github.com/constructorfabric/insight/issues/1321)).

## Notes
- Freshness is its own command (`dbt source freshness`), not part of `dbt build`/`test` — so sources not yet ingested (#1319) don't break the normal run.
- Verified `_airbyte_extracted_at` exists on the ingested bronze tables.
- **Next in this branch:** enforced contracts (`data_type`) on silver models — those need the warehouse-gated CI dbt run to validate the type declarations, so they land once `data-checks.yml` runs against a populated ClickHouse (can't be validated on a machine without dbt).

Draft until the freshness thresholds are confirmed with the team.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled DBT data freshness monitoring across 20+ connectors, so stale or missing upstream data now surfaces as freshness warnings/errors within configured time windows.
  * Added source-level defaults (based on ingestion/extraction time) and table-level overrides for better alignment to the most relevant business or event timestamps, with tuned thresholds (commonly ~36h/72h, and stricter settings like ~72–168h for specific datasets).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->