### PR TITLE
fix(analytics): re-trigger chart publish for the unified-metrics image

### DIFF
--- a/src/backend/services/analytics/helm/Chart.yaml
+++ b/src/backend/services/analytics/helm/Chart.yaml
@@ -2,5 +2,7 @@ apiVersion: v2
 name: insight-analytics
 description: Insight Analytics — query service over ClickHouse views
 version: 0.2.0
+# appVersion is managed by the release pipeline (build-images.yml): it is
+# bumped to the freshly built image tag on merges that change this service.
 appVersion: "2026.07.07.16.30-6b993eb"
 type: application


### PR DESCRIPTION
## What

Re-triggers the umbrella chart publish so the release references the analytics image built for the unified-metrics merge (#1656).

## Why

That merge built and pushed the `insight-analytics` image, but `publish-chart` was **skipped** on the merge run because the same merge also triggered a descriptor-bump commit (`publish-chart` guards on `bump-descriptors.committed != 'true'`). The follow-up run that published the umbrella saw only descriptor changes, so `changes.analytics` was false and the analytics `appVersion` bump was never applied — the release kept referencing the pre-merge image.

This is a general release-pipeline defect (any backend service + descriptor change in one merge); tracked separately. This PR is the immediate recovery.

## How

A doc comment on the analytics subchart `Chart.yaml` — a change scoped to `src/backend/services/analytics/**` with no descriptor change. On merge to main, `changes.analytics` is true and no descriptor commit intervenes, so `publish-chart` runs: rebuilds the image, bumps the subchart appVersion to the fresh tag, and republishes the umbrella. `appVersion` is left for the pipeline to own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a note clarifying that the app version is updated automatically during releases and reflects the latest built image version after service changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->