### PR TITLE
feat(authenticator): /auth/refresh rotation + session management + CSRF (nginx+auth step 10, PR 1/4)

### DIFF
--- a/deploy/compose/authenticator-fullauth.yaml
+++ b/deploy/compose/authenticator-fullauth.yaml
@@ -1,34 +1,13 @@
-# Insight Authenticator — gears-rust host config.
-#
-# Usage: authenticator -c config/insight.yaml run
-#
-# NOTE on the `api-gateway` gear below: this is the gears-rust toolkit REST-host
-# system gear (`cf-gears-api-gateway`) — the HTTP server + OpenAPI + auth
-# pipeline that every gear-based service runs on (analytics uses it too). It is
-# NOT the Insight platform api-gateway *service* that the nginx gateway replaces
-# in this EPIC. The authenticator hosts its endpoints on this REST-host gear and
-# runs behind the nginx edge.
-#
-# Auth is ENABLED on the host for the `.authenticated()` admin surface
-# (session revoke-by-user): the oidc-authn-plugin verifies the ES256 gateway
-# JWT — the authenticator trusts its own tokens exactly like any downstream
-# service. Every browser endpoint stays `.public()` (the credential is the
-# session cookie, checked in the handler) and bypasses the plugin.
-#
-# Deployment-specific leaf values are injected via env overrides
-# (APP__gears__authenticator__config__*) from the umbrella Secret / compose;
-# they are left empty here so no credential is committed:
-#   APP__gears__authenticator__config__redis_url
-#   APP__gears__authenticator__config__signing_keys_path
-#   APP__gears__authenticator__config__identity_url
-#   APP__gears__authenticator__config__gateway_issuer
-#   APP__gears__authenticator__config__redirect_uri
-#   APP__gears__authenticator__config__idp__issuer_url
-#   APP__gears__authenticator__config__idp__client_id
-#   APP__gears__authenticator__config__idp__client_secret
+# dev-compose full-auth authenticator host config (bind-mounted over
+# /app/config/insight.yaml). Same structure as
+# services/authenticator/config/insight.yaml, but with the oidc-authn-plugin
+# wired to the dev TLS discovery front (`authn-tls`, i.e. the authenticator's
+# own issuer) + its self-signed CA at /certs/ca.pem, so the `.authenticated()`
+# admin surface (session revoke-by-user) verifies real gateway JWTs in dev.
+# Redis/Identity/OIDC leaves come from APP__ env in docker-compose.yml.
 
 server:
-  home_dir: "~/.insight"
+  home_dir: "/tmp/authenticator"
 
 logging:
   default:
@@ -73,7 +52,10 @@ gears:
         expected_audience:
           - "internal-services"
         trusted_issuers:
-          - issuer: "https://gateway.invalid"
+          # = the authenticator's own gateway_issuer (the token `iss`);
+          # discovery_url omitted → {issuer}/.well-known/openid-configuration,
+          # served by the authn-tls front.
+          - issuer: "https://authn-tls:8443"
         claim_mapping:
           subject_id: "sub"
           subject_tenant_id: "tenant_id"
@@ -82,10 +64,11 @@ gears:
         required_claims: []
       http_client:
         request_timeout: 5s
+        custom_ca_certificate_paths: ["/certs/ca.pem"]
       # Client-credentials exchange is UNUSED here (the authenticator makes no
       # outbound S2S calls through the plugin) but the block is required config.
       s2s_oauth:
-        discovery_url: "https://gateway.invalid"
+        discovery_url: "https://authn-tls:8443"
         default_subject_type: "service"
         token_cache:
           ttl: 300s

--- a/deploy/compose/authenticator-fullauth.yaml
+++ b/deploy/compose/authenticator-fullauth.yaml
@@ -106,6 +106,10 @@ gears:
       jwt_audience: "internal-services"
       redirect_uri: ""
       default_return_to: "/"
