### PR TITLE
fix(analytics): stop logging raw email + identity body on lookup failure (#1846)

### DIFF
--- a/src/backend/services/analytics/src/api/handlers.rs
+++ b/src/backend/services/analytics/src/api/handlers.rs
@@ -51,7 +51,7 @@ pub async fn get_person(
         .get_person(&email, authorization)
         .await
         .map_err(|e| {
-            tracing::error!(error = %e, email = %email, "identity resolution request failed");
+            tracing::error!(error = %e, "identity resolution request failed");
             CanonicalError::internal("identity resolution unavailable").create()
         })?;
 

--- a/src/backend/services/analytics/src/infra/identity/mod.rs
+++ b/src/backend/services/analytics/src/infra/identity/mod.rs
@@ -180,8 +180,8 @@ impl IdentityClient {
 
         if !resp.status().is_success() {
             let status = resp.status();
-            let body = resp.text().await.unwrap_or_default();
-            tracing::warn!(email = %email, status = %status, body = %body, "identity lookup failed");
+            // No email/body in the log: both are PII (#1846); status is enough.
+            tracing::warn!(status = %status, "identity lookup failed");
             anyhow::bail!("identity service returned {status}");
         }
 


### PR DESCRIPTION
Closes #1846.

## Problem
Two log lines in the analytics identity client leaked PII into the log stream (which feeds centralized logging, #1816):

- `infra/identity/mod.rs` — on a non-2xx `/v1/profiles` response: `warn!(email = %email, status = %status, body = %body, …)` logged the raw **email** and the identity **error body**.
- `api/handlers.rs` — when the lookup call errors: `error!(error = %e, email = %email, …)` logged the raw **email**.

This is inconsistent with the identity service's own discipline (it redacts the email in URLs → `/v1/persons/<redacted>`).

## Fix
Drop `email` from both lines and stop reading/logging the response `body`. `status` (resp. the error) plus the request's trace id are enough to diagnose; no behavior change.

Verified: `cargo build` / `fmt --check` / `clippy` clean. (The identity-resolution service's by-email logs were checked too — they log `error` only, no email.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)