### PR TITLE
feat(gitops): keycloak-config-cli sync Job — broker realms as code (Phase 1, box 1)

### DIFF
--- a/charts/insight/templates/keycloak-config-job.yaml
+++ b/charts/insight/templates/keycloak-config-job.yaml
@@ -1,0 +1,117 @@
+{{/*
+==============================================================================
+ Keycloak realm configuration (broker realms as code)
+==============================================================================
+
+Helm Hook Job that applies the versioned broker realm YAML against the
+environment's Keycloak with keycloak-config-cli (ADR-0003
+cpt-insightspec-adr-auth-0003-keycloak-identity-broker: realm content is
+configuration-as-code only — no admin-UI channel).
+
+The realm YAML lives in the gitops tree
+(deploy/gitops/environments/<env>/keycloak/realms/*.yaml) and is applied as
+the `<release>-keycloak-config-realms` ConfigMap by the gitops
+`keycloak-broker-realms` Makefile target before this chart deploys — the
+same pre-created-ConfigMap contract the insight-keycloak subchart uses for
+its imported dev realm. This Job only mounts and applies it.
+
+Hook timing: `post-install,post-upgrade`, so the Job re-runs on EVERY
+deploy (every gitops sync is a `helm upgrade`), re-asserting the versioned
+realm content and reverting any drift. `IMPORT_CACHE_ENABLED=false` is
+load-bearing for that: with the cache on, config-cli skips
+checksum-unchanged files, so hand-made drift on the server would survive
+until the next realm-YAML change (Phase-0 finding on #2194; `IMPORT_FORCE`
+alone does not bypass the skip). hook-weight "10" orders it after the
+clickhouse-migrate hook ("5") within the post-* phase; there is no
+dependency between them.
+
+The Keycloak this applies to is selected by `keycloakConfig.url`: the
+shared pre-provisioned Keycloak on deployed stands (ADR-0002), or the
+in-cluster insight-keycloak subchart service where that is deployed.
+
+Credentials and realm-YAML substitution values come from ONE existing
+Secret (`keycloakConfig.existingSecret`, envFrom): it must define
+KEYCLOAK_USER + KEYCLOAK_PASSWORD (the config-cli admin login) and every
+VAR the realm YAML references as $(env:VAR). Secret material never appears
+in realm YAML, values files, or images — the Secret is sealed in the
+gitops tree (SealedSecrets).
+
+Failure behavior: loud. Helm blocks on the hook Job, so a rejected import
+fails `helm upgrade` (and `--atomic` rolls the release back). backoffLimit
+is low because import errors are deterministic (bad YAML, unresolvable
+$(env:VAR)), not transient.
+
+Gated on `keycloakConfig.enabled` (default false — environments opt in as
+they are migrated behind the broker, EPIC #2193 Phase 4).
+*/}}
+{{- if .Values.keycloakConfig.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "insight.fullname" . }}-keycloak-config
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "10"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    {{- include "insight.labels" . | nindent 4 }}
+    app.kubernetes.io/component: keycloak-config
+spec:
+  # Low on purpose: import errors are deterministic (see header). A couple
+  # of attempts still absorbs a transient Keycloak blip mid-apply.
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "insight.fullname" . }}-keycloak-config
+        app.kubernetes.io/component: keycloak-config
+    spec:
+      # Suppress the legacy `<SVC>_SERVICE_HOST/PORT/…` Docker-link env-vars
+      # kubelet auto-injects for every Service in the namespace at pod-start.
+      enableServiceLinks: false
+      restartPolicy: OnFailure
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: keycloak-config-cli
+          image: "{{ .Values.keycloakConfig.image.repository }}:{{ .Values.keycloakConfig.image.tag }}"
+          imagePullPolicy: {{ .Values.keycloakConfig.image.pullPolicy }}
+          env:
+            - name: KEYCLOAK_URL
+              value: {{ tpl (required "keycloakConfig.url is required when keycloakConfig.enabled" .Values.keycloakConfig.url) . | quote }}
+            - name: IMPORT_FILES_LOCATIONS
+              value: "/config/*.yaml"
+            # Substitute $(env:VAR) placeholders from the environment — the
+            # only channel secret material may enter realm content through.
+            - name: IMPORT_VARSUBSTITUTION_ENABLED
+              value: "true"
+            # Never checksum-skip an unchanged file: re-applying on every
+            # sync is what reverts server-side drift (see header).
+            - name: IMPORT_CACHE_ENABLED
+              value: "false"
+            # Wait for Keycloak to answer before importing, instead of
+            # failing the first attempts while it boots (the in-cluster
+            # subchart case) or a stand's shared IdP blips.
+            - name: KEYCLOAK_AVAILABILITYCHECK_ENABLED
+              value: "true"
+            - name: KEYCLOAK_AVAILABILITYCHECK_TIMEOUT
+              value: "120s"
+          envFrom:
+            - secretRef:
+                name: {{ tpl (required "keycloakConfig.existingSecret is required when keycloakConfig.enabled" .Values.keycloakConfig.existingSecret) . | quote }}
+          volumeMounts:
+            - name: realms
+              mountPath: /config
+              readOnly: true
+          {{- with .Values.keycloakConfig.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: realms
+          configMap:
+            name: {{ default (printf "%s-keycloak-config-realms" (include "insight.fullname" .)) .Values.keycloakConfig.realmsConfigMap | quote }}
+{{- end }}

--- a/charts/insight/templates/keycloak-config-job.yaml
+++ b/charts/insight/templates/keycloak-config-job.yaml
@@ -45,6 +45,10 @@ Gated on `keycloakConfig.enabled` (default false — environments opt in as
 they are migrated behind the broker, EPIC #2193 Phase 4).
 */}}
 {{- if .Values.keycloakConfig.enabled }}
+{{- $kcUrl := tpl (required "keycloakConfig.url is required when keycloakConfig.enabled" .Values.keycloakConfig.url) . }}
+{{- if and (not (hasPrefix "https://" $kcUrl)) (not .Values.keycloakConfig.allowInsecureUrl) }}
+{{- fail (printf "keycloakConfig.url %q must be https:// — the Job sends the config-cli admin credentials to it. For an in-cluster dev/CI Keycloak reached over plain HTTP on the cluster network, set keycloakConfig.allowInsecureUrl=true explicitly." $kcUrl) }}
+{{- end }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -81,7 +85,7 @@ spec:
           imagePullPolicy: {{ .Values.keycloakConfig.image.pullPolicy }}
           env:
             - name: KEYCLOAK_URL
-              value: {{ tpl (required "keycloakConfig.url is required when keycloakConfig.enabled" .Values.keycloakConfig.url) . | quote }}
+              value: {{ $kcUrl | quote }}
             - name: IMPORT_FILES_LOCATIONS
               value: "/config/*.yaml"
             # Substitute $(env:VAR) placeholders from the environment — the

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -413,6 +413,39 @@ keycloak:
   realmConfigMap: ""
   ingress:
     enabled: false
+# ─── keycloakConfig (broker realms as code — ADR-0003, EPIC #2193) ──────────
+# Applies the environment's versioned broker realm YAML against its Keycloak
+# with keycloak-config-cli, as a post-install/post-upgrade hook Job that
+# re-runs on every deploy (reverting server-side drift). Realm content is
+# configuration-as-code ONLY: no admin-UI channel. The realm YAML lives in the
+# gitops tree (deploy/gitops/environments/<env>/keycloak/realms/) and reaches
+# the Job as a pre-created ConfigMap (gitops `keycloak-broker-realms` target).
+# Independent of `keycloak.deploy`: the target may be the shared
+# pre-provisioned Keycloak of a deployed stand (ADR-0002) or the in-cluster
+# dev subchart.
+keycloakConfig:
+  enabled: false
+  image:
+    repository: adorsys/keycloak-config-cli
+    # config-cli release line must match the Keycloak server major (this tag
+    # is config-cli 6.5.1 built against Keycloak 26.1; server runs 26.x).
+    tag: "6.5.1-26.1.0"
+    pullPolicy: IfNotPresent
+  # Base URL of the Keycloak the realm YAML is applied to (rendered with
+  # `tpl`), e.g. the in-cluster subchart `http://{{ .Release.Name }}-keycloak:8085/kc`
+  # or a stand's shared Keycloak `https://idp.example.com/kc`.
+  url: ""
+  # Existing Secret (envFrom) providing KEYCLOAK_USER + KEYCLOAK_PASSWORD (the
+  # config-cli login) and every VAR the realm YAML references as $(env:VAR)
+  # (client secrets etc.). Sealed in the gitops tree — secret material never
+  # appears in realm YAML or values files.
+  existingSecret: "insight-keycloak-config"
+  # Pre-created ConfigMap holding the realm YAML files (empty =
+  # <release>-keycloak-config-realms).
+  realmsConfigMap: ""
+  resources:
+    requests: {cpu: 100m, memory: 256Mi}
+    limits: {cpu: 500m, memory: 512Mi}
 # ─── Analytics ────────────────────────────────────────────────────────────
 analytics:
   replicaCount: 2

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -432,9 +432,15 @@ keycloakConfig:
     tag: "6.5.1-26.1.0"
     pullPolicy: IfNotPresent
   # Base URL of the Keycloak the realm YAML is applied to (rendered with
-  # `tpl`), e.g. the in-cluster subchart `http://{{ .Release.Name }}-keycloak:8085/kc`
-  # or a stand's shared Keycloak `https://idp.example.com/kc`.
+  # `tpl`), e.g. a stand's shared Keycloak `https://idp.example.com/kc` or the
+  # in-cluster subchart `http://{{ .Release.Name }}-keycloak:8085/kc`. MUST be
+  # https:// — the Job sends the config-cli admin credentials to it. Rendering
+  # fails on a plain-http URL unless `allowInsecureUrl` is set.
   url: ""
+  # Escape hatch for the in-cluster dev/CI Keycloak, which serves plain HTTP
+  # over the cluster network (like the rest of the local stack). NEVER set
+  # this for a Keycloak reached across the cluster boundary.
+  allowInsecureUrl: false
   # Existing Secret (envFrom) providing KEYCLOAK_USER + KEYCLOAK_PASSWORD (the
   # config-cli login) and every VAR the realm YAML references as $(env:VAR)
   # (client secrets etc.). Sealed in the gitops tree — secret material never

--- a/deploy/gitops/Makefile
+++ b/deploy/gitops/Makefile
@@ -360,6 +360,24 @@ keycloak-realm: kube-ctx values-present
 	  kubectl --context $(KUBE_CTX) -n $(NS_APP) apply -f -; \
 	echo "$(C_GRN)applied$(C_RST) configmap $(RELEASE)-keycloak-realm → $(NS_APP)"
 
+.PHONY: keycloak-broker-realms
+# Apply the environment's versioned broker realm YAML
+# (environments/$(ENV)/keycloak/realms/*.yaml) as the
+# `$(RELEASE)-keycloak-config-realms` ConfigMap that the umbrella's
+# keycloak-config-cli hook Job mounts and re-applies on every deploy
+# (ADR-0003: realm content is configuration-as-code; drift reverts on sync).
+# Chained into deploy-insight. No-op unless keycloakConfig.enabled=true.
+keycloak-broker-realms: kube-ctx values-present
+	@if [ "$$(yq -r '.keycloakConfig.enabled // false' $(VALUES))" != "true" ]; then \
+	  echo "$(C_YEL)skip$(C_RST) keycloak-broker-realms (keycloakConfig.enabled != true)"; exit 0; fi; \
+	DIR=environments/$(ENV)/keycloak/realms; \
+	ls $$DIR/*.yaml >/dev/null 2>&1 \
+	  || { echo "$(C_RED)ERROR$(C_RST): keycloakConfig.enabled=true but no realm YAML in $$DIR/"; exit 1; }; \
+	kubectl --context $(KUBE_CTX) -n $(NS_APP) create configmap $(RELEASE)-keycloak-config-realms \
+	  --from-file="$$DIR" --dry-run=client -o yaml | \
+	  kubectl --context $(KUBE_CTX) -n $(NS_APP) apply -f -; \
+	echo "$(C_GRN)applied$(C_RST) configmap $(RELEASE)-keycloak-config-realms → $(NS_APP)"
+
 .PHONY: deploy-app
 deploy-app: deploy-insight
 
@@ -408,7 +426,7 @@ validate-insight: values-present local-chart-present
 	@kubeconform -strict -summary < $(RENDER_DIR)/validate-render-$(ENV).yaml
 
 .PHONY: deploy-insight
-deploy-insight: sync-clean vpn-up kube-ctx confirm values-present chart-present apply-app-secrets
+deploy-insight: sync-clean vpn-up kube-ctx confirm values-present chart-present apply-app-secrets keycloak-broker-realms
 	@mkdir -p $(RENDER_DIR)
 	@helm template $(RELEASE) $(CHART) --version $(INSIGHT_VERSION) $(HELM_EXTRA_FLAGS) \
 		-n $(NS_APP) -f $(VALUES) \

--- a/deploy/gitops/README.md
+++ b/deploy/gitops/README.md
@@ -229,6 +229,28 @@ OIDC IdP (Okta, Entra, Auth0, Keycloak, …), and seal a corresponding
 [`environments/local/sealed-secrets/insight/insight-oidc-sealedsecret.yaml.template`](environments/local/sealed-secrets/insight/insight-oidc-sealedsecret.yaml.template)
 for the seven required keys.
 
+## Keycloak broker realms as code
+
+Environments whose Keycloak realm content is managed as code (ADR-0003,
+EPIC constructorfabric/insight#2193) keep their realm definitions as
+plain [keycloak-config-cli](https://github.com/adorsys/keycloak-config-cli)
+YAML files under `environments/<env>/keycloak/realms/*.yaml` — a realm
+change is a reviewable pull request, never an admin-UI session.
+
+Flip `keycloakConfig.enabled: true` in the env's `values.yaml` and set
+`keycloakConfig.url` to the Keycloak the realms belong on (the shared
+pre-provisioned stand IdP, or the in-cluster dev subchart). On every
+`make deploy`, the `keycloak-broker-realms` target applies the files as
+the `<release>-keycloak-config-realms` ConfigMap, and the umbrella's
+post-upgrade hook Job runs keycloak-config-cli against that ConfigMap —
+idempotently, with the import cache off, so every sync re-asserts the
+versioned content and reverts drift.
+
+Secrets never go in realm YAML: reference them as `$(env:VAR)` and
+provide the values (plus `KEYCLOAK_USER`/`KEYCLOAK_PASSWORD`, the
+config-cli login) through the sealed `insight-keycloak-config` Secret
+(`keycloakConfig.existingSecret`).
+
 ## Secret management
 
 Sealed secrets ([Bitnami sealed-secrets](https://github.com/bitnami-labs/sealed-secrets))

--- a/deploy/gitops/README.md
+++ b/deploy/gitops/README.md
@@ -239,7 +239,11 @@ change is a reviewable pull request, never an admin-UI session.
 
 Flip `keycloakConfig.enabled: true` in the env's `values.yaml` and set
 `keycloakConfig.url` to the Keycloak the realms belong on (the shared
-pre-provisioned stand IdP, or the in-cluster dev subchart). On every
+pre-provisioned stand IdP, or the in-cluster dev subchart). The URL must
+be `https://` — the config-cli Job authenticates to it with admin
+credentials; only an in-cluster dev/CI Keycloak on the cluster network
+may use plain HTTP, behind the explicit
+`keycloakConfig.allowInsecureUrl: true` opt-in. On every
 `make deploy`, the `keycloak-broker-realms` target applies the files as
 the `<release>-keycloak-config-realms` ConfigMap, and the umbrella's
 post-upgrade hook Job runs keycloak-config-cli against that ConfigMap —


### PR DESCRIPTION
## What

The first Phase-1 building block of the Keycloak identity-broker rollout: Keycloak realm content becomes **versioned keycloak-config-cli YAML in the gitops tree, applied idempotently on every deploy** — per ADR-0003, configuration-as-code is the only realm-configuration channel (no admin UI).

- **`charts/insight/templates/keycloak-config-job.yaml`** — a `post-install,post-upgrade` hook Job (same pattern as `clickhouse-migrate-job.yaml`) running `adorsys/keycloak-config-cli` against the environment's Keycloak (`keycloakConfig.url`: a stand's shared pre-provisioned IdP per ADR-0002, or the in-cluster dev subchart). Off by default (`keycloakConfig.enabled: false`); environments opt in as they migrate behind the broker (Phase 4).
- **`deploy/gitops/Makefile`** — new `keycloak-broker-realms` target packs `environments/<env>/keycloak/realms/*.yaml` into the `<release>-keycloak-config-realms` ConfigMap the Job mounts (the same pre-created-ConfigMap contract the existing `keycloak-realm` target uses). Chained into `deploy-insight`; skips unless `keycloakConfig.enabled`.
- **`deploy/gitops/README.md`** — operator docs for the flow.

## Why these knobs

- `IMPORT_CACHE_ENABLED=false` is load-bearing: the Phase-0 PoC (#2194) showed config-cli checksum-skips unchanged files (and `IMPORT_FORCE` does not bypass the skip), so without this, server-side drift would survive until the next realm-YAML edit. With it, **every sync re-asserts the versioned content and reverts drift**.
- `IMPORT_VARSUBSTITUTION_ENABLED=true` + one `envFrom` Secret (`keycloakConfig.existingSecret`) carrying `KEYCLOAK_USER`/`KEYCLOAK_PASSWORD` and all `$(env:VAR)` values: secret material never appears in realm YAML, values files, or images. Sealing that Secret (SealedSecrets templates + CI guard) is the next Phase-1 checkbox.
- Failure is loud: helm blocks on the hook, so a rejected import fails the upgrade and `--atomic` rolls back.

## Verification

- `helm lint` + `helm template` with the gate off (no objects rendered) and on; `kubeconform -strict` clean (the one pre-existing `Certificate` CRD schema miss aside).
- Live smoke on a scratch cluster: a throwaway Keycloak 26.4, the Secret + realm ConfigMap created exactly as the Makefile target does, then the rendered Job applied — realm imported (discovery endpoint 200), `$(env:VAR)` client secret substituted, and a second run completed idempotently.
- `make -n keycloak-broker-realms` recipe checked; skip path verified against an env without `keycloakConfig`.

Refs #2195
Part of #2193

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional automated Keycloak broker realm configuration during installation and upgrades.
  * Supports environment-specific realm definitions, idempotent updates, and configuration drift correction.
  * Added configurable credentials, container images, resource settings, secure endpoints, and realm sources.
  * Deployments now validate required realm configuration and credentials before applying changes.

* **Documentation**
  * Documented setup, deployment behavior, realm file locations, endpoint configuration, and Secret requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->