### PR TITLE
fix(jira): tag bronze_promoted 'staging' so prod promotes bronze before enrich (#1886)

### DIFF
--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__bronze_promoted.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__bronze_promoted.sql
@@ -30,10 +30,18 @@
    ------------------------------------------------------------------------- #}
 
 -- @cpt-principle:cpt-dataflow-principle-promote-bronze:p1
+{# `staging` tag (not just `jira`): the prod pipeline's staging step selects
+   `tag:staging,tag:jira` (an AND-intersection — see render_cronworkflow.py /
+   render_sync_trigger.py). Tagged only `jira`, this promote model was excluded
+   from that selection (and, with no `+` in the selector, not pulled in as an
+   upstream either), so on a real Airbyte sync bronze stayed plain MergeTree and
+   the downstream `jira-enrich` step crashed with `Storage MergeTree doesn't
+   support FINAL` (issue #1886). `schema='staging'` sets the target DATABASE, not
+   a dbt tag, so it does not participate in tag selection. #}
 {{ config(
     materialized='view',
     schema='staging',
-    tags=['jira']
+    tags=['jira', 'staging']
 ) }}
 
 {# All Jira bronze tables carry a `unique_key` column added by the connector

--- a/src/ingestion/tests/e2e/meta/test_dbt_runner.py
+++ b/src/ingestion/tests/e2e/meta/test_dbt_runner.py
@@ -9,13 +9,10 @@ silver placeholder table — to keep the test fast.
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
-
 from lib.dbt_runner import DbtError, DbtRunner
 from lib.worker import WorkerContext
-
 
 pytestmark = pytest.mark.smoke
 
@@ -42,13 +39,49 @@ def test_dbt_profiles_written(dbt_runner: DbtRunner) -> None:
     assert "ReplacingMergeTree" in body
 
 
+def test_jira_staging_selector_includes_bronze_promoted(dbt_runner: DbtRunner) -> None:
+    """Regression guard for issue #1886.
+
+    The prod jira pipeline runs its staging dbt step with the selector
+    ``tag:staging,tag:jira`` (an AND-intersection of both tags — hardcoded in
+    ``reconcile-connectors/python/render_cronworkflow.py`` and
+    ``render_sync_trigger.py``). The MergeTree -> ReplacingMergeTree promotion
+    lives in the ``jira__bronze_promoted`` model, and the enrich step that runs
+    right after reads ``bronze_jira.jira_issue FINAL`` — illegal unless that
+    promotion already flipped bronze to ReplacingMergeTree.
+
+    When ``jira__bronze_promoted`` was tagged only ``['jira']`` the AND-selector
+    excluded it (and, with no ``+`` in the selector, it was not pulled in as an
+    upstream either), so prod never promoted, bronze stayed MergeTree, and enrich
+    crashed with ``Storage MergeTree doesn't support FINAL`` on every real sync.
+    Assert the promote model carries BOTH tags so the prod selector picks it up.
+    """
+    manifest = dbt_runner.target_dir / "manifest.json"
+    data = json.loads(manifest.read_text(encoding="utf-8"))
+
+    # Reproduce `tag:staging,tag:jira` (AND) against the parsed manifest: a model
+    # is selected iff its config tags contain every tag in the intersection.
+    required = {"staging", "jira"}
+    selected = {
+        node["name"]
+        for node in data["nodes"].values()
+        if node.get("resource_type") == "model" and required.issubset(set(node.get("config", {}).get("tags", [])))
+    }
+
+    assert "jira__bronze_promoted" in selected, (
+        "jira__bronze_promoted is not selected by the prod staging selector "
+        "'tag:staging,tag:jira'; it must be tagged both 'jira' and 'staging' or "
+        "the MergeTree->ReplacingMergeTree promotion never runs on a real sync "
+        "and jira-enrich crashes with ILLEGAL_FINAL (issue #1886)."
+    )
+
+
 def test_dbt_build_unknown_selector_raises(dbt_runner: DbtRunner) -> None:
     """A selector that matches no models surfaces a clear DbtError."""
     # `dbt build --select <nonsense>` is NOT an error in dbt — it just runs
     # zero models. So we instead pass an invalid selector syntax that dbt
     # rejects. The point of the test is that the wrapper surfaces failures
     # without swallowing the dbt output.
-    runner = dbt_runner
     # Use a deliberately broken --vars to force a non-zero exit
     # (more reliable than guessing bad selector syntax across dbt versions).
     with pytest.raises(DbtError):
@@ -74,7 +107,6 @@ def test_dbt_build_with_worker_context_passes_var(dbt_runner: DbtRunner) -> None
     Running a real dbt build is exercised end-to-end by feature-yaml-rig; here we
     only verify that worker context produces a deterministic --vars payload.
     """
-    runner = dbt_runner
     ctx = WorkerContext(worker_id="gw0", schema_suffix="_w0")
     # We don't call .build() (which would shell out); we just check the worker
     # id translation works as advertised.


### PR DESCRIPTION
## Summary

Fixes #1886 — on a real Airbyte-synced install the jira pipeline crashes at the **enrich** step every run with `Code: 181 … Storage MergeTree doesn't support FINAL (ILLEGAL_FINAL)`, so dbt silver/gold never runs and no jira/task metrics ever appear.

## Root cause

The prod jira pipeline's staging dbt step uses the selector `tag:staging,tag:jira` (an **AND-intersection**, hardcoded in `reconcile-connectors/python/render_cronworkflow.py` and `render_sync_trigger.py`). The MergeTree → ReplacingMergeTree promotion lives in the `jira__bronze_promoted` model, which was tagged **only** `['jira']`.

Because the selector requires *both* tags and has no `+` (so no upstream pull-in), it never selected the promote model. On a real sync bronze therefore stayed a plain `MergeTree`, and the enrich step's `FROM bronze_jira.jira_issue AS ji FINAL` is illegal on `MergeTree` in ClickHouse 25.7 → enrich exits 1 → pipeline aborts before silver/gold.

`schema='staging'` on the model sets the target **database**, not a dbt tag, so it never participated in tag selection.

This was masked everywhere we test:
- **bootstrap-db** (dev/CI) selects the promote model *by name* (`--select jira__bronze_promoted`).
- The **e2e rig** builds `+<staging>` (the `+` pulls the promote in as an upstream) and seeds silver directly, bypassing the Rust enrich binary.

So "works in dev" was never evidence the real Airbyte path worked.

## Fix

Add the `staging` tag: `tags=['jira', 'staging']`. The existing prod staging step now selects the promote model and runs it (before enrich, via the `depends_on` edges the other staging models already declare). Minimal and aligns prod with the bootstrap-db contract.

**jira is the only connector with an enrich step** (verified: only `connectors/task-tracking/jira` has `images.enrich` / an `enrich/` dir). Non-enrich connectors use the legacy `tag:<connector>+` path, which already pulls in their `<connector>__bronze_promoted`, so no other connector needs this change. `tag:staging` is never used bare anywhere — only inside `tag:staging,tag:jira` — so this has no side effects elsewhere.

## Verification (ClickHouse 25.7.5)

1. `dbt ls --select tag:staging,tag:jira`: **before** = 3 models (no promote); **after** = includes `jira__bronze_promoted`. Select-by-name (bootstrap-db) still works.
2. Live repro: seeded `bronze_jira.jira_issue` as plain `MergeTree`, ran the exact enrich query → `Code: 181 ILLEGAL_FINAL`. Ran `dbt run --select jira__bronze_promoted` → migrated to `ReplacingMergeTree`. Re-ran the FINAL query → succeeds and dedups (3 rows → 2 issues, latest version kept). Idempotent on re-run.

## Regression test

Added a manifest-level meta test asserting the prod staging selector `tag:staging,tag:jira` selects `jira__bronze_promoted`. A metric e2e test can't cover this (the rig bypasses enrich and uses a masking selector), so a manifest-level guard is the correct layer.

## Follow-up (out of scope)

`render_cronworkflow.py` / `render_sync_trigger.py` hardcode the staging selector as `"tag:staging,tag:jira" if connector == "jira" else ""`. A second enrich connector would silently get `""` (no staging step). Deriving the staging selector from the connector descriptor would prevent a future recurrence — worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Jira staging pipeline selection so bronze promotion models are included correctly.
  * Prevented downstream failures caused by Jira bronze tables not being promoted to the expected table type.

* **Tests**
  * Added regression coverage to verify Jira staging models are selected as expected.
  * Improved validation of dbt selector behavior and worker-context variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->