### PR TITLE
fix(ingestion): add reconcile-connectors.sh entrypoint wrapper

### DIFF
--- a/src/ingestion/reconcile-connectors.sh
+++ b/src/ingestion/reconcile-connectors.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Entrypoint wrapper for the connector reconcile engine.
+#
+# The reconcile CLI lives at reconcile-connectors/main.sh, but the docs,
+# connector READMEs, ADRs, and main.sh's own usage string all refer to it as
+# `reconcile-connectors.sh`. This wrapper makes that name real, so the
+# documented invocation works verbatim:
+#
+#   ./reconcile-connectors.sh [adopt | reconcile] [--dry-run] [--connector NAME] [--no-gc]
+#
+# All arguments pass straight through; `exec` propagates main.sh's exit code.
+set -euo pipefail
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+exec "${SCRIPT_DIR}/reconcile-connectors/main.sh" "$@"


### PR DESCRIPTION
The reconcile CLI lives at reconcile-connectors/main.sh, but the docs, connector READMEs, ADRs, and main.sh's own usage() string all refer to it as `reconcile-connectors.sh` — a name that had no file behind it (verified: never existed in git history). So every `./reconcile-connectors.sh ...` invocation in the docs was broken.

Add a thin wrapper that execs reconcile-connectors/main.sh "$@", making the documented invocation real with one small script instead of rewriting ~70 doc references. main.sh's usage() string is now accurate. Args + exit code pass straight through.