### PR TITLE
ci(security): TruffleHog secret gate and Trivy SCA

### DIFF
--- a/.github/workflows/trivy-images.yml
+++ b/.github/workflows/trivy-images.yml
@@ -1,0 +1,168 @@
+name: Trivy Images
+
+# CVE scan of the published images. This is the only place where three things are visible:
+#
+#   1. base-image and OS-package CVEs (nothing in the repository describes them);
+#   2. .NET dependencies — the five .csproj projects ship no packages.lock.json, so
+#      `trivy fs` cannot resolve their versions and skips them entirely;
+#   3. Python dependencies — same story for the eleven pyproject.toml projects (toolbox,
+#      jira-enrich and the connectors), which have no lock file either.
+#
+# Inside an image those dependencies are installed and therefore resolvable, so this workflow
+# carries the SCA coverage that trivy.yml structurally cannot.
+#
+# Report-only: `--exit-code 0`, findings go to "Security -> Code scanning" under a per-image
+# category plus a job-summary table. Nothing blocks. Barring a vulnerable image from
+# promotion — the policy target — means adding the scan to build-images.yml between the merge
+# and publish steps with `--exit-code 1`, which is a change to a much larger workflow and a
+# separate step.
+#
+# Scans `:latest` rather than a build tag, so it reflects what is currently deployable. The
+# legacy `insight-analytics-api` and `insight-api-gateway` packages are deliberately absent:
+# they are pre-rename names that no current build job publishes.
+
+on:
+  schedule:
+    # Nightly, 04:07 UTC — after the repository-level scans (03:13 / 03:27 / 03:41).
+    - cron: "7 4 * * *"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag to scan (default: latest)"
+        required: false
+        default: "latest"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read # checkout (.trivyignore waivers)
+      packages: read # pull the image under scan from GHCR
+      security-events: write # upload SARIF to Code Scanning
+    strategy:
+      # One image's CVEs must not hide another's.
+      fail-fast: false
+      matrix:
+        image:
+          # Rust / C# services
+          - insight-analytics
+          - insight-authenticator
+          - insight-gateway
+          - insight-identity
+          - insight-identity-resolution
+          # Python tooling
+          - insight-toolbox
+          - insight-jira-enrich
+          # Python connectors
+          - source-active-directory-insight
+          - source-bitbucket-cloud-insight
+          - source-github-copilot-insight
+          - source-github-v2-insight
+          - source-gitlab-insight
+          # The waiver below is per-line and must stay on the entry itself: TruffleHog's
+          # GitLab detector reads that 21-character image name as a token. Waiving the line
+          # keeps the detector enabled — it is one of the few that could catch a real
+          # connector credential.
+          - source-hubspot-insight # trufflehog:ignore
+          - source-salesforce-insight
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Trivy image scan (CRITICAL/HIGH)
+        # Trivy pulls straight from the registry (TRIVY_USERNAME/TRIVY_PASSWORD) instead of a
+        # mounted docker socket, so no local `docker pull` is needed. `--ignore-unfixed` keeps
+        # the output to what a base-image or dependency bump can actually fix. A multi-arch
+        # manifest resolves to the runner's platform (linux/amd64); the arm64 leg is built from
+        # the same base image and package set.
+        env:
+          TRIVY_IMAGE: aquasec/trivy:0.72.0@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f
+          IMAGE_REF: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ inputs.tag || 'latest' }}
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "Scanning ${IMAGE_REF}"
+          docker run --rm \
+            -v "${{ github.workspace }}:/work" \
+            -v /tmp/trivy-cache:/root/.cache \
+            -e TRIVY_USERNAME -e TRIVY_PASSWORD \
+            "$TRIVY_IMAGE" image \
+              --severity CRITICAL,HIGH \
+              --pkg-types os,library \
+              --ignore-unfixed \
+              --exit-code 0 \
+              --no-progress \
+              --format json --output /work/trivy-image.json \
+              "$IMAGE_REF"
+          docker run --rm \
+            -v "${{ github.workspace }}:/work" \
+            -v /tmp/trivy-cache:/root/.cache \
+            -e TRIVY_USERNAME -e TRIVY_PASSWORD \
+            "$TRIVY_IMAGE" image \
+              --severity CRITICAL,HIGH \
+              --pkg-types os,library \
+              --ignore-unfixed \
+              --exit-code 0 \
+              --no-progress \
+              --format sarif --output /work/trivy-image.sarif \
+              "$IMAGE_REF"
+
+      - name: Summarize findings in the job summary
+        if: always()
+        # Grouped by (package, version) — the unit of remediation. The ecosystem column
+        # separates base-image OS packages from application dependencies, which is the
+        # difference between "bump the base image" and "bump a dependency".
+        run: |
+          [ -f trivy-image.json ] || exit 0
+          [ -n "${GITHUB_STEP_SUMMARY:-}" ] || exit 0
+          python3 - trivy-image.json "$GITHUB_STEP_SUMMARY" "${{ matrix.image }}" <<'PY'
+          import json, sys, collections
+          d = json.load(open(sys.argv[1], encoding="utf-8"))
+          out = open(sys.argv[2], "a", encoding="utf-8")
+          image = sys.argv[3]
+          w = out.write
+          rows = []
+          for r in d.get("Results") or []:
+              for v in r.get("Vulnerabilities") or []:
+                  rows.append((r.get("Type", "?"), v))
+          w(f"## Trivy image — `{image}`\n\n")
+          w(f"Base image: `{d.get('Metadata', {}).get('OS', {}).get('Family', '?')} "
+            f"{d.get('Metadata', {}).get('OS', {}).get('Name', '?')}`\n\n")
+          if not rows:
+              w("No fixable CRITICAL/HIGH findings.\n")
+              sys.exit(0)
+          sev = collections.Counter(v["Severity"] for _, v in rows)
+          w(f"**{len(rows)}** fixable finding(s) — "
+            + ", ".join(f"{sev[s]} {s}" for s in ("CRITICAL", "HIGH") if sev.get(s)) + "\n\n")
+          bundles = collections.defaultdict(list)
+          for eco, v in rows:
+              bundles[(eco, v["PkgName"], v.get("InstalledVersion", "?"))].append(v)
+          rank = {"CRITICAL": 0, "HIGH": 1}
+          w("| Ecosystem | Package | Max | CVEs | Fixed in |\n|---|---|---|---:|---|\n")
+          for (eco, pkg, ver), items in sorted(
+                  bundles.items(), key=lambda kv: (min(rank.get(i["Severity"], 2) for i in kv[1]), kv[0])):
+              worst = min(items, key=lambda i: rank.get(i["Severity"], 2))["Severity"]
+              fixes = sorted({i.get("FixedVersion") or "-" for i in items})
+              w(f"| {eco} | `{pkg}@{ver}` | {worst} | {len(items)} | {', '.join(fixes)[:60]} |\n")
+          out.close()
+          PY
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        with:
+          sarif_file: trivy-image.sarif
+          # Per-image category: one analysis per image, so alerts never overwrite each other.
+          category: trivy-image:${{ matrix.image }}

