### PR TITLE
fix(helm): run the frontend as a non-root user on 8080 (#1340)

### DIFF
--- a/src/frontend/helm/templates/deployment.yaml
+++ b/src/frontend/helm/templates/deployment.yaml
@@ -28,6 +28,11 @@ spec:
       # kubelet auto-injects for every Service in the namespace at pod-start
       # (see api-gateway deployment for the longer explanation).
       enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        fsGroup: 101
       containers:
         - name: frontend
           image: "{{ required "image.repository is required" .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -59,8 +64,14 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8080
               protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            # No readOnlyRootFilesystem: the entrypoint renders the nginx config
+            # from /etc/nginx/templates at start, and nginx needs its cache dir.
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
**Merge constructorfabric/insight-front#252 first, then this one immediately.** See the ordering note.

Closes the frontend part of #1340 (AVD-KSV-0118 x2). Pairs with the unprivileged image.

| | Before | After |
|---|---|---|
| pod `runAsNonRoot` / uid / gid / `fsGroup` | absent | 101 |
| `allowPrivilegeEscalation` | default (true) | false |
| `capabilities` | full default set | `drop: ["ALL"]` |
| `containerPort` | 80 | 8080 |

Only the container port moves. The Service resolves the container by port *name* and still listens on 80, so the gateway `frontUrl` is untouched.

`readOnlyRootFilesystem` is deliberately left off, measured rather than assumed: with a read-only root the container exits at start — the entrypoint renders the nginx config from `/etc/nginx/templates` into `conf.d`, and nginx needs a writable cache directory. Backing those paths with emptyDir risks shadowing image content, the same failure already seen with keycloak in #2085. AVD-KSV-0014 stays reported for this Deployment; nothing is suppressed.

## Ordering — there is a window

Chart and image must move together. Whichever lands first, the probe targets a port nothing listens on and the pod restarts. Merge the image PR, then this one without waiting for the poller tick, then smoke the frontend.

## Test plan

- [x] Image verified separately: runs as `uid=101(nginx)`, `GET /` and `GET /healthz` both 200 on 8080
- [x] Read-only root filesystem measured and rejected — container exits at start
- [ ] `helm template` renders and the rendered Deployment reports no KSV-0118
- [ ] Frontend reachable through the gateway after both PRs roll out
