### PR TITLE
ci(security): Trivy scan gate — misconfig + fs + image, report-only (#1796)

### DIFF
--- a/.github/workflows/security-trivy-image.yml
+++ b/.github/workflows/security-trivy-image.yml
@@ -1,0 +1,95 @@
+# Security — Trivy image scanning (umbrella #1478; sibling to #1796's config+fs gate).
+#
+# Scans the BUILT container images this repo publishes for OS-package + installed-
+# library vulnerabilities (Trivy `image`) — the coverage that config (Dockerfile
+# text) and fs (source lockfiles) scans cannot see.
+#
+# STATUS: REPORT-ONLY (exit-code "0") — findings surface in the job summary but
+# never fail the build. This is the first stage of its own ratchet; flip to
+# exit-code "1" + a required check once an image baseline is triaged and agreed.
+#
+# Runs on the nightly schedule + manual dispatch ONLY: images are published to
+# GHCR on `main` by build-images.yml, so there is nothing new to scan per-PR.
+# Images are enumerated (5 backend/toolbox services + descriptor-discovered
+# connectors, ADR-0016) and pulled from ghcr.io/constructorfabric/<name>:latest.
+# (Frontend builds in a separate repo and is out of scope here.) Honors
+# .trivyignore when present.
+name: Security — Trivy image
+
+on:
+  schedule:
+    - cron: "0 4 * * *" # nightly, 04:00 UTC (offset from the config/fs gate at 03:00)
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # Enumerate the container images this repo builds: the 5 static backend/toolbox
+  # services plus every descriptor-discovered connector image (ADR-0016), reusing
+  # the repo's own discovery script so the list never drifts from build-images.yml.
+  discover-images:
+    name: Discover built image names
+    runs-on: ubuntu-latest
+    outputs:
+      images: ${{ steps.list.outputs.images }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install PyYAML
+        run: python3 -m pip install --quiet pyyaml
+      - name: Enumerate images (static services + discovered connectors)
+        id: list
+        run: |
+          set -euo pipefail
+          STATIC='["insight-api-gateway","insight-analytics","insight-authenticator","insight-identity","insight-toolbox"]'
+          CONNECTORS="$(python3 .github/workflows/scripts/discover-image-matrix.py \
+            --connectors-root src/ingestion/connectors --all \
+            | jq -c '[.[].name] | unique')"
+          IMAGES="$(jq -cn --argjson a "$STATIC" --argjson b "$CONNECTORS" '($a + $b) | unique')"
+          echo "images=$IMAGES" >> "$GITHUB_OUTPUT"
+          echo "Images to scan:"; echo "$IMAGES" | jq -r '.[]'
+
+  # One matrix leg per image so a single noisy image doesn't hide the rest.
+  # GITHUB_TOKEN + packages:read pulls the org's private GHCR images.
+  trivy-image:
+    name: Trivy image (${{ matrix.image }})
+    needs: discover-images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ${{ fromJson(needs.discover-images.outputs.images) }}
+    steps:
+      - uses: actions/checkout@v5 # provides .trivyignore when present
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Trivy image scan (report-only)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: image
+          image-ref: ghcr.io/constructorfabric/${{ matrix.image }}:latest
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "0" # report-only; flip to "1" once the image baseline is agreed
+          format: table
+          output: trivy-image.txt
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "## Trivy image — ${{ matrix.image }}:latest (report-only)"
+            echo '```'
+            cat trivy-image.txt 2>/dev/null || echo "(no output produced)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/security-trivy.yml
+++ b/.github/workflows/security-trivy.yml
@@ -1,0 +1,83 @@
+# Security — Trivy (issue #1796, part of security-scanner umbrella #1478).
+#
+# Two scans over the whole repo at CRITICAL,HIGH severity:
+#   - trivy-config: IaC + Dockerfile misconfiguration (Trivy `config`).
+#   - trivy-fs:     filesystem vulnerabilities (Trivy `fs`, unfixed suppressed).
+#
+# STATUS: REPORT-ONLY (both jobs, exit-code "0") — findings are surfaced in the
+# job summary but never fail the build. This is the first stage of the #1796
+# ratchet: report-only first, then flip to blocking once the team agrees on the
+# baseline. A local baseline triage (#1796) found all config misconfigs covered
+# by .trivyignore waivers and the fs scan clean, so the follow-up flip to
+# exit-code "1" on CRITICAL,HIGH is expected to be zero-disruption. When flipping,
+# also add "Trivy config (IaC + Dockerfile misconfig)" and "Trivy fs (filesystem
+# vulnerabilities)" as REQUIRED status checks on main (branch protection).
+# Waivers live in .trivyignore (tracked in #1340).
+name: Security — Trivy
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 3 * * *" # nightly, 03:00 UTC
+  workflow_dispatch:
+
+# A new push obsoletes any run still in flight for the same ref — cancel it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Read-only: report-only scanning needs no write scopes. Add security-events:
+# write only if a SARIF upload to code-scanning is introduced later.
+permissions:
+  contents: read
+
+jobs:
+  trivy-config:
+    name: Trivy config (IaC + Dockerfile misconfig)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Trivy config scan (report-only)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: config
+          scan-ref: .
+          severity: CRITICAL,HIGH
+          exit-code: "0" # report-only; flip to "1" once the baseline is agreed (#1796)
+          format: table
+          output: trivy-config.txt
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "## Trivy config findings (report-only)"
+            echo '```'
+            cat trivy-config.txt 2>/dev/null || echo "(no output produced)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  trivy-fs:
+    name: Trivy fs (filesystem vulnerabilities)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Trivy fs scan (report-only)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "0" # report-only; flip to "1" once the baseline is agreed (#1796)
+          format: table
+          output: trivy-fs.txt
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "## Trivy fs findings (report-only)"
+            echo '```'
+            cat trivy-fs.txt 2>/dev/null || echo "(no output produced)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,28 @@
+# .trivyignore — Trivy misconfiguration waivers.
+#
+# POLICY: every entry below MUST be a documented, tracked waiver. No undocumented
+# suppressions. Each waiver is tracked in constructorfabric/insight#1340 and MUST
+# be removed as its underlying issue is fixed. See issue #1796 for context.
+
+# AVD-DS-0002 — image runs as root (build/test/tooling images that set no USER):
+#   deploy/seed/Dockerfile
+#   src/ingestion/tools/toolbox/Dockerfile
+#   src/ingestion/tools/declarative-connector/Dockerfile
+#   src/ingestion/tests/e2e/compose/Dockerfile.runner
+#   Tracked: #1340. Remove once these images drop to a non-root USER.
+AVD-DS-0002
+
+# AVD-DS-0029 — apt-get install without --no-install-recommends
+#   (src/ingestion/tools/toolbox/Dockerfile: the `apt-get install -y nodejs` line).
+#   Tracked: #1340. Remove once that line adds --no-install-recommends.
+AVD-DS-0029
+
+# AVD-KSV-0118 — Deployment missing securityContext
+#   (src/frontend/helm/templates/deployment.yaml). Tracked: #1340.
+#   Remove once a securityContext is set on the pod/containers.
+AVD-KSV-0118
+
+# AVD-KSV-0014 — root filesystem not read-only
+#   (src/frontend/helm/templates/deployment.yaml). Tracked: #1340.
+#   Remove once readOnlyRootFilesystem: true is set.
+AVD-KSV-0014


### PR DESCRIPTION
Implements #1796 (part of security-scanner umbrella #1478; split from closed PR #1463).

## What
Three Trivy scans, all `CRITICAL,HIGH`, `aquasecurity/trivy-action` SHA-pinned (`@ed142fd…c25` # v0.36.0), findings in the job summary:

- **`.github/workflows/security-trivy.yml`** — runs on PR→`main` + nightly + dispatch:
  - `trivy-config` — IaC + Dockerfile misconfiguration (`scan-type: config`, `scan-ref: .`).
  - `trivy-fs` — filesystem vulnerabilities (`scan-type: fs`, `ignore-unfixed: true`).
- **`.github/workflows/security-trivy-image.yml`** — runs nightly + dispatch only (images publish on `main`, nothing to scan per-PR):
  - `trivy-image` — built-image vulnerabilities (OS packages + installed libs) over the 12 images this repo ships (5 services + `insight-jira-enrich` + 6 `source-*` connectors), enumerated via `discover-image-matrix.py`, pulled from `ghcr.io/constructorfabric/<name>:latest`.
- **`.trivyignore`** — 4 documented, tracked waivers → #1340: `AVD-DS-0002`, `AVD-DS-0029`, `AVD-KSV-0118`, `AVD-KSV-0014`.

## Report-only first (the ratchet)
All scans run `exit-code: "0"` — surfaced, non-blocking. Local baseline (Trivy v0.72.0): config = 8 HIGH, all waived, 0 actionable; fs = 0 (Rust `Cargo.lock` only — Python/.NET deps lack committed lockfiles; the image scan is the coverage answer for those). Image baseline pending its first published-image run.

## Follow-ups
- Triage the image baseline, then flip each scan to `exit-code: "1"` + required checks once the team agrees.
- Widen `trivy fs` coverage or rely on the image scan for Python/.NET.

## Acceptance criteria (#1796)
- [x] config + fs on PR→main + nightly, in the job summary
- [x] image scan on nightly + dispatch over every built image, in the job summary
- [x] `.trivyignore` with documented, tracked waivers only
- [x] baseline triaged (config + fs; image pending first run)
- [ ] gate threshold agreed + flip to blocking (follow-up)
