### PR TITLE
ci: exclude identity from coverage collection and gating (tests still run)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,10 +199,12 @@ jobs:
           # missing file means something went wrong — fail rather than ignore.
           if-no-files-found: error
 
-  # One producer job per changed .NET component (Identity today). Collects inline
-  # with `dotnet test --collect "XPlat Code Coverage"` + dotnet-coverage merge.
+  # One producer job per changed .NET component (Identity today). Runs unit +
+  # integration tests; coverage is collected only for entries with cover=true —
+  # identity is cover=false (see components.py): its tests still gate the
+  # pipeline, but no Cobertura is produced and the coverage gates skip it.
   dotnet:
-    name: .NET coverage — ${{ matrix.entry.name }}
+    name: .NET — ${{ matrix.entry.name }}
     needs: changes
     if: ${{ needs.changes.outputs.dotnet != '[]' }}
     runs-on: ubuntu-latest
@@ -228,6 +230,7 @@ jobs:
             nuget-${{ runner.os }}-
 
       - name: Install dotnet-coverage
+        if: ${{ matrix.entry.cover }}
         run: |
           dotnet tool install --global dotnet-coverage
           echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
@@ -235,6 +238,7 @@ jobs:
       # Restores, builds, runs unit + integration (Testcontainers MariaDB) tests
       # under coverage, and merges the per-project Cobertura files into one.
       - name: Coverage (${{ matrix.entry.name }} -> Cobertura)
+        if: ${{ matrix.entry.cover }}
         working-directory: ${{ matrix.entry.root }}
         run: |
           set -euo pipefail
@@ -249,7 +253,22 @@ jobs:
             -o "$GITHUB_WORKSPACE/coverage/dotnet-${{ matrix.entry.name }}.cobertura.xml" \
             coverage-raw/*/coverage.cobertura.xml
 
+      # cover=false entries: same restore/build/test cycle, no collection —
+      # a test failure still fails this job and therefore the coverage-gate's
+      # "Guard against incomplete reports" step.
+      - name: Test (${{ matrix.entry.name }}, no coverage)
+        if: ${{ !matrix.entry.cover }}
+        working-directory: ${{ matrix.entry.root }}
+        run: |
+          set -euo pipefail
+          dotnet restore "${{ matrix.entry.solution }}"
+          dotnet build "${{ matrix.entry.solution }}" --no-restore -c Release
+          for proj in tests/*/*.csproj; do
+            dotnet test "$proj" --no-build -c Release
+          done
+
       - name: Upload Cobertura
+        if: ${{ matrix.entry.cover }}
         uses: actions/upload-artifact@v7
         with:
           name: cobertura-dotnet-${{ matrix.entry.name }}
@@ -375,11 +394,12 @@ jobs:
           PYTHON_CHANGED: ${{ needs.changes.outputs.python }}
           FULL: ${{ github.event.inputs.full }}
         run: |
-          # Only crates that actually produce coverage are "required" — rust
-          # entries may be lint-only (cover=false), so filter them out.
+          # Only components that actually produce coverage are "required" —
+          # rust entries may be lint-only and dotnet entries test-only
+          # (cover=false, e.g. identity), so filter both out.
           required=$(jq -rn \
             --argjson r "$RUST_CHANGED" --argjson d "$DOTNET_CHANGED" --argjson p "$PYTHON_CHANGED" \
-            '[($r[] | select(.cover)), $d[], $p[]] | map(.name) | join(",")')
+            '[($r[] | select(.cover)), ($d[] | select(.cover)), $p[]] | map(.name) | join(",")')
           echo "required components: ${required:-<none>}"
           # A full/baseline run measures overall coverage; skip the new-code gate
           # (there is no meaningful "patch" for a manual all-components run).

--- a/scripts/ci/changed.py
+++ b/scripts/ci/changed.py
@@ -7,7 +7,8 @@ globs are duplicated in YAML and there is one source of truth. Runs no tests.
 Usage: python3 scripts/ci/changed.py [--all]
 Output: {"rust": [<entry>...], "dotnet": [...], "python": [...]}
         rust entries carry name/root/package/all_features plus lint+cover flags
-        (a crate may be lint-only); dotnet carries solution, python cov_package.
+        (a crate may be lint-only); dotnet carries solution + cover (a component
+        may be test-only, e.g. identity); python carries cov_package.
 """
 from __future__ import annotations
 
@@ -44,6 +45,9 @@ def _matrix_entry(comp: dict, *, lint: bool = False, cover: bool = True) -> dict
         entry["cover_ignore_regex"] = comp.get("cover_ignore_regex", "")
     elif comp["lang"] == "dotnet":
         entry["solution"] = comp.get("solution", "")
+        # False ⇒ tests run but coverage is neither collected nor gated
+        # (identity — see components.py). Mirrors the rust cover flag.
+        entry["cover"] = comp.get("cover", True)
     elif comp["lang"] == "python":
         entry["cov_package"] = comp.get("cov_package", "")
     return entry

--- a/scripts/ci/components.py
+++ b/scripts/ci/components.py
@@ -62,8 +62,13 @@ COMPONENTS = [
      "paths": ["src/ingestion/connectors/task-tracking/jira/enrich"]},
 
     # .NET
+    # cover=False: identity is excluded from coverage collection and gating
+    # entirely (2026-07 decision) — its tests still run in the dotnet CI job
+    # and still fail the pipeline on regressions; only the Cobertura
+    # collection, upload, and the per-component/new-code gates are dropped.
     {"name": "identity", "lang": "dotnet", "root": "src/backend/services/identity",
      "solution": "Insight.Identity.sln",
+     "cover": False,
      "paths": ["src/backend/services/identity"]},
 
     # Python CDK connectors


### PR DESCRIPTION
## What

Removes identity resolution from coverage **entirely** — collection, artifact upload, and both gates — while its tests keep running and keep gating the pipeline.

Mechanism mirrors the existing rust lint-only pattern (`cover=false`):

- `scripts/ci/components.py` — identity gets `cover: False` (with rationale comment)
- `scripts/ci/changed.py` — dotnet matrix entries now carry the `cover` flag
- `.github/workflows/ci.yml` dotnet job — `cover=false` entries run the same restore/build/test cycle (unit + Testcontainers MariaDB) **without** `--collect`/merge/upload; a test failure still fails the job → still trips the coverage-gate's "Guard against incomplete reports"
- gate `--require` derivation filters dotnet by `.cover` (same as rust), so an identity-only PR isn't flagged as a changed component with a missing report

`coverage.py` needs no changes:
- overall gate: no dotnet report → identity lands in the *skipped* list
- new-code gate: diff-cover omits files absent from every report, so changed `.cs` lines don't count
- identity-only PR (zero XMLs): short-circuits to "No component reports — nothing to gate" (verified locally, exit 0)

## Verified

- YAML valid; matrix entry emits `cover: False` for identity
- `--require` jq derivation with identity in the changed set → empty (excluded)
- gate on an empty reports dir → PASS, exit 0
- no other consumers of `cobertura-dotnet-*` artifacts in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CI now runs tests for all .NET components, while collecting code coverage only for components that support it.
  * Coverage checks now align with the components that actually publish coverage results, preventing unrelated failures.
  * One .NET component is now treated as test-only, so it still gets tested without affecting coverage reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->