### PR TITLE
fix(helm): read-only root filesystem for the remaining backend charts (#2118)

### DIFF
--- a/src/backend/services/analytics/helm/templates/deployment.yaml
+++ b/src/backend/services/analytics/helm/templates/deployment.yaml
@@ -54,6 +54,13 @@ spec:
               mountPath: /etc/insight/authn-ca
               readOnly: true
             {{- end }}
+            # The only two paths the process writes under a read-only root:
+            # the gears host creates `server.home_dir` at boot, and grpc-hub
+            # binds its UDS under /tmp (both set in the ConfigMap).
+            - name: data
+              mountPath: /app/data
+            - name: tmp
+              mountPath: /tmp
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -70,6 +77,9 @@ spec:
                 name: {{ required "existingSecret is required (umbrella provides `insight-analytics-config`; standalone installs supply their own)" .Values.existingSecret | quote }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
@@ -91,15 +101,26 @@ spec:
               mountPath: /app/config/analytics.yaml
               subPath: analytics.yaml
               readOnly: true
+            # `migrate` builds the same host_dir but never starts grpc-hub,
+            # so it needs /app/data only.
+            - name: data
+              mountPath: /app/data
           envFrom:
             - secretRef:
                 name: {{ .Values.existingSecret | quote }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
       volumes:
         - name: analytics-config
           configMap:
             name: {{ include "insight-analytics.fullname" . }}-gears-config
+        - name: data
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
         {{- if .Values.gateway.caCertSecret }}
         - name: authn-ca
           secret:

--- a/src/backend/services/authenticator/helm/templates/deployment.yaml
+++ b/src/backend/services/authenticator/helm/templates/deployment.yaml
@@ -78,6 +78,13 @@ spec:
               mountPath: {{ dir .Values.idp.extraCaCertPath | quote }}
               readOnly: true
             {{- end }}
+            # The only two paths the process writes under a read-only root:
+            # the gears host creates `server.home_dir` at boot, and grpc-hub
+            # binds its UDS under /tmp (both set in the ConfigMap).
+            - name: data
+              mountPath: /app/data
+            - name: tmp
+              mountPath: /tmp
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -103,6 +110,9 @@ spec:
           {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
@@ -132,10 +142,18 @@ spec:
             - name: authn-tls-cert
               mountPath: /tls
               readOnly: true
+            # nginx-unprivileged keeps its pid and every *_temp dir under /tmp.
+            # Its own volume, not the authenticator's — that one carries the
+            # grpc-hub UDS, which nothing outside the process may reach.
+            - name: authn-tls-tmp
+              mountPath: /tmp
           securityContext:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
             runAsUser: 101       # the nginx-unprivileged user (owns /tmp paths)
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
         {{- end }}
       volumes:
         - name: authenticator-config
@@ -144,6 +162,10 @@ spec:
         - name: signing-keys
           secret:
             secretName: {{ required "signingKeysSecret is required (mount the ES256 current.pem/previous.pem)" .Values.signingKeysSecret | quote }}
+        - name: data
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
         {{- if .Values.idp.extraCaCertSecret }}
         - name: idp-extra-ca
           secret:
@@ -159,4 +181,6 @@ spec:
         - name: authn-tls-cert
           secret:
             secretName: {{ include "insight-authenticator.authnTlsSecret" . }}
+        - name: authn-tls-tmp
+          emptyDir: {}
         {{- end }}

--- a/src/backend/services/identity-resolution/helm/templates/deployment.yaml
+++ b/src/backend/services/identity-resolution/helm/templates/deployment.yaml
@@ -94,11 +94,18 @@ spec:
               mountPath: /app/config/insight.yaml
               subPath: insight.yaml
               readOnly: true
+            # `migrate` builds the same host_dir but never starts grpc-hub,
+            # so it needs /app/data only.
+            - name: data
+              mountPath: /app/data
           envFrom:
             - secretRef:
                 name: {{ .Values.existingSecret | quote }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
       containers:
         - name: identity-resolution
           image: "{{ required "image.repository is required" .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
@@ -118,6 +125,13 @@ spec:
               mountPath: /etc/insight/authn-ca
               readOnly: true
             {{- end }}
+            # The only two paths the process writes under a read-only root:
+            # the gears host creates `server.home_dir` at boot, and grpc-hub
+            # binds its UDS under /tmp (both set in the ConfigMap).
+            - name: data
+              mountPath: /app/data
+            - name: tmp
+              mountPath: /tmp
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -134,6 +148,9 @@ spec:
                 name: {{ required "existingSecret is required (umbrella provides `insight-identity-resolution-config`; standalone installs supply their own)" .Values.existingSecret | quote }}
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
           {{- with .Values.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
@@ -148,6 +165,10 @@ spec:
         - name: identity-resolution-config
           configMap:
             name: {{ include "insight-identity-resolution.fullname" . }}-gears-config
+        - name: data
+          emptyDir: {}
+        - name: tmp
+          emptyDir: {}
         {{- if .Values.gateway.caCertSecret }}
         - name: authn-ca
           secret:

--- a/src/backend/services/identity-resolution/helm/templates/seed-cronjob.yaml
+++ b/src/backend/services/identity-resolution/helm/templates/seed-cronjob.yaml
@@ -64,6 +64,11 @@ spec:
                   mountPath: /app/config/insight.yaml
                   subPath: insight.yaml
                   readOnly: true
+                # The gears host creates `server.home_dir` at boot; the `seed`
+                # subcommand never starts grpc-hub, so /app/data is the only
+                # writable path it needs under a read-only root.
+                - name: data
+                  mountPath: /app/data
               envFrom:
                 # Same Secret as the deployment: database_url, clickhouse_*,
                 # tenant_default_id — everything the seed needs.
@@ -82,10 +87,15 @@ spec:
               {{- end }}
               securityContext:
                 allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
               resources:
                 {{- toYaml .Values.seed.resources | nindent 16 }}
           volumes:
             - name: identity-resolution-config
               configMap:
                 name: {{ include "insight-identity-resolution.fullname" . }}-gears-config
+            - name: data
+              emptyDir: {}
 {{- end }}

--- a/src/backend/services/identity-resolution/helm/templates/sync-cronjob.yaml
+++ b/src/backend/services/identity-resolution/helm/templates/sync-cronjob.yaml
@@ -66,6 +66,11 @@ spec:
                   mountPath: /app/config/insight.yaml
                   subPath: insight.yaml
                   readOnly: true
+                # The gears host creates `server.home_dir` at boot; the `sync`
+                # subcommand never starts grpc-hub, so /app/data is the only
+                # writable path it needs under a read-only root.
+                - name: data
+                  mountPath: /app/data
               envFrom:
                 # Same Secret as the deployment: database_url, clickhouse_*,
                 # tenant_default_id — everything the sync needs. The
@@ -82,10 +87,15 @@ spec:
               {{- end }}
               securityContext:
                 allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
               resources:
                 {{- toYaml .Values.sync.resources | nindent 16 }}
           volumes:
             - name: identity-resolution-config
               configMap:
                 name: {{ include "insight-identity-resolution.fullname" . }}-gears-config
+            - name: data
+              emptyDir: {}
 {{- end }}


### PR DESCRIPTION
Closes #2118. Same change as #2085, applied to the three charts it did not cover.

Every container in `analytics`, `authenticator` and `identity-resolution` gets
`readOnlyRootFilesystem: true` and `capabilities.drop: ["ALL"]`, plus `emptyDir` volumes on
exactly the paths it writes. The pod-level `runAsNonRoot` / `runAsUser: 1000` / `fsGroup: 1000`
and the per-container `allowPrivilegeEscalation: false` were already in place — that is why
`KSV-0118` never fired on these three. `wait-for-mariadb` already carried the full set and is
untouched.

## What each container writes

Enumerated with `docker diff` on the images currently running in insight-dev, against a local
mariadb + clickhouse + redis + fakeidp stack, fed the chart's **own rendered ConfigMap** rather
than the dev-compose one.

| Container | `/app/data` | `/tmp` | Measured writes |
|---|:-:|:-:|---|
| `analytics` | yes | yes | `data/logs/cf-gears.log`, `tmp/analytics-grpc` |
| `migrate` (analytics) | yes | — | `/app/data` only |
| `authenticator` | yes | yes | `data/logs/cf-gears.log`, `tmp/authenticator-grpc` |
| `authn-tls` | — | yes | `nginx.pid`, `{proxy,client,fastcgi,scgi,uwsgi}_temp` |
| `identity-resolution` | yes | yes | `data/logs/cf-gears.log`, `tmp/identity-resolution-grpc` |
| `migrate` (identity) | yes | — | `/app/data` only |
| `persons-seed` | yes | — | `/app/data` only |
| `persons-sync` | yes | — | `/app/data` only |

`/app/data` is `server.home_dir`; `/tmp/<svc>-grpc` is the grpc-hub UDS. Both come from the
ConfigMap the chart renders. `migrate` / `seed` / `sync` never start grpc-hub — zero grpc
mentions in their logs — so they mount `/app/data` alone.

## Why `/tmp` is not optional

Read-only with `/app/data` but **without** `/tmp`, all three servers stay `Running` with both
probes green, `/health` and `/healthz` return 200 — and grpc-hub silently fails:

```
ERROR toolkit::lifecycle: lifecycle task error
      error=failed to bind UDS listener at '/tmp/analytics-grpc' gear=grpc-hub
```

`Registered gear in Directory` never appears. A start-and-probe check passes this state.

## The authn-tls sidecar

`nginxinc/nginx-unprivileged:1.27-alpine`, terminating TLS on 8443 for the OIDC discovery
surface. It carries no Code Scanning alert because `trivy.yml` renders each subchart with its
own defaults, where `tlsDiscovery.enabled: false` drops the container from the output — but the
umbrella sets it `true` and the container runs in insight-dev. Same two controls added.

Its `/tmp` is a **separate** `emptyDir`, not the authenticator's: that one carries the grpc-hub
socket, and a shared volume would hand nginx the internal gear bus.

## Test plan

- [x] `docker diff` on all 8 containers, writable root, against real backing services —
      writes enumerated above; servers 200, `migrate` exit 0, `persons-seed` exit 0
      (`minted: 2, observations_inserted: 3`), `persons-sync` exit 0 (`rows: 3` published to
      `identity.identity_persons`)
- [x] Read-only, **no** volumes — 8/8 fail: `Failed to create home_dir / Read-only file system
      (os error 30)`; nginx `mkdir() "/tmp/proxy_temp" failed (30)`
- [x] Read-only, **with** the volumes as rendered by this chart — servers up, `/health` and
      `/healthz` 200, `Registered gear in Directory` present; `migrate` / `seed` / `sync` exit 0
- [x] Sidecar in pod shape (shared netns, both containers read-only) —
      `https://…/.well-known/openid-configuration` 200 through nginx into the authenticator
- [x] `trivy fs --scanners misconfig` (`aquasec/trivy:0.72.0`, charts rendered exactly as
      `trivy.yml` does): 17 HIGH → 10. All seven `KSV-0014` on these charts cleared; the
      remaining ten belong to #2085 / #2095 plus one dismissed false positive
- [x] Authenticator rendered with `tlsDiscovery.enabled=true` (umbrella shape): 0
      misconfigurations
- [x] `helm lint` — 3 charts, 0 failed
- [x] `src/backend/services/identity-resolution/helm/tests/test_seed_cronjob_contract.py` —
      17 passed
- [x] `git diff --check` clean
- [ ] Post-merge: confirm the seven alerts close. Note that `trivy.yml` triggers only on
      `main` (pull_request/push) plus the nightly schedule, so nothing runs against
      `security-hardening` — the alerts will not move until this branch reaches `main`, or
      until someone fires the workflow manually via `workflow_dispatch`.

## Notes

- `KSV-0109` on `identity-resolution.yaml` (alert 1110) was dismissed separately as a false
  positive: the ConfigMap renders `clickhouse_password: ""`, an empty placeholder overridden by
  the Secret through `envFrom`. No code change, no waiver.
- No merge-order constraint against the other open PRs — this branch touches only these five
  files.
