### PR TITLE
docs(product): main scenarios by persona

### DIFF
--- a/docs/product/SCENARIOS.md
+++ b/docs/product/SCENARIOS.md
@@ -2,191 +2,314 @@
 
 **Status:** draft for review · Companion to [VISION.md](VISION.md)
 
-The vision states what Insight is and what it can do. This document states **who is standing in
-front of it and how far each of them may reach**. It adds no new capability and changes no
-commitment: personas are the four target user groups of VISION §6.1, and the main scenarios are the
-nine product capabilities of VISION §8, expressed as scenarios and attributed per persona.
+The vision says what Insight is and what it can do. This document says **who is standing in front of
+it and how far each of them may reach**. It adds no capability and changes no commitment.
 
-**Why the per-persona split matters.** A capability is not one scenario. "Work with metrics" is a
-single capability, but an individual contributor working with metrics sees their own work placed
-against a department or cohort median and no team metrics at all; a team manager sees their subtree
-and the people in it by name, with cohorts recomputed inside that scope rather than carried over from
-the organization; an executive sees the whole organization. The capability is shared; the boundary is
-not. The **must never** column is the part that is easy to lose in implementation, so it is written
-here as a statement rather than left implied.
+- **Personas** — the four target user groups of VISION §6.1.
+- **Main scenarios** — the nine product capabilities of VISION §8, written as scenarios and split per
+  persona.
+- **Underneath** — the detailed user scenarios (Appendix A): 30 concrete questions, one person asking
+  one thing at one moment. Each is traced to the scenario it belongs to.
 
-**How this document is used.** It is the level above feature specs: a feature changes, a scenario
-does not. Specs under `docs/components/<area>/specs/` describe how a surface behaves; this document
-describes what must be true of every surface serving that capability, for each persona.
+**Why split by persona.** A capability is not one scenario. "Work with metrics" is a single
+capability, but it means three different things:
+
+- an **individual contributor** sees their own work against a department or cohort median, and no
+  team metrics at all;
+- a **team manager** sees their team, the people in it by name, and groups recalculated for that team
+  rather than carried over from the organization;
+- an **executive** sees the whole organization.
+
+The capability is shared. The boundary is not, and the boundary is the part that gets lost in
+implementation. That is why it is written down as a statement rather than left implied.
+
+**How to read a scenario block**
+
+- **The scenario** — what holds for everyone, whoever is looking.
+- **Per persona** — what each of them can do, and what must never happen to them. Only the personas
+  the scenario concerns are listed.
+- **Not this** — what the scenario deliberately does not do, so it is not promised in a demo.
+- **Detail** — the user-scenario IDs from Appendix A that belong to this capability.
 
 ---
 
 ## 1. Personas
 
-The four target user groups of VISION §6.1, with short codes used throughout this document.
+The four target user groups of VISION §6.1, with the short codes used throughout.
 
 | Code | Group (VISION §6.1) | Arrives asking |
 |---|---|---|
 | **EXEC** | Executives and portfolio leaders | "Did it get better, or did we just get busier?" |
-| **LEAD** | Functional leaders and team managers | "Where exactly is work blocked, and what can I do about it?" |
-| **IC** | Functional teams and individual contributors | "How does my own work context look, and what is getting in my way?" |
-| **ADMIN** | Data stewards and administrators | "Which of these numbers can be trusted, and who is allowed to see them?" |
+| **LEAD** | Functional leaders and team managers | "Where exactly is work blocked, and what can I do?" |
+| **IC** | Functional teams and individual contributors | "How does my own work look, and what is in my way?" |
+| **ADMIN** | Data stewards and administrators | "Which of these numbers can be trusted, and who may see them?" |
+
+Finance and product management are not separate personas here. Their questions are carried by these
+four: cost by EXEC, forward-looking planning by EXEC and LEAD. VISION §6.2 lists nine functions —
+engineering, product, design, DevOps, QA, support, sales, marketing, finance — and a functional lead
+in any of them is a LEAD.
 
 ### 1.1 Reach
 
-The boundary each persona inherits in every scenario below. The **Never** row states the guarantees
-in the form they have to hold — not as a description of the current UI.
+The boundary each persona carries into every scenario below.
 
 | | EXEC | LEAD | IC | ADMIN |
 |---|---|---|---|---|
-| **Scope** | Organization and everything under it | Own subtree | Self | Configuration, not scope |
-| **Aggregation depth** | Organization, function, team, and the people in them | Team, sub-team, cohort within own scope, and their own reports | Self, with the department or cohort present only as a median | n/a |
-| **Named individuals** | Yes, anywhere in the organization, where person-level access is granted | Yes — a team view names the people reporting to them; that is what a team view is for | Self only | Only in identity resolution, which is about identity, not performance |
-| **Comparison** | Between functions, teams and people inside the organization | Between cohorts recomputed **inside the active scope**, and between their own reports | Against a department or cohort median, never against a named colleague | n/a |
-| **Cost data** | Where granted | Where granted | No | Where granted |
-| **Diagnosis / recommendation** | Reads diagnoses | Reads diagnoses, receives recommendations | Neither | Neither |
-| **Never** | Raw data · a default view that ranks people against one another · a number without its coverage and confidence | Anything outside the subtree · a default view that ranks their reports against one another · cohorts inherited from the organization instead of recomputed in scope | Any other person's activity · any team metric beyond the median they are placed against · own position in a ranked list | Administrative rights do **not** imply data visibility — each data class is granted separately (VISION §9) |
+| **How far they see** | The whole organization | Their own team, and no further | Themselves | Settings, not people's data |
+| **How far they zoom** | Organization, function, team, person | Team, sub-team, group, their own reports | Themselves, with the department or cohort as a median | n/a |
+| **People by name** | Anyone, where person-level access is granted | The people reporting to them — that is what a team view is for | Themselves | Only while resolving who is who |
+| **Comparison** | Between functions, teams and people | Between groups inside their own team, and between their own reports | Against a median, never against a named colleague | n/a |
+| **Cost figures** | Where granted | Where granted | No | Where granted |
+| **Conclusions and advice** | Reads conclusions | Reads conclusions, receives recommendations | Neither | Neither |
+| **Never** | The underlying records · a default view that ranks people against one another · a number with no statement of coverage and confidence | Anything outside their own team · a default view that ranks their reports · group figures carried over from the organization instead of recalculated for the team | Any other person's activity · any team metric beyond the median they are placed against · their own place in a ranking | Administrative rights do **not** carry the right to see data — each kind is granted separately (VISION §9) |
 
-**On naming and ranking.** These are two different things and only one is restricted. People are
-named wherever person-level access has been granted for them — a manager's team view names their
-reports, and that is the point of it. What VISION §3 rules out is a *default* view that ranks named
-individuals against one another, or an unexplained productivity score. The line is the default
-surface, not the name.
+**Naming and ranking are different things, and only one is restricted.** People are named wherever
+person-level access has been granted: a manager's team view names their reports, and that is the
+point of it. What VISION §3 rules out is a *default* view that ranks named individuals against one
+another, or an unexplained productivity score. The line is the default surface and the granted scope
+— not the name.
 
 ---
 
 ## 2. Main scenarios
 
-One scenario per product capability (VISION §8), classified and ordered.
+One scenario per capability in VISION §8.
 
-**Class** — **Core** is the improvement loop the product exists for (measure → diagnose → recommend
-→ validate, plus the forward-looking half); **Service** is what makes that loop possible or safe.
-**Priority** is not a delivery order; it is which scenario has to hold before the ones after it mean
-anything.
+**Class.** **Core** is the improvement loop the product exists for — measure → diagnose → recommend
+→ validate, plus the forward-looking half. **Service** is what makes that loop possible or safe.
 
-**The ordering rule:** a Service scenario outranks a Core one when it *gates* it, or when its
-failure cannot be undone. Identity gates every number, so a wrong person makes every conclusion
-wrong. An access failure cannot be repaired by a later fix.
+**Priority** is not a delivery order. It is which scenario has to hold before the ones after it mean
+anything. The rule: *a service scenario outranks a core one when it gates it, or when its failure
+cannot be undone.* A wrong person makes every number wrong; an access failure cannot be repaired by a
+later fix.
 
-| Priority | ID | Scenario | Class | VISION |
-|---|---|---|---|---|
-| **P0** | **S-2** | Identity, role, and organization model | Service | §8.2, §7.2 |
-| **P0** | **S-4** | Measurement and metric definitions | Core | §8.4 |
-| **P0** | **S-7** | Configuration and access control | Service | §8.7, §9, §3 |
-| **P1** | **S-1** | Source connection and evidence coverage | Service | §8.1, §7.5, §10.10 |
-| **P1** | **S-3** | Work, outcome, and cost lineage | Core | §8.3, §7.3 |
-| **P1** | **S-5** | Analysis, diagnosis, and forecasting | Core | §8.5, §5.1, §7.1 |
-| **P1** | **S-6** | Recommendation and validation | Core | §8.6, §1, §9 |
-| **P2** | **S-8** | Exposure and consumption | Service | §8.8, §15.2 |
-| **P3** | **S-9** | Benchmarks and shared intelligence | Core | §8.9, §12 |
+| Priority | ID | Scenario | Class | VISION | Detail |
+|---|---|---|---|---|---|
+| **P0** | **S-2** | Identity, role and organization model | Service | §8.2, §7.2 | A2, A3, C7 |
+| **P0** | **S-4** | Measurement and metric definitions | Core | §8.4 | B1–B8 |
+| **P0** | **S-7** | Configuration and access control | Service | §8.7, §9, §3 | G1, A3, B7 |
+| **P1** | **S-1** | Source connection and evidence coverage | Service | §8.1, §7.5, §10.10 | A1, A4, C8, G3 |
+| **P1** | **S-3** | Work, outcome and cost lineage | Core | §8.3, §7.3 | B6, C4, C5, C6 |
+| **P1** | **S-5** | Analysis, diagnosis and forecasting | Core | §8.5, §5.1 | C1, C2, C3, E1, E2 |
+| **P1** | **S-6** | Recommendation and validation | Core | §8.6, §1 | D1, D2, D3 |
+| **P2** | **S-8** | Exposure and consumption | Service | §8.8, §15.2 | G2, G4 |
+| **P3** | **S-9** | Benchmarks and shared intelligence | Core | §8.9, §12 | F1 |
 
-### S-2 · Identity, role, and organization model · P0 · Service
+Read the three P0 rows as the answer to "what has to be right first": one core scenario and two
+service ones, because those two are the failures that cannot be undone.
 
-**The scenario.** A person appearing in several source systems resolves to one identity with a
-stated confidence; the customer can correct the result and the correction survives the next sync;
-roles and team membership keep their history, so past periods are not recomputed under a model that
-was not valid at the time.
+### S-2 · Identity, role and organization model · P0 · Service
 
-| Persona | Can | Must never |
-|---|---|---|
-| ADMIN | Review what was matched automatically, where the system is unsure, and where it was wrong; merge and split reversibly; configure roles, multiple roles per person, and role history | Lose a manual correction to the next sync; face a merge that cannot be undone |
-| LEAD, EXEC | Trust that the organization tree they roll up into is the one the customer recognises | Be shown a subtree silently reshaped by re-resolution, with past periods recomputed |
-| IC | Be one person rather than several | Have their work attributed to a duplicate of themselves |
+**The scenario.** Someone who appears separately in code, tickets, chat and the HR system is
+recognised as one person, with a stated confidence. The customer can correct the result, the
+correction survives the next sync, and role and team history is preserved so past periods are not
+recalculated under a model that was not valid at the time.
+
+**ADMIN** — Sort out who is who.
+- sees what was matched automatically, where the system is unsure, and where it got it wrong
+- merges and splits reversibly
+- defines roles, several roles per person, and role history
+- never loses a manual correction to the next sync
+
+**LEAD, EXEC** — Trust the tree they roll up into.
+- the organization structure they see is the one the customer recognises
+- never a subtree quietly reshaped by re-resolution, with past periods recalculated underneath it
+
+**IC** — Be one person, not four.
+- never has their work attributed to a duplicate of themselves
+
+**Not this.** Role definitions are the customer's, not ours. Where observed work does not match the
+configured role model, Insight recommends changing the configuration — not the person (VISION §9).
+
+**Detail.** A2 (identity queue), A3 (roles and expected activities), C7 (role vs observed work).
 
 ### S-4 · Measurement and metric definitions · P0 · Core
 
 **The scenario.** Every number carries a governed definition, unit, granularity, confidence and
-stated limitations, and is computed the same way for every persona and every scope.
+stated limitations, and is worked out the same way for every persona and every scope.
 
-| Persona | Can | Must never |
-|---|---|---|
-| EXEC | Roll the organization up by function, team and person, with change over time | See a coverage figure produced by treating missing data as zero, or a default view that ranks people against one another |
-| LEAD | See their subtree for a period, the people in it by name, where work is blocked, and cohorts recomputed inside the active scope | Compare against a team outside the subtree; inherit cohorts from the organization; be shown a group small enough to identify an individual; be handed a "who is best" ordering as the default view |
-| IC | See their own activity, flow and AI usage, placed against a department or cohort median | See another person's activity, a team metric beyond that median, or their own position in a ranked list |
-| ADMIN | Configure which metrics matter, thresholds, cohorts and comparison groups | Gain data visibility implicitly from administrative rights |
+**EXEC** — See how the organization as a whole is doing.
+- organization, function and team, with change over time
+- coverage counted from people who actually have data behind the figure, never by treating missing
+  data as zero
+- never a default view that ranks people against one another
+
+**LEAD** — See how their team is doing and where work is stuck.
+- their own team at any depth, and the people in it by name
+- groups recalculated for the team in view, not carried over from the organization
+- a group too small to keep an individual unidentifiable is not shown at all
+- never a team they do not manage
+
+**IC** — See their own work, with a reference point.
+- their own activity, flow and AI usage
+- the department or cohort as a median to place themselves against
+- never another person's activity, never a team metric beyond that median, never their own rank
+
+**ADMIN** — Nothing by default.
+- configures which metrics matter, thresholds, cohorts and comparison groups
+- never gains data visibility implicitly from administrative rights
+
+**Not this.** No single "value of AI" number: seat-based and usage-based cost are not summed into
+one figure, and unattributed cost stays its own line rather than being spread across the rest
+(VISION §6.2.9, §11.4).
+
+**Detail.** B1 (own context), B2 (team over a period), B3 (where work is stuck), B4 (knowledge
+concentration), B5 (organization roll-up), B6 (AI cost), B7 (cohorts), B8 (cost of coordination).
 
 ### S-7 · Configuration and access control · P0 · Service
 
 **The scenario.** The customer configures roles, activities, sources, metrics, thresholds, cohorts,
