### PR TITLE
fix(ingestion): resolve nltk and langchain-core to fixed versions (#2061)

### DIFF
--- a/src/ingestion/connectors/ai/github-copilot/pyproject.toml
+++ b/src/ingestion/connectors/ai/github-copilot/pyproject.toml
@@ -22,6 +22,9 @@ dev = [
 source-github-copilot = "source_github_copilot.source:main"
 
 [tool.uv]
+# Do not resolve a version published in the last week: a freshly pushed release is
+# where a compromised maintainer account shows up first.
+exclude-newer = "7 days"
 # airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.0
 # over it (see Dockerfile), so keep the resolved dependency graph on the same version.
 override-dependencies = ["nltk>=3.10.0"]

--- a/src/ingestion/connectors/ai/github-copilot/pyproject.toml
+++ b/src/ingestion/connectors/ai/github-copilot/pyproject.toml
@@ -21,6 +21,11 @@ dev = [
 [project.scripts]
 source-github-copilot = "source_github_copilot.source:main"
 
+[tool.uv]
+# airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.0
+# over it (see Dockerfile), so keep the resolved dependency graph on the same version.
+override-dependencies = ["nltk>=3.10.0"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 

--- a/src/ingestion/connectors/crm/hubspot/pyproject.toml
+++ b/src/ingestion/connectors/crm/hubspot/pyproject.toml
@@ -22,6 +22,11 @@ dev = [
 [project.scripts]
 source-hubspot-insight = "source_hubspot.source:main"
 
+[tool.uv]
+# airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.0
+# over it (see Dockerfile), so keep the resolved dependency graph on the same version.
+override-dependencies = ["nltk>=3.10.0"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 

--- a/src/ingestion/connectors/crm/hubspot/pyproject.toml
+++ b/src/ingestion/connectors/crm/hubspot/pyproject.toml
@@ -23,6 +23,9 @@ dev = [
 source-hubspot-insight = "source_hubspot.source:main"
 
 [tool.uv]
+# Do not resolve a version published in the last week: a freshly pushed release is
+# where a compromised maintainer account shows up first.
+exclude-newer = "7 days"
 # airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.0
 # over it (see Dockerfile), so keep the resolved dependency graph on the same version.
 override-dependencies = ["nltk>=3.10.0"]

--- a/src/ingestion/connectors/crm/salesforce/pyproject.toml
+++ b/src/ingestion/connectors/crm/salesforce/pyproject.toml
@@ -22,6 +22,9 @@ dev = [
 source-salesforce-insight = "source_salesforce.source:main"
 
 [tool.uv]
+# Do not resolve a version published in the last week: a freshly pushed release is
+# where a compromised maintainer account shows up first.
+exclude-newer = "7 days"
 # airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.0
 # over it (see Dockerfile), so keep the resolved dependency graph on the same version.
 override-dependencies = ["nltk>=3.10.0"]

--- a/src/ingestion/connectors/crm/salesforce/pyproject.toml
+++ b/src/ingestion/connectors/crm/salesforce/pyproject.toml
@@ -21,6 +21,11 @@ dev = [
 [project.scripts]
 source-salesforce-insight = "source_salesforce.source:main"
 
+[tool.uv]
+# airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.0
+# over it (see Dockerfile), so keep the resolved dependency graph on the same version.
+override-dependencies = ["nltk>=3.10.0"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 

--- a/src/ingestion/connectors/git/bitbucket-cloud/pyproject.toml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/pyproject.toml
@@ -21,6 +21,9 @@ dev = [
 source-bitbucket-cloud-insight = "source_bitbucket_cloud.source:main"
 
 [tool.uv]
+# Do not resolve a version published in the last week: a freshly pushed release is
+# where a compromised maintainer account shows up first.
+exclude-newer = "7 days"
 # airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.0
 # over it (see Dockerfile), so keep the resolved dependency graph on the same version.
 override-dependencies = ["nltk>=3.10.0"]

--- a/src/ingestion/connectors/git/bitbucket-cloud/pyproject.toml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/pyproject.toml
@@ -20,6 +20,11 @@ dev = [
 [project.scripts]
 source-bitbucket-cloud-insight = "source_bitbucket_cloud.source:main"
 
+[tool.uv]
+# airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.0
+# over it (see Dockerfile), so keep the resolved dependency graph on the same version.
+override-dependencies = ["nltk>=3.10.0"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 

--- a/src/ingestion/connectors/git/github-v2/pyproject.toml
+++ b/src/ingestion/connectors/git/github-v2/pyproject.toml
@@ -21,6 +21,9 @@ dev = [
 source-github-insight-v2 = "source_github_v2.source:main"
 
 [tool.uv]
+# Do not resolve a version published in the last week: a freshly pushed release is
+# where a compromised maintainer account shows up first.
+exclude-newer = "7 days"
 # airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.0
 # over it (see Dockerfile), so keep the resolved dependency graph on the same version.
 override-dependencies = ["nltk>=3.10.0"]

--- a/src/ingestion/connectors/git/github-v2/pyproject.toml
+++ b/src/ingestion/connectors/git/github-v2/pyproject.toml
@@ -20,6 +20,11 @@ dev = [
 [project.scripts]
 source-github-insight-v2 = "source_github_v2.source:main"
 
+[tool.uv]
+# airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.0
+# over it (see Dockerfile), so keep the resolved dependency graph on the same version.
+override-dependencies = ["nltk>=3.10.0"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 

--- a/src/ingestion/connectors/git/gitlab/pyproject.toml
+++ b/src/ingestion/connectors/git/gitlab/pyproject.toml
@@ -24,6 +24,9 @@ dev = [
 source-gitlab-insight = "source_gitlab.source:main"
 
 [tool.uv]
+# Do not resolve a version published in the last week: a freshly pushed release is
+# where a compromised maintainer account shows up first.
+exclude-newer = "7 days"
 # airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.0
 # over it (see Dockerfile), so keep the resolved dependency graph on the same version.
 override-dependencies = ["nltk>=3.10.0"]

--- a/src/ingestion/connectors/git/gitlab/pyproject.toml
+++ b/src/ingestion/connectors/git/gitlab/pyproject.toml
@@ -23,6 +23,11 @@ dev = [
 [project.scripts]
 source-gitlab-insight = "source_gitlab.source:main"
 
+[tool.uv]
+# airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.0
+# over it (see Dockerfile), so keep the resolved dependency graph on the same version.
+override-dependencies = ["nltk>=3.10.0"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 

--- a/src/ingestion/connectors/hr-directory/active-directory/pyproject.toml
+++ b/src/ingestion/connectors/hr-directory/active-directory/pyproject.toml
@@ -17,6 +17,11 @@ dependencies = [
 [project.scripts]
 source-active-directory = "source_active_directory.source:main"
 
+[tool.uv]
+# airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.0
+# over it (see Dockerfile), so keep the resolved dependency graph on the same version.
+override-dependencies = ["nltk>=3.10.0"]
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["source_active_directory*"]

--- a/src/ingestion/connectors/hr-directory/active-directory/pyproject.toml
+++ b/src/ingestion/connectors/hr-directory/active-directory/pyproject.toml
@@ -18,6 +18,9 @@ dependencies = [
 source-active-directory = "source_active_directory.source:main"
 
 [tool.uv]
+# Do not resolve a version published in the last week: a freshly pushed release is
+# where a compromised maintainer account shows up first.
+exclude-newer = "7 days"
 # airbyte-cdk pins nltk==3.9.1 (fixed CRITICAL CVE-2025-14009); the image installs 3.10.0
 # over it (see Dockerfile), so keep the resolved dependency graph on the same version.
 override-dependencies = ["nltk>=3.10.0"]

--- a/src/ingestion/tests/connectors/pyproject.toml
+++ b/src/ingestion/tests/connectors/pyproject.toml
@@ -28,6 +28,9 @@ dev = [
 ]
 
 [tool.uv]
+# Do not resolve a version published in the last week: a freshly pushed release is
+# where a compromised maintainer account shows up first.
+exclude-newer = "7 days"
 # airbyte-cdk 6.60.x pins nltk and langchain-core to exact versions carrying fixed
 # CRITICALs (CVE-2025-14009, CVE-2025-68664). Neither is reachable from the mock
 # harness: nltk serves the file-based unstructured parser and langchain-core the

--- a/src/ingestion/tests/connectors/pyproject.toml
+++ b/src/ingestion/tests/connectors/pyproject.toml
@@ -27,6 +27,16 @@ dev = [
     "pytest-cov>=5.0",
 ]
 
+[tool.uv]
+# airbyte-cdk 6.60.x pins nltk and langchain-core to exact versions carrying fixed
+# CRITICALs (CVE-2025-14009, CVE-2025-68664). Neither is reachable from the mock
+# harness: nltk serves the file-based unstructured parser and langchain-core the
+# vector-db sink, and no nocode manifest uses either.
+override-dependencies = [
+    "nltk>=3.9.3",
+    "langchain-core>=0.3.81",
+]
+
 [tool.pytest.ini_options]
 # Collection is owned by harness_plugin (root-level module, loaded early via
 # -p): a bare `pytest` run collects the harness's `meta/` tests plus every


### PR DESCRIPTION
Closes #2061, closes #2102.

`airbyte-cdk` pins `nltk==3.9.1` in all seven CDK connectors and, in the 6.60.x line the nocode harness runs on, `langchain-core==0.1.42`. Both have a released fix for a CRITICAL. An exact upstream pin cannot be moved by declaring a floor downstream — a resolver reports the conflict and fails — so the version is stated as `[tool.uv] override-dependencies`.

| Package | Was | Now | CVE |
|---|---|---|---|
| `nltk` | 3.9.1 | 3.10.0 | CVE-2025-14009 |
| `langchain-core` | 0.1.42 | 1.5.x | CVE-2025-68664 |

The connector images were already clean: their Dockerfiles install `nltk==3.10.0` with `--no-deps`, which skips resolution entirely, so the fixed version lived only inside the image while the declared dependencies still resolved to 3.9.1. Scanners and `uv sync` read the declared side. This makes the two agree.

`exclude-newer = "7 days"` accompanies each override: an override that only sets a floor would otherwise resolve straight into a release published minutes ago, which is where a compromised maintainer account surfaces first.

Raising the harness to CDK 7 was measured and rejected: 7 failures in the zoom parent-child substream suite, because CDK 7 emits a different parent request. Details in #2061.

## Test plan

- [x] `uv pip compile` + `trivy fs --scanners vuln --severity CRITICAL` on each of the 8 projects — **0 CRITICAL** (was 8), resolving `nltk==3.10.0` and a fixed `langchain-core`
- [x] Re-verified after adding the cooldown: resolution still succeeds and still lands above both fixes; the cooldown demonstrably held the newest `langchain-core` back one patch, as intended
- [x] Harness suites with the overrides resolved by `uv`: `pytest --suites-only` → 42 passed, 1 skipped — identical to the pre-change baseline
- [x] Connector runtime unchanged: `source-gitlab` emits a valid `SPEC`, and the image already carried 3.10.0
- [ ] `trivy-fs` on this branch reports 8 fewer CRITICAL than the base
