### PR TITLE
perf(ci): e2e runner consumes pre-built images on PRs instead of recompiling

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -317,10 +317,25 @@ jobs:
           context: src/backend
           file: src/backend/services/analytics/Dockerfile
           platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/insight-analytics,push-by-digest=true,name-canonical=true,push=${{ needs.changes.outputs.should_push == 'true' }}
+          # PR amd64 legs write a loadable tarball instead of discarding the
+          # result — the e2e rig consumes it (see "Upload image for the e2e
+          # rig" below). Other legs keep the push-by-digest output.
+          tags: ${{ github.event_name == 'pull_request' && matrix.arch == 'amd64' && 'insight-analytics:e2e-prebuilt' || '' }}
+          outputs: ${{ github.event_name == 'pull_request' && matrix.arch == 'amd64' && 'type=docker,dest=/tmp/e2e-prebuilt.tar' || format('type=image,name={0}/insight-analytics,push-by-digest=true,name-canonical=true,push={1}', env.IMAGE_PREFIX, needs.changes.outputs.should_push == 'true') }}
           cache-from: type=gha,scope=analytics-${{ matrix.arch }}
           # Cache writes from PR runs land in branch-isolated caches invisible to other refs, yet still consume the shared 10 GB repo quota — only main/dispatch runs export.
           cache-to: ${{ needs.changes.outputs.should_push == 'true' && format('type=gha,mode=max,scope=analytics-{0},ignore-error=true', matrix.arch) || '' }}
+      # Hand the PR-built image to e2e-bronze-to-api.yml's runner build so it
+      # doesn't recompile the same source (registry has no PR images to pull).
+      - name: Upload image for the e2e rig
+        if: github.event_name == 'pull_request' && matrix.arch == 'amd64'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: e2e-prebuilt-insight-analytics
+          path: /tmp/e2e-prebuilt.tar
+          if-no-files-found: error
+          retention-days: 1
+          overwrite: true
       - name: Export digest
         if: needs.changes.outputs.should_push == 'true'
         run: |
@@ -621,9 +636,20 @@ jobs:
           context: src/backend
           file: src/backend/services/identity-resolution/Dockerfile
           platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/insight-identity-resolution,push-by-digest=true,name-canonical=true,push=${{ needs.changes.outputs.should_push == 'true' }}
+          # PR amd64 legs feed the e2e rig — see backend-analytics.
+          tags: ${{ github.event_name == 'pull_request' && matrix.arch == 'amd64' && 'insight-identity-resolution:e2e-prebuilt' || '' }}
+          outputs: ${{ github.event_name == 'pull_request' && matrix.arch == 'amd64' && 'type=docker,dest=/tmp/e2e-prebuilt.tar' || format('type=image,name={0}/insight-identity-resolution,push-by-digest=true,name-canonical=true,push={1}', env.IMAGE_PREFIX, needs.changes.outputs.should_push == 'true') }}
           cache-from: type=gha,scope=identity-resolution-${{ matrix.arch }}
           cache-to: ${{ needs.changes.outputs.should_push == 'true' && format('type=gha,mode=max,scope=identity-resolution-{0},ignore-error=true', matrix.arch) || '' }}
+      - name: Upload image for the e2e rig
+        if: github.event_name == 'pull_request' && matrix.arch == 'amd64'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: e2e-prebuilt-insight-identity-resolution
+          path: /tmp/e2e-prebuilt.tar
+          if-no-files-found: error
+          retention-days: 1
+          overwrite: true
       - name: Export digest
         if: needs.changes.outputs.should_push == 'true'
         run: |
@@ -1015,11 +1041,23 @@ jobs:
           context: ${{ matrix.entry.connector_dir }}/${{ matrix.entry.context }}
           file: ${{ matrix.entry.connector_dir }}/${{ matrix.entry.dockerfile }}
           platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/${{ matrix.entry.name }},push-by-digest=true,name-canonical=true,push=${{ needs.changes.outputs.should_push == 'true' }}
