### PR TITLE
ci(backend): calculate code coverage baseline in backend checks

### DIFF
--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -1,15 +1,10 @@
 name: Backend Lint & Test
 
 on:
-  # Runs on PRs touching the backend (the lint/test gate) AND on push to main —
-  # GitHub's native code coverage compares each PR against the default-branch
-  # baseline, so main must upload coverage too. workflow_dispatch = manual rerun.
+  # PR-only gate (+ manual dispatch). Coverage is reported self-contained via a
+  # sticky PR comment + job summary — no external service, no default-branch
+  # baseline run needed (works on any plan, including Free).
   pull_request:
-    branches: [main]
-    paths:
-      - "src/backend/**"
-      - ".github/workflows/backend-checks.yml"
-  push:
     branches: [main]
     paths:
       - "src/backend/**"
@@ -26,11 +21,10 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
 
-# Uploading to GitHub's native code-coverage API needs code-quality: write;
-# everything else only reads the repo.
+# The coverage summary is posted as a sticky PR comment.
 permissions:
   contents: read
-  code-quality: write
+  pull-requests: write
 
 jobs:
   check:
@@ -42,10 +36,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          # Check out the PR head (not the merge commit) so coverage line
-          # numbers map to the diff; falls back to the pushed SHA on main.
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
@@ -70,20 +60,38 @@ jobs:
 
       # cargo-llvm-cov runs the suite under coverage instrumentation (this
       # replaces the plain `cargo test`, so tests still run) and emits a single
-      # Cobertura report for upload.
+      # Cobertura report.
       - name: Run tests with coverage
         run: |
           cargo llvm-cov --no-report --all-features --workspace
           cargo llvm-cov report --cobertura --output-path cobertura.xml
 
-      - name: Upload coverage to GitHub
-        uses: actions/upload-code-coverage@v1
+      # Cobertura -> markdown summary (no HTML, no .NET SDK). This is a Docker
+      # action that runs at the workspace root, so the path is repo-root-relative
+      # and code-coverage-results.md is written there.
+      - name: Coverage summary
+        uses: irongut/CodeCoverageSummary@v1.3.0
         with:
-          file: src/backend/cobertura.xml
-          language: Rust
-          label: code-coverage/rust
-          # Report-only: a coverage-upload hiccup must never fail the gate.
-          fail-on-error: false
+          filename: src/backend/cobertura.xml
+          format: markdown
+          output: both
+          badge: true
+          hide_complexity: true
+          fail_below_min: false # report-only — never fail the job
+          thresholds: "60 80"
+
+      - name: Post coverage PR comment
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: rust-backend-coverage
+          recreate: true
+          path: code-coverage-results.md
+
+      - name: Coverage to job summary
+        if: always()
+        run: cat "$GITHUB_WORKSPACE/code-coverage-results.md" >> "$GITHUB_STEP_SUMMARY"
 
   dotnet-identity:
     name: .NET — Identity Service Build & Test
@@ -94,8 +102,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: actions/setup-dotnet@v4
         with:
@@ -128,17 +134,33 @@ jobs:
           --collect:"XPlat Code Coverage" --results-directory ./coverage
 
       # The two test runs each emit a Cobertura file for the same assemblies;
