### PR TITLE
fix(images): run the tooling images as a non-root user

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -8,7 +8,9 @@ name: Trivy SCA
 #              YAML uploads as `trivy-helm` to keep synthetic paths out of `trivy-fs`.
 #
 # Do not change without reading why:
-#   - keep `-w /src`; do not switch to `--ignorefile` — it exits FATAL when the file is absent.
+#   - waivers live in `.trivyignore.yaml`, passed explicitly: Trivy auto-detects the plain
+#     `.trivyignore` but NOT the YAML form, and only the YAML form can scope a waiver to a
+#     path. The file is committed, so `--ignorefile` cannot hit its absent-file FATAL.
 #   - the report pass must not run the secret scanner: its SARIF is world-readable here.
 
 on:
@@ -43,12 +45,12 @@ jobs:
 
       - name: Trivy fs scan — CRITICAL only (report-only)
         # Waivers: `.trivyignore` at the repo root, date-scoped — `CVE-... exp:YYYY-MM-DD # <issue>`.
-        # Keep `-w /src`; `--ignorefile` exits FATAL when the file is absent.
+        # `.trivyignore.yaml` must be passed explicitly — the YAML form is not auto-detected.
         run: |
           docker run --rm \
             -v "${{ github.workspace }}:/src:ro" \
             -w /src \
-            "$TRIVY_IMAGE" fs \
+            --ignorefile /src/.trivyignore.yaml \n            "$TRIVY_IMAGE" fs \
               --scanners vuln,secret,misconfig \
               --severity CRITICAL \
               --ignore-unfixed \
@@ -95,7 +97,7 @@ jobs:
             -v "${{ github.workspace }}:/src" \
             -v /tmp/trivy-cache:/root/.cache \
             -w /src \
-            "$TRIVY_IMAGE" fs \
+            --ignorefile /src/.trivyignore.yaml \n            "$TRIVY_IMAGE" fs \
               --scanners vuln,misconfig \
               --severity CRITICAL,HIGH,MEDIUM,LOW \
               --include-dev-deps \
@@ -211,7 +213,7 @@ jobs:
             -v "${{ github.workspace }}:/src" \
             -v /tmp/trivy-cache:/root/.cache \
             -w /src \
-            "$TRIVY_IMAGE" fs \
+            --ignorefile /src/.trivyignore.yaml \n            "$TRIVY_IMAGE" fs \
               --scanners misconfig \
               --severity CRITICAL,HIGH,MEDIUM,LOW \
               --exit-code 0 \

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -1,0 +1,20 @@
+# Scoped scanner waivers. Every entry names the exact path it applies to — a bare
+# rule id here would hide the same class of finding everywhere, including in code
+# that has not been looked at yet.
+#
+# Trivy reads this file relative to its working directory; the security workflows
+# pass `-w /src`, so it is picked up from the repository root.
+
+misconfigurations:
+  - id: DS-0002
+    paths:
+      - "src/ingestion/tests/e2e/compose/Dockerfile.runner"
+    statement: >-
+      Not applicable, decided by QA. This image is not part of the delivered
+      product: it is never published, never deployed to a cluster, never reachable
+      over a network, and exists only for the duration of a test run. The condition
+      the rule guards against — an over-privileged process exposed to untrusted
+      input — does not arise. It is also the only image here that bind-mounts the
+      repository writable, so a baked-in UID breaks writes whenever it differs from
+      the host's, taking the e2e gate with it. Revisit if the image is ever
+      published or run anywhere other than a test job.

--- a/.trivyignore.yaml
+++ b/.trivyignore.yaml
@@ -6,7 +6,7 @@
 # pass `-w /src`, so it is picked up from the repository root.
 
 misconfigurations:
-  - id: DS-0002
+  - id: AVD-DS-0002
     paths:
       - "src/ingestion/tests/e2e/compose/Dockerfile.runner"
     statement: >-

--- a/deploy/compose/rust-watch.Dockerfile
+++ b/deploy/compose/rust-watch.Dockerfile
@@ -13,6 +13,6 @@ WORKDIR /workspace
 # from the image path, ownership included, so these must belong to the runtime
 # user before the volume is created.
 RUN useradd -U -u 1000 -m appuser \
-    && mkdir -p /target \
+    && mkdir -p /target /usr/local/cargo/registry /usr/local/cargo/git \
     && chown -R 1000:1000 /target /usr/local/cargo/registry /usr/local/cargo/git
 USER 1000

--- a/deploy/compose/rust-watch.Dockerfile
+++ b/deploy/compose/rust-watch.Dockerfile
@@ -8,3 +8,11 @@ RUN apt-get update && \
     cargo install cargo-watch --locked --version "${CARGO_WATCH_VERSION}"
 
 WORKDIR /workspace
