### PR TITLE
fix(task-delivery): surface Jira work from emailless assignees via accountId fallback (#1776)

### DIFF
--- a/src/ingestion/scripts/migrations/20260708000000_task-delivery-status-category.sql
+++ b/src/ingestion/scripts/migrations/20260708000000_task-delivery-status-category.sql
@@ -116,7 +116,19 @@ SELECT
     s.created_at                                                     AS created_at,
     sc.final_close_at                                                AS final_close_at,
     s.last_status_event_at                                           AS last_status_event_at,
-    lower(u.email)                                                   AS assignee_email,
+    -- Person key for every per-person Task Delivery metric. Prefer the
+    -- assignee's email; when the Jira account exposes none (only ~31% do),
+    -- fall back to a namespaced accountId (#1776) so the work is surfaced as
+    -- an unattributed-but-present person instead of being silently dropped by
+    -- the downstream `assignee_email != ''` guards. Truly unassigned issues
+    -- (no accountId) keep an empty key and stay excluded. The `jira-account:`
+    -- prefix cannot collide with an email (no '@') and never matches
+    -- insight.people, so org_unit_id stays NULL (honestly unattributed).
+    multiIf(
+        u.email != '',               lower(u.email),
+        s.assignee_account_id != '', concat('jira-account:', s.assignee_account_id),
+        ''
+    )                                                                AS assignee_email,
     p.org_unit_id                                                    AS org_unit_id
 FROM issue_state AS s
 LEFT JOIN status_cat AS sc

--- a/src/ingestion/tests/e2e/metrics/task_delivery_tasks_completed_emailless_assignee_jira.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/task_delivery_tasks_completed_emailless_assignee_jira.test.yaml
@@ -1,0 +1,112 @@
+spec_version: 1
+description: |
+  Metric: tasks_completed — IC Bullet Task Delivery (...0011), JIRA. Regression
+  guard for #1776: Jira work assigned to an account with NO email must NOT be
+  silently dropped from per-person Task Delivery.
+
+  How it's computed (bronze -> silver -> gold). bronze: jira_issue (assignee =
+  an account whose jira_user carries an EMPTY email) + jira_issue_history
+  (Status -> Closed event = the close date) + jira_user. silver: jira-enrich
+  produces one closed task per issue; the assignee resolves to class_task_users,
+  whose email is empty. gold: task_issue_current_state derives the person key
+  from the assignee's email, falling back to jira-account:<accountId> when the
+  email is empty (#1776) instead of leaving it blank and being dropped by the
+  downstream assignee_email != '' guards; jira_closed_tasks then counts the
+  closed tasks under that fallback key.
+
+  Bob Nomail has a Jira account with an empty email and NO org-chart identity,
+  so he can only be keyed by accountId. He closes TWO tasks on 2026-12-25.
+  Querying his fallback person_id must return tasks_completed = 2 — the work is
+  surfaced (honestly unattributed: no org, so peer stats are null), not
+  discarded. Before the fix his rows never reach task_delivery_bullet_rows and
+  the query returns nothing.
+
+  Cases: (1) custom window 2026-12-20..12-31 surfaces the 2 closed tasks under
+  the accountId fallback key; (2) empty window 2026-06 -> no items.
+
+bronze:
+  # Deliberately NO bronze_bamboohr.employees row for Bob: he has no org-chart
+  # identity, which is the whole point — an emailless, unresolvable assignee.
+
+  bronze_jira.jira_user:
+    # Empty email is the crux — this is what used to drop all of Bob's work.
+    - {$ref: templates/jira_task.yaml#/templates/jira_user, unique_key: jira-test-bob-nomail-acct, account_id: bob-nomail-acct, email: "", display_name: Bob Nomail,}
+
+  bronze_jira.jira_statuses:
+    - $ref: templates/jira_task.yaml#/templates/status_open
+    - $ref: templates/jira_task.yaml#/templates/status_in_progress
+    - $ref: templates/jira_task.yaml#/templates/status_closed
+
+  bronze_jira.jira_fields:
+    - $ref: templates/jira_task.yaml#/templates/field_status
+    - $ref: templates/jira_task.yaml#/templates/field_assignee
+    - $ref: templates/jira_task.yaml#/templates/field_issuetype
+
+  bronze_jira.jira_issue:
+    - $ref: templates/jira_task.yaml#/templates/jira_issue
+      id: TNM-1
+      jira_id: TNM-1
+      unique_key: jira-test-TNM-1
+      id_readable: TNM1
+      created: "2026-01-05T09:00:00"
+      custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"bob-nomail-acct","displayName":"Bob Nomail"}}'
+    - $ref: templates/jira_task.yaml#/templates/jira_issue
+      id: TNM-2
+      jira_id: TNM-2
+      unique_key: jira-test-TNM-2
+      id_readable: TNM2
+      created: "2026-01-05T09:00:00"
+      custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"bob-nomail-acct","displayName":"Bob Nomail"}}'
+
+  bronze_jira.jira_issue_history:
+    - $ref: templates/jira_task.yaml#/templates/jira_history
+      id_readable: TNM1
+      changelog_id: "70000"
+      unique_key: jira-test-TNM1-70000
+      created_at: "2026-12-25T14:00:00.000+0000"
+      author_account_id: bob-nomail-acct
+      items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'
+    - $ref: templates/jira_task.yaml#/templates/jira_history
+      id_readable: TNM2
+      changelog_id: "70001"
+      unique_key: jira-test-TNM2-70001
+      created_at: "2026-12-25T14:00:00.000+0000"
+      author_account_id: bob-nomail-acct
+      items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'
+
+cases:
+  - name: "emailless assignee's closed tasks are surfaced under the accountId fallback key (#1776)"
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: task_delivery
+            metric_id: 00000000-0000-0000-0001-000000000011
+            $filter: "person_id eq 'jira-account:bob-nomail-acct' and metric_date ge '2026-12-20' and metric_date le '2026-12-31'"
+    expect:
+      - assert: "status == 200"
+      - in: task_delivery
+        assert: "result.status == 'ok'"
+      # The regression: before #1776 the emailless assignee was dropped upstream,
+      # so no tasks_completed row existed for this person. Assert via CEL on the
+      # items array (not `find`) because a person with no org has null peer stats
+      # (honest "No peer data"); only the person's own value is meaningful here.
+      - in: task_delivery
+        assert: "items.exists(x, x.metric_key == 'tasks_completed' && double(x.value) == 2.0)"
+
+  - name: "empty window (no close events) -> no items"
+    request:
+      url: /v1/metrics/queries
+      method: POST
+      body:
+        queries:
+          - id: task_delivery
+            metric_id: 00000000-0000-0000-0001-000000000011
+            $filter: "person_id eq 'jira-account:bob-nomail-acct' and metric_date ge '2026-06-01' and metric_date le '2026-06-30'"
+    expect:
+      - assert: "status == 200"
+      - in: task_delivery
+        assert: "result.status == 'ok'"
+      - in: task_delivery
+        assert: "size(items) == 0"


