### PR TITLE
feat(realm): tenant translation contract + single-tenant guard (Phase 3, #2196)

### DIFF
--- a/.github/workflows/keycloak-realm-contract.yml
+++ b/.github/workflows/keycloak-realm-contract.yml
@@ -1,0 +1,43 @@
+name: Keycloak realm — tenant claim contract
+
+# Guards the single-tenant_id invariant (ADR-0003 / DD-AUTH-04) against the
+# canonical broker realm: fail-closed with no tenant source, correct
+# group-to-tenant translation, and detection of the two cases token
+# inspection cannot see (two tenant groups; attribute shadowed by a group).
+# Boots a throwaway Keycloak in docker; no cluster.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "deploy/gitops/environments/*/keycloak/realms/**"
+      - "deploy/compose/keycloak/tests/**"
+      - ".github/workflows/keycloak-realm-contract.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  tenant-contract:
+    name: tenant translation guard
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install PyYAML
+        run: python3 -m pip install --quiet pyyaml
+
+      - name: Tenant translation guard
+        run: python3 deploy/compose/keycloak/tests/tenant_translation_guard.py

--- a/.github/workflows/keycloak-realm-contract.yml
+++ b/.github/workflows/keycloak-realm-contract.yml
@@ -1,10 +1,9 @@
 name: Keycloak realm — tenant claim contract
 
-# Guards the single-tenant_id invariant (ADR-0003 / DD-AUTH-04) against the
-# canonical broker realm: fail-closed with no tenant source, correct
-# group-to-tenant translation, and detection of the two cases token
-# inspection cannot see (two tenant groups; attribute shadowed by a group).
-# Boots a throwaway Keycloak in docker; no cluster.
+# Guards the pinned-tenant contract (ADR-0003 / DD-AUTH-04) against the
+# canonical broker realm: fail-closed with no pinned attribute, the pin
+# emitted verbatim as a single string, tenant-bearing groups inert AND
+# flagged as a policy violation. Boots a throwaway Keycloak in docker.
 
 on:
   pull_request:
@@ -24,7 +23,7 @@ permissions:
 
 jobs:
   tenant-contract:
-    name: tenant translation guard
+    name: tenant contract guard
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -40,4 +39,4 @@ jobs:
         run: python3 -m pip install --quiet pyyaml
 
       - name: Tenant translation guard
-        run: python3 deploy/compose/keycloak/tests/tenant_translation_guard.py
+        run: python3 deploy/compose/keycloak/tests/tenant_contract_guard.py

--- a/.github/workflows/keycloak-realm-contract.yml
+++ b/.github/workflows/keycloak-realm-contract.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.12"
+          python-version: "3.13"
 
       - name: Install PyYAML
         run: python3 -m pip install --quiet pyyaml

--- a/charts/insight/templates/secrets.yaml
+++ b/charts/insight/templates/secrets.yaml
@@ -201,8 +201,10 @@ stringData:
   APP__gears__authenticator__config__idp__client_secret: {{ .Values.authenticator.oidc.clientSecret | default "" | quote }}
   # Browser-facing callback the IdP redirects back to (through the gateway edge).
   APP__gears__authenticator__config__redirect_uri:       {{ tpl (required "authenticator.oidc.redirectUri is required" .Values.authenticator.oidc.redirectUri) . | quote }}
-  # Tenant resolution. `tenant_claim` = the id_token claim naming the user's
-  # tenant (Entra=`tid`; fakeidp/Keycloak=`tenant_id`). `default_tenant_id` is
+  # Tenant resolution. `tenant_claim` defaults to `tenant_id` and is FROZEN
+  # there (ADR-0003: the broker always emits `tenant_id`); the value remains
+  # configurable only for third-party consumers wiring a non-broker IdP
+  # directly (e.g. Entra=`tid`). `default_tenant_id` is
   # the single-tenant fallback, used ONLY when that claim is absent (Okta and
   # other claim-less IdPs — see #1853). It is sourced from `global.tenantDefaultId`
   # — the same single source of truth the rest of the platform keys on — so a

--- a/deploy/compose/keycloak/tests/tenant_contract_guard.py
+++ b/deploy/compose/keycloak/tests/tenant_contract_guard.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python3
-"""Single-tenant_id contract guard (ADR-0003, insight#2196).
+"""Pinned-tenant contract guard (ADR-0003, insight#2196).
 
-Imports the canonical broker realm into a throwaway Keycloak and asserts the
-tenant claim contract the platform relies on (DD-AUTH-04: exactly one string
-tenant, or none — never two, never an ambiguous source):
+The tenant is ALWAYS the pinned per-registration value (a user attribute
+stamped by each IdP mapper); an IdP's own tenancy assertions are never
+consulted, and group-sourced tenants are rejected by policy. Imports the
+canonical broker realm into a throwaway Keycloak and asserts:
 
-1. no tenant source          -> token carries NO tenant_id (fail closed)
-2. one tenant group          -> token tenant_id == that group's value (string)
-3. two tenant groups         -> AMBIGUOUS: Keycloak silently emits one of
-                                them, so the token cannot reveal the problem;
-                                the guard's membership check must flag it
-4. user attribute + group    -> AMBIGUOUS: the group value shadows the
-                                pinned attribute; flagged the same way
+1. clean baseline            -> the canonical realm ships zero tenant groups
+2. no pinned attribute       -> token carries NO tenant_id (fail closed)
+3. pinned attribute          -> token tenant_id == the pin, a single string
+4. tenant-bearing group      -> must NOT influence the token (no aggregation)
+                                AND the realm scan flags it as a violation
 
 Requires docker and PyYAML. Boots quay.io/keycloak/keycloak, converts the
 canonical realm YAML to a realm representation (env placeholders substituted
@@ -47,9 +46,8 @@ SYNTHETIC = {
     "INSIGHT_TENANT_ID": "00000000-0000-0000-0000-00000000feed",
 }
 
-TENANT_A = "aaaaaaaa-0000-0000-0000-000000000001"
-TENANT_B = "bbbbbbbb-0000-0000-0000-000000000002"
-TENANT_ATTR = "cccccccc-0000-0000-0000-000000000003"
+TENANT_GROUP = "aaaaaaaa-0000-0000-0000-000000000001"
+TENANT_PIN = "cccccccc-0000-0000-0000-000000000003"
 
 
 def sh(*args: str) -> None:
@@ -110,27 +108,14 @@ def tenant_claim(admin: Admin, client_id: str, user_id: str):
     return token.get("tenant_id")
 
 
-def tenant_group_count(admin: Admin, user_id: str) -> int:
-    groups = admin.realm(f"/users/{user_id}/groups")
-    with_tenant = 0
-    for g in groups:
+def tenant_bearing_groups(admin: Admin) -> list[str]:
+    """Policy scan: NO group in the realm may carry a tenant_id attribute."""
+    offenders = []
+    for g in admin.realm("/groups"):
         detail = admin.realm(f"/groups/{g['id']}")
         if (detail.get("attributes") or {}).get("tenant_id"):
-            with_tenant += 1
-    return with_tenant
-
-
-def has_pinned_attribute(admin: Admin, user_id: str) -> bool:
-    user = admin.realm(f"/users/{user_id}")
-    return bool((user.get("attributes") or {}).get("tenant_id"))
-
-
-def unambiguous_tenant_source(admin: Admin, user_id: str) -> bool:
-    """The invariant: exactly one tenant source. Token inspection cannot see
-    a violation (Keycloak silently emits one value), so this checks sources."""
-    groups = tenant_group_count(admin, user_id)
-    attr = has_pinned_attribute(admin, user_id)
-    return (groups + (1 if attr else 0)) <= 1
+            offenders.append(g["name"])
+    return offenders
 
 
 def main() -> int:
@@ -168,9 +153,8 @@ def main() -> int:
         profile["unmanagedAttributePolicy"] = "ADMIN_EDIT"
         admin.realm("/users/profile", "PUT", profile)
 
-        admin.realm("/groups", "POST", {"name": "tenant-a", "attributes": {"tenant_id": [TENANT_A]}})
-        admin.realm("/groups", "POST", {"name": "tenant-b", "attributes": {"tenant_id": [TENANT_B]}})
-        groups = {g["name"]: g["id"] for g in admin.realm("/groups")}
+        check("clean-baseline", not tenant_bearing_groups(admin), "canonical realm ships zero tenant groups")
+
         admin.realm(
             "/users",
             "POST",
@@ -180,40 +164,32 @@ def main() -> int:
         client = admin.realm("/clients?clientId=insight-authenticator")[0]["id"]
 
         claim = tenant_claim(admin, client, user)
-        check("fail-closed", claim is None, f"no tenant source -> claim {claim!r}")
-
-        admin.realm(f"/users/{user}/groups/{groups['tenant-a']}", "PUT")
-        claim = tenant_claim(admin, client, user)
-        check("group-translation", claim == TENANT_A, f"one group -> claim {claim!r}")
-        check("single-source(1 group)", unambiguous_tenant_source(admin, user), "one tenant source")
-
-        admin.realm(f"/users/{user}/groups/{groups['tenant-b']}", "PUT")
-        claim = tenant_claim(admin, client, user)
-        check(
-            "two-groups-detected",
-            not unambiguous_tenant_source(admin, user),
-            f"two tenant groups; token silently emits {claim!r} — sources check must flag it",
-        )
+        check("fail-closed", claim is None, f"no pinned attribute -> claim {claim!r}")
 
         u = admin.realm(f"/users/{user}")
-        u["attributes"] = {"tenant_id": [TENANT_ATTR]}
+        u["attributes"] = {"tenant_id": [TENANT_PIN]}
         admin.realm(f"/users/{user}", "PUT", u)
         claim = tenant_claim(admin, client, user)
-        check(
-            "mixed-source-detected",
-            not unambiguous_tenant_source(admin, user),
-            f"attribute + groups; token emits {claim!r} (group shadows pin) — flagged",
-        )
+        check("pinned-tenant", claim == TENANT_PIN, f"pinned attribute -> claim {claim!r}")
+        check("claim-is-scalar", isinstance(claim, str), f"claim type {type(claim).__name__}")
 
+        admin.realm("/groups", "POST", {"name": "tenant-a", "attributes": {"tenant_id": [TENANT_GROUP]}})
+        groups = {g["name"]: g["id"] for g in admin.realm("/groups")}
+        admin.realm(f"/users/{user}/groups/{groups['tenant-a']}", "PUT")
         claim = tenant_claim(admin, client, user)
-        check("claim-is-scalar", claim is None or isinstance(claim, str), f"claim type {type(claim).__name__}")
+        check("group-inert", claim == TENANT_PIN, f"tenant group must not affect the token -> claim {claim!r}")
+        check(
+            "group-policy-detected",
+            bool(tenant_bearing_groups(admin)),
+            "a tenant-bearing group exists and the realm scan flags it",
+        )
     finally:
         subprocess.run(["docker", "rm", "-f", CONTAINER], capture_output=True, check=False)
 
     if failures:
-        print(f"\ntenant-translation guard FAILED: {failures}")
+        print(f"\ntenant-contract guard FAILED: {failures}")
         return 1
-    print("\ntenant-translation guard OK")
+    print("\ntenant-contract guard OK")
     return 0
 
 

--- a/deploy/compose/keycloak/tests/tenant_contract_guard.py
+++ b/deploy/compose/keycloak/tests/tenant_contract_guard.py
@@ -84,7 +84,7 @@ class Admin:
             headers=headers,
             data=raw if raw is not None else (json.dumps(body).encode() if body is not None else None),
         )
-        with urllib.request.urlopen(req) as resp:
+        with urllib.request.urlopen(req, timeout=30) as resp:
             payload = resp.read()
             return json.loads(payload) if payload else None
 
@@ -108,14 +108,50 @@ def tenant_claim(admin: Admin, client_id: str, user_id: str):
     return token.get("tenant_id")
 
 
+def all_groups(admin: Admin) -> list[dict]:
+    groups, first, page = [], 0, 100
+    while True:
+        batch = admin.realm(f"/groups?first={first}&max={page}")
+        groups.extend(batch)
+        if len(batch) < page:
+            return groups
+        first += page
+
+
 def tenant_bearing_groups(admin: Admin) -> list[str]:
     """Policy scan: NO group in the realm may carry a tenant_id attribute."""
     offenders = []
-    for g in admin.realm("/groups"):
+    for g in all_groups(admin):
         detail = admin.realm(f"/groups/{g['id']}")
         if (detail.get("attributes") or {}).get("tenant_id"):
             offenders.append(g["name"])
     return offenders
+
+
+def registration_violations(realm_doc: dict) -> list[str]:
+    """Static contract on a realm file: every IdP registration must pin the
+    tenant (hardcoded mapper from the INSIGHT_TENANT_ID placeholder) and
+    stamp idp_sub; no group may carry a tenant_id attribute."""
+    problems = []
+    mappers = realm_doc.get("identityProviderMappers") or []
+    for idp in realm_doc.get("identityProviders") or []:
+        alias = idp.get("alias", "?")
+        mine = [m for m in mappers if m.get("identityProviderAlias") == alias]
+        pins = [
+            m
+            for m in mine
+            if m.get("identityProviderMapper") == "hardcoded-attribute-idp-mapper"
+            and (m.get("config") or {}).get("attribute") == "tenant_id"
+            and (m.get("config") or {}).get("attribute.value") == "$(env:INSIGHT_TENANT_ID)"
+        ]
+        if len(pins) != 1:
+            problems.append(f"idp '{alias}': expected exactly one INSIGHT_TENANT_ID pin mapper, found {len(pins)}")
+        if not any((m.get("config") or {}).get("user.attribute") == "idp_sub" for m in mine):
+            problems.append(f"idp '{alias}': no mapper stamps the idp_sub attribute")
+    for g in realm_doc.get("groups") or []:
+        if (g.get("attributes") or {}).get("tenant_id"):
+            problems.append(f"group '{g.get('name')}': carries a tenant_id attribute")
+    return problems
 
 
 def main() -> int:
@@ -125,6 +161,14 @@ def main() -> int:
         print(f"{'ok  ' if ok else 'FAIL'} {name}: {detail}")
         if not ok:
             failures.append(name)
+
+    for realm_file in sorted(REPO_ROOT.glob("deploy/gitops/environments/*/keycloak/realms/*.yaml")):
+        problems = registration_violations(yaml.safe_load(realm_file.read_text()))
+        check(
+            f"registrations({realm_file.parent.parent.parent.name})",
+            not problems,
+            f"{realm_file.name}: {problems or 'contract holds'}",
+        )
 
     realm = substitute(yaml.safe_load(CANONICAL_REALM.read_text()))
 
@@ -147,7 +191,11 @@ def main() -> int:
     try:
         wait_for_keycloak()
         admin = Admin()
-        admin._call("/admin/realms", "POST", realm)
+        try:
+            admin._call("/admin/realms", "POST", realm)
+        except urllib.error.HTTPError as e:
+            check("realm-import", False, f"canonical realm rejected: HTTP {e.code} {e.read()[:200]!r}")
+            return 1
 
         profile = admin.realm("/users/profile")
         profile["unmanagedAttributePolicy"] = "ADMIN_EDIT"

--- a/deploy/compose/keycloak/tests/tenant_contract_guard.py
+++ b/deploy/compose/keycloak/tests/tenant_contract_guard.py
@@ -84,7 +84,10 @@ class Admin:
             headers=headers,
             data=raw if raw is not None else (json.dumps(body).encode() if body is not None else None),
         )
-        with urllib.request.urlopen(req, timeout=30) as resp:
+        # URLs are module constants targeting the throwaway 127.0.0.1 Keycloak.
+        with urllib.request.urlopen(
+            req, timeout=30
+        ) as resp:  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
             payload = resp.read()
             return json.loads(payload) if payload else None
 
@@ -96,7 +99,9 @@ def wait_for_keycloak(timeout_s: int = 180) -> None:
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
         try:
-            urllib.request.urlopen(f"{BASE}/realms/master/.well-known/openid-configuration", timeout=3)
+            urllib.request.urlopen(
+                f"{BASE}/realms/master/.well-known/openid-configuration", timeout=3
+            )  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected, python.lang.security.audit.insecure-transport.urllib.insecure-urlopen.insecure-urlopen
             return
         except (urllib.error.URLError, OSError):
             time.sleep(3)

--- a/deploy/compose/keycloak/tests/tenant_contract_guard.py
+++ b/deploy/compose/keycloak/tests/tenant_contract_guard.py
@@ -85,9 +85,8 @@ class Admin:
             data=raw if raw is not None else (json.dumps(body).encode() if body is not None else None),
         )
         # URLs are module constants targeting the throwaway 127.0.0.1 Keycloak.
-        with urllib.request.urlopen(
-            req, timeout=30
-        ) as resp:  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+        with urllib.request.urlopen(req, timeout=30) as resp:
             payload = resp.read()
             return json.loads(payload) if payload else None
 
@@ -99,9 +98,8 @@ def wait_for_keycloak(timeout_s: int = 180) -> None:
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
         try:
-            urllib.request.urlopen(
-                f"{BASE}/realms/master/.well-known/openid-configuration", timeout=3
-            )  # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected, python.lang.security.audit.insecure-transport.urllib.insecure-urlopen.insecure-urlopen
+            # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected, python.lang.security.audit.insecure-transport.urllib.insecure-urlopen.insecure-urlopen
+            urllib.request.urlopen(f"{BASE}/realms/master/.well-known/openid-configuration", timeout=3)
             return
         except (urllib.error.URLError, OSError):
             time.sleep(3)

--- a/deploy/compose/keycloak/tests/tenant_translation_guard.py
+++ b/deploy/compose/keycloak/tests/tenant_translation_guard.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Single-tenant_id contract guard (ADR-0003, insight#2196).
+
+Imports the canonical broker realm into a throwaway Keycloak and asserts the
+tenant claim contract the platform relies on (DD-AUTH-04: exactly one string
+tenant, or none — never two, never an ambiguous source):
+
+1. no tenant source          -> token carries NO tenant_id (fail closed)
+2. one tenant group          -> token tenant_id == that group's value (string)
+3. two tenant groups         -> AMBIGUOUS: Keycloak silently emits one of
+                                them, so the token cannot reveal the problem;
+                                the guard's membership check must flag it
+4. user attribute + group    -> AMBIGUOUS: the group value shadows the
+                                pinned attribute; flagged the same way
+
+Requires docker and PyYAML. Boots quay.io/keycloak/keycloak, converts the
+canonical realm YAML to a realm representation (env placeholders substituted
+with synthetic values), creates it via the admin API, and evaluates example
+tokens. Exit 0 = contract holds.
+"""
+
+# ruff: noqa: T201  — stdout IS this script's CI report.
+
+import json
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CANONICAL_REALM = REPO_ROOT / "deploy/gitops/environments/local/keycloak/realms/insight-broker.yaml"
+KC_IMAGE = "quay.io/keycloak/keycloak:26.4"
+KC_PORT = 18086
+BASE = f"http://127.0.0.1:{KC_PORT}"
+CONTAINER = "tenant-guard-kc"
+
+PLACEHOLDER = re.compile(r"\$\(env:([A-Za-z_][A-Za-z0-9_]*)\)")
+SYNTHETIC = {
+    "INSIGHT_AUTHENTICATOR_CLIENT_SECRET": "guard-secret",
+    "INSIGHT_AUTHENTICATOR_REDIRECT_URI": "http://localhost/auth/callback",
+    "INSIGHT_TENANT_ID": "00000000-0000-0000-0000-00000000feed",
+}
+
+TENANT_A = "aaaaaaaa-0000-0000-0000-000000000001"
+TENANT_B = "bbbbbbbb-0000-0000-0000-000000000002"
+TENANT_ATTR = "cccccccc-0000-0000-0000-000000000003"
+
+
+def sh(*args: str) -> None:
+    subprocess.run(args, check=True, capture_output=True)
+
+
+def substitute(node):
+    if isinstance(node, str):
+        return PLACEHOLDER.sub(lambda m: SYNTHETIC.get(m.group(1), f"missing-{m.group(1)}"), node)
+    if isinstance(node, list):
+        return [substitute(v) for v in node]
+    if isinstance(node, dict):
+        return {k: substitute(v) for k, v in node.items()}
+    return node
+
+
+class Admin:
+    def __init__(self) -> None:
+        self.token = self._call(
+            "/realms/master/protocol/openid-connect/token",
+            method="POST",
+            raw=urllib.parse.urlencode(
+                {"grant_type": "password", "client_id": "admin-cli", "username": "admin", "password": "admin"}
+            ).encode(),
+        )["access_token"]
+
+    def _call(self, path: str, method: str = "GET", body=None, raw: bytes | None = None):
+        headers = {"Content-Type": "application/x-www-form-urlencoded" if raw else "application/json"}
+        if hasattr(self, "token"):
+            headers["Authorization"] = f"Bearer {self.token}"
+        req = urllib.request.Request(
+            f"{BASE}{path}",
+            method=method,
+            headers=headers,
+            data=raw if raw is not None else (json.dumps(body).encode() if body is not None else None),
+        )
+        with urllib.request.urlopen(req) as resp:
+            payload = resp.read()
+            return json.loads(payload) if payload else None
+
+    def realm(self, path: str, method: str = "GET", body=None):
+        return self._call(f"/admin/realms/insight-broker{path}", method, body)
+
+
+def wait_for_keycloak(timeout_s: int = 180) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            urllib.request.urlopen(f"{BASE}/realms/master/.well-known/openid-configuration", timeout=3)
+            return
+        except (urllib.error.URLError, OSError):
+            time.sleep(3)
+    raise TimeoutError("Keycloak did not come up")
+
+
+def tenant_claim(admin: Admin, client_id: str, user_id: str):
+    token = admin.realm(f"/clients/{client_id}/evaluate-scopes/generate-example-id-token?userId={user_id}&scope=openid")
+    return token.get("tenant_id")
+
+
+def tenant_group_count(admin: Admin, user_id: str) -> int:
+    groups = admin.realm(f"/users/{user_id}/groups")
+    with_tenant = 0
+    for g in groups:
+        detail = admin.realm(f"/groups/{g['id']}")
+        if (detail.get("attributes") or {}).get("tenant_id"):
+            with_tenant += 1
+    return with_tenant
+
+
+def has_pinned_attribute(admin: Admin, user_id: str) -> bool:
+    user = admin.realm(f"/users/{user_id}")
+    return bool((user.get("attributes") or {}).get("tenant_id"))
+
+
+def unambiguous_tenant_source(admin: Admin, user_id: str) -> bool:
+    """The invariant: exactly one tenant source. Token inspection cannot see
+    a violation (Keycloak silently emits one value), so this checks sources."""
+    groups = tenant_group_count(admin, user_id)
+    attr = has_pinned_attribute(admin, user_id)
+    return (groups + (1 if attr else 0)) <= 1
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    def check(name: str, ok: bool, detail: str) -> None:
+        print(f"{'ok  ' if ok else 'FAIL'} {name}: {detail}")
+        if not ok:
+            failures.append(name)
+
+    realm = substitute(yaml.safe_load(CANONICAL_REALM.read_text()))
+
+    subprocess.run(["docker", "rm", "-f", CONTAINER], capture_output=True, check=False)
+    sh(
+        "docker",
+        "run",
+        "-d",
+        "--name",
+        CONTAINER,
+        "-p",
+        f"127.0.0.1:{KC_PORT}:8080",
+        "-e",
+        "KC_BOOTSTRAP_ADMIN_USERNAME=admin",
+        "-e",
+        "KC_BOOTSTRAP_ADMIN_PASSWORD=admin",
+        KC_IMAGE,
+        "start-dev",
+    )
+    try:
+        wait_for_keycloak()
+        admin = Admin()
+        admin._call("/admin/realms", "POST", realm)
+
+        profile = admin.realm("/users/profile")
+        profile["unmanagedAttributePolicy"] = "ADMIN_EDIT"
+        admin.realm("/users/profile", "PUT", profile)
+
+        admin.realm("/groups", "POST", {"name": "tenant-a", "attributes": {"tenant_id": [TENANT_A]}})
+        admin.realm("/groups", "POST", {"name": "tenant-b", "attributes": {"tenant_id": [TENANT_B]}})
+        groups = {g["name"]: g["id"] for g in admin.realm("/groups")}
+        admin.realm(
+            "/users",
+            "POST",
+            {"username": "guard@example.com", "email": "guard@example.com", "enabled": True, "emailVerified": True},
+        )
+        user = admin.realm("/users?username=guard@example.com&exact=true")[0]["id"]
+        client = admin.realm("/clients?clientId=insight-authenticator")[0]["id"]
+
+        claim = tenant_claim(admin, client, user)
+        check("fail-closed", claim is None, f"no tenant source -> claim {claim!r}")
+
+        admin.realm(f"/users/{user}/groups/{groups['tenant-a']}", "PUT")
+        claim = tenant_claim(admin, client, user)
+        check("group-translation", claim == TENANT_A, f"one group -> claim {claim!r}")
+        check("single-source(1 group)", unambiguous_tenant_source(admin, user), "one tenant source")
+
+        admin.realm(f"/users/{user}/groups/{groups['tenant-b']}", "PUT")
+        claim = tenant_claim(admin, client, user)
+        check(
+            "two-groups-detected",
+            not unambiguous_tenant_source(admin, user),
+            f"two tenant groups; token silently emits {claim!r} — sources check must flag it",
+        )
+
+        u = admin.realm(f"/users/{user}")
+        u["attributes"] = {"tenant_id": [TENANT_ATTR]}
+        admin.realm(f"/users/{user}", "PUT", u)
+        claim = tenant_claim(admin, client, user)
+        check(
+            "mixed-source-detected",
+            not unambiguous_tenant_source(admin, user),
+            f"attribute + groups; token emits {claim!r} (group shadows pin) — flagged",
+        )
+
+        claim = tenant_claim(admin, client, user)
+        check("claim-is-scalar", claim is None or isinstance(claim, str), f"claim type {type(claim).__name__}")
+    finally:
+        subprocess.run(["docker", "rm", "-f", CONTAINER], capture_output=True, check=False)
+
+    if failures:
+        print(f"\ntenant-translation guard FAILED: {failures}")
+        return 1
+    print("\ntenant-translation guard OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/gitops/README.md
+++ b/deploy/gitops/README.md
@@ -254,14 +254,35 @@ so an IdP swap or upstream drift cannot change the tenant. Canonical
 realm shape to copy:
 [`environments/local/keycloak/realms/insight-broker.yaml`](environments/local/keycloak/realms/insight-broker.yaml).
 
-The guard `deploy/compose/keycloak/tests/tenant_translation_guard.py`
-(CI lane) enforces the pinned-tenant contract against the canonical
-realm: no tenant source means no claim (fail closed), the pinned
-attribute is emitted verbatim as a single string, and no group in the
-realm may carry a `tenant_id` attribute — group-sourced tenants are
-rejected by policy (an IdP's own tenancy assertions are never
-consulted; a customer with several IdPs pins the same tenant on each
-registration).
+Every IdP registration carries the same two mappers — the tenant pin
+and the upstream-id stamp (a customer with several IdPs pins the same
+tenant on each; an IdP's own tenancy assertions are never consulted):
+
+```yaml
+identityProviderMappers:
+  - name: tenant-id
+    identityProviderAlias: <alias>
+    identityProviderMapper: hardcoded-attribute-idp-mapper
+    config:
+      syncMode: FORCE
+      attribute: tenant_id
+      attribute.value: <env placeholder INSIGHT_TENANT_ID>
+  - name: idp-sub
+    identityProviderAlias: <alias>
+    identityProviderMapper: oidc-user-attribute-idp-mapper
+    config:
+      syncMode: FORCE
+      claim: <upstream stable id claim, e.g. Entra oid>
+      user.attribute: idp_sub
+```
+
+CI runs `deploy/compose/keycloak/tests/tenant_contract_guard.py` — a
+contract test, not an audit of deployed realms: it statically checks
+every committed realm file (each registration has exactly one tenant
+pin and an `idp_sub` stamp; no group carries a `tenant_id` attribute)
+and imports the canonical realm into a throwaway Keycloak to assert
+token behavior (fail closed without the pin, pin emitted verbatim as a
+single string, tenant-bearing groups inert).
 
 ## Secret management
 

--- a/deploy/gitops/README.md
+++ b/deploy/gitops/README.md
@@ -254,6 +254,35 @@ so an IdP swap or upstream drift cannot change the tenant. Canonical
 realm shape to copy:
 [`environments/local/keycloak/realms/insight-broker.yaml`](environments/local/keycloak/realms/insight-broker.yaml).
 
+Where a SINGLE upstream registration serves several tenants, translate
+inside the realm instead of pinning: per-tenant groups carry the
+internal UUID in a `tenant_id` group attribute, and one advanced
+claim-to-group mapper per external tenant value puts the user in its
+group (`syncMode: FORCE`; unmapped values fail closed — no group, no
+`tenant_id`, token rejected downstream):
+
+```yaml
+groups:
+  - name: tenant-example-corp
+    attributes:
+      tenant_id: ["033dcbad-2374-4548-a9fa-04e2d5e0889a"]
+identityProviderMappers:
+  - name: tenant-example-corp
+    identityProviderAlias: upstream
+    identityProviderMapper: oidc-advanced-group-idp-mapper
+    config:
+      syncMode: FORCE
+      claims: '[{"key":"tid","value":"<external tenant value>"}]'
+      group: /tenant-example-corp
+```
+
+The canonical scope's `tenant_id` mapper aggregates over groups, so no
+scope change is needed. Two rules the CI guard
+(`deploy/compose/keycloak/tests/tenant_translation_guard.py`) enforces:
+a user must never sit in two tenant groups, and never mix the pinned
+attribute with tenant groups — Keycloak silently emits one value in
+both cases, so only source inspection catches it.
+
 ## Secret management
 
 Sealed secrets ([Bitnami sealed-secrets](https://github.com/bitnami-labs/sealed-secrets))

--- a/deploy/gitops/README.md
+++ b/deploy/gitops/README.md
@@ -254,34 +254,14 @@ so an IdP swap or upstream drift cannot change the tenant. Canonical
 realm shape to copy:
 [`environments/local/keycloak/realms/insight-broker.yaml`](environments/local/keycloak/realms/insight-broker.yaml).
 
-Where a SINGLE upstream registration serves several tenants, translate
-inside the realm instead of pinning: per-tenant groups carry the
-internal UUID in a `tenant_id` group attribute, and one advanced
-claim-to-group mapper per external tenant value puts the user in its
-group (`syncMode: FORCE`; unmapped values fail closed — no group, no
-`tenant_id`, token rejected downstream):
-
-```yaml
-groups:
-  - name: tenant-example-corp
-    attributes:
-      tenant_id: ["033dcbad-2374-4548-a9fa-04e2d5e0889a"]
-identityProviderMappers:
-  - name: tenant-example-corp
-    identityProviderAlias: upstream
-    identityProviderMapper: oidc-advanced-group-idp-mapper
-    config:
-      syncMode: FORCE
-      claims: '[{"key":"tid","value":"<external tenant value>"}]'
-      group: /tenant-example-corp
-```
-
-The canonical scope's `tenant_id` mapper aggregates over groups, so no
-scope change is needed. Two rules the CI guard
-(`deploy/compose/keycloak/tests/tenant_translation_guard.py`) enforces:
-a user must never sit in two tenant groups, and never mix the pinned
-attribute with tenant groups — Keycloak silently emits one value in
-both cases, so only source inspection catches it.
+The guard `deploy/compose/keycloak/tests/tenant_translation_guard.py`
+(CI lane) enforces the pinned-tenant contract against the canonical
+realm: no tenant source means no claim (fail closed), the pinned
+attribute is emitted verbatim as a single string, and no group in the
+realm may carry a `tenant_id` attribute — group-sourced tenants are
+rejected by policy (an IdP's own tenancy assertions are never
+consulted; a customer with several IdPs pins the same tenant on each
+registration).
 
 ## Secret management
 

--- a/deploy/gitops/environments/local/keycloak/realms/insight-broker.yaml
+++ b/deploy/gitops/environments/local/keycloak/realms/insight-broker.yaml
@@ -10,10 +10,15 @@ realm: insight-broker
 enabled: true
 
 clientScopes:
-  # The claim allow-list: tokens carry exactly email + single-string tenant_id
-  # (plus protocol-level sub). tenant_id is a user attribute stamped per IdP by
-  # a hardcoded-attribute-idp-mapper from the INSIGHT_TENANT_ID placeholder
-  # (global.tenantDefaultId) — pinned per env, never from an upstream claim.
+  # The claim allow-list: tokens carry exactly email, single-string tenant_id,
+  # and idp_sub (plus protocol-level sub). tenant_id comes from a user
+  # attribute OR a tenant group's attribute (aggregation below): fixed
+  # per-registration installs stamp the attribute from INSIGHT_TENANT_ID
+  # (global.tenantDefaultId — pinned per env, never an upstream claim);
+  # single-registration-multi-tenant installs put users in per-tenant groups
+  # via claim-to-group translation (see the gitops README). idp_sub carries
+  # the upstream directory id (e.g. Entra oid) for the login-bootstrap
+  # person lookup, stamped per IdP by an attribute-importer mapper.
   - name: insight
     description: Canonical Insight claim allow-list (email + single-string tenant_id)
     protocol: openid-connect
@@ -40,6 +45,23 @@ clientScopes:
         config:
           user.attribute: tenant_id
           claim.name: tenant_id
+          jsonType.label: String
+          # Aggregate over groups: a tenant group's tenant_id attribute is
+          # emitted when the user carries none. Exactly one tenant group per
+          # user is an invariant (tenant-translation guard).
+          aggregate.attrs: "true"
+          multivalued: "false"
+          id.token.claim: "true"
+          access.token.claim: "true"
+          userinfo.token.claim: "true"
+      # Upstream directory id passthrough (login-bootstrap external id).
+      - name: idp_sub
+        protocol: openid-connect
+        protocolMapper: oidc-usermodel-attribute-mapper
+        consentRequired: false
+        config:
+          user.attribute: idp_sub
+          claim.name: idp_sub
           jsonType.label: String
           id.token.claim: "true"
           access.token.claim: "true"

--- a/deploy/gitops/environments/local/keycloak/realms/insight-broker.yaml
+++ b/deploy/gitops/environments/local/keycloak/realms/insight-broker.yaml
@@ -11,14 +11,12 @@ enabled: true
 
 clientScopes:
   # The claim allow-list: tokens carry exactly email, single-string tenant_id,
-  # and idp_sub (plus protocol-level sub). tenant_id comes from a user
-  # attribute OR a tenant group's attribute (aggregation below): fixed
-  # per-registration installs stamp the attribute from INSIGHT_TENANT_ID
-  # (global.tenantDefaultId — pinned per env, never an upstream claim);
-  # single-registration-multi-tenant installs put users in per-tenant groups
-  # via claim-to-group translation (see the gitops README). idp_sub carries
-  # the upstream directory id (e.g. Entra oid) for the login-bootstrap
-  # person lookup, stamped per IdP by an attribute-importer mapper.
+  # and idp_sub (plus protocol-level sub). tenant_id is ALWAYS the pinned
+  # per-registration tenant: every IdP's hardcoded-attribute-idp-mapper stamps
+  # INSIGHT_TENANT_ID (global.tenantDefaultId); a customer with several IdPs
+  # pins the same tenant on each. What an IdP asserts about tenancy is never
+  # consulted. idp_sub carries the upstream directory id (e.g. Entra oid) for
+  # the login-bootstrap person lookup, stamped per IdP by an importer mapper.
   - name: insight
     description: Canonical Insight claim allow-list (email + single-string tenant_id)
     protocol: openid-connect
@@ -46,11 +44,6 @@ clientScopes:
           user.attribute: tenant_id
           claim.name: tenant_id
           jsonType.label: String
-          # Aggregate over groups: a tenant group's tenant_id attribute is
-          # emitted when the user carries none. Exactly one tenant group per
-          # user is an invariant (tenant-translation guard).
-          aggregate.attrs: "true"
-          multivalued: "false"
           id.token.claim: "true"
           access.token.claim: "true"
           userinfo.token.claim: "true"

--- a/docs/components/backend/authenticator/specs/ADR/0003-keycloak-identity-broker.md
+++ b/docs/components/backend/authenticator/specs/ADR/0003-keycloak-identity-broker.md
@@ -9,6 +9,13 @@ date: 2026-08-04
 
 **Status history**:
 
+- 2026-08-06: AMENDED -- claim-value-to-tenant translation (the advanced claim-to-group mapper
+  sketched in the Decision Outcome) is REJECTED: the tenant is always the fixed per-registration
+  pin from environment values, an IdP's own tenancy assertions are never consulted, and a
+  customer with several IdPs pins the same tenant on each registration. Two customers sharing
+  an IdP vendor do not intersect: realm-per-customer gives each its own registration, client,
+  and pin. A CI guard asserts the contract against the canonical realm (fail-closed without the
+  pin, single-string claim, tenant-bearing groups inert and flagged).
 - 2026-08-05: AMENDED -- of the instance-deployment options this ADR left open, the umbrella
   subchart is chosen: the broker runs **in-stack** (production-mode `insight-keycloak`,
   MariaDB-backed) as part of each environment's auth services, amending ADR-0002's shared

--- a/docs/components/backend/authenticator/specs/ADR/0003-keycloak-identity-broker.md
+++ b/docs/components/backend/authenticator/specs/ADR/0003-keycloak-identity-broker.md
@@ -111,19 +111,18 @@ for multi-customer (cloud) installations (see realm selection below).
   secrets; nothing lands in the repository or an image (the #2163 credentials criterion). The
   admin UI is read-only in practice: `KeycloakRealmImport` and hand edits are not configuration
   channels, and config-cli re-applies the versioned realm on every sync, reverting drift.
-- **Claims are shaped at the broker.** Per-provider **identity provider mappers** inject or
-  import the Insight `tenant_id` (`hardcoded-attribute-idp-mapper` for a fixed per-registration
-  tenant; claim-importer mappers where the upstream carries tenancy, e.g. Entra `tid`). The
-  client's **protocol mappers / client scopes** are the allow-list: the token contains only what
-  is explicitly emitted -- `sub`, `email`, one string `tenant_id` -- matching what the compose
-  realm generator already emits today. Upstream claims never pass through by default. Where a
-  single upstream registration itself distinguishes tenants by a claim value, the external value
-  is translated inside the realm: an advanced claim-to-group mapper (`syncMode: FORCE`) puts the
-  user in a per-tenant group whose `tenant_id` attribute carries the internal UUID, emitted by
-  the protocol mapper with group-attribute aggregation. The translation table is realm YAML, one
-  entry per external tenant, and an unmapped value fails closed -- no group, no `tenant_id`
-  claim, token rejected downstream. Exactly one group per user is an invariant the end-to-end
-  tests guard.
+- **Claims are shaped at the broker.** Every provider registration carries a
+  `hardcoded-attribute-idp-mapper` pinning the fixed per-registration Insight `tenant_id` from
+  environment values, plus an attribute-importer stamping `idp_sub` (the upstream's stable
+  directory id, e.g. Entra `oid` -- the login-bootstrap external id). An upstream's own tenancy
+  assertions are never consulted (amended 2026-08-06; the claim-to-group translation once
+  sketched here is rejected): a customer with several IdPs pins the same tenant on each
+  registration, and two customers sharing an IdP vendor never intersect -- realm-per-customer
+  gives each its own registration, client, and pin. The client's **protocol mappers / client
+  scopes** are the allow-list: the token contains only what is explicitly emitted -- `sub`,
+  `email`, one string `tenant_id`, `idp_sub` -- and deliberately does NOT aggregate attributes
+  over groups, so a group-sourced tenant is mechanically impossible; a CI guard asserts the
+  contract on every committed realm file and against a live import.
 - **Topology: one realm per customer**, holding that customer's brokered IdPs and one
   confidential client. The single-`tenant_id` rule holds because each provider registration (or
   upstream tenancy claim) maps to exactly one Insight tenant. Realm-per-tenant remains available


### PR DESCRIPTION
## What (boxes 1–3 of #2196, per the pinned-tenant decision)

**Tenant policy — pinned only, translation REJECTED.** Review decision on this PR: the tenant is *always* the fixed per-registration pin (`INSIGHT_TENANT_ID` from environment values); an IdP's own tenancy assertions are never consulted; a customer with several IdPs pins the same tenant on each registration. The claim-to-group translation sketched in ADR-0003 is rejected — the ADR is amended in this PR (status-history entry; `cfs` clean for authenticator artifacts). Two customers sharing an IdP vendor never intersect: realm-per-customer gives each its own registration, client, and pin.

**Canonical claim contract** — the `insight` scope formalizes `idp_sub` (upstream directory id feeding the login-bootstrap, proven on the first migrated stand). No group aggregation: without it a tenant-bearing group *cannot* influence the token, eliminating the shadowing hazard at the mechanism level rather than policing it.

**Pinned-contract CI guard** — `deploy/compose/keycloak/tests/tenant_contract_guard.py` + a small workflow lane (docker Keycloak, no cluster). It imports the **actual canonical realm file** and asserts against real token evaluation:
- clean baseline: the canonical realm ships zero tenant-bearing groups
- no pinned attribute → claim absent (fail closed)
- pinned attribute → emitted verbatim, a single string
- a tenant-bearing group is **inert** (token unchanged) *and* flagged by the realm scan as a policy violation

All four verified green locally against KC 26.4.

**`tenant_claim` freeze** — already defaults to `tenant_id` at every surface; the chart comment records the freeze per ADR-0003, configurable only for third-party consumers wiring a non-broker IdP directly.

Refs #2196
Part of #2193

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added identity-provider subject identifiers to authentication tokens.
  * Added automated validation for tenant isolation and token-claim behavior.
  * Added manual and change-triggered CI checks for Keycloak tenant configuration.

* **Documentation**
  * Clarified that tenant assignment is fixed per identity provider and fails closed when unavailable.
  * Documented configurable tenant claims for direct identity-provider integrations.
  * Clarified that upstream tenant claims and groups cannot override the pinned tenant.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->