+          # insight-jira-enrich is the one connector image the e2e rig bakes
+          # into its runner — its PR amd64 leg feeds it (see backend-analytics).
+          tags: ${{ github.event_name == 'pull_request' && matrix.arch == 'amd64' && matrix.entry.name == 'insight-jira-enrich' && format('{0}:e2e-prebuilt', matrix.entry.name) || '' }}
+          outputs: ${{ github.event_name == 'pull_request' && matrix.arch == 'amd64' && matrix.entry.name == 'insight-jira-enrich' && 'type=docker,dest=/tmp/e2e-prebuilt.tar' || format('type=image,name={0}/{1},push-by-digest=true,name-canonical=true,push={2}', env.IMAGE_PREFIX, matrix.entry.name, needs.changes.outputs.should_push == 'true') }}
           # Scope cache per (image name, arch) so unrelated connectors and
           # cross-arch builds don't evict each other.
           cache-from: type=gha,scope=${{ matrix.entry.name }}-${{ matrix.arch }}
           cache-to: ${{ needs.changes.outputs.should_push == 'true' && format('type=gha,mode=max,scope={0}-{1},ignore-error=true', matrix.entry.name, matrix.arch) || '' }}
+      - name: Upload image for the e2e rig
+        if: github.event_name == 'pull_request' && matrix.arch == 'amd64' && matrix.entry.name == 'insight-jira-enrich'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: e2e-prebuilt-insight-jira-enrich
+          path: /tmp/e2e-prebuilt.tar
+          if-no-files-found: error
+          retention-days: 1
+          overwrite: true
       - name: Export digest
         if: needs.changes.outputs.should_push == 'true'
         run: |

--- a/.github/workflows/e2e-bronze-to-api.yml
+++ b/.github/workflows/e2e-bronze-to-api.yml
@@ -15,9 +15,11 @@ name: E2E — Bronze to API
 # here is what only this rig can do — bronze → dbt → ClickHouse → analytics
 # response, over fixtures it seeds itself.
 #
-# Topology: a shared upstream `build` job compiles the runner image ONCE (the
-# expensive step — baking in analytics + each connector's enrich binary via
-# build-only services) and hands it to `e2e-metrics` as a saved image
+# Topology: a shared upstream `build` job assembles the runner image ONCE —
+# on PRs from the component images build-images.yml already built (or the
+# published :latest for path-skipped components), elsewhere by compiling
+# analytics + each connector's enrich binary via build-only services — and
+# hands it to `e2e-metrics` as a saved image
 # artifact, which also makes `build` the SOLE writer of the GHA BuildKit
 # cache scopes wired in compose/docker-compose.cache.yml (two concurrent
 # writers to the same scope key just thrash each other's cache). The lane
@@ -86,7 +88,11 @@ jobs:
 
       # docker-container buildx driver — required for the gha cache export that
       # compose/docker-compose.cache.yml wires onto the build-only services.
+      # From-source path only: the PR path below needs the DEFAULT driver, which
+      # is the only one that resolves `docker-image://` contexts from the local
+      # daemon store (compose/docker-compose.prebuilt.yml).
       - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        if: github.event_name != 'pull_request'
 
       # Expose ACTIONS_RUNTIME_TOKEN / ACTIONS_CACHE_URL to run steps. The
       # type=gha cache backend needs them; GitHub only hands them to JS
@@ -94,6 +100,72 @@ jobs:
       # them and buildx SILENTLY drops the cache_from/cache_to config —
       # every run was a full Rust recompile.
       - uses: crazy-max/ghaction-github-runtime@3cb05d89e1f492524af3d41a1c98c83bc3025124 # v3
