### PR TITLE
fix(frontend): honest empty states — never a fabricated zero (#1977)

### DIFF
--- a/src/frontend/src/lib/format.test.ts
+++ b/src/frontend/src/lib/format.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  NO_METRIC_VALUE,
   formatMetricNumber,
   formatMetricValue,
   formatPp,
@@ -22,6 +23,19 @@ describe("formatMetricNumber / formatMetricValue / metricDisplayUnit", () => {
     expect(formatMetricValue(42.4, "percent")).toBe("42%");
     expect(formatMetricValue(5, "integer", "h")).toBe("5 h");
     expect(formatMetricValue(5, "integer", null)).toBe("5");
+  });
+
+  it("renders no-data as an em-dash, never a fabricated zero", () => {
+    // A null/undefined/non-finite metric must read as "no data", never 0.
+    for (const empty of [null, undefined, NaN, Infinity, -Infinity] as const) {
+      expect(formatMetricNumber(empty, "integer")).toBe(NO_METRIC_VALUE);
+      expect(formatMetricValue(empty, "currency", "USD")).toBe(NO_METRIC_VALUE);
+      expect(formatMetricValue(empty, "percent")).toBe(NO_METRIC_VALUE);
+      expect(formatMetricValue(empty, "integer", "h")).toBe(NO_METRIC_VALUE);
+    }
+    // A real zero is still a real value and must format as such.
+    expect(formatMetricNumber(0, "integer")).toBe("0");
+    expect(formatMetricValue(0, "percent")).toBe("0%");
   });
 
   it("hides the side unit when the number already carries it", () => {

--- a/src/frontend/src/lib/format.ts
+++ b/src/frontend/src/lib/format.ts
@@ -13,25 +13,37 @@ const METRIC_CURRENCY_FORMAT = new Intl.NumberFormat(LOCALE, {
 });
 
 /**
+ * The em-dash stands in for a metric that has no honest value — a null,
+ * undefined, or non-finite result. It reads as "no data", never as a real
+ * zero (insight#1977).
+ */
+export const NO_METRIC_VALUE = "—";
+
+/**
  * Formatting for `/v1/metric-results` values: the wire `format` decides
  * rounding and presentation; `unit` is a display suffix only. Bare number —
  * no unit/percent suffix (use `formatMetricValue` for the suffixed form,
  * `metricDisplayUnit` when the unit renders as a separate element).
+ *
+ * A null/undefined/non-finite value renders as `NO_METRIC_VALUE`, never a
+ * fabricated `0`: honesty is guaranteed here rather than left to each caller.
  */
 export function formatMetricNumber(
-  v: number,
+  v: number | null | undefined,
   fmt: MetricFormat,
 ): string {
+  if (v == null || !Number.isFinite(v)) return NO_METRIC_VALUE;
   if (fmt === "currency") return METRIC_CURRENCY_FORMAT.format(v);
   const rounded = fmt === "decimal" ? Math.round(v * 10) / 10 : Math.round(v);
   return NF_THOUSANDS.format(rounded);
 }
 
 export function formatMetricValue(
-  v: number,
+  v: number | null | undefined,
   fmt: MetricFormat,
   unit?: string | null,
 ): string {
+  if (v == null || !Number.isFinite(v)) return NO_METRIC_VALUE;
   const s = formatMetricNumber(v, fmt);
   if (fmt === "currency") return s;
   if (fmt === "percent") return `${s}%`;


### PR DESCRIPTION
## What

Port of the **#1977** fix into the monorepo FE (`src/frontend`, merged from `insight-front` by #2223). **Supersedes insight-front#268** (opened before the monorepo merge).

## Context

#1977 ("honest empty states — kill mocks, NULL → Coming Soon") was already ~90% shipped in the FE: every metric render site routes null/no-data through explicit empty states (`—`, `ComingSoon`, chart/KPI placeholders), and mocks are gated behind `DEV && VITE_ENABLE_MOCKS`. The one real gap was the shared formatters.

## Change

`formatMetricNumber` / `formatMetricValue` typed their input as `number` with no internal null guard — `Math.round(null) === 0`, so a single forgetful (current or future) caller could silently render a **fabricated `0`** for missing data.

- Widen both to `number | null | undefined`; return a new exported `NO_METRIC_VALUE` (`—`) for null/undefined/non-finite. A real `0` still formats as `0`.
- The "no data, never a fake zero" guarantee is now **structural** (guaranteed in the formatter) rather than caller-dependent. Existing guarded call sites are unaffected — defense in depth.
- Added a `format.test.ts` case: null/undefined/NaN/±Infinity → `—`; real `0` → `0`/`0%`.

## Test

- `pnpm exec vitest run src/lib/format.test.ts` — 6/6 pass (incl. the new case).
- `pnpm typecheck` — clean (the widening breaks no callers).

Closes #1977
Part of #1803

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Missing or invalid metric values now display as “—” instead of producing misleading or unusable output.
  * Valid zero values continue to display correctly with their expected formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->