### PR TITLE
feat(metrics): add evidence metadata and drilldown capability

### DIFF
--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -550,6 +550,14 @@
         ],
         "type": "object"
       },
+      "EvidenceGranularity": {
+        "enum": [
+          "event",
+          "source_summary",
+          "derived_population"
+        ],
+        "type": "string"
+      },
       "GetMetricsRequest": {
         "additionalProperties": false,
         "description": "Request body for `POST /v1/catalog/get_metrics`.\n\n`tenant_id` is intentionally NOT accepted here — it is resolved server-side\nfrom the session by `tenant_middleware` (Refs #522 auth-trait). Allowing a\nbody-supplied `tenant_id` would open a cross-tenant disclosure surface.\n`deny_unknown_fields` enforces that defensively at the parser layer: a\ncaller that smuggles `\"tenant_id\": \"...\"` into the body gets a 400 instead\nof a silent ignore.",
@@ -707,6 +715,16 @@
           "direction": {
             "$ref": "#/components/schemas/MetricDirection"
           },
+          "drilldown": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MetricDrilldownCapability"
+              }
+            ]
+          },
           "explanation": {
             "type": [
               "string",
@@ -793,6 +811,24 @@
         ],
         "type": "object"
       },
+      "MetricDimensionFilterDto": {
+        "properties": {
+          "dimension": {
+            "type": "string"
+          },
+          "values": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "dimension",
+          "values"
+        ],
+        "type": "object"
+      },
       "MetricDimensionFilterRequest": {
         "properties": {
           "dimension": {
@@ -818,6 +854,20 @@
           "neutral"
         ],
         "type": "string"
+      },
+      "MetricDrilldownCapability": {
+        "properties": {
+          "granularity": {
+            "items": {
+              "$ref": "#/components/schemas/EvidenceGranularity"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "granularity"
+        ],
+        "type": "object"
       },
       "MetricFormat": {
         "enum": [
@@ -928,6 +978,16 @@
               "direction": {
                 "$ref": "#/components/schemas/MetricDirection"
               },
+              "drilldown": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/MetricDrilldownCapability"
+                  }
+                ]
+              },
               "explanation": {
                 "type": [
                   "string",
@@ -942,6 +1002,9 @@
               },
               "metric_key": {
                 "type": "string"
+              },
+              "selection": {
+                "$ref": "#/components/schemas/MetricResultSelectionDto"
               },
               "short_label": {
                 "type": [
@@ -967,11 +1030,38 @@
               "label",
               "format",
               "direction",
-              "views"
+              "views",
+              "selection"
             ],
             "type": "object"
           }
         ]
+      },
+      "MetricResultSelectionDto": {
+        "properties": {
+          "entity": {
+            "$ref": "#/components/schemas/MetricResultsEntityDto"
+          },
+          "filters": {
+            "items": {
+              "$ref": "#/components/schemas/MetricDimensionFilterDto"
+            },
+            "type": "array"
+          },
+          "metric_key": {
+            "type": "string"
+          },
+          "period": {
+            "$ref": "#/components/schemas/MetricResultsPeriodDto"
+          }
+        },
+        "required": [
+          "metric_key",
+          "entity",
+          "period",
+          "filters"
+        ],
+        "type": "object"
       },
       "MetricResultViewDto": {
         "oneOf": [
@@ -1111,7 +1201,40 @@
         ],
         "type": "object"
       },
+      "MetricResultsEntityDto": {
+        "properties": {
+          "ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "ids"
+        ],
+        "type": "object"
+      },
       "MetricResultsPeriod": {
+        "properties": {
+          "from": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "from",
+          "to"
+        ],
+        "type": "object"
+      },
+      "MetricResultsPeriodDto": {
         "properties": {
           "from": {
             "type": "string"

--- a/docs/domain/metrics/specs/DESIGN.md
+++ b/docs/domain/metrics/specs/DESIGN.md
@@ -124,6 +124,19 @@ has one granularity:
 - `source_summary`: the finest summary preserved by silver.
 - `derived_population`: a source entity participating in a derived metric.
 
+Definitions do not declare a separate drilldown strategy. The runtime resolves
+the definition's existing input roles and source measures, requires every input
+to use the same evidence relation, and compiles the evidence selection from
+that metadata. A new metric over existing evidence-backed measures therefore
+inherits drilldown without metric-specific SQL, backend branches, or frontend
+configuration.
+
+The schema validator probes every standard column. Drilldown capability is
+absent until the probe is definitively healthy and every metric input has
+granularity metadata. Missing, unchecked, or invalid evidence fails closed.
+`POST /v1/metric-results` and `GET /v1/metric-definitions` expose that
+capability; consumers omit evidence actions when it is absent.
+
 The evidence contract has these limitations:
 
 - Summary-grain silver cannot produce event-grain evidence. AI and
@@ -326,10 +339,20 @@ type MetricResult = {
   format: "integer" | "decimal" | "currency" | "percent"
   direction: "higher_is_better" | "lower_is_better" | "neutral"
   views: MetricResultView[]
+  selection: {
+    metric_key: string
+    entity: { type: string; ids: string[] }
+    period: { from: string; to: string }
+    filters: Array<{ dimension: string; values: string[] }>
+  }
+  drilldown?: {
+    granularity: Array<"event" | "source_summary" | "derived_population">
+  }
 } & (
   | { computation: "sum" }
   | { computation: "ratio"; scale: number }
   | { computation: "median" }
+  | { computation: "distinct_count" }
 )
 ```
 

--- a/src/backend/services/analytics/src/api/metric_results.rs
+++ b/src/backend/services/analytics/src/api/metric_results.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -10,6 +10,7 @@ use toolkit_canonical_errors::CanonicalError;
 
 use super::AppState;
 use super::error::MetricError;
+use crate::domain::metric_drilldown::load_capabilities;
 use crate::domain::metric_results::{
     BatchItem, BreakdownQueryRow, CompiledQuery, HistogramQueryRow, MetricResultViewDto,
     MetricResultsRequest, MetricResultsResponse, PeerWideRow, PeriodWideRow, PlannedQuery,
@@ -32,23 +33,36 @@ pub async fn query_metric_results(
     Extension(ctx): Extension<SecurityContext>,
     Json(req): Json<MetricResultsRequest>,
 ) -> Result<Json<MetricResultsResponse>, CanonicalError> {
-    let req = validate_request(&state.db, ctx.subject_tenant_id(), req).await?;
-    let mut ranking_results = BTreeMap::new();
-    let mut rankings = stream::iter(plan_rankings(&req))
-        .map(|ranking| {
-            let state = Arc::clone(&state);
-            async move {
-                let comment = format!("metric-results:ranking:{}", ranking.key.rank_metric_key);
-                let rows = fetch_rows::<RankingQueryRow>(&state, ranking.query, &comment).await?;
-                let groups = build_ranked_groups(&ranking.dimensions, rows)?;
-                Ok::<_, CanonicalError>((ranking.key, groups))
-            }
-        })
-        .buffer_unordered(QUERY_CONCURRENCY);
-    while let Some(result) = rankings.next().await {
-        let (key, groups) = result?;
-        ranking_results.insert(key, groups);
-    }
+    let tenant_id = ctx.subject_tenant_id();
+    let req = validate_request(&state.db, tenant_id, req).await?;
+    let metric_keys = req
+        .metrics
+        .iter()
+        .map(|metric| metric.def.key().to_owned())
+        .collect::<Vec<_>>();
+    let capabilities = load_capabilities(&state.db, tenant_id, &metric_keys);
+    let rankings = async {
+        let mut ranking_results = BTreeMap::new();
+        let mut rankings = stream::iter(plan_rankings(&req))
+            .map(|ranking| {
+                let state = Arc::clone(&state);
+                async move {
+                    let comment = format!("metric-results:ranking:{}", ranking.key.rank_metric_key);
+                    let rows =
+                        fetch_rows::<RankingQueryRow>(&state, ranking.query, &comment).await?;
+                    let groups = build_ranked_groups(&ranking.dimensions, rows)?;
+                    Ok::<_, CanonicalError>((ranking.key, groups))
+                }
+            })
+            .buffer_unordered(QUERY_CONCURRENCY);
+        while let Some(result) = rankings.next().await {
+            let (key, groups) = result?;
+            ranking_results.insert(key, groups);
+        }
+        Ok::<_, CanonicalError>(ranking_results)
+    };
+    let (ranking_results, capabilities) = tokio::join!(rankings, capabilities);
+    let ranking_results = ranking_results?;
     let planned = plan_queries(&req, &ranking_results)?;
 
     let mut views_by_metric: Vec<Vec<Option<MetricResultViewDto>>> = req
@@ -68,6 +82,13 @@ pub async fn query_metric_results(
         }
     }
 
+    let capabilities = match capabilities {
+        Ok(capabilities) => capabilities,
+        Err(error) => {
+            tracing::warn!(error = ?error, "metric drilldown capability load failed");
+            HashMap::default()
+        }
+    };
     let mut metrics = Vec::with_capacity(req.metrics.len());
     for (idx, metric) in req.metrics.iter().enumerate() {
         let mut views = Vec::with_capacity(metric.views.len());
@@ -78,7 +99,31 @@ pub async fn query_metric_results(
             enforce_view_row_limit(&view, format!("metrics[{idx}].views[{view_index}]"))?;
             views.push(view);
         }
-        metrics.push(build_metric_result(&metric.def, views));
+        let selection = crate::domain::metric_results::MetricResultSelectionDto {
+            metric_key: metric.def.key().to_owned(),
+            entity: crate::domain::metric_results::MetricResultsEntityDto {
+                r#type: req.entity_type.clone(),
+                ids: req.entity_ids.clone(),
+            },
+            period: crate::domain::metric_results::MetricResultsPeriodDto {
+                from: req.from.to_string(),
+                to: req.to.to_string(),
+            },
+            filters: metric
+                .filters
+                .iter()
+                .map(
+                    |filter| crate::domain::metric_results::MetricDimensionFilterDto {
+                        dimension: filter.dimension.clone(),
+                        values: filter.values.clone(),
+                    },
+                )
+                .collect(),
+        };
+
+        let mut result = build_metric_result(&metric.def, views, selection);
+        result.drilldown = capabilities.get(metric.def.key()).cloned();
+        metrics.push(result);
     }
 
     let response = MetricResultsResponse { metrics };

--- a/src/backend/services/analytics/src/domain/metric_definitions/builtin.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/builtin.rs
@@ -1,5 +1,6 @@
 use crate::domain::metric_definitions::definition::{
-    MetricComputation, MetricDirection, MetricFormat, MetricInputRole, SourceKind, ValueTransform,
+    EvidenceGranularity, MetricComputation, MetricDirection, MetricFormat, MetricInputRole,
+    SourceKind, ValueTransform,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -60,12 +61,40 @@ pub struct SourceSeed {
     /// Managed-observation relation name; must satisfy
     /// `ObservationRelation::parse` (pinned by a registry test).
     pub source_ref: &'static str,
+    pub evidence_ref: &'static str,
 }
 
 pub struct BuiltinSource {
     pub source: SourceSeed,
     pub measures: &'static [&'static str],
     pub dimensions: &'static [&'static str],
+}
+
+impl BuiltinSource {
+    pub fn evidence_granularity(&self, measure_key: &str) -> EvidenceGranularity {
+        match (self.source.key, measure_key) {
+            (
+                "git",
+                "commit_count" | "commit_change_size" | "pr_created" | "pr_created_merged"
+                | "pr_merged" | "pr_cycle_hours" | "pr_change_size",
+            )
+            | (
+                "task",
+                "tasks_closed" | "bugs_fixed" | "due_date_on_time" | "due_date_with_due"
+                | "slip_days_total" | "late_count" | "dev_time_hours" | "resolution_days"
+                | "pickup_days",
+            )
+            | ("wiki", "pages_created") => EvidenceGranularity::Event,
+            ("ai_usage", "active_day")
+            | (
+                "collab",
+                "active_day" | "active_modality" | "meeting_free_day" | "focus_hours"
+                | "working_hours",
+            )
+            | ("task", _) => EvidenceGranularity::DerivedPopulation,
+            _ => EvidenceGranularity::SourceSummary,
+        }
+    }
 }
 
 pub struct MetricSeed {
@@ -101,6 +130,7 @@ pub const BUILTIN_SOURCES: &[BuiltinSource] = &[
             key: "ai_usage",
             kind: SourceKind::ManagedObservation,
             source_ref: "ai_metric_observations",
+            evidence_ref: "ai_metric_evidence",
         },
         measures: &[
             "accepted_lines",
@@ -121,6 +151,7 @@ pub const BUILTIN_SOURCES: &[BuiltinSource] = &[
             key: "git",
             kind: SourceKind::ManagedObservation,
             source_ref: "git_metric_observations",
+            evidence_ref: "git_metric_evidence",
         },
         measures: &[
             "commit_count",
@@ -150,6 +181,7 @@ pub const BUILTIN_SOURCES: &[BuiltinSource] = &[
             key: "collab",
             kind: SourceKind::ManagedObservation,
             source_ref: "collab_metric_observations",
+            evidence_ref: "collab_metric_evidence",
         },
         measures: &[
             "total_chat_messages",
@@ -181,6 +213,7 @@ pub const BUILTIN_SOURCES: &[BuiltinSource] = &[
             key: "task",
             kind: SourceKind::ManagedObservation,
             source_ref: "task_metric_observations",
+            evidence_ref: "task_metric_evidence",
         },
         measures: &[
             "tasks_closed",
@@ -209,6 +242,7 @@ pub const BUILTIN_SOURCES: &[BuiltinSource] = &[
             key: "wiki",
             kind: SourceKind::ManagedObservation,
             source_ref: "wiki_metric_observations",
+            evidence_ref: "wiki_metric_evidence",
         },
         measures: &["pages_created", "edits", "pages_edited", "comments"],
         dimensions: &[],

--- a/src/backend/services/analytics/src/domain/metric_definitions/definition.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/definition.rs
@@ -17,7 +17,7 @@ pub enum MetricFormat {
     Percent,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum MetricComputation {
     Sum,
@@ -26,12 +26,39 @@ pub enum MetricComputation {
     DistinctCount,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum MetricInputRole {
     Value,
     Numerator,
     Denominator,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceGranularity {
+    Event,
+    SourceSummary,
+    DerivedPopulation,
+}
+
+impl EvidenceGranularity {
+    pub fn as_db(self) -> &'static str {
+        match self {
+            Self::Event => "event",
+            Self::SourceSummary => "source_summary",
+            Self::DerivedPopulation => "derived_population",
+        }
+    }
+
+    pub fn from_db(value: &str) -> Option<Self> {
+        match value {
+            "event" => Some(Self::Event),
+            "source_summary" => Some(Self::SourceSummary),
+            "derived_population" => Some(Self::DerivedPopulation),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -65,6 +92,9 @@ impl SourceKind {
 /// a dbt model plus registry seed rows — no code change here.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ObservationRelation(String);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvidenceRelation(String);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CohortSource {
@@ -218,20 +248,7 @@ impl ObservationRelation {
     /// lowercase `snake_case` ending in `_metric_observations`, with a
     /// non-empty family prefix. Anything else is a configuration error.
     pub fn parse(value: &str) -> Option<Self> {
-        let family = value.strip_suffix("_metric_observations")?;
-        if family.is_empty() {
-            return None;
-        }
-        let mut chars = family.chars();
-        let starts_alpha = chars.next().is_some_and(|c| c.is_ascii_lowercase());
-        let rest_ok = family
-            .chars()
-            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_');
-        if starts_alpha && rest_ok {
-            Some(Self(value.to_owned()))
-        } else {
-            None
-        }
+        parse_relation(value, "_metric_observations").map(Self)
     }
 
     pub fn table_ref(&self) -> (&'static str, &str) {
@@ -243,6 +260,30 @@ impl ObservationRelation {
     pub fn source_ref(&self) -> &str {
         &self.0
     }
+}
+
+impl EvidenceRelation {
+    pub const DATABASE: &'static str = "insight";
+
+    pub fn parse(value: &str) -> Option<Self> {
+        parse_relation(value, "_metric_evidence").map(Self)
+    }
+
+    pub fn table_ref(&self) -> (&'static str, &str) {
+        (Self::DATABASE, &self.0)
+    }
+
+    pub fn source_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+fn parse_relation(value: &str, suffix: &str) -> Option<String> {
+    let family = value.strip_suffix(suffix)?;
+    let mut chars = family.chars();
+    let starts_alpha = chars.next().is_some_and(|c| c.is_ascii_lowercase());
+    let rest_ok = chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_');
+    (starts_alpha && rest_ok).then(|| value.to_owned())
 }
 
 impl CohortSource {
@@ -401,6 +442,17 @@ mod tests {
         ] {
             assert_eq!(MetricInputRole::from_db(role.as_db()), Some(role));
         }
+        for granularity in [
+            EvidenceGranularity::Event,
+            EvidenceGranularity::SourceSummary,
+            EvidenceGranularity::DerivedPopulation,
+        ] {
+            assert_eq!(
+                EvidenceGranularity::from_db(granularity.as_db()),
+                Some(granularity)
+            );
+        }
+        assert_eq!(EvidenceGranularity::from_db("unknown"), None);
         let relation = ObservationRelation::parse("ai_metric_observations")
             .unwrap_or_else(|| panic!("builtin relation name must parse"));
         let (_, table) = relation.table_ref();
@@ -415,6 +467,10 @@ mod tests {
         ] {
             assert_eq!(SourceKind::from_db(kind.as_db()), Some(kind));
         }
+        let evidence = EvidenceRelation::parse("ai_metric_evidence")
+            .unwrap_or_else(|| panic!("builtin evidence must parse"));
+        assert_eq!(evidence.table_ref(), ("insight", "ai_metric_evidence"));
+        assert_eq!(evidence.source_ref(), "ai_metric_evidence");
     }
 
     #[test]

--- a/src/backend/services/analytics/src/domain/metric_definitions/listing.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/listing.rs
@@ -19,6 +19,7 @@ use uuid::Uuid;
 use crate::domain::metric_definitions::definition::{MetricDirection, MetricFormat};
 use crate::domain::metric_definitions::error_code::{MetricSchemaErrorCode, SchemaStatus};
 use crate::domain::metric_definitions::repository::fetch_dimensions;
+use crate::domain::metric_drilldown::{MetricDrilldownCapability, load_capabilities};
 
 /// Response body for `GET /v1/metric-definitions`. Metrics are sorted by
 /// `metric_key` ascending so the payload is byte-stable for caching and
@@ -51,6 +52,8 @@ pub struct MetricDefinitionView {
     /// measures; absent when no observation has ever been seen. Freshness
     /// signal, orthogonal to `schema_status`.
     pub last_observed_date: Option<chrono::NaiveDate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub drilldown: Option<MetricDrilldownCapability>,
 }
 
 impl toolkit::api::api_dto::ResponseApiDto for MetricDefinitionListResponse {}
@@ -81,6 +84,17 @@ pub async fn list_definition_views(
         .await
         .map_err(|error| db_error(&error))?;
     let selected = select_rows(rows);
+    let metric_keys = selected
+        .iter()
+        .map(|row| row.metric_key.clone())
+        .collect::<Vec<_>>();
+    let mut capabilities = match load_capabilities(db, tenant_id, &metric_keys).await {
+        Ok(capabilities) => capabilities,
+        Err(error) => {
+            tracing::warn!(error = ?error, "metric drilldown capability load failed");
+            HashMap::new()
+        }
+    };
 
     let definition_ids = selected
         .iter()
@@ -90,7 +104,10 @@ pub async fn list_definition_views(
         .await
         .map_err(|error| db_error(&error))?;
 
-    let metrics = build_views(selected, dimensions)?;
+    let mut metrics = build_views(selected, dimensions)?;
+    for metric in &mut metrics {
+        metric.drilldown = capabilities.remove(&metric.metric_key);
+    }
     Ok(MetricDefinitionListResponse { metrics })
 }
 
@@ -148,6 +165,7 @@ fn build_views(
             schema_status,
             schema_error_code,
             last_observed_date: row.last_observed_date,
+            drilldown: None,
         });
     }
     Ok(metrics)

--- a/src/backend/services/analytics/src/domain/metric_definitions/live_tests.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/live_tests.rs
@@ -13,7 +13,12 @@ use uuid::Uuid;
 
 use crate::domain::metric_definitions::error_code::SchemaStatus;
 use crate::domain::metric_definitions::listing::list_definition_views;
-use crate::domain::metric_definitions::repository::update_definition_status;
+use crate::domain::metric_definitions::repository::{
+    update_definition_status, update_evidence_status, update_source_status,
+};
+use crate::domain::metric_definitions::test_fixture::DrilldownFixture;
+use crate::domain::metric_definitions::validator::MetricDefinitionValidator;
+use crate::domain::metric_drilldown::load_capabilities;
 
 const ENV_VAR: &str = "INTEGRATION_TESTS_MARIADB_URL";
 
@@ -149,4 +154,195 @@ async fn update_definition_status_advances_but_never_regresses_freshness() -> an
     update_definition_status(&db, id, SchemaStatus::Ok, None, Some(newest)).await?;
     assert_eq!(stored_last_observed(&db, id).await?, Some(newest));
     Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires live MariaDB 11+; set INTEGRATION_TESTS_MARIADB_URL to enable"]
+async fn drilldown_capabilities_follow_healthy_evidence_metadata() -> anyhow::Result<()> {
+    let Some(db) = connect_or_skip().await else {
+        return Ok(());
+    };
+    let fixture = DrilldownFixture::insert(&db, &["git.commits", "tasks.closed"], &[]).await?;
+    let keys = vec![
+        "git.commits".to_owned(),
+        "tasks.closed".to_owned(),
+        "missing.metric".to_owned(),
+    ];
+    let result = async {
+        let capabilities = load_capabilities(&db, fixture.tenant_id, &keys).await?;
+        anyhow::ensure!(capabilities.contains_key("git.commits"));
+        anyhow::ensure!(capabilities.contains_key("tasks.closed"));
+        anyhow::ensure!(!capabilities.contains_key("missing.metric"));
+        anyhow::ensure!(
+            load_capabilities(&db, fixture.tenant_id, &[])
+                .await?
+                .is_empty()
+        );
+        Ok(())
+    }
+    .await;
+    fixture.delete(&db).await?;
+    result
+}
+
+#[tokio::test]
+#[ignore = "requires live MariaDB 11+; set INTEGRATION_TESTS_MARIADB_URL to enable"]
+async fn evidence_status_writer_is_revision_conditional() -> anyhow::Result<()> {
+    let Some(db) = connect_or_skip().await else {
+        return Ok(());
+    };
+    let fixture = DrilldownFixture::insert(&db, &["git.commits"], &[]).await?;
+    let result = async {
+        let revision = fixture.config_revision(&db).await?;
+        update_evidence_status(
+            &db,
+            fixture.source_id,
+            &revision,
+            SchemaStatus::Error,
+            Some(crate::domain::metric_definitions::error_code::MetricSchemaErrorCode::Unknown),
+        )
+        .await?;
+        let current = fixture.statuses(&db).await?;
+        anyhow::ensure!(
+            current
+                == (
+                    "ok".to_owned(),
+                    "error".to_owned(),
+                    Some("unknown".to_owned())
+                )
+        );
+        update_evidence_status(
+            &db,
+            fixture.source_id,
+            "1970-01-01 00:00:00.000000",
+            SchemaStatus::Ok,
+            None,
+        )
+        .await?;
+        let stale = fixture.statuses(&db).await?;
+        anyhow::ensure!(
+            stale == current,
+            "stale evidence status write changed {current:?} to {stale:?}"
+        );
+        Ok(())
+    }
+    .await;
+    fixture.delete(&db).await?;
+    result
+}
+
+#[tokio::test]
+#[ignore = "requires live MariaDB 11+; set INTEGRATION_TESTS_MARIADB_URL to enable"]
+async fn source_status_writer_is_revision_conditional() -> anyhow::Result<()> {
+    let Some(db) = connect_or_skip().await else {
+        return Ok(());
+    };
+    let fixture = DrilldownFixture::insert(&db, &["git.commits"], &["repository"]).await?;
+    let result = async {
+        let revision = fixture.config_revision(&db).await?;
+        update_source_status(
+            &db,
+            fixture.source_id,
+            &revision,
+            SchemaStatus::Error,
+            Some(
+                crate::domain::metric_definitions::error_code::MetricSchemaErrorCode::TableNotFound,
+            ),
+        )
+        .await?;
+        let current = fixture.statuses(&db).await?;
+        anyhow::ensure!(
+            current.0 == "error",
+            "revision-matched write did not land: {current:?}"
+        );
+
+        update_source_status(
+            &db,
+            fixture.source_id,
+            "1970-01-01 00:00:00.000000",
+            SchemaStatus::Ok,
+            None,
+        )
+        .await?;
+        let stale = fixture.statuses(&db).await?;
+        anyhow::ensure!(
+            stale == current,
+            "stale source status write changed {current:?} to {stale:?}"
+        );
+        Ok(())
+    }
+    .await;
+    fixture.delete(&db).await?;
+    result
+}
+
+#[tokio::test]
+#[ignore = "requires live MariaDB 11+; set INTEGRATION_TESTS_MARIADB_URL to enable"]
+async fn invalid_evidence_reference_is_an_error_not_unchecked() -> anyhow::Result<()> {
+    let Some(db) = connect_or_skip().await else {
+        return Ok(());
+    };
+    let fixture = DrilldownFixture::insert(&db, &["git.commits"], &[]).await?;
+    let result = async {
+        db.execute(Statement::from_sql_and_values(
+            db.get_database_backend(),
+            "UPDATE metric_sources SET evidence_ref = ? WHERE id = ?",
+            [
+                Value::from("Not A Relation"),
+                Value::Bytes(Some(Box::new(fixture.source_id.as_bytes().to_vec()))),
+            ],
+        ))
+        .await?;
+        let invalidated = fixture.statuses(&db).await?;
+        anyhow::ensure!(
+            invalidated.1 == "unchecked",
+            "changing evidence_ref must invalidate the probe: {invalidated:?}"
+        );
+
+        let ch = insight_clickhouse::Client::new(insight_clickhouse::Config::new(
+            "http://127.0.0.1:1",
+            "analytics",
+        ));
+        MetricDefinitionValidator::new(db.clone(), ch)
+            .validate_all()
+            .await;
+
+        let after = fixture.statuses(&db).await?;
+        anyhow::ensure!(
+            after.1 == "error" && after.2.as_deref() == Some("unknown"),
+            "an unparseable evidence_ref must fail closed as an error: {after:?}"
+        );
+        Ok(())
+    }
+    .await;
+    fixture.delete(&db).await?;
+    result
+}
+
+#[tokio::test]
+#[ignore = "requires live MariaDB 11+; set INTEGRATION_TESTS_MARIADB_URL to enable"]
+async fn metric_definition_validator_handles_unavailable_clickhouse() -> anyhow::Result<()> {
+    let Some(db) = connect_or_skip().await else {
+        return Ok(());
+    };
+    let fixture = DrilldownFixture::insert(&db, &["git.commits"], &[]).await?;
+    let result = async {
+        let before = fixture.statuses(&db).await?;
+        let ch = insight_clickhouse::Client::new(insight_clickhouse::Config::new(
+            "http://127.0.0.1:1",
+            "analytics",
+        ));
+        MetricDefinitionValidator::new(db.clone(), ch)
+            .validate_all()
+            .await;
+        let after = fixture.statuses(&db).await?;
+        anyhow::ensure!(
+            after == before,
+            "unavailable ClickHouse changed source status from {before:?} to {after:?}"
+        );
+        Ok(())
+    }
+    .await;
+    fixture.delete(&db).await?;
+    result
 }

--- a/src/backend/services/analytics/src/domain/metric_definitions/mod.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/mod.rs
@@ -6,11 +6,13 @@ pub mod listing;
 mod live_tests;
 mod repository;
 mod seeds;
+#[cfg(test)]
+pub(crate) mod test_fixture;
 pub mod validator;
 
 pub use definition::{
-    CohortSource, ComputationSpec, MetricDefinition, MetricDirection, MetricFormat,
-    ObservationRelation,
+    CohortSource, ComputationSpec, EvidenceGranularity, EvidenceRelation, MetricDefinition,
+    MetricDirection, MetricFormat, ObservationRelation,
 };
 pub use repository::load_definitions;
 pub use seeds::reconcile_builtin_definitions;

--- a/src/backend/services/analytics/src/domain/metric_definitions/repository.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/repository.rs
@@ -84,6 +84,21 @@ pub async fn load_definitions(
     tenant_id: Uuid,
     metric_keys: &[String],
 ) -> Result<HashMap<String, MetricDefinition>, CanonicalError> {
+    load_definitions_with_ids(db, tenant_id, metric_keys)
+        .await
+        .map(|definitions| {
+            definitions
+                .into_iter()
+                .map(|(key, (_, definition))| (key, definition))
+                .collect()
+        })
+}
+
+pub async fn load_definitions_with_ids(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    metric_keys: &[String],
+) -> Result<HashMap<String, (Uuid, MetricDefinition)>, CanonicalError> {
     if metric_keys.is_empty() {
         return Ok(HashMap::new());
     }
@@ -115,7 +130,7 @@ pub async fn load_definitions(
             row_inputs,
             dimensions.get(&definition_id).cloned().unwrap_or_default(),
         )?;
-        definitions.insert(metric_key, definition);
+        definitions.insert(metric_key, (definition_id, definition));
     }
 
     for key in metric_keys {
@@ -529,27 +544,53 @@ fn one_input(
     }
 }
 
+#[derive(FromQueryResult)]
+pub struct ManagedSourceValidationTarget {
+    pub id: Uuid,
+    pub source_key: String,
+    pub source_kind: String,
+    pub source_ref: String,
+    pub evidence_ref: Option<String>,
+    pub config_revision: String,
+}
+
 pub async fn all_managed_sources(
     db: &DatabaseConnection,
-) -> Result<Vec<(Uuid, String, String)>, sea_orm::DbErr> {
-    #[derive(FromQueryResult)]
-    struct Row {
-        id: Uuid,
-        source_kind: String,
-        source_ref: String,
-    }
-
-    Row::find_by_statement(Statement::from_string(
+) -> Result<Vec<ManagedSourceValidationTarget>, sea_orm::DbErr> {
+    ManagedSourceValidationTarget::find_by_statement(Statement::from_string(
         db.get_database_backend(),
-        "SELECT id, source_kind, source_ref \
+        "SELECT id, source_key, source_kind, source_ref, evidence_ref, \
+                DATE_FORMAT(updated_at, '%Y-%m-%d %H:%i:%s.%f') AS config_revision \
          FROM metric_sources \
          WHERE is_enabled = TRUE",
     ))
     .all(db)
     .await
+}
+
+pub async fn source_evidence_granularities(
+    db: &DatabaseConnection,
+    source_id: Uuid,
+) -> Result<Vec<(String, Option<String>)>, sea_orm::DbErr> {
+    #[derive(FromQueryResult)]
+    struct Row {
+        measure_key: String,
+        evidence_granularity: Option<String>,
+    }
+
+    Row::find_by_statement(Statement::from_sql_and_values(
+        db.get_database_backend(),
+        "SELECT measure_key, evidence_granularity \
+         FROM metric_source_measures \
+         WHERE source_id = ? AND is_enabled = TRUE \
+         ORDER BY measure_key",
+        [uuid_value(source_id)],
+    ))
+    .all(db)
+    .await
     .map(|rows| {
         rows.into_iter()
-            .map(|row| (row.id, row.source_kind, row.source_ref))
+            .map(|row| (row.measure_key, row.evidence_granularity))
             .collect()
     })
 }
@@ -557,30 +598,77 @@ pub async fn all_managed_sources(
 // `updated_at = updated_at` in the status writers below pins the column so
 // ON UPDATE CURRENT_TIMESTAMP(3) does not fire: updated_at tracks config
 // edits, not validator sweeps.
-pub async fn update_source_status(
+pub async fn update_evidence_status(
     db: &DatabaseConnection,
     source_id: Uuid,
+    config_revision: &str,
     status: SchemaStatus,
     error_code: Option<MetricSchemaErrorCode>,
 ) -> Result<(), sea_orm::DbErr> {
-    db.execute(Statement::from_sql_and_values(
-        db.get_database_backend(),
-        "UPDATE metric_sources \
+    let result = db
+        .execute(Statement::from_sql_and_values(
+            db.get_database_backend(),
+            "UPDATE metric_sources \
+         SET evidence_schema_status = ?, \
+             evidence_schema_checked_at = CURRENT_TIMESTAMP(3), \
+             evidence_schema_error_code = ?, \
+             updated_at = updated_at \
+         WHERE id = ? AND updated_at = ?",
+            [
+                Value::from(status.as_db()),
+                match error_code {
+                    Some(code) => Value::from(code.as_db()),
+                    None => Value::String(None),
+                },
+                uuid_value(source_id),
+                Value::from(config_revision),
+            ],
+        ))
+        .await?;
+    if result.rows_affected() == 0 {
+        tracing::trace!(
+            %source_id,
+            config_revision,
+            "metric evidence status update skipped for stale configuration revision"
+        );
+    }
+    Ok(())
+}
+
+pub async fn update_source_status(
+    db: &DatabaseConnection,
+    source_id: Uuid,
+    config_revision: &str,
+    status: SchemaStatus,
+    error_code: Option<MetricSchemaErrorCode>,
+) -> Result<(), sea_orm::DbErr> {
+    let result = db
+        .execute(Statement::from_sql_and_values(
+            db.get_database_backend(),
+            "UPDATE metric_sources \
          SET schema_status = ?, \
              schema_checked_at = CURRENT_TIMESTAMP(3), \
              schema_error_code = ?, \
              updated_at = updated_at \
-         WHERE id = ?",
-        [
-            Value::from(status.as_db()),
-            match error_code {
-                Some(code) => Value::from(code.as_db()),
-                None => Value::String(None),
-            },
-            Value::Bytes(Some(Box::new(source_id.as_bytes().to_vec()))),
-        ],
-    ))
-    .await?;
+         WHERE id = ? AND updated_at = ?",
+            [
+                Value::from(status.as_db()),
+                match error_code {
+                    Some(code) => Value::from(code.as_db()),
+                    None => Value::String(None),
+                },
+                uuid_value(source_id),
+                Value::from(config_revision),
+            ],
+        ))
+        .await?;
+    if result.rows_affected() == 0 {
+        tracing::trace!(
+            %source_id,
+            config_revision,
+            "metric source status update skipped for stale configuration revision"
+        );
+    }
     Ok(())
 }
 

--- a/src/backend/services/analytics/src/domain/metric_definitions/seeds.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/seeds.rs
@@ -33,14 +33,16 @@ async fn reconcile_source(
         db.execute(Statement::from_sql_and_values(
             db.get_database_backend(),
             "INSERT INTO metric_source_measures \
-                (id, source_id, measure_key, is_enabled) \
-             VALUES (?, ?, ?, TRUE) \
+                (id, source_id, measure_key, evidence_granularity, is_enabled) \
+             VALUES (?, ?, ?, ?, TRUE) \
              ON DUPLICATE KEY UPDATE \
+                evidence_granularity = VALUES(evidence_granularity), \
                 is_enabled = VALUES(is_enabled)",
             [
                 uuid_value(Uuid::now_v7()),
                 uuid_value(source_id),
                 Value::from(*measure_key),
+                Value::from(builtin_source.evidence_granularity(measure_key).as_db()),
             ],
         ))
         .await?;
@@ -74,11 +76,12 @@ async fn upsert_source(
     db.execute(Statement::from_sql_and_values(
         db.get_database_backend(),
         "INSERT INTO metric_sources \
-            (id, tenant_id, source_key, source_kind, source_ref, origin, is_enabled) \
-         VALUES (?, NULL, ?, ?, ?, 'builtin', TRUE) \
+            (id, tenant_id, source_key, source_kind, source_ref, evidence_ref, origin, is_enabled) \
+         VALUES (?, NULL, ?, ?, ?, ?, 'builtin', TRUE) \
          ON DUPLICATE KEY UPDATE \
             source_kind = VALUES(source_kind), \
             source_ref = VALUES(source_ref), \
+            evidence_ref = VALUES(evidence_ref), \
             origin = VALUES(origin), \
             is_enabled = VALUES(is_enabled)",
         [
@@ -86,6 +89,7 @@ async fn upsert_source(
             Value::from(builtin_source.source.key),
             Value::from(builtin_source.source.kind.as_db()),
             Value::from(builtin_source.source.source_ref),
+            Value::from(builtin_source.source.evidence_ref),
         ],
     ))
     .await?;

--- a/src/backend/services/analytics/src/domain/metric_definitions/test_fixture.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/test_fixture.rs
@@ -1,0 +1,218 @@
+use sea_orm::{ConnectionTrait, DatabaseConnection, Statement, Value};
+use uuid::Uuid;
+
+pub(crate) struct DrilldownFixture {
+    pub(crate) tenant_id: Uuid,
+    pub(crate) source_id: Uuid,
+}
+
+impl DrilldownFixture {
+    pub(crate) async fn insert(
+        db: &DatabaseConnection,
+        metric_keys: &[&str],
+        dimensions: &[&str],
+    ) -> Result<Self, sea_orm::DbErr> {
+        let tenant_id = Uuid::now_v7();
+        let source_id = Uuid::now_v7();
+        let measure_id = Uuid::now_v7();
+        let suffix = tenant_id.simple().to_string();
+        let source_key = format!("test_{suffix}");
+        let source_ref = format!("test_{suffix}_metric_observations");
+        let evidence_ref = format!("test_{suffix}_metric_evidence");
+
+        db.execute(Statement::from_sql_and_values(
+            db.get_database_backend(),
+            "INSERT INTO metric_sources \
+                (id, tenant_id, source_key, source_kind, source_ref, evidence_ref, origin, \
+                 schema_status, evidence_schema_status) \
+             VALUES (?, ?, ?, 'managed_observation', ?, ?, 'custom', 'ok', 'ok')",
+            [
+                uuid_value(source_id),
+                uuid_value(tenant_id),
+                Value::from(source_key),
+                Value::from(source_ref),
+                Value::from(evidence_ref),
+            ],
+        ))
+        .await?;
+        db.execute(Statement::from_sql_and_values(
+            db.get_database_backend(),
+            "INSERT INTO metric_source_measures \
+                (id, source_id, measure_key, evidence_granularity, schema_status) \
+             VALUES (?, ?, 'value_count', 'event', 'ok')",
+            [uuid_value(measure_id), uuid_value(source_id)],
+        ))
+        .await?;
+
+        let source_dimensions = insert_dimensions(db, source_id, dimensions).await?;
+        insert_definitions(db, tenant_id, measure_id, metric_keys, &source_dimensions).await?;
+
+        db.execute(Statement::from_sql_and_values(
+            db.get_database_backend(),
+            "UPDATE metric_sources \
+             SET schema_status = 'ok', schema_error_code = NULL, \
+                 evidence_schema_status = 'ok', evidence_schema_error_code = NULL, \
+                 updated_at = updated_at \
+             WHERE id = ?",
+            [uuid_value(source_id)],
+        ))
+        .await?;
+
+        Ok(Self {
+            tenant_id,
+            source_id,
+        })
+    }
+
+    pub(crate) async fn delete(self, db: &DatabaseConnection) -> Result<(), sea_orm::DbErr> {
+        db.execute(Statement::from_sql_and_values(
+            db.get_database_backend(),
+            "DELETE FROM metric_definitions WHERE tenant_id = ?",
+            [uuid_value(self.tenant_id)],
+        ))
+        .await?;
+        db.execute(Statement::from_sql_and_values(
+            db.get_database_backend(),
+            "DELETE FROM metric_sources WHERE id = ?",
+            [uuid_value(self.source_id)],
+        ))
+        .await?;
+        Ok(())
+    }
+
+    pub(crate) async fn config_revision(
+        &self,
+        db: &DatabaseConnection,
+    ) -> Result<String, sea_orm::DbErr> {
+        let row = db
+            .query_one(Statement::from_sql_and_values(
+                db.get_database_backend(),
+                "SELECT DATE_FORMAT(updated_at, '%Y-%m-%d %H:%i:%s.%f') AS config_revision \
+                 FROM metric_sources WHERE id = ?",
+                [uuid_value(self.source_id)],
+            ))
+            .await?
+            .ok_or_else(|| sea_orm::DbErr::Custom("test source disappeared".to_owned()))?;
+        row.try_get("", "config_revision")
+    }
+
+    pub(crate) async fn statuses(
+        &self,
+        db: &DatabaseConnection,
+    ) -> Result<(String, String, Option<String>), sea_orm::DbErr> {
+        let row = db
+            .query_one(Statement::from_sql_and_values(
+                db.get_database_backend(),
+                "SELECT schema_status, evidence_schema_status, evidence_schema_error_code \
+                 FROM metric_sources WHERE id = ?",
+                [uuid_value(self.source_id)],
+            ))
+            .await?
+            .ok_or_else(|| sea_orm::DbErr::Custom("test source disappeared".to_owned()))?;
+        Ok((
+            row.try_get("", "schema_status")?,
+            row.try_get("", "evidence_schema_status")?,
+            row.try_get("", "evidence_schema_error_code")?,
+        ))
+    }
+}
+
+async fn insert_dimensions(
+    db: &DatabaseConnection,
+    source_id: Uuid,
+    dimensions: &[&str],
+) -> Result<Vec<Uuid>, sea_orm::DbErr> {
+    let mut source_dimensions = Vec::with_capacity(dimensions.len());
+    for (display_order, dimension) in dimensions.iter().enumerate() {
+        let display_order = checked_display_order(display_order)?;
+        let dimension_id = Uuid::now_v7();
+        db.execute(Statement::from_sql_and_values(
+            db.get_database_backend(),
+            "INSERT INTO metric_source_dimensions \
+                (id, source_id, dimension_key, display_order) \
+             VALUES (?, ?, ?, ?)",
+            [
+                uuid_value(dimension_id),
+                uuid_value(source_id),
+                Value::from(*dimension),
+                Value::from(display_order),
+            ],
+        ))
+        .await?;
+        source_dimensions.push(dimension_id);
+    }
+    Ok(source_dimensions)
+}
+
+async fn insert_definitions(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    measure_id: Uuid,
+    metric_keys: &[&str],
+    source_dimensions: &[Uuid],
+) -> Result<(), sea_orm::DbErr> {
+    for metric_key in metric_keys {
+        let definition_id = Uuid::now_v7();
+        db.execute(Statement::from_sql_and_values(
+            db.get_database_backend(),
+            "INSERT INTO metric_definitions \
+                (id, tenant_id, metric_key, label, format, direction, entity_type, \
+                 computation_type, origin, schema_status) \
+             VALUES (?, ?, ?, ?, 'integer', 'higher_is_better', 'person', \
+                     'sum', 'custom', 'ok')",
+            [
+                uuid_value(definition_id),
+                uuid_value(tenant_id),
+                Value::from(*metric_key),
+                Value::from(format!("Test {metric_key}")),
+            ],
+        ))
+        .await?;
+        db.execute(Statement::from_sql_and_values(
+            db.get_database_backend(),
+            "INSERT INTO metric_definition_inputs \
+                (id, metric_definition_id, input_role, source_measure_id) \
+             VALUES (?, ?, 'value', ?)",
+            [
+                uuid_value(Uuid::now_v7()),
+                uuid_value(definition_id),
+                uuid_value(measure_id),
+            ],
+        ))
+        .await?;
+        insert_definition_dimensions(db, definition_id, source_dimensions).await?;
+    }
+    Ok(())
+}
+
+async fn insert_definition_dimensions(
+    db: &DatabaseConnection,
+    definition_id: Uuid,
+    source_dimensions: &[Uuid],
+) -> Result<(), sea_orm::DbErr> {
+    for (display_order, dimension_id) in source_dimensions.iter().enumerate() {
+        let display_order = checked_display_order(display_order)?;
+        db.execute(Statement::from_sql_and_values(
+            db.get_database_backend(),
+            "INSERT INTO metric_definition_dimensions \
+                (id, metric_definition_id, source_dimension_id, display_order) \
+             VALUES (?, ?, ?, ?)",
+            [
+                uuid_value(Uuid::now_v7()),
+                uuid_value(definition_id),
+                uuid_value(*dimension_id),
+                Value::from(display_order),
+            ],
+        ))
+        .await?;
+    }
+    Ok(())
+}
+
+fn checked_display_order(value: usize) -> Result<i32, sea_orm::DbErr> {
+    i32::try_from(value).map_err(|_| sea_orm::DbErr::Custom("too many test dimensions".to_owned()))
+}
+
+fn uuid_value(value: Uuid) -> Value {
+    Value::Bytes(Some(Box::new(value.as_bytes().to_vec())))
+}

--- a/src/backend/services/analytics/src/domain/metric_definitions/validator.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/validator.rs
@@ -6,12 +6,18 @@ use sea_orm::DatabaseConnection;
 use serde::Deserialize;
 
 use crate::domain::metric_definitions::definition::{
-    CohortSource, MetricInput, ObservationRelation, SourceKind,
+    CohortSource, EvidenceGranularity, EvidenceRelation, MetricInput, ObservationRelation,
+    SourceKind,
 };
 use crate::domain::metric_definitions::error_code::{MetricSchemaErrorCode, SchemaStatus};
 use crate::domain::metric_definitions::repository::{
     MetricDefinitionValidationSpec, all_managed_sources, managed_definition_validation_specs,
-    update_definition_status, update_definitions_for_source_status, update_source_status,
+    source_evidence_granularities, update_definition_status, update_definitions_for_source_status,
+    update_evidence_status, update_source_status,
+};
+use crate::domain::metric_drilldown::{
+    EVIDENCE_QUERY_MEMORY_BYTES, EVIDENCE_QUERY_READ_BYTES, EVIDENCE_QUERY_RESULT_BYTES,
+    EVIDENCE_QUERY_TIMEOUT_SECS,
 };
 
 // Dimension coverage is checked over a trailing window anchored at the
@@ -59,25 +65,40 @@ impl MetricDefinitionValidator {
             }
         };
 
-        for (source_id, source_kind, source_ref) in sources {
+        for source in sources {
+            self.validate_evidence(
+                source.id,
+                &source.source_key,
+                &source.source_kind,
+                &source.source_ref,
+                source.evidence_ref.as_deref(),
+                &source.config_revision,
+            )
+            .await;
             let outcome = self
-                .validate_source(source_kind.as_str(), source_ref.as_str())
+                .validate_source(source.source_kind.as_str(), source.source_ref.as_str())
                 .await;
 
             match outcome {
                 ProbeOutcome::Definitive(state) => {
                     let (status, error_code) = state.as_db();
-                    if let Err(error) =
-                        update_source_status(&self.db, source_id, status, error_code).await
+                    if let Err(error) = update_source_status(
+                        &self.db,
+                        source.id,
+                        &source.config_revision,
+                        status,
+                        error_code,
+                    )
+                    .await
                     {
                         tracing::warn!(error = %error, "metric definition source status update failed");
                         continue;
                     }
                     if state.is_ok() {
-                        self.validate_definitions_for_source(source_id, source_ref.as_str())
+                        self.validate_definitions_for_source(source.id, source.source_ref.as_str())
                             .await;
                     } else if let Err(error) = update_definitions_for_source_status(
-                        &self.db, source_id, status, error_code,
+                        &self.db, source.id, status, error_code,
                     )
                     .await
                     {
@@ -86,11 +107,110 @@ impl MetricDefinitionValidator {
                 }
                 ProbeOutcome::Inconclusive => {
                     tracing::warn!(
-                        source_ref = %source_ref,
+                        source_ref = %source.source_ref,
                         "metric source validation inconclusive; keeping previous status"
                     );
                 }
             }
+        }
+    }
+
+    async fn validate_evidence(
+        &self,
+        source_id: uuid::Uuid,
+        source_key: &str,
+        source_kind: &str,
+        source_ref: &str,
+        evidence_ref: Option<&str>,
+        config_revision: &str,
+    ) {
+        if SourceKind::from_db(source_kind) == Some(SourceKind::CustomObservationSql) {
+            return;
+        }
+        let configured_evidence = match evidence_ref {
+            None => Ok(None),
+            Some(reference) => EvidenceRelation::parse(reference)
+                .map(Some)
+                .ok_or(reference),
+        };
+        let Ok(configured_evidence) = configured_evidence else {
+            tracing::warn!(
+                source_key,
+                evidence_ref,
+                "metric evidence relation name is not a valid evidence relation"
+            );
+            self.write_evidence_status(
+                source_id,
+                config_revision,
+                ValidationState::Error(MetricSchemaErrorCode::Unknown),
+            )
+            .await;
+            return;
+        };
+        let state = match (configured_evidence, ObservationRelation::parse(source_ref)) {
+            (Some(relation), Some(observation_relation)) => match self
+                .has_exact_columns(relation.table_ref(), EVIDENCE_COLUMN_TYPES)
+                .await
+            {
+                Ok(ColumnCheck::Present) => {
+                    let expected = match source_evidence_granularities(&self.db, source_id).await {
+                        Ok(expected) => expected,
+                        Err(error) => {
+                            tracing::warn!(error = %error, "metric evidence granularity metadata load failed");
+                            return;
+                        }
+                    };
+                    match self
+                        .evidence_granularities_match(
+                            &relation,
+                            &observation_relation,
+                            source_key,
+                            &expected,
+                        )
+                        .await
+                    {
+                        Ok(true) => Some(ValidationState::Ok),
+                        Ok(false) => {
+                            tracing::warn!(
+                                source_key,
+                                evidence_ref,
+                                expected = ?expected,
+                                "metric evidence granularity does not match configured measures"
+                            );
+                            Some(ValidationState::Error(MetricSchemaErrorCode::Unknown))
+                        }
+                        Err(error) => {
+                            tracing::warn!(error = %error, "metric evidence granularity validation failed");
+                            None
+                        }
+                    }
+                }
+                Ok(missing) => Some(ValidationState::Error(missing.error_code())),
+                Err(error) => {
+                    tracing::warn!(error = %error, "metric evidence validation failed");
+                    None
+                }
+            },
+            _ => Some(ValidationState::Unchecked),
+        };
+        let Some(state) = state else {
+            return;
+        };
+        self.write_evidence_status(source_id, config_revision, state)
+            .await;
+    }
+
+    async fn write_evidence_status(
+        &self,
+        source_id: uuid::Uuid,
+        config_revision: &str,
+        state: ValidationState,
+    ) {
+        let (status, error_code) = state.as_db();
+        if let Err(error) =
+            update_evidence_status(&self.db, source_id, config_revision, status, error_code).await
+        {
+            tracing::warn!(error = %error, "metric evidence status update failed");
         }
     }
 
@@ -334,6 +454,101 @@ impl MetricDefinitionValidator {
         Ok(ColumnCheck::Present)
     }
 
+    async fn has_exact_columns(
+        &self,
+        table: (&str, &str),
+        columns: &[(&str, &str)],
+    ) -> Result<ColumnCheck, clickhouse::error::Error> {
+        let (database, table) = table;
+        let exact_columns = columns
+            .iter()
+            .map(|(name, r#type)| format!("(name = '{name}' AND type = '{type}')"))
+            .collect::<Vec<_>>()
+            .join(" OR ");
+        let sql = format!(
+            "SELECT \
+                count() AS total_columns, \
+                countIf({exact_columns}) AS matching_columns \
+             FROM system.columns \
+             WHERE database = ? AND table = ?"
+        );
+        let row: ColumnProbeRow = self
+            .ch
+            .query(&sql)
+            .bind(database)
+            .bind(table)
+            .fetch_one()
+            .await?;
+        if row.total_columns == 0 {
+            return Ok(ColumnCheck::TableMissing);
+        }
+        if row.matching_columns < columns.len() as u64 {
+            return Ok(ColumnCheck::ColumnsMissing);
+        }
+        Ok(ColumnCheck::Present)
+    }
+
+    async fn evidence_granularities_match(
+        &self,
+        relation: &EvidenceRelation,
+        observation_relation: &ObservationRelation,
+        source_key: &str,
+        expected: &[(String, Option<String>)],
+    ) -> Result<bool, clickhouse::error::Error> {
+        if !expected_granularities_are_known(expected) {
+            return Ok(false);
+        }
+
+        let (observation_database, observation_table) = observation_relation.table_ref();
+        let observation_sql =
+            evidence_observation_dates_sql(observation_database, observation_table, expected.len());
+        let mut observation_query = self
+            .ch
+            .query(&observation_sql)
+            .with_option(
+                "max_execution_time",
+                EVIDENCE_QUERY_TIMEOUT_SECS.to_string(),
+            )
+            .with_option("max_memory_usage", EVIDENCE_QUERY_MEMORY_BYTES.to_string())
+            .with_option("max_bytes_to_read", EVIDENCE_QUERY_READ_BYTES.to_string())
+            .with_option("max_result_bytes", EVIDENCE_QUERY_RESULT_BYTES.to_string())
+            .bind(source_key);
+        for (measure_key, _) in expected {
+            observation_query = observation_query.bind(measure_key);
+        }
+        let observed_dates = parse_measure_last_dates(observation_query.fetch_all().await?)?;
+        let observed_measures = observed_dates.keys().cloned().collect::<BTreeSet<_>>();
+        let window_start = evidence_window_start(&observed_dates);
+
+        let (database, table) = relation.table_ref();
+        let sql = evidence_granularity_sql(database, table, expected.len(), window_start.is_some());
+        let mut query = self
+            .ch
+            .query(&sql)
+            .with_option(
+                "max_execution_time",
+                EVIDENCE_QUERY_TIMEOUT_SECS.to_string(),
+            )
+            .with_option("max_memory_usage", EVIDENCE_QUERY_MEMORY_BYTES.to_string())
+            .with_option("max_bytes_to_read", EVIDENCE_QUERY_READ_BYTES.to_string())
+            .with_option("max_result_bytes", EVIDENCE_QUERY_RESULT_BYTES.to_string())
+            .bind(source_key);
+        for (measure_key, _) in expected {
+            query = query.bind(measure_key);
+        }
+        if let Some(window_start) = window_start {
+            query = query.bind(window_start.to_string());
+        }
+        let actual = query
+            .fetch_all::<EvidenceGranularityProbeRow>()
+            .await?
+            .into_iter()
+            .map(|row| (row.measure_key, row.granularities))
+            .collect::<HashMap<_, _>>();
+
+        Ok(granularities_match(expected, &actual, &observed_measures))
+    }
+
     async fn measure_last_dates(
         &self,
         relation: &ObservationRelation,
@@ -407,6 +622,27 @@ const OBSERVATION_COLUMNS: &[&str] = &[
     "dimensions",
 ];
 
+const EVIDENCE_COLUMN_TYPES: &[(&str, &str)] = &[
+    ("tenant_id", "String"),
+    ("source_key", "String"),
+    ("entity_type", "String"),
+    ("entity_id", "String"),
+    ("metric_date", "Date"),
+    ("observed_at", "Nullable(DateTime64(3))"),
+    ("measure_key", "String"),
+    ("record_id", "String"),
+    ("record_kind", "String"),
+    ("granularity", "String"),
+    ("record_label", "String"),
+    ("contribution", "Nullable(Float64)"),
+    ("subject_key", "Nullable(String)"),
+    (
+        "dimensions",
+        "Array(Tuple(key String, value String, label Nullable(String)))",
+    ),
+    ("details", "Map(String, String)"),
+];
+
 const COHORT_COLUMNS: &[&str] = &[
     "tenant_id",
     "entity_type",
@@ -432,6 +668,12 @@ struct DimensionCoverageProbeRow {
     measure_key: String,
     total_rows: u64,
     matching_rows: u64,
+}
+
+#[derive(Row, Deserialize)]
+struct EvidenceGranularityProbeRow {
+    measure_key: String,
+    granularities: Vec<String>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -568,6 +810,81 @@ fn measure_last_dates_sql(database: &str, table: &str, measure_count: usize) -> 
            AND measure_key IN ({placeholders}) \
          GROUP BY measure_key"
     )
+}
+
+fn expected_granularities_are_known(expected: &[(String, Option<String>)]) -> bool {
+    !expected.is_empty()
+        && expected.iter().all(|(_, value)| {
+            value
+                .as_deref()
+                .and_then(EvidenceGranularity::from_db)
+                .is_some()
+        })
+}
+
+fn evidence_observation_dates_sql(database: &str, table: &str, measure_count: usize) -> String {
+    let placeholders = vec!["?"; measure_count].join(", ");
+    format!(
+        "SELECT measure_key, toString(max(metric_date)) AS last_date \
+         FROM {database}.{table} \
+         WHERE source_key = ? AND measure_key IN ({placeholders}) \
+         GROUP BY measure_key"
+    )
+}
+
+fn evidence_granularity_sql(
+    database: &str,
+    table: &str,
+    measure_count: usize,
+    windowed: bool,
+) -> String {
+    let placeholders = vec!["?"; measure_count].join(", ");
+    let window_sql = if windowed {
+        " AND metric_date >= toDate(?)"
+    } else {
+        ""
+    };
+    format!(
+        "SELECT measure_key, groupUniqArray(granularity) AS granularities \
+         FROM {database}.{table} \
+         WHERE source_key = ? AND measure_key IN ({placeholders}){window_sql} \
+         GROUP BY measure_key"
+    )
+}
+
+// The window trails the oldest per-measure last-observed date so a stale
+// measure widens it instead of falling outside it.
+fn evidence_window_start(observed_dates: &HashMap<String, NaiveDate>) -> Option<NaiveDate> {
+    observed_dates
+        .values()
+        .min()
+        .map(|date| *date - chrono::Duration::days(i64::from(PROBE_WINDOW_DAYS)))
+}
+
+fn granularities_match(
+    expected: &[(String, Option<String>)],
+    actual: &HashMap<String, Vec<String>>,
+    observed_measures: &BTreeSet<String>,
+) -> bool {
+    expected.iter().all(|(measure_key, granularity)| {
+        let Some(granularity) = granularity.as_deref() else {
+            return false;
+        };
+        let matches = match actual.get(measure_key) {
+            Some(values) => values.len() == 1 && values[0] == granularity,
+            None => !observed_measures.contains(measure_key),
+        };
+        if !matches {
+            tracing::warn!(
+                measure_key,
+                expected_granularity = granularity,
+                actual_granularities = ?actual.get(measure_key),
+                observed = observed_measures.contains(measure_key),
+                "metric evidence measure granularity mismatch"
+            );
+        }
+        matches
+    })
 }
 
 fn parse_measure_last_dates(
@@ -732,6 +1049,148 @@ mod tests {
         assert_eq!(cov.matches("measure_key = ?").count(), 3);
         assert_eq!(cov.matches(" OR ").count(), 2);
         assert!(cov.contains(&format!("toDate(?) - {PROBE_WINDOW_DAYS}")));
+    }
+
+    fn granularity(measure_key: &str, value: Option<&str>) -> (String, Option<String>) {
+        (measure_key.to_owned(), value.map(str::to_owned))
+    }
+
+    #[test]
+    fn expected_granularities_reject_empty_and_unknown_values() {
+        for (expected, want, case) in [
+            (vec![granularity("a", Some("event"))], true, "known"),
+            (
+                vec![
+                    granularity("a", Some("event")),
+                    granularity("b", Some("source_summary")),
+                ],
+                true,
+                "all known",
+            ),
+            (Vec::new(), false, "empty"),
+            (vec![granularity("a", None)], false, "missing"),
+            (vec![granularity("a", Some("nonsense"))], false, "unknown"),
+            (
+                vec![granularity("a", Some("event")), granularity("b", None)],
+                false,
+                "one missing",
+            ),
+        ] {
+            assert_eq!(
+                expected_granularities_are_known(&expected),
+                want,
+                "case: {case}"
+            );
+        }
+    }
+
+    #[test]
+    fn evidence_sql_binds_one_placeholder_per_measure_and_windows_on_demand() {
+        let dates = evidence_observation_dates_sql("insight", "ai_metric_observations", 2);
+        assert!(dates.contains("measure_key IN (?, ?)"));
+        assert!(dates.contains("max(metric_date)"));
+        assert!(!dates.contains("entity_type"));
+
+        let windowed = evidence_granularity_sql("insight", "ai_metric_evidence", 3, true);
+        assert!(windowed.contains("measure_key IN (?, ?, ?)"));
+        assert!(windowed.contains("groupUniqArray(granularity)"));
+        assert!(windowed.contains("AND metric_date >= toDate(?)"));
+
+        let unwindowed = evidence_granularity_sql("insight", "ai_metric_evidence", 1, false);
+        assert!(!unwindowed.contains("metric_date >="));
+    }
+
+    #[test]
+    fn evidence_window_trails_the_oldest_observed_measure() {
+        assert_eq!(evidence_window_start(&HashMap::new()), None);
+
+        let observed = HashMap::from([
+            ("fresh".to_owned(), date("2026-07-30")),
+            ("stale".to_owned(), date("2026-01-15")),
+        ]);
+        assert_eq!(
+            evidence_window_start(&observed),
+            Some(date("2026-01-15") - chrono::Duration::days(i64::from(PROBE_WINDOW_DAYS)))
+        );
+    }
+
+    #[test]
+    fn granularities_match_only_on_a_single_expected_value_per_measure() {
+        let expected = vec![granularity("a", Some("event"))];
+        let observed = BTreeSet::from(["a".to_owned()]);
+
+        let exact = HashMap::from([("a".to_owned(), vec!["event".to_owned()])]);
+        assert!(granularities_match(&expected, &exact, &observed));
+
+        let wrong = HashMap::from([("a".to_owned(), vec!["source_summary".to_owned()])]);
+        assert!(!granularities_match(&expected, &wrong, &observed));
+
+        let mixed = HashMap::from([(
+            "a".to_owned(),
+            vec!["event".to_owned(), "source_summary".to_owned()],
+        )]);
+        assert!(!granularities_match(&expected, &mixed, &observed));
+
+        assert!(!granularities_match(
+            &[granularity("a", None)],
+            &exact,
+            &observed
+        ));
+    }
+
+    #[test]
+    fn column_check_maps_missing_table_and_columns_to_distinct_codes() {
+        assert_eq!(
+            ColumnCheck::TableMissing.error_code(),
+            MetricSchemaErrorCode::TableNotFound
+        );
+        assert_eq!(
+            ColumnCheck::ColumnsMissing.error_code(),
+            MetricSchemaErrorCode::ColumnNotFound
+        );
+        assert_eq!(
+            ColumnCheck::Present.error_code(),
+            MetricSchemaErrorCode::ColumnNotFound
+        );
+    }
+
+    #[test]
+    fn validation_state_carries_an_error_code_only_when_erroring() {
+        assert!(ValidationState::Ok.is_ok());
+        assert!(!ValidationState::Unchecked.is_ok());
+        assert!(!ValidationState::Error(MetricSchemaErrorCode::Unknown).is_ok());
+
+        assert_eq!(
+            ValidationState::Ok.as_db(),
+            (SchemaStatus::Ok, None),
+            "ok carries no code"
+        );
+        assert_eq!(
+            ValidationState::Unchecked.as_db(),
+            (SchemaStatus::Unchecked, None),
+            "unchecked carries no code"
+        );
+        assert_eq!(
+            ValidationState::Error(MetricSchemaErrorCode::TableNotFound).as_db(),
+            (
+                SchemaStatus::Error,
+                Some(MetricSchemaErrorCode::TableNotFound)
+            ),
+            "error carries its code"
+        );
+    }
+
+    #[test]
+    fn measures_without_evidence_pass_only_when_never_observed() {
+        let expected = vec![granularity("a", Some("event"))];
+        let empty = HashMap::new();
+
+        assert!(granularities_match(&expected, &empty, &BTreeSet::new()));
+        assert!(!granularities_match(
+            &expected,
+            &empty,
+            &BTreeSet::from(["a".to_owned()])
+        ));
     }
 
     #[test]

--- a/src/backend/services/analytics/src/domain/metric_drilldown/mod.rs
+++ b/src/backend/services/analytics/src/domain/metric_drilldown/mod.rs
@@ -1,0 +1,202 @@
+use std::collections::{BTreeMap, HashMap};
+
+use sea_orm::{ConnectionTrait, DatabaseConnection, FromQueryResult, Statement, Value};
+use serde::Serialize;
+use toolkit_canonical_errors::CanonicalError;
+use uuid::Uuid;
+
+use crate::domain::metric_definitions::definition::MetricInputRole;
+use crate::domain::metric_definitions::{EvidenceGranularity, EvidenceRelation};
+
+pub const EVIDENCE_QUERY_TIMEOUT_SECS: u64 = 45;
+pub const EVIDENCE_QUERY_MEMORY_BYTES: usize = 256 * 1024 * 1024;
+pub const EVIDENCE_QUERY_READ_BYTES: usize = 512 * 1024 * 1024;
+pub const EVIDENCE_QUERY_RESULT_BYTES: usize = 32 * 1024 * 1024;
+
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+pub struct MetricDrilldownCapability {
+    pub granularity: Vec<EvidenceGranularity>,
+}
+
+#[derive(Debug, FromQueryResult)]
+struct CapabilityRow {
+    metric_key: String,
+    input_role: String,
+    evidence_granularity: Option<String>,
+    source_key: String,
+    evidence_ref: Option<String>,
+    evidence_schema_status: String,
+}
+
+pub async fn load_capabilities(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    metric_keys: &[String],
+) -> Result<HashMap<String, MetricDrilldownCapability>, CanonicalError> {
+    if metric_keys.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let placeholders = vec!["?"; metric_keys.len()].join(", ");
+    let sql = format!(
+        "SELECT d.metric_key, i.input_role, m.evidence_granularity, s.source_key, \
+                s.evidence_ref, s.evidence_schema_status \
+         FROM metric_definitions d \
+         INNER JOIN metric_definition_inputs i ON i.metric_definition_id = d.id \
+         INNER JOIN metric_source_measures m ON m.id = i.source_measure_id \
+         INNER JOIN metric_sources s ON s.id = m.source_id \
+         WHERE d.metric_key IN ({placeholders}) \
+           AND d.id = COALESCE( \
+               (SELECT td.id FROM metric_definitions td WHERE td.metric_key = d.metric_key AND td.tenant_id = ? LIMIT 1), \
+               (SELECT pd.id FROM metric_definitions pd WHERE pd.metric_key = d.metric_key AND pd.tenant_id IS NULL LIMIT 1) \
+           ) \
+           AND d.is_enabled = TRUE AND d.schema_status = 'ok' \
+           AND m.is_enabled = TRUE AND s.is_enabled = TRUE \
+         ORDER BY d.metric_key, i.input_role, m.measure_key"
+    );
+    let mut values = metric_keys.iter().map(Value::from).collect::<Vec<_>>();
+    values.push(Value::Bytes(Some(Box::new(tenant_id.as_bytes().to_vec()))));
+    let rows = CapabilityRow::find_by_statement(Statement::from_sql_and_values(
+        db.get_database_backend(),
+        sql,
+        values,
+    ))
+    .all(db)
+    .await
+    .map_err(|error| db_error(&error))?;
+    let mut grouped: BTreeMap<String, Vec<CapabilityRow>> = BTreeMap::new();
+    for row in rows {
+        grouped.entry(row.metric_key.clone()).or_default().push(row);
+    }
+
+    Ok(grouped
+        .into_iter()
+        .filter_map(|(metric_key, rows)| {
+            capability_from_rows(&rows).map(|capability| (metric_key, capability))
+        })
+        .collect())
+}
+
+fn capability_from_rows(rows: &[CapabilityRow]) -> Option<MetricDrilldownCapability> {
+    let first = rows.first()?;
+    let relation = EvidenceRelation::parse(first.evidence_ref.as_deref()?)?;
+    let source_key = first.source_key.as_str();
+
+    let healthy = rows.iter().all(|row| {
+        MetricInputRole::from_db(&row.input_role).is_some()
+            && row.evidence_schema_status == "ok"
+            && row.source_key == source_key
+            && row.evidence_ref.as_deref() == Some(relation.source_ref())
+            && row
+                .evidence_granularity
+                .as_deref()
+                .and_then(EvidenceGranularity::from_db)
+                .is_some()
+    });
+    if !healthy {
+        return None;
+    }
+
+    let mut granularity = rows
+        .iter()
+        .filter_map(|row| {
+            row.evidence_granularity
+                .as_deref()
+                .and_then(EvidenceGranularity::from_db)
+        })
+        .collect::<Vec<_>>();
+    granularity.sort_by_key(|value| value.as_db());
+    granularity.dedup();
+
+    Some(MetricDrilldownCapability { granularity })
+}
+
+fn db_error(error: &sea_orm::DbErr) -> CanonicalError {
+    tracing::error!(error = %error, "metric drilldown metadata query failed");
+    CanonicalError::internal("failed to load metric evidence metadata").create()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(status: &str, granularity: Option<&str>) -> CapabilityRow {
+        CapabilityRow {
+            metric_key: "ai.accepted_lines".to_owned(),
+            input_role: "value".to_owned(),
+            evidence_granularity: granularity.map(str::to_owned),
+            source_key: "ai_usage".to_owned(),
+            evidence_ref: Some("ai_metric_evidence".to_owned()),
+            evidence_schema_status: status.to_owned(),
+        }
+    }
+
+    #[test]
+    fn healthy_rows_yield_sorted_deduplicated_granularity() {
+        let rows = vec![
+            row("ok", Some("source_summary")),
+            row("ok", Some("event")),
+            row("ok", Some("event")),
+        ];
+        let Some(capability) = capability_from_rows(&rows) else {
+            panic!("healthy rows must yield a capability");
+        };
+        assert_eq!(
+            capability
+                .granularity
+                .iter()
+                .map(|value| value.as_db())
+                .collect::<Vec<_>>(),
+            ["event", "source_summary"]
+        );
+    }
+
+    #[test]
+    fn capability_fails_closed_on_any_unhealthy_input() {
+        let cases = [
+            (Vec::new(), "no rows"),
+            (vec![row("error", Some("event"))], "probe error"),
+            (vec![row("unchecked", Some("event"))], "unchecked probe"),
+            (vec![row("ok", None)], "granularity missing"),
+            (vec![row("ok", Some("nonsense"))], "granularity unknown"),
+            (
+                vec![row("ok", Some("event")), row("error", Some("event"))],
+                "one input unhealthy",
+            ),
+        ];
+        for (rows, case) in cases {
+            assert!(
+                capability_from_rows(&rows).is_none(),
+                "should fail closed: {case}"
+            );
+        }
+    }
+
+    #[test]
+    fn inputs_must_share_one_source_and_evidence_relation() {
+        let mut other_source = row("ok", Some("event"));
+        other_source.source_key = "task".to_owned();
+        assert!(capability_from_rows(&[row("ok", Some("event")), other_source]).is_none());
+
+        let mut other_relation = row("ok", Some("event"));
+        other_relation.evidence_ref = Some("task_metric_evidence".to_owned());
+        assert!(capability_from_rows(&[row("ok", Some("event")), other_relation]).is_none());
+    }
+
+    #[test]
+    fn unparseable_evidence_relation_yields_no_capability() {
+        let mut invalid = row("ok", Some("event"));
+        invalid.evidence_ref = Some("Not A Relation".to_owned());
+        assert!(capability_from_rows(&[invalid]).is_none());
+
+        let mut absent = row("ok", Some("event"));
+        absent.evidence_ref = None;
+        assert!(capability_from_rows(&[absent]).is_none());
+    }
+
+    #[test]
+    fn unknown_input_role_yields_no_capability() {
+        let mut row = row("ok", Some("event"));
+        row.input_role = "nonsense".to_owned();
+        assert!(capability_from_rows(&[row]).is_none());
+    }
+}

--- a/src/backend/services/analytics/src/domain/metric_results/builder.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/builder.rs
@@ -265,6 +265,7 @@ pub fn build_histogram_view(
 pub fn build_metric_result(
     def: &MetricDefinition,
     views: Vec<MetricResultViewDto>,
+    selection: super::dto::MetricResultSelectionDto,
 ) -> MetricResultDto {
     let computation = match &def.spec {
         ComputationSpec::Sum { .. } => ComputationDto::Sum,
@@ -283,6 +284,8 @@ pub fn build_metric_result(
         direction: def.base.direction,
         computation,
         views,
+        drilldown: None,
+        selection,
     }
 }
 
@@ -760,26 +763,58 @@ mod tests {
         );
     }
 
+    fn selection(metric_key: &str) -> super::super::dto::MetricResultSelectionDto {
+        super::super::dto::MetricResultSelectionDto {
+            metric_key: metric_key.to_owned(),
+            entity: super::super::dto::MetricResultsEntityDto {
+                r#type: "person".to_owned(),
+                ids: vec!["person@example.com".to_owned()],
+            },
+            period: super::super::dto::MetricResultsPeriodDto {
+                from: "2026-07-01".to_owned(),
+                to: "2026-07-28".to_owned(),
+            },
+            filters: Vec::new(),
+        }
+    }
+
     #[test]
     fn metric_result_wire_shape_is_flat_with_computation_tag() {
-        let sum = build_metric_result(&sum_metric(), Vec::new());
+        let sum = build_metric_result(&sum_metric(), Vec::new(), selection("ai.accepted_lines"));
         let sum_json = serde_json::to_value(&sum).unwrap_or_else(|e| panic!("{e}"));
         assert_eq!(sum_json["computation"], "sum");
         assert_eq!(sum_json["metric_key"], "ai.accepted_lines");
         assert_eq!(sum_json["format"], "integer");
         assert!(sum_json.get("scale").is_none());
+        assert_eq!(sum_json["selection"]["metric_key"], "ai.accepted_lines");
+        assert_eq!(sum_json["selection"]["entity"]["type"], "person");
+        assert_eq!(
+            sum_json["selection"]["entity"]["ids"][0],
+            "person@example.com"
+        );
+        assert_eq!(sum_json["selection"]["period"]["from"], "2026-07-01");
+        assert_eq!(sum_json["selection"]["period"]["to"], "2026-07-28");
+        assert_eq!(sum_json["selection"]["filters"], serde_json::json!([]));
+        assert!(
+            sum_json.get("drilldown").is_none(),
+            "absent drilldown capability must be omitted from the wire shape"
+        );
 
-        let ratio = build_metric_result(&ratio_metric(), Vec::new());
+        let ratio = build_metric_result(&ratio_metric(), Vec::new(), selection("ai.ratio"));
         let ratio_json = serde_json::to_value(&ratio).unwrap_or_else(|e| panic!("{e}"));
         assert_eq!(ratio_json["computation"], "ratio");
         assert_eq!(ratio_json["scale"], 100.0);
 
-        let median = build_metric_result(&median_metric(), Vec::new());
+        let median = build_metric_result(&median_metric(), Vec::new(), selection("ai.median"));
         let median_json = serde_json::to_value(&median).unwrap_or_else(|e| panic!("{e}"));
         assert_eq!(median_json["computation"], "median");
         assert!(median_json.get("scale").is_none());
 
-        let distinct = build_metric_result(&distinct_count_metric(), Vec::new());
+        let distinct = build_metric_result(
+            &distinct_count_metric(),
+            Vec::new(),
+            selection("ai.distinct"),
+        );
         let distinct_json = serde_json::to_value(&distinct).unwrap_or_else(|e| panic!("{e}"));
         assert_eq!(distinct_json["computation"], "distinct_count");
         assert!(distinct_json.get("scale").is_none());

--- a/src/backend/services/analytics/src/domain/metric_results/dto.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/dto.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use super::view::{Bucket, MetricResultViewKind};
 use crate::domain::metric_definitions::{MetricDirection, MetricFormat};
+use crate::domain::metric_drilldown::MetricDrilldownCapability;
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct MetricResultsRequest {
@@ -95,6 +96,35 @@ pub struct MetricResultDto {
     #[serde(flatten)]
     pub computation: ComputationDto,
     pub views: Vec<MetricResultViewDto>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub drilldown: Option<MetricDrilldownCapability>,
+    pub selection: MetricResultSelectionDto,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct MetricResultSelectionDto {
+    pub metric_key: String,
+    pub entity: MetricResultsEntityDto,
+    pub period: MetricResultsPeriodDto,
+    pub filters: Vec<MetricDimensionFilterDto>,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct MetricResultsEntityDto {
+    pub r#type: String,
+    pub ids: Vec<String>,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct MetricResultsPeriodDto {
+    pub from: String,
+    pub to: String,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct MetricDimensionFilterDto {
+    pub dimension: String,
+    pub values: Vec<String>,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]

--- a/src/backend/services/analytics/src/domain/metric_results/mod.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/mod.rs
@@ -16,5 +16,8 @@ pub use builder::{
 pub use compiler::{
     BreakdownQueryRow, CompiledQuery, HistogramQueryRow, RankingQueryRow, TimeseriesQueryRow,
 };
-pub use dto::{MetricResultViewDto, MetricResultsRequest, MetricResultsResponse};
+pub use dto::{
+    MetricDimensionFilterDto, MetricResultSelectionDto, MetricResultViewDto,
+    MetricResultsEntityDto, MetricResultsPeriodDto, MetricResultsRequest, MetricResultsResponse,
+};
 pub use validation::{ValidatedMetricResultsRequest, validate_request};

--- a/src/backend/services/analytics/src/domain/metric_results/validation.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/validation.rs
@@ -499,7 +499,7 @@ fn validate_filters(
     Ok(out)
 }
 
-fn normalize_entity_type(entity_type: &str) -> Result<String, CanonicalError> {
+pub(crate) fn normalize_entity_type(entity_type: &str) -> Result<String, CanonicalError> {
     normalize_key("entity.type", entity_type)
 }
 
@@ -527,7 +527,7 @@ fn normalize_entity_ids(
 // Id normalization is a property of the entity type: person ids are emails
 // and the observation sources emit them lowercased, so equality requires
 // lowercasing here too. Other entity types keep their casing.
-fn normalize_entity_id(entity_type: &str, entity_id: &str) -> String {
+pub(crate) fn normalize_entity_id(entity_type: &str, entity_id: &str) -> String {
     let trimmed = entity_id.trim();
     match entity_type {
         "person" => trimmed.to_ascii_lowercase(),
@@ -553,7 +553,10 @@ fn normalize_key(field: &'static str, value: &str) -> Result<String, CanonicalEr
     Ok(value)
 }
 
-fn normalize_metric_key(field: &'static str, value: &str) -> Result<String, CanonicalError> {
+pub(crate) fn normalize_metric_key(
+    field: &'static str,
+    value: &str,
+) -> Result<String, CanonicalError> {
     let value = value.trim().to_ascii_lowercase();
     if parse_metric_key(&value).is_err() {
         return invalid(field, "expected a metric key");

--- a/src/backend/services/analytics/src/domain/mod.rs
+++ b/src/backend/services/analytics/src/domain/mod.rs
@@ -3,6 +3,7 @@ pub mod auth;
 pub mod catalog;
 pub mod metric;
 pub mod metric_definitions;
+pub mod metric_drilldown;
 pub mod metric_results;
 pub mod query;
 pub mod query_gate;

--- a/src/backend/services/analytics/src/migration/m20260727_000001_metric_evidence.rs
+++ b/src/backend/services/analytics/src/migration/m20260727_000001_metric_evidence.rs
@@ -1,0 +1,130 @@
+use sea_orm::ConnectionTrait;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        add_evidence_columns(manager).await?;
+        replace_evidence_constraints(manager).await?;
+        replace_evidence_triggers(manager).await?;
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        Err(DbErr::Custom("we have only forward migrations".to_owned()))
+    }
+}
+
+async fn add_evidence_columns(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    let conn = manager.get_connection();
+    let columns = [
+        (
+            "metric_sources",
+            "evidence_ref",
+            "ALTER TABLE metric_sources ADD COLUMN evidence_ref VARCHAR(256) NULL AFTER source_ref",
+        ),
+        (
+            "metric_sources",
+            "evidence_schema_status",
+            "ALTER TABLE metric_sources ADD COLUMN evidence_schema_status ENUM('ok','error','unchecked') NOT NULL DEFAULT 'unchecked' AFTER schema_error_code",
+        ),
+        (
+            "metric_sources",
+            "evidence_schema_checked_at",
+            "ALTER TABLE metric_sources ADD COLUMN evidence_schema_checked_at DATETIME(3) NULL AFTER evidence_schema_status",
+        ),
+        (
+            "metric_sources",
+            "evidence_schema_error_code",
+            "ALTER TABLE metric_sources ADD COLUMN evidence_schema_error_code VARCHAR(64) NULL AFTER evidence_schema_checked_at",
+        ),
+        (
+            "metric_source_measures",
+            "evidence_granularity",
+            "ALTER TABLE metric_source_measures ADD COLUMN evidence_granularity ENUM('event','source_summary','derived_population') NULL AFTER measure_key",
+        ),
+    ];
+    for (table, column, ddl) in columns {
+        if !manager.has_column(table, column).await? {
+            conn.execute_unprepared(ddl).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn replace_evidence_constraints(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    let conn = manager.get_connection();
+    let constraints = [
+        (
+            "chk_metric_sources_evidence_error_biconditional",
+            "ALTER TABLE metric_sources ADD CONSTRAINT chk_metric_sources_evidence_error_biconditional CHECK ((evidence_schema_status = 'error') = (evidence_schema_error_code IS NOT NULL))",
+        ),
+        (
+            "chk_metric_sources_evidence_error_enum",
+            "ALTER TABLE metric_sources ADD CONSTRAINT chk_metric_sources_evidence_error_enum CHECK (evidence_schema_error_code IS NULL OR evidence_schema_error_code IN ('table_not_found','column_not_found','unknown'))",
+        ),
+    ];
+    for (name, ddl) in constraints {
+        conn.execute_unprepared(&format!(
+            "ALTER TABLE metric_sources DROP CONSTRAINT IF EXISTS {name}"
+        ))
+        .await?;
+        conn.execute_unprepared(ddl).await?;
+    }
+    Ok(())
+}
+
+async fn replace_evidence_triggers(manager: &SchemaManager<'_>) -> Result<(), DbErr> {
+    let conn = manager.get_connection();
+    let triggers = [
+        (
+            "trg_metric_sources_evidence_ref_invalidate",
+            "CREATE TRIGGER trg_metric_sources_evidence_ref_invalidate
+             BEFORE UPDATE ON metric_sources
+             FOR EACH ROW
+             BEGIN
+                 IF NOT (OLD.evidence_ref <=> NEW.evidence_ref)
+                     OR NOT (OLD.source_ref <=> NEW.source_ref) THEN
+                     SET NEW.evidence_schema_status = 'unchecked';
+                     SET NEW.evidence_schema_checked_at = NULL;
+                     SET NEW.evidence_schema_error_code = NULL;
+                 END IF;
+             END",
+        ),
+        (
+            "trg_metric_source_measures_evidence_insert",
+            "CREATE TRIGGER trg_metric_source_measures_evidence_insert
+             AFTER INSERT ON metric_source_measures
+             FOR EACH ROW
+             UPDATE metric_sources
+             SET evidence_schema_status = 'unchecked',
+                 evidence_schema_checked_at = NULL,
+                 evidence_schema_error_code = NULL
+             WHERE id = NEW.source_id",
+        ),
+        (
+            "trg_metric_source_measures_evidence_update",
+            "CREATE TRIGGER trg_metric_source_measures_evidence_update
+             AFTER UPDATE ON metric_source_measures
+             FOR EACH ROW
+             BEGIN
+                 IF NOT (OLD.evidence_granularity <=> NEW.evidence_granularity) THEN
+                     UPDATE metric_sources
+                     SET evidence_schema_status = 'unchecked',
+                         evidence_schema_checked_at = NULL,
+                         evidence_schema_error_code = NULL
+                     WHERE id = NEW.source_id;
+                 END IF;
+             END",
+        ),
+    ];
+    for (name, ddl) in triggers {
+        conn.execute_unprepared(&format!("DROP TRIGGER IF EXISTS {name}"))
+            .await?;
+        conn.execute_unprepared(ddl).await?;
+    }
+    Ok(())
+}

--- a/src/backend/services/analytics/src/migration/mod.rs
+++ b/src/backend/services/analytics/src/migration/mod.rs
@@ -54,6 +54,7 @@ mod m20260710_000001_metric_distinct_count_computation;
 mod m20260714_000001_metric_value_transform;
 mod m20260721_000001_metric_definition_short_label;
 mod m20260722_000001_metric_definition_last_observed;
+mod m20260727_000001_metric_evidence;
 mod m20260730_000001_saved_queries;
 
 use sea_orm_migration::prelude::*;
@@ -118,6 +119,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260714_000001_metric_value_transform::Migration),
             Box::new(m20260721_000001_metric_definition_short_label::Migration),
             Box::new(m20260722_000001_metric_definition_last_observed::Migration),
+            Box::new(m20260727_000001_metric_evidence::Migration),
             Box::new(m20260730_000001_saved_queries::Migration),
         ]
     }


### PR DESCRIPTION
## Summary

- store evidence relation and per-measure granularity in the metric registry
- probe the evidence contract in the schema validator; missing or invalid evidence fails closed
- advertise drilldown capability through `POST /v1/metric-results` and `GET /v1/metric-definitions`
- return the canonical selection with every metric result


## Stack

Merges bottom-up; each PR retargets to `main` as its parent lands.

1.    #2071 — evidence serving tables
1. **→** #2072 — capability metadata
1.    #2073 — drilldown endpoint
1.    #2074 — CSV/XLSX export

UI layer: constructorfabric/insight-front#226

Closes constructorfabric/insight#2068

## Validation

- `cargo test -p analytics`




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metric definitions now expose available evidence-based drilldown granularity.
  * Metric results now include a required selection object (metric key, entity, period, and dimension filters).
  * Optionally returned drilldown granularity is included only when evidence is validated and available.
* **Bug Fixes**
  * Improved evidence and source status validation, with revision-guarded updates to prevent stale overwrites.
* **Documentation**
  * Updated API/metric documentation to describe drilldown capability, result selection, and the `distinct_count` computation variant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->