### PR TITLE
feat(wiki): Confluence → frontend (Gold + metric views/catalog, connector v1.2.0)

### DIFF
--- a/src/backend/services/analytics-api/src/migration/m20260620_000001_seed_wiki_metrics.rs
+++ b/src/backend/services/analytics-api/src/migration/m20260620_000001_seed_wiki_metrics.rs
@@ -1,21 +1,21 @@
 //! Seed the Team / IC "Bullet Wiki" metric views (wiki class → frontend).
 //!
 //! Pairs with ingestion migration `20260620000000_wiki-bullet-rows.sql`
-//! which creates `insight.wiki_bullet_rows` (long format: person_id,
-//! org_unit_id, metric_date, metric_key, metric_value) from the wiki Silver
+//! which creates `insight.wiki_bullet_rows` (long format: `person_id`,
+//! `org_unit_id`, `metric_date`, `metric_key`, `metric_value`) from the wiki Silver
 //! classes (Confluence today; Outline later).
 //!
 //! Adds two new rows to the `metrics` table (the FE references them by id
-//! via METRIC_REGISTRY):
-//!   • TEAM_BULLET_WIKI = ...0040 — company-wide range (median/min/max).
-//!   • IC_BULLET_WIKI   = ...0041 — per-org-unit (team) range.
+//! via `METRIC_REGISTRY)`:
+//!   • `TEAM_BULLET_WIKI` = ...0040 — company-wide range (median/min/max).
+//!   • `IC_BULLET_WIKI`   = ...0041 — per-org-unit (team) range.
 //!
-//! query_ref shape mirrors the AI bullet (m20260618_000001): a per-person
+//! `query_ref` shape mirrors the AI bullet (`m20260618_000001)`: a per-person
 //! wide-aggregate → ARRAY JOIN unpivot → outer dispatch where the marker
-//! `wiki_active_authors` aggregates with sum() of the per-person 0/1 (= count
-//! of active authors) and the counters aggregate with avg() per person; the
-//! range subquery uses count() as the marker's max scale (like the AI
-//! active-member markers). 4 metric_keys total.
+//! `wiki_active_authors` aggregates with `sum()` of the per-person 0/1 (= count
+//! of active authors) and the counters aggregate with `avg()` per person; the
+//! range subquery uses `count()` as the marker's max scale (like the AI
+//! active-member markers). 4 `metric_keys` total.
 
 use sea_orm_migration::prelude::*;
 
@@ -30,7 +30,7 @@ const ZERO_TENANT: &str = "00000000000000000000000000000000";
 /// authors. Counters are NOT here (they average per person).
 const ACTIVE_LIST: &str = "'wiki_active_authors'";
 
-/// Per-person wide-aggregate over insight.wiki_bullet_rows.
+/// Per-person wide-aggregate over `insight.wiki_bullet_rows`.
 fn wide_aggregate_pp() -> &'static str {
     "SELECT person_id, any(org_unit_id) AS org_unit_id, \
          if(countIf(metric_key = 'wiki_active_authors') > 0, toFloat64(1), CAST(NULL AS Nullable(Float64))) AS wiki_active_authors_v, \

