### PR TITLE
fix(gitops): ignore wizard/make-generated artifacts in local env

### DIFF
--- a/deploy/gitops/.gitignore
+++ b/deploy/gitops/.gitignore
@@ -13,15 +13,22 @@ secrets.local.*
 # are the only safe-to-commit representation).
 secrets-store.yaml
 
-# The wizard writes a concrete inventory.yaml from inventory.yaml.template
-# on first `make deploy ENV=local`. Each env's inventory.yaml IS committed
-# (it's the source of truth for that cluster's topology), so this ignore
-# is intentionally narrow — only the sandbox local copy is gitignored,
-# because the wizard regenerates it from the template.
+# Wizard-/make-generated artifacts for the LOCAL sandbox env.
+#
+# Real envs commit all of these — they're the gitops source of truth
+# for that cluster. The `local` env is different: it's the starter
+# template that the first-run wizard regenerates per-developer, so
+# committing the generated files would conflict between contributors
+# and pollute the branch. Narrow path-scoped to `environments/local/`
+# only; `environments/<other>/sealed-secrets/**/*.yaml` is NOT ignored.
+#
+#   inventory.yaml         — wizard writes from inventory.yaml.template
+#   pub-cert.pem           — `make fetch-cert` writes from the cluster
+#   *-sealedsecret.yaml    — `make seal` writes via kubeseal
 environments/local/inventory.yaml
+environments/local/pub-cert.pem
+environments/local/sealed-secrets/*/*-sealedsecret.yaml
 
-# pub-cert is fetched from the cluster via `make fetch-cert`; the
-# corresponding generated *.pem is committed, but never the controller's
-# private key.
+# Never commit the sealed-secrets-controller's private key.
 *.key
 *.pkcs8


### PR DESCRIPTION
`make deploy ENV=local`'s sync-clean step aborts on a fresh wizard run because the chain writes per-developer artifacts that aren't yet gitignored:

  - environments/local/pub-cert.pem        (`make fetch-cert`)
  - environments/local/sealed-secrets/<ns>/*-sealedsecret.yaml (`make seal`)

For real envs these are the gitops source of truth and must be committed; for the `local` sandbox they're regenerated by the wizard per-developer (same pattern as the already-gitignored `environments/local/inventory.yaml`). Narrow the ignore to `environments/local/` only — other envs' sealed-secrets stay tracked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated gitignore rules to prevent accidental commits of local development artifacts and sensitive configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->