### PR TITLE
fix(helm): declare securityContext for fakeidp and keycloak (#2084)

### DIFF
--- a/src/backend/services/fakeidp/helm/templates/deployment.yaml
+++ b/src/backend/services/fakeidp/helm/templates/deployment.yaml
@@ -14,6 +14,11 @@ spec:
       labels:
         {{- include "insight-fakeidp.selectorLabels" . | nindent 8 }}
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: fakeidp
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -21,6 +26,11 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           env:
             - name: FAKEIDP_ISSUER
               value: {{ tpl (required "fakeidp.issuer is required (the in-cluster fakeidp URL)" .Values.issuer) . | quote }}

--- a/src/backend/services/keycloak/helm/templates/deployment.yaml
+++ b/src/backend/services/keycloak/helm/templates/deployment.yaml
@@ -15,6 +15,11 @@ spec:
         {{- include "insight-keycloak.selectorLabels" . | nindent 8 }}
     spec:
       enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
       containers:
         - name: keycloak
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -44,6 +49,13 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            # No readOnlyRootFilesystem: `start-dev` re-augments Quarkus into
+            # /opt/keycloak/lib/quarkus on every boot, and an emptyDir there hides
+            # quarkus-application.dat from the image. See #2084.
           volumeMounts:
             - name: realm
               mountPath: /opt/keycloak/data/import


### PR DESCRIPTION
Closes #2084.

Both Deployments declared no `securityContext`, so their containers could escalate privileges and kept the full default capability set. Adopts the shape already used by `src/backend/services/gateway/helm`.

| | fakeidp | keycloak |
|---|---|---|
| `runAsNonRoot` / UID / GID / `fsGroup` 1000 | yes | yes |
| `allowPrivilegeEscalation: false` | yes | yes |
| `capabilities.drop: ["ALL"]` | yes | yes |
| `readOnlyRootFilesystem: true` | yes | **no** — see below |

Neither image's runtime user changes: `fakeidp` already carries `USER 1000` and upstream `quay.io/keycloak/keycloak` ships non-root. The charts simply never asserted it.

`readOnlyRootFilesystem` is omitted for keycloak because `start-dev` re-augments Quarkus into `/opt/keycloak/lib/quarkus` on every boot. Making it work needs an initContainer that pre-populates that path from the image, which is not worth the failure mode on the component that owns login. AVD-KSV-0014 stays reported for keycloak; the misconfig scan is report-only, so nothing is suppressed and no waiver file is introduced.

## Test plan

- [x] `helm template` renders both charts — 83 and 115 lines, no template errors
- [x] `trivy fs --scanners misconfig --severity HIGH,CRITICAL` on the rendered output: **6 HIGH → 1 HIGH**. fakeidp fully clean (KSV-0014 + 2× KSV-0118 gone); keycloak keeps only KSV-0014
- [x] fakeidp under the **full** set, including read-only root FS (`docker run --read-only --user 1000:1000 --cap-drop ALL --security-opt no-new-privileges`): starts, `/.well-known/openid-configuration` → 200, `jwks_uri` → 200
- [x] keycloak under the set as shipped here: starts in 5.9s, `/kc/realms/master/.well-known/openid-configuration` → 200
- [x] keycloak with `readOnlyRootFilesystem: true` and no volumes: fails — `ReadOnlyFileSystemException` in Quarkus `JarResultBuildStep`
- [x] keycloak with `readOnlyRootFilesystem: true` + emptyDir on `/opt/keycloak/data`, `/opt/keycloak/lib/quarkus`, `/tmp`: fails — `NoSuchFileException: /opt/keycloak/lib/quarkus/quarkus-application.dat`
- [ ] Both pods reach Ready in insight-dev after the chart rolls out