-dashboards, localization and access rules; access to raw, people-level, aggregate, cost and
+dashboards, localization and access rules. Access to raw, people-level, aggregate, cost and
 recommendation data is role-based and policy-controlled, and the boundary holds on every surface.
 
-| Persona | Can | Must never |
-|---|---|---|
-| ADMIN | Grant the five data classes independently (VISION §9); adapt roles, metrics and thresholds without engineering involvement | Hold all classes implicitly; have a grant enforced in the interface but not underneath it |
-| LEAD | Reach every depth of their subtree | Reach one node above or sideways — the boundary is structural, not a filter |
-| EXEC | Read organization-wide aggregates, and people where person-level access is granted | Reach raw data, or a default view that ranks people against one another |
-| IC | Read themselves | Be named to anyone outside the part of the organization that has been granted person-level access to them |
+**ADMIN** — Decide who gets what.
+- grants the five kinds of data one by one (VISION §9)
+- adapts roles, metrics and thresholds without engineering involvement
+- never holds all five implicitly; a refusal is enforced underneath, not only hidden on screen
+
+**LEAD** — Their own team, in full.
+- every depth inside it
+- never one level up, and never sideways — the limit is structural, not a filter on a screen
+
+**EXEC** — The organization as a whole.
+- aggregates, and people where person-level access is granted
+- never the underlying records
+
+**IC** — Themselves.
+- named to their own management chain and to anyone else granted person-level access for their part
+  of the organization — and to nobody outside it
+
+**Not this.** Insight is read-only towards connected systems: it writes its own configuration and
+annotations, nothing else (VISION §13.3).
+
+**Detail.** G1 (who sees what), A3 (role configuration), B7 (cohort definition).
 
 ### S-1 · Source connection and evidence coverage · P1 · Service
 
-**The scenario.** Whatever the wiring state, the product states it honestly: what is connected, what
+**The scenario.** Whatever the wiring state, the product says so plainly: what is connected, what
 that unlocks, and — where an answer is not possible — the cause and the smallest set of fixes with
 the largest gain in confidence (readiness mode, VISION §7.5). Each source declares its fields,
 window, freshness, blind spots and the level it supports (VISION §10.10).
 
-| Persona | Can | Must never |
-|---|---|---|
-| ADMIN | See every evidence category as connected, partial or absent, and which metrics each one unlocks | Be left to guess why a surface is empty |
-| LEAD, EXEC | Meet a broken evidence chain and be told the cause and the minimal fix | Be shown a zero, or an approximate estimate, in place of missing data |
-| IC | The same guarantee on their own context | — |
+**ADMIN** — Know what can be proven.
+- every evidence category as connected, partly connected or absent, and which metrics each unlocks
+- never left to guess why a screen is empty
 
-### S-3 · Work, outcome, and cost lineage · P1 · Core
+**LEAD, EXEC** — Meet a gap and know what to do about it.
+- the cause named directly: which source is missing, which identities are unresolved, which link is
+  broken — plus the minimal fix
+- freshness per source wherever a comparison is drawn
+- never a comparison across two periods whose source windows do not overlap
 
-**The scenario.** Work is followed across the systems it passes through, and **lineage comes before
-attribution** (VISION §7.3): what cannot be traced is shown as an evidence gap, never converted into
-a confident claim.
+**IC** — The same guarantee on their own context.
 
-| Persona | Can | Must never |
-|---|---|---|
-| EXEC | Follow cost and outcome to the function, team or product that produced it | Be given attribution stronger than the lineage supports |
-| LEAD | See where a chain breaks in their own area | Have a broken link silently filled in |
-| ADMIN | See which links are weak and what would repair them | — |
-| IC | — | Be attributed work that was traced to them only by inference |
+**Not this.** No zero in place of missing data — a zero looks like a measurement and raises a false
+alarm. And no "rough estimate for now": the honest answer to a missing source is what is missing.
 
-### S-5 · Analysis, diagnosis, and forecasting · P1 · Core
+**Detail.** A1 (what can be proven), A4 (no answer, but what to connect), C8 (not believing a
+number), G3 (timezone and locale caveats).
 
-**The scenario.** The product moves from showing shape to asserting a relationship — bottlenecks,
-risks, anomalies, cost drivers, role and activity mismatches — and states which kind of claim it is
-making, with confidence and limitations. Forward-looking estimates (feasibility, cost, time, risk)
-are grounded in the organization's own history and presented as extrapolations, not guarantees.
+### S-3 · Work, outcome and cost lineage · P1 · Core
 
-| Persona | Can | Must never |
-|---|---|---|
-| LEAD | Read a diagnosis for their team or cohort, with the evidence behind it | Receive a verdict about a named individual, or a conclusion drawn from a group too small to protect one |
-| EXEC | Read the same at organization level, and a forecast for proposed work | Be handed a causal claim where the evidence supports a correlation, or a forecast presented as a guarantee |
-| ADMIN | See which evidence gaps and known defects limit a diagnosis | — |
-| IC | — | Appear as a named example inside a diagnosis |
+**The scenario.** Work is followed across the systems it passes through — intent to work item to
+change to review to release to incident; ticket to product area; campaign to deal; cost record to
+team or service. **Lineage comes before attribution** (VISION §7.3): what cannot be traced is shown
+as an evidence gap, never converted into a confident claim.
+
+**EXEC** — Follow cost and outcome to where they came from.
+- to the function, team, product or service, as far as the trail actually goes
+- never attribution stronger than the lineage supports
+
+**LEAD** — See where the chain breaks in their own area.
+- never a broken link quietly filled in
+
+**ADMIN** — See which links are weak and what would repair them.
+
+**IC** — Never attributed work that reached them only by inference.
+
+**Not this.** Attribution has a ceiling, and the ceiling is stated rather than worked around: "this
+change was written by AI" and "this change cost $N" are not claims Insight makes.
+
+**Detail.** B6 (cost attribution ceiling), C4 (support load vs release), C5 (sales activity vs
+pipeline), C6 (cost moved rather than fell).
+
+### S-5 · Analysis, diagnosis and forecasting · P1 · Core
+
+**The scenario.** The product stops showing shape and starts asserting a relationship — bottlenecks,
+risks, anomalies, cost drivers, quality issues, role and activity mismatches — and says which kind of
+claim it is making, with confidence and limitations. Forward-looking estimates (feasibility, cost,
+time, risk) are grounded in the organization's own history and shown as extrapolations, not
+guarantees.
+
+**LEAD** — Understand why, not just what.
+- a conclusion for their team or cohort, with the evidence behind it
+- never a verdict about a named individual
+- never a conclusion drawn from a group too small to protect one
+
+**EXEC** — The same at organization level, plus a forecast for proposed work.
+- never a causal claim where the evidence supports a correlation
+- never a forecast presented as a guarantee
+
+**ADMIN** — See which evidence gaps and known defects limit a conclusion.
+
+**IC** — Not an audience for diagnosis, and never a named example inside one.
+
+**Not this.** "AI sped up development by X%" is not a claim Insight makes. What it can say is that a
+cohort with high usage differs from one with low usage in stated ways, correlationally — with the
+word said on the surface, not in a footnote.
+
+**Detail.** C1 (AI gain and price together), C2 (review as a bottleneck), C3 (did quality hold),
+E1 (assess a feature before starting), E2 (where to invest next).
 
 ### S-6 · Recommendation and validation · P1 · Core
 
 **The scenario.** A recommendation is a structured improvement object (VISION §1): observed problem,
-affected area, evidence and confidence, recommended action, owner, expected metric movement and the
-follow-up window used to validate it — with its origin declared as evidence-derived or heuristic.
-Validation is read from the measured system afterwards, not from self-reporting.
+affected area, evidence and confidence, recommended action, owner, expected metric movement, and the
+follow-up window used to check it. Its origin is declared — evidence-derived from the customer's own
+data, or heuristic. Afterwards the product reads the outcome from the measured system.
 
-| Persona | Can | Must never |
-|---|---|---|
-| LEAD | Receive an action they can own, with what should move, and when it will be checked | Receive a recommendation that passes judgement on a named individual rather than on a process, team or cohort, or one whose origin is unstated — a named *owner* is expected, a named *subject* is not |
-| EXEC | Read whether recommendations changed the measured system | Be shown a validation result assembled from metrics chosen after the fact |
-| ADMIN | Configure which recommendation families are enabled, who owns them and how validation windows are defined | — |
-| IC | — | Be the object of a recommendation |
+**LEAD** — Get an action, not an observation.
+- one lever they can own, with what should move, which guardrail must not slip, and when it is checked
+- never a recommendation that passes judgement on a named individual rather than on a process, team
+  or cohort — a named *owner* is expected, a named *subject* is not
+- never a recommendation whose origin is unstated
 
-**Also true of the product as a whole:** Insight recommends and does not execute (VISION §13.3). It
-writes its own configuration and annotations, nothing else.
+**EXEC** — Know whether it worked.
+- whether the lever moved, whether the outcome moved, and the honest fourth answer: not enough data
+- never a result assembled from metrics chosen after the fact — they are fixed when the
+  recommendation is issued
+
+**ADMIN** — Configure which recommendation families are enabled, who owns them, and how validation
+windows are defined.
+
+**IC** — Never the subject of a recommendation.
+
+**Not this.** No surveys, and no self-reported productivity as an input. Validation is read from the
+measured system. Insight recommends; it does not execute (VISION §13.3).
+
+**Detail.** D1 (a recommendation, not an observation), D2 (did it work, a month later), D3 (context
+the system cannot see).
 
 ### S-8 · Exposure and consumption · P2 · Service
 
-**The scenario.** A number keeps its meaning when it leaves the product — exported through views,
-summaries, APIs and governed data access together with its definition, coverage and confidence — and
-keeps it when history is migrated from a system Insight replaces, with anything that cannot be
-reproduced stated openly (VISION §15.2).
+**The scenario.** A number keeps its meaning when it leaves the product, and when the product
+replaces a system that came before it. Exports carry the definition, coverage and confidence with the
+number. Migration states openly what could not be reproduced (VISION §15.2).
 
-| Persona | Can | Must never |
-|---|---|---|
-| ADMIN | Take metrics into another system under the same access rules | Export a number stripped of its definition and confidence, where it becomes a fact without caveats |
-| EXEC | See parity against the replaced system over an agreed period | Be shown a parity claim that quietly omits what could not be reproduced |
-| LEAD, IC | Keep their history across a migration | Have a past period silently recomputed under a new model |
+**ADMIN** — Take Insight's output elsewhere.
+- views, summaries, APIs and governed data access, under the same access rules
+- never a number stripped of its definition and confidence, so that outside the product it becomes a
+  fact without caveats
+
+**EXEC** — Replace what exists without losing history.
+- an inventory of current dashboards and metrics, then keep / rename / replace / retire
+- history imported where retention allows, and parity checked over an agreed period
+- never a parity claim that quietly omits what could not be reproduced
+
+**LEAD, IC** — Keep their history across the change.
+- never a past period silently recalculated under a new model
+
+**Detail.** G2 (use conclusions in another system), G4 (migrate off a legacy system).
 
 ### S-9 · Benchmarks and shared intelligence · P3 · Core
 
@@ -194,47 +317,97 @@ reproduced stated openly (VISION §15.2).
 against peers and public data where enabled. Every benchmark declares its source, cohort definition,
 coverage and confidence.
 
-| Persona | Can | Must never |
-|---|---|---|
-| EXEC | Compare the organization against peers where the customer has opted in | Have raw customer data leave the customer boundary; receive individual-level or stack-ranked comparison (VISION §3, §12.2) |
-| LEAD | Compare their area against the organization's own history without sharing anything | — |
-| ADMIN | Turn participation on and off; it is revocable | — |
+**EXEC** — Know whether a number is bad or normal.
+- own history first, which requires sharing nothing
+- peer comparison only where the customer has opted in
+
+**ADMIN** — Turn participation on and off; it is revocable.
+
+**Not this.** Raw customer data never leaves the customer boundary. Only anonymized aggregates at
+cohort, team or organization level are shared — never individual data, never stack ranking
+(VISION §3, §12.2).
+
+**Detail.** F1 (are we slow, or is this normal).
 
 ---
 
 ## 3. Rules that hold in every scenario
 
-These come from the vision itself and are not restated in each scenario above. They apply to every
-surface serving any capability.
+From the vision, stated once here instead of repeated in each capability.
 
-1. **Evidence gaps are shown, not hidden** (§3, §7.5) — missing data is never rendered as zero, and
-   never replaced by an approximate estimate.
+1. **Evidence gaps are shown, not hidden** (§3, §7.5) — never a zero for missing data, never an
+   approximate estimate in place of an answer.
 2. **Confidence and limitations travel with every conclusion** (§3) — a strong finding, a directional
-   signal and an instrumentation problem are distinguishable.
+   signal and an instrumentation problem stay distinguishable.
 3. **Lineage before attribution** (§7.3) — untraceable work is a gap, not a quiet claim.
-4. **No default stack ranking or unexplained productivity scores** (§3) — people are named where
-   person-level access has been granted; what is ruled out is a default view that ranks them against
-   one another.
-5. **People-level access is role-based and policy-controlled** (§3, §9) — five independently granted
-   data classes.
+4. **No default ranking of named individuals, and no unexplained productivity scores** (§3) — people
+   are named where person-level access has been granted; the ranking is what is ruled out.
+5. **People-level access is role-based and policy-controlled** (§3, §9) — five kinds of data, granted
+   separately.
 6. **Cost movement is preserved, not folded away** (§11.4) — a local saving that shifts cost, risk or
-   effort downstream is shown as a shift; seat-based and usage-based cost are not summed into one
-   figure (§6.2.9).
-7. **Insight observes and advises; people act** (§13.3).
+   effort downstream is shown as a shift; seat-based and usage-based cost are never one figure.
+7. **Insight observes and advises; people act** (§13.3) — it writes its own configuration and
+   annotations, nothing else.
 8. **Clean room** (§12.2) — raw data stays inside the customer boundary; only anonymized aggregates
-   at cohort, team or organization level are shared, opt-in and revocable.
+   are shared, opt-in and revocable.
 9. **Role and activity are separate axes** (§7.2) — expected role model and observed activity are
-   compared, never conflated, and history is preserved under the model valid at the time.
+   compared, never conflated; history is kept under the model valid at the time.
+10. **A group too small to keep an individual unidentifiable is not shown** — the threshold protects a
+    person from being identified through a cohort.
 
 ---
 
