### PR TITLE
feat(gitops): identityUrl knob — the consumers' .NET→Rust cutover switch

### DIFF
--- a/deploy/gitops/scripts/compose-app-secrets.sh
+++ b/deploy/gitops/scripts/compose-app-secrets.sh
@@ -35,6 +35,10 @@
 #                                 single-tenant-tr-plugin.)
 #   .identity.orgChartSourceType (optional; empty falls back to the
 #                                 appsettings default `bamboohr`)
+#   .identityUrl                 (optional; the identity URL analytics +
+#                                 authenticator call — the .NET→Rust cutover
+#                                 switch. Empty = the historical .NET
+#                                 `http://<release>-identity:8082`.)
 #
 # Cleartext passwords live only in this shell's memory; they are never
 # written to disk and never echoed.
@@ -75,6 +79,15 @@ IDENTITY_RESOLUTION_BOOTSTRAP_ADMIN=$(yq -r '.identityResolution.bootstrapAdminP
 # when both deploy with diverging names, so the fallback only fires on
 # Rust-only installs that didn't set it.
 IDENTITY_RESOLUTION_DB=$(yq -r '.identityResolution.databaseName // .identity.databaseName // "identity"' "$VALUES")
+# Which identity implementation the CONSUMERS (analytics, authenticator) call —
+# the .NET→Rust cutover switch (constructorfabric/insight#1602). Empty keeps
+# the historical default (the .NET `<release>-identity` Service), so existing
+# environments are untouched; the flip sets it to
+# `http://<release>-identity-resolution:8082`, and the ROLLBACK is clearing it
+# back (plus a rollout restart of analytics + authenticator — they read the
+# composed Secret at pod start).
+IDENTITY_URL=$(yq -r '.identityUrl // ""' "$VALUES")
+[ -n "$IDENTITY_URL" ] && [ "$IDENTITY_URL" != "null" ] || IDENTITY_URL="http://${RELEASE}-identity:8082"
 
 # ── Authenticator OIDC (NGINX_BFF). issuerUrl/redirectUri may be Helm template
 #    strings in values.yaml; render {{ .Release.Name }}/{{ .Release.Namespace }}
@@ -196,7 +209,7 @@ stringData:
   APP__gears__analytics__config__clickhouse_database: "${CH_DB}"
   APP__gears__analytics__config__clickhouse_user: "${CH_USER}"
   APP__gears__analytics__config__clickhouse_password: "${CH_PW}"
-  APP__gears__analytics__config__identity_url: "http://${RELEASE}-identity:8082"
+  APP__gears__analytics__config__identity_url: "${IDENTITY_URL}"
   APP__gears__analytics__config__redis_url: "${REDIS_URL}"
 EOF
   # Metric Catalog single-tenant fallback. Mirrors the chart-side block
@@ -225,7 +238,7 @@ metadata:
 type: Opaque
 stringData:
   APP__gears__authenticator__config__redis_url: "${REDIS_URL}"
-  APP__gears__authenticator__config__identity_url: "http://${RELEASE}-identity:8082"
+  APP__gears__authenticator__config__identity_url: "${IDENTITY_URL}"
   APP__gears__authenticator__config__gateway_issuer: "${GATEWAY_ISSUER}"
   APP__gears__authenticator__config__idp__issuer_url: "${AUTH_IDP_ISSUER}"
   APP__gears__authenticator__config__idp__client_id: "${AUTH_CLIENT_ID}"


### PR DESCRIPTION
Adds an optional `.identityUrl` values key to `deploy/gitops/scripts/compose-app-secrets.sh`: the identity URL both consumers (analytics, authenticator) get in their composed Secrets. Empty keeps the historical .NET `http://<release>-identity:8082`, so every existing environment is untouched.

This is the last missing piece for the dev traffic flip (#1602): the gateway `/api/identity` route is already values-overridable with a checksum-driven restart; the two `identity_url`s were hardcoded in this script. The flip MR in the gitops repo sets `identityUrl: http://<release>-identity-resolution:8082`; **rollback = clearing the key back** (plus a rollout restart of the two consumer deployments — they read the Secret at pod start).

Script-only change, no product code; `bash -n` clean. The private gitops copy gets the same change via its mirror-sync in the flip MR.

Refs #1602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom identity service URL per environment.
  * Applied the configured URL consistently across analytics and authentication settings.
  * Preserved the existing default URL when no custom value is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->