### PR TITLE
feat(ingestion): add connector to data-quality findings

### DIFF
--- a/charts/insight/templates/ingestion/data-quality-test.yaml
+++ b/charts/insight/templates/ingestion/data-quality-test.yaml
@@ -110,6 +110,10 @@ spec:
                   "check_id": n.get("name"),
                   "title": meta.get("title", n.get("name")),
                   "domain": meta.get("domain", "unknown"),
+                  # connector lets the Grafana alert group findings per source
+                  # (promoted to a Loki label via `| json`). Defaults to
+                  # "unknown" for cross-connector / silver-generic checks.
+                  "connector": meta.get("connector", "unknown"),
                   "category": meta.get("category", "uncategorized"),
                   "gate": cfg.get("severity"),
                   "tier": meta.get("tier", "warn"),

--- a/src/ingestion/dbt/tests/README.md
+++ b/src/ingestion/dbt/tests/README.md
@@ -30,6 +30,7 @@ Create `tests/<domain>/assert_<subject>_<rule>.sql`:
     meta={
         'title': 'Short human label',
         'domain': 'collab',            -- collab | git | task | ai | hr | gold | ...
+        'connector': 'zoom',           -- source connector, or 'silver' for cross-connector checks
         'category': 'physical_bound',  -- source_uniqueness | grain | physical_bound | freshness | ...
         'tier': 'error',               -- triage importance: info | warn | error
         'remediation': 'What to check / how to fix when this fires.'
@@ -61,6 +62,10 @@ Conventions:
   stop the pipeline.
 - **`meta.tier`** is independent of the gate — how alarming a violation is to a
   human, surfaced in the finding regardless of the gate.
+- **`meta.connector`** names the source connector (e.g. `zoom`, `jira`) or
+  `silver` for cross-connector checks. It is emitted on every finding and
+  promoted to a Loki label, so the Grafana data-quality alert can group and
+  route by connector. Findings without it land under `connector="unknown"`.
 - Register any new gold view in `silver/_shared/gold_sources.yml` before
   referencing it with `source('gold', '<view>')`.
 - Read `ReplacingMergeTree` tables with `FINAL` (or the project's dedup pattern)


### PR DESCRIPTION
## What

Adds a `connector` field to every `data_quality` finding emitted by the `data-quality-test` WorkflowTemplate, and documents the `meta.connector` convention for authoring DQ tests.

## Why

The DQ findings are shipped to Loki (stdout → log collector) and alerting is done as a Grafana pull over Loki. To group and route alerts per source connector (e.g. `zoom`, `jira`) we need the connector on each finding. It is read from the test's `meta.connector`, emitted in the JSON event, and available as a query-time label via `| json`. Findings without it fall back to `connector="unknown"` (cross-connector / silver-generic checks).

This does not change the stdout→Loki contract — it only adds one field to the existing JSON event.

## Changes

- `charts/insight/templates/ingestion/data-quality-test.yaml` — emit `connector` (from `meta.connector`, default `"unknown"`) in the finding JSON.
- `src/ingestion/dbt/tests/README.md` — document the `meta.connector` convention.

## Notes

Follow-up (separate PRs): backfill `meta.connector` into existing tests, and the Grafana alert rules live in the gitops repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Data-quality findings now include a connector label, making it easier to group and route alerts by source.
  * If no connector is provided, findings fall back to `unknown` to keep behavior consistent.

* **Documentation**
  * Updated guidance for creating data-quality tests to show the new connector field in examples.
  * Clarified how connector values are used in alerting and routing, including cross-connector checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->