### PR TITLE
fix(zoom): persist _meetings parent cursor in participants state (Heavy-quota fix)

### DIFF
--- a/src/ingestion/connectors/collaboration/zoom/README.md
+++ b/src/ingestion/connectors/collaboration/zoom/README.md
@@ -40,6 +40,15 @@ There is no start-date knob: the `meetings` stream reads the Zoom Dashboard API
 sync automatically backfills from `now - 150 days` (a safety margin inside that
 window); later syncs continue incrementally from saved state.
 
+The same applies to `participants`: its private `_meetings` parent cursor is
+persisted in the substream state (`incremental_dependency` + a formal
+`join_time` cursor that filters nothing), so each sync fans out one
+`/metrics/meetings/{uuid}/participants` request per meeting **newer than the
+saved cursor minus 7 days** — not per meeting of the whole 150-day window.
+This keeps the sync well inside the Zoom Dashboard-API "Heavy" quota
+(60k requests/day per account); the full fan-out is ~25k requests on a busy
+account and exhausted the quota when run repeatedly (dev-vhc, 2026-07-14).
+
 ### Automatically injected
 
 | Field | Source |

--- a/src/ingestion/connectors/collaboration/zoom/connector.yaml
+++ b/src/ingestion/connectors/collaboration/zoom/connector.yaml
@@ -127,6 +127,8 @@ streams:
               backoff_strategies:
                 - type: WaitTimeFromHeader
                   header: Retry-After
+                - type: ExponentialBackoffStrategy
+                  factor: 10
             - type: DefaultErrorHandler
               response_filters:
                 - type: HttpResponseFilter
@@ -292,8 +294,7 @@ streams:
             path:
               - unique_key
             value: >-
-              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record['id'] }}
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}
   - type: DeclarativeStream
     name: meetings
     retriever:
@@ -335,6 +336,8 @@ streams:
               backoff_strategies:
                 - type: WaitTimeFromHeader
                   header: Retry-After
+                - type: ExponentialBackoffStrategy
+                  factor: 10
             - type: DefaultErrorHandler
               response_filters:
                 - type: HttpResponseFilter
@@ -558,8 +561,7 @@ streams:
             path:
               - unique_key
             value: >-
-              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record['uuid'] }}
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['uuid'] }}
   - type: DeclarativeStream
     name: participants
     retriever:
@@ -570,12 +572,16 @@ streams:
           - type: ParentStreamConfig
             parent_key: uuid
             partition_field: meeting_uuid
-            # NOTE: incremental_dependency is deliberately NOT set. It only has
-            # an effect when the substream itself is incremental (the parent
-            # cursor piggybacks on the child state); participants is
-            # full-refresh, so the CDK emits no child state at all — verified
-            # by tests/test_participants.py. Partition enumeration is instead
-            # bounded by the parent's now-150d window.
+            # Persist the _meetings parent cursor inside the participants
+            # state (parent_state) so each sync enumerates only meetings newer
+            # than the saved cursor (minus the parent's P7D lookback) instead
+            # of re-fanning out over the full now-150d window (~25k Heavy
+            # requests — exhausts Zoom's 60k/day Dashboard-API quota; the
+            # 2026-07-14 dev-vhc 429 incident). Requires the substream itself
+            # to be incremental: the parent cursor piggybacks on the child
+            # state message, a full-refresh child persists nothing — verified
+            # by tests/test_participants.py.
+            incremental_dependency: true
             stream:
               type: DeclarativeStream
               name: _meetings
@@ -620,6 +626,8 @@ streams:
                         backoff_strategies:
                           - type: WaitTimeFromHeader
                             header: Retry-After
+                          - type: ExponentialBackoffStrategy
+                            factor: 10
                       - type: DefaultErrorHandler
                         response_filters:
                           - type: HttpResponseFilter
@@ -745,6 +753,8 @@ streams:
               backoff_strategies:
                 - type: WaitTimeFromHeader
                   header: Retry-After
+                - type: ExponentialBackoffStrategy
+                  factor: 10
             - type: DefaultErrorHandler
               response_filters:
                 - type: HttpResponseFilter
@@ -769,9 +779,7 @@ streams:
         request_parameters:
           $ref: "#/definitions/linked/HttpRequester/request_parameters"
         url: >-
