### PR TITLE
Move the session keyspace to a single cluster slot ({asm}: hash tag)

### DIFF
--- a/docs/components/backend/authenticator/DESIGN.md
+++ b/docs/components/backend/authenticator/DESIGN.md
@@ -47,6 +47,7 @@ date: 2026-07-06
   - [DD-AUTH-07: Access-Control Claims Fetched Once, at Login](#dd-auth-07-access-control-claims-fetched-once-at-login)
   - [DD-AUTH-08: Empty-Table First-Admin Bootstrap plus INSTALLER](#dd-auth-08-empty-table-first-admin-bootstrap-plus-installer)
   - [DD-AUTH-09: View-As Override at Session Mint, Gated by an Environment Flag](#dd-auth-09-view-as-override-at-session-mint-gated-by-an-environment-flag)
+  - [DD-AUTH-10: Single-Slot Session Keyspace (`{asm}:` Hash Tag)](#dd-auth-10-single-slot-session-keyspace-asm-hash-tag)
   - [RESOLVED (step 07): ES256 for the Gateway JWT](#resolved-step-07-es256-for-the-gateway-jwt)
 - [6. Traceability](#6-traceability)
 
@@ -71,7 +72,7 @@ The authenticator is a plain HTTP service: no proxying, no K8s API access, no st
 | Requirement | Design Response |
 |---|---|
 | `cpt-insightspec-fr-auth-oidc-login` | Confidential OIDC client with PKCE; IdP tokens stored in the session record only; session-fixation revoke on callback |
-| `cpt-insightspec-fr-auth-session-model` | Stable `session_id` (UUIDv7) keys everything; `asm:token:{token}` mapping is the only rotating artifact |
+| `cpt-insightspec-fr-auth-session-model` | Stable `session_id` (UUIDv7) keys everything; `{asm}:token:{token}` mapping is the only rotating artifact |
 | `cpt-insightspec-fr-auth-session-cookie` | `__Host-`-prefixed opaque cookie, TTL 600 s default, set on `/auth/callback` |
 | `cpt-insightspec-fr-auth-session-refresh` | New mapping write + old-mapping grace TTL; `refresh_at` with 90 s margin and 120 s jitter window |
 | `cpt-insightspec-fr-auth-session-store` | Redis keyspace in 3.7: session HASH, token mapping, linked JWT, ZSET index, sid index, refresh-due ZSET; MULTI/EXEC pipelines |
@@ -81,7 +82,7 @@ The authenticator is a plain HTTP service: no proxying, no K8s API access, no st
 | `cpt-insightspec-fr-auth-session-list`, `cpt-insightspec-fr-auth-session-revoke` | ZSET index reads; one revoke pipeline shared by logout, back-channel, admin, and `invalid_grant` paths |
 | `cpt-insightspec-fr-auth-logout` | Local + RP-initiated + back-channel receiver with `jti` replay guard |
 | `cpt-insightspec-fr-auth-csrf` | Double-submit token bound to the session + `Origin` allowlist |
-| `cpt-insightspec-fr-auth-idp-refresh` | Leader-elected refresher over `asm:idp_refresh_due`; per-session rotation lock; fail-open transport / fail-closed verdict |
+| `cpt-insightspec-fr-auth-idp-refresh` | Leader-elected refresher over `{asm}:idp_refresh_due`; per-session rotation lock; fail-open transport / fail-closed verdict |
 | `cpt-insightspec-fr-auth-service-tokens` | Token listener + RFC 7523 verification against the registry; same signer, same JWKS |
 | `cpt-insightspec-fr-auth-bootstrap` | Empty-table guard in the login path; INSTALLER as the production path |
 | `cpt-insightspec-fr-auth-internal-reachability` | Two listeners (3.10); NetworkPolicies; credential checks on every endpoint |
@@ -124,7 +125,7 @@ graph TB
     end
 
     subgraph State
-        RD[(Redis - asm:* keys)]
+        RD[(Redis - {asm}:* keys)]
         SEC[Mounted Secret<br/>signing keys]
         REG[Service registry<br/>gitops config]
     end
@@ -232,13 +233,13 @@ The authenticator is an idiomatic gears-rust gear built on the published `cf-gea
 
 | Entity | Purpose | Storage |
 |---|---|---|
-| `Session` | Active login of one user on one device; stable identity (`session_id`, UUIDv7); holds person, tenants, roles snapshot, IdP linkage, IdP refresh token, expiries, CSRF token | Redis HASH `asm:session:{session_id}` |
-| `SessionToken` | Rotating cookie credential; maps token to `session_id` | Redis STRING `asm:token:{token}` |
-| `LinkedJwt` | The signed gateway JWT linked 1:1 to the session | Redis STRING `asm:jwt:{session_id}` |
-| `UserSessionIndex` | All `session_id`s for one person, scored by expiry | Redis ZSET `asm:user_sessions:{person_id}` |
-| `SidIndex` | Map (OIDC issuer, OIDC sid) to local sessions | Redis SET `asm:sid_index:{iss}:{idp_sid}` |
-| `LoginState` | Per-login transient state (PKCE verifier, nonce) | Redis HASH `asm:login_state:{state}`, TTL 5 min |
-| `IdpRefreshSchedule` | Sessions due for IdP token refresh, scored by due time | Redis ZSET `asm:idp_refresh_due` |
+| `Session` | Active login of one user on one device; stable identity (`session_id`, UUIDv7); holds person, tenants, roles snapshot, IdP linkage, IdP refresh token, expiries, CSRF token | Redis HASH `{asm}:session:{session_id}` |
+| `SessionToken` | Rotating cookie credential; maps token to `session_id` | Redis STRING `{asm}:token:{token}` |
+| `LinkedJwt` | The signed gateway JWT linked 1:1 to the session | Redis STRING `{asm}:jwt:{session_id}` |
+| `UserSessionIndex` | All `session_id`s for one person, scored by expiry | Redis ZSET `{asm}:user_sessions:{person_id}` |
+| `SidIndex` | Map (OIDC issuer, OIDC sid) to local sessions | Redis SET `{asm}:sid_index:{iss}:{idp_sid}` |
+| `LoginState` | Per-login transient state (PKCE verifier, nonce) | Redis HASH `{asm}:login_state:{state}`, TTL 5 min |
+| `IdpRefreshSchedule` | Sessions due for IdP token refresh, scored by due time | Redis ZSET `{asm}:idp_refresh_due` |
 | `ServiceRegistryEntry` | Service name, public key(s) (inline or by file path), allowed roles | Gitops-reviewable config (mounted) |
 | `SigningKey` | Current + previous JWT signing keys | Mounted K8s Secret, in-process cache |
 
@@ -342,7 +343,7 @@ Does not call the OIDC provider. Does not authenticate requests by itself. Does 
 The gateway's `auth_request` target -- the session check and JWT injection behind one subrequest.
 
 ##### Responsibility scope
-`GET /internal/authz`: resolve `asm:token:{token}` to `session_id`, load session, read the linked JWT; under the reissue age, return it as-is; past it, rebuild claims from the session record, sign, `SET asm:jwt:{session_id} NX EX` (parallel requests converge on one canonical JWT), return the winner. Emit `X-Gateway-Jwt` and the `Cache-Control` header (`max-age = min(authz_cache_max_age, jwt_exp - now - 60 s)` on 200, `no-store` otherwise).
+`GET /internal/authz`: resolve `{asm}:token:{token}` to `session_id`, load session, read the linked JWT; under the reissue age, return it as-is; past it, rebuild claims from the session record, sign, `SET {asm}:jwt:{session_id} NX EX` (parallel requests converge on one canonical JWT), return the winner. Emit `X-Gateway-Jwt` and the `Cache-Control` header (`max-age = min(authz_cache_max_age, jwt_exp - now - 60 s)` on 200, `no-store` otherwise).
 
 ##### Responsibility boundaries
 Never writes session state other than the JWT slot. Never sets cookies (the subrequest response's `Set-Cookie` would be discarded by nginx anyway). No correlation-id generation -- the response is cacheable; correlation ids are minted at the edge.
@@ -377,7 +378,7 @@ Does not verify inbound JWTs (the host's auth pipeline does, for the admin surfa
 No-user workloads need signed identity without a secret in transit.
 
 ##### Responsibility scope
-`POST /internal/token` on the second listener: validate the RFC 7523 assertion (signature against the registry's public keys, `aud`, `exp` at most 60 s), require a tenant scope (reject `400` if none), replay-guard `jti` (`SET NX`, same pattern as `asm:logout_jti`), audit, and mint a token with a stable per-service UUID `sub` (deterministic v5), `sub_type = service`, registry roles (including `service`), and the requested single `tenant_id`.
+`POST /internal/token` on the second listener: validate the RFC 7523 assertion (signature against the registry's public keys, `aud`, `exp` at most 60 s), require a tenant scope (reject `400` if none), replay-guard `jti` (`SET NX`, same pattern as `{asm}:logout_jti`), audit, and mint a token with a stable per-service UUID `sub` (deterministic v5), `sub_type = service`, registry roles (including `service`), and the requested single `tenant_id`.
 
 ##### Responsibility boundaries
 Does not manage the registry (gitops does). Does not issue user tokens.
@@ -411,7 +412,7 @@ Does not store sessions; holds no IdP tokens beyond one operation.
 The session must not outlive the IdP's willingness to vouch for the user, even when the IdP has no back-channel logout.
 
 ##### Responsibility scope
-Leader-elected worker (Redis lock) owned by the gear's runnable capability. Loop: `ZRANGEBYSCORE asm:idp_refresh_due 0 now`, spawn one refresh task per due session under a per-session lock (refresh-token rotation is one-time-use; racing burns the grant), bounded by a semaphore (`idp.refresh_concurrency`, default 128 -- politeness toward the customer IdP, not our capacity). Store rotated tokens back and re-schedule with write-time jitter. `invalid_grant` verdict: revoke all linked sessions via the Session Manager's standard pipeline. Transient errors (timeout, 5xx, 429 with `Retry-After`): backoff and retry, never revoke.
+Leader-elected worker (Redis lock) owned by the gear's runnable capability. Loop: `ZRANGEBYSCORE {asm}:idp_refresh_due 0 now`, spawn one refresh task per due session under a per-session lock (refresh-token rotation is one-time-use; racing burns the grant), bounded by a semaphore (`idp.refresh_concurrency`, default 128 -- politeness toward the customer IdP, not our capacity). Store rotated tokens back and re-schedule with write-time jitter. `invalid_grant` verdict: revoke all linked sessions via the Session Manager's standard pipeline. Transient errors (timeout, 5xx, 429 with `Retry-After`): backoff and retry, never revoke.
 
 ##### Responsibility boundaries
 Does not talk to the browser. Does not decide policy beyond the configured `no_refresh_token_policy`.
@@ -444,7 +445,7 @@ Does not protect `/api/*` (gateway strips nothing relevant there; `SameSite=Stri
 Per-key Redis TTLs remove records, but the ZSET indexes and the refresh schedule still list dead members until trimmed.
 
 ##### Responsibility scope
-Leader-elected periodic pass over single, well-known keys: `ZREMRANGEBYSCORE` expired members from `asm:login_state_live` and orphans from `asm:idp_refresh_due`; emit backlog/removed metrics. Per-user session indexes are trimmed inline by their writers and TTL-bounded, so the pass never scans the keyspace.
+Leader-elected periodic pass over single, well-known keys: `ZREMRANGEBYSCORE` expired members from `{asm}:login_state_live` and orphans from `{asm}:idp_refresh_due`; emit backlog/removed metrics. Per-user session indexes are trimmed inline by their writers and TTL-bounded, so the pass never scans the keyspace.
 
 ##### Responsibility boundaries
 Does not delete session records (TTL does). One leader per pass.
@@ -570,15 +571,15 @@ sequenceDiagram
     participant R as Redis
 
     N->>B: GET /internal/authz (subrequest on exchange-cache miss)
-    B->>R: GET asm:token:{token} -> session_id; load session
+    B->>R: GET {asm}:token:{token} -> session_id; load session
     alt no / expired session
         B-->>N: 401 + Cache-Control: no-store
     else JWT age < reissue threshold (4 min)
-        B->>R: GET asm:jwt:{session_id}
+        B->>R: GET {asm}:jwt:{session_id}
         B-->>N: 200 + X-Gateway-Jwt (stored JWT as-is,<br/>>= 60 s validity left) + Cache-Control: max-age
     else JWT age >= reissue threshold
         B->>B: rebuild claims from session record, sign fresh JWT
-        B->>R: SET asm:jwt:{session_id} NX EX (stampede-safe)
+        B->>R: SET {asm}:jwt:{session_id} NX EX (stampede-safe)
         B-->>N: 200 + X-Gateway-Jwt (canonical winner) + Cache-Control: max-age
     end
 ```
@@ -599,10 +600,10 @@ sequenceDiagram
     participant R as Redis
 
     U->>B: POST /auth/refresh (cookie = old token)
-    B->>R: GET asm:token:{old} -> session_id; load session
+    B->>R: GET {asm}:token:{old} -> session_id; load session
     alt mapping resolves, under absolute cap
         B->>B: new token = csprng()<br/>new_exp = min(now + ttl, absolute_expires_at)<br/>refresh_at = new_exp - 90s +/- 60s jitter
-        B->>R: pipeline: SET asm:token:{new} session_id EX new_exp<br/>PEXPIRE asm:token:{old} grace_ms<br/>update session expires_at + TTL + ZSET score
+        B->>R: pipeline: SET {asm}:token:{new} session_id EX new_exp<br/>PEXPIRE {asm}:token:{old} grace_ms<br/>update session expires_at + TTL + ZSET score
         B-->>U: 200 {expires_at, refresh_at} + Set-Cookie (new token)
         Note over B,R: session_id, linked JWT, indexes: UNTOUCHED.<br/>No RENAME, no swap key -- the expiring old<br/>mapping IS the grace window.
     else mapping gone
@@ -628,7 +629,7 @@ sequenceDiagram
     participant I as OIDC IdP
 
     loop every tick
-        W->>R: ZRANGEBYSCORE asm:idp_refresh_due 0 now
+        W->>R: ZRANGEBYSCORE {asm}:idp_refresh_due 0 now
         R-->>W: due session_ids
         par per session, semaphore-capped
             W->>R: acquire per-session lock (rotation safety)
@@ -663,17 +664,17 @@ sequenceDiagram
 
     I->>B: POST /auth/oidc/back-channel-logout (logout_token)
     B->>B: validate (sig, iss, aud, iat, events, jti)
-    B->>R: SET asm:logout_jti:{iss}:{jti} NX EX ...
+    B->>R: SET {asm}:logout_jti:{iss}:{jti} NX EX ...
     alt replay (NX failed)
         B-->>I: 200 (idempotent, no revoke)
     else first delivery
-        B->>R: resolve sessions via asm:sid_index (or asm:sub_index on sub-only fallback)
+        B->>R: resolve sessions via {asm}:sid_index (or {asm}:sub_index on sub-only fallback)
         B->>R: standard revoke pipeline per session
         B-->>I: 200
     end
 ```
 
-**Description**: Includes the `jti` replay guard and the documented sub-only blast-radius fallback — resolved via the `asm:sub_index` written at login (Identity cannot resolve a bare `sub`, and the logout path must not depend on another service).
+**Description**: Includes the `jti` replay guard and the documented sub-only blast-radius fallback — resolved via the `{asm}:sub_index` written at login (Identity cannot resolve a bare `sub`, and the logout path must not depend on another service).
 
 #### Service token issuance
 
@@ -705,20 +706,20 @@ sequenceDiagram
 
 - [ ] `p3` - **ID**: `cpt-insightspec-db-auth-redis`
 
-This module's "database" is Redis. All keys carry the `asm:` prefix (authenticator session management) -- owner-prefixed keys on the shared Redis instance, one prefix per module, so operators can identify the owner from the key name. Explicitly absent: **no swap-key family, no RENAME-based rotation, no separate JWT-cache prefix** -- the linked JWT lives under `asm:jwt:*` with the same lifecycle as the session.
+This module's "database" is Redis. All keys carry the `{asm}:` prefix (authenticator session management) -- owner-prefixed keys on the shared Redis instance, one prefix per module, so operators can identify the owner from the key name. Explicitly absent: **no swap-key family, no RENAME-based rotation, no separate JWT-cache prefix** -- the linked JWT lives under `{asm}:jwt:*` with the same lifecycle as the session.
 
 ```mermaid
 graph LR
     P[person_id]
-    IDX["asm:user_sessions:{person_id}<br/>ZSET - score = expires_at"]
-    S["asm:session:{session_id}<br/>HASH"]
-    T1["asm:token:{token}<br/>STRING -> session_id"]
-    T2["asm:token:{old_token}<br/>STRING -> session_id (grace TTL)"]
-    J["asm:jwt:{session_id}<br/>STRING (signed JWT)"]
-    SIDX["asm:sid_index:{iss}:{idp_sid}<br/>SET of session_id"]
-    LS["asm:login_state:{state}<br/>HASH (5 min TTL)"]
-    LJTI["asm:logout_jti:{iss}:{jti}<br/>STRING - replay guard"]
-    DUE["asm:idp_refresh_due<br/>ZSET - score = refresh due time"]
+    IDX["{asm}:user_sessions:{person_id}<br/>ZSET - score = expires_at"]
+    S["{asm}:session:{session_id}<br/>HASH"]
+    T1["{asm}:token:{token}<br/>STRING -> session_id"]
+    T2["{asm}:token:{old_token}<br/>STRING -> session_id (grace TTL)"]
+    J["{asm}:jwt:{session_id}<br/>STRING (signed JWT)"]
+    SIDX["{asm}:sid_index:{iss}:{idp_sid}<br/>SET of session_id"]
+    LS["{asm}:login_state:{state}<br/>HASH (5 min TTL)"]
+    LJTI["{asm}:logout_jti:{iss}:{jti}<br/>STRING - replay guard"]
+    DUE["{asm}:idp_refresh_due<br/>ZSET - score = refresh due time"]
 
     P --> IDX
     IDX --> S
@@ -729,7 +730,7 @@ graph LR
     S -. scheduled refresh .-> DUE
 ```
 
-#### Key: `asm:token:{token}`
+#### Key: `{asm}:token:{token}`
 
 **Type**: Redis STRING. Value: `session_id`.
 
@@ -737,7 +738,7 @@ graph LR
 
 **TTL**: session `expires_at` for the live mapping; `grace_ms` (PX) for the superseded one.
 
-#### Key: `asm:session:{session_id}`
+#### Key: `{asm}:session:{session_id}`
 
 **Type**: Redis HASH. Keyed by the **stable** `session_id` (UUIDv7), never by the cookie value.
 
@@ -763,7 +764,7 @@ graph LR
 
 **Redis TTL**: matches `expires_at`; re-set on every refresh.
 
-#### Key: `asm:jwt:{session_id}`
+#### Key: `{asm}:jwt:{session_id}`
 
 **Type**: Redis STRING. Value: the full signed gateway JWT.
 
@@ -771,7 +772,7 @@ graph LR
 
 **TTL**: `jwt_reissue_after_seconds` on NX fill; bounded overall by the session's lifecycle.
 
-#### Key: `asm:user_sessions:{person_id}`
+#### Key: `{asm}:user_sessions:{person_id}`
 
 **Type**: Redis ZSET. Member: `session_id`. Score: `expires_at`.
 
@@ -779,51 +780,51 @@ graph LR
 
 **Cleanup**: session-create trims already-expired members in the same pipeline (same key, so the transaction stays single-slot on Redis Cluster), and the key carries an `EXPIREAT` at the longest member's absolute expiry, applied `NX` then `GT` so it only ever extends. Abandoned indexes self-expire; no keyspace `SCAN` is required anywhere (Redis Cluster has no cluster-wide cursor).
 
-**Upgrade from pre-TTL builds**: indexes written before this scheme carry no TTL, and writer-driven cleanup only reaches indexes a writer touches. Flush `asm:*` at upgrade (sessions are ephemeral; users re-login); otherwise pre-upgrade sessions live out their TTL with a possible listing/revocation blind spot.
+**Upgrade from pre-TTL builds**: indexes written before this scheme carry no TTL, and writer-driven cleanup only reaches indexes a writer touches. Flush `{asm}:*` at upgrade (sessions are ephemeral; users re-login); otherwise pre-upgrade sessions live out their TTL with a possible listing/revocation blind spot.
 
-#### Key: `asm:sid_index:{iss}:{idp_sid}`
+#### Key: `{asm}:sid_index:{iss}:{idp_sid}`
 
 **Type**: Redis SET of `session_id`.
 
 **Purpose**: Resolve back-channel `logout_token` (`iss` + `sid`) to local sessions. Never churned by rotation.
 
-#### Key: `asm:login_state:{state}`
+#### Key: `{asm}:login_state:{state}`
 
 **Type**: Redis HASH. Fields: `pkce_verifier`, `nonce`, `redirect_to`, `override_email` (view-as target, DD-AUTH-09; empty on normal logins). **TTL**: 5 minutes, one-shot. The live count is capped (layer-2 rate limiting).
 
-#### Key: `asm:logout_jti:{iss}:{jti}`
+#### Key: `{asm}:logout_jti:{iss}:{jti}`
 
 **Type**: Redis STRING presence flag, `SET NX`. Replay guard for back-channel logout tokens. **TTL**: `(iat + max_clock_skew + grace) - now`. The same pattern guards `/internal/token` assertion `jti`s (next key).
 
-#### Key: `asm:svc_jti:{service}:{jti}`
+#### Key: `{asm}:svc_jti:{service}:{jti}`
 
 **Type**: Redis STRING presence flag, `SET NX EX`. One-shot replay guard for RFC 7523 service-token client assertions (DD-AUTH-05): the token issuer sets it the first time a `jti` is seen for a service and rejects any later reuse. **TTL**: the assertion's remaining lifetime plus `service_tokens.clock_skew_leeway_seconds`, so an assertion cannot be replayed within its own validity window and the key expires once it no longer could be accepted.
 
-#### Key: `asm:idp_refresh_due`
+#### Key: `{asm}:idp_refresh_due`
 
 **Type**: Redis ZSET. Member: `session_id`. Score: IdP access-token expiry minus `idp.refresh_safety_margin_seconds`, **jittered at write** so sessions do not come due in the same second after a deploy or Redis restore.
 
 **Purpose**: The refresher's schedule -- `ZRANGEBYSCORE ... 0 now`, no scanning. Maintained in the same pipelines as the session record.
 
-#### Key: `asm:sub_index:{iss}:{idp_sub}`
+#### Key: `{asm}:sub_index:{iss}:{idp_sub}`
 
 **Type**: Redis SET of `session_id`. Maintained in the create/revoke pipelines like the sid index.
 
 **Purpose**: Resolve a back-channel `logout_token` that carries only `(iss, sub)` (no `sid`) to the user's sessions — the documented log-out-everywhere fallback.
 
-#### Key: `asm:login_state_live`
+#### Key: `{asm}:login_state_live`
 
 **Type**: Redis ZSET. Member: OIDC `state`. Score: login-state expiry.
 
-**Purpose**: Counts live `asm:login_state:*` entries for the layer-2 login cap (counting via SCAN per login would be pathological). Written/removed in the login-state pipelines; the janitor trims expired members.
+**Purpose**: Counts live `{asm}:login_state:*` entries for the layer-2 login cap (counting via SCAN per login would be pathological). Written/removed in the login-state pipelines; the janitor trims expired members.
 
-#### Key: `asm:rl:{class}:{key}`
+#### Key: `{asm}:rl:{class}:{key}`
 
 **Type**: Redis HASH (`tokens`, `ts`), driven by an atomic Lua token-bucket script; self-expiring.
 
-**Purpose**: Layer-2 rate-limit buckets — `asm:rl:refresh:{session_id}` and `asm:rl:callback:{state}` (DESIGN section 4.4).
+**Purpose**: Layer-2 rate-limit buckets — `{asm}:rl:refresh:{session_id}` and `{asm}:rl:callback:{state}` (DESIGN section 4.4).
 
-#### Keys: `asm:leader:{worker}`, `asm:refresh_lock:{session_id}`
+#### Keys: `{asm}:leader:{worker}`, `{asm}:refresh_lock:{session_id}`
 
 **Type**: Redis STRING locks (`SET NX PX`).
 
@@ -931,7 +932,7 @@ service_tokens:
       roles: ["service"]      # baked into the token; "service" is always added
 ```
 
-Validation at boot: every registered entry must carry at least one key (inline or by path) -- each is parsed into a verifier, so a malformed or missing key fails the gear at boot, not on the first request -- and `audience` must be non-empty whenever `services` is non-empty, and `token_bind_addr` must differ from the main `bind_addr`. The assertion `jti` replay guard reuses the `logout_jti` `SET NX EX` pattern under `asm:svc_jti:{service}:{jti}` (see 3.7). Dev/compose seed a single `testclient` entry via `public_key_paths`; the keypair is **generated at bring-up** (like the gateway signing key) and never committed. No real registry entry ships in the chart by default.
+Validation at boot: every registered entry must carry at least one key (inline or by path) -- each is parsed into a verifier, so a malformed or missing key fails the gear at boot, not on the first request -- and `audience` must be non-empty whenever `services` is non-empty, and `token_bind_addr` must differ from the main `bind_addr`. The assertion `jti` replay guard reuses the `logout_jti` `SET NX EX` pattern under `{asm}:svc_jti:{service}:{jti}` (see 3.7). Dev/compose seed a single `testclient` entry via `public_key_paths`; the keypair is **generated at bring-up** (like the gateway signing key) and never committed. No real registry entry ships in the chart by default.
 
 ### 3.10 Gear Anatomy
 
@@ -962,11 +963,11 @@ A single helper sets every session cookie; attributes are hard-coded (`__Host-si
 
 ### 4.3 Janitor and Leader Election
 
-Background tasks (janitor, IdP refresher) run on every pod but elect one leader per pass via a Redis lock (TTL slightly longer than the interval) -- DD-BFF-09: no extra K8s objects, Redis is already a hard dependency, a missed pass costs little. The janitor trims `asm:login_state_live` and `asm:idp_refresh_due` -- both single, well-known keys, so the pass issues no keyspace `SCAN` (Redis Cluster has no cluster-wide cursor). Per-user session indexes need no pass: writers trim them inline and a guarded `EXPIREAT` bounds abandoned keys. Backlog metrics alert if no pod runs a pass for twice the interval.
+Background tasks (janitor, IdP refresher) run on every pod but elect one leader per pass via a Redis lock (TTL slightly longer than the interval) -- DD-BFF-09: no extra K8s objects, Redis is already a hard dependency, a missed pass costs little. The janitor trims `{asm}:login_state_live` and `{asm}:idp_refresh_due` -- both single, well-known keys, so the pass issues no keyspace `SCAN` (Redis Cluster has no cluster-wide cursor). Per-user session indexes need no pass: writers trim them inline and a guarded `EXPIREAT` bounds abandoned keys. Backlog metrics alert if no pod runs a pass for twice the interval.
 
 ### 4.4 Rate Limiting
 
-Two layers by design: the gateway carries the coarse per-IP flood guard (`limit_req`, order of 60 r/min with generous burst -- legitimate steady-state traffic is smooth by construction thanks to the big refresh jitter). The authenticator owns the precise layer: a Redis token bucket keyed by session/user, and the login-state cap (default 1000 live `asm:login_state:*` entries per pod, 429 beyond) that stops a slow-trickle Redis-exhaustion attack the edge cannot see. Both run before any expensive work and emit metrics.
+Two layers by design: the gateway carries the coarse per-IP flood guard (`limit_req`, order of 60 r/min with generous burst -- legitimate steady-state traffic is smooth by construction thanks to the big refresh jitter). The authenticator owns the precise layer: a Redis token bucket keyed by session/user, and the login-state cap (default 1000 live `{asm}:login_state:*` entries per pod, 429 beyond) that stops a slow-trickle Redis-exhaustion attack the edge cannot see. Both run before any expensive work and emit metrics.
 
 ### 4.5 Key Rotation
 
@@ -1006,7 +1007,7 @@ Decisions that predate this spec, recorded here with their original IDs (code an
 - **DD-BFF-02 -- Explicit session refresh, no sliding TTL**: only `POST /auth/refresh` extends the session; API traffic never does. Unchanged (TTL default now 600 s).
 - **DD-BFF-03 -- ZSET for the user-session index**: score = expiry makes listing and inline cleanup O(log N). Unchanged; members are now stable `session_id`s, so rotation no longer touches the index at all.
 - **DD-BFF-09 -- Workers coordinate via Redis lock**: one leader per pass, no extra K8s objects. Unchanged; now also covers the IdP refresher.
-- **DD-ROUTER-03 -- Redis-backed JWT storage (not in-memory)**: multi-pod correctness and single-DEL invalidation. Unchanged in spirit; the key is now `asm:jwt:{session_id}` with a login-time fill instead of `router:jwt_cache:{sid}` with a lazy fill.
+- **DD-ROUTER-03 -- Redis-backed JWT storage (not in-memory)**: multi-pod correctness and single-DEL invalidation. Unchanged in spirit; the key is now `{asm}:jwt:{session_id}` with a login-time fill instead of `router:jwt_cache:{sid}` with a lazy fill.
 - **DD-ROUTER-09 -- JWT storage size cap**: bounded by per-entry TTL plus Redis `allkeys-lru`; losing an entry only costs a re-sign. Unchanged.
 - **DD-ROUTER-10 -- Fill uses `SET ... NX EX`**: parallel reissues converge on one canonical JWT per session per window. Unchanged, applied to the reissue-ahead path.
 
@@ -1019,7 +1020,7 @@ Decisions that predate this spec, recorded here with their original IDs (code an
 
 ### DD-AUTH-01: JWT Minted at Login, Linked 1:1 to the Session
 
-**Decision**: The gateway JWT is created at `/auth/callback` in the same pipeline as the session, stored at `asm:jwt:{session_id}`, served as-is while under the reissue age, and reissued ahead of expiry.
+**Decision**: The gateway JWT is created at `/auth/callback` in the same pipeline as the session, stored at `{asm}:jwt:{session_id}`, served as-is while under the reissue age, and reissued ahead of expiry.
 
 **Why**:
 - The hot path becomes two Redis reads -- no signing, no claim rebuilding per request.
@@ -1030,7 +1031,7 @@ Decisions that predate this spec, recorded here with their original IDs (code an
 
 ### DD-AUTH-02: Session Identity / Credential Split
 
-**Decision**: Stable `session_id` (UUIDv7) as the universal server-side key and JWT `sid`; the cookie value is only an `asm:token:{token}` mapping. Rotation = write new mapping + let the old one expire after `grace_ms`. No `RENAME`, no ZSET member replacement, no sid-index churn, no dedicated swap/grace key family.
+**Decision**: Stable `session_id` (UUIDv7) as the universal server-side key and JWT `sid`; the cookie value is only an `{asm}:token:{token}` mapping. Rotation = write new mapping + let the old one expire after `grace_ms`. No `RENAME`, no ZSET member replacement, no sid-index churn, no dedicated swap/grace key family.
 
 **Why**:
 - Conflating cookie value = session id = Redis key = `sid` claim was the actual bug behind the earlier design's stale-`sid` problem and heavyweight rotation pipeline.
@@ -1041,7 +1042,7 @@ Decisions that predate this spec, recorded here with their original IDs (code an
 
 ### DD-AUTH-03: Background IdP Token Refresh
 
-**Decision**: Store the IdP refresh token at login; a leader-elected worker refreshes ahead of IdP expiry off the `asm:idp_refresh_due` schedule; `invalid_grant` kills all linked sessions; transport failures retry forever without killing anything; `no_refresh_token_policy` governs IdPs that issue no refresh token.
+**Decision**: Store the IdP refresh token at login; a leader-elected worker refreshes ahead of IdP expiry off the `{asm}:idp_refresh_due` schedule; `invalid_grant` kills all linked sessions; transport failures retry forever without killing anything; `no_refresh_token_policy` governs IdPs that issue no refresh token.
 
 **Why**:
 - A session must not outlive the IdP's willingness to vouch for the user; back-channel logout is optional in the wild, so the refresher is the guaranteed deactivation path.
@@ -1106,7 +1107,15 @@ Decisions that predate this spec, recorded here with their original IDs (code an
 
 **Why**: The gateway hardening made viewer identity exclusively gateway-authored (inbound `X-Insight-*` stripped), which correctly killed the old client-side override; the replacement must therefore act where identity is authored. All decision inputs are server-side (flag, login-state value, person store) — the parameter itself is never trusted as identity, so the spoofing hole stays closed. A per-user allowlist is deliberately absent: roles are `default_roles` until the permissions service exists, so the flag marks the whole *environment* (dev/demo) as impersonation-capable instead of pretending to per-user authorization we cannot yet enforce. Once DD-AUTH-07 lands, the gate can become a role check without changing the flow.
 
-**Consequences**: The session behaves as the target everywhere downstream (JWT `sub`, scope, session index) — that is the point. The record keeps `impersonator_*` fields and the real `idp_sub`/`idp_sid`/refresh token, so audit attribution, back-channel logout, and the background refresher keep targeting the real principal's IdP grant; the session is additionally indexed under the impersonator's `asm:user_sessions:*` (scored at the absolute cap — rotation only re-scores the target's index) so revoke-by-person against the real principal reaches it, and the real principal may list/revoke it as their own. `/auth/me` exposes `impersonator_email` for the SPA's "viewing as" banner. An unknown target is denied 403 (audited to the durable sink, not just the log), never silently ignored. Two accepted sharp edges, bounded by flag-on environments holding no real users: the Identity lookup is email-only (no tenant memberships until #1687), so a target from another tenant resolves and is paired with the caller's tenant claim; and compromise of any account grants impersonation of any known person. Both are why the default is `false` at every layer.
+**Consequences**: The session behaves as the target everywhere downstream (JWT `sub`, scope, session index) — that is the point. The record keeps `impersonator_*` fields and the real `idp_sub`/`idp_sid`/refresh token, so audit attribution, back-channel logout, and the background refresher keep targeting the real principal's IdP grant; the session is additionally indexed under the impersonator's `{asm}:user_sessions:*` (scored at the absolute cap — rotation only re-scores the target's index) so revoke-by-person against the real principal reaches it, and the real principal may list/revoke it as their own. `/auth/me` exposes `impersonator_email` for the SPA's "viewing as" banner. An unknown target is denied 403 (audited to the durable sink, not just the log), never silently ignored. Two accepted sharp edges, bounded by flag-on environments holding no real users: the Identity lookup is email-only (no tenant memberships until #1687), so a target from another tenant resolves and is paired with the caller's tenant claim; and compromise of any account grants impersonation of any known person. Both are why the default is `false` at every layer.
+
+### DD-AUTH-10: Single-Slot Session Keyspace (`{asm}:` Hash Tag)
+
+**Decision**: The session-management key prefix is the Redis Cluster hash tag itself: every key starts with `{asm}:`, so all session keys hash to one cluster slot.
+
+**Why**: The store's guarantees rest on multi-key atomics — the `MULTI/EXEC` create/revoke pipelines, the 4-key rotation CAS, and the guarded refresh store — and Redis Cluster only permits them within one slot. A shared tag preserves every one of them verbatim. Finer-grained tags cannot work here: the token→session lookup knows only the cookie token (no tag derivable), and the refresh schedule and login-state cap are deliberately global structures. Sharding is not the goal — auth traffic is orders of magnitude below one shard's capacity — cluster support is about HA and infra standardization, and a replica-backed slot preserves both.
+
+**Consequences**: All `{asm}:*` data lives on one shard, including the rate-limit buckets (single-key scripts that could shard; co-located for naming consistency, revisit only if that shard ever runs hot). On standalone Redis the braces are inert characters. The rename is deliberately not backward compatible: pre-rename keys are unreachable and age out via their TTLs; live sessions drop once at rollout and users re-login.
 
 ### RESOLVED (step 07): ES256 for the Gateway JWT
 

--- a/docs/components/backend/authenticator/PRD.md
+++ b/docs/components/backend/authenticator/PRD.md
@@ -256,12 +256,12 @@ The system **MUST NOT** extend the session on any other endpoint. A stale cookie
 
 The system **MUST**:
 
-1. **Persist sessions** -- record every active session server-side with all fields needed to validate, refresh, and revoke it (person, tenants, roles snapshot, IdP linkage, IdP refresh token and expiries, timestamps, hard cap, CSRF token). Key family `asm:session:{session_id}`.
-2. **Maintain the token-credential mapping** `asm:token:{token}` to `session_id`, TTL-bounded (see 5.2, 5.4).
-3. **Store the linked JWT** at `asm:jwt:{session_id}` (see 5.6).
-4. **Maintain a per-user session index** for "list my devices" and "log out everywhere" in sub-linear time. Key family `asm:user_sessions:{person_id}`.
-5. **Maintain an IdP-sid lookup** resolving `(iss, idp_sid)` from back-channel logout tokens to local sessions. Key family `asm:sid_index:*`.
-6. **Maintain the IdP refresh schedule** `asm:idp_refresh_due` so the background refresher can find sessions due for refresh without scanning (see 5.12).
+1. **Persist sessions** -- record every active session server-side with all fields needed to validate, refresh, and revoke it (person, tenants, roles snapshot, IdP linkage, IdP refresh token and expiries, timestamps, hard cap, CSRF token). Key family `{asm}:session:{session_id}`.
+2. **Maintain the token-credential mapping** `{asm}:token:{token}` to `session_id`, TTL-bounded (see 5.2, 5.4).
+3. **Store the linked JWT** at `{asm}:jwt:{session_id}` (see 5.6).
+4. **Maintain a per-user session index** for "list my devices" and "log out everywhere" in sub-linear time. Key family `{asm}:user_sessions:{person_id}`.
+5. **Maintain an IdP-sid lookup** resolving `(iss, idp_sid)` from back-channel logout tokens to local sessions. Key family `{asm}:sid_index:*`.
+6. **Maintain the IdP refresh schedule** `{asm}:idp_refresh_due` so the background refresher can find sessions due for refresh without scanning (see 5.12).
 7. **Make create / refresh / revoke atomic** -- session record, token mapping, linked JWT, and all indexes change in one pipeline; a partial failure **MUST NOT** leave them out of sync. Revocation deletes session **and** linked JWT together.
 8. **Run a periodic janitor** that trims expired entries from the indexes and emits a drift metric.
 
@@ -307,7 +307,7 @@ Session revoke/logout **MUST** delete the session and the linked JWT in one pipe
 
 The system **MUST** expose `GET /internal/authz` on the main listener as the gateway's `auth_request` target:
 
-1. Read the `__Host-sid` cookie, resolve `asm:token:{token}` to `session_id`, load the session; on miss return **401**.
+1. Read the `__Host-sid` cookie, resolve `{asm}:token:{token}` to `session_id`, load the session; on miss return **401**.
 2. On hit, read the linked JWT; serve it as-is while fresh, reissue ahead of expiry per 5.6.
 3. Respond `200` with the JWT in the `X-Gateway-Jwt` response header (`Bearer <jwt>`).
 4. A `200` response **MUST** carry `Cache-Control: max-age = min(authz_cache_max_age, jwt_exp - now - 60 s)` so the gateway-side exchange cache can never serve a JWT past its travel margin. Any non-200 response **MUST** carry `Cache-Control: no-store` -- a cached 401 would lock out a user who just logged in.
@@ -362,7 +362,7 @@ The admin surface (revoke by user) **MUST** itself require a valid gateway JWT w
 
 The system **MUST** provide `POST /auth/logout` that revokes the current session, clears the cookie (`Max-Age=0`), and redirects (or returns a redirect URL) to the OIDC `end_session_endpoint` for RP-initiated logout.
 
-The system **MUST** accept OIDC back-channel logout tokens at a dedicated endpoint, validate the `logout_token` per spec, locate sessions by `(iss, sid)` (via the sid index) or `(iss, sub)` (via the sub index `asm:sub_index:*`, maintained at login — Identity cannot resolve a `sub` without an email, and the logout path must not depend on another service), and revoke them.
+The system **MUST** accept OIDC back-channel logout tokens at a dedicated endpoint, validate the `logout_token` per spec, locate sessions by `(iss, sid)` (via the sid index) or `(iss, sub)` (via the sub index `{asm}:sub_index:*`, maintained at login — Identity cannot resolve a `sub` without an email, and the logout path must not depend on another service), and revoke them.
 
 The system **MUST** protect the back-channel endpoint against replay: every accepted `logout_token` **MUST** be recorded by `(iss, jti)` with a TTL of at least `iat + max_clock_skew`, and any subsequent delivery of the same `(iss, jti)` **MUST** short-circuit to a successful response without performing another revoke.
 
@@ -399,7 +399,7 @@ The session must not outlive the IdP's willingness to vouch for the user. Theref
 
 1. At login the system **MUST** store the IdP **refresh token** (and access-token expiry) in the session record, alongside the `id_token`.
 2. A **background worker** (one leader elected via Redis lock) **MUST** refresh each session's IdP tokens `authenticator.idp.refresh_safety_margin_seconds` before expiry and store the rotated refresh token back. A per-session lock **MUST** guard each refresh: most IdPs rotate refresh tokens one-time-use, and two pods racing the same rotation would burn the grant and falsely kill the session.
-3. The worker **MUST** find due sessions via the `asm:idp_refresh_due` schedule (no scanning), with due-times jittered at write so sessions do not herd after a deploy or Redis restore. In-flight refreshes are capped by `authenticator.idp.refresh_concurrency` (default 128) -- politeness toward the customer IdP; IdP `429` is handled as transient honoring `Retry-After`.
+3. The worker **MUST** find due sessions via the `{asm}:idp_refresh_due` schedule (no scanning), with due-times jittered at write so sessions do not herd after a deploy or Redis restore. In-flight refreshes are capped by `authenticator.idp.refresh_concurrency` (default 128) -- politeness toward the customer IdP; IdP `429` is handled as transient honoring `Retry-After`.
 4. **Definitive refusal** (`invalid_grant`: revoked, expired, user disabled) **MUST** kill every session linked to that grant through the same revoke pipeline as logout. **Transient failures** (IdP unreachable, timeout, 5xx) **MUST NOT** kill sessions: retry with backoff until success or a definitive verdict. Fail open on transport, fail closed on verdict.
 5. When the IdP issues no refresh token, `authenticator.idp.no_refresh_token_policy` applies: `strict` (default) caps the session at the IdP access-token lifetime; `login_only` lets sessions live to the absolute cap, killed only by back-channel logout or manual revoke.
 6. The system **MUST** emit metrics for refresh outcomes, a consecutive-transient-failure gauge, and an `invalid_grant` counter -- alert before the mass logout, not after.
@@ -519,7 +519,7 @@ Every login, logout, session refresh, session revocation, back-channel logout, I
 
 - [x] `p1` - **ID**: `cpt-insightspec-nfr-auth-rate-limit`
 
-The gateway carries a coarse per-IP flood guard (layer 1). The authenticator **MUST** enforce the precise layer: a Redis token bucket keyed by session/user (not IP -- corporate NAT makes per-IP limits at the precise layer wrong), and a global cap on concurrent live `asm:login_state:*` entries (default 1000 per pod) rejecting excess `/auth/login` with 429 before any Redis write.
+The gateway carries a coarse per-IP flood guard (layer 1). The authenticator **MUST** enforce the precise layer: a Redis token bucket keyed by session/user (not IP -- corporate NAT makes per-IP limits at the precise layer wrong), and a global cap on concurrent live `{asm}:login_state:*` entries (default 1000 per pod) rejecting excess `/auth/login` with 429 before any Redis write.
 
 **Threshold**: under a sustained login flood, login-state entries stay at or below the cap and CPU is bounded.
 
@@ -706,7 +706,7 @@ All endpoints are registered through the toolkit operation builder and land in t
 **Preconditions**: User disabled/revoked at the IdP; linked session still live; IdP has no back-channel logout.
 
 **Main Flow**:
-1. The refresher leader pops the session from `asm:idp_refresh_due`.
+1. The refresher leader pops the session from `{asm}:idp_refresh_due`.
 2. Refresh attempt returns `invalid_grant` (definitive).
 3. Every session linked to that grant is revoked through the standard pipeline.
 

--- a/src/backend/services/authenticator/src/config.rs
+++ b/src/backend/services/authenticator/src/config.rs
@@ -186,7 +186,7 @@ impl Default for AuditConfig {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct RateLimitConfig {
-    /// Cap on concurrent live `asm:login_state:*` entries; excess
+    /// Cap on concurrent live `{asm}:login_state:*` entries; excess
     /// `/auth/login` gets 429 before any state is written (stops a
     /// slow-trickle Redis-exhaustion attack the edge cannot see).
     pub login_state_max: u64,

--- a/src/backend/services/authenticator/src/janitor.rs
+++ b/src/backend/services/authenticator/src/janitor.rs
@@ -16,7 +16,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::api::AppState;
 
-const LEADER_KEY: &str = "asm:leader:janitor";
+const LEADER_KEY: &str = "{asm}:leader:janitor";
 /// A refresh-schedule entry still due after this long has no live owner (the
 /// refresher reschedules live sessions every attempt).
 const ORPHAN_GRACE_SECONDS: u64 = 600;

--- a/src/backend/services/authenticator/src/ratelimit.rs
+++ b/src/backend/services/authenticator/src/ratelimit.rs
@@ -9,7 +9,7 @@
 //!   precise layer.
 //! - a **global live login-state cap** for `/auth/login`: pre-auth there is
 //!   no per-caller key, so the guarded resource is the store itself —
-//!   `asm:login_state_live` (ZSET, score = expiry) counts live entries and
+//!   `{asm}:login_state_live` (ZSET, score = expiry) counts live entries and
 //!   excess logins get 429 before any state is written, stopping a
 //!   slow-trickle Redis-exhaustion attack the edge cannot see.
 
@@ -70,7 +70,7 @@ impl BucketSpec {
     }
 }
 
-/// Take one token from `asm:rl:{class}:{key-digest}`. `Ok(true)` = allowed.
+/// Take one token from `{asm}:rl:{class}:{key-digest}`. `Ok(true)` = allowed.
 /// A zero/absent spec (burst 0) disables the bucket (always allowed).
 ///
 /// The key component is SHA-256-hashed (hex) before use, so an attacker-chosen
@@ -95,7 +95,7 @@ pub async fn take(
     let mut conn = conn.clone();
     let script = redis::Script::new(TOKEN_BUCKET_LUA);
     let allowed: i64 = script
-        .key(format!("asm:rl:{class}:{key_hex}"))
+        .key(format!("{{asm}}:rl:{class}:{key_hex}"))
         .arg(spec.burst)
         .arg(spec.refill_per_second())
         .arg(now)

--- a/src/backend/services/authenticator/src/refresher.rs
+++ b/src/backend/services/authenticator/src/refresher.rs
@@ -1,6 +1,6 @@
 //! IdP background token refresher (PRD 5.12, G5 — the decided design).
 //!
-//! One leader (Redis lock, DD-BFF-09) polls the `asm:idp_refresh_due` ZSET
+//! One leader (Redis lock, DD-BFF-09) polls the `{asm}:idp_refresh_due` ZSET
 //! every tick and spawns per-session refresh tasks behind a semaphore
 //! (`idp.refresh_concurrency` — politeness toward the customer IdP, not our
 //! capacity). Each task takes a per-session lock (refresh tokens are
@@ -34,7 +34,7 @@ use crate::api::AppState;
 use crate::oidc::RefreshOutcome;
 use crate::session::SessionManager;
 
-const LEADER_KEY: &str = "asm:leader:idp_refresher";
+const LEADER_KEY: &str = "{asm}:leader:idp_refresher";
 /// Per-session lock TTL — covers one grant round-trip with generous margin.
 const SESSION_LOCK_TTL_MS: u64 = 30_000;
 /// Wall-clock cap on the whole lock-holding critical section (grant + store

--- a/src/backend/services/authenticator/src/session.rs
+++ b/src/backend/services/authenticator/src/session.rs
@@ -1,5 +1,5 @@
 //! Session Manager — the single owner of session state in Redis (DESIGN §3.2,
-//! §3.7). All keys carry the `asm:` prefix (authenticator session management).
+//! §3.7). All keys carry the `{asm}:` prefix (authenticator session management).
 //!
 //! Multi-key writes go through `MULTI/EXEC` pipelines so a session and its
 //! linked JWT, indexes, and refresh schedule stay consistent. The store fails
@@ -28,7 +28,7 @@ pub struct LoginState {
 }
 
 impl LoginState {
-    /// The HASH fields for `asm:login_state:{state}`.
+    /// The HASH fields for `{asm}:login_state:{state}`.
     fn to_fields(&self) -> Vec<(&'static str, String)> {
         vec![
             ("pkce_verifier", self.pkce_verifier.clone()),
@@ -50,7 +50,7 @@ impl LoginState {
     }
 }
 
-/// A session record — the `asm:session:{session_id}` HASH (DESIGN §3.7).
+/// A session record — the `{asm}:session:{session_id}` HASH (DESIGN §3.7).
 #[derive(Debug, Clone)]
 pub struct SessionRecord {
     pub person_id: String,
@@ -81,7 +81,7 @@ pub struct SessionRecord {
 }
 
 impl SessionRecord {
-    /// The HASH fields for `asm:session:{session_id}` (DESIGN §3.7). `Vec`
+    /// The HASH fields for `{asm}:session:{session_id}` (DESIGN §3.7). `Vec`
     /// arrays serialize as JSON; optional fields store `""` when absent.
     fn to_fields(&self) -> Vec<(&'static str, String)> {
         let json = |v: &[String]| serde_json::to_string(v).unwrap_or_else(|_| "[]".to_owned());
@@ -169,36 +169,36 @@ pub struct NewSession {
 }
 
 fn session_key(session_id: &str) -> String {
-    format!("asm:session:{session_id}")
+    format!("{{asm}}:session:{session_id}")
 }
 fn token_key(token: &str) -> String {
-    format!("asm:token:{token}")
+    format!("{{asm}}:token:{token}")
 }
 fn jwt_key(session_id: &str) -> String {
-    format!("asm:jwt:{session_id}")
+    format!("{{asm}}:jwt:{session_id}")
 }
 fn user_sessions_key(person_id: &str) -> String {
-    format!("asm:user_sessions:{person_id}")
+    format!("{{asm}}:user_sessions:{person_id}")
 }
 fn sid_index_key(iss: &str, idp_sid: &str) -> String {
-    format!("asm:sid_index:{iss}:{idp_sid}")
+    format!("{{asm}}:sid_index:{iss}:{idp_sid}")
 }
 fn sub_index_key(iss: &str, idp_sub: &str) -> String {
-    format!("asm:sub_index:{iss}:{idp_sub}")
+    format!("{{asm}}:sub_index:{iss}:{idp_sub}")
 }
 fn logout_jti_key(iss: &str, jti: &str) -> String {
-    format!("asm:logout_jti:{iss}:{jti}")
+    format!("{{asm}}:logout_jti:{iss}:{jti}")
 }
 fn login_state_key(state: &str) -> String {
-    format!("asm:login_state:{state}")
+    format!("{{asm}}:login_state:{state}")
 }
 /// Live login-state index (ZSET, score = expiry) backing the layer-2 cap:
-/// counting `asm:login_state:*` cheaply requires an index, not SCAN-per-login.
-const LOGIN_STATE_LIVE_KEY: &str = "asm:login_state_live";
+/// counting `{asm}:login_state:*` cheaply requires an index, not SCAN-per-login.
+const LOGIN_STATE_LIVE_KEY: &str = "{asm}:login_state_live";
 fn service_jti_key(service: &str, jti: &str) -> String {
-    format!("asm:svc_jti:{service}:{jti}")
+    format!("{{asm}}:svc_jti:{service}:{jti}")
 }
-const REFRESH_DUE_KEY: &str = "asm:idp_refresh_due";
+const REFRESH_DUE_KEY: &str = "{asm}:idp_refresh_due";
 
 /// The Session Manager. Cheap to clone (the connection manager is `Arc`-backed).
 #[derive(Clone)]
@@ -342,7 +342,7 @@ impl SessionManager {
     // ── Service-token assertion replay guard ───────────────────────────────
 
     /// One-shot replay guard for an RFC 7523 client assertion `jti`
-    /// (`asm:svc_jti:{service}:{jti}`), mirroring the back-channel `logout_jti`
+    /// (`{asm}:svc_jti:{service}:{jti}`), mirroring the back-channel `logout_jti`
     /// pattern: `SET NX EX`. Returns `true` when this `jti` was seen for the
     /// first time (the caller may proceed), `false` when it is a replay.
     ///
@@ -649,7 +649,7 @@ impl SessionManager {
         Ok(led == 1)
     }
 
-    /// Sessions due for IdP refresh (`ZRANGEBYSCORE asm:idp_refresh_due 0 now`,
+    /// Sessions due for IdP refresh (`ZRANGEBYSCORE {asm}:idp_refresh_due 0 now`,
     /// bounded).
     ///
     /// # Errors
@@ -690,7 +690,7 @@ impl SessionManager {
         let mut conn = self.conn.clone();
         let token = uuid::Uuid::now_v7().to_string();
         let set: Option<String> = redis::cmd("SET")
-            .arg(format!("asm:refresh_lock:{session_id}"))
+            .arg(format!("{{asm}}:refresh_lock:{session_id}"))
             .arg(&token)
             .arg("NX")
             .arg("PX")
@@ -721,7 +721,7 @@ impl SessionManager {
         ";
         let mut conn = self.conn.clone();
         let _: i64 = redis::Script::new(UNLOCK)
-            .key(format!("asm:refresh_lock:{session_id}"))
+            .key(format!("{{asm}}:refresh_lock:{session_id}"))
             .arg(owner_token)
             .invoke_async(&mut conn)
             .await
@@ -884,7 +884,7 @@ impl SessionManager {
     // ── Back-channel logout (PRD 5.10) ─────────────────────────────────────
 
     /// One-shot replay guard for a back-channel `logout_token` `jti`
-    /// (`asm:logout_jti:{iss}:{jti}`, `SET NX EX`). Returns `true` on first
+    /// (`{asm}:logout_jti:{iss}:{jti}`, `SET NX EX`). Returns `true` on first
     /// delivery; `false` when this `(iss, jti)` was already accepted.
     ///
     /// # Errors

--- a/src/backend/services/authenticator/tests/e2e_override.rs
+++ b/src/backend/services/authenticator/tests/e2e_override.rs
@@ -191,7 +191,7 @@ async fn csrf_token(http: &common::Client, auth_base: &str, token: &str) -> Stri
 /// Login with one override, log out, log in with ANOTHER override: no state
 /// from the first view-as session may leak into the second. Every layer keys
 /// on values that change across logins — the cookie token, the `session_id`,
-/// and the linked `asm:jwt:{session_id}` are all minted fresh, and the nginx
+/// and the linked `{asm}:jwt:{session_id}` are all minted fresh, and the nginx
 /// exchange cache (not in this stack) is keyed by the cookie value, so a new
 /// cookie can never hit the old entry. This test pins the authenticator side:
 /// the old credential is fully dead and the new session is the new target.


### PR DESCRIPTION
## Summary

Second step of Redis cluster preparation (after #2139). The `asm:` key prefix becomes `{asm}:` — the prefix itself is now the Redis Cluster hash tag, so every session-management key hashes to one slot. Verified with `CLUSTER KEYSLOT`: all key families (sessions, token mappings, JWTs, user/sid/sub indexes, refresh schedule, login-state, rate-limit buckets, leader locks) land on the same slot; the old untagged form does not.

**Why one shared tag:** the store's guarantees rest on multi-key atomics — the `MULTI/EXEC` create/revoke pipelines, the 4-key rotation CAS (`ROTATE_LUA`), and the guarded refresh store (`STORE_LUA`) — and Redis Cluster only permits those within one slot. The shared tag preserves all of them verbatim, with zero logic change. Finer-grained tags cannot work: the token→session lookup knows only the cookie token (no tag derivable from it), and the refresh schedule / login-state cap are deliberately global structures. Sharding is not the goal — cluster support is about HA, and a replica-backed slot preserves it.

Recorded as **DD-AUTH-10** in DESIGN.md; the §3.7 key schema and PRD references are updated throughout.

## Compatibility

Deliberately **not** backward compatible (agreed upfront): pre-rename keys are unreachable to the new build and age out via their TTLs; live sessions drop once at rollout and users re-login. On standalone Redis the braces are inert characters — this ships and runs fine before any cluster code exists.

## Validation

- `cargo clippy --all-targets` clean; unit tests pass
- Authenticator e2e (`tests/run-e2e.sh`, live Redis + binaries): 9/9 suites passed on the renamed keyspace
- `CLUSTER KEYSLOT` spot-check on a cluster-enabled Redis 7: all `{asm}:*` shapes → one slot
- `cfs validate` green on DESIGN.md and PRD.md

## Remaining for cluster mode

Connection wrapper (`RedisConn` standalone/cluster enum + `cluster-async` feature + config/chart plumbing) and a cluster e2e rig — next PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated authenticator documentation and diagrams to reflect the standardized `{asm}:` Redis key namespace.
  - Documented Redis Cluster key-slot requirements, atomic-operation considerations, and compatibility implications.

- **Bug Fixes**
  - Updated session, token, rate-limit, refresh, scheduling, and leader-election keys to consistently use the hash-tagged namespace.
  - Aligned related configuration and test documentation with the new key format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->