### PR TITLE
poc(auth): Keycloak broker realm as config-cli code, brokered login end-to-end

### DIFF
--- a/deploy/compose/keycloak/broker-poc/README.md
+++ b/deploy/compose/keycloak/broker-poc/README.md
@@ -1,0 +1,68 @@
+# Keycloak identity-broker PoC (ADR-0003, issue #2194)
+
+Throwaway compose setup proving the first Phase-0 gate of EPIC #2193: a
+Keycloak **broker** realm defined **only** in
+[keycloak-config-cli](https://github.com/adorsys/keycloak-config-cli) YAML,
+brokering one upstream OIDC provider, with the **unchanged** authenticator
+(stock published image, config-surface change only) completing login against
+the broker issuer and minting a gateway JWT that carries the single
+`tenant_id` claim.
+
+## Topology
+
+```text
+browser ── /auth/login ─▶ authenticator ── code+PKCE ─▶ insight-broker realm
+                                                          │ auto-redirect (sole IdP)
+                                                          ▼
+                                                        poc-upstream realm  (stands in for a customer IdP)
+                                                          │ code back to /realms/insight-broker/broker/poc-upstream/endpoint
+                                                          ▼
+                              authenticator ◀── broker code ── insight-broker realm
+                                   │  exchanges code, resolves person via Identity,
+                                   ▼  sets __Host-sid, mints gateway JWT {tenant_id}
+                              gateway auth_request ─▶ analytics / identity
+```
+
+Both realms live in the compose stack's existing Keycloak container; they are
+**not** imported at startup — `keycloak-config-cli` applies them idempotently
+to the running server, exactly as the gitops sync job will in Phase 1
+(#2195). The `tenant_id` is stamped by a `hardcoded-attribute-idp-mapper` on
+the brokered IdP (ADR-0003's fixed per-registration tenant) and emitted by
+the client's user-attribute protocol mapper.
+
+## Files
+
+- `realms/poc-upstream.yaml` — the upstream: one user (the seeded dev
+  persona, so Identity resolves it) and the broker's confidential client.
+- `realms/insight-broker.yaml` — the broker: OIDC identity provider toward
+  the upstream, the `tenant_id` IdP mapper, the `insight-authenticator`
+  confidential client, and a browser flow that auto-redirects to the sole
+  IdP (no broker login page).
+- `poc-up.sh` — applies both realms with keycloak-config-cli, then recreates
+  only the authenticator container with its issuer pointed at
+  `.../realms/insight-broker`.
+- `verify.sh` — headless end-to-end proof (no browser, no shortcut at any
+  step); PASSes only if the gateway JWT carries the single string
+  `tenant_id`.
+
+Secrets and host-specific URLs never appear in the realm YAML: config-cli's
+env-var substitution injects them at apply time (the same mechanism that
+carries SealedSecret-provided values in gitops later). The defaults in
+`poc-up.sh` are synthetic compose-only dev values, like the rest of the
+compose stack's.
+
+## Run it
+
+```bash
+./dev-compose.sh up --auth=keycloak          # the normal keycloak-mode stack
+deploy/compose/keycloak/broker-poc/poc-up.sh
+deploy/compose/keycloak/broker-poc/verify.sh # expect: PASS
+```
+
+Undo (back to the direct realm): `./dev-compose.sh up --auth=keycloak`.
+
+## Scope
+
+This covers only the first #2194 checkbox (broker login + `tenant_id`).
+Refresh-token passthrough and logout propagation through the two-hop chain
+are the next Phase-0 items and are not exercised here.

--- a/deploy/compose/keycloak/broker-poc/poc-up.sh
+++ b/deploy/compose/keycloak/broker-poc/poc-up.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# ADR-0003 broker PoC (#2194) — apply the broker + upstream realms with
+# keycloak-config-cli and re-point the UNCHANGED authenticator at the broker.
+#
+# Prerequisite: the compose stack is up in keycloak mode:
+#     ./dev-compose.sh up --auth=keycloak
+#
+# What this does, on top of that stack:
+#   1. Applies realms/*.yaml to the running Keycloak with keycloak-config-cli
+#      (idempotent; secrets and host-specific URLs arrive via $(env:...)
+#      substitution, never from the YAML itself).
+#   2. Recreates ONLY the authenticator container with its issuer pointed at
+#      the broker realm (`insight-broker`) instead of the direct realm — the
+#      same binary/image, config-surface change only, exactly as ADR-0003
+#      prescribes.
+#
+# Undo: re-run `./dev-compose.sh up --auth=keycloak` (restores the direct
+# realm issuer); the PoC realms stay in Keycloak until the container is
+# recreated, which is harmless.
+set -euo pipefail
+cd "$(dirname "$0")/../../../.."   # repo root
+
+CONFIG_CLI_IMAGE="adorsys/keycloak-config-cli:6.5.1-26.1.0"
+ENV_FILE="${ENV_FILE:-.env.compose}"
+PROJECT="${COMPOSE_PROJECT_NAME:-insight}"
+
+# Same host-IP trick as dev-compose.sh: one issuer URL that the browser AND
+# the containers can both reach.
+detect_host_ip() {
+  if command -v ipconfig >/dev/null 2>&1; then           # macOS
+    local ifc
+    ifc="$(route -n get default 2>/dev/null | awk '/interface:/{print $2}')"
+    if [[ -n "$ifc" ]] && ipconfig getifaddr "$ifc" 2>/dev/null; then return 0; fi
+    ipconfig getifaddr en0 2>/dev/null && return 0
+    return 1
+  fi
+  ip route get 1.1.1.1 2>/dev/null \
+    | awk '{for (i=1;i<=NF;i++) if ($i=="src") {print $(i+1); exit}}'
+}
+
+HOST_IP="$(detect_host_ip)" || { echo "ERROR: cannot detect host IP" >&2; exit 1; }
+KC_PUBLIC_BASE="http://${HOST_IP}:8085/kc"
+
+# DEV_USER_EMAIL from the env file: the upstream user must resolve to a seeded
+# person or the authenticator refuses the login.
+DEV_USER_EMAIL="$(grep -E '^DEV_USER_EMAIL=' "$ENV_FILE" | tail -1 | cut -d= -f2-)"
+: "${DEV_USER_EMAIL:?DEV_USER_EMAIL not found in $ENV_FILE}"
+TENANT_ID="$(grep -E '^TENANT_DEFAULT_ID=' "$ENV_FILE" | tail -1 | cut -d= -f2-)"
+TENANT_ID="${TENANT_ID:-00000000-df51-5b42-9538-d2b56b7ee953}"
+
+# Dev-only PoC credentials (same convention as gen-realm.py's dev secret —
+# synthetic, compose-only, never used on a deployed stand).
+POC_AUTHENTICATOR_CLIENT_SECRET="${POC_AUTHENTICATOR_CLIENT_SECRET:-poc-broker-authenticator-dev-secret}"
+POC_BROKER_CLIENT_SECRET="${POC_BROKER_CLIENT_SECRET:-poc-upstream-broker-dev-secret}"
+POC_UPSTREAM_USER_PASSWORD="${POC_UPSTREAM_USER_PASSWORD:-insight-dev}"
+
+echo "=== [1/2] Applying PoC realms with keycloak-config-cli ==="
+docker run --rm --network "$PROJECT" \
+  -v "$(pwd)/deploy/compose/keycloak/broker-poc/realms:/config:ro" \
+  -e KEYCLOAK_URL="http://keycloak:8085/kc" \
+  -e KEYCLOAK_USER=admin \
+  -e KEYCLOAK_PASSWORD=admin \
+  -e KEYCLOAK_AVAILABILITYCHECK_ENABLED=true \
+  -e KEYCLOAK_AVAILABILITYCHECK_TIMEOUT=120s \
+  -e IMPORT_FILES_LOCATIONS='/config/*.yaml' \
+  -e IMPORT_VARSUBSTITUTION_ENABLED=true \
+  -e POC_KC_PUBLIC_BASE="$KC_PUBLIC_BASE" \
+  -e POC_UPSTREAM_USER_EMAIL="$DEV_USER_EMAIL" \
+  -e POC_UPSTREAM_USER_PASSWORD="$POC_UPSTREAM_USER_PASSWORD" \
+  -e POC_BROKER_CLIENT_SECRET="$POC_BROKER_CLIENT_SECRET" \
+  -e POC_AUTHENTICATOR_CLIENT_SECRET="$POC_AUTHENTICATOR_CLIENT_SECRET" \
+  -e POC_TENANT_ID="$TENANT_ID" \
+  "$CONFIG_CLI_IMAGE"
+
+echo "=== [2/2] Re-pointing the (unchanged) authenticator at the broker realm ==="
+compose_cmd=(docker compose --project-name "$PROJECT" --env-file "$ENV_FILE" -f docker-compose.yml)
+[[ -f deploy/compose/override.generated.yml ]] && compose_cmd+=(-f deploy/compose/override.generated.yml)
+
+KEYCLOAK_HOSTNAME="$KC_PUBLIC_BASE" \
+AUTHENTICATOR_OIDC_ISSUER="${KC_PUBLIC_BASE}/realms/insight-broker" \
+OIDC_CLIENT_ID="insight-authenticator" \
+OIDC_CLIENT_SECRET="$POC_AUTHENTICATOR_CLIENT_SECRET" \
+  "${compose_cmd[@]}" --profile auth-keycloak up -d --no-deps authenticator
+
+echo
+echo "Broker PoC is live:"
+echo "  issuer     ${KC_PUBLIC_BASE}/realms/insight-broker  (authenticator now points here)"
+echo "  upstream   ${KC_PUBLIC_BASE}/realms/poc-upstream    (login: ${DEV_USER_EMAIL} / ${POC_UPSTREAM_USER_PASSWORD})"
+echo "Verify end to end:  deploy/compose/keycloak/broker-poc/verify.sh"

--- a/deploy/compose/keycloak/broker-poc/realms/insight-broker.yaml
+++ b/deploy/compose/keycloak/broker-poc/realms/insight-broker.yaml
@@ -1,0 +1,108 @@
+# Throwaway BROKER realm for the ADR-0003 PoC (#2194).
+#
+# This is the shape ADR-0003 decides on, reduced to one upstream:
+#   - one brokered OIDC identity provider (`poc-upstream`),
+#   - a hardcoded-attribute-idp-mapper stamping the single `tenant_id`
+#     user attribute at first broker login,
+#   - the `insight-authenticator` confidential client whose protocol mapper
+#     emits that attribute as the `tenant_id` token claim,
+#   - a browser flow that auto-redirects to the sole IdP (the "single-IdP
+#     realm auto-redirects" behaviour the ADR promises).
+#
+# Applied by keycloak-config-cli (see ../poc-up.sh); env-var placeholders are
+# substituted at apply time — no secret material lives in this file.
+realm: insight-broker
+enabled: true
+sslRequired: none
+browserFlow: poc-broker-browser
+
+identityProviders:
+  - alias: poc-upstream
+    displayName: PoC upstream OIDC
+    providerId: oidc
+    enabled: true
+    # The upstream asserts the email; trust it so first broker login does not
+    # stop at a verify-email step.
+    trustEmail: true
+    firstBrokerLoginFlowAlias: first broker login
+    config:
+      issuer: $(env:POC_KC_PUBLIC_BASE)/realms/poc-upstream
+      authorizationUrl: $(env:POC_KC_PUBLIC_BASE)/realms/poc-upstream/protocol/openid-connect/auth
+      tokenUrl: $(env:POC_KC_PUBLIC_BASE)/realms/poc-upstream/protocol/openid-connect/token
+      jwksUrl: $(env:POC_KC_PUBLIC_BASE)/realms/poc-upstream/protocol/openid-connect/certs
+      logoutUrl: $(env:POC_KC_PUBLIC_BASE)/realms/poc-upstream/protocol/openid-connect/logout
+      useJwksUrl: "true"
+      validateSignature: "true"
+      clientId: insight-broker
+      clientSecret: $(env:POC_BROKER_CLIENT_SECRET)
+      clientAuthMethod: client_secret_post
+      defaultScope: openid profile email
+      syncMode: FORCE
+      backchannelSupported: "true"
+
+identityProviderMappers:
+  # ADR-0003: a fixed per-registration tenant — every identity arriving via
+  # this provider belongs to exactly one Insight tenant. The mapper writes the
+  # user attribute; the client protocol mapper below turns it into the claim.
+  - name: tenant-id
+    identityProviderAlias: poc-upstream
+    identityProviderMapper: hardcoded-attribute-idp-mapper
+    config:
+      syncMode: INHERIT
+      attribute: tenant_id
+      attribute.value: $(env:POC_TENANT_ID)
+
+clients:
+  # Same shape as the compose realm generator's insight-authenticator client
+  # (deploy/compose/keycloak/gen-realm.py): confidential, code flow only, and
+  # a user-attribute protocol mapper emitting the single-string `tenant_id`.
+  - clientId: insight-authenticator
+    protocol: openid-connect
+    publicClient: false
+    secret: $(env:POC_AUTHENTICATOR_CLIENT_SECRET)
+    standardFlowEnabled: true
+    directAccessGrantsEnabled: false
+    serviceAccountsEnabled: false
+    redirectUris:
+      - http://localhost:3000/auth/callback
+      - http://localhost:8080/auth/callback
+    webOrigins: []
+    protocolMappers:
+      - name: tenant_id
+        protocol: openid-connect
+        protocolMapper: oidc-usermodel-attribute-mapper
+        consentRequired: false
+        config:
+          id.token.claim: "true"
+          access.token.claim: "true"
+          userinfo.token.claim: "true"
+          user.attribute: tenant_id
+          claim.name: tenant_id
+          jsonType.label: String
+
+authenticationFlows:
+  # Browser flow with no local login form: an existing SSO cookie wins,
+  # otherwise the identity-provider redirector sends the user straight to the
+  # realm's default (and only) IdP.
+  - alias: poc-broker-browser
+    description: Auto-redirect to the sole brokered IdP
+    providerId: basic-flow
+    topLevel: true
+    builtIn: false
+    authenticationExecutions:
+      - authenticator: auth-cookie
+        requirement: ALTERNATIVE
+        priority: 10
+        autheticatorFlow: false
+        userSetupAllowed: false
+      - authenticator: identity-provider-redirector
+        authenticatorConfig: poc-default-idp
+        requirement: ALTERNATIVE
+        priority: 20
+        autheticatorFlow: false
+        userSetupAllowed: false
+
+authenticatorConfig:
+  - alias: poc-default-idp
+    config:
+      defaultProvider: poc-upstream

--- a/deploy/compose/keycloak/broker-poc/realms/poc-upstream.yaml
+++ b/deploy/compose/keycloak/broker-poc/realms/poc-upstream.yaml
@@ -1,0 +1,35 @@
+# Throwaway UPSTREAM OIDC provider for the ADR-0003 broker PoC (#2194).
+#
+# Stands in for "a customer IdP": a realm with one login-capable user and one
+# confidential client (`insight-broker`) that the broker realm's identity
+# provider uses for the code exchange. Applied by keycloak-config-cli
+# (see ../poc-up.sh); env-var placeholders are substituted at apply time.
+realm: poc-upstream
+enabled: true
+sslRequired: none
+users:
+  # Must match a seeded person in Identity: the (unchanged) authenticator
+  # refuses logins that resolve to no person. poc-up.sh passes DEV_USER_EMAIL.
+  - username: $(env:POC_UPSTREAM_USER_EMAIL)
+    email: $(env:POC_UPSTREAM_USER_EMAIL)
+    firstName: Upstream
+    lastName: Persona
+    enabled: true
+    emailVerified: true
+    credentials:
+      - type: password
+        value: $(env:POC_UPSTREAM_USER_PASSWORD)
+        temporary: false
+clients:
+  # The broker's registration at this upstream. Its redirect is the broker
+  # realm's brokering endpoint — the only place codes may return to.
+  - clientId: insight-broker
+    protocol: openid-connect
+    publicClient: false
+    secret: $(env:POC_BROKER_CLIENT_SECRET)
+    standardFlowEnabled: true
+    directAccessGrantsEnabled: false
+    serviceAccountsEnabled: false
+    redirectUris:
+      - $(env:POC_KC_PUBLIC_BASE)/realms/insight-broker/broker/poc-upstream/endpoint
+    webOrigins: []

--- a/deploy/compose/keycloak/broker-poc/verify.sh
+++ b/deploy/compose/keycloak/broker-poc/verify.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# ADR-0003 broker PoC (#2194) — headless end-to-end proof.
+#
+# Drives the full brokered login with no shortcut at any step:
+#   GET /auth/login                      authenticator starts code+PKCE, 302 to the BROKER realm
+#   broker authorize                     auto-redirects (identity-provider-redirector) to the upstream realm
+#   upstream login form                  real username/password POST
+#   upstream -> broker/.../endpoint      code returns to the broker, first-broker-login runs,
+#                                        the hardcoded-attribute mapper stamps tenant_id
+#   broker -> /auth/callback             the UNCHANGED authenticator exchanges the broker's code,
+#                                        resolves the person via Identity, sets __Host-sid
+#   GET /internal/authz                  the gateway auth_request target returns X-Gateway-Jwt
+#
+# PASS = the gateway JWT carries a single string `tenant_id`.
+#
+# usage: verify.sh [gateway-base] [email] [password]
+set -euo pipefail
+
+BASE="${1:-http://localhost:8080}"
+ENV_FILE="${ENV_FILE:-$(cd "$(dirname "$0")/../../../.." && pwd)/.env.compose}"
+DEFAULT_EMAIL="$(grep -E '^DEV_USER_EMAIL=' "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2- || true)"
+EMAIL="${2:-${DEFAULT_EMAIL:?no email given and DEV_USER_EMAIL not in $ENV_FILE}}"
+PASS="${3:-${POC_UPSTREAM_USER_PASSWORD:-insight-dev}}"
+EXPECTED_TENANT="$(grep -E '^TENANT_DEFAULT_ID=' "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2- || true)"
+EXPECTED_TENANT="${EXPECTED_TENANT:-00000000-df51-5b42-9538-d2b56b7ee953}"
+
+JAR="$(mktemp)"; trap 'rm -f "$JAR"' EXIT
+fail() { echo "FAIL: $*" >&2; exit 1; }
+location_of() { tr -d '\r' | awk 'tolower($1)=="location:"{print $2}'; }
+
+# 1. the authenticator must send the browser to the BROKER realm
+AUTHZ_URL=$(curl -sS -o /dev/null -D - "$BASE/auth/login" | location_of)
+[[ -n "$AUTHZ_URL" ]] || fail "/auth/login did not redirect (stack not up?)"
+case "$AUTHZ_URL" in
+  */realms/insight-broker/*) echo "ok: login starts at the broker realm" ;;
+  *) fail "authorize URL is not the broker realm: $AUTHZ_URL (run poc-up.sh first)" ;;
+esac
+
+# 2. follow redirects to the upstream login form; the chain must traverse the
+#    brokering hop (single-IdP auto-redirect, no broker login page)
+URL="$AUTHZ_URL" PAGE="" SAW_UPSTREAM_AUTHORIZE=false
+for _ in 1 2 3 4 5 6; do
+  HDRS="$(mktemp)"
+  PAGE=$(curl -sS -c "$JAR" -b "$JAR" -D "$HDRS" "$URL")
+  CODE=$(awk 'NR==1{print $2}' "$HDRS"); LOC=$(location_of < "$HDRS"); rm -f "$HDRS"
+  [[ "$CODE" == 200 ]] && break
+  [[ -n "$LOC" ]] || fail "HTTP $CODE with no Location at $URL"
+  case "$LOC" in */realms/poc-upstream/protocol/openid-connect/auth*) SAW_UPSTREAM_AUTHORIZE=true ;; esac
+  URL="$LOC"
+done
+$SAW_UPSTREAM_AUTHORIZE || fail "broker did not auto-redirect to the upstream IdP"
+echo "ok: broker auto-redirected to the upstream authorize endpoint"
+
+ACTION=$(printf '%s' "$PAGE" | grep -o 'action="[^"]*login-actions/authenticate[^"]*"' | head -1 \
+  | sed 's/^action="//; s/"$//; s/\&amp;/\&/g')
+[[ -n "$ACTION" ]] || fail "no upstream login form at $URL"
+case "$ACTION" in
+  */realms/poc-upstream/*) echo "ok: credentials go to the UPSTREAM realm's form" ;;
+  *) fail "login form is not the upstream realm's: $ACTION" ;;
+esac
+
+# 3. submit credentials; walk redirects until the code lands at /auth/callback.
+#    The chain must pass through the broker's endpoint (the brokered exchange).
+NEXT=$(curl -sS -c "$JAR" -b "$JAR" -o /dev/null -D - \
+  --data-urlencode "username=$EMAIL" --data-urlencode "password=$PASS" \
+  "$ACTION" | location_of)
+[[ -n "$NEXT" ]] || fail "upstream rejected the credentials for $EMAIL"
+SAW_BROKER_ENDPOINT=false
+for _ in 1 2 3 4 5 6 7 8; do
+  case "$NEXT" in
+    */realms/insight-broker/broker/poc-upstream/endpoint*) SAW_BROKER_ENDPOINT=true ;;
+    */auth/callback\?*) break ;;
+  esac
+  NEXT=$(curl -sS -c "$JAR" -b "$JAR" -o /dev/null -D - "$NEXT" | location_of)
+  [[ -n "$NEXT" ]] || fail "redirect chain ended before /auth/callback"
+done
+$SAW_BROKER_ENDPOINT || fail "the code never traversed the broker endpoint"
+echo "ok: upstream code returned via the broker endpoint, broker code issued to the authenticator"
+
+# 4. deliver the code at the gateway origin; capture __Host-sid by hand (it is
+#    Secure, so curl stores but will not replay it over plain http)
+SID=$(curl -sS -c "$JAR" -b "$JAR" -o /dev/null -D - "$BASE/${NEXT#*://*/}" | tr -d '\r' \
+  | awk 'tolower($1)=="set-cookie:"{print $2}' | grep '^__Host-sid=' | cut -d';' -f1 | cut -d= -f2)
+[[ -n "$SID" ]] || fail "the authenticator's callback set no __Host-sid"
+echo "ok: unchanged authenticator exchanged the broker's code and opened a session"
+
+# 5. session works through the gateway
+ME=$(curl -sS -H "Cookie: __Host-sid=$SID" "$BASE/auth/me")
+printf 'ok: /auth/me -> %s\n' "$ME"
+
+# 6. the minted gateway JWT carries the single string tenant_id
+JWT=$(curl -sS -o /dev/null -D - -H "Cookie: __Host-sid=$SID" "http://localhost:8083/internal/authz" \
+  | tr -d '\r' | awk 'tolower($1)=="x-gateway-jwt:"{print $3}')
+[[ -n "$JWT" ]] || fail "/internal/authz returned no X-Gateway-Jwt"
+printf '%s' "$JWT" | cut -d. -f2 | EXPECTED_TENANT="$EXPECTED_TENANT" python3 -c '
+import base64, json, os, sys
+raw = sys.stdin.read().strip()
+claims = json.loads(base64.urlsafe_b64decode(raw + "=" * (-len(raw) % 4)))
+print("gateway JWT claims:", json.dumps(claims, sort_keys=True))
+tid = claims.get("tenant_id")
+assert isinstance(tid, str) and tid, f"tenant_id must be a single string, got {tid!r}"
+expected = os.environ["EXPECTED_TENANT"]
+assert tid == expected, f"tenant_id {tid!r} != expected {expected!r}"
+print(f"PASS: gateway JWT carries the single string tenant_id = {tid}")
+'


