### PR TITLE
Remove deprecated airbyte-webapp config

### DIFF
--- a/deploy/gitops/Makefile
+++ b/deploy/gitops/Makefile
@@ -102,6 +102,10 @@ REDPANDA_CONSOLE_RELEASE ?= redpanda-console
 REDPANDA_CONSOLE_CHART   ?= redpanda/console
 REDPANDA_CONSOLE_VERSION ?= 3.7.0
 
+# Airbyte 1.8+ merged the webapp service into server and stopped publishing
+# a separate webapp image — UI is served by the server service. Bumping below
+# 1.8 (or rolling back) requires re-adding the webapp subchart/routing that
+# system/airbyte/values.yaml removed; see issue #1910.
 AIRBYTE_RELEASE  ?= airbyte
 AIRBYTE_VERSION  ?= 1.9.2
 

--- a/deploy/gitops/system/airbyte/values.yaml
+++ b/deploy/gitops/system/airbyte/values.yaml
@@ -56,14 +56,6 @@ server:
     requests: { cpu: 100m, memory: 256Mi }
     limits:   { cpu: "1",  memory: 1Gi }
 
-webapp:
-  replicaCount: 1
-  resources:
-    requests: { cpu: 50m,  memory: 128Mi }
-    limits:   { cpu: 500m, memory: 512Mi }
-  ingress:
-    enabled: false
-
 worker:
   replicaCount: 1
   resources:

--- a/docs/domain/ingestion/README.md
+++ b/docs/domain/ingestion/README.md
@@ -70,7 +70,7 @@ for ingress hostnames and the services/ports it provisions.
 
 | Service | Access | Credentials |
 |---------|--------|-------------|
-| Airbyte | ingress or `kubectl -n insight port-forward svc/airbyte-webapp-svc 8000:80` | from gitops secrets |
+| Airbyte | ingress or `kubectl -n insight port-forward svc/airbyte-airbyte-server-svc 8000:8001` | from gitops secrets |
 | Argo UI | ingress or `kubectl -n insight port-forward svc/argo-server 2746:2746` | No auth (local) |
 | ClickHouse | ingress or `kubectl -n insight port-forward svc/insight-clickhouse 8123:8123` | user: `default`, password: `clickhouse` |
 


### PR DESCRIPTION
Airbyte 1.5+ merged webapp into server. Remove vestigial webapp block causing ImagePullBackOff + 503 errors. Closes #1910.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Airbyte port-forward instructions to use port `8001`.
  * Added guidance for Airbyte 1.8+ packaging changes and version rollbacks.

* **Bug Fixes**
  * Updated Airbyte deployment configuration to use the server component’s resources after the web application image was consolidated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->