### PR TITLE
fix(frontend): read-only root filesystem for the frontend chart (#1340)

### DIFF
--- a/src/frontend/helm/templates/deployment.yaml
+++ b/src/frontend/helm/templates/deployment.yaml
@@ -43,10 +43,16 @@ spec:
               protocol: TCP
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: ["ALL"]
-            # No readOnlyRootFilesystem: the entrypoint renders the nginx config
-            # from /etc/nginx/templates at start, and nginx needs its cache dir.
+          volumeMounts:
+            # The only writes the image makes: nginx-unprivileged puts its pid and
+            # every *_temp_path in /tmp, the entrypoint writes the config to conf.d.
+            - name: tmp
+              mountPath: /tmp
+            - name: nginx-conf
+              mountPath: /etc/nginx/conf.d
           livenessProbe:
             httpGet:
               path: /healthz
@@ -61,3 +67,8 @@ spec:
             periodSeconds: 5
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: nginx-conf
+          emptyDir: {}


### PR DESCRIPTION
Closes the last open finding in #1340: `AVD-KSV-0014` on the frontend Deployment, the only HIGH left from that issue's original eight.

Same shape as #2119 did for analytics, authenticator and identity-resolution, so the seven charts now agree.

## What the image actually writes

Measured against the published image rather than assumed, since a wrong guess here takes the frontend down:

```
$ docker run --rm --read-only ghcr.io/constructorfabric/insight-front:latest
cp: can't create '/etc/nginx/conf.d/default.conf': File exists
```

Two paths, no others:

- **`/tmp`** — the base is `nginxinc/nginx-unprivileged`, whose `nginx.conf` already points `pid` and all five `*_temp_path` directives there.
- **`/etc/nginx/conf.d`** — `docker-entrypoint.sh` copies the served config in at start.

Both become an `emptyDir`. The pod already sets `fsGroup: 101`, so kubelet makes the volumes writable for the nginx uid; no extra permission handling is needed.

The `emptyDir` over `conf.d` masks the `default.conf` baked into the base image. That is not a loss — it differs from ours, and the entrypoint overwrites it today anyway.

## Test plan

- [x] `helm template` renders; the Deployment carries `readOnlyRootFilesystem: true`, two `volumeMounts` and two `volumes`.
- [x] Trivy on the rendered chart: **6 failures (HIGH: 1) → 5 (HIGH: 0)**. The remaining four LOW (KSV-0020, KSV-0021, KSV-0030, KSV-0110) and one MEDIUM (KSV-0104) are byte-identical before and after — nothing new introduced.
- [x] Published image under `--read-only` with the two mounts writable: container starts, `/` → 200, `/healthz` → 200, SPA fallback `/ic/1/personal` → 200, missing asset → 404 (the fallback does not swallow it). `/tmp` gets `nginx.pid` plus the five temp dirs, `conf.d` gets our config.
- [ ] Rollout in dev after the chart ships.

## Follow-up, not in this PR

`docker-entrypoint.sh` does nothing but that one `cp` — the Dockerfile comment states runtime templating is already gone. Copying the config into `conf.d` at build time in `constructorfabric/insight-front` would drop the second volume entirely. Verified it works, but it spans the other repo and needs an image rebuild, so it belongs in its own change.