### PR TITLE
fix(identity): HOTFIX — drop tenant filter from persons-seed read entirely (#1550)

### DIFF
--- a/src/backend/services/identity/src/Insight.Identity.Infrastructure/ClickHouse/ClickHouseIdentityInputsReader.cs
+++ b/src/backend/services/identity/src/Insight.Identity.Infrastructure/ClickHouse/ClickHouseIdentityInputsReader.cs
@@ -19,28 +19,29 @@ public sealed class ClickHouseIdentityInputsReader : IIdentityInputsReader
     // current email and to detect a closed account (latest row is a
     // DELETE). DELETE rows are streamed too; they flag the account as
     // closed but never produce a persons observation.
-    // identity_inputs stores insight_tenant_id / insight_source_id as
-    // Nullable(String) (dashed UUID text). The `_str` aliases avoid
-    // shadowing the source columns referenced in WHERE (a same-name
-    // SELECT alias would otherwise be substituted into the WHERE clause).
+    // The `_str` aliases avoid shadowing the source columns referenced
+    // in WHERE (a same-name SELECT alias would otherwise be substituted
+    // into the WHERE clause).
     //
     // HOTFIX (#1550) — TEMPORARY, identity-scoped, pre-release. The dbt
-    // producer writes insight_tenant_id *hashed* — sipHash128(rawTenant)
-    // rendered as a dashed UUID string (identity_inputs_from_history.sql,
-    // documented there as a TEMPORARY cross-source join key). So a plain
-    // `= {tenant}` matched nothing when the service is configured with the raw
-    // tenant, and persons-seed silently read 0 rows.
+    // producer writes insight_tenant_id *hashed* — sipHash128 of whatever
+    // raw string the connector was configured with (identity_inputs_from_
+    // history.sql, documented there as a TEMPORARY cross-source join key) —
+    // so the stored tenant never equals the caller's tenant and persons-seed
+    // silently read 0 rows. There is no reliable representation to match
+    // against (connector configs are free-form strings), so the tenant
+    // filter is DROPPED for now: Insight deployments are single-tenant, all
+    // identity_inputs rows belong to the deployment, and the seed writes
+    // its output under the caller's tenant regardless of what the rows
+    // carry (PersonsSeedService binds the request tenant, never the row's).
     //
-    // Match BOTH representations of the caller's tenant — the raw value AND its
-    // sipHash — so the read works whether the deployment is configured with the
-    // raw tenant (the hash term matches the hashed data) OR already with the
-    // hashed value (the raw term matches; some envs were worked around that
-    // way). This is strictly additive to the previous `= {tenant}`, so it
-    // cannot regress a currently-working deployment and needs no config /
-    // ingestion / re-seed change. Both terms derive from the single bound
-    // tenant, so tenant isolation holds (a collision would need a real tenant
-    // UUID to equal a sipHash output). Remove once the tenant representation is
-    // unified end to end.
+    // MULTI-TENANT PREREQUISITE: the tenant filter MUST come back before any
+    // multi-tenant deployment — without it every tenant's seed would read
+    // (and re-file under itself) all other tenants' rows. Restoring it
+    // requires the producer side to be fixed first: the tenant representation
+    // unified end to end (dbt resolves real tenant UUIDs instead of hashing
+    // free-form connector strings), then reinstate
+    // `WHERE insight_tenant_id = {tenant:String}` here and in the Rust port.
     private const string StreamSql = """
         SELECT
             toString(insight_tenant_id) AS tenant_id_str,
@@ -52,11 +53,7 @@ public sealed class ClickHouseIdentityInputsReader : IIdentityInputsReader
             _synced_at,
             operation_type
         FROM identity.identity_inputs
-        WHERE insight_tenant_id IN (
-                  {tenant:String},
-                  toString(toUUID(UUIDNumToString(sipHash128({tenant:String}))))
-              )
-          AND operation_type    IN ('UPSERT', 'DELETE')
+        WHERE operation_type    IN ('UPSERT', 'DELETE')
           AND value             IS NOT NULL
           AND value             != ''
         ORDER BY
@@ -79,9 +76,12 @@ public sealed class ClickHouseIdentityInputsReader : IIdentityInputsReader
         Guid tenantId,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
+        // tenantId is intentionally unused while the HOTFIX (#1550) drops the
+        // tenant filter — kept so the interface (and the Rust port tracking
+        // it) stays stable for when the filter comes back.
+        _ = tenantId;
         await using var conn = await _factory.OpenAsync(cancellationToken).ConfigureAwait(false);
         await using var cmd = conn.CreateCommand(StreamSql);
-        cmd.Parameters.AddWithValue("tenant", tenantId.ToString("D"));
         await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {


### PR DESCRIPTION
Follow-up to #1865 / fixes #1550 for real.

> ⚠️ **HOTFIX** — pre-release, temporary, identity-scoped. Supersedes the
> `IN (raw, sipHash(raw))` shim merged in #1865, which turned out to be
> insufficient (see below).

## Why #1865 is not enough

The merged shim matches the caller's tenant raw OR sipHash-hashed. Live
verification on the dev stand (`insight-dev-vhc`) showed a **three-way
mismatch** it cannot cover: the connector config's `insight_tenant_id` is a
free-form string (`'default'` on dev) that need not equal the caller's tenant
at all, so the stored value is `sipHash128('default')` while the caller
presents the real tenant UUID — neither term matches, and persons-seed still
silently reads **0 rows** (verified: the shim's exact WHERE returns 0 against
dev data with the JWT tenant bound).

## Fix

Drop the tenant predicate from the `identity_inputs` read entirely:

- Insight deployments are **single-tenant** — every `identity_inputs` row
  belongs to the deployment, whatever tenant string the connector stamped.
- The **write side is unchanged and stays tenant-scoped**: `PersonsSeedService`
  binds the request tenant for every row it writes and never uses the row's
  tenant, so output lands under the caller's tenant and tenant-scoped
  deletes/rebuilds are untouched.
- `StreamAsync(tenantId, …)` keeps its signature so the interface (and the
  Rust port tracking it) stays stable for when the filter comes back.

Temporary shim; restore the filter once the producer resolves real tenant
UUIDs instead of hashing (tracked follow-up of #1550).

## Verified live (dev stand, patched image, synthetic admin tenant, all changes reverted after)

| build | accounts_read | result |
|---|---|---|
| old `= tenant` filter | **0**, status `completed` | reproduces #1550 — silent empty seed |
| `IN (raw, hash)` shim (#1865) with the dev JWT tenant | **0** | three-way mismatch — still broken |
| this PR | **4758** (all 36,581 rows, 5 sources) | 4629 persons, 25,206 observations, org_chart 4225 rows |

Output was written **only** under the caller's tenant; the pre-existing
tenant's `persons` (42,698) and `org_chart` (4,719) were identical
before/after — write isolation holds without the read filter. Counts line up
with the last known-good seed run (2026-07-20, accounts_read=4740).

## Follow-ups (not in this PR)

- **Silent success**: seed completing with `accounts_read = 0` still emits no warning.
- **Rust port**: `identity-resolution` reader (`infra/identity_inputs.rs`) needs the same change before cutover.
- **Chart gap (#1551)**: helm chart wires no `IDENTITY__clickhouse__*` for identity — persons-seed fails at startup on a fresh chart deploy; must be closed for the release.
- **Proper fix**: unify tenant representation end to end, then restore the filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
