### PR TITLE
fix(chart): warn when reconcile is enabled but argoInstanceId is unset

### DIFF
--- a/charts/insight/templates/NOTES.txt
+++ b/charts/insight/templates/NOTES.txt
@@ -51,6 +51,19 @@ Next steps:
             authenticator.oidc.issuerUrl at your real IdP for anything else.
 {{- end }}
 
+{{- if and .Values.ingestion.templates.enabled (not .Values.ingestion.reconcile.argoInstanceId) }}
+⚠  WARNING: ingestion.templates.enabled=true but ingestion.reconcile.argoInstanceId
+            is empty. If this cluster's Argo workflow-controller runs with an
+            `instanceID` configured (e.g. installed via `make system-argo`, which
+            sets one), it will only schedule CronWorkflows carrying a matching
+            `workflows.argoproj.io/controller-instanceid` label. With this value
+            empty the label is omitted, so the reconcile loop is SILENTLY ignored
+            — lastScheduled stays `never` and no connectors sync, with no error.
+            Set ingestion.reconcile.argoInstanceId to the controller's instanceID
+            to match. Leave it empty ONLY if your controller runs without an
+            instanceID.
+{{- end }}
+
 {{- if .Values.credentials.autoGenerate }}
 
 Auto-generated DB credentials (stored in Secret insight-db-creds — fixed name):


### PR DESCRIPTION
## What

When the Argo controller runs with an instanceID configured (as `make system-argo` sets), it only schedules CronWorkflows carrying a matching `workflows.argoproj.io/controller-instanceid` label. The chart's `ingestion.reconcile.argoInstanceId` defaults to empty, so the label is omitted and the reconcile loop is silently ignored — `lastScheduled` stays `never`, no connectors sync, nothing errors.

## Change

Emit a `NOTES.txt` warning when `ingestion.templates.enabled` is true but `argoInstanceId` is empty, so the misconfiguration is visible at install time.

Empty stays valid for controllers without an instanceID, so this is a warning rather than a hard render failure (a hard fail would break legitimate non-instanceID installs).

## Scope

Single file: `charts/insight/templates/NOTES.txt`. `helm lint` passes.

Refs #1908

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Helm deployment warning when ingestion templates are enabled but the Argo instance ID is not set.
  * Clarified that an empty Argo instance ID can omit the controller label, causing CronWorkflows scheduling to be ignored and connectors not to sync.
  * Recommended setting `ingestion.reconcile.argoInstanceId` to match the workflow-controller instance ID, or leaving it empty only when no instance ID is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->