### PR TITLE
chart(insight): drop L2 subchart bundling (clickhouse/mariadb/redis/redpanda)

### DIFF
--- a/charts/insight/Chart.lock
+++ b/charts/insight/Chart.lock
@@ -1,16 +1,4 @@
 dependencies:
-- name: clickhouse
-  repository: file://../../helmfile/charts/clickhouse
-  version: 0.1.0
-- name: mariadb
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 20.0.0
-- name: redis
-  repository: oci://registry-1.docker.io/bitnamicharts
-  version: 21.0.3
-- name: redpanda
-  repository: https://charts.redpanda.com
-  version: 5.0.10
 - name: insight-api-gateway
   repository: file://../../src/backend/services/api-gateway/helm
   version: 0.1.0
@@ -23,5 +11,5 @@ dependencies:
 - name: insight-frontend
   repository: file://../../src/frontend/helm
   version: 0.1.0
-digest: sha256:c459b435deac85d6312a9ac5ad4022c3e4f2c9d62d972b237a24b8b7fa915b69
-generated: "2026-05-12T13:07:43.7606569+02:00"
+digest: sha256:7556fa96a2d4a77c01f410c944290f88f8bf0d701a7ffe55dbcc7da1cfe58c38
+generated: "2026-06-22T13:27:58.875272+02:00"

--- a/charts/insight/Chart.yaml
+++ b/charts/insight/Chart.yaml
@@ -5,10 +5,12 @@
 ## Emits almost nothing on its own — it orchestrates subcharts.
 ##
 ## What is INCLUDED here:
-##   - Infrastructure: ClickHouse, MariaDB, Redis, Redpanda
-##   - Application:    api-gateway, analytics-api, identity, frontend
+##   - Application: api-gateway, analytics-api, identity, frontend
 ##
 ## What is NOT included (deployed separately):
+##   - L2 infra (ClickHouse, MariaDB, Redis, Redpanda) — deployed as
+##     separate releases in `insight-infra` via gitops `make system-*`.
+##     The umbrella only dials them through `<dep>.host` wiring.
 ##   - Airbyte        — see scripts/install-airbyte.sh
 ##   - Argo Workflows — see scripts/install-argo.sh
 ##
@@ -22,7 +24,7 @@ type: application
 # version    — packaging version of the chart. Bump on EVERY chart change.
 # appVersion — product version. Matches the image tag of all insight-* images.
 # Release pipeline: git tag v0.1.0 → version=0.1.0, appVersion="0.1.0".
-version: 0.1.84
+version: 0.2.0
 appVersion: "2026.06.19.10.39-e006ef2"
 kubeVersion: ">=1.27.0-0"
 home: https://github.com/constructorfabric/insight
@@ -33,10 +35,15 @@ maintainers:
     url: https://github.com/constructorfabric
 # Dependencies — the heart of the umbrella.
 #
+# This chart bundles ONLY the first-party application services. The L2
+# infrastructure (ClickHouse, MariaDB, Redis, Redpanda) is deployed
+# separately in `insight-infra` via gitops `make system-*`; the umbrella
+# dials those out-of-chart hosts through `<dep>.host` wiring in values.yaml.
+#
 # Fields:
 #   name        — dependency chart name (must match the dependency's Chart.yaml name)
-#   version     — strict pin for first-party charts, ~X.Y for bitnami/redpanda
-#   repository  — file:// for local charts, oci:// / https:// for remote
+#   version     — strict pin for first-party charts
+#   repository  — file:// for local app-service charts
 #   condition   — toggle in values (path to a boolean field)
 #   alias       — short key name in values.yaml (otherwise the full chart name is needed)
 #
@@ -45,31 +52,6 @@ maintainers:
 #   2. add a matching block in values.yaml under the same key (or alias)
 #
 dependencies:
-  # ─── Infrastructure ─────────────────────────────────────────────────────
-
-  # ClickHouse — OLAP store. Local wrapper chart so we keep control over
-  # keeper/shards/macros configuration.
-  - name: clickhouse
-    version: "0.1.0"
-    repository: "file://../../helmfile/charts/clickhouse"
-    condition: clickhouse.deploy
-  # MariaDB — operational DB (tenants, plugin installs, configs).
-  # Bitnami chart, OCI registry. Semver ~20.0.0 = 20.x security patches.
-  - name: mariadb
-    version: "~20.0.0"
-    repository: "oci://registry-1.docker.io/bitnamicharts"
-    condition: mariadb.deploy
-  # Redis — query response cache for analytics-api.
-  - name: redis
-    version: "~21.0.0"
-    repository: "oci://registry-1.docker.io/bitnamicharts"
-    condition: redis.deploy
-  # Redpanda — event bus (notifications, audit log, future).
-  # Kafka-compatible, simpler to operate.
-  - name: redpanda
-    version: "~5.0.0"
-    repository: "https://charts.redpanda.com"
-    condition: redpanda.deploy
   # ─── Application services ──────────────────────────────────────────────
   # All aliases are camelCase so values.yaml stays clean.
   # Service names inside the cluster stay kebab-case: `insight-api-gateway`.

--- a/charts/insight/README.md
+++ b/charts/insight/README.md
@@ -8,12 +8,11 @@ Single canonical unit of delivery for the Insight platform.
 
 ## What it contains
 
+The umbrella bundles ONLY the first-party application services. Each is a
+local `file://` subchart:
+
 | Component             | Kind                 | Source                                       | Toggle                          |
 |-----------------------|----------------------|----------------------------------------------|---------------------------------|