-## 4. Open points
+## Appendix A · The detailed user scenarios
 
-- **IC has the narrowest surface and the strictest boundary.** Everything an IC sees is either their
-  own or a median. That combination makes it the sharpest case to get wrong quietly.
-- **Administrative rights vs data visibility.** §1.1 asserts that ADMIN gains no data visibility
-  implicitly. This needs confirming against the access model rather than the interface.
-- **Small-group thresholds are stated per surface today.** They protect an individual from being
-  identified through a cohort, so they belong to the shared rules in §3 rather than to individual
-  features — the exact values are worth agreeing in one place.
-- **S-9 has no surface yet.** It is listed so the capability stays planned for, not to imply it exists.
+Thirty concrete questions — one person, one question, one moment — from the product scenario draft of
+2026-08-04. They are the level at which features are specified and tested; the capabilities in §2 are
+what all of them must obey. Availability is deliberately not recorded here: it changes per release
+and per customer, since the connected source set differs.
+
+| ID | The question behind it | Who asks | Capability |
+|---|---|---|---|
+| A1 | Which questions can I already ask, and which not? | ADMIN | S-1 |
+| A2 | Which identity links did the system make, where is it unsure, where wrong? | ADMIN | S-2 |
+| A3 | How do I tell the product who is supposed to do what here? | ADMIN | S-2, S-7 |
+| A4 | Why is this empty, and what would make it not empty? | ADMIN, LEAD | S-1 |
+| B1 | What is visible about me, and what is in my way? | IC | S-4 |
+| B2 | What changed for my team over the period? | LEAD | S-4 |
+| B3 | Where is work stalling? | LEAD | S-4 |
+| B4 | What falls apart if a specific person drops out? | LEAD, EXEC | S-4 |
+| B5 | Where are we improving, and where just getting busier? | EXEC | S-4 |
+| B6 | How much does AI cost, who spends it, in what form? | EXEC | S-4, S-3 |
+| B7 | How does group A differ from group B in the same scope? | LEAD, EXEC | S-4, S-7 |
+| B8 | How much goes into coordination instead of work? | LEAD | S-4 |
+| C1 | Did throughput rise where AI was adopted, and what did it cost? | LEAD, EXEC | S-5 |
+| C2 | Is speed limited by writing code or by reviewing it? | LEAD | S-5 |
+| C3 | Speed went up — did quality hold? | LEAD | S-5 |
+| C4 | Is this ticket spike caused by what we shipped? | LEAD, EXEC | S-3 |
+| C5 | Activity rose — did the deals move? | LEAD, EXEC | S-3 |
+| C6 | Development got cheaper — did the cost move somewhere else? | EXEC | S-3 |
+| C7 | Someone is listed in one role and does another — error or reality? | LEAD, ADMIN | S-2 |
+| C8 | Is this an event in the business, or a break in the data? | ADMIN, LEAD, EXEC | S-1 |
+| D1 | I can see the problem — what do I do? | LEAD | S-6 |
+| D2 | Was it applied? Did it help? | LEAD, EXEC | S-6 |
+| D3 | We had a reorg that month — how do I say so? | LEAD | S-6 |
+| E1 | Is it feasible, what will it cost, how long, what risks? | EXEC, LEAD | S-5 |
+| E2 | Where is the effect larger for less effort? | EXEC | S-5 |
+| F1 | Our three-day cycle — is that bad? | EXEC | S-9 |
+| G1 | How do I give a lead their team and nothing more? | ADMIN | S-7 |
+| G2 | How do we pull this into our own BI or report? | ADMIN, LEAD | S-8 |
+| G3 | Can we work in our own language and timezone? | all | S-1 |
+| G4 | How do we replace what we have without losing history? | ADMIN, EXEC | S-8 |
+
+Every one of the thirty maps to a capability; no capability in §2 is left without a concrete question
+underneath it, except S-9, which has none yet.
+
+---
+
+## Appendix B · Open points
+
+- **Administrative rights and data visibility.** §1.1 asserts that ADMIN gains no data visibility
+  implicitly. Worth confirming against the access model rather than the interface.
+- **The small-group threshold** is stated per surface today. It protects an individual from being
+  identified through a cohort, so it belongs to §3 with one agreed value.
+- **IC has the narrowest surface and the tightest boundary.** Everything an IC sees is their own or a
+  median — the combination that is easiest to get wrong quietly.
+- **S-9 has no surface yet.** Listed so the capability stays planned for, not to imply it exists.

--- a/docs/product/SCENARIOS.md
+++ b/docs/product/SCENARIOS.md
@@ -8,11 +8,12 @@ commitment: personas are the four target user groups of VISION §6.1, and the ma
 nine product capabilities of VISION §8, expressed as scenarios and attributed per persona.
 
 **Why the per-persona split matters.** A capability is not one scenario. "Work with metrics" is a
-single capability, but an individual contributor working with metrics sees themselves against a
-median and never a colleague; a team manager sees their subtree and cohorts recomputed inside it,
-never a peer team outside it; an executive sees the organization but never a named individual. The
-capability is shared; the boundary is not. The **must never** column is the part that is easy to
-lose in implementation, so it is written here as a statement rather than left implied.
+single capability, but an individual contributor working with metrics sees their own work placed
+against a department or cohort median and no team metrics at all; a team manager sees their subtree
+and the people in it by name, with cohorts recomputed inside that scope rather than carried over from
+the organization; an executive sees the whole organization. The capability is shared; the boundary is
+not. The **must never** column is the part that is easy to lose in implementation, so it is written
+here as a statement rather than left implied.
 
 **How this document is used.** It is the level above feature specs: a feature changes, a scenario
 does not. Specs under `docs/components/<area>/specs/` describe how a surface behaves; this document
@@ -39,12 +40,18 @@ in the form they have to hold — not as a description of the current UI.
 | | EXEC | LEAD | IC | ADMIN |
 |---|---|---|---|---|
 | **Scope** | Organization and everything under it | Own subtree | Self | Configuration, not scope |
-| **Aggregation depth** | Organization, function, team | Team, sub-team, cohort within own scope | Self, plus context as a median | n/a |
-| **Named individuals** | No — collective views are anonymous | No — a person is reached by navigation, never as a named row in a cut | Self only | Only in identity resolution, which is about identity, not performance |
-| **Comparison** | Between functions and teams inside the organization | Between cohorts recomputed **inside the active scope** | Against a median, never against a named person | n/a |
+| **Aggregation depth** | Organization, function, team, and the people in them | Team, sub-team, cohort within own scope, and their own reports | Self, with the department or cohort present only as a median | n/a |
+| **Named individuals** | Yes, anywhere in the organization, where person-level access is granted | Yes — a team view names the people reporting to them; that is what a team view is for | Self only | Only in identity resolution, which is about identity, not performance |
+| **Comparison** | Between functions, teams and people inside the organization | Between cohorts recomputed **inside the active scope**, and between their own reports | Against a department or cohort median, never against a named colleague | n/a |
 | **Cost data** | Where granted | Where granted | No | Where granted |
 | **Diagnosis / recommendation** | Reads diagnoses | Reads diagnoses, receives recommendations | Neither | Neither |
-| **Never** | Raw data · default stack ranking · a number without its coverage and confidence | Anything outside the subtree · named rows in collective cuts · cohorts inherited from the organization instead of recomputed in scope | Any other person's raw activity · own position in a ranked list · any team roll-up | Administrative rights do **not** imply data visibility — each data class is granted separately (VISION §9) |
+| **Never** | Raw data · a default view that ranks people against one another · a number without its coverage and confidence | Anything outside the subtree · a default view that ranks their reports against one another · cohorts inherited from the organization instead of recomputed in scope | Any other person's activity · any team metric beyond the median they are placed against · own position in a ranked list | Administrative rights do **not** imply data visibility — each data class is granted separately (VISION §9) |
+
+**On naming and ranking.** These are two different things and only one is restricted. People are
+named wherever person-level access has been granted for them — a manager's team view names their
+reports, and that is the point of it. What VISION §3 rules out is a *default* view that ranks named
+individuals against one another, or an unexplained productivity score. The line is the default
+surface, not the name.
 
 ---
 
@@ -93,9 +100,9 @@ stated limitations, and is computed the same way for every persona and every sco
 
 | Persona | Can | Must never |
 |---|---|---|
-| EXEC | Roll the organization up by function and team, with change over time | See a coverage figure produced by treating missing data as zero, or a named row in a roll-up |
-| LEAD | See their subtree for a period, find where work is blocked, compare cohorts recomputed inside the active scope | Compare against a team outside the subtree; inherit cohorts from the organization; be shown a group small enough to identify an individual; receive a "who is best" ordering |
-| IC | See their own activity, flow and AI usage, with team context as a median | See another person's activity, or their own position in a ranked list |
+| EXEC | Roll the organization up by function, team and person, with change over time | See a coverage figure produced by treating missing data as zero, or a default view that ranks people against one another |
+| LEAD | See their subtree for a period, the people in it by name, where work is blocked, and cohorts recomputed inside the active scope | Compare against a team outside the subtree; inherit cohorts from the organization; be shown a group small enough to identify an individual; be handed a "who is best" ordering as the default view |
+| IC | See their own activity, flow and AI usage, placed against a department or cohort median | See another person's activity, a team metric beyond that median, or their own position in a ranked list |
 | ADMIN | Configure which metrics matter, thresholds, cohorts and comparison groups | Gain data visibility implicitly from administrative rights |
 
 ### S-7 · Configuration and access control · P0 · Service
@@ -108,8 +115,8 @@ recommendation data is role-based and policy-controlled, and the boundary holds 
 |---|---|---|
 | ADMIN | Grant the five data classes independently (VISION §9); adapt roles, metrics and thresholds without engineering involvement | Hold all classes implicitly; have a grant enforced in the interface but not underneath it |
 | LEAD | Reach every depth of their subtree | Reach one node above or sideways — the boundary is structural, not a filter |
-| EXEC | Read organization-wide aggregates | Reach raw data, or a default stack ranking of people |
-| IC | Read themselves | Be reachable as a named row by anyone browsing a collective view |
+| EXEC | Read organization-wide aggregates, and people where person-level access is granted | Reach raw data, or a default view that ranks people against one another |
+| IC | Read themselves | Be named to anyone outside the part of the organization that has been granted person-level access to them |
 
 ### S-1 · Source connection and evidence coverage · P1 · Service
 
@@ -160,7 +167,7 @@ Validation is read from the measured system afterwards, not from self-reporting.
 
 | Persona | Can | Must never |
 |---|---|---|
-| LEAD | Receive an action they can own, with what should move, and when it will be checked | Receive a recommendation about a named individual, or one whose origin is unstated |
+| LEAD | Receive an action they can own, with what should move, and when it will be checked | Receive a recommendation that passes judgement on a named individual rather than on a process, team or cohort, or one whose origin is unstated — a named *owner* is expected, a named *subject* is not |
 | EXEC | Read whether recommendations changed the measured system | Be shown a validation result assembled from metrics chosen after the fact |
 | ADMIN | Configure which recommendation families are enabled, who owns them and how validation windows are defined | — |
 | IC | — | Be the object of a recommendation |
@@ -205,8 +212,9 @@ surface serving any capability.
 2. **Confidence and limitations travel with every conclusion** (§3) — a strong finding, a directional
    signal and an instrumentation problem are distinguishable.
 3. **Lineage before attribution** (§7.3) — untraceable work is a gap, not a quiet claim.
-4. **No default stack ranking or unexplained productivity scores** (§3) — collective views carry no
-   named rows.
+4. **No default stack ranking or unexplained productivity scores** (§3) — people are named where
+   person-level access has been granted; what is ruled out is a default view that ranks them against
+   one another.
 5. **People-level access is role-based and policy-controlled** (§3, §9) — five independently granted
    data classes.
 6. **Cost movement is preserved, not folded away** (§11.4) — a local saving that shifts cost, risk or

