### PR TITLE
ci: pin branch-built images into the chart on release-* branches (#1994)

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -985,7 +985,7 @@ jobs:
     if: |
       always()
       && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-      && (github.ref == 'refs/heads/main' || startsWith(github.ref_name, 'release-'))
+      && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
       && needs.discover-images.outputs.any == 'true'
       && (needs.merge-image.result == 'success' || needs.merge-image.result == 'skipped')
       && (needs.merge-analytics.result == 'success' || needs.merge-analytics.result == 'skipped')
@@ -1163,7 +1163,7 @@ jobs:
     if: |
       always()
       && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-      && (github.ref == 'refs/heads/main' || startsWith(github.ref_name, 'release-'))
+      && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
       && (needs.merge-analytics.result == 'success' || needs.merge-analytics.result == 'skipped')
       && (needs.merge-authenticator.result == 'success' || needs.merge-authenticator.result == 'skipped')
       && (needs.merge-gateway.result       == 'success' || needs.merge-gateway.result       == 'skipped')
@@ -1322,7 +1322,7 @@ jobs:
           # suffixed form (…-sha7.<sanitized-branch>) is the canonical tag
           # shape for images built from the branch, so accept it there.
           TAG_RE='^[0-9]{4}(\.[0-9]{2}){4}-[0-9a-f]{7}$'
-          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+          if [ "${GITHUB_REF}" != "refs/heads/main" ]; then
             TAG_RE='^[0-9]{4}(\.[0-9]{2}){4}-[0-9a-f]{7}(\.[A-Za-z0-9._-]+)?$'
           fi
           if ! echo "$NEW_APP" | grep -Eq "$TAG_RE"; then

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -2,7 +2,11 @@ name: Build & Push Container Images
 
 on:
   push:
-    branches: [main]
+    # release-** pushes get the full main treatment (build → pin → publish),
+    # with the branch-suffixed image tag and a PATCH-only umbrella bump. Safe
+    # because trunk's minor version is bumped right after a release branch is
+    # cut, so the branch's patch stream can never collide with main's.
+    branches: [main, "release-**"]
     paths:
       - "src/backend/**"
       - "src/ingestion/**"
@@ -10,7 +14,7 @@ on:
       - ".github/workflows/build-images.yml"
       - ".github/workflows/scripts/discover-image-matrix.py"
   pull_request:
-    branches: [main]
+    branches: [main, "release-**"]
     paths:
       - "src/backend/**"
       - "src/ingestion/**"
@@ -67,14 +71,22 @@ jobs:
       # 'true' for a main push and for ANY workflow_dispatch (including a
       # branch dispatch — that is what branch image builds are, #1994);
       # 'false' for pull_request runs, which build without pushing.
-      # Publishing side-effects stay main-only via their own ref guards:
-      # bump-descriptors, publish-chart, and the `latest` tag.
+      # Publishing side-effects are gated per-ref: bump-descriptors and
+      # publish-chart run on main AND release-** (branch builds get pinned
+      # into the branch's chart, #1994 follow-up); the `latest` tag and the
+      # strict suffix-less appVersion regex stay main-only.
       should_push: ${{ steps.tag.outputs.should_push }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          # Diff against the pushed-to branch itself, NOT the repo default
+          # branch (dorny's default base). On a release-** push the default
+          # would diff the whole branch against main and mark every service
+          # changed on every push; base=ref_name keeps the per-push diff
+          # semantics main has always had. Ignored on pull_request events.
+          base: ${{ github.ref_name }}
           filters: |
             analytics:
               - 'src/backend/services/analytics/**'
@@ -116,7 +128,8 @@ jobs:
       # Branch builds (#1994) append `.<sanitized-branch>` after the sha so a
       # branch image can never be mistaken for (or `sort -V`-beat) a main
       # release tag — main keeps the suffix-less format, and publish-chart's
-      # appVersion regex rejects the suffixed form as a backstop.
+      # appVersion regex rejects the suffixed form on main as a backstop
+      # (release-** publishes accept it — that's their canonical tag shape).
       - name: Compute build tag and push policy
         id: tag
         env:
@@ -972,7 +985,7 @@ jobs:
     if: |
       always()
       && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-      && github.ref == 'refs/heads/main'
+      && (github.ref == 'refs/heads/main' || startsWith(github.ref_name, 'release-'))
       && needs.discover-images.outputs.any == 'true'
       && (needs.merge-image.result == 'success' || needs.merge-image.result == 'skipped')
       && (needs.merge-analytics.result == 'success' || needs.merge-analytics.result == 'skipped')
@@ -1120,10 +1133,14 @@ jobs:
           fi
 
   # ─── Umbrella chart publish ────────────────────────────────────────────────
-  # Per merge to main: bump subchart appVersions for whichever services were
-  # rebuilt in this run, patch-bump the umbrella version, regenerate
-  # Chart.lock, package, push to oci://ghcr.io/constructorfabric/charts/insight,
-  # and commit the bumps back to main with [skip ci] so we don't recurse.
+  # Per merge to main — and per push/dispatch on a release-** branch: bump
+  # subchart appVersions for whichever services were rebuilt in this run,
+  # patch-bump the umbrella version, regenerate Chart.lock, package, push to
+  # oci://ghcr.io/constructorfabric/charts/insight, and commit the bumps back
+  # to the triggering branch with [skip ci] so we don't recurse. The
+  # patch-only bump keeps release-branch chart versions inside the minor
+  # stream the branch was cut with (trunk minor-bumps right after cutting a
+  # release branch, so the streams never collide on the OCI registry).
   #
   # Skipped in this run when bump-descriptors committed (`committed=true`):
   # the descriptor commit's push re-triggers the workflow, and publish-chart
@@ -1146,7 +1163,7 @@ jobs:
     if: |
       always()
       && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-      && github.ref == 'refs/heads/main'
+      && (github.ref == 'refs/heads/main' || startsWith(github.ref_name, 'release-'))
       && (needs.merge-analytics.result == 'success' || needs.merge-analytics.result == 'skipped')
       && (needs.merge-authenticator.result == 'success' || needs.merge-authenticator.result == 'skipped')
       && (needs.merge-gateway.result       == 'success' || needs.merge-gateway.result       == 'skipped')
@@ -1300,8 +1317,16 @@ jobs:
             | sort -V | tail -1)
           # Fail loud unless the result is a build tag (YYYY.MM.DD.HH.MM-sha):
           # a malformed appVersion must never reach a published chart again.
-          if ! echo "$NEW_APP" | grep -Eq '^[0-9]{4}(\.[0-9]{2}){4}-[0-9a-f]{7}$'; then
-            echo "ERROR: computed umbrella appVersion '$NEW_APP' is not a valid build tag" >&2
+          # On main the regex stays strict — a branch-suffixed tag leaking
+          # into a main-published chart must abort. On release-** the
+          # suffixed form (…-sha7.<sanitized-branch>) is the canonical tag
+          # shape for images built from the branch, so accept it there.
+          TAG_RE='^[0-9]{4}(\.[0-9]{2}){4}-[0-9a-f]{7}$'
+          if [ "${GITHUB_REF_NAME}" != "main" ]; then
+            TAG_RE='^[0-9]{4}(\.[0-9]{2}){4}-[0-9a-f]{7}(\.[A-Za-z0-9._-]+)?$'
+          fi
+          if ! echo "$NEW_APP" | grep -Eq "$TAG_RE"; then
+            echo "ERROR: computed umbrella appVersion '$NEW_APP' is not a valid build tag for ref '${GITHUB_REF_NAME}'" >&2
             exit 1
           fi
           echo "Umbrella version $CURRENT → $NEXT (appVersion → $NEW_APP)"
@@ -1365,7 +1390,7 @@ jobs:
           subject-digest: ${{ steps.helm_push.outputs.digest }}
           push-to-registry: true
 
-      - name: Commit version bumps back to main
+      - name: Commit version bumps back to the branch
         env:
           UMBRELLA_VERSION: ${{ steps.umbrella.outputs.version }}
           BUILD_TAG: ${{ needs.changes.outputs.build_tag }}


### PR DESCRIPTION
## What

Completes the release-branch half of #1994: a build on a `release-*` branch now pins the freshly pushed branch-suffixed images into the chart and publishes it with a **patch-only** umbrella version bump. This is collision-safe because trunk's minor version is bumped right after a release branch is cut, so the branch's `x.y.Z` patch stream and main's stream never overlap on the OCI registry.

## Why nothing was pinned before

- `bump-descriptors` and `publish-chart` were hard-gated `github.ref == 'refs/heads/main'`.
- Even if opened up, the flow could not converge: `bump-descriptors` commits without `[skip ci]` and relies on the resulting **push** re-triggering the workflow (toolbox rebake with patched descriptors + deferred `publish-chart`) — but `on.push` only covered `main`, so on a release branch that follow-up run never fires.
- The umbrella `appVersion` sanity regex deliberately rejects the branch-suffixed tag form.

## Changes

1. **`on.push` / `on.pull_request`: add `release-**`** — release-branch pushes get the same paths-filtered build → pin → publish machinery as main, and the `bump-descriptors` auto-commit re-triggers the workflow exactly like it does on main.
2. **`dorny/paths-filter` gets `base: ${{ github.ref_name }}`** — without it, dorny diffs a release-branch push against the repo default branch and marks every service changed on every push. With `base=ref_name` the per-push diff semantics main has always had apply to release branches too. (Ignored on `pull_request`; on `workflow_dispatch` it yields no-diff, same as today — dispatch builds fire via the full-rebuild condition.)
3. **Ref gates on `bump-descriptors` / `publish-chart`** widened to `main || startsWith(ref_name, 'release-')`.
4. **Umbrella `appVersion` regex**: non-main refs accept the branch-suffixed tag shape (`YYYY.MM.DD.HH.MM-sha7.<branch>`); `main` keeps the strict suffix-less regex as the backstop against branch tags leaking into main-published charts.

Unchanged: `latest` image tag stays main-only; PR runs still build without pushing; umbrella bump is patch-only (existing behavior).

## Resulting flow on a release branch

- `gh workflow run build-images.yml --ref release-YYYY.MM.N` (full rebuild) → all images pushed with `.release-YYYY.MM.N`-suffixed tags → `bump-descriptors` pins connector descriptors + service subchart appVersions and commits → that push re-triggers → toolbox rebakes, `publish-chart` bumps the umbrella patch version and publishes `oci://ghcr.io/constructorfabric/charts/insight:<x.y.Z+1>`.
- A plain push (e.g. a merged backport) to the branch auto-builds only the changed images and publishes the pinned chart, same as main.
- Frontend: a manual dispatch on the release ref with `frontend_tag=<tag>` pins the frontend subchart without rebuilding backends (the cross-repo auto-dispatch from insight-front remains main-only).

## Notes

- Descriptor `version:` bumps stay **minor** on release branches (per ADR-0015 the minor bump drives catalog re-discovery without a full refresh — same rationale as main; descriptor versions are compared per-environment, not across chart streams).
- The very first push that creates a `release-*` branch may build everything once (paths-filter can't diff an initial push) — that gives the branch its own tagged image baseline, which is desirable.
- Verified `release-*` branches carry no branch protection, so the App-token auto-commits push cleanly.

Refs #1994

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Expanded image build automation to support both the main branch and release branches.
  - Release branches now receive branch-specific image tags.
  - Descriptor and chart publishing is supported for eligible release branches.
  - Main-branch-only safeguards remain in place for the `latest` tag and strict version validation.
  - Improved branch-aware chart validation and publishing commit messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->