### PR DESCRIPTION
Closes #1776.

## Problem
Per-person Task Delivery metrics key each Jira issue by resolving the assignee's `accountId` to an email. When the account exposes **no email** (on a realistic dataset only ~31% of Jira accounts carry one), `assignee_email` was left empty in `insight.task_issue_current_state`, and every downstream metric dropped the row via its `assignee_email != ''` guard.

Result: **~17% of all assigned issues silently vanished** from every per-person metric (Tasks Completed, MTTR, Dev Time, Estimation Accuracy, Bugs Fixed, Reopen Rate, …), and team/manager rollups undercounted. The person read as *"did nothing"* rather than *"couldn't attribute"* — absent from gold, not present-but-null.

## Root cause
`assignee_email = lower(u.email)` with no fallback (`task_issue_current_state`, migration `20260708000000_task-delivery-status-category.sql`). Emailless assignees survive the LEFT JOIN with an empty `assignee_email`, then get filtered out by the `assignee_email IS NOT NULL AND assignee_email != ''` guards on every metric CTE. `jira_closed_tasks` even writes `coalesce(assignee_email,'') AS person_id`, but the `!= ''` filter makes that fallback dead code.

## Fix
Derive the person key with a fallback in the **one** view every per-person metric reads `assignee_email` from:

```sql
multiIf(
    u.email != '',               lower(u.email),
    s.assignee_account_id != '', concat('jira-account:', s.assignee_account_id),
    ''
) AS assignee_email
```

- Emailless-but-assigned work is surfaced under a stable `jira-account:<accountId>` key (the issue's pre-approved "accountId-based fallback" outcome) instead of being discarded.
- Truly **unassigned** issues (no accountId) keep an empty key and stay excluded — no false "unassigned person".
- The `jira-account:` prefix can't collide with an email (no `@`) and never matches `insight.people`, so `org_unit_id` stays NULL: the person is *honestly unattributed* (peer stats render as "No peer data") rather than folded into a wrong cohort.
- **The emailed path is byte-identical to before** (`u.email != ''` → `lower(u.email)`), so existing behavior and all existing e2e specs are unaffected.

Because `task_issue_current_state` is a plain view read at query time by `jira_closed_tasks`, `task_dev_seconds_per_issue`, `task_close_events_daily`, `task_reopen_events_daily`, etc., the single change propagates to all Task Delivery metrics.

## Test
Adds an e2e regression fixture (`task_delivery_tasks_completed_emailless_assignee_jira.test.yaml`): an assignee whose `jira_user.email` is empty and who has no org-chart identity closes 2 tasks; querying his `jira-account:<id>` key must return `tasks_completed = 2`. **Pre-fix that person produced no rows at all.** Asserted via CEL on `items` (not `find`), since an unattributed person legitimately has null peer stats.

## Note
This surfaces the work and stops the silent drop; full attribution of emailless accounts to org teams remains the domain of the identity-resolution effort (#1765/#1766). The chosen fallback is deliberately compatible with that direction — it's a distinct, greppable key namespace, not a guessed email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task assignment tracking for Jira issues where the assignee has no email address.
  * Preserved metric visibility by using a Jira account identifier when email data is unavailable.
  * Correctly excludes unassigned issues from assignee-based results.

* **Tests**
  * Added coverage confirming completed-task metrics work with email-less Jira assignees and date filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->