--- a/docs/product/SCENARIOS.md
+++ b/docs/product/SCENARIOS.md
@@ -1,0 +1,232 @@
+# Constructor Insight — Main Scenarios by Persona
+
+**Status:** draft for review · Companion to [VISION.md](VISION.md)
+
+The vision states what Insight is and what it can do. This document states **who is standing in
+front of it and how far each of them may reach**. It adds no new capability and changes no
+commitment: personas are the four target user groups of VISION §6.1, and the main scenarios are the
+nine product capabilities of VISION §8, expressed as scenarios and attributed per persona.
+
+**Why the per-persona split matters.** A capability is not one scenario. "Work with metrics" is a
+single capability, but an individual contributor working with metrics sees themselves against a
+median and never a colleague; a team manager sees their subtree and cohorts recomputed inside it,
+never a peer team outside it; an executive sees the organization but never a named individual. The
+capability is shared; the boundary is not. The **must never** column is the part that is easy to
+lose in implementation, so it is written here as a statement rather than left implied.
+
+**How this document is used.** It is the level above feature specs: a feature changes, a scenario
+does not. Specs under `docs/components/<area>/specs/` describe how a surface behaves; this document
+describes what must be true of every surface serving that capability, for each persona.
+
+---
+
+## 1. Personas
+
+The four target user groups of VISION §6.1, with short codes used throughout this document.
+
+| Code | Group (VISION §6.1) | Arrives asking |
+|---|---|---|
+| **EXEC** | Executives and portfolio leaders | "Did it get better, or did we just get busier?" |
+| **LEAD** | Functional leaders and team managers | "Where exactly is work blocked, and what can I do about it?" |
+| **IC** | Functional teams and individual contributors | "How does my own work context look, and what is getting in my way?" |
+| **ADMIN** | Data stewards and administrators | "Which of these numbers can be trusted, and who is allowed to see them?" |
+
+### 1.1 Reach
+
+The boundary each persona inherits in every scenario below. The **Never** row states the guarantees
+in the form they have to hold — not as a description of the current UI.
+
+| | EXEC | LEAD | IC | ADMIN |
+|---|---|---|---|---|
+| **Scope** | Organization and everything under it | Own subtree | Self | Configuration, not scope |
+| **Aggregation depth** | Organization, function, team | Team, sub-team, cohort within own scope | Self, plus context as a median | n/a |
+| **Named individuals** | No — collective views are anonymous | No — a person is reached by navigation, never as a named row in a cut | Self only | Only in identity resolution, which is about identity, not performance |
+| **Comparison** | Between functions and teams inside the organization | Between cohorts recomputed **inside the active scope** | Against a median, never against a named person | n/a |
+| **Cost data** | Where granted | Where granted | No | Where granted |
+| **Diagnosis / recommendation** | Reads diagnoses | Reads diagnoses, receives recommendations | Neither | Neither |
+| **Never** | Raw data · default stack ranking · a number without its coverage and confidence | Anything outside the subtree · named rows in collective cuts · cohorts inherited from the organization instead of recomputed in scope | Any other person's raw activity · own position in a ranked list · any team roll-up | Administrative rights do **not** imply data visibility — each data class is granted separately (VISION §9) |
+
+---
+
+## 2. Main scenarios
+
+One scenario per product capability (VISION §8), classified and ordered.
+
+**Class** — **Core** is the improvement loop the product exists for (measure → diagnose → recommend
+→ validate, plus the forward-looking half); **Service** is what makes that loop possible or safe.
+**Priority** is not a delivery order; it is which scenario has to hold before the ones after it mean
+anything.
+
+**The ordering rule:** a Service scenario outranks a Core one when it *gates* it, or when its
+failure cannot be undone. Identity gates every number, so a wrong person makes every conclusion
+wrong. An access failure cannot be repaired by a later fix.
+
+| Priority | ID | Scenario | Class | VISION |
+|---|---|---|---|---|
+| **P0** | **S-2** | Identity, role, and organization model | Service | §8.2, §7.2 |
+| **P0** | **S-4** | Measurement and metric definitions | Core | §8.4 |
+| **P0** | **S-7** | Configuration and access control | Service | §8.7, §9, §3 |
+| **P1** | **S-1** | Source connection and evidence coverage | Service | §8.1, §7.5, §10.10 |
+| **P1** | **S-3** | Work, outcome, and cost lineage | Core | §8.3, §7.3 |
+| **P1** | **S-5** | Analysis, diagnosis, and forecasting | Core | §8.5, §5.1, §7.1 |
+| **P1** | **S-6** | Recommendation and validation | Core | §8.6, §1, §9 |
+| **P2** | **S-8** | Exposure and consumption | Service | §8.8, §15.2 |
+| **P3** | **S-9** | Benchmarks and shared intelligence | Core | §8.9, §12 |
+
+### S-2 · Identity, role, and organization model · P0 · Service
+
+**The scenario.** A person appearing in several source systems resolves to one identity with a
+stated confidence; the customer can correct the result and the correction survives the next sync;
+roles and team membership keep their history, so past periods are not recomputed under a model that
+was not valid at the time.
+
+| Persona | Can | Must never |
+|---|---|---|
+| ADMIN | Review what was matched automatically, where the system is unsure, and where it was wrong; merge and split reversibly; configure roles, multiple roles per person, and role history | Lose a manual correction to the next sync; face a merge that cannot be undone |
+| LEAD, EXEC | Trust that the organization tree they roll up into is the one the customer recognises | Be shown a subtree silently reshaped by re-resolution, with past periods recomputed |
+| IC | Be one person rather than several | Have their work attributed to a duplicate of themselves |
+
+### S-4 · Measurement and metric definitions · P0 · Core
+
+**The scenario.** Every number carries a governed definition, unit, granularity, confidence and
+stated limitations, and is computed the same way for every persona and every scope.
+
+| Persona | Can | Must never |
+|---|---|---|
+| EXEC | Roll the organization up by function and team, with change over time | See a coverage figure produced by treating missing data as zero, or a named row in a roll-up |
+| LEAD | See their subtree for a period, find where work is blocked, compare cohorts recomputed inside the active scope | Compare against a team outside the subtree; inherit cohorts from the organization; be shown a group small enough to identify an individual; receive a "who is best" ordering |
+| IC | See their own activity, flow and AI usage, with team context as a median | See another person's activity, or their own position in a ranked list |
+| ADMIN | Configure which metrics matter, thresholds, cohorts and comparison groups | Gain data visibility implicitly from administrative rights |
+
+### S-7 · Configuration and access control · P0 · Service
+
+**The scenario.** The customer configures roles, activities, sources, metrics, thresholds, cohorts,
+dashboards, localization and access rules; access to raw, people-level, aggregate, cost and
+recommendation data is role-based and policy-controlled, and the boundary holds on every surface.
+
+| Persona | Can | Must never |
+|---|---|---|
+| ADMIN | Grant the five data classes independently (VISION §9); adapt roles, metrics and thresholds without engineering involvement | Hold all classes implicitly; have a grant enforced in the interface but not underneath it |
+| LEAD | Reach every depth of their subtree | Reach one node above or sideways — the boundary is structural, not a filter |
+| EXEC | Read organization-wide aggregates | Reach raw data, or a default stack ranking of people |
+| IC | Read themselves | Be reachable as a named row by anyone browsing a collective view |
+
+### S-1 · Source connection and evidence coverage · P1 · Service
+
+**The scenario.** Whatever the wiring state, the product states it honestly: what is connected, what
+that unlocks, and — where an answer is not possible — the cause and the smallest set of fixes with
+the largest gain in confidence (readiness mode, VISION §7.5). Each source declares its fields,
+window, freshness, blind spots and the level it supports (VISION §10.10).
+
+| Persona | Can | Must never |
+|---|---|---|
+| ADMIN | See every evidence category as connected, partial or absent, and which metrics each one unlocks | Be left to guess why a surface is empty |
+| LEAD, EXEC | Meet a broken evidence chain and be told the cause and the minimal fix | Be shown a zero, or an approximate estimate, in place of missing data |
+| IC | The same guarantee on their own context | — |
+
+### S-3 · Work, outcome, and cost lineage · P1 · Core
+
+**The scenario.** Work is followed across the systems it passes through, and **lineage comes before
+attribution** (VISION §7.3): what cannot be traced is shown as an evidence gap, never converted into
+a confident claim.
+
+| Persona | Can | Must never |
+|---|---|---|
+| EXEC | Follow cost and outcome to the function, team or product that produced it | Be given attribution stronger than the lineage supports |
+| LEAD | See where a chain breaks in their own area | Have a broken link silently filled in |
+| ADMIN | See which links are weak and what would repair them | — |
+| IC | — | Be attributed work that was traced to them only by inference |
+
+### S-5 · Analysis, diagnosis, and forecasting · P1 · Core
+
+**The scenario.** The product moves from showing shape to asserting a relationship — bottlenecks,
+risks, anomalies, cost drivers, role and activity mismatches — and states which kind of claim it is
+making, with confidence and limitations. Forward-looking estimates (feasibility, cost, time, risk)
+are grounded in the organization's own history and presented as extrapolations, not guarantees.
+
+| Persona | Can | Must never |
+|---|---|---|
+| LEAD | Read a diagnosis for their team or cohort, with the evidence behind it | Receive a verdict about a named individual, or a conclusion drawn from a group too small to protect one |
+| EXEC | Read the same at organization level, and a forecast for proposed work | Be handed a causal claim where the evidence supports a correlation, or a forecast presented as a guarantee |
+| ADMIN | See which evidence gaps and known defects limit a diagnosis | — |
+| IC | — | Appear as a named example inside a diagnosis |
+
+### S-6 · Recommendation and validation · P1 · Core
+
+**The scenario.** A recommendation is a structured improvement object (VISION §1): observed problem,
+affected area, evidence and confidence, recommended action, owner, expected metric movement and the
+follow-up window used to validate it — with its origin declared as evidence-derived or heuristic.
+Validation is read from the measured system afterwards, not from self-reporting.
+
+| Persona | Can | Must never |
+|---|---|---|
+| LEAD | Receive an action they can own, with what should move, and when it will be checked | Receive a recommendation about a named individual, or one whose origin is unstated |
+| EXEC | Read whether recommendations changed the measured system | Be shown a validation result assembled from metrics chosen after the fact |
+| ADMIN | Configure which recommendation families are enabled, who owns them and how validation windows are defined | — |
+| IC | — | Be the object of a recommendation |
+
+**Also true of the product as a whole:** Insight recommends and does not execute (VISION §13.3). It
+writes its own configuration and annotations, nothing else.
+
+### S-8 · Exposure and consumption · P2 · Service
+
+**The scenario.** A number keeps its meaning when it leaves the product — exported through views,
+summaries, APIs and governed data access together with its definition, coverage and confidence — and
+keeps it when history is migrated from a system Insight replaces, with anything that cannot be
+reproduced stated openly (VISION §15.2).
+
+| Persona | Can | Must never |
+|---|---|---|
+| ADMIN | Take metrics into another system under the same access rules | Export a number stripped of its definition and confidence, where it becomes a fact without caveats |
+| EXEC | See parity against the replaced system over an agreed period | Be shown a parity claim that quietly omits what could not be reproduced |
+| LEAD, IC | Keep their history across a migration | Have a past period silently recomputed under a new model |
+
+### S-9 · Benchmarks and shared intelligence · P3 · Core
+
+**The scenario.** Comparison against the organization's own history by default; opt-in comparison
+against peers and public data where enabled. Every benchmark declares its source, cohort definition,
+coverage and confidence.
+
+| Persona | Can | Must never |
+|---|---|---|
+| EXEC | Compare the organization against peers where the customer has opted in | Have raw customer data leave the customer boundary; receive individual-level or stack-ranked comparison (VISION §3, §12.2) |
+| LEAD | Compare their area against the organization's own history without sharing anything | — |
+| ADMIN | Turn participation on and off; it is revocable | — |
+
+---
+
+## 3. Rules that hold in every scenario
+
+These come from the vision itself and are not restated in each scenario above. They apply to every
+surface serving any capability.
+
+1. **Evidence gaps are shown, not hidden** (§3, §7.5) — missing data is never rendered as zero, and
+   never replaced by an approximate estimate.
+2. **Confidence and limitations travel with every conclusion** (§3) — a strong finding, a directional
+   signal and an instrumentation problem are distinguishable.
+3. **Lineage before attribution** (§7.3) — untraceable work is a gap, not a quiet claim.
+4. **No default stack ranking or unexplained productivity scores** (§3) — collective views carry no
+   named rows.
+5. **People-level access is role-based and policy-controlled** (§3, §9) — five independently granted
+   data classes.
+6. **Cost movement is preserved, not folded away** (§11.4) — a local saving that shifts cost, risk or
+   effort downstream is shown as a shift; seat-based and usage-based cost are not summed into one
+   figure (§6.2.9).
+7. **Insight observes and advises; people act** (§13.3).
+8. **Clean room** (§12.2) — raw data stays inside the customer boundary; only anonymized aggregates
+   at cohort, team or organization level are shared, opt-in and revocable.
+9. **Role and activity are separate axes** (§7.2) — expected role model and observed activity are
+   compared, never conflated, and history is preserved under the model valid at the time.
+
+---
+
+## 4. Open points
+
+- **IC has the narrowest surface and the strictest boundary.** Everything an IC sees is either their
+  own or a median. That combination makes it the sharpest case to get wrong quietly.
+- **Administrative rights vs data visibility.** §1.1 asserts that ADMIN gains no data visibility
+  implicitly. This needs confirming against the access model rather than the interface.
+- **Small-group thresholds are stated per surface today.** They protect an individual from being
+  identified through a cohort, so they belong to the shared rules in §3 rather than to individual
+  features — the exact values are worth agreeing in one place.
+- **S-9 has no surface yet.** It is listed so the capability stays planned for, not to imply it exists.

--- a/docs/product/SCENARIOS.md
+++ b/docs/product/SCENARIOS.md
@@ -3,33 +3,46 @@
 **Status:** draft for review · Companion to [VISION.md](VISION.md)
 
 The vision says what Insight is and what it can do. This document says **who is standing in front of
-it and how far each of them may reach**. It adds no capability and changes no commitment.
+it, what they are there to do, and how far each of them may reach**. It adds no capability and changes
+no commitment.
 
 - **Personas** — the four target user groups of VISION §6.1.
-- **Main scenarios** — the nine product capabilities of VISION §8, written as scenarios and split per
-  persona.
-- **Underneath** — the detailed user scenarios (Appendix A): 30 concrete questions, one person asking
-  one thing at one moment. Each is traced to the scenario it belongs to.
+- **Scenarios** — ten, in three tiers, ordered by what the product is for.
+- **Underneath** — the detailed user scenarios (Appendix A): thirty concrete questions, one person
+  asking one thing at one moment, each traced to the scenario it belongs to.
 
-**Why split by persona.** A capability is not one scenario. "Work with metrics" is a single
-capability, but it means three different things:
+## The three tiers
 
-- an **individual contributor** sees their own work against a department or cohort median, and no
-  team metrics at all;
+| Tier | What it is | Scenarios |
+|---|---|---|
+| **Main** | Review metrics, analyse them, reach conclusions. This is what the product is for. | S-1, S-2, S-3 |
+| **Secondary** | Build new views, explore, take the output elsewhere, compare with the outside world. | S-4, S-5, S-6 |
+| **Service** | Set the product up, keep it configured, keep it running. | S-7, S-8, S-9, S-10 |
+
+The order is by importance to the reader, not by build order. Technically the service tier comes
+first — sources and identity have to be right before a metric can be — but a customer does not buy
+setup, and a scenario list that opens with configuration describes an installation rather than a
+product.
+
+**Why split by persona.** A capability is not one scenario. "Review metrics" is a single tier, but it
+means three different things:
+
+- an **individual contributor** sees their own work against a department or cohort median, and no team
+  metrics at all;
 - a **team manager** sees their team, the people in it by name, and groups recalculated for that team
   rather than carried over from the organization;
 - an **executive** sees the whole organization.
 
-The capability is shared. The boundary is not, and the boundary is the part that gets lost in
+The activity is shared. The boundary is not, and the boundary is the part that gets lost in
 implementation. That is why it is written down as a statement rather than left implied.
 
 **How to read a scenario block**
 
 - **The scenario** — what holds for everyone, whoever is looking.
-- **Per persona** — what each of them can do, and what must never happen to them. Only the personas
-  the scenario concerns are listed.
+- **Per persona** — what each of them does, and what must never happen to them. Only the personas the
+  scenario concerns are listed.
 - **Not this** — what the scenario deliberately does not do, so it is not promised in a demo.
-- **Detail** — the user-scenario IDs from Appendix A that belong to this capability.
+- **Detail** — the user-scenario IDs from Appendix A that belong here.
 
 ---
 
@@ -64,69 +77,22 @@ The boundary each persona carries into every scenario below.
 | **Never** | The underlying records · a default view that ranks people against one another · a number with no statement of coverage and confidence | Anything outside their own team · a default view that ranks their reports · group figures carried over from the organization instead of recalculated for the team | Any other person's activity · any team metric beyond the median they are placed against · their own place in a ranking | Administrative rights do **not** carry the right to see data — each kind is granted separately (VISION §9) |
 
 **Naming and ranking are different things, and only one is restricted.** People are named wherever
