### PR TITLE
docs: reference organisations for performance, soak and efficiency testing

### DIFF
--- a/docs/REFERENCE-ORGS.md
+++ b/docs/REFERENCE-ORGS.md
@@ -118,236 +118,101 @@ A 392-person organisation carrying ~12,000 repositories and 17 years of issue hi
 "mid-size" workload in any sense a load test cares about. Record the entity inventory alongside
 the headcount whenever a reference organisation is cited.
 
-## 4. Typical organisation data
+## 4. Typical organisation data, by metric class
 
-Everything an organisation produces, per **active** person, with a 1,000-person column. The range
-is the observed span between two real installations — read it as *"a real organisation lands in
-here"*, never as a mean or a distribution.
+What an organisation produces, one row per **metric class**.
 
-| What | Per active person | At 1,000 active people *(×3 for REF-L)* |
-|---|---|---|
-| **People** | | |
-| Active people (org size) | 1 | 1,000 |
-| Person records incl. terminated | 3.7 – 5.5 | 3,700 – 5,500 |
-| Directory accounts | 1.0 – 2.8 | 1,000 – 2,800 |
-| Identities per metric class | 0.07 – 1.77 | 70 – 1,770 |
-| Identity-store rows | 71 – 146 | 71,000 – 146,000 |
-| **Entities** | | |
-| Repositories | 3.5 – 30.5 | 3,500 – 30,500 |
-| Wiki pages | 2.7 – 38.1 | 2,700 – 38,100 |
-| Work items | 182 – 380 | 182,000 – 380,000 |
-| Connected systems | — | 8 – 11 |
-| Years of history | — | 10.2 – 17.6 |
-| **Daily activity** (logical rows/day) | | |
-| Issue change events | 5.7 – 9.6 | 5,700 – 9,600 |
-| Git file changes | 4.6 – 5.2 | 4,600 – 5,200 |
-| Chat | 0.73 – 1.55 | 730 – 1,550 *(13.9–15.2 messages/person/day)* |
-| Git commits | 0.76 – 1.44 | 760 – 1,440 |
-| Email activity | 0.70 – 1.10 | 700 – 1,100 |
-| Task comments | 0.32 – 0.82 | 320 – 820 |
-| Worklogs | 0.17 – 0.91 | 170 – 910 *(1.81–6.80 h per entry)* |
-| Document activity | 0.50 – 0.66 | 500 – 660 |
-| Meetings | 0.37 – 0.58 | 370 – 580 |
-| Issues created | 0.34 – 0.41 | 340 – 410 |
-| Pull-request comments | 0.22 – 0.49 | 220 – 490 |
-| Pull requests | 0.12 – 0.23 | 120 – 230 |
-| AI dev usage | 0.11 – 0.20 | 110 – 200 *(49–281 accepted lines per adopter-day)* |
-| Wiki edits | 0.08 – 0.17 | 85 – 170 |
-| Wiki pages created | 0.015 – 0.021 | 15 – 21 |
-| AI chat | 0.030 – 0.046 | 30 – 46 |
-| **Volume** | | |
-| Rows/day, all layers | 71.6 – 100.9 | **72,000 – 101,000** |
-| Bytes/day, all layers | 44.3 – 74.7 kB | **42 – 71 MiB** |
-| 12-month dataset (logical) | 15.4 – 26.0 MiB | **26–37 M rows · 15–25 GiB** |
-| What an installation actually holds | 61.7 – 110.7 MiB | **60 – 111 GiB** |
-| Re-emission multiplier (bronze) | — | **1.58× – 8.36×** |
+* **Rows per active person-day** — the observed span between the two installations. Two
+  organisations, not a distribution: read it as *"a real organisation lands in here"*, never as a
+  mean. *(one-sided)* marks a class only one installation populates — a coverage gap, not a zero.
+* **p50 per participant-week** — rows per ISO week for the people who actually appear in the class.
+  Contamination-resistant, so it is the figure to calibrate a generator against.
+* **Adoption** — share of the active roster appearing in the class at all. Above 100 % is correct,
+  not an error: external meeting attendees, service accounts, shared mailboxes, automation and
+  departed employees still attached to history all author rows.
+* **REF-L rows** — the fixture target at 3,000 active people over 365 days, at each class's
+  canonical layer (one layer per class, so the total is not the whole-install figure in §3.1).
 
-**The last two volume rows are the point.** The *logical content* of a 1,000-person organisation is
-15–25 GiB. What its ClickHouse actually stores is 60–111 GiB. The difference is ReplacingMergeTree
-re-emission plus retained history — not user activity. That single gap drives both the TCO figure
-and the soak workload.
+| Metric class | Rows per active person-day | p50 per participant-week | Adoption | REF-L rows (365 d) |
+|---|---|--:|--:|--:|
+| **Git** | | | | |
+| `git_commits` | 0.76 – 1.44 | 7 – 8 | 47 – 84 % | 1,580,852 |
+| `git_file_changes` | 4.62 – 5.22 | 19 – 31 | 43 – 68 % | 5,717,871 |
+| `git_prs` | 0.12 – 0.23 | 3 – 4 | 34 – 36 % | 250,098 |
+| `git_pr_comments` | 0.22 – 0.49 | 6 | 26 – 44 % | 533,046 |
+| `git_pr_reviews` | 0.21 *(one-sided)* | 4 | 30 % | 231,812 |
+| `git_branches` | 0.11 *(one-sided)* | — | — | — |
+| **Task** | | | | |
+| `task_history` | 5.71 – 9.60 | 25 – 30 | 58 – 58 % | 10,513,971 |
+| `task_issues` | 0.34 – 0.41 | 3 – 4 | 52 – 69 % | 453,440 |
+| `task_comments` | 0.32 – 0.82 | 4 | 53 – 58 % | 894,725 |
+| `task_worklogs` | 0.17 – 0.91 | 5 – 13 | 32 – 47 % | 995,793 |
+| `task_sprints` | 0.00 – 0.01 | — | — | — |
+| **Collaboration** | | | | |
+| `collab_chat` | 0.73 – 1.55 | 6 – 7 | 107 – 130 % | 1,694,732 |
+| `collab_email` | 0.70 – 1.10 | 6 – 7 | 89 – 163 % | 1,205,704 |
+| `collab_docs` | 0.50 – 0.66 | 5 – 6 | 73 – 109 % | 721,167 |
+| `collab_meeting` | 0.37 – 0.58 | 4 | 100 – 177 % | 633,895 |
+| **AI** | | | | |
+| `ai_dev` | 0.11 – 0.20 | 4 – 6 | 30 – 36 % | 218,343 |
+| `ai_chat` | 0.03 – 0.05 | 3 – 4 | 9 – 28 % | 50,589 |
+| `ai_cost` | 0.00 – 1.01 | 1 – 40 | 20 – 29 % | — |
+| `ai_api` | — | — | — | — |
+| **Wiki** | | | | |
+| `wiki_edits` | 0.08 – 0.17 | 3 | 33 – 33 % | 187,136 |
+| `wiki_pages` | 0.02 – 0.02 | 0.98 – 1 | 20 – 23 % | 22,995 |
+| `wiki_comments` | 0.00 – 0.01 | 1.76 – 2 | 8 – 9 % | 6,022 |
+| `wiki_engagement` | 0.00 – 0.00 | — | — | 2,190 |
+| **CRM & Support** | | | | |
+| `crm_activities` | 1.39 *(one-sided)* | — | — | 1,523,145 |
+| `crm_contacts` | 0.43 *(one-sided)* | — | — | 475,011 |
+| `crm_accounts` | 0.12 *(one-sided)* | — | — | 128,006 |
+| `crm_deals` | 0.03 *(one-sided)* | — | — | 30,770 |
+| `support_tickets` | 0.03 *(one-sided)* | — | — | 33,178 |
+| `support_events` | — | — | — | — |
+| **HR & Identity** | | | | |
+| `hr_hours` | 0.33 – 0.47 | 4 | 100 – 177 % | 509,941 |
+| `hr_people` | 0.02 – 0.03 | — | — | 31,755 |
+| `hr_events` | 0.07 *(one-sided)* | — | — | 81,030 |
+| `identity_inputs` | — | — | — | — |
+| `identity_aliases` | 0.06 *(one-sided)* | — | — | 68,985 |
+| **total, canonical layer** | | | | **28,796,200** |
 
-## 5. REF-L — the fixture specification
+**Two classes carry most of the volume** — `task_history` and `git_file_changes` are 57 % of the
+canonical-layer rows, and `task_issues` and `task_history` are 82 % of its bytes. An organisation
+that spreads its volume evenly across classes does not exist.
 
-Single-valued. Where the two installations disagreed, REF-L takes the **higher** value: under-
-provisioning makes a P95 budget look achievable when it is not, while over-provisioning only costs
-disk. Where the higher value comes from a **connector artefact** rather than human behaviour, the
-class is sized on the human-rate figure that transfers and the artefact is applied as a named,
-visible multiplier.
+**Some classes do not scale with headcount** and must be set from another input: `git_branches`
+from repository count, `task_sprints` flat (40–500 boards), `crm_contacts` from a customer count
+(they are *external* people), `crm_accounts` and `crm_deals` from the sales sub-roster (7.1 % and
+4.4 % adoption), `support_tickets` as a flat organisation rate, `wiki_engagement` from page count,
+`identity_inputs` from accounts × rows-per-account.
 
