### PR TITLE
docs: call Studio, Insight, and Gears elements, not products

### DIFF
--- a/docs/product/VISION.md
+++ b/docs/product/VISION.md
@@ -561,15 +561,15 @@ This layer does not weaken the ownership and control promise in Sections 2 and 3
 
 Business and monetization models for shared intelligence — acquiring useful public or commercial datasets, reselling third-party datasets where licensing permits, selling or licensing proprietary datasets, and offering anonymized aggregated benchmarks from participating customers — are out of scope for this document. The Vision describes the capability and its guardrails, not how it is offered commercially.
 
-## 13\. Constructor Fabric: Studio, Insight, and Gears
+## 13\. Constructor Fabric Elements: Studio, Insight, and Gears
 
-Constructor Insight is one of three Constructor Fabric products. Constructor Studio supports how software is specified, designed, and built. Constructor Gears provides reusable, operable components that applications are assembled from. Insight observes and improves how work is performed.
+Constructor Fabric has three elements: Constructor Studio, Constructor Insight, and Constructor Gears. Studio supports how software is specified, designed, and built. Gears provides reusable, operable components that applications are assembled from. Insight observes and improves how work is performed.
 
-Each product is usable on its own. The promises in Sections 2 and 3 are unchanged: Insight is tool-agnostic and source-agnostic, it does not require Studio or Gears, and no capability described in this document depends on them.
+Each element is usable on its own. The promises in Sections 2 and 3 are unchanged: Insight is tool-agnostic and source-agnostic, it does not require Studio or Gears, and no capability described in this document depends on them.
 
-Where a customer does run them, the three products enrich each other. Studio and Gears become high-quality evidence sources for Insight, and Insight's findings return to the place where they can be acted on. Evidence from Studio and Gears passes through the same connector evidence contract (Section 10.10) as any other source — declared fields, coverage, freshness, identity assumptions, and limitations.
+Where a customer does run them, the three elements enrich each other. Studio and Gears become high-quality evidence sources for Insight, and Insight's findings return to the place where they can be acted on. Evidence from Studio and Gears passes through the same connector evidence contract (Section 10.10) as any other source — declared fields, coverage, freshness, identity assumptions, and limitations.
 
-Studio and Gears also enrich each other directly: Studio composes applications from Gears modules and contributes reusable workflows and components back. That relationship sits outside Insight's boundary and is described in Fabric-level product material, not here.
+Studio and Gears also enrich each other directly: Studio composes applications from Gears modules and contributes reusable workflows and components back. That relationship sits outside Insight's boundary and is described in Fabric-level material, not here.
 
 ### 13.1 What Insight Consumes
 
@@ -715,6 +715,7 @@ Plain-language definitions; terminology is consistent across this document.
 | **Benchmark**            | An anonymized, aggregated comparison point — from the organization's own history, opt-in peer data, or public/market sources — declared with cohort definition, coverage, and confidence. Never individual-level. |
 | **Shared intelligence**  | The opt-in layer that combines an organization's own evidence with anonymized peer benchmarks and public/market data (Section 12). |
 | **Clean room**           | A data-sharing model where raw data never leaves its owner's boundary and only anonymized, aggregated results are exchanged. |
-| **Constructor Fabric**   | The product family Insight belongs to, alongside Constructor Studio and Constructor Gears (Section 13). |
-| **Constructor Studio**   | The Fabric product supporting how software is specified, designed, and built. An optional evidence source for Insight, and a destination for Insight's design and implementation findings. Not required to run Insight. |
-| **Constructor Gears**    | The Fabric product providing reusable, operable components that applications are assembled from. An optional source of operational evidence for Insight, and a destination for component-level findings. Not required to run Insight. |
+| **Constructor Fabric**   | The whole that Constructor Studio, Constructor Insight, and Constructor Gears are the three elements of (Section 13). |
+| **Element**              | One of the three parts of Constructor Fabric — Studio, Insight, or Gears. Preferred over describing them as three separate products. |
+| **Constructor Studio**   | The Fabric element supporting how software is specified, designed, and built. An optional evidence source for Insight, and a destination for Insight's design and implementation findings. Not required to run Insight. |
+| **Constructor Gears**    | The Fabric element providing reusable, operable components that applications are assembled from. An optional source of operational evidence for Insight, and a destination for component-level findings. Not required to run Insight. |


### PR DESCRIPTION
Follow-up to #2173. Studio, Insight, and Gears are the three **elements** of Constructor Fabric, not three separate products. Section 13 landed with the wrong term; this corrects it.

## Changes

- Section 13 heading: "Constructor Fabric: Studio, Insight, and Gears" -> "Constructor Fabric **Elements**: Studio, Insight, and Gears".
- Opening sentence now leads with Fabric having three elements, rather than positioning Insight as "one of three Constructor Fabric products".
- "Each product is usable on its own" -> "Each element is usable on its own"; "the three products enrich each other" -> "the three elements enrich each other".
- "Fabric-level product material" -> "Fabric-level material". With the term corrected, "product material" read ambiguously — it meant documentation, not a product.
- Glossary: `Constructor Fabric` redefined as the whole the three elements belong to; `Constructor Studio` and `Constructor Gears` described as Fabric elements; new `Element` entry recording the preferred term so the distinction survives future edits.

## One deliberate exception

Section 13.3 keeps the sentence "Insight remains an observation and analysis product." That describes what Insight *is*, not its membership in the triad, and it matches how Section 1 introduces Insight ("an AI-assisted intelligence product"). Changing it would read oddly in isolation.

Whether the standalone "product" framing should change document-wide — starting with Section 1's opening sentence — is a broader positioning question and is deliberately **not** touched here. Happy to follow up if the intent is that Insight is never called a product on its own either.

Docs-only change — no code, schema, or config touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the product vision to describe Constructor Fabric as three elements: Studio, Insight, and Gears.
  * Added an “Element” glossary definition and clarified terminology for Studio and Gears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->