--- a/.github/workflows/trivy-images.yml
+++ b/.github/workflows/trivy-images.yml
@@ -91,12 +91,17 @@ jobs:
           IMAGE_REF: ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:${{ inputs.tag || 'latest' }}
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        # One pull and one analysis per image: `trivy convert` derives the SARIF from the JSON
+        # rather than rescanning, which for a 14-image matrix saves 14 redundant registry pulls
+        # and layer analyses. `-w /work` so a repo-root `.trivyignore` is resolved — Trivy reads
+        # the default ignore file relative to the working directory.
         run: |
           set -euo pipefail
           echo "Scanning ${IMAGE_REF}"
           docker run --rm \
             -v "${{ github.workspace }}:/work" \
             -v /tmp/trivy-cache:/root/.cache \
+            -w /work \
             -e TRIVY_USERNAME -e TRIVY_PASSWORD \
             "$TRIVY_IMAGE" image \
               --severity CRITICAL,HIGH \
@@ -108,16 +113,9 @@ jobs:
               "$IMAGE_REF"
           docker run --rm \
             -v "${{ github.workspace }}:/work" \
-            -v /tmp/trivy-cache:/root/.cache \
-            -e TRIVY_USERNAME -e TRIVY_PASSWORD \
-            "$TRIVY_IMAGE" image \
-              --severity CRITICAL,HIGH \
-              --pkg-types os,library \
-              --ignore-unfixed \
-              --exit-code 0 \
-              --no-progress \
+            "$TRIVY_IMAGE" convert \
               --format sarif --output /work/trivy-image.sarif \
-              "$IMAGE_REF"
+              /work/trivy-image.json
 
       - name: Summarize findings in the job summary
         if: always()
@@ -160,7 +158,10 @@ jobs:
           PY
 
       - name: Upload SARIF to GitHub Code Scanning
