### PR TITLE
fix(ingestion): exclude vendored/generated files from authored git LOC (#1798)

### DIFF
--- a/src/ingestion/dbt/dbt_project.yml
+++ b/src/ingestion/dbt/dbt_project.yml
@@ -59,11 +59,22 @@ vars:
     - '\\.generated\\.'
     - '\\.designer\\.cs$'
     - '\\.d\\.ts$'
+    # lockfiles / machine-managed manifests (checked before the `config`
+    # branch, so all lockfiles land in one auditable `vendored` bucket)
     - '(^|/)go\\.sum$'
     - '(^|/)Cargo\\.lock$'
     - '(^|/)composer\\.lock$'
     - '(^|/)Gemfile\\.lock$'
     - '(^|/)pnpm-lock\\.yaml$'
+    - '(^|/)package-lock\\.json$'
+    - '(^|/)npm-shrinkwrap\\.json$'
+    - '(^|/)yarn\\.lock$'
+    - '(^|/)poetry\\.lock$'
+    - '(^|/)Pipfile\\.lock$'
+    - '(^|/)packages\\.lock\\.json$'
+    - '(^|/)gradle\\.lockfile$'
+    - '(^|/)mix\\.lock$'
+    - '(^|/)flake\\.lock$'
 
 # on-run-start hooks:
 #  - create_task_field_history_staging:

--- a/src/ingestion/dbt/dbt_project.yml
+++ b/src/ingestion/dbt/dbt_project.yml
@@ -17,6 +17,54 @@ clean-targets:
   - target
   - dbt_packages
 
+vars:
+  # Path patterns (ClickHouse `match` / RE2 regex fragments, matched
+  # case-insensitively) that mark a git file as vendored/generated rather than
+  # authored. Files matching any pattern are classified `vendored` by the
+  # shared `git_file_category` macro and so are excluded from authored
+  # line-count metrics (code_loc / clean_loc / code_lines_added) while still
+  # being retained — and auditable — under the `vendored` category in the
+  # total lines_added breakdown. Override per deployment to extend coverage.
+  # NOTE: values are RE2 fragments embedded into a ClickHouse SQL *string
+  # literal*, so backslashes are doubled (`\\.` -> ClickHouse unescapes to
+  # `\.` -> RE2 sees a literal dot), matching the convention in the other
+  # hand-written regexes in git_file_category.sql. Single-quoted YAML keeps the
+  # doubled backslashes verbatim.
+  git_vendored_path_patterns:
+    # dependency / vendored trees
+    - '(^|/)node_modules/'
+    - '(^|/)bower_components/'
+    - '(^|/)vendor/'
+    - '(^|/)third_party/'
+    - '(^|/)Pods/'
+    - '(^|/)\\.venv/'
+    - '(^|/)site-packages/'
+    - '(^|/)Carthage/'
+    # build / generated output
+    - '(^|/)dist/'
+    - '(^|/)build/'
+    - '(^|/)out/'
+    - '(^|/)target/'
+    - '(^|/)bin/'
+    - '(^|/)obj/'
+    - '(^|/)\\.next/'
+    - '(^|/)\\.nuxt/'
+    - '(^|/)__pycache__/'
+    - '(^|/)(__generated__|generated|gen)/'
+    - '(^|/)coverage/'
+    # generated / minified single files
+    - '\\.min\\.(js|css)$'
+    - '\\.(pb|pb\\.go)$'
+    - '\\.g\\.(dart|cs)$'
+    - '\\.generated\\.'
+    - '\\.designer\\.cs$'
+    - '\\.d\\.ts$'
+    - '(^|/)go\\.sum$'
+    - '(^|/)Cargo\\.lock$'
+    - '(^|/)composer\\.lock$'
+    - '(^|/)Gemfile\\.lock$'
+    - '(^|/)pnpm-lock\\.yaml$'
+
 # on-run-start hooks:
 #  - create_task_field_history_staging:
 #      DDL for `staging.jira__task_field_history` (Rust-owned table, ADR-003).

--- a/src/ingestion/dbt/macros/git_file_category.sql
+++ b/src/ingestion/dbt/macros/git_file_category.sql
@@ -3,12 +3,24 @@
    baked at staging time would only apply to newly synced rows; computed in
    a gold view it applies retroactively on every read.
 
-   Precedence: test -> docs -> config -> code. A `.yaml` under `tests/` is
-   test; a `.md` under `docs/` is docs. Labels are static product
-   vocabulary, not source data. #}
+   Precedence: vendored -> test -> docs -> config -> code. `vendored` wins
+   over everything so machine-produced content (vendored deps, build output,
+   generated code, minified assets) never inflates authored line counts, no
+   matter its extension or folder — a `.js` under `node_modules/` is vendored,
+   not code. A `.yaml` under `tests/` is test; a `.md` under `docs/` is docs.
+   Labels are static product vocabulary, not source data. #}
+
+{# Single source of truth for the vendored/generated path patterns, shared by
+   every classifier call site so the exclusion is defined once and applied
+   consistently. Patterns are configurable via the `git_vendored_path_patterns`
+   dbt var (see dbt_project.yml) so the list evolves without a code change. #}
+{% macro git_vendored_path_regex() -%}
+'(?i)(' ~ (var('git_vendored_path_patterns') | join('|')) ~ ')'
+{%- endmacro %}
 
 {% macro git_file_category(path_expr) %}
 multiIf(
+    match({{ path_expr }}, {{ git_vendored_path_regex() }}), 'vendored',
     match({{ path_expr }}, '(?i)(\\.spec\\.|\\.test\\.|__tests__/|(^|/)tests?/)'), 'test',
     match({{ path_expr }}, '(?i)(\\.(md|rst|adoc)$|(^|/)docs/)'), 'docs',
     match({{ path_expr }}, '(?i)(\\.lock$|package-lock\\.json|yarn\\.lock|poetry\\.lock|\\.ya?ml$|\\.toml$|\\.cfg$|\\.ini$)'), 'config',
@@ -22,6 +34,7 @@ multiIf(
     {{ category_expr }} = 'test', 'Tests',
     {{ category_expr }} = 'config', 'Configuration',
     {{ category_expr }} = 'docs', 'Documentation',
+    {{ category_expr }} = 'vendored', 'Vendored / Generated',
     {{ category_expr }}
 )
 {% endmacro %}

--- a/src/ingestion/dbt/macros/git_file_category.sql
+++ b/src/ingestion/dbt/macros/git_file_category.sql
@@ -15,7 +15,16 @@
    consistently. Patterns are configurable via the `git_vendored_path_patterns`
    dbt var (see dbt_project.yml) so the list evolves without a code change. #}
 {% macro git_vendored_path_regex() -%}
-'(?i)(' ~ (var('git_vendored_path_patterns') | join('|')) ~ ')'
+{%- set patterns = var('git_vendored_path_patterns') -%}
+{%- if patterns | length == 0 -%}
+{# Empty override disables the exclusion. Emit a never-match pattern rather
+   than an empty group `(?i)()`, which would match every path and flag all
+   files as vendored. `[^\s\S]` is the RE2-safe never-match (RE2 has no
+   lookahead), doubled-escaped for the ClickHouse string literal. #}
+'[^\\s\\S]'
+{%- else -%}
+'(?i)(' ~ (patterns | join('|')) ~ ')'
+{%- endif -%}
 {%- endmacro %}
 
 {% macro git_file_category(path_expr) %}

--- a/src/ingestion/dbt/tests/gold/assert_git_file_category_vendored.sql
+++ b/src/ingestion/dbt/tests/gold/assert_git_file_category_vendored.sql
@@ -1,0 +1,38 @@
+-- Data-independent contract test for the shared `git_file_category` macro:
+-- representative vendored/generated paths must classify as `vendored` (so they
+-- drop out of authored line-count metrics), and representative authored paths
+-- must NOT. Runs against a literal fixture set so it holds on a fresh cluster
+-- with no ingested data. Any mismatch fails `dbt build` (untagged -> error).
+WITH fixtures AS (
+    SELECT
+        tupleElement(row, 1) AS path,
+        tupleElement(row, 2) AS expected
+    FROM (
+        SELECT arrayJoin([
+            -- (path, expected_category)
+            ('node_modules/react/index.js', 'vendored'),
+            ('app/vendor/jquery.js', 'vendored'),
+            ('src/__generated__/schema.ts', 'vendored'),
+            ('dist/bundle.min.js', 'vendored'),
+            ('proto/user.pb.go', 'vendored'),
+            ('lib/model.g.dart', 'vendored'),
+            ('go.sum', 'vendored'),
+            ('frontend/pnpm-lock.yaml', 'vendored'),
+            ('services/.venv/lib/site-packages/foo.py', 'vendored'),
+            ('api/types.d.ts', 'vendored'),
+            ('src/app/main.py', 'code'),
+            ('src/components/Button.tsx', 'code'),
+            ('lib/vendorize.py', 'code'),
+            ('src/building_blocks/x.js', 'code'),
+            ('README.md', 'docs'),
+            ('config/settings.yaml', 'config'),
+            ('tests/test_main.py', 'test')
+        ]) AS row
+    )
+)
+SELECT
+    path,
+    expected,
+    {{ git_file_category('path') }} AS actual
+FROM fixtures
+WHERE {{ git_file_category('path') }} != expected

--- a/src/ingestion/dbt/tests/gold/assert_git_file_category_vendored.sql
+++ b/src/ingestion/dbt/tests/gold/assert_git_file_category_vendored.sql
@@ -20,6 +20,8 @@ WITH fixtures AS (
             ('frontend/pnpm-lock.yaml', 'vendored'),
             ('services/.venv/lib/site-packages/foo.py', 'vendored'),
             ('api/types.d.ts', 'vendored'),
+            ('package-lock.json', 'vendored'),
+            ('backend/Cargo.lock', 'vendored'),
             ('src/app/main.py', 'code'),
             ('src/components/Button.tsx', 'code'),
             ('lib/vendorize.py', 'code'),

--- a/src/ingestion/dbt/tests/gold/assert_git_observations_dimension_values.sql
+++ b/src/ingestion/dbt/tests/gold/assert_git_observations_dimension_values.sql
@@ -11,7 +11,7 @@ FROM {{ ref('git_metric_observations') }}
 WHERE arrayExists(
         d -> (
             (tupleElement(d, 1) = 'category'
-                AND tupleElement(d, 2) NOT IN ('code', 'test', 'config', 'docs'))
+                AND tupleElement(d, 2) NOT IN ('code', 'test', 'config', 'docs', 'vendored'))
             OR (tupleElement(d, 1) = 'source'
                 AND tupleElement(d, 2) NOT IN ('github', 'gitlab', 'bitbucket_cloud'))
             OR tupleElement(d, 2) = ''

--- a/src/ingestion/silver/git/README.md
+++ b/src/ingestion/silver/git/README.md
@@ -30,7 +30,7 @@ Git silver models. Two layers:
 |---|---|---|
 | `fct_git_pr` | one row per PR | `person_key`, `state_norm`, `cycle_time_h` |
 | `fct_git_commit` | one row per commit | `person_key`, `week` |
-| `fct_git_file_change` | one row per file change | `person_key` (via commit), `week`, `file_category` (code\|spec\|config) |
+| `fct_git_file_change` | one row per file change | `person_key` (via commit), `week`, `file_category` (vendored\|code\|spec\|config) |
 | `fct_git_review` | one row per review | reviewer `person_key` |
 
 ### Metrics
@@ -82,6 +82,10 @@ dbt run --select tag:silver
   `merge_commit_hash` resolves, else `closed_on` week). All CTEs share the
   same week semantic so the final join never splits a person across rows.
 - `file_category` regex matches common test/spec/config path patterns.
+  Vendored/generated content (deps, build output, generated/minified files) is
+  classified `vendored` first — via the shared `git_vendored_path_regex` macro,
+  configurable through the `git_vendored_path_patterns` dbt var — and so is
+  excluded from `code_loc` / `clean_loc`.
 - PR `state` values are source-case-preserved (`MERGED`, `OPEN`). Facts expose
   `state_norm = lower(state)` for downstream use.
 - `pickup_time` and `rework_ratio` are excluded here because Bitbucket Cloud
@@ -97,8 +101,12 @@ the class models directly. PR authors resolve to an email from the PR's
 own field or from the dominant email of its linked commits; PRs that
 resolve to no email are excluded (honest absence). File classification
 for unified measures lives in the shared gold macro
-`dbt/macros/git_file_category.sql` (`code | test | config | docs`),
-computed at read time so taxonomy changes apply retroactively.
+`dbt/macros/git_file_category.sql` (`vendored | code | test | config | docs`),
+computed at read time so taxonomy changes apply retroactively. `vendored`
+(machine-produced deps/build/generated output, matched by the shared
+`git_vendored_path_patterns` var) is excluded from the `code_lines_added`
+measure and surfaced distinctly under the `vendored` category in the total
+`lines_added` breakdown.
 
 `fct_git_*` and `mtr_git_*` serve the legacy `insight.*` views
 (`git_bullet_rows`, `ic_kpis`, `ic_chart_loc`) only and are scheduled for

--- a/src/ingestion/silver/git/fct_git_file_change.sql
+++ b/src/ingestion/silver/git/fct_git_file_change.sql
@@ -21,7 +21,11 @@ SELECT
     fc.change_type,
     fc.lines_added,
     fc.lines_removed,
+    -- `vendored` is checked first (shared pattern from the git_file_category
+    -- macro) so machine-produced content never counts toward code_loc /
+    -- clean_loc downstream, regardless of its extension or folder.
     multiIf(
+        match(fc.file_path, {{ git_vendored_path_regex() }}), 'vendored',
         match(fc.file_path, '(?i)(\\.spec\\.|\\.test\\.|__tests__/|/tests?/)'), 'spec',
         match(fc.file_path, '(?i)(\\.lock$|package-lock\\.json|yarn\\.lock|poetry\\.lock|\\.ya?ml$|\\.toml$|\\.cfg$|\\.ini$)'), 'config',
         'code'

--- a/src/ingestion/silver/git/schema.yml
+++ b/src/ingestion/silver/git/schema.yml
@@ -138,7 +138,7 @@ models:
         description: "inherited from the joined commit"
         tests: [not_null]
       - name: file_category
-        description: "spec | config | code"
+        description: "vendored | spec | config | code (vendored = machine-produced deps/build/generated output, excluded from code_loc)"
 
   - name: fct_git_review
     description: "Review-row facts: adds reviewer person_key (reviewer-login namespace, not unified with email-based person_key)."
@@ -175,7 +175,7 @@ models:
         description: "concat(tenant_id, '|', person_key, '|', week) — enforces one row per person per tenant per week"
         tests: [not_null, unique]
       - name: code_loc
-        description: "Lines added in code-category files (file_category='code')."
+        description: "Lines added in code-category files (file_category='code'). Excludes vendored/generated files (file_category='vendored')."
       - name: spec_lines
         description: "Lines added in spec/test-category files (file_category='spec')."
       - name: config_loc


### PR DESCRIPTION
Closes #1798.

## Problem
Git line-count metrics classify files by **extension only**, so machine-produced content — vendored deps (`node_modules/`, `site-packages/`, `vendor/`), build output (`dist/`, `target/`), and generated/minified files — is counted as authored code. A single commit adding a vendored tree inflates a person's LOC by hundreds of thousands of lines, and because peer standing is computed against a cohort median/quartiles, one such outlier skews the benchmark for everyone in the cohort.

## Fix
Add a `vendored` category, checked **first** in both classifier call sites:
- the shared `git_file_category` gold macro (`src/ingestion/dbt/macros/git_file_category.sql`), consumed by `git_metric_observations`
- the inline classifier in `fct_git_file_change` (`src/ingestion/silver/git/`), consumed by `mtr_git_person_*`

Authored line-count metrics already filter to `category = 'code'` (`code_lines_added`, `code_loc`, `clean_loc`), so they now exclude vendored/generated files automatically. The total `lines_added` breakdown **retains** them under the `vendored` category, so the signal stays auditable rather than silently dropped (as the issue suggested).

Patterns are defined **once** — the new `git_vendored_path_regex` macro backed by the `git_vendored_path_patterns` dbt var (`dbt_project.yml`) — so the exclusion is applied upstream and evolvable via config without a code change.

## Acceptance criteria
- [x] Vendored/generated files excluded from authored line-count metrics (`code_lines_added` / `code_loc` / `clean_loc`).
- [x] Exclusion patterns configurable (`git_vendored_path_patterns` var), not hard-coded per call site (shared `git_vendored_path_regex` macro).
- [x] Applied once upstream and reflected in every line-count metric + peer/cohort aggregation.
- [x] Coverage for representative vendored/generated path patterns (`assert_git_file_category_vendored.sql`, data-independent so it holds on a fresh cluster).

## Notes
- Escaping: var patterns are RE2 fragments embedded into a ClickHouse SQL string literal, so backslashes are doubled to match the existing hand-written regexes; verified end-to-end (YAML load → ClickHouse literal unescape → RE2) against vendored vs authored fixtures.
- Extended the closed-taxonomy contract test (`assert_git_observations_dimension_values.sql`) with `vendored`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic classification of vendored and generated files in Git metrics.
  * Added configurable patterns covering dependencies, build outputs, generated files, and lock files.
  * Added a distinct “Vendored / Generated” category in file and line breakdowns.

* **Bug Fixes**
  * Vendored content is now excluded from code-location metrics and code-line attribution.

* **Documentation**
  * Updated Git metric definitions and category descriptions to explain vendored-file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->