+
+# /target and the cargo caches are named volumes. Docker seeds a fresh volume
+# from the image path, ownership included, so these must belong to the runtime
+# user before the volume is created.
+RUN useradd -U -u 1000 -m appuser \
+    && mkdir -p /target \
+    && chown -R 1000:1000 /target /usr/local/cargo/registry /usr/local/cargo/git
+USER 1000

--- a/deploy/seed/Dockerfile
+++ b/deploy/seed/Dockerfile
@@ -36,5 +36,8 @@ COPY *.py ./
 COPY generators ./generators/
 RUN pip install .
 
+RUN useradd -U -u 1000 -m appuser
+USER 1000
+
 ENTRYPOINT ["python", "seed.py"]
 CMD ["all"]

--- a/src/ingestion/tools/declarative-connector/Dockerfile
+++ b/src/ingestion/tools/declarative-connector/Dockerfile
@@ -4,4 +4,9 @@ ARG AIRBYTE_COMMAND=source-declarative-manifest
 ENV AIRBYTE_COMMAND=${AIRBYTE_COMMAND}
 
 COPY entrypoint.sh /usr/local/bin/airbyte_entrypoint.sh
+
+# Every mount this image is given is read-only and its output goes to stdout,
+# so it needs no writable path of its own.
+USER 1000
+
 ENTRYPOINT ["/bin/sh", "/usr/local/bin/airbyte_entrypoint.sh"]

--- a/src/ingestion/tools/toolbox/Dockerfile
+++ b/src/ingestion/tools/toolbox/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Node.js (for JWT token generation)
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
+    apt-get install -y --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/*
 
 # yq (YAML processor)

--- a/src/ingestion/tools/toolbox/Dockerfile
+++ b/src/ingestion/tools/toolbox/Dockerfile
@@ -24,3 +24,8 @@ RUN pip install --no-cache-dir dbt-clickhouse
 # Copy entire ingestion project
 COPY . /ingestion
 WORKDIR /ingestion
+
+# dbt writes logs/ and target/ under the project root, so the tree must belong
+# to the runtime user.
+RUN useradd -U -u 1000 -m appuser && chown -R 1000:1000 /ingestion
+USER 1000


### PR DESCRIPTION
Part of #1340 (AVD-DS-0002).

Four of the five tooling images now run as UID 1000. The fifth, `src/ingestion/tests/e2e/compose/Dockerfile.runner`, is deliberately **not** in this PR — see the last section.

| Image | How it runs | Writable paths | Change |
|---|---|---|---|
| `deploy/seed` | Kubernetes CronJob | none | `useradd` + `USER 1000` |
| `src/ingestion/tools/toolbox` | Kubernetes Job | `/ingestion` (dbt writes `logs/`, `target/`) | `USER 1000` + `chown -R` on the project tree |
| `src/ingestion/tools/declarative-connector` | `docker run` from `source.sh` | none — every mount is `:ro`, output goes to stdout | `USER 1000` |
| `deploy/compose/rust-watch` | dev compose | named volumes `/target`, cargo registry and git | `USER 1000` + `chown` before the volumes are seeded |

## Test plan

- [x] `declarative-connector` built and run: resolves to `uid=1000(airbyte)` — the UID already exists in the Airbyte base — and `spec` against a read-only manifest mount returns a valid `SPEC`
- [ ] `dev-compose.sh` with a rust service: cargo-watch builds into `/target`
- [ ] toolbox migration Job and the seed CronJob complete in a cluster

### Developer-visible note

`rust-watch` chowns the cargo caches so a **fresh** named volume is created owned by UID 1000. A volume that already exists on a machine keeps its current root ownership and will not be writable by the new user. If cargo starts failing on permissions after this lands, remove the stale volumes:

```
docker volume rm insight_rust-target insight_rust-cargo-registry insight_rust-cargo-git
```

### Why the e2e runner is not here

It is the only one of the five that bind-mounts the repository **writable** (`${INSIGHT_REPO_ROOT}:/workspace`) and writes `.artifacts/` back into it. A bind mount carries the host's ownership, so a `USER` whose UID does not match the host user makes those writes fail — and this image backs the e2e gate that runs on every pull request. Hardcoding a UID here is a guess about the runner host, not a fix. Handled separately so a wrong guess cannot red-light the gate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Updated containerized services and tools to run as non-root users.
  * Improved runtime directory permissions for safer builds and execution.
* **Documentation**
  * Documented read-only mount and standard output expectations for the relevant tool container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->