--- a/src/backend/services/analytics-api/src/migration/m20260620_000001_seed_wiki_metrics.rs
+++ b/src/backend/services/analytics-api/src/migration/m20260620_000001_seed_wiki_metrics.rs
@@ -1,0 +1,184 @@
+//! Seed the Team / IC "Bullet Wiki" metric views (wiki class → frontend).
+//!
+//! Pairs with ingestion migration `20260620000000_wiki-bullet-rows.sql`
+//! which creates `insight.wiki_bullet_rows` (long format: person_id,
+//! org_unit_id, metric_date, metric_key, metric_value) from the wiki Silver
+//! classes (Confluence today; Outline later).
+//!
+//! Adds two new rows to the `metrics` table (the FE references them by id
+//! via METRIC_REGISTRY):
+//!   • TEAM_BULLET_WIKI = ...0040 — company-wide range (median/min/max).
+//!   • IC_BULLET_WIKI   = ...0041 — per-org-unit (team) range.
+//!
+//! query_ref shape mirrors the AI bullet (m20260618_000001): a per-person
+//! wide-aggregate → ARRAY JOIN unpivot → outer dispatch where the marker
+//! `wiki_active_authors` aggregates with sum() of the per-person 0/1 (= count
+//! of active authors) and the counters aggregate with avg() per person; the
+//! range subquery uses count() as the marker's max scale (like the AI
+//! active-member markers). 4 metric_keys total.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const TEAM_BULLET_WIKI_ID: &str = "00000000000000000001000000000040";
+const IC_BULLET_WIKI_ID: &str = "00000000000000000001000000000041";
+const ZERO_TENANT: &str = "00000000000000000000000000000000";
+
+/// Active-marker keys — outer uses sum(per-person 0/1) = count of active
+/// authors. Counters are NOT here (they average per person).
+const ACTIVE_LIST: &str = "'wiki_active_authors'";
+
+/// Per-person wide-aggregate over insight.wiki_bullet_rows.
+fn wide_aggregate_pp() -> &'static str {
+    "SELECT person_id, any(org_unit_id) AS org_unit_id, \
+         if(countIf(metric_key = 'wiki_active_authors') > 0, toFloat64(1), CAST(NULL AS Nullable(Float64))) AS wiki_active_authors_v, \
+         sumIf(metric_value, metric_key = 'wiki_pages_created') AS wiki_pages_created_v, \
+         sumIf(metric_value, metric_key = 'wiki_edits') AS wiki_edits_v, \
+         sumIf(metric_value, metric_key = 'wiki_comments') AS wiki_comments_v \
+     FROM insight.wiki_bullet_rows \
+     GROUP BY person_id"
+}
+
+/// ARRAY JOIN unpivot: wide columns → long rows per person. 4 keys.
+fn array_join_kv() -> &'static str {
+    "ARRAY JOIN [ \
+         ('wiki_active_authors', wiki_active_authors_v), \
+         ('wiki_pages_created',  wiki_pages_created_v), \
+         ('wiki_edits',          wiki_edits_v), \
+         ('wiki_comments',       wiki_comments_v) \
+     ] AS kv"
+}
+
+fn team_query() -> String {
+    let pp = wide_aggregate_pp();
+    let kv = array_join_kv();
+    format!(
+        "SELECT p.metric_key AS metric_key, \
+                multiIf(p.metric_key IN ({ACTIVE_LIST}), sum(p.v_period), avg(p.v_period)) AS value, \
+                any(c.company_median) AS median, \
+                any(c.company_min) AS range_min, \
+                any(c.company_max) AS range_max \
+         FROM ( \
+             SELECT person_id, org_unit_id, kv.1 AS metric_key, kv.2 AS v_period \
+             FROM ({pp}) pp {kv} \
+         ) p \
+         LEFT JOIN ( \
+             SELECT metric_key, \
+                    multiIf(metric_key IN ({ACTIVE_LIST}), if(count(v_period) = 0, CAST(NULL AS Nullable(Float64)), toFloat64(0)), quantileExact(0.5)(v_period)) AS company_median, \
+                    multiIf(metric_key IN ({ACTIVE_LIST}), if(count(v_period) = 0, CAST(NULL AS Nullable(Float64)), toFloat64(0)), min(v_period)) AS company_min, \
+                    multiIf(metric_key IN ({ACTIVE_LIST}), if(count(v_period) = 0, CAST(NULL AS Nullable(Float64)), toFloat64(count())), max(v_period)) AS company_max \
+             FROM (SELECT kv.1 AS metric_key, kv.2 AS v_period FROM ({pp}) ppc {kv}) inner_c \
+             GROUP BY metric_key \
+         ) c ON c.metric_key = p.metric_key \
+         GROUP BY p.metric_key"
+    )
+}
+
+fn ic_query() -> String {
+    let pp = wide_aggregate_pp();
+    let kv = array_join_kv();
+    format!(
+        "SELECT p.metric_key AS metric_key, \
+                multiIf(p.metric_key IN ({ACTIVE_LIST}), sum(p.v_period), avg(p.v_period)) AS value, \
+                any(c.team_median) AS median, \
+                any(c.team_min) AS range_min, \
+                any(c.team_max) AS range_max \
+         FROM ( \
+             SELECT person_id, org_unit_id, kv.1 AS metric_key, kv.2 AS v_period \
+             FROM ({pp}) pp {kv} \
+         ) p \
+         LEFT JOIN ( \
+             SELECT metric_key, org_unit_id, \
+                    multiIf(metric_key IN ({ACTIVE_LIST}), if(count(v_period) = 0, CAST(NULL AS Nullable(Float64)), toFloat64(0)), quantileExact(0.5)(v_period)) AS team_median, \
+                    multiIf(metric_key IN ({ACTIVE_LIST}), if(count(v_period) = 0, CAST(NULL AS Nullable(Float64)), toFloat64(0)), min(v_period)) AS team_min, \
+                    multiIf(metric_key IN ({ACTIVE_LIST}), if(count(v_period) = 0, CAST(NULL AS Nullable(Float64)), toFloat64(count())), max(v_period)) AS team_max \
+             FROM (SELECT person_id, org_unit_id, kv.1 AS metric_key, kv.2 AS v_period FROM ({pp}) ppc {kv}) inner_c \
+             GROUP BY metric_key, org_unit_id \
+         ) c ON c.metric_key = p.metric_key AND c.org_unit_id = p.org_unit_id \
+         GROUP BY p.metric_key"
+    )
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+        for (hex_id, name, desc, qr) in [
+            (TEAM_BULLET_WIKI_ID, "Team Bullet Wiki",
+             "Wiki (Confluence/Outline) per-person bullets — team view, company-wide range.",
+             team_query()),
+            (IC_BULLET_WIKI_ID, "IC Bullet Wiki",
+             "Wiki (Confluence/Outline) per-person bullets — IC view, per-org-unit range.",
+             ic_query()),
+        ] {
+            db.execute_unprepared(&format!(
+                "INSERT INTO metrics (id, insight_tenant_id, name, description, query_ref, is_enabled) \
+                 VALUES (UNHEX('{hex_id}'), UNHEX('{ZERO_TENANT}'), '{name}', '{desc}', '{q}', 1) \
+                 ON DUPLICATE KEY UPDATE name=VALUES(name), description=VALUES(description), query_ref=VALUES(query_ref)",
+                q = qr.replace('\'', "''"),
+            ))
+            .await?;
+        }
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+        for id in [TEAM_BULLET_WIKI_ID, IC_BULLET_WIKI_ID] {
+            db.execute_unprepared(&format!("DELETE FROM metrics WHERE id = UNHEX('{id}')"))
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KEYS: &[&str] = &[
+        "wiki_active_authors",
+        "wiki_pages_created",
+        "wiki_edits",
+        "wiki_comments",
+    ];
+
+    #[test]
+    fn array_join_has_all_four_keys() {
+        let kv = array_join_kv();
+        for k in KEYS {
+            assert!(kv.contains(&format!("('{k}',")), "ARRAY JOIN missing {k}");
+        }
+        assert_eq!(kv.matches("('").count(), 4, "expected exactly 4 keys");
+    }
+
+    #[test]
+    fn marker_is_active_counters_are_not() {
+        assert!(ACTIVE_LIST.contains("wiki_active_authors"));
+        for c in ["wiki_pages_created", "wiki_edits", "wiki_comments"] {
+            assert!(!ACTIVE_LIST.contains(c), "{c} is a counter, not active");
+        }
+    }
+
+    #[test]
+    fn counters_use_sumif_marker_uses_countif() {
+        let pp = wide_aggregate_pp();
+        assert!(pp.contains("countIf(metric_key = 'wiki_active_authors') > 0"));
+        for c in ["wiki_pages_created", "wiki_edits", "wiki_comments"] {
+            assert!(pp.contains(&format!("sumIf(metric_value, metric_key = '{c}')")));
+        }
+    }
+
+    #[test]
+    fn queries_reference_view_and_unpivot() {
+        for q in [team_query(), ic_query()] {
+            assert!(q.contains("insight.wiki_bullet_rows"));
+            assert!(q.contains("ARRAY JOIN"));
+            assert!(q.contains("wiki_comments"));
+        }
+        assert!(team_query().contains("company_median"));
+        assert!(ic_query().contains("team_median") && ic_query().contains("c.org_unit_id = p.org_unit_id"));
+    }
+}

--- a/src/backend/services/analytics-api/src/migration/m20260620_000001_seed_wiki_metrics.rs
+++ b/src/backend/services/analytics-api/src/migration/m20260620_000001_seed_wiki_metrics.rs
@@ -106,12 +106,18 @@ impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         let db = manager.get_connection();
         for (hex_id, name, desc, qr) in [
-            (TEAM_BULLET_WIKI_ID, "Team Bullet Wiki",
-             "Wiki (Confluence/Outline) per-person bullets — team view, company-wide range.",
-             team_query()),
-            (IC_BULLET_WIKI_ID, "IC Bullet Wiki",
-             "Wiki (Confluence/Outline) per-person bullets — IC view, per-org-unit range.",
-             ic_query()),
+            (
+                TEAM_BULLET_WIKI_ID,
+                "Team Bullet Wiki",
+                "Wiki (Confluence/Outline) per-person bullets — team view, company-wide range.",
+                team_query(),
+            ),
+            (
+                IC_BULLET_WIKI_ID,
+                "IC Bullet Wiki",
+                "Wiki (Confluence/Outline) per-person bullets — IC view, per-org-unit range.",
+                ic_query(),
+            ),
         ] {
             db.execute_unprepared(&format!(
                 "INSERT INTO metrics (id, insight_tenant_id, name, description, query_ref, is_enabled) \
@@ -179,6 +185,9 @@ mod tests {
             assert!(q.contains("wiki_comments"));
         }
         assert!(team_query().contains("company_median"));
-        assert!(ic_query().contains("team_median") && ic_query().contains("c.org_unit_id = p.org_unit_id"));
+        assert!(
+            ic_query().contains("team_median")
+                && ic_query().contains("c.org_unit_id = p.org_unit_id")
+        );
     }
 }

--- a/src/backend/services/analytics-api/src/migration/m20260620_000002_seed_wiki_catalog.rs
+++ b/src/backend/services/analytics-api/src/migration/m20260620_000002_seed_wiki_catalog.rs
@@ -3,7 +3,7 @@
 //! (paired gold view `insight.wiki_bullet_rows`).
 //!
 //! 4 `metric_keys`, all routed through `wiki_bullet_rows`, `source_tags`
-//! `["confluence"]` (Outline will share the same keys later):
+//! `["confluence", "outline"]` (both wiki sources feed the same keys):
 //!   `wiki_pages_created` / `wiki_edits` / `wiki_comments` — counters (higher better);
 //!   `wiki_active_authors` — 0/1 member-scale marker.
 //!
@@ -62,7 +62,7 @@ const SEEDS: &[SeedRow] = &[
         format: None,
         higher_is_better: true,
         is_member_scale: false,
-        source_tags: &["confluence"],
+        source_tags: &["confluence", "outline"],
         good: 5.0,
         warn: 1.0,
     },
@@ -75,7 +75,7 @@ const SEEDS: &[SeedRow] = &[
         format: None,
         higher_is_better: true,
         is_member_scale: false,
-        source_tags: &["confluence"],
+        source_tags: &["confluence", "outline"],
         good: 30.0,
         warn: 10.0,
     },
@@ -88,7 +88,7 @@ const SEEDS: &[SeedRow] = &[
         format: None,
         higher_is_better: true,
         is_member_scale: false,
-        source_tags: &["confluence"],
+        source_tags: &["confluence", "outline"],
         good: 10.0,
         warn: 2.0,
     },
@@ -101,7 +101,7 @@ const SEEDS: &[SeedRow] = &[
         format: None,
         higher_is_better: true,
         is_member_scale: true,
-        source_tags: &["confluence"],
+        source_tags: &["confluence", "outline"],
         good: 5.0,
         warn: 2.0,
     },
@@ -237,9 +237,9 @@ mod tests {
     }
 
     #[test]
-    fn tagged_confluence() {
+    fn tagged_confluence_and_outline() {
         for r in SEEDS {
-            assert_eq!(r.source_tags, &["confluence"]);
+            assert_eq!(r.source_tags, &["confluence", "outline"]);
         }
     }
 

--- a/src/backend/services/analytics-api/src/migration/m20260620_000002_seed_wiki_catalog.rs
+++ b/src/backend/services/analytics-api/src/migration/m20260620_000002_seed_wiki_catalog.rs
@@ -1,13 +1,13 @@
 //! Seed `metric_catalog` + product-default `metric_threshold` rows for the
-//! wiki bullet metric_keys introduced in `m20260620_000001_seed_wiki_metrics`
+//! wiki bullet `metric_keys` introduced in `m20260620_000001_seed_wiki_metrics`
 //! (paired gold view `insight.wiki_bullet_rows`).
 //!
-//! 4 metric_keys, all routed through `wiki_bullet_rows`, source_tags
-//! ["confluence"] (Outline will share the same keys later):
-//!   wiki_pages_created / wiki_edits / wiki_comments — counters (higher better);
-//!   wiki_active_authors — 0/1 member-scale marker.
+//! 4 `metric_keys`, all routed through `wiki_bullet_rows`, `source_tags`
+//! `["confluence"]` (Outline will share the same keys later):
+//!   `wiki_pages_created` / `wiki_edits` / `wiki_comments` — counters (higher better);
+//!   `wiki_active_authors` — 0/1 member-scale marker.
 //!
-//! Mirrors m20260601_000002_seed_claude_team_metrics_catalog (additive
+//! Mirrors `m20260601_000002_seed_claude_team_metrics_catalog` (additive
 //! catalog seed). Thresholds are product-default placeholders; tune per
 //! tenant via the admin CRUD API.
 

--- a/src/backend/services/analytics-api/src/migration/m20260620_000002_seed_wiki_catalog.rs
+++ b/src/backend/services/analytics-api/src/migration/m20260620_000002_seed_wiki_catalog.rs
@@ -1,0 +1,240 @@
+//! Seed `metric_catalog` + product-default `metric_threshold` rows for the
+//! wiki bullet metric_keys introduced in `m20260620_000001_seed_wiki_metrics`
+//! (paired gold view `insight.wiki_bullet_rows`).
+//!
+//! 4 metric_keys, all routed through `wiki_bullet_rows`, source_tags
+//! ["confluence"] (Outline will share the same keys later):
+//!   wiki_pages_created / wiki_edits / wiki_comments — counters (higher better);
+//!   wiki_active_authors — 0/1 member-scale marker.
+//!
+//! Mirrors m20260601_000002_seed_claude_team_metrics_catalog (additive
+//! catalog seed). Thresholds are product-default placeholders; tune per
+//! tenant via the admin CRUD API.
+
+use sea_orm::{ConnectionTrait, Statement, Value};
+use sea_orm_migration::prelude::*;
+use uuid::Uuid;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+struct SeedRow {
+    metric_key: &'static str,
+    label: &'static str,
+    sublabel: Option<&'static str>,
+    description: Option<&'static str>,
+    unit: Option<&'static str>,
+    format: Option<&'static str>,
+    higher_is_better: bool,
+    is_member_scale: bool,
+    source_tags: &'static [&'static str],
+    good: f64,
+    warn: f64,
+}
+
+fn source_tags_json(tags: &[&'static str]) -> String {
+    let mut out = String::from("[");
+    for (i, tag) in tags.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push('"');
+        for c in tag.chars() {
+            match c {
+                '"' => out.push_str("\\\""),
+                '\\' => out.push_str("\\\\"),
+                _ => out.push(c),
+            }
+        }
+        out.push('"');
+    }
+    out.push(']');
+    out
+}
+
+const SEEDS: &[SeedRow] = &[
+    SeedRow {
+        metric_key: "wiki_bullet_rows.wiki_pages_created",
+        label: "Wiki Pages Created",
+        sublabel: Some("Confluence \u{b7} pages authored \u{b7} period total"),
+        description: Some("Wiki pages created by the person in the period (Confluence/Outline)."),
+        unit: Some("pages"),
+        format: None,
+        higher_is_better: true,
+        is_member_scale: false,
+        source_tags: &["confluence"],
+        good: 5.0,
+        warn: 1.0,
+    },
+    SeedRow {
+        metric_key: "wiki_bullet_rows.wiki_edits",
+        label: "Wiki Edits",
+        sublabel: Some("Confluence \u{b7} page revisions \u{b7} period total"),
+        description: Some("Page revisions (version_count \u{2212} 1) attributed to the person."),
+        unit: Some("edits"),
+        format: None,
+        higher_is_better: true,
+        is_member_scale: false,
+        source_tags: &["confluence"],
+        good: 30.0,
+        warn: 10.0,
+    },
+    SeedRow {
+        metric_key: "wiki_bullet_rows.wiki_comments",
+        label: "Wiki Comments",
+        sublabel: Some("Confluence \u{b7} comments on the person's pages \u{b7} period total"),
+        description: Some("Comments (footer + inline + replies) received on the person's pages."),
+        unit: Some("comments"),
+        format: None,
+        higher_is_better: true,
+        is_member_scale: false,
+        source_tags: &["confluence"],
+        good: 10.0,
+        warn: 2.0,
+    },
+    SeedRow {
+        metric_key: "wiki_bullet_rows.wiki_active_authors",
+        label: "Active Wiki Authors",
+        sublabel: Some("Confluence \u{b7} members who authored/edited this period"),
+        description: Some("Count of members active in the wiki this period (member-scale marker)."),
+        unit: None,
+        format: None,
+        higher_is_better: true,
+        is_member_scale: true,
+        source_tags: &["confluence"],
+        good: 5.0,
+        warn: 2.0,
+    },
+];
+
+const INSERT_CATALOG_SQL: &str = "\
+    INSERT INTO metric_catalog \
+        (id, tenant_id, metric_key, label, sublabel, description, unit, format, \
+         higher_is_better, is_member_scale, source_tags, is_enabled) \
+    VALUES (?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, TRUE) \
+    ON DUPLICATE KEY UPDATE \
+        label = VALUES(label), \
+        sublabel = VALUES(sublabel), \
+        description = VALUES(description), \
+        unit = VALUES(unit), \
+        format = VALUES(format), \
+        higher_is_better = VALUES(higher_is_better), \
+        is_member_scale = VALUES(is_member_scale), \
+        source_tags = VALUES(source_tags), \
+        is_enabled = VALUES(is_enabled)";
+
+const INSERT_THRESHOLD_SQL: &str = "\
+    INSERT INTO metric_threshold \
+        (id, tenant_id, metric_key, scope, role_slug, team_id, good, warn, is_locked) \
+    VALUES (?, NULL, ?, 'product-default', '', '', ?, ?, FALSE) \
+    ON DUPLICATE KEY UPDATE \
+        good = VALUES(good), \
+        warn = VALUES(warn)";
+
+fn nullable_str_value(v: Option<&str>) -> Value {
+    match v {
+        Some(s) => Value::from(s),
+        None => Value::String(None),
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+        let backend = manager.get_database_backend();
+
+        for row in SEEDS {
+            let catalog_id = Uuid::now_v7();
+            let threshold_id = Uuid::now_v7();
+            let source_tags_json_str = source_tags_json(row.source_tags);
+
+            conn.execute(Statement::from_sql_and_values(
+                backend,
+                INSERT_CATALOG_SQL,
+                [
+                    Value::Bytes(Some(Box::new(catalog_id.as_bytes().to_vec()))),
+                    Value::from(row.metric_key),
+                    Value::from(row.label),
+                    nullable_str_value(row.sublabel),
+                    nullable_str_value(row.description),
+                    nullable_str_value(row.unit),
+                    nullable_str_value(row.format),
+                    Value::from(row.higher_is_better),
+                    Value::from(row.is_member_scale),
+                    Value::from(source_tags_json_str.as_str()),
+                ],
+            ))
+            .await?;
+
+            conn.execute(Statement::from_sql_and_values(
+                backend,
+                INSERT_THRESHOLD_SQL,
+                [
+                    Value::Bytes(Some(Box::new(threshold_id.as_bytes().to_vec()))),
+                    Value::from(row.metric_key),
+                    Value::from(row.good),
+                    Value::from(row.warn),
+                ],
+            ))
+            .await?;
+        }
+
+        tracing::info!(seeded = SEEDS.len(), "wiki metric_catalog seed applied");
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        Err(DbErr::Custom(
+            "m20260620_000002_seed_wiki_catalog is irreversible: \
+             delete the 4 wiki_bullet_rows catalog rows manually if needed."
+                .to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seed_count_is_four() {
+        assert_eq!(SEEDS.len(), 4);
+    }
+
+    #[test]
+    fn all_keys_route_to_wiki_bullet_rows() {
+        for r in SEEDS {
+            assert!(
+                r.metric_key.starts_with("wiki_bullet_rows."),
+                "metric_key {:?} must route to wiki_bullet_rows",
+                r.metric_key
+            );
+        }
+    }
+
+    #[test]
+    fn active_authors_is_member_scale_counters_are_not() {
+        for r in SEEDS {
+            if r.metric_key.ends_with("wiki_active_authors") {
+                assert!(r.is_member_scale, "wiki_active_authors must be member-scale");
+            } else {
+                assert!(!r.is_member_scale, "{} must not be member-scale", r.metric_key);
+            }
+            assert!(r.higher_is_better, "{} should be higher-is-better", r.metric_key);
+        }
+    }
+
+    #[test]
+    fn tagged_confluence() {
+        for r in SEEDS {
+            assert_eq!(r.source_tags, &["confluence"]);
+        }
+    }
+
+    #[test]
+    fn source_tags_json_well_formed() {
+        let j = source_tags_json(SEEDS[0].source_tags);
+        assert!(j.starts_with('[') && j.ends_with(']') && j.len() > 2);
+    }
+}

--- a/src/backend/services/analytics-api/src/migration/m20260620_000002_seed_wiki_catalog.rs
+++ b/src/backend/services/analytics-api/src/migration/m20260620_000002_seed_wiki_catalog.rs
@@ -56,7 +56,7 @@ const SEEDS: &[SeedRow] = &[
     SeedRow {
         metric_key: "wiki_bullet_rows.wiki_pages_created",
         label: "Wiki Pages Created",
-        sublabel: Some("Confluence \u{b7} pages authored \u{b7} period total"),
+        sublabel: Some("Confluence/Outline \u{b7} pages authored \u{b7} period total"),
         description: Some("Wiki pages created by the person in the period (Confluence/Outline)."),
         unit: Some("pages"),
         format: None,
@@ -69,7 +69,7 @@ const SEEDS: &[SeedRow] = &[
     SeedRow {
         metric_key: "wiki_bullet_rows.wiki_edits",
         label: "Wiki Edits",
-        sublabel: Some("Confluence \u{b7} page revisions \u{b7} period total"),
+        sublabel: Some("Confluence/Outline \u{b7} page revisions \u{b7} period total"),
         description: Some("Page revisions (version_count \u{2212} 1) attributed to the person."),
         unit: Some("edits"),
         format: None,
@@ -82,7 +82,9 @@ const SEEDS: &[SeedRow] = &[
     SeedRow {
         metric_key: "wiki_bullet_rows.wiki_comments",
         label: "Wiki Comments",
-        sublabel: Some("Confluence \u{b7} comments on the person's pages \u{b7} period total"),
+        sublabel: Some(
+            "Confluence/Outline \u{b7} comments on the person's pages \u{b7} period total",
+        ),
         description: Some("Comments (footer + inline + replies) received on the person's pages."),
         unit: Some("comments"),
         format: None,
@@ -95,7 +97,7 @@ const SEEDS: &[SeedRow] = &[
     SeedRow {
         metric_key: "wiki_bullet_rows.wiki_active_authors",
         label: "Active Wiki Authors",
-        sublabel: Some("Confluence \u{b7} members who authored/edited this period"),
+        sublabel: Some("Confluence/Outline \u{b7} members who authored/edited this period"),
         description: Some("Count of members active in the wiki this period (member-scale marker)."),
         unit: None,
         format: None,

--- a/src/backend/services/analytics-api/src/migration/m20260620_000002_seed_wiki_catalog.rs
+++ b/src/backend/services/analytics-api/src/migration/m20260620_000002_seed_wiki_catalog.rs
@@ -217,11 +217,22 @@ mod tests {
     fn active_authors_is_member_scale_counters_are_not() {
         for r in SEEDS {
             if r.metric_key.ends_with("wiki_active_authors") {
-                assert!(r.is_member_scale, "wiki_active_authors must be member-scale");
+                assert!(
+                    r.is_member_scale,
+                    "wiki_active_authors must be member-scale"
+                );
             } else {
-                assert!(!r.is_member_scale, "{} must not be member-scale", r.metric_key);
+                assert!(
+                    !r.is_member_scale,
+                    "{} must not be member-scale",
+                    r.metric_key
+                );
             }
-            assert!(r.higher_is_better, "{} should be higher-is-better", r.metric_key);
+            assert!(
+                r.higher_is_better,
+                "{} should be higher-is-better",
+                r.metric_key
+            );
         }
     }
 

--- a/src/backend/services/analytics-api/src/migration/mod.rs
+++ b/src/backend/services/analytics-api/src/migration/mod.rs
@@ -38,6 +38,8 @@ mod m20260612_000002_seed_support_catalog;
 mod m20260612_000003_link_support_query_catalog;
 mod m20260618_000001_ai_claude_team_overage_metric;
 mod m20260618_000002_seed_claude_team_overage_catalog;
+mod m20260620_000001_seed_wiki_metrics;
+mod m20260620_000002_seed_wiki_catalog;
 
 #[cfg(test)]
 mod live_tests;
@@ -88,6 +90,8 @@ impl MigratorTrait for Migrator {
             Box::new(m20260612_000003_link_support_query_catalog::Migration),
             Box::new(m20260618_000001_ai_claude_team_overage_metric::Migration),
             Box::new(m20260618_000002_seed_claude_team_overage_catalog::Migration),
+            Box::new(m20260620_000001_seed_wiki_metrics::Migration),
+            Box::new(m20260620_000002_seed_wiki_catalog::Migration),
         ]
     }
 }

--- a/src/ingestion/connectors/wiki/confluence/connector.yaml
+++ b/src/ingestion/connectors/wiki/confluence/connector.yaml
@@ -38,6 +38,30 @@ definitions:
         action: FAIL
         http_codes: [401, 403]
 
+  # Substream children only: a parent page/comment deleted between the parent
+  # enumeration and the child fetch returns 404 on /pages/{id}/* or
+  # /*-comments/{id}/children. Without IGNORE, one deleted parent fails the
+  # whole sync (the Jira/Zendesk substream lesson). Parents (spaces/pages)
+  # deliberately keep the strict handler so a wrong instance_url (404 on the
+  # list endpoint) surfaces instead of silently syncing empty.
+  child_error_handler:
+    type: DefaultErrorHandler
+    backoff_strategies:
+      - type: WaitTimeFromHeader
+        header: Retry-After
+        max_waiting_time_in_seconds: 600
+    response_filters:
+      - type: HttpResponseFilter
+        action: IGNORE
+        http_codes: [404]
+        error_message: "Parent page/comment not found (deleted mid-sync) — partition skipped."
+      - type: HttpResponseFilter
+        action: RETRY
+        http_codes: [429, 503]
+      - type: HttpResponseFilter
+        action: FAIL
+        http_codes: [401, 403]
+
   base_requester:
     type: HttpRequester
     url_base: "{{ config['confluence_instance_url'] }}"
@@ -381,6 +405,8 @@ streams:
         path: /wiki/api/v2/pages/{{ stream_partition.page_id }}/versions
         request_parameters:
           limit: "{{ config.get('confluence_page_size', 100) }}"
+        error_handler:
+          $ref: "#/definitions/child_error_handler"
       paginator:
         $ref: "#/definitions/confluence_paginator"
       record_selector:
@@ -445,6 +471,8 @@ streams:
         request_parameters:
           limit: "{{ config.get('confluence_page_size', 100) }}"
           body-format: storage
+        error_handler:
+          $ref: "#/definitions/child_error_handler"
       paginator:
         $ref: "#/definitions/confluence_paginator"
       record_selector:
@@ -503,6 +531,8 @@ streams:
         request_parameters:
           limit: "{{ config.get('confluence_page_size', 100) }}"
           body-format: storage
+        error_handler:
+          $ref: "#/definitions/child_error_handler"
       paginator:
         $ref: "#/definitions/confluence_paginator"
       record_selector:
@@ -561,6 +591,8 @@ streams:
         request_parameters:
           limit: "{{ config.get('confluence_page_size', 100) }}"
           body-format: storage
+        error_handler:
+          $ref: "#/definitions/child_error_handler"
       paginator:
         $ref: "#/definitions/confluence_paginator"
       record_selector:
@@ -625,6 +657,8 @@ streams:
         request_parameters:
           limit: "{{ config.get('confluence_page_size', 100) }}"
           body-format: storage
+        error_handler:
+          $ref: "#/definitions/child_error_handler"
       paginator:
         $ref: "#/definitions/confluence_paginator"
       record_selector:

--- a/src/ingestion/connectors/wiki/confluence/descriptor.yaml
+++ b/src/ingestion/connectors/wiki/confluence/descriptor.yaml
@@ -1,5 +1,9 @@
 name: confluence
-version: "1.1.1"
+# 1.2.0: substream children (versions + footer/inline comments + replies)
+# now IGNORE HTTP 404 — a parent page/comment deleted mid-sync no longer
+# fails the whole sync (Jira/Zendesk substream large-data lesson). Parents
+# (spaces/pages) keep the strict handler. Additive → MINOR per ADR-0015.
+version: "1.2.0"
 schedule: "0 4 * * *"
 workflow: sync
 

--- a/src/ingestion/connectors/wiki/outline/connector.yaml
+++ b/src/ingestion/connectors/wiki/outline/connector.yaml
@@ -434,6 +434,14 @@ streams:
               header: Retry-After
               max_waiting_time_in_seconds: 600
           response_filters:
+            # Substream child: a document deleted/made inaccessible between the
+            # documents.list enumeration and this revisions.list fetch returns
+            # 404 — skip that partition instead of failing the whole sync
+            # (Jira/Zendesk substream large-data lesson; mirrors confluence).
+            - type: HttpResponseFilter
+              action: IGNORE
+              http_codes: [404]
+              error_message: "Document not found (deleted mid-sync) — revisions partition skipped."
             - type: HttpResponseFilter
               action: RETRY
               http_codes: [429, 503]

--- a/src/ingestion/connectors/wiki/outline/descriptor.yaml
+++ b/src/ingestion/connectors/wiki/outline/descriptor.yaml
@@ -1,5 +1,9 @@
 name: outline
-version: "1.0.0"
+# 1.1.0: revisions.list substream now IGNOREs HTTP 404 — a document deleted
+# between documents.list enumeration and the per-doc revisions fetch no
+# longer fails the whole sync (Jira/Zendesk substream large-data lesson;
+# mirrors confluence). Additive → MINOR per ADR-0015.
+version: "1.1.0"
 schedule: "0 4 * * *"
 workflow: sync
 

--- a/src/ingestion/scripts/create-bronze-placeholders.sh
+++ b/src/ingestion/scripts/create-bronze-placeholders.sh
@@ -595,6 +595,66 @@ CREATE TABLE IF NOT EXISTS silver.class_wiki_activity (
 SQL
 fi
 
+# silver.class_wiki_pages — per-page snapshot. Referenced by the wiki gold
+# view 20260620000000_wiki-bullet-rows.sql; CREATE VIEW fails with
+# UNKNOWN_TABLE on a fresh cluster (migrations run before dbt builds silver)
+# unless this placeholder exists. Columns mirror the dbt model (the view
+# reads tenant_id/page_id/author_id/author_email/version_count/created_at).
+if ! ch_table_exists silver class_wiki_pages; then
+  echo "  Creating placeholder: silver.class_wiki_pages"
+  run_ch <<'SQL'
+CREATE TABLE IF NOT EXISTS silver.class_wiki_pages (
+    tenant_id         Nullable(String),
+    source_id         Nullable(String),
+    unique_key        String,
+    page_id           Nullable(String),
+    space_id          Nullable(String),
+    space_name        Nullable(String),
+    title             Nullable(String),
+    status            Nullable(String),
+    author_id         Nullable(String),
+    author_email      Nullable(String),
+    last_editor_id    Nullable(String),
+    last_editor_email Nullable(String),
+    parent_page_id    Nullable(String),
+    version_count     UInt32,
+    created_at        Nullable(DateTime64(3)),
+    updated_at        Nullable(DateTime64(3)),
+    space_url         Nullable(String),
+    source            String,
+    data_source       String,
+    _version          UInt64
+) ENGINE = ReplacingMergeTree(_version) ORDER BY unique_key COMMENT 'INSIGHT_PLACEHOLDER_v1';
+SQL
+fi
+
+# silver.class_wiki_engagement — per-page per-day comment engagement.
+# Referenced by the wiki gold view 20260620000000_wiki-bullet-rows.sql
+# (reads tenant_id/page_id/day/total_comments). Same fresh-cluster CREATE
+# VIEW guard as class_wiki_pages above.
+if ! ch_table_exists silver class_wiki_engagement; then
+  echo "  Creating placeholder: silver.class_wiki_engagement"
+  run_ch <<'SQL'
+CREATE TABLE IF NOT EXISTS silver.class_wiki_engagement (
+    tenant_id               Nullable(String),
+    source_id               Nullable(String),
+    unique_key              String,
+    page_id                 Nullable(String),
+    day                     Nullable(Date),
+    total_comments          UInt32,
+    footer_comments         Nullable(UInt32),
+    inline_comments         Nullable(UInt32),
+    replies                 Nullable(UInt32),
+    unique_commenters       Nullable(UInt32),
+    unresolved_inline_count Nullable(UInt32),
+    source                  String,
+    data_source             String,
+    collected_at            Nullable(DateTime64(3)),
+    _version                UInt64
+) ENGINE = ReplacingMergeTree(_version) ORDER BY unique_key COMMENT 'INSIGHT_PLACEHOLDER_v1';
+SQL
+fi
+
 # silver.mtr_git_person_totals — pre-aggregated git person metrics.
 if ! ch_table_exists silver mtr_git_person_totals; then
   echo "  Creating placeholder: silver.mtr_git_person_totals"

--- a/src/ingestion/scripts/migrations/20260620000000_wiki-bullet-rows.sql
+++ b/src/ingestion/scripts/migrations/20260620000000_wiki-bullet-rows.sql
@@ -1,0 +1,67 @@
+-- =====================================================================
+-- wiki_bullet_rows — Gold long-format bullet rows for the wiki class
+-- =====================================================================
+-- Surfaces the wiki Silver classes (Confluence today; Outline later) in a
+-- per-person long-format bullet view, mirroring ai_bullet_rows. Feeds the
+-- "Team/IC Bullet Wiki" metric views (analytics-api m20260620_000001).
+--
+-- Grain: one row per (person, day, metric_key). Person key:
+--   person_id = coalesce(lower(author_email), author_id)
+-- author_email is resolved upstream via a Jira accountId→email join; when
+-- Jira is absent (e.g. a standalone Confluence) it is NULL, so we fall back
+-- to the raw author_id (Atlassian accountId) — the row still aggregates and
+-- renders (team view), and lights up per-person once identity resolves.
+--
+-- Sources (the two STABLE wiki Silver classes):
+--   • class_wiki_pages       → wiki_pages_created (1/page), wiki_edits
+--       (version_count-1), wiki_active_authors (member marker)
+--   • class_wiki_engagement  → wiki_comments, attributed to the page author
+--       (INNER JOIN to class_wiki_pages on page_id)
+-- (class_wiki_activity is intentionally NOT read here — it is the per-day
+--  author rollup and proved unstable on dev; pages carries the same signal.)
+--
+-- Both Silver tables are ReplacingMergeTree → read with FINAL for current
+-- state. Counters → sum in the metric query_ref; wiki_active_authors is a
+-- 0/1 member marker (max per person, count() as the company/team range).
+--
+-- Idempotent: CREATE OR REPLACE VIEW. Auto-discovered by the migration
+-- runner in filename order (no registry edit needed).
+-- =====================================================================
+
+CREATE OR REPLACE VIEW insight.wiki_bullet_rows AS
+
+-- ─── Branch 1: page authorship / edits (from class_wiki_pages) ────────
+SELECT
+    coalesce(lower(pg.author_email), pg.author_id)          AS person_id,
+    p.org_unit_id                                           AS org_unit_id,
+    toDate(pg.created_at)                                   AS metric_date,
+    kv.1                                                    AS metric_key,
+    kv.2                                                    AS metric_value
+FROM (SELECT * FROM silver.class_wiki_pages FINAL) AS pg
+LEFT JOIN insight.people AS p
+    ON coalesce(lower(pg.author_email), pg.author_id) = p.person_id
+ARRAY JOIN [
+    ('wiki_pages_created',  toFloat64(1)),
+    ('wiki_edits',          toFloat64(greatest(toInt64(pg.version_count) - 1, 0))),
+    ('wiki_active_authors', toFloat64(1))
+] AS kv
+WHERE pg.author_id IS NOT NULL AND pg.author_id != ''
+  AND pg.created_at IS NOT NULL
+
+UNION ALL
+
+-- ─── Branch 2: engagement comments (from class_wiki_engagement) ───────
+-- Attributed to the PAGE AUTHOR (engagement received on their pages).
+SELECT
+    coalesce(lower(pg.author_email), pg.author_id)          AS person_id,
+    p.org_unit_id                                           AS org_unit_id,
+    e.day                                                   AS metric_date,
+    'wiki_comments'                                         AS metric_key,
+    toFloat64(e.total_comments)                             AS metric_value
+FROM (SELECT * FROM silver.class_wiki_engagement FINAL) AS e
+INNER JOIN (SELECT * FROM silver.class_wiki_pages FINAL) AS pg
+    ON e.page_id = pg.page_id AND e.tenant_id = pg.tenant_id
+LEFT JOIN insight.people AS p
+    ON coalesce(lower(pg.author_email), pg.author_id) = p.person_id
+WHERE pg.author_id IS NOT NULL AND pg.author_id != ''
+  AND e.day IS NOT NULL;

--- a/src/ingestion/silver/wiki/class_wiki_activity.sql
+++ b/src/ingestion/silver/wiki/class_wiki_activity.sql
@@ -10,6 +10,7 @@
 ) }}
 
 -- depends_on: {{ ref('confluence__wiki_activity') }}
+-- depends_on: {{ ref('outline__wiki_activity') }}
 
 SELECT * FROM (
     {{ union_by_tag('silver:class_wiki_activity') }}

--- a/src/ingestion/silver/wiki/class_wiki_engagement.sql
+++ b/src/ingestion/silver/wiki/class_wiki_engagement.sql
@@ -10,6 +10,7 @@
 ) }}
 
 -- depends_on: {{ ref('confluence__wiki_engagement') }}
+-- depends_on: {{ ref('outline__wiki_engagement') }}
 
 SELECT * FROM (
     {{ union_by_tag('silver:class_wiki_engagement') }}

--- a/src/ingestion/silver/wiki/class_wiki_pages.sql
+++ b/src/ingestion/silver/wiki/class_wiki_pages.sql
@@ -10,6 +10,7 @@
 ) }}
 
 -- depends_on: {{ ref('confluence__wiki_pages') }}
+-- depends_on: {{ ref('outline__wiki_pages') }}
 
 SELECT * FROM (
     {{ union_by_tag('silver:class_wiki_pages') }}


### PR DESCRIPTION
## What

Builds the missing **top half** of the wiki-class pipeline (Confluence). It was bronze→silver only; this adds Gold → metric API so the wiki data reaches the frontend. Source-agnostic gold (Outline joins later via the same keys).

## Layers

- **Gold** — `20260620000000_wiki-bullet-rows.sql`: `insight.wiki_bullet_rows` (long format) from `silver.class_wiki_pages` + `class_wiki_engagement` (FINAL reads). metric_keys: `wiki_pages_created`, `wiki_edits` (version_count−1), `wiki_comments` (page-author-attributed), `wiki_active_authors` (member marker). `person_id = coalesce(lower(author_email), author_id)` so rows render even when Jira identity is absent (author_email NULL on standalone Confluence). Reads the **stable** silver tables (not `class_wiki_activity`, which proved unstable on dev).
- **analytics-api** `m20260620_000001`: seed **Team Bullet Wiki** (`…0040`) + **IC Bullet Wiki** (`…0041`) metric views with AI-style `query_ref` (marker→sum/count, counters→avg, company/team range).
- **analytics-api** `m20260620_000002`: seed `metric_catalog` + product-default thresholds for the 4 `wiki_bullet_rows.*` keys (`source_tags ["confluence"]`).
- Both registered in `migration/mod.rs`.

## Review fixes folded in

- **E2E placeholder** (recurring class): `create-bronze-placeholders.sh` now seeds `silver.class_wiki_pages` + `class_wiki_engagement` placeholders — without them `CREATE VIEW` fails `UNKNOWN_TABLE` on a fresh cluster (migrations run before dbt).
- **Connector substream hardening** (Jira/Zendesk large-data lesson): the 5 Confluence substream children (versions, footer/inline comments + replies) now `IGNORE 404` (a parent page/comment deleted mid-sync no longer fails the whole sync). Parents stay strict so a wrong `instance_url` still surfaces. descriptor **1.1.1 → 1.2.0**. (incremental_dependency deliberately withheld from comment children — a new comment may not bump the page's updated_at, so coupling would silently drop comments.)

## Validation

- `cargo test migration` green (9 wiki tests + suite).
- **Live e2e on dev** with seeded Confluence (5 spaces / 41 pages / 71 versions / 70 comments+replies): bronze → silver → gold `wiki_bullet_rows` returns real numbers (pages_created 41, edits 30, comments 70, active_authors 1); both stored query_refs (Team `…0040` + IC `…0041`) executed against ClickHouse return those values.

## Paired FE

constructorfabric/insight-front `feat/wiki-confluence-frontend` — new "Wiki" section on v2 team + IC dashboards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the `wiki_bullet_rows` data view and seeded wiki bullet analytics metrics, thresholds, and metric catalog (including active authors) for reporting.

* **Improvements**
  * Enhanced wiki ingestion robustness by ignoring HTTP 404s for deleted Confluence/Outline content during sync.
  * Improved Confluence resilience to rate limiting with retry/backoff using `Retry-After`.
  * Bumped connector versions (Confluence to 1.2.0, Outline to 1.1.0).

* **Chores**
  * Added required placeholder tables on fresh clusters and updated wiki model dependency hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->