### PR TITLE
docs: add per-language style rules for coding agents

### DIFF
--- a/src/backend/CLAUDE.md
+++ b/src/backend/CLAUDE.md
@@ -25,6 +25,10 @@ deny). These rules cover only what tooling cannot enforce.
 - States that cannot coexist are enum variants, not bool/Option field
   combinations; make the invalid combination unrepresentable rather than
   checked at runtime.
+- When an API has call-order rules, encode them as type state so the wrong
+  order fails to compile (`Session<Anonymous>` has no `.send()`;
+  `authenticate()` returns `Session<Authenticated>` which does) — instead of
+  a runtime `is_ready` check.
 - Smallest visibility that compiles; `pub(crate)` before `pub`. No speculative
   API surface.
 - `#[derive(Debug)]` always; `Clone` only when a consumer clones.
@@ -49,15 +53,46 @@ deny). These rules cover only what tooling cannot enforce.
 - Prefer `#[expect(clippy::...)]` over `#[allow]` — it errors when the lint
   stops firing; either way the justification rides on the same line.
 
+## Concurrency
+
+- Never hold a lock or semaphore permit across an `.await` unless the hold is
+  the point (a concurrency cap); when it is, say so with an `// INVARIANT:`
+  line.
+- CPU-heavy or blocking work (serialization of large payloads, file I/O,
+  crypto) goes through `spawn_blocking`, never inline in an async handler.
+- Bound every unbounded thing at the edge: concurrent requests (semaphore),
+  response sizes, queue depths. A missing bound is a bug, not a default.
+- Shared mutable state wants a redesign before it wants `Arc<Mutex<_>>`;
+  message passing or single-owner tasks first.
+
+## Performance
+
+- Measure before optimizing; no speculative micro-optimization in review
+  feedback or code.
+- No allocation in per-row/per-item loops when the value can be borrowed or
+  hoisted; watch `.collect()` used only to iterate again.
+- Streaming over buffering when payloads can be large; if buffering is
+  required, cap it.
+
 ## Comments
 
-- None, unless code cannot express the why: intentional redundancy
-  (defense-in-depth re-checks), cross-function invariants ("the cursor is not
-  an authorization token"), `#[allow]` justifications. One line each.
-- No module headers, no `///` on self-describing items, no issue numbers in
-  source, no phase/scope notes — that context lives in issues and PRs.
+- None, unless code cannot express the why. Allowed categories, one line
+  each, tagged so they are greppable and an untagged comment stands out:
+  - `// SAFETY:` — soundness argument for an `unsafe` block.
+  - `// INVARIANT:` — a cross-function fact a future edit could silently
+    break ("the cursor is not an authorization token").
+  - `// WORKAROUND:` — external bug or platform behavior being dodged, with
+    the reason it is needed.
+  - lint suppressions — justification on the same line as the attribute.
+- No module headers, no issue numbers in source, no phase/scope notes — that
+  context lives in issues and PRs. Anything that deserves to outlive a PR
+  becomes a type, a test, or a design-doc section, never a comment.
 - Non-obvious semantics get a test whose name states the rule
   (`absent_null_and_value_are_three_distinct_states`), not a comment.
+- `///` doc comments: only in shared library crates on exported items —
+  what it does and its error conditions, briefly. Binaries and services get
+  none; their consumers read the source. No `missing_docs` enforcement
+  anywhere.
 
 ## Readability
 

--- a/src/backend/CLAUDE.md
+++ b/src/backend/CLAUDE.md
@@ -22,10 +22,32 @@ deny). These rules cover only what tooling cannot enforce.
 - Parse, don't validate: newtypes at boundaries (`RelationName::parse(&str) ->
   Option<RelationName>`), never raw `String` carried through layers.
 - Exhaustive `match` on our own enums — no `_` arm.
+- States that cannot coexist are enum variants, not bool/Option field
+  combinations; make the invalid combination unrepresentable rather than
+  checked at runtime.
 - Smallest visibility that compiles; `pub(crate)` before `pub`. No speculative
   API surface.
 - `#[derive(Debug)]` always; `Clone` only when a consumer clones.
 - Constants: module top, grouped, unit-suffixed (`_BYTES`, `_SECS`, `_DAYS`).
