### PR TITLE
fix(ingestion): normalize CRM UNION branch types to fix NO_COMMON_TYPE (#1709, #1708)

### DIFF
--- a/src/ingestion/connectors/crm/salesforce/dbt/salesforce__crm_activities.sql
+++ b/src/ingestion/connectors/crm/salesforce/dbt/salesforce__crm_activities.sql
@@ -82,7 +82,9 @@ events AS (
             CAST(ActivityDate AS Nullable(DateTime64(3))),
             CreatedDate
         )                                           AS timestamp,
-        DurationInMinutes * 60                      AS duration_seconds,
+        -- toInt64 to match the tasks branch + hubspot (Int64); Airbyte may
+        -- infer DurationInMinutes as float, which broke the UNION (#1709).
+        toInt64(DurationInMinutes * 60)             AS duration_seconds,
         CAST(NULL AS Nullable(String))              AS outcome,
         toJSONString(map(
             'Subject',      coalesce(toString(Subject), ''),

--- a/src/ingestion/scripts/migrations/20260512000000_crm-gold-views.sql
+++ b/src/ingestion/scripts/migrations/20260512000000_crm-gold-views.sql
@@ -358,7 +358,8 @@ WITH
       o.person_id                          AS person_id,
       coalesce(p.org_unit_id, 'Unknown')   AS org_unit_id,
       'deal_size'                          AS metric_key,
-      coalesce(d.amount_home, 0)           AS metric_value
+      -- toFloat64 to match the other UNION branches; amount_home is Decimal (#1708)
+      toFloat64(coalesce(d.amount_home, 0)) AS metric_value
     FROM deals_dedup d
     INNER JOIN owners o ON o.user_id = d.owner_id
     LEFT JOIN people p ON p.person_id = o.person_id


### PR DESCRIPTION
Closes #1709. Closes #1708.

Two CRM `UNION`s mix incompatible numeric types, so a branch fails `NO_COMMON_TYPE` (ClickHouse Code 386). Both are pre-existing and masked only by the Int64/Float64-typed demo bronze; they fire on real Salesforce/HubSpot data.

## #1709 — `salesforce__crm_activities` (staging)
The `tasks` CTE emits `duration_seconds` as **Int64** (`toInt64(CallDurationInSeconds)`); the `events` CTE emits **Float64** (`DurationInMinutes * 60`) because Airbyte infers `DurationInMinutes` as a float on real syncs → the `tasks UNION ALL events` has no supertype and `class_crm_activities` never builds (drops all CRM activity metrics).

**Fix:** `toInt64(DurationInMinutes * 60)`. Int64 (not Float64) is deliberate — the `hubspot__crm_activities` sibling that unions into the same `silver.class_crm_activities` (via `union_by_tag`) already emits `Nullable(Int64)`, so normalizing to Int64 keeps the cross-connector union consistent too.

## #1708 — `crm_bullet_rows` (gold view, migration)
The `deal_size` branch passed `coalesce(d.amount_home, 0)` (**Decimal(38,9)**) while the other five UNION branches are **Float64**. ClickHouse resolves view column types at `CREATE`, so `CREATE OR REPLACE VIEW` threw — and since it runs inside `20260512000000_crm-gold-views.sql`, **every later migration silently never applied**.

**Fix:** `toFloat64(coalesce(d.amount_home, 0))` (matches the sibling branches; no-op when already Float64).

## Verification
Static: both casts align each branch with its sibling/consumer type. The e2e `metrics` lane will confirm the models/gold still build. Note the current fixtures *mask* these (Int64/Float64-typed demo bronze) — a float-`DurationInMinutes` / Decimal-`amount_home` fixture would exercise the failing path directly and is a good follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CRM reporting by standardizing activity duration values to the expected integer type.
  * Fixed deal size metric calculation by explicitly casting numeric outputs to a consistent floating-point type, reducing type-mismatch risks in combined CRM views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->