-person-level access has been granted: a manager's team view names their reports, and that is the
-point of it. What VISION §3 rules out is a *default* view that ranks named individuals against one
-another, or an unexplained productivity score. The line is the default surface and the granted scope
-— not the name.
+person-level access has been granted: a manager's team view names their reports, and that is the point
+of it. What VISION §3 rules out is a *default* view that ranks named individuals against one another,
+or an unexplained productivity score. The line is the default surface and the granted scope — not the
+name.
 
 ---
 
-## 2. Main scenarios
+# 2. Main — review, analysis, conclusions
 
-One scenario per capability in VISION §8.
+The loop the product exists for: measure → diagnose → recommend → validate (VISION §1).
 
-**Class.** **Core** is the improvement loop the product exists for — measure → diagnose → recommend
-→ validate, plus the forward-looking half. **Service** is what makes that loop possible or safe.
+## S-1 · Metrics review · Main
 
-**Priority** is not a delivery order. It is which scenario has to hold before the ones after it mean
-anything. The rule: *a service scenario outranks a core one when it gates it, or when its failure
-cannot be undone.* A wrong person makes every number wrong; an access failure cannot be repaired by a
-later fix.
-
-| Priority | ID | Scenario | Class | VISION | Detail |
-|---|---|---|---|---|---|
-| **P0** | **S-2** | Identity, role and organization model | Service | §8.2, §7.2 | A2, A3, C7 |
-| **P0** | **S-4** | Measurement and metric definitions | Core | §8.4 | B1–B8 |
-| **P0** | **S-7** | Configuration and access control | Service | §8.7, §9, §3 | G1, A3, B7 |
-| **P1** | **S-1** | Source connection and evidence coverage | Service | §8.1, §7.5, §10.10 | A1, A4, C8, G3 |
-| **P1** | **S-3** | Work, outcome and cost lineage | Core | §8.3, §7.3 | B6, C4, C5, C6 |
-| **P1** | **S-5** | Analysis, diagnosis and forecasting | Core | §8.5, §5.1 | C1, C2, C3, E1, E2 |
-| **P1** | **S-6** | Recommendation and validation | Core | §8.6, §1 | D1, D2, D3 |
-| **P2** | **S-8** | Exposure and consumption | Service | §8.8, §15.2 | G2, G4 |
-| **P3** | **S-9** | Benchmarks and shared intelligence | Core | §8.9, §12 | F1 |
-
-Read the three P0 rows as the answer to "what has to be right first": one core scenario and two
-service ones, because those two are the failures that cannot be undone.
-
-### S-2 · Identity, role and organization model · P0 · Service
-
-**The scenario.** Someone who appears separately in code, tickets, chat and the HR system is
-recognised as one person, with a stated confidence. The customer can correct the result, the
-correction survives the next sync, and role and team history is preserved so past periods are not
-recalculated under a model that was not valid at the time.
-
-**ADMIN** — Sort out who is who.
-- sees what was matched automatically, where the system is unsure, and where it got it wrong
-- merges and splits reversibly
-- defines roles, several roles per person, and role history
-- never loses a manual correction to the next sync
-
-**LEAD, EXEC** — Trust the tree they roll up into.
-- the organization structure they see is the one the customer recognises
-- never a subtree quietly reshaped by re-resolution, with past periods recalculated underneath it
-
-**IC** — Be one person, not four.
-- never has their work attributed to a duplicate of themselves
-
-**Not this.** Role definitions are the customer's, not ours. Where observed work does not match the
-configured role model, Insight recommends changing the configuration — not the person (VISION §9).
-
-**Detail.** A2 (identity queue), A3 (roles and expected activities), C7 (role vs observed work).
-
-### S-4 · Measurement and metric definitions · P0 · Core
-
-**The scenario.** Every number carries a governed definition, unit, granularity, confidence and
-stated limitations, and is worked out the same way for every persona and every scope.
+**The scenario.** Someone opens the product to see how things are going. Every number carries a
+governed definition, unit, granularity, confidence and stated limitations, and is worked out the same
+way for every persona and every scope (VISION §8.4).
 
 **EXEC** — See how the organization as a whole is doing.
 - organization, function and team, with change over time
@@ -146,107 +112,34 @@ stated limitations, and is worked out the same way for every persona and every s
 - never another person's activity, never a team metric beyond that median, never their own rank
 
 **ADMIN** — Nothing by default.
-- configures which metrics matter, thresholds, cohorts and comparison groups
 - never gains data visibility implicitly from administrative rights
 
-**Not this.** No single "value of AI" number: seat-based and usage-based cost are not summed into
-one figure, and unattributed cost stays its own line rather than being spread across the rest
+**Not this.** No single "value of AI" number: seat-based and usage-based cost are not summed into one
+figure, and unattributed cost stays its own line rather than being spread across the rest
 (VISION §6.2.9, §11.4).
 
 **Detail.** B1 (own context), B2 (team over a period), B3 (where work is stuck), B4 (knowledge
-concentration), B5 (organization roll-up), B6 (AI cost), B7 (cohorts), B8 (cost of coordination).
+concentration), B5 (organization roll-up), B6 (AI cost), B8 (cost of coordination).
 
-### S-7 · Configuration and access control · P0 · Service
-
-**The scenario.** The customer configures roles, activities, sources, metrics, thresholds, cohorts,
-dashboards, localization and access rules. Access to raw, people-level, aggregate, cost and
-recommendation data is role-based and policy-controlled, and the boundary holds on every surface.
-
-**ADMIN** — Decide who gets what.
-- grants the five kinds of data one by one (VISION §9)
-- adapts roles, metrics and thresholds without engineering involvement
-- never holds all five implicitly; a refusal is enforced underneath, not only hidden on screen
-
-**LEAD** — Their own team, in full.
-- every depth inside it
-- never one level up, and never sideways — the limit is structural, not a filter on a screen
-
-**EXEC** — The organization as a whole.
-- aggregates, and people where person-level access is granted
-- never the underlying records
-
-**IC** — Themselves.
-- named to their own management chain and to anyone else granted person-level access for their part
-  of the organization — and to nobody outside it
-
-**Not this.** Insight is read-only towards connected systems: it writes its own configuration and
-annotations, nothing else (VISION §13.3).
-
-**Detail.** G1 (who sees what), A3 (role configuration), B7 (cohort definition).
-
-### S-1 · Source connection and evidence coverage · P1 · Service
-
-**The scenario.** Whatever the wiring state, the product says so plainly: what is connected, what
-that unlocks, and — where an answer is not possible — the cause and the smallest set of fixes with
-the largest gain in confidence (readiness mode, VISION §7.5). Each source declares its fields,
-window, freshness, blind spots and the level it supports (VISION §10.10).
-
-**ADMIN** — Know what can be proven.
-- every evidence category as connected, partly connected or absent, and which metrics each unlocks
-- never left to guess why a screen is empty
-
-**LEAD, EXEC** — Meet a gap and know what to do about it.
-- the cause named directly: which source is missing, which identities are unresolved, which link is
-  broken — plus the minimal fix
-- freshness per source wherever a comparison is drawn
-- never a comparison across two periods whose source windows do not overlap
-
-**IC** — The same guarantee on their own context.
-
-**Not this.** No zero in place of missing data — a zero looks like a measurement and raises a false
-alarm. And no "rough estimate for now": the honest answer to a missing source is what is missing.
-
-**Detail.** A1 (what can be proven), A4 (no answer, but what to connect), C8 (not believing a
-number), G3 (timezone and locale caveats).
-
-### S-3 · Work, outcome and cost lineage · P1 · Core
-
-**The scenario.** Work is followed across the systems it passes through — intent to work item to
-change to review to release to incident; ticket to product area; campaign to deal; cost record to
-team or service. **Lineage comes before attribution** (VISION §7.3): what cannot be traced is shown
-as an evidence gap, never converted into a confident claim.
-
-**EXEC** — Follow cost and outcome to where they came from.
-- to the function, team, product or service, as far as the trail actually goes
-- never attribution stronger than the lineage supports
-
-**LEAD** — See where the chain breaks in their own area.
-- never a broken link quietly filled in
-
-**ADMIN** — See which links are weak and what would repair them.
-
-**IC** — Never attributed work that reached them only by inference.
-
-**Not this.** Attribution has a ceiling, and the ceiling is stated rather than worked around: "this
-change was written by AI" and "this change cost $N" are not claims Insight makes.
-
-**Detail.** B6 (cost attribution ceiling), C4 (support load vs release), C5 (sales activity vs
-pipeline), C6 (cost moved rather than fell).
-
-### S-5 · Analysis, diagnosis and forecasting · P1 · Core
+## S-2 · Analysis and diagnosis · Main
 
 **The scenario.** The product stops showing shape and starts asserting a relationship — bottlenecks,
 risks, anomalies, cost drivers, quality issues, role and activity mismatches — and says which kind of
-claim it is making, with confidence and limitations. Forward-looking estimates (feasibility, cost,
-time, risk) are grounded in the organization's own history and shown as extrapolations, not
-guarantees.
+claim it is making, with confidence and limitations (VISION §8.5). It rests on lineage: work is
+followed across the systems it passes through, and **lineage comes before attribution** (VISION §7.3)
+— what cannot be traced is shown as an evidence gap, never converted into a confident claim.
+Forward-looking estimates (feasibility, cost, time, risk) come from the organization's own history and
+are shown as extrapolations, not guarantees.
 
 **LEAD** — Understand why, not just what.
 - a conclusion for their team or cohort, with the evidence behind it
+- where the chain of evidence breaks in their own area, and what would repair it
 - never a verdict about a named individual
 - never a conclusion drawn from a group too small to protect one
 
 **EXEC** — The same at organization level, plus a forecast for proposed work.
+- cost and outcome followed to the function, team, product or service — as far as the trail goes
+- never attribution stronger than the lineage supports
 - never a causal claim where the evidence supports a correlation
 - never a forecast presented as a guarantee
 
@@ -254,14 +147,17 @@ guarantees.
 
 **IC** — Not an audience for diagnosis, and never a named example inside one.
 
-**Not this.** "AI sped up development by X%" is not a claim Insight makes. What it can say is that a
-cohort with high usage differs from one with low usage in stated ways, correlationally — with the
-word said on the surface, not in a footnote.
+**Not this.** "AI sped up development by X%" is not a claim Insight makes; what it can say is that a
+cohort with high usage differs from one with low usage in stated ways, correlationally — with the word
+said on the surface, not in a footnote. Attribution also has a ceiling, and the ceiling is stated
+rather than worked around: "this change was written by AI" and "this change cost $N" are not claims
+Insight makes.
 
 **Detail.** C1 (AI gain and price together), C2 (review as a bottleneck), C3 (did quality hold),
+C4 (support load vs release), C5 (sales activity vs pipeline), C6 (cost moved rather than fell),
 E1 (assess a feature before starting), E2 (where to invest next).
 
-### S-6 · Recommendation and validation · P1 · Core
+## S-3 · Conclusions: recommendation and validation · Main
 
 **The scenario.** A recommendation is a structured improvement object (VISION §1): observed problem,
 affected area, evidence and confidence, recommended action, owner, expected metric movement, and the
@@ -270,14 +166,14 @@ data, or heuristic. Afterwards the product reads the outcome from the measured s
 
 **LEAD** — Get an action, not an observation.
 - one lever they can own, with what should move, which guardrail must not slip, and when it is checked
-- never a recommendation that passes judgement on a named individual rather than on a process, team
-  or cohort — a named *owner* is expected, a named *subject* is not
+- never a recommendation that passes judgement on a named individual rather than on a process, team or
+  cohort — a named *owner* is expected, a named *subject* is not
 - never a recommendation whose origin is unstated
 
 **EXEC** — Know whether it worked.
 - whether the lever moved, whether the outcome moved, and the honest fourth answer: not enough data
-- never a result assembled from metrics chosen after the fact — they are fixed when the
-  recommendation is issued
+- never a result assembled from metrics chosen after the fact — they are fixed when the recommendation
+  is issued
 
 **ADMIN** — Configure which recommendation families are enabled, who owns them, and how validation
 windows are defined.
@@ -290,32 +186,58 @@ measured system. Insight recommends; it does not execute (VISION §13.3).
 **Detail.** D1 (a recommendation, not an observation), D2 (did it work, a month later), D3 (context
 the system cannot see).
 
-### S-8 · Exposure and consumption · P2 · Service
+---
 
-**The scenario.** A number keeps its meaning when it leaves the product, and when the product
-replaces a system that came before it. Exports carry the definition, coverage and confidence with the
-number. Migration states openly what could not be reproduced (VISION §15.2).
+# 3. Secondary — new views, exploration, reuse
+
+Everything here extends the main loop. None of it is where a customer starts.
+
+## S-4 · Dashboards, views and exploration · Secondary
+
+**The scenario.** Someone builds a view rather than reading one: composing dashboards from the metric
+and recommendation catalog, slicing by an attribute, defining a cohort, drilling from a figure into
+what produced it, saving the result and sharing it (VISION §8.7, §9). Exploration moves the question,
+never the boundary.
+
+**LEAD** — Build the view their team actually needs.
+- compose from the catalog; slice by attribute; define cohorts and comparison groups
+- drill from any figure to what it was computed from
+- groups recalculated for whatever is on screen at the time
+- never an exploration path that reaches outside their own team
+
+**EXEC** — Build the portfolio view.
+- the same, at organization and function level
+
+**IC** — Explore their own context only.
+
+**ADMIN** — Curate what can be built.
+- which metrics and thresholds exist, which cohorts are valid, who may publish a shared view
+
+**Not this.** A shared or saved view is not a way around access rules: what a viewer sees is
+re-evaluated for that viewer, so the same saved dashboard shows each person only what they may see. A
+view carries the definitions and coverage of the metrics in it, not bare numbers.
+
+**Detail.** B7 (compare cohorts), and the slicing side of B2–B5.
+
+## S-5 · Sharing and reuse · Secondary
+
+**The scenario.** A number keeps its meaning when it leaves the product — views, summaries, APIs and
+governed data access carry the definition, coverage and confidence with the number (VISION §8.8).
 
 **ADMIN** — Take Insight's output elsewhere.
-- views, summaries, APIs and governed data access, under the same access rules
+- API and governed data access, under the same access rules that apply inside the product
 - never a number stripped of its definition and confidence, so that outside the product it becomes a
   fact without caveats
 
