### PR TITLE
fix(gateway): bump openresty base to 1.31.1.1-2-alpine

### DIFF
--- a/src/backend/services/gateway/Dockerfile
+++ b/src/backend/services/gateway/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN cargo build --release -p routegen
 
 # Stage 2: OpenResty runtime.
-FROM openresty/openresty:1.27.1.2-alpine
+FROM openresty/openresty:1.31.1.1-2-alpine
 
 # Runtime deps not bundled in the base image:
 #   - lua-resty-http (ADR-0001): the access-phase exchange cosocket.

--- a/src/backend/services/gateway/tests/conftest.py
+++ b/src/backend/services/gateway/tests/conftest.py
@@ -11,6 +11,7 @@ the client rewrites them to the published localhost ports (see GatewayClient).
 
 from __future__ import annotations
 
+import json
 import subprocess
 import time
 import urllib.error
@@ -77,6 +78,12 @@ class GatewayClient:
             if part.startswith("__Host-sid="):
                 return part[len("__Host-sid=") :]
         raise AssertionError(f"no __Host-sid in Set-Cookie: {h.get('set-cookie')!r}")
+
+    def csrf_token(self, sid):
+        """Fetch the per-session CSRF token; required on state-changing /auth/*."""
+        status, _, body = self.request(f"{GW}/auth/csrf", headers={"Cookie": f"__Host-sid={sid}"})
+        assert status == 200, f"/auth/csrf got {status}"
+        return json.loads(body)["csrf_token"]
 
 
 def _wait_http(url, want, timeout_s=90):

--- a/src/backend/services/gateway/tests/test_gateway.py
+++ b/src/backend/services/gateway/tests/test_gateway.py
@@ -127,7 +127,12 @@ class TestAuthenticatorDown:
 
 
 def test_revocation_within_cache_window(client, session_sid):
-    logout = client.request(f"{GW}/auth/logout", headers={"Cookie": f"__Host-sid={session_sid}"}, method="POST")
+    # Logout is state-changing: it needs the per-session CSRF token (§10.5).
+    logout = client.request(
+        f"{GW}/auth/logout",
+        headers={"Cookie": f"__Host-sid={session_sid}", "X-CSRF-Token": client.csrf_token(session_sid)},
+        method="POST",
+    )
     assert logout[0] == 200, f"logout got {logout[0]}"
     # Revocation reaches the gateway once the cached exchange expires (<= max-age).
     deadline = time.monotonic() + AUTHZ_CACHE_MAX_AGE + 5


### PR DESCRIPTION
## Summary
Bumps the gateway base image `openresty/openresty:1.27.1.2-alpine` → `1.31.1.1-2-alpine` to clear CVE-2026-31789 (heap buffer overflow parsing large X.509 certificates in OpenSSL).

Fixes #2013

## Verification
Inspected and scanned the new tag directly:
- Alpine 3.23.5 with `libssl3`/`libcrypto3` **3.5.7-r0** (fix landed in 3.5.6-r0)
- OpenResty binary itself built with OpenSSL 3.5.7, so the linked TLS stack is patched, not just the apk metadata
- `trivy image --severity CRITICAL,HIGH --ignore-unfixed`: **0 findings**
- `libuuid` 2.41.4 is preinstalled in the new base (≥ 2.41 as required for `uuid_generate_time_v7`); the Dockerfile's `apk add libuuid` is now a no-op and left in place as documentation of the dependency

## Notes
- 1.27 → 1.31 skips two OpenResty release lines (nginx core 1.27 → 1.31); the gateway's Lua deps (`lua-resty-http`, `lua-resty-uuid` via opm) use stable APIs
- Trivy's secret scanner flags OpenResty's bundled sample RSA key in the base image — pre-existing upstream content, unrelated to #2013

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the gateway’s underlying web server runtime to a newer OpenResty version.
  * No user-facing functionality or configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->