### PR TITLE
fix(ingestion): unblock deploy-time gold build

### DIFF
--- a/src/ingestion/dbt/macros/drop_silver_placeholders_at_start.sql
+++ b/src/ingestion/dbt/macros/drop_silver_placeholders_at_start.sql
@@ -56,7 +56,8 @@
         {%- for silver_node in graph.nodes.values() -%}
             {%- if 'silver' in silver_node.tags
                   and silver_node.resource_type == 'model'
-                  and silver_node.config.materialized != 'ephemeral' -%}
+                  and silver_node.config.materialized != 'ephemeral'
+                  and silver_node.unique_id in selected_resources -%}
 
                 {%- set silver_id = silver_node.alias or silver_node.name -%}
                 {%- set silver_tag = 'silver:' ~ silver_id -%}

--- a/src/ingestion/dbt/macros/git_file_category.sql
+++ b/src/ingestion/dbt/macros/git_file_category.sql
@@ -23,7 +23,7 @@
    lookahead), doubled-escaped for the ClickHouse string literal. #}
 '[^\\s\\S]'
 {%- else -%}
-'(?i)(' ~ (patterns | join('|')) ~ ')'
+{{ "'(?i)(" ~ (patterns | join('|')) ~ ")'" }}
 {%- endif -%}
 {%- endmacro %}
 


### PR DESCRIPTION
Summary
- render the vendored-path regex as Jinja output instead of literal concatenation syntax
- only drop silver placeholders when their owning silver model is selected

Verification
- ran the gold-tagged dbt models against ClickHouse with a materialized staging relation and placeholder present
- all gold models built successfully and the placeholder remained available

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data processing so placeholder cleanup only applies to selected silver data models.
  * Corrected handling of configured vendored-file path patterns, ensuring non-empty patterns are properly applied.
  * Preserved the existing behavior for empty pattern configurations, which continue to match no files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->