### PR TITLE
fix(ci): publish the gateway image + bump authenticator/gateway subchart appVersions

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -58,6 +58,7 @@ jobs:
     outputs:
       analytics: ${{ steps.filter.outputs.analytics }}
       authenticator: ${{ steps.filter.outputs.authenticator }}
+      gateway: ${{ steps.filter.outputs.gateway }}
       identity: ${{ steps.filter.outputs.identity }}
       toolbox: ${{ steps.filter.outputs.toolbox }}
       umbrella: ${{ steps.filter.outputs.umbrella }}
@@ -75,6 +76,11 @@ jobs:
             authenticator:
               - 'src/backend/services/authenticator/**'
               - 'src/backend/libs/authenticator-sdk/**'
+              - 'src/backend/Cargo.toml'
+              - 'src/backend/Cargo.lock'
+            gateway:
+              - 'src/backend/services/gateway/**'
+              - 'src/backend/tools/routegen/**'
               - 'src/backend/Cargo.toml'
               - 'src/backend/Cargo.lock'
             identity:
@@ -378,6 +384,103 @@ jobs:
         uses: actions/attest-build-provenance@v2
         with:
           subject-name: ${{ env.IMAGE_PREFIX }}/insight-authenticator
+          subject-digest: ${{ steps.inspect.outputs.digest }}
+          push-to-registry: true
+
+  backend-gateway:
+    needs: changes
+    if: |
+      needs.changes.outputs.gateway == 'true'
+      || (github.event_name == 'workflow_dispatch' && inputs.frontend_tag == '')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+            platform: linux/amd64
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        id: build
+        with:
+          context: src/backend
+          file: src/backend/services/gateway/Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/insight-gateway,push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/main' }}
+          cache-from: type=gha,scope=gateway-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=gateway-${{ matrix.arch }},ignore-error=true
+      - name: Export digest
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-gateway-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge-gateway:
+    needs: [changes, backend-gateway]
+    if: |
+      always()
+      && needs.backend-gateway.result == 'success'
+      && github.event_name != 'pull_request'
+      && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-gateway-*
+          merge-multiple: true
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ${{ env.IMAGE_PREFIX }}/insight-gateway
+          tags: |
+            type=raw,value=${{ needs.changes.outputs.build_tag }}
+            type=raw,value=latest
+      - name: Create multi-arch manifest and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE_PREFIX }}/insight-gateway@sha256:%s ' *)
+      - name: Inspect manifest digest
+        id: inspect
+        run: |
+          DIGEST=$(docker buildx imagetools inspect \
+            ${{ env.IMAGE_PREFIX }}/insight-gateway:${{ needs.changes.outputs.build_tag }} \
+            --format '{{json .Manifest}}' | jq -r .digest)
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.IMAGE_PREFIX }}/insight-gateway
           subject-digest: ${{ steps.inspect.outputs.digest }}
           push-to-registry: true
 
@@ -781,6 +884,7 @@ jobs:
       - discover-images
       - merge-analytics
       - merge-authenticator
+      - merge-gateway
       - merge-identity
       - merge-toolbox
       - merge-image
@@ -801,6 +905,7 @@ jobs:
       && needs.merge-image.result == 'success'
       && (needs.merge-analytics.result == 'success' || needs.merge-analytics.result == 'skipped')
       && (needs.merge-authenticator.result == 'success' || needs.merge-authenticator.result == 'skipped')
+      && (needs.merge-gateway.result       == 'success' || needs.merge-gateway.result       == 'skipped')
       && (needs.merge-identity.result      == 'success' || needs.merge-identity.result      == 'skipped')
       && (needs.merge-toolbox.result       == 'success' || needs.merge-toolbox.result       == 'skipped')
     runs-on: ubuntu-latest
@@ -936,6 +1041,7 @@ jobs:
       - discover-images
       - merge-analytics
       - merge-authenticator
+      - merge-gateway
       - merge-identity
       - merge-toolbox
       - merge-image
@@ -946,6 +1052,7 @@ jobs:
       && github.ref == 'refs/heads/main'
       && (needs.merge-analytics.result == 'success' || needs.merge-analytics.result == 'skipped')
       && (needs.merge-authenticator.result == 'success' || needs.merge-authenticator.result == 'skipped')
+      && (needs.merge-gateway.result       == 'success' || needs.merge-gateway.result       == 'skipped')
       && (needs.merge-identity.result      == 'success' || needs.merge-identity.result      == 'skipped')
       && (needs.merge-toolbox.result       == 'success' || needs.merge-toolbox.result       == 'skipped')
       && (needs.merge-image.result         == 'success' || needs.merge-image.result         == 'skipped')
