### PR TITLE
ci: pin backend appVersions in bump-descriptors too (fix manual rebuild)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -972,6 +972,24 @@ jobs:
               .github/workflows/scripts/bump-descriptor-version.sh --descriptor "$desc"
             done
 
+      # Pin backend service subchart appVersions here too. This job commits
+      # WITHOUT [skip ci] and re-triggers the workflow; because publish-chart
+      # is deferred to that follow-up run (see its `committed != 'true'`
+      # gate), a backend built alongside a connector — or every backend on a
+      # manual full rebuild — would otherwise never get pinned: the follow-up
+      # run doesn't see the backend source as changed. Bumping the subchart
+      # Chart.yaml here makes the follow-up run rebuild that backend and
+      # publish-chart persist its tag. Uses the same script as publish-chart.
+      - name: Bump per-service subchart appVersions (built this run)
+        env:
+          BUILD_TAG: ${{ needs.changes.outputs.build_tag }}
+          FULL_REBUILD: ${{ github.event_name == 'workflow_dispatch' && inputs.frontend_tag == '' }}
+          ANALYTICS: ${{ needs.changes.outputs.analytics }}
+          AUTHENTICATOR: ${{ needs.changes.outputs.authenticator }}
+          GATEWAY: ${{ needs.changes.outputs.gateway }}
+          IDENTITY: ${{ needs.changes.outputs.identity }}
+        run: .github/workflows/scripts/bump-service-appversions.sh
+
       - name: Commit descriptor patches (no [skip ci])
         id: commit
         env:
@@ -988,6 +1006,13 @@ jobs:
             | jq -r '.[].connector_dir + "/descriptor.yaml"' \
             | sort -u \
             | xargs -r git add
+
+          # Stage any backend subchart appVersion bumps from the step above.
+          # git add of an unchanged file is a harmless no-op.
+          git add src/backend/services/analytics/helm/Chart.yaml \
+                  src/backend/services/authenticator/helm/Chart.yaml \
+                  src/backend/services/gateway/helm/Chart.yaml \
+                  src/backend/services/identity/helm/Chart.yaml
 
           if git diff --staged --quiet; then
             echo "no descriptor changes to commit"
@@ -1127,7 +1152,10 @@ jobs:
       # tag in the published chart still resolves to an image that exists.
       # A manual full rebuild (workflow_dispatch, no frontend_tag) rebuilds
       # every service image, so it bumps every service — mirroring the build
-      # jobs' own `workflow_dispatch && frontend_tag == ''` trigger.
+      # jobs' own `workflow_dispatch && frontend_tag == ''` trigger. When
+      # bump-descriptors runs (connectors changed / full rebuild) it does the
+      # bump instead, in its re-triggering commit; this step is the canonical
+      # path when no connector changed and bump-descriptors was skipped.
       - name: Bump per-service subchart appVersions
         env:
           BUILD_TAG: ${{ needs.changes.outputs.build_tag }}
@@ -1136,24 +1164,7 @@ jobs:
           AUTHENTICATOR: ${{ needs.changes.outputs.authenticator }}
           GATEWAY: ${{ needs.changes.outputs.gateway }}
           IDENTITY: ${{ needs.changes.outputs.identity }}
-        run: |
-          set -euo pipefail
-          if [ "$ANALYTICS" = "true" ] || [ "$FULL_REBUILD" = "true" ]; then
-            echo "Bumping analytics subchart appVersion → $BUILD_TAG"
-            yq -i ".appVersion = \"$BUILD_TAG\"" src/backend/services/analytics/helm/Chart.yaml
-          fi
-          if [ "$AUTHENTICATOR" = "true" ] || [ "$FULL_REBUILD" = "true" ]; then
-            echo "Bumping authenticator subchart appVersion → $BUILD_TAG"
-            yq -i ".appVersion = \"$BUILD_TAG\"" src/backend/services/authenticator/helm/Chart.yaml
-          fi
-          if [ "$GATEWAY" = "true" ] || [ "$FULL_REBUILD" = "true" ]; then
-            echo "Bumping gateway subchart appVersion → $BUILD_TAG"
-            yq -i ".appVersion = \"$BUILD_TAG\"" src/backend/services/gateway/helm/Chart.yaml
-          fi
-          if [ "$IDENTITY" = "true" ] || [ "$FULL_REBUILD" = "true" ]; then
-            echo "Bumping identity subchart appVersion → $BUILD_TAG"
-            yq -i ".appVersion = \"$BUILD_TAG\"" src/backend/services/identity/helm/Chart.yaml
-          fi
+        run: .github/workflows/scripts/bump-service-appversions.sh
 
       # Cross-repo frontend bump. The frontend lives in
       # constructorfabric/insight-front and builds its own image; on