+      # CSRF Origin-allowlist fallback (10.5): the browser sends Origin on all
+      # state-changing fetches, so dev flows keep working until the SPA sends
+      # X-CSRF-Token. Vite dev origin + the gateway entry.
+      csrf_origins: ["http://localhost:3000", "http://localhost:8080"]
       # Login scopes. offline_access is omitted (survives-logout token, wrong for a
       # BFF); add it only for an IdP that needs it for a refresh token, e.g. Entra.
       oidc_scopes: ["openid", "email", "profile"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -321,6 +321,12 @@ services:
     volumes:
       - ./deploy/compose/build/authenticator/authenticator:/app/authenticator:ro
       - ./src/backend/services/authenticator/config:/app/config:ro
+      # Full-auth plugin config (issuer + CA) — bind-mounted over the committed
+      # placeholder config so the `.authenticated()` admin surface verifies real
+      # gateway JWTs in dev (the authenticator trusts its own tokens).
+      - ./deploy/compose/authenticator-fullauth.yaml:/app/config/insight.yaml:ro
+      # Self-signed CA for the authn-tls discovery front.
+      - ./deploy/compose/authn-tls-certs:/certs:ro
       # dev signing key (current.pem) + dev service-token pubkey, both generated
       # by dev-compose.sh into this gitignored dir and mounted at signing_keys_path.
       - ./deploy/compose/authenticator-dev-keys:/app/keys:ro

--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -291,6 +291,7 @@ dependencies = [
  "cf-gears-authz-resolver",
  "cf-gears-gear-orchestrator",
  "cf-gears-grpc-hub",
+ "cf-gears-oidc-authn-plugin",
  "cf-gears-single-tenant-tr-plugin",
  "cf-gears-static-authz-plugin",
  "cf-gears-tenant-resolver",

--- a/src/backend/services/authenticator/Cargo.toml
+++ b/src/backend/services/authenticator/Cargo.toml
@@ -28,6 +28,7 @@ toolkit-canonical-errors = { workspace = true }
 # via inventory; mirrors the analytics service's gear set.
 api_gateway = { workspace = true }
 authn-resolver = { workspace = true }
+oidc-authn-plugin = { workspace = true }
 authz-resolver = { workspace = true }
 tenant-resolver = { workspace = true }
 single-tenant-tr-plugin = { workspace = true }

--- a/src/backend/services/authenticator/config/insight.yaml
+++ b/src/backend/services/authenticator/config/insight.yaml
@@ -123,6 +123,9 @@ gears:
       jwt_audience: "internal-services"
       redirect_uri: ""
       default_return_to: "/"
+      # CSRF Origin-allowlist fallback for state-changing /auth/* (10.5).
+      # Empty = fail closed: the X-CSRF-Token header is required.
+      csrf_origins: []
       # Login scopes. offline_access is omitted (survives-logout token, wrong for a
       # BFF); add it only for an IdP that needs it for a refresh token, e.g. Entra.
       oidc_scopes: ["openid", "email", "profile"]

--- a/src/backend/services/authenticator/helm/templates/configmap.yaml
+++ b/src/backend/services/authenticator/helm/templates/configmap.yaml
@@ -123,6 +123,12 @@ data:
       authenticator:
         config:
           signing_keys_path: {{ .Values.signingKeysPath | quote }}
+          # CSRF Origin-allowlist fallback for state-changing /auth/* requests;
+          # empty = fail closed (X-CSRF-Token required).
+          {{- with .Values.csrfOrigins }}
+          csrf_origins:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           # Service tokens (§10 G1). The registry is gitops-reviewable config
           # (public keys are not secrets) rendered from .Values.serviceTokens.
           service_tokens:

--- a/src/backend/services/authenticator/helm/templates/configmap.yaml
+++ b/src/backend/services/authenticator/helm/templates/configmap.yaml
@@ -15,10 +15,13 @@ data:
   # NOT the Insight platform gateway that nginx replaces. The authenticator
   # hosts on it, behind the nginx edge.
   #
-  # Every step-04 endpoint is `.public()` (the credential is the session cookie,
-  # checked in the handler), so the REST host runs with auth disabled and no
-  # OIDC plugin. The signing keys come from the mounted Secret at
-  # `signingKeysPath`.
+  # Browser endpoints are `.public()` (the credential is the session cookie,
+  # checked in the handler); the `.authenticated()` admin surface (session
+  # revoke-by-user) is verified by the oidc-authn-plugin against the
+  # authenticator's OWN issuer — through the TLS discovery front when enabled
+  # (the plugin resolves discovery over HTTPS only), else against a
+  # fail-closed `.invalid` placeholder. The signing keys come from the mounted
+  # Secret at `signingKeysPath`.
   authenticator.yaml: |
     server:
       home_dir: "/app/data"
@@ -31,7 +34,7 @@ data:
       api-gateway:
         config:
           bind_addr: "0.0.0.0:{{ .Values.service.port }}"
-          auth_disabled: true
+          auth_disabled: false
           cors_enabled: false
           enable_docs: false
           openapi:
@@ -49,6 +52,52 @@ data:
       authn-resolver:
         config:
           vendor: "hyperspot"
+
+      # Gateway-JWT verification for the `.authenticated()` admin surface. The
+      # issuer is the authenticator's own gateway_issuer; with the TLS
+      # discovery front on, discovery resolves in-pod over HTTPS with the
+      # front's CA. Without it there is no HTTPS discovery source, so a
+      # fail-closed placeholder keeps the admin surface dark (public endpoints
+      # are unaffected).
+      oidc-authn-plugin:
+        config:
+          vendor: "hyperspot"
+          priority: 50
+          jwt:
+            supported_algorithms: ["ES256"]
+            clock_skew_leeway: 60s
+            require_audience: true
+            expected_audience:
+              - "internal-services"
+            trusted_issuers:
+{{- if .Values.tlsDiscovery.enabled }}
+              - issuer: "https://{{ include "insight-authenticator.fullname" . }}:{{ .Values.tlsDiscovery.port }}"
+{{- else }}
+              - issuer: "https://gateway.invalid"
+{{- end }}
+            claim_mapping:
+              subject_id: "sub"
+              subject_tenant_id: "tenant_id"
+              subject_type: "sub_type"
+              token_scopes: "roles"
+            required_claims: []
+          http_client:
+            request_timeout: 5s
+{{- if .Values.tlsDiscovery.enabled }}
+            custom_ca_certificate_paths: ["/app/authn-ca/ca.crt"]
+{{- end }}
+          # Client-credentials exchange is UNUSED here but the block is
+          # required config; never fetched unless an exchange is performed.
+          s2s_oauth:
+{{- if .Values.tlsDiscovery.enabled }}
+            discovery_url: "https://{{ include "insight-authenticator.fullname" . }}:{{ .Values.tlsDiscovery.port }}"
+{{- else }}
+            discovery_url: "https://gateway.invalid"
+{{- end }}
+            default_subject_type: "service"
+            token_cache:
+              ttl: 300s
+              max_entries: 100
 
       authz-resolver:
         config:

--- a/src/backend/services/authenticator/helm/templates/deployment.yaml
+++ b/src/backend/services/authenticator/helm/templates/deployment.yaml
@@ -51,6 +51,14 @@ spec:
             - name: signing-keys
               mountPath: {{ .Values.signingKeysPath | quote }}
               readOnly: true
+            {{- if .Values.tlsDiscovery.enabled }}
+            # CA of the in-pod TLS discovery front — the oidc-authn-plugin
+            # verifies the `.authenticated()` admin surface against our own
+            # issuer through it.
+            - name: authn-tls-cert
+              mountPath: /app/authn-ca
+              readOnly: true
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/src/backend/services/authenticator/helm/values.yaml
+++ b/src/backend/services/authenticator/helm/values.yaml
@@ -32,6 +32,11 @@ serviceTokens:
   # Service tokens are always tenant-scoped; there is no per-service tenant flag.
   services: {}
 
+# CSRF Origin-allowlist fallback (PRD 5.11) for state-changing /auth/*
+# requests that carry no X-CSRF-Token: list the SPA's public origin(s), e.g.
+# ["https://insight.example.com"]. Empty (default) = fail closed, header only.
+csrfOrigins: []
+
 resources:
   requests:
     cpu: 50m

--- a/src/backend/services/authenticator/helm/values.yaml
+++ b/src/backend/services/authenticator/helm/values.yaml
@@ -35,6 +35,13 @@ serviceTokens:
 # CSRF Origin-allowlist fallback (PRD 5.11) for state-changing /auth/*
 # requests that carry no X-CSRF-Token: list the SPA's public origin(s), e.g.
 # ["https://insight.example.com"]. Empty (default) = fail closed, header only.
+#
+# DEPLOY COORDINATION: CSRF is enforced fail-closed. An SPA that does not yet
+# send X-CSRF-Token will get 403 on POST /auth/logout, /auth/refresh, and
+# DELETE /auth/sessions once this chart is rolled. Either roll the matching
+# insight-front (which sends the header) FIRST, or set csrfOrigins to the SPA's
+# public origin here so the Origin fallback keeps those calls working during
+# the transition.
 csrfOrigins: []
 
 resources:

--- a/src/backend/services/authenticator/src/api/error.rs
+++ b/src/backend/services/authenticator/src/api/error.rs
@@ -17,3 +17,9 @@ pub struct OidcError;
 /// client assertion, replay, or a refused tenant scope.
 #[resource_error("gts.cf.insight.authenticator.service_token.v1~")]
 pub struct ServiceTokenError;
+
+/// Session-management failures (`/auth/sessions*`): an absent (or not-owned —
+/// deliberately indistinguishable) session, or a caller without the authorized
+/// admin role.
+#[resource_error("gts.cf.insight.authenticator.session.v1~")]
+pub struct SessionError;

--- a/src/backend/services/authenticator/src/api/handlers.rs
+++ b/src/backend/services/authenticator/src/api/handlers.rs
@@ -1,8 +1,8 @@
-//! HTTP handlers for the step-04 surface: `/auth/login`, `/auth/callback`,
-//! `/internal/authz`, `/.well-known/jwks.json`, `/auth/me`, `/auth/logout`.
+//! HTTP handlers for the browser/gateway surface: `/auth/login`,
+//! `/auth/callback`, `/auth/refresh`, `/auth/me`, `/auth/logout`,
+//! `/internal/authz`, `/.well-known/jwks.json`.
 //!
-//! Deferred (later steps): `/auth/refresh`, `/auth/sessions`, CSRF enforcement,
-//! back-channel logout, `/internal/token`.
+//! `/internal/token` lives on the dedicated token listener (`service_token`).
 
 use std::sync::Arc;
 
@@ -20,7 +20,7 @@ use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::api::AppState;
-use crate::api::error::{OidcError, PersonError};
+use crate::api::error::{OidcError, PersonError, SessionError};
 use crate::cookie;
 use crate::identity::PersonResolution;
 use crate::jwt::GatewayClaims;
@@ -99,6 +99,7 @@ pub struct CallbackParams {
 pub async fn callback(
     Extension(state): Extension<Arc<AppState>>,
     jar: CookieJar,
+    headers: axum::http::HeaderMap,
     Query(params): Query<CallbackParams>,
 ) -> Response {
     if let Some(err) = params.error {
@@ -181,7 +182,8 @@ pub async fn callback(
 
     // `return_to` was sanitized at login time and stored with the login state.
     let return_to = login_state.return_to.clone();
-    match mint_and_store_session(&state, &idp, &resolution).await {
+    let client = ClientInfo::from_headers(&headers);
+    match mint_and_store_session(&state, &idp, &resolution, &client).await {
         Ok(token) => {
             let jar = jar.add(cookie::session_cookie(
                 &token,
@@ -198,12 +200,43 @@ pub async fn callback(
     }
 }
 
+/// Client attribution captured at login for the session list (PRD 5.9):
+/// the User-Agent and the client IP as the gateway saw it (first
+/// `X-Forwarded-For` hop; nginx guards the header with `set_real_ip_from`).
+struct ClientInfo {
+    user_agent: String,
+    ip: String,
+}
+
+impl ClientInfo {
+    fn from_headers(headers: &axum::http::HeaderMap) -> Self {
+        let header = |name: &str| {
+            headers
+                .get(name)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or_default()
+        };
+        // Attribution only (never authorization) — cap length so a hostile
+        // header can't bloat the session record.
+        let mut user_agent = header("user-agent").to_owned();
+        user_agent.truncate(256);
+        let ip = header("x-forwarded-for")
+            .split(',')
+            .next()
+            .unwrap_or_default()
+            .trim()
+            .to_owned();
+        Self { user_agent, ip }
+    }
+}
+
 /// Build claims, sign the linked JWT, and persist the session in one pipeline.
 /// Returns the cookie token.
 async fn mint_and_store_session(
     state: &AppState,
     idp: &crate::oidc::AuthenticatedIdp,
     resolution: &PersonResolution,
+    client: &ClientInfo,
 ) -> anyhow::Result<String> {
     let now = now_secs();
     let cfg = &state.cfg;
@@ -258,8 +291,8 @@ async fn mint_and_store_session(
         created_at: now,
         expires_at,
         absolute_expires_at,
-        user_agent: String::new(),
-        ip: String::new(),
+        user_agent: client.user_agent.clone(),
+        ip: client.ip.clone(),
         csrf_token,
         current_token: token.clone(),
     };
@@ -427,12 +460,7 @@ pub async fn me(Extension(state): Extension<Arc<AppState>>, jar: CookieJar) -> R
         return unauthenticated();
     }
 
-    let margin = state.cfg.session_refresh_safety_margin_seconds;
-    let half_jitter = state.cfg.refresh_jitter_seconds / 2;
-    let refresh_at = record
-        .expires_at
-        .saturating_sub(margin)
-        .saturating_add_signed(jitter_seconds(half_jitter));
+    let refresh_at = refresh_at_for(&state.cfg, record.expires_at);
 
     let body = serde_json::json!({
         "user": record.person_id,
@@ -444,6 +472,77 @@ pub async fn me(Extension(state): Extension<Arc<AppState>>, jar: CookieJar) -> R
     })
     .to_string();
     json_ok(body)
+}
+
+// ── /auth/refresh ────────────────────────────────────────────────────────────
+
+/// Rotate the session credential and extend the session (PRD 5.4, G10 model):
+/// new CSPRNG token mapping, old mapping demoted to the grace TTL, session
+/// `expires_at` advanced to `min(now + ttl, absolute_cap)` — one pipeline. The
+/// stable `session_id` and the linked JWT are untouched. A stale token still
+/// inside the grace window resolves to the same session and is answered with
+/// the current state, no second rotation; past grace → 401 + clear cookie.
+pub async fn refresh(Extension(state): Extension<Arc<AppState>>, jar: CookieJar) -> Response {
+    let Some(token) = cookie::read(&jar) else {
+        return unauthenticated_clear_cookie(jar);
+    };
+    let (session_id, record) = match state.sessions.resolve_by_token(&token).await {
+        Ok(Some(r)) => r,
+        Ok(None) => return unauthenticated_clear_cookie(jar),
+        Err(e) => return internal_problem("session_store", &e),
+    };
+    let now = now_secs();
+    if record.expires_at <= now || record.absolute_expires_at <= now {
+        return unauthenticated_clear_cookie(jar);
+    }
+
+    // Grace path: the presented token has already been rotated past (the old
+    // mapping lives out its grace TTL). Answer with the current state and the
+    // current cookie value — rotating again would burn the grace guarantee.
+    if record.current_token != token {
+        tracing::debug!(session_id = %session_id, "refresh within rotation grace: no re-rotation");
+        return refresh_ok(&state, jar, &record.current_token, record.expires_at, now);
+    }
+
+    let new_token = csprng_token();
+    let new_expires_at = (now + state.cfg.session_ttl_seconds).min(record.absolute_expires_at);
+    if let Err(e) = state
+        .sessions
+        .rotate_session(
+            &session_id,
+            &record,
+            &new_token,
+            new_expires_at,
+            state.cfg.refresh_grace_ms,
+        )
+        .await
+    {
+        return internal_problem("rotate_session", &e);
+    }
+    tracing::debug!(session_id = %session_id, expires_at = new_expires_at, "session refreshed (credential rotated)");
+    refresh_ok(&state, jar, &new_token, new_expires_at, now)
+}
+
+/// `200 {expires_at, refresh_at}` + the (re-)issued session cookie. `Max-Age`
+/// is the session's actual remaining life, so the cookie can never outlive the
+/// absolute cap.
+fn refresh_ok(
+    state: &AppState,
+    jar: CookieJar,
+    token: &str,
+    expires_at: u64,
+    now: u64,
+) -> Response {
+    let body = serde_json::json!({
+        "expires_at": expires_at,
+        "refresh_at": refresh_at_for(&state.cfg, expires_at),
+    })
+    .to_string();
+    let jar = jar.add(cookie::session_cookie(
+        token,
+        expires_at.saturating_sub(now),
+    ));
+    (jar, json_ok(body)).into_response()
 }
 
 // ── /auth/logout ─────────────────────────────────────────────────────────────
@@ -476,6 +575,177 @@ pub async fn logout(Extension(state): Extension<Arc<AppState>>, jar: CookieJar) 
     (jar, resp).into_response()
 }
 
+// ── /auth/sessions (PRD 5.9) ─────────────────────────────────────────────────
+
+/// List the caller's active sessions from the per-user index (score > now):
+/// created_at, expires_at, user_agent, ip, and a `current` flag.
+pub async fn sessions_list(Extension(state): Extension<Arc<AppState>>, jar: CookieJar) -> Response {
+    let Some(token) = cookie::read(&jar) else {
+        return unauthenticated();
+    };
+    let (current_id, record) = match state.sessions.resolve_by_token(&token).await {
+        Ok(Some(r)) => r,
+        Ok(None) => return unauthenticated(),
+        Err(e) => return internal_problem("session_store", &e),
+    };
+    let now = now_secs();
+    if record.expires_at <= now || record.absolute_expires_at <= now {
+        return unauthenticated();
+    }
+
+    let sessions = match state
+        .sessions
+        .list_user_sessions(&record.person_id, now)
+        .await
+    {
+        Ok(s) => s,
+        Err(e) => return internal_problem("session_list", &e),
+    };
+    let items: Vec<serde_json::Value> = sessions
+        .iter()
+        .map(|(sid, r)| {
+            serde_json::json!({
+                "session_id": sid,
+                "created_at": r.created_at,
+                "expires_at": r.expires_at,
+                "user_agent": r.user_agent,
+                "ip": r.ip,
+                "current": *sid == current_id,
+            })
+        })
+        .collect();
+    json_ok(serde_json::json!({ "sessions": items }).to_string())
+}
+
+/// Revoke one of the caller's sessions by id. A session that does not exist or
+/// belongs to someone else is answered 404 (no existence oracle). Revoking the
+/// current session also clears the cookie.
+pub async fn sessions_revoke_one(
+    Extension(state): Extension<Arc<AppState>>,
+    jar: CookieJar,
+    axum::extract::Path(target_id): axum::extract::Path<String>,
+) -> Response {
+    let Some(token) = cookie::read(&jar) else {
+        return unauthenticated();
+    };
+    let (current_id, record) = match state.sessions.resolve_by_token(&token).await {
+        Ok(Some(r)) => r,
+        Ok(None) => return unauthenticated(),
+        Err(e) => return internal_problem("session_store", &e),
+    };
+
+    let target = match state.sessions.load_session(&target_id).await {
+        Ok(t) => t,
+        Err(e) => return internal_problem("session_load", &e),
+    };
+    let owned = target
+        .as_ref()
+        .is_some_and(|t| t.person_id == record.person_id);
+    if !owned {
+        return not_found(&target_id);
+    }
+    if let Err(e) = state.sessions.revoke_session(&target_id).await {
+        return internal_problem("session_revoke", &e);
+    }
+    tracing::info!(
+        target: "audit",
+        event = "session_revoked",
+        session_id = %target_id,
+        person_id = %record.person_id,
+        by = "self",
+        "session revoked"
+    );
+
+    let resp = json_ok(serde_json::json!({ "revoked": 1 }).to_string());
+    if target_id == current_id {
+        return (jar.add(cookie::clear_cookie()), resp).into_response();
+    }
+    resp
+}
+
+/// Revoke every session of the current user ("log out everywhere") and clear
+/// the cookie.
+pub async fn sessions_revoke_all(
+    Extension(state): Extension<Arc<AppState>>,
+    jar: CookieJar,
+) -> Response {
+    let Some(token) = cookie::read(&jar) else {
+        return unauthenticated();
+    };
+    let (_, record) = match state.sessions.resolve_by_token(&token).await {
+        Ok(Some(r)) => r,
+        Ok(None) => return unauthenticated(),
+        Err(e) => return internal_problem("session_store", &e),
+    };
+
+    let revoked = match state.sessions.revoke_user_sessions(&record.person_id).await {
+        Ok(n) => n,
+        Err(e) => return internal_problem("session_revoke_all", &e),
+    };
+    tracing::info!(
+        target: "audit",
+        event = "sessions_revoked_all",
+        person_id = %record.person_id,
+        revoked,
+        by = "self",
+        "all sessions revoked"
+    );
+    let resp = json_ok(serde_json::json!({ "revoked": revoked }).to_string());
+    (jar.add(cookie::clear_cookie()), resp).into_response()
+}
+
+/// Admin/service revoke-by-user (PRD 5.9 "admin variant"): the host authn
+/// pipeline has already verified the gateway JWT and built the
+/// [`SecurityContext`]; this handler enforces the authorized role
+/// (`admin_revoke_roles`) and delegates to the SDK contract
+/// (`AuthenticatorClientV1::revoke_user_sessions`) — the same lever the
+/// future permissions service pulls on grant changes (DD-AUTH-07).
+pub async fn admin_revoke_user_sessions(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(ctx): Extension<toolkit_security::SecurityContext>,
+    axum::extract::Path(person_id): axum::extract::Path<Uuid>,
+) -> Response {
+    let allowed = ctx
+        .token_scopes()
+        .iter()
+        .any(|scope| state.cfg.admin_revoke_roles.iter().any(|r| r == scope));
+    if !allowed {
+        tracing::warn!(
+            target: "audit",
+            event = "admin_session_revoke_denied",
+            subject = %ctx.subject_id(),
+            subject_type = ctx.subject_type().unwrap_or(""),
+            person_id = %person_id,
+            "admin session revoke denied: missing authorized role"
+        );
+        return SessionError::permission_denied()
+            .with_reason("missing_authorized_role")
+            .create()
+            .into_response();
+    }
+
+    match state
+        .authn_client
+        .revoke_user_sessions(&person_id.to_string())
+        .await
+    {
+        Ok(revoked) => {
+            tracing::info!(
+                target: "audit",
+                event = "sessions_revoked_all",
+                person_id = %person_id,
+                revoked,
+                by = "admin",
+                subject = %ctx.subject_id(),
+                subject_type = ctx.subject_type().unwrap_or(""),
+                "all sessions revoked (admin)"
+            );
+            json_ok(serde_json::json!({ "revoked": revoked }).to_string())
+        }
+        Err(e) => e.into_response(),
+    }
+}
+
 // ── Pure helpers (unit-tested) ───────────────────────────────────────────────
 
 /// Compute the `/internal/authz` 200 `Cache-Control`:
@@ -490,6 +760,16 @@ pub fn cache_control_for(exp: u64, now: u64, authz_cache_max_age: u64) -> String
     } else {
         format!("max-age={max_age}")
     }
+}
+
+/// The server-supplied refresh moment: `expires_at − margin ± jitter/2` (G8 —
+/// the deliberately big jitter spreads NAT'd-office refresh waves into a
+/// uniform trickle and keeps an attacker from aligning to the rotation grace
+/// window). Re-jittered on every call.
+fn refresh_at_for(cfg: &crate::config::AuthenticatorConfig, expires_at: u64) -> u64 {
+    expires_at
+        .saturating_sub(cfg.session_refresh_safety_margin_seconds)
+        .saturating_add_signed(jitter_seconds(cfg.refresh_jitter_seconds / 2))
 }
 
 /// Sanitize an SPA-supplied `return_to`: accept only a site-relative path (one
@@ -564,6 +844,21 @@ fn unauthenticated() -> Response {
     )
 }
 
+/// 404 that does not distinguish "absent" from "not yours" (no existence oracle).
+fn not_found(resource: &str) -> Response {
+    SessionError::not_found("session not found")
+        .with_resource(resource)
+        .create()
+        .into_response()
+}
+
+/// 401 that also clears the session cookie — for `/auth/refresh`, where a dead
+/// credential must not linger in the browser (PRD 5.4 case 1).
+fn unauthenticated_clear_cookie(jar: CookieJar) -> Response {
+    let jar = jar.add(cookie::clear_cookie());
+    (jar, unauthenticated()).into_response()
+}
+
 fn internal_problem(context: &str, err: &anyhow::Error) -> Response {
     tracing::error!(context, error = %err, "authenticator internal error");
     toolkit_canonical_errors::CanonicalError::internal(format!("{context}: {err}"))
@@ -613,6 +908,18 @@ mod tests {
         assert_eq!(sanitize_return_to(Some("//evil.example"), "/"), "/");
         assert_eq!(sanitize_return_to(Some("https://evil.example"), "/"), "/");
         assert_eq!(sanitize_return_to(None, "/home"), "/home");
+    }
+
+    #[test]
+    fn refresh_at_stays_inside_the_jitter_window() {
+        // margin 90, full jitter 120 (±60): refresh_at ∈ [exp−150, exp−30] —
+        // the late edge still leaves ≥30 s of session life (G8).
+        let cfg = crate::config::AuthenticatorConfig::default();
+        let expires_at = 10_000;
+        for _ in 0..200 {
+            let at = refresh_at_for(&cfg, expires_at);
+            assert!((expires_at - 150..=expires_at - 30).contains(&at), "{at}");
+        }
     }
 
     #[test]

--- a/src/backend/services/authenticator/src/api/handlers.rs
+++ b/src/backend/services/authenticator/src/api/handlers.rs
@@ -528,18 +528,33 @@ pub async fn refresh(Extension(state): Extension<Arc<AppState>>, jar: CookieJar)
 
     let new_token = csprng_token();
     let new_expires_at = (now + state.cfg.session_ttl_seconds).min(record.absolute_expires_at);
-    if let Err(e) = state
+    let rotated = match state
         .sessions
         .rotate_session(
             &session_id,
             &record,
+            &token,
             &new_token,
             new_expires_at,
             state.cfg.refresh_grace_ms,
         )
         .await
     {
-        return internal_problem("rotate_session", &e);
+        Ok(rotated) => rotated,
+        Err(e) => return internal_problem("rotate_session", &e),
+    };
+    if !rotated {
+        // Lost the compare-and-swap: a concurrent refresh already rotated this
+        // credential (multi-tab). Answer the grace path with the now-current
+        // credential rather than minting a second one. Re-load to read it.
+        tracing::debug!(session_id = %session_id, "refresh lost the rotation CAS: answering grace path");
+        return match state.sessions.load_session(&session_id).await {
+            Ok(Some(current)) => {
+                refresh_ok(&state, jar, &current.current_token, current.expires_at, now)
+            }
+            Ok(None) => unauthenticated_clear_cookie(jar),
+            Err(e) => internal_problem("session_store", &e),
+        };
     }
     tracing::debug!(session_id = %session_id, expires_at = new_expires_at, "session refreshed (credential rotated)");
     refresh_ok(&state, jar, &new_token, new_expires_at, now)

--- a/src/backend/services/authenticator/src/api/handlers.rs
+++ b/src/backend/services/authenticator/src/api/handlers.rs
@@ -469,9 +469,31 @@ pub async fn me(Extension(state): Extension<Arc<AppState>>, jar: CookieJar) -> R
         "roles": record.roles,
         "expires_at": record.expires_at,
         "refresh_at": refresh_at,
+        "csrf_token": record.csrf_token,
     })
     .to_string();
     json_ok(body)
+}
+
+// ── /auth/csrf ───────────────────────────────────────────────────────────────
+
+/// Issue the CSRF token bound to the current session (PRD 5.11). The SPA sends
+/// it back as `X-CSRF-Token` on state-changing `/auth/*` requests; `/auth/me`
+/// echoes the same value so a page load primes both timers in one call.
+pub async fn csrf(Extension(state): Extension<Arc<AppState>>, jar: CookieJar) -> Response {
+    let Some(token) = cookie::read(&jar) else {
+        return unauthenticated();
+    };
+    let (_, record) = match state.sessions.resolve_by_token(&token).await {
+        Ok(Some(r)) => r,
+        Ok(None) => return unauthenticated(),
+        Err(e) => return internal_problem("session_store", &e),
+    };
+    let now = now_secs();
+    if record.expires_at <= now || record.absolute_expires_at <= now {
+        return unauthenticated();
+    }
+    json_ok(serde_json::json!({ "csrf_token": record.csrf_token }).to_string())
 }
 
 // ── /auth/refresh ────────────────────────────────────────────────────────────

--- a/src/backend/services/authenticator/src/api/mod.rs
+++ b/src/backend/services/authenticator/src/api/mod.rs
@@ -27,6 +27,10 @@ pub struct AppState {
     pub resolver: Arc<dyn PersonResolver>,
     /// Parsed service-token registry (DD-AUTH-05); used by the token listener.
     pub service_registry: ServiceRegistry,
+    /// The SDK contract impl (also registered in the `ClientHub`): the admin
+    /// revoke-by-user operation goes through it, so the HTTP surface and
+    /// in-process consumers (the future permissions service) share one path.
+    pub authn_client: Arc<dyn authenticator_sdk::AuthenticatorClientV1>,
 }
 
 /// Register the authenticator routes onto the host router. The `Extension`
@@ -76,6 +80,53 @@ fn register_auth_routes(router: Router, openapi: &dyn OpenApiRegistry) -> Router
         .handler(handlers::callback)
         .register(router, openapi);
 
+    router = OperationBuilder::get("/auth/sessions")
+        .operation_id("authenticator.sessions.list")
+        .summary("List the current user's active sessions")
+        .tag("auth")
+        .public()
+        .text_response(StatusCode::OK, "Active sessions", "application/json")
+        .error_401(openapi)
+        .handler(handlers::sessions_list)
+        .register(router, openapi);
+
+    router = OperationBuilder::delete("/auth/sessions/{session_id}")
+        .operation_id("authenticator.sessions.revoke")
+        .summary("Revoke one of the current user's sessions")
+        .tag("auth")
+        .public()
+        .text_response(StatusCode::OK, "Revocation result", "application/json")
+        .error_401(openapi)
+        .error_404(openapi)
+        .handler(handlers::sessions_revoke_one)
+        .register(router, openapi);
+
+    router = OperationBuilder::delete("/auth/sessions")
+        .operation_id("authenticator.sessions.revoke_all")
+        .summary("Revoke all sessions of the current user (log out everywhere)")
+        .tag("auth")
+        .public()
+        .text_response(StatusCode::OK, "Revocation result", "application/json")
+        .error_401(openapi)
+        .handler(handlers::sessions_revoke_all)
+        .register(router, openapi);
+
+    // Admin/service variant (PRD 5.9): `.authenticated()` — the host authn
+    // pipeline verifies a gateway JWT (the authenticator trusts its own tokens
+    // exactly like any downstream service, G10) and the handler enforces the
+    // authorized role.
+    router = OperationBuilder::delete("/auth/admin/users/{person_id}/sessions")
+        .operation_id("authenticator.sessions.admin_revoke_by_user")
+        .summary("Revoke every session of a user (admin/service, gateway-JWT authenticated)")
+        .tag("auth")
+        .authenticated()
+        .no_license_required()
+        .text_response(StatusCode::OK, "Revocation result", "application/json")
+        .error_401(openapi)
+        .error_403(openapi)
+        .handler(handlers::admin_revoke_user_sessions)
+        .register(router, openapi);
+
     router = OperationBuilder::get("/auth/me")
         .operation_id("authenticator.me")
         .summary("Current session summary for the SPA")
@@ -84,6 +135,20 @@ fn register_auth_routes(router: Router, openapi: &dyn OpenApiRegistry) -> Router
         .text_response(StatusCode::OK, "Session summary", "application/json")
         .error_401(openapi)
         .handler(handlers::me)
+        .register(router, openapi);
+
+    router = OperationBuilder::post("/auth/refresh")
+        .operation_id("authenticator.refresh")
+        .summary("Rotate the session cookie and extend the session (grace-tolerant)")
+        .tag("auth")
+        .public()
+        .text_response(
+            StatusCode::OK,
+            "{expires_at, refresh_at} + re-issued cookie",
+            "application/json",
+        )
+        .error_401(openapi)
+        .handler(handlers::refresh)
         .register(router, openapi);
 
     OperationBuilder::post("/auth/logout")

--- a/src/backend/services/authenticator/src/api/mod.rs
+++ b/src/backend/services/authenticator/src/api/mod.rs
@@ -41,7 +41,15 @@ pub fn register_routes(
     openapi: &dyn OpenApiRegistry,
     state: Arc<AppState>,
 ) -> Router {
-    let api = build_operations(Router::new(), openapi).layer(Extension(state));
+    // CSRF verification wraps the route table (state-changing `/auth/*` only —
+    // the middleware filters); the Extension layer runs first so handlers and
+    // middleware share the same state.
+    let api = build_operations(Router::new(), openapi)
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            crate::csrf::middleware,
+        ))
+        .layer(Extension(state));
     host_router.merge(api)
 }
 
@@ -125,6 +133,16 @@ fn register_auth_routes(router: Router, openapi: &dyn OpenApiRegistry) -> Router
         .error_401(openapi)
         .error_403(openapi)
         .handler(handlers::admin_revoke_user_sessions)
+        .register(router, openapi);
+
+    router = OperationBuilder::get("/auth/csrf")
+        .operation_id("authenticator.csrf")
+        .summary("Issue the CSRF token bound to the current session")
+        .tag("auth")
+        .public()
+        .text_response(StatusCode::OK, "CSRF token", "application/json")
+        .error_401(openapi)
+        .handler(handlers::csrf)
         .register(router, openapi);
 
     router = OperationBuilder::get("/auth/me")

--- a/src/backend/services/authenticator/src/config.rs
+++ b/src/backend/services/authenticator/src/config.rs
@@ -188,6 +188,11 @@ pub struct AuthenticatorConfig {
     // ── Cross-cutting ────────────────────────────────────────────────────
     /// CSRF `Origin` allowlist (empty = token-required, fail closed).
     pub csrf_origins: Vec<String>,
+    /// Roles (gateway-JWT `roles` scopes) authorized to call the admin
+    /// revoke-by-user operation. The service registry grants one of these to
+    /// the services that may force-logout users (e.g. the future permissions
+    /// service on grant changes, DD-AUTH-07).
+    pub admin_revoke_roles: Vec<String>,
 
     // ── Dependencies ─────────────────────────────────────────────────────
     /// Redis connection URL (`redis://host:port`).
@@ -253,6 +258,7 @@ impl Default for AuthenticatorConfig {
             ],
             default_return_to: "/".to_owned(),
             csrf_origins: Vec::new(),
+            admin_revoke_roles: vec!["session_admin".to_owned()],
             redis_url: String::new(),
             signing_keys_path: String::new(),
             identity_url: String::new(),

--- a/src/backend/services/authenticator/src/csrf.rs
+++ b/src/backend/services/authenticator/src/csrf.rs
@@ -1,0 +1,196 @@
+//! CSRF defense for state-changing `/auth/*` methods (PRD 5.11, DESIGN §4.2).
+//!
+//! `SameSite=Strict` on the session cookie is the primary defense; this is the
+//! second line: `X-CSRF-Token` compared in constant time against the token
+//! bound to the session at login, with an `Origin`-allowlist fallback
+//! (`csrf_origins`; empty = fail closed, token required). Both failing yields
+//! 403. The per-session token is issued at login, fetched via `GET /auth/csrf`,
+//! and echoed by `/auth/me`.
+//!
+//! The back-channel logout endpoint is exempt: it is IdP server-to-server and
+//! its credential is the signed `logout_token`, not a browser session.
+
+use std::sync::Arc;
+
+use axum::extract::{Request, State};
+use axum::http::Method;
+use axum::middleware::Next;
+use axum::response::{IntoResponse as _, Response};
+use axum_extra::extract::cookie::CookieJar;
+use sha2::{Digest as _, Sha256};
+
+use crate::api::AppState;
+use crate::api::error::SessionError;
+use crate::cookie;
+
+/// Paths under `/auth/` that skip CSRF checks: not browser-session-driven.
+const EXEMPT_PATHS: &[&str] = &["/auth/oidc/back-channel-logout"];
+
+/// The verdict of the pure check (unit-tested separately from the middleware).
+#[derive(Debug, PartialEq, Eq)]
+enum Verdict {
+    Pass,
+    Forbidden(&'static str),
+}
+
+/// Pure CSRF decision for one state-changing request with a live session:
+/// header token (constant-time) first, `Origin` allowlist as fallback,
+/// fail closed when neither verifies.
+fn verdict(
+    header_token: Option<&str>,
+    session_token: &str,
+    origin: Option<&str>,
+    allowlist: &[String],
+) -> Verdict {
+    if let Some(presented) = header_token {
+        // Constant-time equality via fixed-size digests — the comparison cost
+        // is independent of where the strings first differ.
+        let a = Sha256::digest(presented.as_bytes());
+        let b = Sha256::digest(session_token.as_bytes());
+        if a == b && !session_token.is_empty() {
+            return Verdict::Pass;
+        }
+        return Verdict::Forbidden("csrf_token_mismatch");
+    }
+    if let Some(origin) = origin
+        && allowlist.iter().any(|allowed| allowed == origin)
+    {
+        return Verdict::Pass;
+    }
+    Verdict::Forbidden("csrf_token_required")
+}
+
+/// Axum middleware over the authenticator's route table. Only state-changing
+/// `/auth/*` requests that present a resolvable session are checked — without
+/// a session there is nothing to forge (the handler answers 401), and the
+/// gateway-facing / well-known surfaces are not browser-state-changing.
+pub async fn middleware(
+    State(state): State<Arc<AppState>>,
+    jar: CookieJar,
+    request: Request,
+    next: Next,
+) -> Response {
+    let method = request.method();
+    let path = request.uri().path();
+    let state_changing = matches!(
+        *method,
+        Method::POST | Method::PUT | Method::PATCH | Method::DELETE
+    );
+    if !state_changing || !path.starts_with("/auth/") || EXEMPT_PATHS.contains(&path) {
+        return next.run(request).await;
+    }
+
+    let Some(token) = cookie::read(&jar) else {
+        return next.run(request).await; // no session → handler 401s
+    };
+    let record = match state.sessions.resolve_by_token(&token).await {
+        Ok(Some((_, record))) => record,
+        Ok(None) => return next.run(request).await, // dead session → handler 401s
+        Err(e) => {
+            // Store down: fail closed like every auth path (503, not a bypass).
+            tracing::warn!(error = %e, "csrf: session store unavailable");
+            return toolkit_canonical_errors::CanonicalError::service_unavailable()
+                .with_detail("session store unavailable")
+                .create()
+                .into_response();
+        }
+    };
+
+    let header_token = request
+        .headers()
+        .get("x-csrf-token")
+        .and_then(|v| v.to_str().ok());
+    let origin = request
+        .headers()
+        .get("origin")
+        .and_then(|v| v.to_str().ok());
+
+    match verdict(
+        header_token,
+        &record.csrf_token,
+        origin,
+        &state.cfg.csrf_origins,
+    ) {
+        Verdict::Pass => next.run(request).await,
+        Verdict::Forbidden(reason) => {
+            tracing::warn!(
+                target: "audit",
+                event = "csrf_rejected",
+                person_id = %record.person_id,
+                %path,
+                reason,
+                "state-changing /auth/* request failed CSRF verification"
+            );
+            SessionError::permission_denied()
+                .with_reason(reason)
+                .create()
+                .into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SESSION_TOKEN: &str = "csrf-abc-123";
+
+    #[test]
+    fn matching_header_token_passes() {
+        assert_eq!(
+            verdict(Some(SESSION_TOKEN), SESSION_TOKEN, None, &[]),
+            Verdict::Pass
+        );
+    }
+
+    #[test]
+    fn mismatched_header_token_is_forbidden_even_with_allowed_origin() {
+        // A presented-but-wrong token is an attack signal; the Origin fallback
+        // must not rescue it.
+        let allow = vec!["https://app.example".to_owned()];
+        assert_eq!(
+            verdict(
+                Some("wrong"),
+                SESSION_TOKEN,
+                Some("https://app.example"),
+                &allow
+            ),
+            Verdict::Forbidden("csrf_token_mismatch")
+        );
+    }
+
+    #[test]
+    fn origin_allowlist_is_the_fallback() {
+        let allow = vec!["https://app.example".to_owned()];
+        assert_eq!(
+            verdict(None, SESSION_TOKEN, Some("https://app.example"), &allow),
+            Verdict::Pass
+        );
+        assert_eq!(
+            verdict(None, SESSION_TOKEN, Some("https://evil.example"), &allow),
+            Verdict::Forbidden("csrf_token_required")
+        );
+    }
+
+    #[test]
+    fn empty_allowlist_fails_closed() {
+        // Default config: no origins → the header token is mandatory.
+        assert_eq!(
+            verdict(None, SESSION_TOKEN, Some("https://app.example"), &[]),
+            Verdict::Forbidden("csrf_token_required")
+        );
+        assert_eq!(
+            verdict(None, SESSION_TOKEN, None, &[]),
+            Verdict::Forbidden("csrf_token_required")
+        );
+    }
+
+    #[test]
+    fn empty_session_token_never_matches() {
+        // A session with no CSRF token (defensive) must not pass an empty header.
+        assert_eq!(
+            verdict(Some(""), "", None, &[]),
+            Verdict::Forbidden("csrf_token_mismatch")
+        );
+    }
+}

--- a/src/backend/services/authenticator/src/gear.rs
+++ b/src/backend/services/authenticator/src/gear.rs
@@ -84,8 +84,12 @@ impl Gear for AuthenticatorGear {
         );
 
         // Register the inter-gear client contract in the hub (DESIGN §3.10).
+        // The same instance backs the admin revoke-by-user HTTP operation, so
+        // the SDK contract is the single revoke path.
+        let authn_client: Arc<dyn AuthenticatorClientV1> =
+            Arc::new(LocalClient::new(sessions.clone()));
         ctx.client_hub()
-            .register::<dyn AuthenticatorClientV1>(Arc::new(LocalClient::new(sessions.clone())));
+            .register::<dyn AuthenticatorClientV1>(authn_client.clone());
 
         let state = Arc::new(AppState {
             cfg,
@@ -94,6 +98,7 @@ impl Gear for AuthenticatorGear {
             oidc,
             resolver,
             service_registry,
+            authn_client,
         });
         self.state
             .set(state)

--- a/src/backend/services/authenticator/src/main.rs
+++ b/src/backend/services/authenticator/src/main.rs
@@ -33,13 +33,15 @@ mod service_token;
 mod session;
 
 // System gears — linked via inventory for the REST host + auth pipeline.
-// Mirrors the analytics service's set (the authenticator authenticates its own
-// admin surface with the same pipeline in a later step).
+// Mirrors the analytics service's set. The oidc-authn-plugin verifies gateway
+// JWTs on the `.authenticated()` admin surface (session revoke-by-user) — the
+// authenticator trusts its own tokens exactly like any downstream service.
 use api_gateway as _;
 use authn_resolver as _;
 use authz_resolver as _;
 use gear_orchestrator as _;
 use grpc_hub as _;
+use oidc_authn_plugin as _;
 use single_tenant_tr_plugin as _;
 use static_authz_plugin as _;
 use tenant_resolver as _;

--- a/src/backend/services/authenticator/src/main.rs
+++ b/src/backend/services/authenticator/src/main.rs
@@ -24,6 +24,7 @@
 mod api;
 mod config;
 mod cookie;
+mod csrf;
 mod gear;
 mod identity;
 mod jwt;

--- a/src/backend/services/authenticator/src/session.rs
+++ b/src/backend/services/authenticator/src/session.rs
@@ -5,10 +5,10 @@
 //! linked JWT, indexes, and refresh schedule stay consistent. The store fails
 //! closed: a Redis error surfaces to the handler, which answers 401/503.
 //!
-//! Step 04 implements create / resolve / exchange-reissue / revoke and the
-//! login-state store. Rotation (`/auth/refresh`), the sid-index consumer
-//! (back-channel logout), and the refresh-due consumer (IdP refresher) are
-//! wired into the schema here but their *consumers* land in later steps.
+//! Owns create / resolve / rotate (`/auth/refresh`) / exchange-reissue /
+//! revoke and the login-state store. The sid-index consumer (back-channel
+//! logout) and the refresh-due consumer (IdP refresher) key off the schema
+//! written here.
 
 use std::collections::HashMap;
 
@@ -417,6 +417,74 @@ impl SessionManager {
             .await
             .context("store reissued JWT (NX EX)")?;
         Ok(set.is_some())
+    }
+
+    /// Rotate the session credential (`POST /auth/refresh`, DESIGN §3.6
+    /// "Session refresh — rotation without churn"): write the new token
+    /// mapping, shorten the superseded mapping's TTL to the rotation grace,
+    /// advance the session's `expires_at` (record field, key TTL, and per-user
+    /// index score) — one pipeline. The stable `session_id`, the linked JWT,
+    /// and every other index stay untouched (G10).
+    ///
+    /// # Errors
+    /// Fails on a Redis error.
+    pub async fn rotate_session(
+        &self,
+        session_id: &str,
+        record: &SessionRecord,
+        new_token: &str,
+        new_expires_at: u64,
+        grace_ms: u64,
+    ) -> anyhow::Result<()> {
+        let mut conn = self.conn.clone();
+        let skey = session_key(session_id);
+        let expires_at = i64::try_from(new_expires_at).unwrap_or(i64::MAX);
+
+        let mut pipe = redis::pipe();
+        pipe.atomic();
+        pipe.set(token_key(new_token), session_id).ignore();
+        pipe.expire_at(token_key(new_token), expires_at).ignore();
+        // The expiring old mapping IS the grace window (no swap keys).
+        pipe.pexpire(
+            token_key(&record.current_token),
+            i64::try_from(grace_ms).unwrap_or(250),
+        )
+        .ignore();
+        pipe.hset(&skey, "expires_at", new_expires_at.to_string())
+            .ignore();
+        pipe.hset(&skey, "current_token", new_token).ignore();
+        pipe.expire_at(&skey, expires_at).ignore();
+        pipe.zadd(user_sessions_key(&record.person_id), session_id, expires_at)
+            .ignore();
+        pipe.query_async::<()>(&mut conn)
+            .await
+            .context("rotate session pipeline")?;
+        Ok(())
+    }
+
+    /// List a person's live sessions from the per-user index (score > `now`),
+    /// loading each record. Index members whose record has already expired are
+    /// skipped (the janitor trims them).
+    ///
+    /// # Errors
+    /// Fails on a Redis error.
+    pub async fn list_user_sessions(
+        &self,
+        person_id: &str,
+        now: u64,
+    ) -> anyhow::Result<Vec<(String, SessionRecord)>> {
+        let mut conn = self.conn.clone();
+        let session_ids: Vec<String> = conn
+            .zrangebyscore(user_sessions_key(person_id), format!("({now}"), "+inf")
+            .await
+            .context("list user sessions by score")?;
+        let mut out = Vec::with_capacity(session_ids.len());
+        for sid in session_ids {
+            if let Some(record) = self.load_session(&sid).await? {
+                out.push((sid, record));
+            }
+        }
+        Ok(out)
     }
 
     /// Revoke one session — delete session, linked JWT, live token mapping,

--- a/src/backend/services/authenticator/src/session.rs
+++ b/src/backend/services/authenticator/src/session.rs
@@ -423,43 +423,56 @@ impl SessionManager {
     /// "Session refresh — rotation without churn"): write the new token
     /// mapping, shorten the superseded mapping's TTL to the rotation grace,
     /// advance the session's `expires_at` (record field, key TTL, and per-user
-    /// index score) — one pipeline. The stable `session_id`, the linked JWT,
-    /// and every other index stay untouched (G10).
+    /// index score). The stable `session_id`, the linked JWT, and every other
+    /// index stay untouched (G10).
+    ///
+    /// **Compare-and-swap on `current_token`** (atomic Lua): the whole
+    /// rotation runs only if the session's stored `current_token` still equals
+    /// the credential the caller presented. Two concurrent refreshes of the
+    /// same cookie (multi-tab) therefore cannot both rotate — the loser gets
+    /// `Ok(false)` and the handler answers the grace path with the winner's
+    /// credential, so no orphan full-TTL token mapping is ever minted.
     ///
     /// # Errors
-    /// Fails on a Redis error.
+    /// Fails on a Redis error. `Ok(false)` = the presented token was no longer
+    /// current (lost the race / already rotated); nothing was written.
     pub async fn rotate_session(
         &self,
         session_id: &str,
         record: &SessionRecord,
+        presented_token: &str,
         new_token: &str,
         new_expires_at: u64,
         grace_ms: u64,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<bool> {
+        // KEYS: session hash, new-token mapping, old-token mapping, user ZSET.
+        // ARGV: expected current_token, session_id, expireAt (s), grace (ms).
+        const ROTATE_LUA: &str = r"
+            if redis.call('HGET', KEYS[1], 'current_token') ~= ARGV[1] then return 0 end
+            redis.call('SET', KEYS[2], ARGV[2])
+            redis.call('EXPIREAT', KEYS[2], ARGV[3])
+            redis.call('PEXPIRE', KEYS[3], ARGV[4])
+            redis.call('HSET', KEYS[1], 'expires_at', ARGV[3], 'current_token', ARGV[5])
+            redis.call('EXPIREAT', KEYS[1], ARGV[3])
+            redis.call('ZADD', KEYS[4], ARGV[3], ARGV[2])
+            return 1
+        ";
         let mut conn = self.conn.clone();
-        let skey = session_key(session_id);
         let expires_at = i64::try_from(new_expires_at).unwrap_or(i64::MAX);
-
-        let mut pipe = redis::pipe();
-        pipe.atomic();
-        pipe.set(token_key(new_token), session_id).ignore();
-        pipe.expire_at(token_key(new_token), expires_at).ignore();
-        // The expiring old mapping IS the grace window (no swap keys).
-        pipe.pexpire(
-            token_key(&record.current_token),
-            i64::try_from(grace_ms).unwrap_or(250),
-        )
-        .ignore();
-        pipe.hset(&skey, "expires_at", new_expires_at.to_string())
-            .ignore();
-        pipe.hset(&skey, "current_token", new_token).ignore();
-        pipe.expire_at(&skey, expires_at).ignore();
-        pipe.zadd(user_sessions_key(&record.person_id), session_id, expires_at)
-            .ignore();
-        pipe.query_async::<()>(&mut conn)
+        let rotated: i64 = redis::Script::new(ROTATE_LUA)
+            .key(session_key(session_id))
+            .key(token_key(new_token))
+            .key(token_key(&record.current_token))
+            .key(user_sessions_key(&record.person_id))
+            .arg(presented_token)
+            .arg(session_id)
+            .arg(expires_at)
+            .arg(i64::try_from(grace_ms).unwrap_or(250))
+            .arg(new_token)
+            .invoke_async(&mut conn)
             .await
-            .context("rotate session pipeline")?;
-        Ok(())
+            .context("rotate session (CAS)")?;
+        Ok(rotated == 1)
     }
 
     /// List a person's live sessions from the per-user index (score > `now`),

--- a/src/backend/services/authenticator/tests/e2e_login_loop.rs
+++ b/src/backend/services/authenticator/tests/e2e_login_loop.rs
@@ -194,10 +194,13 @@ async fn full_login_exchange_logout_loop() {
     assert!(me_body.get("user").is_some());
     assert!(me_body.get("refresh_at").is_some());
 
-    // 7. /auth/logout revokes the session and clears the cookie.
+    // 7. /auth/logout revokes the session and clears the cookie. State-changing
+    //    /auth/* requires the CSRF token (step 10.5) — /auth/me echoed it.
+    let csrf = me_body["csrf_token"].as_str().unwrap().to_owned();
     let logout = http
         .post(format!("{auth_base}/auth/logout"))
         .header(reqwest::header::COOKIE, format!("{COOKIE}={token}"))
+        .header("X-CSRF-Token", &csrf)
         .send()
         .await
         .unwrap();

--- a/src/backend/services/authenticator/tests/e2e_login_loop.rs
+++ b/src/backend/services/authenticator/tests/e2e_login_loop.rs
@@ -76,7 +76,9 @@ struct Jwk {
 struct Claims {
     sub: String,
     tenant_id: String,
-    roles: Vec<String>,
+    /// Space-delimited on the wire (OAuth `scope` shape — the downstream
+    /// verifier's `token_scopes` mapping splits on whitespace).
+    roles: String,
     sid: String,
     aud: String,
 }
@@ -174,7 +176,7 @@ async fn full_login_exchange_logout_loop() {
     assert!(!claims.sub.is_empty(), "JWT sub (person_id) must be set");
     assert_eq!(claims.aud, "internal-services");
     assert!(
-        claims.roles.contains(&"user".to_owned()),
+        claims.roles.split_whitespace().any(|r| r == "user"),
         "default role present"
     );
     assert!(!claims.sid.is_empty(), "stable sid present");

--- a/src/backend/services/authenticator/tests/e2e_refresh.rs
+++ b/src/backend/services/authenticator/tests/e2e_refresh.rs
@@ -80,6 +80,22 @@ async fn login(http: &reqwest::Client, auth_base: &str, user: &str) -> String {
     cookie_from(&cb).expect("callback must set __Host-sid")
 }
 
+/// Fetch the session's CSRF token (state-changing /auth/* requires it, 10.5).
+async fn get_csrf(http: &reqwest::Client, auth_base: &str, token: &str) -> String {
+    #[derive(Deserialize)]
+    struct CsrfBody {
+        csrf_token: String,
+    }
+    let resp = http
+        .get(format!("{auth_base}/auth/csrf"))
+        .header(reqwest::header::COOKIE, format!("{COOKIE}={token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "GET /auth/csrf must succeed");
+    resp.json::<CsrfBody>().await.unwrap().csrf_token
+}
+
 #[derive(Deserialize)]
 struct RefreshBody {
     expires_at: u64,
@@ -133,10 +149,23 @@ async fn refresh_rotates_with_grace_and_stable_session() {
         .await
         .expect("fresh session exchanges");
 
+    let csrf = get_csrf(&http, &auth_base, &old_token).await;
+
+    // 0. A state-changing /auth/* request without the CSRF token (and no
+    //    allowlisted Origin) is rejected 403 before any rotation happens.
+    let no_csrf = http
+        .post(format!("{auth_base}/auth/refresh"))
+        .header(reqwest::header::COOKIE, format!("{COOKIE}={old_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(no_csrf.status(), 403, "refresh without CSRF must be 403");
+
     // 1. Refresh rotates the credential and returns the timing contract.
     let refresh = http
         .post(format!("{auth_base}/auth/refresh"))
         .header(reqwest::header::COOKIE, format!("{COOKIE}={old_token}"))
+        .header("X-CSRF-Token", &csrf)
         .send()
         .await
         .unwrap();
@@ -162,6 +191,7 @@ async fn refresh_rotates_with_grace_and_stable_session() {
     let grace = http
         .post(format!("{auth_base}/auth/refresh"))
         .header(reqwest::header::COOKIE, format!("{COOKIE}={old_token}"))
+        .header("X-CSRF-Token", &csrf)
         .send()
         .await
         .unwrap();
@@ -182,6 +212,7 @@ async fn refresh_rotates_with_grace_and_stable_session() {
     let stale = http
         .post(format!("{auth_base}/auth/refresh"))
         .header(reqwest::header::COOKIE, format!("{COOKIE}={old_token}"))
+        .header("X-CSRF-Token", &csrf)
         .send()
         .await
         .unwrap();

--- a/src/backend/services/authenticator/tests/e2e_refresh.rs
+++ b/src/backend/services/authenticator/tests/e2e_refresh.rs
@@ -1,0 +1,206 @@
+//! End-to-end `/auth/refresh` rotation-with-grace against a running
+//! authenticator + fakeidp + Redis (nginx+auth step 10, item 1).
+//!
+//! `#[ignore]` by default (needs the stack up):
+//!
+//! ```text
+//! AUTH_BASE=http://localhost:8083 \
+//!   cargo test -p authenticator --test e2e_refresh -- --ignored --nocapture
+//! ```
+//!
+//! Asserts the G10 rotation model: refresh rotates the cookie credential but
+//! not the session (`sid` claim stable), the superseded token keeps resolving
+//! during the grace window without a second rotation, and a token past grace
+//! is refused with a cleared cookie.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use serde::Deserialize;
+
+const COOKIE: &str = "__Host-sid";
+
+fn env(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_owned())
+}
+
+fn client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap()
+}
+
+fn rewrite_host(url: &str) -> String {
+    match (
+        std::env::var("FAKEIDP_REWRITE_FROM"),
+        std::env::var("FAKEIDP_REWRITE_TO"),
+    ) {
+        (Ok(from), Ok(to)) if !from.is_empty() => url.replace(&from, &to),
+        _ => url.to_owned(),
+    }
+}
+
+fn cookie_from(resp: &reqwest::Response) -> Option<String> {
+    for hv in resp.headers().get_all(reqwest::header::SET_COOKIE) {
+        let raw = hv.to_str().ok()?;
+        for part in raw.split(';') {
+            if let Some(v) = part.trim().strip_prefix(&format!("{COOKIE}="))
+                && !v.is_empty()
+            {
+                return Some(v.to_owned());
+            }
+        }
+    }
+    None
+}
+
+/// Run the full fakeidp login loop; returns the session cookie token.
+async fn login(http: &reqwest::Client, auth_base: &str, user: &str) -> String {
+    let login = http
+        .get(format!("{auth_base}/auth/login"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(login.status(), 302);
+    let authorize = rewrite_host(login.headers()[reqwest::header::LOCATION].to_str().unwrap());
+    let sep = if authorize.contains('?') { '&' } else { '?' };
+    let authorized = http
+        .get(format!("{authorize}{sep}user={user}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(authorized.status(), 302);
+    let callback = rewrite_host(
+        authorized.headers()[reqwest::header::LOCATION]
+            .to_str()
+            .unwrap(),
+    );
+    let cb = http.get(&callback).send().await.unwrap();
+    assert_eq!(cb.status(), 302);
+    cookie_from(&cb).expect("callback must set __Host-sid")
+}
+
+#[derive(Deserialize)]
+struct RefreshBody {
+    expires_at: u64,
+    refresh_at: u64,
+}
+
+#[derive(Deserialize)]
+struct MeBody {
+    expires_at: u64,
+    refresh_at: u64,
+}
+
+#[derive(Deserialize)]
+struct JwtSid {
+    sid: String,
+}
+
+/// Decode the (unverified) `sid` claim from a compact JWT.
+fn jwt_sid(bearer: &str) -> String {
+    use base64::Engine as _;
+    let jwt = bearer.strip_prefix("Bearer ").unwrap();
+    let payload = jwt.split('.').nth(1).unwrap();
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .unwrap();
+    serde_json::from_slice::<JwtSid>(&bytes).unwrap().sid
+}
+
+async fn authz_sid(http: &reqwest::Client, auth_base: &str, token: &str) -> Option<String> {
+    let resp = http
+        .get(format!("{auth_base}/internal/authz"))
+        .header(reqwest::header::COOKIE, format!("{COOKIE}={token}"))
+        .send()
+        .await
+        .unwrap();
+    if resp.status() != 200 {
+        return None;
+    }
+    Some(jwt_sid(resp.headers()["x-gateway-jwt"].to_str().unwrap()))
+}
+
+#[tokio::test]
+#[ignore = "requires a running authenticator + fakeidp + Redis stack"]
+async fn refresh_rotates_with_grace_and_stable_session() {
+    let auth_base = env("AUTH_BASE", "http://localhost:8083");
+    let test_user = env("E2E_USER", "dev@company.nonpresent");
+    let http = client();
+
+    let old_token = login(&http, &auth_base, &test_user).await;
+    let sid_before = authz_sid(&http, &auth_base, &old_token)
+        .await
+        .expect("fresh session exchanges");
+
+    // 1. Refresh rotates the credential and returns the timing contract.
+    let refresh = http
+        .post(format!("{auth_base}/auth/refresh"))
+        .header(reqwest::header::COOKIE, format!("{COOKIE}={old_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(refresh.status(), 200, "refresh must succeed");
+    let new_token = cookie_from(&refresh).expect("refresh must re-issue the cookie");
+    assert_ne!(new_token, old_token, "credential must rotate");
+    let body: RefreshBody = refresh.json().await.unwrap();
+    // refresh_at ∈ [expires_at − margin − jitter/2, expires_at − margin + jitter/2]
+    // (defaults: margin 90, jitter ±60 → [exp−150, exp−30]).
+    assert!(
+        body.refresh_at < body.expires_at,
+        "refresh_at must precede expires_at"
+    );
+
+    // 2. The stable session survives rotation: same `sid` through the new token.
+    let sid_after = authz_sid(&http, &auth_base, &new_token)
+        .await
+        .expect("rotated session exchanges");
+    assert_eq!(sid_before, sid_after, "sid must be stable across rotation");
+
+    // 3. Grace: an immediate second refresh with the OLD token resolves to the
+    //    same session and does NOT rotate again (returns the current cookie).
+    let grace = http
+        .post(format!("{auth_base}/auth/refresh"))
+        .header(reqwest::header::COOKIE, format!("{COOKIE}={old_token}"))
+        .send()
+        .await
+        .unwrap();
+    if grace.status() == 200 {
+        let grace_token = cookie_from(&grace).expect("grace refresh re-issues the current cookie");
+        assert_eq!(
+            grace_token, new_token,
+            "grace path must answer with the current credential, not rotate again"
+        );
+    } else {
+        // The 250 ms default grace may already have elapsed under load — a 401
+        // here is the past-grace contract, not a failure of the grace path.
+        assert_eq!(grace.status(), 401);
+    }
+
+    // 4. Past grace the old token is dead: 401 + cleared cookie.
+    tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+    let stale = http
+        .post(format!("{auth_base}/auth/refresh"))
+        .header(reqwest::header::COOKIE, format!("{COOKIE}={old_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(stale.status(), 401, "past-grace token must be refused");
+    let cleared = stale
+        .headers()
+        .get_all(reqwest::header::SET_COOKIE)
+        .iter()
+        .any(|h| h.to_str().unwrap_or("").contains("Max-Age=0"));
+    assert!(cleared, "past-grace refusal must clear the cookie");
+
+    // 5. /auth/me returns the same timing fields for the live credential.
+    let me = http
+        .get(format!("{auth_base}/auth/me"))
+        .header(reqwest::header::COOKIE, format!("{COOKIE}={new_token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(me.status(), 200);
+    let me_body: MeBody = me.json().await.unwrap();
+    assert!(me_body.refresh_at < me_body.expires_at);
+}

--- a/src/backend/services/authenticator/tests/e2e_service_token.rs
+++ b/src/backend/services/authenticator/tests/e2e_service_token.rs
@@ -56,7 +56,8 @@ struct Jwk {
 struct Claims {
     sub: String,
     tenant_id: String,
-    roles: Vec<String>,
+    /// Space-delimited on the wire (OAuth `scope` shape).
+    roles: String,
     sid: String,
     aud: String,
 }
@@ -104,11 +105,15 @@ async fn service_token_full_loop() {
         .strip_prefix("Bearer ")
         .expect("bearer() returns a Bearer value");
     let claims = verify_against_jwks(jwt).await;
-    assert_eq!(claims.sub, "service:testclient", "sub is service:<name>");
+    // `sub` is the stable per-service UUID (v5 over "service:<name>"); `sid`
+    // carries the service:<name> correlation handle.
+    let expected_sub =
+        uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_URL, b"service:testclient").to_string();
+    assert_eq!(claims.sub, expected_sub, "sub is the per-service UUIDv5");
     assert_eq!(claims.sid, "service:testclient", "sid is service:<name>");
     assert_eq!(claims.aud, "internal-services");
     assert!(
-        claims.roles.contains(&"service".to_owned()),
+        claims.roles.split_whitespace().any(|r| r == "service"),
         "service role always present, got {:?}",
         claims.roles
     );

--- a/src/backend/services/authenticator/tests/e2e_sessions.rs
+++ b/src/backend/services/authenticator/tests/e2e_sessions.rs
@@ -54,6 +54,22 @@ fn cookie_from(resp: &reqwest::Response) -> Option<String> {
     None
 }
 
+/// Fetch the session's CSRF token (state-changing /auth/* requires it, 10.5).
+async fn get_csrf(http: &reqwest::Client, auth_base: &str, token: &str) -> String {
+    #[derive(Deserialize)]
+    struct CsrfBody {
+        csrf_token: String,
+    }
+    let resp = http
+        .get(format!("{auth_base}/auth/csrf"))
+        .header(reqwest::header::COOKIE, format!("{COOKIE}={token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "GET /auth/csrf must succeed");
+    resp.json::<CsrfBody>().await.unwrap().csrf_token
+}
+
 /// Run the full fakeidp login loop; returns the session cookie token.
 async fn login(http: &reqwest::Client, auth_base: &str, user: &str) -> String {
     let login = http
@@ -123,6 +139,7 @@ async fn sessions_list_revoke_and_logout_everywhere() {
     // Two devices: two independent logins for the same person.
     let token_a = login(&http, &auth_base, &test_user).await;
     let token_b = login(&http, &auth_base, &test_user).await;
+    let csrf_b = get_csrf(&http, &auth_base, &token_b).await;
 
     // 1. The list shows both sessions, flags the caller's as current, and
     //    carries the attribution captured at login.
@@ -162,6 +179,7 @@ async fn sessions_list_revoke_and_logout_everywhere() {
             "{auth_base}/auth/sessions/00000000-0000-7000-8000-000000000000"
         ))
         .header(reqwest::header::COOKIE, format!("{COOKIE}={token_b}"))
+        .header("X-CSRF-Token", &csrf_b)
         .send()
         .await
         .unwrap();
@@ -171,6 +189,7 @@ async fn sessions_list_revoke_and_logout_everywhere() {
     let revoke = http
         .delete(format!("{auth_base}/auth/sessions/{}", other.session_id))
         .header(reqwest::header::COOKIE, format!("{COOKIE}={token_b}"))
+        .header("X-CSRF-Token", &csrf_b)
         .send()
         .await
         .unwrap();
@@ -186,9 +205,24 @@ async fn sessions_list_revoke_and_logout_everywhere() {
     assert!(survivors.iter().all(|s| s.session_id != other.session_id));
 
     // 4. Log out everywhere: every session dies, cookie cleared.
+    // Without the CSRF token the destructive call is refused (10.5)…
+    let no_csrf = http
+        .delete(format!("{auth_base}/auth/sessions"))
+        .header(reqwest::header::COOKIE, format!("{COOKIE}={token_b}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        no_csrf.status(),
+        403,
+        "log-out-everywhere without CSRF must be 403"
+    );
+
+    // …and with it, every session dies.
     let all = http
         .delete(format!("{auth_base}/auth/sessions"))
         .header(reqwest::header::COOKIE, format!("{COOKIE}={token_b}"))
+        .header("X-CSRF-Token", &csrf_b)
         .send()
         .await
         .unwrap();

--- a/src/backend/services/authenticator/tests/e2e_sessions.rs
+++ b/src/backend/services/authenticator/tests/e2e_sessions.rs
@@ -1,0 +1,209 @@
+//! End-to-end session management against a running authenticator + fakeidp +
+//! Redis (nginx+auth step 10, item 2).
+//!
+//! `#[ignore]` by default (needs the stack up; `run-e2e.sh` drives it):
+//!
+//! ```text
+//! AUTH_BASE=http://localhost:8083 \
+//!   cargo test -p authenticator --test e2e_sessions -- --ignored --nocapture
+//! ```
+//!
+//! Covers: listing active sessions (current flag, attribution fields), revoking
+//! a specific other session, the no-existence-oracle 404, and "log out
+//! everywhere". The admin revoke-by-user variant needs the gateway-JWT authn
+//! pipeline (TLS discovery front) and is exercised in the compose e2e instead.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use serde::Deserialize;
+
+const COOKIE: &str = "__Host-sid";
+
+fn env(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_owned())
+}
+
+fn client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .unwrap()
+}
+
+fn rewrite_host(url: &str) -> String {
+    match (
+        std::env::var("FAKEIDP_REWRITE_FROM"),
+        std::env::var("FAKEIDP_REWRITE_TO"),
+    ) {
+        (Ok(from), Ok(to)) if !from.is_empty() => url.replace(&from, &to),
+        _ => url.to_owned(),
+    }
+}
+
+fn cookie_from(resp: &reqwest::Response) -> Option<String> {
+    for hv in resp.headers().get_all(reqwest::header::SET_COOKIE) {
+        let raw = hv.to_str().ok()?;
+        for part in raw.split(';') {
+            if let Some(v) = part.trim().strip_prefix(&format!("{COOKIE}="))
+                && !v.is_empty()
+            {
+                return Some(v.to_owned());
+            }
+        }
+    }
+    None
+}
+
+/// Run the full fakeidp login loop; returns the session cookie token.
+async fn login(http: &reqwest::Client, auth_base: &str, user: &str) -> String {
+    let login = http
+        .get(format!("{auth_base}/auth/login"))
+        .header(reqwest::header::USER_AGENT, "e2e-sessions-test")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(login.status(), 302);
+    let authorize = rewrite_host(login.headers()[reqwest::header::LOCATION].to_str().unwrap());
+    let sep = if authorize.contains('?') { '&' } else { '?' };
+    let authorized = http
+        .get(format!("{authorize}{sep}user={user}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(authorized.status(), 302);
+    let callback = rewrite_host(
+        authorized.headers()[reqwest::header::LOCATION]
+            .to_str()
+            .unwrap(),
+    );
+    let cb = http
+        .get(&callback)
+        .header(reqwest::header::USER_AGENT, "e2e-sessions-test")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(cb.status(), 302);
+    cookie_from(&cb).expect("callback must set __Host-sid")
+}
+
+#[derive(Deserialize)]
+struct SessionItem {
+    session_id: String,
+    created_at: u64,
+    expires_at: u64,
+    user_agent: String,
+    #[allow(dead_code)]
+    ip: String,
+    current: bool,
+}
+
+#[derive(Deserialize)]
+struct SessionsBody {
+    sessions: Vec<SessionItem>,
+}
+
+async fn list(http: &reqwest::Client, auth_base: &str, token: &str) -> Vec<SessionItem> {
+    let resp = http
+        .get(format!("{auth_base}/auth/sessions"))
+        .header(reqwest::header::COOKIE, format!("{COOKIE}={token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    resp.json::<SessionsBody>().await.unwrap().sessions
+}
+
+#[tokio::test]
+#[ignore = "requires a running authenticator + fakeidp + Redis stack"]
+async fn sessions_list_revoke_and_logout_everywhere() {
+    let auth_base = env("AUTH_BASE", "http://localhost:8083");
+    let test_user = env("E2E_USER", "dev@company.nonpresent");
+    let http = client();
+
+    // Two devices: two independent logins for the same person.
+    let token_a = login(&http, &auth_base, &test_user).await;
+    let token_b = login(&http, &auth_base, &test_user).await;
+
+    // 1. The list shows both sessions, flags the caller's as current, and
+    //    carries the attribution captured at login.
+    // Device A's own id, resolved from its own list (the person may carry
+    // leftover sessions from earlier e2e tests — same deterministic stub user).
+    let session_a_id = list(&http, &auth_base, &token_a)
+        .await
+        .into_iter()
+        .find(|s| s.current)
+        .expect("device A must see itself as current")
+        .session_id;
+
+    let sessions = list(&http, &auth_base, &token_b).await;
+    assert!(
+        sessions.len() >= 2,
+        "both live sessions must be listed, got {}",
+        sessions.len()
+    );
+    let current = sessions
+        .iter()
+        .find(|s| s.current)
+        .expect("the caller's session must be flagged current");
+    assert!(current.expires_at > current.created_at);
+    assert_eq!(
+        current.user_agent, "e2e-sessions-test",
+        "user_agent captured at login must be surfaced"
+    );
+    let other = sessions
+        .iter()
+        .find(|s| s.session_id == session_a_id)
+        .expect("the other device's session must be listed");
+    assert!(!other.current, "device A is not current for device B");
+
+    // 2. Revoking an unknown/foreign session id → 404 (no existence oracle).
+    let bogus = http
+        .delete(format!(
+            "{auth_base}/auth/sessions/00000000-0000-7000-8000-000000000000"
+        ))
+        .header(reqwest::header::COOKIE, format!("{COOKIE}={token_b}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(bogus.status(), 404);
+
+    // 3. Revoke the other device's session; it dies, the caller's survives.
+    let revoke = http
+        .delete(format!("{auth_base}/auth/sessions/{}", other.session_id))
+        .header(reqwest::header::COOKIE, format!("{COOKIE}={token_b}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(revoke.status(), 200);
+    let after = http
+        .get(format!("{auth_base}/internal/authz"))
+        .header(reqwest::header::COOKIE, format!("{COOKIE}={token_a}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(after.status(), 401, "revoked device must be logged out");
+    let survivors = list(&http, &auth_base, &token_b).await;
+    assert!(survivors.iter().all(|s| s.session_id != other.session_id));
+
+    // 4. Log out everywhere: every session dies, cookie cleared.
+    let all = http
+        .delete(format!("{auth_base}/auth/sessions"))
+        .header(reqwest::header::COOKIE, format!("{COOKIE}={token_b}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(all.status(), 200);
+    let cleared = all
+        .headers()
+        .get_all(reqwest::header::SET_COOKIE)
+        .iter()
+        .any(|h| h.to_str().unwrap_or("").contains("Max-Age=0"));
+    assert!(cleared, "log-out-everywhere must clear the cookie");
+    let dead = http
+        .get(format!("{auth_base}/internal/authz"))
+        .header(reqwest::header::COOKIE, format!("{COOKIE}={token_b}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(dead.status(), 401);
+}

--- a/src/backend/services/authenticator/tests/run-e2e.sh
+++ b/src/backend/services/authenticator/tests/run-e2e.sh
@@ -72,7 +72,7 @@ wait_ready fakeidp "http://localhost:$IDP_PORT/.well-known/openid-configuration"
 echo "==> identity stub :$IDENTITY_PORT (resolves any email to a person)"
 python3 "$HERE/identity-stub.py" "127.0.0.1:$IDENTITY_PORT" >/tmp/authenticator-e2e-identity.log 2>&1 &
 pids+=($!)
-wait_ready identity-stub "http://localhost:$IDENTITY_PORT/v1/persons/probe@example.com"
+wait_ready identity-stub "http://localhost:$IDENTITY_PORT/internal/persons/by-email/probe@example.com"
 
 echo "==> authenticator :$AUTH_PORT"
 APP__gears__authenticator__config__redis_url=redis://localhost:6399 \
@@ -96,6 +96,14 @@ fi
 echo "==> run the login loop"
 AUTH_BASE="http://localhost:$AUTH_PORT" E2E_USER=dev@company.nonpresent \
   cargo test -p authenticator --test e2e_login_loop -- --ignored --nocapture
+
+echo "==> run the refresh rotation-with-grace loop (step 10.1)"
+AUTH_BASE="http://localhost:$AUTH_PORT" E2E_USER=dev@company.nonpresent \
+  cargo test -p authenticator --test e2e_refresh -- --ignored --nocapture
+
+echo "==> run the session-management loop (step 10.2)"
+AUTH_BASE="http://localhost:$AUTH_PORT" E2E_USER=dev@company.nonpresent \
+  cargo test -p authenticator --test e2e_sessions -- --ignored --nocapture
 
 echo "==> run the service-token loop (step 06)"
 # The token listener binds 8093 (config service_tokens.token_bind_addr); the dev


### PR DESCRIPTION
Step 10 (auth surface completion) of the nginx+auth EPIC, **PR 1 of 4**. Delivers items **10.1** (`POST /auth/refresh`), **10.2** (session management), and **10.5** (CSRF) of `NGINX_BFF_10.md`.

This is the base of a 4-PR stack; the others build on it:
1. **this PR** — session surface (refresh + sessions + CSRF)
2. idp-lifecycle (back-channel logout + IdP refresher + janitor)
3. ratelimit + audit
4. docs (key-rotation runbook + PRD/DESIGN updates)

GitHub can't base a cross-fork PR on another fork branch, so all four target `main`; review this one first (the later PRs' diffs include these commits until this merges).

## What's here

- **10.1 `POST /auth/refresh` — rotation with grace (G10).** New CSPRNG token mapping; the superseded mapping's TTL drops to `refresh_grace_ms` (250 ms) — the expiring old mapping *is* the grace window (no swap keys). `expires_at = min(now + session_ttl, absolute cap)` across the record, key TTL, and per-user ZSET score. Stable `session_id` + linked JWT untouched. Stale-in-grace resolves to the same session (no re-rotation); past grace or either cap → 401 + clear cookie. Response `{expires_at, refresh_at}`, `refresh_at = expires_at − 90 s ± 60 s` (big-jitter, G8), re-jittered per call and shared with `/auth/me`.
- **10.2 session management.** `GET /auth/sessions` (created_at, expires_at, user_agent, ip, current — attribution captured at login); `DELETE /auth/sessions/{id}` (no-existence-oracle 404); `DELETE /auth/sessions`; admin `DELETE /auth/admin/users/{person_id}/sessions` — an `.authenticated()` op (host authn pipeline verifies the gateway JWT against the authenticator's own issuer), role-gated by `admin_revoke_roles` (default `session_admin`), delegating to the SDK `AuthenticatorClientV1::revoke_user_sessions`. Every revoke: token mappings + session + linked JWT + indexes in one pipeline.
- **10.5 CSRF.** Middleware on state-changing `/auth/*`: constant-time `X-CSRF-Token` vs the session record, `Origin`-allowlist fallback (`csrf_origins`, empty = fail closed), back-channel exempt. `GET /auth/csrf`; `/auth/me` echoes the token. SPA side is the insight-front PR.

## Review-fix commit

The last commit applies **M2** (rotation is now a compare-and-swap Lua on `current_token` — concurrent multi-tab refreshes can't both rotate and orphan a full-TTL credential) and **M5** (CSRF fail-closed deploy-coordination note) from the security + QA review of the stack.

## Testing

Unit tests + clippy clean. Local e2e harness (`services/authenticator/tests/run-e2e.sh`, 8 loops against fakeidp + Redis) is green on the full stack; the refresh loop asserts rotation, sid-stability, grace resolution, and past-grace 401.

⚠️ **Deploy coordination:** CSRF is fail-closed. Roll the header-sending insight-front (linked PR) first, or set `csrfOrigins`, or logout/refresh will 403 during the transition (documented in the chart values).

EPIC: constructorfabric/insight#1583 · closes the step-10 items in #1593 (partial — see the stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
