### PR TITLE
seed: build silver+gold via real deploy scripts; fix gold data conformance

### DIFF
--- a/deploy/compose/clickhouse-user-defaults.xml
+++ b/deploy/compose/clickhouse-user-defaults.xml
@@ -11,11 +11,23 @@
      of 'join_use_nulls' setting."
   Setting join_use_nulls=1 as the profile default means views are both
   CREATEd and queried under the same regime.
+
+  allow_experimental_refreshable_materialized_view=1: the task-delivery
+  migrations (e.g. 20260429000000_task-delivery-silver-rewrite.sql) create
+  refreshable MATERIALIZED VIEWs. They enable the flag with a leading
+  `SET allow_experimental_refreshable_materialized_view = 1;`, but the
+  deploy migration runner (scripts/lib/ch-exec.sh `run_ch`) sends each
+  `;`-separated statement as a SEPARATE, stateless HTTP request, so the
+  SET does not persist to the later CREATE. Production ClickHouse allows
+  refreshable MVs at the server level; enabling it here as a profile
+  default gives the compose CH the same regime so the real deploy scripts
+  (apply-ch-migrations.sh) run unchanged.
 -->
 <clickhouse>
   <profiles>
     <default>
       <join_use_nulls>1</join_use_nulls>
+      <allow_experimental_refreshable_materialized_view>1</allow_experimental_refreshable_materialized_view>
     </default>
   </profiles>
 </clickhouse>

--- a/deploy/seed/Dockerfile
+++ b/deploy/seed/Dockerfile
@@ -4,7 +4,10 @@
 # bind-mounted at runtime so iterating on seed.py doesn't trigger an
 # image rebuild.
 
-FROM python:3.13-slim
+# Pinned to 3.12 to match src/ingestion/tools/toolbox/Dockerfile (the
+# deploy dbt-run image) — apply-ch-migrations.sh runs dbt here, and
+# dbt-clickhouse is validated against 3.12 on that image.
+FROM python:3.12-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -13,11 +16,13 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 WORKDIR /app
 
