### PR TITLE
feat(analytics): named run params — inject {tenant}, bind {period} (#1966)

### DIFF
--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -1643,6 +1643,18 @@
         ],
         "type": "object"
       },
+      "RunSavedQueryRequest": {
+        "description": "Optional parameters for `POST /v1/queries/{id}/run` (#1966).\n\nThe `{tenant}` parameter is always injected from the session context and is\nnever client-settable, so it is absent here. `period` is the first optional\nnamed parameter an author can reference as `{period:<Type>}`; it is bound as\na ClickHouse server-side parameter, never interpolated into the SQL text.",
+        "properties": {
+          "period": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "type": "object"
+      },
       "SavedQuery": {
         "description": "A saved query row.",
         "properties": {
@@ -4694,6 +4706,16 @@
     "/v1/queries/{id}/run": {
       "post": {
         "operationId": "analytics_api.queries.run",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RunSavedQueryRequest"
+              }
+            }
+          },
+          "description": "Optional named parameters (`period`); `tenant` is always injected from context"
+        },
         "responses": {
           "200": {
             "content": {

--- a/docs/domain/presentation-layer/specs/DESIGN.md
+++ b/docs/domain/presentation-layer/specs/DESIGN.md
@@ -358,7 +358,7 @@ Entity `presentation.queries`: `{ id, insight_tenant_id, name, description, sql,
 | `GET` | `/v1/queries/{id}` | Fetch one | unstable |
 | `PUT` | `/v1/queries/{id}` | Update (re-validates SQL) | unstable |
 | `DELETE` | `/v1/queries/{id}` | Delete | unstable |
-| `POST` | `/v1/queries/{id}/run` | Execute read-only as `presentation_ro`, return rows; optional body `{ "period": "<value>" }` binds `{period}`; `{tenant}` always bound from context (tenant-row filter injected in #1967) | unstable |
+| `POST` | `/v1/queries/{id}/run` | Execute read-only as `presentation_ro`, return rows; optional body `{ "period": "<value>" }` binds `{period}`; `{tenant}` always bound from context (tenant-row *filter* deferred to #1967 — the run path binds the tenant value but adds no `insight_tenant_id` predicate yet) | unstable |
 
 `run` executes as `presentation_ro` and returns untyped JSON rows, the same shape as the existing metric query path. The request body is optional; named parameters (`tenant`/`period`, #1966) are bound as ClickHouse server-side parameters. No metric metadata, thresholds, or passports in Phase A.
 

--- a/docs/domain/presentation-layer/specs/DESIGN.md
+++ b/docs/domain/presentation-layer/specs/DESIGN.md
@@ -264,19 +264,21 @@ The second, independent barrier behind the query gate: once analytics connects a
 
 ##### Why this component exists
 
-Plain CRUD over stored queries so a new analytics slice needs no engineering change and no re-ingest. The one new surface Phase A adds ("Data Analytics"). CRUD + run shipped (#1965); named parameters follow in #1966.
+Plain CRUD over stored queries so a new analytics slice needs no engineering change and no re-ingest. The one new surface Phase A adds ("Data Analytics"). CRUD + run shipped (#1965); named parameters (`tenant`/`period`) shipped (#1966).
 
 ##### Responsibility scope
 
 - CRUD over `presentation.queries` (the `saved_queries` service-DB table), tenant-scoped from the session `SecurityContext`. Handlers mirror the metric CRUD in `api::handlers`; delete is a hard delete.
 - Validate SQL via the query gate (`validate_single_select`) on create, update, **and** run — the run-side re-validation keeps a stored SQL from reaching ClickHouse as anything but a single read.
 - Run: execute the stored single-SELECT read-only as `presentation_ro` and return untyped JSON rows (`JSONEachRow`, same shape as the existing metric query path).
+- Bind named parameters on run (#1966): `{tenant}` is always bound from the session `SecurityContext` (never client-settable); `{period}` is bound when supplied on the run request body. Values are passed as ClickHouse server-side parameters (`Query::param` → `param_<name>`), so a value can never change query structure; the gate already tolerates `{name:Type}` placeholders. A query that references a parameter left unbound (e.g. `{period}` with no period supplied) fails as a 400, not a 5xx.
 
 ##### Responsibility boundaries
 
 - Does NOT carry metric metadata, thresholds, or passports — those are Phase B.
 - Does NOT bypass the gate.
-- Does NOT yet inject named parameters (`tenant`/`period`, #1966) or the tenant-row filter (#1967) — #1965 executes the stored SQL as authored; those cross-cutting concerns extend the run path in their own sub-issues.
+- Does NOT string-interpolate parameter values — binding is server-side only.
+- Does NOT yet inject the tenant-row filter (#1967) — the run path binds the `{tenant}` *value* but does not yet add an `insight_tenant_id = {tenant}` predicate to queries that omit it; that cross-cutting concern lands in its own sub-issue.
 
 ##### Related components (by ID)
 
@@ -356,9 +358,9 @@ Entity `presentation.queries`: `{ id, insight_tenant_id, name, description, sql,
 | `GET` | `/v1/queries/{id}` | Fetch one | unstable |
 | `PUT` | `/v1/queries/{id}` | Update (re-validates SQL) | unstable |
 | `DELETE` | `/v1/queries/{id}` | Delete | unstable |
-| `POST` | `/v1/queries/{id}/run` | Execute read-only as `presentation_ro`, return rows (tenant filter injected in #1967) | unstable |
+| `POST` | `/v1/queries/{id}/run` | Execute read-only as `presentation_ro`, return rows; optional body `{ "period": "<value>" }` binds `{period}`; `{tenant}` always bound from context (tenant-row filter injected in #1967) | unstable |
 
-`run` executes as `presentation_ro` and returns untyped JSON rows, the same shape as the existing metric query path. No metric metadata, thresholds, or passports in Phase A.
+`run` executes as `presentation_ro` and returns untyped JSON rows, the same shape as the existing metric query path. The request body is optional; named parameters (`tenant`/`period`, #1966) are bound as ClickHouse server-side parameters. No metric metadata, thresholds, or passports in Phase A.
 
 ### 3.4 Internal Dependencies
 

--- a/docs/domain/presentation-layer/specs/PRD.md
+++ b/docs/domain/presentation-layer/specs/PRD.md
@@ -195,9 +195,9 @@ The system **MUST** allow an analyst to create, list, fetch, update, delete, and
 
 #### Named Query Parameters
 
-- [ ] `p1` - **ID**: `cpt-presentation-fr-query-params`
+- [x] `p1` - **ID**: `cpt-presentation-fr-query-params`
 
-The system **MUST** support named query parameters, always injecting `tenant` from request context and supporting a `period` parameter. The `tenant` parameter **MUST NOT** be settable from client SQL. (#1966.)
+The system **MUST** support named query parameters, always injecting `tenant` from request context and supporting a `period` parameter supplied on the run request. The `tenant` parameter **MUST NOT** be settable from client SQL. Parameter values **MUST** be bound as ClickHouse server-side parameters (`{name:Type}`), never string-interpolated, so a value can never alter query structure. (Shipped, #1966.)
 
 **Rationale**: Consistent, safe parameterization; the tenant value is authoritative from context.
 
@@ -311,7 +311,7 @@ Contract reads for tenant A **MUST NOT** return rows from tenant B, regardless o
 
 **Stability**: unstable
 
-**Description**: CRUD and read-only run over saved queries, tenant-scoped. The one new surface Phase A adds. Detailed endpoint contracts live in DESIGN. (CRUD + run shipped in #1965; named parameters follow in #1966.)
+**Description**: CRUD and read-only run over saved queries, tenant-scoped. The one new surface Phase A adds. Detailed endpoint contracts live in DESIGN. (CRUD + run shipped in #1965; named parameters shipped in #1966.)
 
 **Breaking Change Policy**: Unstable in Phase A; contract hardens in a later phase.
 

--- a/src/backend/services/analytics/src/api/mod.rs
+++ b/src/backend/services/analytics/src/api/mod.rs
@@ -310,6 +310,11 @@ fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) -> Router {
         .summary("Run a saved query")
         .authenticated()
         .no_license_required()
+        .json_request::<saved_query::RunSavedQueryRequest>(
+            openapi,
+            "Optional named parameters (`period`); `tenant` is always injected from context",
+        )
+        .request_optional()
         .json_response_with_schema::<saved_query::RunResponse>(
             openapi,
             StatusCode::OK,

--- a/src/backend/services/analytics/src/api/saved_queries.rs
+++ b/src/backend/services/analytics/src/api/saved_queries.rs
@@ -6,9 +6,9 @@
 //! gate on create, update, and run. Only `/run` reaches ClickHouse — it
 //! executes the stored SQL as `presentation_ro` and returns untyped JSON rows.
 //!
-//! Phase-A scope: named parameters (`tenant`/`period`, #1966) and the injected
-//! tenant-row filter (#1967) are separate sub-issues — `/run` here executes the
-//! stored single-SELECT as authored.
+//! Phase-A scope: `/run` binds named parameters server-side — `{tenant}` always
+//! (from context), `{period}` when supplied (#1966). The injected tenant-row
+//! filter (#1967) is a separate sub-issue.
 
 use std::sync::Arc;
 
@@ -25,7 +25,8 @@ use super::AppState;
 use super::error::SavedQueryError;
 use crate::domain::query_gate::validate_single_select;
 use crate::domain::saved_query::{
-    CreateSavedQueryRequest, RunResponse, SavedQuery, SavedQuerySummary, UpdateSavedQueryRequest,
+    CreateSavedQueryRequest, RunResponse, RunSavedQueryRequest, SavedQuery, SavedQuerySummary,
+    UpdateSavedQueryRequest,
 };
 use crate::infra::db::entities::saved_queries;
 
@@ -141,6 +142,7 @@ pub async fn run_saved_query(
     Extension(state): Extension<Arc<AppState>>,
     Extension(ctx): Extension<SecurityContext>,
     Path(id): Path<Uuid>,
+    body: Option<Json<RunSavedQueryRequest>>,
 ) -> Result<impl IntoResponse, CanonicalError> {
     let saved = find_saved_query(&state, ctx.subject_tenant_id(), id).await?;
 
@@ -149,39 +151,74 @@ pub async fn run_saved_query(
     // single read (defense in depth alongside the `presentation_ro` grants).
     validate_single_select(&saved.sql).map_err(|e| invalid_sql_for(id, e))?;
 
-    // #1966 (named params) and #1967 (injected tenant-row filter) extend this
-    // path; Phase-A #1965 executes the stored single-SELECT as authored.
-    let rows = execute_read(&state, &saved.sql).await?;
+    // Named parameters (#1966): `{tenant}` is always bound from context; the
+    // optional `period` binds `{period}`. Both go through ClickHouse's
+    // server-side parameter interface, so a value can never alter the SQL. The
+    // injected tenant-row *filter* (#1967) is a separate concern.
+    let period = body.and_then(|Json(b)| b.period);
+    let rows = execute_read(
+        &state,
+        id,
+        &saved.sql,
+        ctx.subject_tenant_id(),
+        period.as_deref(),
+    )
+    .await?;
     Ok(Json(RunResponse { rows }))
 }
 
 /// Execute a single read statement against ClickHouse and parse the
 /// `JSONEachRow` stream into untyped rows — the same read path the metric query
-/// uses.
+/// uses. Binds the `tenant`/`period` named parameters server-side (#1966).
 async fn execute_read(
     state: &AppState,
+    id: Uuid,
     sql: &str,
+    tenant_id: Uuid,
+    period: Option<&str>,
 ) -> Result<Vec<serde_json::Value>, CanonicalError> {
     tracing::debug!(sql = %sql, "executing saved query");
 
-    let mut cursor = state
-        .ch
-        .query(sql)
-        .fetch_bytes("JSONEachRow")
-        .map_err(|e| {
-            tracing::error!(error = %e, sql = %sql, "ClickHouse query failed");
-            CanonicalError::internal("query execution failed").create()
-        })?;
+    // `.param` sets `param_<name>` on the request; the SQL references it as
+    // `{name:Type}`. `tenant` is always bound (unused by a query that omits it
+    // — ClickHouse ignores extra params); `period` only when supplied.
+    let mut query = state.ch.query(sql).param("tenant", tenant_id.to_string());
+    if let Some(period) = period {
+        query = query.param("period", period);
+    }
+
+    let mut cursor = query.fetch_bytes("JSONEachRow").map_err(|e| {
+        tracing::error!(error = %e, sql = %sql, "ClickHouse query failed");
+        classify_run_error(id, &e.to_string())
+    })?;
 
     let raw_bytes = cursor.collect().await.map_err(|e| {
         tracing::error!(error = %e, sql = %sql, "ClickHouse fetch failed");
-        CanonicalError::internal("query execution failed").create()
+        classify_run_error(id, &e.to_string())
     })?;
 
     parse_json_each_row(&raw_bytes).map_err(|e| {
         tracing::error!(error = %e, "failed to parse ClickHouse JSON response");
         CanonicalError::internal("failed to parse query results").create()
     })
+}
+
+/// Map a ClickHouse run error to a canonical error. A query that references a
+/// named parameter left unbound (e.g. `{period}` with no `period` supplied) is
+/// caller error (`UNKNOWN_QUERY_PARAMETER`, code 456) — surface it as a 400 so
+/// the console can prompt for the missing value rather than a bare 500.
+fn classify_run_error(id: Uuid, message: &str) -> CanonicalError {
+    if message.contains("UNKNOWN_QUERY_PARAMETER") || message.contains("Code: 456") {
+        return SavedQueryError::invalid_argument()
+            .with_resource(id.to_string())
+            .with_field_violation(
+                "period",
+                "query references a named parameter that was not supplied",
+                "MISSING",
+            )
+            .create();
+    }
+    CanonicalError::internal("query execution failed").create()
 }
 
 /// Parse a `JSONEachRow` byte stream (one JSON object per line) into untyped
@@ -254,10 +291,54 @@ fn model_to_summary(m: saved_queries::Model) -> SavedQuerySummary {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_json_each_row;
+    use super::{classify_run_error, parse_json_each_row};
     use serde_json::json;
+    use toolkit_canonical_errors::Problem;
+    use uuid::Uuid;
 
     type R = Result<(), Box<dyn std::error::Error>>;
+
+    fn status_of(
+        err: toolkit_canonical_errors::CanonicalError,
+    ) -> Result<serde_json::Value, serde_json::Error> {
+        Ok(serde_json::to_value(Problem::from(err))?["status"].clone())
+    }
+
+    /// A ClickHouse unbound-parameter error (code 456) is caller error → 400 on
+    /// the `period` field, not a bare 500 (#1966). Both the numeric code and the
+    /// symbolic name the server includes are matched.
+    #[test]
+    fn missing_named_param_is_a_400() -> R {
+        for msg in [
+            "bad response: Code: 456. DB::Exception: Substitution `period` is not set (UNKNOWN_QUERY_PARAMETER)",
+            "Code: 456. DB::Exception: Substitution `period` is not set",
+            "DB::Exception: ... (UNKNOWN_QUERY_PARAMETER)",
+        ] {
+            assert_eq!(
+                status_of(classify_run_error(Uuid::now_v7(), msg))?,
+                400,
+                "should be a 400: {msg:?}"
+            );
+        }
+        Ok(())
+    }
+
+    /// Any other ClickHouse failure stays an opaque 500 — we do not leak engine
+    /// internals or misclassify a genuine server fault as caller error.
+    #[test]
+    fn other_ch_errors_stay_500() -> R {
+        for msg in [
+            "bad response: Code: 60. DB::Exception: Unknown table",
+            "network error: connection refused",
+        ] {
+            assert_eq!(
+                status_of(classify_run_error(Uuid::now_v7(), msg))?,
+                500,
+                "should be a 500: {msg:?}"
+            );
+        }
+        Ok(())
+    }
 
     #[test]
     fn empty_input_yields_no_rows() -> R {

--- a/src/backend/services/analytics/src/api/saved_queries.rs
+++ b/src/backend/services/analytics/src/api/saved_queries.rs
@@ -206,19 +206,34 @@ async fn execute_read(
 /// Map a ClickHouse run error to a canonical error. A query that references a
 /// named parameter left unbound (e.g. `{period}` with no `period` supplied) is
 /// caller error (`UNKNOWN_QUERY_PARAMETER`, code 456) — surface it as a 400 so
-/// the console can prompt for the missing value rather than a bare 500.
+/// the console can prompt for the missing value rather than a bare 500. The
+/// unbound parameter's name is reported when ClickHouse names it, so a query
+/// using `{region}` is not mislabeled as a missing `period`.
 fn classify_run_error(id: Uuid, message: &str) -> CanonicalError {
     if message.contains("UNKNOWN_QUERY_PARAMETER") || message.contains("Code: 456") {
+        let param = missing_param_name(message);
+        let reason = match param {
+            Some(name) => {
+                format!("named parameter `{name}` is referenced by the query but was not supplied")
+            }
+            None => "a named parameter referenced by the query was not supplied".to_owned(),
+        };
         return SavedQueryError::invalid_argument()
             .with_resource(id.to_string())
-            .with_field_violation(
-                "period",
-                "query references a named parameter that was not supplied",
-                "MISSING",
-            )
+            .with_field_violation(param.unwrap_or("params"), reason, "MISSING")
             .create();
     }
     CanonicalError::internal("query execution failed").create()
+}
+
+/// Extract the unbound parameter's name from a ClickHouse
+/// `UNKNOWN_QUERY_PARAMETER` message. ClickHouse backtick-quotes the name
+/// (`Substitution ``period`` is not set`); return the first such token, or
+/// `None` when the message does not name it.
+fn missing_param_name(message: &str) -> Option<&str> {
+    let start = message.find('`')? + 1;
+    let len = message[start..].find('`')?;
+    Some(&message[start..start + len])
 }
 
 /// Parse a `JSONEachRow` byte stream (one JSON object per line) into untyped
@@ -291,22 +306,22 @@ fn model_to_summary(m: saved_queries::Model) -> SavedQuerySummary {
 
 #[cfg(test)]
 mod tests {
-    use super::{classify_run_error, parse_json_each_row};
+    use super::{classify_run_error, missing_param_name, parse_json_each_row};
     use serde_json::json;
     use toolkit_canonical_errors::Problem;
     use uuid::Uuid;
 
     type R = Result<(), Box<dyn std::error::Error>>;
 
-    fn status_of(
+    fn problem_of(
         err: toolkit_canonical_errors::CanonicalError,
     ) -> Result<serde_json::Value, serde_json::Error> {
-        Ok(serde_json::to_value(Problem::from(err))?["status"].clone())
+        serde_json::to_value(Problem::from(err))
     }
 
-    /// A ClickHouse unbound-parameter error (code 456) is caller error → 400 on
-    /// the `period` field, not a bare 500 (#1966). Both the numeric code and the
-    /// symbolic name the server includes are matched.
+    /// A ClickHouse unbound-parameter error (code 456) is caller error → 400, not
+    /// a bare 500 (#1966). Both the numeric code and the symbolic name the server
+    /// includes are matched.
     #[test]
     fn missing_named_param_is_a_400() -> R {
         for msg in [
@@ -314,13 +329,46 @@ mod tests {
             "Code: 456. DB::Exception: Substitution `period` is not set",
             "DB::Exception: ... (UNKNOWN_QUERY_PARAMETER)",
         ] {
+            let p = problem_of(classify_run_error(Uuid::now_v7(), msg))?;
+            assert_eq!(p["status"], 400, "should be a 400: {msg:?}");
+        }
+        Ok(())
+    }
+
+    /// The 400 names the parameter ClickHouse reports as unbound, so a query
+    /// using `{region}` is not mislabeled as a missing `period`; when the message
+    /// does not name it, the violation falls back to a generic `params` field.
+    #[test]
+    fn missing_param_400_reports_the_named_parameter() -> R {
+        for (msg, field) in [
+            (
+                "Code: 456. DB::Exception: Substitution `period` is not set",
+                "period",
+            ),
+            (
+                "Code: 456. DB::Exception: Substitution `region` is not set",
+                "region",
+            ),
+            ("DB::Exception: ... (UNKNOWN_QUERY_PARAMETER)", "params"),
+        ] {
+            let p = problem_of(classify_run_error(Uuid::now_v7(), msg))?;
             assert_eq!(
-                status_of(classify_run_error(Uuid::now_v7(), msg))?,
-                400,
-                "should be a 400: {msg:?}"
+                p["context"]["field_violations"][0]["field"], field,
+                "wrong field for {msg:?}"
             );
         }
         Ok(())
+    }
+
+    /// The name extractor returns the first backtick-quoted token, or `None`.
+    #[test]
+    fn missing_param_name_extracts_backtick_token() {
+        assert_eq!(
+            missing_param_name("Substitution `period` is not set"),
+            Some("period")
+        );
+        assert_eq!(missing_param_name("no backticks here"), None);
+        assert_eq!(missing_param_name("unterminated `oops"), None);
     }
 
     /// Any other ClickHouse failure stays an opaque 500 — we do not leak engine
@@ -331,11 +379,8 @@ mod tests {
             "bad response: Code: 60. DB::Exception: Unknown table",
             "network error: connection refused",
         ] {
-            assert_eq!(
-                status_of(classify_run_error(Uuid::now_v7(), msg))?,
-                500,
-                "should be a 500: {msg:?}"
-            );
+            let p = problem_of(classify_run_error(Uuid::now_v7(), msg))?;
+            assert_eq!(p["status"], 500, "should be a 500: {msg:?}");
         }
         Ok(())
     }

--- a/src/backend/services/analytics/src/domain/saved_query.rs
+++ b/src/backend/services/analytics/src/domain/saved_query.rs
@@ -59,6 +59,18 @@ pub struct UpdateSavedQueryRequest {
     pub sql: Option<String>,
 }
 
+/// Optional parameters for `POST /v1/queries/{id}/run` (#1966).
+///
+/// The `{tenant}` parameter is always injected from the session context and is
+/// never client-settable, so it is absent here. `period` is the first optional
+/// named parameter an author can reference as `{period:<Type>}`; it is bound as
+/// a ClickHouse server-side parameter, never interpolated into the SQL text.
+#[derive(Debug, Default, Deserialize, utoipa::ToSchema)]
+pub struct RunSavedQueryRequest {
+    #[serde(default)]
+    pub period: Option<String>,
+}
+
 /// Result of `POST /v1/queries/{id}/run`.
 ///
 /// `rows` carry a per-query dynamic schema (the `SELECT` columns vary), so each
@@ -85,10 +97,23 @@ impl toolkit::api::api_dto::ResponseApiDto for SavedQueryListResponse {}
 impl toolkit::api::api_dto::ResponseApiDto for RunResponse {}
 impl toolkit::api::api_dto::RequestApiDto for CreateSavedQueryRequest {}
 impl toolkit::api::api_dto::RequestApiDto for UpdateSavedQueryRequest {}
+impl toolkit::api::api_dto::RequestApiDto for RunSavedQueryRequest {}
 
 #[cfg(test)]
 mod tests {
-    use super::UpdateSavedQueryRequest;
+    use super::{RunSavedQueryRequest, UpdateSavedQueryRequest};
+
+    /// The run body is optional and its `period` defaults to absent: `{}` and an
+    /// omitted `period` both parse to `None`; a value parses through.
+    #[test]
+    fn run_request_period_is_optional() -> Result<(), Box<dyn std::error::Error>> {
+        let empty: RunSavedQueryRequest = serde_json::from_str("{}")?;
+        assert_eq!(empty.period, None);
+
+        let set: RunSavedQueryRequest = serde_json::from_str(r#"{"period": "2026-01"}"#)?;
+        assert_eq!(set.period.as_deref(), Some("2026-01"));
+        Ok(())
+    }
 
     /// The triple-state `description` deserializer: absent → unchanged (`None`),
     /// explicit `null` → clear (`Some(None)`), value → set (`Some(Some(..))`).

--- a/src/ingestion/tests/e2e/api/test_queries.py
+++ b/src/ingestion/tests/e2e/api/test_queries.py
@@ -5,17 +5,23 @@
   GET    /v1/queries/{id}         200 · 400 non-uuid · 404 unknown · 404 deleted
   PUT    /v1/queries/{id}         200 · 400 bad-sql · 400 non-uuid · 404 unknown · 415 wrong-ct · 400 off-schema (xfail)
   DELETE /v1/queries/{id}         204 · 400 non-uuid · 404 unknown
-  POST   /v1/queries/{id}/run     200 rows · 400 non-uuid · 404 unknown
+  POST   /v1/queries/{id}/run     200 rows · 200 {tenant}/{period} params · 400 missing param · 400 non-uuid · 404 unknown
 
 The scratch query's `sql` runs the REAL read path end-to-end: gated by the
 single-SELECT gate on write and run, then executed on ClickHouse as
 `presentation_ro` — one deterministic row {one: 1} comes back. CRUD is a hard
 delete (no soft-delete flag), so a deleted id is a plain 404.
+
+Named parameters (#1966) are bound server-side: `{tenant}` is always the signed
+session tenant, `{period}` binds from the optional run body.
 """
 
 from __future__ import annotations
 
+import uuid
+
 import pytest
+from lib.config import TEST_TENANT_ID
 
 from api.endpoint_helpers import NON_UUID, SCRATCH_QUERY_REF, UNKNOWN_ID, create_scratch_saved_query, text_body_request
 
@@ -166,6 +172,49 @@ def test_run_saved_query_200(api, scratch_saved_query: dict) -> None:
     r = api.post(f"/v1/queries/{scratch_saved_query['id']}/run")
     assert r.status_code == 200, f"status={r.status_code} body={r.text}"
     assert r.json()["rows"] == [{"one": 1}]
+
+
+def _create_query(api, name_prefix: str, sql: str) -> dict:
+    """POST a saved query with arbitrary `sql` (the shared helper pins the
+    scratch ref). Caller owns the hard-delete cleanup."""
+    r = api.post("/v1/queries", json={"name": f"{name_prefix}-{uuid.uuid4().hex[:8]}", "sql": sql})
+    assert r.status_code == 201, f"create: status={r.status_code} body={r.text}"
+    return r.json()
+
+
+def test_run_saved_query_200_injects_tenant_param(api) -> None:
+    """`{tenant}` is always bound from the signed session context (#1966): a
+    query echoing it returns the session tenant, never a client-supplied value."""
+    q = _create_query(api, "e2e-tenant-param", "SELECT {tenant:String} AS tenant FROM system.one")
+    try:
+        r = api.post(f"/v1/queries/{q['id']}/run")
+        assert r.status_code == 200, f"status={r.status_code} body={r.text}"
+        assert r.json()["rows"] == [{"tenant": str(TEST_TENANT_ID)}]
+    finally:
+        api.delete(f"/v1/queries/{q['id']}")
+
+
+def test_run_saved_query_200_binds_period_param(api) -> None:
+    """`period` supplied on the run body binds `{period}` server-side (#1966)."""
+    q = _create_query(api, "e2e-period-param", "SELECT {period:String} AS period FROM system.one")
+    try:
+        r = api.post(f"/v1/queries/{q['id']}/run", json={"period": "2026-Q1"})
+        assert r.status_code == 200, f"status={r.status_code} body={r.text}"
+        assert r.json()["rows"] == [{"period": "2026-Q1"}]
+    finally:
+        api.delete(f"/v1/queries/{q['id']}")
+
+
+def test_run_saved_query_400_missing_named_param(api) -> None:
+    """A query referencing a parameter left unbound (`{period}` with no period on
+    the run body) is caller error → 400, not a bare 500 (#1966 classifies
+    ClickHouse's UNKNOWN_QUERY_PARAMETER)."""
+    q = _create_query(api, "e2e-missing-param", "SELECT {period:String} AS period FROM system.one")
+    try:
+        r = api.post(f"/v1/queries/{q['id']}/run")
+        assert r.status_code == 400, f"status={r.status_code} body={r.text}"
+    finally:
+        api.delete(f"/v1/queries/{q['id']}")
 
 
 def test_run_saved_query_400_non_uuid(api) -> None:


### PR DESCRIPTION
## What

Adds named query parameters to the saved-query run path (Phase A, presentation layer).

`POST /v1/queries/{id}/run` now binds **ClickHouse server-side parameters**:

- **`{tenant}`** — always injected from the session `SecurityContext`; never client-settable.
- **`{period}`** — optional, supplied on the run body `{ "period": "<value>" }`.

Values are passed through ClickHouse's `param_<name>` interface (`Query::param`), so a parameter value can **never alter query structure** — no string interpolation. The single-SELECT gate already tolerates `{name:Type}` placeholders, so authored SQL like `SELECT ... WHERE insight_tenant_id = {tenant:UUID} AND ts >= {period:Date}` passes on write and run. A query that references an unbound named parameter (e.g. `{period}` with no `period` supplied) is surfaced as a **400**, not a bare 500.

The run request body is optional (`Option<Json<..>>`), so existing param-less runs are unchanged.

## Scope boundary

This binds the `{tenant}` **value**. The injected tenant-row **filter** (`insight_tenant_id = {tenant}` added to the compiler's shared `WHERE`) remains #1967.

## Specs

Registered `cfs` artifacts updated: `cpt-presentation-fr-query-params` marked shipped; run endpoint contract in DESIGN §3.3 and the saved-query-api component updated. `cfs validate` green on both PRD and DESIGN. OpenAPI contract regenerated (new `RunSavedQueryRequest` schema + optional request body).

## Tests

- Offline unit: `classify_run_error` (456 → 400, others → 500) and `RunSavedQueryRequest` deserializer (absent/`{}`/value).
- Live e2e (`test_queries.py`): `{tenant}` injection returns the signed session tenant, `{period}` binding echoes the supplied value, missing-param → 400.
- `cargo test -p analytics` (487 passed), clippy + fmt clean, OpenAPI drift gate passes.

Closes #1966
Part of #1803

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Saved queries can now accept an optional `period` value when run.
  - Tenant context is automatically applied; clients cannot override it.
  - Requests may omit the JSON body when no parameters are needed.
  - Missing required query parameters now return a clear 400 error.

- **Documentation**
  - Updated API specifications and examples to describe named parameter support and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->