-      # merge them into one report (the upload action takes a single file).
+      # merge them into one report (CodeCoverageSummary takes a single file).
       - name: Merge coverage
         run: |
           dotnet tool install --global dotnet-coverage
           export PATH="$PATH:$HOME/.dotnet/tools"
           dotnet-coverage merge -f cobertura -o merged.cobertura.xml coverage/*/coverage.cobertura.xml
 
-      - name: Upload coverage to GitHub
-        uses: actions/upload-code-coverage@v1
+      - name: Coverage summary
+        uses: irongut/CodeCoverageSummary@v1.3.0
         with:
-          file: src/backend/services/identity/merged.cobertura.xml
-          language: C#
-          label: code-coverage/identity
-          fail-on-error: false
+          filename: src/backend/services/identity/merged.cobertura.xml
+          format: markdown
+          output: both
+          badge: true
+          hide_complexity: true
+          fail_below_min: false # report-only — never fail the job
+          thresholds: "60 80"
+
+      - name: Post coverage PR comment
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: dotnet-identity-coverage
+          recreate: true
+          path: code-coverage-results.md
+
+      - name: Coverage to job summary
+        if: always()
+        run: cat "$GITHUB_WORKSPACE/code-coverage-results.md" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -1,22 +1,23 @@
 name: Backend Lint & Test
 
 on:
-  # PR-only: every change touching the backend must pass these checks before
-  # it lands. Re-running the same suite on the merge commit just burns minutes
-  # — the PR already proved the tree is green, and branch protection ensures
-  # nothing reaches `main` without that PR. Use workflow_dispatch for an
-  # explicit manual rerun against `main` (e.g. after a runner-image rollover
-  # that might shift behaviour).
+  # Runs on PRs touching the backend (the lint/test gate) AND on push to main —
+  # GitHub's native code coverage compares each PR against the default-branch
+  # baseline, so main must upload coverage too. workflow_dispatch = manual rerun.
   pull_request:
+    branches: [main]
+    paths:
+      - "src/backend/**"
+      - ".github/workflows/backend-checks.yml"
+  push:
     branches: [main]
     paths:
       - "src/backend/**"
       - ".github/workflows/backend-checks.yml"
   workflow_dispatch:
 
-# A new push to a PR obsoletes any run still in flight for the same ref. Cancel
-# it so a rebase/force-push (or rapid re-pushes) doesn't leave a stale, slow
-# instrumented coverage build burning runner minutes in parallel.
+# A new push obsoletes any run still in flight for the same ref — cancel it so a
+# rebase/force-push doesn't leave a slow instrumented build burning minutes.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -25,11 +26,11 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
 
-# The coverage steps post a sticky PR comment, which needs write access to the
-# pull request. Everything else in this workflow only reads the repo.
+# Uploading to GitHub's native code-coverage API needs code-quality: write;
+# everything else only reads the repo.
 permissions:
   contents: read
-  pull-requests: write
+  code-quality: write
 
 jobs:
   check:
@@ -41,6 +42,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Check out the PR head (not the merge commit) so coverage line
+          # numbers map to the diff; falls back to the pushed SHA on main.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Install protoc
         run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
@@ -61,54 +66,24 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets --all-features
 
-      # cargo-llvm-cov runs the suite under LLVM source-based coverage
-      # instrumentation — this replaces the plain `cargo test --all`, so the
-      # tests still run and we capture coverage from the same pass. The
-      # instrumented build uses different RUSTFLAGS than the clippy/test cache,
-      # so it recompiles the workspace and runs slower than a bare test pass.
       - uses: taiki-e/install-action@cargo-llvm-cov
 
+      # cargo-llvm-cov runs the suite under coverage instrumentation (this
+      # replaces the plain `cargo test`, so tests still run) and emits a single
+      # Cobertura report for upload.
       - name: Run tests with coverage
         run: |
           cargo llvm-cov --no-report --all-features --workspace
-          cargo llvm-cov report --html
           cargo llvm-cov report --cobertura --output-path cobertura.xml
-          cargo llvm-cov report --summary-only
 
-      # cargo-llvm-cov already emitted the source-annotated HTML report under
-      # target/llvm-cov/html (best fidelity for Rust). ReportGenerator (a .NET
-      # global tool, hence the SDK install) is used only to render the aggregate
-      # Cobertura numbers as a GitHub markdown summary for the PR comment.
-      - uses: actions/setup-dotnet@v4
+      - name: Upload coverage to GitHub
+        uses: actions/upload-code-coverage@v1
         with:
-          dotnet-version: "9.0.x"
-
-      - name: Generate markdown coverage summary
-        run: |
-          dotnet tool install --global dotnet-reportgenerator-globaltool
-          export PATH="$PATH:$HOME/.dotnet/tools"
-          reportgenerator \
-            -reports:cobertura.xml \
-            -targetdir:coverage-report \
-            -reporttypes:"MarkdownSummaryGithub" \
-            -title:"Rust backend"
-
-      - name: Upload HTML coverage report
-        uses: actions/upload-artifact@v4
-        with:
-          name: rust-backend-coverage-html
-          path: src/backend/target/llvm-cov/html
-
-      # Report-only: posts/updates a sticky comment, never fails the job
-      # (continue-on-error keeps fork PRs — read-only token — green).
-      - name: Post coverage PR comment
-        if: github.event_name == 'pull_request'
-        continue-on-error: true
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: rust-backend-coverage
-          recreate: true
-          path: src/backend/coverage-report/SummaryGithub.md
+          file: src/backend/cobertura.xml
+          language: Rust
+          label: code-coverage/rust
+          # Report-only: a coverage-upload hiccup must never fail the gate.
+          fail-on-error: false
 
   dotnet-identity:
     name: .NET — Identity Service Build & Test
@@ -119,6 +94,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - uses: actions/setup-dotnet@v4
         with:
@@ -150,29 +127,18 @@ jobs:
           --no-build --configuration Release
           --collect:"XPlat Code Coverage" --results-directory ./coverage
 
-      # Merge the unit + integration Cobertura outputs into one HTML report
-      # (artifact) plus a GitHub markdown summary (PR comment). Report-only.
-      - name: Generate coverage report
+      # The two test runs each emit a Cobertura file for the same assemblies;
+      # merge them into one report (the upload action takes a single file).
+      - name: Merge coverage
         run: |
-          dotnet tool install --global dotnet-reportgenerator-globaltool
+          dotnet tool install --global dotnet-coverage
           export PATH="$PATH:$HOME/.dotnet/tools"
-          reportgenerator \
-            -reports:"coverage/**/coverage.cobertura.xml" \
-            -targetdir:coverage/report \
-            -reporttypes:"Html;MarkdownSummaryGithub" \
-            -title:"Identity (.NET)"
+          dotnet-coverage merge -f cobertura -o merged.cobertura.xml coverage/*/coverage.cobertura.xml
 
-      - name: Upload HTML coverage report
-        uses: actions/upload-artifact@v4
+      - name: Upload coverage to GitHub
+        uses: actions/upload-code-coverage@v1
         with:
-          name: dotnet-identity-coverage-html
-          path: src/backend/services/identity/coverage/report
-
-      - name: Post coverage PR comment
-        if: github.event_name == 'pull_request'
-        continue-on-error: true
-        uses: marocchino/sticky-pull-request-comment@v2
-        with:
-          header: dotnet-identity-coverage
-          recreate: true
-          path: src/backend/services/identity/coverage/report/SummaryGithub.md
+          file: src/backend/services/identity/merged.cobertura.xml
+          language: C#
+          label: code-coverage/identity
+          fail-on-error: false

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -14,6 +14,13 @@ on:
       - ".github/workflows/backend-checks.yml"
   workflow_dispatch:
 
+# A new push to a PR obsoletes any run still in flight for the same ref. Cancel
+# it so a rebase/force-push (or rapid re-pushes) doesn't leave a stale, slow
+# instrumented coverage build burning runner minutes in parallel.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -18,6 +18,12 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
 
+# The coverage steps post a sticky PR comment, which needs write access to the
+# pull request. Everything else in this workflow only reads the repo.
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   check:
     name: Lint & Test
@@ -35,7 +41,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: "1.95.0"
-          components: rustfmt, clippy
+          # llvm-tools-preview ships the LLVM coverage tooling cargo-llvm-cov drives.
+          components: rustfmt, clippy, llvm-tools-preview
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -47,8 +54,54 @@ jobs:
       - name: Clippy
         run: cargo clippy --all-targets --all-features
 
-      - name: Run tests
-        run: cargo test --all
+      # cargo-llvm-cov runs the suite under LLVM source-based coverage
+      # instrumentation — this replaces the plain `cargo test --all`, so the
+      # tests still run and we capture coverage from the same pass. The
+      # instrumented build uses different RUSTFLAGS than the clippy/test cache,
+      # so it recompiles the workspace and runs slower than a bare test pass.
+      - uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Run tests with coverage
+        run: |
+          cargo llvm-cov --no-report --all-features --workspace
+          cargo llvm-cov report --html
+          cargo llvm-cov report --cobertura --output-path cobertura.xml
+          cargo llvm-cov report --summary-only
+
+      # cargo-llvm-cov already emitted the source-annotated HTML report under
+      # target/llvm-cov/html (best fidelity for Rust). ReportGenerator (a .NET
+      # global tool, hence the SDK install) is used only to render the aggregate
+      # Cobertura numbers as a GitHub markdown summary for the PR comment.
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "9.0.x"
+
+      - name: Generate markdown coverage summary
+        run: |
+          dotnet tool install --global dotnet-reportgenerator-globaltool
+          export PATH="$PATH:$HOME/.dotnet/tools"
+          reportgenerator \
+            -reports:cobertura.xml \
+            -targetdir:coverage-report \
+            -reporttypes:"MarkdownSummaryGithub" \
+            -title:"Rust backend"
+
+      - name: Upload HTML coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: rust-backend-coverage-html
+          path: src/backend/target/llvm-cov/html
+
+      # Report-only: posts/updates a sticky comment, never fails the job
+      # (continue-on-error keeps fork PRs — read-only token — green).
+      - name: Post coverage PR comment
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: rust-backend-coverage
+          recreate: true
+          path: src/backend/coverage-report/SummaryGithub.md
 
   dotnet-identity:
     name: .NET — Identity Service Build & Test
@@ -82,8 +135,37 @@ jobs:
         run: >
           dotnet test tests/Insight.Identity.Tests.Unit/Insight.Identity.Tests.Unit.csproj
           --no-build --configuration Release
+          --collect:"XPlat Code Coverage" --results-directory ./coverage
 
       - name: Integration tests (Testcontainers MariaDB)
         run: >
           dotnet test tests/Insight.Identity.Tests.Integration/Insight.Identity.Tests.Integration.csproj
           --no-build --configuration Release
+          --collect:"XPlat Code Coverage" --results-directory ./coverage
+
+      # Merge the unit + integration Cobertura outputs into one HTML report
+      # (artifact) plus a GitHub markdown summary (PR comment). Report-only.
+      - name: Generate coverage report
+        run: |
+          dotnet tool install --global dotnet-reportgenerator-globaltool
+          export PATH="$PATH:$HOME/.dotnet/tools"
+          reportgenerator \
+            -reports:"coverage/**/coverage.cobertura.xml" \
+            -targetdir:coverage/report \
+            -reporttypes:"Html;MarkdownSummaryGithub" \
+            -title:"Identity (.NET)"
+
+      - name: Upload HTML coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: dotnet-identity-coverage-html
+          path: src/backend/services/identity/coverage/report
+
+      - name: Post coverage PR comment
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: dotnet-identity-coverage
+          recreate: true
+          path: src/backend/services/identity/coverage/report/SummaryGithub.md