--- a/.github/workflows/scripts/bump-service-appversions.sh
+++ b/.github/workflows/scripts/bump-service-appversions.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Bump each backend service subchart's appVersion to $BUILD_TAG when that
+# service's image was (re)built this run: its paths-filter flag is 'true', or
+# this is a manual full rebuild (FULL_REBUILD=true).
+#
+# Shared by the bump-descriptors and publish-chart jobs so both pin the exact
+# same set of services in the same way. A service that wasn't built is left
+# untouched — it keeps its previous appVersion, which still resolves to an
+# image that exists.
+#
+# Env: BUILD_TAG (required), FULL_REBUILD (default false), and one flag per
+# service (ANALYTICS/AUTHENTICATOR/GATEWAY/IDENTITY) carrying the paths-filter
+# output ('true' when that service changed).
+set -euo pipefail
+
+: "${BUILD_TAG:?BUILD_TAG is required}"
+FULL_REBUILD="${FULL_REBUILD:-false}"
+
+# service-flag-env : subchart Chart.yaml
+services=(
+  "ANALYTICS:src/backend/services/analytics/helm/Chart.yaml"
+  "AUTHENTICATOR:src/backend/services/authenticator/helm/Chart.yaml"
+  "GATEWAY:src/backend/services/gateway/helm/Chart.yaml"
+  "IDENTITY:src/backend/services/identity/helm/Chart.yaml"
+)
+
+for entry in "${services[@]}"; do
+  flag_name="${entry%%:*}"
+  chart="${entry#*:}"
+  flag_val="${!flag_name:-false}"
+  if [ "$flag_val" = "true" ] || [ "$FULL_REBUILD" = "true" ]; then
+    echo "Bumping $chart appVersion -> $BUILD_TAG"
+    yq -i ".appVersion = \"$BUILD_TAG\"" "$chart"
+  fi
+done


### PR DESCRIPTION
## Why #1890 wasn't enough

#1890 added the backend subchart `appVersion` bump + persistence, but only inside **`publish-chart`**. On a manual full rebuild (run [30071800363](https://github.com/constructorfabric/insight/actions/runs/30071800363)), `bump-descriptors` committed the connector bumps and **`publish-chart` was skipped** — its `needs.bump-descriptors.outputs.committed != 'true'` gate defers it to the re-triggered push run. So the backend bump never executed.

The re-triggered push run (from the connector-descriptor commit) doesn't see any backend *source* as changed, so backends aren't rebuilt or bumped there either. Net result: **connectors bumped, backends not** — exactly what was observed.

This affects every run where `bump-descriptors` commits: a manual full rebuild, or any push that changes a backend *and* a connector together.

## Fix

- Extract the per-service `appVersion` bump into `scripts/bump-service-appversions.sh`, shared by `publish-chart` and `bump-descriptors` so both pin the same set of services identically.
- **`bump-descriptors` now also bumps + stages the backend subchart `Chart.yaml`s** in its (re-triggering) commit. The follow-up push run then sees those backends as changed, rebuilds them, and `publish-chart` persists their tags (via the git-add from #1890). Backends end pinned to an image that exists; connectors keep their bumps.

### Flow after this change

**Manual full rebuild** (`workflow_dispatch`, no `frontend_tag`):
1. All images build at tag T1; `bump-descriptors` patches connector descriptors **and** bumps all backend `appVersion`s → one commit (no `[skip ci]`) → re-trigger.
2. Re-triggered push run: toolbox rebuilds against patched descriptors, backends rebuild (their `Chart.yaml` changed), `publish-chart` runs and persists every backend `appVersion` + publishes the umbrella.

**Backend-only push** (unchanged): `bump-descriptors` is skipped (no connector), `publish-chart` bumps + persists directly (the #1890 path).

## Trade-off

On the full-rebuild / combined-push paths the backends build a second time in the re-triggered run. Those events are infrequent (manual re-pin, or a PR touching both a backend and a connector), so the extra build is acceptable in exchange for a single canonical chart publish.

Refs #1583

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release automation to keep backend service chart versions synchronized with built images.
  * Added consistent handling for targeted service builds and full rebuilds.
  * Streamlined chart version updates across publishing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->