### PR TITLE
test(analytics-api): starter unit tests for identity + OData parser (#1433)

### DIFF
--- a/src/backend/services/analytics-api/src/api/handlers.rs
+++ b/src/backend/services/analytics-api/src/api/handlers.rs
@@ -1290,6 +1290,25 @@ mod tests {
         );
     }
 
+    #[test]
+    fn extract_in_list_unescapes_doubled_quotes() {
+        // OData escapes an apostrophe inside a string literal by doubling it;
+        // the parser must collapse `''` back to a single `'` in the value.
+        let f = "person_id in ('o''brien@x.com')";
+        assert_eq!(
+            extract_odata_in_values(f, "person_id"),
+            Some(vec!["o'brien@x.com".into()])
+        );
+    }
+
+    #[test]
+    fn extract_in_list_unknown_field_is_none() {
+        // A field that never appears in the filter yields no `in (` anchor,
+        // so the extractor short-circuits to None rather than mis-parsing.
+        let f = "person_id in ('a@x.com')";
+        assert_eq!(extract_odata_in_values(f, "org_unit_id"), None);
+    }
+
     // ── parse_query_ref ─────────────────────────────────────
 
     #[test]

--- a/src/backend/services/analytics-api/src/infra/identity/mod.rs
+++ b/src/backend/services/analytics-api/src/infra/identity/mod.rs
@@ -81,3 +81,32 @@ impl IdentityClient {
         !self.base_url.is_empty()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_trims_trailing_slash() {
+        // `base_url` is private, but an in-module test sees it via `super::*`.
+        // Trailing slashes must be stripped so `get_person` builds
+        // `{base}/v1/persons/…` without a doubled `//`.
+        let c = IdentityClient::new("http://insight-identity:8082/");
+        assert_eq!(c.base_url, "http://insight-identity:8082");
+    }
+
+    #[test]
+    fn new_trims_repeated_trailing_slashes() {
+        let c = IdentityClient::new("http://insight-identity:8082///");
+        assert_eq!(c.base_url, "http://insight-identity:8082");
+    }
+
+    #[test]
+    fn is_configured_reflects_non_empty_url() {
+        assert!(IdentityClient::new("http://x").is_configured());
+        // An empty URL (identity not wired) collapses to "" → not configured.
+        assert!(!IdentityClient::new("").is_configured());
+        // A URL that is only slashes trims to "" and is likewise unconfigured.
+        assert!(!IdentityClient::new("///").is_configured());
+    }
+}


### PR DESCRIPTION
First, small slice toward #1433 — raising `analytics-api` line coverage (65.8% → ≥80%, part of release #1526). Adds DB-free, network-free pure-logic unit tests; **no production code changed**.

## Tests added (5)
**`src/infra/identity/mod.rs`** — module had zero tests; new `#[cfg(test)] mod tests`:
- `new_trims_trailing_slash` / `new_trims_repeated_trailing_slashes` — `IdentityClient::new` strips trailing `/` so `get_person` builds `{base}/v1/persons/…` without a doubled slash.
- `is_configured_reflects_non_empty_url` — empty / slash-only URL collapses to `""` → not configured.

**`src/api/handlers.rs`** — extend the existing OData test block:
- `extract_in_list_unescapes_doubled_quotes` — covers the `''`→`'` unescape branch.
- `extract_in_list_unknown_field_is_none` — unknown field short-circuits to `None`.

## Scope note
Intentionally the easiest, highest-signal first increment (pure logic, no DB/network). The larger coverage gains under #1433 — the `admin_threshold` service validation gauntlet (mock-trait based) and `auth.rs` middleware reject paths (`tower::oneshot`) — are follow-ups. `live_tests.rs` (gated on `INTEGRATION_TESTS_MARIADB_URL`, `#[ignore]`) is not counted by CI coverage, so gains come from these DB-free tests.

## Testing
- `cargo test -p analytics-api` — 5 new tests green.
- `cargo fmt` + `cargo clippy --all-targets -- -D warnings -D clippy::pedantic` clean.

Refs #1433 · #1432

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for filter value parsing to ensure quoted values are handled correctly and missing fields return no results.
  * Added coverage for connection setup checks to confirm server URLs are normalized consistently and empty or invalid URLs are treated as not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->