### PR TITLE
fix(jira): jira_issue_field_snapshot OOM'd ClickHouse — dedup without SELECT *

### DIFF
--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__issue_field_snapshot.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__issue_field_snapshot.sql
@@ -5,7 +5,11 @@
     schema='staging',
     engine='ReplacingMergeTree(_version)',
     order_by=['unique_key'],
-    settings={'allow_nullable_key': 1},
+    settings={
+        'allow_nullable_key': 1,
+        'max_bytes_before_external_group_by': 2000000000,
+        'max_bytes_before_external_sort': 2000000000,
+    },
     tags=['staging', 'jira']
 ) }}
 
@@ -42,11 +46,16 @@ WITH issue AS (
         -- so take the raw JSON and let the UNION branch parse it as Array(String).
         JSONExtractRaw(custom_fields_json, 'labels')                 AS labels_raw,
         due_date
-    FROM (
-        SELECT * FROM {{ source('bronze_jira', 'jira_issue') }}
-        ORDER BY _airbyte_extracted_at DESC
-        LIMIT 1 BY source_id, jira_id
-    ) AS ji
+    -- Read + dedup in ONE level, projecting only the small extracted columns.
+    -- The previous form `SELECT * ... ORDER BY ... LIMIT 1 BY` carried the
+    -- ~2 MB custom_fields_json of every row (≈140k issues on this instance)
+    -- through the sort buffer, blowing past ClickHouse's 7.2 GiB query memory
+    -- limit (code 241 MEMORY_LIMIT_EXCEEDED) — the model never built. Here the
+    -- JSON is read per row to compute the projections but only the extracted
+    -- (small) columns enter the ORDER BY / LIMIT 1 BY, so peak memory is tiny.
+    FROM {{ source('bronze_jira', 'jira_issue') }}
+    ORDER BY _airbyte_extracted_at DESC
+    LIMIT 1 BY source_id, jira_id
 )
 
 SELECT


### PR DESCRIPTION
## Problem

The jira staging dbt step fails on virtuozzo:

```
Database Error in model jira__issue_field_snapshot
Code: 241. DB::Exception: (total) memory limit exceeded: would use 7.20 GiB ...
maximum: 7.20 GiB ... MEMORY_LIMIT_EXCEEDED
```

`staging.jira_issue_field_snapshot` stays at **0 rows**, which fails `transform-jira-staging` → `enrich` and `transform-jira-silver` never run → the jira silver layer stays frozen. (Until #1421 this was hidden: the staging selector `tag:jira-staging` matched no models, so the model never even attempted to build. #1421 fixed the selector, exposing this.)

## Root cause

The dedup subquery:

```sql
SELECT * FROM jira_issue
ORDER BY _airbyte_extracted_at DESC
LIMIT 1 BY source_id, jira_id
```

`SELECT *` carries `custom_fields_json` (~2 MB/row — the connector keeps all fields) through the ORDER BY sort buffer. With ~140k issues that's hundreds of GB of sort payload → blows past ClickHouse's 7.2 GiB query limit. `max_bytes_before_external_sort` is 0 (no spill), so it OOMs instead of spilling.

## Fix

1. **Project the extracted (small) columns in the same SELECT that does `ORDER BY / LIMIT 1 BY`** — no `SELECT *`. The JSON is read per row to compute the `JSONExtract` projections but never enters the sort buffer.
2. Add `max_bytes_before_external_sort` / `max_bytes_before_external_group_by` (2 GB) to the model settings as a spill safety net.

## Verified (live virtuozzo bronze, `max_memory_usage` capped at 4 GiB)

The full model (dedup + 10× UNION ALL) completes under 4 GiB — well under the 7.2 GiB that failed — and returns **1,404,780 rows** (140,478 issues × 10 fields), all `unique_key` distinct.

> This is the last of the jira recovery chain. Ships with the toolbox image (dbt-only change, no manifest/descriptor bump). After it lands and the toolbox rebuilds, the nightly jira staging step will build the snapshot, enrich + silver will run, and the jira silver layer (frozen since early June) unfreezes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Jira issue data processing and deduplication for improved performance.
  * Enhanced memory management configuration for more efficient handling of large datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->