### PR TITLE
fix(ci): trigger publish-chart when only identity-resolution changed

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1207,6 +1207,7 @@ jobs:
         || needs.changes.outputs.authenticator == 'true'
         || needs.changes.outputs.gateway      == 'true'
         || needs.changes.outputs.identity     == 'true'
+        || needs.changes.outputs.identity_resolution == 'true'
         || needs.changes.outputs.toolbox      == 'true'
         || needs.changes.outputs.umbrella     == 'true'
         || inputs.frontend_tag != ''


### PR DESCRIPTION
## Summary
- Follow-up to #1939. `publish-chart`'s `if:` condition gates on an OR-list of `needs.changes.outputs.*` flags (`analytics`/`authenticator`/`gateway`/`identity`/`toolbox`/`umbrella`) — `identity_resolution` was never in that list, even though it's the only backend service missing.
- Consequence: a merge that touches only identity-resolution (source, Chart.yaml, or its own workflow wiring) rebuilds the image fine (`backend-identity-resolution` + `merge-identity-resolution` both run and succeed), but `publish-chart` never fires — so the umbrella chart is never republished and the freshly-bumped appVersion is never committed back to `main`. Same end symptom as the two hardcoded `git add` lists #1939 fixed, but via a different mechanism: the job doesn't run at all here, rather than running and dropping the file.
- Caught by re-checking `build-images.yml` run [30255126297](https://github.com/constructorfabric/insight/actions/runs/30255126297) — the run #1939 itself triggered: `backend-identity-resolution`/`merge-identity-resolution` succeeded, but `bump-descriptors` and `publish-chart` both show `skipped`.

## Test plan
- [ ] YAML validated locally (`yaml.safe_load`)
- [ ] Next merge touching only `identity-resolution` should have `publish-chart` actually run and commit a real appVersion bump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated release automation so chart publishing proceeds when identity-resolution backend changes are detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->