### PR TITLE
ci(functional): run k3s smoke on pull requests

### DIFF
--- a/.github/workflows/functional-k3s.yml
+++ b/.github/workflows/functional-k3s.yml
@@ -8,6 +8,13 @@ name: Functional K3s Smoke
 
 on:
   workflow_dispatch:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: functional-k3s-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Runs the functional K3s smoke workflow automatically for PR changes.

The workflow still supports manual `workflow_dispatch`, but now also runs when a PR targeting `main` is opened, updated, reopened, or marked ready for review.

## What changed

- Added `pull_request` trigger for:
  - `opened`
  - `synchronize`
  - `reopened`
  - `ready_for_review`
- Added workflow concurrency so superseded runs for the same PR are cancelled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated a validation workflow for pull requests targeting the main branch.
  * Reduced duplicate workflow runs by cancelling older in-progress runs when a new update is pushed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->