### PR TITLE
chore: ignore .NET build output (#2102)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -423,3 +423,8 @@ trivy-fs.sarif
 trivy-image.json
 trivy-image.sarif
 trufflehog-findings.jsonl
+
+# .NET build output. No .csproj is tracked today, but a working copy predating the
+# identity service removal still holds these, and they embed machine-local paths.
+[Oo]bj/
+[Bb]in/


### PR DESCRIPTION
Closes #2102.

`.gitignore` had no rule for .NET intermediate output. A working copy predating the identity service removal still holds `**/obj/` restore artifacts, and a broad `git add` commits them back — which is exactly what happened in #2083.

## Test plan

- [x] `git ls-files` reports 0 tracked files under any `bin/` or `obj/` directory, so nothing is retroactively ignored
- [x] No `.csproj` is tracked, so no build depends on these paths being visible
