### PR TITLE
fix(jira): widen jira_project_discovery cursor formats to parse child parent_state

### DIFF
--- a/src/ingestion/connectors/task-tracking/jira/connector.yaml
+++ b/src/ingestion/connectors/task-tracking/jira/connector.yaml
@@ -129,8 +129,17 @@ definitions:
       type: DatetimeBasedCursor
       cursor_field: last_issue_update_time
       is_client_side_incremental: true
+      # insight.lastIssueUpdateTime is ISO (the first format), but this cursor
+      # also has to parse values flowing through the parent_state of its child
+      # substreams (jira_issue / jira_issue_keys serialise their cursor as
+      # "%Y-%m-%d %H:%M"). With only the ISO format here, reading such a value
+      # crashed the stream: "No format in ['%Y-%m-%dT%H:%M:%S.%f%z'] matching
+      # 2026-06-15 02:00". Accept all three formats the issue streams use so
+      # parent/child cursor values are mutually parseable.
       cursor_datetime_formats:
         - "%Y-%m-%dT%H:%M:%S.%f%z"
+        - "%Y-%m-%d %H:%M"
+        - "%Y-%m-%d"
       datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
       start_datetime:
         type: MinMaxDatetime

--- a/src/ingestion/connectors/task-tracking/jira/descriptor.yaml
+++ b/src/ingestion/connectors/task-tracking/jira/descriptor.yaml
@@ -6,7 +6,10 @@ name: jira
 # 2.0.1 (patch): force global_substream_cursor on jira_issue/jira_issue_keys —
 # 2.0.0's per-partition cursor did not persist, making every sync a full
 # re-sync. Bump required so reconcile republishes the manifest.
-version: "2.0.1"
+# 2.0.2 (patch): widen jira_project_discovery cursor_datetime_formats so it can
+# parse child-stream cursor values carried in parent_state (was crashing with
+# "No format ['%Y-%m-%dT%H:%M:%S.%f%z'] matching 2026-06-15 02:00").
+version: "2.0.2"
 schedule: "0 3 * * *"
 workflow: sync
 # CI build metadata + runtime image refs (ADR-0016). The `images:` block is


### PR DESCRIPTION
## Problem

jira syncs crash mid-stream:

```
Exception while syncing stream jira_issue:
No format in ['%Y-%m-%dT%H:%M:%S.%f%z'] matching 2026-06-15 02:00
```

(Observed on job 187, 2h8m / 2.1M records, "Sync did not complete".)

## Root cause

`jira_project_discovery` (the auto-discovery parent from #1316) declares only the ISO format `%Y-%m-%dT%H:%M:%S.%f%z` in `cursor_datetime_formats` — correct for `insight.lastIssueUpdateTime`. But its child substreams `jira_issue` / `jira_issue_keys` serialise their own cursor as `%Y-%m-%d %H:%M`, and that value flows back through `parent_state`. When the discovery cursor parses it, none of its (single) formats match `2026-06-15 02:00` → the stream throws.

This is latent now that #1370 ships `global_substream_cursor` and the descriptor bump 2.0.0→2.0.1 is a **patch** (no state reset), so reconcile carries stale per-partition state into the new manifest.

## Fix

Add the two child formats to the parent's `cursor_datetime_formats`:

```yaml
cursor_datetime_formats:
  - "%Y-%m-%dT%H:%M:%S.%f%z"
  - "%Y-%m-%d %H:%M"
  - "%Y-%m-%d"
```

`datetime_format` (serialisation) stays ISO since `lastIssueUpdateTime` is always ISO — this only widens what the cursor can *parse*, so parent and child cursor values are mutually parseable.

descriptor `2.0.1 → 2.0.2` so reconcile republishes the manifest.

`validate` (CDK runtime): manifest valid.

> Note: this is one of two issues blocking jira on virtuozzo. The other is airbyte-server OOMKilling at its 1Gi eval limit under the full auto-discovery sync (211 projects) — handled separately in the gitops Airbyte overlay (server/worker → 3Gi), not in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The Jira connector now supports multiple datetime formats, preventing synchronization failures caused by timestamp format incompatibilities. This enhancement improves reliability when syncing data from various Jira project configurations and cursor states.

* **Version Updates**
  * Jira connector updated to version 2.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->