-| Dimension | REF-L |
-|---|--:|
-| Active people | **3,000** |
-| Person records incl. terminated | 16,500 |
-| Directory accounts | 8,400 |
-| Repositories | 91,500 |
-| Wiki pages | 114,300 |
-| Work items | 1,140,000 |
-| Connected systems | 10 |
-| History span | 365 days |
-| **Rows (365 d, logical)** | **122,500,947** |
-| **Uncompressed** | **89.43 GiB** |
-| **On ClickHouse disk (LZ4)** | **18.63 GiB** |
-| Rows per active person-day | 111.9 |
-| Identity-store rows (`identity_inputs`) | 438,000 |
-| Identity persons store | 248,000 |
-| Re-emission multiplier, if sync-replayed | 8.36× |
+**Row counts do not transfer between products; human rates do.** Chat row emission differs 2.12×
+between two chat products for message volumes that agree within 9 %; a worklog entry is 1.81 h in
+one organisation and 6.80 h in the other, so the same effort emits 3.8× the rows; the same logical
+issue costs 80.6 kB in one tracker and 19.2 kB in another. Size a class on the human rate, then
+apply the product's emission multiplier explicitly.
 
-**Minimum viable variant — 91 days:** 30,541,332 rows / 22.30 GiB uncompressed / 4.64 GiB on disk
-(bronze 6.69 M · staging 7.81 M · silver 5.94 M · gold 10.09 M · identity 17 k). This is the window
-every coefficient was measured over, so it is the least extrapolated fixture available. Use it when
-regenerating a 365-day fixture is too expensive.
+## 5. Evidence and limits
 
-### 5.1 Connector mix
+Measured on **two production installations** — 392 and 521 active people — with identical SQL and
+matching ClickHouse builds, 2026-08-05.
 
-| # | Slot | Pick | Load-bearing for |
-|--:|---|---|---|
-| 1 | HR system of record | BambooHR | **36 of 49 gold views** resolve through `insight.people`, a view over the HR employees table. Non-negotiable |
-| 2 | Second directory | MS Entra | Produces the people union and the person-in-two-directories case that identity resolution must handle |
-| 3 | Issue tracker | Jira | Largest class either way, and the heavier: **80.6 kB per logical issue vs 19.2 kB** for the alternative. Also the only genuine silver fan-out observed |
-| 4 | Git | GitLab | The only complete git measurement available, and the only source of a PR-review stream |
-| 5 | Wiki | Outline | 2.01× the row emission of the alternative for identical human effort |
-| 6 | Chat | any one, **sized in messages** | Row emission differs 2.12× between products; **message volume agrees within 9 %** |
-| 7 | Email + documents | M365 | The only connector measured identically on both installations |
-| 8 | Meetings | Zoom | Widest identity axis observed (1.77× the roster — external attendees) |
-| 9 | AI dev | Claude Team + Cursor | Higher line volume; Cursor is the only per-call cost event stream |
-| 10 | CRM + support | HubSpot | Without it, 6 gold CRM views and 3 support views scan empty tables |
+Density **per person** transfers across products: issue creation agrees to **1.20×** across two
+different trackers, git file changes to **1.13×** across two git products, chat messages to within
+**9 %**. Of 22 classes measured on both, 15 agree within 2×, median 1.62×. **None of the seven
+disagreements is a difference in how people work** — every one is a property of the connector.
 
-**Deploy the empty bronze schemas too.** A real installation deploys ~25 bronze databases and
-populates ~9. Gold views reference tables that may be empty; a fixture that omits unconfigured
-connectors' schemas fails to resolve views that a real installation resolves-but-returns-nothing.
+Limits, stated rather than implied:
 
