### PR TITLE
test(e2e): per-metric collaboration specs for the remaining m365 metrics (#1413)

### DIFF
--- a/.claude/skills/metric-e2e-test/SKILL.md
+++ b/.claude/skills/metric-e2e-test/SKILL.md
@@ -119,10 +119,10 @@ cases:
 
 The request carries only `id` + `metric_id` + `$filter` (person_id + metric_date `ge`/`le`):
 the live FE sends **no** `$top`/`$orderby`/`org_unit`, and the backend computes the team
-(org_unit) cohort itself. **Assert only the metric under test** — one `metric_key` per file
+(org_unit / department) distribution itself. **Assert only the metric under test** — one `metric_key` per file
 via `find`+`equal`; do NOT assert a fixed positive `size(items)` count or an unrelated
 metric_key. (The team shown in the UI comes from a *separate* identity service and can
-disagree with the analytics cohort — irrelevant to these assertions.)
+disagree with the analytics team (org_unit) — irrelevant to these assertions.)
 
 ### `assert` (CEL) bindings
 
@@ -165,9 +165,9 @@ with a dedicated spec (see `specs/collab_emails_read.test.yaml`):
    (`grep -rn "<label>" src/backend/services/analytics-api/src/migration/*.rs`) and
    the live `query_ref` rewrite for that metric. Note whether it returns a bullet
    (`metric_key`/`value`/`median`/`range_*`) or per-person rows. For the collaboration
-   bullets the median/range cohort is **DEPARTMENT/org_unit-scoped for BOTH** the Team
+   bullets the median/range is **DEPARTMENT/org_unit-scoped for BOTH** the Team
    bullet (`…0005`) and the IC bullet (`…0012`) — `median`/`range_*` come from
