### PR TITLE
fix(seed): drop retired AI label cols + stale MV refresh from seed layer

### DIFF
--- a/deploy/seed/generators/ai.py
+++ b/deploy/seed/generators/ai.py
@@ -30,17 +30,19 @@ if TYPE_CHECKING:
 
 
 _DEV_TOOLS = (
-    # (tool string, tool_label, source_type key in profile weights)
-    ("cursor",       "Cursor",      "cursor"),
-    ("claude_code",  "Claude Code", "claude_team"),
+    # (tool string, source_type key in profile weights)
+    # tool_label derives in gold now (macros/ai_labels.sql), not seeded.
+    ("cursor", "cursor"),
+    ("claude_code", "claude_team"),
 )
 _ASSISTANT_TOOLS = (
-    # (tool string, surface, tool_label, surface_label, source_type key)
+    # (tool string, surface, source_type key in profile weights)
     # surface must be a canonical value the gold model filters on
     # (ai_metric_observations gates chat_assistant_conversations on
     # surface = 'chat'); 'web' is not in the surface enum.
-    ("chatgpt",       "chat", "ChatGPT", "Chat", "chatgpt"),
-    ("claude",        "chat", "Claude",  "Chat", "claude_team"),
+    # tool_label/surface_label derive in gold now, not seeded.
+    ("chatgpt", "chat", "chatgpt"),
+    ("claude", "chat", "claude_team"),
 )
 
 
@@ -52,14 +54,29 @@ def seed_ai_dev_usage(
 ) -> int:
     truncate(client, "silver", "class_ai_dev_usage")
     cols = [
-        "insight_tenant_id", "email", "day", "tool", "is_active",
-        "agent_sessions", "chat_requests", "tool_use_offered",
-        "tool_use_accepted", "lines_added", "lines_removed",
-        "total_lines_added", "total_lines_removed",
-        "accepted_lines_added", "spec_lines", "session_count",
-        "total_chat_messages", "cost_cents", "commits_count",
-        "pull_requests_count", "prs_with_cc_count", "prs_total_count",
-        "conversation_count", "tool_label",
+        "insight_tenant_id",
+        "email",
+        "day",
+        "tool",
+        "is_active",
+        "agent_sessions",
+        "chat_requests",
+        "tool_use_offered",
+        "tool_use_accepted",
+        "lines_added",
+        "lines_removed",
+        "total_lines_added",
+        "total_lines_removed",
+        "accepted_lines_added",
+        "spec_lines",
+        "session_count",
+        "total_chat_messages",
+        "cost_cents",
+        "commits_count",
+        "pull_requests_count",
+        "prs_with_cc_count",
+        "prs_total_count",
+        "conversation_count",
         "_version",
     ]
     rows: list[tuple[object, ...]] = []