-# curl: needed by src/ingestion/scripts/create-bronze-placeholders.sh
-# (bind-mounted at /ingestion-scripts), which silver.py runs to create
-# the placeholder tables — same script as the k8s clickhouse-migrate Job.
+# curl: needed by src/ingestion/scripts/{create-bronze-placeholders,
+# apply-ch-migrations}.sh (bind-mounted at /ingestion), which silver.py runs
+# to create the placeholder tables + build the gold layer — the same scripts
+# the k8s clickhouse-migrate Hook Job runs.
+# bash: the scripts use bashisms (process substitution, [[ ]]); slim ships dash.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl \
+    && apt-get install -y --no-install-recommends curl bash \
     && rm -rf /var/lib/apt/lists/*
 
 COPY requirements.txt .

--- a/deploy/seed/generators/ai.py
+++ b/deploy/seed/generators/ai.py
@@ -30,14 +30,17 @@ if TYPE_CHECKING:
 
 
 _DEV_TOOLS = (
-    # (tool string, source_type key in profile weights)
-    ("cursor",       "cursor"),
-    ("claude_code",  "claude_team"),
+    # (tool string, tool_label, source_type key in profile weights)
+    ("cursor",       "Cursor",      "cursor"),
+    ("claude_code",  "Claude Code", "claude_team"),
 )
 _ASSISTANT_TOOLS = (
-    # (tool string, surface, source_type key in profile weights)
-    ("chatgpt",       "web", "chatgpt"),
-    ("claude",        "web", "claude_team"),
+    # (tool string, surface, tool_label, surface_label, source_type key)
+    # surface must be a canonical value the gold model filters on
+    # (ai_metric_observations gates chat_assistant_conversations on
+    # surface = 'chat'); 'web' is not in the surface enum.
+    ("chatgpt",       "chat", "ChatGPT", "Chat", "chatgpt"),
+    ("claude",        "chat", "Claude",  "Chat", "claude_team"),
 )
 
 
@@ -56,6 +59,7 @@ def seed_ai_dev_usage(
         "accepted_lines_added", "spec_lines", "session_count",
         "total_chat_messages", "cost_cents", "commits_count",
         "pull_requests_count", "prs_with_cc_count", "prs_total_count",
+        "conversation_count", "tool_label",
         "_version",
     ]
     rows: list[tuple[object, ...]] = []
@@ -65,7 +69,7 @@ def seed_ai_dev_usage(
             continue
         profile = TEAM_PROFILES[p.team]
         persona = persona_multiplier(p.uuid)
-        for tool, src_key in _DEV_TOOLS:
+        for tool, tool_label, src_key in _DEV_TOOLS:
             weight = profile.weights.get(src_key, 0)
             if weight <= 0:
                 continue
@@ -92,6 +96,7 @@ def seed_ai_dev_usage(
                     float(rng.randint(0, 3)),
                     float(rng.randint(0, 2)),
                     float(rng.randint(0, 4)),
+                    float(sessions), tool_label,
                     version,
                 ))
     return bulk_insert(client, "silver", "class_ai_dev_usage", cols, rows)
@@ -106,7 +111,8 @@ def seed_ai_assistant_usage(
     truncate(client, "silver", "class_ai_assistant_usage")
     cols = [
         "insight_tenant_id", "source_id", "unique_key", "email", "day",
-        "tool", "surface", "session_count", "conversation_count",
+        "tool", "surface", "tool_label", "surface_label",
+        "session_count", "conversation_count",
         "message_count", "action_count", "files_uploaded_count",
         "artifacts_created_count", "projects_created_count",
         "projects_used_count", "skills_used_count", "connectors_used_count",
@@ -122,7 +128,7 @@ def seed_ai_assistant_usage(
             continue
         profile = TEAM_PROFILES[p.team]
         persona = persona_multiplier(p.uuid)
-        for tool, surface, src_key in _ASSISTANT_TOOLS:
+        for tool, surface, tool_label, surface_label, src_key in _ASSISTANT_TOOLS:
             weight = profile.weights.get(src_key, 0)
             if weight <= 0:
                 continue
@@ -138,7 +144,7 @@ def seed_ai_assistant_usage(
                     tenant_uuid,
                     deterministic_uuid("ai.assistant.src", p.uuid, tool),
                     deterministic_uuid("ai.assistant.row", p.uuid, d.isoformat(), tool),
-                    p.email, d, tool, surface,
+                    p.email, d, tool, surface, tool_label, surface_label,
                     sessions, conversations, msgs,
                     sessions * 2,
                     rng.randint(0, 3), rng.randint(0, 2), rng.randint(0, 1),

--- a/deploy/seed/generators/base.py
+++ b/deploy/seed/generators/base.py
@@ -87,6 +87,12 @@ def deterministic_uuid(*parts: str) -> str:
     return f"{digest[:8]}-{digest[8:12]}-{digest[12:16]}-{digest[16:20]}-{digest[20:]}"
 
 
+def deterministic_int(*parts: str) -> int:
+    """Build a stable positive Int64 from input parts. For integer id columns."""
+    digest = hashlib.blake2b("|".join(parts).encode(), digest_size=8).digest()
+    return int.from_bytes(digest, "big") & 0x7FFFFFFFFFFFFFFF
+
+
 # ─── Insert helpers ──────────────────────────────────────────────────────
 
 

--- a/deploy/seed/generators/git.py
+++ b/deploy/seed/generators/git.py
@@ -15,6 +15,7 @@ from generators.base import (
     bulk_insert,
     clamp,
     days_window,
+    deterministic_int,
     deterministic_uuid,
     persona_multiplier,
     poisson,
@@ -53,7 +54,7 @@ def seed_class_git_commits(
     cols = [
         "insight_tenant_id", "commit_hash", "project_key", "repo_slug",
         "tenant_id", "author_email", "date", "is_merge_commit",
-        "file_path", "lines_added", "lines_removed", "_version",
+        "file_path", "lines_added", "lines_removed", "data_source", "_version",
     ]
     rows: list[tuple[object, ...]] = []
     version = 1
@@ -73,7 +74,7 @@ def seed_class_git_commits(
                 rows.append((
                     tenant_uuid, sha.replace("-", ""), "insight", "insight/insight",
                     tenant_uuid, p.email, d, is_merge,
-                    "src/main.rs", added, removed, version,
+                    "src/main.rs", added, removed, "insight_github", version,
                 ))
     return bulk_insert(client, "silver", "class_git_commits", cols, rows)
 
@@ -88,7 +89,7 @@ def seed_class_git_pull_requests(
     cols = [
         "insight_tenant_id", "pr_id", "author_email", "author_name",
         "state", "created_on", "merged_on", "closed_on",
-        "lines_added", "lines_removed", "_version",
+        "lines_added", "lines_removed", "tenant_id", "data_source", "_version",
     ]
     rows: list[tuple[object, ...]] = []
     version = 1
@@ -101,7 +102,7 @@ def seed_class_git_pull_requests(
             mean = 0.8 * persona * weight * weekday_multiplier(d)
             n_prs = min(poisson(rng, mean), PRS_CAP)
             for i in range(n_prs):
-                pr_id = deterministic_uuid("git.pr", p.uuid, d.isoformat(), str(i))[:36]
+                pr_id = deterministic_int("git.pr", p.uuid, d.isoformat(), str(i))
                 created = _dt.datetime.combine(
                     d, _dt.time(9 + rng.randint(0, 8), rng.randint(0, 59), tzinfo=_dt.UTC),
                 )
@@ -111,7 +112,9 @@ def seed_class_git_pull_requests(
                     if merged_in_h is not None
                     else None
                 )
-                state = "merged" if merged_on else "open"
+                # Uppercase to match the gold model's state filters
+                # (git_metric_observations: prs.state = 'MERGED').
+                state = "MERGED" if merged_on else "OPEN"
                 merged_naive = None if merged_on is None else merged_on.replace(tzinfo=None)
                 pr_added = float(rng.randint(20, 350))
                 pr_removed = float(rng.randint(0, 180))
@@ -120,6 +123,7 @@ def seed_class_git_pull_requests(
                     state, created.replace(tzinfo=None),
                     merged_naive, merged_naive,   # closed_on tracks merged_on for merged PRs
                     pr_added, pr_removed,
+                    tenant_uuid, "insight_github",
                     version,
                 ))
     return bulk_insert(client, "silver", "class_git_pull_requests", cols, rows)

--- a/deploy/seed/generators/people.py
+++ b/deploy/seed/generators/people.py
@@ -88,9 +88,15 @@ def _supervisor_email(roster: Sequence[Person], p: Person) -> str | None:
 def seed_class_people(
     client: clickhouse_connect.driver.client.Client,
     roster: Sequence[Person],
+    tenant_uuid: str,
 ) -> int:
     truncate(client, "silver", "class_people")
-    cols = ["unique_key", "email", "department_name", "_version"]
+    # workspace_id carries the tenant: metric_entity_cohorts_current filters
+    # `workspace_id IS NOT NULL AND workspace_id != ''` and selects it AS
+    # tenant_id, so an empty value drops every person from the cohort view.
+    # It MUST equal the tenant_uuid the git/ai generators use, or the
+    # observation↔cohort join yields nothing.
+    cols = ["unique_key", "email", "department_name", "workspace_id", "_version"]
     # Constant `_version` — every other generator emits version=1 too.
     # `int(time.time())` would make re-runs emit "newer" rows on every
     # invocation, defeating the deterministic-reseed contract baked into
@@ -103,6 +109,7 @@ def seed_class_people(
             deterministic_uuid("class_people", p.email),
             p.email.lower(),
             dept,
+            tenant_uuid,
             version,
         ))
     return bulk_insert(client, "silver", "class_people", cols, rows)
@@ -154,8 +161,9 @@ def seed_bamboohr_employees(
 def generate(
     client: clickhouse_connect.driver.client.Client,
     roster: Sequence[Person],
+    tenant_uuid: str,
 ) -> dict[str, int]:
     return {
-        "silver.class_people":           seed_class_people(client, roster),
+        "silver.class_people":           seed_class_people(client, roster, tenant_uuid),
         "bronze_bamboohr.employees":     seed_bamboohr_employees(client, roster),
     }

--- a/deploy/seed/generators/task.py
+++ b/deploy/seed/generators/task.py
@@ -127,6 +127,22 @@ _ISSUE_TYPES = ("Bug", "Task", "Story", "Improvement")
 _PRIORITIES = ("Highest", "High", "Medium", "Medium", "Low")
 _CLOSE_STATUSES = ("Closed", "Resolved", "Verified")
 
+# Status dimension. The task_issue_current_state MV resolves a status to a
+# lifecycle category by joining class_task_statuses on
+# (insight_source_id, status_id), and gold detects a closed task via
+# status_category = 'done' (never a localized name — see issue #1541). So
+# status field-history events MUST carry a status_id (value_ids[1]) that
+# matches a class_task_statuses row, and that dimension must be seeded.
+# status_category values are the reconciled set: new / in_progress / done.
+_STATUS_DIM = {
+    # status_name: (status_id, status_category)
+    "To Do":    ("1",     "new"),
+    "Closed":   ("6",     "done"),
+    "Resolved": ("5",     "done"),
+    "Verified": ("10001", "done"),
+}
+_STATUS_CATEGORY_ID = {"new": 2, "in_progress": 4, "done": 3, "undefined": 1}
+
 # Per-team data_source for task-tracking rows. Support uses the
 # `zendesk-placeholder` marker — there's no real Zendesk connector in
 # the repo so this keeps the per-team distinction visible without
@@ -226,7 +242,7 @@ def seed_task_field_history(
                 due_date = (created_day + _dt.timedelta(days=rng.randint(7, 30))).isoformat()
                 # 7 synthetic_initial rows.
                 base_fields = [
-                    ("status", "Status", None, "To Do"),
+                    ("status", "Status", _STATUS_DIM["To Do"][0], "To Do"),
                     ("assignee", "Assignee", p.email, p.email),
                     ("issuetype", "Issue Type", None, issue_type),
                     ("priority", "Priority", None, priority),
@@ -260,11 +276,40 @@ def seed_task_field_history(
                             data_source=data_source, issue_id=issue_id,
                             event_at=close_at, event_kind="changelog",
                             field_id="status", field_name="Status",
-                            value_id=None, value_display=close_status,
+                            value_id=_STATUS_DIM[close_status][0],
+                            value_display=close_status,
                             author_id=p.email, seq=100,
                         ))
 
     return bulk_insert(client, "silver", "class_task_field_history", cols, rows)
+
+
+def seed_class_task_statuses(
+    client: clickhouse_connect.driver.client.Client,
+    roster: Sequence[Person],
+) -> int:
+    """Status dimension: one row per (source, status) mapping a status_id to
+    its lifecycle status_category. task_issue_current_state joins this on
+    (insight_source_id, status_id); without it status_category is NULL and
+    jira_closed_tasks (which filters status_category = 'done') is empty."""
+    truncate(client, "silver", "class_task_statuses")
+    cols = [
+        "insight_source_id", "data_source", "status_id", "status_name",
+        "category_id", "category_key", "status_category", "collected_at",
+        "unique_key", "_version",
+    ]
+    now = _dt.datetime.now(_dt.UTC).replace(tzinfo=None)
+    rows: list[tuple[object, ...]] = []
+    for p in _task_persons(roster):
+        src_id = deterministic_uuid("task.source", p.uuid)
+        data_source = _task_data_source(p.team)
+        for name, (status_id, category) in _STATUS_DIM.items():
+            rows.append((
+                src_id, data_source, status_id, name,
+                _STATUS_CATEGORY_ID[category], category, category, now,
+                deterministic_uuid("task.status", src_id, status_id), 1,
+            ))
+    return bulk_insert(client, "silver", "class_task_statuses", cols, rows)
 
 
 # Refreshable materialized views that derive from class_task_field_history.
@@ -296,6 +341,10 @@ def generate(
         "silver.class_task_worklogs":      seed_task_worklogs(client, roster, tenant_uuid, days),
         "silver.class_task_users":         seed_task_users(client, roster, tenant_uuid),
         "silver.class_task_field_history": seed_task_field_history(client, roster, tenant_uuid, days),
+        "silver.class_task_statuses":      seed_class_task_statuses(client, roster),
     }
-    refresh_dependent_mvs(client)
+    # NOTE: the refreshable MVs these rows feed (see refresh_dependent_mvs)
+    # are created by apply-ch-migrations.sh, which the orchestrator runs
+    # AFTER seeding — so the refresh is triggered by silver.run() once the
+    # migrations exist, not here. See silver.py.
     return totals

--- a/deploy/seed/requirements.txt
+++ b/deploy/seed/requirements.txt
@@ -1,2 +1,7 @@
 PyMySQL==1.2.0
 clickhouse-connect==1.2.0
+# apply-ch-migrations.sh runs `dbt run --select tag:gold` to build the
+# dbt-owned gold models (same mechanism as the k8s clickhouse-migrate Job /
+# toolbox image). Unpinned to match src/ingestion/tools/toolbox/Dockerfile.
+# dbt-core pulls in PyYAML, which the script's profiles.yml generator imports.
+dbt-clickhouse

--- a/deploy/seed/silver.py
+++ b/deploy/seed/silver.py
@@ -1,30 +1,41 @@
 """
-ClickHouse silver-layer schema bootstrap + sample-data generation.
+ClickHouse silver-layer sample-data generation.
 
-Three responsibilities, run in order on every `silver` subcommand. All
-three are idempotent — re-running converges on the same end state.
+Table + gold-layer setup uses the SAME mechanism as a real deployment —
+the seed does not reimplement any DDL. It runs the exact two scripts the
+k8s clickhouse-migrate Hook Job runs, from the ingestion tree bind-mounted
+at /ingestion (docker-compose.yml `seed-sample.volumes`):
 
-1. Create the bronze + silver placeholder tables that the gold-view
-   migrations reference, by running the same
-   `insight/src/ingestion/scripts/create-bronze-placeholders.sh` the
-   k8s clickhouse-migrate Hook Job runs. One source of truth — the
-   script only needs bash + curl + CLICKHOUSE_URL/USER/PASSWORD (it
-   talks plain HTTP via lib/ch-exec.sh, no k8s coupling).
+1. `create-bronze-placeholders.sh` — CREATE DATABASE + bronze/silver
+   placeholder tables (CREATE TABLE IF NOT EXISTS; each silver placeholder
+   carries the INSIGHT_PLACEHOLDER_v1 marker). This gives the generators
+   real tables to write into.
 
-2. Apply the gold-view migrations from
-   `insight/src/ingestion/scripts/migrations/*.sql` in lexicographic
-   order. Migrations are `DROP VIEW IF EXISTS` + `CREATE VIEW`.
+2. Generate per-team activity rows via `generators/*.py` INTO those silver
+   tables. Volumes scale by team profile + persona; per-day caps live in
+   each generator module.
 
-3. Generate per-team activity rows via `generators/*.py`. Volumes scale
-   by team profile + persona; per-day caps live in each generator
-   module.
+3. `apply-ch-migrations.sh` — applies migrations/*.sql (gold VIEWs), the
+   staging label repair, and `dbt run --select tag:gold` to build the
+   dbt-owned gold models. Run AFTER seeding so the one materialized gold
+   model (`insight.git_metric_observations`, materialized='table') is built
+   over real seeded silver instead of empty placeholders. The migration
+   views and the two view-materialized gold models are read-time, so their
+   order relative to seeding does not matter; the table model's does.
+
+   Re-running create-bronze-placeholders.sh from inside this script is a
+   no-op on the seeded tables (IF NOT EXISTS, no DROP/TRUNCATE), and the
+   dbt on-run-start `drop_silver_placeholders_at_start` hook does NOT fire
+   because `--select tag:gold` never materializes a staging model (the
+   hook's required second factor) — so the seeded rows survive.
+
+All steps are idempotent — re-running converges on the same end state.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-import re
 import subprocess
 from pathlib import Path
 
@@ -37,21 +48,36 @@ LOG = logging.getLogger("seed.silver")
 
 DEFAULT_DAYS = 60
 
+
 def _ingestion_scripts_dir() -> Path:
     """Locate src/ingestion/scripts — no env knobs needed.
 
-    In the seed-sample container the dir is bind-mounted at
-    /ingestion-scripts (docker-compose.yml `seed-sample.volumes`).
-    Host runs resolve it relative to this file: deploy/seed lives in
-    the same repo as src/ingestion, two levels below the root.
-
-    Both schema inputs live under it: create-bronze-placeholders.sh
-    (+ its lib/) and migrations/*.sql.
+    In the seed-sample container the whole ingestion tree is bind-mounted
+    at /ingestion (docker-compose.yml `seed-sample.volumes`), mirroring the
+    toolbox image layout the scripts resolve their relative paths against
+    (apply-ch-migrations.sh cd's into ../dbt). Host runs resolve it relative
+    to this file: deploy/seed lives in the same repo as src/ingestion, two
+    levels below the root.
     """
-    mounted = Path("/ingestion-scripts")
+    mounted = Path("/ingestion/scripts")
     if mounted.is_dir():
         return mounted
-    return Path(__file__).resolve().parents[2] / "src/ingestion/scripts"
+    return Path(__file__).resolve().parent.parent / "src/ingestion/scripts"
+
+
+def _script_env() -> dict[str, str]:
+    """Env for the ingestion shell scripts (create-bronze-placeholders.sh,
+    apply-ch-migrations.sh) — CLICKHOUSE_URL/USER/PASSWORD/DATABASE per
+    lib/ch-exec.sh + apply-ch-migrations.sh's own asserts."""
+    host = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
+    port = os.environ.get("CLICKHOUSE_HTTP_PORT", "8123")
+    return {
+        **os.environ,
+        "CLICKHOUSE_URL": f"http://{host}:{port}",
+        "CLICKHOUSE_USER": os.environ.get("CLICKHOUSE_USER", "insight"),
+        "CLICKHOUSE_PASSWORD": os.environ.get("CLICKHOUSE_PASSWORD", "insight-local"),
+        "CLICKHOUSE_DATABASE": os.environ.get("CLICKHOUSE_DATABASE", "insight"),
+    }
 
 
 def _ch_client() -> clickhouse_connect.driver.client.Client:
@@ -59,89 +85,51 @@ def _ch_client() -> clickhouse_connect.driver.client.Client:
     port = int(os.environ.get("CLICKHOUSE_HTTP_PORT", "8123"))
     user = os.environ.get("CLICKHOUSE_USER", "insight")
     pwd = os.environ.get("CLICKHOUSE_PASSWORD", "insight-local")
-    # CRITICAL: analytics queries with join_use_nulls=1, so views must
-    # be CREATED with the same setting — otherwise the view's declared
-    # column types disagree with what the query sees at runtime
-    # ("Nullable column having not Nullable type in structure").
+    # Views (gold) are created by apply-ch-migrations.sh, not this client;
+    # the compose CH ships join_use_nulls=1 as a profile default
+    # (deploy/compose/clickhouse-user-defaults.xml) so those CREATE VIEWs
+    # type-check server-side. This client only INSERTs silver rows.
     return clickhouse_connect.get_client(
         host=host, port=port, username=user, password=pwd,
-        settings={"join_use_nulls": 1},
     )
-
-
-_FULL_LINE_COMMENT = re.compile(r"^\s*--.*$", re.MULTILINE)
-
-
-def _split_statements(sql: str) -> list[str]:
-    """Split a multi-statement SQL block on `;` boundaries.
-
-    Mirrors the init.sh sed pass that drops full-line `--` comments
-    before piping into clickhouse-client. We do the same so a migration
-    starting with a 20-line preamble doesn't choke the parser. Inline
-    `-- foo` after SQL is left alone — those rarely break CH.
-    """
-    cleaned = _FULL_LINE_COMMENT.sub("", sql)
-    return [stmt.strip() for stmt in cleaned.split(";") if stmt.strip()]
-
-
-def _apply_sql_file(client: clickhouse_connect.driver.client.Client, path: Path) -> int:
-    """Apply one SQL file. Returns the number of statements executed."""
-    sql = path.read_text(encoding="utf-8")
-    statements = _split_statements(sql)
-    for stmt in statements:
-        client.command(stmt)
-    return len(statements)
 
 
 def apply_placeholders() -> None:
     """CREATE DATABASE + bronze/silver placeholder tables.
 
-    Delegates to the ingestion repo's create-bronze-placeholders.sh —
-    the exact script the k8s clickhouse-migrate Hook Job runs — so the
-    placeholder DDL has a single source of truth and cannot drift.
+    Runs the ingestion repo's create-bronze-placeholders.sh — the exact
+    script the k8s clickhouse-migrate Hook Job runs — so placeholder DDL
+    has a single source of truth and cannot drift.
     """
     script = _ingestion_scripts_dir() / "create-bronze-placeholders.sh"
     if not script.is_file():
         raise FileNotFoundError(
-            f"placeholders script not found at {script}. "
-            "In compose, the seed-sample container must mount "
-            "/ingestion-scripts; on a host run, deploy/seed must sit "
-            "inside the insight repo next to src/ingestion."
+            f"placeholders script not found at {script}. In compose, the "
+            "seed-sample container must mount /ingestion; on a host run, "
+            "deploy/seed must sit inside the insight repo next to src/ingestion."
         )
-    host = os.environ.get("CLICKHOUSE_HOST", "clickhouse")
-    port = os.environ.get("CLICKHOUSE_HTTP_PORT", "8123")
-    env = {
-        **os.environ,
-        "CLICKHOUSE_URL": f"http://{host}:{port}",
-        "CLICKHOUSE_USER": os.environ.get("CLICKHOUSE_USER", "insight"),
-        "CLICKHOUSE_PASSWORD": os.environ.get(
-            "CLICKHOUSE_PASSWORD", "insight-local"
-        ),
-    }
-    subprocess.run(["bash", str(script)], env=env, check=True)
+    subprocess.run(["bash", str(script)], env=_script_env(), check=True)
     LOG.info("placeholders: %s applied", script.name)
 
 
-def apply_migrations(client: clickhouse_connect.driver.client.Client) -> int:
-    """Apply gold-view migrations in lexicographic order."""
-    migrations_dir = _ingestion_scripts_dir() / "migrations"
-    if not migrations_dir.is_dir():
+def apply_ch_migrations() -> None:
+    """Apply gold-view migrations + build dbt-owned gold models.
+
+    Runs the ingestion repo's apply-ch-migrations.sh — the exact script the
+    k8s clickhouse-migrate Hook Job runs. It re-creates placeholders (no-op
+    here), applies migrations/*.sql, repairs staging labels, and runs
+    `dbt run --select tag:gold`. Must run AFTER seeding so the materialized
+    gold model reflects seeded silver (see module docstring).
+    """
+    script = _ingestion_scripts_dir() / "apply-ch-migrations.sh"
+    if not script.is_file():
         raise FileNotFoundError(
-            f"migrations dir not found at {migrations_dir}. "
-            "In compose, the seed-sample container must mount "
-            "/ingestion-scripts; on a host run, deploy/seed must sit "
-            "inside the insight repo next to src/ingestion."
+            f"migrations script not found at {script}. In compose, the "
+            "seed-sample container must mount /ingestion; on a host run, "
+            "deploy/seed must sit inside the insight repo next to src/ingestion."
         )
-    migrations = sorted(migrations_dir.glob("*.sql"))
-    if not migrations:
-        raise FileNotFoundError(f"no *.sql migrations under {migrations_dir}")
-    total = 0
-    for m in migrations:
-        n = _apply_sql_file(client, m)
-        LOG.info("migration %s: %d statements", m.name, n)
-        total += n
-    LOG.info("migrations: %d files applied, %d statements total", len(migrations), total)
-    return total
+    subprocess.run(["bash", str(script)], env=_script_env(), check=True)
+    LOG.info("migrations + gold: %s applied", script.name)
 
 
 def generate_rows(
@@ -160,7 +148,7 @@ def generate_rows(
     )
 
     totals: dict[str, int] = {}
-    totals.update(people.generate(client, roster))
+    totals.update(people.generate(client, roster, tenant_uuid))
     totals.update(git.generate(client, roster, tenant_uuid, days))
     totals.update(crm.generate(client, roster, tenant_uuid, days))
     totals.update(collab.generate(client, roster, tenant_uuid, days))
@@ -180,15 +168,27 @@ def run() -> None:
         level=logging.INFO,
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
+    # 1. Real deploy mechanism: create the placeholder tables.
     apply_placeholders()
     client = _ch_client()
     try:
         LOG.info("ClickHouse version: %s", client.server_version)
-        apply_migrations(client)
+        # 2. Seed silver rows into those tables.
         generate_rows(client)
-        LOG.info("DONE: silver schema + gold views + sample rows in place.")
+        # 3. Real deploy mechanism: migrations + gold (incl. dbt gold build
+        #    over the now-seeded silver). Creates the task refreshable MVs
+        #    but intentionally does NOT populate them (SYSTEM REFRESH is
+        #    synchronous — see apply-ch-migrations.sh / refresh-task-views.sh).
+        apply_ch_migrations()
+        # 4. Post-deploy: populate the task refreshable MVs from seeded
+        #    silver — the Python analog of scripts/post-deploy/
+        #    refresh-task-views.sh (the seed image has clickhouse-connect,
+        #    not clickhouse-client). Must run AFTER step 3 creates the MVs.
+        task.refresh_dependent_mvs(client)
+        LOG.info("task refreshable MVs refreshed")
     finally:
         client.close()
+    LOG.info("DONE: silver rows seeded + gold layer built via deploy scripts.")
 
 
 if __name__ == "__main__":

--- a/deploy/seed/silver.py
+++ b/deploy/seed/silver.py
@@ -94,7 +94,7 @@ def _ch_client() -> clickhouse_connect.driver.client.Client:
     )
 
 
-def apply_placeholders() -> None:
+def apply_create_bronze_placeholders() -> None:
     """CREATE DATABASE + bronze/silver placeholder tables.
 
     Runs the ingestion repo's create-bronze-placeholders.sh — the exact
@@ -169,21 +169,22 @@ def run() -> None:
         format="%(asctime)s %(levelname)s %(name)s %(message)s",
     )
     # 1. Real deploy mechanism: create the placeholder tables.
-    apply_placeholders()
+    apply_create_bronze_placeholders()
     client = _ch_client()
     try:
         LOG.info("ClickHouse version: %s", client.server_version)
-        # 2. Seed silver rows into those tables.
+        # 2. Seed silver rows into the created tables.
         generate_rows(client)
         # 3. Real deploy mechanism: migrations + gold (incl. dbt gold build
-        #    over the now-seeded silver). Creates the task refreshable MVs
-        #    but intentionally does NOT populate them (SYSTEM REFRESH is
-        #    synchronous — see apply-ch-migrations.sh / refresh-task-views.sh).
+        #    over the now-seeded silver). Runs AFTER seeding so the one
+        #    materialized gold model (git_metric_observations, a table) and
+        #    the migration views all reflect real rows.
         apply_ch_migrations()
-        # 4. Post-deploy: populate the task refreshable MVs from seeded
-        #    silver — the Python analog of scripts/post-deploy/
-        #    refresh-task-views.sh (the seed image has clickhouse-connect,
-        #    not clickhouse-client). Must run AFTER step 3 creates the MVs.
+        # 4. Populate the task refreshable MVs from seeded silver — DDL was
+        #    created in step 3; SYSTEM REFRESH must run once the rows exist.
+        #    Python analog of scripts/post-deploy/refresh-task-views.sh (that
+        #    script needs clickhouse-client, which the seed image omits to
+        #    stay lean — the two SYSTEM REFRESH statements are identical).
         task.refresh_dependent_mvs(client)
         LOG.info("task refreshable MVs refreshed")
     finally:

--- a/deploy/seed/silver.py
+++ b/deploy/seed/silver.py
@@ -62,7 +62,8 @@ def _ingestion_scripts_dir() -> Path:
     mounted = Path("/ingestion/scripts")
     if mounted.is_dir():
         return mounted
-    return Path(__file__).resolve().parent.parent / "src/ingestion/scripts"
+    # parents[2] = repo root (silver.py -> seed -> deploy -> root).
+    return Path(__file__).resolve().parents[2] / "src/ingestion/scripts"
 
 
 def _script_env() -> dict[str, str]:

--- a/dev-compose.sh
+++ b/dev-compose.sh
@@ -400,15 +400,11 @@ cmd_urls() {
       *) echo "ERROR: unknown arg: $1" >&2; return 2 ;;
     esac
   done
-  env_file="$(resolve_env_file "$env_file")"
-  if [[ ! -f "$env_file" ]]; then
-    echo "ERROR: $env_file not found — run ./dev-compose.sh up first." >&2
-    return 1
-  fi
+  env_file="$(resolve_env_file "$env_file")" || return $?
   set -a; source "$env_file"; set +a
-  local frontend_up=true
-  [[ "${FRONTEND_MODE:-dev}" == "none" ]] && frontend_up=false
-  report_service_urls "$frontend_up"
+  # FRONTEND_MODE is always dev|built|ghcr (cmd_up enforces it), so the
+  # frontend is assumed up; report_service_urls defaults to showing it.
+  report_service_urls
 }
 
 # ──────────────────────────────────────────────────────────────────────

--- a/dev-compose.sh
+++ b/dev-compose.sh
@@ -341,10 +341,74 @@ YML
     echo
   fi
 
-  echo "Stop: ./dev-compose.sh down"
+  local frontend_up=true
+  [[ "$no_frontend" == "true" ]] && frontend_up=false
+  report_service_urls "$frontend_up"
+  echo
+
+  echo "Service URLs: ./dev-compose.sh urls"
+  echo "Stop:        ./dev-compose.sh down"
   echo "Rebuild one: ./dev-compose.sh build <service>"
   echo "Re-seed:     ./dev-compose.sh seed"
   echo "Wipe state:  ./dev-compose.sh prune"
+}
+
+# ──────────────────────────────────────────────────────────────────────
+# Service access report
+# ──────────────────────────────────────────────────────────────────────
+
+# Print how to reach every exposed service on the host, honouring the
+# configurable ports (and defaults) from .env.compose / docker-compose.yml.
+# Callers must have sourced the env file first. Local-only DBs are shown
+# unless pointed at an external host; the frontend line is gated by the
+# caller (arg 1 = "true" when a front-* profile is active).
+report_service_urls() {
+  local frontend_up="${1:-true}"
+  local h="localhost"
+  echo "=== Service URLs (exposed host ports) ==="
+  if [[ "$frontend_up" == "true" ]]; then
+    printf '  %-18s %s\n' "Frontend UI"   "http://$h:${FRONTEND_PORT:-3000}"
+  fi
+  printf '  %-18s %s\n' "API Gateway"     "http://$h:${API_GATEWAY_PORT:-8080}"
+  printf '  %-18s %s\n' "Analytics API"   "http://$h:${ANALYTICS_PORT:-8081}"
+  printf '  %-18s %s\n' "Identity API"    "http://$h:${IDENTITY_PORT:-8082}"
+  printf '  %-18s %s\n' "Authenticator"   "http://$h:${AUTHENTICATOR_PORT:-8083}"
+  printf '  %-18s %s\n' "Fake IdP"        "http://$h:${FAKEIDP_PORT:-8084}"
+  if [[ "${CLICKHOUSE_EXTERNAL:-false}" != "true" ]]; then
+    printf '  %-18s %s\n' "ClickHouse HTTP" \
+      "http://$h:${CLICKHOUSE_HTTP_PORT:-8123}  (native $h:${CLICKHOUSE_NATIVE_PORT:-9000}, user ${CLICKHOUSE_USER:-insight})"
+  fi
+  if [[ "${MARIADB_EXTERNAL:-false}" != "true" ]]; then
+    printf '  %-18s %s\n' "MariaDB"        "$h:${MARIADB_PORT:-3306}  (user ${MARIADB_USER:-insight})"
+  fi
+  printf '  %-18s %s\n' "Redis"           "$h:${REDIS_PORT:-6379}"
+  printf '  %-18s %s\n' "Redpanda Kafka"  \
+    "$h:${REDPANDA_KAFKA_PORT:-19092}  (admin $h:${REDPANDA_ADMIN_PORT:-19644}, schema $h:${REDPANDA_SCHEMA_PORT:-18081})"
+}
+
+# ──────────────────────────────────────────────────────────────────────
+# urls
+# ──────────────────────────────────────────────────────────────────────
+
+cmd_urls() {
+  local env_file=".env.compose"
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --env-file=*) env_file="${1#*=}"; shift ;;
+      --env-file)   env_file="$2"; shift 2 ;;
+      -h|--help)    echo "usage: dev-compose.sh urls [--env-file FILE]"; return 0 ;;
+      *) echo "ERROR: unknown arg: $1" >&2; return 2 ;;
+    esac
+  done
+  env_file="$(resolve_env_file "$env_file")"
+  if [[ ! -f "$env_file" ]]; then
+    echo "ERROR: $env_file not found — run ./dev-compose.sh up first." >&2
+    return 1
+  fi
+  set -a; source "$env_file"; set +a
+  local frontend_up=true
+  [[ "${FRONTEND_MODE:-dev}" == "none" ]] && frontend_up=false
+  report_service_urls "$frontend_up"
 }
 
 # ──────────────────────────────────────────────────────────────────────
@@ -646,6 +710,7 @@ Subcommands:
   down    Stop everything. --volumes to wipe data.
   build   Rebuild one host-side artefact.
   seed    Populate the demo dataset (identity / silver / all).
+  urls    Print how to reach each service (exposed host ports).
   prune   Destructive wipe of containers, volumes, build/, override,
           and .env.compose. Asks for confirmation.
   help    Print this message.
@@ -662,6 +727,7 @@ main() {
     down)  cmd_down  "$@" ;;
     build) cmd_build "$@" ;;
     seed)  cmd_seed  "$@" ;;
+    urls)  cmd_urls  "$@" ;;
     prune) cmd_prune "$@" ;;
     help|-h|--help) usage ;;
     *) echo "ERROR: unknown subcommand: $sub" >&2; usage; return 2 ;;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -598,10 +598,20 @@ services:
       CLICKHOUSE_HTTP_PORT: "${CLICKHOUSE_INTERNAL_HTTP_PORT:-8123}"
       CLICKHOUSE_USER: "${CLICKHOUSE_USER:-insight}"
       CLICKHOUSE_PASSWORD: "${CLICKHOUSE_PASSWORD:-insight-local}"
+      CLICKHOUSE_DATABASE: "${CLICKHOUSE_DATABASE:-insight}"
+      # apply-ch-migrations.sh runs `dbt run` from /ingestion/dbt. The
+      # ingestion tree is bind-mounted read-only (below), so redirect dbt's
+      # writable outputs (target/, logs/) to a writable scratch dir.
+      DBT_TARGET_PATH: "/tmp/dbt-target"
+      DBT_LOG_PATH: "/tmp/dbt-logs"
     volumes:
       # Bind-mount the source so seed.py edits don't need a rebuild.
       - ./deploy/seed:/app:ro
-      # Schema inputs: create-bronze-placeholders.sh + lib/ch-exec.sh
-      # (the same placeholder DDL the k8s clickhouse-migrate Hook Job
-      # applies) and the gold-view migrations/*.sql.
-      - ./src/ingestion/scripts:/ingestion-scripts:ro
+      # Schema + gold inputs: the SAME scripts the k8s clickhouse-migrate
+      # Hook Job runs — create-bronze-placeholders.sh (+ lib/ch-exec.sh),
+      # apply-ch-migrations.sh, migrations/*.sql — plus the full dbt project
+      # (dbt/, silver/, gold/, connectors/ referenced by dbt model-paths)
+      # so `dbt run --select tag:gold` can build the dbt-owned gold models.
+      # Mounted at /ingestion to match the toolbox image layout the scripts
+      # resolve paths against.
+      - ./src/ingestion:/ingestion:ro


### PR DESCRIPTION
## What

Rebuilds the sample-data seed so **table + gold-layer setup uses the same mechanism as a real deployment** instead of a Python reimplementation that skipped the dbt-owned gold layer.

`silver.py` now runs the exact scripts the k8s clickhouse-migrate Hook Job runs:
1. `create-bronze-placeholders.sh` — creates the silver tables
2. seed generators — insert synthetic rows
3. `apply-ch-migrations.sh` — migrations (gold views) + staging repair + `dbt run --select tag:gold`
4. refresh the task refreshable MVs

Seeding sits **between** steps 1 and 3 so the one `materialized='table'` gold model (`git_metric_observations`) is built over real seeded rows rather than empty placeholders. Re-running the placeholder script inside step 3 is a no-op (`IF NOT EXISTS`), and the dbt `drop_silver_placeholders_at_start` hook can't fire on a `tag:gold`-only run, so seeded rows survive.

## Why

The old seed reimplemented DDL/migrations in Python and never built the 3 dbt-owned gold observation models — so `insight.ai_metric_observations`, `git_metric_observations`, and `metric_entity_cohorts_current` didn't exist on a seeded stack, and any metric routed through the unified observation runtime was blank.

## Changes

**Mechanism**
- `Dockerfile`: pin `python:3.12-slim` (matches the toolbox dbt image), add `bash`; add `dbt-clickhouse` to `requirements.txt`.
- `docker-compose.yml`: mount the full `./src/ingestion` at `/ingestion` (dbt needs the whole project), set `CLICKHOUSE_DATABASE`, redirect dbt `target/`/`logs/` to `/tmp`.
- `clickhouse-user-defaults.xml`: enable `allow_experimental_refreshable_materialized_view` — the migrations `SET` it per-statement but the deploy runner (`run_ch`) is stateless; production CH allows it server-side.

**Data conformance** (so the gold relations actually populate)
- `git.py`: PR `state` → `MERGED`/`OPEN`; add `tenant_id` + `data_source`; commit `data_source`.
- `ai.py`: assistant `surface` → `chat`; add `conversation_count` + tool/surface display labels.
- `people.py`: seed `workspace_id` (was collapsing `metric_entity_cohorts_current` to zero rows).
- `task.py`: seed `class_task_statuses` dimension + carry `status_id` on status events (fixes `jira_closed_tasks = 0`).
- `base.py`: `deterministic_int` for `Int64` id columns (`pr_id`).

## Verification

Ran end-to-end against a local compose stack (CH 24.8):
- dbt gold build `Completed successfully`, 5 gold tests PASS.
- `metric_entity_cohorts_current`: 25 rows / 5 cohorts (was 0).
- `git_metric_observations`: `pr_merged` 270, `pr_cycle_hours` 9728 (were 0/NULL); source dimension `github`/`GitHub`.
- `ai_metric_observations`: `dev_conversations` 4594, `chat_assistant_conversations` 2110 (were 0); labels populated.
- `jira_closed_tasks`: 212 rows / 236 tasks closed (was 0).
- `tenant_id` consistent across all three relations; observation↔cohort join resolves.

## Notes / out of scope
- `class_git_pull_requests_commits` link table left unseeded — it feeds a PR-author-email fallback that never fires (PR `author_email` is always seeded).
- Cohorts keyed by department name (correct for the analytics layer's org-unit representation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `urls` command to display local service addresses, including optional frontend, APIs, databases, and supporting services.
  - Expanded seeded AI usage data with clearer tool and surface labels.
  - Added complete task status data for more accurate task histories and reporting.

- **Bug Fixes**
  - Improved sample data accuracy for people, Git activity, pull requests, and tenant associations.
  - Improved deployment and seeding reliability, including materialized view creation and refresh behavior.
  - Updated development container setup for more consistent script execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->