### PR TITLE
fix(gold): resolve task_status_intervals name collision

### DIFF
--- a/src/ingestion/gold/schema.yml
+++ b/src/ingestion/gold/schema.yml
@@ -359,7 +359,7 @@ models:
         tests:
           - not_null
 
-  - name: task_status_intervals
+  - name: task_status_spans
     description: >
       Per-issue status spans for the task-delivery observation pipeline: each
       status event paired with the next; the last span ends at the close for

--- a/src/ingestion/gold/task_metric_observations.sql
+++ b/src/ingestion/gold/task_metric_observations.sql
@@ -17,7 +17,7 @@
 -- measure is emitted through macros/metric_observation_measures.sql.
 --
 -- The per-issue reconstruction is materialized upstream (task_issue_state,
--- task_status_intervals): ClickHouse re-inlines every WITH reference, so the
+-- task_status_spans): ClickHouse re-inlines every WITH reference, so the
 -- measure branches would otherwise re-run it once per branch.
 --
 -- Grain: event rows per closed issue for the median metrics (dev_time_hours,
@@ -43,7 +43,7 @@ issue_state AS (
 ),
 status_intervals AS (
     SELECT *
-    FROM {{ ref('task_status_intervals') }}
+    FROM {{ ref('task_status_spans') }}
 ),
 -- Per closed issue (metric_date = close date): dev seconds, lead, pickup.
 -- Only spans started before the close count — live rework on a reopened

--- a/src/ingestion/gold/task_status_spans.sql
+++ b/src/ingestion/gold/task_status_spans.sql
@@ -3,7 +3,7 @@
     engine='MergeTree',
     order_by=['insight_source_id', 'issue_id', 'interval_start'],
     schema='insight',
-    alias='task_status_intervals',
+    alias='task_status_spans',
     tags=['gold'],
     query_settings={
         'max_memory_usage': 1610612736,


### PR DESCRIPTION
The dbt gold model `task_status_intervals` (materialized=table) and the refreshable materialized view of the same name from migrations 20260429/20260708 both target `insight.task_status_intervals`. The gold build runs after migrations in the deploy hook, so dbt replaces the MV with a MergeTree table; a later migration run then executes `DROP VIEW IF EXISTS task_status_intervals` against a non-view and fails with code 80 (`... is not a View`), failing the post-upgrade hook.

Rename the dbt model and its alias to `task_status_spans`. The sibling `task_issue_state` already uses a name distinct from its MV counterpart `task_issue_current_state`; the intervals model missed the same treatment. Migrations are unchanged.

Validated with `dbt parse` (clean) and `dbt ls`: `task_status_spans+` resolves `task_metric_observations`, and `task_status_intervals` no longer matches any node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized task status lifecycle data under the `task_status_spans` name.
  * Updated downstream task metrics to use the renamed status lifecycle data source.
  * Preserved existing status transition, in-progress, close, and reopen calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->