### PR TITLE
Bump redis crate from 0.27 to 1.5

### DIFF
--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -209,6 +209,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +236,17 @@ dependencies = [
  "compression-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -2170,6 +2187,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fakeidp"
 version = "0.1.0"
 dependencies = [
@@ -2903,7 +2930,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3170,15 +3197,6 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -4530,7 +4548,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4569,7 +4587,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -4748,28 +4766,30 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.27.6"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
+checksum = "3257df217f7eab0044627a268c9cc6cdb60c0c421c88f83ac41c4e31520b6b84"
 dependencies = [
  "arc-swap",
- "async-trait",
+ "arcstr",
+ "async-lock",
  "backon",
  "bytes",
+ "cfg-if",
  "combine",
- "futures",
+ "futures-channel",
  "futures-util",
- "itertools 0.13.0",
  "itoa",
  "num-bigint",
  "percent-encoding",
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2 0.5.10",
+ "socket2",
  "tokio",
  "tokio-util",
  "url",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -5889,16 +5909,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -6432,7 +6442,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -6543,7 +6553,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.3",
+ "socket2",
  "sync_wrapper",
  "tokio",
  "tokio-stream",

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -80,7 +80,7 @@ secrecy = { version = "0.10", features = ["serde"] }
 reqwest = { version = "0.12", features = ["json"] }
 
 # Caching
-redis = { version = "0.27", features = ["tokio-comp", "connection-manager"] }
+redis = { version = "1", features = ["tokio-comp", "connection-manager"] }
 
 # JWT (gateway-JWT mint/verify, RFC 7523 assertions, fakeidp id_tokens).
 # One version + one crypto provider (aws_lc_rs) across the workspace: v10 needs

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -80,7 +80,7 @@ secrecy = { version = "0.10", features = ["serde"] }
 reqwest = { version = "0.12", features = ["json"] }
 
 # Caching
-redis = { version = "1", features = ["tokio-comp", "connection-manager"] }
+redis = { version = "1.5", features = ["tokio-comp", "connection-manager"] }
 
 # JWT (gateway-JWT mint/verify, RFC 7523 assertions, fakeidp id_tokens).
 # One version + one crypto provider (aws_lc_rs) across the workspace: v10 needs


### PR DESCRIPTION
## Summary

Bumps the `redis` workspace dependency from 0.27 to 1.5.0 (redis-rs reached 1.0 in December 2025; the 0.27 pin was simply stale).

No source changes are required: the async command API used by the authenticator and analytics services is unchanged, and the `tokio-comp` / `connection-manager` feature names carry over. The 1.x line also brings default response timeouts on async connections and fixed `ConnectionManager` retry behavior.

This is groundwork for supporting Redis cluster mode alongside standalone (`cluster_async::ClusterConnection` implements `aio::ConnectionLike` in 1.5, so a mode-switching connection wrapper is straightforward).

## Validation

- `cargo clippy --workspace --all-targets` clean
- Unit tests: 589 passed (authenticator + analytics)
- Authenticator e2e suite (`tests/run-e2e.sh`, live Redis in docker): 8/8 suites passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)