@@ -69,7 +86,7 @@ def seed_ai_dev_usage(
             continue
         profile = TEAM_PROFILES[p.team]
         persona = persona_multiplier(p.uuid)
-        for tool, tool_label, src_key in _DEV_TOOLS:
+        for tool, src_key in _DEV_TOOLS:
             weight = profile.weights.get(src_key, 0)
             if weight <= 0:
                 continue
@@ -84,21 +101,34 @@ def seed_ai_dev_usage(
                 lines_add = min(int(accepted * rng.randint(3, 18)), 400)
                 lines_rem = int(lines_add * rng.uniform(0.2, 0.8))
                 cost = float(sessions) * rng.uniform(2.0, 12.0)
-                rows.append((
-                    tenant_uuid, p.email, d, tool, 1,
-                    float(sessions), float(sessions * rng.randint(2, 6)),
-                    float(offered), float(accepted),
-                    float(lines_add), float(lines_rem),
-                    float(lines_add), float(lines_rem),
-                    float(lines_add), 0.0, float(sessions),
-                    float(sessions * 4), round(cost, 2),
-                    float(rng.randint(0, 4)),
-                    float(rng.randint(0, 3)),
-                    float(rng.randint(0, 2)),
-                    float(rng.randint(0, 4)),
-                    float(sessions), tool_label,
-                    version,
-                ))
+                rows.append(
+                    (
+                        tenant_uuid,
+                        p.email,
+                        d,
+                        tool,
+                        1,
+                        float(sessions),
+                        float(sessions * rng.randint(2, 6)),
+                        float(offered),
+                        float(accepted),
+                        float(lines_add),
+                        float(lines_rem),
+                        float(lines_add),
+                        float(lines_rem),
+                        float(lines_add),
+                        0.0,
+                        float(sessions),
+                        float(sessions * 4),
+                        round(cost, 2),
+                        float(rng.randint(0, 4)),
+                        float(rng.randint(0, 3)),
+                        float(rng.randint(0, 2)),
+                        float(rng.randint(0, 4)),
+                        float(sessions),
+                        version,
+                    )
+                )
     return bulk_insert(client, "silver", "class_ai_dev_usage", cols, rows)
 
 
@@ -110,15 +140,32 @@ def seed_ai_assistant_usage(
 ) -> int:
     truncate(client, "silver", "class_ai_assistant_usage")
     cols = [
-        "insight_tenant_id", "source_id", "unique_key", "email", "day",
-        "tool", "surface", "tool_label", "surface_label",
-        "session_count", "conversation_count",
-        "message_count", "action_count", "files_uploaded_count",
-        "artifacts_created_count", "projects_created_count",
-        "projects_used_count", "skills_used_count", "connectors_used_count",
-        "thinking_message_count", "dispatch_turn_count", "search_count",
-        "cost_cents", "surface_metrics_json", "source", "data_source",
-        "collected_at", "_version",
+        "insight_tenant_id",
+        "source_id",
+        "unique_key",
+        "email",
+        "day",
+        "tool",
+        "surface",
+        "session_count",
+        "conversation_count",
+        "message_count",
+        "action_count",
+        "files_uploaded_count",
+        "artifacts_created_count",
+        "projects_created_count",
+        "projects_used_count",
+        "skills_used_count",
+        "connectors_used_count",
+        "thinking_message_count",
+        "dispatch_turn_count",
+        "search_count",
+        "cost_cents",
+        "surface_metrics_json",
+        "source",
+        "data_source",
+        "collected_at",
+        "_version",
     ]
     rows: list[tuple[object, ...]] = []
     version = 1
@@ -128,7 +175,7 @@ def seed_ai_assistant_usage(
             continue
         profile = TEAM_PROFILES[p.team]
         persona = persona_multiplier(p.uuid)
-        for tool, surface, tool_label, surface_label, src_key in _ASSISTANT_TOOLS:
+        for tool, surface, src_key in _ASSISTANT_TOOLS:
             weight = profile.weights.get(src_key, 0)
             if weight <= 0:
                 continue
@@ -140,19 +187,36 @@ def seed_ai_assistant_usage(
                     continue
                 msgs = sessions * rng.randint(4, 14)
                 conversations = max(1, int(sessions * rng.uniform(0.6, 1.0)))
-                rows.append((
-                    tenant_uuid,
-                    deterministic_uuid("ai.assistant.src", p.uuid, tool),
-                    deterministic_uuid("ai.assistant.row", p.uuid, d.isoformat(), tool),
-                    p.email, d, tool, surface, tool_label, surface_label,
-                    sessions, conversations, msgs,
-                    sessions * 2,
-                    rng.randint(0, 3), rng.randint(0, 2), rng.randint(0, 1),
-                    rng.randint(0, 3), rng.randint(0, 4), rng.randint(0, 2),
-                    sessions, sessions, msgs // 3,
-                    int(sessions * rng.uniform(3.0, 9.0)),
-                    None, tool, tool, now, version,
-                ))
+                rows.append(
+                    (
+                        tenant_uuid,
+                        deterministic_uuid("ai.assistant.src", p.uuid, tool),
+                        deterministic_uuid("ai.assistant.row", p.uuid, d.isoformat(), tool),
+                        p.email,
+                        d,
+                        tool,
+                        surface,
+                        sessions,
+                        conversations,
+                        msgs,
+                        sessions * 2,
+                        rng.randint(0, 3),
+                        rng.randint(0, 2),
+                        rng.randint(0, 1),
+                        rng.randint(0, 3),
+                        rng.randint(0, 4),
+                        rng.randint(0, 2),
+                        sessions,
+                        sessions,
+                        msgs // 3,
+                        int(sessions * rng.uniform(3.0, 9.0)),
+                        None,
+                        tool,
+                        tool,
+                        now,
+                        version,
+                    )
+                )
     return bulk_insert(client, "silver", "class_ai_assistant_usage", cols, rows)
 
 
@@ -163,6 +227,8 @@ def generate(
     days: int,
 ) -> dict[str, int]:
     return {
-        "silver.class_ai_dev_usage":       seed_ai_dev_usage(client, roster, tenant_uuid, days),
-        "silver.class_ai_assistant_usage": seed_ai_assistant_usage(client, roster, tenant_uuid, days),
+        "silver.class_ai_dev_usage": seed_ai_dev_usage(client, roster, tenant_uuid, days),
+        "silver.class_ai_assistant_usage": seed_ai_assistant_usage(
+            client, roster, tenant_uuid, days
+        ),
     }

--- a/deploy/seed/generators/task.py
+++ b/deploy/seed/generators/task.py
@@ -40,8 +40,10 @@ if TYPE_CHECKING:
 
 def _task_persons(roster: Sequence[Person]) -> list[Person]:
     return [
-        p for p in roster
-        if p.team and (
+        p
+        for p in roster
+        if p.team
+        and (
             TEAM_PROFILES[p.team].weights.get("jira", 0) > 0
             or TEAM_PROFILES[p.team].weights.get("zendesk-placeholder", 0) > 0
         )
@@ -56,9 +58,17 @@ def seed_task_worklogs(
 ) -> int:
     truncate(client, "silver", "class_task_worklogs")
     cols = [
-        "insight_tenant_id", "insight_source_id", "worklog_id",
-        "issue_id", "author_id", "author_email", "work_date",
-        "duration_seconds", "worklog_seconds", "unique_key", "_version",
+        "insight_tenant_id",
+        "insight_source_id",
+        "worklog_id",
+        "issue_id",
+        "author_id",
+        "author_email",
+        "work_date",
+        "duration_seconds",
+        "worklog_seconds",
+        "unique_key",
+        "_version",
     ]
     rows: list[tuple[object, ...]] = []
     version = 1
@@ -87,14 +97,21 @@ def seed_task_worklogs(
                 spent += duration
                 worklog_id = deterministic_uuid("task.worklog", p.uuid, d.isoformat(), str(i))
                 issue_id = f"INSIGHT-{rng.randint(1000, 9999)}"
-                rows.append((
-                    tenant_uuid,
-                    deterministic_uuid("task.source", p.uuid),
-                    worklog_id, issue_id,
-                    p.email, p.email, d,
-                    float(duration), float(duration),
-                    worklog_id, version,
-                ))
+                rows.append(
+                    (
+                        tenant_uuid,
+                        deterministic_uuid("task.source", p.uuid),
+                        worklog_id,
+                        issue_id,
+                        p.email,
+                        p.email,
+                        d,
+                        float(duration),
+                        float(duration),
+                        worklog_id,
+                        version,
+                    )
+                )
     return bulk_insert(client, "silver", "class_task_worklogs", cols, rows)
 
 
@@ -107,8 +124,12 @@ def seed_task_users(
     on insight_source_id + user_id) actually emits rows."""
     truncate(client, "silver", "class_task_users")
     cols = [
-        "insight_tenant_id", "insight_source_id", "user_id", "email",
-        "unique_key", "_version",
+        "insight_tenant_id",
+        "insight_source_id",
+        "user_id",
+        "email",
+        "unique_key",
+        "_version",
     ]
     rows: list[tuple[object, ...]] = []
     version = 1
@@ -116,10 +137,16 @@ def seed_task_users(
         src_id = deterministic_uuid("task.source", p.uuid)
         # author_id in class_task_worklogs == p.email — mirror that here so
         # the JOIN matches.
-        rows.append((
-            tenant_uuid, src_id, p.email, p.email,
-            deterministic_uuid("task.user", p.uuid), version,
-        ))
+        rows.append(
+            (
+                tenant_uuid,
+                src_id,
+                p.email,
+                p.email,
+                deterministic_uuid("task.user", p.uuid),
+                version,
+            )
+        )
     return bulk_insert(client, "silver", "class_task_users", cols, rows)
 
 
@@ -136,9 +163,9 @@ _CLOSE_STATUSES = ("Closed", "Resolved", "Verified")
 # status_category values are the reconciled set: new / in_progress / done.
 _STATUS_DIM = {
     # status_name: (status_id, status_category)
-    "To Do":    ("1",     "new"),
-    "Closed":   ("6",     "done"),
-    "Resolved": ("5",     "done"),
+    "To Do": ("1", "new"),
+    "Closed": ("6", "done"),
+    "Resolved": ("5", "done"),
     "Verified": ("10001", "done"),
 }
 _STATUS_CATEGORY_ID = {"new": 2, "in_progress": 4, "done": 3, "undefined": 1}
@@ -184,14 +211,27 @@ def _fh_row(
     event_id = deterministic_uuid("task.fh", issue_id, field_id, str(seq))
     return (
         deterministic_uuid("task.fh.uk", issue_id, field_id, str(seq)),
-        src_id, data_source, issue_id,
+        src_id,
+        data_source,
+        issue_id,
         f"INSIGHT-{issue_id[-4:]}",
-        event_id, event_at, event_kind, seq,
-        author_id, author_id,
-        field_id, field_name, "single", "set",
-        value_id, value_display,
-        value_ids, value_displays,
-        _value_id_type(field_id), event_at, 1,
+        event_id,
+        event_at,
+        event_kind,
+        seq,
+        author_id,
+        author_id,
+        field_id,
+        field_name,
+        "single",
+        "set",
+        value_id,
+        value_display,
+        value_ids,
+        value_displays,
+        _value_id_type(field_id),
+        event_at,
+        1,
     )
 
 
@@ -206,12 +246,28 @@ def seed_task_field_history(
     closing it."""
     truncate(client, "silver", "class_task_field_history")
     cols = [
-        "unique_key", "insight_source_id", "data_source", "issue_id",
-        "id_readable", "event_id", "event_at", "event_kind", "_seq",
-        "author_id", "author_display", "field_id", "field_name",
-        "field_cardinality", "delta_action", "delta_value_id",
-        "delta_value_display", "value_ids", "value_displays",
-        "value_id_type", "collected_at", "_version",
+        "unique_key",
+        "insight_source_id",
+        "data_source",
+        "issue_id",
+        "id_readable",
+        "event_id",
+        "event_at",
+        "event_kind",
+        "_seq",
+        "author_id",
+        "author_display",
+        "field_id",
+        "field_name",
+        "field_cardinality",
+        "delta_action",
+        "delta_value_id",
+        "delta_value_display",
+        "value_ids",
+        "value_displays",
+        "value_id_type",
+        "collected_at",
+        "_version",
     ]
     rows: list[tuple[object, ...]] = []
     window = days_window(days)
@@ -235,7 +291,8 @@ def seed_task_field_history(
                 issue_type = _ISSUE_TYPES[rng.randint(0, len(_ISSUE_TYPES) - 1)]
                 priority = _PRIORITIES[rng.randint(0, len(_PRIORITIES) - 1)]
                 created_at = _dt.datetime.combine(
-                    created_day, _dt.time(9 + rng.randint(0, 8), rng.randint(0, 59)),
+                    created_day,
+                    _dt.time(9 + rng.randint(0, 8), rng.randint(0, 59)),
                 )
                 est_seconds = float(rng.randint(2, 16) * 3600)
                 spent_seconds = float(est_seconds * rng.uniform(0.5, 1.5))
@@ -247,20 +304,26 @@ def seed_task_field_history(
                     ("issuetype", "Issue Type", None, issue_type),
                     ("priority", "Priority", None, priority),
                     ("duedate", "Due Date", None, due_date),
-                    ("timeoriginalestimate", "Original Estimate",
-                     None, str(int(est_seconds))),
-                    ("timespent", "Time Spent",
-                     None, str(int(spent_seconds))),
+                    ("timeoriginalestimate", "Original Estimate", None, str(int(est_seconds))),
+                    ("timespent", "Time Spent", None, str(int(spent_seconds))),
                 ]
                 for seq, (fid, fname, vid, vdisp) in enumerate(base_fields):
-                    rows.append(_fh_row(
-                        tenant_uuid=tenant_uuid, src_id=src_id,
-                        data_source=data_source, issue_id=issue_id,
-                        event_at=created_at, event_kind="synthetic_initial",
-                        field_id=fid, field_name=fname,
-                        value_id=vid, value_display=vdisp,
-                        author_id=p.email, seq=seq,
-                    ))
+                    rows.append(
+                        _fh_row(
+                            tenant_uuid=tenant_uuid,
+                            src_id=src_id,
+                            data_source=data_source,
+                            issue_id=issue_id,
+                            event_at=created_at,
+                            event_kind="synthetic_initial",
+                            field_id=fid,
+                            field_name=fname,
+                            value_id=vid,
+                            value_display=vdisp,
+                            author_id=p.email,
+                            seq=seq,
+                        )
+                    )
                 # ~55% of issues get closed before today.
                 if rng.random() < 0.55:
                     days_to_close = rng.randint(3, 28)
@@ -269,17 +332,25 @@ def seed_task_field_history(
                     if close_day < today:
                         close_status = _CLOSE_STATUSES[rng.randint(0, len(_CLOSE_STATUSES) - 1)]
                         close_at = _dt.datetime.combine(
-                            close_day, _dt.time(rng.randint(10, 17), rng.randint(0, 59)),
+                            close_day,
+                            _dt.time(rng.randint(10, 17), rng.randint(0, 59)),
                         )
-                        rows.append(_fh_row(
-                            tenant_uuid=tenant_uuid, src_id=src_id,
-                            data_source=data_source, issue_id=issue_id,
-                            event_at=close_at, event_kind="changelog",
-                            field_id="status", field_name="Status",
-                            value_id=_STATUS_DIM[close_status][0],
-                            value_display=close_status,
-                            author_id=p.email, seq=100,
-                        ))
+                        rows.append(
+                            _fh_row(
+                                tenant_uuid=tenant_uuid,
+                                src_id=src_id,
+                                data_source=data_source,
+                                issue_id=issue_id,
+                                event_at=close_at,
+                                event_kind="changelog",
+                                field_id="status",
+                                field_name="Status",
+                                value_id=_STATUS_DIM[close_status][0],
+                                value_display=close_status,
+                                author_id=p.email,
+                                seq=100,
+                            )
+                        )
 
     return bulk_insert(client, "silver", "class_task_field_history", cols, rows)
 
@@ -294,9 +365,16 @@ def seed_class_task_statuses(
     jira_closed_tasks (which filters status_category = 'done') is empty."""
     truncate(client, "silver", "class_task_statuses")
     cols = [
-        "insight_source_id", "data_source", "status_id", "status_name",
-        "category_id", "category_key", "status_category", "collected_at",
-        "unique_key", "_version",
+        "insight_source_id",
+        "data_source",
+        "status_id",
+        "status_name",
+        "category_id",
+        "category_key",
+        "status_category",
+        "collected_at",
+        "unique_key",
+        "_version",
     ]
     now = _dt.datetime.now(_dt.UTC).replace(tzinfo=None)
     rows: list[tuple[object, ...]] = []
@@ -304,21 +382,32 @@ def seed_class_task_statuses(
         src_id = deterministic_uuid("task.source", p.uuid)
         data_source = _task_data_source(p.team)
         for name, (status_id, category) in _STATUS_DIM.items():
-            rows.append((
-                src_id, data_source, status_id, name,
-                _STATUS_CATEGORY_ID[category], category, category, now,
-                deterministic_uuid("task.status", src_id, status_id), 1,
-            ))
+            rows.append(
+                (
+                    src_id,
+                    data_source,
+                    status_id,
+                    name,
+                    _STATUS_CATEGORY_ID[category],
+                    category,
+                    category,
+                    now,
+                    deterministic_uuid("task.status", src_id, status_id),
+                    1,
+                )
+            )
     return bulk_insert(client, "silver", "class_task_statuses", cols, rows)
 
 
 # Refreshable materialized views that derive from class_task_field_history.
 # Listed explicitly so a CH version mismatch errors loudly here rather than
 # leaving downstream metrics stale until the scheduled refresh tick.
-_TASK_REFRESHABLE_MVS = (
-    "insight.task_issue_current_state",
-    "insight.task_status_intervals",
-)
+# NOTE: task_status_intervals is NOT here — the migration creates it as a
+# stub (so that migration's own downstream CREATE VIEWs type-check), but it
+# is a dbt-owned gold *table* now (gold/task_status_intervals.sql), rebuilt
+# fresh over seeded silver by `dbt run --select tag:gold` in
+# apply-ch-migrations.sh. SYSTEM REFRESH VIEW on a table errors.
+_TASK_REFRESHABLE_MVS = ("insight.task_issue_current_state",)
 
 
 def refresh_dependent_mvs(client: clickhouse_connect.driver.client.Client) -> None:
@@ -337,14 +426,15 @@ def generate(
     tenant_uuid: str,
     days: int,
 ) -> dict[str, int]:
-    totals = {
-        "silver.class_task_worklogs":      seed_task_worklogs(client, roster, tenant_uuid, days),
-        "silver.class_task_users":         seed_task_users(client, roster, tenant_uuid),
-        "silver.class_task_field_history": seed_task_field_history(client, roster, tenant_uuid, days),
-        "silver.class_task_statuses":      seed_class_task_statuses(client, roster),
-    }
     # NOTE: the refreshable MVs these rows feed (see refresh_dependent_mvs)
     # are created by apply-ch-migrations.sh, which the orchestrator runs
     # AFTER seeding — so the refresh is triggered by silver.run() once the
     # migrations exist, not here. See silver.py.
-    return totals
+    return {
+        "silver.class_task_worklogs": seed_task_worklogs(client, roster, tenant_uuid, days),
+        "silver.class_task_users": seed_task_users(client, roster, tenant_uuid),
+        "silver.class_task_field_history": seed_task_field_history(
+            client, roster, tenant_uuid, days
+        ),
+        "silver.class_task_statuses": seed_class_task_statuses(client, roster),
+    }


### PR DESCRIPTION
## Problem
`./dev-compose.sh seed all` (and the k8s CH-migrate seed) dies in the silver generator:

```
clickhouse_connect.driver.exceptions.ProgrammingError:
Unrecognized column 'tool_label' in table class_ai_dev_usage
```

The `20260716000000_class_contract_heal` migration removed the derived-label columns from the AI silver tables — labels now derive in gold (`dbt/macros/ai_labels.sql`), so the columns left the contract. The seed generators still wrote them.

## Fix (seed layer only)
**`deploy/seed/generators/ai.py`** — match the healed silver contract:
- `seed_ai_dev_usage`: drop `tool_label` from `cols` + row tuples.
- `seed_ai_assistant_usage`: drop `tool_label` and `surface_label`.
- Retire the now-unused label fields from `_DEV_TOOLS` / `_ASSISTANT_TOOLS`.

**`deploy/seed/generators/task.py`** — a second seed-layer staleness the `tool_label` error had masked (it aborted the run earlier). The recent `perf(gold)` change made `insight.task_status_intervals` a dbt-owned gold **table**, but `_TASK_REFRESHABLE_MVS` still listed it and issued `SYSTEM REFRESH VIEW` on it, which errors on a table. Removed it — the migration still creates it as a stub so its own downstream `CREATE VIEW`s type-check, and dbt rebuilds it fresh over seeded silver, so no refresh is needed. `task_issue_current_state` (a genuine migration-owned refreshable MV) stays.

## Audit
Statically cross-checked **every** generator's `cols` against the live healed silver schema (`system.columns` after placeholders + all migrations). `ai.py` was the only column drift. Tuple arity `== len(cols)` verified for both AI functions.

## Verification (real end-to-end)
`./dev-compose.sh seed all` reaches `DONE: silver rows seeded + gold layer built` with no Unrecognized-column and no refresh error. Data confirmed: `class_ai_dev_usage` 973 rows, `class_ai_assistant_usage` 1464 rows, `task_status_intervals` (gold table) 804 rows, `task_issue_current_state` MV refreshed. `pre-commit run` passes (ruff check + format green).

## Follow-up (not in this PR)
Migrations `20260429` / `20260708` do `DROP VIEW IF EXISTS insight.task_status_intervals` *before* `DROP TABLE`. On a re-run where a prior run left it as a dbt table, `DROP VIEW` on a table errors (Code 80) before `DROP TABLE` is reached (fresh cluster is unaffected). Worth reordering `DROP TABLE` first in a future migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of AI usage reporting by deriving tool and surface labels from identifiers.
  * Updated seeded AI usage data to align with the current reporting schema.
  * Refined task status data refresh behavior for more reliable issue-state reporting.

* **Chores**
  * Improved the consistency and readability of seeded task and usage data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->