### PR TITLE
feat(analytics-api): collab Messaging peer-counter query + catalog seed (#1527)

### DIFF
--- a/src/backend/services/analytics-api/src/domain/catalog/live_tests.rs
+++ b/src/backend/services/analytics-api/src/domain/catalog/live_tests.rs
@@ -205,6 +205,17 @@ async fn product_default_wins_when_no_tenant_overlay() -> anyhow::Result<()> {
             "no locks present → bounded_by_lock must be false"
         );
     }
+    // #1527: the Messaging modality's counters must be seeded at product-default.
+    // Later collab modalities (#1528–#1532) extend this expected set.
+    for key in [
+        "collab_person_counter_daily.messages_sent",
+        "collab_person_counter_daily.channel_posts",
+    ] {
+        assert!(
+            response.metrics.iter().any(|m| m.metric_key == key),
+            "seed must expose {key} at product-default"
+        );
+    }
     Ok(())
 }
 

--- a/src/backend/services/analytics-api/src/migration/m20260702_000001_collab_messaging_queries.rs
+++ b/src/backend/services/analytics-api/src/migration/m20260702_000001_collab_messaging_queries.rs
@@ -1,0 +1,94 @@
+//! Peer-counter `query_ref` for the collaboration Messaging modality
+//! (issue #1527, epic #1516 · release #1526).
+//!
+//! Clone of #1514's `ai_personal_counters_qr` (`m20260623_000001`): reads the
+//! `insight.collab_person_counter_daily` gold view (PR A of #1527), re-aggregates
+//! per person over the window with the honest-NULL wrapper
+//! `if(countIf(x IS NOT NULL) > 0, sumIf(x, …), NULL)`, unpivots to
+//! `(metric_key, value)` long rows via ARRAY JOIN (dropping NULLs so a person
+//! with no source is absent, never a fake 0), then LEFT JOINs per-`org_unit_id`
+//! cohort bands (`quantileExact` median/p25/p75 + min/max/count).
+//!
+//! This lays the shared peer-query scaffold; later modalities (#1528–#1532) add
+//! their `collab_person_counter_daily.*` keys to the ARRAY JOIN tuple list.
+//! Thresholds/bands calibration is out of scope (seed writes initial defaults).
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const ZERO_TENANT: &str = "00000000000000000000000000000000";
+/// `metrics.id` for the collab Messaging peer-counter query. Next free slot
+/// after the AI-personal counters (`…0052`).
+const COLLAB_MESSAGING_COUNTERS_HEX: &str = "00000000000000000001000000000053";
+
+/// Per-person long-format values: wide honest-NULL aggregate over the gold view
+/// → ARRAY JOIN unpivot (NULLs dropped) → `org_unit_id` via `insight.people`.
+const COLLAB_PERSON_COUNTER_VALUES_QR: &str = r"SELECT metric_values.person_id AS person_id, p.org_unit_id AS org_unit_id, metric_values.metric_key AS metric_key, metric_values.value AS value FROM (SELECT person_id, kv.1 AS metric_key, kv.2 AS value FROM (SELECT person_id, if(countIf(messages_sent IS NOT NULL) > 0, sumIf(messages_sent, messages_sent IS NOT NULL), CAST(NULL AS Nullable(Float64))) AS messages_sent, if(countIf(channel_posts IS NOT NULL) > 0, sumIf(channel_posts, channel_posts IS NOT NULL), CAST(NULL AS Nullable(Float64))) AS channel_posts FROM insight.collab_person_counter_daily GROUP BY person_id) d ARRAY JOIN [('collab_person_counter_daily.messages_sent', messages_sent), ('collab_person_counter_daily.channel_posts', channel_posts)] AS kv WHERE kv.2 IS NOT NULL) metric_values LEFT JOIN insight.people AS p ON metric_values.person_id = p.person_id";
+
+fn collab_messaging_counters_qr() -> String {
+    format!(
+        "SELECT p.person_id AS person_id, p.org_unit_id AS org_unit_id, p.metric_key AS metric_key, p.value AS value, c.team_median AS median, c.team_p25 AS p25, c.team_p75 AS p75, c.team_n AS n, c.team_min AS range_min, c.team_max AS range_max FROM ({COLLAB_PERSON_COUNTER_VALUES_QR}) p LEFT JOIN (SELECT metric_key, org_unit_id, quantileExact(0.5)(value) AS team_median, quantileExact(0.25)(value) AS team_p25, quantileExact(0.75)(value) AS team_p75, toFloat64(count()) AS team_n, min(value) AS team_min, max(value) AS team_max FROM ({COLLAB_PERSON_COUNTER_VALUES_QR}) person_values GROUP BY metric_key, org_unit_id) c ON c.metric_key = p.metric_key AND c.org_unit_id = p.org_unit_id"
+    )
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+        let query = collab_messaging_counters_qr();
+        db.execute_unprepared(&format!(
+            "INSERT INTO metrics (id, insight_tenant_id, name, description, query_ref, is_enabled) \
+             VALUES (UNHEX('{COLLAB_MESSAGING_COUNTERS_HEX}'), UNHEX('{ZERO_TENANT}'), \
+             'Collab Messaging Peer Counters', 'Per-person collaboration messaging peer counter rows.', '{qr}', 1) \
+             ON DUPLICATE KEY UPDATE name=VALUES(name), description=VALUES(description), query_ref=VALUES(query_ref), is_enabled=1",
+            qr = query.replace('\'', "''"),
+        ))
+        .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(&format!(
+                "DELETE FROM metrics WHERE id = UNHEX('{COLLAB_MESSAGING_COUNTERS_HEX}')"
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the generated peer-counter SQL shape (feeds #1433 coverage). Mirrors
+    /// the assertion style of `handlers.rs::parse_simple_select` — no DB needed.
+    #[test]
+    fn counters_qr_emits_both_keys_with_honest_null_and_per_org_unit_bands() {
+        let qr = collab_messaging_counters_qr();
+
+        // Both Messaging metric keys are unpivoted.
+        assert!(qr.contains("'collab_person_counter_daily.messages_sent'"));
+        assert!(qr.contains("'collab_person_counter_daily.channel_posts'"));
+
+        // Honest-NULL wrapper on each counter (no fake-0 fallback).
+        assert!(qr.contains(
+            "if(countIf(messages_sent IS NOT NULL) > 0, sumIf(messages_sent, messages_sent IS NOT NULL), CAST(NULL AS Nullable(Float64)))"
+        ));
+        assert!(qr.contains(
+            "if(countIf(channel_posts IS NOT NULL) > 0, sumIf(channel_posts, channel_posts IS NOT NULL), CAST(NULL AS Nullable(Float64)))"
+        ));
+
+        // Reads the PR-A gold view, drops NULL rows on unpivot.
+        assert!(qr.contains("FROM insight.collab_person_counter_daily GROUP BY person_id"));
+        assert!(qr.contains("WHERE kv.2 IS NOT NULL"));
+
+        // Per-org_unit cohort bands joined on (metric_key, org_unit_id).
+        assert!(qr.contains("quantileExact(0.5)(value) AS team_median"));
+        assert!(qr.contains("GROUP BY metric_key, org_unit_id"));
+        assert!(qr.contains("c.metric_key = p.metric_key AND c.org_unit_id = p.org_unit_id"));
+    }
+}

--- a/src/backend/services/analytics-api/src/migration/m20260702_000002_seed_collab_messaging_catalog.rs
+++ b/src/backend/services/analytics-api/src/migration/m20260702_000002_seed_collab_messaging_catalog.rs
@@ -1,0 +1,168 @@
+//! Catalog seed for the collaboration Messaging modality (issue #1527,
+//! epic #1516 · release #1526).
+//!
+//! Clone of #1514's AI-personal seed (`m20260623_000002`): for each metric it
+//! writes a product-default `metric_catalog` row, an initial product-default
+//! `metric_threshold` (the catalog probe requires one per row), and a
+//! `metric_query_catalog` junction row linking the peer-counter query
+//! (`m20260702_000001`) to the catalog metric by key.
+//!
+//! Thresholds here are **initial defaults, not calibrated** — per-org_unit
+//! calibration is a post-release follow-up (#1527 scope note). Honest-NULL "No
+//! data"/source-tooltip rendering is #1517. `source_tags` carry the vendors so
+//! the FE can render source attribution (a connector is a tag, not a new row).
+
+use sea_orm::{ConnectionTrait, Statement, Value};
+use sea_orm_migration::prelude::*;
+use uuid::Uuid;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+/// Must match `m20260702_000001_collab_messaging_queries::COLLAB_MESSAGING_COUNTERS_HEX`.
+const COLLAB_MESSAGING_COUNTERS_HEX: &str = "00000000000000000001000000000053";
+
+struct SeedRow {
+    metric_key: &'static str,
+    label: &'static str,
+    sublabel: Option<&'static str>,
+    description: Option<&'static str>,
+    unit: Option<&'static str>,
+    format: Option<&'static str>,
+    higher_is_better: bool,
+    /// JSON array of vendor source tags (a connector is a tag, not a new row).
+    source_tags: &'static str,
+    good: f64,
+    warn: f64,
+}
+
+const SEEDS: &[SeedRow] = &[
+    SeedRow {
+        metric_key: "collab_person_counter_daily.messages_sent",
+        label: "Messages sent",
+        sublabel: Some("Chat messages across sources · period total"),
+        description: Some(
+            "Total chat messages sent across M365 Teams, Slack and Zulip. Vendor \
+             semantics differ (Slack is a superset incl. replies; M365 excludes \
+             group chats and replies) — a chat-engagement signal, not a comparable \
+             absolute.",
+        ),
+        unit: Some("messages"),
+        format: Some("integer"),
+        higher_is_better: true,
+        source_tags: r#"["m365","slack","zulip"]"#,
+        good: 200.0,
+        warn: 50.0,
+    },
+    SeedRow {
+        metric_key: "collab_person_counter_daily.channel_posts",
+        label: "Channel posts",
+        sublabel: Some("Channel posts + replies · period total"),
+        description: Some(
+            "Channel posts across M365 and Slack, folding posts and replies for \
+             vendor comparability (Slack cannot separate them; M365 posts + replies \
+             are summed). Zulip does not surface channel posts.",
+        ),
+        unit: Some("messages"),
+        format: Some("integer"),
+        higher_is_better: true,
+        source_tags: r#"["m365","slack"]"#,
+        good: 20.0,
+        warn: 5.0,
+    },
+];
+
+const INSERT_CATALOG_SQL: &str = "\
+    INSERT INTO metric_catalog \
+        (id, tenant_id, metric_key, label, sublabel, description, unit, format, \
+         higher_is_better, is_member_scale, source_tags, is_enabled) \
+    VALUES (?, NULL, ?, ?, ?, ?, ?, ?, ?, FALSE, ?, TRUE) \
+    ON DUPLICATE KEY UPDATE \
+        label = VALUES(label), \
+        sublabel = VALUES(sublabel), \
+        description = VALUES(description), \
+        unit = VALUES(unit), \
+        format = VALUES(format), \
+        higher_is_better = VALUES(higher_is_better), \
+        is_member_scale = VALUES(is_member_scale), \
+        source_tags = VALUES(source_tags), \
+        is_enabled = VALUES(is_enabled)";
+
+const INSERT_THRESHOLD_SQL: &str = "\
+    INSERT INTO metric_threshold \
+        (id, tenant_id, metric_key, scope, role_slug, team_id, good, warn, is_locked) \
+    VALUES (?, NULL, ?, 'product-default', '', '', ?, ?, FALSE) \
+    ON DUPLICATE KEY UPDATE \
+        good = VALUES(good), \
+        warn = VALUES(warn)";
+
+const INSERT_LINK_SQL: &str = "\
+    INSERT IGNORE INTO metric_query_catalog \
+        (id, metrics_id, metric_catalog_id) \
+    SELECT UNHEX(REPLACE(UUID(),'-','')), UNHEX(?), c.id \
+    FROM metric_catalog c \
+    WHERE c.metric_key = ? AND c.tenant_id IS NULL";
+
+fn nullable_str_value(v: Option<&str>) -> Value {
+    match v {
+        Some(s) => Value::from(s),
+        None => Value::String(None),
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+        let backend = manager.get_database_backend();
+
+        for row in SEEDS {
+            let catalog_id = Uuid::now_v7();
+            conn.execute(Statement::from_sql_and_values(
+                backend,
+                INSERT_CATALOG_SQL,
+                [
+                    Value::Bytes(Some(Box::new(catalog_id.as_bytes().to_vec()))),
+                    Value::from(row.metric_key),
+                    Value::from(row.label),
+                    nullable_str_value(row.sublabel),
+                    nullable_str_value(row.description),
+                    nullable_str_value(row.unit),
+                    nullable_str_value(row.format),
+                    Value::from(row.higher_is_better),
+                    Value::from(row.source_tags),
+                ],
+            ))
+            .await?;
+
+            let threshold_id = Uuid::now_v7();
+            conn.execute(Statement::from_sql_and_values(
+                backend,
+                INSERT_THRESHOLD_SQL,
+                [
+                    Value::Bytes(Some(Box::new(threshold_id.as_bytes().to_vec()))),
+                    Value::from(row.metric_key),
+                    Value::from(row.good),
+                    Value::from(row.warn),
+                ],
+            ))
+            .await?;
+
+            conn.execute(Statement::from_sql_and_values(
+                backend,
+                INSERT_LINK_SQL,
+                [
+                    Value::from(COLLAB_MESSAGING_COUNTERS_HEX),
+                    Value::from(row.metric_key),
+                ],
+            ))
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        Err(DbErr::Custom("we have only forward migrations".to_owned()))
+    }
+}

--- a/src/backend/services/analytics-api/src/migration/mod.rs
+++ b/src/backend/services/analytics-api/src/migration/mod.rs
@@ -45,6 +45,8 @@ mod m20260623_000002_seed_ai_personal_metric_catalog;
 mod m20260624_000001_collab_zulip_chat;
 mod m20260624_000002_seed_zulip_collab_catalog;
 mod m20260624_000003_ic_chart_loc_git_breakdown;
+mod m20260702_000001_collab_messaging_queries;
+mod m20260702_000002_seed_collab_messaging_catalog;
 
 #[cfg(test)]
 mod live_tests;
@@ -102,6 +104,8 @@ impl MigratorTrait for Migrator {
             Box::new(m20260624_000001_collab_zulip_chat::Migration),
             Box::new(m20260624_000002_seed_zulip_collab_catalog::Migration),
             Box::new(m20260624_000003_ic_chart_loc_git_breakdown::Migration),
+            Box::new(m20260702_000001_collab_messaging_queries::Migration),
+            Box::new(m20260702_000002_seed_collab_messaging_catalog::Migration),
         ]
     }
 }


### PR DESCRIPTION
**PR B of the #1527 split** — the backend layer over PR A's gold view (#1567). Clones the #1514 AI-personal counter pattern for the collaboration **Messaging** modality.

Split plan: A gold view (#1567) → **B (this)** → C e2e YAML → D FE (insight-front).

## Changes
- **Query_ref migration** `m20260702_000001_collab_messaging_queries` — `collab_messaging_counters_qr`:
  - reads `insight.collab_person_counter_daily` (PR A), re-aggregates per person with the honest-NULL `if(countIf(x IS NOT NULL) > 0, sumIf(x, …), NULL)` wrapper,
  - ARRAY JOIN unpivot dropping NULLs (person with no source → absent, not fake 0),
  - LEFT JOIN per-`org_unit_id` `quantileExact` bands (median/p25/p75 + min/max/count).
  - Stored on `metrics.id` `…0053` (next free after AI counters `…0052`).
- **Catalog seed** `m20260702_000002_seed_collab_messaging_catalog` — product-default `metric_catalog` rows for `messages_sent` + `channel_posts`, each with an initial product-default `metric_threshold` (catalog-probe requirement) and a `metric_query_catalog` junction link. `source_tags` carry the vendors (`["m365","slack","zulip"]` / `["m365","slack"]`).
- Register both migrations in `mod.rs`.

## Tests
- **Rust unit** (feeds #1433, runs in CI — no DB): asserts the generated SQL emits both keys with the honest-NULL wrapper + per-org_unit band join on `(metric_key, org_unit_id)`.
- **Live test**: extend `domain/catalog/live_tests.rs::product_default_wins_when_no_tenant_overlay` to assert both Messaging keys resolve at product-default (`#[ignore]`, needs MariaDB — not in CI coverage).
- fmt + clippy::pedantic clean.

## Scope / notes
- **Thresholds are initial defaults, not calibrated** — per-org_unit calibration is a post-release follow-up (#1527 scope).
- Honest-NULL "No data"/source-tooltip rendering is #1517.
- Depends on PR A (#1567) gold view at deploy time (migration artifacts are independent; the query string just references the view).
- ⚠️ **Coverage gate** will likely red again — same known repo-wide floor (analytics-api < 80%, tracked by #1433). The new unit test raises coverage but does not close the whole gap.

Refs #1527 · #1516

🤖 Generated with [Claude Code](https://claude.com/claude-code)