--- a/src/backend/services/identity/tests/Insight.Identity.Tests.Integration/Insight.Identity.Tests.Integration.csproj
+++ b/src/backend/services/identity/tests/Insight.Identity.Tests.Integration/Insight.Identity.Tests.Integration.csproj
@@ -5,6 +5,12 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <!-- Coverlet data collector. Backs the "XPlat Code Coverage" collector that
+         dotnet test runs to emit Cobertura coverage. Dev-only asset; never shipped. -->
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />

--- a/src/backend/services/identity/tests/Insight.Identity.Tests.Unit/Insight.Identity.Tests.Unit.csproj
+++ b/src/backend/services/identity/tests/Insight.Identity.Tests.Unit/Insight.Identity.Tests.Unit.csproj
@@ -5,6 +5,12 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <!-- Coverlet data collector. Backs the "XPlat Code Coverage" collector that
+         dotnet test runs to emit Cobertura coverage. Dev-only asset; never shipped. -->
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="FluentAssertions" Version="6.12.2" />


### PR DESCRIPTION
## What

Adds **report-only, self-contained** code-coverage reporting for `src/backend` to the `Backend Lint & Test` workflow — a coverage summary on every backend PR, with no external service and no plan requirement (works on Free).

- **Rust workspace** (`analytics-api`, `api-gateway`, `insight-clickhouse`, `oidc-authn-plugin`): `cargo-llvm-cov` runs the suite under instrumentation (replacing plain `cargo test`, so tests still run) and emits a single Cobertura report.
- **Identity (.NET)**: `dotnet test --collect:"XPlat Code Coverage"` on the unit + integration projects; the two Cobertura files are merged with `dotnet-coverage`.
- Each is rendered to markdown by `irongut/CodeCoverageSummary` and posted as a **sticky PR comment** + appended to the **Actions job summary**. No HTML, no artifacts, no Codecov.