-   `quantileExact`/min/max over the person's own `org_unit_id` cohort (live query
+   `quantileExact`/min/max over the person's own `org_unit_id` (department) team (live query
    `m20260604_000002_collab_bullet_distribution.rs`, `GROUP BY metric_key, org_unit_id`
    joined `ON c.org_unit_id = p.org_unit_id`). The two bullets differ only in `value`
    (Team = team average `avg(p.v_period)`/`avg(c.team_*)`; IC = the requested member
@@ -196,17 +196,17 @@ with a dedicated spec (see `specs/collab_emails_read.test.yaml`):
    **Seed the department, not a UUID.** In the GOLD/served layer `org_unit_id` is the
    BambooHR **department STRING** — `insight.people.org_unit_id = argMax(department, …)`,
    keyed `person_id = lower(workEmail)`; it is a UUID only in silver/`person.persons`. So
-   for a team/org_unit-cohort metric set `department: "Engineering"` on the bamboohr
-   `employees` base record (people sharing a department form one cohort), and if you scope
+   for a team/department (org_unit) metric set `department: "Engineering"` on the bamboohr
+   `employees` base record (people sharing a department form one team), and if you scope
    a team-view request use the string (`org_unit_id eq 'Engineering'`), never a UUID.
 
-   **Identity match is load-bearing (silent NULL trap).** Cohort attribution is a LEFT
+   **Identity match is load-bearing (silent NULL trap).** Team/department attribution is a LEFT
    JOIN: `collab_bullet_rows` joins `insight.people` ON `lower(silver.email) = person_id`,
    where `person_id = lower(workEmail)`. There is no `email` column on bronze — bamboohr
    carries `workEmail`, M365 carries `userPrincipalName`, and silver `email` derives from
    `userPrincipalName`. So a seeded person's `userPrincipalName` must equal their bamboohr
    `workEmail` **case-insensitively**; any mismatch → `org_unit_id` resolves NULL, the
-   person silently drops out of the cohort (no error), and the median/range is computed
+   person silently drops out of the team/department (no error), and the median/range is computed
    over the wrong roster. Set the SAME email on both `workEmail` and `userPrincipalName`.
 4. **Write `bronze`** with `$ref`+overrides; include a duplicate row when the metric
    should dedup.
@@ -215,11 +215,11 @@ with a dedicated spec (see `specs/collab_emails_read.test.yaml`):
    and counts/inequalities via `assert`.
 6. **Pick numbers that distinguish behaviors** — e.g. for a median test use values
    where median ≠ mean (`[40,20,10]` → median 20, mean 23.33) so the test actually
-   pins the aggregation. Use an **odd-size** cohort: ClickHouse `quantileExact(0.5)`
+   pins the aggregation. Use an **odd-size** team (an odd number of members with data): ClickHouse `quantileExact(0.5)`
    (which both collab bullets use) is NOT the average of the two middle values on an
-   EVEN cohort — it returns the UPPER middle element (index `floor(n/2)`): `{100,200}` →
-   200, not 150. An even cohort whose median you compute as the mean of the middles will
-   produce a wrong `equal:` (this bit the live specs twice), so prefer odd cohorts.
+   EVEN team — it returns the UPPER middle element (index `floor(n/2)`): `{100,200}` →
+   200, not 150. An even team whose median you compute as the mean of the middles will
+   produce a wrong `equal:` (this bit the live specs twice), so prefer odd teams.
 
 ## Validating a test (no ClickHouse needed)
 

--- a/.claude/skills/metric-e2e-test/SKILL.md
+++ b/.claude/skills/metric-e2e-test/SKILL.md
@@ -70,6 +70,37 @@ templates:
     userPrincipalName: alice@example.com
 ```
 
+### `description` — metric + bronze→silver→gold formula
+
+A folded `>` block stating WHAT the metric is and HOW it's computed, in plain
+language — **not** dbt model / silver-column names. Keep it short. Shape:
+
+```yaml
+description: >
+  Metric: <metric_key> — <bullet name> (…0012), #<issue>.
+  How it's computed (bronze → silver → gold):
+    • bronze: <the raw source report(s) that arrive>
+    • silver: <how they're deduped / normalized to per-person/day counts>
+    • gold:   <the metric rule — the aggregation, exclusions, cross-source sums>
+
+  Team (median/range = the person's department):
+    <one-line member distribution> → median <m>, range [<lo>, <hi>].
+  Cases: <one-line list of what each case proves>.
+```
+
+- The **gold** line carries the metric-specific logic — e.g. "passive emails
+  (received/read) excluded", "Teams + Zoom additive", "longest modality, not the
+  sum", "Teams-only — Zoom excluded". This is where a reader learns the real rule.
+- Describe the *transformation* in human terms; do NOT name staging models or silver
+  columns (`m365__collab_*`, `*_count`) — the **layer flow** is the point, not the
+  artifacts. (To trace the real artifacts, read the staging dbt models + the gold
+  migration; see "Source of truth".)
+- Keep the **Team** line concrete (seeded member values → the resulting
+  median/range) so a reviewer can verify the `equal:` numbers without reading every
+  case. For date-windowed metrics (no single Team), drop the Team line and let the
+  Cases line enumerate the window kinds (see `collab_emails_read.test.yaml`).
+- Canonical example: `collab_active_days.test.yaml`.
+
 ### `bronze` — what to seed
 
 Keyed by table name (the key IS the table + which schema validates it). Each row =
@@ -208,8 +239,9 @@ with a dedicated spec (see `specs/collab_emails_read.test.yaml`):
    `workEmail` **case-insensitively**; any mismatch → `org_unit_id` resolves NULL, the
    person silently drops out of the team/department (no error), and the median/range is computed
    over the wrong roster. Set the SAME email on both `workEmail` and `userPrincipalName`.
-4. **Write `bronze`** with `$ref`+overrides; include a duplicate row when the metric
-   should dedup.
+4. **Write the `description`** (metric + bronze→silver→gold formula + Team/Cases —
+   see § `description`), then **`bronze`** with `$ref`+overrides; include a duplicate
+   row when the metric should dedup.
 5. **Write `cases`**: one batch `query` per metric under test (and one `metric_key` per
    file — see File layout); assert ONLY the target metric's few fields via `find`+`equal`,
    and counts/inequalities via `assert`.

--- a/src/ingestion/scripts/create-bronze-placeholders.sh
+++ b/src/ingestion/scripts/create-bronze-placeholders.sh
@@ -831,15 +831,48 @@ if ! ch_table_exists bronze_zoom participants; then
   echo "  Creating placeholder: bronze_zoom.participants"
   run_ch <<'SQL'
 CREATE TABLE IF NOT EXISTS bronze_zoom.participants (
+    tenant_id String,
+    source_id String,
     email String,
+    user_name Nullable(String),
     meeting_uuid String,
+    participant_uuid String,
     join_time String,
     leave_time String,
+    camera Nullable(String),
+    share_desktop Nullable(Bool),
+    share_application Nullable(Bool),
+    share_whiteboard Nullable(Bool),
+    video_connection_type Nullable(String),
     _airbyte_raw_id        String        DEFAULT toString(generateUUIDv4()),
     _airbyte_extracted_at  DateTime64(3) DEFAULT now64(3),
     _airbyte_meta          String        DEFAULT '{}',
     _airbyte_generation_id UInt32        DEFAULT 0
 ) ENGINE = ReplacingMergeTree(_airbyte_extracted_at) ORDER BY email;
+SQL
+fi
+
+# bronze_zoom.meetings — read by zoom__meeting_sessions (session stitching).
+# The meeting-hours path computes duration from participants join/leave, so this
+# table may be empty in tests; it only needs to EXIST so the sessions model builds
+# (the participant→session LEFT JOIN then falls back to meeting_uuid).
+if ! ch_table_exists bronze_zoom meetings; then
+  echo "  Creating placeholder: bronze_zoom.meetings"
+  run_ch <<'SQL'
+CREATE TABLE IF NOT EXISTS bronze_zoom.meetings (
+    tenant_id String,
+    source_id String,
+    id Nullable(String),
+    uuid String,
+    start_time Nullable(String),
+    end_time Nullable(String),
+    has_video Nullable(Bool),
+    has_screen_share Nullable(Bool),
+    _airbyte_raw_id        String        DEFAULT toString(generateUUIDv4()),
+    _airbyte_extracted_at  DateTime64(3) DEFAULT now64(3),
+    _airbyte_meta          String        DEFAULT '{}',
+    _airbyte_generation_id UInt32        DEFAULT 0
+) ENGINE = ReplacingMergeTree(_airbyte_extracted_at) ORDER BY uuid;
 SQL
 fi
 

--- a/src/ingestion/tests/e2e/conftest.py
+++ b/src/ingestion/tests/e2e/conftest.py
@@ -101,13 +101,16 @@ def compose_stack(session_cfg: SessionConfig):
 
 
 # Silver/staging tables that a fixture may READ via a gold view but NOT seed
-# (each collab fixture seeds at most one of the four class_collab_* tables, yet
-# insight.collab_bullet_rows reads all four). The per-test ledger only truncates
-# what a fixture seeds, so on a WARM ClickHouse (re-running `./e2e.sh test`
-# without `down`) the first collab fixture would inherit a prior session's rows
-# in the tables it does not seed — and stale rows in the dbt-rebuilt
-# class_collab_email_activity would skew its neighbours. Truncating these once
-# at session start makes warm re-runs deterministic; CI starts fresh anyway.
+# (each collab fixture seeds at most one class_collab_* table, yet
+# insight.collab_bullet_rows reads all four — and each class_collab_* unions
+# several per-source staging feeders). The per-test ledger only truncates what a
+# fixture seeds, so on a WARM ClickHouse (re-running `./e2e.sh test` without
+# `down`) the first collab fixture would inherit a prior session's rows in the
+# tables it does not seed — stale rows in a dbt-rebuilt class_collab_* would skew
+# its neighbours. The zoom staging models are also `incremental`/`append`, so a
+# warm rebuild would ALSO accumulate duplicate unique_keys (failing their dbt
+# `unique` test). Truncating these once at session start makes warm re-runs
+# deterministic; CI starts fresh anyway.
 _SESSION_START_TRUNCATE = [
     ("silver", "class_collab_email_activity"),
     ("silver", "class_collab_chat_activity"),
@@ -118,6 +121,9 @@ _SESSION_START_TRUNCATE = [
     ("staging", "m365__collab_meeting_activity"),
     ("staging", "m365__collab_document_activity_onedrive"),
     ("staging", "m365__collab_document_activity_sharepoint"),
+    # Zoom feeds class_collab_meeting_activity (cross-source meeting_hours).
+    ("staging", "zoom__collab_meeting_activity"),
+    ("staging", "zoom__meeting_sessions"),
 ]
 
 

--- a/src/ingestion/tests/e2e/specs/collab_active_days.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_active_days.test.yaml
@@ -1,13 +1,26 @@
 spec_version: 1
 description: >
-  Per-metric E2E check for m365_active_days (#1413). Seeds email + teams + onedrive
-  bronze for 3 people in one team and asserts the IC Bullet Collaboration metric
-  (…0012). m365_active_days = count of days with any DELIBERATE m365 activity —
-  email sent, chat messages, or file engagement/shares — across the email, chat
-  and document silver classes; receiveCount/readCount are EXCLUDED (passive).
-  Cross-class coverage: alice is active via email, bob via chat, carol via docs.
-  alice also has a receive/read-only day that must NOT count. value = member,
-  median/range = team.
+  Metric: m365_active_days — IC Bullet Collaboration (…0012), #1413.
+  m365_active_days = count of distinct days with DELIBERATE m365 activity (email
+  sent, chat sent, file engaged/shared); passive signals (receiveCount/readCount)
+  are EXCLUDED.
+
+  Path (bronze → silver → gold):
+    • bronze_m365.email_activity    → staging m365__collab_email_activity        → silver.class_collab_email_activity
+    • bronze_m365.teams_activity    → staging m365__collab_chat_activity         → silver.class_collab_chat_activity
+    • bronze_m365.onedrive_activity → staging m365__collab_document_activity_*    → silver.class_collab_document_activity
+    → insight.collab_bullet_rows (gold) → metric …0012.
+
+  Team (the peer group median+range are computed over — one department here;
+  cross-class coverage exercises all three silver classes):
+    • alice — active via EMAIL on 2 days (01-05, 01-06)  → 2
+    • bob   — active via CHAT  (1 day)                    → 1
+    • carol — active via DOCS  (1 day)                    → 1
+    team {2, 1, 1} → median 1, range [1, 2].
+
+  One case, asserting alice (value = member, median+range = team):
+    value 2, median 1, range [1, 2]. Teeth: a recv/read-only day (01-07,
+    sendCount=0) must NOT count; a duplicate 01-05 row must dedup, not double.
 
 bronze:
   bronze_bamboohr.employees:

--- a/src/ingestion/tests/e2e/specs/collab_active_days.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_active_days.test.yaml
@@ -1,0 +1,68 @@
+spec_version: 1
+description: >
+  Per-metric E2E check for m365_active_days (#1413). Seeds email + teams + onedrive
+  bronze for 3 people in one team and asserts the IC Bullet Collaboration metric
+  (…0012). m365_active_days = count of days with any DELIBERATE m365 activity —
+  email sent, chat messages, or file engagement/shares — across the email, chat
+  and document silver classes; receiveCount/readCount are EXCLUDED (passive).
+  Cross-class coverage: alice is active via email, bob via chat, carol via docs.
+  alice also has a receive/read-only day that must NOT count. value = member,
+  median/range = team.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+    - $ref: templates/people.yaml#/templates/bob
+    - $ref: templates/people.yaml#/templates/carol
+
+  bronze_m365.email_activity:
+    - $ref: templates/m365_email.yaml#/templates/alice_email      # active day 1 (sent>0)
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-ad-20260105
+      sendCount: 10
+    - $ref: templates/m365_email.yaml#/templates/alice_email      # active day 1 (sent>0)  # verbatim duplicate -> must dedup, not double
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-ad-20260105
+      sendCount: 10
+    - $ref: templates/m365_email.yaml#/templates/alice_email      # active day 2 (sent>0)
+      reportRefreshDate: "2026-01-06"
+      unique_key: m365-alice-ad-20260106
+      sendCount: 10
+    - $ref: templates/m365_email.yaml#/templates/alice_email      # passive day → NOT active (recv/read only)
+      reportRefreshDate: "2026-01-07"
+      unique_key: m365-alice-ad-20260107
+      sendCount: 0
+      receiveCount: 30
+      readCount: 20
+
+  bronze_m365.teams_activity:
+    - $ref: templates/m365_teams.yaml#/templates/bob_teams        # bob active via chat
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-bob-ad-chat-20260105
+      privateChatMessageCount: 5
+
+  bronze_m365.onedrive_activity:
+    - $ref: templates/m365_onedrive.yaml#/templates/carol_onedrive  # carol active via documents
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-carol-ad-od-20260105
+      viewedOrEditedFileCount: 3
+
+cases:
+  # team m365_active_days = [alice 2 (01-05,01-06; 01-07 passive excluded), bob 1, carol 1]
+  #   value (alice) = 2 ; median[1,1,2] = 1 ; range = [1,2]
+  - name: m365_active_days — IC bullet (alice value vs team median/range)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'alice@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        assert: "result.status == 'ok'"
+      - in: collaboration
+        find: { metric_key: m365_active_days }
+        equal: { value: 2, median: 1, range_min: 1, range_max: 2 }

--- a/src/ingestion/tests/e2e/specs/collab_active_days.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_active_days.test.yaml
@@ -11,14 +11,14 @@ description: >
     • bronze_m365.onedrive_activity → staging m365__collab_document_activity_*    → silver.class_collab_document_activity
     → insight.collab_bullet_rows (gold) → metric …0012.
 
-  Team (the peer group median+range are computed over — one department here;
+  Team (department `org_unit_id` — the peer group the median/range span;
   cross-class coverage exercises all three silver classes):
     • alice — active via EMAIL on 2 days (01-05, 01-06)  → 2
     • bob   — active via CHAT  (1 day)                    → 1
     • carol — active via DOCS  (1 day)                    → 1
     team {2, 1, 1} → median 1, range [1, 2].
 
-  One case, asserting alice (value = member, median+range = team):
+  One case, asserting alice (value = member, median/range = team):
     value 2, median 1, range [1, 2]. Teeth: a recv/read-only day (01-07,
     sendCount=0) must NOT count; a duplicate 01-05 row must dedup, not double.
 

--- a/src/ingestion/tests/e2e/specs/collab_active_days.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_active_days.test.yaml
@@ -1,26 +1,16 @@
 spec_version: 1
 description: >
   Metric: m365_active_days — IC Bullet Collaboration (…0012), #1413.
-  m365_active_days = count of distinct days with DELIBERATE m365 activity (email
-  sent, chat sent, file engaged/shared); passive signals (receiveCount/readCount)
-  are EXCLUDED.
+  How it's computed (bronze → silver → gold):
+    • bronze: daily M365 reports — email, Teams chat, OneDrive/SharePoint files
+    • silver: deduped to one row per person/day carrying each signal's count
+    • gold:   a day is "active" if any deliberate signal (email sent, chat sent,
+              file engaged/shared) > 0; metric = count of active days in the
+              window — passive emails (received/read) are excluded
 
-  Path (bronze → silver → gold):
-    • bronze_m365.email_activity    → staging m365__collab_email_activity        → silver.class_collab_email_activity
-    • bronze_m365.teams_activity    → staging m365__collab_chat_activity         → silver.class_collab_chat_activity
-    • bronze_m365.onedrive_activity → staging m365__collab_document_activity_*    → silver.class_collab_document_activity
-    → insight.collab_bullet_rows (gold) → metric …0012.
-
-  Team (department `org_unit_id` — the peer group the median/range span;
-  cross-class coverage exercises all three silver classes):
-    • alice — active via EMAIL on 2 days (01-05, 01-06)  → 2
-    • bob   — active via CHAT  (1 day)                    → 1
-    • carol — active via DOCS  (1 day)                    → 1
-    team {2, 1, 1} → median 1, range [1, 2].
-
-  One case, asserting alice (value = member, median/range = team):
-    value 2, median 1, range [1, 2]. Teeth: a recv/read-only day (01-07,
-    sendCount=0) must NOT count; a duplicate 01-05 row must dedup, not double.
+  Team (median/range = the person's department):
+    alice EMAIL on 2 days · bob CHAT 1 day · carol DOCS 1 day → median 1, range [1, 2].
+  Cases: alice email-active (2) · bob chat-only (1) · carol docs-only (1).
 
 bronze:
   bronze_bamboohr.employees:
@@ -79,3 +69,35 @@ cases:
       - in: collaboration
         find: { metric_key: m365_active_days }
         equal: { value: 2, median: 1, range_min: 1, range_max: 2 }
+
+  # bob is active via CHAT only (1 day) — proves the chat class path directly
+  - name: m365_active_days — bob CHAT-only (value 1 vs team median/range)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'bob@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        find: { metric_key: m365_active_days }
+        equal: { value: 1, median: 1, range_min: 1, range_max: 2 }
+
+  # carol is active via DOCS only (1 day) — proves the document class path directly
+  - name: m365_active_days — carol DOCS-only (value 1 vs team median/range)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'carol@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        find: { metric_key: m365_active_days }
+        equal: { value: 1, median: 1, range_min: 1, range_max: 2 }

--- a/src/ingestion/tests/e2e/specs/collab_emails_read.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_emails_read.test.yaml
@@ -4,8 +4,9 @@ description: >
   query's date-window options — week / month / quarter / custom — with
   boundary-value and equivalence-partition coverage. Asserts ONLY the target
   metric (m365_emails_read) on the IC Bullet Collaboration metric (…0012):
-  value = the requested member's period total over the window, median/range =
-  over the members who have data in that window (org_unit = Engineering).
+  value = the requested member's period total over the window; median/range =
+  the team distribution over the member's department (`org_unit_id` = Engineering)
+  — counting only department members with data in that window.
 
   Test design — alice's reads are placed on/around the bounds of each window so
   every period sum proves inclusive [ge, le] bounds and exclusion just outside:
@@ -22,12 +23,14 @@ description: >
     2026-03-31     2    quarter UPPER bound                  → included (BVA, =le)
     2026-04-01   888    one day AFTER quarter upper          → excluded (BVA+)
 
-  bob/carol each have a single read on 2026-01-08 (inside week/month/quarter but
-  NOT the Feb custom windows), so the cohort is {alice,bob,carol} for the three
-  calendar periods and narrows to {alice} for the Feb windows — exercising that
-  median/range span only members with data in the window. alice's 01-08 row is a
-  verbatim duplicate (same unique_key): it must dedup to 20, otherwise the
-  week/month/quarter sums (and the medians/ranges) would all drift.
+  bob/carol each have a single read on 2026-01-08 (inside week/month/quarter
+  but NOT the Feb custom windows), so all three have data in the three
+  calendar periods while only alice does in the Feb windows — the team
+  median/range spans {alice,bob,carol} for the three calendar periods and only
+  {alice} for Feb (it covers only department members with data in the window).
+  alice's 01-08 row is a verbatim duplicate (same unique_key): it must dedup
+  to 20, otherwise the week/month/quarter sums (and the medians/ranges) would
+  all drift.
 
 bronze:
   bronze_bamboohr.employees:
@@ -53,7 +56,7 @@ bronze:
 cases:
   # ── WEEK (7-day window, Mon 01-05 .. Sun 01-11) ──────────────────────────────
   # alice = 10(05)+20(08)+5(11) = 35  (01-01 below & 01-12 above excluded;
-  #   bounds 01-05/01-11 inclusive). cohort {35,30,15} → median 30, range [15,35]
+  #   bounds 01-05/01-11 inclusive). team {35,30,15} → median 30, range [15,35]
   - name: "m365_emails_read — WEEK window (boundary-inclusive lower/upper)"
     request:
       url: /v1/metrics/queries
@@ -73,7 +76,7 @@ cases:
 
   # ── MONTH (calendar January) ─────────────────────────────────────────────────
   # alice = 1+10+20+5+100+3 = 139  (12-31 excluded, 02-11 excluded; 01-01/01-31
-  #   bounds inclusive). cohort {139,30,15} → median 30, range [15,139]
+  #   bounds inclusive). team {139,30,15} → median 30, range [15,139]
   - name: "m365_emails_read — MONTH window (lower/upper bound inclusive, prior day excluded)"
     request:
       url: /v1/metrics/queries
@@ -91,7 +94,7 @@ cases:
 
   # ── QUARTER (Q1 2026) ────────────────────────────────────────────────────────
   # alice = 139(Jan) + 50(02-11) + 2(03-31) = 191  (12-31 & 04-01 excluded;
-  #   03-31 bound inclusive). cohort {191,30,15} → median 30, range [15,191]
+  #   03-31 bound inclusive). team {191,30,15} → median 30, range [15,191]
   - name: "m365_emails_read — QUARTER window (full Q1 sum, just-after excluded)"
     request:
       url: /v1/metrics/queries
@@ -108,8 +111,8 @@ cases:
         equal: { value: 191, median: 30, range_min: 15, range_max: 191 }
 
   # ── CUSTOM (narrow mid-quarter range 02-10 .. 02-12) ─────────────────────────
-  # alice = 50(02-11); bob/carol have no data in range → cohort {50} only
-  - name: "m365_emails_read — CUSTOM narrow window (cohort narrows to members with data)"
+  # alice = 50(02-11); bob/carol have no data in range → team {50} only
+  - name: "m365_emails_read — CUSTOM narrow window (median/range narrows to members with data)"
     request:
       url: /v1/metrics/queries
       method: POST

--- a/src/ingestion/tests/e2e/specs/collab_emails_read.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_emails_read.test.yaml
@@ -8,6 +8,10 @@ description: >
   the team distribution over the member's department (`org_unit_id` = Engineering)
   — counting only department members with data in that window.
 
+  Path (bronze → silver → gold):
+    • bronze_m365.email_activity → staging m365__collab_email_activity → silver.class_collab_email_activity
+    → insight.collab_bullet_rows (gold) → metric …0012.
+
   Test design — alice's reads are placed on/around the bounds of each window so
   every period sum proves inclusive [ge, le] bounds and exclusion just outside:
 

--- a/src/ingestion/tests/e2e/specs/collab_emails_read.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_emails_read.test.yaml
@@ -1,40 +1,13 @@
 spec_version: 1
 description: >
-  Per-metric E2E check for m365_emails_read (#1413), exercising the metric
-  query's date-window options — week / month / quarter / custom — with
-  boundary-value and equivalence-partition coverage. Asserts ONLY the target
-  metric (m365_emails_read) on the IC Bullet Collaboration metric (…0012):
-  value = the requested member's period total over the window; median/range =
-  the team distribution over the member's department (`org_unit_id` = Engineering)
-  — counting only department members with data in that window.
+  Metric: m365_emails_read — IC Bullet Collaboration (…0012), #1413.
+  How it's computed (bronze → silver → gold):
+    • bronze: daily M365 email-activity report per person (send/receive/read counts)
+    • silver: deduped to one row per person/day with the read-email count
+    • gold:   metric = sum of emails read over the window
 
-  Path (bronze → silver → gold):
-    • bronze_m365.email_activity → staging m365__collab_email_activity → silver.class_collab_email_activity
-    → insight.collab_bullet_rows (gold) → metric …0012.
-
-  Test design — alice's reads are placed on/around the bounds of each window so
-  every period sum proves inclusive [ge, le] bounds and exclusion just outside:
-
-    date         read   role in the coverage
-    2025-12-31   999    one day BEFORE quarter/month lower  → excluded (BVA-)
-    2026-01-01     1    quarter & month LOWER bound          → included (BVA, =ge)
-    2026-01-05    10    week LOWER bound                     → included (BVA, =ge)
-    2026-01-08    20    interior of week/month/quarter (duplicated → dedup)
-    2026-01-11     5    week UPPER bound                     → included (BVA, =le)
-    2026-01-12   100    one day AFTER week upper             → excluded from week
-    2026-01-31     3    month UPPER bound                    → included (BVA, =le)
-    2026-02-11    50    interior of quarter; custom window
-    2026-03-31     2    quarter UPPER bound                  → included (BVA, =le)
-    2026-04-01   888    one day AFTER quarter upper          → excluded (BVA+)
-
-  bob/carol each have a single read on 2026-01-08 (inside week/month/quarter
-  but NOT the Feb custom windows), so all three have data in the three
-  calendar periods while only alice does in the Feb windows — the team
-  median/range spans {alice,bob,carol} for the three calendar periods and only
-  {alice} for Feb (it covers only department members with data in the window).
-  alice's 01-08 row is a verbatim duplicate (same unique_key): it must dedup
-  to 20, otherwise the week/month/quarter sums (and the medians/ranges) would
-  all drift.
+  Cases (median/range = department members with data in the window): week · month
+  · quarter · custom · single-day · cross-year · empty window.
 
 bronze:
   bronze_bamboohr.employees:

--- a/src/ingestion/tests/e2e/specs/collab_emails_received.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_emails_received.test.yaml
@@ -4,8 +4,9 @@ description: >
   query's date-window options — week / month / quarter / custom — with
   boundary-value and equivalence-partition coverage. Asserts ONLY the target
   metric (m365_emails_received) on the IC Bullet Collaboration metric (…0012):
-  value = the requested member's period total over the window, median/range =
-  over the members who have data in that window (org_unit = Engineering).
+  value = the requested member's period total over the window; median/range =
+  the team distribution over the member's department (`org_unit_id` = Engineering)
+  — counting only department members with data in that window.
 
   Test design — alice's receives are placed on/around the bounds of each window
   so every period sum proves inclusive [ge, le] bounds and exclusion just outside:
@@ -22,12 +23,14 @@ description: >
     2026-03-31     4    quarter UPPER bound                  → included (BVA, =le)
     2026-04-01   900    one day AFTER quarter upper          → excluded (BVA+)
 
-  bob/carol each have a single receive on 2026-01-08 (inside week/month/quarter
-  but NOT the Feb custom windows), so the cohort is {alice,bob,carol} for the
-  three calendar periods and narrows to {alice} for the Feb windows — exercising
-  that median/range span only members with data in the window. alice's 01-08 row
-  is a verbatim duplicate (same unique_key): it must dedup to 40, otherwise the
-  week/month/quarter sums (and the medians/ranges) would all drift.
+  bob/carol each have a single receive on 2026-01-08 (inside
+  week/month/quarter but NOT the Feb custom windows), so all three have data
+  in the three calendar periods while only alice does in the Feb windows — the
+  team median/range spans {alice,bob,carol} for the three calendar periods and
+  only {alice} for Feb (it covers only department members with data in the
+  window). alice's 01-08 row is a verbatim duplicate (same unique_key): it
+  must dedup to 40, otherwise the week/month/quarter sums (and the
+  medians/ranges) would all drift.
 
 bronze:
   bronze_bamboohr.employees:
@@ -53,7 +56,7 @@ bronze:
 cases:
   # ── WEEK (7-day window, Mon 01-05 .. Sun 01-11) ──────────────────────────────
   # alice = 20(05)+40(08)+8(11) = 68  (01-01 below & 01-12 above excluded;
-  #   bounds 01-05/01-11 inclusive). cohort {68,60,25} → median 60, range [25,68]
+  #   bounds 01-05/01-11 inclusive). team {68,60,25} → median 60, range [25,68]
   - name: "m365_emails_received — WEEK window (boundary-inclusive lower/upper)"
     request:
       url: /v1/metrics/queries
@@ -73,7 +76,7 @@ cases:
 
   # ── MONTH (calendar January) ─────────────────────────────────────────────────
   # alice = 2+20+40+8+200+6 = 276  (12-31 excluded, 02-11 excluded; 01-01/01-31
-  #   bounds inclusive). cohort {276,60,25} → median 60, range [25,276]
+  #   bounds inclusive). team {276,60,25} → median 60, range [25,276]
   - name: "m365_emails_received — MONTH window (lower/upper bound inclusive, prior day excluded)"
     request:
       url: /v1/metrics/queries
@@ -91,7 +94,7 @@ cases:
 
   # ── QUARTER (Q1 2026) ────────────────────────────────────────────────────────
   # alice = 276(Jan) + 70(02-11) + 4(03-31) = 350  (12-31 & 04-01 excluded;
-  #   03-31 bound inclusive). cohort {350,60,25} → median 60, range [25,350]
+  #   03-31 bound inclusive). team {350,60,25} → median 60, range [25,350]
   - name: "m365_emails_received — QUARTER window (full Q1 sum, just-after excluded)"
     request:
       url: /v1/metrics/queries
@@ -108,8 +111,8 @@ cases:
         equal: { value: 350, median: 60, range_min: 25, range_max: 350 }
 
   # ── CUSTOM (narrow mid-quarter range 02-10 .. 02-12) ─────────────────────────
-  # alice = 70(02-11); bob/carol have no data in range → cohort {70} only
-  - name: "m365_emails_received — CUSTOM narrow window (cohort narrows to members with data)"
+  # alice = 70(02-11); bob/carol have no data in range → team {70} only
+  - name: "m365_emails_received — CUSTOM narrow window (median/range narrows to members with data)"
     request:
       url: /v1/metrics/queries
       method: POST

--- a/src/ingestion/tests/e2e/specs/collab_emails_received.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_emails_received.test.yaml
@@ -8,6 +8,10 @@ description: >
   the team distribution over the member's department (`org_unit_id` = Engineering)
   — counting only department members with data in that window.
 
+  Path (bronze → silver → gold):
+    • bronze_m365.email_activity → staging m365__collab_email_activity → silver.class_collab_email_activity
+    → insight.collab_bullet_rows (gold) → metric …0012.
+
   Test design — alice's receives are placed on/around the bounds of each window
   so every period sum proves inclusive [ge, le] bounds and exclusion just outside:
 

--- a/src/ingestion/tests/e2e/specs/collab_emails_received.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_emails_received.test.yaml
@@ -1,40 +1,13 @@
 spec_version: 1
 description: >
-  Per-metric E2E check for m365_emails_received (#1413), exercising the metric
-  query's date-window options — week / month / quarter / custom — with
-  boundary-value and equivalence-partition coverage. Asserts ONLY the target
-  metric (m365_emails_received) on the IC Bullet Collaboration metric (…0012):
-  value = the requested member's period total over the window; median/range =
-  the team distribution over the member's department (`org_unit_id` = Engineering)
-  — counting only department members with data in that window.
+  Metric: m365_emails_received — IC Bullet Collaboration (…0012), #1413.
+  How it's computed (bronze → silver → gold):
+    • bronze: daily M365 email-activity report per person (send/receive/read counts)
+    • silver: deduped to one row per person/day with the received-email count
+    • gold:   metric = sum of emails received over the window
 
-  Path (bronze → silver → gold):
-    • bronze_m365.email_activity → staging m365__collab_email_activity → silver.class_collab_email_activity
-    → insight.collab_bullet_rows (gold) → metric …0012.
-
-  Test design — alice's receives are placed on/around the bounds of each window
-  so every period sum proves inclusive [ge, le] bounds and exclusion just outside:
-
-    date         recv   role in the coverage
-    2025-12-31   700    one day BEFORE quarter/month lower  → excluded (BVA-)
-    2026-01-01     2    quarter & month LOWER bound          → included (BVA, =ge)
-    2026-01-05    20    week LOWER bound                     → included (BVA, =ge)
-    2026-01-08    40    interior of week/month/quarter (duplicated → dedup)
-    2026-01-11     8    week UPPER bound                     → included (BVA, =le)
-    2026-01-12   200    one day AFTER week upper             → excluded from week
-    2026-01-31     6    month UPPER bound                    → included (BVA, =le)
-    2026-02-11    70    interior of quarter; custom window
-    2026-03-31     4    quarter UPPER bound                  → included (BVA, =le)
-    2026-04-01   900    one day AFTER quarter upper          → excluded (BVA+)
-
-  bob/carol each have a single receive on 2026-01-08 (inside
-  week/month/quarter but NOT the Feb custom windows), so all three have data
-  in the three calendar periods while only alice does in the Feb windows — the
-  team median/range spans {alice,bob,carol} for the three calendar periods and
-  only {alice} for Feb (it covers only department members with data in the
-  window). alice's 01-08 row is a verbatim duplicate (same unique_key): it
-  must dedup to 40, otherwise the week/month/quarter sums (and the
-  medians/ranges) would all drift.
+  Cases (median/range = department members with data in the window): week · month
+  · quarter · custom · single-day · cross-year · empty window.
 
 bronze:
   bronze_bamboohr.employees:

--- a/src/ingestion/tests/e2e/specs/collab_emails_sent.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_emails_sent.test.yaml
@@ -4,8 +4,9 @@ description: >
   query's date-window options — week / month / quarter / custom — with
   boundary-value and equivalence-partition coverage. Asserts ONLY the target
   metric (m365_emails_sent) on the IC Bullet Collaboration metric (…0012):
-  value = the requested member's period total over the window, median/range =
-  over the members who have data in that window (org_unit = Engineering).
+  value = the requested member's period total over the window; median/range =
+  the team distribution over the member's department (`org_unit_id` = Engineering)
+  — counting only department members with data in that window.
 
   Test design — alice's sends are placed on/around the bounds of each window so
   every period sum proves inclusive [ge, le] bounds and exclusion just outside:
@@ -22,12 +23,14 @@ description: >
     2026-03-31     6    quarter UPPER bound                  → included (BVA, =le)
     2026-04-01   700    one day AFTER quarter upper          → excluded (BVA+)
 
-  bob/carol each have a single send on 2026-01-08 (inside week/month/quarter but
-  NOT the Feb custom windows), so the cohort is {alice,bob,carol} for the three
-  calendar periods and narrows to {alice} for the Feb windows — exercising that
-  median/range span only members with data in the window. alice's 01-08 row is a
-  verbatim duplicate (same unique_key): it must dedup to 25, otherwise the
-  week/month/quarter sums (and the medians/ranges) would all drift.
+  bob/carol each have a single send on 2026-01-08 (inside week/month/quarter
+  but NOT the Feb custom windows), so all three have data in the three
+  calendar periods while only alice does in the Feb windows — the team
+  median/range spans {alice,bob,carol} for the three calendar periods and only
+  {alice} for Feb (it covers only department members with data in the window).
+  alice's 01-08 row is a verbatim duplicate (same unique_key): it must dedup
+  to 25, otherwise the week/month/quarter sums (and the medians/ranges) would
+  all drift.
 
 bronze:
   bronze_bamboohr.employees:
@@ -53,7 +56,7 @@ bronze:
 cases:
   # ── WEEK (7-day window, Mon 01-05 .. Sun 01-11) ──────────────────────────────
   # alice = 20(05)+25(08)+12(11) = 57  (01-01 below & 01-12 above excluded;
-  #   bounds 01-05/01-11 inclusive). cohort {57,50,18} → median 50, range [18,57]
+  #   bounds 01-05/01-11 inclusive). team {57,50,18} → median 50, range [18,57]
   - name: "m365_emails_sent — WEEK window (boundary-inclusive lower/upper)"
     request:
       url: /v1/metrics/queries
@@ -73,7 +76,7 @@ cases:
 
   # ── MONTH (calendar January) ─────────────────────────────────────────────────
   # alice = 3+20+25+12+150+4 = 214  (12-31 excluded, 02-11 excluded; 01-01/01-31
-  #   bounds inclusive). cohort {214,50,18} → median 50, range [18,214]
+  #   bounds inclusive). team {214,50,18} → median 50, range [18,214]
   - name: "m365_emails_sent — MONTH window (lower/upper bound inclusive, prior day excluded)"
     request:
       url: /v1/metrics/queries
@@ -91,7 +94,7 @@ cases:
 
   # ── QUARTER (Q1 2026) ────────────────────────────────────────────────────────
   # alice = 214(Jan) + 60(02-11) + 6(03-31) = 280  (12-31 & 04-01 excluded;
-  #   03-31 bound inclusive). cohort {280,50,18} → median 50, range [18,280]
+  #   03-31 bound inclusive). team {280,50,18} → median 50, range [18,280]
   - name: "m365_emails_sent — QUARTER window (full Q1 sum, just-after excluded)"
     request:
       url: /v1/metrics/queries
@@ -108,8 +111,8 @@ cases:
         equal: { value: 280, median: 50, range_min: 18, range_max: 280 }
 
   # ── CUSTOM (narrow mid-quarter range 02-10 .. 02-12) ─────────────────────────
-  # alice = 60(02-11); bob/carol have no data in range → cohort {60} only
-  - name: "m365_emails_sent — CUSTOM narrow window (cohort narrows to members with data)"
+  # alice = 60(02-11); bob/carol have no data in range → team {60} only
+  - name: "m365_emails_sent — CUSTOM narrow window (median/range narrows to members with data)"
     request:
       url: /v1/metrics/queries
       method: POST

--- a/src/ingestion/tests/e2e/specs/collab_emails_sent.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_emails_sent.test.yaml
@@ -8,6 +8,10 @@ description: >
   the team distribution over the member's department (`org_unit_id` = Engineering)
   — counting only department members with data in that window.
 
+  Path (bronze → silver → gold):
+    • bronze_m365.email_activity → staging m365__collab_email_activity → silver.class_collab_email_activity
+    → insight.collab_bullet_rows (gold) → metric …0012.
+
   Test design — alice's sends are placed on/around the bounds of each window so
   every period sum proves inclusive [ge, le] bounds and exclusion just outside:
 

--- a/src/ingestion/tests/e2e/specs/collab_emails_sent.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_emails_sent.test.yaml
@@ -1,40 +1,13 @@
 spec_version: 1
 description: >
-  Per-metric E2E check for m365_emails_sent (#1413), exercising the metric
-  query's date-window options — week / month / quarter / custom — with
-  boundary-value and equivalence-partition coverage. Asserts ONLY the target
-  metric (m365_emails_sent) on the IC Bullet Collaboration metric (…0012):
-  value = the requested member's period total over the window; median/range =
-  the team distribution over the member's department (`org_unit_id` = Engineering)
-  — counting only department members with data in that window.
+  Metric: m365_emails_sent — IC Bullet Collaboration (…0012), #1413.
+  How it's computed (bronze → silver → gold):
+    • bronze: daily M365 email-activity report per person (send/receive/read counts)
+    • silver: deduped to one row per person/day with the sent-email count
+    • gold:   metric = sum of emails sent over the window
 
-  Path (bronze → silver → gold):
-    • bronze_m365.email_activity → staging m365__collab_email_activity → silver.class_collab_email_activity
-    → insight.collab_bullet_rows (gold) → metric …0012.
-
-  Test design — alice's sends are placed on/around the bounds of each window so
-  every period sum proves inclusive [ge, le] bounds and exclusion just outside:
-
-    date         sent   role in the coverage
-    2025-12-31   500    one day BEFORE quarter/month lower  → excluded (BVA-)
-    2026-01-01     3    quarter & month LOWER bound          → included (BVA, =ge)
-    2026-01-05    20    week LOWER bound                     → included (BVA, =ge)
-    2026-01-08    25    interior of week/month/quarter (duplicated → dedup)
-    2026-01-11    12    week UPPER bound                     → included (BVA, =le)
-    2026-01-12   150    one day AFTER week upper             → excluded from week
-    2026-01-31     4    month UPPER bound                    → included (BVA, =le)
-    2026-02-11    60    interior of quarter; custom window
-    2026-03-31     6    quarter UPPER bound                  → included (BVA, =le)
-    2026-04-01   700    one day AFTER quarter upper          → excluded (BVA+)
-
-  bob/carol each have a single send on 2026-01-08 (inside week/month/quarter
-  but NOT the Feb custom windows), so all three have data in the three
-  calendar periods while only alice does in the Feb windows — the team
-  median/range spans {alice,bob,carol} for the three calendar periods and only
-  {alice} for Feb (it covers only department members with data in the window).
-  alice's 01-08 row is a verbatim duplicate (same unique_key): it must dedup
-  to 25, otherwise the week/month/quarter sums (and the medians/ranges) would
-  all drift.
+  Cases (median/range = department members with data in the window): week · month
+  · quarter · custom · single-day · cross-year · empty window.
 
 bronze:
   bronze_bamboohr.employees:

--- a/src/ingestion/tests/e2e/specs/collab_files_engaged.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_files_engaged.test.yaml
@@ -1,0 +1,58 @@
+spec_version: 1
+description: >
+  Per-metric E2E check for m365_files_engaged (#1413). Seeds
+  bronze_m365.onedrive_activity + bronze_m365.sharepoint_activity for 3 people in
+  one team and asserts the IC Bullet Collaboration metric (…0012).
+  m365_files_engaged = Σ viewedOrEditedFileCount across BOTH products and the
+  period. alice has both products (30 + 20 = 50) to pin the cross-product sum.
+  value = member, median/range = team.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+    - $ref: templates/people.yaml#/templates/bob
+    - $ref: templates/people.yaml#/templates/carol
+
+  bronze_m365.onedrive_activity:
+    - $ref: templates/m365_onedrive.yaml#/templates/alice_onedrive
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-od-eng-20260105
+      viewedOrEditedFileCount: 30
+    - $ref: templates/m365_onedrive.yaml#/templates/alice_onedrive  # verbatim duplicate -> must dedup, not double
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-od-eng-20260105
+      viewedOrEditedFileCount: 30
+    - $ref: templates/m365_onedrive.yaml#/templates/bob_onedrive
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-bob-od-eng-20260105
+      viewedOrEditedFileCount: 15
+
+  bronze_m365.sharepoint_activity:
+    - $ref: templates/m365_sharepoint.yaml#/templates/alice_sharepoint
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-sp-eng-20260105
+      viewedOrEditedFileCount: 20
+    - $ref: templates/m365_sharepoint.yaml#/templates/carol_sharepoint
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-carol-sp-eng-20260105
+      viewedOrEditedFileCount: 5
+
+cases:
+  # team m365_files_engaged = [alice 30+20=50, bob 15, carol 5]
+  #   value (alice) = 50 ; median[5,15,50] = 15 ; range = [5,50]
+  - name: m365_files_engaged — IC bullet (alice value vs team median/range)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'alice@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        assert: "result.status == 'ok'"
+      - in: collaboration
+        find: { metric_key: m365_files_engaged }
+        equal: { value: 50, median: 15, range_min: 5, range_max: 50 }

--- a/src/ingestion/tests/e2e/specs/collab_files_engaged.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_files_engaged.test.yaml
@@ -1,11 +1,23 @@
 spec_version: 1
 description: >
-  Per-metric E2E check for m365_files_engaged (#1413). Seeds
-  bronze_m365.onedrive_activity + bronze_m365.sharepoint_activity for 3 people in
-  one team and asserts the IC Bullet Collaboration metric (…0012).
-  m365_files_engaged = Σ viewedOrEditedFileCount across BOTH products and the
-  period. alice has both products (30 + 20 = 50) to pin the cross-product sum.
-  value = member, median/range = team.
+  Metric: m365_files_engaged — IC Bullet Collaboration (…0012), #1413.
+  m365_files_engaged = Σ viewed_or_edited_count over the period, summed ACROSS
+  both document products (OneDrive + SharePoint).
+
+  Path (bronze → silver → gold):
+    • bronze_m365.onedrive_activity   → staging m365__collab_document_activity_onedrive   → silver.class_collab_document_activity
+    • bronze_m365.sharepoint_activity → staging m365__collab_document_activity_sharepoint → silver.class_collab_document_activity
+    → insight.collab_bullet_rows (gold) → metric …0012.
+
+  Team (department `org_unit_id` — the peer group the median/range span):
+    • alice — 30 OneDrive + 20 SharePoint = 50  (pins the cross-product sum)
+    • bob   — 15 OneDrive                 = 15
+    • carol —  5 SharePoint               =  5
+    team {50, 15, 5} → median 15, range [5, 50].
+
+  One case, asserting alice (value = member, median/range = team):
+    value 50, median 15, range [5, 50]. Teeth: alice's OneDrive row is a verbatim
+    duplicate → must dedup (still 50, not 80).
 
 bronze:
   bronze_bamboohr.employees:

--- a/src/ingestion/tests/e2e/specs/collab_files_engaged.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_files_engaged.test.yaml
@@ -1,23 +1,15 @@
 spec_version: 1
 description: >
   Metric: m365_files_engaged — IC Bullet Collaboration (…0012), #1413.
-  m365_files_engaged = Σ viewed_or_edited_count over the period, summed ACROSS
-  both document products (OneDrive + SharePoint).
+  How it's computed (bronze → silver → gold):
+    • bronze: daily OneDrive and SharePoint file-activity reports per person
+    • silver: each product deduped to per-person/day file counts (viewed/edited, shared)
+    • gold:   metric = sum of files viewed or edited over the window, across both products
 
-  Path (bronze → silver → gold):
-    • bronze_m365.onedrive_activity   → staging m365__collab_document_activity_onedrive   → silver.class_collab_document_activity
-    • bronze_m365.sharepoint_activity → staging m365__collab_document_activity_sharepoint → silver.class_collab_document_activity
-    → insight.collab_bullet_rows (gold) → metric …0012.
-
-  Team (department `org_unit_id` — the peer group the median/range span):
-    • alice — 30 OneDrive + 20 SharePoint = 50  (pins the cross-product sum)
-    • bob   — 15 OneDrive                 = 15
-    • carol —  5 SharePoint               =  5
-    team {50, 15, 5} → median 15, range [5, 50].
-
-  One case, asserting alice (value = member, median/range = team):
-    value 50, median 15, range [5, 50]. Teeth: alice's OneDrive row is a verbatim
-    duplicate → must dedup (still 50, not 80).
+  Team (median/range = the person's department):
+    alice 30 OneDrive + 20 SharePoint = 50 · bob 15 OneDrive · carol 5 SharePoint
+    → median 15, range [5, 50].
+  Cases: alice cross-product (50) · bob OneDrive-only (15) · carol SharePoint-only (5).
 
 bronze:
   bronze_bamboohr.employees:
@@ -52,7 +44,7 @@ bronze:
 cases:
   # team m365_files_engaged = [alice 30+20=50, bob 15, carol 5]
   #   value (alice) = 50 ; median[5,15,50] = 15 ; range = [5,50]
-  - name: m365_files_engaged — IC bullet (alice value vs team median/range)
+  - name: m365_files_engaged — alice OneDrive+SharePoint (cross-product sum vs team median/range)
     request:
       url: /v1/metrics/queries
       method: POST
@@ -68,3 +60,35 @@ cases:
       - in: collaboration
         find: { metric_key: m365_files_engaged }
         equal: { value: 50, median: 15, range_min: 5, range_max: 50 }
+
+  # bob is engaged via OneDrive only — proves the OneDrive product path directly
+  - name: m365_files_engaged — bob OneDrive-only (value 15 vs team median/range)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'bob@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        find: { metric_key: m365_files_engaged }
+        equal: { value: 15, median: 15, range_min: 5, range_max: 50 }
+
+  # carol is engaged via SharePoint only — proves the SharePoint product path directly
+  - name: m365_files_engaged — carol SharePoint-only (value 5 vs team median/range)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'carol@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        find: { metric_key: m365_files_engaged }
+        equal: { value: 5, median: 15, range_min: 5, range_max: 50 }

--- a/src/ingestion/tests/e2e/specs/collab_files_shared_external.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_files_shared_external.test.yaml
@@ -4,8 +4,8 @@ description: >
   bronze_m365.onedrive_activity + bronze_m365.sharepoint_activity for 3 people in
   one team and asserts the IC Bullet Collaboration metric (…0012).
   m365_files_shared_external = Σ sharedExternallyFileCount across BOTH products
-  and the period. alice has both (2 + 1 = 3); carol = 0 (a real 0 in the cohort).
-  value = member, median/range = team.
+  and the period. alice has both (2 + 1 = 3); carol = 0 (a real 0 in the team).
+  value = member; median/range = team (department `org_unit_id`).
 
 bronze:
   bronze_bamboohr.employees:

--- a/src/ingestion/tests/e2e/specs/collab_files_shared_external.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_files_shared_external.test.yaml
@@ -1,0 +1,58 @@
+spec_version: 1
+description: >
+  Per-metric E2E check for m365_files_shared_external (#1413). Seeds
+  bronze_m365.onedrive_activity + bronze_m365.sharepoint_activity for 3 people in
+  one team and asserts the IC Bullet Collaboration metric (…0012).
+  m365_files_shared_external = Σ sharedExternallyFileCount across BOTH products
+  and the period. alice has both (2 + 1 = 3); carol = 0 (a real 0 in the cohort).
+  value = member, median/range = team.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+    - $ref: templates/people.yaml#/templates/bob
+    - $ref: templates/people.yaml#/templates/carol
+
+  bronze_m365.onedrive_activity:
+    - $ref: templates/m365_onedrive.yaml#/templates/alice_onedrive
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-od-ext-20260105
+      sharedExternallyFileCount: 2
+    - $ref: templates/m365_onedrive.yaml#/templates/alice_onedrive  # verbatim duplicate -> must dedup, not double
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-od-ext-20260105
+      sharedExternallyFileCount: 2
+    - $ref: templates/m365_onedrive.yaml#/templates/bob_onedrive
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-bob-od-ext-20260105
+      sharedExternallyFileCount: 1
+
+  bronze_m365.sharepoint_activity:
+    - $ref: templates/m365_sharepoint.yaml#/templates/alice_sharepoint
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-sp-ext-20260105
+      sharedExternallyFileCount: 1
+    - $ref: templates/m365_sharepoint.yaml#/templates/carol_sharepoint
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-carol-sp-ext-20260105
+      sharedExternallyFileCount: 0
+
+cases:
+  # team m365_files_shared_external = [alice 2+1=3, bob 1, carol 0]
+  #   value (alice) = 3 ; median[0,1,3] = 1 ; range = [0,3]
+  - name: m365_files_shared_external — IC bullet (alice value vs team median/range)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'alice@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        assert: "result.status == 'ok'"
+      - in: collaboration
+        find: { metric_key: m365_files_shared_external }
+        equal: { value: 3, median: 1, range_min: 0, range_max: 3 }

--- a/src/ingestion/tests/e2e/specs/collab_files_shared_external.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_files_shared_external.test.yaml
@@ -1,11 +1,24 @@
 spec_version: 1
 description: >
-  Per-metric E2E check for m365_files_shared_external (#1413). Seeds
-  bronze_m365.onedrive_activity + bronze_m365.sharepoint_activity for 3 people in
-  one team and asserts the IC Bullet Collaboration metric (…0012).
-  m365_files_shared_external = Σ sharedExternallyFileCount across BOTH products
-  and the period. alice has both (2 + 1 = 3); carol = 0 (a real 0 in the team).
-  value = member; median/range = team (department `org_unit_id`).
+  Metric: m365_files_shared_external — IC Bullet Collaboration (…0012), #1413.
+  m365_files_shared_external = Σ shared_externally_count over the period, summed
+  ACROSS both document products (OneDrive + SharePoint).
+
+  Path (bronze → silver → gold):
+    • bronze_m365.onedrive_activity   → staging m365__collab_document_activity_onedrive   → silver.class_collab_document_activity
+    • bronze_m365.sharepoint_activity → staging m365__collab_document_activity_sharepoint → silver.class_collab_document_activity
+    → insight.collab_bullet_rows (gold) → metric …0012.
+
+  Team (department `org_unit_id` — the peer group the median/range span):
+    • alice — 2 OneDrive + 1 SharePoint = 3  (cross-product sum)
+    • bob   — 1 OneDrive                = 1
+    • carol — 0 (a real zero in the team)
+    team {3, 1, 0} → median 1, range [0, 3].
+
+  One case, asserting alice (value = member, median/range = team):
+    value 3, median 1, range [0, 3]. Teeth: alice's OneDrive row is a verbatim
+    duplicate → must dedup (still 3, not 5); carol's 0 is a real in-team zero,
+    pinning range_min = 0.
 
 bronze:
   bronze_bamboohr.employees:

--- a/src/ingestion/tests/e2e/specs/collab_files_shared_external.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_files_shared_external.test.yaml
@@ -1,24 +1,15 @@
 spec_version: 1
 description: >
   Metric: m365_files_shared_external — IC Bullet Collaboration (…0012), #1413.
-  m365_files_shared_external = Σ shared_externally_count over the period, summed
-  ACROSS both document products (OneDrive + SharePoint).
+  How it's computed (bronze → silver → gold):
+    • bronze: daily OneDrive and SharePoint file-activity reports per person
+    • silver: each product deduped to per-person/day share counts
+    • gold:   metric = sum of files shared externally over the window, across both products
 
-  Path (bronze → silver → gold):
-    • bronze_m365.onedrive_activity   → staging m365__collab_document_activity_onedrive   → silver.class_collab_document_activity
-    • bronze_m365.sharepoint_activity → staging m365__collab_document_activity_sharepoint → silver.class_collab_document_activity
-    → insight.collab_bullet_rows (gold) → metric …0012.
-
-  Team (department `org_unit_id` — the peer group the median/range span):
-    • alice — 2 OneDrive + 1 SharePoint = 3  (cross-product sum)
-    • bob   — 1 OneDrive                = 1
-    • carol — 0 (a real zero in the team)
-    team {3, 1, 0} → median 1, range [0, 3].
-
-  One case, asserting alice (value = member, median/range = team):
-    value 3, median 1, range [0, 3]. Teeth: alice's OneDrive row is a verbatim
-    duplicate → must dedup (still 3, not 5); carol's 0 is a real in-team zero,
-    pinning range_min = 0.
+  Team (median/range = the person's department):
+    alice 2 OneDrive + 1 SharePoint = 3 · bob 1 OneDrive · carol 0 (SharePoint, real zero)
+    → median 1, range [0, 3].
+  Cases: alice cross-product (3) · bob OneDrive-only (1) · carol SharePoint-only (0, real zero).
 
 bronze:
   bronze_bamboohr.employees:
@@ -53,7 +44,7 @@ bronze:
 cases:
   # team m365_files_shared_external = [alice 2+1=3, bob 1, carol 0]
   #   value (alice) = 3 ; median[0,1,3] = 1 ; range = [0,3]
-  - name: m365_files_shared_external — IC bullet (alice value vs team median/range)
+  - name: m365_files_shared_external — alice OneDrive+SharePoint (cross-product sum vs team median/range)
     request:
       url: /v1/metrics/queries
       method: POST
@@ -69,3 +60,35 @@ cases:
       - in: collaboration
         find: { metric_key: m365_files_shared_external }
         equal: { value: 3, median: 1, range_min: 0, range_max: 3 }
+
+  # bob shares externally via OneDrive only — proves the OneDrive product path directly
+  - name: m365_files_shared_external — bob OneDrive-only (value 1 vs team median/range)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'bob@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        find: { metric_key: m365_files_shared_external }
+        equal: { value: 1, median: 1, range_min: 0, range_max: 3 }
+
+  # carol has a SharePoint row but shared 0 externally — a real in-team zero member
+  - name: m365_files_shared_external — carol SharePoint-only (real zero, value 0)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'carol@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        find: { metric_key: m365_files_shared_external }
+        equal: { value: 0, median: 1, range_min: 0, range_max: 3 }

--- a/src/ingestion/tests/e2e/specs/collab_files_shared_internal.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_files_shared_internal.test.yaml
@@ -1,11 +1,24 @@
 spec_version: 1
 description: >
-  Per-metric E2E check for m365_files_shared_internal (#1413). Seeds
-  bronze_m365.onedrive_activity + bronze_m365.sharepoint_activity for 3 people in
-  one team and asserts the IC Bullet Collaboration metric (…0012).
-  m365_files_shared_internal = Σ sharedInternallyFileCount across BOTH products
-  and the period. alice has both products (5 + 3 = 8). value = member,
-  median/range = team.
+  Metric: m365_files_shared_internal — IC Bullet Collaboration (…0012), #1413.
+  m365_files_shared_internal = Σ shared_internally_count over the period, summed
+  ACROSS both document products (OneDrive + SharePoint).
+
+  Path (bronze → silver → gold):
+    • bronze_m365.onedrive_activity   → staging m365__collab_document_activity_onedrive   → silver.class_collab_document_activity
+    • bronze_m365.sharepoint_activity → staging m365__collab_document_activity_sharepoint → silver.class_collab_document_activity
+    → insight.collab_bullet_rows (gold) → metric …0012.
+
+  Team (department `org_unit_id` — the peer group the median/range span):
+    • alice — 5 OneDrive + 3 SharePoint = 8  (cross-product sum)
+    • bob   — 2 OneDrive                = 2
+    • carol — 1 SharePoint              = 1
+    team {8, 2, 1} → median 2, range [1, 8].
+
+  One case, asserting alice (value = member, median/range = team):
+    value 8, median 2, range [1, 8]. Teeth: alice's OneDrive row is a verbatim
+    duplicate → must dedup (still 8, not 13).
+
 
 bronze:
   bronze_bamboohr.employees:

--- a/src/ingestion/tests/e2e/specs/collab_files_shared_internal.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_files_shared_internal.test.yaml
@@ -1,0 +1,58 @@
+spec_version: 1
+description: >
+  Per-metric E2E check for m365_files_shared_internal (#1413). Seeds
+  bronze_m365.onedrive_activity + bronze_m365.sharepoint_activity for 3 people in
+  one team and asserts the IC Bullet Collaboration metric (…0012).
+  m365_files_shared_internal = Σ sharedInternallyFileCount across BOTH products
+  and the period. alice has both products (5 + 3 = 8). value = member,
+  median/range = team.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+    - $ref: templates/people.yaml#/templates/bob
+    - $ref: templates/people.yaml#/templates/carol
+
+  bronze_m365.onedrive_activity:
+    - $ref: templates/m365_onedrive.yaml#/templates/alice_onedrive
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-od-int-20260105
+      sharedInternallyFileCount: 5
+    - $ref: templates/m365_onedrive.yaml#/templates/alice_onedrive  # verbatim duplicate -> must dedup, not double
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-od-int-20260105
+      sharedInternallyFileCount: 5
+    - $ref: templates/m365_onedrive.yaml#/templates/bob_onedrive
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-bob-od-int-20260105
+      sharedInternallyFileCount: 2
+
+  bronze_m365.sharepoint_activity:
+    - $ref: templates/m365_sharepoint.yaml#/templates/alice_sharepoint
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-sp-int-20260105
+      sharedInternallyFileCount: 3
+    - $ref: templates/m365_sharepoint.yaml#/templates/carol_sharepoint
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-carol-sp-int-20260105
+      sharedInternallyFileCount: 1
+
+cases:
+  # team m365_files_shared_internal = [alice 5+3=8, bob 2, carol 1]
+  #   value (alice) = 8 ; median[1,2,8] = 2 ; range = [1,8]
+  - name: m365_files_shared_internal — IC bullet (alice value vs team median/range)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'alice@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        assert: "result.status == 'ok'"
+      - in: collaboration
+        find: { metric_key: m365_files_shared_internal }
+        equal: { value: 8, median: 2, range_min: 1, range_max: 8 }

--- a/src/ingestion/tests/e2e/specs/collab_files_shared_internal.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_files_shared_internal.test.yaml
@@ -1,24 +1,15 @@
 spec_version: 1
 description: >
   Metric: m365_files_shared_internal — IC Bullet Collaboration (…0012), #1413.
-  m365_files_shared_internal = Σ shared_internally_count over the period, summed
-  ACROSS both document products (OneDrive + SharePoint).
+  How it's computed (bronze → silver → gold):
+    • bronze: daily OneDrive and SharePoint file-activity reports per person
+    • silver: each product deduped to per-person/day share counts
+    • gold:   metric = sum of files shared internally over the window, across both products
 
-  Path (bronze → silver → gold):
-    • bronze_m365.onedrive_activity   → staging m365__collab_document_activity_onedrive   → silver.class_collab_document_activity
-    • bronze_m365.sharepoint_activity → staging m365__collab_document_activity_sharepoint → silver.class_collab_document_activity
-    → insight.collab_bullet_rows (gold) → metric …0012.
-
-  Team (department `org_unit_id` — the peer group the median/range span):
-    • alice — 5 OneDrive + 3 SharePoint = 8  (cross-product sum)
-    • bob   — 2 OneDrive                = 2
-    • carol — 1 SharePoint              = 1
-    team {8, 2, 1} → median 2, range [1, 8].
-
-  One case, asserting alice (value = member, median/range = team):
-    value 8, median 2, range [1, 8]. Teeth: alice's OneDrive row is a verbatim
-    duplicate → must dedup (still 8, not 13).
-
+  Team (median/range = the person's department):
+    alice 5 OneDrive + 3 SharePoint = 8 · bob 2 OneDrive · carol 1 SharePoint
+    → median 2, range [1, 8].
+  Cases: alice cross-product (8) · bob OneDrive-only (2) · carol SharePoint-only (1).
 
 bronze:
   bronze_bamboohr.employees:
@@ -53,7 +44,7 @@ bronze:
 cases:
   # team m365_files_shared_internal = [alice 5+3=8, bob 2, carol 1]
   #   value (alice) = 8 ; median[1,2,8] = 2 ; range = [1,8]
-  - name: m365_files_shared_internal — IC bullet (alice value vs team median/range)
+  - name: m365_files_shared_internal — alice OneDrive+SharePoint (cross-product sum vs team median/range)
     request:
       url: /v1/metrics/queries
       method: POST
@@ -69,3 +60,35 @@ cases:
       - in: collaboration
         find: { metric_key: m365_files_shared_internal }
         equal: { value: 8, median: 2, range_min: 1, range_max: 8 }
+
+  # bob shares internally via OneDrive only — proves the OneDrive product path directly
+  - name: m365_files_shared_internal — bob OneDrive-only (value 2 vs team median/range)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'bob@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        find: { metric_key: m365_files_shared_internal }
+        equal: { value: 2, median: 2, range_min: 1, range_max: 8 }
+
+  # carol shares internally via SharePoint only — proves the SharePoint product path directly
+  - name: m365_files_shared_internal — carol SharePoint-only (value 1 vs team median/range)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'carol@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        find: { metric_key: m365_files_shared_internal }
+        equal: { value: 1, median: 2, range_min: 1, range_max: 8 }

--- a/src/ingestion/tests/e2e/specs/collab_meeting_free.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_meeting_free.test.yaml
@@ -1,12 +1,27 @@
 spec_version: 1
 description: >
-  Per-metric E2E check for meeting_free (#1413). Seeds bronze_m365.teams_activity
-  for 3 people in one team and asserts the IC Bullet Collaboration metric (…0012).
-  meeting_free counts days that HAVE a meeting-activity row but ZERO total
-  duration (sum of audio+video+screenShare = 0); a day with any duration counts
-  0, and a day with no row at all does not count. alice has a zero-duration row
-  (free=1); bob/carol have nonzero duration (free=0). value = member,
-  median/range = team.
+  Metric: meeting_free — IC Bullet Collaboration (…0012), #1413.
+  meeting_free counts a person's meeting-free DAYS: per day it is 1 when a
+  meeting-activity row EXISTS but total duration is zero
+  (audio + video + screenShare = 0), else 0; summed over the period. A day with
+  any duration counts 0, and a day with NO row is not counted — so "row exists,
+  zero duration" is what distinguishes a free day from an absent one.
+
+  Path (bronze → silver → gold):
+    • bronze_m365.teams_activity → staging m365__collab_meeting_activity → silver.class_collab_meeting_activity
+    • bronze_zoom.participants   → staging zoom__collab_meeting_activity  → silver.class_collab_meeting_activity
+    → insight.collab_bullet_rows (gold) → metric …0012.
+
+  Team (department `org_unit_id` — the peer group the median/range span):
+    • alice — zero-duration row (PT0S/PT0S/PT0S) → free = 1
+    • bob   — PT1H audio                         → free = 0
+    • carol — PT30M audio                        → free = 0
+    team {1, 0, 0} → median 0, range [0, 1].
+
+  One case, asserting alice (value = member, median/range = team):
+    value 1, median 0, range [0, 1]. Teeth: alice's zero-duration row is
+    duplicated → must dedup (still 1 free day, not 2); bob/carol have nonzero
+    duration → not free.
 
 bronze:
   bronze_bamboohr.employees:

--- a/src/ingestion/tests/e2e/specs/collab_meeting_free.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_meeting_free.test.yaml
@@ -1,0 +1,63 @@
+spec_version: 1
+description: >
+  Per-metric E2E check for meeting_free (#1413). Seeds bronze_m365.teams_activity
+  for 3 people in one team and asserts the IC Bullet Collaboration metric (…0012).
+  meeting_free counts days that HAVE a meeting-activity row but ZERO total
+  duration (sum of audio+video+screenShare = 0); a day with any duration counts
+  0, and a day with no row at all does not count. alice has a zero-duration row
+  (free=1); bob/carol have nonzero duration (free=0). value = member,
+  median/range = team.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+    - $ref: templates/people.yaml#/templates/bob
+    - $ref: templates/people.yaml#/templates/carol
+
+  bronze_m365.teams_activity:
+    - $ref: templates/m365_teams.yaml#/templates/alice_teams   # row exists, zero duration → meeting-free day
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-mfree-20260105
+      meetingsAttendedCount: 0
+      audioDuration: PT0S
+      videoDuration: PT0S
+      screenShareDuration: PT0S
+    - $ref: templates/m365_teams.yaml#/templates/alice_teams   # row exists, zero duration → meeting-free day  # verbatim duplicate -> must dedup, not double
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-mfree-20260105
+      meetingsAttendedCount: 0
+      audioDuration: PT0S
+      videoDuration: PT0S
+      screenShareDuration: PT0S
+    - $ref: templates/m365_teams.yaml#/templates/bob_teams     # has duration → not free
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-bob-mfree-20260105
+      audioDuration: PT1H
+      videoDuration: PT0S
+      screenShareDuration: PT0S
+    - $ref: templates/m365_teams.yaml#/templates/carol_teams   # has duration → not free
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-carol-mfree-20260105
+      audioDuration: PT30M
+      videoDuration: PT0S
+      screenShareDuration: PT0S
+
+cases:
+  # team meeting_free = [alice 1, bob 0, carol 0]
+  #   value (alice) = 1 ; median[0,0,1] = 0 ; range = [0,1]
+  - name: meeting_free — IC bullet (alice value vs team median/range)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'alice@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        assert: "result.status == 'ok'"
+      - in: collaboration
+        find: { metric_key: meeting_free }
+        equal: { value: 1, median: 0, range_min: 0, range_max: 1 }

--- a/src/ingestion/tests/e2e/specs/collab_meeting_free.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_meeting_free.test.yaml
@@ -1,27 +1,15 @@
 spec_version: 1
 description: >
   Metric: meeting_free — IC Bullet Collaboration (…0012), #1413.
-  meeting_free counts a person's meeting-free DAYS: per day it is 1 when a
-  meeting-activity row EXISTS but total duration is zero
-  (audio + video + screenShare = 0), else 0; summed over the period. A day with
-  any duration counts 0, and a day with NO row is not counted — so "row exists,
-  zero duration" is what distinguishes a free day from an absent one.
+  How it's computed (bronze → silver → gold):
+    • bronze: daily Teams meeting report + Zoom participant sessions per person
+    • silver: both sources deduped to per-person/day meeting durations (audio/video/screen)
+    • gold:   a day is "meeting-free" if a meeting row exists but total duration = 0;
+              metric = count of such days over the window (no row at all does not count)
 
-  Path (bronze → silver → gold):
-    • bronze_m365.teams_activity → staging m365__collab_meeting_activity → silver.class_collab_meeting_activity
-    • bronze_zoom.participants   → staging zoom__collab_meeting_activity  → silver.class_collab_meeting_activity
-    → insight.collab_bullet_rows (gold) → metric …0012.
-
-  Team (department `org_unit_id` — the peer group the median/range span):
-    • alice — zero-duration row (PT0S/PT0S/PT0S) → free = 1
-    • bob   — PT1H audio                         → free = 0
-    • carol — PT30M audio                        → free = 0
-    team {1, 0, 0} → median 0, range [0, 1].
-
-  One case, asserting alice (value = member, median/range = team):
-    value 1, median 0, range [0, 1]. Teeth: alice's zero-duration row is
-    duplicated → must dedup (still 1 free day, not 2); bob/carol have nonzero
-    duration → not free.
+  Team (median/range = the person's department):
+    alice zero-duration day = 1 · bob 1h = 0 · carol 30m = 0 → median 0, range [0, 1].
+  Cases: alice (1 meeting-free day vs the team).
 
 bronze:
   bronze_bamboohr.employees:

--- a/src/ingestion/tests/e2e/specs/collab_meeting_hours.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_meeting_hours.test.yaml
@@ -8,11 +8,11 @@ description: >
   over the person's rows, summed ACROSS both sources (Teams + Zoom are additive;
   Zulip is chat-only and does NOT feed meeting_hours).
 
-  Data-source matrix via a one-team (Engineering) roster, one case per person:
+  Data-source matrix via a one-department (Engineering) roster, one case per person:
     • alice — Teams (1.0h) + Zoom (1.0h)  → COMBINED 2.0h  (proves cross-source sum)
     • bob   — Teams only (1.5h)
     • carol — Zoom only (0.5h)
-  cohort {2.0, 1.5, 0.5} → median 1.5, range [0.5, 2.0].
+  department {2.0, 1.5, 0.5} → median 1.5, range [0.5, 2.0].
 
   Teams duration = greatest of audio/video/screenShare ISO-8601 durations. Zoom
   duration = dateDiff(join_time, leave_time) as audio (video gated by `camera`,

--- a/src/ingestion/tests/e2e/specs/collab_meeting_hours.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_meeting_hours.test.yaml
@@ -1,0 +1,60 @@
+spec_version: 1
+description: >
+  Per-metric E2E check for meeting_hours (#1413). Seeds bronze_m365.teams_activity
+  durations for 3 people in one team and asserts the IC Bullet Collaboration
+  metric (…0012). Daily value = greatest(audio, video, screenShare) seconds / 3600
+  (longest modality), summed over the period (cross-source; only m365 here).
+  ISO-8601 durations parsed by iso8601_duration_seconds. value = member,
+  median/range = team.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+    - $ref: templates/people.yaml#/templates/bob
+    - $ref: templates/people.yaml#/templates/carol
+
+  bronze_m365.teams_activity:
+    - $ref: templates/m365_teams.yaml#/templates/alice_teams
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-meet-20260105
+      audioDuration: PT2H
+      videoDuration: PT1H
+      screenShareDuration: PT0S
+    - $ref: templates/m365_teams.yaml#/templates/alice_teams  # verbatim duplicate -> must dedup, not double
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-meet-20260105
+      audioDuration: PT2H
+      videoDuration: PT1H
+      screenShareDuration: PT0S
+    - $ref: templates/m365_teams.yaml#/templates/bob_teams
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-bob-meet-20260105
+      audioDuration: PT1H
+      videoDuration: PT0S
+      screenShareDuration: PT0S
+    - $ref: templates/m365_teams.yaml#/templates/carol_teams
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-carol-meet-20260105
+      audioDuration: PT30M
+      videoDuration: PT0S
+      screenShareDuration: PT0S
+
+cases:
+  # greatest-per-day / 3600: alice greatest(7200,3600,0)=2.0h, bob 1.0h, carol 0.5h
+  #   value (alice) = 2.0 ; median[0.5,1.0,2.0] = 1.0 ; range = [0.5,2.0]
+  - name: meeting_hours — IC bullet (alice value vs team median/range)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'alice@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        assert: "result.status == 'ok'"
+      - in: collaboration
+        find: { metric_key: meeting_hours }
+        equal: { value: 2.0, median: 1.0, range_min: 0.5, range_max: 2.0 }

--- a/src/ingestion/tests/e2e/specs/collab_meeting_hours.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_meeting_hours.test.yaml
@@ -8,6 +8,11 @@ description: >
   over the person's rows, summed ACROSS both sources (Teams + Zoom are additive;
   Zulip is chat-only and does NOT feed meeting_hours).
 
+  Path (bronze → silver → gold):
+    • bronze_m365.teams_activity → staging m365__collab_meeting_activity → silver.class_collab_meeting_activity
+    • bronze_zoom.participants   → staging zoom__collab_meeting_activity  → silver.class_collab_meeting_activity
+    → insight.collab_bullet_rows (gold) → metric …0012.
+
   Data-source matrix via a one-department (Engineering) roster, one case per person:
     • alice — Teams (1.0h) + Zoom (1.0h)  → COMBINED 2.0h  (proves cross-source sum)
     • bob   — Teams only (1.5h)

--- a/src/ingestion/tests/e2e/specs/collab_meeting_hours.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_meeting_hours.test.yaml
@@ -1,29 +1,16 @@
 spec_version: 1
 description: >
-  Per-metric E2E check for meeting_hours (#1413) across its TWO data sources —
-  Teams (bronze_m365.teams_activity, data_source insight_m365) and Zoom
-  (bronze_zoom.participants, data_source insight_zoom) — which union into
-  silver.class_collab_meeting_activity. The IC Bullet Collaboration metric (…0012)
-  computes meeting_hours = Σ greatest(audio, video, screenShare) seconds / 3600
-  over the person's rows, summed ACROSS both sources (Teams + Zoom are additive;
-  Zulip is chat-only and does NOT feed meeting_hours).
+  Metric: meeting_hours — IC Bullet Collaboration (…0012), #1413.
+  How it's computed (bronze → silver → gold):
+    • bronze: daily Teams meeting report + Zoom participant sessions per person
+    • silver: both sources deduped to per-person/day durations (audio/video/screen)
+    • gold:   per meeting take the longest single modality; metric = sum of those
+              hours over the window, across Teams + Zoom (additive; Zulip is chat-only)
 
-  Path (bronze → silver → gold):
-    • bronze_m365.teams_activity → staging m365__collab_meeting_activity → silver.class_collab_meeting_activity
-    • bronze_zoom.participants   → staging zoom__collab_meeting_activity  → silver.class_collab_meeting_activity
-    → insight.collab_bullet_rows (gold) → metric …0012.
-
-  Data-source matrix via a one-department (Engineering) roster, one case per person:
-    • alice — Teams (1.0h) + Zoom (1.0h)  → COMBINED 2.0h  (proves cross-source sum)
-    • bob   — Teams only (1.5h)
-    • carol — Zoom only (0.5h)
-  department {2.0, 1.5, 0.5} → median 1.5, range [0.5, 2.0].
-
-  Teams duration = greatest of audio/video/screenShare ISO-8601 durations. Zoom
-  duration = dateDiff(join_time, leave_time) as audio (video gated by `camera`,
-  screen-share by share_* flags — both 0 here). Dedup teeth on BOTH sources:
-  alice's Teams row (same unique_key) and Zoom row (same meeting_uuid/
-  participant_uuid/join_time) are each duplicated and must collapse, not double.
+  Team (median/range = the person's department):
+    alice Teams 1.0 + Zoom 1.0 = 2.0 · bob Teams 1.5 · carol Zoom 0.5
+    → median 1.5, range [0.5, 2.0].
+  Cases: alice Teams+Zoom (2.0) · bob Teams-only (1.5) · carol Zoom-only (0.5).
 
 bronze:
   bronze_bamboohr.employees:

--- a/src/ingestion/tests/e2e/specs/collab_meeting_hours.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_meeting_hours.test.yaml
@@ -1,11 +1,24 @@
 spec_version: 1
 description: >
-  Per-metric E2E check for meeting_hours (#1413). Seeds bronze_m365.teams_activity
-  durations for 3 people in one team and asserts the IC Bullet Collaboration
-  metric (…0012). Daily value = greatest(audio, video, screenShare) seconds / 3600
-  (longest modality), summed over the period (cross-source; only m365 here).
-  ISO-8601 durations parsed by iso8601_duration_seconds. value = member,
-  median/range = team.
+  Per-metric E2E check for meeting_hours (#1413) across its TWO data sources —
+  Teams (bronze_m365.teams_activity, data_source insight_m365) and Zoom
+  (bronze_zoom.participants, data_source insight_zoom) — which union into
+  silver.class_collab_meeting_activity. The IC Bullet Collaboration metric (…0012)
+  computes meeting_hours = Σ greatest(audio, video, screenShare) seconds / 3600
+  over the person's rows, summed ACROSS both sources (Teams + Zoom are additive;
+  Zulip is chat-only and does NOT feed meeting_hours).
+
+  Data-source matrix via a one-team (Engineering) roster, one case per person:
+    • alice — Teams (1.0h) + Zoom (1.0h)  → COMBINED 2.0h  (proves cross-source sum)
+    • bob   — Teams only (1.5h)
+    • carol — Zoom only (0.5h)
+  cohort {2.0, 1.5, 0.5} → median 1.5, range [0.5, 2.0].
+
+  Teams duration = greatest of audio/video/screenShare ISO-8601 durations. Zoom
+  duration = dateDiff(join_time, leave_time) as audio (video gated by `camera`,
+  screen-share by share_* flags — both 0 here). Dedup teeth on BOTH sources:
+  alice's Teams row (same unique_key) and Zoom row (same meeting_uuid/
+  participant_uuid/join_time) are each duplicated and must collapse, not double.
 
 bronze:
   bronze_bamboohr.employees:
@@ -13,36 +26,50 @@ bronze:
     - $ref: templates/people.yaml#/templates/bob
     - $ref: templates/people.yaml#/templates/carol
 
+  # Teams side (insight_m365): alice 1.0h, bob 1.5h. (carol has no Teams row.)
   bronze_m365.teams_activity:
     - $ref: templates/m365_teams.yaml#/templates/alice_teams
       reportRefreshDate: "2026-01-05"
       unique_key: m365-alice-meet-20260105
-      audioDuration: PT2H
-      videoDuration: PT1H
+      audioDuration: PT1H
+      videoDuration: PT0S
       screenShareDuration: PT0S
     - $ref: templates/m365_teams.yaml#/templates/alice_teams  # verbatim duplicate -> must dedup, not double
       reportRefreshDate: "2026-01-05"
       unique_key: m365-alice-meet-20260105
-      audioDuration: PT2H
-      videoDuration: PT1H
+      audioDuration: PT1H
+      videoDuration: PT0S
       screenShareDuration: PT0S
     - $ref: templates/m365_teams.yaml#/templates/bob_teams
       reportRefreshDate: "2026-01-05"
       unique_key: m365-bob-meet-20260105
-      audioDuration: PT1H
-      videoDuration: PT0S
-      screenShareDuration: PT0S
-    - $ref: templates/m365_teams.yaml#/templates/carol_teams
-      reportRefreshDate: "2026-01-05"
-      unique_key: m365-carol-meet-20260105
-      audioDuration: PT30M
+      audioDuration: PT1H30M
       videoDuration: PT0S
       screenShareDuration: PT0S
 
+  # Zoom side (insight_zoom): alice 60-min session (1.0h), carol 30-min (0.5h).
+  # (bob has no Zoom row.) Duration = leave_time - join_time; camera/share unset → 0.
+  bronze_zoom.participants:
+    - $ref: templates/zoom.yaml#/templates/alice_zoom
+      meeting_uuid: zmtg-alice-1
+      participant_uuid: zp-alice-1
+      join_time: "2026-01-05T10:00:00"
+      leave_time: "2026-01-05T11:00:00"
+    - $ref: templates/zoom.yaml#/templates/alice_zoom   # verbatim duplicate -> must dedup, not double
+      meeting_uuid: zmtg-alice-1
+      participant_uuid: zp-alice-1
+      join_time: "2026-01-05T10:00:00"
+      leave_time: "2026-01-05T11:00:00"
+    - $ref: templates/zoom.yaml#/templates/carol_zoom
+      meeting_uuid: zmtg-carol-1
+      participant_uuid: zp-carol-1
+      join_time: "2026-01-05T14:00:00"
+      leave_time: "2026-01-05T14:30:00"
+
 cases:
-  # greatest-per-day / 3600: alice greatest(7200,3600,0)=2.0h, bob 1.0h, carol 0.5h
-  #   value (alice) = 2.0 ; median[0.5,1.0,2.0] = 1.0 ; range = [0.5,2.0]
-  - name: meeting_hours — IC bullet (alice value vs team median/range)
+  # ── COMBINED (alice: Teams 1.0 + Zoom 1.0 = 2.0) ─────────────────────────────
+  # proves meeting_hours sums across both sources for the same person/day.
+  - name: "meeting_hours — alice COMBINED Teams+Zoom (cross-source sum = 2.0)"
     request:
       url: /v1/metrics/queries
       method: POST
@@ -57,4 +84,36 @@ cases:
         assert: "result.status == 'ok'"
       - in: collaboration
         find: { metric_key: meeting_hours }
-        equal: { value: 2.0, median: 1.0, range_min: 0.5, range_max: 2.0 }
+        equal: { value: 2.0, median: 1.5, range_min: 0.5, range_max: 2.0 }
+
+  # ── Teams-only (bob: 1.5) ────────────────────────────────────────────────────
+  - name: "meeting_hours — bob Teams-only (1.5)"
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'bob@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        find: { metric_key: meeting_hours }
+        equal: { value: 1.5, median: 1.5, range_min: 0.5, range_max: 2.0 }
+
+  # ── Zoom-only (carol: 0.5) ───────────────────────────────────────────────────
+  - name: "meeting_hours — carol Zoom-only (0.5)"
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'carol@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        find: { metric_key: meeting_hours }
+        equal: { value: 0.5, median: 1.5, range_min: 0.5, range_max: 2.0 }

--- a/src/ingestion/tests/e2e/specs/collab_meetings_count.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_meetings_count.test.yaml
@@ -1,9 +1,23 @@
 spec_version: 1
 description: >
-  Per-metric E2E check for meetings_count (#1413). Seeds
-  bronze_m365.teams_activity meetingsAttendedCount for 3 people in one team and
-  asserts the IC Bullet Collaboration metric (…0012). Period Σ of meetings
-  attended (cross-source; only m365 here). value = member, median/range = team.
+  Metric: meetings_count — IC Bullet Collaboration (…0012), #1413.
+  meetings_count = Σ meetings_attended over the period, summed ACROSS both meeting
+  sources (M365 Teams + Zoom; additive). Only Teams is seeded here → Zoom adds 0.
+
+  Path (bronze → silver → gold):
+    • bronze_m365.teams_activity → staging m365__collab_meeting_activity → silver.class_collab_meeting_activity
+    • bronze_zoom.participants   → staging zoom__collab_meeting_activity  → silver.class_collab_meeting_activity
+    → insight.collab_bullet_rows (gold) → metric …0012.
+
+  Team (department `org_unit_id` — the peer group the median/range span):
+    • alice — 4 meetings
+    • bob   — 2
+    • carol — 1
+    team {4, 2, 1} → median 2, range [1, 4].
+
+  One case, asserting alice (value = member, median/range = team):
+    value 4, median 2, range [1, 4]. Teeth: alice's row is a verbatim duplicate
+    (same unique_key) → must dedup to 4, not 8.
 
 bronze:
   bronze_bamboohr.employees:

--- a/src/ingestion/tests/e2e/specs/collab_meetings_count.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_meetings_count.test.yaml
@@ -1,0 +1,50 @@
+spec_version: 1
+description: >
+  Per-metric E2E check for meetings_count (#1413). Seeds
+  bronze_m365.teams_activity meetingsAttendedCount for 3 people in one team and
+  asserts the IC Bullet Collaboration metric (…0012). Period Σ of meetings
+  attended (cross-source; only m365 here). value = member, median/range = team.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+    - $ref: templates/people.yaml#/templates/bob
+    - $ref: templates/people.yaml#/templates/carol
+
+  bronze_m365.teams_activity:
+    - $ref: templates/m365_teams.yaml#/templates/alice_teams
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-mcount-20260105
+      meetingsAttendedCount: 4
+    - $ref: templates/m365_teams.yaml#/templates/alice_teams  # verbatim duplicate -> must dedup, not double
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-mcount-20260105
+      meetingsAttendedCount: 4
+    - $ref: templates/m365_teams.yaml#/templates/bob_teams
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-bob-mcount-20260105
+      meetingsAttendedCount: 2
+    - $ref: templates/m365_teams.yaml#/templates/carol_teams
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-carol-mcount-20260105
+      meetingsAttendedCount: 1
+
+cases:
+  # team meetings_count = [alice 4, bob 2, carol 1]
+  #   value (alice) = 4 ; median[1,2,4] = 2 ; range = [1,4]
+  - name: meetings_count — IC bullet (alice value vs team median/range)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'alice@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        assert: "result.status == 'ok'"
+      - in: collaboration
+        find: { metric_key: meetings_count }
+        equal: { value: 4, median: 2, range_min: 1, range_max: 4 }

--- a/src/ingestion/tests/e2e/specs/collab_meetings_count.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_meetings_count.test.yaml
@@ -1,23 +1,14 @@
 spec_version: 1
 description: >
   Metric: meetings_count — IC Bullet Collaboration (…0012), #1413.
-  meetings_count = Σ meetings_attended over the period, summed ACROSS both meeting
-  sources (M365 Teams + Zoom; additive). Only Teams is seeded here → Zoom adds 0.
+  How it's computed (bronze → silver → gold):
+    • bronze: daily Teams meeting report + Zoom participant sessions per person
+    • silver: both sources deduped to per-person/day meetings-attended counts
+    • gold:   metric = sum of meetings attended over the window, across Teams + Zoom (additive)
 
-  Path (bronze → silver → gold):
-    • bronze_m365.teams_activity → staging m365__collab_meeting_activity → silver.class_collab_meeting_activity
-    • bronze_zoom.participants   → staging zoom__collab_meeting_activity  → silver.class_collab_meeting_activity
-    → insight.collab_bullet_rows (gold) → metric …0012.
-
-  Team (department `org_unit_id` — the peer group the median/range span):
-    • alice — 4 meetings
-    • bob   — 2
-    • carol — 1
-    team {4, 2, 1} → median 2, range [1, 4].
-
-  One case, asserting alice (value = member, median/range = team):
-    value 4, median 2, range [1, 4]. Teeth: alice's row is a verbatim duplicate
-    (same unique_key) → must dedup to 4, not 8.
+  Team (median/range = the person's department):
+    alice Teams 4 + Zoom 1 = 5 · bob Teams 2 · carol Zoom 1 → median 2, range [1, 5].
+  Cases: alice Teams+Zoom (5) · bob Teams-only (2) · carol Zoom-only (1).
 
 bronze:
   bronze_bamboohr.employees:
@@ -25,6 +16,7 @@ bronze:
     - $ref: templates/people.yaml#/templates/bob
     - $ref: templates/people.yaml#/templates/carol
 
+  # Teams side (insight_m365): alice 4, bob 2. (carol has no Teams row → Zoom-only.)
   bronze_m365.teams_activity:
     - $ref: templates/m365_teams.yaml#/templates/alice_teams
       reportRefreshDate: "2026-01-05"
@@ -38,15 +30,30 @@ bronze:
       reportRefreshDate: "2026-01-05"
       unique_key: m365-bob-mcount-20260105
       meetingsAttendedCount: 2
-    - $ref: templates/m365_teams.yaml#/templates/carol_teams
-      reportRefreshDate: "2026-01-05"
-      unique_key: m365-carol-mcount-20260105
-      meetingsAttendedCount: 1
+
+  # Zoom side (insight_zoom): alice 1 meeting, carol 1 meeting. meetings_attended =
+  # uniqExact(meeting_uuid) per person/day, so one distinct meeting_uuid → 1.
+  bronze_zoom.participants:
+    - $ref: templates/zoom.yaml#/templates/alice_zoom
+      meeting_uuid: zmtg-alice-mc-1
+      participant_uuid: zp-alice-mc-1
+      join_time: "2026-01-05T10:00:00"
+      leave_time: "2026-01-05T11:00:00"
+    - $ref: templates/zoom.yaml#/templates/alice_zoom   # verbatim duplicate -> must dedup, not double
+      meeting_uuid: zmtg-alice-mc-1
+      participant_uuid: zp-alice-mc-1
+      join_time: "2026-01-05T10:00:00"
+      leave_time: "2026-01-05T11:00:00"
+    - $ref: templates/zoom.yaml#/templates/carol_zoom
+      meeting_uuid: zmtg-carol-mc-1
+      participant_uuid: zp-carol-mc-1
+      join_time: "2026-01-05T14:00:00"
+      leave_time: "2026-01-05T14:30:00"
 
 cases:
-  # team meetings_count = [alice 4, bob 2, carol 1]
-  #   value (alice) = 4 ; median[1,2,4] = 2 ; range = [1,4]
-  - name: meetings_count — IC bullet (alice value vs team median/range)
+  # ── COMBINED (alice: Teams 4 + Zoom 1 = 5) ───────────────────────────────────
+  # proves meetings_count sums across both sources for the same person/day.
+  - name: "meetings_count — alice COMBINED Teams+Zoom (cross-source sum = 5)"
     request:
       url: /v1/metrics/queries
       method: POST
@@ -61,4 +68,36 @@ cases:
         assert: "result.status == 'ok'"
       - in: collaboration
         find: { metric_key: meetings_count }
-        equal: { value: 4, median: 2, range_min: 1, range_max: 4 }
+        equal: { value: 5, median: 2, range_min: 1, range_max: 5 }
+
+  # ── Teams-only (bob: 2) ──────────────────────────────────────────────────────
+  - name: "meetings_count — bob Teams-only (2)"
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'bob@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        find: { metric_key: meetings_count }
+        equal: { value: 2, median: 2, range_min: 1, range_max: 5 }
+
+  # ── Zoom-only (carol: 1) ─────────────────────────────────────────────────────
+  - name: "meetings_count — carol Zoom-only (1)"
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'carol@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        find: { metric_key: meetings_count }
+        equal: { value: 1, median: 2, range_min: 1, range_max: 5 }

--- a/src/ingestion/tests/e2e/specs/collab_teams_chats.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_teams_chats.test.yaml
@@ -1,0 +1,54 @@
+spec_version: 1
+description: >
+  Per-metric E2E check for m365_teams_chats (#1413). Seeds
+  bronze_m365.teams_activity for 3 people in one team and asserts the IC Bullet
+  Collaboration metric (…0012). total_chat_messages = privateChatMessageCount +
+  teamChatMessageCount, summed over the period. value = member, median/range = team.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+    - $ref: templates/people.yaml#/templates/bob
+    - $ref: templates/people.yaml#/templates/carol
+
+  bronze_m365.teams_activity:
+    - $ref: templates/m365_teams.yaml#/templates/alice_teams
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-chat-20260105
+      privateChatMessageCount: 15
+      teamChatMessageCount: 25
+    - $ref: templates/m365_teams.yaml#/templates/alice_teams  # verbatim duplicate -> must dedup, not double
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-chat-20260105
+      privateChatMessageCount: 15
+      teamChatMessageCount: 25
+    - $ref: templates/m365_teams.yaml#/templates/bob_teams
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-bob-chat-20260105
+      privateChatMessageCount: 10
+      teamChatMessageCount: 10
+    - $ref: templates/m365_teams.yaml#/templates/carol_teams
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-carol-chat-20260105
+      privateChatMessageCount: 5
+      teamChatMessageCount: 5
+
+cases:
+  # team m365_teams_chats = [alice 40, bob 20, carol 10]
+  #   value (alice) = 40 ; median[10,20,40] = 20 ; range = [10,40]
+  - name: m365_teams_chats — IC bullet (alice value vs team median/range)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'alice@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        assert: "result.status == 'ok'"
+      - in: collaboration
+        find: { metric_key: m365_teams_chats }
+        equal: { value: 40, median: 20, range_min: 10, range_max: 40 }

--- a/src/ingestion/tests/e2e/specs/collab_teams_chats.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_teams_chats.test.yaml
@@ -1,9 +1,23 @@
 spec_version: 1
 description: >
-  Per-metric E2E check for m365_teams_chats (#1413). Seeds
-  bronze_m365.teams_activity for 3 people in one team and asserts the IC Bullet
-  Collaboration metric (…0012). total_chat_messages = privateChatMessageCount +
-  teamChatMessageCount, summed over the period. value = member, median/range = team.
+  Metric: m365_teams_chats — IC Bullet Collaboration (…0012), #1413.
+  m365_teams_chats = Σ total_chat_messages over the period, where
+  total_chat_messages = privateChatMessageCount + teamChatMessageCount
+  (data_source insight_m365).
+
+  Path (bronze → silver → gold):
+    • bronze_m365.teams_activity → staging m365__collab_chat_activity → silver.class_collab_chat_activity
+    → insight.collab_bullet_rows (gold) → metric …0012.
+
+  Team (department `org_unit_id` — the peer group the median/range span):
+    • alice — 15 private + 25 team = 40
+    • bob   — 10 + 10             = 20
+    • carol —  5 +  5             = 10
+    team {40, 20, 10} → median 20, range [10, 40].
+
+  One case, asserting alice (value = member, median/range = team):
+    value 40, median 20, range [10, 40]. Teeth: alice's row is a verbatim
+    duplicate (same unique_key) → must dedup to 40, not 80.
 
 bronze:
   bronze_bamboohr.employees:

--- a/src/ingestion/tests/e2e/specs/collab_teams_chats.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_teams_chats.test.yaml
@@ -1,23 +1,15 @@
 spec_version: 1
 description: >
   Metric: m365_teams_chats — IC Bullet Collaboration (…0012), #1413.
-  m365_teams_chats = Σ total_chat_messages over the period, where
-  total_chat_messages = privateChatMessageCount + teamChatMessageCount
-  (data_source insight_m365).
+  How it's computed (bronze → silver → gold):
+    • bronze: daily Teams activity report per person (private-DM + team-channel counts)
+    • silver: deduped to per-person/day; total = private DMs + team-channel messages
+    • gold:   metric = sum of Teams chat messages over the window
 
-  Path (bronze → silver → gold):
-    • bronze_m365.teams_activity → staging m365__collab_chat_activity → silver.class_collab_chat_activity
-    → insight.collab_bullet_rows (gold) → metric …0012.
-
-  Team (department `org_unit_id` — the peer group the median/range span):
-    • alice — 15 private + 25 team = 40
-    • bob   — 10 + 10             = 20
-    • carol —  5 +  5             = 10
-    team {40, 20, 10} → median 20, range [10, 40].
-
-  One case, asserting alice (value = member, median/range = team):
-    value 40, median 20, range [10, 40]. Teeth: alice's row is a verbatim
-    duplicate (same unique_key) → must dedup to 40, not 80.
+  Team (median/range = the person's department):
+    alice 15 private + 25 team = 40 · bob 20 private · carol 10 team
+    → median 20, range [10, 40].
+  Cases: alice both fields (40) · bob private-only (20) · carol team-only (10).
 
 bronze:
   bronze_bamboohr.employees:
@@ -36,21 +28,21 @@ bronze:
       unique_key: m365-alice-chat-20260105
       privateChatMessageCount: 15
       teamChatMessageCount: 25
-    - $ref: templates/m365_teams.yaml#/templates/bob_teams
+    - $ref: templates/m365_teams.yaml#/templates/bob_teams    # private-DM field only (team = 0)
       reportRefreshDate: "2026-01-05"
       unique_key: m365-bob-chat-20260105
-      privateChatMessageCount: 10
-      teamChatMessageCount: 10
-    - $ref: templates/m365_teams.yaml#/templates/carol_teams
+      privateChatMessageCount: 20
+      teamChatMessageCount: 0
+    - $ref: templates/m365_teams.yaml#/templates/carol_teams  # team-channel field only (private = 0)
       reportRefreshDate: "2026-01-05"
       unique_key: m365-carol-chat-20260105
-      privateChatMessageCount: 5
-      teamChatMessageCount: 5
+      privateChatMessageCount: 0
+      teamChatMessageCount: 10
 
 cases:
-  # team m365_teams_chats = [alice 40, bob 20, carol 10]
+  # team m365_teams_chats = [alice 15+25=40, bob 20+0=20, carol 0+10=10]
   #   value (alice) = 40 ; median[10,20,40] = 20 ; range = [10,40]
-  - name: m365_teams_chats — IC bullet (alice value vs team median/range)
+  - name: m365_teams_chats — alice private+team (both fields vs team median/range)
     request:
       url: /v1/metrics/queries
       method: POST
@@ -66,3 +58,35 @@ cases:
       - in: collaboration
         find: { metric_key: m365_teams_chats }
         equal: { value: 40, median: 20, range_min: 10, range_max: 40 }
+
+  # bob's chat is all private DMs (teamChatMessageCount = 0) — proves the private field alone
+  - name: m365_teams_chats — bob private-only (value 20 vs team median/range)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'bob@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        find: { metric_key: m365_teams_chats }
+        equal: { value: 20, median: 20, range_min: 10, range_max: 40 }
+
+  # carol's chat is all team-channel posts (privateChatMessageCount = 0) — proves the team field alone
+  - name: m365_teams_chats — carol team-only (value 10 vs team median/range)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'carol@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        find: { metric_key: m365_teams_chats }
+        equal: { value: 10, median: 20, range_min: 10, range_max: 40 }

--- a/src/ingestion/tests/e2e/specs/collab_teams_meeting_hours.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_teams_meeting_hours.test.yaml
@@ -2,16 +2,16 @@ spec_version: 1
 description: >
   Metric: teams_meeting_hours — IC Bullet Collaboration (…0012), #1413.
   How it's computed (bronze → silver → gold):
-    • bronze: daily Teams meeting report per person (+ Zoom sessions, filtered out below)
-    • silver: meeting durations per person/day, tagged by source (Teams vs Zoom)
-    • gold:   per meeting take the longest single modality; metric = sum of those hours
-              over the window, Teams-only — Zoom is excluded (the M365 slice of meeting_hours)
+    • bronze: daily Teams meeting report per person (audio/video/screen durations)
+    • silver: deduped to per-person/day durations
+    • gold:   per meeting take the longest single modality; metric = sum of those
+              hours over the window, Teams-only — the M365 slice of meeting_hours
+              (Zoom is filtered out by definition)
 
   Team (median/range = the person's department):
     alice greatest(2h audio, 1h video) = 2.0 · bob 1.0 · carol 0.5
     → median 1.0, range [0.5, 2.0].
-  Cases: alice Teams slice (2.0, a seeded Zoom hour is excluded) · same fixture's
-    cross-source meeting_hours = 3.0 (Zoom counts there) proves the exclusion.
+  Cases: alice (2.0 vs the team; longest modality — 2h audio beats 1h video → 2.0, not 3.0).
 
 bronze:
   bronze_bamboohr.employees:
@@ -45,19 +45,9 @@ bronze:
       videoDuration: PT0S
       screenShareDuration: PT0S
 
-  # Zoom side (insight_zoom): alice's 1h session (audio only). EXCLUDED from
-  # teams_meeting_hours (m365-only) but INCLUDED in the cross-source meeting_hours.
-  bronze_zoom.participants:
-    - $ref: templates/zoom.yaml#/templates/alice_zoom
-      meeting_uuid: zmtg-alice-tmh-1
-      participant_uuid: zp-alice-tmh-1
-      join_time: "2026-01-05T10:00:00"
-      leave_time: "2026-01-05T11:00:00"
-
 cases:
-  # alice teams_meeting_hours = 2.0 (Zoom EXCLUDED by data_source filter)
-  #   team {2.0,1.0,0.5} → median 1.0, range [0.5,2.0]
-  - name: teams_meeting_hours — alice m365-only slice (Zoom excluded → value 2.0)
+  # alice teams_meeting_hours = 2.0 ; team {2.0,1.0,0.5} → median 1.0, range [0.5,2.0]
+  - name: teams_meeting_hours — IC bullet (alice value vs team median/range)
     request:
       url: /v1/metrics/queries
       method: POST
@@ -73,20 +63,3 @@ cases:
       - in: collaboration
         find: { metric_key: teams_meeting_hours }
         equal: { value: 2.0, median: 1.0, range_min: 0.5, range_max: 2.0 }
-
-  # SAME fixture: meeting_hours INCLUDES the Zoom session → alice = 2.0 Teams + 1.0 Zoom = 3.0
-  #   team {3.0,1.0,0.5} → median 1.0, range [0.5,3.0]. Proves the Zoom row landed.
-  - name: teams_meeting_hours — Zoom counts in cross-source meeting_hours (value 3.0)
-    request:
-      url: /v1/metrics/queries
-      method: POST
-      body:
-        queries:
-          - id: collaboration
-            metric_id: 00000000-0000-0000-0001-000000000012
-            $filter: "person_id eq 'alice@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
-    expect:
-      - assert: "status == 200"
-      - in: collaboration
-        find: { metric_key: meeting_hours }
-        equal: { value: 3.0, median: 1.0, range_min: 0.5, range_max: 3.0 }

--- a/src/ingestion/tests/e2e/specs/collab_teams_meeting_hours.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_teams_meeting_hours.test.yaml
@@ -1,11 +1,26 @@
 spec_version: 1
 description: >
-  Per-metric E2E check for teams_meeting_hours (#1413). Seeds
-  bronze_m365.teams_activity durations for 3 people in one team and asserts the
-  IC Bullet Collaboration metric (…0012). teams_meeting_hours =
-  sumIf(greatest(audio,video,screenShare)/3600, data_source = insight_m365) —
-  the m365-only slice of meeting_hours (equal to it here, no zoom). value =
-  member, median/range = team.
+  Metric: teams_meeting_hours — IC Bullet Collaboration (…0012), #1413.
+  teams_meeting_hours = sumIf(greatest(audio, video, screenShare) seconds / 3600,
+  data_source = insight_m365) — the M365-only slice of meeting_hours. Per row the
+  duration is the LONGEST modality (not the sum). Equal to meeting_hours here (no
+  Zoom data).
+
+  Path (bronze → silver → gold):
+    • bronze_m365.teams_activity → staging m365__collab_meeting_activity → silver.class_collab_meeting_activity
+      (Zoom rows excluded — teams_meeting_hours filters data_source = insight_m365)
+    → insight.collab_bullet_rows (gold) → metric …0012.
+
+  Team (department `org_unit_id` — the peer group the median/range span):
+    • alice — greatest(2h audio, 1h video, 0) = 2.0h
+    • bob   — 1h audio                        = 1.0h
+    • carol — 30m audio                       = 0.5h
+    team {2.0, 1.0, 0.5} → median 1.0, range [0.5, 2.0].
+
+  One case, asserting alice (value = member, median/range = team):
+    value 2.0, median 1.0, range [0.5, 2.0]. Teeth: alice's row is a verbatim
+    duplicate → must dedup (still 2.0, not 4.0); duration is the longest modality
+    (alice's 2h audio beats 1h video → 2.0, not 3.0).
 
 bronze:
   bronze_bamboohr.employees:

--- a/src/ingestion/tests/e2e/specs/collab_teams_meeting_hours.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_teams_meeting_hours.test.yaml
@@ -1,0 +1,60 @@
+spec_version: 1
+description: >
+  Per-metric E2E check for teams_meeting_hours (#1413). Seeds
+  bronze_m365.teams_activity durations for 3 people in one team and asserts the
+  IC Bullet Collaboration metric (…0012). teams_meeting_hours =
+  sumIf(greatest(audio,video,screenShare)/3600, data_source = insight_m365) —
+  the m365-only slice of meeting_hours (equal to it here, no zoom). value =
+  member, median/range = team.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+    - $ref: templates/people.yaml#/templates/bob
+    - $ref: templates/people.yaml#/templates/carol
+
+  bronze_m365.teams_activity:
+    - $ref: templates/m365_teams.yaml#/templates/alice_teams
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-tmh-20260105
+      audioDuration: PT2H
+      videoDuration: PT1H
+      screenShareDuration: PT0S
+    - $ref: templates/m365_teams.yaml#/templates/alice_teams  # verbatim duplicate -> must dedup, not double
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-tmh-20260105
+      audioDuration: PT2H
+      videoDuration: PT1H
+      screenShareDuration: PT0S
+    - $ref: templates/m365_teams.yaml#/templates/bob_teams
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-bob-tmh-20260105
+      audioDuration: PT1H
+      videoDuration: PT0S
+      screenShareDuration: PT0S
+    - $ref: templates/m365_teams.yaml#/templates/carol_teams
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-carol-tmh-20260105
+      audioDuration: PT30M
+      videoDuration: PT0S
+      screenShareDuration: PT0S
+
+cases:
+  # alice 2.0h, bob 1.0h, carol 0.5h (all m365)
+  #   value (alice) = 2.0 ; median[0.5,1.0,2.0] = 1.0 ; range = [0.5,2.0]
+  - name: teams_meeting_hours — IC bullet (alice value vs team median/range)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'alice@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        assert: "result.status == 'ok'"
+      - in: collaboration
+        find: { metric_key: teams_meeting_hours }
+        equal: { value: 2.0, median: 1.0, range_min: 0.5, range_max: 2.0 }

--- a/src/ingestion/tests/e2e/specs/collab_teams_meeting_hours.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_teams_meeting_hours.test.yaml
@@ -1,26 +1,17 @@
 spec_version: 1
 description: >
   Metric: teams_meeting_hours — IC Bullet Collaboration (…0012), #1413.
-  teams_meeting_hours = sumIf(greatest(audio, video, screenShare) seconds / 3600,
-  data_source = insight_m365) — the M365-only slice of meeting_hours. Per row the
-  duration is the LONGEST modality (not the sum). Equal to meeting_hours here (no
-  Zoom data).
+  How it's computed (bronze → silver → gold):
+    • bronze: daily Teams meeting report per person (+ Zoom sessions, filtered out below)
+    • silver: meeting durations per person/day, tagged by source (Teams vs Zoom)
+    • gold:   per meeting take the longest single modality; metric = sum of those hours
+              over the window, Teams-only — Zoom is excluded (the M365 slice of meeting_hours)
 
-  Path (bronze → silver → gold):
-    • bronze_m365.teams_activity → staging m365__collab_meeting_activity → silver.class_collab_meeting_activity
-      (Zoom rows excluded — teams_meeting_hours filters data_source = insight_m365)
-    → insight.collab_bullet_rows (gold) → metric …0012.
-
-  Team (department `org_unit_id` — the peer group the median/range span):
-    • alice — greatest(2h audio, 1h video, 0) = 2.0h
-    • bob   — 1h audio                        = 1.0h
-    • carol — 30m audio                       = 0.5h
-    team {2.0, 1.0, 0.5} → median 1.0, range [0.5, 2.0].
-
-  One case, asserting alice (value = member, median/range = team):
-    value 2.0, median 1.0, range [0.5, 2.0]. Teeth: alice's row is a verbatim
-    duplicate → must dedup (still 2.0, not 4.0); duration is the longest modality
-    (alice's 2h audio beats 1h video → 2.0, not 3.0).
+  Team (median/range = the person's department):
+    alice greatest(2h audio, 1h video) = 2.0 · bob 1.0 · carol 0.5
+    → median 1.0, range [0.5, 2.0].
+  Cases: alice Teams slice (2.0, a seeded Zoom hour is excluded) · same fixture's
+    cross-source meeting_hours = 3.0 (Zoom counts there) proves the exclusion.
 
 bronze:
   bronze_bamboohr.employees:
@@ -54,10 +45,19 @@ bronze:
       videoDuration: PT0S
       screenShareDuration: PT0S
 
+  # Zoom side (insight_zoom): alice's 1h session (audio only). EXCLUDED from
+  # teams_meeting_hours (m365-only) but INCLUDED in the cross-source meeting_hours.
+  bronze_zoom.participants:
+    - $ref: templates/zoom.yaml#/templates/alice_zoom
+      meeting_uuid: zmtg-alice-tmh-1
+      participant_uuid: zp-alice-tmh-1
+      join_time: "2026-01-05T10:00:00"
+      leave_time: "2026-01-05T11:00:00"
+
 cases:
-  # alice 2.0h, bob 1.0h, carol 0.5h (all m365)
-  #   value (alice) = 2.0 ; median[0.5,1.0,2.0] = 1.0 ; range = [0.5,2.0]
-  - name: teams_meeting_hours — IC bullet (alice value vs team median/range)
+  # alice teams_meeting_hours = 2.0 (Zoom EXCLUDED by data_source filter)
+  #   team {2.0,1.0,0.5} → median 1.0, range [0.5,2.0]
+  - name: teams_meeting_hours — alice m365-only slice (Zoom excluded → value 2.0)
     request:
       url: /v1/metrics/queries
       method: POST
@@ -73,3 +73,20 @@ cases:
       - in: collaboration
         find: { metric_key: teams_meeting_hours }
         equal: { value: 2.0, median: 1.0, range_min: 0.5, range_max: 2.0 }
+
+  # SAME fixture: meeting_hours INCLUDES the Zoom session → alice = 2.0 Teams + 1.0 Zoom = 3.0
+  #   team {3.0,1.0,0.5} → median 1.0, range [0.5,3.0]. Proves the Zoom row landed.
+  - name: teams_meeting_hours — Zoom counts in cross-source meeting_hours (value 3.0)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'alice@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        find: { metric_key: meeting_hours }
+        equal: { value: 3.0, median: 1.0, range_min: 0.5, range_max: 3.0 }

--- a/src/ingestion/tests/e2e/specs/collab_teams_meetings.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_teams_meetings.test.yaml
@@ -2,15 +2,14 @@ spec_version: 1
 description: >
   Metric: teams_meetings — IC Bullet Collaboration (…0012), #1413.
   How it's computed (bronze → silver → gold):
-    • bronze: daily Teams meeting report per person (+ Zoom sessions, filtered out below)
-    • silver: meetings-attended per person/day, tagged by source (Teams vs Zoom)
-    • gold:   metric = sum of meetings attended over the window, Teams-only —
-              Zoom is excluded (the M365 slice of meetings_count)
+    • bronze: daily Teams meeting report per person (meetings attended)
+    • silver: deduped to meetings-attended per person/day
+    • gold:   metric = sum of meetings attended over the window, Teams-only — the
+              M365 slice of meetings_count (Zoom is filtered out by definition)
 
   Team (median/range = the person's department):
     alice 4 · bob 2 · carol 1 → median 2, range [1, 4].
-  Cases: alice Teams slice (4, a seeded Zoom meeting is excluded) · same fixture's
-    cross-source meetings_count = 5 (Zoom counts there) proves the exclusion.
+  Cases: alice (4 vs the team).
 
 bronze:
   bronze_bamboohr.employees:
@@ -36,19 +35,9 @@ bronze:
       unique_key: m365-carol-tm-20260105
       meetingsAttendedCount: 1
 
-  # Zoom side (insight_zoom): alice attends 1 Zoom meeting. It must be EXCLUDED from
-  # teams_meetings (m365-only) but INCLUDED in the cross-source meetings_count.
-  bronze_zoom.participants:
-    - $ref: templates/zoom.yaml#/templates/alice_zoom
-      meeting_uuid: zmtg-alice-tm-1
-      participant_uuid: zp-alice-tm-1
-      join_time: "2026-01-05T10:00:00"
-      leave_time: "2026-01-05T11:00:00"
-
 cases:
-  # alice teams_meetings = 4 (Zoom EXCLUDED by data_source filter)
-  #   team {4,2,1} → median 2, range [1,4]
-  - name: teams_meetings — alice m365-only slice (Zoom excluded → value 4)
+  # alice teams_meetings = 4 ; team {4,2,1} → median 2, range [1,4]
+  - name: teams_meetings — IC bullet (alice value vs team median/range)
     request:
       url: /v1/metrics/queries
       method: POST
@@ -64,20 +53,3 @@ cases:
       - in: collaboration
         find: { metric_key: teams_meetings }
         equal: { value: 4, median: 2, range_min: 1, range_max: 4 }
-
-  # SAME fixture: meetings_count INCLUDES the Zoom meeting → alice = 4 Teams + 1 Zoom = 5
-  #   team {5,2,1} → median 2, range [1,5]. Proves the Zoom row landed.
-  - name: teams_meetings — Zoom counts in cross-source meetings_count (value 5)
-    request:
-      url: /v1/metrics/queries
-      method: POST
-      body:
-        queries:
-          - id: collaboration
-            metric_id: 00000000-0000-0000-0001-000000000012
-            $filter: "person_id eq 'alice@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
-    expect:
-      - assert: "status == 200"
-      - in: collaboration
-        find: { metric_key: meetings_count }
-        equal: { value: 5, median: 2, range_min: 1, range_max: 5 }

--- a/src/ingestion/tests/e2e/specs/collab_teams_meetings.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_teams_meetings.test.yaml
@@ -1,10 +1,23 @@
 spec_version: 1
 description: >
-  Per-metric E2E check for teams_meetings (#1413). Seeds
-  bronze_m365.teams_activity meetingsAttendedCount for 3 people in one team and
-  asserts the IC Bullet Collaboration metric (…0012). teams_meetings =
-  sumIf(meetings_attended, data_source = insight_m365) — the m365-only slice of
-  meetings_count (equal here, no zoom). value = member, median/range = team.
+  Metric: teams_meetings — IC Bullet Collaboration (…0012), #1413.
+  teams_meetings = sumIf(meetings_attended, data_source = insight_m365) — the
+  M365-only slice of meetings_count. Equal to meetings_count here (no Zoom data).
+
+  Path (bronze → silver → gold):
+    • bronze_m365.teams_activity → staging m365__collab_meeting_activity → silver.class_collab_meeting_activity
+      (Zoom rows excluded — teams_meetings filters data_source = insight_m365)
+    → insight.collab_bullet_rows (gold) → metric …0012.
+
+  Team (department `org_unit_id` — the peer group the median/range span):
+    • alice — 4 meetings
+    • bob   — 2
+    • carol — 1
+    team {4, 2, 1} → median 2, range [1, 4].
+
+  One case, asserting alice (value = member, median/range = team):
+    value 4, median 2, range [1, 4]. Teeth: alice's row is a verbatim duplicate
+    (same unique_key) → must dedup to 4, not 8.
 
 bronze:
   bronze_bamboohr.employees:

--- a/src/ingestion/tests/e2e/specs/collab_teams_meetings.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_teams_meetings.test.yaml
@@ -1,0 +1,51 @@
+spec_version: 1
+description: >
+  Per-metric E2E check for teams_meetings (#1413). Seeds
+  bronze_m365.teams_activity meetingsAttendedCount for 3 people in one team and
+  asserts the IC Bullet Collaboration metric (…0012). teams_meetings =
+  sumIf(meetings_attended, data_source = insight_m365) — the m365-only slice of
+  meetings_count (equal here, no zoom). value = member, median/range = team.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+    - $ref: templates/people.yaml#/templates/bob
+    - $ref: templates/people.yaml#/templates/carol
+
+  bronze_m365.teams_activity:
+    - $ref: templates/m365_teams.yaml#/templates/alice_teams
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-tm-20260105
+      meetingsAttendedCount: 4
+    - $ref: templates/m365_teams.yaml#/templates/alice_teams  # verbatim duplicate -> must dedup, not double
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-alice-tm-20260105
+      meetingsAttendedCount: 4
+    - $ref: templates/m365_teams.yaml#/templates/bob_teams
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-bob-tm-20260105
+      meetingsAttendedCount: 2
+    - $ref: templates/m365_teams.yaml#/templates/carol_teams
+      reportRefreshDate: "2026-01-05"
+      unique_key: m365-carol-tm-20260105
+      meetingsAttendedCount: 1
+
+cases:
+  # team teams_meetings = [alice 4, bob 2, carol 1]
+  #   value (alice) = 4 ; median[1,2,4] = 2 ; range = [1,4]
+  - name: teams_meetings — IC bullet (alice value vs team median/range)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'alice@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        assert: "result.status == 'ok'"
+      - in: collaboration
+        find: { metric_key: teams_meetings }
+        equal: { value: 4, median: 2, range_min: 1, range_max: 4 }

--- a/src/ingestion/tests/e2e/specs/collab_teams_meetings.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_teams_meetings.test.yaml
@@ -1,23 +1,16 @@
 spec_version: 1
 description: >
   Metric: teams_meetings — IC Bullet Collaboration (…0012), #1413.
-  teams_meetings = sumIf(meetings_attended, data_source = insight_m365) — the
-  M365-only slice of meetings_count. Equal to meetings_count here (no Zoom data).
+  How it's computed (bronze → silver → gold):
+    • bronze: daily Teams meeting report per person (+ Zoom sessions, filtered out below)
+    • silver: meetings-attended per person/day, tagged by source (Teams vs Zoom)
+    • gold:   metric = sum of meetings attended over the window, Teams-only —
+              Zoom is excluded (the M365 slice of meetings_count)
 
-  Path (bronze → silver → gold):
-    • bronze_m365.teams_activity → staging m365__collab_meeting_activity → silver.class_collab_meeting_activity
-      (Zoom rows excluded — teams_meetings filters data_source = insight_m365)
-    → insight.collab_bullet_rows (gold) → metric …0012.
-
-  Team (department `org_unit_id` — the peer group the median/range span):
-    • alice — 4 meetings
-    • bob   — 2
-    • carol — 1
-    team {4, 2, 1} → median 2, range [1, 4].
-
-  One case, asserting alice (value = member, median/range = team):
-    value 4, median 2, range [1, 4]. Teeth: alice's row is a verbatim duplicate
-    (same unique_key) → must dedup to 4, not 8.
+  Team (median/range = the person's department):
+    alice 4 · bob 2 · carol 1 → median 2, range [1, 4].
+  Cases: alice Teams slice (4, a seeded Zoom meeting is excluded) · same fixture's
+    cross-source meetings_count = 5 (Zoom counts there) proves the exclusion.
 
 bronze:
   bronze_bamboohr.employees:
@@ -43,10 +36,19 @@ bronze:
       unique_key: m365-carol-tm-20260105
       meetingsAttendedCount: 1
 
+  # Zoom side (insight_zoom): alice attends 1 Zoom meeting. It must be EXCLUDED from
+  # teams_meetings (m365-only) but INCLUDED in the cross-source meetings_count.
+  bronze_zoom.participants:
+    - $ref: templates/zoom.yaml#/templates/alice_zoom
+      meeting_uuid: zmtg-alice-tm-1
+      participant_uuid: zp-alice-tm-1
+      join_time: "2026-01-05T10:00:00"
+      leave_time: "2026-01-05T11:00:00"
+
 cases:
-  # team teams_meetings = [alice 4, bob 2, carol 1]
-  #   value (alice) = 4 ; median[1,2,4] = 2 ; range = [1,4]
-  - name: teams_meetings — IC bullet (alice value vs team median/range)
+  # alice teams_meetings = 4 (Zoom EXCLUDED by data_source filter)
+  #   team {4,2,1} → median 2, range [1,4]
+  - name: teams_meetings — alice m365-only slice (Zoom excluded → value 4)
     request:
       url: /v1/metrics/queries
       method: POST
@@ -62,3 +64,20 @@ cases:
       - in: collaboration
         find: { metric_key: teams_meetings }
         equal: { value: 4, median: 2, range_min: 1, range_max: 4 }
+
+  # SAME fixture: meetings_count INCLUDES the Zoom meeting → alice = 4 Teams + 1 Zoom = 5
+  #   team {5,2,1} → median 2, range [1,5]. Proves the Zoom row landed.
+  - name: teams_meetings — Zoom counts in cross-source meetings_count (value 5)
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000012
+            $filter: "person_id eq 'alice@example.com' and metric_date ge '2026-01-01' and metric_date le '2026-01-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        find: { metric_key: meetings_count }
+        equal: { value: 5, median: 2, range_min: 1, range_max: 5 }

--- a/src/ingestion/tests/e2e/specs/collab_zulip_chat.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_zulip_chat.test.yaml
@@ -1,10 +1,25 @@
 spec_version: 1
-description: >-
-  Zulip chat activity flows bronze → silver class_collab_chat_activity (via
-  union_by_tag) → gold insight.collab_bullet_rows (Branch 4b,
-  data_source='insight_zulip_proxy') → IC Bullet Collaboration metric_key
-  `zulip_messages_sent`. Mirrors collab_emails_sent: alice's own value vs her
-  team's median/range, with a bronze duplicate that must dedup.
+description: >
+  Metric: zulip_messages_sent — IC Bullet Collaboration (…0012), #1413.
+  zulip_messages_sent = Σ total_chat_messages over the period
+  (data_source insight_zulip_proxy). Zulip is chat-only.
+
+  Path (bronze → silver → gold):
+    • bronze_zulip_proxy.users + bronze_zulip_proxy.messages → staging zulip__collab_chat_activity → silver.class_collab_chat_activity
+      (users supply the email that joins to a person; messages carry per-sender counts)
+    → insight.collab_bullet_rows (gold, data_source insight_zulip_proxy) → metric …0012.
+
+  Team (department `org_unit_id` — the peer group the median/range span):
+    • alice — 40 messages
+    • bob   — 20
+    • carol — 10
+    team {40, 20, 10} → median 20, range [10, 40].
+
+  One case, asserting alice (value = member, median/range = team):
+    value 40, median 20, range [10, 40]. Teeth: alice's message row is a
+    verbatim duplicate (same `uniq`) → must dedup to 40, not 80; the bullet
+    exposes 21 FE-visible keys (Zulip add: 20 → 21); slack_dm_ratio is null
+    (no Slack seeded).
 
 # bronze — seed fixture. Key = TABLE NAME. People (org_unit) come from
 # bamboohr; Zulip users supply the emails that join to them; Zulip messages

--- a/src/ingestion/tests/e2e/specs/collab_zulip_chat.test.yaml
+++ b/src/ingestion/tests/e2e/specs/collab_zulip_chat.test.yaml
@@ -1,25 +1,15 @@
 spec_version: 1
 description: >
   Metric: zulip_messages_sent — IC Bullet Collaboration (…0012), #1413.
-  zulip_messages_sent = Σ total_chat_messages over the period
-  (data_source insight_zulip_proxy). Zulip is chat-only.
+  How it's computed (bronze → silver → gold):
+    • bronze: Zulip users (emails) + per-sender message counts from the Zulip proxy
+    • silver: deduped to per-person/day chat-message totals
+    • gold:   metric = sum of Zulip messages sent over the window (chat-only)
 
-  Path (bronze → silver → gold):
-    • bronze_zulip_proxy.users + bronze_zulip_proxy.messages → staging zulip__collab_chat_activity → silver.class_collab_chat_activity
-      (users supply the email that joins to a person; messages carry per-sender counts)
-    → insight.collab_bullet_rows (gold, data_source insight_zulip_proxy) → metric …0012.
-
-  Team (department `org_unit_id` — the peer group the median/range span):
-    • alice — 40 messages
-    • bob   — 20
-    • carol — 10
-    team {40, 20, 10} → median 20, range [10, 40].
-
-  One case, asserting alice (value = member, median/range = team):
-    value 40, median 20, range [10, 40]. Teeth: alice's message row is a
-    verbatim duplicate (same `uniq`) → must dedup to 40, not 80; the bullet
-    exposes 21 FE-visible keys (Zulip add: 20 → 21); slack_dm_ratio is null
-    (no Slack seeded).
+  Team (median/range = the person's department):
+    alice 40 · bob 20 · carol 10 → median 20, range [10, 40].
+  Cases: alice (40 vs team; also checks the bullet exposes 21 keys and that
+    slack_dm_ratio is null when no Slack is seeded).
 
 # bronze — seed fixture. Key = TABLE NAME. People (org_unit) come from
 # bamboohr; Zulip users supply the emails that join to them; Zulip messages

--- a/src/ingestion/tests/e2e/specs/schemas/bronze_m365.onedrive_activity.yaml
+++ b/src/ingestion/tests/e2e/specs/schemas/bronze_m365.onedrive_activity.yaml
@@ -1,0 +1,25 @@
+# Reusable JSON schema for the table (all real fields). Resolved by table name.
+# Mirrors the bronze_m365.onedrive_activity placeholder DDL in
+# src/ingestion/scripts/create-bronze-placeholders.sh. NOTE: onedrive has NO
+# visitedPageCount column (sharepoint does).
+schemas:
+  bronze_m365.onedrive_activity:
+    $schema: http://json-schema.org/draft-07/schema#
+    type: object
+    additionalProperties: false
+    properties:
+      _airbyte_raw_id: { type: string }
+      _airbyte_extracted_at: { type: string, format: date-time }
+      _airbyte_meta: { type: string }
+      _airbyte_generation_id: { type: integer }
+      tenant_id: { type: [string, "null"] }
+      source_id: { type: [string, "null"] }
+      unique_key: { type: [string, "null"] }
+      userPrincipalName: { type: [string, "null"] }
+      reportRefreshDate: { type: [string, "null"] }
+      reportPeriod: { type: [string, "null"] }
+      lastActivityDate: { type: [string, "null"] }
+      viewedOrEditedFileCount: { type: [number, "null"] }
+      syncedFileCount: { type: [number, "null"] }
+      sharedInternallyFileCount: { type: [number, "null"] }
+      sharedExternallyFileCount: { type: [number, "null"] }

--- a/src/ingestion/tests/e2e/specs/schemas/bronze_m365.sharepoint_activity.yaml
+++ b/src/ingestion/tests/e2e/specs/schemas/bronze_m365.sharepoint_activity.yaml
@@ -1,0 +1,25 @@
+# Reusable JSON schema for the table (all real fields). Resolved by table name.
+# Mirrors the bronze_m365.sharepoint_activity placeholder DDL in
+# src/ingestion/scripts/create-bronze-placeholders.sh (= onedrive + visitedPageCount).
+schemas:
+  bronze_m365.sharepoint_activity:
+    $schema: http://json-schema.org/draft-07/schema#
+    type: object
+    additionalProperties: false
+    properties:
+      _airbyte_raw_id: { type: string }
+      _airbyte_extracted_at: { type: string, format: date-time }
+      _airbyte_meta: { type: string }
+      _airbyte_generation_id: { type: integer }
+      tenant_id: { type: [string, "null"] }
+      source_id: { type: [string, "null"] }
+      unique_key: { type: [string, "null"] }
+      userPrincipalName: { type: [string, "null"] }
+      reportRefreshDate: { type: [string, "null"] }
+      reportPeriod: { type: [string, "null"] }
+      lastActivityDate: { type: [string, "null"] }
+      viewedOrEditedFileCount: { type: [number, "null"] }
+      syncedFileCount: { type: [number, "null"] }
+      sharedInternallyFileCount: { type: [number, "null"] }
+      sharedExternallyFileCount: { type: [number, "null"] }
+      visitedPageCount: { type: [number, "null"] }

--- a/src/ingestion/tests/e2e/specs/schemas/bronze_m365.teams_activity.yaml
+++ b/src/ingestion/tests/e2e/specs/schemas/bronze_m365.teams_activity.yaml
@@ -1,0 +1,38 @@
+# Reusable JSON schema for the table (all real fields). Resolved by table name.
+# Mirrors the bronze_m365.teams_activity placeholder DDL in
+# src/ingestion/scripts/create-bronze-placeholders.sh (additionalProperties:false
+# => every placeholder column must be listed, incl. the 4 _airbyte_* CDK cols).
+schemas:
+  bronze_m365.teams_activity:
+    $schema: http://json-schema.org/draft-07/schema#
+    type: object
+    additionalProperties: false
+    properties:
+      _airbyte_raw_id: { type: string }
+      _airbyte_extracted_at: { type: string, format: date-time }
+      _airbyte_meta: { type: string }
+      _airbyte_generation_id: { type: integer }
+      tenant_id: { type: [string, "null"] }
+      source_id: { type: [string, "null"] }
+      unique_key: { type: [string, "null"] }
+      userPrincipalName: { type: [string, "null"] }
+      reportRefreshDate: { type: [string, "null"] }
+      reportPeriod: { type: [string, "null"] }
+      lastActivityDate: { type: [string, "null"] }
+      teamChatMessageCount: { type: [number, "null"] }
+      privateChatMessageCount: { type: [number, "null"] }
+      postMessages: { type: [number, "null"] }
+      replyMessages: { type: [number, "null"] }
+      urgentMessages: { type: [number, "null"] }
+      callCount: { type: [number, "null"] }
+      meetingsAttendedCount: { type: [number, "null"] }
+      meetingsOrganizedCount: { type: [number, "null"] }
+      adHocMeetingsAttendedCount: { type: [number, "null"] }
+      adHocMeetingsOrganizedCount: { type: [number, "null"] }
+      scheduledOneTimeMeetingsAttendedCount: { type: [number, "null"] }
+      scheduledOneTimeMeetingsOrganizedCount: { type: [number, "null"] }
+      scheduledRecurringMeetingsAttendedCount: { type: [number, "null"] }
+      scheduledRecurringMeetingsOrganizedCount: { type: [number, "null"] }
+      audioDuration: { type: [string, "null"] }
+      videoDuration: { type: [string, "null"] }
+      screenShareDuration: { type: [string, "null"] }

--- a/src/ingestion/tests/e2e/specs/schemas/bronze_zoom.participants.yaml
+++ b/src/ingestion/tests/e2e/specs/schemas/bronze_zoom.participants.yaml
@@ -1,0 +1,27 @@
+# Reusable JSON schema for bronze_zoom.participants (the columns the zoom collab
+# meeting models read). Zoom has NO bronze unique_key column — silver derives
+# MD5(tenant, source, lower(email), date-of-join_time); the staging model also
+# dedups participants via `LIMIT 1 BY (meeting_uuid, participant_uuid, join_time)`.
+schemas:
+  bronze_zoom.participants:
+    $schema: http://json-schema.org/draft-07/schema#
+    type: object
+    additionalProperties: false
+    properties:
+      _airbyte_raw_id: { type: string }
+      _airbyte_extracted_at: { type: string, format: date-time }
+      _airbyte_meta: { type: string }
+      _airbyte_generation_id: { type: integer }
+      tenant_id: { type: string }
+      source_id: { type: string }
+      email: { type: string }
+      user_name: { type: [string, "null"] }
+      meeting_uuid: { type: string }
+      participant_uuid: { type: string }
+      join_time: { type: string }
+      leave_time: { type: string }
+      camera: { type: [string, "null"] }
+      share_desktop: { type: [boolean, "null"] }
+      share_application: { type: [boolean, "null"] }
+      share_whiteboard: { type: [boolean, "null"] }
+      video_connection_type: { type: [string, "null"] }

--- a/src/ingestion/tests/e2e/specs/templates/m365_onedrive.yaml
+++ b/src/ingestion/tests/e2e/specs/templates/m365_onedrive.yaml
@@ -1,0 +1,32 @@
+# Reusable OneDrive-activity records (bronze_m365.onedrive_activity).
+# Base lists every schema field (counts null); per-person records override only
+# userPrincipalName. Feeds class_collab_document_activity (product = onedrive).
+templates:
+  m365_onedrive:
+    _airbyte_raw_id: "00000000-0000-0000-0000-000000000000"
+    _airbyte_extracted_at: "2026-01-05T00:00:00"
+    _airbyte_meta: "{}"
+    _airbyte_generation_id: 0
+    tenant_id: "00000000-0000-0000-0000-000000000000"
+    source_id: "m365-test"
+    unique_key: null
+    userPrincipalName: null
+    reportPeriod: "D1"
+    reportRefreshDate: null
+    lastActivityDate: null
+    viewedOrEditedFileCount: null
+    syncedFileCount: null
+    sharedInternallyFileCount: null
+    sharedExternallyFileCount: null
+
+  alice_onedrive:
+    $ref: "#/templates/m365_onedrive"
+    userPrincipalName: alice@example.com
+
+  bob_onedrive:
+    $ref: "#/templates/m365_onedrive"
+    userPrincipalName: bob@example.com
+
+  carol_onedrive:
+    $ref: "#/templates/m365_onedrive"
+    userPrincipalName: carol@example.com

--- a/src/ingestion/tests/e2e/specs/templates/m365_sharepoint.yaml
+++ b/src/ingestion/tests/e2e/specs/templates/m365_sharepoint.yaml
@@ -1,0 +1,34 @@
+# Reusable SharePoint-activity records (bronze_m365.sharepoint_activity).
+# Base lists every schema field (counts null) incl. visitedPageCount; per-person
+# records override only userPrincipalName. Feeds class_collab_document_activity
+# (product = sharepoint).
+templates:
+  m365_sharepoint:
+    _airbyte_raw_id: "00000000-0000-0000-0000-000000000000"
+    _airbyte_extracted_at: "2026-01-05T00:00:00"
+    _airbyte_meta: "{}"
+    _airbyte_generation_id: 0
+    tenant_id: "00000000-0000-0000-0000-000000000000"
+    source_id: "m365-test"
+    unique_key: null
+    userPrincipalName: null
+    reportPeriod: "D1"
+    reportRefreshDate: null
+    lastActivityDate: null
+    viewedOrEditedFileCount: null
+    syncedFileCount: null
+    sharedInternallyFileCount: null
+    sharedExternallyFileCount: null
+    visitedPageCount: null
+
+  alice_sharepoint:
+    $ref: "#/templates/m365_sharepoint"
+    userPrincipalName: alice@example.com
+
+  bob_sharepoint:
+    $ref: "#/templates/m365_sharepoint"
+    userPrincipalName: bob@example.com
+
+  carol_sharepoint:
+    $ref: "#/templates/m365_sharepoint"
+    userPrincipalName: carol@example.com

--- a/src/ingestion/tests/e2e/specs/templates/m365_teams.yaml
+++ b/src/ingestion/tests/e2e/specs/templates/m365_teams.yaml
@@ -1,0 +1,50 @@
+# Reusable Teams-activity records (bronze_m365.teams_activity).
+# A record is a plain field map; an optional `$ref` inherits from another record
+# and sibling keys override it. The base lists EVERY schema field so a merged
+# bronze row is complete; unused fields default to null. The 4 `_airbyte_*` CDK
+# columns are included (non-nullable). Carry ONLY identity boilerplate; the
+# fields under test (reportRefreshDate, unique_key, chat/meeting counters,
+# durations) are set in each test's `bronze`. teams_activity feeds BOTH
+# class_collab_chat_activity AND class_collab_meeting_activity.
+templates:
+  m365_teams:
+    _airbyte_raw_id: "00000000-0000-0000-0000-000000000000"
+    _airbyte_extracted_at: "2026-01-05T00:00:00"
+    _airbyte_meta: "{}"
+    _airbyte_generation_id: 0
+    tenant_id: "00000000-0000-0000-0000-000000000000"
+    source_id: "m365-test"
+    unique_key: null
+    userPrincipalName: null
+    reportPeriod: "D1"
+    reportRefreshDate: null
+    lastActivityDate: null
+    teamChatMessageCount: null
+    privateChatMessageCount: null
+    postMessages: null
+    replyMessages: null
+    urgentMessages: null
+    callCount: null
+    meetingsAttendedCount: null
+    meetingsOrganizedCount: null
+    adHocMeetingsAttendedCount: null
+    adHocMeetingsOrganizedCount: null
+    scheduledOneTimeMeetingsAttendedCount: null
+    scheduledOneTimeMeetingsOrganizedCount: null
+    scheduledRecurringMeetingsAttendedCount: null
+    scheduledRecurringMeetingsOrganizedCount: null
+    audioDuration: null
+    videoDuration: null
+    screenShareDuration: null
+
+  alice_teams:
+    $ref: "#/templates/m365_teams"
+    userPrincipalName: alice@example.com
+
+  bob_teams:
+    $ref: "#/templates/m365_teams"
+    userPrincipalName: bob@example.com
+
+  carol_teams:
+    $ref: "#/templates/m365_teams"
+    userPrincipalName: carol@example.com

--- a/src/ingestion/tests/e2e/specs/templates/zoom.yaml
+++ b/src/ingestion/tests/e2e/specs/templates/zoom.yaml
@@ -1,0 +1,34 @@
+# Reusable Zoom participant records (bronze_zoom.participants).
+# The base carries EVERY schema column (so a merged row is complete); the fields
+# under test (join_time / leave_time / meeting_uuid / participant_uuid) are set in
+# each test's `bronze`. Meeting duration = dateDiff(join_time, leave_time); video is
+# gated by `camera` (NULL/'' => 0) and screen-share by the share_* flags, so a
+# participant with audio only contributes audio seconds as the longest modality.
+# There is NO bronze unique_key column — silver derives its own key.
+templates:
+  zoom_participant:
+    _airbyte_raw_id: "00000000-0000-0000-0000-000000000000"
+    _airbyte_extracted_at: "2026-01-05T00:00:00"
+    _airbyte_meta: "{}"
+    _airbyte_generation_id: 0
+    tenant_id: "00000000-0000-0000-0000-000000000000"
+    source_id: "zoom-test"
+    email: null
+    user_name: null
+    meeting_uuid: null
+    participant_uuid: null
+    join_time: null
+    leave_time: null
+    camera: null
+    share_desktop: null
+    share_application: null
+    share_whiteboard: null
+    video_connection_type: null
+
+  alice_zoom:
+    $ref: "#/templates/zoom_participant"
+    email: alice@example.com
+
+  carol_zoom:
+    $ref: "#/templates/zoom_participant"
+    email: carol@example.com


### PR DESCRIPTION
## Summary

Completes the per-metric E2E coverage of the m365 **Collaboration** bullet. The
email metrics landed in #1472; this PR adds the remaining 10 metrics, each driving
the full `bronze → dbt silver → gold view → analytics-api` path and asserting on
the IC bullet (`…0012`) over a one-team (Engineering) cohort.

| stream (bronze) | metrics |
|---|---|
| **Teams** (`teams_activity`) | `m365_teams_chats`, `meetings_count`, `teams_meetings`, `meeting_hours`, `teams_meeting_hours`, `meeting_free` |
| **Files** (`onedrive_activity` + `sharepoint_activity`) | `m365_files_engaged`, `m365_files_shared_internal`, `m365_files_shared_external` |
| **multi-stream** (email + onedrive + teams) | `m365_active_days` |

Each spec:
- asserts **only** the target `metric_key`'s `value` / `median` / `range_*` (value = the
  member, median/range = the team cohort), per the skill convention;
- seeds a **verbatim-duplicate** alice row so RMT/`union_by_tag` dedup is exercised on
  each new silver class (`class_collab_chat_activity`, `class_collab_meeting_activity`,
  `class_collab_document_activity`) — the value must dedup, not double.

Also adds the `teams`/`onedrive`/`sharepoint` bronze schemas + `$ref` templates.

## Testing

```
cd src/ingestion/tests/e2e && ./e2e.sh test
======================== 45 passed in 117.77s ========================
```

(10 new specs + the email/zulip specs + meta framework tests.) Goldens were
confirmed twice — once before and once after adding the dedup rows (unchanged,
proving dedup).

## Scope / follow-up

Covers all 13 m365 collaboration bullet metric_keys (3 email in #1472 + these 10).
Still deferred (separate concerns, can follow up): the `collab_team_cohort` spec
(Team bullet `…0005`, multi-team) and the `collab_smoke` integration spec.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded end-to-end coverage for collaboration metrics, including active days, meeting-free, meeting hours/counts, Teams chats, Teams meetings/hours, and internal/external file engagement & sharing.
* **Bug Fixes**
  * Improved end-to-end determinism by truncating additional Zoom staging tables at session start.
  * Strengthened validation that duplicate activity rows are deduplicated and not double-counted.
* **Documentation / Chores**
  * Added reusable fixture templates and JSON schemas for M365 and Zoom activity, plus expanded Zoom bronze placeholders.
  * Refined end-to-end metric test guidance and updated collaboration test documentation text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->