-**EXEC** — Replace what exists without losing history.
-- an inventory of current dashboards and metrics, then keep / rename / replace / retire
-- history imported where retention allows, and parity checked over an agreed period
-- never a parity claim that quietly omits what could not be reproduced
+**LEAD, EXEC** — Use a conclusion in their own report or review.
 
-**LEAD, IC** — Keep their history across the change.
-- never a past period silently recalculated under a new model
+**Detail.** G2 (use conclusions in another system).
 
-**Detail.** G2 (use conclusions in another system), G4 (migrate off a legacy system).
-
-### S-9 · Benchmarks and shared intelligence · P3 · Core
+## S-6 · External comparison · Secondary
 
 **The scenario.** Comparison against the organization's own history by default; opt-in comparison
 against peers and public data where enabled. Every benchmark declares its source, cohort definition,
-coverage and confidence.
+coverage and confidence (VISION §8.9, §12).
 
 **EXEC** — Know whether a number is bad or normal.
 - own history first, which requires sharing nothing
@@ -331,9 +253,119 @@ cohort, team or organization level are shared — never individual data, never s
 
 ---
 
-## 3. Rules that hold in every scenario
+# 4. Service — setup, configuration, operation
 
-From the vision, stated once here instead of repeated in each capability.
+None of this is why anyone buys the product, and all of it has to work before the rest does.
+
+## S-7 · Sources and evidence coverage · Service
+
+**The scenario.** Whatever the wiring state, the product says so plainly: what is connected, what that
+unlocks, and — where an answer is not possible — the cause and the smallest set of fixes with the
+largest gain in confidence (readiness mode, VISION §7.5). Each source declares its fields, window,
+freshness, blind spots and the level it supports (VISION §10.10).
+
+**ADMIN** — Know what can be proven.
+- every evidence category as connected, partly connected or absent, and which metrics each unlocks
+- freshness per source
+- never left to guess why a screen is empty
+
+**LEAD, EXEC** — Meet a gap and know what to do about it.
+- the cause named directly: which source is missing, which identities are unresolved, which link is
+  broken — plus the minimal fix
+- never a comparison across two periods whose source windows do not overlap
+
+**IC** — The same guarantee on their own context.
+
+**Not this.** No zero in place of missing data — a zero looks like a measurement and raises a false
+alarm. And no "rough estimate for now": the honest answer to a missing source is what is missing.
+
+**Detail.** A1 (what can be proven), A4 (no answer, but what to connect), C8 (event in the business or
+break in the data).
+
+## S-8 · Identity, roles and organization model · Service
+
+**The scenario.** Someone who appears separately in code, tickets, chat and the HR system is
+recognised as one person, with a stated confidence. The customer can correct the result, the correction
+survives the next sync, and role and team history is preserved so past periods are not recalculated
+under a model that was not valid at the time (VISION §8.2, §7.2).
+
+**ADMIN** — Sort out who is who.
+- sees what was matched automatically, where the system is unsure, and where it got it wrong
+- merges and splits reversibly
+- defines roles, several roles per person, and role history
+- never loses a manual correction to the next sync
+
+**LEAD, EXEC** — Trust the tree they roll up into.
+- never a subtree quietly reshaped by re-resolution, with past periods recalculated underneath it
+
+**IC** — Be one person, not four.
+- never has their work attributed to a duplicate of themselves
+
+**Not this.** Where observed work does not match the configured role model, Insight recommends
+changing the configuration — not the person (VISION §9).
+
+**Detail.** A2 (identity queue), A3 (roles and expected activities), C7 (role vs observed work).
+
+## S-9 · Configuration and access · Service
+
+**The scenario.** The customer configures roles, activities, sources, metrics, thresholds, cohorts,
+dashboards, localization and access rules (VISION §9). Access to raw, people-level, aggregate, cost and
+recommendation data is role-based and policy-controlled, and the boundary holds on every surface.
+
+**ADMIN** — Decide who gets what.
+- grants the five kinds of data one by one
+- adapts roles, metrics and thresholds without engineering involvement
+- sets language, date, number, currency and timezone rules
+- never holds all five kinds implicitly; a refusal is enforced underneath, not only hidden on screen
+
+**LEAD** — Their own team, in full.
+- every depth inside it
+- never one level up, and never sideways — the limit is structural, not a filter on a screen
+
+**EXEC** — The organization as a whole.
+- aggregates, and people where person-level access is granted
+- never the underlying records
+
+**IC** — Themselves.
+- named to their own management chain and to anyone else granted person-level access for their part of
+  the organization — and to nobody outside it
+
+**Not this.** Insight is read-only towards connected systems: it writes its own configuration and
+annotations, nothing else (VISION §13.3).
+
+**Detail.** G1 (who sees what), G3 (language and timezone), and the configuration half of A3.
+
+## S-10 · Deployment, upgrade and migration · Service
+
+**The scenario.** The product is installed, updated, upgraded and — where it replaces something —
+migrated into, without losing what already worked. Deployment models differ (Constructor-hosted,
+customer cloud, private cloud, customer-operated), and in all of them customer data stays under
+customer control (VISION §1, §14.1, §15.2).
+
+**ADMIN** — Run it.
+- install, configure, update and upgrade a customer-operated deployment
+- inventory what exists first, then keep / rename / replace / retire
+- import history where retention allows, and check parity over an agreed period
+- never lose a surface that worked before an upgrade
+- never discover a broken screen from a user
+
+**EXEC** — Replace the previous system with confidence.
+- parity stated openly, including what could not be reproduced
+- never a parity claim that quietly omits it
+
+**LEAD, IC** — Keep their history across the change.
+- never a past period silently recalculated under a new model
+
+**Not this.** Insight does not require Constructor to have default access to customer data in order to
+operate (VISION §1).
+
+**Detail.** G4 (migrate off a legacy system).
+
+---
+
+## 5. Rules that hold in every scenario
+
+From the vision, stated once here instead of repeated in each scenario.
 
 1. **Evidence gaps are shown, not hidden** (§3, §7.5) — never a zero for missing data, never an
    approximate estimate in place of an answer.
@@ -343,7 +375,7 @@ From the vision, stated once here instead of repeated in each capability.
 4. **No default ranking of named individuals, and no unexplained productivity scores** (§3) — people
    are named where person-level access has been granted; the ranking is what is ruled out.
 5. **People-level access is role-based and policy-controlled** (§3, §9) — five kinds of data, granted
-   separately.
+   separately, enforced where the data is produced rather than on the screen.
 6. **Cost movement is preserved, not folded away** (§11.4) — a local saving that shifts cost, risk or
    effort downstream is shown as a shift; seat-based and usage-based cost are never one figure.
 7. **Insight observes and advises; people act** (§13.3) — it writes its own configuration and
@@ -360,54 +392,77 @@ From the vision, stated once here instead of repeated in each capability.
 ## Appendix A · The detailed user scenarios
 
 Thirty concrete questions — one person, one question, one moment — from the product scenario draft of
-2026-08-04. They are the level at which features are specified and tested; the capabilities in §2 are
-what all of them must obey. Availability is deliberately not recorded here: it changes per release
-and per customer, since the connected source set differs.
+2026-08-04. They are the level at which features are specified and tested; the scenarios in §2–§4 are
+what all of them must obey. Availability is deliberately not recorded here: it changes per release and
+per customer, since the connected source set differs.
 
-| ID | The question behind it | Who asks | Capability |
+| ID | The question behind it | Who asks | Scenario |
 |---|---|---|---|
-| A1 | Which questions can I already ask, and which not? | ADMIN | S-1 |
-| A2 | Which identity links did the system make, where is it unsure, where wrong? | ADMIN | S-2 |
-| A3 | How do I tell the product who is supposed to do what here? | ADMIN | S-2, S-7 |
-| A4 | Why is this empty, and what would make it not empty? | ADMIN, LEAD | S-1 |
-| B1 | What is visible about me, and what is in my way? | IC | S-4 |
-| B2 | What changed for my team over the period? | LEAD | S-4 |
-| B3 | Where is work stalling? | LEAD | S-4 |
-| B4 | What falls apart if a specific person drops out? | LEAD, EXEC | S-4 |
-| B5 | Where are we improving, and where just getting busier? | EXEC | S-4 |
-| B6 | How much does AI cost, who spends it, in what form? | EXEC | S-4, S-3 |
-| B7 | How does group A differ from group B in the same scope? | LEAD, EXEC | S-4, S-7 |
-| B8 | How much goes into coordination instead of work? | LEAD | S-4 |
-| C1 | Did throughput rise where AI was adopted, and what did it cost? | LEAD, EXEC | S-5 |
-| C2 | Is speed limited by writing code or by reviewing it? | LEAD | S-5 |
-| C3 | Speed went up — did quality hold? | LEAD | S-5 |
-| C4 | Is this ticket spike caused by what we shipped? | LEAD, EXEC | S-3 |
-| C5 | Activity rose — did the deals move? | LEAD, EXEC | S-3 |
-| C6 | Development got cheaper — did the cost move somewhere else? | EXEC | S-3 |
-| C7 | Someone is listed in one role and does another — error or reality? | LEAD, ADMIN | S-2 |
-| C8 | Is this an event in the business, or a break in the data? | ADMIN, LEAD, EXEC | S-1 |
-| D1 | I can see the problem — what do I do? | LEAD | S-6 |
-| D2 | Was it applied? Did it help? | LEAD, EXEC | S-6 |
-| D3 | We had a reorg that month — how do I say so? | LEAD | S-6 |
-| E1 | Is it feasible, what will it cost, how long, what risks? | EXEC, LEAD | S-5 |
-| E2 | Where is the effect larger for less effort? | EXEC | S-5 |
-| F1 | Our three-day cycle — is that bad? | EXEC | S-9 |
-| G1 | How do I give a lead their team and nothing more? | ADMIN | S-7 |
-| G2 | How do we pull this into our own BI or report? | ADMIN, LEAD | S-8 |
-| G3 | Can we work in our own language and timezone? | all | S-1 |
-| G4 | How do we replace what we have without losing history? | ADMIN, EXEC | S-8 |
+| B1 | What is visible about me, and what is in my way? | IC | S-1 |
+| B2 | What changed for my team over the period? | LEAD | S-1 |
+| B3 | Where is work stalling? | LEAD | S-1 |
+| B4 | What falls apart if a specific person drops out? | LEAD, EXEC | S-1 |
+| B5 | Where are we improving, and where just getting busier? | EXEC | S-1 |
+| B6 | How much does AI cost, who spends it, in what form? | EXEC | S-1 |
+| B8 | How much goes into coordination instead of work? | LEAD | S-1 |
+| C1 | Did throughput rise where AI was adopted, and what did it cost? | LEAD, EXEC | S-2 |
+| C2 | Is speed limited by writing code or by reviewing it? | LEAD | S-2 |
+| C3 | Speed went up — did quality hold? | LEAD | S-2 |
+| C4 | Is this ticket spike caused by what we shipped? | LEAD, EXEC | S-2 |
+| C5 | Activity rose — did the deals move? | LEAD, EXEC | S-2 |
+| C6 | Development got cheaper — did the cost move somewhere else? | EXEC | S-2 |
+| E1 | Is it feasible, what will it cost, how long, what risks? | EXEC, LEAD | S-2 |
+| E2 | Where is the effect larger for less effort? | EXEC | S-2 |
+| D1 | I can see the problem — what do I do? | LEAD | S-3 |
+| D2 | Was it applied? Did it help? | LEAD, EXEC | S-3 |
+| D3 | We had a reorg that month — how do I say so? | LEAD | S-3 |
+| B7 | How does group A differ from group B in the same scope? | LEAD, EXEC | S-4 |
+| G2 | How do we pull this into our own BI or report? | ADMIN, LEAD | S-5 |
+| F1 | Our three-day cycle — is that bad? | EXEC | S-6 |
+| A1 | Which questions can I already ask, and which not? | ADMIN | S-7 |
+| A4 | Why is this empty, and what would make it not empty? | ADMIN, LEAD | S-7 |
+| C8 | Is this an event in the business, or a break in the data? | ADMIN, LEAD, EXEC | S-7 |
+| A2 | Which identity links did the system make, where is it unsure, where wrong? | ADMIN | S-8 |
+| A3 | How do I tell the product who is supposed to do what here? | ADMIN | S-8, S-9 |
+| C7 | Someone is listed in one role and does another — error or reality? | LEAD, ADMIN | S-8 |
+| G1 | How do I give a lead their team and nothing more? | ADMIN | S-9 |
+| G3 | Can we work in our own language and timezone? | all | S-9 |
+| G4 | How do we replace what we have without losing history? | ADMIN, EXEC | S-10 |
 
-Every one of the thirty maps to a capability; no capability in §2 is left without a concrete question
-underneath it, except S-9, which has none yet.
+All thirty map to a scenario. S-6 is the only scenario with no surface behind it yet.
 
 ---
 
-## Appendix B · Open points
+## Appendix B · Scenarios against VISION §8
+
+The vision lists nine product capabilities. The scenarios above are organised by what a person is
+doing rather than by capability, so the mapping is not one-to-one: configuration splits in two, and
+deployment comes from elsewhere in the vision.
+
+| VISION §8 capability | Scenario |
+|---|---|
+| 8.1 Source connection and evidence coverage | S-7 |
+| 8.2 Identity, role and organization model | S-8 |
+| 8.3 Work, outcome and cost lineage | S-2 (what analysis rests on) |
+| 8.4 Measurement and metric definitions | S-1 |
+| 8.5 Analysis, diagnosis and forecasting | S-2 |
+| 8.6 Recommendation and validation | S-3 |
+| 8.7 Customer configuration | S-9, and the view-building half in S-4 |
+| 8.8 Exposure and consumption | S-5 |
+| 8.9 Benchmarks and shared intelligence | S-6 |
+| §1, §14.1, §15.2 — deployment models, adoption, migration | S-10 |
+
+---
+
+## Appendix C · Open points
 
 - **Administrative rights and data visibility.** §1.1 asserts that ADMIN gains no data visibility
   implicitly. Worth confirming against the access model rather than the interface.
+- **Shared views and access.** S-4 asserts that a saved or shared view re-evaluates what each viewer
+  may see. This is the easiest place for the access boundary to leak, and it needs confirming rather
+  than assuming.
 - **The small-group threshold** is stated per surface today. It protects an individual from being
-  identified through a cohort, so it belongs to §3 with one agreed value.
+  identified through a cohort, so it belongs to §5 with one agreed value.
 - **IC has the narrowest surface and the tightest boundary.** Everything an IC sees is their own or a
   median — the combination that is easiest to get wrong quietly.
