### PR TITLE
feat(analytics-api): collab Messaging query + catalog seed + e2e (#1527 B+C)

### DIFF
--- a/src/backend/services/analytics/src/domain/catalog/live_tests.rs
+++ b/src/backend/services/analytics/src/domain/catalog/live_tests.rs
@@ -164,6 +164,17 @@ async fn product_default_wins_when_no_tenant_overlay() -> anyhow::Result<()> {
             "no locks present → bounded_by_lock must be false"
         );
     }
+    // #1527: the Messaging modality's counters must be seeded at product-default.
+    // Later collab modalities (#1528–#1532) extend this expected set.
+    for key in [
+        "collab_person_counter_daily.messages_sent",
+        "collab_person_counter_daily.channel_posts",
+    ] {
+        assert!(
+            response.metrics.iter().any(|m| m.metric_key == key),
+            "seed must expose {key} at product-default"
+        );
+    }
     Ok(())
 }
 

--- a/src/backend/services/analytics/src/migration/m20260702_000001_collab_messaging_queries.rs
+++ b/src/backend/services/analytics/src/migration/m20260702_000001_collab_messaging_queries.rs
@@ -1,0 +1,94 @@
+//! Peer-counter `query_ref` for the collaboration Messaging modality
+//! (issue #1527, epic #1516 · release #1526).
+//!
+//! Clone of #1514's `ai_personal_counters_qr` (`m20260623_000001`): reads the
+//! `insight.collab_person_counter_daily` gold view (PR A of #1527), re-aggregates
+//! per person over the window with the honest-NULL wrapper
+//! `if(countIf(x IS NOT NULL) > 0, sumIf(x, …), NULL)`, unpivots to
+//! `(metric_key, value)` long rows via ARRAY JOIN (dropping NULLs so a person
+//! with no source is absent, never a fake 0), then LEFT JOINs per-`org_unit_id`
+//! cohort bands (`quantileExact` median/p25/p75 + min/max/count).
+//!
+//! This lays the shared peer-query scaffold; later modalities (#1528–#1532) add
+//! their `collab_person_counter_daily.*` keys to the ARRAY JOIN tuple list.
+//! Thresholds/bands calibration is out of scope (seed writes initial defaults).
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const ZERO_TENANT: &str = "00000000000000000000000000000000";
+/// `metrics.id` for the collab Messaging peer-counter query. Next free slot
+/// after the AI-personal counters (`…0052`).
+const COLLAB_MESSAGING_COUNTERS_HEX: &str = "00000000000000000001000000000053";
+
+/// Per-person long-format values: wide honest-NULL aggregate over the gold view
+/// → ARRAY JOIN unpivot (NULLs dropped) → `org_unit_id` via `insight.people`.
+const COLLAB_PERSON_COUNTER_VALUES_QR: &str = r"SELECT metric_values.person_id AS person_id, p.org_unit_id AS org_unit_id, metric_values.metric_key AS metric_key, metric_values.value AS value FROM (SELECT person_id, kv.1 AS metric_key, kv.2 AS value FROM (SELECT person_id, if(countIf(messages_sent IS NOT NULL) > 0, sumIf(messages_sent, messages_sent IS NOT NULL), CAST(NULL AS Nullable(Float64))) AS messages_sent, if(countIf(channel_posts IS NOT NULL) > 0, sumIf(channel_posts, channel_posts IS NOT NULL), CAST(NULL AS Nullable(Float64))) AS channel_posts FROM insight.collab_person_counter_daily GROUP BY person_id) d ARRAY JOIN [('collab_person_counter_daily.messages_sent', messages_sent), ('collab_person_counter_daily.channel_posts', channel_posts)] AS kv WHERE kv.2 IS NOT NULL) metric_values LEFT JOIN insight.people AS p ON metric_values.person_id = p.person_id";
+
+fn collab_messaging_counters_qr() -> String {
+    format!(
+        "SELECT p.person_id AS person_id, p.org_unit_id AS org_unit_id, p.metric_key AS metric_key, p.value AS value, c.team_median AS median, c.team_p25 AS p25, c.team_p75 AS p75, c.team_n AS n, c.team_min AS range_min, c.team_max AS range_max FROM ({COLLAB_PERSON_COUNTER_VALUES_QR}) p LEFT JOIN (SELECT metric_key, org_unit_id, quantileExact(0.5)(value) AS team_median, quantileExact(0.25)(value) AS team_p25, quantileExact(0.75)(value) AS team_p75, toFloat64(count()) AS team_n, min(value) AS team_min, max(value) AS team_max FROM ({COLLAB_PERSON_COUNTER_VALUES_QR}) person_values GROUP BY metric_key, org_unit_id) c ON c.metric_key = p.metric_key AND c.org_unit_id = p.org_unit_id"
+    )
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+        let query = collab_messaging_counters_qr();
+        db.execute_unprepared(&format!(
+            "INSERT INTO metrics (id, insight_tenant_id, name, description, query_ref, is_enabled) \
+             VALUES (UNHEX('{COLLAB_MESSAGING_COUNTERS_HEX}'), UNHEX('{ZERO_TENANT}'), \
+             'Collab Messaging Peer Counters', 'Per-person collaboration messaging peer counter rows.', '{qr}', 1) \
+             ON DUPLICATE KEY UPDATE name=VALUES(name), description=VALUES(description), query_ref=VALUES(query_ref), is_enabled=1",
+            qr = query.replace('\'', "''"),
+        ))
+        .await?;
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(&format!(
+                "DELETE FROM metrics WHERE id = UNHEX('{COLLAB_MESSAGING_COUNTERS_HEX}')"
+            ))
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the generated peer-counter SQL shape (feeds #1433 coverage). Mirrors
+    /// the assertion style of `handlers.rs::parse_simple_select` — no DB needed.
+    #[test]
+    fn counters_qr_emits_both_keys_with_honest_null_and_per_org_unit_bands() {
+        let qr = collab_messaging_counters_qr();
+
+        // Both Messaging metric keys are unpivoted.
+        assert!(qr.contains("'collab_person_counter_daily.messages_sent'"));
+        assert!(qr.contains("'collab_person_counter_daily.channel_posts'"));
+
+        // Honest-NULL wrapper on each counter (no fake-0 fallback).
+        assert!(qr.contains(
+            "if(countIf(messages_sent IS NOT NULL) > 0, sumIf(messages_sent, messages_sent IS NOT NULL), CAST(NULL AS Nullable(Float64)))"
+        ));
+        assert!(qr.contains(
+            "if(countIf(channel_posts IS NOT NULL) > 0, sumIf(channel_posts, channel_posts IS NOT NULL), CAST(NULL AS Nullable(Float64)))"
+        ));
+
+        // Reads the PR-A gold view, drops NULL rows on unpivot.
+        assert!(qr.contains("FROM insight.collab_person_counter_daily GROUP BY person_id"));
+        assert!(qr.contains("WHERE kv.2 IS NOT NULL"));
+
+        // Per-org_unit cohort bands joined on (metric_key, org_unit_id).
+        assert!(qr.contains("quantileExact(0.5)(value) AS team_median"));
+        assert!(qr.contains("GROUP BY metric_key, org_unit_id"));
+        assert!(qr.contains("c.metric_key = p.metric_key AND c.org_unit_id = p.org_unit_id"));
+    }
+}

--- a/src/backend/services/analytics/src/migration/m20260702_000002_seed_collab_messaging_catalog.rs
+++ b/src/backend/services/analytics/src/migration/m20260702_000002_seed_collab_messaging_catalog.rs
@@ -1,0 +1,168 @@
+//! Catalog seed for the collaboration Messaging modality (issue #1527,
+//! epic #1516 · release #1526).
+//!
+//! Clone of #1514's AI-personal seed (`m20260623_000002`): for each metric it
+//! writes a product-default `metric_catalog` row, an initial product-default
+//! `metric_threshold` (the catalog probe requires one per row), and a
+//! `metric_query_catalog` junction row linking the peer-counter query
+//! (`m20260702_000001`) to the catalog metric by key.
+//!
+//! Thresholds here are **initial defaults, not calibrated** — per-org_unit
+//! calibration is a post-release follow-up (#1527 scope note). Honest-NULL "No
+//! data"/source-tooltip rendering is #1517. `source_tags` carry the vendors so
+//! the FE can render source attribution (a connector is a tag, not a new row).
+
+use sea_orm::{ConnectionTrait, Statement, Value};
+use sea_orm_migration::prelude::*;
+use uuid::Uuid;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+/// Must match `m20260702_000001_collab_messaging_queries::COLLAB_MESSAGING_COUNTERS_HEX`.
+const COLLAB_MESSAGING_COUNTERS_HEX: &str = "00000000000000000001000000000053";
+
+struct SeedRow {
+    metric_key: &'static str,
+    label: &'static str,
+    sublabel: Option<&'static str>,
+    description: Option<&'static str>,
+    unit: Option<&'static str>,
+    format: Option<&'static str>,
+    higher_is_better: bool,
+    /// JSON array of vendor source tags (a connector is a tag, not a new row).
+    source_tags: &'static str,
+    good: f64,
+    warn: f64,
+}
+
+const SEEDS: &[SeedRow] = &[
+    SeedRow {
+        metric_key: "collab_person_counter_daily.messages_sent",
+        label: "Messages sent",
+        sublabel: Some("Chat messages across sources · period total"),
+        description: Some(
+            "Total chat messages sent across M365 Teams, Slack and Zulip. Vendor \
+             semantics differ (Slack is a superset incl. replies; M365 excludes \
+             group chats and replies) — a chat-engagement signal, not a comparable \
+             absolute.",
+        ),
+        unit: Some("messages"),
+        format: Some("integer"),
+        higher_is_better: true,
+        source_tags: r#"["m365","slack","zulip"]"#,
+        good: 200.0,
+        warn: 50.0,
+    },
+    SeedRow {
+        metric_key: "collab_person_counter_daily.channel_posts",
+        label: "Channel posts",
+        sublabel: Some("Channel posts + replies · period total"),
+        description: Some(
+            "Channel posts across M365 and Slack, folding posts and replies for \
+             vendor comparability (Slack cannot separate them; M365 posts + replies \
+             are summed). Zulip does not surface channel posts.",
+        ),
+        unit: Some("messages"),
+        format: Some("integer"),
+        higher_is_better: true,
+        source_tags: r#"["m365","slack"]"#,
+        good: 20.0,
+        warn: 5.0,
+    },
+];
+
+const INSERT_CATALOG_SQL: &str = "\
+    INSERT INTO metric_catalog \
+        (id, tenant_id, metric_key, label, sublabel, description, unit, format, \
+         higher_is_better, is_member_scale, source_tags, is_enabled) \
+    VALUES (?, NULL, ?, ?, ?, ?, ?, ?, ?, FALSE, ?, TRUE) \
+    ON DUPLICATE KEY UPDATE \
+        label = VALUES(label), \
+        sublabel = VALUES(sublabel), \
+        description = VALUES(description), \
+        unit = VALUES(unit), \
+        format = VALUES(format), \
+        higher_is_better = VALUES(higher_is_better), \
+        is_member_scale = VALUES(is_member_scale), \
+        source_tags = VALUES(source_tags), \
+        is_enabled = VALUES(is_enabled)";
+
+const INSERT_THRESHOLD_SQL: &str = "\
+    INSERT INTO metric_threshold \
+        (id, tenant_id, metric_key, scope, role_slug, team_id, good, warn, is_locked) \
+    VALUES (?, NULL, ?, 'product-default', '', '', ?, ?, FALSE) \
+    ON DUPLICATE KEY UPDATE \
+        good = VALUES(good), \
+        warn = VALUES(warn)";
+
+const INSERT_LINK_SQL: &str = "\
+    INSERT IGNORE INTO metric_query_catalog \
+        (id, metrics_id, metric_catalog_id) \
+    SELECT UNHEX(REPLACE(UUID(),'-','')), UNHEX(?), c.id \
+    FROM metric_catalog c \
+    WHERE c.metric_key = ? AND c.tenant_id IS NULL";
+
+fn nullable_str_value(v: Option<&str>) -> Value {
+    match v {
+        Some(s) => Value::from(s),
+        None => Value::String(None),
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+        let backend = manager.get_database_backend();
+
+        for row in SEEDS {
+            let catalog_id = Uuid::now_v7();
+            conn.execute(Statement::from_sql_and_values(
+                backend,
+                INSERT_CATALOG_SQL,
+                [
+                    Value::Bytes(Some(Box::new(catalog_id.as_bytes().to_vec()))),
+                    Value::from(row.metric_key),
+                    Value::from(row.label),
+                    nullable_str_value(row.sublabel),
+                    nullable_str_value(row.description),
+                    nullable_str_value(row.unit),
+                    nullable_str_value(row.format),
+                    Value::from(row.higher_is_better),
+                    Value::from(row.source_tags),
+                ],
+            ))
+            .await?;
+
+            let threshold_id = Uuid::now_v7();
+            conn.execute(Statement::from_sql_and_values(
+                backend,
+                INSERT_THRESHOLD_SQL,
+                [
+                    Value::Bytes(Some(Box::new(threshold_id.as_bytes().to_vec()))),
+                    Value::from(row.metric_key),
+                    Value::from(row.good),
+                    Value::from(row.warn),
+                ],
+            ))
+            .await?;
+
+            conn.execute(Statement::from_sql_and_values(
+                backend,
+                INSERT_LINK_SQL,
+                [
+                    Value::from(COLLAB_MESSAGING_COUNTERS_HEX),
+                    Value::from(row.metric_key),
+                ],
+            ))
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        Err(DbErr::Custom("we have only forward migrations".to_owned()))
+    }
+}

--- a/src/backend/services/analytics/src/migration/mod.rs
+++ b/src/backend/services/analytics/src/migration/mod.rs
@@ -45,6 +45,8 @@ mod m20260623_000002_seed_ai_personal_metric_catalog;
 mod m20260624_000001_collab_zulip_chat;
 mod m20260624_000002_seed_zulip_collab_catalog;
 mod m20260624_000003_ic_chart_loc_git_breakdown;
+mod m20260702_000001_collab_messaging_queries;
+mod m20260702_000002_seed_collab_messaging_catalog;
 
 use sea_orm_migration::prelude::*;
 
@@ -99,6 +101,8 @@ impl MigratorTrait for Migrator {
             Box::new(m20260624_000001_collab_zulip_chat::Migration),
             Box::new(m20260624_000002_seed_zulip_collab_catalog::Migration),
             Box::new(m20260624_000003_ic_chart_loc_git_breakdown::Migration),
+            Box::new(m20260702_000001_collab_messaging_queries::Migration),
+            Box::new(m20260702_000002_seed_collab_messaging_catalog::Migration),
         ]
     }
 }

