### PR TITLE
fix(backend): revert reqwest to 0.12 — authenticator OIDC stack pins its client impls to it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,12 @@ updates:
       rust-minor-patch:
         patterns: ["*"]
         update-types: [minor, patch]
+    # reqwest 0.13 breaks the authenticator: openidconnect 4 / oauth2 5 implement
+    # their HTTP-client traits only for reqwest 0.12. Lift when a released
+    # openidconnect supports reqwest 0.13.
+    ignore:
+      - dependency-name: reqwest
+        versions: [">=0.13"]
 
   - package-ecosystem: pip
     directory: /deploy/seed

--- a/.github/workflows/authenticator.yml
+++ b/.github/workflows/authenticator.yml
@@ -16,6 +16,11 @@ on:
       - "src/backend/services/authenticator/**"
       - "src/backend/services/fakeidp/**"
       - "src/backend/libs/authenticator-sdk/**"
+      # A workspace-wide dependency bump can break the authenticator build
+      # without touching its sources (reqwest 0.12 -> 0.13 did, via
+      # openidconnect's pinned HTTP-client impls).
+      - "src/backend/Cargo.toml"
+      - "src/backend/Cargo.lock"
       - "src/ingestion/tests/e2e/lib/api_coverage.py"
       - "docs/components/backend/authenticator/openapi.json"
       - ".github/workflows/authenticator.yml"

--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -99,7 +99,7 @@ dependencies = [
  "futures-util",
  "insight-clickhouse",
  "redis",
- "reqwest 0.13.4",
+ "reqwest 0.12.28",
  "rust_xlsxwriter",
  "sea-orm",
  "sea-orm-migration",
@@ -350,7 +350,7 @@ dependencies = [
  "rand 0.8.6",
  "rdkafka",
  "redis",
- "reqwest 0.13.4",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -374,7 +374,7 @@ dependencies = [
  "async-trait",
  "cf-gears-toolkit-canonical-errors",
  "jsonwebtoken",
- "reqwest 0.13.4",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
@@ -2246,7 +2246,7 @@ dependencies = [
  "base64 0.22.1",
  "jsonwebtoken",
  "rand 0.8.6",
- "reqwest 0.13.4",
+ "reqwest 0.12.28",
  "rsa",
  "serde",
  "serde_json",
@@ -2387,6 +2387,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2922,6 +2937,22 @@ dependencies = [
  "hyper-util",
  "pin-project-lite",
  "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
  "tower-service",
 ]
 
@@ -3569,6 +3600,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "never-say-never"
 version = "6.6.666"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3826,10 +3874,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -4860,17 +4945,22 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4881,6 +4971,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -6427,6 +6518,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -79,7 +79,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 secrecy = { version = "0.10", features = ["serde"] }
 
 # HTTP client (for Identity Resolution API)
-reqwest = { version = "0.13", features = ["json"] }
+reqwest = { version = "0.12", features = ["json"] }
 
 # Caching
 redis = { version = "1.5", features = ["tokio-comp", "connection-manager"] }


### PR DESCRIPTION
## What / why

Dependabot #2160 bumped the workspace `reqwest` 0.12.28 → 0.13.4. `openidconnect` 4 / `oauth2` 5 — the authenticator's OIDC client stack — implement `AsyncHttpClient` only for reqwest **0.12**, and no released version supports 0.13 yet (checked crates.io: openidconnect 4.0.1 and oauth2 5.0.0 are the latest). Result: the authenticator does not compile on main (9 × E0277, "multiple different versions of crate `reqwest`"), first surfaced by the drift gate on the unrelated docs PR #2170.

It slipped through because the authenticator workflow's path filter covers only authenticator sources — not the workspace `Cargo.toml`/`Cargo.lock` the bump touched.

## Changes

- Pin workspace `reqwest` back to `0.12` (lock re-resolved; the gears `oidc-authn-plugin` keeps its private 0.13 copy exactly as before the bump).
- `dependabot.yml`: ignore `reqwest >= 0.13` until a released openidconnect supports it (rule carries the lift condition as a comment).
- `authenticator.yml` workflow: also trigger on `src/backend/Cargo.toml` + `Cargo.lock` so workspace dependency bumps exercise the authenticator build.

## Verification

- `cargo check -p authenticator` and `cargo check --workspace`: clean.
- `cargo test -p authenticator`: 57 passed, 0 failed.
- pre-commit (incl. clippy, yamlfmt): passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)