### PR TITLE
fix(deploy): HOTFIX — wire ClickHouse into insight-identity-config (#1551)

### DIFF
--- a/charts/insight/templates/secrets.yaml
+++ b/charts/insight/templates/secrets.yaml
@@ -245,6 +245,14 @@ stringData:
   # plugin's https-only discovery).
   IDENTITY__identity__auth_gateway_issuer:   {{ printf "https://%s-authenticator.%s.svc.cluster.local:8443" .Release.Name .Release.Namespace | quote }}
   IDENTITY__identity__auth_gateway_jwks_url: {{ printf "http://%s-authenticator.%s.svc.cluster.local:8083/.well-known/jwks.json" .Release.Name .Release.Namespace | quote }}
+  # ClickHouse for persons-seed (reads identity.identity_inputs). The identity
+  # service uses the NATIVE protocol (Octonica client, port 9000) — NOT the HTTP
+  # port (clickhouse.port, 8123) the analytics-api uses (#1551).
+  IDENTITY__clickhouse__host:     {{ include "insight.clickhouse.host" . | quote }}
+  IDENTITY__clickhouse__port:     {{ .Values.clickhouse.nativePort | default 9000 | quote }}
+  IDENTITY__clickhouse__user:     {{ required "clickhouse.username is required" .Values.clickhouse.username | quote }}
+  IDENTITY__clickhouse__password: {{ $chPass | quote }}
+  IDENTITY__clickhouse__database: {{ include "insight.clickhouse.database" . | quote }}
   {{- with (default "" (default dict .Values.global).tenantDefaultId) }}
   # Sourced from `global.tenantDefaultId` — see the secrets.yaml comment on
   # APP__gears__analytics__config__metric_catalog__tenant_default_id

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -244,6 +244,7 @@ ingestion:
 clickhouse:
   host: "" # MUST be set (external L2 ClickHouse host)
   port: 8123 # RFC standard for CH HTTP
+  nativePort: 9000 # native (Octonica) protocol port — the identity service uses this, not the HTTP port
   protocol: http # http|https for the Bronze airbyte/destination-clickhouse 2.x connection
   database: "" # MUST be set
   username: "" # MUST be set

--- a/deploy/gitops/scripts/compose-app-secrets.sh
+++ b/deploy/gitops/scripts/compose-app-secrets.sh
@@ -59,6 +59,10 @@ MDB_USER=$(yq -r '.mariadb.username'         "$VALUES")
 MDB_DB=$(  yq -r '.mariadb.database'         "$VALUES")
 CH_HOST=$( yq -r '.clickhouse.host'          "$VALUES")
 CH_PORT=$( yq -r '.clickhouse.port  // 8123' "$VALUES")
+# Native (Octonica) port for the identity service — it speaks the native
+# protocol, not HTTP (CH_PORT above, used by analytics-api). Overridable via
+# .clickhouse.nativePort; defaults to the standard 9000.
+CH_NATIVE_PORT=$( yq -r '.clickhouse.nativePort // 9000' "$VALUES")
 CH_USER=$( yq -r '.clickhouse.username'      "$VALUES")
 CH_DB=$(   yq -r '.clickhouse.database'      "$VALUES")
 RD_HOST=$( yq -r '.redis.host'               "$VALUES")
@@ -253,6 +257,14 @@ stringData:
   # port (identity validates iss as a string, RequireHttpsMetadata=false).
   IDENTITY__identity__auth_gateway_issuer: "${GATEWAY_ISSUER}"
   IDENTITY__identity__auth_gateway_jwks_url: "${GATEWAY_JWKS_URL}"
+  # ClickHouse for persons-seed (reads identity.identity_inputs). The identity
+  # service uses the NATIVE protocol (Octonica client, port 9000) — NOT the HTTP
+  # port (8123) analytics-api uses. Section \`clickhouse\` -> IDENTITY__clickhouse__*.
+  IDENTITY__clickhouse__host: "${CH_HOST}"
+  IDENTITY__clickhouse__port: "${CH_NATIVE_PORT}"
+  IDENTITY__clickhouse__user: "${CH_USER}"
+  IDENTITY__clickhouse__password: "${CH_PW}"
+  IDENTITY__clickhouse__database: "${CH_DB}"
 EOF
   if [ -n "$TENANT_DEFAULT" ] && [ "$TENANT_DEFAULT" != "null" ]; then
     echo "  IDENTITY__identity__tenant_default_id: \"${TENANT_DEFAULT}\""


### PR DESCRIPTION
Fixes #1551.

> ⚠️ **HOTFIX** — pre-release. Fresh installs cannot run `persons-seed`.

## Problem

The identity service is never given ClickHouse connection settings, so
`persons-seed` (which reads `identity.identity_inputs`) throws immediately:

```
System.ArgumentException: clickhouse options must set either 'url' or 'host'
(+ port/user/password/database)
```

The `insight-identity-config` Secret carried only `IDENTITY__mariadb__url` +
tenant/auth keys — **no `IDENTITY__clickhouse__*`** — so identity's
`ClickHouseOptions` (section `clickhouse`) bound empty and
`ClickHouseConnectionFactory` threw on first use.

## Fix — both producers of `insight-identity-config`

Emit `IDENTITY__clickhouse__{host,port,user,password,database}`, reusing the CH
values each producer already has:

1. **gitops** — `deploy/gitops/scripts/compose-app-secrets.sh` (the composer;
   in gitops `credentials.autoGenerate=false`, so this script is the sole
   producer of the secret).
2. **Helm chart** — `charts/insight/templates/secrets.yaml`
   (`credentials.autoGenerate=true` path), mirroring the analytics CH block.

**Native protocol, port 9000 (not 8123).** Identity uses the native ClickHouse
protocol (Octonica client), unlike analytics-api (HTTP, 8123). So the port is a
separate `nativePort` (script: `.clickhouse.nativePort` // 9000; chart:
`clickhouse.nativePort`, default 9000), not the HTTP port.

## Verification

- gitops: rendered block substitutes correctly (`host`/`user`/`password`/
  `database` + `port: "9000"`); `bash -n` clean; escaped backticks stay literal.
- chart: `values.yaml` parses; mirrors the proven analytics CH block on existing
  helpers (`insight.clickhouse.host`/`database`, `$chPass`). Full `helm template`
  not run locally (subchart deps not vendored) — CI renders it.
- Env keys match the .NET `ClickHouseOptions` (`Host`/`Port`/`User`/`Password`/
  `Database`, section `clickhouse`, prefix `IDENTITY__`).
- Confirmed on the dev stand that identity connects to
  `clickhouse.insight-infra.svc:9000` via the native protocol with the
  `insight-db-creds` clickhouse password — i.e. exactly the values these keys
  supply (8123 would not work for Octonica).

## Post-merge note

The **dev stand currently has NO ClickHouse keys** in `insight-identity-config`
(verified by dumping the secret + pod env); the stock seed throws the
`ArgumentException` above. This fix corrects the **producers**, so the secret
must be **re-composed** (re-run the composer / re-sync) after merge — it does not
self-heal an already-applied secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed identity service ClickHouse connectivity by using the native protocol port instead of the HTTP port.
  * Added complete ClickHouse connection settings for identity-related data seeding.
  * Added a configurable native ClickHouse port, defaulting to `9000`, for more reliable deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->