-| ClickHouse            | infra                | `helmfile/charts/clickhouse` (local wrapper) | `clickhouse.deploy`             |
-| MariaDB               | infra                | bitnami/mariadb ~20                          | `mariadb.deploy`                |
-| Redis                 | infra                | bitnami/redis ~21                            | `redis.deploy`                  |
-| Redpanda              | infra                | redpanda/redpanda ~5                         | `redpanda.deploy`               |
 | API Gateway           | app service (req'd)  | `src/backend/services/api-gateway/helm`      | mandatory (no flag)             |
 | Analytics API         | app service (req'd)  | `src/backend/services/analytics-api/helm`    | mandatory (no flag)             |
 | Frontend (SPA)        | app service (req'd)  | `src/frontend/helm`                          | mandatory (no flag)             |
@@ -23,11 +22,12 @@ Single canonical unit of delivery for the Insight platform.
 
 ## What it does NOT contain
 
-| Component        | Why separate                                          | How to install                 |
-|------------------|-------------------------------------------------------|--------------------------------|
-| Airbyte          | Heavy (10+ pods), its own release cadence             | Separate helm release          |
-| Argo Workflows   | Cluster-scoped infra, often shared across products    | Separate helm release          |
-| Plugins          | Runtime-managed via UI (not Helm — see architecture)  | Through platform API           |
+| Component                          | Why separate                                          | How to install                              |
+|------------------------------------|-------------------------------------------------------|---------------------------------------------|
+| ClickHouse / MariaDB / Redis / Redpanda (L2 infra) | Operated independently; shared lifecycle / managed services | Separate releases in `insight-infra` (gitops `make system-*`); the umbrella dials them via `<dep>.host` |
+| Airbyte                            | Heavy (10+ pods), its own release cadence             | Separate helm release                       |
+| Argo Workflows                     | Cluster-scoped infra, often shared across products    | Separate helm release                       |
+| Plugins                            | Runtime-managed via UI (not Helm — see architecture)  | Through platform API                        |
 
 See [`docs/distribution/README.md`](../../docs/distribution/README.md) for the full distribution model.
 
@@ -35,7 +35,7 @@ See [`docs/distribution/README.md`](../../docs/distribution/README.md) for the f
 
 **This chart assumes release name = `insight`.**
 
-Internal DNS references (e.g. `http://insight-analytics-api:8081`, `http://insight-clickhouse:8123`) are hardcoded in `values.yaml` with the `insight-` prefix. Helm subcharts use `{{ .Release.Name }}-{chart-suffix}` for service naming, which produces these exact names when the release is `insight`.
+Internal DNS references between app services (e.g. `http://insight-analytics-api:8081`, `http://insight-identity:8082`) are templated with the `insight-` prefix. Helm subcharts use `{{ .Release.Name }}-{chart-suffix}` for service naming, which produces these exact names when the release is `insight`. (External L2 infra is reached via the explicit `<dep>.host` wiring, not the release-name convention.)
 
 If you install under a different name, override all cross-service URLs in your own values.yaml. Prefer sticking to the convention.
 
@@ -67,26 +67,19 @@ Before going to prod:
 - [ ] Set OIDC via `apiGateway.oidc.existingSecret` (preferred) or all three of `issuer` + `clientId` + `redirectUri` together. Never inline secrets.
 - [ ] Enable ingress + TLS: `apiGateway.ingress`, `frontend.ingress`
 - [ ] Bump resources where needed (default `requests` are conservative)
-- [ ] `redpanda.tls.enabled: true`, `redpanda.auth.sasl.enabled: true`
-- [ ] Point MariaDB/ClickHouse/Redis/Redpanda to external managed services if running inside Constructor Platform — set `<dep>.deploy: false` and fill `<dep>.host` / `.port` / `.passwordSecret`. App-service URLs follow automatically (resolved by helpers).
+- [ ] Provision the L2 infra (ClickHouse / MariaDB / Redis / Redpanda) out-of-chart and fill `<dep>.host` / `.port` / `.passwordSecret`. App-service URLs follow automatically (resolved by helpers).
 - [ ] Set `global.imagePullSecrets` if pulling from a private registry
 
-## Integration modes
+## Infra wiring
 
-The chart uses ONE unified shape per infra dependency (ClickHouse, MariaDB, Redis, Redpanda). The `deploy` flag toggles whether the umbrella runs the subchart; everything else (host, port, credentials) is the same data the consumers read in either case.
+L2 infra (ClickHouse, MariaDB, Redis, Redpanda) is always **external** — deployed out-of-chart as separate releases in `insight-infra` (gitops `make system-*`), or pointed at managed services. The umbrella only carries the wiring it needs to dial them:
 
-**Standalone** (eval, on-prem single-tenant, dev):
-- `<dep>.deploy: true` — the umbrella runs the subchart.
-- `<dep>.host: ""` — defaults to `{release}-<dep>` (internal in-cluster service).
-- `<dep>.passwordSecret` points at `insight-db-creds`, which the umbrella auto-generates on first install (or you pre-create for BYO).
+- `<dep>.host` is required (the validator / helpers fail fast otherwise). Redpanda uses `<dep>.brokers`.
+- `<dep>.port` / `.database` / `.username` as applicable.
+- `<dep>.passwordSecret` points at a Secret in the namespace (e.g. `insight-db-creds`) — auto-generated by the umbrella, mirrored by a platform operator, or pre-created (BYO).
+- App-service URLs are computed by helpers from `<dep>.host` / `.port`, so no extra overrides are needed.
 
-**Constructor Platform component** (Insight ships inside the platform):
-- `<dep>.deploy: false` — the umbrella does NOT run the subchart.
-- `<dep>.host` is required (validator fails fast otherwise).
-- `<dep>.passwordSecret` points at a Secret the platform created in the namespace.
-- App-service URLs are computed by helpers from the same `<dep>.host` / `.port`, so no extra overrides are needed.
-
-The umbrella validator (`templates/_helpers.tpl` → `insight.validate`) fails fast on the typical typos: `deploy: false` without `host`, OIDC enabled without `existingSecret` or all inline fields, missing `passwordSecret.{name,key}`.
+The umbrella validator (`templates/_helpers.tpl` → `insight.validate`) fails fast on the typical typos: missing `<dep>.host` / `.brokers`, OIDC enabled without `existingSecret` or all inline fields, missing `passwordSecret.{name,key}`.
 
 ## Values reference
 
@@ -95,38 +88,13 @@ See comments in [`values.yaml`](./values.yaml) — every block is documented inl
 Key groups:
 
 - `credentials.autoGenerate` — toggle umbrella-managed `insight-db-creds`
-- `global.*` — cluster-wide defaults (pull secrets, storage class, bitnami image policy)
-- `<dep>.deploy` / `<dep>.host` / `<dep>.port` / `<dep>.passwordSecret` — unified shape for ClickHouse, MariaDB, Redis, Redpanda
+- `global.*` — cluster-wide defaults (pull secrets, storage class)
+- `<dep>.host` / `<dep>.port` / `<dep>.passwordSecret` (Redpanda: `<dep>.brokers`) — external-infra wiring for ClickHouse, MariaDB, Redis, Redpanda
 - `apiGateway` / `analyticsApi` / `frontend` — **mandatory** app services (no deploy-flag; the gateway is the single entrance and the product is one unit)
 - `identity.deploy` — **optional** .NET identity service (off by default; not an OIDC provider)
 - `apiGateway.oidc` — OIDC configuration (prefer `existingSecret`; inline requires `issuer` + `clientId` + `redirectUri` together)
 - `apiGateway.proxy.routes` — reverse-proxy config to downstream services
 - `ingestion.templates.enabled` — whether to ship Argo WorkflowTemplates; requires Argo CRDs to be present in the cluster
-
-## Bitnami Legacy images — maintenance model
-
-In late 2025 Bitnami removed free image distribution from `docker.io/bitnami/*` ([bitnami/charts#30850](https://github.com/bitnami/charts/issues/30850)) and moved unsupported tags to a `docker.io/bitnamilegacy/*` namespace. The umbrella points the bundled MariaDB and Redis subcharts at `bitnamilegacy` so the eval / on-prem path keeps working without a paid Bitnami subscription. This is documented inline in `values.yaml` (`mariadb.image.repository`, `redis.image.repository`).
-
-**Ownership and cadence.** Insight maintainers own the upgrade cadence for these images. The chart `~20.0.0` / `~21.0.0` constraints allow patch-level (CVE) bumps, but **minor releases require an explicit chart edit** — minors can carry breaking changes that need verification.
-
-- **CVE-driven bumps**: tracked via Renovate against `bitnamilegacy/mariadb` and `bitnamilegacy/redis` tags; a critical CVE in either image opens a PR within 24h.
-- **Routine bumps**: scheduled monthly review of the `~MAJOR.0.0` constraint window. Minor-version bumps (e.g. `mariadb 20.x → 21.x`) ship in a dedicated PR with regression tests.
-- **Upstream deprecation risk**: if Bitnami deprecates `bitnamilegacy/*` (no announced timeline as of 2026-04), Insight will mirror the last-good tags into a self-hosted registry and update `image.repository` / `image.registry` in `values.yaml`.
-
-**Enterprise customers** with a Bitnami subscription or an internal mirror should override the registry once in their values overlay:
-
-```yaml
-mariadb:
-  image:
-    registry: registry.internal.example.com
-    repository: my-mirror/mariadb
-redis:
-  image:
-    registry: registry.internal.example.com
-    repository: my-mirror/redis
-```
-
-…and unset `global.security.allowInsecureImages` (the Bitnami chart's `secure-images` allowlist will accept your registry once images come from a non-`bitnamilegacy` path).
 
 ## Operations
 
@@ -145,27 +113,6 @@ helm -n insight rollback insight <REVISION>
 helm -n insight uninstall insight
 kubectl -n insight delete pvc -l app.kubernetes.io/part-of=insight
 ```
-
-## Subchart prerequisites (done as part of this change)
-
-To make the umbrella compose cleanly, two subcharts were patched:
-
-- `helmfile/charts/clickhouse` — added `clickhouse.fullname` helper so the Service is named `<release>-clickhouse`, not just `<release>`.
-- `src/frontend/helm` — changed `insight-frontend.fullname` to append `-frontend`, so it doesn't collide with other resources that use bare `{release}`.
-
-Both charts remain compatible with the existing Helmfile (`helmfile sync`) — they add a suffix that wasn't there before, so service names under Helmfile become `clickhouse-clickhouse` / `frontend-frontend`. If Helmfile references old names anywhere, update those too.
-
-## Relationship to `helmfile.yaml.gotmpl`
-
-| Concern           | `helmfile` (dev)                   | umbrella (distribution)            |
-|-------------------|------------------------------------|------------------------------------|
-| Audience          | Developers                          | Customers / GitOps                 |
-| Invocation        | `helmfile -e local sync`            | `helm install insight charts/insight` |
-| Templating        | gotmpl DSL                          | Pure Helm + YAML                   |
-| Secret injection  | `.env.local` → helmfile vars        | `existingSecret` references        |
-| Publishing        | Not published                       | OCI registry (`helm push`)          |
-
-They coexist. Devs keep using Helmfile locally for fast iteration; distribution goes through the umbrella.
 
 ## Publishing (release workflow — not wired up yet)
 

--- a/charts/insight/templates/NOTES.txt
+++ b/charts/insight/templates/NOTES.txt
@@ -7,11 +7,11 @@
 Release:    {{ .Release.Name }}
 Revision:   {{ .Release.Revision }}
 
-Resolved infra endpoints (see ConfigMap {{ .Release.Name }}-platform):
-  ClickHouse:  {{ include "insight.clickhouse.url" . }}  {{ if not .Values.clickhouse.deploy }}[external]{{ end }}
-  MariaDB:     {{ include "insight.mariadb.host" . }}:{{ include "insight.mariadb.port" . }}  {{ if not .Values.mariadb.deploy }}[external]{{ end }}
-  Redis:       {{ include "insight.redis.url" . }}  {{ if not .Values.redis.deploy }}[external]{{ end }}
-  Redpanda:    {{ include "insight.redpanda.brokers" . }}  {{ if not .Values.redpanda.deploy }}[external]{{ end }}
+Resolved infra endpoints (external L2, see ConfigMap {{ .Release.Name }}-platform):
+  ClickHouse:  {{ include "insight.clickhouse.url" . }}
+  MariaDB:     {{ include "insight.mariadb.host" . }}:{{ include "insight.mariadb.port" . }}
+  Redis:       {{ include "insight.redis.url" . }}
+  Redpanda:    {{ include "insight.redpanda.brokers" . }}
   Airbyte:     {{ include "insight.airbyte.url" . }}
 
 Application services (always-on):

--- a/charts/insight/templates/_helpers.tpl
+++ b/charts/insight/templates/_helpers.tpl
@@ -3,11 +3,9 @@
  Umbrella helpers
 ==============================================================================
 Central place for release/component names (DRY) and service-reference
-resolution. No separate `internal` vs `external` paths — each dep has a
-single `host`/`port` field that either carries a default (empty → compute
-from release name) or a user-supplied value (e.g. a Constructor Platform
-hostname). The `deploy` flag only controls whether the umbrella itself
-runs the dep as a subchart.
+resolution. L2 infra (ClickHouse/MariaDB/Redis/Redpanda) is always
+external — deployed out-of-chart at L2 — so each dep's `host`/`brokers`
+field MUST be supplied; the helpers `required`-fail when it is empty.
 
 Every fail-fast check lives in `insight.validate` at the bottom.
 ==============================================================================
@@ -30,42 +28,31 @@ app.kubernetes.io/part-of: insight
 ==============================================================================
  SERVICE RESOLUTION
 ==============================================================================
-Contract per dep:
-  - `<dep>.host` — if empty, defaults to the internal service name.
+Contract per dep (all infra is external — out-of-chart L2):
+  - `<dep>.host` — required (the helper `required`-fails when empty).
   - `<dep>.port` — required (has a value in values.yaml default).
   - `<dep>.url`  — composed "<scheme>://<host>:<port>" via helpers below.
-  - `<dep>.fqdn` — fully-qualified DNS when the dep is internal, host
-                   verbatim when external — useful for services that live
-                   OUTSIDE the cluster but are resolved via kubelet.
+  - `<dep>.fqdn` — the operator-supplied host verbatim.
 ==============================================================================
 */}}
 
 {{/* ---------- ClickHouse ---------- *
      `host` resolution is fail-fast at the helper level (defense-in-depth):
-     - deploy=true  → if .host is empty, default to `{release}-clickhouse`
-                      (the bundled subchart Service name).
-     - deploy=false → .host MUST be supplied; we `required`-fail right here
-                      so any consumer that resolves the host before the
-                      validator template renders still gets a readable
-                      error rather than an empty/stale value. */}}
+     CH is external (out-of-chart L2), so `.host` MUST be supplied; we
+     `required`-fail right here so any consumer that resolves the host
+     before the validator template renders still gets a readable error
+     rather than an empty/stale value. */}}
 {{- define "insight.clickhouse.host" -}}
-{{- if .Values.clickhouse.deploy -}}
-{{- default (printf "%s-clickhouse" .Release.Name) .Values.clickhouse.host -}}
-{{- else -}}
-{{- required "clickhouse.host is required when clickhouse.deploy=false" .Values.clickhouse.host -}}
-{{- end -}}
+{{- required "clickhouse.host is required" .Values.clickhouse.host -}}
 {{- end -}}
 
 {{- define "insight.clickhouse.port" -}}
 {{- required "clickhouse.port is required" .Values.clickhouse.port -}}
 {{- end -}}
 
+{{/* External CH: the FQDN is the operator-supplied host verbatim. */}}
 {{- define "insight.clickhouse.fqdn" -}}
-{{- if .Values.clickhouse.deploy -}}
-{{ include "insight.clickhouse.host" . }}.{{ .Release.Namespace }}.svc.cluster.local
-{{- else -}}
 {{ include "insight.clickhouse.host" . }}
-{{- end -}}
 {{- end -}}
 
 {{- define "insight.clickhouse.url" -}}
@@ -76,20 +63,16 @@ http://{{ include "insight.clickhouse.host" . }}:{{ include "insight.clickhouse.
 {{- required "clickhouse.database is required" .Values.clickhouse.database -}}
 {{- end -}}
 
-{{/* Wire protocol (http|https) for the Bronze ClickHouse destination. The
-     bundled ClickHouse serves plain HTTP on 8123, matching the http:// in
-     insight.clickhouse.url above; override clickhouse.protocol for a TLS CH. */}}
+{{/* Wire protocol (http|https) for the Bronze ClickHouse destination.
+     Defaults to plain HTTP (matching the http:// in insight.clickhouse.url
+     above); override clickhouse.protocol for a TLS CH. */}}
 {{- define "insight.clickhouse.protocol" -}}
 {{- default "http" .Values.clickhouse.protocol -}}
 {{- end -}}
 
-{{/* ---------- MariaDB ---------- */}}
+{{/* ---------- MariaDB (external) ---------- */}}
 {{- define "insight.mariadb.host" -}}
-{{- if .Values.mariadb.deploy -}}
-{{- default (printf "%s-mariadb" .Release.Name) .Values.mariadb.host -}}
-{{- else -}}
-{{- required "mariadb.host is required when mariadb.deploy=false" .Values.mariadb.host -}}
-{{- end -}}
+{{- required "mariadb.host is required" .Values.mariadb.host -}}
 {{- end -}}
 
 {{- define "insight.mariadb.port" -}}
@@ -100,13 +83,9 @@ http://{{ include "insight.clickhouse.host" . }}:{{ include "insight.clickhouse.
 {{- required "mariadb.database is required" .Values.mariadb.database -}}
 {{- end -}}
 
-{{/* ---------- Redis ---------- */}}
+{{/* ---------- Redis (external) ---------- */}}
 {{- define "insight.redis.host" -}}
-{{- if .Values.redis.deploy -}}
-{{- default (printf "%s-redis-master" .Release.Name) .Values.redis.host -}}
-{{- else -}}
-{{- required "redis.host is required when redis.deploy=false" .Values.redis.host -}}
-{{- end -}}
+{{- required "redis.host is required" .Values.redis.host -}}
 {{- end -}}
 
 {{- define "insight.redis.port" -}}
@@ -117,19 +96,13 @@ http://{{ include "insight.clickhouse.host" . }}:{{ include "insight.clickhouse.
 redis://{{ include "insight.redis.host" . }}:{{ include "insight.redis.port" . }}
 {{- end -}}
 
-{{/* ---------- Redpanda ----------
-     The Redpanda Helm chart exposes Kafka on two listeners:
-       - 9093 — INTERNAL (in-cluster clients connect here)
-       - 9092 — EXTERNAL (outside-cluster; goes through NodePort/LB)
-     We resolve to the internal listener by default. Override via
-     redpanda.brokers when pointing at an external cluster.
+{{/* ---------- Redpanda (external) ----------
+     The external Redpanda cluster's bootstrap brokers, as a single
+     comma-separated host:port string (in-cluster clients use the
+     internal listener, conventionally :9093).
 */}}
 {{- define "insight.redpanda.brokers" -}}
-{{- if .Values.redpanda.deploy -}}
-{{- default (printf "%s-redpanda:9093" .Release.Name) .Values.redpanda.brokers -}}
-{{- else -}}
-{{- required "redpanda.brokers is required when redpanda.deploy=false" .Values.redpanda.brokers -}}
-{{- end -}}
+{{- required "redpanda.brokers is required" .Values.redpanda.brokers -}}
 {{- end -}}
 
 {{/*
@@ -216,29 +189,11 @@ Invoked from NOTES.txt so they fire on every install.
     {{- fail (printf "frontend.devUserEmail (%q) is only valid when apiGateway.authDisabled=true. Either clear devUserEmail (real OIDC flow) or set apiGateway.authDisabled=true (sandbox dev impersonation)." $fe.devUserEmail) -}}
   {{- end -}}
 
-  {{- /* External-mode hosts (deploy=false → consumer must supply host):
-         the helper templates `insight.<dep>.host` already `required`-fail
-         in this case, so any template that resolves the host before this
-         validator runs gets a readable error. We keep the redpanda check
-         here because `insight.redpanda.brokers` covers it the same way. */ -}}
-
-  {{- /* MariaDB top-level vs subchart drift. The umbrella's secrets.yaml
-         interpolates `mariadb.username` / `mariadb.database` into
-         ANALYTICS__database_url; the bitnami subchart actually creates
-         the user and database from `mariadb.auth.username` /
-         `mariadb.auth.database`. values.yaml is not Helm-templated, so
-         we cannot reference one from the other — operators must keep
-         them in sync, and this validator catches drift loudly. */ -}}
-  {{- if .Values.mariadb.deploy -}}
-    {{- $mdb := .Values.mariadb -}}
-    {{- $mdbAuth := default dict $mdb.auth -}}
-    {{- if ne (default "" $mdb.username) (default "" $mdbAuth.username) -}}
-      {{- fail (printf "mariadb.username (%q) and mariadb.auth.username (%q) must match. The umbrella uses the former for ANALYTICS__database_url; the bitnami subchart uses the latter to CREATE USER. Set both to the same value (or unset both)." $mdb.username $mdbAuth.username) -}}
-    {{- end -}}
-    {{- if ne (default "" $mdb.database) (default "" $mdbAuth.database) -}}
-      {{- fail (printf "mariadb.database (%q) and mariadb.auth.database (%q) must match. Set both to the same value (or unset both)." $mdb.database $mdbAuth.database) -}}
-    {{- end -}}
-  {{- end -}}
+  {{- /* External hosts (L2 infra is out-of-chart → consumer must supply
+         host/brokers): the helper templates `insight.<dep>.host` and
+         `insight.redpanda.brokers` already `required`-fail when empty, so
+         any template that resolves the host before this validator runs
+         gets a readable error. */ -}}
 
   {{- /* Passwords live in Secrets — never inline. Validate that the
          passwordSecret reference is present; the actual Secret may be

--- a/charts/insight/templates/_helpers.tpl
+++ b/charts/insight/templates/_helpers.tpl
@@ -56,7 +56,7 @@ Contract per dep (all infra is external — out-of-chart L2):
 {{- end -}}
 
 {{- define "insight.clickhouse.url" -}}
-http://{{ include "insight.clickhouse.host" . }}:{{ include "insight.clickhouse.port" . }}
+{{ include "insight.clickhouse.protocol" . }}://{{ include "insight.clickhouse.host" . }}:{{ include "insight.clickhouse.port" . }}
 {{- end -}}
 
 {{- define "insight.clickhouse.database" -}}

--- a/charts/insight/templates/clickhouse-init-svcdbs-job.yaml
+++ b/charts/insight/templates/clickhouse-init-svcdbs-job.yaml
@@ -5,27 +5,14 @@
 
 Helm Hook Job that provisions each database listed in
 `clickhouse.initDatabases` against whatever `clickhouse.host` resolves
-to. Works in both modes from a single source of truth:
-
-- Bundled (`clickhouse.deploy=true`):  in-namespace CH StatefulSet
-                                       (`{release}-clickhouse`); this
-                                       Job waits for `/ping` to succeed
-                                       (which means the bundled CH has
-                                       finished bootstrapping
-                                       `CLICKHOUSE_USER` + the
-                                       privileged service user), then
-                                       runs the DDL.
-- External (`clickhouse.deploy=false`): CH is hosted out-of-chart
-                                       (gitops L2, Constructor Platform,
-                                       managed warehouse, …); this Job
-                                       dials `clickhouse.host` directly.
+to. ClickHouse is external (out-of-chart L2 — gitops L2, Constructor
+Platform, managed warehouse, …); this Job dials `clickhouse.host`
+directly and waits for `/ping` to succeed before running the DDL.
 
 ClickHouse auth model: the service user (`clickhouse.username`, default
 `insight`) is the bootstrap user — there is no separate root in this
-chart's contract. Bundled installs run with
-`CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1` so the service user has full
-admin (incl. CREATE DATABASE). External installs MUST grant the
-service user CREATE DATABASE — that's the operator-side contract.
+chart's contract. The external CH MUST grant the service user CREATE
+DATABASE — that's the operator-side contract.
 
 Hook timing: `pre-install,pre-upgrade`. Mirrors the MariaDB Hook —
 the DB must exist BEFORE application pods that read it (analytics-api,
@@ -44,10 +31,9 @@ later runs. Connector-specific bronze databases beyond the configured
 `initDatabases` list are created lazily by the ingestion pipelines
 themselves — this Job owns only the chart-declared list.
 
-Replaces the bundled-only ConfigMap path that was in the CH subchart
-(`helmfile/charts/clickhouse/templates/init-configmap.yaml`), which
-only ran during the CH container's docker-entrypoint-initdb.d phase
-and therefore did nothing for external/layered installs.
+Replaces the legacy bundled-only ConfigMap path that ran during the CH
+container's docker-entrypoint-initdb.d phase and therefore did nothing
+for external/layered installs.
 ==============================================================================
 */}}
 {{- if .Values.clickhouse.initDatabases }}

--- a/charts/insight/templates/clickhouse-init-svcdbs-job.yaml
+++ b/charts/insight/templates/clickhouse-init-svcdbs-job.yaml
@@ -9,10 +9,10 @@ to. ClickHouse is external (out-of-chart L2 — gitops L2, Constructor
 Platform, managed warehouse, …); this Job dials `clickhouse.host`
 directly and waits for `/ping` to succeed before running the DDL.
 
-ClickHouse auth model: the service user (`clickhouse.username`, default
-`insight`) is the bootstrap user — there is no separate root in this
-chart's contract. The external CH MUST grant the service user CREATE
-DATABASE — that's the operator-side contract.
+ClickHouse auth model: the service user (`clickhouse.username`, which the
+operator MUST set — no default) is the bootstrap user; there is no
+separate root in this chart's contract. The external CH MUST grant the
+service user CREATE DATABASE — that's the operator-side contract.
 
 Hook timing: `pre-install,pre-upgrade`. Mirrors the MariaDB Hook —
 the DB must exist BEFORE application pods that read it (analytics-api,

--- a/charts/insight/templates/ingestion/dbt-run.yaml
+++ b/charts/insight/templates/ingestion/dbt-run.yaml
@@ -29,8 +29,8 @@ spec:
             default: "false"
           # Operator-pinned values from umbrella chart. Submitter may override
           # per-call but typically just submits and gets these defaults baked in
-          # at chart-render time. `insight.<dep>.host/port` helpers know whether
-          # to emit cluster-internal FQDN or external host based on `<dep>.deploy`.
+          # at chart-render time. `insight.<dep>.host/port` helpers resolve the
+          # operator-supplied external L2 host/port.
           - name: toolbox_image
             default: {{ required "ingestion.toolboxImage is required when ingestion.templates.enabled=true" .Values.ingestion.toolboxImage | quote }}
           - name: clickhouse_host

--- a/charts/insight/templates/mariadb-init-svcdbs-job.yaml
+++ b/charts/insight/templates/mariadb-init-svcdbs-job.yaml
@@ -5,16 +5,9 @@
 
 Helm Hook Job that provisions each backend service's owned MariaDB
 database — CREATE DATABASE + GRANT — against whatever `mariadb.host`
-resolves to. Works in both modes from a single source of truth:
-
-- Bundled (`mariadb.deploy=true`):     bitnami subchart starts the
-                                       MariaDB pod; this Job waits for
-                                       it to accept connections, then
-                                       runs the SQL.
-- External (`mariadb.deploy=false`):   MariaDB is hosted out-of-chart
-                                       (layered L2, managed RDS / Cloud
-                                       SQL, …); this Job dials
-                                       `mariadb.host` directly.
+resolves to. MariaDB is external (out-of-chart L2 — layered L2, managed
+RDS / Cloud SQL, …); this Job dials `mariadb.host` directly, waits for
+it to accept connections, then runs the SQL.
 
 Hook timing: `pre-install,pre-upgrade`. The DB must exist BEFORE the
 application pods (identity, etc.) start — otherwise their migration
@@ -68,9 +61,10 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: db-init
-          # Track the bundled MariaDB minor so client/server protocols
+          # MariaDB client image, pinned independently — bump in lockstep
+          # with the external L2 MariaDB minor so client/server protocols
           # align. Bitnami legacy image namespace (post-2025 Bitnami
-          # licensing change — see umbrella `mariadb.image.repository`).
+          # licensing change).
           image: docker.io/bitnamilegacy/mariadb:11.4.4-debian-12-r0
           imagePullPolicy: IfNotPresent
           env:

--- a/charts/insight/templates/secrets.yaml
+++ b/charts/insight/templates/secrets.yaml
@@ -4,9 +4,9 @@
 ==============================================================================
 The umbrella provisions two (or three) Secrets per install:
 
-  1. `insight-db-creds` — raw passwords consumed by the bundled infra
-     charts (mariadb, redis, clickhouse). Keys match the field names
-     those charts expect natively (or that we configure them to use).
+  1. `insight-db-creds` — raw passwords for the external L2 infra
+     (mariadb, redis, clickhouse). Keys match the field names the app
+     services and init-DB Hook Jobs read.
 
   2. `insight-analytics-api-config` — pre-assembled env vars for the
      analytics-api Rust service, including a full `ANALYTICS__database_url`
@@ -181,10 +181,9 @@ stringData:
   # The .NET identity service owns its own MariaDB database (per ADR-0006)
   # — separate from the analytics-api `insight` database — and applies its
   # own DbUp migrations against it at startup. The umbrella provisions the
-  # empty database via the bitnami MariaDB subchart's
-  # `primary.initdbScriptsConfigMap` (see templates/mariadb-initdb-scripts.yaml),
-  # which runs on the first MariaDB pod boot and is restart-safe (data
-  # lives in the PVC).
+  # empty database against the external L2 MariaDB via the pre-install
+  # Hook Job (templates/mariadb-init-svcdbs-job.yaml), which CREATEs the
+  # DB + GRANTs before the identity pod starts.
   #
   # `IDENTITY__mariadb__url` is the URL form. The service also accepts
   # `IDENTITY__mariadb__connection_string` (raw MySqlConnector KV form)

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -22,16 +22,16 @@
 ##    different namespaces — each is self-contained.
 ##
 ## 3. Every INFRA dependency (ClickHouse, MariaDB, Redis, Redpanda) is
-##    configured with ONE unified shape, regardless of who runs it:
-##      <dep>.deploy         — the umbrella runs this dep as a subchart (yes/no)
-##      <dep>.host           — host ("" → default to {release}-<dep>)
+##    deployed OUT-OF-CHART (separate releases in `insight-infra` via
+##    gitops `make system-*`). The umbrella only carries the wiring it
+##    needs to dial them:
+##      <dep>.host           — host (MUST be set)
 ##      <dep>.port           — port
 ##      <dep>.database       — db name (where applicable)
 ##      <dep>.username       — login user
 ##      <dep>.passwordSecret — {name, key} pointing at a K8s Secret
-##    When `deploy: false`, the umbrella DOES NOT install the subchart;
-##    everything else — host/port/creds — is just strings the consumers
-##    read, identical to the `deploy: true` case.
+##    These are just strings the consumers (and the pre-install init-DB
+##    Hook Jobs) read — the umbrella never runs the dep itself.
 ##
 ## 4. Core app services (apiGateway, analyticsApi, frontend) are MANDATORY
 ##    components of the umbrella — no deploy-flag. The gateway is the
@@ -150,7 +150,7 @@ observability:
 #  EXTERNAL — Airbyte (installed as a separate Helm release, SAME namespace)
 # ═══════════════════════════════════════════════════════════════════════════
 airbyte:
-  releaseName: airbyte # Helm release name used by install-airbyte.sh
+  releaseName: airbyte # Helm release name of the L2 Airbyte system release
   apiUrl: "" # "" = compute from releaseName + .Release.Namespace
   jwtSecret:
     name: airbyte-auth-secrets # created by the Airbyte chart itself
@@ -185,9 +185,8 @@ ingestion:
   # The `argo-workflow` ServiceAccount + supplemental RBAC (Role
   # `argo-workflow-executor` granting create/patch on
   # `workflowtaskresults.argoproj.io`) are NOT shipped by this chart —
-  # they come from `deploy/scripts/install-argo.sh` and
-  # `deploy/argo/rbac.yaml`. Run them before `helm install`, or use
-  # `deploy/scripts/install-insight.sh` which orders them for you.
+  # they come from the gitops Argo Workflows system layer
+  # (`deploy/gitops/system/argo-workflows`, applied via `make system-argo`).
   # Otherwise workflow submission fails with
   # `serviceaccount "argo-workflow" not found`.
   templates:
@@ -237,164 +236,57 @@ ingestion:
         cpu: "500m"
         memory: "512Mi"
 # ═══════════════════════════════════════════════════════════════════════════
-#  INFRASTRUCTURE
+#  INFRASTRUCTURE (external — deployed out-of-chart at L2)
 # ═══════════════════════════════════════════════════════════════════════════
 #
-# Shape per dep:
-#   <dep>.deploy           — umbrella runs the dep as a subchart
-#   <dep>.host / .port     — connection target ("" = default internal)
+# ClickHouse, MariaDB, Redis and Redpanda are NOT bundled by this chart.
+# They run as separate releases in `insight-infra` (gitops `make system-*`).
+# The blocks below are pure WIRING — the host/port/creds the app services
+# and the pre-install init-DB Hook Jobs use to reach them:
+#   <dep>.host / .port     — connection target (host MUST be set)
 #   <dep>.database         — db name (where applicable)
 #   <dep>.username         — login user
 #   <dep>.passwordSecret   — {name, key}
-# The fields below each `deploy: true` block are passed through to the
-# bundled subchart and are ignored when `deploy: false`.
 
 # ─── ClickHouse ──────────────────────────────────────────────────────────
-# NO defaults for username / database / image.tag — operator MUST supply.
+# NO defaults for host / username / database — operator MUST supply.
 # Ports are RFC standards and may stay defaulted.
 clickhouse:
-  deploy: true
-  host: "" # deploy=true → host computed by helper from release name; deploy=false → operator MUST set
+  host: "" # MUST be set (external L2 ClickHouse host)
   port: 8123 # RFC standard for CH HTTP
-  protocol: http # http|https for the Bronze airbyte/destination-clickhouse 2.x connection; bundled CH is plain HTTP on 8123
+  protocol: http # http|https for the Bronze airbyte/destination-clickhouse 2.x connection
   database: "" # MUST be set
   username: "" # MUST be set
   passwordSecret:
     # Fixed Secret name — chart convention (one Insight per namespace).
     name: "insight-db-creds"
     key: "clickhouse-password"
-  image:
-    repository: clickhouse/clickhouse-server
-    tag: "" # MUST be set (CH version pin, e.g. "25.3")
-  # Databases the CH wrapper creates on first boot via
-  # /docker-entrypoint-initdb.d/. Connector-specific bronze schemas
-  # (bronze_jira, bronze_slack, …) are created by ingestion pipelines
-  # themselves; only schemas required at startup live here.
+  # Databases the chart's pre-install Hook Job (clickhouse-init-svcdbs-job)
+  # creates against the external ClickHouse via CREATE DATABASE IF NOT
+  # EXISTS. Connector-specific bronze schemas (bronze_jira, bronze_slack, …)
+  # are created by ingestion pipelines themselves; only schemas required
+  # at startup live here.
   initDatabases:
     - insight
-  persistence:
-    size: 10Gi
-  resources:
-    requests: {cpu: 250m, memory: 512Mi}
-    limits: {cpu: "2", memory: 4Gi}
-  auth:
-    # Synced with passwordSecret above; the umbrella's validator enforces
-    # they match. The CH subchart now `required`s both — no fallback to
-    # an inline auth.password.
-    existingSecret: "insight-db-creds"
-    existingSecretPasswordKey: "clickhouse-password"
-# ─── MariaDB (bitnami) ───────────────────────────────────────────────────
-# NB: bitnami removed free images from docker.io/bitnami/* in 2025
-# (see https://github.com/bitnami/charts/issues/30850). We point at the
-# bitnamilegacy repository — same images, still free. For enterprise use
-# your own registry.
+# ─── MariaDB ─────────────────────────────────────────────────────────────
 mariadb:
-  deploy: true
-  host: "" # deploy=true → helper; deploy=false → MUST set
+  host: "" # MUST be set (external L2 MariaDB host)
   port: 3306 # RFC standard for MySQL/MariaDB
   database: "" # MUST be set
   username: "" # MUST be set
   passwordSecret:
     name: "insight-db-creds"
     key: "mariadb-password"
-  # Bitnami chart settings (read only when deploy=true).
-  architecture: standalone
-  image:
-    registry: docker.io
-    repository: bitnamilegacy/mariadb
-  auth:
-    # bitnami/mariadb natively reads `mariadb-password` and
-    # `mariadb-root-password` keys from auth.existingSecret.
-    #
-    # `auth.username` and `auth.database` ARE WHAT bitnami uses to
-    # CREATE USER + CREATE DATABASE on first pod boot. They MUST match
-    # the umbrella's top-level `mariadb.username` / `mariadb.database`
-    # (which downstream secrets.yaml uses for ANALYTICS__database_url).
-    # values.yaml is not Helm-templated, so we cannot reference one from
-    # the other — the umbrella validator (`insight.validate`) checks the
-    # match at render time and fails with a readable error on drift.
-    username: "" # MUST match mariadb.username
-    database: "" # MUST match mariadb.database
-    existingSecret: "insight-db-creds"
-  # Per-service MariaDB databases (ADR-0006 — each backend service owns
-  # its own DB) are now provisioned by a post-install / post-upgrade
-  # Helm Hook Job (see templates/mariadb-init-svcdbs-job.yaml). The Job
-  # authenticates as MariaDB root using `mariadb-root-password` from
-  # `insight-db-creds`, runs idempotent CREATE DATABASE + GRANT against
-  # whatever `mariadb.host` resolves to — works for both bundled
-  # (`mariadb.deploy=true`) and external (layered gitops with
-  # `mariadb.deploy=false`) modes from a SINGLE source of truth.
-  #
-  # Replaces the previous bundled-only `mariadb-initdb-scripts.yaml`
-  # ConfigMap. The earlier `pre-install` Hook had a chicken-and-egg with
-  # the regular-template `insight-db-creds`; the new Hook uses
-  # `post-install` so the Secret is already applied when the Job runs,
-  # and the Job has an internal wait-for-MariaDB loop so the bundled
-  # subchart's first-boot delay doesn't matter.
-  # Reset of a legacy value persisted in helm release storage from a
-  # pre-#406 chart version (`insight-mariadb-initdb-scripts`). The
-  # ConfigMap it referenced was deleted in #406; the bitnami subchart
-  # rendered a `custom-init-scripts` mount as long as this value stayed
-  # truthy, so any MariaDB pod recreation hit FailedMount. Explicit
-  # empty string ensures bitnami emits the StatefulSet without the
-  # mount even when an operator runs `helm upgrade --reuse-values`.
-  initdbScriptsConfigMap: ""
-  primary:
-    persistence:
-      size: 5Gi
-    resources:
-      requests: {cpu: 100m, memory: 256Mi}
-      limits: {cpu: 500m, memory: 512Mi}
-# ─── Redis (bitnami) ─────────────────────────────────────────────────────
+# ─── Redis ───────────────────────────────────────────────────────────────
 redis:
-  deploy: true
-  host: "" # deploy=true → helper; deploy=false → MUST set
+  host: "" # MUST be set (external L2 Redis host)
   port: 6379 # RFC standard for Redis
   passwordSecret:
     name: "insight-db-creds"
     key: "redis-password"
-  # Bitnami chart settings (read only when deploy=true).
-  architecture: standalone
-  image:
-    registry: docker.io
-    repository: bitnamilegacy/redis
-  auth:
-    enabled: true
-    existingSecret: "insight-db-creds"
-    existingSecretPasswordKey: "redis-password"
-  master:
-    persistence:
-      size: 1Gi
-    resources:
-      requests: {cpu: 50m, memory: 64Mi}
-      limits: {cpu: 250m, memory: 128Mi}
 # ─── Redpanda ────────────────────────────────────────────────────────────
-# For enterprise: TLS on, SASL on, 3+ replicas.
 redpanda:
-  deploy: true
-  brokers: "" # "" = {release}-redpanda:9092
-  # Redpanda chart settings (read only when deploy=true).
-  statefulset:
-    replicas: 1
-  resources:
-    cpu:
-      cores: 1
-    memory:
-      container:
-        max: 1536Mi
-      redpanda:
-        memory: 1Gi
-        reserveMemory: 256Mi
-  storage:
-    persistentVolume:
-      size: 10Gi
-  tls:
-    enabled: false
-  auth:
-    sasl:
-      enabled: false
-  console:
-    enabled: true
+  brokers: "" # MUST be set (external L2 Redpanda brokers, comma-separated host:port)
 # ═══════════════════════════════════════════════════════════════════════════
 #  APPLICATION SERVICES (mandatory — no deploy-flag)
 # ═══════════════════════════════════════════════════════════════════════════

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -241,6 +241,8 @@ ingestion:
 #
 # ClickHouse, MariaDB, Redis and Redpanda are NOT bundled by this chart.
 # They run as separate releases in `insight-infra` (gitops `make system-*`).
+# See CONTRIBUTING.md ("Deployment paths" → Kubernetes) and
+# docs/components/deployment/specs/DESIGN.md for the layered L0/L2/L3 model.
 # The blocks below are pure WIRING — the host/port/creds the app services
 # and the pre-install init-DB Hook Jobs use to reach them:
 #   <dep>.host / .port     — connection target (host MUST be set)


### PR DESCRIPTION
Part of #1414. Closes #1417.

Phase 2 of the legacy `dev-up.sh` retirement. Makes `charts/insight` a pure application bundle by dropping the four L2 infrastructure subchart dependencies.

## What changed

The umbrella previously bundled `clickhouse` / `mariadb` / `redis` / `redpanda` as subcharts, each gated by a `<svc>.deploy` boolean. In gitops those are **always** `deploy: false` — the L2 infra runs as separate releases in `insight-infra` and the umbrella dials it via `<dep>.host`. The `deploy: true` bundled path was used only by the now-retired `dev-up.sh` flow, so it's dead code.

- **`Chart.yaml`** — removed the four `dependencies` blocks; **version bumped `0.1.84` → `0.2.0`** (breaking chart-API change); header comment realigned.
- **`Chart.lock`** — regenerated; only the four `file://` app-service subcharts remain (api-gateway, analytics-api, identity, frontend).
- **`values.yaml`** — each infra block trimmed to wiring fields only (`host`/`port`/`protocol`/`database`/`username`/`passwordSecret`, `redpanda.brokers`). Dropped `deploy`/`image`/`persistence`/`resources`/`auth`/`architecture`/`statefulset`/`storage`/etc. Stripped stale `install-argo.sh` / `deploy/argo/rbac.yaml` / `install-airbyte.sh` comment refs.
- **`templates/_helpers.tpl`** — collapsed the host/fqdn/brokers helpers to the external-only path; removed the dead `mariadb.deploy` drift validator (it referenced the now-removed `mariadb.auth.*`).
- **`templates/{NOTES.txt,clickhouse-init-svcdbs-job,mariadb-init-svcdbs-job,secrets,ingestion/dbt-run}.yaml`** + **`README.md`** — comments/docs realigned to the external-L2 model (dropped bundled-mode docs, the Bitnami-legacy section, and the helmfile-relationship section).

### Deliberate deviation from the issue checklist
`clickhouse.initDatabases: [insight]` was **kept** (the issue said delete it). It drives the `clickhouse-init-svcdbs-job` pre-install Hook Job, which provisions databases against the **external** ClickHouse too — deleting it would drop that Job from the render. Confirmed present in the rendered output.

## Verification

- `helm dependency update` → `Chart.lock` with only the 4 app-service entries. ✅
- `helm template charts/insight --values deploy/gitops/environments/local/values.yaml.template` diffed against the Phase 0 baseline → **only** the chart-version label (`0.1.82`→`0.2.0`) and a pre-existing analytics-api image-tag drift; **no structural manifest changes** (the bundled subcharts never rendered under `deploy: false`). ✅
- `helm lint` (gitops local values) → passes. ✅
- `helm install --dry-run=server` against a live cluster → passes (14 resources, API-server validated). ✅
- Independent code-review agent on the diff → no blockers; confirmed no template reads a removed values field and no stray infra `.deploy` reference remains.

The full `make deploy ENV=local` smoke test is deferred to **Phase 4 (#1419)** inside the Phase 3 PR (per the EPIC plan) — it requires a full L2 bootstrap.

## ⚠️ Breaking change — coordination required

This bumps the chart's `version` to `0.2.0` with a **removed chart-API surface** (the `<dep>.deploy: true` bundled mode no longer exists). CI's patch-only auto-bump will publish `0.2.1` on merge.

- **`insight-gitops`** (read-only sibling repo) pins the chart via `.insight-version`. After this PR's OCI publish lands, that pin must be bumped to the `0.2.x` line. No action needed in this repo.
- Any downstream consumer relying on `<dep>.deploy: true` to bundle infra must migrate to external L2 + `<dep>.host` wiring.

## Follow-up (not in this PR)
- The gitops `deploy/gitops/environments/local/values.yaml.template` still carries inert `<dep>.deploy: false` lines — harmless no-op overrides now; can be cleaned in Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Separated infrastructure dependencies from the application chart; ClickHouse, MariaDB, Redis, and Redpanda are now always treated as external and wired via required connection settings
  * Updated URL/endpoint resolution to reflect external L2 targets (and always display external endpoints)
  * Added support for configuring the ClickHouse protocol

* **Documentation**
  * Updated umbrella chart docs and installation checklist to match the external-infra model and revised release naming guidance
  * Refreshed values and notes to clarify required host/credential wiring and remove outdated bundled-mode explanations

* **Chores**
  * Bumped chart version to **0.2.0**
<!-- end of auto-generated comment: release notes by coderabbit.ai -->