-- **S-9 has no surface yet.** Listed so the capability stays planned for, not to imply it exists.
+- **S-6 has no surface yet.** Listed so the capability stays planned for, not to imply it exists.

--- a/docs/product/SCENARIOS.md
+++ b/docs/product/SCENARIOS.md
@@ -43,7 +43,10 @@ implementation. That is why it is written down as a statement rather than left i
 - **Per persona** — what each of them does, and what must never happen to them. Only the personas the
   scenario concerns are listed.
 - **Not this** — what the scenario deliberately does not do, so it is not promised in a demo.
-- **Detail** — the user-scenario IDs from Appendix A that belong here.
+- **Detail** — the user-scenario IDs from Appendix A that belong here. It lists the detailed
+  *questions*, not the source of every persona line: reach comes from VISION §6.1, what an
+  administrator may configure from §9. So a persona can appear in a scenario with no question of its
+  own beneath it — usually stating a limit rather than claiming a need.
 
 ---
 
@@ -75,7 +78,7 @@ The boundary each persona carries into every scenario below.
 | **Comparison** | Between functions, teams and people | Between groups inside their own team, and between their own reports | Against a median, never against a named colleague | n/a |
 | **Cost figures** | Where granted | Where granted | No | Where granted |
 | **Conclusions and advice** | Reads conclusions | Reads conclusions, receives recommendations | Neither | Neither |
-| **Never** | The underlying records · a default view that ranks people against one another · a number with no statement of coverage and confidence | Anything outside their own team · a default view that ranks their reports · group figures carried over from the organization instead of recalculated for the team | Any other person's activity · any team metric beyond the median they are placed against · their own place in a ranking | Administrative rights do **not** carry the right to see data — each kind is granted separately (VISION §9) |
+| **Never** | A default view that ranks people against one another · a number with no statement of coverage and confidence | Anything outside their own team · a default view that ranks their reports · group figures carried over from the organization instead of recalculated for the team | Any other person's activity · any team metric beyond the median they are placed against · their own place in a ranking | Administrative rights do **not** carry the right to see data — each kind is granted separately (VISION §9) |
 
 **Naming and ranking are different things, and only one is restricted.** People are named wherever
 person-level access has been granted: a manager's team view names their reports, and that is the point
@@ -151,9 +154,10 @@ it is measured against belongs to S-8.
 - never a causal claim where the evidence supports a correlation
 - never a forecast presented as a guarantee
 
-**ADMIN** — See which evidence gaps and known defects limit a conclusion.
+**IC** — Not an audience for diagnosis, and never a named example inside one (VISION §6.1).
 
-**IC** — Not an audience for diagnosis, and never a named example inside one.
+What limits a conclusion — which sources are missing, which windows do not overlap, which metric is
+under a known defect — is an administrator's view, and it lives in S-7.
 
 ### Looking forward — the other direction of the same scenario
 
@@ -205,7 +209,7 @@ data, or heuristic. Afterwards the product reads the outcome from the measured s
   is not mistaken for an effect
 
 **ADMIN** — Configure which recommendation families are enabled, who owns them, and how validation
-windows are defined.
+windows are defined (VISION §9).
 
 **IC** — Never the subject of a recommendation.
 
@@ -249,7 +253,7 @@ activity is not.
 
 **IC** — Explore their own context only.
 
-**ADMIN** — Curate what can be built.
+**ADMIN** — Curate what can be built (VISION §9).
 - which metrics and thresholds exist, which cohorts are valid, who may publish a shared view
 
 **Not this.** A view carries the definitions and coverage of the metrics in it, not bare numbers.
@@ -272,7 +276,7 @@ governed data access carry the definition, coverage and confidence with the numb
 - never a number stripped of its definition and confidence, so that outside the product it becomes a
   fact without caveats
 
-**LEAD, EXEC** — Use a conclusion in their own report or review.
+**LEAD** — Use a conclusion in their own report or review.
 
 **Detail.** G2 (use conclusions in another system).
 
@@ -286,7 +290,7 @@ coverage and confidence (VISION §8.9, §12).
 - own history first, which requires sharing nothing
 - peer comparison only where the customer has opted in
 
-**ADMIN** — Turn participation on and off; it is revocable.
+**ADMIN** — Turn participation on and off; it is revocable (VISION §12).
 
 **Not this.** Raw customer data never leaves the customer boundary. Only anonymized aggregates at
 cohort, team or organization level are shared — never individual data, never stack ranking
@@ -346,7 +350,7 @@ under a model that was not valid at the time (VISION §8.2, §7.2).
 - defines roles, several roles per person, and role history
 - never loses a manual correction to the next sync
 
-**LEAD, EXEC** — Trust the tree they roll up into.
+**LEAD, EXEC** — Trust the tree they roll up into (VISION §7.2 — temporal team membership).
 - never a subtree quietly reshaped by re-resolution, with past periods recalculated underneath it
 
 **IC** — Be one person, not four.
@@ -381,7 +385,7 @@ gaps in §5.
 
 **EXEC** — The organization as a whole.
 - aggregates, and people where person-level access is granted
-- never the underlying records
+- the underlying records only where granted — raw access is one of the five grants, not a privilege of rank
 
 **IC** — Themselves.
 - named to their own management chain and to anyone else granted person-level access for their part of
@@ -409,7 +413,7 @@ customer control (VISION §1, §14.1, §15.2).
 - parity stated openly, including what could not be reproduced
 - never a parity claim that quietly omits it
 
-**LEAD, IC** — Keep their history across the change.
+**LEAD, IC** — Keep their history across the change (VISION §7.2 — past periods stay under the model valid at the time).
 - never a past period silently recalculated under a new model
 
 **Not this.** Insight does not require Constructor to have default access to customer data in order to
@@ -446,6 +450,9 @@ From the vision, stated once here instead of repeated in each scenario.
     individual unidentifiable behind a number; the second keeps a claim from resting on a handful.
 11. **A metric with a known defect says so on the metric itself** — and where a conclusion would rest
     on it, the metric is excluded by name rather than quietly included.
+12. **A group figure is computed for the group in view** — never inherited from a wider scope. This is
+    why the same cohort produces different numbers at team level and at organization level, and why
+    that is correct rather than a discrepancy.
 
 ---
 

--- a/docs/product/SCENARIOS.md
+++ b/docs/product/SCENARIOS.md
@@ -15,14 +15,15 @@ no commitment.
 
 | Tier | What it is | Scenarios |
 |---|---|---|
-| **Main** | Review metrics, analyse them, reach conclusions. This is what the product is for. | S-1, S-2, S-3 |
+| **Main** | Review metrics, analyse them, reach conclusions — and, looking forward, estimate work not yet started. This is what the product is for. | S-1, S-2, S-3 |
 | **Secondary** | Build new views, explore, take the output elsewhere, compare with the outside world. | S-4, S-5, S-6 |
 | **Service** | Set the product up, keep it configured, keep it running. | S-7, S-8, S-9, S-10 |
 
 The order is by importance to the reader, not by build order. Technically the service tier comes
 first — sources and identity have to be right before a metric can be — but a customer does not buy
 setup, and a scenario list that opens with configuration describes an installation rather than a
-product.
+product. **Secondary and service do not mean low priority on a roadmap**; they mean a customer does
+not arrive for them.
 
 **Why split by persona.** A capability is not one scenario. "Review metrics" is a single tier, but it
 means three different things:
@@ -103,7 +104,11 @@ way for every persona and every scope (VISION §8.4).
 **LEAD** — See how their team is doing and where work is stuck.
 - their own team at any depth, and the people in it by name
 - groups recalculated for the team in view, not carried over from the organization
-- a group too small to keep an individual unidentifiable is not shown at all
+- a group of fewer than four people is not shown at all — that is what keeps an individual
+  unidentifiable behind a group figure
+- concentration read with the meaning of its domain: in code and documentation a high top-decile
+  share is a bus-factor risk, in communication it is a load imbalance. Same arithmetic, different
+  conclusion, and the surface says which one it means
 - never a team they do not manage
 
 **IC** — See their own work, with a reference point.