+        if: github.event_name != 'pull_request'
+
+      # ─── PR path: consume the images build-images.yml already built ─────
+      # A PR run of that workflow compiles the exact same source this rig
+      # would (same Dockerfiles, same contexts) and uploads the amd64 legs as
+      # e2e-prebuilt-* artifacts; components it path-skipped are unchanged in
+      # the merge ref, so the published :latest IS their build. Either way the
+      # rig compiles no Rust here. Components whose artifact the run inventory
+      # promises must download — no silent registry fallback, that would bake
+      # a stale binary into a green run.
+      #
+      # merge_group / dispatch SHAs have no build-images run, so those events
+      # keep the from-source path below.
+      - name: Fetch pre-built component images
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          run_json=""
+          for attempt in $(seq 1 40); do
+            run_json=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${HEAD_SHA}&per_page=100" \
+              --jq '[.workflow_runs[] | select(.name == "Build & Push Container Images")] | sort_by(.run_started_at) | last // empty')
+            if [ -z "$run_json" ]; then
+              echo "No image-build run for ${HEAD_SHA} — every component comes from the registry."
+              break
+            fi
+            conclusion=$(jq -r '.conclusion // ""' <<<"$run_json")
+            if [ "$conclusion" = "success" ]; then
+              break
+            fi
+            if [ -n "$conclusion" ]; then
+              echo "::error::Image-build run concluded '${conclusion}' — its artifacts can't be trusted; see $(jq -r '.html_url' <<<"$run_json")"
+              exit 1
+            fi
+            echo "Image-build run still in progress (attempt ${attempt}/40); retrying in 30s…"
+            sleep 30
+          done
+          if [ -n "$run_json" ] && [ "$(jq -r '.conclusion // ""' <<<"$run_json")" != "success" ]; then
+            echo "::error::Image-build run did not finish within the polling window."
+            exit 1
+          fi
+
+          expected=""
+          if [ -n "$run_json" ]; then
+            run_id=$(jq -r '.id' <<<"$run_json")
+            expected=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts?per_page=100" \
+              --jq '[.artifacts[].name | select(startswith("e2e-prebuilt-"))] | join(" ")')
+            if [ -n "$expected" ]; then
+              gh run download "$run_id" -R "$GITHUB_REPOSITORY" -p 'e2e-prebuilt-*' -D /tmp/e2e-prebuilt
+            fi
+          fi
+
+          for name in insight-analytics insight-identity-resolution insight-jira-enrich; do
+            case " ${expected} " in
+              *" e2e-prebuilt-${name} "*)
+                docker load < "/tmp/e2e-prebuilt/e2e-prebuilt-${name}/e2e-prebuilt.tar"
+                echo "${name}: PR-built artifact"
+                ;;
+              *)
+                docker pull -q "ghcr.io/constructorfabric/${name}:latest"
+                docker tag "ghcr.io/constructorfabric/${name}:latest" "${name}:e2e-prebuilt"
+                echo "${name}: registry :latest (unchanged by this PR)"
+                ;;
+            esac
+          done
 
       # ─── Build the runner image ─────────────────────────────────────────
       # The runner bakes in analytics + each connector's enrich binary, each
@@ -101,14 +173,16 @@ jobs:
       # `additional_contexts` (see compose/docker-compose.runner.yml). Nothing is
       # compiled inside the runner at test time.
       #
-      # E2E_COMPOSE_OVERLAYS layers compose/docker-compose.cache.yml on top, which
-      # points each Rust build (and the runner's pip layer) at the GitHub Actions
-      # BuildKit cache. On a warm cache with an unchanged Cargo.lock/pyproject.toml
-      # the dependency-compile layers restore instead of recompiling.
+      # E2E_COMPOSE_OVERLAYS picks the source of those binaries: PRs point the
+      # contexts at the pre-built images fetched above (docker-compose.prebuilt.yml
+      # — pip layer uncached, but no Rust compiles at all); merge_group /
+      # dispatch compile from source with the GHA BuildKit cache
+      # (docker-compose.cache*.yml) — on a warm cache with an unchanged
+      # Cargo.lock the dependency-compile layers restore instead of recompiling.
       - name: Build runner image
         run: ./e2e.sh build
         env:
