### PR TITLE
fix(ci): fail Run E2E suite when this SHA's image builds failed

### DIFF
--- a/.github/workflows/e2e-bronze-to-api.yml
+++ b/.github/workflows/e2e-bronze-to-api.yml
@@ -54,6 +54,8 @@ env:
 
 permissions:
   contents: read
+  # e2e-suite reads this SHA's "Build & Push Container Images" run conclusion.
+  actions: read
 
 jobs:
   # `e2e-suite` emits the "Run E2E suite" status check the `main` ruleset
@@ -291,12 +293,19 @@ jobs:
     # It no longer folds in an endpoint-coverage gate: after the api/identity
     # retirement this workflow has none — those contracts and their gate live in
     # `e2e-stand.yml`, under its own umbrella ("Stand E2E").
+    #
+    # It DOES fold in the image-build gate: this required check also goes red
+    # when this SHA's "Build & Push Container Images" run failed, so a PR with
+    # a broken service image can't be merged even though that workflow's own
+    # checks aren't in the ruleset.
     needs:
       - build
       - e2e-metrics
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # 5 min sufficed for the needs-check alone; the image-build gate below may
+    # poll a straggling build-images run for up to 10 more.
+    timeout-minutes: 15
     steps:
       - name: Require the build and the data-path lane to have succeeded
         run: |
@@ -307,3 +316,40 @@ jobs:
             exit 1
           fi
           echo "E2E suite passed: build + the metrics lane succeeded."
+
+      # build-images.yml is a separate workflow, so `needs:` can't reach it;
+      # ask the API for this SHA's run instead. Absent (path-skipped, or a
+      # merge_group SHA — that workflow has no merge_group trigger) passes;
+      # anything but success fails. The image builds finish long before this
+      # job starts, so the poll loop only covers stragglers.
+      - name: Require image builds on this SHA to be green or absent
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          for attempt in $(seq 1 20); do
+            run_json=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${HEAD_SHA}&per_page=100" \
+              --jq '[.workflow_runs[] | select(.name == "Build & Push Container Images")] | sort_by(.run_started_at) | last // empty')
+            if [ -z "$run_json" ]; then
+              echo "No image-build run for ${HEAD_SHA} — builds were path-skipped."
+              exit 0
+            fi
+            conclusion=$(jq -r '.conclusion // ""' <<<"$run_json")
+            run_url=$(jq -r '.html_url' <<<"$run_json")
+            case "$conclusion" in
+              success)
+                echo "Image builds succeeded: ${run_url}"
+                exit 0
+                ;;
+              "")
+                echo "Image-build run still in progress (attempt ${attempt}/20); retrying in 30s…"
+                sleep 30
+                ;;
+              *)
+                echo "::error::Image builds concluded '${conclusion}' on this commit — see ${run_url}"
+                exit 1
+                ;;
+            esac
+          done
+          echo "::error::Image-build run did not finish within the polling window."
+          exit 1


### PR DESCRIPTION
The `main` ruleset does not require the `build-images.yml` checks, so a PR whose service-image build is red can still be merged (as happened with the reqwest 0.13 bump: `backend-authenticator` failed on the PR, every required check was green).

`Run E2E suite` is already the required check, and `needs:` cannot reach another workflow — so `e2e-suite` now queries this SHA's "Build & Push Container Images" run via the API:

- **absent** (path-skipped, or a merge_group SHA — that workflow has no `merge_group` trigger) → passes
- **success** → passes
- **anything else** → the required check goes red

The image builds finish well before `e2e-suite` starts (~25 min into the run), so the 30 s × 20 poll loop only covers stragglers; job timeout raised 5 → 15 min accordingly. Added `actions: read` to the workflow's permissions for the runs API.

Verified the query against real history: the SHA of the reqwest bump PR resolves to `conclusion=failure` (gate would have blocked the merge), and a SHA without a build-images run passes as absent. Validated with actionlint and YAML parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)