### PR TITLE
fix(identity): exclude no-parent sentinel rows from parents query

### DIFF
--- a/src/backend/services/identity/src/Insight.Identity.Infrastructure/MariaDb/Sql.OrgChart.cs
+++ b/src/backend/services/identity/src/Insight.Identity.Infrastructure/MariaDb/Sql.OrgChart.cs
@@ -35,6 +35,7 @@ internal static class SqlOrgChart
         FROM org_chart
         WHERE insight_tenant_id = @tenant_id
           AND child_person_id   = @child_person_id
+          AND parent_person_id IS NOT NULL
           AND valid_to IS NULL
         ORDER BY insight_source_type, insight_source_id
         """;

--- a/src/backend/services/identity/tests/Insight.Identity.Tests.Integration/MariaDbFixture.cs
+++ b/src/backend/services/identity/tests/Insight.Identity.Tests.Integration/MariaDbFixture.cs
@@ -264,7 +264,7 @@ public sealed class MariaDbFixture : IAsyncLifetime
             insight_source_type VARCHAR(30) NOT NULL,
             insight_source_id BINARY(16) NOT NULL,
             child_person_id BINARY(16) NOT NULL,
-            parent_person_id BINARY(16) NOT NULL,
+            parent_person_id BINARY(16) NULL,
             author_person_id BINARY(16) NOT NULL,
             reason VARCHAR(50) NULL,
             valid_from DATETIME(6) NOT NULL,
@@ -273,7 +273,7 @@ public sealed class MariaDbFixture : IAsyncLifetime
                 insight_tenant_id, insight_source_type, insight_source_id,
                 child_person_id, valid_from
             ),
-            CONSTRAINT chk_no_self_loop CHECK (child_person_id <> parent_person_id),
+            CONSTRAINT chk_no_self_loop CHECK (parent_person_id IS NULL OR child_person_id <> parent_person_id),
             INDEX idx_current_parent (
                 insight_tenant_id, insight_source_type, insight_source_id,
                 child_person_id, valid_to

--- a/src/backend/services/identity/tests/Insight.Identity.Tests.Integration/OrgChartTests.cs
+++ b/src/backend/services/identity/tests/Insight.Identity.Tests.Integration/OrgChartTests.cs
@@ -165,6 +165,27 @@ public sealed class OrgChartTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task GetCurrentParents_excludes_no_parent_sentinel_row()
+    {
+        await InsertEdgeAsync("bamboohr", BambooSourceId, child: AlicePersonId, parent: null).ConfigureAwait(false);
+
+        var parents = await _repo!.GetCurrentParentsAsync(TenantId, AlicePersonId, CancellationToken.None);
+        parents.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetCurrentParents_returns_real_edge_alongside_sentinel_from_other_source()
+    {
+        await InsertEdgeAsync("bamboohr", BambooSourceId, child: AlicePersonId, parent: BobPersonId).ConfigureAwait(false);
+        await InsertEdgeAsync("slack",    SlackSourceId,  child: AlicePersonId, parent: null).ConfigureAwait(false);
+
+        var parents = await _repo!.GetCurrentParentsAsync(TenantId, AlicePersonId, CancellationToken.None);
+
+        parents.Should().HaveCount(1);
+        parents[0].ParentPersonId.Should().Be(BobPersonId);
+    }
+
+    [Fact]
     public async Task GetCurrentChildren_excludes_child_whose_latest_row_is_closed()
     {
         // Bob has two direct reports: Alice (deactivated, never
@@ -189,7 +210,7 @@ public sealed class OrgChartTests : IAsyncLifetime
         string sourceType,
         Guid sourceId,
         Guid child,
-        Guid parent,
+        Guid? parent,
         DateTime? validFrom = null,
         DateTime? validTo   = null,
         Guid? tenantId      = null)
@@ -208,7 +229,7 @@ public sealed class OrgChartTests : IAsyncLifetime
         cmd.Parameters.AddWithValue("@st",  sourceType);
         cmd.Parameters.AddWithValue("@sid", sourceId.ToByteArray(bigEndian: true));
         cmd.Parameters.AddWithValue("@c",   child.ToByteArray(bigEndian: true));
-        cmd.Parameters.AddWithValue("@p",   parent.ToByteArray(bigEndian: true));
+        cmd.Parameters.AddWithValue("@p",   (object?)parent?.ToByteArray(bigEndian: true) ?? DBNull.Value);
         cmd.Parameters.AddWithValue("@a",   AuthorPersonId.ToByteArray(bigEndian: true));
         cmd.Parameters.AddWithValue("@vf",  validFrom ?? new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
         cmd.Parameters.AddWithValue("@vt",  (object?)validTo ?? DBNull.Value);


### PR DESCRIPTION
Path-B sentinel rows (parent_person_id IS NULL, added in #579) leak into CurrentParentsForChild; the reader hard-casts parent_person_id to byte[], so any org-chain hydration reaching a root throws InvalidCastException → 500 on GET /v1/persons/{email}.

- Guard: `AND parent_person_id IS NOT NULL` in CurrentParentsForChild — sentinels stay for subchart root lookup, parents-walk never sees them
- Test fixture org_chart DDL synced with migration 012 (nullable parent + null-safe self-loop check) — the drift is why tests missed this
- Regression tests: sentinel-only child returns empty; real edge survives alongside sentinel from another source

🤖 Generated with [Claude Code](https://claude.com/claude-code)