-### 5.2 Classes that must not be scaled by headcount
-
-| Class | Scale by instead |
-|---|---|
-| Git branches | repository count (observed 40–380 branches per active person — repo inventory, not headcount) |
-| Sprints / boards | flat, 40–500 |
-| CRM contacts | a target customer count — these are **external** people |
-| CRM accounts, deals | the **sales sub-roster** (measured adoption 7.1 % and 4.4 %) |
-| Support tickets | flat organisation rate — the source has no owner field |
-| Wiki engagement | page count (grain is page × day) |
-| Identity inputs | accounts per person × rows per account |
-| Dimension tables | flat — organisation-shaped, not headcount-shaped; they do **not** shrink in a small fixture |
-
-### 5.3 Coverage gaps — absent, not zero
-
-AI-API usage and support events are **deployed and empty on both** measured installations. No
-coefficient exists for them anywhere in the evidence base; they must not be interpolated. The
-ClickHouse alias table is empty on every installation observed — the live store is the identity
-service's relational alias map.
-
-## 6. Build rules
-
-1. **Logical vs as-stored.** Every figure above is logical: one row per real event. A running
-   installation stores **1.58×–8.36×** more, because ReplacingMergeTree re-emits each logical row
-   on every connector sync. A **bulk-loaded** fixture sees none of that; a **sync-replayed** one
-   sees all of it. State which method the fixture uses and, if replayed, which multiplier it
-   targets. There is no basis for a value in between.
-2. **History ceilings.** Four classes cannot honestly fill 365 days: email and document activity
-   cap at **122–137 days** (usage-report retention at the source), HR events and identity records
-   at the connector install date. Cap the class and document it, or generate the tail and label it
-   synthetic. **Never extend history by linear pro-rata** — activity grows over time, so
-   back-filling early years at today's rate overstates them. Taper.
-3. **Scale down by truncating payloads, not rows.** No gold object reads the dominant bronze table;
-   fitting its JSON blob columns to a realistic length distribution removes **~29 GiB of 89 GiB
-   with zero P95 impact**. Dropping rows is invalid — row count drives the merge and scan cost the
-   P95 budget measures.
-4. **Do not size gold from its disk footprint.** Gold is ~1 % of disk but **2.3 % of everything the
-   server decompresses** (10.4× compression against bronze's 4.4×), and it is the only layer on the
-   request path. Sizing it from disk under-provisions the measured layer by more than 2×.
-5. **Realism markers.** Weekend share must be **1.4–5 %** on event classes; distributions must be
-   heavy-tailed at **p99/p50 of 5–30×**. Flat distributions and 25–31 % weekend share are the
-   signature of un-calibrated synthetic data.
-
-## 7. Soak
-
-At REF-L the connectors add **335,619 logical rows/day (251 MiB/day)** — **+0.27 %/day** against a
-122.5 M-row fixture. **Dataset growth is not the soak workload; merge and deduplication are.** Under
-sync-replay, bronze grows ~432 MiB per 24 h and a 7-day soak adds ~3 GiB of stored bronze for
-~360 MiB of logical content. Instrument part counts, not dataset size.
-
-**Identity.** The identity service's existing NFR specifies a 24 h soak at 100 RPS against a
-**50,000-row** dataset, and separately a p95 bound *"for tenants under 50,000 persons"*. These are
-**not the same scale — they differ 11–17×**. 50,000 rows in the persons store corresponds to
-605–1,246 active people — **only 20–42 % of REF-L**, i.e. mid-size scale. Either resize that dataset
-to **120 k–248 k rows** to match REF-L, or keep 50,000 and re-label it explicitly as a mid-size
-fixture. Separately, *"under 50,000 persons"* implies a **565 k–864 k-row** store, 2.3–4.7× REF-L's
-and a different fixture again. The identity store grows ~63 rows/day at REF-L (0.03 % of itself):
-its soak is a **memory/GC test, not a growth test**.
-
-## 8. Acceptance checks
-
-A REF-L fixture is correct when:
-
-1. The people model holds **3,000 active** and **16,500 total** person rows.
-2. Per-class distinct active identities match the target ratios — **including the classes above
-   1.0** (meetings ≈1.77×, email ≈1.63×).
-3. Per-active-person-week medians land in band: issues created 3–4, git file changes 19–31, email
-   6–7, issue change events 25–30.
-4. Weekend share is 1.4–5 % on event classes.
-5. Distributions are heavy-tailed (p99/p50 of 5–30×), not flat.
-6. 36 of 49 gold views resolve non-empty; unconfigured-connector views resolve and return zero.
-7. Totals land on **122.5 M rows / 89.4 GiB** at 365 days, or **30.5 M rows / 22.3 GiB** at 91 days.
-
-## 9. Confidence and limits
-
-* **Evidence base is two production installations**, of 392 and 521 active people — both within
-  30 % of the mid/large tier boundary. REF-M is near-measured; **REF-L is a 5.8–7.7× extrapolation** and is the largest single source of
-  error in this document; REF-S is an 8–10× extrapolation downward; 5,000 people has no support.
-  A third measured installation above 1,000 active people would reduce the error more than any
-  other work.
-* **Density per person transfers across products; density per table does not.** Issue creation
-  agrees to 1.20× across two different issue trackers, git file changes to 1.13× across two git
-  products, chat messages to within 9 %. Of 22 classes measured on both, 15 agree within 2×, median
-  1.62×. **None of the 7 disagreements is a difference in how people work** — every one is a
-  property of the connector: emission policy, record grain, ingest completeness or automation share.
-* **The transfer test is arithmetically circular.** Both coefficients are per-person-per-day and
+* **REF-L is a 5.8–7.7× extrapolation.** Both installations sit within 30 % of the mid/large tier
+  boundary, so REF-M is near-measured, REF-L is reached by extrapolation and REF-S by extrapolating
+  downward 8–10×. The 5,000-person figures have no support at all. A third measured installation
+  above 1,000 active people would reduce the error more than any other work.
+* **The transfer test is arithmetically circular** — both coefficients are per-person-per-day and
   headcount is the only multiplier, so the prediction error equals the coefficient ratio by
-  construction. It measures transferability, not correctness, and four of the 15 passing classes
-  carry uncorrected asymmetric contamination. Read 1.62× as *"same order of magnitude, connector
-  effects removed"*, not as an error bar.
-* **Concurrency and query mix are not measured at all.** The 100 RPS figure is inherited from an
-  existing NFR and has no evidence behind it for the metric endpoints. This is the largest gap
-  between this document and a runnable performance plan.
-* **Both measured installations are ~80 % one connector and ~50 % four columns.** Any total is
-  dominated by one product's record shape. A fixture that spreads its volume evenly across metric
-  classes models a system that does not exist.
-
-## 10. Open decisions
-
-1. Whether the 5,000-person tier ceiling is gated at all — it needs evidence not yet collected.
-2. The entity inventory per reference organisation (repositories, wiki pages, work items), which
-   headcount does not determine.
-3. Fixture window: 365 days, or the 91-day least-extrapolated variant.
-4. Build method: bulk-load, or sync-replay and which re-emission multiplier.
-5. Whether CRM and support are in scope — decides whether 9 gold views are ever exercised.
-6. Whether the 50,000-*person* identity boundary is gated, which needs a second dataset.
-7. The concurrency profile — still unmeasured, and still the framework's open product input.
-
-## 11. Scan volume per data slice
-
-`TESTING.md` §7 and #1655 both express Performance as latency per **week / month / quarter / year**
-data slice. At REF-L those slices are this much work. Gold is the only layer on the request path;
-silver is shown because some drill-downs reach it.
-
-| Slice | Gold rows | Gold uncompressed | Silver rows | Silver uncompressed |
-|---|--:|--:|--:|--:|
-| Week (7 d) | 775,975 | 189 MiB | 457,048 | 161 MiB |
-| Month (30 d) | 3,325,608 | 810 MiB | 1,958,778 | 689 MiB |
-| Quarter (91 d) | 10,087,677 | 2.40 GiB | 5,941,626 | 2.04 GiB |
-| Year (365 d) | 40,461,562 | 9.63 GiB | 23,831,797 | 8.18 GiB |
-
-Per-day rates behind it, at 3,000 active people: gold 110,854 rows / 27.0 MiB · silver 65,293 /
-23.0 MiB · staging 85,813 / 31.1 MiB · bronze 73,471 / 169.9 MiB.
-
-The **ratio** matters more than the absolute: a year slice is a ~40 M-row / ~9.6 GiB read against a
-**52× smaller** week slice, and that spread is what a per-slice latency budget has to survive. Per
-active person a drill-down is **259 gold rows** for a week and **13,487** for a year.
-
-Slice sizes are stable across a soak: the fixture grows 335,619 logical rows/day (251 MiB/day), only
-**+0.27 %/day**. What moves under sync-replay is part count, not scan volume.
-
-**Not derivable from this data:** request rate, concurrency, query mix, cache-hit behaviour, and how
-many metric calls a dashboard load issues. Those must be set by measurement or by an explicit,
-recorded assumption.
+  construction. It measures transferability, not correctness.
+* **Both installations are ~80 % one connector**, so any total is dominated by one product's record
+  shape.
+* **Concurrency and query mix are not measured**, and cannot be inferred from this data.

--- a/docs/REFERENCE-ORGS.md
+++ b/docs/REFERENCE-ORGS.md
@@ -1,0 +1,353 @@
+# Reference Organisations
+
+Defines the organisation sizes Insight is tested against, how much data each one holds, and the
+rules for building a fixture that matches. It exists so that a performance or soak fixture can be
+built to scale, latency budgets are comparable run to run, and a cost-of-ownership figure has a
+denominator.
+
+Figures are derived from measuring **two production installations** with identical SQL and are
+stated here as project standards. Companion documents: [`TESTING.md`](TESTING.md) (where these
+fixtures run) and [`product/VISION.md`](product/VISION.md) §6.4.2 (the company-size tiers).
+Tracked in #2215 (reference organisations) and #2216 (recommended resource requirements).
+
+---
+
+## 1. Scope and purpose
+
+The quality framework names one measurement fixture — *a reference organisation of ~1,000 users
+with a typical connector mix* — shared by the **Efficiency** vector (#1785: compute footprint →
+cost of ownership) and the **Performance** vector (#1787: P95 per data endpoint), and records its
+connector and concurrency profile as an open input. [`TESTING.md`](TESTING.md) §7 places load,
+stress and soak in the **Test** and **Beta** stages, and #1655 asks for latency budgets per
+week / month / quarter / year data slice.
+
+Neither states **how much data** a reference organisation holds. Without that, a fixture cannot be
+built to scale, latency budgets cannot be compared run to run, and a TCO figure has no denominator.
+This document supplies those numbers.
+
+## 2. How organisation size is defined
+
+> **Organisation size is counted in ACTIVE people only.** People marked terminated in the HR
+> system of record are excluded from every denominator, every per-person figure and every
+> extrapolation.
+
+The distinction is load-bearing, not cosmetic: in one measured installation **71 % of person
+records were terminated**, so quoting record counts would have overstated the organisation by
+**3.7×**.
+
+Four populations exist and must never be substituted for one another:
+
+| Population | Definition | Used for |
+|---|---|---|
+| **Active people** | HR system of record, active status, distinct work emails | **the org size** — every density figure |
+| Person records incl. terminated | all rows in the people model | storage accounting only |
+| Directory accounts | active accounts in the identity directory | identity-store sizing, authentication load |
+| Identities present in activity data | distinct actors per metric class | fixture population per class |
+
+The last one is the trap: measured per-class activity identities run **0.07× to 1.77×** the active
+roster. Ratios **above 1.0** are correct, not errors — external meeting attendees, service
+accounts, shared mailboxes, automation and departed employees still attached to historical records
+all author rows. A fixture populated only from the employee list will never reproduce them, and
+identity resolution is precisely what they stress.
+
+## 3. The reference organisations
+
+Aligned to the company-size tiers in [`product/VISION.md`](product/VISION.md) §6.4.2. One reference
+organisation per tier, placed at the tier ceiling so that passing at the reference covers the tier
+below it.
+
+| Tier | Span (people) | Reference org | Active people | Confidence |
+|---|---|---|--:|---|
+| Small teams | 5–50 | **REF-S** | 50 | extrapolated **down** 8–10× |
+| Mid-size organizations | 50–500 | **REF-M** | 500 | **near-measured** |
+| Large organizations | 500–5,000 | **REF-L** | **3,000** | extrapolated 5.8–7.7× |
+| Enterprise organizations | 5,000+ | *not defined* | — | outside the evidence base |
+
+**REF-L is the primary fixture.** At 78 % into the Large band it represents the tier's upper half
+rather than its floor, and it matches the 3,000-user dataset already scoped for the shared load
+harness, so one fixture serves every dependent scenario. **The cost is confidence:** 3,000 active
+people is a **5.8–7.7× extrapolation** from installations of 392 and 521 active people, against
+1.9–2.6× for a 1,000-person fixture — this is the largest single source of error in this document.
+Note that the quality framework currently names *"~1,000 users"*; REF-L = 3,000 supersedes that
+number and the framework text needs updating to match (tracked in #2215).
+
+**REF-L covers the tier's upper half but not its ceiling.** A 5,000-person installation is 1.7×
+REF-L, and no evidence in this study reaches either point directly. Figures for 5,000 people appear
+below as an informational extrapolation only — not a defined reference organisation.
+
+### 3.1 Volume per reference organisation
+
+Logical rows and uncompressed bytes — what a generator must emit. The two figures are the observed
+range between the two measured installations, which differ in connector mix; they are not
+competing estimates of one quantity.
+
+| Reference org | Active people | Window | Rows | GiB uncompressed | GiB on disk (LZ4) |
+|---|--:|---|---|---|---|
+| **REF-S** | 50 | 91 days | 0.33 – 0.46 M | 0.19 – 0.32 | 0.04 – 0.07 |
+| | | 365 days | 1.3 – 1.8 M | 0.75 – 1.27 | 0.17 – 0.28 |
+| **REF-M** | 500 | 91 days | 3.3 – 4.6 M | 1.9 – 3.2 | 0.42 – 0.70 |
+| | | 365 days | 13 – 18 M | 7.5 – 12.7 | 1.7 – 2.8 |
+| **REF-L** | 3,000 | 91 days | 19.5 – 27.6 M | 11.3 – 19.0 | 2.5 – 4.2 |
+| | | 365 days | 78 – 111 M | 45 – 76 | 8.7 – 17.0 |
+| *(informational)* | 5,000 | 365 days | 131 – 184 M | 75 – 127 | 17 – 28 |
+
+Scaling is linear in active headcount. Both coefficients, all layers combined:
+**71.6–100.9 logical rows** and **44.3–74.7 kB uncompressed** per active person per day.
+
+### 3.2 Size is not only headcount
+
+[`product/VISION.md`](product/VISION.md) §6.4.2 states it directly: *"Scale is defined not only by employee count, but also by
+number of connected systems, repositories, work items, events, products, services, roles, teams,
+and years of retained history."* The measurements bear this out sharply — the two installations
+differ by up to **14× per active person** on entity inventory while their activity **rates** agree
+within 1.62×.
+
+**Headcount predicts event volume well and entity inventory badly.** Entity counts are therefore
+fixture **inputs**, chosen and recorded, not derived from headcount:
+
+| Entity | Observed per active person | REF-L (3,000) |
+|---|---|--:|
+| Repositories | 3.5 – 30.5 | 10,500 – 91,500 |
+| Wiki pages | 2.7 – 38.1 | 8,100 – 114,300 |
+| Work items (issues) | 182 – 380 | 546,000 – 1,140,000 |
+| Agile boards / sprints | no person axis | 40 – 500 |
+| Connected systems | — | 8 – 11 |
+| Years of retained history | — | 10.2 – 17.6 (real installs) |
+
+A 392-person organisation carrying ~12,000 repositories and 17 years of issue history is not a
+"mid-size" workload in any sense a load test cares about. Record the entity inventory alongside
+the headcount whenever a reference organisation is cited.
+
+## 4. Typical organisation data
+
+Everything an organisation produces, per **active** person, with a 1,000-person column. The range
+is the observed span between two real installations — read it as *"a real organisation lands in
+here"*, never as a mean or a distribution.
+
+| What | Per active person | At 1,000 active people *(×3 for REF-L)* |
+|---|---|---|
+| **People** | | |
+| Active people (org size) | 1 | 1,000 |
+| Person records incl. terminated | 3.7 – 5.5 | 3,700 – 5,500 |
+| Directory accounts | 1.0 – 2.8 | 1,000 – 2,800 |
+| Identities per metric class | 0.07 – 1.77 | 70 – 1,770 |
+| Identity-store rows | 71 – 146 | 71,000 – 146,000 |
+| **Entities** | | |
+| Repositories | 3.5 – 30.5 | 3,500 – 30,500 |
+| Wiki pages | 2.7 – 38.1 | 2,700 – 38,100 |
+| Work items | 182 – 380 | 182,000 – 380,000 |
+| Connected systems | — | 8 – 11 |
+| Years of history | — | 10.2 – 17.6 |
+| **Daily activity** (logical rows/day) | | |
+| Issue change events | 5.7 – 9.6 | 5,700 – 9,600 |
+| Git file changes | 4.6 – 5.2 | 4,600 – 5,200 |
+| Chat | 0.73 – 1.55 | 730 – 1,550 *(13.9–15.2 messages/person/day)* |
+| Git commits | 0.76 – 1.44 | 760 – 1,440 |
+| Email activity | 0.70 – 1.10 | 700 – 1,100 |
+| Task comments | 0.32 – 0.82 | 320 – 820 |
+| Worklogs | 0.17 – 0.91 | 170 – 910 *(1.81–6.80 h per entry)* |
+| Document activity | 0.50 – 0.66 | 500 – 660 |
+| Meetings | 0.37 – 0.58 | 370 – 580 |
+| Issues created | 0.34 – 0.41 | 340 – 410 |
+| Pull-request comments | 0.22 – 0.49 | 220 – 490 |
+| Pull requests | 0.12 – 0.23 | 120 – 230 |
+| AI dev usage | 0.11 – 0.20 | 110 – 200 *(49–281 accepted lines per adopter-day)* |
+| Wiki edits | 0.08 – 0.17 | 85 – 170 |
+| Wiki pages created | 0.015 – 0.021 | 15 – 21 |
+| AI chat | 0.030 – 0.046 | 30 – 46 |
+| **Volume** | | |
+| Rows/day, all layers | 71.6 – 100.9 | **72,000 – 101,000** |
+| Bytes/day, all layers | 44.3 – 74.7 kB | **42 – 71 MiB** |
+| 12-month dataset (logical) | 15.4 – 26.0 MiB | **26–37 M rows · 15–25 GiB** |
+| What an installation actually holds | 61.7 – 110.7 MiB | **60 – 111 GiB** |
+| Re-emission multiplier (bronze) | — | **1.58× – 8.36×** |
+
+**The last two volume rows are the point.** The *logical content* of a 1,000-person organisation is
+15–25 GiB. What its ClickHouse actually stores is 60–111 GiB. The difference is ReplacingMergeTree
+re-emission plus retained history — not user activity. That single gap drives both the TCO figure
+and the soak workload.
+
+## 5. REF-L — the fixture specification
+
+Single-valued. Where the two installations disagreed, REF-L takes the **higher** value: under-
+provisioning makes a P95 budget look achievable when it is not, while over-provisioning only costs
+disk. Where the higher value comes from a **connector artefact** rather than human behaviour, the
+class is sized on the human-rate figure that transfers and the artefact is applied as a named,
+visible multiplier.
+
+| Dimension | REF-L |
+|---|--:|
+| Active people | **3,000** |
+| Person records incl. terminated | 16,500 |
+| Directory accounts | 8,400 |
+| Repositories | 91,500 |
+| Wiki pages | 114,300 |
+| Work items | 1,140,000 |
+| Connected systems | 10 |
+| History span | 365 days |
+| **Rows (365 d, logical)** | **122,500,947** |
+| **Uncompressed** | **89.43 GiB** |
+| **On ClickHouse disk (LZ4)** | **18.63 GiB** |
+| Rows per active person-day | 111.9 |
+| Identity-store rows (`identity_inputs`) | 438,000 |
+| Identity persons store | 248,000 |
+| Re-emission multiplier, if sync-replayed | 8.36× |
+
+**Minimum viable variant — 91 days:** 30,541,332 rows / 22.30 GiB uncompressed / 4.64 GiB on disk
+(bronze 6.69 M · staging 7.81 M · silver 5.94 M · gold 10.09 M · identity 17 k). This is the window
+every coefficient was measured over, so it is the least extrapolated fixture available. Use it when
+regenerating a 365-day fixture is too expensive.
+
+### 5.1 Connector mix
+
+| # | Slot | Pick | Load-bearing for |
+|--:|---|---|---|
+| 1 | HR system of record | BambooHR | **36 of 49 gold views** resolve through `insight.people`, a view over the HR employees table. Non-negotiable |
+| 2 | Second directory | MS Entra | Produces the people union and the person-in-two-directories case that identity resolution must handle |
+| 3 | Issue tracker | Jira | Largest class either way, and the heavier: **80.6 kB per logical issue vs 19.2 kB** for the alternative. Also the only genuine silver fan-out observed |
+| 4 | Git | GitLab | The only complete git measurement available, and the only source of a PR-review stream |
+| 5 | Wiki | Outline | 2.01× the row emission of the alternative for identical human effort |
+| 6 | Chat | any one, **sized in messages** | Row emission differs 2.12× between products; **message volume agrees within 9 %** |
+| 7 | Email + documents | M365 | The only connector measured identically on both installations |
+| 8 | Meetings | Zoom | Widest identity axis observed (1.77× the roster — external attendees) |
+| 9 | AI dev | Claude Team + Cursor | Higher line volume; Cursor is the only per-call cost event stream |
+| 10 | CRM + support | HubSpot | Without it, 6 gold CRM views and 3 support views scan empty tables |
+
+**Deploy the empty bronze schemas too.** A real installation deploys ~25 bronze databases and
+populates ~9. Gold views reference tables that may be empty; a fixture that omits unconfigured
+connectors' schemas fails to resolve views that a real installation resolves-but-returns-nothing.
+
+### 5.2 Classes that must not be scaled by headcount
+
+| Class | Scale by instead |
+|---|---|
+| Git branches | repository count (observed 40–380 branches per active person — repo inventory, not headcount) |
+| Sprints / boards | flat, 40–500 |
+| CRM contacts | a target customer count — these are **external** people |
+| CRM accounts, deals | the **sales sub-roster** (measured adoption 7.1 % and 4.4 %) |
+| Support tickets | flat organisation rate — the source has no owner field |
+| Wiki engagement | page count (grain is page × day) |
+| Identity inputs | accounts per person × rows per account |
+| Dimension tables | flat — organisation-shaped, not headcount-shaped; they do **not** shrink in a small fixture |
+
+### 5.3 Coverage gaps — absent, not zero
+
+AI-API usage and support events are **deployed and empty on both** measured installations. No
+coefficient exists for them anywhere in the evidence base; they must not be interpolated. The
+ClickHouse alias table is empty on every installation observed — the live store is the identity
+service's relational alias map.
+
+## 6. Build rules
+
+1. **Logical vs as-stored.** Every figure above is logical: one row per real event. A running
+   installation stores **1.58×–8.36×** more, because ReplacingMergeTree re-emits each logical row
+   on every connector sync. A **bulk-loaded** fixture sees none of that; a **sync-replayed** one
+   sees all of it. State which method the fixture uses and, if replayed, which multiplier it
+   targets. There is no basis for a value in between.
+2. **History ceilings.** Four classes cannot honestly fill 365 days: email and document activity
+   cap at **122–137 days** (usage-report retention at the source), HR events and identity records
+   at the connector install date. Cap the class and document it, or generate the tail and label it
+   synthetic. **Never extend history by linear pro-rata** — activity grows over time, so
+   back-filling early years at today's rate overstates them. Taper.
+3. **Scale down by truncating payloads, not rows.** No gold object reads the dominant bronze table;
+   fitting its JSON blob columns to a realistic length distribution removes **~29 GiB of 89 GiB
+   with zero P95 impact**. Dropping rows is invalid — row count drives the merge and scan cost the
+   P95 budget measures.
+4. **Do not size gold from its disk footprint.** Gold is ~1 % of disk but **2.3 % of everything the
+   server decompresses** (10.4× compression against bronze's 4.4×), and it is the only layer on the
+   request path. Sizing it from disk under-provisions the measured layer by more than 2×.
+5. **Realism markers.** Weekend share must be **1.4–5 %** on event classes; distributions must be
+   heavy-tailed at **p99/p50 of 5–30×**. Flat distributions and 25–31 % weekend share are the
+   signature of un-calibrated synthetic data.
+
+## 7. Soak
+
+At REF-L the connectors add **335,619 logical rows/day (251 MiB/day)** — **+0.27 %/day** against a
+122.5 M-row fixture. **Dataset growth is not the soak workload; merge and deduplication are.** Under
+sync-replay, bronze grows ~432 MiB per 24 h and a 7-day soak adds ~3 GiB of stored bronze for
+~360 MiB of logical content. Instrument part counts, not dataset size.
+
+**Identity.** The identity service's existing NFR specifies a 24 h soak at 100 RPS against a
+**50,000-row** dataset, and separately a p95 bound *"for tenants under 50,000 persons"*. These are
+**not the same scale — they differ 11–17×**. 50,000 rows in the persons store corresponds to
+605–1,246 active people — **only 20–42 % of REF-L**, i.e. mid-size scale. Either resize that dataset
+to **120 k–248 k rows** to match REF-L, or keep 50,000 and re-label it explicitly as a mid-size
+fixture. Separately, *"under 50,000 persons"* implies a **565 k–864 k-row** store, 2.3–4.7× REF-L's
+and a different fixture again. The identity store grows ~63 rows/day at REF-L (0.03 % of itself):
+its soak is a **memory/GC test, not a growth test**.
+
+## 8. Acceptance checks
+
+A REF-L fixture is correct when:
+
+1. The people model holds **3,000 active** and **16,500 total** person rows.
+2. Per-class distinct active identities match the target ratios — **including the classes above
+   1.0** (meetings ≈1.77×, email ≈1.63×).
+3. Per-active-person-week medians land in band: issues created 3–4, git file changes 19–31, email
+   6–7, issue change events 25–30.
+4. Weekend share is 1.4–5 % on event classes.
+5. Distributions are heavy-tailed (p99/p50 of 5–30×), not flat.
+6. 36 of 49 gold views resolve non-empty; unconfigured-connector views resolve and return zero.
+7. Totals land on **122.5 M rows / 89.4 GiB** at 365 days, or **30.5 M rows / 22.3 GiB** at 91 days.
+
+## 9. Confidence and limits
+
+* **Evidence base is two production installations**, of 392 and 521 active people — both within
+  30 % of the mid/large tier boundary. REF-M is near-measured; **REF-L is a 5.8–7.7× extrapolation** and is the largest single source of
+  error in this document; REF-S is an 8–10× extrapolation downward; 5,000 people has no support.
+  A third measured installation above 1,000 active people would reduce the error more than any
+  other work.
+* **Density per person transfers across products; density per table does not.** Issue creation
+  agrees to 1.20× across two different issue trackers, git file changes to 1.13× across two git
+  products, chat messages to within 9 %. Of 22 classes measured on both, 15 agree within 2×, median
+  1.62×. **None of the 7 disagreements is a difference in how people work** — every one is a
+  property of the connector: emission policy, record grain, ingest completeness or automation share.
+* **The transfer test is arithmetically circular.** Both coefficients are per-person-per-day and
+  headcount is the only multiplier, so the prediction error equals the coefficient ratio by
+  construction. It measures transferability, not correctness, and four of the 15 passing classes
+  carry uncorrected asymmetric contamination. Read 1.62× as *"same order of magnitude, connector
+  effects removed"*, not as an error bar.
+* **Concurrency and query mix are not measured at all.** The 100 RPS figure is inherited from an
+  existing NFR and has no evidence behind it for the metric endpoints. This is the largest gap
+  between this document and a runnable performance plan.
+* **Both measured installations are ~80 % one connector and ~50 % four columns.** Any total is
+  dominated by one product's record shape. A fixture that spreads its volume evenly across metric
+  classes models a system that does not exist.
+
+## 10. Open decisions
+
+1. Whether the 5,000-person tier ceiling is gated at all — it needs evidence not yet collected.
+2. The entity inventory per reference organisation (repositories, wiki pages, work items), which
+   headcount does not determine.
+3. Fixture window: 365 days, or the 91-day least-extrapolated variant.
+4. Build method: bulk-load, or sync-replay and which re-emission multiplier.
+5. Whether CRM and support are in scope — decides whether 9 gold views are ever exercised.
+6. Whether the 50,000-*person* identity boundary is gated, which needs a second dataset.
+7. The concurrency profile — still unmeasured, and still the framework's open product input.
+
+## 11. Scan volume per data slice
+
+`TESTING.md` §7 and #1655 both express Performance as latency per **week / month / quarter / year**
+data slice. At REF-L those slices are this much work. Gold is the only layer on the request path;
+silver is shown because some drill-downs reach it.
+
+| Slice | Gold rows | Gold uncompressed | Silver rows | Silver uncompressed |
+|---|--:|--:|--:|--:|
+| Week (7 d) | 775,975 | 189 MiB | 457,048 | 161 MiB |
+| Month (30 d) | 3,325,608 | 810 MiB | 1,958,778 | 689 MiB |
+| Quarter (91 d) | 10,087,677 | 2.40 GiB | 5,941,626 | 2.04 GiB |
+| Year (365 d) | 40,461,562 | 9.63 GiB | 23,831,797 | 8.18 GiB |
+
+Per-day rates behind it, at 3,000 active people: gold 110,854 rows / 27.0 MiB · silver 65,293 /
+23.0 MiB · staging 85,813 / 31.1 MiB · bronze 73,471 / 169.9 MiB.
+
+The **ratio** matters more than the absolute: a year slice is a ~40 M-row / ~9.6 GiB read against a
+**52× smaller** week slice, and that spread is what a per-slice latency budget has to survive. Per
+active person a drill-down is **259 gold rows** for a week and **13,487** for a year.
+
+Slice sizes are stable across a soak: the fixture grows 335,619 logical rows/day (251 MiB/day), only
+**+0.27 %/day**. What moves under sync-replay is part count, not scan volume.
+
+**Not derivable from this data:** request rate, concurrency, query mix, cache-hit behaviour, and how
+many metric calls a dashboard load issues. Those must be set by measurement or by an explicit,
+recorded assumption.

--- a/docs/REFERENCE-ORGS.md
+++ b/docs/REFERENCE-ORGS.md
@@ -75,56 +75,59 @@ number and the framework text needs updating to match (tracked in #2215).
 REF-L, and no evidence in this study reaches either point directly. Figures for 5,000 people appear
 below as an informational extrapolation only — not a defined reference organisation.
 
-### 3.1 The approximation — headcount × organisation age
+### 3.1 How much data a reference organisation holds
 
-**Insight is installed into brownfield organisations**, so the sizing assumes accumulated history by
-default. A greenfield year of flow is the *floor*, not the target.
+Two inputs: **how many active people**, and **how old the organisation is**. Insight is installed
+into brownfield organisations, so accumulated history is the default — one year of activity is the
+*floor*, not the target.
 
-    TOTAL(N, A)  =  N × 365 × Σ_families [ ρ_f × M_f(A) ]  +  STOCK(N)
+**Step 1 — one year of activity.** Active people × 365 days × **112 rows / 88 kB per person per
+day**. At REF-L that is 122.5 M rows and 89.4 GiB.
 
-`N` = active people · `A` = organisation age in years · `ρ_f` = the family's rows per active person
-per day · `M_f(A)` = how many years of *today's* activity the accumulated corpus is worth.
+**Step 2 — multiply each family by its age factor.** Older organisations hold more, but far less
+than you would expect: if activity were flat, a 10-year-old organisation would hold 10 years of
+data. It does not. An 18-year-old tracker corpus is worth **4.2 years** of today's volume, because
+activity compounds — the early years are thin — and several sources refuse to serve old data at all.
 
-**`M` is far below `A`, and that is the central finding.** A constant-rate organisation would give
-`M = A`. Measured, an 18-year-old tracker corpus is worth **4.2 years** of today's volume, not 18 —
-two unrelated installs converge on **17 %** per year of age for task classes. Activity compounds, so
-the early years are thin; and several sources refuse to serve old data at all.
+| Family | Share of a year's rows | at 5 years | at 10 years | at 20 years | What limits it |
+|---|--:|--:|--:|--:|---|
+| Task | 45 % *(and 90 % of bytes)* | ×1.7 | ×2.5 | ×4.2 | nothing — trackers keep everything |
+| Git | 29 % | ×1.7 | ×2.5 | ×3.4 | nothing at source; see limits |
+| Collaboration | 15 % | **×1** | **×1** | **×1** | source serves 27 days (M365), 150 (Zoom) |
+| CRM & support | 8 % | ×2.8 | ×3.2 | ×3.2 | when the CRM was adopted, not the org's age |
+| HR & identity | 2 % | **×1** | **×1** | **×1** | no history — starts at connector install |
+| AI | 1 % | **×1** | **×1** | **×1** | vendor keeps 7–10 months |
+| Wiki | 1 % | ×3.2 | ×6.0 | ×11.5 | nothing — pages persist as content |
 
-| Family | ρ (rows/a-p-d) | M(A) | M(5) | M(10) | M(20) | Why |
-|---|--:|---|--:|--:|--:|---|
-| Task | 49.95 | 1 + 0.17(A−1) | 1.68 | 2.53 | 4.23 | measured on 2 trackers, ages 10.8 y and 18.3 y |
-| Git | 32.30 | 1 + 0.17(A−1), capped 3.4 | 1.68 | 2.53 | 3.40 | τ **inherited from task** — see limits |
-| Collaboration | 16.53 | **1.00, constant** | 1.00 | 1.00 | 1.00 | source serves 27 d (M365) / 150 d (Zoom): **no brownfield exists** |
-| CRM & Support | 8.51 | 1 + 0.44(min(A,6)−1) | 2.76 | 3.20 | 3.20 | bounded by CRM-platform adoption age, not org age |
-| HR & Identity | 2.69 | **1.00, constant** | 1.00 | 1.00 | 1.00 | no history at all — starts at connector install |
-| AI | 1.04 | **1.00, constant** | 1.00 | 1.00 | 1.00 | vendor floor 203–299 d; day-one arrival 0.56–0.82 y |
-| Wiki | 0.85 | 1 + 0.55(A−1) | 3.20 | 5.95 | 11.45 | flattest accumulator — pages persist as content |
+Between those columns the factors grow by a fixed amount per year, so interpolate linearly.
 
-Three of the seven families **do not accumulate at all**. Collaboration, AI and HR are bounded by
-what the source will serve, not by how old the organisation is: a twenty-year-old company and a
+**Three of the seven families do not accumulate at all.** Collaboration, AI and HR are capped by
+what the source will serve, not by the organisation's age — a twenty-year-old company and a
 two-year-old one arrive with **identical** email, chat, meeting and AI corpora.
 
-**Volume per reference organisation.** `A = 10` is the default — mid-range of the two measured
-installs and where the model is best anchored. `A = 0` is the greenfield flow-only floor.
+**Step 3 — add the stock**, the inventory that arrives whole (below): 0.5–2.5 M rows.
 
-| Reference org | Active people | A = 0 *(floor)* | A = 5 | **A = 10** *(default)* | A = 20 |
+**The result.** **Ten years is the default** — mid-range of the two measured installs, and where
+the model is best anchored. The *no history* column is the one-year-of-flow floor.
+
+| Reference org | Active people | No history *(floor)* | 5 years old | **10 years old** *(default)* | 20 years old |
 |---|--:|---|---|---|---|
 | **REF-S** | 50 | 2.0 M · 1.5 GiB | 3.4 M · 2.5 GiB | **4.8 M · 3.7 GiB** | 6.9 M · 6.1 GiB |
 | **REF-M** | 500 | 20.4 M · 14.9 GiB | 33.7 M · 25.2 GiB | **47.6 M · 37.5 GiB** | 69.0 M · 61.1 GiB |
 | **REF-L** | 3,000 | 122.5 M · 89.4 GiB | 202.2 M · 150.9 GiB | **285.4 M · 224.8 GiB** | 414.3 M · 366.5 GiB |
 | *(informational)* | 5,000 | 204.2 M · 149.1 GiB | 337.0 M · 251.5 GiB | *475.7 M · 374.7 GiB* | 690.5 M · 610.8 GiB |
 
-Rows are logical (dedup-free); bytes are uncompressed. Scaling is linear in `N`. **Bytes grow faster
-than rows** — 4.10× versus 3.38× at `A = 20` — because 89.5 % of the bytes are the task family, the
+Rows are logical (dedup-free); bytes are uncompressed. Double the people, double the numbers. **Bytes grow faster
+than rows** — 4.1× versus 3.4× at twenty years — because 89.5 % of the bytes are the task family, the
 second-steepest accumulator. Any storage or cost-of-ownership figure is therefore more sensitive to
 the brownfield correction than any row count or query-latency figure.
 
 **This is a bracket, not a point estimate.** The upper bound is an established enterprise that did
 *not* grow into its headcount — its history is thin only because tools got chattier, measured at
-**1.13×/yr** per-author intensity growth. At `A = 20` that is **1.9× the central figure**. Use the
+**1.13× a year** in per-author intensity. At twenty years that is **1.9× the central figure**. Use the
 central column as the sizing target and the upper bracket as the soak and headroom target.
 
-| Scenario | A = 5 | A = 10 | A = 20 |
+| Scenario | 5 years | 10 years | 20 years |
 |---|--:|--:|--:|
 | As-configured *(what the measured installs actually ingest)* | 192 M · 149 GiB | 244 M · 218 GiB | 337 M · 354 GiB |
 | **Central** *(above)* | **202 M · 151 GiB** | **285 M · 225 GiB** | **414 M · 366 GiB** |
@@ -166,8 +169,8 @@ What an organisation produces, one row per **metric class**.
   departed employees still attached to history all author rows.
 * **REF-L annual flow** — one year of rows at 3,000 active people, at each class's canonical layer
   (one layer per class, so the total is not the whole-install figure in §3.1). For a brownfield
-  organisation multiply by that family's `M(A)` from §3.1 — ×2.53 for task and git at `A = 10`,
-  ×5.95 for wiki, ×1.00 for collaboration, AI and HR.
+  organisation multiply by that family's age factor from §3.1 — ×2.5 for task and git at ten years,
+  ×6.0 for wiki, ×1 for collaboration, AI and HR.
 
 | Metric class | Rows per active person-day | p50 per participant-week | Adoption | REF-L annual flow |
 |---|---|--:|--:|--:|
@@ -214,7 +217,7 @@ What an organisation produces, one row per **metric class**.
 | `identity_aliases` | 0.06 *(one-sided)* | — | — | 68,985 |
 | **total, canonical layer** | | | | **28,796,200** |
 
-At the default `A = 10` the same classes carry roughly **2.5×** this in task and git, **6×** in wiki
+At the ten-year default the same classes carry roughly **2.5×** this in task and git, **6×** in wiki
 and **1×** in collaboration, AI and HR — see §3.1.
 
 **Two classes carry most of the volume** — `task_history` and `git_file_changes` are 57 % of the
@@ -259,13 +262,12 @@ Limits, stated rather than implied:
   operator-configured backfill floor — one has **zero** rows before 2025-01-01, the other before
   2026-01-05 — so neither can show how git accumulates. Git sources retain everything forever, so
   this is under-collection by configuration, not a source limit: an operator who changes that
-  setting changes the volume. Its τ is borrowed from the task family and capped by a growth
-  decomposition. Git is **28.9 % of the rows**, so this is the largest unmeasured term.
+  setting changes the volume. Its age factor is borrowed from the task family and capped by a
+  growth decomposition. Git is **28.9 % of the rows**, so this is the largest unmeasured term.
 * **CRM and support are one-sided** — measured on one installation only; the other has the connector
   provisioned and never synced.
-* **The wiki taper rests on two products that disagree 1.4×** (τ 0.41 vs 0.56), and the older one is
-  corrected upward for truncation. Wiki is the steepest accumulator, so `A = 20` is where this
-  matters.
+* **The wiki age factor rests on two products that disagree 1.4×**, and the older one is corrected
+  upward for truncation. Wiki is the steepest accumulator, so twenty years is where this matters.
 * **Both readings of the taper are real, and which one dominates is a property of the connector.**
   Compounding is *demonstrated* for task and wiki — every year present and non-zero, no
   zero-then-jump anywhere. Truncation is *demonstrated* for git and collaboration — hard floors in

--- a/docs/REFERENCE-ORGS.md
+++ b/docs/REFERENCE-ORGS.md
@@ -75,48 +75,82 @@ number and the framework text needs updating to match (tracked in #2215).
 REF-L, and no evidence in this study reaches either point directly. Figures for 5,000 people appear
 below as an informational extrapolation only — not a defined reference organisation.
 
-### 3.1 Volume per reference organisation
+### 3.1 The approximation — headcount × organisation age
 
-Logical rows and uncompressed bytes — what a generator must emit. The two figures are the observed
-range between the two measured installations, which differ in connector mix; they are not
-competing estimates of one quantity.
+**Insight is installed into brownfield organisations**, so the sizing assumes accumulated history by
+default. A greenfield year of flow is the *floor*, not the target.
 
-| Reference org | Active people | Window | Rows | GiB uncompressed | GiB on disk (LZ4) |
+    TOTAL(N, A)  =  N × 365 × Σ_families [ ρ_f × M_f(A) ]  +  STOCK(N)
+
+`N` = active people · `A` = organisation age in years · `ρ_f` = the family's rows per active person
+per day · `M_f(A)` = how many years of *today's* activity the accumulated corpus is worth.
+
+**`M` is far below `A`, and that is the central finding.** A constant-rate organisation would give
+`M = A`. Measured, an 18-year-old tracker corpus is worth **4.2 years** of today's volume, not 18 —
+two unrelated installs converge on **17 %** per year of age for task classes. Activity compounds, so
+the early years are thin; and several sources refuse to serve old data at all.
+
+| Family | ρ (rows/a-p-d) | M(A) | M(5) | M(10) | M(20) | Why |
+|---|--:|---|--:|--:|--:|---|
+| Task | 49.95 | 1 + 0.17(A−1) | 1.68 | 2.53 | 4.23 | measured on 2 trackers, ages 10.8 y and 18.3 y |
+| Git | 32.30 | 1 + 0.17(A−1), capped 3.4 | 1.68 | 2.53 | 3.40 | τ **inherited from task** — see limits |
+| Collaboration | 16.53 | **1.00, constant** | 1.00 | 1.00 | 1.00 | source serves 27 d (M365) / 150 d (Zoom): **no brownfield exists** |
+| CRM & Support | 8.51 | 1 + 0.44(min(A,6)−1) | 2.76 | 3.20 | 3.20 | bounded by CRM-platform adoption age, not org age |
+| HR & Identity | 2.69 | **1.00, constant** | 1.00 | 1.00 | 1.00 | no history at all — starts at connector install |
+| AI | 1.04 | **1.00, constant** | 1.00 | 1.00 | 1.00 | vendor floor 203–299 d; day-one arrival 0.56–0.82 y |
+| Wiki | 0.85 | 1 + 0.55(A−1) | 3.20 | 5.95 | 11.45 | flattest accumulator — pages persist as content |
+
+Three of the seven families **do not accumulate at all**. Collaboration, AI and HR are bounded by
+what the source will serve, not by how old the organisation is: a twenty-year-old company and a
+two-year-old one arrive with **identical** email, chat, meeting and AI corpora.
+
+**Volume per reference organisation.** `A = 10` is the default — mid-range of the two measured
+installs and where the model is best anchored. `A = 0` is the greenfield flow-only floor.
+
+| Reference org | Active people | A = 0 *(floor)* | A = 5 | **A = 10** *(default)* | A = 20 |
 |---|--:|---|---|---|---|
-| **REF-S** | 50 | 91 days | 0.33 – 0.46 M | 0.19 – 0.32 | 0.04 – 0.07 |
-| | | 365 days | 1.3 – 1.8 M | 0.75 – 1.27 | 0.17 – 0.28 |
-| **REF-M** | 500 | 91 days | 3.3 – 4.6 M | 1.9 – 3.2 | 0.42 – 0.70 |
-| | | 365 days | 13 – 18 M | 7.5 – 12.7 | 1.7 – 2.8 |
-| **REF-L** | 3,000 | 91 days | 19.5 – 27.6 M | 11.3 – 19.0 | 2.5 – 4.2 |
-| | | 365 days | 78 – 111 M | 45 – 76 | 8.7 – 17.0 |
-| *(informational)* | 5,000 | 365 days | 131 – 184 M | 75 – 127 | 17 – 28 |
+| **REF-S** | 50 | 2.0 M · 1.5 GiB | 3.4 M · 2.5 GiB | **4.8 M · 3.7 GiB** | 6.9 M · 6.1 GiB |
+| **REF-M** | 500 | 20.4 M · 14.9 GiB | 33.7 M · 25.2 GiB | **47.6 M · 37.5 GiB** | 69.0 M · 61.1 GiB |
+| **REF-L** | 3,000 | 122.5 M · 89.4 GiB | 202.2 M · 150.9 GiB | **285.4 M · 224.8 GiB** | 414.3 M · 366.5 GiB |
+| *(informational)* | 5,000 | 204.2 M · 149.1 GiB | 337.0 M · 251.5 GiB | *475.7 M · 374.7 GiB* | 690.5 M · 610.8 GiB |
 
-Scaling is linear in active headcount. Both coefficients, all layers combined:
-**71.6–100.9 logical rows** and **44.3–74.7 kB uncompressed** per active person per day.
+Rows are logical (dedup-free); bytes are uncompressed. Scaling is linear in `N`. **Bytes grow faster
+than rows** — 4.10× versus 3.38× at `A = 20` — because 89.5 % of the bytes are the task family, the
+second-steepest accumulator. Any storage or cost-of-ownership figure is therefore more sensitive to
+the brownfield correction than any row count or query-latency figure.
 
-### 3.2 Size is not only headcount
+**This is a bracket, not a point estimate.** The upper bound is an established enterprise that did
+*not* grow into its headcount — its history is thin only because tools got chattier, measured at
+**1.13×/yr** per-author intensity growth. At `A = 20` that is **1.9× the central figure**. Use the
+central column as the sizing target and the upper bracket as the soak and headroom target.
 
-[`product/VISION.md`](product/VISION.md) §6.4.2 states it directly: *"Scale is defined not only by employee count, but also by
-number of connected systems, repositories, work items, events, products, services, roles, teams,
-and years of retained history."* The measurements bear this out sharply — the two installations
-differ by up to **14× per active person** on entity inventory while their activity **rates** agree
-within 1.62×.
+| Scenario | A = 5 | A = 10 | A = 20 |
+|---|--:|--:|--:|
+| As-configured *(what the measured installs actually ingest)* | 192 M · 149 GiB | 244 M · 218 GiB | 337 M · 354 GiB |
+| **Central** *(above)* | **202 M · 151 GiB** | **285 M · 225 GiB** | **414 M · 366 GiB** |
+| Mature, flat headcount | 421 M · 350 GiB | 622 M · 536 GiB | 790 M · 691 GiB |
 
-**Headcount predicts event volume well and entity inventory badly.** Entity counts are therefore
-fixture **inputs**, chosen and recorded, not derived from headcount:
+**Plus STOCK — what arrives whole.** Inventory, not flow: it lands complete on day one and has no
+taper. It is **0.4–2.0 % of the rows** but it is what stresses joins, identity resolution and
+dimension lookups. Each entry is a **fixture input to be recorded**, never derived from headcount —
+the two installations differ by up to **14× per active person** here while their activity *rates*
+agree within 1.62×.
 
-| Entity | Observed per active person | REF-L (3,000) |
-|---|---|--:|
-| Repositories | 3.5 – 30.5 | 10,500 – 91,500 |
-| Wiki pages | 2.7 – 38.1 | 8,100 – 114,300 |
-| Work items (issues) | 182 – 380 | 546,000 – 1,140,000 |
-| Agile boards / sprints | no person axis | 40 – 500 |
-| Connected systems | — | 8 – 11 |
-| Years of retained history | — | 10.2 – 17.6 (real installs) |
+| Stock | Scales with | Per active person | REF-L (3,000) |
+|---|---|--:|--:|
+| Git repositories | estate age, M&A, monorepo policy | 3.5 – 30.5 | 10,500 – 91,500 |
+| Git branches | **repository count** (12–16 per repo) | 40 – 380 | 127,000 – 1,470,000 |
+| Wiki pages | age — the *flow* is edits; pages accumulate | 2.7 – 38.1 | 8,100 – 114,300 |
+| Work items | age + tracker adoption | 182 – 380 | 546,000 – 1,140,000 |
+| Boards / sprints | teams and projects, no person axis | — | 40–500 boards · 1,800–22,500 sprints |
+| Tracker + directory accounts | **lifetime** headcount × connected tools | 5.8 – 20.2 | 17,400 – 60,600 |
+| HR roster incl. terminated | lifetime employees, capped at HRIS adoption | 2.0 – 3.6 × active | 6,000 – 10,800 |
+| Identity inputs / persons | **accounts × tools** (~7.6 rows/account), not age | 111 – 229 | 334,000 – 686,000 |
+| **Total stock** | | | **0.5 – 2.5 M rows · 0.2 – 1.5 GiB** |
 
-A 392-person organisation carrying ~12,000 repositories and 17 years of issue history is not a
-"mid-size" workload in any sense a load test cares about. Record the entity inventory alongside
-the headcount whenever a reference organisation is cited.
+Repository inventory is the sharpest illustration: one install carries 10,548 repositories against
+392 active people — **27 per person** — and 71 % of them were created in a single month by a
+platform migration that rewrote their creation dates. It is a sizing input, never an organic rate.
 
 ## 4. Typical organisation data, by metric class
 
@@ -130,10 +164,12 @@ What an organisation produces, one row per **metric class**.
 * **Adoption** — share of the active roster appearing in the class at all. Above 100 % is correct,
   not an error: external meeting attendees, service accounts, shared mailboxes, automation and
   departed employees still attached to history all author rows.
-* **REF-L rows** — the fixture target at 3,000 active people over 365 days, at each class's
-  canonical layer (one layer per class, so the total is not the whole-install figure in §3.1).
+* **REF-L annual flow** — one year of rows at 3,000 active people, at each class's canonical layer
+  (one layer per class, so the total is not the whole-install figure in §3.1). For a brownfield
+  organisation multiply by that family's `M(A)` from §3.1 — ×2.53 for task and git at `A = 10`,
+  ×5.95 for wiki, ×1.00 for collaboration, AI and HR.
 
-| Metric class | Rows per active person-day | p50 per participant-week | Adoption | REF-L rows (365 d) |
+| Metric class | Rows per active person-day | p50 per participant-week | Adoption | REF-L annual flow |
 |---|---|--:|--:|--:|
 | **Git** | | | | |
 | `git_commits` | 0.76 – 1.44 | 7 – 8 | 47 – 84 % | 1,580,852 |
@@ -178,6 +214,9 @@ What an organisation produces, one row per **metric class**.
 | `identity_aliases` | 0.06 *(one-sided)* | — | — | 68,985 |
 | **total, canonical layer** | | | | **28,796,200** |
 
+At the default `A = 10` the same classes carry roughly **2.5×** this in task and git, **6×** in wiki
+and **1×** in collaboration, AI and HR — see §3.1.
+
 **Two classes carry most of the volume** — `task_history` and `git_file_changes` are 57 % of the
 canonical-layer rows, and `task_issues` and `task_history` are 82 % of its bytes. An organisation
 that spreads its volume evenly across classes does not exist.
@@ -216,3 +255,19 @@ Limits, stated rather than implied:
 * **Both installations are ~80 % one connector**, so any total is dominated by one product's record
   shape.
 * **Concurrency and query mix are not measured**, and cannot be inferred from this data.
+* **The git taper is inherited, not measured.** Both installations bound their git history with an
+  operator-configured backfill floor — one has **zero** rows before 2025-01-01, the other before
+  2026-01-05 — so neither can show how git accumulates. Git sources retain everything forever, so
+  this is under-collection by configuration, not a source limit: an operator who changes that
+  setting changes the volume. Its τ is borrowed from the task family and capped by a growth
+  decomposition. Git is **28.9 % of the rows**, so this is the largest unmeasured term.
+* **CRM and support are one-sided** — measured on one installation only; the other has the connector
+  provisioned and never synced.
+* **The wiki taper rests on two products that disagree 1.4×** (τ 0.41 vs 0.56), and the older one is
+  corrected upward for truncation. Wiki is the steepest accumulator, so `A = 20` is where this
+  matters.
+* **Both readings of the taper are real, and which one dominates is a property of the connector.**
+  Compounding is *demonstrated* for task and wiki — every year present and non-zero, no
+  zero-then-jump anywhere. Truncation is *demonstrated* for git and collaboration — hard floors in
+  the connector configuration and the vendor API. The model fits the observable either way, but a
+  fixture built on the truncation classes is sensitive to settings an operator can change.

--- a/docs/REFERENCE-ORGS.md
+++ b/docs/REFERENCE-ORGS.md
@@ -56,12 +56,12 @@ Aligned to the company-size tiers in [`product/VISION.md`](product/VISION.md) §
 organisation per tier, placed at the tier ceiling so that passing at the reference covers the tier
 below it.
 
-| Tier | Span (people) | Reference org | Active people | Confidence |
-|---|---|---|--:|---|
-| Small teams | 5–50 | **REF-S** | 50 | extrapolated **down** 8–10× |
-| Mid-size organizations | 50–500 | **REF-M** | 500 | **near-measured** |
-| Large organizations | 500–5,000 | **REF-L** | **3,000** | extrapolated 5.8–7.7× |
-| Enterprise organizations | 5,000+ | *not defined* | — | outside the evidence base |
+| Tier | Span (people) | Reference org | Active people |
+|---|---|---|--:|
+| Small teams | 5–50 | **REF-S** | 50 |
+| Mid-size organizations | 50–500 | **REF-M** | 500 |
+| Large organizations | 500–5,000 | **REF-L** | **3,000** |
+| Enterprise organizations | 5,000+ | *not defined* | — |
 
 **REF-L is the primary fixture.** At 78 % into the Large band it represents the tier's upper half
 rather than its floor, and it matches the 3,000-user dataset already scoped for the shared load

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -127,8 +127,8 @@ still unmeasured.
 
 - Query latency (p50/p95/p99), load, stress, soak/endurance.
 - **Not** on PR — runs in **Test** (baselines / nightly) and **Beta** (prod-load + soak). Requires the metrics stack.
-- **Fixture sizes** — which organisation sizes these run against, how much data each holds, and the
-  scan volume per week / month / quarter / year slice: [`REFERENCE-ORGS.md`](REFERENCE-ORGS.md).
+- **Fixture sizes** — which organisation sizes these run against, and how much data each holds per
+  metric class: [`REFERENCE-ORGS.md`](REFERENCE-ORGS.md).
 
 ---
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -127,6 +127,8 @@ still unmeasured.
 
 - Query latency (p50/p95/p99), load, stress, soak/endurance.
 - **Not** on PR — runs in **Test** (baselines / nightly) and **Beta** (prod-load + soak). Requires the metrics stack.
+- **Fixture sizes** — which organisation sizes these run against, how much data each holds, and the
+  scan volume per week / month / quarter / year slice: [`REFERENCE-ORGS.md`](REFERENCE-ORGS.md).
 
 ---
 


### PR DESCRIPTION
## What

Adds `docs/REFERENCE-ORGS.md` — the organisation sizes Insight is tested against, how much data each
one holds, and how that scales with headcount **and organisation age**. Linked from `TESTING.md` §7.

Five sections: scope · how organisation size is defined · the reference organisations and the sizing
approximation · typical organisation data by metric class · evidence and limits.

## Why

The quality framework names one measurement fixture — *"a reference organisation of ~1,000 users,
typical connector mix"* — shared by the Performance (#1787) and Efficiency (#1785) vectors, and
records its profile as the open product input. Nothing said **how much data** that is, so a perf or
soak fixture could not be built to scale, latency budgets were not comparable run to run, and a
cost-of-ownership figure had no denominator. #1655 asks for latency per week/month/quarter/year
slice; this supplies the volume behind it.

## Organisation size is counted in active people only

Not cosmetic: on one measured installation **71 % of person records were terminated**, so counting
records would have overstated that organisation by **3.7×**. The doc also separates the four
populations that get conflated — active people, person records, directory accounts, and identities
that actually appear in activity data (which runs **0.07×–1.77×** the roster, and above 1.0 is
correct: externals, service accounts, bots, leavers).

## The sizing is brownfield by default

Insight is installed into organisations that already have years of history in their sources, so a
greenfield year of flow is the **floor**, not the target:

```
TOTAL(N, A) = N × 365 × Σ_families [ ρ_f × M_f(A) ] + STOCK(N)
```

**`M` is far below `A`.** A constant-rate organisation would give `M = A`. Measured, an 18-year-old
tracker corpus is worth **4.2 years** of today's volume, not 18 — two unrelated installs converge on
**17 % per year of age** for task classes.

**Three of the seven families do not accumulate at all.** Collaboration (M365 serves 27 d, Zoom
150 d), AI (vendor floors 203–299 d) and HR (starts at connector install) are bounded by what the
*source* will serve — a twenty-year-old company and a two-year-old one arrive with **identical**
email, chat, meeting and AI corpora.

| Reference org | Active people | A = 0 *(floor)* | **A = 10** *(default)* | A = 20 |
|---|--:|---|---|---|
| REF-S | 50 | 2.0 M · 1.5 GiB | **4.8 M · 3.7 GiB** | 6.9 M · 6.1 GiB |
| REF-M | 500 | 20.4 M · 14.9 GiB | **47.6 M · 37.5 GiB** | 69.0 M · 61.1 GiB |
| **REF-L** | **3,000** | 122.5 M · 89.4 GiB | **285.4 M · 224.8 GiB** | 414.3 M · 366.5 GiB |

REF-L at the default is **2.33× the rows and 2.51× the bytes** of the greenfield figure. Bytes grow
faster than rows because 89.5 % of the bytes are the task family, so a TCO figure is more sensitive
to this correction than a latency figure. Published as a **bracket**, not a point estimate — the
upper bound is an enterprise that did not grow into its headcount (1.13×/yr intensity growth, 1.9×
the central figure at `A = 20`).

REF-L = 3,000 matches the fixture already scoped in #2137, so one dataset serves the scenarios that
depend on it.

## Per-metric-class detail

§4 gives one row per metric class — rows per active person-day (observed range), p50 per
participant-week (the contamination-resistant figure to calibrate a generator against), adoption,
and the REF-L annual flow. Plus the classes that must **not** be scaled by headcount (git branches
from repo count, CRM contacts from a customer count, sales-only classes at 7.1 % and 4.4 % adoption)
and the stock inventory that arrives whole.

## Evidence

Two production installations — 392 and 521 active people — identical SQL, matching ClickHouse builds,
2026-08-05. Density **per person** transfers across products: issue creation **1.20×** across two
different trackers, git file changes **1.13×** across two git products, chat messages within **9 %**.
Density **per table** does not, and none of the seven classes that failed to transfer failed because
of how people work — every one was a connector property.

## Limits, in the doc rather than buried

- **REF-L is a 5.8–7.7× extrapolation** from installs of 392 and 521 active people — the largest
  single source of error. A third measured install above 1,000 active would reduce it more than any
  other work.
- **The git taper is inherited, not measured.** Both installs bound git history with an
  operator-configured backfill floor — one has zero rows before 2025-01-01, the other before
  2026-01-05. Git sources retain everything forever, so this is under-collection by configuration,
  not a source limit. Git is **28.9 % of the rows**: the largest unmeasured term.
- **CRM and support are one-sided**; the **two wiki products disagree 1.4×** on the taper.
- **The transfer test is arithmetically circular** — it measures transferability, not correctness.
- **Concurrency and query mix are not measured** and cannot be inferred from this data.

## Review notes

- Content is **de-attributed** — no customer or installation names anywhere.
- REF-L = 3,000 **supersedes** the framework's "~1,000 users" wording, which still needs updating
  (tracked in #2215).
- Three things are decisions rather than measurements, and are the ones worth challenging: REF-L is
  single-valued by taking the **higher** of the two measured shapes on each axis (never
  under-stress); `A = 10` is chosen as the default because it is mid-range of the two measured
  installs; and the 5,000-person figures are informational, **not** a defined reference organisation.

Refs #2215, #2216, #1655, #1785, #1787, #2137.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance defining reference organisation sizes and fixture data volumes.
  * Documented metric scaling, connector-specific accumulation, adoption and activity measurements, and extrapolation limitations.
  * Updated performance testing documentation with links to the new reference organisation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->