### PR TITLE
feat(gold): collab_person_counter_daily scaffold + Messaging counters (#1527)

### DIFF
--- a/src/ingestion/dbt/tests/gold/assert_collab_messaging_bounds.sql
+++ b/src/ingestion/dbt/tests/gold/assert_collab_messaging_bounds.sql
@@ -1,0 +1,25 @@
+{{ config(
+    tags=['data_quality'],
+    severity='warn',
+    store_failures=true,
+    meta={
+        'title': 'collab_person_counter_daily messaging counters within sane bounds',
+        'domain': 'gold',
+        'category': 'physical_bound',
+        'tier': 'error',
+        'remediation': 'A collaboration messaging counter is negative. messages_sent and channel_posts are period totals and must be non-negative by construction. Inspect the insight.collab_person_counter_daily view (#1527) — a row here usually means a UNION-branch sign error or a join fanout.'
+    }
+) }}
+-- Gold-layer check. `insight.collab_person_counter_daily` is a database view
+-- (not a dbt model); a singular test reads it via the registered `gold` source.
+-- The Messaging counters are honest-NULL period totals, so NULL is legal but a
+-- negative value never is. A violation is one or more rows. Grain: one row per
+-- (person_id, metric_date).
+SELECT
+    person_id,
+    metric_date,
+    messages_sent,
+    channel_posts
+FROM {{ source('gold', 'collab_person_counter_daily') }}
+WHERE (messages_sent IS NOT NULL AND messages_sent < 0)
+   OR (channel_posts IS NOT NULL AND channel_posts < 0)

--- a/src/ingestion/scripts/create-bronze-placeholders.sh
+++ b/src/ingestion/scripts/create-bronze-placeholders.sh
@@ -175,6 +175,7 @@ CREATE TABLE IF NOT EXISTS silver.class_collab_chat_activity (
     total_chat_messages           Float64,
     channel_messages_posted_count Float64,
     channel_posts                 Float64,
+    channel_replies               Float64,
     _version                      UInt64
 -- `data_source` in the sort key: the compose seed writes one row per
 -- source (insight_m365 + insight_slack) for the same (email, date);

--- a/src/ingestion/scripts/migrations/20260702000000_collab-person-counter-daily.sql
+++ b/src/ingestion/scripts/migrations/20260702000000_collab-person-counter-daily.sql
@@ -1,0 +1,92 @@
+-- Gold view: insight.collab_person_counter_daily  (issue #1527, epic #1516)
+--
+-- The SHARED SCAFFOLD for the modality-named collaboration counters. This is
+-- the first modality (Messaging) and lays the skeleton the other five
+-- (#1528–#1532: meetings, email, documents, knowledge base, cadence) extend by
+-- adding columns + UNION-ALL source branches — NOT new vendor-named rows.
+--
+-- Shape (clone of #1514's `ai_person_counter_daily`):
+--   • honest-NULL `UNION ALL` over the per-vendor silver chat classes, each
+--     branch filling only the columns it can source and NULLing the rest;
+--   • outer GROUP BY (person_id, metric_date) with the
+--     `if(countIf(x IS NOT NULL) > 0, sumIf(x, …), NULL)` wrapper so a person
+--     with NO source on a day yields NULL (honest), never a fake 0. A real 0
+--     (a row that exists with a zero count) is preserved as 0;
+--   • `LEFT JOIN insight.people` to carry `org_unit_id` for the peer bands
+--     computed in the query_ref (#1527 PR B), keyed on `person_id = lower(email)`.
+--
+-- Metrics (Messaging modality):
+--   messages_sent  Σ total_chat_messages across M365 Teams · Slack · Zulip.
+--                  Vendor semantics differ (Slack is a superset incl. replies;
+--                  M365 excludes group chats & replies) — treat as chat
+--                  engagement, not a comparable absolute (see silver
+--                  collaboration/schema.yml).
+--   channel_posts  Σ (channel_posts + channel_replies) across M365 · Slack.
+--                  Slack folds posts+replies into `channel_posts` already
+--                  (`channel_replies` NULL); M365 splits them, so we add both
+--                  for vendor comparability. Zulip does not surface channel
+--                  posts → NULL (honest-NULL, not 0).
+--
+-- Source: silver.class_collab_chat_activity (grain: person, date, data_source).
+
+DROP VIEW IF EXISTS insight.collab_person_counter_daily;
+CREATE VIEW insight.collab_person_counter_daily AS
+SELECT
+    d.person_id AS person_id,
+    p.org_unit_id AS org_unit_id,
+    d.metric_date AS metric_date,
+    d.messages_sent AS messages_sent,
+    d.channel_posts AS channel_posts
+FROM (
+    SELECT
+        person_id,
+        metric_date,
+        if(countIf(messages_sent IS NOT NULL) > 0, sumIf(messages_sent, messages_sent IS NOT NULL), CAST(NULL AS Nullable(Float64))) AS messages_sent,
+        if(countIf(channel_posts IS NOT NULL) > 0, sumIf(channel_posts, channel_posts IS NOT NULL), CAST(NULL AS Nullable(Float64))) AS channel_posts
+    FROM (
+        -- ─── M365 Teams ─────────────────────────────────────────────────
+        -- channel_posts = postMessages + replyMessages (comparable to Slack,
+        -- which folds replies into channel_posts).
+        SELECT
+            lower(c.email) AS person_id,
+            c.date AS metric_date,
+            if(c.total_chat_messages IS NULL, CAST(NULL AS Nullable(Float64)), toFloat64(c.total_chat_messages)) AS messages_sent,
+            if(c.channel_posts IS NULL, CAST(NULL AS Nullable(Float64)), toFloat64(c.channel_posts) + toFloat64(ifNull(c.channel_replies, 0))) AS channel_posts
+        FROM silver.class_collab_chat_activity AS c
+        WHERE c.data_source = 'insight_m365'
+          AND c.email IS NOT NULL
+          AND c.email != ''
+
+        UNION ALL
+
+        -- ─── Slack ──────────────────────────────────────────────────────
+        -- channel_posts already includes replies (Slack cannot split them, so
+        -- channel_replies is NULL) — use it as-is.
+        SELECT
+            lower(s.email) AS person_id,
+            s.date AS metric_date,
+            if(s.total_chat_messages IS NULL, CAST(NULL AS Nullable(Float64)), toFloat64(s.total_chat_messages)) AS messages_sent,
+            if(s.channel_posts IS NULL, CAST(NULL AS Nullable(Float64)), toFloat64(s.channel_posts)) AS channel_posts
+        FROM silver.class_collab_chat_activity AS s
+        WHERE s.data_source = 'insight_slack'
+          AND s.email IS NOT NULL
+          AND s.email != ''
+
+        UNION ALL
+
+        -- ─── Zulip ──────────────────────────────────────────────────────
+        -- Zulip proxy exposes only total chat messages; no channel-post split
+        -- → channel_posts is honest-NULL.
+        SELECT
+            lower(z.email) AS person_id,
+            z.date AS metric_date,
+            if(z.total_chat_messages IS NULL, CAST(NULL AS Nullable(Float64)), toFloat64(z.total_chat_messages)) AS messages_sent,
+            CAST(NULL AS Nullable(Float64)) AS channel_posts
+        FROM silver.class_collab_chat_activity AS z
+        WHERE z.data_source = 'insight_zulip_proxy'
+          AND z.email IS NOT NULL
+          AND z.email != ''
+    ) raw
+    GROUP BY person_id, metric_date
+) d
+LEFT JOIN insight.people AS p ON d.person_id = p.person_id;

--- a/src/ingestion/scripts/migrations/20260702000000_collab-person-counter-daily.sql
+++ b/src/ingestion/scripts/migrations/20260702000000_collab-person-counter-daily.sql
@@ -52,7 +52,10 @@ FROM (
             c.date AS metric_date,
             if(c.total_chat_messages IS NULL, CAST(NULL AS Nullable(Float64)), toFloat64(c.total_chat_messages)) AS messages_sent,
             if(c.channel_posts IS NULL, CAST(NULL AS Nullable(Float64)), toFloat64(c.channel_posts) + toFloat64(ifNull(c.channel_replies, 0))) AS channel_posts
-        FROM silver.class_collab_chat_activity AS c
+        -- FINAL dedups the ReplacingMergeTree at read time (a re-synced day can
+        -- leave >1 version per key before a background merge) — matches the
+        -- class_collab_meeting_activity read in 20260518000000_collab-bullet-rewrite.sql.
+        FROM silver.class_collab_chat_activity AS c FINAL
         WHERE c.data_source = 'insight_m365'
           AND c.email IS NOT NULL
           AND c.email != ''
@@ -67,7 +70,7 @@ FROM (
             s.date AS metric_date,
             if(s.total_chat_messages IS NULL, CAST(NULL AS Nullable(Float64)), toFloat64(s.total_chat_messages)) AS messages_sent,
             if(s.channel_posts IS NULL, CAST(NULL AS Nullable(Float64)), toFloat64(s.channel_posts)) AS channel_posts
-        FROM silver.class_collab_chat_activity AS s
+        FROM silver.class_collab_chat_activity AS s FINAL
         WHERE s.data_source = 'insight_slack'
           AND s.email IS NOT NULL
           AND s.email != ''
@@ -82,7 +85,7 @@ FROM (
             z.date AS metric_date,
             if(z.total_chat_messages IS NULL, CAST(NULL AS Nullable(Float64)), toFloat64(z.total_chat_messages)) AS messages_sent,
             CAST(NULL AS Nullable(Float64)) AS channel_posts
-        FROM silver.class_collab_chat_activity AS z
+        FROM silver.class_collab_chat_activity AS z FINAL
         WHERE z.data_source = 'insight_zulip_proxy'
           AND z.email IS NOT NULL
           AND z.email != ''

--- a/src/ingestion/silver/_shared/gold_sources.yml
+++ b/src/ingestion/silver/_shared/gold_sources.yml
@@ -13,3 +13,8 @@ sources:
         description: Per-person, per-date individual-contributor KPI view.
       - name: ic_chart_loc
         description: Per-person, per-week LOC breakdown view (code/spec/config lines).
+      - name: collab_person_counter_daily
+        description: >
+          Per-person, per-date collaboration peer-counter view (#1527). Shared
+          scaffold for the modality-named collab counters; Messaging modality
+          exposes messages_sent + channel_posts with per-org_unit peer bands.


### PR DESCRIPTION
**PR A of the #1527 split** (see #1516 · release #1526) — the data-layer foundation. Establishes the shared gold view the other collab modalities (#1528–#1532) extend, and delivers the **Messaging** modality's two counters.

Split plan: **A (this) → B backend query_ref + catalog seed → C e2e YAML → D FE (insight-front)**.

## Changes
- **New gold view** `insight.collab_person_counter_daily` (migration `20260702000000`), cloning #1514's `ai_person_counter_daily`:
  - honest-NULL `UNION ALL` over the per-vendor silver chat classes (M365 Teams · Slack · Zulip),
  - outer `GROUP BY (person_id, metric_date)` with `if(countIf(x IS NOT NULL) > 0, sumIf(x, …), NULL)` → a person with **no source** on a day is **NULL, never a fake 0** (a real 0 row stays 0),
  - `LEFT JOIN insight.people` for `org_unit_id` (feeds the per-org_unit peer bands in PR B).
- **Metrics**
  | metric | formula | note |
  |---|---|---|
  | `messages_sent` | Σ `total_chat_messages` over M365 · Slack · Zulip | vendor semantics differ (Slack superset incl. replies; M365 excludes group chats & replies) — chat-engagement signal, not comparable absolute |
  | `channel_posts` | Σ (`channel_posts` + `channel_replies`) over M365 · Slack | Slack folds replies into `channel_posts` already (`channel_replies` NULL); M365 splits → add both for comparability; Zulip has no channel split → honest-NULL |
- **dbt singular test** `assert_collab_messaging_bounds.sql`: counters ≥ 0.
- Register the view in `silver/_shared/gold_sources.yml`.

## Design-for-extension
The view/test are the scaffold: later modalities add columns + UNION branches (not new vendor-named rows). Honest-NULL rendering ("No data" / source tooltip) is #1517; thresholds/bands land with PR B; this PR is data-layer only.

## Testing / validation
- Static: YAML valid, migration timestamp-ordered last, no name collisions.
- ⚠️ Not executed against a live ClickHouse locally (no cluster available). View SQL is validated end-to-end by the e2e YAML in **PR C** and a dev-cluster no-loss spot check (`ch.sh --target dev`): `messages_sent == m365_teams_chats + slack_messages_sent + zulip_messages_sent` per #1517 NULL rules.

Refs #1527 · #1516

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new daily collaboration metrics view with per-person, per-day totals for messages sent and channel posts across supported chat sources.
* **Bug Fixes**
  * Improved metric handling so days with no activity remain blank (instead of showing zero), and added warning-level checks when computed totals become negative.
* **Chores**
  * Updated the silver placeholder schema and added a Gold-layer catalog entry to support the new collaboration metrics, including an added channel replies field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->