### PR TITLE
fix(deps): clear the remaining uv.lock highs — cryptography override, seed resolution (#2120)

### DIFF
--- a/deploy/seed/pyproject.toml
+++ b/deploy/seed/pyproject.toml
@@ -22,8 +22,13 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "mypy==2.1.0",
-    "ruff==0.15.16",
+    # dbt-core 1.12 raised its own cap to pathspec<1.1 (dbt-labs/dbt-core#12385),
+    # so a current mypy resolves again. Below 2.0 it would pull pathspec<1.0 and
+    # drag dbt-core back to the 1.11 line.
+    "mypy>=2,<3",
+    # Same pin as the ruff-pre-commit hook in .pre-commit-config.yaml, so a local
+    # run and the commit hook cannot reach different verdicts.
+    "ruff==0.15.21",
     "types-PyMySQL==1.1.0.20260518",
 ]
 

--- a/src/ingestion/tests/connectors/pyproject.toml
+++ b/src/ingestion/tests/connectors/pyproject.toml
@@ -38,6 +38,12 @@ exclude-newer = "7 days"
 override-dependencies = [
     "nltk>=3.9.3",
     "langchain-core>=0.3.81",
+    # airbyte-cdk 6.60.x resolves cryptography 44.0.3, which carries a Bleichenbacher
+    # timing oracle in PKCS#1 v1.5 decryption (CVE-2026-26007) and GHSA-537c-gmf6-5ccf.
+    # The harness never handles a key or a TLS handshake of its own -- requests-mock
+    # intercepts every call before the transport -- but the CDK's connector-builder
+    # secret handling imports it, so the version still ships.
+    "cryptography>=48.0.1",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Closes #2120. Clears the last ten `uv.lock` findings the scan reports at GitHub-high severity —
the remainder after #2083 covered `nltk` and `langchain-core`.

## How this is measured

`uv.lock` is not tracked (`.gitignore:24`). `.github/workflows/trivy.yml` regenerates every lock
with `uv lock` before scanning, so the findings describe uv's resolution of the committed
`pyproject.toml` files. Every number here comes from running that same step locally — same pinned
`uv` and `trivy` images, same flags.

One caveat worth stating: `uv lock` is **incremental** and keeps whatever an existing lock already
pins. CI locks a clean checkout; locally the lock must be deleted first or the result is fiction.

## 1. `cryptography` in the connector harness — 2 high

`airbyte-cdk 6.60.x` resolves `cryptography 44.0.3`: a Bleichenbacher timing oracle in PKCS#1 v1.5
decryption (`CVE-2026-26007`, fixed in 46.0.5) and `GHSA-537c-gmf6-5ccf` (fixed in 48.0.1). One
more entry in the existing override list; resolves 49.0.0.

## 2. `deploy/seed` — mypy and dbt-core could not share a `pathspec`, 8 high

The eight findings name `jinja2 2.11.3`, `werkzeug 2.1.2` and `sqlparse 0.4.3` — a 2022 dependency
set nothing installs. `uv` resolves the base dependencies and the dev extra together, and
`mypy==2.1.0` needs `pathspec>=1.0.0` while `dbt-core` on the 1.11 line caps `pathspec` below 0.13.
The pin could not move, so `dbt-core` gave: the resolver walked it back to 1.2.6, before that
constraint existed, and locked its dependency tree.

`dbt-core` 1.12 raised its own cap to `pathspec<1.1` ([dbt-labs/dbt-core#12385][1]), so a current
`mypy` resolves against a current `dbt-core`. The extra now asks for `mypy>=2,<3`:

| | before | after |
|---|---|---|
| mypy | 2.1.0 (pinned, unresolvable) | **2.3.0** |
| pathspec | 1.1.1 requested, 0.9.x locked | **1.0.4** |
| dbt-core | 1.2.6 | **1.12.0** |
| dbt-adapters | — | 1.24.5 |
| dbt-clickhouse | 1.2.2 | 1.9.3 |
| jinja2 | 2.11.3 | 3.1.6 |
| sqlparse | 0.4.3 | 0.5.5 |
| werkzeug | 2.1.2 | not installed |

`dbt-clickhouse` settles on 1.9.3 rather than 1.10.1: the 1.10 line caps `dbt-adapters` below
1.23.0, under `dbt-core` 1.12.0's 1.24.5 floor, and 1.9.3 carries no adapter bound at all.
Requesting `dbt-clickhouse>=1.10` together with `mypy>=2` gives `No solution found`, so the
adapter version is not a free choice here.

`ruff` moves 0.15.16 → 0.15.21 to match the `ruff-pre-commit` hook, which was already on
`v0.15.21`. Two different pins meant a local run and the commit hook could reach different
verdicts.

Unchanged: `[project.dependencies]`, the `[tool.ruff]` and `[tool.mypy]` config, the Dockerfile
(`pip install .` does not install the extra), the compose `seed-sample` service, the developer
recipe in the README, and CI — no workflow references `deploy/seed`.

[1]: https://github.com/dbt-labs/dbt-core/issues/12385

## Test plan

- [x] Repo-wide rescan from clean locks, all 11 Python projects — **0 CRITICAL, 0 HIGH**
      (`trivy fs --scanners vuln --include-dev-deps`, `aquasec/trivy:0.72.0`). By GitHub's
      CVSS-derived severity: 10 high → 0
- [x] `deploy/seed` locks to dbt-clickhouse 1.9.3, dbt-core 1.12.0, dbt-adapters 1.24.5,
      pathspec 1.0.4, mypy 2.3.0, ruff 0.15.21, jinja2 3.1.6, sqlparse 0.5.5, no werkzeug
- [x] The documented recipe, run end to end: `pip install -e '.[dev]'` succeeds,
      `ruff check .` → All checks passed (so 0.15.21 introduces no new failures),
      `mypy .` → Success, no issues found in 14 source files
- [x] `pip install .`, the Dockerfile path — succeeds; `seed`, `silver`, `identity`, `profiles`,
      `generators` all import
- [x] Harness `pytest --suites-only` with the cryptography override — 42 passed, 1 skipped,
      identical to baseline
- [x] `git diff --check` clean
- [ ] Post-merge: confirm the ten alerts close. `trivy.yml` triggers on `main` plus the nightly
      schedule, so nothing runs against `security-hardening` — they will not move until this
      reaches `main`, or the workflow is fired via `workflow_dispatch`
