### PR TITLE
feat(preview): gate experiments off on production by default (#1973)

### DIFF
--- a/deploy/preview/README.md
+++ b/deploy/preview/README.md
@@ -45,7 +45,13 @@ helm uninstall preview-<name> --namespace <ns>
   job (not FE-side OIDC), extended with a Redis-backed opaque `state` through the
   single fixed callback that `302`s back to `/exp/<name>`. This chart deliberately
   carries no auth env; that wiring lands with #1972.
-- **#1973** — pin the shared preview backend to synthetic data only.
+- **#1973** — experiments are a gated capability, off by default. The authenticator
+  takes `experiments_enabled` (default `false`); only when a stand sets it `true` is a
+  login return into `/exp/<name>` honored, so a **production** stand cannot host
+  experimental frontends against its data. Dev/demo preview hosts opt in and run
+  experiments over that stand's own data (no synthetic pin). This FE chart carries no
+  backend/auth env; the gate lives on the authenticator (gitops), like the return
+  prefix in #1972. A per-user RBAC capability supersedes this env-level gate later.
 - **#1981** — CI-driven provisioning, sequenced after the nginx-to-Envoy move; the
   `pathType: ImplementationSpecific` route becomes a Gateway API `HTTPRoute` then.
 

--- a/deploy/preview/values.yaml
+++ b/deploy/preview/values.yaml
@@ -37,9 +37,13 @@ ingress:
   # Extra annotations merged onto the per-experiment route object.
   annotations: {}
 
-# No auth values: preview login is the gateway+authenticator's job, not FE-side
-# OIDC. The authenticated return path for /exp/<name> arrives with #1972; the
-# synthetic-data pin is #1973.
+# No auth or backend values: preview login is the gateway+authenticator's job,
+# not FE-side OIDC (authenticated return path shipped in #1972). Experiments are
+# a gated capability, off by default: only a stand whose authenticator sets
+# `experiments_enabled: true` honors a login return into `/exp/<name>`, so a
+# production stand cannot host experimental frontends against its data. Dev/demo
+# preview hosts opt in and serve experiments over that stand's own data. The gate
+# lives on the authenticator (gitops), not this FE chart (#1973).
 
 resources:
   requests:

--- a/docs/domain/presentation-layer/specs/DESIGN.md
+++ b/docs/domain/presentation-layer/specs/DESIGN.md
@@ -56,7 +56,7 @@ Requirements that significantly influence architecture decisions.
 | `cpt-presentation-fr-contract-surface-doc` | Contract surface documented as the read boundary in [CONTRACT-SURFACE.md](./CONTRACT-SURFACE.md): the `class_*`/`fct_*`/`mtr_*`/`dim_*` silver families and `person.*`/`identity.*` objects, with the additive-only rules and the granted `insight` legacy gold. Shipped (#1968) |
 | `cpt-presentation-fr-contract-version-stamp` | Engineering stamps `silver.contract_version` (single-row constant view, ledgerless CH migration); analytics pins `PINNED_CONTRACT_VERSION` and verifies the stamp in a periodic post-boot sweep, logging a mismatch or missing stamp without gating boot. Shipped (#1969) |
 | `cpt-presentation-fr-query-console` | Single stable FE app on the saved-query API: author, list, run, render table / auto-chart. Shipped (#1970) |
-| `cpt-presentation-fr-preview-envs` | Path-based `/exp/<name>` on one host, one shared read-only synthetic backend, FE-only variation. Per-experiment bundle (`Deployment` + `Service` + one prefix-strip `Ingress`) shipped as the `insight-preview` chart at `deploy/preview/`, applied by hand (#1971); pinning the shared backend to synthetic data (#1973) stays open |
+| `cpt-presentation-fr-preview-envs` | Path-based `/exp/<name>` on one host, one shared read-only backend, FE-only variation. Per-experiment bundle (`Deployment` + `Service` + one prefix-strip `Ingress`) shipped as the `insight-preview` chart at `deploy/preview/`, applied by hand (#1971). Experiments are a capability gated off on production by default (`cpt-presentation-constraint-experiments-off-prod`, #1973). Shipped |
 | `cpt-presentation-fr-preview-auth` | Single fixed callback with a Redis-backed opaque `state` return path (already stashing `state -> { return_to, pkce_verifier, nonce }`, delete-on-read), extended so `return_to` is validated at store time against a configurable `/exp/` prefix. Shipped (#1972) |
 
 #### NFR Allocation
@@ -157,6 +157,12 @@ There is no Argo/GitOps in the platform. Preview provisioning is manual `kubectl
 - [ ] `p2` - **ID**: `cpt-presentation-constraint-single-host`
 
 One host serves all preview experiments, giving one Entra redirect URI (Entra has no reliable wildcard redirect). Addressing is path-based (`/exp/<name>`) with a same-origin session cookie and zero per-experiment Entra change.
+
+#### Experiments Off on Production by Default
+
+- [ ] `p2` - **ID**: `cpt-presentation-constraint-experiments-off-prod`
+
+Experimental frontends (`/exp/<name>`) are a capability, off by default, so a production stand cannot host them against customer data (PRD R1.4). The authenticator takes `experiments_enabled` (default `false`); a login return into the reserved `/exp/` subtree is honored only when it is `true`, otherwise the return falls back to `default_return_to` and the attempt is audit-logged. A production stand leaves it `false`; dev/demo preview hosts set `true` and serve experiments over that stand's own data (no synthetic requirement). This is the environment-level gate; a per-user RBAC capability supersedes it later, as the same surface becomes the analyst query builder. The gate lives on the authenticator (gitops); the `deploy/preview/` FE chart carries no auth env. The sanctioned saved-query console/CRUD is a separate, prod-safe surface and is not gated by this flag.
 
 #### No tenant_id on New Gold Outside the Coordinated Retrofit
 
@@ -370,17 +376,18 @@ Makes the saved-query API tangible: a single stable FE app (not a per-branch sta
 
 #### Preview Environment Router
 
-- [ ] `p2` - **ID**: `cpt-presentation-component-preview-router`
+- [x] `p2` - **ID**: `cpt-presentation-component-preview-router`
 
 ##### Why this component exists
 
-Serves many experimental FE builds under one host against one shared read-only synthetic backend, so FE developers get a tier-3 authoring loop that cannot touch customer data.
+Serves many experimental FE builds under one host against one shared read-only backend, gated so the capability is off on production and can never touch customer data there.
 
 ##### Responsibility scope
 
 - Path-based addressing `preview.insight…/exp/<name>/`: one host, one Entra redirect URI, same-origin session cookie. FE built with a relative asset base and a runtime router basepath so one image serves under any prefix; `/api/...` stays the shared absolute path.
 - Auth return path (shipped #1972): the authenticator's login-initiation already writes Redis `state → { return_to, pkce_verifier, nonce }` with a short TTL; Entra echoes the random `state` to the single fixed callback; the authenticator looks it up (miss/expired ⇒ reject; delete-on-read), exchanges the code, sets the cookie, and `302`s to `return_to`. #1972 adds the store-time `/exp/` prefix check: `sanitize_return_to` takes a configurable `return_to_prefix` (authenticator config) — empty keeps the permissive main-app posture; a preview-host deployment sets `/exp/` so a login can only return to an `/exp/<name>` path (same-origin already enforced by the site-relative check; `..`-traversal rejected), otherwise the configured default. The FE preview chart (`deploy/preview/`) still carries no auth env; the prefix is set on the preview-host authenticator deployment (gitops), which owns the single fixed Entra redirect URI.
-- Deployment: one route object per experiment applied by hand (`Deployment` + `Service` + one routing object with prefix-strip rewrite). The controller merges same-host route objects, so `apply` adds a path and `delete` removes it; no central config is rewritten. Portable by intent (Gateway API `HTTPRoute` after the Envoy move), but nginx-specific today: the route uses `pathType: ImplementationSpecific` with `nginx.ingress.kubernetes.io/{use-regex,rewrite-target}`. Shipped (#1971) as the `insight-preview` Helm chart at `deploy/preview/`: each experiment is one release named `preview-<name>`, the `Ingress` prefix-strips `/exp/<name>` (`rewrite-target: /$2`), and the experiment slug is validated as a DNS-1123 label of at most 55 characters at template time. Render-contract tests plus a `.github/workflows/preview-helm.yml` lane guard it. The auth return path above shipped (#1972); the synthetic-data pin (#1973) remains open, so this component stays unchecked.
+- Deployment: one route object per experiment applied by hand (`Deployment` + `Service` + one routing object with prefix-strip rewrite). The controller merges same-host route objects, so `apply` adds a path and `delete` removes it; no central config is rewritten. Portable by intent (Gateway API `HTTPRoute` after the Envoy move), but nginx-specific today: the route uses `pathType: ImplementationSpecific` with `nginx.ingress.kubernetes.io/{use-regex,rewrite-target}`. Shipped (#1971) as the `insight-preview` Helm chart at `deploy/preview/`: each experiment is one release named `preview-<name>`, the `Ingress` prefix-strips `/exp/<name>` (`rewrite-target: /$2`), and the experiment slug is validated as a DNS-1123 label of at most 55 characters at template time. Render-contract tests plus a `.github/workflows/preview-helm.yml` lane guard it. The auth return path above shipped (#1972).
+- Experiments-off-on-prod gate (shipped #1973): experiments are a capability, off by default, enforced at the authenticator's `/exp/` return path rather than the FE chart. The authenticator's `experiments_enabled` (default `false`) makes `login` honor a return into the reserved `/exp/` subtree only when `true`; otherwise it falls back to `default_return_to` and audit-logs `experiment_return_ignored`. A production stand leaves it `false`, so an experimental frontend cannot obtain a session there; dev/demo preview hosts set `true` and run over that stand's own data (`cpt-presentation-constraint-experiments-off-prod`). Enforced by `is_preview_return` + the `experiments_enabled` check in `login` (unit-tested), and set on the authenticator deployment behind the preview host (gitops). A future per-user RBAC capability replaces this single env-level check.
 
 ##### Responsibility boundaries
 
@@ -553,7 +560,7 @@ Ordered by quick win; each step ships value or safety on its own, and no step de
 4. **Tenant filter** (correctness, #1967) — replace the no-op with the injected predicate in the compiler's shared `WHERE`; `insight_tenant_id` first in `ORDER BY` for new gold; cover with an e2e metric test (`src/ingestion/tests/e2e`). Coordinated with engineering #1829.
 5. **Contract surface + version stamp** (stability, done, #1968/#1969) — the surface and additive-only rules named in CONTRACT-SURFACE.md; `silver.contract_version` stamped by migration and pinned/verified by analytics in a periodic sweep.
 6. **Query console** (value, FE, #1970) — thin stable app on the saved-query API: auth shell, author, list, run, render table / auto-chart. Tier-2 "promote to card" can follow.
-7. **Preview environments** (infra, FE, #1971-#1973) — path-based `/exp/<name>` on a shared read-only synthetic backend; Redis-`state` return path; one route object per experiment; manual `kubectl`/`helm`.
+7. **Preview environments** (infra, FE, #1971-#1973) — path-based `/exp/<name>` on a shared read-only backend; Redis-`state` return path; experiments gated off on production by default; one route object per experiment; manual `kubectl`/`helm`.
 
 Deferred: relocate legacy gold from `insight` to `presentation` (#1979-#1981); CI-driven preview provisioning (after the nginx-to-Envoy move).
 

--- a/docs/domain/presentation-layer/specs/PRD.md
+++ b/docs/domain/presentation-layer/specs/PRD.md
@@ -62,7 +62,7 @@ Phase A draws the contract and makes it safe by construction, so a new analytics
 | The source is safe | **Baseline**: presentation and engineering share one writable surface. **Target**: no presentation-side operation can write, alter, or drop engineering-owned data; worst case is damage to `presentation` scratch. **Timeframe**: end of Phase A. |
 | Self-serve analytics without engineering change | **Baseline**: every new slice needs an engineering change or re-ingest. **Target**: an analyst authors, saves, and runs a new query with no deploy. **Timeframe**: end of Phase A. |
 | Every read is tenant-scoped | **Baseline**: tenant filter is a no-op. **Target**: 100% of contract reads carry a server-injected tenant predicate the client cannot widen. **Timeframe**: end of Phase A. |
-| Isolated FE authoring loop | **Baseline**: no isolated place to build widgets. **Target**: FE developers build and validate widgets on a shared read-only preview backend on synthetic data. **Timeframe**: end of Phase A. |
+| Isolated FE authoring loop | **Baseline**: no isolated place to build widgets. **Target**: FE developers build and validate widgets on a shared read-only preview backend on non-production stands (dev/demo); the experiment capability is disabled on production. **Timeframe**: end of Phase A. |
 
 ### 1.4 Glossary
 
@@ -75,7 +75,7 @@ Phase A draws the contract and makes it safe by construction, so a new analytics
 | Single-SELECT gate | A parse-and-reject check that accepts exactly one `SELECT`/`WITH` statement and rejects everything else. |
 | `presentation_ro` role | A ClickHouse role with `SELECT` on the contract and `CREATE`/`INSERT` only in `presentation`. |
 | Saved query | A stored `SELECT`/`WITH` over the contract with an id, name, and tenant, runnable read-only. |
-| Preview environment | A path-based FE deployment (`/exp/<name>`) against a shared read-only synthetic backend. |
+| Preview environment | A path-based FE deployment (`/exp/<name>`) against a shared read-only backend, enabled only on non-production stands. |
 | Relabel, not migrate | Legacy gold stays read-only in the `insight` DB; only new gold is authored in `presentation`. |
 
 ## 2. Actors
@@ -253,13 +253,13 @@ The system **MUST** provide a single stable FE app (not per-branch stands) where
 
 #### Preview Environments
 
-- [ ] `p2` - **ID**: `cpt-presentation-fr-preview-envs`
+- [x] `p2` - **ID**: `cpt-presentation-fr-preview-envs`
 
-The system **MUST** serve many experimental FE builds under path-based addressing (`/exp/<name>`) on a single host, against one shared read-only backend on synthetic data (never customer production). Only the FE varies per experiment. (#1971, #1973.)
+The system **MUST** serve many experimental FE builds under path-based addressing (`/exp/<name>`) on a single host, against one shared read-only backend. Only the FE varies per experiment. Experiments **MUST** be a capability that is disabled on production by default, so a production stand cannot host experimental frontends against customer data; non-production stands (dev/demo) enable it and run over that stand's own data. (#1971, #1973.)
 
 **Rationale**: FE developers need an isolated tier-3 authoring loop that cannot touch customer data.
 
-**Status**: Serving path shipped (#1971): the `insight-preview` Helm chart (`deploy/preview/`) provisions one experiment per release — `Deployment` + `Service` + one prefix-strip `Ingress` under `/exp/<name>` on the shared host, applied and removed by hand. Pinning the shared backend to synthetic data (#1973) is still open, so this requirement stays open.
+**Status**: Shipped. Serving path (#1971): the `insight-preview` Helm chart (`deploy/preview/`) provisions one experiment per release — `Deployment` + `Service` + one prefix-strip `Ingress` under `/exp/<name>` on the shared host, applied and removed by hand. Experiments-off-on-prod gate (#1973): the authenticator's `experiments_enabled` (default `false`) honors a login return into the `/exp/` subtree only when set, so a production stand cannot host experimental frontends; dev/demo preview hosts opt in. A per-user RBAC capability supersedes this environment-level gate later.
 
 **Actors**: `cpt-presentation-actor-fe-dev`
 
@@ -362,22 +362,22 @@ Contract reads for tenant A **MUST NOT** return rows from tenant B, regardless o
 
 ### Validate a Widget on a Preview Environment
 
-- [ ] `p2` - **ID**: `cpt-presentation-usecase-preview-widget`
+- [x] `p2` - **ID**: `cpt-presentation-usecase-preview-widget`
 
 **Actor**: `cpt-presentation-actor-fe-dev`
 
 **Preconditions**:
 - A preview route object exists for the experiment (`/exp/<name>`).
-- The shared read-only synthetic backend is available.
+- The stand is non-production with experiments enabled, and its shared read-only backend is available.
 
 **Main Flow**:
 1. FE developer applies the per-experiment bundle (FE image plus route object).
 2. Developer opens `/exp/<name>/` and authenticates through the fixed callback.
 3. System resolves the Redis-backed `state` return path and establishes the session.
-4. Developer exercises the widget against the shared read-only synthetic backend.
+4. Developer exercises the widget against the shared read-only backend on that non-production stand.
 
 **Postconditions**:
-- The widget is validated against synthetic data with no access to customer production.
+- The widget is validated on a non-production stand; production stands do not host experiments, so customer data is never exposed to an experimental frontend.
 
 **Alternative Flows**:
 - **`state` missing or expired**: System rejects the callback; the developer restarts login.
@@ -391,7 +391,7 @@ Contract reads for tenant A **MUST NOT** return rows from tenant B, regardless o
 - [ ] Cross-tenant reads return no rows.
 - [ ] The `presentation` namespace exists and legacy gold remains read-only in `insight`.
 - [ ] The query console runs a saved query and renders the result as a table or auto-chart.
-- [ ] A preview environment serves an FE build under `/exp/<name>` on the shared read-only synthetic backend with an authenticated return path.
+- [x] A preview environment serves an FE build under `/exp/<name>` on the shared read-only backend with an authenticated return path, and the experiment capability is disabled on production by default.
 
 ## 10. Dependencies
 

--- a/src/backend/services/authenticator/src/api/handlers.rs
+++ b/src/backend/services/authenticator/src/api/handlers.rs
@@ -58,6 +58,23 @@ pub async fn login(
         &state.cfg.return_to_prefix,
     );
 
+    // Preview experiments (`/exp/<name>`) are a capability, off by default. A
+    // production stand leaves `experiments_enabled=false`, so a login can never
+    // return into the preview subtree — an experimental frontend cannot be
+    // driven against that stand's data. Dev/demo preview hosts opt in. A future
+    // per-user RBAC check replaces this environment-level gate.
+    let return_to = if state.cfg.experiments_enabled || !is_preview_return(&return_to) {
+        return_to
+    } else {
+        tracing::warn!(
+            target: "audit",
+            event = "experiment_return_ignored",
+            "return_to under the /exp/ preview prefix but experiments_enabled=false: \
+             falling back to default_return_to"
+        );
+        state.cfg.default_return_to.clone()
+    };
+
     // `__override` (view-as, #1941): carried into the login state only when
     // the environment opts in; otherwise the parameter is inert — and logged,
     // so an attempt against a real environment is visible, not silent.
@@ -1408,6 +1425,19 @@ pub fn sanitize_return_to(candidate: Option<&str>, default: &str, prefix: &str) 
         .to_owned()
 }
 
+/// Reserved path prefix that preview experiments (`/exp/<name>`) are served
+/// under. The single point the experiments capability keys on — a login return
+/// into this subtree is honored only when experiments are enabled.
+const PREVIEW_RETURN_PREFIX: &str = "/exp/";
+
+/// Whether a (already-sanitized, site-relative) `return_to` targets the preview
+/// experiments subtree. Case-folded so `/EXP/` cannot slip the gate.
+fn is_preview_return(return_to: &str) -> bool {
+    return_to
+        .to_ascii_lowercase()
+        .starts_with(PREVIEW_RETURN_PREFIX)
+}
+
 /// Same-origin and (when `prefix` is set) confined to it — checked on a form
 /// the browser cannot fold into an escape. `\`, `%5c`, `%2e`, `%2f`, and a
 /// literal `..` path segment are rejected, since the WHATWG URL parser turns
@@ -1654,6 +1684,22 @@ mod tests {
                 sanitize_return_to(Some(evil), "/", ""),
                 "/",
                 "should reject: {evil:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn is_preview_return_matches_exp_subtree_case_folded() {
+        for hit in ["/exp/widget-1/", "/exp/", "/EXP/Widget/", "/Exp/x"] {
+            assert!(
+                is_preview_return(hit),
+                "should be a preview return: {hit:?}"
+            );
+        }
+        for miss in ["/", "/dashboard", "/expunge", "/experiments"] {
+            assert!(
+                !is_preview_return(miss),
+                "should not be a preview return: {miss:?}"
             );
         }
     }

--- a/src/backend/services/authenticator/src/config.rs
+++ b/src/backend/services/authenticator/src/config.rs
@@ -261,6 +261,13 @@ pub struct AuthenticatorConfig {
     /// in `/`. Empty (default) = any same-origin path. A preview host sets
     /// `/exp/` to confine logins to `/exp/<name>`.
     pub return_to_prefix: String,
+    /// Master switch for the preview experiments capability (`/exp/<name>`
+    /// tier-3 frontends). Default `false`: a login can never return into the
+    /// `/exp/` subtree, so a production stand cannot host experimental
+    /// frontends against its data. Dev/demo preview hosts set `true` and serve
+    /// experiments over that stand's own data. A per-user RBAC capability will
+    /// supersede this environment-level gate.
+    pub experiments_enabled: bool,
 
     // NOTE: first-admin bootstrap (DD-AUTH-08) and RBAC/ACL are deliberately
     // NOT in step 04 — deferred to a separate universe-admin initiative. Local
@@ -359,6 +366,7 @@ impl Default for AuthenticatorConfig {
             ],
             default_return_to: "/".to_owned(),
             return_to_prefix: String::new(),
+            experiments_enabled: false,
             csrf_origins: Vec::new(),
             janitor_interval_seconds: 30,
             rate_limit: RateLimitConfig::default(),


### PR DESCRIPTION
## What & why

Phase A, last task for epic #1803. Preview experiments (`/exp/<name>`) let developers build and validate FE widgets against a shared read-only backend. The thing that must never happen is an **experimental, unreviewed frontend running against a production stand's customer data**.

The original approach here pinned the preview backend to *synthetic data*. That was the wrong lever: the value of the tier-3 loop is validating against a stand's **real** data (clean synthetic fixtures hide the bugs real data exposes), and "is this data synthetic?" is never crisply decidable. So this now gates the **capability**, keyed to the stand, not the data source.

## Change

- **`experiments_enabled`** added to the authenticator (default `false`). `login` honors a `return_to` into the reserved `/exp/` subtree **only** when it is `true`; otherwise the return falls back to `default_return_to` and the attempt is audit-logged (`experiment_return_ignored`). Mirrors the existing `override_enabled` view-as gate.
- A **production** stand leaves the flag `false`, so a login can never land in an experimental frontend there — it cannot obtain a session against prod data. **Dev/demo** preview hosts set `true` and run experiments over that stand's own real data. Fail-closed by default.
- `is_preview_return` + the flag are a single, named check point; a **per-user RBAC** capability supersedes this environment-level gate later, as the same surface grows into the analyst query builder.
- The **sanctioned saved-query console/CRUD stays available on every stand** — it's a separate, prod-safe surface (single-SELECT gate + `presentation_ro` + tenant filter) and is not gated by this flag.
- Specs: replaced the synthetic-data constraint with `cpt-presentation-constraint-experiments-off-prod`; the `deploy/preview/` chart docs point to the authenticator gate. The gate is set on the authenticator deployment behind the preview host (gitops); the FE chart carries no auth env.

## Testing

- `cargo test -p authenticator` — 57 pass, incl. a new `is_preview_return` gate test (positive/negative/`/expunge` boundary/case-fold).
- `cargo test -p analytics` — 537 pass (this revises the earlier synthetic-pin approach; analytics is back to baseline).
- `cargo clippy`/`fmt` clean on both crates; `deploy/preview` render tests unaffected (comment-only doc edits).
- `cfs validate` PRD/DESIGN: 0 errors; `cfs check-language` clean.

Closes #1973
Part of #1803

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in gate for preview experiments, disabled by default.
  * Enabled preview environments to use their stand’s own read-only data.
* **Bug Fixes**
  * Production login redirects now block experimental preview paths when experiments are disabled.
  * Invalid or unsafe preview destinations fall back to the configured default.
* **Documentation**
  * Updated preview deployment, authentication, routing, and acceptance documentation to reflect the shipped behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->