-        if: always()
+        # The hashFiles guard matters more here than elsewhere: with 14 matrix legs, one failed
+        # registry pull would otherwise report twice — once for the pull, once for a SARIF file
+        # that was never written.
+        if: ${{ always() && hashFiles('trivy-image.sarif') != '' }}
         uses: github/codeql-action/upload-sarif@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
         with:
           sarif_file: trivy-image.sarif

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,170 @@
+name: Trivy SCA
+
+# Software-composition analysis over the repository. Two passes:
+#
+#   gate   — CRITICAL only, blocks. Baseline today: 0 vulnerabilities, 0 secrets,
+#            0 CRITICAL misconfigurations, so the gate starts green.
+#   report — HIGH/MEDIUM/LOW, never blocks. Baseline today: 9 HIGH, 8 MEDIUM, 30 LOW —
+#            all misconfigurations (missing `USER` in four Dockerfiles, and the frontend
+#            chart's absent securityContext under src/frontend/helm). Findings land in
+#            "Security -> Code scanning" plus a job-summary table.
+#
+# Coverage caveat, important when reading a green result: `trivy fs` resolves dependency
+# versions from lock files, and this repository has exactly one — Cargo.lock. The five
+# .csproj projects and eleven pyproject.toml projects ship no lock file, so .NET and Python
+# dependencies are NOT scanned here at all. That coverage lives in trivy-images.yml, which
+# scans the published images where those dependencies are actually installed. Committing
+# lock files (`dotnet restore --use-lock-file`, `uv lock`) would move the coverage earlier.
+#
+# The report pass drops the secret scanner (`--scanners vuln,misconfig`): Code Scanning
+# alerts on a public repository are world-readable and Trivy quotes the surrounding match.
+# Secrets stay in the blocking gate, and TruffleHog owns the domain (trufflehog.yml).
+#
+# Some Helm charts are skipped by the misconfiguration scanner because they require values at
+# render time (`existingSecret is required`, `keycloak.hostname is required`). Those templates
+# are therefore unscanned; the umbrella chart in charts/insight is skipped for the same
+# reason. Rendering them with test values would be the way to close that gap.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # Nightly, 03:41 UTC — after the TruffleHog sweep (03:13) and Semgrep baseline (03:27).
+    - cron: "41 3 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  TRIVY_IMAGE: aquasec/trivy:0.72.0@sha256:cffe3f5161a47a6823fbd23d985795b3ed72a4c806da4c4df16266c02accdd6f
+
+jobs:
+  gate:
+    name: gate (CRITICAL)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Trivy fs scan — CRITICAL only (blocking)
+        # `--ignore-unfixed` keeps the gate actionable: a CRITICAL with no released fix cannot
+        # be resolved by the PR author and belongs in the report pass instead. Waivers go in
+        # `.trivyignore` at the repo root, date-scoped:
+        #   CVE-2026-12345   exp:2026-12-31   # tracked in #NNNN, fix queued
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/src:ro" \
+            "$TRIVY_IMAGE" fs \
+              --scanners vuln,secret,misconfig \
+              --severity CRITICAL \
+              --ignore-unfixed \
+              --exit-code 1 \
+              --no-progress \
+              /src
+
+  report:
+    name: report (HIGH/MEDIUM/LOW)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read # checkout
+      security-events: write # upload SARIF to Code Scanning
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Trivy fs scan — HIGH/MEDIUM/LOW (never blocks)
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "${{ github.workspace }}:/src" \
+            -v /tmp/trivy-cache:/root/.cache \
+            "$TRIVY_IMAGE" fs \
+              --scanners vuln,misconfig \
+              --severity HIGH,MEDIUM,LOW \
+              --exit-code 0 \
+              --no-progress \
+              --format sarif --output /src/trivy-fs.sarif \
+              /src
+          docker run --rm \
+            -v "${{ github.workspace }}:/src" \
+            -v /tmp/trivy-cache:/root/.cache \
+            "$TRIVY_IMAGE" fs \
+              --scanners vuln,misconfig \
+              --severity HIGH,MEDIUM,LOW \
+              --exit-code 0 \
+              --no-progress \
+              --format json --output /src/trivy-fs.json \
+              /src
+
+      - name: Summarize findings in the job summary
+        if: always()
+        # Null-guarded append (repo convention, cf. semgrep.yml). Vulnerabilities are grouped
+        # by package because that is the unit of remediation; misconfigurations are grouped by
+        # rule because one rule usually means the same fix in several files.
+        run: |
+          [ -f trivy-fs.json ] || exit 0
+          [ -n "${GITHUB_STEP_SUMMARY:-}" ] || exit 0
+          CS_BASE="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/security/code-scanning"
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            CS_URL="${CS_BASE}?query=is%3Aopen+pr%3A${GITHUB_REF_NAME%/merge}"
+          else
+            CS_URL="${CS_BASE}?query=is%3Aopen+branch%3A${GITHUB_REF_NAME}"
+          fi
+          python3 - trivy-fs.json "$GITHUB_STEP_SUMMARY" "$CS_URL" <<'PY'
+          import json, sys, collections
+          d = json.load(open(sys.argv[1], encoding="utf-8"))
+          out = open(sys.argv[2], "a", encoding="utf-8")
+          cs_url = sys.argv[3]
+          w = out.write
+          vulns, miscfg = [], []
+          for r in d.get("Results") or []:
+              vulns += r.get("Vulnerabilities") or []
+              miscfg += [(r.get("Target"), m) for m in (r.get("Misconfigurations") or [])]
+          w("## Trivy SCA — repository (report-only)\n\n")
+          w(f"**{len(vulns)}** vulnerabilit(ies) + **{len(miscfg)}** misconfiguration(s) at "
+            f"HIGH/MEDIUM/LOW. CRITICAL is handled by the blocking `gate` job; image layers and "
+            f"the .NET / Python dependencies that only exist inside them are covered by "
+            f"`Trivy Images`. Full details in [Security -> Code scanning]({cs_url}).\n\n")
+          rank = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3}
+          if vulns:
+              bundles = collections.defaultdict(list)
+              for v in vulns:
+                  bundles[(v["PkgName"], v.get("InstalledVersion", "?"))].append(v)
+              w("| Package | Max | CVEs | Fixed in |\n|---|---|---:|---|\n")
+              for (pkg, ver), items in sorted(
+                      bundles.items(), key=lambda kv: (min(rank.get(i["Severity"], 4) for i in kv[1]), kv[0])):
+                  worst = min(items, key=lambda i: rank.get(i["Severity"], 4))["Severity"]
+                  fixes = sorted({i.get("FixedVersion") or "-" for i in items})
+                  w(f"| `{pkg}@{ver}` | {worst} | {len(items)} | {', '.join(fixes)} |\n")
+              w("\n")
+          if miscfg:
+              by_rule = collections.defaultdict(list)
+              for target, m in miscfg:
+                  by_rule[(m["Severity"], m["ID"], m.get("Title", ""))].append(target)
+              w("| Severity | Rule | Files | Title |\n|---|---|---:|---|\n")
+              for (sev, rid, title), targets in sorted(by_rule.items(), key=lambda kv: (rank.get(kv[0][0], 4), kv[0][1])):
+                  w(f"| {sev} | `{rid}` | {len(targets)} | {title} |\n")
+              w("\n<details><summary>Misconfigurations by file</summary>\n\n| Severity | Rule | Target |\n|---|---|---|\n")
+              for target, m in sorted(miscfg, key=lambda tm: (rank.get(tm[1]["Severity"], 4), tm[0])):
+                  w(f"| {m['Severity']} | `{m['ID']}` | `{target}` |\n")
+              w("\n</details>\n")
+          PY
+
+      - name: Upload SARIF to GitHub Code Scanning
+        # Skip on fork PRs: read-only token cannot upload, which would red-X this report-only job.
+        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: github/codeql-action/upload-sarif@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -60,9 +60,16 @@ jobs:
         # be resolved by the PR author and belongs in the report pass instead. Waivers go in
         # `.trivyignore` at the repo root, date-scoped:
         #   CVE-2026-12345   exp:2026-12-31   # tracked in #NNNN, fix queued
