### PR TITLE
fix(connectors): GitLab — RFR loop on full-refresh streams + max-workers via secret

### DIFF
--- a/src/ingestion/connectors/git/gitlab/source_gitlab/spec.json
+++ b/src/ingestion/connectors/git/gitlab/source_gitlab/spec.json
@@ -64,7 +64,7 @@
         "order": 6
       },
       "gitlab_max_workers": {
-        "type": "integer",
+        "type": ["integer", "string"],
         "title": "Max Concurrent Requests",
         "description": "Maximum number of GitLab API requests in flight at once. Higher values speed up large syncs but put more load on the instance; the connector still backs off reactively on HTTP 429. Raise it for a controlled self-hosted instance, lower it for a shared one.",
         "default": 8,

--- a/src/ingestion/connectors/git/gitlab/source_gitlab/streams/base.py
+++ b/src/ingestion/connectors/git/gitlab/source_gitlab/streams/base.py
@@ -87,6 +87,10 @@ class GitlabStream(HttpStream, ABC):
     def url_base(self) -> str:
         return f"{self._base_url}/api/v4/"
 
+    @property
+    def is_resumable(self) -> bool:
+        return self.supports_incremental
+
     def request_headers(
         self,
         stream_state: Mapping[str, Any] | None = None,

--- a/src/ingestion/connectors/git/gitlab/tests/test_resumability.py
+++ b/src/ingestion/connectors/git/gitlab/tests/test_resumability.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from source_gitlab.streams.branches import BranchesStream
+from source_gitlab.streams.commits import CommitsStream
+from source_gitlab.streams.concurrency import RequestGate
+from source_gitlab.streams.file_changes import CommitFileChangesStream
+from source_gitlab.streams.projects import ProjectsStream
+from source_gitlab.streams.users import UsersStream
+
+SH = dict(base_url="https://x", token="t", tenant_id="tn", source_id="s")
+
+
+def _streams() -> dict[str, object]:
+    p = ProjectsStream(groups=(), projects=(), **SH)
+    b = BranchesStream(parent=p, gate=RequestGate(2), **SH)
+    return {
+        "projects": p,
+        "users": UsersStream(groups=(), projects=(), **SH),
+        "branches": b,
+        "commits": CommitsStream(
+            parent=p, branches=b, gate=RequestGate(2), start_date="2025-01-01", **SH
+        ),
+        "file_changes": CommitFileChangesStream(
+            parent=p, branches=b, gate=RequestGate(2), start_date="2025-01-01", **SH
+        ),
+    }
+
+
+class TestResumability:
+    def test_full_refresh_streams_are_not_resumable(self) -> None:
+        streams = _streams()
+        for name in ("projects", "users", "branches"):
+            assert streams[name].is_resumable is False, name
+
+    def test_incremental_streams_are_resumable(self) -> None:
+        streams = _streams()
+        for name in ("commits", "file_changes"):
+            assert streams[name].is_resumable is True, name


### PR DESCRIPTION
Two deploy fixes (GitLab connector, found on dev bringup).

**RFR loop — critical.** Full-refresh streams (projects/users/branches) yield one `{}` slice, read fully in one `read_records` call → never advance RFR state. `HttpStream` defaults `is_resumable=True` → CDK `ResumableFullRefreshCheckpointReader` re-calls `read_records` on `{}` forever, re-emitting every record. `branches` looped → sync never finished → ~2300x dup rows.
Fix: `GitlabStream.is_resumable = supports_incremental` (full-refresh → single-pass; incremental → cursor reader). + regression test.

**max_workers 422.** Platform sends secret scalars as strings → `"16"` vs integer-only spec → Airbyte 422 on source create. Accept `["integer","string"]` (config already `int()`-coerces, clamps 1..32).

**Verify.** Earlier checks called `read_records` directly (skips the CDK checkpoint reader) and compared key-sets not row counts → missed it. Verify via full sync: streams terminate, rows ≈ unique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
