### PR TITLE
fix(analytics): declare real error codes on unified-metric routes

### DIFF
--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -3283,16 +3283,6 @@
             },
             "description": "Unauthorized"
           },
-          "403": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Problem"
-                }
-              }
-            },
-            "description": "Forbidden"
-          },
           "404": {
             "content": {
               "application/problem+json": {
@@ -3303,7 +3293,7 @@
             },
             "description": "Not Found"
           },
-          "409": {
+          "415": {
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -3311,7 +3301,7 @@
                 }
               }
             },
-            "description": "Conflict"
+            "description": "Unsupported Media Type"
           },
           "429": {
             "content": {
@@ -3397,7 +3387,7 @@
             },
             "description": "Forbidden"
           },
-          "404": {
+          "415": {
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -3405,27 +3395,7 @@
                 }
               }
             },
-            "description": "Not Found"
-          },
-          "409": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Problem"
-                }
-              }
-            },
-            "description": "Conflict"
-          },
-          "429": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Problem"
-                }
-              }
-            },
-            "description": "Too Many Requests"
+            "description": "Unsupported Media Type"
           },
           "500": {
             "content": {

--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -3209,16 +3209,6 @@
             },
             "description": "Metric definitions"
           },
-          "400": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Problem"
-                }
-              }
-            },
-            "description": "Bad Request"
-          },
           "401": {
             "content": {
               "application/problem+json": {
@@ -3228,46 +3218,6 @@
               }
             },
             "description": "Unauthorized"
-          },
-          "403": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Problem"
-                }
-              }
-            },
-            "description": "Forbidden"
-          },
-          "404": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Problem"
-                }
-              }
-            },
-            "description": "Not Found"
-          },
-          "409": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Problem"
-                }
-              }
-            },
-            "description": "Conflict"
-          },
-          "429": {
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Problem"
-                }
-              }
-            },
-            "description": "Too Many Requests"
           },
           "500": {
             "content": {

--- a/src/backend/services/analytics/src/api/mod.rs
+++ b/src/backend/services/analytics/src/api/mod.rs
@@ -235,7 +235,11 @@ fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) -> Router {
             StatusCode::OK,
             "Metric results",
         )
-        .standard_errors(openapi)
+        .error_400(openapi)
+        .error_401(openapi)
+        .error_403(openapi)
+        .error_415(openapi)
+        .error_500(openapi)
         .handler(metric_results::query_metric_results)
         .register(router, openapi);
 
@@ -345,7 +349,12 @@ fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) -> Router {
             StatusCode::OK,
             "Metric evidence",
         )
-        .standard_errors(openapi)
+        .error_400(openapi)
+        .error_401(openapi)
+        .error_404(openapi)
+        .error_415(openapi)
+        .error_429(openapi)
+        .error_500(openapi)
         .handler(metric_drilldown::query_metric_drilldown)
         .register(router, openapi);
 

--- a/src/backend/services/analytics/src/api/mod.rs
+++ b/src/backend/services/analytics/src/api/mod.rs
@@ -480,7 +480,8 @@ fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) -> Router {
             StatusCode::OK,
             "Metric definitions",
         )
-        .standard_errors(openapi)
+        .error_401(openapi)
+        .error_500(openapi)
         .handler(metric_definitions::list_metric_definitions)
         .register(router, openapi);
 

--- a/src/ingestion/tests/e2e/api/test_metric_results.py
+++ b/src/ingestion/tests/e2e/api/test_metric_results.py
@@ -64,7 +64,7 @@ def test_metric_results_400_reversed_period(api) -> None:
 def test_metric_results_400_unknown_metric_key(api) -> None:
     """An unknown `metric_key` is resolved against the catalog and rejected as a
     400 (`unavailable`) — NOT a 404. Pins that the compute endpoint has no
-    not-found path (the spec's declared 404 is `.standard_errors` boilerplate)."""
+    not-found path, which is why the spec declares no 404 for it."""
     body = _request(
         metrics=[{"metric_key": "e2e.definitely-not-a-real-metric", "views": [{"view": "period"}]}],
     )

--- a/src/ingestion/tests/e2e/lib/api_coverage.py
+++ b/src/ingestion/tests/e2e/lib/api_coverage.py
@@ -76,8 +76,6 @@ BLOCKED: dict[str, frozenset[int]] = {
     "POST /v1/admin/metric-thresholds": frozenset({404, 409}),  # 404 boilerplate; 409=#1664
     # persons 200/404 covered via the in-process Identity stub (#1691); rest boilerplate
     "GET /v1/persons/{email}": frozenset({400, 403, 409}),
-    # 404/409 boilerplate; 403 IS reachable (person outside the caller's visible set)
-    "POST /v1/metric-results": frozenset({404, 409}),
     # saved-query CRUD + run (#1965): 403 (no role gate — cross-tenant is 404 by
     # opacity) and 409 (no conflict path) are `.standard_errors` boilerplate.
     "GET /v1/queries": frozenset({400, 403, 404, 409}),  # boilerplate: list, no input/lookup/conflict


### PR DESCRIPTION
## Problem

`.standard_errors(openapi)` is a fixed list in the toolkit — all-or-nothing, no status selection. Three unified-metric operations declared the same eight codes regardless of what their handlers can answer.

| operation | before | after |
|---|---|---|
| `GET /v1/metric-definitions` | 200, 400, 401, 403, 404, 409, 429, 500 | 200, 401, 500 |
| `POST /v1/metric-results` | 200, 400, 401, 403, 404, 409, 429, 500 | 200, 400, 401, 403, 415, 500 |
| `POST /v1/metric-drilldown` | 200, 400, 401, 403, 404, 409, 429, 500 | 200, 400, 401, 404, 415, 429, 500 |

Both directions were wrong. Unanswerable codes: none of the three has a license gate or a conflict path; `metric-definitions` takes no body and no params; an unknown `metric_key` on `metric-results` is a 400 (`unavailable`), not a 404, pinned by its contract test. Missing codes: 415 on the two body routes, and 429 on drilldown from its own concurrency cap.

## Fix

Per-route declaration via the toolkit's granular `error_4xx`/`error_5xx` builders — same `Problem` schema and `application/problem+json` content type as `.standard_errors`. Sets derived from the canonical-error kinds reachable from each handler plus its extractors.

401 stays on all three: the operations carry a `bearerAuth` requirement, and an operation that declares auth must document the answer to failing it — the gateway emits it, not this process.

## Coverage gate

`POST /v1/metric-results` loses its `BLOCKED` entry (it excluded 404/409, neither now declared). No other entry moves; the other two operations never had one.

No test changes needed — every newly required code already has a test (415 on both routes, 403 on metric-results, 401 via `api/test_unauthorized.py`). Both routes end up with a strictly smaller required set than before, so no new coverage advisories.

## Scope

Three operations. The remaining 26 still call `.standard_errors`, so #1669 stays open — including the admin threshold writes, which answer a real, undeclared 503 when the audit sink is down.

Refs #1669
