### PR TITLE
fix(ingestion): tag jira__task_field_metadata as staging so enrich builds it (#1743)

### DIFF
--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__task_field_metadata.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__task_field_metadata.sql
@@ -7,10 +7,10 @@
     engine='ReplacingMergeTree(_version)',
     order_by=['unique_key'],
     settings={'allow_nullable_key': 1},
-    -- 'staging' required: jira-enrich reads this and the staging phase selects
-    -- `tag:staging,tag:jira` (intersection); without it enrich aborts (#1743).
     tags=['staging', 'jira', 'silver:class_task_field_metadata']
 ) }}
+-- 'staging' tag is required: jira-enrich reads this table and the staging phase
+-- selects `tag:staging,tag:jira` (intersection); without it enrich aborts (#1743).
 
 -- Jira field metadata → `staging.jira__task_field_metadata` → unioned into
 -- `silver.class_task_field_metadata`. Classifies every field by cardinality / id-ness.

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__task_field_metadata.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__task_field_metadata.sql
@@ -7,7 +7,9 @@
     engine='ReplacingMergeTree(_version)',
     order_by=['unique_key'],
     settings={'allow_nullable_key': 1},
-    tags=['jira', 'silver:class_task_field_metadata']
+    -- 'staging' required: jira-enrich reads this and the staging phase selects
+    -- `tag:staging,tag:jira` (intersection); without it enrich aborts (#1743).
+    tags=['staging', 'jira', 'silver:class_task_field_metadata']
 ) }}
 
 -- Jira field metadata → `staging.jira__task_field_metadata` → unioned into


### PR DESCRIPTION
Closes #1743.

> Note: #1743 is assigned to @mitasovr — flagging in case of overlap. It's a `vz_blocker` with no PR yet and a trivial fix, so opening this to unblock; happy to defer if it conflicts with in-flight work.

## Problem
After a successful Jira sync, **Task Delivery** and **Code Quality** KPIs are all blank (`silver.class_task_*` = 0) even though `bronze_jira.jira_issue` is populated.

## Root cause
The pipeline's staging phase runs `dbt_select_staging = "tag:staging,tag:jira"` — a comma is an **intersection**. `jira__task_field_metadata` was tagged only `['jira', 'silver:class_task_field_metadata']` (no `staging`), so the intersection never built it. But `jira-enrich` reads it first thing — `FROM staging.jira__task_field_metadata` (`enrich/src/io/reader.rs:34`) — so the enrich step aborts on the missing relation and the pipeline stops before silver, leaving `class_task_*` empty.

Its sibling enrich inputs `jira__changelog_items` and `jira__issue_field_snapshot` are both tagged `['staging', 'jira']` and build fine — `jira__task_field_metadata` was the lone outlier.

## Fix
Add the `staging` tag (one line) so it builds in the staging phase alongside the other enrich inputs:
```
tags=['staging', 'jira', 'silver:class_task_field_metadata']
```
This matches the issue's suggested fix and the sibling models. Low-risk: adding a tag only makes the model eligible in one more selector; the `silver:` union tag is unchanged.

## Verification
Traced statically: enrich's `fetch_field_metadata` reads `staging.jira__task_field_metadata`; the model was the only enrich input missing `staging`. The issue's confirmed workaround (`dbt_select_staging = "tag:jira"`) builds it — this fix makes the default intersection build it too. (Full pipeline needs ClickHouse+Argo; not runnable locally.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the required `staging` classification for Jira task field metadata.
  * Clarified that enrichment processes require both Jira and staging classifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->