### PR TITLE
feat(metrics): declarative YAML metric registry (#1974)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -761,10 +761,9 @@ services:
       # tracks the calendar. Both are recorded in the emitted manifest.
       SEED_ANCHOR_DATE: "${SEED_ANCHOR_DATE:-}"
       SEED_DAYS: "${SEED_DAYS:-60}"
-      # Which IdP the stand is running, and the issuer the authenticator
-      # resolved for this run. `test-stand up` persists both after cmd_up so
-      # the manifest records the real IdP instead of assuming the default.
-      AUTH_MODE: "${AUTH_MODE:-fakeidp}"
+      # The issuer the authenticator resolved for this run. `test-stand up`
+      # persists it (with AUTH_MODE, set above) after cmd_up so the manifest
+      # records the real IdP instead of assuming the default.
       AUTHENTICATOR_OIDC_ISSUER: "${AUTHENTICATOR_OIDC_ISSUER:-}"
     volumes:
       # Bind-mount the source so seed.py edits don't need a rebuild.

--- a/docs/domain/metrics/specs/DESIGN.md
+++ b/docs/domain/metrics/specs/DESIGN.md
@@ -354,10 +354,16 @@ Rules:
 
 ## Builtin Seed Reconciliation
 
-Builtin definitions are declared in one code registry
-(`src/backend/services/analytics/src/domain/metric_definitions/builtin.rs`)
-and converged into the DB by a startup reconciler, not by migrations.
-Migrations own schema only.
+Builtin definitions are declared in one declarative registry
+(`src/backend/services/analytics/src/domain/metric_definitions/registry.yaml`:
+one `sources` list and one `metrics` list) and converged into the DB by a
+startup reconciler, not by migrations. Migrations own schema only. The registry
+is embedded at build time (`include_str!`) and deserialized once into the seed
+types in `builtin.rs`; the reconciler reads it through `builtin_sources()` /
+`builtin_metrics()`. Registry invariants (key shape and uniqueness,
+input/measure references, computation field combinations, presentation-complete
+formats) are pinned by the `builtin.rs` tests, which parse the same embedded
+registry — a malformed or drifted registry fails the build.
 
 Rules:
 
@@ -588,14 +594,14 @@ one that applies.
 ### Case 1: metric over an existing measure
 
 The measure already appears in a managed source. Check the source's `measures`
-list in `builtin.rs`, the emitting evidence model, and the observation model
+list in `registry.yaml`, the emitting evidence model, and the observation model
 derived from it.
 
-1. Add one `MetricSeed` to `BUILTIN_METRICS` in
-   `src/backend/services/analytics/src/domain/metric_definitions/builtin.rs`:
+1. Add one entry to the `metrics` list in
+   `src/backend/services/analytics/src/domain/metric_definitions/registry.yaml`:
    metric key (`namespace.metric_name`, lowercase snake case), label,
-   description, unit, format, direction, entity type, computation type,
-   input role mapping to the measure, allowed dimensions, peer cohort key.
+   description, unit, format, direction, entity type, computation, input role
+   mapping to the measure, allowed dimensions, peer cohort key.
 2. Run `cargo test -p analytics` — the registry invariant tests validate
    key shapes, input/measure references, and computation field combinations.
 
@@ -627,12 +633,12 @@ The source exists but does not emit the measure yet.
    the population that explains it.
 4. Add the `measure_key` to the observation model's `schema.yml`
    `accepted_values` test.
-5. Add the measure key to the source's `measures` list in `builtin.rs` and
+5. Add the measure key to the source's `measures` list in `registry.yaml` and
    classify its evidence granularity.
 6. Add or reuse a source-measure presentation rule when the default
    date-plus-value table is insufficient. Declare detail keys there and add
    explicit column metadata only for fields that are not humanized strings.
-7. Add the `MetricSeed` as in case 1.
+7. Add the metric entry as in case 1.
 8. Validate: `dbt parse` + `cargo test -p analytics` (see Validation
    commands).
 
@@ -648,14 +654,15 @@ The metric family reads data no managed source covers.
    the evidence contract; the observation model derives the aggregate-ready
    observation contract from it. Document both in
    `src/ingestion/gold/schema.yml`.
-2. Add a `BuiltinSource` (source + measures + dimensions) to `builtin.rs`,
-   with `source_ref` and `evidence_ref` set to their relation names and every
-   measure assigned an evidence granularity. No backend enum or table-name
-   code changes are required: relation names are validated data and both
-   contracts are probed by the runtime schema validator.
+2. Add a source entry (source + measures + dimensions) to the `sources` list
+   in `registry.yaml`, with `source_ref` and `evidence_ref` set to their
+   relation names and every measure assigned an evidence granularity. No
+   backend enum or table-name code changes are required: relation names are
+   validated data and both contracts are probed by the runtime schema
+   validator.
 3. Add source-measure presentation rules for event shapes that need
    human-facing detail columns.
-4. Add `MetricSeed`s as in case 1.
+4. Add metric entries as in case 1.
 5. Validate: `dbt parse` + `cargo test -p analytics` (see Validation
    commands). The runtime schema validator probes the new relation at
    startup.

--- a/docs/domain/presentation-layer/specs/DESIGN.md
+++ b/docs/domain/presentation-layer/specs/DESIGN.md
@@ -22,7 +22,7 @@
   - [4.1 Implementation Plan](#41-implementation-plan)
   - [4.2 Promotion Ladder (FE)](#42-promotion-ladder-fe)
   - [4.3 Open Decisions](#43-open-decisions)
-  - [4.4 Out of Scope (Phase B)](#44-out-of-scope-phase-b)
+  - [4.4 Phase B and Out of Scope](#44-phase-b-and-out-of-scope)
 - [5. Traceability](#5-traceability)
 
 <!-- /toc -->
@@ -58,6 +58,7 @@ Requirements that significantly influence architecture decisions.
 | `cpt-presentation-fr-query-console` | Single stable FE app on the saved-query API: author, list, run, render table / auto-chart. Shipped (#1970) |
 | `cpt-presentation-fr-preview-envs` | Path-based `/exp/<name>` on one host, one shared read-only backend, FE-only variation. Per-experiment bundle (`Deployment` + `Service` + one prefix-strip `Ingress`) shipped as the `insight-preview` chart at `deploy/preview/`, applied by hand (#1971). Experiments are a capability gated off on production by default (`cpt-presentation-constraint-experiments-off-prod`, #1973). Shipped |
 | `cpt-presentation-fr-preview-auth` | Single fixed callback with a Redis-backed opaque `state` return path (already stashing `state -> { return_to, pkce_verifier, nonce }`, delete-on-read), extended so `return_to` is validated at store time against a configurable `/exp/` prefix. Shipped (#1972) |
+| `cpt-presentation-fr-metric-registry` | Single declarative `registry.yaml` (a `sources` list and a `metrics` list) embedded at build time and reconciled into the service DB at boot; replaces the code-literal seed with no change to reconcile semantics; invariants pinned by tests that parse the same registry. Shipped (#1974) |
 
 #### NFR Allocation
 
@@ -400,6 +401,32 @@ Serves many experimental FE builds under one host against one shared read-only b
 
 ---
 
+#### Metric Registry
+
+- [x] `p3` - **ID**: `cpt-presentation-component-metric-registry`
+
+##### Why this component exists
+
+Collapses the metric-definition seed into one declarative artifact so a metric can be added or changed without editing Rust, and so Phase B (semantic compiler, passports) has a single source of truth to build on. Shipped (#1974). The detailed metric contract is governed by the metrics DESIGN (`docs/domain/metrics/specs/DESIGN.md`).
+
+##### Responsibility scope
+
+- `registry.yaml` (`domain/metric_definitions/`): one `sources` list and one `metrics` list, embedded at build time (`include_str!`) and deserialized once into the seed types in `builtin.rs`, exposed as `builtin_sources()` / `builtin_metrics()`.
+- The startup reconciler converges the registry into the service DB (`metric_definitions` and its source/measure/dimension/input tables) idempotently: additive upserts plus disable-missing for builtins dropped from the registry; tenant-owned rows untouched. Unchanged from the prior code-literal seed except its source.
+- Registry invariants (key shape and uniqueness, input/measure references, computation field combinations, presentation-complete formats carry no unit) are pinned by tests that parse the same embedded registry, so a malformed or drifted registry fails the build.
+
+##### Responsibility boundaries
+
+- Does NOT define or drive the legacy `metric_catalog`/`metric_threshold` subsystem — that orphaned, frozen path is untouched; its retirement is tracked separately.
+- Does NOT add the semantic raw-to-derived compiler, metric passports, or the drift test — those are later Phase B sub-issues (#1975, #1976).
+- Does NOT change reconcile semantics or the metric-result runtime.
+
+##### Related components (by ID)
+
+- `cpt-presentation-component-metric-compiler` — consumes the reconciled definitions
+
+---
+
 ### 3.3 API Contracts
 
 - [x] `p2` - **ID**: `cpt-presentation-interface-saved-query-endpoints`
@@ -580,9 +607,11 @@ Tiers 1-2 need no deploy — the unit of change is a query row. Tier 3 is the pr
 2. **CI-automated preview provisioning** — whether/when a CI job automates provisioning (best after the nginx-to-Envoy move), and whether tier-3 experiments live on branches of the real FE repo or a prototype repo.
 3. **Read-only on v1** — confirm the presentation layer is strictly read-only for v1 (write-back out of scope).
 
-### 4.4 Out of Scope (Phase B)
+### 4.4 Phase B and Out of Scope
 
-Declarative metric registry (collapse `builtin.rs` + MariaDB `metrics` + FE thresholds into one YAML catalog with passports and a drift test); semantic raw-to-derived compiler; FE metric rework (catalog-driven thresholds, honest NULL-to-ComingSoon). Named here so Phase A does not encode choices that block them.
+The declarative metric registry (`cpt-presentation-component-metric-registry`, #1974) lands as the first Phase B step: one YAML is the source of truth for the sanctioned metric-definition seed. The former "FE thresholds" collapse is already done — the FE renders from the `metric_definitions` catalog API and live peer percentiles, holding no per-metric thresholds.
+
+Still out of scope: metric passports plus their drift test (#1975); the semantic raw-to-derived compiler (#1976); FE metric rework (#1977-#1978). Also deferred: retirement of the orphaned, frozen legacy `metric_catalog`/`metric_threshold` subsystem — no live consumer reads it, so it is left untouched and its removal is tracked separately rather than perpetuated in the new registry.
 
 ## 5. Traceability
 

--- a/docs/domain/presentation-layer/specs/PRD.md
+++ b/docs/domain/presentation-layer/specs/PRD.md
@@ -21,6 +21,7 @@
   - [5.3 Tenant Isolation (p1)](#53-tenant-isolation-p1)
   - [5.4 Contract Stability (p2)](#54-contract-stability-p2)
   - [5.5 FE Loop (p2)](#55-fe-loop-p2)
+  - [5.6 Metric Registry (p3)](#56-metric-registry-p3)
 - [6. Non-Functional Requirements](#6-non-functional-requirements)
   - [6.1 NFR Inclusions](#61-nfr-inclusions)
   - [6.2 NFR Exclusions](#62-nfr-exclusions)
@@ -134,10 +135,12 @@ Phase A draws the contract and makes it safe by construction, so a new analytics
 - Server-injected flat tenant filter replacing the no-op on every contract read.
 - Contract surface documentation and a contract version stamp.
 - A stable query console (FE) and path-based preview environments with an authenticated return path.
+- Declarative metric registry: a single YAML as the source of truth for the sanctioned metric-definition seed (Phase B, #1974).
 
 ### 4.2 Out of Scope
 
-- Declarative metric registry, semantic raw-to-derived compiler, and FE metric rework (Phase B, #1974-#1978).
+- Semantic raw-to-derived compiler, metric passports plus their drift test, and FE metric rework (Phase B, #1975-#1978).
+- Retirement of the orphaned legacy `metric_catalog`/`metric_threshold` subsystem (frozen, no live consumer; tracked separately).
 - Tenant subtree/hierarchy scoping and a row-policy backstop (deferred pending benchmark).
 - Physical relocation of legacy gold from `insight` to `presentation` (deferred, #1979-#1981).
 - Write-back from presentation to the contract (presentation is read-only for v1).
@@ -274,6 +277,20 @@ The system **MUST** authenticate preview environments through a single fixed cal
 **Rationale**: One host means one Entra redirect URI; the return path must be safe with no per-experiment Entra change.
 
 **Actors**: `cpt-presentation-actor-fe-dev`, `cpt-presentation-actor-analytics-svc`
+
+### 5.6 Metric Registry (p3)
+
+#### Declarative Metric Registry
+
+- [x] `p3` - **ID**: `cpt-presentation-fr-metric-registry`
+
+The sanctioned metric definitions **MUST** be declared in a single declarative registry — one YAML document with a `sources` list and a `metrics` list — that is the single source of truth for the metric-definition seed, replacing the former code-literal seed. The registry **MUST** be reconciled into the service database at startup by the existing reconciler, keeping its idempotent, additive-upsert-plus-disable-missing semantics unchanged, and its invariants (key shape and uniqueness, input/measure references, computation field combinations, presentation-complete formats carrying no unit) **MUST** be enforced by tests that parse the same registry, so a malformed or drifted registry fails the build. (#1974.)
+
+**Status**: Shipped for the sanctioned `metric_definitions` seed (#1974): the registry is embedded at build time and loaded once. The orphaned legacy `metric_catalog`/`metric_threshold` subsystem (no live consumer) is untouched; its retirement is tracked separately.
+
+**Rationale**: One declarative source of truth for metric semantics, editable without a code change, is the foundation the Phase B semantic compiler and passports build on.
+
+**Actors**: `cpt-presentation-actor-analytics-svc`, `cpt-presentation-actor-engineering`
 
 ## 6. Non-Functional Requirements
 

--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -105,6 +105,7 @@ dependencies = [
  "sea-orm-migration",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2 0.10.9",
  "sqlparser",
  "thiserror 2.0.18",

--- a/src/backend/services/analytics/Cargo.toml
+++ b/src/backend/services/analytics/Cargo.toml
@@ -52,6 +52,7 @@ redis = { workspace = true }
 
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 # OpenAPI schemas for request/response DTOs. Version pinned to 5.5 to match the
 # `utoipa::ToSchema` the toolkit (`OperationBuilder::json_request` /
 # `json_response_with_schema`) is compiled against (already in Cargo.lock via

--- a/src/backend/services/analytics/src/domain/metric_definitions/builtin.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/builtin.rs
@@ -63,6 +63,7 @@ impl SeedComputation {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct SourceSeed {
     pub key: String,
     pub kind: SourceKind,
@@ -73,41 +74,23 @@ pub struct SourceSeed {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BuiltinSource {
     pub source: SourceSeed,
-    pub measures: Vec<String>,
+    pub measures: Vec<MeasureSeed>,
     #[serde(default)]
     pub dimensions: Vec<String>,
 }
 
-impl BuiltinSource {
-    pub fn evidence_granularity(&self, measure_key: &str) -> EvidenceGranularity {
-        match (self.source.key.as_str(), measure_key) {
-            (
-                "git",
-                "commit_count" | "commit_change_size" | "pr_created" | "pr_created_merged"
-                | "pr_merged" | "pr_cycle_hours" | "pr_change_size",
-            )
-            | (
-                "task",
-                "tasks_closed" | "bugs_fixed" | "due_date_on_time" | "due_date_with_due"
-                | "slip_days_total" | "late_count" | "dev_time_hours" | "resolution_days"
-                | "pickup_days",
-            )
-            | ("wiki", "pages_created") => EvidenceGranularity::Event,
-            ("ai_usage", "active_day")
-            | (
-                "collab",
-                "active_day" | "active_modality" | "meeting_free_day" | "focus_hours"
-                | "working_hours",
-            )
-            | ("task", _) => EvidenceGranularity::DerivedPopulation,
-            _ => EvidenceGranularity::SourceSummary,
-        }
-    }
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MeasureSeed {
+    pub key: String,
+    pub evidence_granularity: EvidenceGranularity,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct MetricSeed {
     pub metric_key: String,
     pub source_key: String,
@@ -138,12 +121,14 @@ pub struct MetricSeed {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct InputSeed {
     pub input_role: MetricInputRole,
     pub measure_key: String,
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct Registry {
     sources: Vec<BuiltinSource>,
     metrics: Vec<MetricSeed>,
@@ -219,12 +204,23 @@ mod tests {
     }
 
     #[test]
+    fn every_source_declares_at_least_one_measure() {
+        for builtin_source in builtin_sources() {
+            assert!(
+                !builtin_source.measures.is_empty(),
+                "source {} declares no measures",
+                builtin_source.source.key
+            );
+        }
+    }
+
+    #[test]
     fn measure_and_dimension_keys_are_unique_per_source() {
         for builtin_source in builtin_sources() {
             let mut measures = BTreeSet::new();
-            for measure_key in &builtin_source.measures {
-                assert!(is_snake_case(measure_key));
-                assert!(measures.insert(measure_key.as_str()));
+            for measure in &builtin_source.measures {
+                assert!(is_snake_case(&measure.key));
+                assert!(measures.insert(measure.key.as_str()));
             }
             let mut dimensions = BTreeSet::new();
             for dimension_key in &builtin_source.dimensions {
@@ -250,7 +246,11 @@ mod tests {
             .map(|builtin_source| {
                 (
                     builtin_source.source.key.as_str(),
-                    builtin_source.measures.iter().map(String::as_str).collect(),
+                    builtin_source
+                        .measures
+                        .iter()
+                        .map(|measure| measure.key.as_str())
+                        .collect(),
                 )
             })
             .collect();

--- a/src/backend/services/analytics/src/domain/metric_definitions/builtin.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/builtin.rs
@@ -1,9 +1,14 @@
+use std::sync::OnceLock;
+
+use serde::Deserialize;
+
 use crate::domain::metric_definitions::definition::{
     EvidenceGranularity, MetricComputation, MetricDirection, MetricFormat, MetricInputRole,
     SourceKind, ValueTransform,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum EntityType {
     Person,
 }
@@ -16,7 +21,8 @@ impl EntityType {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CohortKey {
     OrgUnit,
 }
@@ -29,7 +35,8 @@ impl CohortKey {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum SeedComputation {
     Sum,
     Ratio { scale: f64 },
@@ -55,24 +62,27 @@ impl SeedComputation {
     }
 }
 
+#[derive(Debug, Deserialize)]
 pub struct SourceSeed {
-    pub key: &'static str,
+    pub key: String,
     pub kind: SourceKind,
     /// Managed-observation relation name; must satisfy
     /// `ObservationRelation::parse` (pinned by a registry test).
-    pub source_ref: &'static str,
-    pub evidence_ref: &'static str,
+    pub source_ref: String,
+    pub evidence_ref: String,
 }
 
+#[derive(Debug, Deserialize)]
 pub struct BuiltinSource {
     pub source: SourceSeed,
-    pub measures: &'static [&'static str],
-    pub dimensions: &'static [&'static str],
+    pub measures: Vec<String>,
+    #[serde(default)]
+    pub dimensions: Vec<String>,
 }
 
 impl BuiltinSource {
     pub fn evidence_granularity(&self, measure_key: &str) -> EvidenceGranularity {
-        match (self.source.key, measure_key) {
+        match (self.source.key.as_str(), measure_key) {
             (
                 "git",
                 "commit_count" | "commit_change_size" | "pr_created" | "pr_created_merged"
@@ -97,1541 +107,69 @@ impl BuiltinSource {
     }
 }
 
+#[derive(Debug, Deserialize)]
 pub struct MetricSeed {
-    pub metric_key: &'static str,
-    pub source_key: &'static str,
-    pub label: &'static str,
+    pub metric_key: String,
+    pub source_key: String,
+    pub label: String,
     /// Compact label for dense surfaces (member grids, heatmap columns);
     /// None = the full label is already compact enough.
-    pub short_label: Option<&'static str>,
-    pub description: Option<&'static str>,
-    pub explanation: Option<&'static str>,
-    pub unit: Option<&'static str>,
+    #[serde(default)]
+    pub short_label: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub explanation: Option<String>,
+    #[serde(default)]
+    pub unit: Option<String>,
     pub format: MetricFormat,
     pub direction: MetricDirection,
     pub entity_type: EntityType,
     pub computation: SeedComputation,
     /// Post-aggregation shaping (affine + clamp) applied by the compiler to
     /// every computed value; None = identity.
+    #[serde(default)]
     pub transform: Option<ValueTransform>,
+    #[serde(default)]
     pub peer_cohort_key: Option<CohortKey>,
-    pub inputs: &'static [InputSeed],
-    pub dimensions: &'static [&'static str],
+    pub inputs: Vec<InputSeed>,
+    #[serde(default)]
+    pub dimensions: Vec<String>,
 }
 
+#[derive(Debug, Deserialize)]
 pub struct InputSeed {
     pub input_role: MetricInputRole,
-    pub measure_key: &'static str,
+    pub measure_key: String,
 }
 
-pub const BUILTIN_SOURCES: &[BuiltinSource] = &[
-    BuiltinSource {
-        source: SourceSeed {
-            key: "ai_usage",
-            kind: SourceKind::ManagedObservation,
-            source_ref: "ai_metric_observations",
-            evidence_ref: "ai_metric_evidence",
-        },
-        measures: &[
-            "accepted_lines",
-            "removed_lines",
-            "active_day",
-            "cost_usd",
-            "accepted_edit_actions",
-            "tool_use_offered",
-            "assistant_messages",
-            "assistant_actions",
-            "dev_conversations",
-            "chat_assistant_conversations",
-        ],
-        dimensions: &["tool", "surface"],
-    },
-    BuiltinSource {
-        source: SourceSeed {
-            key: "git",
-            kind: SourceKind::ManagedObservation,
-            source_ref: "git_metric_observations",
-            evidence_ref: "git_metric_evidence",
-        },
-        measures: &[
-            "commit_count",
-            "commit_day",
-            "commit_change_size",
-            "code_lines_added",
-            "lines_added",
-            "lines_removed",
-            "pr_created",
-            "pr_created_merged",
-            "pr_merged",
-            "pr_cycle_hours",
-            "pr_change_size",
-        ],
-        dimensions: &[
-            "category",
-            "change_type",
-            "destination_branch",
-            "file_extension",
-            "project",
-            "repository",
-            "source",
-        ],
-    },
-    BuiltinSource {
-        source: SourceSeed {
-            key: "collab",
-            kind: SourceKind::ManagedObservation,
-            source_ref: "collab_metric_observations",
-            evidence_ref: "collab_metric_evidence",
-        },
-        measures: &[
-            "total_chat_messages",
-            "channel_posts",
-            "direct_and_group_messages",
-            "meeting_hours",
-            "meetings_attended",
-            "meetings_organized",
-            "adhoc_meetings_attended",
-            "scheduled_meetings_attended",
-            "emails_sent",
-            "emails_received",
-            "emails_read",
-            "files_engaged",
-            "files_shared_internal",
-            "files_shared_external",
-            "files_shared",
-            "active_day",
-            "active_modality",
-            "chat_active_day",
-            "meeting_free_day",
-            "focus_hours",
-            "working_hours",
-        ],
-        dimensions: &["tool", "scope"],
-    },
-    BuiltinSource {
-        source: SourceSeed {
-            key: "task",
-            kind: SourceKind::ManagedObservation,
-            source_ref: "task_metric_observations",
-            evidence_ref: "task_metric_evidence",
-        },
-        measures: &[
-            "tasks_closed",
-            "bugs_fixed",
-            "due_date_on_time",
-            "due_date_with_due",
-            "slip_days_total",
-            "late_count",
-            "estimation_error_pct",
-            "estimation_samples",
-            "flow_dev_seconds",
-            "flow_lead_seconds",
-            "close_events",
-            "reopened_within_14d",
-            "worklog_seconds",
-            "in_progress_seconds",
-            "stale_in_progress",
-            "dev_time_hours",
-            "resolution_days",
-            "pickup_days",
-        ],
-        dimensions: &[],
-    },
-    BuiltinSource {
-        source: SourceSeed {
-            key: "wiki",
-            kind: SourceKind::ManagedObservation,
-            source_ref: "wiki_metric_observations",
-            evidence_ref: "wiki_metric_evidence",
-        },
-        measures: &["pages_created", "edits", "pages_edited", "comments"],
-        dimensions: &[],
-    },
-];
+#[derive(Debug, Deserialize)]
+struct Registry {
+    sources: Vec<BuiltinSource>,
+    metrics: Vec<MetricSeed>,
+}
 
-pub const BUILTIN_METRICS: &[MetricSeed] = &[
-    MetricSeed {
-        metric_key: "ai.accepted_lines",
-        source_key: "ai_usage",
-        label: "AI-added lines",
-        short_label: Some("AI lines +"),
-        description: Some("Accepted added coding output"),
-        explanation: Some("Accepted AI-generated added lines across coding AI tools."),
-        unit: Some("lines"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "accepted_lines",
-        }],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "ai.removed_lines",
-        source_key: "ai_usage",
-        label: "AI-removed lines",
-        short_label: Some("AI lines −"),
-        description: Some("Accepted deleted coding output"),
-        explanation: Some("Accepted AI-generated removed lines across coding AI tools."),
-        unit: Some("lines"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "removed_lines",
-        }],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "ai.active_days",
-        source_key: "ai_usage",
-        label: "AI active days",
-        short_label: Some("AI days"),
-        description: Some("Days with any AI activity across dev and assistant tools"),
-        explanation: Some(
-            "Distinct days with person-attributed AI activity across dev and assistant tools.",
-        ),
-        unit: Some("days"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "active_day",
-        }],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "ai.cost",
-        source_key: "ai_usage",
-        label: "AI usage cost",
-        short_label: None,
-        description: Some("AI usage priced at vendor token/usage rates"),
-        explanation: Some(
-            "Person-attributed AI usage priced at the vendor's token or usage rates — what the \
-             consumption would cost if billed purely by usage. Includes usage a seat or \
-             subscription already covered, and excludes seat and subscription fees, so it is not \
-             the amount invoiced. Covers the tools whose connector prices usage per person.",
-        ),
-        unit: None,
-        format: MetricFormat::Currency,
-        direction: MetricDirection::LowerIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "cost_usd",
-        }],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "ai.accepted_edit_actions",
-        source_key: "ai_usage",
-        label: "Accepted AI edits",
-        short_label: Some("AI edits"),
-        description: Some("Accepted tool or edit suggestions"),
-        explanation: Some("Accepted AI edit or tool suggestions across supported coding AI tools."),
-        unit: Some("actions"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "accepted_edit_actions",
-        }],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "ai.tool_acceptance_rate",
-        source_key: "ai_usage",
-        label: "AI tool acceptance",
-        short_label: Some("AI accept %"),
-        description: Some("Accepted divided by offered AI edits"),
-        explanation: Some("Accepted AI edit or tool suggestions divided by offered suggestions."),
-        unit: None,
-        format: MetricFormat::Percent,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Ratio { scale: 100.0 },
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[
-            InputSeed {
-                input_role: MetricInputRole::Numerator,
-                measure_key: "accepted_edit_actions",
-            },
-            InputSeed {
-                input_role: MetricInputRole::Denominator,
-                measure_key: "tool_use_offered",
-            },
-        ],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "ai.assistant_messages",
-        source_key: "ai_usage",
-        label: "AI assistant messages",
-        short_label: Some("AI msgs"),
-        description: Some("Assistant messages"),
-        explanation: Some(
-            "Person-attributed assistant messages from supported AI assistant tools.",
-        ),
-        unit: Some("messages"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "assistant_messages",
-        }],
-        dimensions: &["tool", "surface"],
-    },
-    MetricSeed {
-        metric_key: "ai.assistant_actions",
-        source_key: "ai_usage",
-        label: "AI assistant actions",
-        short_label: Some("AI actions"),
-        description: Some("Assistant actions"),
-        explanation: Some("Person-attributed assistant actions from supported AI assistant tools."),
-        unit: Some("actions"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "assistant_actions",
-        }],
-        dimensions: &["tool", "surface"],
-    },
-    MetricSeed {
-        metric_key: "ai.dev_conversations",
-        source_key: "ai_usage",
-        label: "AI dev conversations",
-        short_label: Some("AI dev chats"),
-        description: Some("Coding tool conversations where the source reports them"),
-        explanation: Some(
-            "Person-attributed coding conversations from dev tools that report them.",
-        ),
-        unit: Some("conversations"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "dev_conversations",
-        }],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "ai.chat_assistant_conversations",
-        source_key: "ai_usage",
-        label: "AI chat conversations",
-        short_label: Some("AI chats"),
-        description: Some("Chat assistant conversations"),
-        explanation: Some(
-            "Person-attributed chat assistant conversations from supported AI chat tools.",
-        ),
-        unit: Some("conversations"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "chat_assistant_conversations",
-        }],
-        dimensions: &["tool", "surface"],
-    },
-    MetricSeed {
-        metric_key: "git.commits",
-        source_key: "git",
-        label: "Commits",
-        short_label: None,
-        description: Some("Authored commits"),
-        explanation: Some(
-            "Distinct authored commits across connected git sources, excluding merge commits.",
-        ),
-        unit: Some("commits"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "commit_count",
-        }],
-        dimensions: &["project", "repository", "source"],
-    },
-    MetricSeed {
-        metric_key: "git.code_lines",
-        source_key: "git",
-        label: "Code lines added",
-        short_label: Some("Code lines"),
-        description: Some("Lines added to code files"),
-        explanation: Some(
-            "Lines added to files classified as code — tests, configuration, and documentation excluded.",
-        ),
-        unit: Some("lines"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "code_lines_added",
-        }],
-        dimensions: &[
-            "change_type",
-            "file_extension",
-            "project",
-            "repository",
-            "source",
-        ],
-    },
-    MetricSeed {
-        metric_key: "git.lines_added",
-        source_key: "git",
-        label: "Lines added",
-        short_label: Some("Lines +"),
-        description: Some("All lines added, by file category"),
-        explanation: Some(
-            "Lines added across all files, split by file category: code, tests, configuration, documentation.",
-        ),
-        unit: Some("lines"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "lines_added",
-        }],
-        dimensions: &[
-            "category",
-            "change_type",
-            "file_extension",
-            "project",
-            "repository",
-            "source",
-        ],
-    },
-    MetricSeed {
-        metric_key: "git.lines_removed",
-        source_key: "git",
-        label: "Lines removed",
-        short_label: Some("Lines −"),
-        description: Some("All lines removed, by file category"),
-        explanation: Some(
-            "Lines removed across all reported file changes, with file-category, repository, and source breakdowns available.",
-        ),
-        unit: Some("lines"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::Neutral,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "lines_removed",
-        }],
-        dimensions: &[
-            "category",
-            "change_type",
-            "file_extension",
-            "project",
-            "repository",
-            "source",
-        ],
-    },
-    MetricSeed {
-        metric_key: "git.prs_created",
-        source_key: "git",
-        label: "Pull requests created",
-        short_label: Some("PRs opened"),
-        description: Some("Authored pull requests"),
-        explanation: Some("Pull requests opened, dated by creation."),
-        unit: Some("PRs"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "pr_created",
-        }],
-        dimensions: &["destination_branch", "project", "repository", "source"],
-    },
-    MetricSeed {
-        metric_key: "git.prs_merged",
-        source_key: "git",
-        label: "Pull requests merged",
-        short_label: Some("PRs merged"),
-        description: Some("Authored pull requests merged"),
-        explanation: Some("Authored pull requests that merged, dated by the merge."),
-        unit: Some("PRs"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "pr_merged",
-        }],
-        dimensions: &["destination_branch", "project", "repository", "source"],
-    },
-    MetricSeed {
-        metric_key: "git.merge_rate",
-        source_key: "git",
-        label: "PR merge rate",
-        short_label: Some("Merge %"),
-        description: Some("Share of created pull requests that merged"),
-        explanation: Some(
-            "Of the pull requests created in the period, the share that have merged. Requests opened near the end of the period may not have merged yet, which lowers the rate at period edges.",
-        ),
-        unit: None,
-        format: MetricFormat::Percent,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Ratio { scale: 100.0 },
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[
-            InputSeed {
-                input_role: MetricInputRole::Numerator,
-                measure_key: "pr_created_merged",
-            },
-            InputSeed {
-                input_role: MetricInputRole::Denominator,
-                measure_key: "pr_created",
-            },
-        ],
-        dimensions: &["destination_branch", "project", "repository", "source"],
-    },
-    MetricSeed {
-        metric_key: "git.commits_per_active_day",
-        source_key: "git",
-        label: "Commits per active day",
-        short_label: Some("Commits/day"),
-        description: Some("Commit cadence on days with commits"),
-        explanation: Some("Commits divided by the number of days with at least one commit."),
-        unit: None,
-        format: MetricFormat::Decimal,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Ratio { scale: 1.0 },
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[
-            InputSeed {
-                input_role: MetricInputRole::Numerator,
-                measure_key: "commit_count",
-            },
-            InputSeed {
-                input_role: MetricInputRole::Denominator,
-                measure_key: "commit_day",
-            },
-        ],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "git.commit_size",
-        source_key: "git",
-        label: "Commit size",
-        short_label: None,
-        description: Some("Typical diff size per commit"),
-        explanation: Some(
-            "Median diff size of authored commits (lines added plus removed). Smaller commits are easier to review.",
-        ),
-        unit: Some("lines"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::LowerIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Median,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "commit_change_size",
-        }],
-        dimensions: &["project", "repository", "source"],
-    },
-    MetricSeed {
-        metric_key: "git.pr_size",
-        source_key: "git",
-        label: "PR size",
-        short_label: None,
-        description: Some("Typical diff size per pull request"),
-        explanation: Some(
-            "Median diff size of authored pull requests (lines added plus removed). Smaller requests are easier to review. Sources that do not report line counts contribute no values.",
-        ),
-        unit: Some("lines"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::LowerIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Median,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "pr_change_size",
-        }],
-        dimensions: &["destination_branch", "project", "repository", "source"],
-    },
-    MetricSeed {
-        metric_key: "git.pr_cycle_time_h",
-        source_key: "git",
-        label: "PR cycle time",
-        short_label: Some("PR cycle"),
-        description: Some("Typical hours from open to merge"),
-        explanation: Some(
-            "Median hours from opening a pull request to merging it, over requests merged in the period.",
-        ),
-        unit: Some("h"),
-        format: MetricFormat::Decimal,
-        direction: MetricDirection::LowerIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Median,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "pr_cycle_hours",
-        }],
-        dimensions: &["destination_branch", "project", "repository", "source"],
-    },
-    // ─────────────────────────── collaboration ───────────────────────────
-    MetricSeed {
-        metric_key: "collab.messages_sent",
-        source_key: "collab",
-        label: "Messages Sent",
-        short_label: Some("Msgs"),
-        description: Some("Chat messages sent"),
-        explanation: Some(
-            "Chat messages a person sent across messaging tools. Counts are not directly comparable between tools: Slack includes thread replies, and Microsoft 365 combines private-chat and channel messages.",
-        ),
-        unit: Some("messages"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "total_chat_messages",
-        }],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "collab.channel_posts",
-        source_key: "collab",
-        label: "Channel Posts",
-        short_label: Some("Channel posts"),
-        description: Some("Messages posted to shared channels, including replies"),
-        explanation: Some(
-            "Channel posts plus thread replies across messaging tools. Tools that report posts and replies separately are folded so counts stay comparable.",
-        ),
-        unit: Some("messages"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "channel_posts",
-        }],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "collab.dm_ratio",
-        source_key: "collab",
-        label: "DM Ratio",
-        short_label: Some("DM %"),
-        description: Some("Share of messages sent in direct or group chats"),
-        explanation: Some(
-            "Direct and group-chat messages divided by all chat messages. A lower ratio means more communication happens in open channels. Tools that do not distinguish message types report no value.",
-        ),
-        unit: None,
-        format: MetricFormat::Percent,
-        direction: MetricDirection::LowerIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Ratio { scale: 100.0 },
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[
-            InputSeed {
-                input_role: MetricInputRole::Numerator,
-                measure_key: "direct_and_group_messages",
-            },
-            InputSeed {
-                input_role: MetricInputRole::Denominator,
-                measure_key: "total_chat_messages",
-            },
-        ],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "collab.msgs_per_active_day",
-        source_key: "collab",
-        label: "Messages per Active Day",
-        short_label: Some("Msgs/day"),
-        description: Some("Chat messages divided by chat-active days"),
-        explanation: Some(
-            "Chat messages sent divided by days with chat messages. Each tool's active days count separately.",
-        ),
-        unit: Some("messages/day"),
-        format: MetricFormat::Decimal,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Ratio { scale: 1.0 },
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[
-            InputSeed {
-                input_role: MetricInputRole::Numerator,
-                measure_key: "total_chat_messages",
-            },
-            InputSeed {
-                input_role: MetricInputRole::Denominator,
-                measure_key: "chat_active_day",
-            },
-        ],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "collab.active_days",
-        source_key: "collab",
-        label: "Active Days",
-        short_label: None,
-        description: Some("Days with collaboration activity"),
-        explanation: Some(
-            "Distinct days on which a person took a deliberate collaboration action — sending a message, sending email, engaging or sharing a file, or attending a meeting. Passive activity such as receiving or reading email is excluded.",
-        ),
-        unit: Some("days"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::DistinctCount,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "active_day",
-        }],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "collab.emails_sent",
-        source_key: "collab",
-        label: "Emails Sent",
-        short_label: Some("Emails sent"),
-        description: Some("Emails sent"),
-        explanation: Some("Emails a person sent."),
-        unit: Some("emails"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "emails_sent",
-        }],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "collab.emails_received",
-        source_key: "collab",
-        label: "Emails Received",
-        short_label: Some("Emails rcvd"),
-        description: Some("Emails received"),
-        explanation: Some("Emails a person received."),
-        unit: Some("emails"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "emails_received",
-        }],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "collab.emails_read",
-        source_key: "collab",
-        label: "Emails Read",
-        short_label: Some("Emails read"),
-        description: Some("Emails read"),
-        explanation: Some("Emails a person read."),
-        unit: Some("emails"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "emails_read",
-        }],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "collab.files_engaged",
-        source_key: "collab",
-        label: "Files Engaged",
-        short_label: None,
-        description: Some("Files viewed or edited"),
-        explanation: Some("Files a person viewed or edited."),
-        unit: Some("files"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "files_engaged",
-        }],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "collab.files_shared_internal",
-        source_key: "collab",
-        label: "Files Shared (Internal)",
-        short_label: Some("Files (int)"),
-        description: Some("Files shared inside the organization"),
-        explanation: Some("Files a person shared with people inside the organization."),
-        unit: Some("files"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "files_shared_internal",
-        }],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "collab.files_shared_external",
-        source_key: "collab",
-        label: "Files Shared (External)",
-        short_label: Some("Files (ext)"),
-        description: Some("Files shared outside the organization"),
-        explanation: Some("Files a person shared with people outside the organization."),
-        unit: Some("files"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "files_shared_external",
-        }],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "collab.files_shared",
-        source_key: "collab",
-        label: "Files Shared",
-        short_label: Some("Files shared"),
-        description: Some("Files shared with any recipient"),
-        explanation: Some(
-            "Files a person shared with recipients inside or outside the organization.",
-        ),
-        unit: Some("files"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "files_shared",
-        }],
-        dimensions: &["scope"],
-    },
-    MetricSeed {
-        metric_key: "collab.meeting_hours",
-        source_key: "collab",
-        label: "Meeting Hours",
-        short_label: Some("Mtg hrs"),
-        description: Some("Hours spent in meetings"),
-        explanation: Some(
-            "Hours spent in meetings, taking the longest active modality (audio, video, or screen share) per meeting. Zoom reports modality durations as full-session estimates, so its figures may run higher than Microsoft Teams.",
-        ),
-        unit: Some("h"),
-        format: MetricFormat::Decimal,
-        direction: MetricDirection::LowerIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "meeting_hours",
-        }],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "collab.meetings_count",
-        source_key: "collab",
-        label: "Meetings Attended",
-        short_label: Some("Mtgs"),
-        description: Some("Distinct meetings attended"),
-        explanation: Some("Distinct meetings a person attended across meeting tools."),
-        unit: Some("meetings"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "meetings_attended",
-        }],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "collab.meeting_free_days",
-        source_key: "collab",
-        label: "Meeting-Free Days",
-        short_label: Some("Mtg-free days"),
-        description: Some("Active days with no meeting time"),
-        explanation: Some(
-            "Days on which a person was actively collaborating but spent no time in meetings — a proxy for uninterrupted working days.",
-        ),
-        unit: Some("days"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "meeting_free_day",
-        }],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "collab.focus_time_pct",
-        source_key: "collab",
-        label: "Focus Time",
-        short_label: Some("Focus %"),
-        description: Some("Share of the workday outside meetings"),
-        explanation: Some(
-            "Share of the workday not spent in meetings: meeting-free hours divided by scheduled working hours. Scheduled hours default to a nominal eight-hour day where an HR source does not provide them.",
-        ),
-        unit: None,
-        format: MetricFormat::Percent,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Ratio { scale: 100.0 },
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[
-            InputSeed {
-                input_role: MetricInputRole::Numerator,
-                measure_key: "focus_hours",
-            },
-            InputSeed {
-                input_role: MetricInputRole::Denominator,
-                measure_key: "working_hours",
-            },
-        ],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "collab.breadth",
-        source_key: "collab",
-        label: "Collaboration Breadth",
-        short_label: Some("Breadth"),
-        description: Some("Distinct collaboration modalities used"),
-        explanation: Some(
-            "Distinct collaboration modalities — chat, meetings, email, documents — a person was deliberately active in during the period.",
-        ),
-        unit: Some("modalities"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::Neutral,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::DistinctCount,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "active_modality",
-        }],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "collab.meetings_organized",
-        source_key: "collab",
-        label: "Meetings Organized",
-        short_label: Some("Mtgs hosted"),
-        description: Some("Meetings organized"),
-        explanation: Some(
-            "Meetings a person organized. Reported only by tools that expose organizer counts.",
-        ),
-        unit: Some("meetings"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::Neutral,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "meetings_organized",
-        }],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "collab.adhoc_meetings",
-        source_key: "collab",
-        label: "Ad-hoc Meetings",
-        short_label: Some("Ad-hoc mtgs"),
-        description: Some("Unscheduled meetings attended"),
-        explanation: Some(
-            "Unscheduled meetings a person attended. Reported only by tools that distinguish ad-hoc from scheduled meetings.",
-        ),
-        unit: Some("meetings"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::Neutral,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "adhoc_meetings_attended",
-        }],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "collab.scheduled_meetings",
-        source_key: "collab",
-        label: "Scheduled Meetings",
-        short_label: Some("Sched. mtgs"),
-        description: Some("Scheduled meetings attended"),
-        explanation: Some(
-            "Scheduled meetings a person attended. Reported only by tools that distinguish ad-hoc from scheduled meetings.",
-        ),
-        unit: Some("meetings"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::Neutral,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "scheduled_meetings_attended",
-        }],
-        dimensions: &["tool"],
-    },
-    MetricSeed {
-        metric_key: "tasks.closed",
-        source_key: "task",
-        label: "Tasks closed",
-        short_label: Some("Tasks"),
-        description: Some("Tasks moved to a closed status"),
-        explanation: Some("Tasks a person moved into a closed status during the period."),
-        unit: Some("tasks"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "tasks_closed",
-        }],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "tasks.bugs_fixed",
-        source_key: "task",
-        label: "Bugs fixed",
-        short_label: Some("Bugs"),
-        description: Some("Bug-type tasks closed"),
-        explanation: Some("Bug-type tasks a person closed during the period."),
-        unit: Some("tasks"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "bugs_fixed",
-        }],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "tasks.dev_time",
-        source_key: "task",
-        label: "Development time",
-        short_label: Some("Dev time"),
-        description: Some("Time a task spends in active development"),
-        explanation: Some(
-            "Median time closed tasks spent in in-progress statuses, from first pickup to close.",
-        ),
-        unit: Some("h"),
-        format: MetricFormat::Decimal,
-        direction: MetricDirection::LowerIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Median,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "dev_time_hours",
-        }],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "tasks.resolution_time",
-        source_key: "task",
-        label: "Time to resolution",
-        short_label: Some("Resolution"),
-        description: Some("Task lifetime from creation to close"),
-        explanation: Some("Median time from task creation to close."),
-        unit: Some("d"),
-        format: MetricFormat::Decimal,
-        direction: MetricDirection::LowerIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Median,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "resolution_days",
-        }],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "tasks.pickup_time",
-        source_key: "task",
-        label: "Pickup time",
-        short_label: Some("Pickup"),
-        description: Some("Wait before work starts on a task"),
-        explanation: Some(
-            "Median time from task creation to first entering an in-progress status.",
-        ),
-        unit: Some("d"),
-        format: MetricFormat::Decimal,
-        direction: MetricDirection::LowerIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Median,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "pickup_days",
-        }],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "tasks.flow_efficiency",
-        source_key: "task",
-        label: "Flow efficiency",
-        short_label: Some("Flow %"),
-        description: Some("Active development share of task lifetime"),
-        explanation: Some(
-            "Time in active development as a share of total task lifetime, across closed tasks.",
-        ),
-        unit: None,
-        format: MetricFormat::Percent,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Ratio { scale: 100.0 },
-        transform: Some(ValueTransform {
-            multiplier: None,
-            offset: None,
-            clamp_min: None,
-            clamp_max: Some(100.0),
-        }),
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[
-            InputSeed {
-                input_role: MetricInputRole::Numerator,
-                measure_key: "flow_dev_seconds",
-            },
-            InputSeed {
-                input_role: MetricInputRole::Denominator,
-                measure_key: "flow_lead_seconds",
-            },
-        ],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "tasks.reopen_rate",
-        source_key: "task",
-        label: "Reopen rate",
-        short_label: Some("Reopen %"),
-        description: Some("Closed tasks reopened shortly after"),
-        explanation: Some("Share of task closes followed by a reopen within 14 days."),
-        unit: None,
-        format: MetricFormat::Percent,
-        direction: MetricDirection::LowerIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Ratio { scale: 100.0 },
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[
-            InputSeed {
-                input_role: MetricInputRole::Numerator,
-                measure_key: "reopened_within_14d",
-            },
-            InputSeed {
-                input_role: MetricInputRole::Denominator,
-                measure_key: "close_events",
-            },
-        ],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "tasks.due_date_compliance",
-        source_key: "task",
-        label: "Due date compliance",
-        short_label: Some("Due date %"),
-        description: Some("On-time share of tasks with a due date"),
-        explanation: Some("Share of tasks that had a due date and were closed on or before it."),
-        unit: None,
-        format: MetricFormat::Percent,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Ratio { scale: 100.0 },
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[
-            InputSeed {
-                input_role: MetricInputRole::Numerator,
-                measure_key: "due_date_on_time",
-            },
-            InputSeed {
-                input_role: MetricInputRole::Denominator,
-                measure_key: "due_date_with_due",
-            },
-        ],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "tasks.on_time_delivery",
-        source_key: "task",
-        label: "On-time delivery",
-        short_label: Some("On-time %"),
-        description: Some("On-time share of all closed tasks"),
-        explanation: Some(
-            "Share of all closed tasks that were closed on or before their due date.",
-        ),
-        unit: None,
-        format: MetricFormat::Percent,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Ratio { scale: 100.0 },
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[
-            InputSeed {
-                input_role: MetricInputRole::Numerator,
-                measure_key: "due_date_on_time",
-            },
-            InputSeed {
-                input_role: MetricInputRole::Denominator,
-                measure_key: "tasks_closed",
-            },
-        ],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "tasks.avg_slip",
-        source_key: "task",
-        label: "Average slip",
-        short_label: Some("Avg slip"),
-        description: Some("How late overdue tasks close"),
-        explanation: Some("Average days past the due date for tasks closed late."),
-        unit: Some("d"),
-        format: MetricFormat::Decimal,
-        direction: MetricDirection::LowerIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Ratio { scale: 1.0 },
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[
-            InputSeed {
-                input_role: MetricInputRole::Numerator,
-                measure_key: "slip_days_total",
-            },
-            InputSeed {
-                input_role: MetricInputRole::Denominator,
-                measure_key: "late_count",
-            },
-        ],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "tasks.estimation_accuracy",
-        source_key: "task",
-        label: "Estimation accuracy",
-        short_label: Some("Estimate %"),
-        description: Some("How close estimates land to time spent"),
-        explanation: Some(
-            "100 minus the average deviation between original estimates and time spent, over days whose estimated work stayed within twice the estimate. 100 means estimates matched reality; over- and under-estimation count equally.",
-        ),
-        unit: None,
-        format: MetricFormat::Percent,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Ratio { scale: 1.0 },
-        transform: Some(ValueTransform {
-            multiplier: Some(-1.0),
-            offset: Some(100.0),
-            clamp_min: Some(0.0),
-            clamp_max: Some(100.0),
-        }),
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[
-            InputSeed {
-                input_role: MetricInputRole::Numerator,
-                measure_key: "estimation_error_pct",
-            },
-            InputSeed {
-                input_role: MetricInputRole::Denominator,
-                measure_key: "estimation_samples",
-            },
-        ],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "tasks.worklog_accuracy",
-        source_key: "task",
-        label: "Worklog accuracy",
-        short_label: Some("Worklog %"),
-        description: Some("Logged time versus tracked development"),
-        explanation: Some(
-            "Logged work time as a share of time tasks spent in in-progress statuses.",
-        ),
-        unit: None,
-        format: MetricFormat::Percent,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Ratio { scale: 100.0 },
-        transform: Some(ValueTransform {
-            multiplier: None,
-            offset: None,
-            clamp_min: None,
-            clamp_max: Some(100.0),
-        }),
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[
-            InputSeed {
-                input_role: MetricInputRole::Numerator,
-                measure_key: "worklog_seconds",
-            },
-            InputSeed {
-                input_role: MetricInputRole::Denominator,
-                measure_key: "in_progress_seconds",
-            },
-        ],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "tasks.bugs_ratio",
-        source_key: "task",
-        label: "Bug ratio",
-        short_label: Some("Bug %"),
-        description: Some("Bugs as a share of closed tasks"),
-        explanation: Some("Bug-type tasks as a share of all closed tasks."),
-        unit: None,
-        format: MetricFormat::Percent,
-        direction: MetricDirection::LowerIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Ratio { scale: 100.0 },
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[
-            InputSeed {
-                input_role: MetricInputRole::Numerator,
-                measure_key: "bugs_fixed",
-            },
-            InputSeed {
-                input_role: MetricInputRole::Denominator,
-                measure_key: "tasks_closed",
-            },
-        ],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "tasks.stale_in_progress",
-        source_key: "task",
-        label: "Stale in progress",
-        short_label: Some("Stale WIP"),
-        description: Some("Open tasks idle for over two weeks"),
-        explanation: Some("Open tasks with no status change in more than 14 days."),
-        unit: Some("tasks"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::LowerIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "stale_in_progress",
-        }],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "wiki.pages_created",
-        source_key: "wiki",
-        label: "Pages created",
-        short_label: Some("New pages"),
-        description: Some("Wiki pages authored"),
-        explanation: Some(
-            "Wiki pages the person created during the period, counted on the \
-             page's creation date.",
-        ),
-        unit: Some("pages"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "pages_created",
-        }],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "wiki.edits",
-        source_key: "wiki",
-        label: "Page edits",
-        short_label: Some("Edits"),
-        description: Some("Wiki edit sessions"),
-        explanation: Some(
-            "Logical wiki edits the person made during the period. Consecutive \
-             saves of the same page within a short window count as one edit, so \
-             autosaves do not inflate the number.",
-        ),
-        unit: Some("edits"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "edits",
-        }],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "wiki.pages_edited",
-        source_key: "wiki",
-        label: "Pages edited",
-        short_label: Some("Pages edited"),
-        description: Some("Distinct wiki pages edited"),
-        explanation: Some(
-            "Distinct wiki pages the person edited during the period, counted \
-             per day the page was touched.",
-        ),
-        unit: Some("pages"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "pages_edited",
-        }],
-        dimensions: &[],
-    },
-    MetricSeed {
-        metric_key: "wiki.comments",
-        source_key: "wiki",
-        label: "Comments received",
-        short_label: Some("Comments"),
-        description: Some("Comments on the person's wiki pages"),
-        explanation: Some(
-            "Comments and replies other people left on wiki pages the person \
-             authored — a signal of how much their documentation is read and \
-             discussed.",
-        ),
-        unit: Some("comments"),
-        format: MetricFormat::Integer,
-        direction: MetricDirection::HigherIsBetter,
-        entity_type: EntityType::Person,
-        computation: SeedComputation::Sum,
-        transform: None,
-        peer_cohort_key: Some(CohortKey::OrgUnit),
-        inputs: &[InputSeed {
-            input_role: MetricInputRole::Value,
-            measure_key: "comments",
-        }],
-        dimensions: &[],
-    },
-];
+static REGISTRY: OnceLock<Registry> = OnceLock::new();
+
+const REGISTRY_YAML: &str = include_str!("registry.yaml");
+
+fn registry() -> &'static Registry {
+    REGISTRY.get_or_init(|| {
+        #[expect(
+            clippy::expect_used,
+            reason = "registry.yaml is embedded at compile time and parsed by the registry tests; a parse failure is a build defect, not a runtime condition"
+        )]
+        serde_yaml::from_str(REGISTRY_YAML).expect("builtin metric registry.yaml must parse")
+    })
+}
+
+pub fn builtin_sources() -> &'static [BuiltinSource] {
+    &registry().sources
+}
+
+pub fn builtin_metrics() -> &'static [MetricSeed] {
+    &registry().metrics
+}
 
 #[cfg(test)]
 mod tests {
@@ -1653,20 +191,26 @@ mod tests {
     }
 
     #[test]
+    fn registry_declares_the_expected_counts() {
+        assert_eq!(builtin_sources().len(), 5, "builtin source count");
+        assert_eq!(builtin_metrics().len(), 59, "builtin metric count");
+    }
+
+    #[test]
     fn source_keys_are_unique_and_shaped() {
         let mut seen = BTreeSet::new();
-        for builtin_source in BUILTIN_SOURCES {
-            assert!(is_snake_case(builtin_source.source.key));
-            assert!(seen.insert(builtin_source.source.key));
+        for builtin_source in builtin_sources() {
+            assert!(is_snake_case(&builtin_source.source.key));
+            assert!(seen.insert(builtin_source.source.key.as_str()));
         }
     }
 
     #[test]
     fn source_refs_parse_as_observation_relations() {
         use crate::domain::metric_definitions::definition::ObservationRelation;
-        for builtin_source in BUILTIN_SOURCES {
+        for builtin_source in builtin_sources() {
             assert!(
-                ObservationRelation::parse(builtin_source.source.source_ref).is_some(),
+                ObservationRelation::parse(&builtin_source.source.source_ref).is_some(),
                 "builtin source {} declares an invalid observation relation {:?}",
                 builtin_source.source.key,
                 builtin_source.source.source_ref,
@@ -1676,16 +220,16 @@ mod tests {
 
     #[test]
     fn measure_and_dimension_keys_are_unique_per_source() {
-        for builtin_source in BUILTIN_SOURCES {
+        for builtin_source in builtin_sources() {
             let mut measures = BTreeSet::new();
-            for measure_key in builtin_source.measures {
+            for measure_key in &builtin_source.measures {
                 assert!(is_snake_case(measure_key));
-                assert!(measures.insert(*measure_key));
+                assert!(measures.insert(measure_key.as_str()));
             }
             let mut dimensions = BTreeSet::new();
-            for dimension_key in builtin_source.dimensions {
+            for dimension_key in &builtin_source.dimensions {
                 assert!(is_snake_case(dimension_key));
-                assert!(dimensions.insert(*dimension_key));
+                assert!(dimensions.insert(dimension_key.as_str()));
             }
         }
     }
@@ -1693,32 +237,32 @@ mod tests {
     #[test]
     fn metric_keys_are_unique_and_shaped() {
         let mut seen = BTreeSet::new();
-        for metric in BUILTIN_METRICS {
-            assert!(is_metric_key(metric.metric_key), "{}", metric.metric_key);
-            assert!(seen.insert(metric.metric_key));
+        for metric in builtin_metrics() {
+            assert!(is_metric_key(&metric.metric_key), "{}", metric.metric_key);
+            assert!(seen.insert(metric.metric_key.as_str()));
         }
     }
 
     #[test]
     fn metric_inputs_reference_declared_measures() {
-        let measures_by_source: HashMap<&str, BTreeSet<&str>> = BUILTIN_SOURCES
+        let measures_by_source: HashMap<&str, BTreeSet<&str>> = builtin_sources()
             .iter()
             .map(|builtin_source| {
                 (
-                    builtin_source.source.key,
-                    builtin_source.measures.iter().copied().collect(),
+                    builtin_source.source.key.as_str(),
+                    builtin_source.measures.iter().map(String::as_str).collect(),
                 )
             })
             .collect();
 
-        for metric in BUILTIN_METRICS {
+        for metric in builtin_metrics() {
             let measures = measures_by_source
-                .get(metric.source_key)
+                .get(metric.source_key.as_str())
                 .unwrap_or_else(|| panic!("unknown source for {}", metric.metric_key));
             assert!(!metric.inputs.is_empty(), "{}", metric.metric_key);
-            for input in metric.inputs {
+            for input in &metric.inputs {
                 assert!(
-                    measures.contains(input.measure_key),
+                    measures.contains(input.measure_key.as_str()),
                     "{} references undeclared measure {}",
                     metric.metric_key,
                     input.measure_key
@@ -1729,23 +273,27 @@ mod tests {
 
     #[test]
     fn metric_dimensions_reference_declared_source_dimensions() {
-        let dimensions_by_source: HashMap<&str, BTreeSet<&str>> = BUILTIN_SOURCES
+        let dimensions_by_source: HashMap<&str, BTreeSet<&str>> = builtin_sources()
             .iter()
             .map(|builtin_source| {
                 (
-                    builtin_source.source.key,
-                    builtin_source.dimensions.iter().copied().collect(),
+                    builtin_source.source.key.as_str(),
+                    builtin_source
+                        .dimensions
+                        .iter()
+                        .map(String::as_str)
+                        .collect(),
                 )
             })
             .collect();
 
-        for metric in BUILTIN_METRICS {
-            let Some(dimensions) = dimensions_by_source.get(metric.source_key) else {
+        for metric in builtin_metrics() {
+            let Some(dimensions) = dimensions_by_source.get(metric.source_key.as_str()) else {
                 panic!("unknown source for {}", metric.metric_key);
             };
-            for dimension in metric.dimensions {
+            for dimension in &metric.dimensions {
                 assert!(
-                    dimensions.contains(dimension),
+                    dimensions.contains(dimension.as_str()),
                     "{} references undeclared dimension {dimension}",
                     metric.metric_key
                 );
@@ -1755,7 +303,7 @@ mod tests {
 
     #[test]
     fn ratio_metrics_have_numerator_and_denominator_roles() {
-        for metric in BUILTIN_METRICS {
+        for metric in builtin_metrics() {
             let SeedComputation::Ratio { .. } = metric.computation else {
                 continue;
             };
@@ -1775,7 +323,7 @@ mod tests {
 
     #[test]
     fn median_metrics_have_single_value_role() {
-        for metric in BUILTIN_METRICS {
+        for metric in builtin_metrics() {
             if metric.computation != SeedComputation::Median {
                 continue;
             }
@@ -1791,7 +339,7 @@ mod tests {
 
     #[test]
     fn distinct_count_metrics_have_single_value_role() {
-        for metric in BUILTIN_METRICS {
+        for metric in builtin_metrics() {
             if metric.computation != SeedComputation::DistinctCount {
                 continue;
             }
@@ -1812,7 +360,7 @@ mod tests {
     // drift (e.g. "percent" vs "%" for the same format) — keep it None.
     #[test]
     fn presentation_complete_formats_carry_no_unit() {
-        for metric in BUILTIN_METRICS {
+        for metric in builtin_metrics() {
             if !matches!(
                 metric.format,
                 MetricFormat::Percent | MetricFormat::Currency

--- a/src/backend/services/analytics/src/domain/metric_definitions/definition.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/definition.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum MetricDirection {
     HigherIsBetter,
@@ -8,7 +8,7 @@ pub enum MetricDirection {
     Neutral,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum MetricFormat {
     Integer,
@@ -26,7 +26,7 @@ pub enum MetricComputation {
     DistinctCount,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum MetricInputRole {
     Value,
@@ -61,7 +61,8 @@ impl EvidenceGranularity {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum SourceKind {
     ManagedObservation,
     CustomObservationSql,
@@ -114,7 +115,8 @@ pub struct MetricDefinition {
 /// Affine + clamp shaping for a computed metric value:
 /// `y = clamp(clamp_min, clamp_max, multiplier * x + offset)`.
 /// Absent fields are identity (multiplier 1, offset 0, no bound).
-#[derive(Debug, Clone, Copy, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Default, Deserialize)]
+#[serde(default)]
 pub struct ValueTransform {
     pub multiplier: Option<f64>,
     pub offset: Option<f64>,

--- a/src/backend/services/analytics/src/domain/metric_definitions/definition.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/definition.rs
@@ -34,7 +34,7 @@ pub enum MetricInputRole {
     Denominator,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum EvidenceGranularity {
     Event,
@@ -116,7 +116,7 @@ pub struct MetricDefinition {
 /// `y = clamp(clamp_min, clamp_max, multiplier * x + offset)`.
 /// Absent fields are identity (multiplier 1, offset 0, no bound).
 #[derive(Debug, Clone, Copy, PartialEq, Default, Deserialize)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct ValueTransform {
     pub multiplier: Option<f64>,
     pub offset: Option<f64>,

--- a/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
+++ b/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
@@ -5,16 +5,26 @@ sources:
       source_ref: ai_metric_observations
       evidence_ref: ai_metric_evidence
     measures:
-      - accepted_lines
-      - removed_lines
-      - active_day
-      - cost_usd
-      - accepted_edit_actions
-      - tool_use_offered
-      - assistant_messages
-      - assistant_actions
-      - dev_conversations
-      - chat_assistant_conversations
+      - key: accepted_lines
+        evidence_granularity: source_summary
+      - key: removed_lines
+        evidence_granularity: source_summary
+      - key: active_day
+        evidence_granularity: derived_population
+      - key: cost_usd
+        evidence_granularity: source_summary
+      - key: accepted_edit_actions
+        evidence_granularity: source_summary
+      - key: tool_use_offered
+        evidence_granularity: source_summary
+      - key: assistant_messages
+        evidence_granularity: source_summary
+      - key: assistant_actions
+        evidence_granularity: source_summary
+      - key: dev_conversations
+        evidence_granularity: source_summary
+      - key: chat_assistant_conversations
+        evidence_granularity: source_summary
     dimensions:
       - tool
       - surface
@@ -24,17 +34,28 @@ sources:
       source_ref: git_metric_observations
       evidence_ref: git_metric_evidence
     measures:
-      - commit_count
-      - commit_day
-      - commit_change_size
-      - code_lines_added
-      - lines_added
-      - lines_removed
-      - pr_created
-      - pr_created_merged
-      - pr_merged
-      - pr_cycle_hours
-      - pr_change_size
+      - key: commit_count
+        evidence_granularity: event
+      - key: commit_day
+        evidence_granularity: source_summary
+      - key: commit_change_size
+        evidence_granularity: event
+      - key: code_lines_added
+        evidence_granularity: source_summary
+      - key: lines_added
+        evidence_granularity: source_summary
+      - key: lines_removed
+        evidence_granularity: source_summary
+      - key: pr_created
+        evidence_granularity: event
+      - key: pr_created_merged
+        evidence_granularity: event
+      - key: pr_merged
+        evidence_granularity: event
+      - key: pr_cycle_hours
+        evidence_granularity: event
+      - key: pr_change_size
+        evidence_granularity: event
     dimensions:
       - category
       - change_type
@@ -49,27 +70,48 @@ sources:
       source_ref: collab_metric_observations
       evidence_ref: collab_metric_evidence
     measures:
-      - total_chat_messages
-      - channel_posts
-      - direct_and_group_messages
-      - meeting_hours
-      - meetings_attended
-      - meetings_organized
-      - adhoc_meetings_attended
-      - scheduled_meetings_attended
-      - emails_sent
-      - emails_received
-      - emails_read
-      - files_engaged
-      - files_shared_internal
-      - files_shared_external
-      - files_shared
-      - active_day
-      - active_modality
-      - chat_active_day
-      - meeting_free_day
-      - focus_hours
-      - working_hours
+      - key: total_chat_messages
+        evidence_granularity: source_summary
+      - key: channel_posts
+        evidence_granularity: source_summary
+      - key: direct_and_group_messages
+        evidence_granularity: source_summary
+      - key: meeting_hours
+        evidence_granularity: source_summary
+      - key: meetings_attended
+        evidence_granularity: source_summary
+      - key: meetings_organized
+        evidence_granularity: source_summary
+      - key: adhoc_meetings_attended
+        evidence_granularity: source_summary
+      - key: scheduled_meetings_attended
+        evidence_granularity: source_summary
+      - key: emails_sent
+        evidence_granularity: source_summary
+      - key: emails_received
+        evidence_granularity: source_summary
+      - key: emails_read
+        evidence_granularity: source_summary
+      - key: files_engaged
+        evidence_granularity: source_summary
+      - key: files_shared_internal
+        evidence_granularity: source_summary
+      - key: files_shared_external
+        evidence_granularity: source_summary
+      - key: files_shared
+        evidence_granularity: source_summary
+      - key: active_day
+        evidence_granularity: derived_population
+      - key: active_modality
+        evidence_granularity: derived_population
+      - key: chat_active_day
+        evidence_granularity: source_summary
+      - key: meeting_free_day
+        evidence_granularity: derived_population
+      - key: focus_hours
+        evidence_granularity: derived_population
+      - key: working_hours
+        evidence_granularity: derived_population
     dimensions:
       - tool
       - scope
@@ -79,24 +121,42 @@ sources:
       source_ref: task_metric_observations
       evidence_ref: task_metric_evidence
     measures:
-      - tasks_closed
-      - bugs_fixed
-      - due_date_on_time
-      - due_date_with_due
-      - slip_days_total
-      - late_count
-      - estimation_error_pct
-      - estimation_samples
-      - flow_dev_seconds
-      - flow_lead_seconds
-      - close_events
-      - reopened_within_14d
-      - worklog_seconds
-      - in_progress_seconds
-      - stale_in_progress
-      - dev_time_hours
-      - resolution_days
-      - pickup_days
+      - key: tasks_closed
+        evidence_granularity: event
+      - key: bugs_fixed
+        evidence_granularity: event
+      - key: due_date_on_time
+        evidence_granularity: event
+      - key: due_date_with_due
+        evidence_granularity: event
+      - key: slip_days_total
+        evidence_granularity: event
+      - key: late_count
+        evidence_granularity: event
+      - key: estimation_error_pct
+        evidence_granularity: derived_population
+      - key: estimation_samples
+        evidence_granularity: derived_population
+      - key: flow_dev_seconds
+        evidence_granularity: derived_population
+      - key: flow_lead_seconds
+        evidence_granularity: derived_population
+      - key: close_events
+        evidence_granularity: derived_population
+      - key: reopened_within_14d
+        evidence_granularity: derived_population
+      - key: worklog_seconds
+        evidence_granularity: derived_population
+      - key: in_progress_seconds
+        evidence_granularity: derived_population
+      - key: stale_in_progress
+        evidence_granularity: derived_population
+      - key: dev_time_hours
+        evidence_granularity: event
+      - key: resolution_days
+        evidence_granularity: event
+      - key: pickup_days
+        evidence_granularity: event
     dimensions: []
   - source:
       key: wiki
@@ -104,10 +164,14 @@ sources:
       source_ref: wiki_metric_observations
       evidence_ref: wiki_metric_evidence
     measures:
-      - pages_created
-      - edits
-      - pages_edited
-      - comments
+      - key: pages_created
+        evidence_granularity: event
+      - key: edits
+        evidence_granularity: source_summary
+      - key: pages_edited
+        evidence_granularity: source_summary
+      - key: comments
+        evidence_granularity: source_summary
     dimensions: []
 metrics:
   - metric_key: ai.accepted_lines

--- a/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
+++ b/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
@@ -1,0 +1,1160 @@
+sources:
+  - source:
+      key: ai_usage
+      kind: managed_observation
+      source_ref: ai_metric_observations
+      evidence_ref: ai_metric_evidence
+    measures:
+      - accepted_lines
+      - removed_lines
+      - active_day
+      - cost_usd
+      - accepted_edit_actions
+      - tool_use_offered
+      - assistant_messages
+      - assistant_actions
+      - dev_conversations
+      - chat_assistant_conversations
+    dimensions:
+      - tool
+      - surface
+  - source:
+      key: git
+      kind: managed_observation
+      source_ref: git_metric_observations
+      evidence_ref: git_metric_evidence
+    measures:
+      - commit_count
+      - commit_day
+      - commit_change_size
+      - code_lines_added
+      - lines_added
+      - lines_removed
+      - pr_created
+      - pr_created_merged
+      - pr_merged
+      - pr_cycle_hours
+      - pr_change_size
+    dimensions:
+      - category
+      - change_type
+      - destination_branch
+      - file_extension
+      - project
+      - repository
+      - source
+  - source:
+      key: collab
+      kind: managed_observation
+      source_ref: collab_metric_observations
+      evidence_ref: collab_metric_evidence
+    measures:
+      - total_chat_messages
+      - channel_posts
+      - direct_and_group_messages
+      - meeting_hours
+      - meetings_attended
+      - meetings_organized
+      - adhoc_meetings_attended
+      - scheduled_meetings_attended
+      - emails_sent
+      - emails_received
+      - emails_read
+      - files_engaged
+      - files_shared_internal
+      - files_shared_external
+      - files_shared
+      - active_day
+      - active_modality
+      - chat_active_day
+      - meeting_free_day
+      - focus_hours
+      - working_hours
+    dimensions:
+      - tool
+      - scope
+  - source:
+      key: task
+      kind: managed_observation
+      source_ref: task_metric_observations
+      evidence_ref: task_metric_evidence
+    measures:
+      - tasks_closed
+      - bugs_fixed
+      - due_date_on_time
+      - due_date_with_due
+      - slip_days_total
+      - late_count
+      - estimation_error_pct
+      - estimation_samples
+      - flow_dev_seconds
+      - flow_lead_seconds
+      - close_events
+      - reopened_within_14d
+      - worklog_seconds
+      - in_progress_seconds
+      - stale_in_progress
+      - dev_time_hours
+      - resolution_days
+      - pickup_days
+    dimensions: []
+  - source:
+      key: wiki
+      kind: managed_observation
+      source_ref: wiki_metric_observations
+      evidence_ref: wiki_metric_evidence
+    measures:
+      - pages_created
+      - edits
+      - pages_edited
+      - comments
+    dimensions: []
+metrics:
+  - metric_key: ai.accepted_lines
+    source_key: ai_usage
+    label: AI-added lines
+    short_label: AI lines +
+    description: Accepted added coding output
+    explanation: Accepted AI-generated added lines across coding AI tools.
+    unit: lines
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: accepted_lines
+    dimensions:
+      - tool
+  - metric_key: ai.removed_lines
+    source_key: ai_usage
+    label: AI-removed lines
+    short_label: AI lines −
+    description: Accepted deleted coding output
+    explanation: Accepted AI-generated removed lines across coding AI tools.
+    unit: lines
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: removed_lines
+    dimensions:
+      - tool
+  - metric_key: ai.active_days
+    source_key: ai_usage
+    label: AI active days
+    short_label: AI days
+    description: Days with any AI activity across dev and assistant tools
+    explanation: Distinct days with person-attributed AI activity across dev and assistant tools.
+    unit: days
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: active_day
+    dimensions: []
+  - metric_key: ai.cost
+    source_key: ai_usage
+    label: AI usage cost
+    description: AI usage priced at vendor token/usage rates
+    explanation: Person-attributed AI usage priced at the vendor's token or usage rates — what the consumption would cost if billed purely by usage. Includes usage a seat or subscription already covered, and excludes seat and subscription fees, so it is not the amount invoiced. Covers the tools whose connector prices usage per person.
+    format: currency
+    direction: lower_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: cost_usd
+    dimensions:
+      - tool
+  - metric_key: ai.accepted_edit_actions
+    source_key: ai_usage
+    label: Accepted AI edits
+    short_label: AI edits
+    description: Accepted tool or edit suggestions
+    explanation: Accepted AI edit or tool suggestions across supported coding AI tools.
+    unit: actions
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: accepted_edit_actions
+    dimensions:
+      - tool
+  - metric_key: ai.tool_acceptance_rate
+    source_key: ai_usage
+    label: AI tool acceptance
+    short_label: AI accept %
+    description: Accepted divided by offered AI edits
+    explanation: Accepted AI edit or tool suggestions divided by offered suggestions.
+    format: percent
+    direction: higher_is_better
+    entity_type: person
+    computation: !ratio
+      scale: 100.0
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: numerator
+        measure_key: accepted_edit_actions
+      - input_role: denominator
+        measure_key: tool_use_offered
+    dimensions:
+      - tool
+  - metric_key: ai.assistant_messages
+    source_key: ai_usage
+    label: AI assistant messages
+    short_label: AI msgs
+    description: Assistant messages
+    explanation: Person-attributed assistant messages from supported AI assistant tools.
+    unit: messages
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: assistant_messages
+    dimensions:
+      - tool
+      - surface
+  - metric_key: ai.assistant_actions
+    source_key: ai_usage
+    label: AI assistant actions
+    short_label: AI actions
+    description: Assistant actions
+    explanation: Person-attributed assistant actions from supported AI assistant tools.
+    unit: actions
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: assistant_actions
+    dimensions:
+      - tool
+      - surface
+  - metric_key: ai.dev_conversations
+    source_key: ai_usage
+    label: AI dev conversations
+    short_label: AI dev chats
+    description: Coding tool conversations where the source reports them
+    explanation: Person-attributed coding conversations from dev tools that report them.
+    unit: conversations
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: dev_conversations
+    dimensions:
+      - tool
+  - metric_key: ai.chat_assistant_conversations
+    source_key: ai_usage
+    label: AI chat conversations
+    short_label: AI chats
+    description: Chat assistant conversations
+    explanation: Person-attributed chat assistant conversations from supported AI chat tools.
+    unit: conversations
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: chat_assistant_conversations
+    dimensions:
+      - tool
+      - surface
+  - metric_key: git.commits
+    source_key: git
+    label: Commits
+    description: Authored commits
+    explanation: Distinct authored commits across connected git sources, excluding merge commits.
+    unit: commits
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: commit_count
+    dimensions:
+      - project
+      - repository
+      - source
+  - metric_key: git.code_lines
+    source_key: git
+    label: Code lines added
+    short_label: Code lines
+    description: Lines added to code files
+    explanation: Lines added to files classified as code — tests, configuration, and documentation excluded.
+    unit: lines
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: code_lines_added
+    dimensions:
+      - change_type
+      - file_extension
+      - project
+      - repository
+      - source
+  - metric_key: git.lines_added
+    source_key: git
+    label: Lines added
+    short_label: Lines +
+    description: All lines added, by file category
+    explanation: 'Lines added across all files, split by file category: code, tests, configuration, documentation.'
+    unit: lines
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: lines_added
+    dimensions:
+      - category
+      - change_type
+      - file_extension
+      - project
+      - repository
+      - source
+  - metric_key: git.lines_removed
+    source_key: git
+    label: Lines removed
+    short_label: Lines −
+    description: All lines removed, by file category
+    explanation: Lines removed across all reported file changes, with file-category, repository, and source breakdowns available.
+    unit: lines
+    format: integer
+    direction: neutral
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: lines_removed
+    dimensions:
+      - category
+      - change_type
+      - file_extension
+      - project
+      - repository
+      - source
+  - metric_key: git.prs_created
+    source_key: git
+    label: Pull requests created
+    short_label: PRs opened
+    description: Authored pull requests
+    explanation: Pull requests opened, dated by creation.
+    unit: PRs
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: pr_created
+    dimensions:
+      - destination_branch
+      - project
+      - repository
+      - source
+  - metric_key: git.prs_merged
+    source_key: git
+    label: Pull requests merged
+    short_label: PRs merged
+    description: Authored pull requests merged
+    explanation: Authored pull requests that merged, dated by the merge.
+    unit: PRs
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: pr_merged
+    dimensions:
+      - destination_branch
+      - project
+      - repository
+      - source
+  - metric_key: git.merge_rate
+    source_key: git
+    label: PR merge rate
+    short_label: Merge %
+    description: Share of created pull requests that merged
+    explanation: Of the pull requests created in the period, the share that have merged. Requests opened near the end of the period may not have merged yet, which lowers the rate at period edges.
+    format: percent
+    direction: higher_is_better
+    entity_type: person
+    computation: !ratio
+      scale: 100.0
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: numerator
+        measure_key: pr_created_merged
+      - input_role: denominator
+        measure_key: pr_created
+    dimensions:
+      - destination_branch
+      - project
+      - repository
+      - source
+  - metric_key: git.commits_per_active_day
+    source_key: git
+    label: Commits per active day
+    short_label: Commits/day
+    description: Commit cadence on days with commits
+    explanation: Commits divided by the number of days with at least one commit.
+    format: decimal
+    direction: higher_is_better
+    entity_type: person
+    computation: !ratio
+      scale: 1.0
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: numerator
+        measure_key: commit_count
+      - input_role: denominator
+        measure_key: commit_day
+    dimensions: []
+  - metric_key: git.commit_size
+    source_key: git
+    label: Commit size
+    description: Typical diff size per commit
+    explanation: Median diff size of authored commits (lines added plus removed). Smaller commits are easier to review.
+    unit: lines
+    format: integer
+    direction: lower_is_better
+    entity_type: person
+    computation: median
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: commit_change_size
+    dimensions:
+      - project
+      - repository
+      - source
+  - metric_key: git.pr_size
+    source_key: git
+    label: PR size
+    description: Typical diff size per pull request
+    explanation: Median diff size of authored pull requests (lines added plus removed). Smaller requests are easier to review. Sources that do not report line counts contribute no values.
+    unit: lines
+    format: integer
+    direction: lower_is_better
+    entity_type: person
+    computation: median
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: pr_change_size
+    dimensions:
+      - destination_branch
+      - project
+      - repository
+      - source
+  - metric_key: git.pr_cycle_time_h
+    source_key: git
+    label: PR cycle time
+    short_label: PR cycle
+    description: Typical hours from open to merge
+    explanation: Median hours from opening a pull request to merging it, over requests merged in the period.
+    unit: h
+    format: decimal
+    direction: lower_is_better
+    entity_type: person
+    computation: median
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: pr_cycle_hours
+    dimensions:
+      - destination_branch
+      - project
+      - repository
+      - source
+  - metric_key: collab.messages_sent
+    source_key: collab
+    label: Messages Sent
+    short_label: Msgs
+    description: Chat messages sent
+    explanation: 'Chat messages a person sent across messaging tools. Counts are not directly comparable between tools: Slack includes thread replies, and Microsoft 365 combines private-chat and channel messages.'
+    unit: messages
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: total_chat_messages
+    dimensions:
+      - tool
+  - metric_key: collab.channel_posts
+    source_key: collab
+    label: Channel Posts
+    short_label: Channel posts
+    description: Messages posted to shared channels, including replies
+    explanation: Channel posts plus thread replies across messaging tools. Tools that report posts and replies separately are folded so counts stay comparable.
+    unit: messages
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: channel_posts
+    dimensions:
+      - tool
+  - metric_key: collab.dm_ratio
+    source_key: collab
+    label: DM Ratio
+    short_label: DM %
+    description: Share of messages sent in direct or group chats
+    explanation: Direct and group-chat messages divided by all chat messages. A lower ratio means more communication happens in open channels. Tools that do not distinguish message types report no value.
+    format: percent
+    direction: lower_is_better
+    entity_type: person
+    computation: !ratio
+      scale: 100.0
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: numerator
+        measure_key: direct_and_group_messages
+      - input_role: denominator
+        measure_key: total_chat_messages
+    dimensions:
+      - tool
+  - metric_key: collab.msgs_per_active_day
+    source_key: collab
+    label: Messages per Active Day
+    short_label: Msgs/day
+    description: Chat messages divided by chat-active days
+    explanation: Chat messages sent divided by days with chat messages. Each tool's active days count separately.
+    unit: messages/day
+    format: decimal
+    direction: higher_is_better
+    entity_type: person
+    computation: !ratio
+      scale: 1.0
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: numerator
+        measure_key: total_chat_messages
+      - input_role: denominator
+        measure_key: chat_active_day
+    dimensions:
+      - tool
+  - metric_key: collab.active_days
+    source_key: collab
+    label: Active Days
+    description: Days with collaboration activity
+    explanation: Distinct days on which a person took a deliberate collaboration action — sending a message, sending email, engaging or sharing a file, or attending a meeting. Passive activity such as receiving or reading email is excluded.
+    unit: days
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: distinct_count
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: active_day
+    dimensions:
+      - tool
+  - metric_key: collab.emails_sent
+    source_key: collab
+    label: Emails Sent
+    short_label: Emails sent
+    description: Emails sent
+    explanation: Emails a person sent.
+    unit: emails
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: emails_sent
+    dimensions:
+      - tool
+  - metric_key: collab.emails_received
+    source_key: collab
+    label: Emails Received
+    short_label: Emails rcvd
+    description: Emails received
+    explanation: Emails a person received.
+    unit: emails
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: emails_received
+    dimensions:
+      - tool
+  - metric_key: collab.emails_read
+    source_key: collab
+    label: Emails Read
+    short_label: Emails read
+    description: Emails read
+    explanation: Emails a person read.
+    unit: emails
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: emails_read
+    dimensions:
+      - tool
+  - metric_key: collab.files_engaged
+    source_key: collab
+    label: Files Engaged
+    description: Files viewed or edited
+    explanation: Files a person viewed or edited.
+    unit: files
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: files_engaged
+    dimensions:
+      - tool
+  - metric_key: collab.files_shared_internal
+    source_key: collab
+    label: Files Shared (Internal)
+    short_label: Files (int)
+    description: Files shared inside the organization
+    explanation: Files a person shared with people inside the organization.
+    unit: files
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: files_shared_internal
+    dimensions:
+      - tool
+  - metric_key: collab.files_shared_external
+    source_key: collab
+    label: Files Shared (External)
+    short_label: Files (ext)
+    description: Files shared outside the organization
+    explanation: Files a person shared with people outside the organization.
+    unit: files
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: files_shared_external
+    dimensions:
+      - tool
+  - metric_key: collab.files_shared
+    source_key: collab
+    label: Files Shared
+    short_label: Files shared
+    description: Files shared with any recipient
+    explanation: Files a person shared with recipients inside or outside the organization.
+    unit: files
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: files_shared
+    dimensions:
+      - scope
+  - metric_key: collab.meeting_hours
+    source_key: collab
+    label: Meeting Hours
+    short_label: Mtg hrs
+    description: Hours spent in meetings
+    explanation: Hours spent in meetings, taking the longest active modality (audio, video, or screen share) per meeting. Zoom reports modality durations as full-session estimates, so its figures may run higher than Microsoft Teams.
+    unit: h
+    format: decimal
+    direction: lower_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: meeting_hours
+    dimensions:
+      - tool
+  - metric_key: collab.meetings_count
+    source_key: collab
+    label: Meetings Attended
+    short_label: Mtgs
+    description: Distinct meetings attended
+    explanation: Distinct meetings a person attended across meeting tools.
+    unit: meetings
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: meetings_attended
+    dimensions:
+      - tool
+  - metric_key: collab.meeting_free_days
+    source_key: collab
+    label: Meeting-Free Days
+    short_label: Mtg-free days
+    description: Active days with no meeting time
+    explanation: Days on which a person was actively collaborating but spent no time in meetings — a proxy for uninterrupted working days.
+    unit: days
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: meeting_free_day
+    dimensions: []
+  - metric_key: collab.focus_time_pct
+    source_key: collab
+    label: Focus Time
+    short_label: Focus %
+    description: Share of the workday outside meetings
+    explanation: 'Share of the workday not spent in meetings: meeting-free hours divided by scheduled working hours. Scheduled hours default to a nominal eight-hour day where an HR source does not provide them.'
+    format: percent
+    direction: higher_is_better
+    entity_type: person
+    computation: !ratio
+      scale: 100.0
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: numerator
+        measure_key: focus_hours
+      - input_role: denominator
+        measure_key: working_hours
+    dimensions: []
+  - metric_key: collab.breadth
+    source_key: collab
+    label: Collaboration Breadth
+    short_label: Breadth
+    description: Distinct collaboration modalities used
+    explanation: Distinct collaboration modalities — chat, meetings, email, documents — a person was deliberately active in during the period.
+    unit: modalities
+    format: integer
+    direction: neutral
+    entity_type: person
+    computation: distinct_count
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: active_modality
+    dimensions: []
+  - metric_key: collab.meetings_organized
+    source_key: collab
+    label: Meetings Organized
+    short_label: Mtgs hosted
+    description: Meetings organized
+    explanation: Meetings a person organized. Reported only by tools that expose organizer counts.
+    unit: meetings
+    format: integer
+    direction: neutral
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: meetings_organized
+    dimensions:
+      - tool
+  - metric_key: collab.adhoc_meetings
+    source_key: collab
+    label: Ad-hoc Meetings
+    short_label: Ad-hoc mtgs
+    description: Unscheduled meetings attended
+    explanation: Unscheduled meetings a person attended. Reported only by tools that distinguish ad-hoc from scheduled meetings.
+    unit: meetings
+    format: integer
+    direction: neutral
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: adhoc_meetings_attended
+    dimensions:
+      - tool
+  - metric_key: collab.scheduled_meetings
+    source_key: collab
+    label: Scheduled Meetings
+    short_label: Sched. mtgs
+    description: Scheduled meetings attended
+    explanation: Scheduled meetings a person attended. Reported only by tools that distinguish ad-hoc from scheduled meetings.
+    unit: meetings
+    format: integer
+    direction: neutral
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: scheduled_meetings_attended
+    dimensions:
+      - tool
+  - metric_key: tasks.closed
+    source_key: task
+    label: Tasks closed
+    short_label: Tasks
+    description: Tasks moved to a closed status
+    explanation: Tasks a person moved into a closed status during the period.
+    unit: tasks
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: tasks_closed
+    dimensions: []
+  - metric_key: tasks.bugs_fixed
+    source_key: task
+    label: Bugs fixed
+    short_label: Bugs
+    description: Bug-type tasks closed
+    explanation: Bug-type tasks a person closed during the period.
+    unit: tasks
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: bugs_fixed
+    dimensions: []
+  - metric_key: tasks.dev_time
+    source_key: task
+    label: Development time
+    short_label: Dev time
+    description: Time a task spends in active development
+    explanation: Median time closed tasks spent in in-progress statuses, from first pickup to close.
+    unit: h
+    format: decimal
+    direction: lower_is_better
+    entity_type: person
+    computation: median
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: dev_time_hours
+    dimensions: []
+  - metric_key: tasks.resolution_time
+    source_key: task
+    label: Time to resolution
+    short_label: Resolution
+    description: Task lifetime from creation to close
+    explanation: Median time from task creation to close.
+    unit: d
+    format: decimal
+    direction: lower_is_better
+    entity_type: person
+    computation: median
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: resolution_days
+    dimensions: []
+  - metric_key: tasks.pickup_time
+    source_key: task
+    label: Pickup time
+    short_label: Pickup
+    description: Wait before work starts on a task
+    explanation: Median time from task creation to first entering an in-progress status.
+    unit: d
+    format: decimal
+    direction: lower_is_better
+    entity_type: person
+    computation: median
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: pickup_days
+    dimensions: []
+  - metric_key: tasks.flow_efficiency
+    source_key: task
+    label: Flow efficiency
+    short_label: Flow %
+    description: Active development share of task lifetime
+    explanation: Time in active development as a share of total task lifetime, across closed tasks.
+    format: percent
+    direction: higher_is_better
+    entity_type: person
+    computation: !ratio
+      scale: 100.0
+    transform:
+      clamp_max: 100.0
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: numerator
+        measure_key: flow_dev_seconds
+      - input_role: denominator
+        measure_key: flow_lead_seconds
+    dimensions: []
+  - metric_key: tasks.reopen_rate
+    source_key: task
+    label: Reopen rate
+    short_label: Reopen %
+    description: Closed tasks reopened shortly after
+    explanation: Share of task closes followed by a reopen within 14 days.
+    format: percent
+    direction: lower_is_better
+    entity_type: person
+    computation: !ratio
+      scale: 100.0
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: numerator
+        measure_key: reopened_within_14d
+      - input_role: denominator
+        measure_key: close_events
+    dimensions: []
+  - metric_key: tasks.due_date_compliance
+    source_key: task
+    label: Due date compliance
+    short_label: Due date %
+    description: On-time share of tasks with a due date
+    explanation: Share of tasks that had a due date and were closed on or before it.
+    format: percent
+    direction: higher_is_better
+    entity_type: person
+    computation: !ratio
+      scale: 100.0
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: numerator
+        measure_key: due_date_on_time
+      - input_role: denominator
+        measure_key: due_date_with_due
+    dimensions: []
+  - metric_key: tasks.on_time_delivery
+    source_key: task
+    label: On-time delivery
+    short_label: On-time %
+    description: On-time share of all closed tasks
+    explanation: Share of all closed tasks that were closed on or before their due date.
+    format: percent
+    direction: higher_is_better
+    entity_type: person
+    computation: !ratio
+      scale: 100.0
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: numerator
+        measure_key: due_date_on_time
+      - input_role: denominator
+        measure_key: tasks_closed
+    dimensions: []
+  - metric_key: tasks.avg_slip
+    source_key: task
+    label: Average slip
+    short_label: Avg slip
+    description: How late overdue tasks close
+    explanation: Average days past the due date for tasks closed late.
+    unit: d
+    format: decimal
+    direction: lower_is_better
+    entity_type: person
+    computation: !ratio
+      scale: 1.0
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: numerator
+        measure_key: slip_days_total
+      - input_role: denominator
+        measure_key: late_count
+    dimensions: []
+  - metric_key: tasks.estimation_accuracy
+    source_key: task
+    label: Estimation accuracy
+    short_label: Estimate %
+    description: How close estimates land to time spent
+    explanation: 100 minus the average deviation between original estimates and time spent, over days whose estimated work stayed within twice the estimate. 100 means estimates matched reality; over- and under-estimation count equally.
+    format: percent
+    direction: higher_is_better
+    entity_type: person
+    computation: !ratio
+      scale: 1.0
+    transform:
+      multiplier: -1.0
+      offset: 100.0
+      clamp_min: 0.0
+      clamp_max: 100.0
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: numerator
+        measure_key: estimation_error_pct
+      - input_role: denominator
+        measure_key: estimation_samples
+    dimensions: []
+  - metric_key: tasks.worklog_accuracy
+    source_key: task
+    label: Worklog accuracy
+    short_label: Worklog %
+    description: Logged time versus tracked development
+    explanation: Logged work time as a share of time tasks spent in in-progress statuses.
+    format: percent
+    direction: higher_is_better
+    entity_type: person
+    computation: !ratio
+      scale: 100.0
+    transform:
+      clamp_max: 100.0
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: numerator
+        measure_key: worklog_seconds
+      - input_role: denominator
+        measure_key: in_progress_seconds
+    dimensions: []
+  - metric_key: tasks.bugs_ratio
+    source_key: task
+    label: Bug ratio
+    short_label: Bug %
+    description: Bugs as a share of closed tasks
+    explanation: Bug-type tasks as a share of all closed tasks.
+    format: percent
+    direction: lower_is_better
+    entity_type: person
+    computation: !ratio
+      scale: 100.0
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: numerator
+        measure_key: bugs_fixed
+      - input_role: denominator
+        measure_key: tasks_closed
+    dimensions: []
+  - metric_key: tasks.stale_in_progress
+    source_key: task
+    label: Stale in progress
+    short_label: Stale WIP
+    description: Open tasks idle for over two weeks
+    explanation: Open tasks with no status change in more than 14 days.
+    unit: tasks
+    format: integer
+    direction: lower_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: stale_in_progress
+    dimensions: []
+  - metric_key: wiki.pages_created
+    source_key: wiki
+    label: Pages created
+    short_label: New pages
+    description: Wiki pages authored
+    explanation: Wiki pages the person created during the period, counted on the page's creation date.
+    unit: pages
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: pages_created
+    dimensions: []
+  - metric_key: wiki.edits
+    source_key: wiki
+    label: Page edits
+    short_label: Edits
+    description: Wiki edit sessions
+    explanation: Logical wiki edits the person made during the period. Consecutive saves of the same page within a short window count as one edit, so autosaves do not inflate the number.
+    unit: edits
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: edits
+    dimensions: []
+  - metric_key: wiki.pages_edited
+    source_key: wiki
+    label: Pages edited
+    short_label: Pages edited
+    description: Distinct wiki pages edited
+    explanation: Distinct wiki pages the person edited during the period, counted per day the page was touched.
+    unit: pages
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: pages_edited
+    dimensions: []
+  - metric_key: wiki.comments
+    source_key: wiki
+    label: Comments received
+    short_label: Comments
+    description: Comments on the person's wiki pages
+    explanation: Comments and replies other people left on wiki pages the person authored — a signal of how much their documentation is read and discussed.
+    unit: comments
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: comments
+    dimensions: []

--- a/src/backend/services/analytics/src/domain/metric_definitions/seeds.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/seeds.rs
@@ -29,7 +29,7 @@ async fn reconcile_source(
     upsert_source(db, builtin_source).await?;
     let source_id = fetch_source_id(db, &builtin_source.source.key).await?;
 
-    for measure_key in &builtin_source.measures {
+    for measure in &builtin_source.measures {
         db.execute(Statement::from_sql_and_values(
             db.get_database_backend(),
             "INSERT INTO metric_source_measures \
@@ -41,8 +41,8 @@ async fn reconcile_source(
             [
                 uuid_value(Uuid::now_v7()),
                 uuid_value(source_id),
-                Value::from(measure_key.as_str()),
-                Value::from(builtin_source.evidence_granularity(measure_key).as_db()),
+                Value::from(measure.key.as_str()),
+                Value::from(measure.evidence_granularity.as_db()),
             ],
         ))
         .await?;
@@ -245,14 +245,18 @@ async fn disable_missing_builtin_rows(db: &DatabaseConnection) -> Result<(), DbE
         let measure_keys = builtin_source
             .measures
             .iter()
-            .map(String::as_str)
+            .map(|measure| measure.key.as_str())
             .collect::<Vec<_>>();
-        let placeholders = vec!["?"; measure_keys.len()].join(", ");
-        let sql = format!(
-            "UPDATE metric_source_measures SET is_enabled = FALSE \
-             WHERE source_id = ? AND is_enabled = TRUE \
-               AND measure_key NOT IN ({placeholders})"
-        );
+
+        let base_sql = "UPDATE metric_source_measures SET is_enabled = FALSE \
+                        WHERE source_id = ? AND is_enabled = TRUE";
+        let sql = if measure_keys.is_empty() {
+            base_sql.to_owned()
+        } else {
+            let placeholders = vec!["?"; measure_keys.len()].join(", ");
+            format!("{base_sql} AND measure_key NOT IN ({placeholders})")
+        };
+
         let mut values = vec![uuid_value(source_id)];
         values.extend(measure_keys.iter().map(|key| Value::from(*key)));
         db.execute(Statement::from_sql_and_values(

--- a/src/backend/services/analytics/src/domain/metric_definitions/seeds.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/seeds.rs
@@ -2,20 +2,20 @@ use sea_orm::{ConnectionTrait, DatabaseConnection, DbErr, Statement, Value};
 use uuid::Uuid;
 
 use crate::domain::metric_definitions::builtin::{
-    BUILTIN_METRICS, BUILTIN_SOURCES, BuiltinSource, CohortKey, InputSeed, MetricSeed,
+    BuiltinSource, CohortKey, InputSeed, MetricSeed, builtin_metrics, builtin_sources,
 };
 
 pub async fn reconcile_builtin_definitions(db: &DatabaseConnection) -> Result<(), DbErr> {
-    for builtin_source in BUILTIN_SOURCES {
+    for builtin_source in builtin_sources() {
         reconcile_source(db, builtin_source).await?;
     }
 
-    for metric in BUILTIN_METRICS {
-        let source_id = fetch_source_id(db, metric.source_key).await?;
+    for metric in builtin_metrics() {
+        let source_id = fetch_source_id(db, &metric.source_key).await?;
         upsert_metric(db, metric).await?;
-        let metric_id = fetch_metric_id(db, metric.metric_key).await?;
-        replace_inputs(db, source_id, metric_id, metric.inputs).await?;
-        replace_dimensions(db, source_id, metric_id, metric.dimensions).await?;
+        let metric_id = fetch_metric_id(db, &metric.metric_key).await?;
+        replace_inputs(db, source_id, metric_id, &metric.inputs).await?;
+        replace_dimensions(db, source_id, metric_id, &metric.dimensions).await?;
     }
 
     disable_missing_builtin_rows(db).await?;
@@ -27,9 +27,9 @@ async fn reconcile_source(
     builtin_source: &BuiltinSource,
 ) -> Result<(), DbErr> {
     upsert_source(db, builtin_source).await?;
-    let source_id = fetch_source_id(db, builtin_source.source.key).await?;
+    let source_id = fetch_source_id(db, &builtin_source.source.key).await?;
 
-    for measure_key in builtin_source.measures {
+    for measure_key in &builtin_source.measures {
         db.execute(Statement::from_sql_and_values(
             db.get_database_backend(),
             "INSERT INTO metric_source_measures \
@@ -41,7 +41,7 @@ async fn reconcile_source(
             [
                 uuid_value(Uuid::now_v7()),
                 uuid_value(source_id),
-                Value::from(*measure_key),
+                Value::from(measure_key.as_str()),
                 Value::from(builtin_source.evidence_granularity(measure_key).as_db()),
             ],
         ))
@@ -59,7 +59,7 @@ async fn reconcile_source(
             [
                 uuid_value(Uuid::now_v7()),
                 uuid_value(source_id),
-                Value::from(*dimension_key),
+                Value::from(dimension_key.as_str()),
                 Value::from(order_value(idx)),
             ],
         ))
@@ -86,10 +86,10 @@ async fn upsert_source(
             is_enabled = VALUES(is_enabled)",
         [
             uuid_value(Uuid::now_v7()),
-            Value::from(builtin_source.source.key),
+            Value::from(builtin_source.source.key.as_str()),
             Value::from(builtin_source.source.kind.as_db()),
-            Value::from(builtin_source.source.source_ref),
-            Value::from(builtin_source.source.evidence_ref),
+            Value::from(builtin_source.source.source_ref.as_str()),
+            Value::from(builtin_source.source.evidence_ref.as_str()),
         ],
     ))
     .await?;
@@ -124,12 +124,12 @@ async fn upsert_metric(db: &DatabaseConnection, metric: &MetricSeed) -> Result<(
             is_enabled = VALUES(is_enabled)",
         [
             uuid_value(Uuid::now_v7()),
-            Value::from(metric.metric_key),
-            Value::from(metric.label),
-            nullable_str(metric.short_label),
-            nullable_str(metric.description),
-            nullable_str(metric.explanation),
-            nullable_str(metric.unit),
+            Value::from(metric.metric_key.as_str()),
+            Value::from(metric.label.as_str()),
+            nullable_str(metric.short_label.as_deref()),
+            nullable_str(metric.description.as_deref()),
+            nullable_str(metric.explanation.as_deref()),
+            nullable_str(metric.unit.as_deref()),
             Value::from(metric.format.as_db()),
             Value::from(metric.direction.as_db()),
             Value::from(metric.entity_type.as_db()),
@@ -163,7 +163,7 @@ async fn replace_inputs(
     .await?;
 
     for input in inputs {
-        let measure_id = fetch_measure_id(db, source_id, input.measure_key).await?;
+        let measure_id = fetch_measure_id(db, source_id, &input.measure_key).await?;
         db.execute(Statement::from_sql_and_values(
             db.get_database_backend(),
             "INSERT INTO metric_definition_inputs \
@@ -185,7 +185,7 @@ async fn replace_dimensions(
     db: &DatabaseConnection,
     source_id: Uuid,
     metric_id: Uuid,
-    dimensions: &[&str],
+    dimensions: &[String],
 ) -> Result<(), DbErr> {
     db.execute(Statement::from_sql_and_values(
         db.get_database_backend(),
@@ -214,9 +214,9 @@ async fn replace_dimensions(
 }
 
 async fn disable_missing_builtin_rows(db: &DatabaseConnection) -> Result<(), DbErr> {
-    let metric_keys = BUILTIN_METRICS
+    let metric_keys = builtin_metrics()
         .iter()
-        .map(|metric| metric.metric_key)
+        .map(|metric| metric.metric_key.as_str())
         .collect::<Vec<_>>();
     disable_missing(
         db,
@@ -227,9 +227,9 @@ async fn disable_missing_builtin_rows(db: &DatabaseConnection) -> Result<(), DbE
     )
     .await?;
 
-    let source_keys = BUILTIN_SOURCES
+    let source_keys = builtin_sources()
         .iter()
-        .map(|builtin_source| builtin_source.source.key)
+        .map(|builtin_source| builtin_source.source.key.as_str())
         .collect::<Vec<_>>();
     disable_missing(
         db,
@@ -240,9 +240,13 @@ async fn disable_missing_builtin_rows(db: &DatabaseConnection) -> Result<(), DbE
     )
     .await?;
 
-    for builtin_source in BUILTIN_SOURCES {
-        let source_id = fetch_source_id(db, builtin_source.source.key).await?;
-        let measure_keys = builtin_source.measures.to_vec();
+    for builtin_source in builtin_sources() {
+        let source_id = fetch_source_id(db, &builtin_source.source.key).await?;
+        let measure_keys = builtin_source
+            .measures
+            .iter()
+            .map(String::as_str)
+            .collect::<Vec<_>>();
         let placeholders = vec!["?"; measure_keys.len()].join(", ");
         let sql = format!(
             "UPDATE metric_source_measures SET is_enabled = FALSE \

--- a/tests/stand/ui/pages/team_view.py
+++ b/tests/stand/ui/pages/team_view.py
@@ -63,5 +63,20 @@ class TeamView:
             exact=True,
         )
 
+    def metric_cell(self, display_name: str, metric_label: str) -> Locator:
+        """That member's cell for a metric, recorded or an honest "not recorded".
+
+        Presence proves the row rendered the column; it does not require a
+        value, so a legitimately unrecorded metric (a member who closed tasks
+        but fixed no bugs) is not a failure.
+        """
+        name = re.compile(rf"^{re.escape(display_name)} — {re.escape(metric_label)}: ")
+        return self.page.get_by_role("button", name=name)
+
+    def any_recorded_metric_cell(self, display_name: str) -> Locator:
+        """Any metric this member has a recorded value for — the row is not blank."""
+        name = re.compile(rf"^{re.escape(display_name)} — .+: (?!not recorded)")
+        return self.page.get_by_role("button", name=name).first
+
     def domain_card(self, label: str) -> Locator:
         return self.page.get_by_role("button", name=f"Open {label} details")

--- a/tests/stand/ui/test_seeded_data_visible.py
+++ b/tests/stand/ui/test_seeded_data_visible.py
@@ -149,6 +149,12 @@ def test_the_team_view_lists_every_report_the_roster_declares(
     expect(team.team_heading(lead.display_name)).to_be_visible()
     expect(team.metrics_overview()).to_be_visible()
 
+    # Every member renders a cell for every column (recorded or an honest
+    # "not recorded") and at least one real recorded value — this catches a
+    # dropped member, a blank row, or a truncated column, without demanding
+    # every metric for every person. A member can legitimately close tasks
+    # yet fix no bugs, so "Bugs fixed: not recorded" for one member is data,
+    # not a defect.
     for name in reports:
         row = team.member_row(name)
         expect(row).to_be_visible()
@@ -162,7 +168,8 @@ def test_the_team_view_lists_every_report_the_roster_declares(
             "Meeting Hours",
             "AI active days",
         ):
-            expect(team.recorded_metric_cell(name, metric_label)).to_be_visible()
+            expect(team.metric_cell(name, metric_label)).to_be_visible()
+        expect(team.any_recorded_metric_cell(name)).to_be_visible()
         expect(team.unrecorded_metric_cell(name, "Page edits")).to_be_visible()
 
     for label in ("Task delivery", "Git output", "Collaboration", "AI adoption"):


### PR DESCRIPTION
Closes #1974. Part of #1803 (Phase B).

## What

One declarative registry (`src/backend/services/analytics/src/domain/metric_definitions/registry.yaml`) is now the single source of truth for the sanctioned metric-definition seed — a `sources` list and a `metrics` list. It replaces the code-literal `BUILTIN_SOURCES` / `BUILTIN_METRICS` arrays in `builtin.rs`.

The registry was generated *from* the const arrays, so it is byte-for-byte parity (5 sources, 59 metrics). It is embedded at build time (`include_str!`) and deserialized once via `OnceLock` into the seed types, exposed as `builtin_sources()` / `builtin_metrics()`. The startup reconciler reads it through those accessors, so reconcile semantics (idempotent additive upserts + disable-missing) are unchanged. The registry invariant tests parse the same embedded file, so a malformed or drifted registry fails the build.

## Aligns with the adopted semantic-layer design

This PR is the **first Phase-1 step** of the semantic-layer target architecture adopted in #2184 (`docs/domain/semantic-layer/specs/` — PRD `cpt-semantic-layer-fr-definitions-as-data`, DESIGN `cpt-semantic-layer-component-definition-store`): metric definitions authored as data, replacing Rust constants.

Per that design, the registry's current **observation-relation shape** (`source_ref`, per-measure `evidence_granularity`, reconcile into `metric_source_measures`) is intentionally **transitional** — it is rewritten to the dataset/measure/metric domain model at the compiler-first cutover (target Phases 2–3). So this PR deliberately does **not** reshape the schema; it moves authoring to data in the existing shape, which is the low-risk first step the design prescribes. Migration cost stays near zero because builtin rows are seed-reconciled.

## Scope

- **FE:** untouched — it already renders from the `metric_definitions` catalog API and live peer percentiles and holds no per-metric thresholds, so the "FE thresholds" collapse was already done.
- **Legacy `metric_catalog` / `metric_threshold`:** untouched. It is an orphaned, frozen subsystem (no live consumer — `/v1/catalog/get_metrics` is not called by the FE), so it is not folded into the new registry. Its retirement is tracked separately (#2167).

## Docs

- Updated the governing metrics DESIGN (`builtin.rs` -> `registry.yaml`) in "Builtin Seed Reconciliation" and "Adding a Metric".
- Extended the registered presentation PRD/DESIGN with `cpt-presentation-fr-metric-registry` + `cpt-presentation-component-metric-registry`.
- The adopted semantic-layer PRD/DESIGN (#2184) record this registry as their Phase-1 down-payment.

## Verification

- `cargo test -p analytics`: 561 passed, 0 failed (registry invariant tests validate the YAML-loaded data, incl. `every_source_declares_at_least_one_measure`).
- `cargo clippy -p analytics`: clean.
- `cfs` per-artifact validation of the presentation PRD/DESIGN: green; zero new whole-registry errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a centralized metric registry covering AI usage, Git, collaboration, task tracking, and wiki activity.
  * Expanded metrics for adoption, delivery, collaboration, workflow, quality, and contribution insights.
  * Metric definitions are synchronized at startup, with missing definitions safely disabled.

* **Reliability**
  * Added validation to detect inconsistent, incomplete, or unsupported metric definitions.

* **Documentation**
  * Updated product and design documentation to describe the registry, supported scope, validation, and deferred work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->