### PR TITLE
fix(seed): add login identity for other-tenant persona

### DIFF
--- a/deploy/seed/identity.py
+++ b/deploy/seed/identity.py
@@ -389,6 +389,7 @@ def run() -> None:
         # subject. An edge would put them in somebody's subtree, and a role
         # would make the refusal ambiguous — is it the tenant or the grant?
         n_persons += seed_persons(cur, TENANT_OTHER, other_roster)
+        n_login_id += seed_login_ids(cur, TENANT_OTHER, other_roster)
         n_names += seed_person_names(cur, TENANT_OTHER, other_roster)
         n_acct += seed_account_person_map(cur, TENANT_OTHER, other_roster)
 

--- a/tests/stand/api/operations.py
+++ b/tests/stand/api/operations.py
@@ -31,10 +31,6 @@ from insight_stand import analytics_path, identity_path
 # authentication, so the gateway never reaches a handler and these are never
 # resolved — they only have to be well-formed enough to route.
 SOME_ID: Final[str] = "01900000-0000-7000-8000-000000000000"
-#: Still used by identity's `/internal/persons/by-email/{email}`, which is a
-#: LOOKUP by email rather than a person-keyed route and so was untouched by the
-#: identity cutover (#2098).
-SOME_EMAIL: Final[str] = "nobody@example.com"
 
 #: Stand-in -> the parameter it stands in for. These values are synthetic and
 #: chosen for this purpose, so a path segment equal to one of them IS the
@@ -42,7 +38,6 @@ SOME_EMAIL: Final[str] = "nobody@example.com"
 #: twice per row.
 _PARAMETERS: Final[dict[str, str]] = {
     SOME_ID: "{id}",
-    SOME_EMAIL: "{email}",
 }
 
 
@@ -104,7 +99,7 @@ ANALYTICS_OPERATIONS: Final[tuple[Operation, ...]] = (
     _a("POST", "/v1/metric-drilldown/export"),
 )
 
-#: identity-resolution — 18 operations. `/health` and `/healthz` are the host
+#: identity-resolution — 17 operations. `/health` and `/healthz` are the host
 #: router's, not the product API, and are deliberately absent: the real probes
 #: address the pod directly rather than passing the gateway.
 IDENTITY_OPERATIONS: Final[tuple[Operation, ...]] = (
@@ -127,7 +122,6 @@ IDENTITY_OPERATIONS: Final[tuple[Operation, ...]] = (
     # `.authenticated()`, not admin-gated — and the substring test below does not
     # catch it, which is correct: `/visible-persons` is not `/visibility`.
     _i("POST", "/v1/visible-persons"),
-    _i("GET", f"/internal/persons/by-email/{SOME_EMAIL}"),
 )
 
 ALL_OPERATIONS: Final[tuple[Operation, ...]] = ANALYTICS_OPERATIONS + IDENTITY_OPERATIONS


### PR DESCRIPTION
## What

Seed the Keycloak login identity for the cross-tenant test persona under its own tenant.

The persona existed in the generated realm and identity roster, but lacked the `value_type=id` observation required by login bootstrap. Its callback was therefore rejected as an unknown person, failing the stand API suite.

## Test

- `python3 -m unittest deploy/seed/test_identity.py -v`
- `ruff check deploy/seed/identity.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved seeded identity data by including login-ID records for secondary tenant scenarios.
- **Tests**
  - Updated identity operation coverage to reflect the removal of an obsolete email-based lookup path.
  - Adjusted operation catalogs and validation expectations accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->