-          https://api.zoom.us/v2/metrics/meetings/{{
-          stream_partition.meeting_uuid | replace('/', '%2F') | replace('+',
-          '%2B') | replace('=', '%3D') }}/participants
+          https://api.zoom.us/v2/metrics/meetings/{{ stream_partition.meeting_uuid | replace('/', '%2F') | replace('+', '%2B') | replace('=', '%3D') }}/participants
       paginator:
         type: DefaultPaginator
         page_token_option:
@@ -790,6 +798,25 @@ streams:
           type: DpathExtractor
           field_path:
             - participants
+    # Formal cursor: the endpoint accepts no time filters (no request options
+    # injected) and nothing is filtered client-side — every enumerated
+    # meeting's participants are always fully emitted. The cursor exists so
+    # the stream is stateful, which is what lets incremental_dependency (on
+    # the parent config above) persist the _meetings cursor as parent_state.
+    # Duplicates from the parent's P7D lookback re-enumeration are deduped at
+    # read time downstream (bronze is append-only ReplacingMergeTree).
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: join_time
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%SZ"
+        - "%Y-%m-%dT%H:%M:%S%z"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: >-
+          {{ (now_utc() - duration('P150D')).strftime('%Y-%m-%d') }}
+        datetime_format: "%Y-%m-%d"
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
     primary_key: unique_key
     schema_loader:
       type: InlineSchemaLoader
@@ -1041,9 +1068,7 @@ streams:
             path:
               - unique_key
             value: >-
-              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ stream_partition.meeting_uuid }}-{{
-              record['participant_uuid'] }}-{{ record['join_time'] }}
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ stream_partition.meeting_uuid }}-{{ record['participant_uuid'] }}-{{ record['join_time'] }}
 
 spec:
   type: Spec

--- a/src/ingestion/connectors/collaboration/zoom/descriptor.yaml
+++ b/src/ingestion/connectors/collaboration/zoom/descriptor.yaml
@@ -1,5 +1,5 @@
 name: zoom
-version: "1.1.0"
+version: "1.2.0"
 schedule: 0 3 * * *
 dbt_select: tag:zoom+
 workflow: sync

--- a/src/ingestion/connectors/collaboration/zoom/tests/test_participants.py
+++ b/src/ingestion/connectors/collaboration/zoom/tests/test_participants.py
@@ -8,15 +8,34 @@ uuid URL-escaped in the path (`/`→%2F, `+`→%2B, `=`→%3D). AddFields stamps
 tenant_id / source_id / meeting_uuid (from the partition) / unique_key =
 "{tenant}-{source}-{meeting_uuid}-{participant_uuid}-{join_time}".
 
+How the sync works, for readers new to Airbyte substreams: `participants` has
+no meeting list of its own — before it can fetch anything it must learn which
+meetings exist. It does that through a private copy of the meetings stream
+(`_meetings`, defined inline in connector.yaml) that it reads itself; the
+top-level `meetings` stream from the catalog is a separate instance and shares
+nothing with it. Every meeting the private parent returns becomes one
+"partition" = one HTTP request to /metrics/meetings/{uuid}/participants.
+
+Those per-meeting requests are the expensive part: they count against Zoom's
+Dashboard-API "Heavy" quota (60 000 requests per day for the whole account).
+If the parent is re-read over its full 150-day window every sync, one sync
+costs ~25k requests on a busy account and two syncs a day exhaust the quota
+(this happened on dev-vhc, 2026-07-14). The fix asserted by the last two
+tests: remember between syncs how far the parent has been read (its
+`end_time` cursor), and on the next sync ask the API only for meetings newer
+than that. The remembering is awkward in Airbyte because state belongs to
+catalog streams and the private parent is not one — its cursor can only be
+saved inside the participants stream's own state, in a `parent_state` field,
+and the CDK only writes that field when participants itself is incremental.
+Hence the "formal" join_time cursor on participants: it filters nothing and
+gates nothing; its sole purpose is to make participants emit a real state
+message that `parent_state` can ride along in (`incremental_dependency: true`
+on the ParentStreamConfig is what turns that on).
+
 Coverage matrix rows: substream_partition (one child request per parent
 partition, uuid escaping), transformations + tenant_source_stamping,