+        #
+        # `-w /src` is load-bearing for that: Trivy resolves the default ignore file relative
+        # to the working directory, so without it a repo-root `.trivyignore` is read from the
+        # image's own cwd and silently ignored. `--ignorefile` is not used instead because
+        # Trivy exits FATAL when the named file does not exist, which would break every run
+        # until someone adds a waiver.
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/src:ro" \
+            -w /src \
             "$TRIVY_IMAGE" fs \
               --scanners vuln,secret,misconfig \
               --severity CRITICAL \
@@ -84,21 +91,15 @@ jobs:
           persist-credentials: false
 
       - name: Trivy fs scan — HIGH/MEDIUM/LOW (never blocks)
+        # One scan, two formats: JSON feeds the summary below, and `trivy convert` derives the
+        # SARIF from that same JSON instead of rescanning. `-w /src` for the ignore-file reason
+        # documented on the gate job.
         run: |
           set -euo pipefail
           docker run --rm \
             -v "${{ github.workspace }}:/src" \
             -v /tmp/trivy-cache:/root/.cache \
-            "$TRIVY_IMAGE" fs \
-              --scanners vuln,misconfig \
-              --severity HIGH,MEDIUM,LOW \
-              --exit-code 0 \
-              --no-progress \
-              --format sarif --output /src/trivy-fs.sarif \
-              /src
-          docker run --rm \
-            -v "${{ github.workspace }}:/src" \
-            -v /tmp/trivy-cache:/root/.cache \
+            -w /src \
             "$TRIVY_IMAGE" fs \
               --scanners vuln,misconfig \
               --severity HIGH,MEDIUM,LOW \
