### PR TITLE
fix(connectors): GitLab dbt — alias qualified key columns in staging joins

### DIFF
--- a/src/ingestion/connectors/git/gitlab/dbt/gitlab__commits.sql
+++ b/src/ingestion/connectors/git/gitlab/dbt/gitlab__commits.sql
@@ -34,9 +34,9 @@ fc AS (
     GROUP BY tenant_id, source_id, project_id, commit_sha
 )
 SELECT
-    c.tenant_id,
-    c.source_id,
-    c.unique_key,
+    c.tenant_id AS tenant_id,
+    c.source_id AS source_id,
+    c.unique_key AS unique_key,
     COALESCE(p.project_key, '') AS project_key,
     COALESCE(p.repo_slug, '') AS repo_slug,
     COALESCE(c.id, '') AS commit_hash,

--- a/src/ingestion/connectors/git/gitlab/dbt/gitlab__file_changes.sql
+++ b/src/ingestion/connectors/git/gitlab/dbt/gitlab__file_changes.sql
@@ -21,9 +21,9 @@ WITH proj AS (
     FROM {{ source('bronze_gitlab', 'projects') }} FINAL
 )
 SELECT
-    fc.tenant_id,
-    fc.source_id,
-    fc.unique_key,
+    fc.tenant_id AS tenant_id,
+    fc.source_id AS source_id,
+    fc.unique_key AS unique_key,
     COALESCE(p.project_key, '') AS project_key,
     COALESCE(p.repo_slug, '') AS repo_slug,
     COALESCE(fc.commit_sha, '') AS commit_hash,

--- a/src/ingestion/connectors/git/gitlab/dbt/gitlab__pull_requests.sql
+++ b/src/ingestion/connectors/git/gitlab/dbt/gitlab__pull_requests.sql
@@ -23,9 +23,9 @@ WITH proj AS (
     FROM {{ source('bronze_gitlab', 'projects') }} FINAL
 )
 SELECT
-    mr.tenant_id,
-    mr.source_id,
-    mr.unique_key,
+    mr.tenant_id AS tenant_id,
+    mr.source_id AS source_id,
+    mr.unique_key AS unique_key,
     COALESCE(p.project_key, '') AS project_key,
     COALESCE(p.repo_slug, '') AS repo_slug,
     COALESCE(mr.iid, 0) AS pr_id,

--- a/src/ingestion/connectors/git/gitlab/dbt/gitlab__pull_requests_comments.sql
+++ b/src/ingestion/connectors/git/gitlab/dbt/gitlab__pull_requests_comments.sql
@@ -22,9 +22,9 @@ WITH proj AS (
     FROM {{ source('bronze_gitlab', 'projects') }} FINAL
 )
 SELECT
-    n.tenant_id,
-    n.source_id,
-    n.unique_key,
+    n.tenant_id AS tenant_id,
+    n.source_id AS source_id,
+    n.unique_key AS unique_key,
     COALESCE(p.project_key, '') AS project_key,
     COALESCE(p.repo_slug, '') AS repo_slug,
     COALESCE(n.mr_iid, 0) AS pr_id,

--- a/src/ingestion/connectors/git/gitlab/dbt/gitlab__pull_requests_commits.sql
+++ b/src/ingestion/connectors/git/gitlab/dbt/gitlab__pull_requests_commits.sql
@@ -21,9 +21,9 @@ WITH proj AS (
     FROM {{ source('bronze_gitlab', 'projects') }} FINAL
 )
 SELECT
-    mc.tenant_id,
-    mc.source_id,
-    mc.unique_key,
+    mc.tenant_id AS tenant_id,
+    mc.source_id AS source_id,
+    mc.unique_key AS unique_key,
     COALESCE(p.project_key, '') AS project_key,
     COALESCE(p.repo_slug, '') AS repo_slug,
     COALESCE(mc.mr_iid, 0) AS pr_id,

--- a/src/ingestion/connectors/git/gitlab/dbt/gitlab__pull_requests_reviewers.sql
+++ b/src/ingestion/connectors/git/gitlab/dbt/gitlab__pull_requests_reviewers.sql
@@ -23,8 +23,8 @@ WITH proj AS (
     FROM {{ source('bronze_gitlab', 'projects') }} FINAL
 )
 SELECT
-    a.tenant_id,
-    a.source_id,
+    a.tenant_id AS tenant_id,
+    a.source_id AS source_id,
     concat(
         COALESCE(a.tenant_id, ''), ':',
         COALESCE(a.source_id, ''), ':',

--- a/src/ingestion/connectors/git/gitlab/dbt/gitlab__repository_branches.sql
+++ b/src/ingestion/connectors/git/gitlab/dbt/gitlab__repository_branches.sql
@@ -21,9 +21,9 @@ WITH proj AS (
     FROM {{ source('bronze_gitlab', 'projects') }} FINAL
 )
 SELECT
-    b.tenant_id,
-    b.source_id,
-    b.unique_key,
+    b.tenant_id AS tenant_id,
+    b.source_id AS source_id,
+    b.unique_key AS unique_key,
     COALESCE(p.project_key, '') AS project_key,
     COALESCE(p.repo_slug, '') AS repo_slug,
     COALESCE(b.name, '') AS branch_name,


### PR DESCRIPTION
## Problem

`gitlab__` staging models join a `projects` CTE (plus `commit_file_changes` in `gitlab__commits`) that also carry `tenant_id` / `source_id`. Unaliased `c.tenant_id` / `c.source_id` are ambiguous; with three joined relations ClickHouse keeps the qualifier as the output column name, so `gitlab__commits` emitted columns named `c.tenant_id` / `c.source_id`. These propagate through `class_git_commits` → `fct_git_commit`, breaking `mtr_git_person_totals` / `_weekly` (`Unknown expression identifier 'tenant_id'`).

## Fix

Explicit aliases (`c.tenant_id AS tenant_id`, …) on the key columns in all 7 join-based `gitlab__` staging models — output names no longer depend on ambiguity resolution. The other 6 survived on 2-way resolution but had the same latent pattern. `dbt parse` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