-schema_conformance, pagination_multi_page, incremental_state — the stream
-carries a formal join_time cursor (no request options, no client-side
-filtering) purely so that `incremental_dependency: true` can persist the
-parent cursor as `parent_state`; the resume test pins that a second sync
-enumerates only meetings newer than the saved parent cursor minus its P7D
-lookback (the Zoom Heavy-quota fix: ~hundreds of requests per sync instead of
-re-fanning out over the full 150-day window).
+schema_conformance, pagination_multi_page, incremental_state (the two
+parent-state tests above).
 """
 
 from __future__ import annotations
@@ -148,11 +167,19 @@ def test_pagination_multi_page(http_mocker: HttpMocker) -> None:
 
 @freezegun.freeze_time(_NOW)
 def test_parent_state_persisted_in_child_state(http_mocker: HttpMocker) -> None:
-    """The child's cursor is a formality; what matters is that its state
-    message carries `parent_state` with the `_meetings` cursor (the max observed
-    end_time record value). A full-refresh child persists nothing — that
-    no-op was pinned by this suite before the cursor existed — so this assert
-    is what keeps the Heavy-quota fix from silently regressing."""
+    """After a sync, the connector's final state message must record how far
+    the private `_meetings` parent was read.
+
+    Scenario: one sync over one meeting (ends 2026-06-15T10:30:00Z, one
+    participant). The state emitted at the end must contain
+    `parent_state._meetings.end_time == that end_time` — this is the value the
+    next sync resumes the meeting enumeration from (see the resume test
+    below), and it is exactly what was NOT saved before the fix: without a
+    cursor on participants the CDK emitted only a "this stream has no cursor"
+    placeholder and no parent_state, so every sync re-listed all 150 days of
+    meetings. If this assert starts failing (placeholder state is back, or
+    parent_state is empty), the quota fix has regressed and nightly syncs are
+    ~25k requests again."""
     config = ZoomConfigBuilder().build()
     mock_token(http_mocker)
     _mock_parent(http_mocker, [_meeting("mtg-uuid-1==", "2026-06-15T10:30:00Z")])
@@ -172,13 +199,28 @@ def test_parent_state_persisted_in_child_state(http_mocker: HttpMocker) -> None:
 
 @freezegun.freeze_time(_NOW)
 def test_resume_enumerates_parent_from_saved_cursor(http_mocker: HttpMocker) -> None:
-    """Second sync, given the first sync's state: the parent must be requested
-    from the saved cursor minus its P7D lookback (exact from/to matcher — a
-    regression back to the full now-150d fan-out would issue requests no
-    matcher accepts), and participants are fetched only for the meetings that
-    enumeration returns. The emitted record's join_time predates the first
-    sync's records: nothing is filtered client-side — the child cursor gates
-    no data, only carries state."""
+    """A second sync must ask the API only for meetings newer than the saved
+    cursor — not re-list the whole 150-day window.
+
+    Sync 1 sees one meeting ending 2026-06-16T10:30:00Z and saves that as the
+    parent cursor. Sync 2 is then started with sync 1's state, and three
+    things are pinned:
+
+    1. The meeting-list request must be `from=2026-06-09&to=<today>` — the
+       saved cursor date minus the parent's 7-day lookback (the lookback
+       re-covers meetings that were still running or landed late around the
+       last sync; the resulting duplicate participant rows are removed
+       downstream at read time). The mock server only answers this exact
+       from/to pair, so a regression back to "always start 150 days ago"
+       makes requests nothing answers and fails the test.
+    2. Participant requests are made only for the meetings that narrowed
+       listing returned (here: the one new meeting) — that is the whole point
+       of the fix, request count follows the meeting listing.
+    3. The new meeting's participant joined at 09:00 on June 10 — EARLIER
+       than everything sync 1 saw. It must still be emitted: the join_time
+       cursor on participants only carries state and must never be used to
+       drop records (a real risk: meetings overlap in time, so "older than
+       the newest thing seen so far" does not mean "already synced")."""
     config = ZoomConfigBuilder().build()
     mock_token(http_mocker)
     _mock_parent(http_mocker, [_meeting("mtg-uuid-1==", "2026-06-16T10:30:00Z")])

--- a/src/ingestion/connectors/collaboration/zoom/tests/test_participants.py
+++ b/src/ingestion/connectors/collaboration/zoom/tests/test_participants.py
@@ -10,9 +10,13 @@ tenant_id / source_id / meeting_uuid (from the partition) / unique_key =
 
 Coverage matrix rows: substream_partition (one child request per parent
 partition, uuid escaping), transformations + tenant_source_stamping,
-schema_conformance, pagination_multi_page. incremental_state is N/A — the
-stream is full-refresh; test_full_refresh_substream_emits_no_cursor_state pins
-that contract (and documents why incremental_dependency is absent).
+schema_conformance, pagination_multi_page, incremental_state — the stream
+carries a formal join_time cursor (no request options, no client-side
+filtering) purely so that `incremental_dependency: true` can persist the
+parent cursor as `parent_state`; the resume test pins that a second sync
+enumerates only meetings newer than the saved parent cursor minus its P7D
+lookback (the Zoom Heavy-quota fix: ~hundreds of requests per sync instead of
+re-fanning out over the full 150-day window).
 """
 
 from __future__ import annotations
@@ -20,7 +24,15 @@ from __future__ import annotations
 import json
 
 import freezegun
-from config import FROZEN_NOW, METRICS_URL, PARENT_MEETING_SLICES, ZoomConfigBuilder, mock_meeting_slices, mock_token
+from config import (
+    FROZEN_NOW,
+    METRICS_URL,
+    PARENT_MEETING_SLICES,
+    ZoomConfigBuilder,
+    metrics_params,
+    mock_meeting_slices,
+    mock_token,
+)
 from connector_tests import HttpMocker, HttpRequest, HttpResponse, assert_records_conform, load_fixture, read_stream
 
 _STREAM = "participants"
@@ -135,13 +147,12 @@ def test_pagination_multi_page(http_mocker: HttpMocker) -> None:
 
 
 @freezegun.freeze_time(_NOW)
-def test_full_refresh_substream_emits_no_cursor_state(http_mocker: HttpMocker) -> None:
-    """participants is a full-refresh substream: the CDK emits only the
-    no-cursor sentinel state, and in particular NO parent_state — this is why
-    `incremental_dependency` is deliberately absent from the ParentStreamConfig
-    (it only piggybacks the parent cursor on an incremental child's state; on a
-    full-refresh child it is a silent no-op — this test found that). Freshness
-    is instead bounded by the parent's now-150d slicing, re-read each sync."""
+def test_parent_state_persisted_in_child_state(http_mocker: HttpMocker) -> None:
+    """The child's cursor is a formality; what matters is that its state
+    message carries `parent_state` with the `_meetings` cursor (the max observed
+    end_time record value). A full-refresh child persists nothing — that
+    no-op was pinned by this suite before the cursor existed — so this assert
+    is what keeps the Heavy-quota fix from silently regressing."""
     config = ZoomConfigBuilder().build()
     mock_token(http_mocker)
     _mock_parent(http_mocker, [_meeting("mtg-uuid-1==", "2026-06-15T10:30:00Z")])
@@ -154,5 +165,47 @@ def test_full_refresh_substream_emits_no_cursor_state(http_mocker: HttpMocker) -
 
     assert output.state_messages, "read must close with a state message"
     final_state = output.state_messages[-1].state.stream.stream_state.__dict__
-    assert final_state.get("__ab_no_cursor_state_message") is True
-    assert "parent_state" not in final_state
+    assert "__ab_no_cursor_state_message" not in final_state
+    parent_state = final_state.get("parent_state")
+    assert parent_state == {"_meetings": {"end_time": "2026-06-15T10:30:00Z"}}, parent_state
+
+
+@freezegun.freeze_time(_NOW)
+def test_resume_enumerates_parent_from_saved_cursor(http_mocker: HttpMocker) -> None:
+    """Second sync, given the first sync's state: the parent must be requested
+    from the saved cursor minus its P7D lookback (exact from/to matcher — a
+    regression back to the full now-150d fan-out would issue requests no
+    matcher accepts), and participants are fetched only for the meetings that
+    enumeration returns. The emitted record's join_time predates the first
+    sync's records: nothing is filtered client-side — the child cursor gates
+    no data, only carries state."""
+    config = ZoomConfigBuilder().build()
+    mock_token(http_mocker)
+    _mock_parent(http_mocker, [_meeting("mtg-uuid-1==", "2026-06-16T10:30:00Z")])
+    http_mocker.get(
+        HttpRequest(_participants_url("mtg-uuid-1%3D%3D"), query_params=_CHILD_PARAMS),
+        _participants_page([_participant("part-1", "alice@example.com", join_time="2026-06-16T10:00:05Z")]),
+    )
+
+    first = read_stream(_CONNECTOR, _STREAM, config)
+    state = [m.state for m in first.state_messages][-1:]
+
+    # Resume: parent cursor 2026-06-16 minus lookback P7D -> from=2026-06-09.
+    resume_mocker = HttpMocker()
+    with resume_mocker:
+        mock_token(resume_mocker)
+        resume_mocker.get(
+            HttpRequest(METRICS_URL, query_params=metrics_params("2026-06-09", "2026-07-01")),
+            _meetings_page([_meeting("mtg-new==", "2026-06-20T10:30:00Z")]),
+        )
+        resume_mocker.get(
+            HttpRequest(_participants_url("mtg-new%3D%3D"), query_params=_CHILD_PARAMS),
+            _participants_page([_participant("part-2", "bob@example.com", join_time="2026-06-10T09:00:00Z")]),
+        )
+
+        second = read_stream(_CONNECTOR, _STREAM, config, state=state)
+
+        assert not second.errors
+        assert [r.record.data["participant_uuid"] for r in second.records] == ["part-2"]
+        final_state = second.state_messages[-1].state.stream.stream_state.__dict__
+        assert final_state.get("parent_state") == {"_meetings": {"end_time": "2026-06-20T10:30:00Z"}}


### PR DESCRIPTION
## Problem

After #1746 unblocked the zoom syncs on dev-vhc, they started tripping Zoom's Dashboard-API quota instead: job 538 succeeded only on attempt 2, job 541 spent hours in 429 retry loops (2026-07-14).

Root cause: `participants` is a substream whose private `_meetings` parent instance has **no persisted state** — parent state only survives piggybacked on an *incremental* child's state message, and `participants` was full-refresh (a no-op pinned by the mock suite in #1746). So **every sync re-enumerated the full now-150d window**: one `GET /v2/metrics/meetings/{uuid}/participants` per meeting ≈ **25k "Heavy" requests per sync** against the account-wide **60k/day** quota. Two syncs plus retry attempts (plus any manual full read) exhaust it; the CDK's six ~10s retries can't outwait a daily quota, so attempts fail.

## Fix

- `participants` gets a **formal `join_time` cursor**: no request options (the endpoint accepts no time filters) and no client-side filtering — it exists solely to make the stream stateful.
- `incremental_dependency: true` on the ParentStreamConfig now actually works: the `_meetings` cursor is persisted as `parent_state`, and each sync enumerates only meetings **newer than the saved cursor minus the parent's P7D lookback** — ~hundreds of Heavy requests per nightly sync instead of ~25k. Lookback duplicates dedup at read time as usual (bronze RMT + `LIMIT 1 BY`).
- **429 policy**: `ExponentialBackoffStrategy(factor 10)` fallback added after `WaitTimeFromHeader` on all four requesters — Zoom omits `Retry-After` on per-second throttles. Daily-quota 429s still fail the attempt (by design: Airbyte's attempt scheduling handles the wait better than an in-process sleep).
- Mock tests: the old "flag is a no-op" pin is replaced by its inverse — `test_parent_state_persisted_in_child_state` and `test_resume_enumerates_parent_from_saved_cursor` (exact from/to matchers prove the second sync's narrowed enumeration; a record older than the child cursor is still emitted, proving nothing is filtered).
- Descriptor 1.2.0, README note on the quota math.

First sync after deploy still does one full 150-day fan-out (no prior parent_state) — expected, same as today's every-sync cost; every following sync is cheap.

## Verification

- Mock suite: 36 passed / 1 skipped (pre-existing jira schema-drift skip)
- `validate-strict` + `validate`: green
- Existing connection state on dev-vhc is compatible: the participants stream simply gains state on its first post-deploy sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Zoom participant synchronization now uses incremental backfills, fetching participants only for recently updated meetings.
  - Saved progress enables synchronization to resume efficiently after interruptions.
  - Reduced unnecessary Zoom Dashboard API requests and improved handling of temporary API errors.
  - Participant records now use more complete identifiers for reliable tracking.
- **Documentation**
  - Updated Zoom connector documentation to explain incremental backfill behavior and API quota benefits.
- **Maintenance**
  - Updated the connector version to 1.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->