### PR TITLE
feat(metrics): metric passports + drift test (#1975)

### DIFF
--- a/docs/domain/presentation-layer/specs/DESIGN.md
+++ b/docs/domain/presentation-layer/specs/DESIGN.md
@@ -59,6 +59,7 @@ Requirements that significantly influence architecture decisions.
 | `cpt-presentation-fr-preview-envs` | Path-based `/exp/<name>` on one host, one shared read-only backend, FE-only variation. Per-experiment bundle (`Deployment` + `Service` + one prefix-strip `Ingress`) shipped as the `insight-preview` chart at `deploy/preview/`, applied by hand (#1971). Experiments are a capability gated off on production by default (`cpt-presentation-constraint-experiments-off-prod`, #1973). Shipped |
 | `cpt-presentation-fr-preview-auth` | Single fixed callback with a Redis-backed opaque `state` return path (already stashing `state -> { return_to, pkce_verifier, nonce }`, delete-on-read), extended so `return_to` is validated at store time against a configurable `/exp/` prefix. Shipped (#1972) |
 | `cpt-presentation-fr-metric-registry` | Single declarative `registry.yaml` (a `sources` list and a `metrics` list) embedded at build time and reconciled into the service DB at boot; replaces the code-literal seed with no change to reconcile semantics; invariants pinned by tests that parse the same registry. Shipped (#1974) |
+| `cpt-presentation-fr-metric-passports` | `passport.rs` renders a source/formula/notes passport per metric from the embedded registry; the offline `analytics passports` subcommand emits the document, committed as `passports.md` next to `registry.yaml`. A Rust drift test compares the render against the committed file and fails on divergence, so a metric change without a passport regeneration breaks the build. Shipped (#1975) |
 
 #### NFR Allocation
 
@@ -418,12 +419,38 @@ Collapses the metric-definition seed into one declarative artifact so a metric c
 ##### Responsibility boundaries
 
 - Does NOT define or drive the legacy `metric_catalog`/`metric_threshold` subsystem — that orphaned, frozen path is untouched; its retirement is tracked separately.
-- Does NOT add the semantic raw-to-derived compiler, metric passports, or the drift test — those are later Phase B sub-issues (#1975, #1976).
+- Does NOT add the semantic raw-to-derived compiler — that is a later Phase B sub-issue (#1976). Metric passports and their drift test ship on top of this registry (#1975); see the Metric Passports component below.
 - Does NOT change reconcile semantics or the metric-result runtime.
 
 ##### Related components (by ID)
 
 - `cpt-presentation-component-metric-compiler` — consumes the reconciled definitions
+- `cpt-presentation-component-metric-passports` — renders the human-readable passport from the same registry
+
+---
+
+#### Metric Passports
+
+- [x] `p3` - **ID**: `cpt-presentation-component-metric-passports`
+
+##### Why this component exists
+
+Gives every metric a reviewable, plain-language derivation record — source, formula, notes — that cannot silently drift from the code that computes it, laying a stable, human-facing surface the Phase B semantic compiler and the FE metric rework build on. Shipped (#1975).
+
+##### Responsibility scope
+
+- `passport.rs` (`domain/metric_definitions/`): `render_passports()` folds `builtin_sources()` / `builtin_metrics()` into one Markdown document, one section per metric in registry order — source relation, the measures it reads, a rendered formula (sum/median/distinct-count/scaled ratio plus any affine-clamp transform), the display shape, and the authored notes.
+- The offline `analytics passports` subcommand emits the document (no database, no config, mirroring `analytics openapi`); it is committed as `passports.md` next to `registry.yaml`.
+- A Rust drift test (`metric_definitions::passport`) re-renders from the embedded registry and asserts byte-equality with the committed `passports.md`, failing the standard backend test job when the two disagree. Regenerate: `(cd src/backend && cargo run -p analytics -- passports) > …/passports.md`.
+
+##### Responsibility boundaries
+
+- Does NOT add a new runtime endpoint or change the metric-result path — passports are a build-time, developer-facing artifact.
+- Does NOT author notes independently — it renders the registry's existing labels, computations, and explanations, so the passport stays a projection of the single source of truth rather than a second one.
+
+##### Related components (by ID)
+
+- `cpt-presentation-component-metric-registry` — the single source of truth the passport is rendered from
 
 ---
 
@@ -611,7 +638,7 @@ Tiers 1-2 need no deploy — the unit of change is a query row. Tier 3 is the pr
 
 The declarative metric registry (`cpt-presentation-component-metric-registry`, #1974) lands as the first Phase B step: one YAML is the source of truth for the sanctioned metric-definition seed. The former "FE thresholds" collapse is already done — the FE renders from the `metric_definitions` catalog API and live peer percentiles, holding no per-metric thresholds.
 
-Still out of scope: metric passports plus their drift test (#1975); the semantic raw-to-derived compiler (#1976); FE metric rework (#1977-#1978). Also deferred: retirement of the orphaned, frozen legacy `metric_catalog`/`metric_threshold` subsystem — no live consumer reads it, so it is left untouched and its removal is tracked separately rather than perpetuated in the new registry.
+Metric passports plus their drift test (`cpt-presentation-component-metric-passports`, #1975) land as the next Phase B step on top of the registry: a source/formula/notes document rendered from the same YAML and pinned by a drift test. Still out of scope: the semantic raw-to-derived compiler (#1976); FE metric rework (#1977-#1978). Also deferred: retirement of the orphaned, frozen legacy `metric_catalog`/`metric_threshold` subsystem — no live consumer reads it, so it is left untouched and its removal is tracked separately rather than perpetuated in the new registry.
 
 ## 5. Traceability
 

--- a/docs/domain/presentation-layer/specs/PRD.md
+++ b/docs/domain/presentation-layer/specs/PRD.md
@@ -292,6 +292,18 @@ The sanctioned metric definitions **MUST** be declared in a single declarative r
 
 **Actors**: `cpt-presentation-actor-analytics-svc`, `cpt-presentation-actor-engineering`
 
+#### Metric Passports
+
+- [x] `p3` - **ID**: `cpt-presentation-fr-metric-passports`
+
+Each sanctioned metric **MUST** carry a human-readable passport — its source, formula, and notes — rendered deterministically from the same declarative registry so the passport cannot describe a metric the registry does not define. The rendered passports **MUST** be committed next to the metric code and **MUST** be guarded by a drift test that fails the build when the committed passports and the registry disagree, so a change to a metric's source, formula, or notes cannot land without the passport being regenerated. (#1975.)
+
+**Status**: Shipped (#1975): passports are rendered from the embedded registry by the offline `analytics passports` subcommand, committed as `passports.md` next to `registry.yaml`, and pinned by a Rust drift test (`metric_definitions::passport`) that runs in the standard backend test job.
+
+**Rationale**: A reviewable, always-current derivation record for every metric — kept honest by a drift test rather than by discipline — is what makes the Phase B semantic compiler safe to build on and gives reviewers a stable, plain-language view of what each metric measures.
+
+**Actors**: `cpt-presentation-actor-analytics-svc`, `cpt-presentation-actor-engineering`
+
 ## 6. Non-Functional Requirements
 
 ### 6.1 NFR Inclusions

--- a/src/backend/services/analytics/src/domain/metric_definitions/mod.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/mod.rs
@@ -4,6 +4,7 @@ pub mod error_code;
 pub mod listing;
 #[cfg(test)]
 mod live_tests;
+pub mod passport;
 mod repository;
 mod seeds;
 #[cfg(test)]

--- a/src/backend/services/analytics/src/domain/metric_definitions/passport.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/passport.rs
@@ -1,0 +1,197 @@
+//! Metric passports: a generated, human-readable derivation record for every
+//! builtin metric — source, formula, and notes — rendered from the same
+//! `registry.yaml` the reconciler seeds from. The rendered document is
+//! committed as `passports.md` and pinned by [`tests::passports_md_is_in_sync`],
+//! so a metric whose source, formula, or notes change without regenerating the
+//! passport fails the build. Regenerate with `analytics passports > …/passports.md`.
+
+use std::collections::HashMap;
+use std::fmt::Write as _;
+
+use crate::domain::metric_definitions::builtin::{
+    MetricSeed, SeedComputation, builtin_metrics, builtin_sources,
+};
+use crate::domain::metric_definitions::definition::{MetricInputRole, ValueTransform};
+
+const HEADER: &str = "\
+# Metric passports
+
+Generated from `registry.yaml` by `analytics passports`. Do not edit by hand —
+regenerate and commit. A drift test (`metric_definitions::passport`) fails when
+this file and the registry disagree.
+";
+
+/// Render the passport document from the builtin registry. Deterministic:
+/// metrics appear in registry order, one section each.
+pub fn render_passports() -> String {
+    let source_refs: HashMap<&str, &str> = builtin_sources()
+        .iter()
+        .map(|source| {
+            (
+                source.source.key.as_str(),
+                source.source.source_ref.as_str(),
+            )
+        })
+        .collect();
+
+    let mut out = String::from(HEADER);
+
+    for metric in builtin_metrics() {
+        let source_ref = source_refs
+            .get(metric.source_key.as_str())
+            .copied()
+            .unwrap_or("?");
+        let reads = metric
+            .inputs
+            .iter()
+            .map(|input| input.measure_key.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let notes = metric
+            .explanation
+            .as_deref()
+            .or(metric.description.as_deref())
+            .unwrap_or("—");
+
+        // Infallible: writing to a String never errors.
+        let _ = write!(
+            out,
+            "\n## {key} — {label}\n\n\
+             - Source: {source_key} ({source_ref})\n\
+             - Reads: {reads}\n\
+             - Formula: {formula}\n\
+             - Shape: {shape}\n\
+             - Notes: {notes}\n",
+            key = metric.metric_key,
+            label = metric.label,
+            source_key = metric.source_key,
+            formula = formula(metric),
+            shape = shape(metric),
+        );
+    }
+
+    out
+}
+
+fn formula(metric: &MetricSeed) -> String {
+    let measure = |role: MetricInputRole| -> &str {
+        metric
+            .inputs
+            .iter()
+            .find(|input| input.input_role == role)
+            .map_or("?", |input| input.measure_key.as_str())
+    };
+
+    let base = match metric.computation {
+        SeedComputation::Sum => format!("sum({})", measure(MetricInputRole::Value)),
+        SeedComputation::Median => format!("median({})", measure(MetricInputRole::Value)),
+        SeedComputation::DistinctCount => {
+            format!("distinct_count({})", measure(MetricInputRole::Value))
+        }
+        SeedComputation::Ratio { scale } => {
+            let ratio = format!(
+                "{} / {}",
+                measure(MetricInputRole::Numerator),
+                measure(MetricInputRole::Denominator)
+            );
+            if (scale - 1.0).abs() < f64::EPSILON {
+                ratio
+            } else {
+                format!("{} * ({ratio})", fmt_num(scale))
+            }
+        }
+    };
+
+    match &metric.transform {
+        Some(transform) if !transform.is_identity() => {
+            format!("{base} -> {}", transform_expr(transform))
+        }
+        _ => base,
+    }
+}
+
+fn transform_expr(transform: &ValueTransform) -> String {
+    let mut expr = String::from("x");
+    if let Some(multiplier) = transform.multiplier {
+        expr = format!("{}*x", fmt_num(multiplier));
+    }
+    if let Some(offset) = transform.offset {
+        expr = format!("{expr} + {}", fmt_num(offset));
+    }
+
+    let clamp = match (transform.clamp_min, transform.clamp_max) {
+        (Some(lo), Some(hi)) => format!(", clamped to [{}, {}]", fmt_num(lo), fmt_num(hi)),
+        (Some(lo), None) => format!(", clamped to >= {}", fmt_num(lo)),
+        (None, Some(hi)) => format!(", clamped to <= {}", fmt_num(hi)),
+        (None, None) => String::new(),
+    };
+
+    format!("{expr}{clamp}")
+}
+
+fn shape(metric: &MetricSeed) -> String {
+    let mut shape = format!("{}, {}", metric.format.as_db(), metric.direction.as_db());
+    if let Some(unit) = &metric.unit {
+        let _ = write!(shape, ", unit {unit}");
+    }
+    shape
+}
+
+/// Format an `f64` registry constant without a spurious `.0` (100.0 -> "100",
+/// 1.5 -> "1.5"), so the passport reads naturally and stays stable.
+fn fmt_num(value: f64) -> String {
+    format!("{value}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The committed passport document, embedded so the drift test compares
+    /// against the exact bytes on disk.
+    const PASSPORTS_MD: &str = include_str!("passports.md");
+
+    #[test]
+    fn passports_md_is_in_sync() {
+        assert_eq!(
+            render_passports(),
+            PASSPORTS_MD,
+            "passports.md is stale — regenerate: \
+             (cd src/backend && cargo run -p analytics -- passports) \
+             > src/backend/services/analytics/src/domain/metric_definitions/passports.md"
+        );
+    }
+
+    #[test]
+    fn every_builtin_metric_has_a_section() {
+        let rendered = render_passports();
+        for metric in builtin_metrics() {
+            assert!(
+                rendered.contains(&format!("\n## {} — ", metric.metric_key)),
+                "no passport section for {}",
+                metric.metric_key
+            );
+        }
+    }
+
+    #[test]
+    fn ratio_scale_of_one_is_elided() {
+        // A ratio with scale 1.0 renders as a bare division; a scaled ratio
+        // carries its multiplier.
+        let rendered = render_passports();
+        assert!(rendered.contains("Formula: commit_count / commit_day"));
+        assert!(rendered.contains("Formula: 100 * (accepted_edit_actions / tool_use_offered)"));
+    }
+
+    #[test]
+    fn transform_is_rendered_after_the_base_formula() {
+        let rendered = render_passports();
+        assert!(
+            rendered.contains(
+                "Formula: estimation_error_pct / estimation_samples \
+                 -> -1*x + 100, clamped to [0, 100]"
+            ),
+            "estimation-accuracy passport should show the affine+clamp transform"
+        );
+    }
+}

--- a/src/backend/services/analytics/src/domain/metric_definitions/passports.md
+++ b/src/backend/services/analytics/src/domain/metric_definitions/passports.md
@@ -1,0 +1,477 @@
+# Metric passports
+
+Generated from `registry.yaml` by `analytics passports`. Do not edit by hand —
+regenerate and commit. A drift test (`metric_definitions::passport`) fails when
+this file and the registry disagree.
+
+## ai.accepted_lines — AI-added lines
+
+- Source: ai_usage (ai_metric_observations)
+- Reads: accepted_lines
+- Formula: sum(accepted_lines)
+- Shape: integer, higher_is_better, unit lines
+- Notes: Accepted AI-generated added lines across coding AI tools.
+
+## ai.removed_lines — AI-removed lines
+
+- Source: ai_usage (ai_metric_observations)
+- Reads: removed_lines
+- Formula: sum(removed_lines)
+- Shape: integer, higher_is_better, unit lines
+- Notes: Accepted AI-generated removed lines across coding AI tools.
+
+## ai.active_days — AI active days
+
+- Source: ai_usage (ai_metric_observations)
+- Reads: active_day
+- Formula: sum(active_day)
+- Shape: integer, higher_is_better, unit days
+- Notes: Distinct days with person-attributed AI activity across dev and assistant tools.
+
+## ai.cost — AI usage cost
+
+- Source: ai_usage (ai_metric_observations)
+- Reads: cost_usd
+- Formula: sum(cost_usd)
+- Shape: currency, lower_is_better
+- Notes: Person-attributed AI usage priced at the vendor's token or usage rates — what the consumption would cost if billed purely by usage. Includes usage a seat or subscription already covered, and excludes seat and subscription fees, so it is not the amount invoiced. Covers the tools whose connector prices usage per person.
+
+## ai.accepted_edit_actions — Accepted AI edits
+
+- Source: ai_usage (ai_metric_observations)
+- Reads: accepted_edit_actions
+- Formula: sum(accepted_edit_actions)
+- Shape: integer, higher_is_better, unit actions
+- Notes: Accepted AI edit or tool suggestions across supported coding AI tools.
+
+## ai.tool_acceptance_rate — AI tool acceptance
+
+- Source: ai_usage (ai_metric_observations)
+- Reads: accepted_edit_actions, tool_use_offered
+- Formula: 100 * (accepted_edit_actions / tool_use_offered)
+- Shape: percent, higher_is_better
+- Notes: Accepted AI edit or tool suggestions divided by offered suggestions.
+
+## ai.assistant_messages — AI assistant messages
+
+- Source: ai_usage (ai_metric_observations)
+- Reads: assistant_messages
+- Formula: sum(assistant_messages)
+- Shape: integer, higher_is_better, unit messages
+- Notes: Person-attributed assistant messages from supported AI assistant tools.
+
+## ai.assistant_actions — AI assistant actions
+
+- Source: ai_usage (ai_metric_observations)
+- Reads: assistant_actions
+- Formula: sum(assistant_actions)
+- Shape: integer, higher_is_better, unit actions
+- Notes: Person-attributed assistant actions from supported AI assistant tools.
+
+## ai.dev_conversations — AI dev conversations
+
+- Source: ai_usage (ai_metric_observations)
+- Reads: dev_conversations
+- Formula: sum(dev_conversations)
+- Shape: integer, higher_is_better, unit conversations
+- Notes: Person-attributed coding conversations from dev tools that report them.
+
+## ai.chat_assistant_conversations — AI chat conversations
+
+- Source: ai_usage (ai_metric_observations)
+- Reads: chat_assistant_conversations
+- Formula: sum(chat_assistant_conversations)
+- Shape: integer, higher_is_better, unit conversations
+- Notes: Person-attributed chat assistant conversations from supported AI chat tools.
+
+## git.commits — Commits
+
+- Source: git (git_metric_observations)
+- Reads: commit_count
+- Formula: sum(commit_count)
+- Shape: integer, higher_is_better, unit commits
+- Notes: Distinct authored commits across connected git sources, excluding merge commits.
+
+## git.code_lines — Code lines added
+
+- Source: git (git_metric_observations)
+- Reads: code_lines_added
+- Formula: sum(code_lines_added)
+- Shape: integer, higher_is_better, unit lines
+- Notes: Lines added to files classified as code — tests, configuration, and documentation excluded.
+
+## git.lines_added — Lines added
+
+- Source: git (git_metric_observations)
+- Reads: lines_added
+- Formula: sum(lines_added)
+- Shape: integer, higher_is_better, unit lines
+- Notes: Lines added across all files, split by file category: code, tests, configuration, documentation.
+
+## git.lines_removed — Lines removed
+
+- Source: git (git_metric_observations)
+- Reads: lines_removed
+- Formula: sum(lines_removed)
+- Shape: integer, neutral, unit lines
+- Notes: Lines removed across all reported file changes, with file-category, repository, and source breakdowns available.
+
+## git.prs_created — Pull requests created
+
+- Source: git (git_metric_observations)
+- Reads: pr_created
+- Formula: sum(pr_created)
+- Shape: integer, higher_is_better, unit PRs
+- Notes: Pull requests opened, dated by creation.
+
+## git.prs_merged — Pull requests merged
+
+- Source: git (git_metric_observations)
+- Reads: pr_merged
+- Formula: sum(pr_merged)
+- Shape: integer, higher_is_better, unit PRs
+- Notes: Authored pull requests that merged, dated by the merge.
+
+## git.merge_rate — PR merge rate
+
+- Source: git (git_metric_observations)
+- Reads: pr_created_merged, pr_created
+- Formula: 100 * (pr_created_merged / pr_created)
+- Shape: percent, higher_is_better
+- Notes: Of the pull requests created in the period, the share that have merged. Requests opened near the end of the period may not have merged yet, which lowers the rate at period edges.
+
+## git.commits_per_active_day — Commits per active day
+
+- Source: git (git_metric_observations)
+- Reads: commit_count, commit_day
+- Formula: commit_count / commit_day
+- Shape: decimal, higher_is_better
+- Notes: Commits divided by the number of days with at least one commit.
+
+## git.commit_size — Commit size
+
+- Source: git (git_metric_observations)
+- Reads: commit_change_size
+- Formula: median(commit_change_size)
+- Shape: integer, lower_is_better, unit lines
+- Notes: Median diff size of authored commits (lines added plus removed). Smaller commits are easier to review.
+
+## git.pr_size — PR size
+
+- Source: git (git_metric_observations)
+- Reads: pr_change_size
+- Formula: median(pr_change_size)
+- Shape: integer, lower_is_better, unit lines
+- Notes: Median diff size of authored pull requests (lines added plus removed). Smaller requests are easier to review. Sources that do not report line counts contribute no values.
+
+## git.pr_cycle_time_h — PR cycle time
+
+- Source: git (git_metric_observations)
+- Reads: pr_cycle_hours
+- Formula: median(pr_cycle_hours)
+- Shape: decimal, lower_is_better, unit h
+- Notes: Median hours from opening a pull request to merging it, over requests merged in the period.
+
+## collab.messages_sent — Messages Sent
+
+- Source: collab (collab_metric_observations)
+- Reads: total_chat_messages
+- Formula: sum(total_chat_messages)
+- Shape: integer, higher_is_better, unit messages
+- Notes: Chat messages a person sent across messaging tools. Counts are not directly comparable between tools: Slack includes thread replies, and Microsoft 365 combines private-chat and channel messages.
+
+## collab.channel_posts — Channel Posts
+
+- Source: collab (collab_metric_observations)
+- Reads: channel_posts
+- Formula: sum(channel_posts)
+- Shape: integer, higher_is_better, unit messages
+- Notes: Channel posts plus thread replies across messaging tools. Tools that report posts and replies separately are folded so counts stay comparable.
+
+## collab.dm_ratio — DM Ratio
+
+- Source: collab (collab_metric_observations)
+- Reads: direct_and_group_messages, total_chat_messages
+- Formula: 100 * (direct_and_group_messages / total_chat_messages)
+- Shape: percent, lower_is_better
+- Notes: Direct and group-chat messages divided by all chat messages. A lower ratio means more communication happens in open channels. Tools that do not distinguish message types report no value.
+
+## collab.msgs_per_active_day — Messages per Active Day
+
+- Source: collab (collab_metric_observations)
+- Reads: total_chat_messages, chat_active_day
+- Formula: total_chat_messages / chat_active_day
+- Shape: decimal, higher_is_better, unit messages/day
+- Notes: Chat messages sent divided by days with chat messages. Each tool's active days count separately.
+
+## collab.active_days — Active Days
+
+- Source: collab (collab_metric_observations)
+- Reads: active_day
+- Formula: distinct_count(active_day)
+- Shape: integer, higher_is_better, unit days
+- Notes: Distinct days on which a person took a deliberate collaboration action — sending a message, sending email, engaging or sharing a file, or attending a meeting. Passive activity such as receiving or reading email is excluded.
+
+## collab.emails_sent — Emails Sent
+
+- Source: collab (collab_metric_observations)
+- Reads: emails_sent
+- Formula: sum(emails_sent)
+- Shape: integer, higher_is_better, unit emails
+- Notes: Emails a person sent.
+
+## collab.emails_received — Emails Received
+
+- Source: collab (collab_metric_observations)
+- Reads: emails_received
+- Formula: sum(emails_received)
+- Shape: integer, higher_is_better, unit emails
+- Notes: Emails a person received.
+
+## collab.emails_read — Emails Read
+
+- Source: collab (collab_metric_observations)
+- Reads: emails_read
+- Formula: sum(emails_read)
+- Shape: integer, higher_is_better, unit emails
+- Notes: Emails a person read.
+
+## collab.files_engaged — Files Engaged
+
+- Source: collab (collab_metric_observations)
+- Reads: files_engaged
+- Formula: sum(files_engaged)
+- Shape: integer, higher_is_better, unit files
+- Notes: Files a person viewed or edited.
+
+## collab.files_shared_internal — Files Shared (Internal)
+
+- Source: collab (collab_metric_observations)
+- Reads: files_shared_internal
+- Formula: sum(files_shared_internal)
+- Shape: integer, higher_is_better, unit files
+- Notes: Files a person shared with people inside the organization.
+
+## collab.files_shared_external — Files Shared (External)
+
+- Source: collab (collab_metric_observations)
+- Reads: files_shared_external
+- Formula: sum(files_shared_external)
+- Shape: integer, higher_is_better, unit files
+- Notes: Files a person shared with people outside the organization.
+
+## collab.files_shared — Files Shared
+
+- Source: collab (collab_metric_observations)
+- Reads: files_shared
+- Formula: sum(files_shared)
+- Shape: integer, higher_is_better, unit files
+- Notes: Files a person shared with recipients inside or outside the organization.
+
+## collab.meeting_hours — Meeting Hours
+
+- Source: collab (collab_metric_observations)
+- Reads: meeting_hours
+- Formula: sum(meeting_hours)
+- Shape: decimal, lower_is_better, unit h
+- Notes: Hours spent in meetings, taking the longest active modality (audio, video, or screen share) per meeting. Zoom reports modality durations as full-session estimates, so its figures may run higher than Microsoft Teams.
+
+## collab.meetings_count — Meetings Attended
+
+- Source: collab (collab_metric_observations)
+- Reads: meetings_attended
+- Formula: sum(meetings_attended)
+- Shape: integer, higher_is_better, unit meetings
+- Notes: Distinct meetings a person attended across meeting tools.
+
+## collab.meeting_free_days — Meeting-Free Days
+
+- Source: collab (collab_metric_observations)
+- Reads: meeting_free_day
+- Formula: sum(meeting_free_day)
+- Shape: integer, higher_is_better, unit days
+- Notes: Days on which a person was actively collaborating but spent no time in meetings — a proxy for uninterrupted working days.
+
+## collab.focus_time_pct — Focus Time
+
+- Source: collab (collab_metric_observations)
+- Reads: focus_hours, working_hours
+- Formula: 100 * (focus_hours / working_hours)
+- Shape: percent, higher_is_better
+- Notes: Share of the workday not spent in meetings: meeting-free hours divided by scheduled working hours. Scheduled hours default to a nominal eight-hour day where an HR source does not provide them.
+
+## collab.breadth — Collaboration Breadth
+
+- Source: collab (collab_metric_observations)
+- Reads: active_modality
+- Formula: distinct_count(active_modality)
+- Shape: integer, neutral, unit modalities
+- Notes: Distinct collaboration modalities — chat, meetings, email, documents — a person was deliberately active in during the period.
+
+## collab.meetings_organized — Meetings Organized
+
+- Source: collab (collab_metric_observations)
+- Reads: meetings_organized
+- Formula: sum(meetings_organized)
+- Shape: integer, neutral, unit meetings
+- Notes: Meetings a person organized. Reported only by tools that expose organizer counts.
+
+## collab.adhoc_meetings — Ad-hoc Meetings
+
+- Source: collab (collab_metric_observations)
+- Reads: adhoc_meetings_attended
+- Formula: sum(adhoc_meetings_attended)
+- Shape: integer, neutral, unit meetings
+- Notes: Unscheduled meetings a person attended. Reported only by tools that distinguish ad-hoc from scheduled meetings.
+
+## collab.scheduled_meetings — Scheduled Meetings
+
+- Source: collab (collab_metric_observations)
+- Reads: scheduled_meetings_attended
+- Formula: sum(scheduled_meetings_attended)
+- Shape: integer, neutral, unit meetings
+- Notes: Scheduled meetings a person attended. Reported only by tools that distinguish ad-hoc from scheduled meetings.
+
+## tasks.closed — Tasks closed
+
+- Source: task (task_metric_observations)
+- Reads: tasks_closed
+- Formula: sum(tasks_closed)
+- Shape: integer, higher_is_better, unit tasks
+- Notes: Tasks a person moved into a closed status during the period.
+
+## tasks.bugs_fixed — Bugs fixed
+
+- Source: task (task_metric_observations)
+- Reads: bugs_fixed
+- Formula: sum(bugs_fixed)
+- Shape: integer, higher_is_better, unit tasks
+- Notes: Bug-type tasks a person closed during the period.
+
+## tasks.dev_time — Development time
+
+- Source: task (task_metric_observations)
+- Reads: dev_time_hours
+- Formula: median(dev_time_hours)
+- Shape: decimal, lower_is_better, unit h
+- Notes: Median time closed tasks spent in in-progress statuses, from first pickup to close.
+
+## tasks.resolution_time — Time to resolution
+
+- Source: task (task_metric_observations)
+- Reads: resolution_days
+- Formula: median(resolution_days)
+- Shape: decimal, lower_is_better, unit d
+- Notes: Median time from task creation to close.
+
+## tasks.pickup_time — Pickup time
+
+- Source: task (task_metric_observations)
+- Reads: pickup_days
+- Formula: median(pickup_days)
+- Shape: decimal, lower_is_better, unit d
+- Notes: Median time from task creation to first entering an in-progress status.
+
+## tasks.flow_efficiency — Flow efficiency
+
+- Source: task (task_metric_observations)
+- Reads: flow_dev_seconds, flow_lead_seconds
+- Formula: 100 * (flow_dev_seconds / flow_lead_seconds) -> x, clamped to <= 100
+- Shape: percent, higher_is_better
+- Notes: Time in active development as a share of total task lifetime, across closed tasks.
+
+## tasks.reopen_rate — Reopen rate
+
+- Source: task (task_metric_observations)
+- Reads: reopened_within_14d, close_events
+- Formula: 100 * (reopened_within_14d / close_events)
+- Shape: percent, lower_is_better
+- Notes: Share of task closes followed by a reopen within 14 days.
+
+## tasks.due_date_compliance — Due date compliance
+
+- Source: task (task_metric_observations)
+- Reads: due_date_on_time, due_date_with_due
+- Formula: 100 * (due_date_on_time / due_date_with_due)
+- Shape: percent, higher_is_better
+- Notes: Share of tasks that had a due date and were closed on or before it.
+
+## tasks.on_time_delivery — On-time delivery
+
+- Source: task (task_metric_observations)
+- Reads: due_date_on_time, tasks_closed
+- Formula: 100 * (due_date_on_time / tasks_closed)
+- Shape: percent, higher_is_better
+- Notes: Share of all closed tasks that were closed on or before their due date.
+
+## tasks.avg_slip — Average slip
+
+- Source: task (task_metric_observations)
+- Reads: slip_days_total, late_count
+- Formula: slip_days_total / late_count
+- Shape: decimal, lower_is_better, unit d
+- Notes: Average days past the due date for tasks closed late.
+
+## tasks.estimation_accuracy — Estimation accuracy
+
+- Source: task (task_metric_observations)
+- Reads: estimation_error_pct, estimation_samples
+- Formula: estimation_error_pct / estimation_samples -> -1*x + 100, clamped to [0, 100]
+- Shape: percent, higher_is_better
+- Notes: 100 minus the average deviation between original estimates and time spent, over days whose estimated work stayed within twice the estimate. 100 means estimates matched reality; over- and under-estimation count equally.
+
+## tasks.worklog_accuracy — Worklog accuracy
+
+- Source: task (task_metric_observations)
+- Reads: worklog_seconds, in_progress_seconds
+- Formula: 100 * (worklog_seconds / in_progress_seconds) -> x, clamped to <= 100
+- Shape: percent, higher_is_better
+- Notes: Logged work time as a share of time tasks spent in in-progress statuses.
+
+## tasks.bugs_ratio — Bug ratio
+
+- Source: task (task_metric_observations)
+- Reads: bugs_fixed, tasks_closed
+- Formula: 100 * (bugs_fixed / tasks_closed)
+- Shape: percent, lower_is_better
+- Notes: Bug-type tasks as a share of all closed tasks.
+
+## tasks.stale_in_progress — Stale in progress
+
+- Source: task (task_metric_observations)
+- Reads: stale_in_progress
+- Formula: sum(stale_in_progress)
+- Shape: integer, lower_is_better, unit tasks
+- Notes: Open tasks with no status change in more than 14 days.
+
+## wiki.pages_created — Pages created
+
+- Source: wiki (wiki_metric_observations)
+- Reads: pages_created
+- Formula: sum(pages_created)
+- Shape: integer, higher_is_better, unit pages
+- Notes: Wiki pages the person created during the period, counted on the page's creation date.
+
+## wiki.edits — Page edits
+
+- Source: wiki (wiki_metric_observations)
+- Reads: edits
+- Formula: sum(edits)
+- Shape: integer, higher_is_better, unit edits
+- Notes: Logical wiki edits the person made during the period. Consecutive saves of the same page within a short window count as one edit, so autosaves do not inflate the number.
+
+## wiki.pages_edited — Pages edited
+
+- Source: wiki (wiki_metric_observations)
+- Reads: pages_edited
+- Formula: sum(pages_edited)
+- Shape: integer, higher_is_better, unit pages
+- Notes: Distinct wiki pages the person edited during the period, counted per day the page was touched.
+
+## wiki.comments — Comments received
+
+- Source: wiki (wiki_metric_observations)
+- Reads: comments
+- Formula: sum(comments)
+- Shape: integer, higher_is_better, unit comments
+- Notes: Comments and replies other people left on wiki pages the person authored — a signal of how much their documentation is read and discussed.

--- a/src/backend/services/analytics/src/main.rs
+++ b/src/backend/services/analytics/src/main.rs
@@ -25,6 +25,7 @@
 //! analytics --config config.yaml          # run the host
 //! analytics --config config.yaml migrate  # run migrations + probes and exit
 //! analytics openapi                        # print the OpenAPI document and exit
+//! analytics passports                      # print the metric passports and exit
 //! ```
 
 mod api;
@@ -90,6 +91,10 @@ enum Commands {
     /// regenerate docs/components/backend/analytics/openapi.json and to
     /// drift-check it in CI.
     Openapi,
+    /// Print the metric passports document to stdout and exit. Built offline
+    /// from the embedded registry — no database, no config. Used to regenerate
+    /// the committed passports.md next to the registry; a drift test guards it.
+    Passports,
 }
 
 #[tokio::main]
@@ -114,6 +119,11 @@ async fn main() -> Result<()> {
         Commands::Check => gear::check_config(&config),
         // Emit the OpenAPI document offline (no backends) — see `print_openapi`.
         Commands::Openapi => print_openapi(),
+        // Emit the metric passports offline (no backends) — see `print_passports`.
+        Commands::Passports => {
+            print_passports();
+            Ok(())
+        }
     }
 }
 
@@ -126,6 +136,16 @@ fn print_openapi() -> Result<()> {
     Ok(())
 }
 
+/// Print the metric passports document rendered from the embedded registry.
+/// Offline — no config or backends. Regenerates the committed `passports.md`
+/// pinned by the `metric_definitions::passport` drift test.
+fn print_passports() {
+    print!(
+        "{}",
+        domain::metric_definitions::passport::render_passports()
+    );
+}
+
 #[cfg(test)]
 mod tests {
     /// The `openapi` subcommand's happy path: build the document offline and
@@ -133,5 +153,12 @@ mod tests {
     #[test]
     fn print_openapi_writes_the_document() -> anyhow::Result<()> {
         super::print_openapi()
+    }
+
+    /// The `passports` subcommand's happy path: render the passports offline
+    /// and write them to stdout (captured by the harness).
+    #[test]
+    fn print_passports_writes_the_document() {
+        super::print_passports();
     }
 }


### PR DESCRIPTION
## What

Gives every builtin metric a **passport** — a human-readable derivation record (source, formula, notes) rendered from the same `registry.yaml` the reconciler seeds from — and guards it with a **drift test** so the passport can never silently disagree with the metric it describes.

The passport is a *projection* of the single source of truth (the declarative registry from #1974), not a second source: it renders the registry's existing labels, computations, and explanations, so it cannot describe a metric the registry does not define.

## How

- `passport.rs`: `render_passports()` folds `builtin_sources()` / `builtin_metrics()` into one Markdown document, one section per metric in registry order — source relation, the measures it reads, a readable formula (sum / median / distinct-count / scaled ratio, plus any affine-clamp transform), the display shape, and the authored notes.
- Offline `analytics passports` subcommand emits the document (mirrors `analytics openapi` — no database, no config), committed as `passports.md` next to `registry.yaml`.
- A Rust drift test (`metric_definitions::passport::passports_md_is_in_sync`) re-renders from the embedded registry and asserts byte-equality with the committed file. It runs in the standard backend test job (`cargo test -p analytics` in `ci.yml`), so a metric whose source/formula/notes change without a regeneration fails the build.

Regenerate: `(cd src/backend && cargo run -p analytics -- passports) > src/backend/services/analytics/src/domain/metric_definitions/passports.md`

## Specs

Registered `cfs` artifacts extended and re-validated (per-artifact validate: 0 errors; `check-language`: clean):
- PRD: `cpt-presentation-fr-metric-passports` (shipped).
- DESIGN: `cpt-presentation-component-metric-passports` (shipped) + Functional Drivers row; registry component boundary and §4.4 updated to reflect passports landing on top of the registry.

## Test

- `cargo test -p analytics` — 565 pass (incl. 5 new passport tests: drift-sync, per-metric coverage, ratio-scale elision, transform rendering, subcommand smoke).
- `cargo clippy -p analytics` / `cargo fmt --check` clean.

Closes #1975
Part of #1803