### PR TITLE
Add daily Dependabot entries for cargo and pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,74 @@ updates:
     groups:
       base-images:
         patterns: ["*"]
+
+  # Language ecosystems below run daily, staggered by 30 minutes so the checks
+  # (and any resulting CI runs) do not all land at once. Times are UTC.
+  # One entry per language/service; majors stay as individual PRs, minor+patch
+  # are grouped per entry.
+  - package-ecosystem: cargo
+    directory: /src/backend
+    schedule:
+      interval: daily
+      time: "02:00"
+      timezone: Etc/UTC
+    cooldown:
+      default-days: 7
+    groups:
+      rust-minor-patch:
+        patterns: ["*"]
+        update-types: [minor, patch]
+
+  - package-ecosystem: pip
+    directory: /deploy/seed
+    schedule:
+      interval: daily
+      time: "02:30"
+      timezone: Etc/UTC
+    cooldown:
+      default-days: 7
+    groups:
+      seed-minor-patch:
+        patterns: ["*"]
+        update-types: [minor, patch]
+
+  # One manifest per connector; grouping applies per directory, so each
+  # connector still gets its own PR.
+  - package-ecosystem: pip
+    directories: ["/src/ingestion/connectors/*/*"]
+    schedule:
+      interval: daily
+      time: "03:00"
+      timezone: Etc/UTC
+    cooldown:
+      default-days: 7
+    groups:
+      connector-minor-patch:
+        patterns: ["*"]
+        update-types: [minor, patch]
+
+  - package-ecosystem: pip
+    directory: /src/ingestion/scripts
+    schedule:
+      interval: daily
+      time: "03:30"
+      timezone: Etc/UTC
+    cooldown:
+      default-days: 7
+    groups:
+      scripts-minor-patch:
+        patterns: ["*"]
+        update-types: [minor, patch]
+
+  - package-ecosystem: pip
+    directories: ["/src/ingestion/tests/connectors", "/src/ingestion/tests/e2e"]
+    schedule:
+      interval: daily
+      time: "04:00"
+      timezone: Etc/UTC
+    cooldown:
+      default-days: 7
+    groups:
+      tests-minor-patch:
+        patterns: ["*"]
+        update-types: [minor, patch]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,15 +35,15 @@ updates:
       base-images:
         patterns: ["*"]
 
-  # Language ecosystems below run daily, staggered by 30 minutes so the checks
-  # (and any resulting CI runs) do not all land at once. Times are UTC.
+  # Language ecosystems below run daily from 21:00 UTC onward, staggered by
+  # 30 minutes so the checks (and any resulting CI runs) do not all land at once.
   # One entry per language/service; majors stay as individual PRs, minor+patch
   # are grouped per entry.
   - package-ecosystem: cargo
     directory: /src/backend
     schedule:
       interval: daily
-      time: "02:00"
+      time: "21:00"
       timezone: Etc/UTC
     cooldown:
       default-days: 7
@@ -56,7 +56,7 @@ updates:
     directory: /deploy/seed
     schedule:
       interval: daily
-      time: "02:30"
+      time: "21:30"
       timezone: Etc/UTC
     cooldown:
       default-days: 7
@@ -71,7 +71,7 @@ updates:
     directories: ["/src/ingestion/connectors/*/*"]
     schedule:
       interval: daily
-      time: "03:00"
+      time: "22:00"
       timezone: Etc/UTC
     cooldown:
       default-days: 7
@@ -84,7 +84,7 @@ updates:
     directory: /src/ingestion/scripts
     schedule:
       interval: daily
-      time: "03:30"
+      time: "22:30"
       timezone: Etc/UTC
     cooldown:
       default-days: 7
@@ -97,7 +97,7 @@ updates:
     directories: ["/src/ingestion/tests/connectors", "/src/ingestion/tests/e2e"]
     schedule:
       interval: daily
-      time: "04:00"
+      time: "23:00"
       timezone: Etc/UTC
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,10 +35,6 @@ updates:
       base-images:
         patterns: ["*"]
 
-  # Language ecosystems below run daily from 21:00 UTC onward, staggered by
-  # 30 minutes so the checks (and any resulting CI runs) do not all land at once.
-  # One entry per language/service; majors stay as individual PRs, minor+patch
-  # are grouped per entry.
   - package-ecosystem: cargo
     directory: /src/backend
     schedule:
@@ -65,8 +61,6 @@ updates:
         patterns: ["*"]
         update-types: [minor, patch]
 
-  # One manifest per connector; grouping applies per directory, so each
-  # connector still gets its own PR.
   - package-ecosystem: pip
     directories: ["/src/ingestion/connectors/*/*"]
     schedule:


### PR DESCRIPTION
Closes #2034 (cargo + pip scope; github-actions and docker were added earlier).

## What
Extends `.github/dependabot.yml` with the remaining ecosystems, one entry per language/service, checked **daily** and staggered 30 minutes apart so the checks (and any resulting CI) do not all land at once:

| Time (UTC) | Ecosystem | Directory |
|---|---|---|
| 21:00 | cargo | `/src/backend` (single workspace `Cargo.lock`) |
| 21:30 | pip | `/deploy/seed` |
| 22:00 | pip | `/src/ingestion/connectors/*/*` (glob — per-connector PRs) |
| 22:30 | pip | `/src/ingestion/scripts` |
| 23:00 | pip | `/src/ingestion/tests/connectors`, `/src/ingestion/tests/e2e` |

## Notes
- Minor+patch bumps are grouped into one PR per entry (per directory for the globbed connectors); majors arrive as individual PRs.
- `cooldown: 7 days` matches the existing actions/docker entries, so daily checks don't pick up hours-old releases.
- The connector glob covers all 8 current connectors and any future ones without enumeration, as suggested in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)