-          E2E_COMPOSE_OVERLAYS: ${{ github.event_name == 'merge_group' && 'compose/docker-compose.cache-ro.yml' || 'compose/docker-compose.cache.yml' }}
+          E2E_COMPOSE_OVERLAYS: ${{ github.event_name == 'pull_request' && 'compose/docker-compose.prebuilt.yml' || (github.event_name == 'merge_group' && 'compose/docker-compose.cache-ro.yml' || 'compose/docker-compose.cache.yml') }}
 
       # ─── Hand the built image to both lanes ─────────────────────────────
       # Only insight-e2e-runner:latest travels: analytics and jira-enrich

--- a/src/ingestion/tests/e2e/compose/docker-compose.prebuilt.yml
+++ b/src/ingestion/tests/e2e/compose/docker-compose.prebuilt.yml
@@ -1,0 +1,16 @@
+# CI-only overlay: source each baked-in binary from a pre-built image instead
+# of compiling it. The e2e workflow loads/pulls these local tags first (PR
+# artifacts from build-images.yml, or the published :latest for path-skipped
+# components) — see .github/workflows/e2e-bronze-to-api.yml.
+#
+# `docker-image://` refs resolve from the local daemon store only with the
+# DEFAULT buildx driver; the docker-container driver the gha-cache overlays
+# need cannot see daemon images. Never combine this overlay with
+# docker-compose.cache*.yml.
+services:
+  runner:
+    build:
+      additional_contexts:
+        jira-enrich: "docker-image://insight-jira-enrich:e2e-prebuilt"
+        analytics: "docker-image://insight-analytics:e2e-prebuilt"
+        identity-resolution: "docker-image://insight-identity-resolution:e2e-prebuilt"


### PR DESCRIPTION
Depends on #2199 (based on that branch; this PR's diff shrinks to one commit once it merges).

On every PR, `build-images.yml` compiles analytics, identity-resolution, and jira-enrich from the exact same Dockerfiles and contexts the e2e rig then compiles **again** in "Build runner image" — and discards its own result after computing the digest. This PR hands the result over instead:

**build-images.yml** — the amd64 legs of `backend-analytics`, `backend-identity-resolution`, and the `insight-jira-enrich` connector leg switch their PR output from a discarded `type=image,push=false` to a `type=docker` tarball uploaded as an `e2e-prebuilt-*` artifact (`retention-days: 1`; nothing new goes to GHCR). arm64 legs and all push behavior unchanged.

**e2e-bronze-to-api.yml** — on `pull_request`, "Build runner image" no longer compiles any Rust:
- waits for this SHA's build-images run (it finishes ~7 min in; this job used to spend ~15 min compiling), fails early if that run is red;
- `docker load`s every artifact the run's inventory promises — no silent registry fallback for a changed component, that would bake a stale binary into a green run;
- pulls the published `:latest` for path-skipped components, which the merge ref leaves unchanged, so `:latest` *is* their build;
- assembles the runner via the new `compose/docker-compose.prebuilt.yml` overlay, whose `additional_contexts` point `docker-image://` at the loaded local tags (resolved from the daemon store by the default buildx driver — the buildx/gha-cache steps are now non-PR only).

`merge_group` and `workflow_dispatch` SHAs have no build-images run, so those events keep the existing from-source path with the gha cache overlays. Local `./e2e.sh build` is untouched.

Verified locally end-to-end: the overlay-merged compose config replaces all three `service:` contexts; the runner assembles from tagged component images with zero Rust compilation; the baked `analytics`/`jira-enrich`/`identity-resolution` binaries execute; and `metrics/test_fixtures.py::test_metric_smoke[ai_active_days]` passes on the resulting runner. Both workflows pass actionlint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)