### PR TITLE
test(stand): cover personal and team metrics dashboards

### DIFF
--- a/tests/stand/ui/pages/person_view.py
+++ b/tests/stand/ui/pages/person_view.py
@@ -31,11 +31,16 @@ class PersonView:
     def person_heading(self, display_name: str) -> Locator:
         return self.page.get_by_role("heading", name=display_name)
 
-    def metric_tile(self, label: str) -> Locator:
-        """The tile for one named metric.
+    def kpi_tile(self, label: str) -> Locator:
+        return self.page.get_by_role("button", name=f"Open {label} details")
 
-        Addressed by its visible label rather than by position: the set of tiles
-        and their order are product decisions, and a test that indexed into them
-        would fail on a layout change that broke nothing.
-        """
-        return self.page.get_by_role("listitem").filter(has_text=label).first
+    def kpi_value(self, label: str) -> Locator:
+        return self.kpi_tile(label).locator("[data-slot='card-title']")
+
+    def populated_domain_card(self, label: str) -> Locator:
+        return self.page.get_by_role("button", name=f"Open {label} details")
+
+    def empty_domain_card(self, label: str) -> Locator:
+        return self.page.locator("[data-slot='card']").filter(
+            has=self.page.get_by_text(label, exact=True)
+        )

--- a/tests/stand/ui/pages/person_view.py
+++ b/tests/stand/ui/pages/person_view.py
@@ -31,6 +31,9 @@ class PersonView:
     def person_heading(self, display_name: str) -> Locator:
         return self.page.get_by_role("heading", name=display_name)
 
+    def team_view_switch(self) -> Locator:
+        return self.page.get_by_role("button", name="Team", exact=True)
+
     def kpi_tile(self, label: str) -> Locator:
         return self.page.get_by_role("button", name=f"Open {label} details")
 

--- a/tests/stand/ui/pages/team_view.py
+++ b/tests/stand/ui/pages/team_view.py
@@ -9,6 +9,7 @@ rather than as a bad URL.
 
 from __future__ import annotations
 
+import re
 from urllib.parse import quote
 
 from playwright.sync_api import Locator, Page
@@ -22,9 +23,6 @@ class TeamView:
     def path(person_id: str) -> str:
         return f"/ic/{quote(person_id, safe='')}/team"
 
-    def go(self, person_id: str) -> None:
-        self.page.goto(self.path(person_id), wait_until="domcontentloaded")
-
     def team_heading(self, display_name: str) -> Locator:
         """The heading naming whose team this is.
 
@@ -33,6 +31,9 @@ class TeamView:
         would put the product's copy in the test.
         """
         return self.page.get_by_role("heading").filter(has_text=display_name).first
+
+    def metrics_overview(self) -> Locator:
+        return self.page.get_by_text(re.compile(r"^Members . metrics$"))
 
     def member_row(self, display_name: str) -> Locator:
         """That member's row in the team table.
@@ -48,3 +49,19 @@ class TeamView:
         only if the table rendered, which is what a caller actually means.
         """
         return self.page.get_by_role("row").filter(has_text=display_name)
+
+    def recorded_metric_cell(self, display_name: str, metric_label: str) -> Locator:
+        name = re.compile(
+            rf"^{re.escape(display_name)} — {re.escape(metric_label)}: (?!not recorded)"
+        )
+        return self.page.get_by_role("button", name=name)
+
+    def unrecorded_metric_cell(self, display_name: str, metric_label: str) -> Locator:
+        return self.page.get_by_role(
+            "button",
+            name=f"{display_name} — {metric_label}: not recorded",
+            exact=True,
+        )
+
+    def domain_card(self, label: str) -> Locator:
+        return self.page.get_by_role("button", name=f"Open {label} details")

--- a/tests/stand/ui/test_seeded_data_visible.py
+++ b/tests/stand/ui/test_seeded_data_visible.py
@@ -15,8 +15,9 @@ is empty by design. So every seeded fact
 asserted here is an IDENTITY fact read from the manifest at runtime — who the
 person is, and who the roster places under them.
 