@@ -953,6 +1060,8 @@ jobs:
       && needs.bump-descriptors.outputs.committed != 'true'
       && (
         needs.changes.outputs.analytics == 'true'
+        || needs.changes.outputs.authenticator == 'true'
+        || needs.changes.outputs.gateway      == 'true'
         || needs.changes.outputs.identity     == 'true'
         || needs.changes.outputs.toolbox      == 'true'
         || needs.changes.outputs.umbrella     == 'true'
@@ -1020,12 +1129,22 @@ jobs:
         env:
           BUILD_TAG: ${{ needs.changes.outputs.build_tag }}
           ANALYTICS: ${{ needs.changes.outputs.analytics }}
+          AUTHENTICATOR: ${{ needs.changes.outputs.authenticator }}
+          GATEWAY: ${{ needs.changes.outputs.gateway }}
           IDENTITY: ${{ needs.changes.outputs.identity }}
         run: |
           set -euo pipefail
           if [ "$ANALYTICS" = "true" ]; then
             echo "Bumping analytics subchart appVersion → $BUILD_TAG"
             yq -i ".appVersion = \"$BUILD_TAG\"" src/backend/services/analytics/helm/Chart.yaml
+          fi
+          if [ "$AUTHENTICATOR" = "true" ]; then
+            echo "Bumping authenticator subchart appVersion → $BUILD_TAG"
+            yq -i ".appVersion = \"$BUILD_TAG\"" src/backend/services/authenticator/helm/Chart.yaml
+          fi
+          if [ "$GATEWAY" = "true" ]; then
+            echo "Bumping gateway subchart appVersion → $BUILD_TAG"
+            yq -i ".appVersion = \"$BUILD_TAG\"" src/backend/services/gateway/helm/Chart.yaml
           fi
           if [ "$IDENTITY" = "true" ]; then
             echo "Bumping identity subchart appVersion → $BUILD_TAG"
@@ -1086,6 +1205,8 @@ jobs:
           # breaks every install (charts 0.1.48–0.1.55 were affected).
           NEW_APP=$(yq -r '.appVersion' \
             src/backend/services/analytics/helm/Chart.yaml \
+            src/backend/services/authenticator/helm/Chart.yaml \
+            src/backend/services/gateway/helm/Chart.yaml \
             src/backend/services/identity/helm/Chart.yaml \
             src/frontend/helm/Chart.yaml \
             | grep -Ev '^(---|null)$' \

--- a/src/backend/services/authenticator/Dockerfile
+++ b/src/backend/services/authenticator/Dockerfile
@@ -92,3 +92,5 @@ EXPOSE 8083
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["/app/authenticator", "--", "/app/authenticator", "-c", "/app/config/insight.yaml", "run"]
+
+# CI rebuild marker -- appVersion bump now covers this subchart (fix/ci-publish-gateway-authenticator).

--- a/src/backend/services/gateway/Dockerfile
+++ b/src/backend/services/gateway/Dockerfile
@@ -48,3 +48,5 @@ EXPOSE 8080
 
 STOPSIGNAL SIGQUIT
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+
+# CI rebuild marker -- first publish of this image (fix/ci-publish-gateway-authenticator).


### PR DESCRIPTION
Chart 0.4.2 broke the dev deploy: pods reference `insight-gateway:0.1.0` / `insight-authenticator:0.1.0` (subchart-appVersion defaults). Root cause, two CI gaps:

1. **No job builds/pushes `insight-gateway`** — the ghcr package does not exist (404). The gateway image was only ever built inside e2e rigs.
2. **The per-service appVersion bump step covers only analytics/identity/frontend** — the authenticator image *is* pushed (`2026.07.22.05.22-f93ba8f`), but its subchart shipped `appVersion: 0.1.0`.

This PR:
- adds `backend-gateway` / `merge-gateway` (clone of the authenticator pair; context `src/backend`, `services/gateway/Dockerfile`),
- adds the `gateway` change filter (`services/gateway/**` + `tools/routegen/**` — routegen is baked into the image),
- bumps authenticator + gateway subchart appVersions when rebuilt,
- adds both to publish-chart `needs`/result-guards/trigger set (authenticator was missing from the trigger list too),
- replaces the deleted `api-gateway` chart path in the umbrella appVersion MAX with authenticator + gateway,
- Dockerfile markers under both services so THIS merge fires the first build + bump → next chart publish resolves real tags.

After merge: redeploy dev (the old `insight-frontend-root`/`insight-api-gateway` ingresses must be deleted right before the upgrade — the nginx admission webhook rejects the new gateway ingress while they hold `host /`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated multi-architecture builds and publishing for the gateway service image.
  * Added gateway support to deployment chart publishing and version updates.
* **Improvements**
  * Gateway and authenticator releases now receive consistent application version updates.
  * Added build provenance attestation for gateway image releases.
  * Deployment publishing now waits for all applicable service images to complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->