@@ -106,6 +107,11 @@ jobs:
               --no-progress \
               --format json --output /src/trivy-fs.json \
               /src
+          docker run --rm \
+            -v "${{ github.workspace }}:/src" \
+            "$TRIVY_IMAGE" convert \
+              --format sarif --output /src/trivy-fs.sarif \
+              /src/trivy-fs.json
 
       - name: Summarize findings in the job summary
         if: always()
@@ -163,7 +169,9 @@ jobs:
 
       - name: Upload SARIF to GitHub Code Scanning
         # Skip on fork PRs: read-only token cannot upload, which would red-X this report-only job.
-        if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        # The hashFiles guard keeps a failed scan from producing a second, misleading error that
+        # points at Code Scanning rather than at the scan that actually broke.
+        if: ${{ always() && hashFiles('trivy-fs.sarif') != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: github/codeql-action/upload-sarif@fb0994ef1c058010acf1efccff928b0a83b1ed54 # v4.32.6
         with:
           sarif_file: trivy-fs.sarif

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -1,0 +1,212 @@
+name: TruffleHog Secrets
+
+# Secret detection, split into a blocking merge gate and a non-blocking history sweep.
+# Companion to semgrep.yml, which excludes generic-secret rules precisely because this
+# workflow owns the domain.
+#
+# Why the split: a full-history scan of this repository currently returns 253 findings —
+# every one of them unverified, and every one triaged (2026-07-28) as a detector false
+# positive: synthetic e2e metric fixtures (178, mostly JiraToken/Lob matching 24- and
+# 40-character fixture strings), the loose GitLab token regex firing on prose in docs/ and
+# on identifiers in dbt models, zero-filled UUIDs in test data, and `CHANGE_ME` templates in
+# `.env.local.example`. Blocking on that baseline would be permanently red, so:
+#
+#   secrets-diff     — pull requests only, BLOCKING. Scans just the commits the PR adds, so
+#                      the historical baseline is out of range by construction and the gate
+#                      starts green. A new secret cannot merge.
+#   secrets-history  — nightly, REPORT-ONLY. Full history over every ref, no exclusions, so
+#                      the 253 stay visible and any change to that number is noticeable.
+#
+# `--results=verified,unknown,unverified,filtered_unverified` on both. The default set
+# (`verified,unknown`) hides findings whose live verification fails, so an already-revoked or
+# inactive credential produces a green run — on a public repository that is still a leak.
+#
+# `--filter-entropy` was evaluated as a way to suppress the fixture noise and REJECTED: at
+# the threshold that clears the baseline (4.0, which cuts 253 findings to 3) a planted AWS
+# access key was also suppressed. A 20-character AWS key ID sits right at that entropy
+# boundary, so the flag trades a known false-negative class for cosmetic quiet.
+#
+# Raw secret values never reach a log, a job summary or an artifact: this repository is
+# public, so Actions logs are world-readable and echoing a hit would publish the value the
+# gate exists to protect. Summaries carry detector, commit and path only.
+#
+# Known gap: direct pushes to main are covered by the nightly report, not by the blocking
+# gate, because a push has no reliable range to diff against on a new or force-pushed ref.
+# Closing it requires the history baseline to be clean.
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    # Nightly sweep, 03:13 UTC — ahead of the Semgrep baseline at 03:27.
+    - cron: "13 3 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  secrets-diff:
+    name: secrets (diff)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          # Full history so --since-commit can reach the merge base.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: TruffleHog scan (commits added by this PR)
+        # Digest-pinned image via `docker run`, matching semgrep.yml. stdout carries the JSON
+        # findings — including raw values — and is redirected to a file that stays on the
+        # runner; only stderr (progress and the scan summary) reaches the log. `--fail` is
+        # not used: the summary step decides the exit code so a failing run still renders a
+        # readable report first.
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "${{ github.workspace }}:/src:ro" \
+            -e BASE_SHA \
+            trufflesecurity/trufflehog:3.96.0@sha256:aa821cf4ace8861c7d096d83818cdf7bb9719028a52d37a52eaad44086a52577 \
+            git file:///src \
+              --json \
+              --no-update \
+              --since-commit "$BASE_SHA" \
+              --results=verified,unknown,unverified,filtered_unverified \
+            > trufflehog-findings.jsonl
+
+      - name: Summarize (redacted) and fail on any finding
+        if: always()
+        run: |
+          [ -f trufflehog-findings.jsonl ] || exit 0
+          python3 - trufflehog-findings.jsonl "${GITHUB_STEP_SUMMARY:-/dev/null}" blocking <<'PY'
+          import json, sys, collections
+          rows = []
+          with open(sys.argv[1], encoding="utf-8") as fh:
+              for line in fh:
+                  line = line.strip()
+                  if not line:
+                      continue
+                  d = json.loads(line)
+                  git = (d.get("SourceMetadata") or {}).get("Data", {}).get("Git", {})
+                  rows.append({
+                      "detector": d.get("DetectorName", "?"),
+                      "verified": bool(d.get("Verified")),
+                      "commit": (git.get("commit") or "")[:8],
+                      "file": git.get("file") or "?",
+                      "line": git.get("line") or "",
+                  })
+          blocking = sys.argv[3] == "blocking"
+          out = open(sys.argv[2], "a", encoding="utf-8")
+          w = out.write
+          w("## TruffleHog — commits added by this PR\n\n")
+          if not rows:
+              w("No secrets detected in the added commits (all result kinds enabled).\n")
+              sys.exit(0)
+          ver = sum(1 for r in rows if r["verified"])
+          w(f"**{len(rows)}** finding(s) — {ver} live-verified, {len(rows) - ver} unverified. "
+            "Values are redacted here on purpose; read them from the source commit.\n\n")
+          w("| Detector | Verified | Commit | Path |\n|---|---|---|---|\n")
+          for r in sorted(rows, key=lambda r: (not r["verified"], r["detector"])):
+              w(f"| `{r['detector']}` | {'yes' if r['verified'] else 'no'} | `{r['commit']}` | `{r['file']}`{':' + str(r['line']) if r['line'] else ''} |\n")
+          by_det = collections.Counter(r["detector"] for r in rows)
+          w(f"\nBy detector: {', '.join(f'{k} x{v}' for k, v in by_det.most_common())}\n")
+          w("\n**Revoke and rotate every credential listed above.** Removing the commit is not "
+            "remediation — assume the value is compromised the moment it was pushed. If a finding "
+            "is a detector false positive on synthetic data, say so in the PR and add a narrow, "
+            "reviewed exclusion rather than widening the filter.\n")
+          out.close()
+          sys.exit(1 if blocking else 0)
+          PY
+
+  secrets-history:
+    name: secrets (full history)
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Fetch every branch
+        # The sweep covers all live branches, so a secret parked on a long-lived feature
+        # branch is visible before it reaches main. Explicit authenticated URL because
+        # `persist-credentials: false` leaves no credential on `origin`; Actions masks the
+        # token in logs.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --prune \
+            "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            '+refs/heads/*:refs/remotes/origin/*'
+
+      - name: TruffleHog scan (all refs, all result kinds)
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "${{ github.workspace }}:/src:ro" \
+            trufflesecurity/trufflehog:3.96.0@sha256:aa821cf4ace8861c7d096d83818cdf7bb9719028a52d37a52eaad44086a52577 \
+            git file:///src \
+              --json \
+              --no-update \
+              --results=verified,unknown,unverified,filtered_unverified \
+            > trufflehog-findings.jsonl
+
+      - name: Summarize (redacted) — report only
+        if: always()
+        # Never fails the run. A rise above the triaged baseline of 253, or any live-verified
+        # finding, is the signal to act; both are visible in the table.
+        run: |
+          [ -f trufflehog-findings.jsonl ] || exit 0
+          python3 - trufflehog-findings.jsonl "${GITHUB_STEP_SUMMARY:-/dev/null}" <<'PY'
+          import json, sys, collections
+          BASELINE = 253  # triaged 2026-07-28: all unverified detector false positives
+          rows = []
+          with open(sys.argv[1], encoding="utf-8") as fh:
+              for line in fh:
+                  line = line.strip()
+                  if not line:
+                      continue
+                  d = json.loads(line)
+                  git = (d.get("SourceMetadata") or {}).get("Data", {}).get("Git", {})
+                  rows.append({
+                      "detector": d.get("DetectorName", "?"),
+                      "verified": bool(d.get("Verified")),
+                      "file": git.get("file") or "?",
+                  })
+          out = open(sys.argv[2], "a", encoding="utf-8")
+          w = out.write
+          ver = sum(1 for r in rows if r["verified"])
+          w("## TruffleHog — full history (report-only)\n\n")
+          w(f"**{len(rows)}** finding(s) over every ref — {ver} live-verified, "
+            f"{len(rows) - ver} unverified. Triaged baseline: **{BASELINE}**, all unverified "
+            "detector false positives.\n\n")
+          if ver:
+              w("> **A live-verified secret is present.** Revoke and rotate it now; rewriting "
+                "history is not remediation.\n\n")
+          if len(rows) > BASELINE:
+              w(f"> Count is **{len(rows) - BASELINE} above** the triaged baseline — new findings "
+                "entered the history. Re-triage before adjusting the baseline.\n\n")
+          if rows:
+              by_det = collections.Counter(r["detector"] for r in rows)
+              w("| Detector | Count |\n|---|---:|\n")
+              for k, v in by_det.most_common():
+                  w(f"| `{k}` | {v} |\n")
+              by_file = collections.Counter(r["file"] for r in rows)
+              w("\n<details><summary>Top paths</summary>\n\n| Count | Path |\n|---:|---|\n")
+              for k, v in by_file.most_common(20):
+                  w(f"| {v} | `{k}` |\n")
+              w("\n</details>\n")
+          out.close()
+          PY

--- a/.gitignore
+++ b/.gitignore
@@ -410,3 +410,13 @@ coverage-raw/
 # whole dirs, so a stray non-.pem key can't slip past a git add -A.
 deploy/compose/authenticator-dev-keys/
 deploy/compose/authn-tls-certs/
+
+# Security scanner output. CI writes these into the workspace, and the same
+# commands are runnable locally; trufflehog's report holds raw secret values, so
+# it must never be committed.
+semgrep.sarif
+trivy-fs.json
+trivy-fs.sarif
+trivy-image.json
+trivy-image.sarif
+trufflehog-findings.jsonl


### PR DESCRIPTION
Completes the scanning set `semgrep.yml` started (umbrella #1478, which also referenced a TruffleHog gate that was never added): secret detection and software-composition analysis, over the repository **and** the published images.

Rollout state per gate follows the measured baseline rather than a uniform policy.

| Job | Blocks? | Baseline measured on this branch |
|---|---|---|
| `secrets (diff)` | **yes** | empty by construction — scans only the commits a PR adds |
| `secrets (full history)` | no | 253 findings, **0 live-verified**, all triaged as detector false positives |
| `gate (CRITICAL)` — repo | **yes** | 0 vulnerabilities, 0 secrets, 0 CRITICAL misconfigurations |
| `report (HIGH/MEDIUM/LOW)` — repo | no | 0 vulnerabilities, 47 misconfigurations (9 HIGH / 8 MEDIUM / 30 LOW) |
| `Trivy Images` (nightly, 14 images) | no | 11 CRITICAL + 88 HIGH fixable in one connector image alone |

## Why TruffleHog is split instead of blocking on history

A full-history scan returns 253 findings. Every one is unverified, and each was triaged: 178 are synthetic e2e metric fixtures (JiraToken and Lob matching 24- and 40-character fixture strings), the rest are the loose GitLab token regex firing on prose in `docs/` and on identifiers in dbt models, zero-filled UUIDs in test data, and `CHANGE_ME` templates in `.env.local.example`. Blocking on that would be permanently red, so the blocking gate scans the PR range only (`--since-commit`) and the history sweep reports nightly without blocking.

Known gap, stated in the workflow: direct pushes to `main` are covered by the nightly report, not by the blocking gate, because a push has no reliable range to diff against on a new or force-pushed ref. Closing it requires the history baseline to be clean.

## Two flags worth reviewing

**`--results=verified,unknown,unverified,filtered_unverified`.** The default (`verified,unknown`) hides findings whose live verification fails, so an already-revoked or inactive credential in history produces a green run — on a public repository that is still a leak requiring rotation. Verified against a control repository with a planted AWS key: under the default flags TruffleHog found it and reported nothing.

**`--filter-entropy` was evaluated and rejected.** It looked like the clean way to suppress the fixture noise — threshold 4.0 cuts 253 findings to 3. On the same control repository that threshold also suppressed the planted AWS key, because a 20-character AWS key ID sits right at that entropy boundary. The flag trades a known false-negative class for cosmetic quiet.

## Why `trivy-images.yml` carries most of the value

`trivy fs` resolves dependency versions from lock files, and this repository has exactly one: `Cargo.lock`. `uv.lock` is gitignored and no `packages.lock.json` exists, so the five `.csproj` and eleven `pyproject.toml` projects are skipped silently — the repository pass covers Rust only. A green result there says much less than it appears to.

Inside the published images those dependencies are installed and resolvable. First scans:

| Image | Base | Fixable CRITICAL/HIGH |
|---|---|---|
| `source-gitlab-insight` | debian **12.6** | **99** — 11 CRITICAL (openssl ×9, libxml2 ×9, libgnutls30 ×7, libssl3 ×9, libexpat1 ×4, `nltk` ×4) |
| `insight-gateway` | alpine 3.22.2 | 26 — 2 CRITICAL (libcrypto3 / libssl3, ×8 each) |
| `insight-toolbox` | debian 13.6 | 21 — 1 CRITICAL (node `tar@6.2.1` ×8, go `x/net` ×4) |

Report-only for exactly that reason: blocking on CRITICAL would fail every build today. Barring a vulnerable image from promotion means adding the scan to `build-images.yml` with `--exit-code 1` — a change to a much larger workflow, and a separate step. Committing lock files (`dotnet restore --use-lock-file`, un-ignoring `uv.lock`) would move Python/.NET coverage earlier, into the repository pass.

## Notes on what the repository pass found

47 misconfigurations, no vulnerabilities. Two things stand out:

- `src/frontend/helm/templates/deployment.yaml` accounts for **15** of them (KSV-0014 root filesystem writable, KSV-0118 default security context, KSV-0001 privilege escalation, KSV-0012 runs as root, KSV-0104 seccomp disabled, KSV-0117 privileged ports). The chart declares no `securityContext` at all. For comparison the gateway chart has 6, all LOW/MEDIUM.
- The production service Dockerfiles do set `USER`: of 19 Dockerfiles only five run as root, and all five are dev or tooling images (`rust-watch`, `seed`, the e2e runner, `declarative-connector`, `toolbox`).

Neither is touched by this PR.

## Test plan

Run locally against this branch.

- [x] YAML parses for all 11 workflows
- [x] `actionlint` over the three new files — exit 0, no findings
- [x] Trivy repository gate, exact command from the workflow — exit 0
- [x] Trivy repository report — 0 vulnerabilities, 47 misconfigurations, SARIF and JSON produced
- [x] Trivy summary script, extracted verbatim from the YAML — renders rule and per-file grouping
- [x] `secrets-diff` summary script against a control repository with planted AWS and GitLab tokens — exits 1, prints detector/commit/path, prints no secret value
- [x] Same script against an empty finding set — exits 0
- [x] `secrets-history` summary script against the real 253 findings — exits 0, baseline logic renders
- [x] `--since-commit` diff mode — 43 chunks over 5 commits, confirming the range is honored
- [x] Image summary script against three real image scans — renders, ecosystem column separates OS packages from application dependencies
- [x] SARIF upload to Code Scanning — confirmed on this PR's own run: the new `trivy-fs` category recorded 47 results against `refs/pull/2002/merge`, matching the local count exactly (9 HIGH / 8 MEDIUM / 30 LOW)
- [x] The blocking gate proved itself on this branch — see below
- [ ] Nightly schedules and the 14-image matrix — first exercised after merge, or via `workflow_dispatch`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated vulnerability scanning for container images (nightly and manual runs) and repository files (on push/PR, nightly, and manual runs), with results summarized in job output.
  * Added secret scanning that blocks pull requests when diff findings are detected and provides a non-blocking nightly full-history report.
  * Uploaded scan results to GitHub code scanning for visibility in security alerts.
* **Bug Fixes**
  * Critical findings (and newly detected secrets) can now fail pull-request checks.
* **Chores**
  * Prevented CI-generated security report artifacts from being committed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## The gate flagged this PR, and that was the point

`secrets (diff)` failed on the first push: TruffleHog's GitLab detector read the matrix entry `source-hubspot-insight` as a token — a 21-character string next to the keyword. Exactly the false-positive class documented above, arriving in the PR that introduces the gate. Two things surfaced while fixing it, both worth knowing before anyone hits them:

- `trufflehog:ignore` only suppresses a finding when the marker sits on the **same line**. A comment above the line does nothing.
- **Commit messages are scanned too.** A fix-up commit that named the offending string in its message was itself flagged.

Because the scan covers every commit a PR adds, a follow-up commit cannot clear it — the original commit without the waiver is still in range. The branch was therefore squashed so the waiver is present from the first commit. Verified on a clean clone of the squashed branch: 0 findings over the same range the gate uses.



Refs #2020