@@ -127,15 +132,18 @@ concentration), B5 (organization roll-up), B6 (AI cost), B8 (cost of coordinatio
 risks, anomalies, cost drivers, quality issues, role and activity mismatches — and says which kind of
 claim it is making, with confidence and limitations (VISION §8.5). It rests on lineage: work is
 followed across the systems it passes through, and **lineage comes before attribution** (VISION §7.3)
-— what cannot be traced is shown as an evidence gap, never converted into a confident claim.
-Forward-looking estimates (feasibility, cost, time, risk) come from the organization's own history and
-are shown as extrapolations, not guarantees.
+— what cannot be traced is shown as an evidence gap, never converted into a confident claim. Where
+observed work diverges from the configured role model, the divergence is surfaced here; the role model
+it is measured against belongs to S-8.
 
 **LEAD** — Understand why, not just what.
 - a conclusion for their team or cohort, with the evidence behind it
 - where the chain of evidence breaks in their own area, and what would repair it
 - never a verdict about a named individual
-- never a conclusion drawn from a group too small to protect one
+- a comparative conclusion needs at least eight people on each side. Below that the surface does not
+  render it, and says why — the threshold is higher than the four that protects a group figure,
+  because a conclusion claims more than a number does
+- never built on a metric known to be defective: it is excluded by name, and the exclusion is stated
 
 **EXEC** — The same at organization level, plus a forecast for proposed work.
 - cost and outcome followed to the function, team, product or service — as far as the trail goes
@@ -147,11 +155,25 @@ are shown as extrapolations, not guarantees.
 
 **IC** — Not an audience for diagnosis, and never a named example inside one.
 
+### Looking forward — the other direction of the same scenario
+
+VISION §1 treats forward-looking work as a direction of its own, not an afterthought to diagnosis:
+looking back, the product improves work that has already happened; looking forward, it helps decide
+what to commit to. Both are analysis, which is why they sit in one scenario — but the questions differ.
+
+**EXEC, LEAD** — Decide what to take on.
+- is this feasible, what will it cost, how long will it take, what are the risks
+- the answer built from the organization's own delivery history, not from generic assumptions
+- ranked opportunities: where the expected effect is larger for less effort
+- the same evidence model, confidence and stated limitations as everything else
+- never a forecast presented as a guarantee — it is an extrapolation, and it strengthens as history
+  and lineage improve
+
 **Not this.** "AI sped up development by X%" is not a claim Insight makes; what it can say is that a
 cohort with high usage differs from one with low usage in stated ways, correlationally — with the word
 said on the surface, not in a footnote. Attribution also has a ceiling, and the ceiling is stated
-rather than worked around: "this change was written by AI" and "this change cost $N" are not claims
-Insight makes.
+rather than worked around: it reaches person × day × tool, and no further, so "this change was written
+by AI" and "this change cost $N" are not claims Insight makes.
 
 **Detail.** C1 (AI gain and price together), C2 (review as a bottleneck), C3 (did quality hold),
 C4 (support load vs release), C5 (sales activity vs pipeline), C6 (cost moved rather than fell),
@@ -165,7 +187,10 @@ follow-up window used to check it. Its origin is declared — evidence-derived f
 data, or heuristic. Afterwards the product reads the outcome from the measured system.
 
 **LEAD** — Get an action, not an observation.
-- one lever they can own, with what should move, which guardrail must not slip, and when it is checked
+- one lever they can own, drawn from a fixed set rather than composed freely — three in the first
+  version: reduce change size, spread review load, raise AI adoption where it is low at comparable load
+- with it: how the lever itself is measured, what should move as a result, which guardrail must not
+  slip, and when it is checked — four weeks, computed automatically
 - never a recommendation that passes judgement on a named individual rather than on a process, team or
   cohort — a named *owner* is expected, a named *subject* is not
 - never a recommendation whose origin is unstated
@@ -174,14 +199,19 @@ data, or heuristic. Afterwards the product reads the outcome from the measured s
 - whether the lever moved, whether the outcome moved, and the honest fourth answer: not enough data
 - never a result assembled from metrics chosen after the fact — they are fixed when the recommendation
   is issued
+- read over a fixed window, four weeks before against four weeks after, rather than by a detector
+  hunting for a shift — on a team of ten a detector finds noise
+- read against a control: a comparable group that received no recommendation, so a company-wide trend
+  is not mistaken for an effect
 
 **ADMIN** — Configure which recommendation families are enabled, who owns them, and how validation
 windows are defined.
 
 **IC** — Never the subject of a recommendation.
 
-**Not this.** No surveys, and no self-reported productivity as an input. Validation is read from the
-measured system. Insight recommends; it does not execute (VISION §13.3).
+**Not this.** No surveys, and no self-reporting of any kind as an input — not because opinions do not
+matter, but because a validation that depends on people filling in a form does not run. Validation is
+read from the measured system. Insight recommends; it does not execute (VISION §13.3).
 
 **Detail.** D1 (a recommendation, not an observation), D2 (did it work, a month later), D3 (context
 the system cannot see).
@@ -195,14 +225,23 @@ Everything here extends the main loop. None of it is where a customer starts.
 ## S-4 · Dashboards, views and exploration · Secondary
 
 **The scenario.** Someone builds a view rather than reading one: composing dashboards from the metric
-and recommendation catalog, slicing by an attribute, defining a cohort, drilling from a figure into
-what produced it, saving the result and sharing it (VISION §8.7, §9). Exploration moves the question,
-never the boundary.
+and recommendation catalog (VISION §8.7, §9), slicing by an attribute, defining a cohort, and following
+a figure back to how it was calculated (VISION §2 — customers can see how metrics are calculated).
+Exploration moves the question, never the boundary.
+
+Two parts of this scenario go beyond what the vision states today and are proposals rather than
+restatements: **saving a composed view and sharing it with someone else**, and the access rule that
+follows from sharing. Both are marked in Appendix C.
+
+**Cohorts appear in two roles, and only one of them is here.** In S-1 a cohort is a fixed backdrop —
+the median an individual is placed against, computed for them. Here a cohort is something a person
+builds: choosing the attribute, the comparison group and the scope. The machinery is shared; the
+activity is not.
 
 **LEAD** — Build the view their team actually needs.
 - compose from the catalog; slice by attribute; define cohorts and comparison groups
-- drill from any figure to what it was computed from
-- groups recalculated for whatever is on screen at the time
+- follow any figure back to how it was calculated
+- groups recalculated for whatever is on screen at the time, and still suppressed below four people
 - never an exploration path that reaches outside their own team
 
 **EXEC** — Build the portfolio view.
@@ -213,9 +252,13 @@ never the boundary.
 **ADMIN** — Curate what can be built.
 - which metrics and thresholds exist, which cohorts are valid, who may publish a shared view
 
-**Not this.** A shared or saved view is not a way around access rules: what a viewer sees is
-re-evaluated for that viewer, so the same saved dashboard shows each person only what they may see. A
-view carries the definitions and coverage of the metrics in it, not bare numbers.
+**Not this.** A view carries the definitions and coverage of the metrics in it, not bare numbers.
+
+**Proposed, and the reason S-4 is worth arguing about.** If a view can be shared, it must not become a
+way around access rules: what a viewer sees would have to be re-evaluated for that viewer, so the same
+saved dashboard shows each person only what they may see. Neither the vision nor the scenario draft
+says this today — which is exactly why it needs deciding before view sharing is built rather than
+after.
 
 **Detail.** B7 (compare cohorts), and the slicing side of B2–B5.
 
@@ -257,16 +300,24 @@ cohort, team or organization level are shared — never individual data, never s
 
 None of this is why anyone buys the product, and all of it has to work before the rest does.
 
+**These four are also a sequence.** A new customer walks them roughly in order — connect the sources
+(S-7), resolve who is who (S-8), configure roles, metrics and access (S-9), with the installation
+itself underneath (S-10) — and only then does the main tier hold anything. VISION §14.1 states the
+same adoption path: connect, configure, run readiness, start with directional insight, improve
+evidence, validate. Listed last by importance; met first in time.
+
 ## S-7 · Sources and evidence coverage · Service
 
 **The scenario.** Whatever the wiring state, the product says so plainly: what is connected, what that
 unlocks, and — where an answer is not possible — the cause and the smallest set of fixes with the
-largest gain in confidence (readiness mode, VISION §7.5). Each source declares its fields, window,
-freshness, blind spots and the level it supports (VISION §10.10).
+largest gain in confidence (readiness mode, VISION §7.5).
 
 **ADMIN** — Know what can be proven.
-- every evidence category as connected, partly connected or absent, and which metrics each unlocks
-- freshness per source
+- all eight evidence categories as connected, partly connected or absent — people, work,
+  communication, delivery, support, sales, cost, AI — and which metrics each one unlocks
+- what each source declares about itself: fields, window, freshness, blind spots, and which level it
+  supports — measurement, diagnosis, recommendation or validation (VISION §10.10)
+- which links between systems are weak or broken, and what would repair them
 - never left to guess why a screen is empty
 
 **LEAD, EXEC** — Meet a gap and know what to do about it.
@@ -316,7 +367,13 @@ recommendation data is role-based and policy-controlled, and the boundary holds 
 - grants the five kinds of data one by one
 - adapts roles, metrics and thresholds without engineering involvement
 - sets language, date, number, currency and timezone rules
-- never holds all five kinds implicitly; a refusal is enforced underneath, not only hidden on screen
+- never holds all five kinds implicitly; a refusal is enforced by the system, not only hidden on screen
+
+**Where a setting cannot yet be honoured, the gap is shown rather than implied.** Timezone is the live
+example: dates are bucketed in UTC while a period is chosen in the viewer's own zone, so an event near
+local midnight can land a day either side. Until sources actually carry people's timezones, the
+divergence is labelled on the surface instead of being quietly absorbed — the same rule as evidence
+gaps in §5.
 
 **LEAD** — Their own team, in full.
 - every depth inside it
@@ -346,8 +403,7 @@ customer control (VISION §1, §14.1, §15.2).
 - install, configure, update and upgrade a customer-operated deployment
 - inventory what exists first, then keep / rename / replace / retire
 - import history where retention allows, and check parity over an agreed period
-- never lose a surface that worked before an upgrade
-- never discover a broken screen from a user
+- never lose a surface that worked before an upgrade — what was live before it is checked after it
 
 **EXEC** — Replace the previous system with confidence.
 - parity stated openly, including what could not be reproduced
@@ -375,7 +431,8 @@ From the vision, stated once here instead of repeated in each scenario.
 4. **No default ranking of named individuals, and no unexplained productivity scores** (§3) — people
    are named where person-level access has been granted; the ranking is what is ruled out.
 5. **People-level access is role-based and policy-controlled** (§3, §9) — five kinds of data, granted
-   separately, enforced where the data is produced rather than on the screen.
+   separately. The scope boundary holds by construction, not as a filter a screen applies: a viewer is
+   handed their own part of the organization and cannot ask for more.
 6. **Cost movement is preserved, not folded away** (§11.4) — a local saving that shifts cost, risk or
    effort downstream is shown as a shift; seat-based and usage-based cost are never one figure.
 7. **Insight observes and advises; people act** (§13.3) — it writes its own configuration and
@@ -384,8 +441,11 @@ From the vision, stated once here instead of repeated in each scenario.
    are shared, opt-in and revocable.
 9. **Role and activity are separate axes** (§7.2) — expected role model and observed activity are
    compared, never conflated; history is kept under the model valid at the time.
-10. **A group too small to keep an individual unidentifiable is not shown** — the threshold protects a
-    person from being identified through a cohort.
+10. **Two group-size thresholds, and they are different** — a group figure is not shown below **four**
+    people, and a comparative conclusion is not drawn below **eight** on each side. The first keeps an
+    individual unidentifiable behind a number; the second keeps a claim from resting on a handful.
+11. **A metric with a known defect says so on the metric itself** — and where a conclusion would rest
+    on it, the metric is excluded by name rather than quietly included.
 
 ---
 
@@ -403,21 +463,21 @@ per customer, since the connected source set differs.
 | B3 | Where is work stalling? | LEAD | S-1 |
 | B4 | What falls apart if a specific person drops out? | LEAD, EXEC | S-1 |
 | B5 | Where are we improving, and where just getting busier? | EXEC | S-1 |
-| B6 | How much does AI cost, who spends it, in what form? | EXEC | S-1 |
+| B6 | How much does AI cost, who spends it, in what form? | EXEC † | S-1 |
 | B8 | How much goes into coordination instead of work? | LEAD | S-1 |
 | C1 | Did throughput rise where AI was adopted, and what did it cost? | LEAD, EXEC | S-2 |
 | C2 | Is speed limited by writing code or by reviewing it? | LEAD | S-2 |
-| C3 | Speed went up — did quality hold? | LEAD | S-2 |
-| C4 | Is this ticket spike caused by what we shipped? | LEAD, EXEC | S-2 |
+| C3 | Speed went up — did quality hold? | LEAD † | S-2 |
+| C4 | Is this ticket spike caused by what we shipped? | LEAD † | S-2 |
 | C5 | Activity rose — did the deals move? | LEAD, EXEC | S-2 |
-| C6 | Development got cheaper — did the cost move somewhere else? | EXEC | S-2 |
-| E1 | Is it feasible, what will it cost, how long, what risks? | EXEC, LEAD | S-2 |
-| E2 | Where is the effect larger for less effort? | EXEC | S-2 |
+| C6 | Development got cheaper — did the cost move somewhere else? | EXEC † | S-2 |
+| E1 | Is it feasible, what will it cost, how long, what risks? | EXEC, LEAD † | S-2 |
+| E2 | Where is the effect larger for less effort? | EXEC † | S-2 |
 | D1 | I can see the problem — what do I do? | LEAD | S-3 |
 | D2 | Was it applied? Did it help? | LEAD, EXEC | S-3 |
 | D3 | We had a reorg that month — how do I say so? | LEAD | S-3 |
 | B7 | How does group A differ from group B in the same scope? | LEAD, EXEC | S-4 |
-| G2 | How do we pull this into our own BI or report? | ADMIN, LEAD | S-5 |
+| G2 | How do we pull this into our BI, a report, or a bot? | ADMIN, LEAD | S-5 |
 | F1 | Our three-day cycle — is that bad? | EXEC | S-6 |
 | A1 | Which questions can I already ask, and which not? | ADMIN | S-7 |
 | A4 | Why is this empty, and what would make it not empty? | ADMIN, LEAD | S-7 |
@@ -429,7 +489,11 @@ per customer, since the connected source set differs.
 | G3 | Can we work in our own language and timezone? | all | S-9 |
 | G4 | How do we replace what we have without losing history? | ADMIN, EXEC | S-10 |
 
-All thirty map to a scenario. S-6 is the only scenario with no surface behind it yet.
+All thirty map to a scenario. S-6 is the only scenario with no concrete question behind it yet.
+
+**†** The source draft tags this question with a persona this document does not keep separate —
+product management or finance. The row shows the persona carrying it here (§1). Six such rows: B6 and
+C6 were finance, C3, C4, E1 and E2 were product management.
 
 ---
 
@@ -443,11 +507,11 @@ deployment comes from elsewhere in the vision.
 |---|---|
 | 8.1 Source connection and evidence coverage | S-7 |
 | 8.2 Identity, role and organization model | S-8 |
-| 8.3 Work, outcome and cost lineage | S-2 (what analysis rests on) |
+| 8.3 Work, outcome and cost lineage | No scenario of its own — nobody opens lineage. It is the rule S-2 and S-3 rest on (§5, rule 3), and repairing it is ADMIN work in S-7 |
 | 8.4 Measurement and metric definitions | S-1 |
 | 8.5 Analysis, diagnosis and forecasting | S-2 |
 | 8.6 Recommendation and validation | S-3 |
-| 8.7 Customer configuration | S-9, and the view-building half in S-4 |
+| 8.7 Customer configuration | S-9 governs it — which metrics, cohorts and views may exist, and who may publish them; S-4 is where people exercise it |
 | 8.8 Exposure and consumption | S-5 |
 | 8.9 Benchmarks and shared intelligence | S-6 |
 | §1, §14.1, §15.2 — deployment models, adoption, migration | S-10 |
@@ -456,13 +520,21 @@ deployment comes from elsewhere in the vision.
 
 ## Appendix C · Open points
 
+Four claims in this document go beyond what VISION.md and the scenario draft state. They are written
+as requirements because the alternative is to leave them undecided, but each needs a decision rather
+than a nod.
+
 - **Administrative rights and data visibility.** §1.1 asserts that ADMIN gains no data visibility
   implicitly. Worth confirming against the access model rather than the interface.
-- **Shared views and access.** S-4 asserts that a saved or shared view re-evaluates what each viewer
-  may see. This is the easiest place for the access boundary to leak, and it needs confirming rather
-  than assuming.
-- **The small-group threshold** is stated per surface today. It protects an individual from being
-  identified through a cohort, so it belongs to §5 with one agreed value.
+- **Saved and shared views** (S-4). Composing a view is in the vision; *saving* it and *sharing* it are
+  not. If sharing exists, the access rule has to come with it — what each viewer sees, re-evaluated for
+  them — and that is far cheaper to decide before the feature than after.
+- **An identity correction surviving the next sync** (S-8). The draft says merges and splits are
+  reversible; neither document says a correction is not undone by re-resolution. Stated here as a
+  requirement, because a correction that does not survive is not a correction.
+- **The two group-size thresholds** (§5, rule 10) are four for a group figure and eight per side for a
+  comparative conclusion. Both come from the scenario draft rather than from the vision, and they are
+  worth confirming as product rules — including whether a customer may configure them.
 - **IC has the narrowest surface and the tightest boundary.** Everything an IC sees is their own or a
   median — the combination that is easiest to get wrong quietly.
 - **S-6 has no surface yet.** Listed so the capability stays planned for, not to imply it exists.


### PR DESCRIPTION
Adds `docs/product/SCENARIOS.md` — a companion to `docs/product/VISION.md`. **Draft: the persona boundaries and the priority order are the two things worth arguing with.**

## Why

The vision states what Insight is and what it can do. It does not state **who is standing in front of each capability and how far they may reach** — and that boundary is where the product is easiest to get wrong quietly. "Work with metrics" is one capability, but an individual contributor sees their own work placed against a department or cohort median and no team metrics at all; a team manager sees their subtree and the people in it by name, with cohorts recomputed inside that scope rather than carried over from the organization; an executive sees the whole organization. The capability is shared; the boundary is not.

## What is in it

- **Personas** — the four target user groups of VISION §6.1, plus a *reach table*: scope, aggregation depth, named individuals, comparison, cost data, diagnosis access, and an explicit **Never** row per persona.
- **Nine main scenarios** — one per product capability of VISION §8, each attributed per persona with a `Can` / `Must never` table.
- **Classification and priority** — Core (the measure → diagnose → recommend → validate loop) vs Service (what makes it possible or safe), prioritised P0–P3 on one stated rule: *a service scenario outranks a core one when it gates it, or when its failure cannot be undone.* That puts Identity (S-2) and Configuration & access (S-7) at P0 alongside Measurement (S-4) — a wrong person makes every number wrong, and an access failure cannot be repaired by a later fix.
- **Rules that hold in every scenario** — evidence gaps shown not hidden, confidence travels with conclusions, lineage before attribution, no default stack ranking, role-based people-level access, cost movement preserved, observe-and-advise, clean room, role ⊥ activity. Taken from the vision and stated once rather than repeated per capability.

**Naming vs ranking.** The doc is explicit that these are different and only one is restricted: people are named wherever person-level access has been granted — a manager's team view names their reports, and that is the point of it. What VISION §3 rules out is a *default* view that ranks named individuals against one another, or an unexplained productivity score. The line is the default surface and the granted scope, not the name.

No new capability is introduced and no commitment is changed — everything traces to a VISION section, cited inline.

## How it is meant to be used

The level above feature specs: a feature changes, a scenario does not. Specs under `docs/components/<area>/specs/` say how a surface behaves; this says what must be true of every surface serving that capability, for each persona. The `Must never` columns are written as statements that can be checked, which is what makes them useful to QA as well.

## Open points (also listed in §4)

- **Administrative rights vs data visibility** — §1.1 asserts ADMIN gains no data visibility implicitly from admin rights. Worth confirming against the access model rather than the interface.
- **Small-group thresholds** are stated per surface today; they protect an individual from being identified through a cohort, so they arguably belong to the shared rules with one agreed value.
- **S-9 (benchmarks)** has no surface — listed so the capability stays planned for, not to imply it exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded the product-scenario documentation with three scenario tiers and four personas.
  * Added detailed scenarios covering review, analysis, recommendations, exploration, sharing, benchmarking, setup, identity, configuration, and deployment.
  * Documented rules for evidence, lineage, confidence, privacy, rankings, costs, access boundaries, and read-only behavior.
  * Added a scenario question appendix, capability mapping, and open product decisions.
  * Clarified persona-specific behaviors, permissions, and prohibitions across scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->