### PR DESCRIPTION
## What

Throwaway compose PoC for the first Phase-0 checkbox of the Keycloak identity-broker EPIC: a Keycloak **broker** realm defined **only** in keycloak-config-cli YAML, brokering one upstream OIDC provider, with the **unchanged** authenticator (stock published image — only its `issuerUrl`/client-secret config changes) completing login against the broker issuer and minting a gateway JWT that carries the single string `tenant_id` claim.

New, fully self-contained under `deploy/compose/keycloak/broker-poc/`:

- `realms/poc-upstream.yaml` — stands in for a customer IdP: one user (the seeded dev persona, so Identity resolves it) + the broker's confidential client.
- `realms/insight-broker.yaml` — the broker: OIDC identity provider toward the upstream, `hardcoded-attribute-idp-mapper` stamping `tenant_id` (ADR-0003's fixed per-registration tenant), the `insight-authenticator` confidential client with the `tenant_id` protocol mapper, and a browser flow that auto-redirects to the sole IdP (the ADR's single-IdP-realm behaviour — no broker login page).
- `poc-up.sh` — applies both realms idempotently with keycloak-config-cli against the running compose Keycloak (env-var substitution for secrets and host URLs; nothing sensitive in YAML — the same mechanism that will carry SealedSecret values in the gitops phase), then recreates only the authenticator with the broker issuer.
- `verify.sh` — headless end-to-end proof with no shortcut at any step; PASSes only when the gateway JWT carries the single string `tenant_id`.

## Why

ADR-0003 (`0003-keycloak-identity-broker.md`) gates the whole EPIC on this confirmation: broker realm as code only, one brokered upstream, unchanged authenticator, single `tenant_id` in the minted token. This PoC proves that path and hands Phase 1 (realm-as-code in gitops) a working realm shape to lift.

## Verification

Ran locally on the compose stack (`AUTH_MODE=keycloak`, all backend services from published ghcr images — nothing built locally, which is the strongest form of "unchanged authenticator"):

- `verify.sh` → PASS: login starts at the broker realm, broker auto-redirects to the upstream authorize endpoint, credentials go to the upstream form, the code returns through `/realms/insight-broker/broker/poc-upstream/endpoint`, the authenticator exchanges the broker's code and sets `__Host-sid`, and `/internal/authz` returns a gateway JWT whose `tenant_id` is a single string equal to the configured tenant.
- `GET /api/analytics/v1/metrics` through the gateway with the brokered session → 200 (the downstream verifier, which fails closed without `tenant_id`, accepted the token).

Refresh-token passthrough and logout propagation are the next Phase-0 checkboxes and are deliberately out of scope here.

Refs #2194
Part of #2193

🤖 Generated with [Claude Code](https://claude.com/claude-code)