### PR TITLE
chore(zoom): bump connector to 1.2.1 to republish the Cloudflare-skip manifest

### DIFF
--- a/src/ingestion/connectors/collaboration/zoom/descriptor.yaml
+++ b/src/ingestion/connectors/collaboration/zoom/descriptor.yaml
@@ -1,5 +1,12 @@
 name: zoom
-version: "1.2.0"
+# 1.2.1 (patch): republish the manifest carrying the Cloudflare-WAF skip filter
+# on the participants stream (#1933). The fix landed in connector.yaml without a
+# version bump, and reconcile publishes a new manifest only on descriptor-version
+# drift (current 1.2.0 == target 1.2.0 → noop), so Airbyte kept serving the
+# pre-fix manifest and every zoom sync kept dying on the blocked meeting UUID.
+# Patch bump per ADR-0015: republish + catalog re-discover, NO full-refresh
+# (bronze→silver semantics unchanged).
+version: "1.2.1"
 schedule: 0 3 * * *
 dbt_select: tag:zoom+
 workflow: sync


### PR DESCRIPTION
## Why

#1933 fixed the `participants` stream (skip partitions 403-blocked by Cloudflare's WAF) in `connector.yaml` but left the descriptor version at `1.2.0` — the version already active in Airbyte (published Jul 14, pre-fix). Reconcile republishes a manifest only on descriptor-version drift (`current 1.2.0 == target 1.2.0` → noop), so the fixed manifest never reaches Airbyte and every nightly zoom sync keeps dying on the blocked meeting UUID.

## What

One-line descriptor bump `1.2.0` → `1.2.1` (+ version-history comment, same style as m365's).

Per [ADR-0015](https://github.com/constructorfabric/insight/blob/main/docs/components/airbyte-toolkit/specs/ADR/0015-semver-and-full-refresh.md) a **patch** bump dispatches republish + catalog re-discover, **no full-refresh** — correct here: the fix only skips poisoned partitions at extract time, bronze→silver semantics are unchanged.

## Verification plan (dev-vhc, after merge+deploy)

1. reconcile-loop publishes manifest `1.2.1` (active manifest description in Airbyte).
2. `argo submit --from cronwf/zoom-default-sync -n insight` → sync green, participants stream skips the CF-blocked meeting, `_meetings` parent cursor finally advances.

Refs #1932, #1933.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Zoom meeting ingestion to prevent valid meeting UUIDs from being blocked.
  * Updated connector behavior to apply filtering corrections without triggering a full data refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->