Adds `coverlet.collector` (dev-only, `PrivateAssets=all`) to the two Identity test projects so the `XPlat Code Coverage` collector emits Cobertura.

## Baseline (from CI, all tests green)

| Component | Line | Notes |
|---|---|---|
| Rust workspace | **62%** (4392/7129) | insight-clickhouse 89%, oidc-authn-plugin 86%, api-gateway 0% (thin binary, no tests), analytics-api mixed |
| Identity (.NET) | **87%** (2618/3011), branch 81% | Domain 97%, Api 86%, Infrastructure 83% |

## Scope / non-goals

Deliberately thin — only **calculates and exposes** the baseline. Out of scope (future follow-ups under #1384): coverage gates / ratchet, a shared task-runner so local == CI, `cargo-nextest`, connector (Python) coverage.

**GitHub-native coverage (Code Quality) was evaluated and rejected for now:** it's a paid Team/Enterprise-Cloud product (GA 2026-07-20, $10/active-committer/mo), *not* free for public repos, and this org is on Free — the upload API returns HTTP 403 ("Code quality is not enabled for this repository"). The Cobertura we emit would feed it directly (`actions/upload-code-coverage`) if the org ever upgrades.

## Test plan

- `backend-checks.yml` runs on this PR (touches `src/backend/**` + the workflow). Both jobs run the full unit (+ integration) suites and post their coverage comments.
- Verified on CI and locally in containers: Rust 315 tests pass; Identity unit + integration pass.

Closes #1384

🤖 Generated with [Claude Code](https://claude.com/claude-code)
