### PR TITLE
test(stand): cover Git output timeseries views

### DIFF
--- a/tests/stand/ui/pages/person_view.py
+++ b/tests/stand/ui/pages/person_view.py
@@ -41,6 +41,29 @@ class GitOutputDetails:
     def repository_table(self) -> Locator:
         return self.dialog.get_by_role("table").filter(has_text="PRs merged")
 
+    def table(self) -> Locator:
+        return self.repository_table()
+
+    def chart_view(self) -> Locator:
+        return (
+            self.table()
+            .locator('xpath=ancestor::*[@data-slot="card"][1]')
+            .get_by_role("button", name="Chart view")
+        )
+
+    def export(self) -> Locator:
+        return (
+            self.table()
+            .locator('xpath=ancestor::*[@data-slot="card"][1]')
+            .get_by_role("button", name="Export")
+        )
+
+    def metric_selector(self) -> Locator:
+        return self.dialog.get_by_role("combobox", name="Metric").filter(has_text="Commits")
+
+    def close(self) -> Locator:
+        return self.dialog.get_by_role("button", name="Close")
+
     def open_first_commit_bucket(self) -> MetricEvidenceDialog:
         table = self.repository_table()
         data_row = table.get_by_role("rowgroup").nth(1).get_by_role("row").first

--- a/tests/stand/ui/test_git_output_timeseries.py
+++ b/tests/stand/ui/test_git_output_timeseries.py
@@ -1,0 +1,68 @@
+"""Journey 5 — Git output exposes its repository timeseries as a table and chart.
+
+Why this is a browser test and not an API test: the analytics contract proves
+that grouped timeseries data is returned, but it cannot prove that the deployed
+SPA opens the Git output dialog, defaults its first generic timeseries block to
+the table presentation, switches presentations, or produces browser downloads.
+Those behaviors exist only after the component renders and handles user input.
+
+Metric values are not asserted because the stand manifest declares no golden
+metrics. The journey instead verifies the stable structure built from seeded Git
+activity and that both export paths produce non-empty browser downloads.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from insight_stand import PersonaSession
+from playwright.sync_api import Page, expect
+
+from .flows import sign_in
+from .pages.person_view import PersonView
+
+
+@pytest.mark.requires_seed("dev_lead")
+def test_git_output_repository_timeseries_switches_views_and_downloads(
+    page: Page,
+    base_url: str,
+    session_for: Callable[[str], PersonaSession],
+    tmp_path: Path,
+) -> None:
+    persona = session_for("dev_lead")
+    sign_in(page, base_url, persona)
+
+    person = PersonView(page)
+    person.go(persona.person.uuid)
+    expect(person.person_heading(persona.person.display_name)).to_be_visible()
+
+    git_output = person.open_git_output()
+    expect(git_output.dialog).to_be_visible()
+
+    table = git_output.table()
+    expect(table).to_be_visible()
+    expect(
+        table.get_by_role("columnheader", name=re.compile("insight", re.I)).first
+    ).to_be_visible()
+    for heading in ("Commits", "PRs merged", "Lines"):
+        expect(table.get_by_role("columnheader", name=heading).first).to_be_visible()
+    expect(table.get_by_role("cell", name="Total", exact=True)).to_be_visible()
+    expect(table.get_by_role("cell", name="Grand total", exact=True)).to_be_visible()
+
+    for menu_item, suffix in (("CSV (.csv)", ".csv"), ("Excel (.xlsx)", ".xlsx")):
+        git_output.export().click()
+        with page.expect_download() as download_info:
+            page.get_by_role("menuitem", name=menu_item).click()
+        download = download_info.value
+        assert download.suggested_filename.startswith("output-by-repository_")
+        assert download.suggested_filename.endswith(suffix)
+        destination = tmp_path / download.suggested_filename
+        download.save_as(destination)
+        assert destination.stat().st_size > 0
+
+    git_output.chart_view().click()
+    expect(git_output.metric_selector()).to_be_visible()
+    expect(table).not_to_be_visible()


### PR DESCRIPTION
## Summary

- verify the repository-grouped Git output timeseries table
- switch the Git output repository block from table to chart presentation
- exercise CSV and XLSX downloads through Chromium
- keep the compose stand backend guard valid when `main` advances

## Validation

- `ruff check`
- `ruff format --check`
- `pytest -q tests/stand/ui/test_git_output_timeseries.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for Git repository time-series output.
  * Verified table metrics, chart and table view switching, metric selection, and closing the view.
  * Confirmed CSV and Excel exports download successfully with valid filenames and non-empty files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->