### PR TITLE
fix(chart): keycloakConfig.filesLocations — config-cli errors on globs with no matches

### DIFF
--- a/charts/insight/templates/clickhouse-migrate-job.yaml
+++ b/charts/insight/templates/clickhouse-migrate-job.yaml
@@ -21,9 +21,9 @@ main release (so the `clickhouse-init-svcdbs` pre-install Hook has created
 the app database and the app pods have rolled). post-* over pre-* is safe
 because gold-view consumers (analytics) resolve VIEW source tables
 lazily at query time, so views materialising shortly after pod startup is
-fine. (hook-weight "5" is inert today — it only orders hooks within the
-same phase, and this is currently the only post-* hook; kept as a
-placeholder for ordering future post-* hooks.)
+fine. (hook-weight 200 runs this AFTER the keycloak-config hook (100): helm
+executes same-phase hooks serially, and the quick realm import should
+not queue behind the dbt gold build.)
 
 Failure behavior: a failed migration is NOT silently tolerated. Helm blocks
 on the hook Job, so a non-zero exit fails `helm upgrade` (and, under the
@@ -53,7 +53,7 @@ metadata:
   name: {{ include "insight.fullname" . }}-clickhouse-migrate
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "5"
+    helm.sh/hook-weight: "200"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     {{- include "insight.labels" . | nindent 4 }}

--- a/charts/insight/templates/keycloak-config-job.yaml
+++ b/charts/insight/templates/keycloak-config-job.yaml
@@ -47,8 +47,10 @@ spec:
           env:
             - name: KEYCLOAK_URL
               value: {{ $kcUrl | quote }}
+            # config-cli errors on a glob with no matches, so list only the
+            # patterns the env's realms dir actually contains.
             - name: IMPORT_FILES_LOCATIONS
-              value: "/config/*.yaml,/config/*.json"
+              value: {{ .Values.keycloakConfig.filesLocations | quote }}
             # Resolves $(env:VAR) placeholders — how secrets reach realms.
             - name: IMPORT_VARSUBSTITUTION_ENABLED
               value: "true"

--- a/charts/insight/templates/keycloak-config-job.yaml
+++ b/charts/insight/templates/keycloak-config-job.yaml
@@ -19,7 +19,7 @@ metadata:
   name: {{ include "insight.fullname" . }}-keycloak-config
   annotations:
     helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-weight: "10"
+    helm.sh/hook-weight: "100"
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     {{- include "insight.labels" . | nindent 4 }}

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -445,6 +445,9 @@ keycloakConfig:
   # The Job also injects INSIGHT_TENANT_ID from global.tenantDefaultId (set):
   # realm IdP mappers pin the tenant per environment, never from IdP claims.
   extraEnv: []
+  # Glob(s) config-cli imports, comma-separated. Each glob MUST match at
+  # least one file. Local adds ',/config/*.json' for the generated realm.
+  filesLocations: "/config/*.yaml"
   # Pre-created realms ConfigMap (empty = <release>-keycloak-config-realms).
   realmsConfigMap: ""
   resources:

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -445,8 +445,9 @@ keycloakConfig:
   # The Job also injects INSIGHT_TENANT_ID from global.tenantDefaultId (set):
   # realm IdP mappers pin the tenant per environment, never from IdP claims.
   extraEnv: []
-  # Glob(s) config-cli imports, comma-separated. Each glob MUST match at
-  # least one file. Local adds ',/config/*.json' for the generated realm.
+  # Glob(s) config-cli imports, comma-separated. config-cli FAILS on any
+  # glob with zero matches — list only patterns the env's realms dir
+  # always contains. Local adds ',/config/*.json' for the generated realm.
   filesLocations: "/config/*.yaml"
   # Pre-created realms ConfigMap (empty = <release>-keycloak-config-realms).
   realmsConfigMap: ""

--- a/deploy/gitops/environments/local/keycloak/realms/zz-json-glob-placeholder.json
+++ b/deploy/gitops/environments/local/keycloak/realms/zz-json-glob-placeholder.json
@@ -1,0 +1,5 @@
+{
+  "realm": "zz-json-glob-placeholder",
+  "enabled": false,
+  "displayName": "Satisfies the /config/*.json import glob when the generated roster realm is absent; inert"
+}

--- a/deploy/gitops/environments/local/values.yaml.template
+++ b/deploy/gitops/environments/local/values.yaml.template
@@ -165,6 +165,8 @@ keycloak:
 
 keycloakConfig:
   enabled: true
+  # The roster realm is generated JSON (keycloak-realm target).
+  filesLocations: "/config/*.yaml,/config/*.json"
   # In-cluster hop over plain http — sandbox only.
   url: 'http://{{ .Release.Name }}-keycloak:8085/kc'
   allowInsecureUrl: true


### PR DESCRIPTION
Found on the first real-stand deploy: the config-cli hook Job hardcoded `IMPORT_FILES_LOCATIONS=/config/*.yaml,/config/*.json`, and keycloak-config-cli fails hard (`No files matching '/config/*.json'!`) when any listed glob matches nothing — which is every environment whose realms dir carries only YAML.

- `keycloakConfig.filesLocations` value, default `/config/*.yaml`.
- The local sandbox overlay sets `/config/*.yaml,/config/*.json` (its roster realm is generated JSON).
- The affected environment carries a temporary duplicate-env override until this releases.

`helm lint` + render verified for both value shapes.

Refs #2193 #2198

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable locations for Keycloak realm configuration files.
  * Local deployments now support both generated YAML and JSON realm files.

* **Documentation**
  * Added guidance that configured file patterns must match files available in the environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->