+
+## Ownership
+
+- Borrow before cloning: `&str` over `String`, `&[T]` over `Vec<T>` in
+  parameters; take ownership only when the function stores or consumes the
+  value.
+- A `.clone()` inside a loop or iterator chain needs a reason; restructure to
+  borrow or hoist it out.
+- Small `Copy` types pass by value.
+
+## Errors and dispatch
+
+- `Result` for everything fallible; panics never cross a request boundary.
+- Typed errors (`thiserror`) in domain and library code; `anyhow` only in
+  binary entry points and startup wiring.
+- Generics for internal hot paths; `dyn Trait` only for genuinely
+  heterogeneous collections or to cut compile-time bloat at an API boundary.
+- Prefer `#[expect(clippy::...)]` over `#[allow]` — it errors when the lint
+  stops firing; either way the justification rides on the same line.
 
 ## Comments
 

--- a/src/backend/CLAUDE.md
+++ b/src/backend/CLAUDE.md
@@ -1,0 +1,56 @@
+# Rust style — backend workspace
+
+Tooling owns formatting (rustfmt) and correctness lints (clippy pedantic,
+deny). These rules cover only what tooling cannot enforce.
+
+## Structure
+
+- One noun per file. A module growing past ~400 lines splits into a directory
+  (`dto.rs`, `validation.rs`, `compiler.rs`, ...) — never a second noun in the
+  same file.
+- Handlers are orchestration skeletons (≤ ~30 lines): extract → validate →
+  domain call → map → respond. No business logic in the API layer; no
+  serialization formats (CSV, XLSX, ...) outside domain.
+- I/O shell, pure core: anything computable without a connection is a free
+  function over values. Tests target the core; no mocks of our own types.
+- Repetition becomes a named helper; the name is the documentation. Error
+  construction lives in one helper per failure kind: log detailed internally,
+  return a generic wire error.
+
+## Types
+
+- Parse, don't validate: newtypes at boundaries (`RelationName::parse(&str) ->
+  Option<RelationName>`), never raw `String` carried through layers.
+- Exhaustive `match` on our own enums — no `_` arm.
+- Smallest visibility that compiles; `pub(crate)` before `pub`. No speculative
+  API surface.
+- `#[derive(Debug)]` always; `Clone` only when a consumer clones.
+- Constants: module top, grouped, unit-suffixed (`_BYTES`, `_SECS`, `_DAYS`).
+
+## Comments
+
+- None, unless code cannot express the why: intentional redundancy
+  (defense-in-depth re-checks), cross-function invariants ("the cursor is not
+  an authorization token"), `#[allow]` justifications. One line each.
+- No module headers, no `///` on self-describing items, no issue numbers in
+  source, no phase/scope notes — that context lives in issues and PRs.
+- Non-obvious semantics get a test whose name states the rule
+  (`absent_null_and_value_are_three_distinct_states`), not a comment.
+
+## Readability
+
+- Paragraph functions: blank line between logical steps (gather → transform →
+  emit). A multi-line statement (builder chain, `match`, closure block) gets a
+  blank line after it before unrelated code. No blank line inside one tight
+  thought.
+- Early return / `let .. else` / `?` over nested `if`: two levels of
+  indentation inside a function body is the ceiling to aim for.
+- One `let` per binding; no expression so dense it needs re-reading — name the
+  intermediate instead.
+- Import order: std, external crates, workspace crates, `crate::`/`super::` —
+  one blank line between groups (rustfmt won't fix this; keep it by hand).
+- Match arms: single-line arms stay single-line; once one arm needs a block,
+  give every arm breathing room.
+- Tests read as spec: table-driven loops with per-case assert messages
+  (`"should reject: {input:?}"`); alias `type R = Result<(), Box<dyn Error>>`
+  to cut ceremony.

--- a/src/ingestion/CLAUDE.md
+++ b/src/ingestion/CLAUDE.md
@@ -1,0 +1,84 @@
+# Python and dbt SQL style — ingestion
+
+Ruff owns Python formatting and import order (config at repo root). dbt SQL
+has no linter — these rules are the floor.
+
+## Python
+
+### Structure
+
+- One concern per module; a module growing past ~400 lines splits.
+- I/O shell, pure core: anything computable without a connection or filesystem
+  is a plain function over values. Tests target the core; no mocks of our own
+  code.
+- Repetition becomes a named helper; the name is the documentation. Log
+  detailed context at the failure site, raise one typed exception per failure
+  kind.
+
+### Types
+
+- Type hints on every signature; no bare `Any` escapes.
+- Parse, don't validate: convert raw input into a typed shape
+  (`@dataclass(frozen=True)`, `NamedTuple`, enum) at the boundary and pass the
+  typed value through.
+
+### Comments
+
+- None, unless code cannot express the why: intentional redundancy,
+  cross-function invariants, workarounds with the reason. One line each.
+- No module docstring headers restating the code, no issue numbers in source,
+  no phase/scope notes — that context lives in issues and PRs.
+- Non-obvious semantics get a test whose name states the rule
+  (`test_missing_and_empty_are_distinct_states`), not a comment.
+
+### Tests
+
+- Test names state the rule, not the mechanics.
+- `pytest.mark.parametrize` over copy-pasted cases; assert messages carry the
+  failing case (`f"should reject: {value!r}"`).
+
+### Readability
+
+- Paragraph functions: blank line between logical steps (gather → transform →
+  emit). A multi-line statement (comprehension, `with` block, long call) gets
+  a blank line after it before unrelated code.
+- Early return over nested `if`: two levels of indentation inside a function
+  body is the ceiling to aim for.
+- Name intermediates instead of nesting calls three deep; comprehensions stay
+  single-clause — a comprehension needing two `for`s or an `else` becomes a
+  loop.
+
+## dbt SQL
+
+### Model shape
+
+- `config` block first. Every ClickHouse setting goes in `query_settings` —
+  never a trailing `SETTINGS` clause in the model body (dbt appends its own;
+  two clauses in one statement is a syntax error).
+- CTEs are the paragraphs: one named transformation each, noun names
+  (`active_users`, `events_per_day`), blank line between CTEs. A CTE doing two
+  jobs splits.
+- Explicit column lists across layer boundaries — no `SELECT *`.
+- One column per line, aliases aligned with the surrounding model.
+- Uppercase keywords, lowercase identifiers.
+
+### Layering
+
+- Gold reads only class-contract columns from silver — never vendor-specific
+  ones. A missing fact means extending the class contract first.
+- Measures emit through the shared shape macros; a new macro appears only when
+  a new computation kind becomes executable.
+- Reads from mutable (ReplacingMergeTree) class relations keep `FINAL` —
+  parts are not duplicate-immune.
+- Every model documents its columns and accepted measure keys in `schema.yml`;
+  key uniqueness gets a dbt data test.
+
+### Comments
+
+- Same rule as everywhere: only the why the SQL cannot express — a ClickHouse
+  behavior being worked around, an invariant a future edit could silently
+  break. One line each. No headers narrating the query.
+
+### Validation
+
+- `dbt parse` before committing model changes.


### PR DESCRIPTION
## Summary

- add directory-scoped `CLAUDE.md` style rules for coding agents: Rust (`src/backend/`), Python + dbt SQL (`src/ingestion/`)
- rules cover only what tooling cannot enforce: module decomposition, pure-core/I/O-shell split, comment policy, vertical rhythm, tests-as-spec
- scoped per directory so each loads only for work in its own tree

## Validation

- documentation only, no code changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added backend Rust style and development guidance.
  * Added ingestion guidance covering Python, dbt SQL, data modeling, testing, and validation practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->