--- a/src/ingestion/tests/e2e/metrics/collab_messaging_channel_posts.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/collab_messaging_channel_posts.test.yaml
@@ -1,0 +1,85 @@
+spec_version: 1
+description: >
+  Metric: collab_person_counter_daily.channel_posts — Collaboration Messaging
+  modality (…0053), #1527.
+  How it's computed (bronze → silver → gold):
+    • bronze: per-person/day channel activity from Teams (post + reply counts)
+      and Slack (once its e2e fixtures land — see note).
+    • silver: each vendor deduped to per-person/day channel counts.
+    • gold:   channel posts FOLD posts + replies for vendor comparability — Slack
+              cannot separate them (replies already folded in), so Teams adds its
+              posts + replies. honest-NULL UNION across vendors; Zulip has no
+              channel split → contributes NULL, never 0. value = the member's
+              per-person SUM over the window; median/p25/p75/range = the
+              distribution across the member's DEPARTMENT (org_unit_id).
+
+  Department: 5 Engineering members with channel_posts totals {2,4,6,8,10}, each
+  dated 2026-12-25 with Teams post + reply counts that sum to the total (proving
+  the posts+replies fold):
+    • alice 2  (post 2, reply 0)
+    • bob   4  (post 2, reply 2)
+    • carol 6  (post 4, reply 2)  ← posts + replies
+    • dave  8  (post 8, reply 0)
+    • erin  10 (post 6, reply 4)
+  IC case requests carol (6) → value 6 (proves post+reply fold); the department
+  of 5 yields median 6, p25 4, p75 8, range [2,10].
+  Cases: posts+replies fold (carol) · empty window → NULL, not 0.
+
+  NOTE: Slack is the other declared source and has no e2e fixtures yet (needs
+  schemas/bronze_slack.users_details.yaml + a template from the real bronze).
+  Teams here proves the fold + honest-NULL; Slack cross-vendor coverage is a
+  follow-up.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+    - $ref: templates/people.yaml#/templates/bob
+    - $ref: templates/people.yaml#/templates/carol
+    - $ref: templates/people.yaml#/templates/dave
+    - $ref: templates/people.yaml#/templates/erin
+
+  # M365 Teams — channel_posts = postMessages + replyMessages (per-person totals
+  # {2,4,6,8,10}). privateChat/teamChat left null (this file asserts channel_posts only).
+  bronze_m365.teams_activity:
+    - { $ref: templates/m365_teams.yaml#/templates/m365_teams, userPrincipalName: alice@example.com, reportRefreshDate: "2026-12-25", unique_key: cp-alice-20261225, postMessages: 2, replyMessages: 0 }
+    - { $ref: templates/m365_teams.yaml#/templates/m365_teams, userPrincipalName: alice@example.com, reportRefreshDate: "2026-12-25", unique_key: cp-alice-20261225, postMessages: 2, replyMessages: 0 }   # duplicate → dedup, not 4
+    - { $ref: templates/m365_teams.yaml#/templates/m365_teams, userPrincipalName: bob@example.com,   reportRefreshDate: "2026-12-25", unique_key: cp-bob-20261225,   postMessages: 2, replyMessages: 2 }
+    - { $ref: templates/m365_teams.yaml#/templates/m365_teams, userPrincipalName: carol@example.com, reportRefreshDate: "2026-12-25", unique_key: cp-carol-20261225, postMessages: 4, replyMessages: 2 }
+    - { $ref: templates/m365_teams.yaml#/templates/m365_teams, userPrincipalName: dave@example.com,  reportRefreshDate: "2026-12-25", unique_key: cp-dave-20261225,  postMessages: 8, replyMessages: 0 }
+    - { $ref: templates/m365_teams.yaml#/templates/m365_teams, userPrincipalName: erin@example.com,  reportRefreshDate: "2026-12-25", unique_key: cp-erin-20261225,  postMessages: 6, replyMessages: 4 }
+
+cases:
+  # dept {2,4,6,8,10}; carol value 6 (post 4 + reply 2). median 6, p25 4, p75 8, range [2,10]
+  - name: "channel_posts — posts + replies fold (carol = post 4 + reply 2)"
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000053
+            $filter: "person_id eq 'carol@example.com' and metric_date ge '2026-12-01' and metric_date le '2026-12-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        assert: "result.status == 'ok'"
+      - in: collaboration
+        find: { metric_key: collab_person_counter_daily.channel_posts }
+        equal: { value: 6, median: 6, range_min: 2, range_max: 10, p25: 4, p75: 8 }
+
+  # ── EMPTY window: no channel rows in range → honest-NULL (no item, not a 0) ──
+  - name: "channel_posts — EMPTY window (no source → NULL, not 0)"
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000053
+            $filter: "person_id eq 'carol@example.com' and metric_date ge '2026-06-01' and metric_date le '2026-06-30'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        assert: "result.status == 'ok'"
+      - in: collaboration
+        assert: "size(items) == 0"

--- a/src/ingestion/tests/e2e/metrics/collab_messaging_messages_sent.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/collab_messaging_messages_sent.test.yaml
@@ -94,7 +94,7 @@ cases:
         assert: "result.status == 'ok'"
       - in: collaboration
         find: { metric_key: collab_person_counter_daily.messages_sent }
-        equal: { value: 20 }
+        equal: { value: 20, median: 30, range_min: 10, range_max: 50, p25: 20, p75: 40 }
 
   # ── EMPTY window: no chat rows in range → honest-NULL (no item, not a 0) ──
   - name: "messages_sent — EMPTY window (no source → NULL, not 0)"

--- a/src/ingestion/tests/e2e/metrics/collab_messaging_messages_sent.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/collab_messaging_messages_sent.test.yaml
@@ -1,0 +1,114 @@
+spec_version: 1
+description: >
+  Metric: collab_person_counter_daily.messages_sent — Collaboration Messaging
+  modality (…0053), #1527.
+  How it's computed (bronze → silver → gold):
+    • bronze: per-person/day chat activity from several vendors (Teams private +
+      team-channel counts; Zulip per-sender message counts; Slack too, once its
+      e2e fixtures land — see note below).
+    • silver: each vendor deduped to per-person/day total chat messages.
+    • gold:   honest-NULL UNION across vendors → per-person/day sum; a person
+              with NO chat source on a day is NULL, never 0. value = the member's
+              per-person SUM over the window across ALL vendors; median/p25/p75/
+              range = the distribution of those per-person SUMs across the
+              member's DEPARTMENT (org_unit_id).
+
+  Department: 5 Engineering members with messages_sent totals {10,20,30,40,50},
+  each dated 2026-12-25 and sourced to prove the cross-vendor union:
+    • alice 10 — Teams only (private 10)
+    • bob   20 — Zulip only (count 20)
+    • carol 30 — Teams 15 + Zulip 15  ← cross-vendor SUM
+    • dave  40 — Teams only (private 40)
+    • erin  50 — Zulip only (count 50)
+  IC case requests carol (30) → value 30 (proves the union sum); the department
+  of 5 yields median 30, p25 20, p75 40, range [10,50].
+  Cases: cross-vendor sum (carol) · single-vendor still non-NULL (bob, Zulip-only)
+  · empty window → NULL, not 0.
+
+  NOTE: Slack is a declared source for this metric but has no e2e fixtures yet
+  (needs schemas/bronze_slack.users_details.yaml + a template generated from the
+  real bronze). The multi-vendor honest-NULL contract ("drop a source → others
+  still non-NULL; drop all → NULL, not 0") is proven here with Teams + Zulip;
+  adding Slack as a third source is a follow-up.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+    - $ref: templates/people.yaml#/templates/bob
+    - $ref: templates/people.yaml#/templates/carol
+    - $ref: templates/people.yaml#/templates/dave
+    - $ref: templates/people.yaml#/templates/erin
+
+  # M365 Teams — alice (10), carol (15, cross-vendor half), dave (40).
+  bronze_m365.teams_activity:
+    - { $ref: templates/m365_teams.yaml#/templates/m365_teams, userPrincipalName: alice@example.com, reportRefreshDate: "2026-12-25", unique_key: ms-alice-20261225, privateChatMessageCount: 10, teamChatMessageCount: 0 }
+    - { $ref: templates/m365_teams.yaml#/templates/m365_teams, userPrincipalName: alice@example.com, reportRefreshDate: "2026-12-25", unique_key: ms-alice-20261225, privateChatMessageCount: 10, teamChatMessageCount: 0 }   # duplicate → dedup, not 20
+    - { $ref: templates/m365_teams.yaml#/templates/m365_teams, userPrincipalName: carol@example.com, reportRefreshDate: "2026-12-25", unique_key: ms-carol-20261225, privateChatMessageCount: 15, teamChatMessageCount: 0 }
+    - { $ref: templates/m365_teams.yaml#/templates/m365_teams, userPrincipalName: dave@example.com,  reportRefreshDate: "2026-12-25", unique_key: ms-dave-20261225,  privateChatMessageCount: 40, teamChatMessageCount: 0 }
+
+  # Zulip directory — only the Zulip senders (bob, carol, erin) need a user row.
+  bronze_zulip_proxy.users:
+    - $ref: templates/zulip.yaml#/templates/bob_user
+    - $ref: templates/zulip.yaml#/templates/carol_user
+    - { $ref: templates/zulip.yaml#/templates/zulip_user, id: 5, email: erin@example.com, full_name: Erin Epsilon, unique_key: zulip-user-5 }
+
+  # Zulip messages — bob (20), carol (15, cross-vendor half), erin (50).
+  bronze_zulip_proxy.messages:
+    - { $ref: templates/zulip.yaml#/templates/zulip_message, sender_id: 2, created_at: "2026-12-25T10:00:00", uniq: ms-z-bob-20261225,   unique_key: msg-bob-20261225,   count: 20 }
+    - { $ref: templates/zulip.yaml#/templates/zulip_message, sender_id: 2, created_at: "2026-12-25T10:00:00", uniq: ms-z-bob-20261225,   unique_key: msg-bob-20261225,   count: 20 }   # duplicate uniq → dedup, not 40
+    - { $ref: templates/zulip.yaml#/templates/zulip_message, sender_id: 3, created_at: "2026-12-25T10:00:00", uniq: ms-z-carol-20261225, unique_key: msg-carol-20261225, count: 15 }
+    - { $ref: templates/zulip.yaml#/templates/zulip_message, sender_id: 5, created_at: "2026-12-25T10:00:00", uniq: ms-z-erin-20261225,  unique_key: msg-erin-20261225,  count: 50 }
+
+cases:
+  # dept {10,20,30,40,50}; carol value 30 (Teams 15 + Zulip 15). median 30, p25 20, p75 40, range [10,50]
+  - name: "messages_sent — cross-vendor SUM (carol = Teams 15 + Zulip 15)"
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000053
+            $filter: "person_id eq 'carol@example.com' and metric_date ge '2026-12-01' and metric_date le '2026-12-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        assert: "result.status == 'ok'"
+      - in: collaboration
+        find: { metric_key: collab_person_counter_daily.messages_sent }
+        equal: { value: 30, median: 30, range_min: 10, range_max: 50, p25: 20, p75: 40 }
+
+  # bob has ONLY Zulip — the metric is still non-NULL from the remaining source
+  - name: "messages_sent — single-vendor still non-NULL (bob, Zulip-only = 20)"
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000053
+            $filter: "person_id eq 'bob@example.com' and metric_date ge '2026-12-01' and metric_date le '2026-12-31'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        assert: "result.status == 'ok'"
+      - in: collaboration
+        find: { metric_key: collab_person_counter_daily.messages_sent }
+        equal: { value: 20 }
+
+  # ── EMPTY window: no chat rows in range → honest-NULL (no item, not a 0) ──
+  - name: "messages_sent — EMPTY window (no source → NULL, not 0)"
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: collaboration
+            metric_id: 00000000-0000-0000-0001-000000000053
+            $filter: "person_id eq 'carol@example.com' and metric_date ge '2026-06-01' and metric_date le '2026-06-30'"
+    expect:
+      - assert: "status == 200"
+      - in: collaboration
+        assert: "result.status == 'ok'"
+      - in: collaboration
+        assert: "size(items) == 0"


### PR DESCRIPTION
**Consolidated PR B+C of the #1527 split** — merges the former #1568 (backend query_ref + catalog seed) and #1578 (e2e YAML) into one unit, **stacked on #1567** (gold view + dbt).

## Why combined
The new **Metric coverage gate** couples catalog-seed ↔ e2e-test: a seeded `metric_key` with no value-test fails ("missing"), and a test asserting an unseeded key fails ("not a catalog metric_key"). Split across two PRs, #1568 and #1578 could each never go green independently (mutual dependency). The **E2E suite** additionally needs the gold view from #1567. Landing seed + query + test together (on top of the view) makes both gates + E2E green on one branch.

## Contents
- **Query_ref** `m20260702_000001_collab_messaging_queries` — `collab_messaging_counters_qr` (honest-NULL wrapper + per-`org_unit_id` `quantileExact` bands), `metrics.id …0053`. Rust unit test on the generated SQL (feeds #1433).
- **Catalog seed** `m20260702_000002_seed_collab_messaging_catalog` — product-default rows for `messages_sent` + `channel_posts` + thresholds + `metric_query_catalog` links; `source_tags` carry the vendors.
- Extend `domain/catalog/live_tests.rs` to assert both keys resolve at product-default.
- **e2e YAML** — `collab_messaging_messages_sent` (cross-vendor SUM · single-vendor non-NULL · empty→NULL) and `collab_messaging_channel_posts` (posts+replies fold · empty→NULL). Bob-case stat assertions completed per CodeRabbit on #1578.

## Review status carried over
- #1568 review: CodeRabbit hit its rate limit (no code findings); prior manual review approved. `metric_query_catalog(metrics_id, metric_catalog_id)` UNIQUE (`uq_metric_query_catalog_pair`) confirmed → `INSERT IGNORE` seed is idempotent.
- #1578 review: the one Major nitpick (bob-case stats) is applied here.

## Notes
- ⚠️ analytics-api **Coverage gate** (<80%) stays red — known repo-wide floor (#1433), not this PR.
- **Slack** e2e fixtures are a follow-up (the gate skip-lists `slack_*` as "needs Slack connector"); honest-NULL contract proven with Teams + Zulip.
- Depends on #1567 (its base); auto-retargets to `main` when #1567 merges.

Supersedes #1568 and #1578. Refs #1527 · #1516

🤖 Generated with [Claude Code](https://claude.com/claude-code)