-That the tiles render at all is still checked, by LABEL rather than by value,
-because a view showing the right name and no metrics is a different defect.
+The dashboard coverage checks every KPI and domain card by its visible product
+label. It verifies that seeded domains are populated and that the unseeded Wiki
+domain renders its explicit empty state.
 """
 
 from __future__ import annotations
@@ -66,21 +67,12 @@ def test_the_landing_view_shows_the_persona_and_their_reports(
 
 
 @pytest.mark.requires_seed("dev_lead")
-def test_the_personal_view_renders_metric_tiles_for_the_persona(
+def test_the_personal_dashboard_renders_every_metric_domain(
     page: Page,
     base_url: str,
     session_for: Callable[[str], PersonaSession],
 ) -> None:
-    """The person's own view is populated, not an empty shell.
-
-    Tiles are asserted BY LABEL and never by value. The labels are the product's
-    own copy, so a renamed tile fails here — the correct outcome for a test whose
-    subject is "the view rendered its content".
-
-    Three labels rather than one: a single tile could render from a placeholder,
-    while three distinct sections all populating means the view is wired to real
-    per-person data.
-    """
+    """The person's dashboard renders every KPI and domain in its seeded state."""
     persona = session_for("dev_lead")
 
     sign_in(page, base_url, persona)
@@ -89,8 +81,23 @@ def test_the_personal_view_renders_metric_tiles_for_the_persona(
     view.go(persona.person.uuid)
     expect(view.person_heading(persona.person.display_name)).to_be_visible()
 
-    for label in ("Tasks closed", "Pull requests merged", "AI-added lines"):
-        expect(view.metric_tile(label)).to_be_visible()
+    for label in (
+        "Tasks closed",
+        "Focus Time",
+        "Pull requests merged",
+        "AI active days",
+        "AI-added lines",
+    ):
+        expect(view.kpi_tile(label)).to_be_visible()
+        expect(view.kpi_value(label)).not_to_have_text("—")
+
+    for label in ("Task delivery", "Git output", "Collaboration", "AI adoption"):
+        expect(view.populated_domain_card(label)).to_be_visible()
+
+    wiki = view.empty_domain_card("Wiki")
+    expect(wiki).to_be_visible()
+    expect(wiki.get_by_text("No data", exact=True)).to_be_visible()
+    expect(wiki.get_by_text("No metrics with data for this period.", exact=True)).to_be_visible()
 
 
 @pytest.mark.requires_seed("dev_lead")

--- a/tests/stand/ui/test_seeded_data_visible.py
+++ b/tests/stand/ui/test_seeded_data_visible.py
@@ -136,8 +136,40 @@ def test_the_team_view_lists_every_report_the_roster_declares(
 
     sign_in(page, base_url, persona)
 
+    personal = PersonView(page)
+    personal.go(lead.uuid)
+    expect(personal.person_heading(lead.display_name)).to_be_visible()
+
+    team_switch = personal.team_view_switch()
+    expect(team_switch).to_be_visible()
+    team_switch.click()
+
     team = TeamView(page)
-    team.go(lead.uuid)
+    expect(page).to_have_url(f"{base_url}{TeamView.path(lead.uuid)}")
     expect(team.team_heading(lead.display_name)).to_be_visible()
+    expect(team.metrics_overview()).to_be_visible()
+
     for name in reports:
-        expect(team.member_row(name)).to_be_visible()
+        row = team.member_row(name)
+        expect(row).to_be_visible()
+        for metric_label in (
+            "Tasks closed",
+            "Time to resolution",
+            "Bugs fixed",
+            "Pull requests merged",
+            "PR cycle time",
+            "Focus Time",
+            "Meeting Hours",
+            "AI active days",
+        ):
+            expect(team.recorded_metric_cell(name, metric_label)).to_be_visible()
+        expect(team.unrecorded_metric_cell(name, "Page edits")).to_be_visible()
+
+    for label in ("Task delivery", "Git output", "Collaboration", "AI adoption"):
+        card = team.domain_card(label)
+        expect(card).to_be_visible()
+        expect(card).not_to_contain_text("No metrics with peer data for this period.")
+
+    wiki = team.domain_card("Wiki")
+    expect(wiki).to_be_visible()
+    expect(wiki).to_contain_text("No metrics with peer data for this period.")


### PR DESCRIPTION
## Summary

- verify every personal-dashboard KPI and metric domain
- navigate to the team dashboard through the header switcher
- verify every seeded team member, heatmap metric, and domain card
- assert the expected unseeded Wiki states without hardcoding runtime metric values

## Validation

- `ruff check`
- `ruff format --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded browser coverage for personal dashboards and team views.
  - Added verification for all KPI values, populated domain cards, and empty-state messaging.
  - Added checks for recorded and unrecorded team metrics across every roster member.
  - Improved validation of team navigation and dashboard details to help ensure consistent, reliable experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->