### PR TITLE
feat(authenticator): host-keyed issuer map (#2197)

### DIFF
--- a/docs/components/backend/authenticator/openapi.json
+++ b/docs/components/backend/authenticator/openapi.json
@@ -191,9 +191,19 @@
         "responses": {
           "302": {
             "description": "Redirect to the IdP authorize endpoint"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
           }
         },
-        "summary": "Start the OIDC code+PKCE login flow",
+        "summary": "Start the OIDC code+PKCE login flow (the request Host selects the issuer)",
         "tags": [
           "auth"
         ]

--- a/src/backend/services/authenticator/src/api/handlers.rs
+++ b/src/backend/services/authenticator/src/api/handlers.rs
@@ -48,10 +48,19 @@ pub struct LoginParams {
 }
 
 /// Start the OIDC code+PKCE flow: stash state/nonce/verifier, 302 to the IdP.
+/// The request `Host` selects the issuer (ADR-0003) — the gateway forwards
+/// the browser's hostname (`proxy_set_header Host $host`); an unmatched host
+/// is rejected fail closed before any state is written.
 pub async fn login(
     Extension(state): Extension<Arc<AppState>>,
+    headers: axum::http::HeaderMap,
     Query(params): Query<LoginParams>,
 ) -> Response {
+    let host = request_host(&headers);
+    let Some(oidc) = state.oidc.for_host(&host) else {
+        return login_denied_unknown_host(&state, &headers, &host);
+    };
+
     let return_to = sanitize_return_to(
         params.return_to.as_deref(),
         &state.cfg.default_return_to,
@@ -117,11 +126,7 @@ pub async fn login(
 
     // openidconnect generates the state, nonce, and PKCE pair; we stash the
     // verifier + nonce under the state key for the callback to replay.
-    let start = match state
-        .oidc
-        .authorize(&state.cfg.redirect_uri, &state.cfg.oidc_scopes)
-        .await
-    {
+    let start = match oidc.authorize(&state.cfg.oidc_scopes).await {
         Ok(s) => s,
         Err(e) => return internal_problem("oidc_authorize", &e),
     };
@@ -134,6 +139,7 @@ pub async fn login(
                 pkce_verifier: start.pkce_verifier,
                 nonce: start.nonce,
                 return_to,
+                issuer: oidc.issuer().to_owned(),
                 override_email,
             },
             300,
@@ -246,14 +252,21 @@ pub async fn callback(
         Err(e) => return internal_problem("login_state_take", &e),
     };
 
-    let idp = match state
-        .oidc
-        .exchange_code_pkce(
-            &state.cfg.redirect_uri,
-            &code,
-            &login_state.pkce_verifier,
-            &login_state.nonce,
-        )
+    // The issuer was pinned at login time; the callback's own Host plays no
+    // part (its ambiguity must not re-route a flow mid-exchange). Unresolvable
+    // only when the map changed while the login was in flight.
+    let Some(oidc) = state.oidc.for_stored_issuer(&login_state.issuer) else {
+        tracing::warn!(
+            target: "audit",
+            event = "callback_denied_unknown_issuer",
+            issuer = %login_state.issuer,
+            "callback denied: login state names an issuer that is no longer configured"
+        );
+        return login_error_redirect(&state.cfg.default_return_to, "access_denied");
+    };
+
+    let idp = match oidc
+        .exchange_code_pkce(&code, &login_state.pkce_verifier, &login_state.nonce)
         .await
     {
         Ok(idp) => idp,
@@ -375,6 +388,55 @@ pub async fn callback(
         }
         Err(e) => internal_problem("create_session", &e),
     }
+}
+
+/// The request's `Host` header — nginx forwards the browser's hostname
+/// (`proxy_set_header Host $host`). Read directly rather than through an
+/// extractor honoring `X-Forwarded-Host`, which the gateway does not set and
+/// a client could therefore inject.
+fn request_host(headers: &axum::http::HeaderMap) -> String {
+    headers
+        .get(axum::http::header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_owned()
+}
+
+/// Fail-closed 403 for a `/auth/login` whose `Host` matches no configured
+/// issuer (ADR-0003), audited like the other login denials. No redirect: the
+/// hostname is not one this deployment serves, so there is no SPA to bounce
+/// back into.
+fn login_denied_unknown_host(
+    state: &AppState,
+    headers: &axum::http::HeaderMap,
+    host: &str,
+) -> Response {
+    // Client-reachable log path: strip control characters so a hostile Host
+    // value cannot forge log lines, and cap the length.
+    let host: String = host.chars().filter(|c| !c.is_control()).take(255).collect();
+    tracing::warn!(
+        target: "audit",
+        event = "login_denied_unknown_host",
+        host,
+        "login denied: request Host matches no configured issuer"
+    );
+    let client = ClientInfo::from_headers(headers);
+    state.audit.emit(AuditEvent {
+        action: "login",
+        outcome: "failure",
+        tenant_id: String::new(),
+        actor_person_id: String::new(),
+        actor_ip: client.ip,
+        actor_user_agent: client.user_agent,
+        correlation_id: correlation_id(headers),
+        resource_type: "session",
+        resource_id: String::new(),
+        details: serde_json::json!({ "reason": "unknown_host", "host": host }),
+    });
+    OidcError::permission_denied()
+        .with_reason("unknown_host")
+        .create()
+        .into_response()
 }
 
 /// Client attribution captured at login for the session list (PRD 5.9):
@@ -966,10 +1028,10 @@ pub async fn logout(
             correlation_id(&headers),
             serde_json::json!({}),
         ));
-        if let Some(url) = state
-            .oidc
-            .rp_logout_url(&record.id_token, &state.cfg.default_return_to)
-            .await
+        if let Some(oidc) = state.oidc.for_stored_issuer(&record.idp_iss)
+            && let Some(url) = oidc
+                .rp_logout_url(&record.id_token, &state.cfg.default_return_to)
+                .await
         {
             rp_logout_url = serde_json::Value::String(url);
         }
@@ -1221,8 +1283,25 @@ pub async fn back_channel_logout(
             .into_response();
     };
 
+    // The token's `iss` (peeked unverified) selects the issuer whose JWKS and
+    // claim checks then validate it in full — a forged `iss` either names no
+    // configured issuer (rejected here) or fails signature verification below.
+    let Some(oidc) =
+        crate::issuers::unverified_issuer(raw).and_then(|iss| state.oidc.for_issuer(&iss))
+    else {
+        tracing::warn!(
+            target: "audit",
+            event = "back_channel_denied_unknown_issuer",
+            "back-channel: logout_token names no configured issuer"
+        );
+        return OidcError::invalid_argument()
+            .with_field_violation("logout_token", "unknown issuer", "INVALID_LOGOUT_TOKEN")
+            .create()
+            .into_response();
+    };
+
     // The IdP's keys — fetched per call (cold path, picks up rotation).
-    let jwks = match state.oidc.idp_jwks().await {
+    let jwks = match oidc.idp_jwks().await {
         Ok(jwks) => jwks,
         Err(e) => {
             tracing::warn!(
@@ -1241,8 +1320,8 @@ pub async fn back_channel_logout(
     let claims = match crate::backchannel::validate_logout_token(
         &jwks,
         raw,
-        state.oidc.issuer(),
-        state.oidc.client_id(),
+        oidc.issuer(),
+        oidc.client_id(),
         now,
         cfg.backchannel_clock_skew_seconds,
         cfg.backchannel_token_max_age_seconds,
@@ -1266,7 +1345,7 @@ pub async fn back_channel_logout(
     );
     match state
         .sessions
-        .guard_logout_jti(state.oidc.issuer(), &claims.jti, ttl)
+        .guard_logout_jti(oidc.issuer(), &claims.jti, ttl)
         .await
     {
         Ok(true) => {}
@@ -1278,9 +1357,9 @@ pub async fn back_channel_logout(
     }
 
     let result = match &claims.sid {
-        Some(idp_sid) => revoke_by_sid_index(&state, idp_sid).await,
+        Some(idp_sid) => revoke_by_sid_index(&state, oidc.issuer(), idp_sid).await,
         None => match &claims.sub {
-            Some(sub) => revoke_by_sub_fallback(&state, sub).await,
+            Some(sub) => revoke_by_sub_fallback(&state, oidc.issuer(), sub).await,
             None => unreachable!("validator requires sub or sid"),
         },
     };
@@ -1321,7 +1400,7 @@ pub async fn back_channel_logout(
             // not happen. Revoke is idempotent, so re-processing is safe.
             if let Err(re) = state
                 .sessions
-                .release_logout_jti(state.oidc.issuer(), &claims.jti)
+                .release_logout_jti(oidc.issuer(), &claims.jti)
                 .await
             {
                 tracing::warn!(error = %re, "back-channel: failed to release jti guard after revoke error");
@@ -1332,11 +1411,8 @@ pub async fn back_channel_logout(
 }
 
 /// Revoke every session indexed under the token's `(iss, sid)`.
-async fn revoke_by_sid_index(state: &AppState, idp_sid: &str) -> anyhow::Result<u64> {
-    let session_ids = state
-        .sessions
-        .sessions_by_idp_sid(state.oidc.issuer(), idp_sid)
-        .await?;
+async fn revoke_by_sid_index(state: &AppState, issuer: &str, idp_sid: &str) -> anyhow::Result<u64> {
+    let session_ids = state.sessions.sessions_by_idp_sid(issuer, idp_sid).await?;
     let mut revoked = 0u64;
     for sid in &session_ids {
         if state.sessions.revoke_session(sid).await? {
@@ -1350,11 +1426,12 @@ async fn revoke_by_sid_index(state: &AppState, idp_sid: &str) -> anyhow::Result<
 /// EVERYTHING for the users behind `(iss, sub)` — with the operator-facing
 /// log line the runbook calls out, so a misconfigured IdP that omits `sid`
 /// is visible, not silent.
-async fn revoke_by_sub_fallback(state: &AppState, idp_sub: &str) -> anyhow::Result<u64> {
-    let session_ids = state
-        .sessions
-        .sessions_by_idp_sub(state.oidc.issuer(), idp_sub)
-        .await?;
+async fn revoke_by_sub_fallback(
+    state: &AppState,
+    issuer: &str,
+    idp_sub: &str,
+) -> anyhow::Result<u64> {
+    let session_ids = state.sessions.sessions_by_idp_sub(issuer, idp_sub).await?;
     // Resolve the distinct person(s) behind those sessions, then run the
     // standard revoke-everything pipeline per person.
     let mut persons: Vec<String> = Vec::new();

--- a/src/backend/services/authenticator/src/api/mod.rs
+++ b/src/backend/services/authenticator/src/api/mod.rs
@@ -12,8 +12,8 @@ use toolkit::api::{OpenApiInfo, OpenApiRegistry, OpenApiRegistryImpl, OperationB
 
 use crate::config::AuthenticatorConfig;
 use crate::identity::PersonResolver;
+use crate::issuers::IssuerSelector;
 use crate::jwt::KeyStore;
-use crate::oidc::OidcClient;
 use crate::service_token::ServiceRegistry;
 use crate::session::SessionManager;
 
@@ -23,7 +23,9 @@ pub struct AppState {
     pub cfg: AuthenticatorConfig,
     pub sessions: SessionManager,
     pub keystore: Arc<KeyStore>,
-    pub oidc: OidcClient,
+    /// The configured OIDC issuer(s): host-keyed at `/auth/login`, pinned by
+    /// issuer everywhere else (ADR-0003).
+    pub oidc: IssuerSelector,
     pub resolver: Arc<dyn PersonResolver>,
     /// Parsed service-token registry (DD-AUTH-05); used by the token listener.
     pub service_registry: ServiceRegistry,
@@ -72,10 +74,11 @@ fn register_auth_routes(router: Router, openapi: &dyn OpenApiRegistry) -> Router
 
     router = OperationBuilder::get("/auth/login")
         .operation_id("authenticator.login")
-        .summary("Start the OIDC code+PKCE login flow")
+        .summary("Start the OIDC code+PKCE login flow (the request Host selects the issuer)")
         .tag("auth")
         .public()
         .no_content_response(StatusCode::FOUND, "Redirect to the IdP authorize endpoint")
+        .error_403(openapi)
         .handler(handlers::login)
         .register(router, openapi);
 

--- a/src/backend/services/authenticator/src/config.rs
+++ b/src/backend/services/authenticator/src/config.rs
@@ -23,6 +23,26 @@ pub enum NoRefreshTokenPolicy {
     LoginOnly,
 }
 
+/// One host-keyed issuer entry: the issuer and its client registration —
+/// the only per-realm settings; everything else in [`IdpConfig`] is global.
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(default, deny_unknown_fields)]
+pub struct HostIdpConfig {
+    /// OIDC issuer URL of this host's realm (discovery root; byte-exact match
+    /// against the realm's own discovery document, like the flat `issuer_url`).
+    pub issuer_url: String,
+    /// Confidential-client id registered with this realm.
+    pub client_id: String,
+    /// Confidential-client secret; empty = public client + PKCE.
+    pub client_secret: String,
+    /// The redirect URI registered with this realm's client; empty = the
+    /// global `redirect_uri`.
+    pub redirect_uri: String,
+    /// Fallback tenant for this realm when the id_token carries no tenant
+    /// claim; empty = the global `idp.default_tenant_id`.
+    pub default_tenant_id: String,
+}
+
 /// OIDC provider settings and the background-refresh knobs (§4.1 `idp.*`).
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]
@@ -63,6 +83,14 @@ pub struct IdpConfig {
     /// only the default store. Mount the PEM file into the pod and point
     /// this at its path.
     pub extra_ca_cert_path: String,
+    /// Host-keyed issuer map (ADR-0003). Empty (default) = single-issuer
+    /// mode: the flat fields above match EVERY host. Non-empty = exact match
+    /// on the normalized `Host` only, unlisted hosts fail closed, and the
+    /// flat client fields take no part in selection. Keys are bare
+    /// hostnames. Also accepts a JSON string, so one `APP__…__idp__hosts`
+    /// env var carries the whole map (env layers can't nest maps).
+    #[serde(deserialize_with = "de_hosts")]
+    pub hosts: HashMap<String, HostIdpConfig>,
     /// Background refresh of IdP tokens per session (workers land in step 10).
     pub refresh_enabled: bool,
     /// Refresh IdP tokens this long before their expiry.
@@ -89,6 +117,7 @@ impl Default for IdpConfig {
             external_id_claim: "sub".to_owned(),
             default_tenant_id: String::new(),
             extra_ca_cert_path: String::new(),
+            hosts: HashMap::new(),
             refresh_enabled: true,
             refresh_safety_margin_seconds: 60,
             refresh_concurrency: 128,
@@ -358,6 +387,25 @@ fn de_scopes<'de, D: serde::Deserializer<'de>>(d: D) -> Result<Vec<String>, D::E
     })
 }
 
+/// `idp.hosts` deserializes from a native map or a JSON string (the env-var
+/// form — env layers can't express nested maps).
+fn de_hosts<'de, D: serde::Deserializer<'de>>(
+    d: D,
+) -> Result<HashMap<String, HostIdpConfig>, D::Error> {
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum MapOrStr {
+        Map(HashMap<String, HostIdpConfig>),
+        Str(String),
+    }
+    match MapOrStr::deserialize(d)? {
+        MapOrStr::Map(m) => Ok(m),
+        MapOrStr::Str(s) if s.trim().is_empty() => Ok(HashMap::new()),
+        MapOrStr::Str(s) => serde_json::from_str(&s)
+            .map_err(|e| serde::de::Error::custom(format!("idp.hosts JSON string: {e}"))),
+    }
+}
+
 impl Default for AuthenticatorConfig {
     fn default() -> Self {
         Self {
@@ -430,12 +478,37 @@ impl AuthenticatorConfig {
             ("redirect_uri", &self.redirect_uri),
             ("signing_keys_path", &self.signing_keys_path),
             ("identity_url", &self.identity_url),
-            ("idp.issuer_url", &self.idp.issuer_url),
-            ("idp.client_id", &self.idp.client_id),
             ("idp.source_type", &self.idp.source_type),
             ("idp.external_id_claim", &self.idp.external_id_claim),
         ] {
             anyhow::ensure!(!value.trim().is_empty(), "{name} is required (empty)");
+        }
+
+        if self.idp.hosts.is_empty() {
+            for (name, value) in [
+                ("idp.issuer_url", &self.idp.issuer_url),
+                ("idp.client_id", &self.idp.client_id),
+            ] {
+                anyhow::ensure!(!value.trim().is_empty(), "{name} is required (empty)");
+            }
+        }
+        for (host, entry) in &self.idp.hosts {
+            anyhow::ensure!(
+                !host.trim().is_empty()
+                    && !host.contains('/')
+                    && !host.contains(':')
+                    && !host.chars().any(char::is_whitespace),
+                "idp.hosts key {host:?} must be a bare hostname (no scheme, port, or path)"
+            );
+            for (name, value) in [
+                ("issuer_url", &entry.issuer_url),
+                ("client_id", &entry.client_id),
+            ] {
+                anyhow::ensure!(
+                    !value.trim().is_empty(),
+                    "idp.hosts.{host}.{name} is required (empty)"
+                );
+            }
         }
 
         // `default_return_to` lands verbatim in Location headers (login
@@ -549,6 +622,78 @@ mod tests {
                 ..valid_config()
             };
             assert!(cfg.validate().is_err(), "should reject prefix {bad:?}");
+        }
+    }
+
+    #[test]
+    fn idp_hosts_parses_native_map_and_json_string_shapes() {
+        let yaml = r#"
+issuer_url: ""
+client_id: ""
+source_type: faketest
+hosts:
+  a.example:
+    issuer_url: https://kc.example/realms/a
+    client_id: client-a
+    client_secret: s3cret
+"#;
+        let idp: IdpConfig = serde_yaml::from_str(yaml).expect("map shape parses");
+        assert_eq!(idp.hosts.len(), 1);
+        assert_eq!(
+            idp.hosts["a.example"].issuer_url,
+            "https://kc.example/realms/a"
+        );
+
+        let yaml = r#"
+source_type: faketest
+hosts: '{"b.example": {"issuer_url": "https://kc.example/realms/b", "client_id": "client-b"}}'
+"#;
+        let idp: IdpConfig = serde_yaml::from_str(yaml).expect("JSON-string shape parses");
+        assert_eq!(idp.hosts["b.example"].client_id, "client-b");
+
+        // Empty string = no map (an unset env override must stay degenerate).
+        let idp: IdpConfig = serde_yaml::from_str("hosts: \"\"").expect("empty string parses");
+        assert!(idp.hosts.is_empty());
+
+        // A malformed JSON string fails loudly, never silently degenerate.
+        assert!(serde_yaml::from_str::<IdpConfig>("hosts: '{broken'").is_err());
+    }
+
+    #[test]
+    fn flat_issuer_fields_required_only_without_a_hosts_map() {
+        let mut cfg = valid_config();
+        cfg.idp.issuer_url = String::new();
+        assert!(cfg.validate().is_err(), "flat issuer_url required");
+
+        let entry = HostIdpConfig {
+            issuer_url: "https://kc.example/realms/a".to_owned(),
+            client_id: "client-a".to_owned(),
+            ..HostIdpConfig::default()
+        };
+        let mut cfg = valid_config();
+        cfg.idp.issuer_url = String::new();
+        cfg.idp.client_id = String::new();
+        cfg.idp.hosts = HashMap::from([("a.example".to_owned(), entry.clone())]);
+        assert!(
+            cfg.validate().is_ok(),
+            "map replaces the flat client fields"
+        );
+
+        let mut cfg = valid_config();
+        cfg.idp.hosts = HashMap::from([(
+            "a.example".to_owned(),
+            HostIdpConfig {
+                issuer_url: String::new(),
+                ..entry.clone()
+            },
+        )]);
+        assert!(cfg.validate().is_err(), "entry issuer_url required");
+
+        // Keys must be bare hostnames: no scheme, port, path, or whitespace.
+        for bad in ["https://a.example", "a.example:8443", "a.example/x", "a b"] {
+            let mut cfg = valid_config();
+            cfg.idp.hosts = HashMap::from([(bad.to_owned(), entry.clone())]);
+            assert!(cfg.validate().is_err(), "should reject key {bad:?}");
         }
     }
 

--- a/src/backend/services/authenticator/src/gear.rs
+++ b/src/backend/services/authenticator/src/gear.rs
@@ -18,9 +18,9 @@ use toolkit::{Gear, GearCtx, RestApiCapability, RunnableCapability};
 use crate::api::{self, AppState};
 use crate::config::AuthenticatorConfig;
 use crate::identity::{IdentityPersonResolver, PersonResolver};
+use crate::issuers::IssuerSelector;
 use crate::jwt::KeyStore;
 use crate::local_client::LocalClient;
-use crate::oidc::OidcClient;
 use crate::service_token::{self, ServiceRegistry};
 use crate::session::SessionManager;
 
@@ -51,6 +51,7 @@ impl Gear for AuthenticatorGear {
         tracing::info!(
             gateway_issuer = %cfg.gateway_issuer,
             idp_issuer = %cfg.idp.issuer_url,
+            idp_hosts = cfg.idp.hosts.len(),
             "starting authenticator gear"
         );
 
@@ -64,7 +65,7 @@ impl Gear for AuthenticatorGear {
         let sessions = SessionManager::connect(&cfg.redis_url).await?;
         sessions.ping().await?;
 
-        let oidc = OidcClient::new(&cfg.idp)?;
+        let oidc = IssuerSelector::build(&cfg)?;
         // The resolver authenticates its internal Identity lookup with a service
         // JWT it mints via the same keystore (fail-closed Identity, R1).
         let resolver: Arc<dyn PersonResolver> = Arc::new(IdentityPersonResolver::new(

--- a/src/backend/services/authenticator/src/issuers.rs
+++ b/src/backend/services/authenticator/src/issuers.rs
@@ -1,0 +1,238 @@
+//! Host-keyed issuer selection (ADR-0003): the request `Host` picks the
+//! broker realm, but only where a flow STARTS (`/auth/login`); everywhere
+//! else (callback, refresh, logout) the issuer is already pinned server-side
+//! and Host is never re-consulted. Empty `idp.hosts` = single-issuer mode,
+//! matching every host; in map mode an unmatched host fails closed.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::config::AuthenticatorConfig;
+use crate::oidc::OidcClient;
+
+/// The configured issuers, keyed by normalized host and by issuer URL.
+pub struct IssuerSelector {
+    by_host: HashMap<String, Arc<OidcClient>>,
+    by_issuer: HashMap<String, Arc<OidcClient>>,
+    /// Single-issuer (degenerate) mode: this client matches every host.
+    any_host: Option<Arc<OidcClient>>,
+}
+
+impl IssuerSelector {
+    /// Build every issuer's client up front (fail closed at boot, not on the
+    /// first login), sharing one HTTP connection pool.
+    ///
+    /// # Errors
+    /// Fails on an unbuildable HTTP client (bad `extra_ca_cert_path`), two
+    /// host keys normalizing to the same host, or one issuer URL appearing
+    /// under two hosts (sessions pin the issuer alone, so it must resolve to
+    /// exactly one client registration).
+    pub fn build(cfg: &AuthenticatorConfig) -> anyhow::Result<Self> {
+        let idp = &cfg.idp;
+        let http = crate::oidc::build_http(idp)?;
+
+        if idp.hosts.is_empty() {
+            let client = Arc::new(OidcClient::flat(idp, &cfg.redirect_uri, http));
+            return Ok(Self {
+                by_host: HashMap::new(),
+                by_issuer: HashMap::from([(idp.issuer_url.clone(), client.clone())]),
+                any_host: Some(client),
+            });
+        }
+
+        let mut by_host = HashMap::new();
+        let mut by_issuer: HashMap<String, Arc<OidcClient>> = HashMap::new();
+        for (host, entry) in &idp.hosts {
+            let client = Arc::new(OidcClient::for_host(
+                idp,
+                entry,
+                &cfg.redirect_uri,
+                http.clone(),
+            ));
+            let key = normalize_host(host);
+            anyhow::ensure!(
+                by_host.insert(key.clone(), client.clone()).is_none(),
+                "idp.hosts: two keys normalize to the same host {key:?}"
+            );
+            anyhow::ensure!(
+                by_issuer.insert(entry.issuer_url.clone(), client).is_none(),
+                "idp.hosts: issuer {:?} appears under two hosts — an issuer must map \
+                 to exactly one client registration (sessions resolve by issuer alone)",
+                entry.issuer_url
+            );
+        }
+        Ok(Self {
+            by_host,
+            by_issuer,
+            any_host: None,
+        })
+    }
+
+    /// Select the issuer for a flow-starting request by its `Host` header.
+    /// `None` = no configured issuer serves this host: reject fail closed.
+    #[must_use]
+    pub fn for_host(&self, host: &str) -> Option<Arc<OidcClient>> {
+        if let Some(single) = &self.any_host {
+            return Some(single.clone());
+        }
+        self.by_host.get(&normalize_host(host)).cloned()
+    }
+
+    /// Resolve a server-side pinned issuer (session record / validated token).
+    #[must_use]
+    pub fn for_issuer(&self, issuer: &str) -> Option<Arc<OidcClient>> {
+        self.by_issuer.get(issuer).cloned()
+    }
+
+    /// Like [`Self::for_issuer`], tolerating the empty issuer that state
+    /// written by a pre-map replica carries: in single-issuer mode it can
+    /// only mean the one client; in map mode it stays unresolvable.
+    #[must_use]
+    pub fn for_stored_issuer(&self, issuer: &str) -> Option<Arc<OidcClient>> {
+        if issuer.is_empty() {
+            return self.any_host.clone();
+        }
+        self.for_issuer(issuer)
+    }
+}
+
+/// Canonical form of a request `Host` / map key for the exact-match lookup:
+/// lowercased, port stripped (`:8443`; bracketed IPv6 literals keep their
+/// colons), trailing FQDN dot dropped. Anything beyond that (scheme, path,
+/// userinfo) is not a hostname and simply won't match a validated map key.
+#[must_use]
+pub fn normalize_host(raw: &str) -> String {
+    let host = raw.trim().to_ascii_lowercase();
+    let host = match host.strip_prefix('[') {
+        Some(rest) => rest.split(']').next().unwrap_or(rest).to_owned(),
+        None => match host.rsplit_once(':') {
+            Some((name, port)) if !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()) => {
+                name.to_owned()
+            }
+            _ => host,
+        },
+    };
+    host.trim_end_matches('.').to_owned()
+}
+
+/// Peek a `logout_token`'s `iss` claim WITHOUT verification — used only to
+/// select the issuer whose JWKS/claims checks then validate the token in
+/// full, so a forged `iss` buys nothing but a verification failure.
+#[must_use]
+pub fn unverified_issuer(jwt: &str) -> Option<String> {
+    crate::oidc::payload_string(jwt, "iss")
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::config::{HostIdpConfig, IdpConfig};
+
+    fn cfg_with_hosts(hosts: &[(&str, &str)]) -> AuthenticatorConfig {
+        AuthenticatorConfig {
+            redirect_uri: "https://gw.example/auth/callback".to_owned(),
+            idp: IdpConfig {
+                issuer_url: "https://idp.example".to_owned(),
+                client_id: "flat-client".to_owned(),
+                hosts: hosts
+                    .iter()
+                    .map(|(host, issuer)| {
+                        (
+                            (*host).to_owned(),
+                            HostIdpConfig {
+                                issuer_url: (*issuer).to_owned(),
+                                client_id: format!("client-{issuer}"),
+                                ..HostIdpConfig::default()
+                            },
+                        )
+                    })
+                    .collect(),
+                ..IdpConfig::default()
+            },
+            ..AuthenticatorConfig::default()
+        }
+    }
+
+    #[test]
+    fn empty_map_is_single_issuer_mode_matching_any_host() {
+        let selector = IssuerSelector::build(&cfg_with_hosts(&[])).unwrap();
+        for host in ["a.example", "b.example:8443", "ANYTHING", ""] {
+            let client = selector.for_host(host).expect("degenerate matches all");
+            assert_eq!(client.issuer(), "https://idp.example", "host {host:?}");
+        }
+        assert!(selector.for_issuer("https://idp.example").is_some());
+        assert!(selector.for_stored_issuer("").is_some());
+    }
+
+    #[test]
+    fn multi_entry_map_selects_by_exact_host_and_fails_closed() {
+        let selector = IssuerSelector::build(&cfg_with_hosts(&[
+            ("a.example", "https://kc.example/realms/a"),
+            ("b.example", "https://kc.example/realms/b"),
+        ]))
+        .unwrap();
+
+        let a = selector
+            .for_host("a.example")
+            .expect("a.example configured");
+        assert_eq!(a.issuer(), "https://kc.example/realms/a");
+        let b = selector
+            .for_host("b.example")
+            .expect("b.example configured");
+        assert_eq!(b.issuer(), "https://kc.example/realms/b");
+
+        for unknown in ["c.example", "a.example.evil", "example", ""] {
+            assert!(
+                selector.for_host(unknown).is_none(),
+                "should fail closed: {unknown:?}"
+            );
+        }
+        // The flat idp.* fields take no part in selection in map mode.
+        assert!(selector.for_issuer("https://idp.example").is_none());
+        assert!(selector.for_stored_issuer("").is_none());
+        assert!(
+            selector
+                .for_stored_issuer("https://kc.example/realms/a")
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn host_matching_normalizes_case_and_port() {
+        let selector = IssuerSelector::build(&cfg_with_hosts(&[(
+            "a.example",
+            "https://kc.example/realms/a",
+        )]))
+        .unwrap();
+        for host in ["A.Example", "a.example:443", "a.example.", "A.EXAMPLE:8443"] {
+            assert!(selector.for_host(host).is_some(), "should match: {host:?}");
+        }
+    }
+
+    #[test]
+    fn duplicate_issuer_across_hosts_is_rejected() {
+        let cfg = cfg_with_hosts(&[
+            ("a.example", "https://kc.example/realms/shared"),
+            ("b.example", "https://kc.example/realms/shared"),
+        ]);
+        assert!(IssuerSelector::build(&cfg).is_err());
+    }
+
+    #[test]
+    fn normalize_host_strips_port_case_and_trailing_dot() {
+        let cases = [
+            ("Portal.Example", "portal.example"),
+            ("portal.example:8443", "portal.example"),
+            ("portal.example.", "portal.example"),
+            ("  portal.example  ", "portal.example"),
+            ("[::1]:8443", "::1"),
+            ("[2001:db8::1]", "2001:db8::1"),
+            // Not a numeric port: leave the value alone (it just won't match).
+            ("portal.example:x", "portal.example:x"),
+        ];
+        for (raw, expected) in cases {
+            assert_eq!(normalize_host(raw), expected, "for {raw:?}");
+        }
+    }
+}

--- a/src/backend/services/authenticator/src/main.rs
+++ b/src/backend/services/authenticator/src/main.rs
@@ -29,6 +29,7 @@ mod cookie;
 mod csrf;
 mod gear;
 mod identity;
+mod issuers;
 mod janitor;
 mod jwt;
 mod local_client;

--- a/src/backend/services/authenticator/src/oidc.rs
+++ b/src/backend/services/authenticator/src/oidc.rs
@@ -19,7 +19,7 @@ use openidconnect::{
     PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, Scope, TokenResponse,
 };
 
-use crate::config::IdpConfig;
+use crate::config::{HostIdpConfig, IdpConfig};
 use crate::identity::IdpIdentity;
 
 /// What `authorize` hands back for the handler to stash in the login state.
@@ -66,13 +66,70 @@ pub enum RefreshOutcome {
     Transient(String),
 }
 
-/// The OIDC client — holds config; builds the `openidconnect` client per op
-/// (discovery is a cold-path login/callback concern).
+/// Build the HTTP client every [`OidcClient`] shares (one connection pool
+/// regardless of how many issuers the deployment serves).
+///
+/// # Errors
+/// Fails when `extra_ca_cert_path` is unreadable/empty or the `reqwest`
+/// client cannot be constructed.
+pub fn build_http(idp: &IdpConfig) -> anyhow::Result<reqwest::Client> {
+    // Do not follow redirects: the RP must never chase the IdP's 3xx itself
+    // (SSRF-safety guidance from the openidconnect docs). A total timeout is
+    // mandatory (reqwest has none by default): the background refresher runs
+    // each grant under a 30 s per-session lock, so a hung IdP connection
+    // (half-open TCP, no RST) must fail well before that — otherwise the
+    // request outlives its lock, a second worker re-runs the grant with the
+    // same one-time-use refresh token, and the IdP burns it → false logout.
+    // It also caps semaphore-permit hold time so hung calls can't wedge the
+    // whole refresher (G5).
+    let mut builder = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(std::time::Duration::from_secs(10))
+        .connect_timeout(std::time::Duration::from_secs(5));
+    // Trust an extra internal/corporate CA for the IdP connection, on
+    // top of whichever trust store this build's TLS backend resolves by
+    // default. Explicit `.add_root_certificate()` works regardless of
+    // whether Cargo's feature unification landed on native-tls (OS trust
+    // store) or rustls (bundled webpki-roots) for this binary — unlike
+    // an OS-level trust-store file/env-var (e.g. SSL_CERT_FILE), which
+    // only applies if native-tls won and cannot be relied on here.
+    if !idp.extra_ca_cert_path.is_empty() {
+        let pem = std::fs::read(&idp.extra_ca_cert_path)
+            .with_context(|| format!("read extra_ca_cert_path {:?}", idp.extra_ca_cert_path))?;
+        // `from_pem_bundle`, not `from_pem`: the file may carry a full
+        // chain (e.g. intermediate + root); `from_pem` only parses the
+        // first certificate in the blob and silently drops the rest.
+        let certs = reqwest::Certificate::from_pem_bundle(&pem).with_context(|| {
+            format!(
+                "parse PEM cert bundle from extra_ca_cert_path {:?}",
+                idp.extra_ca_cert_path
+            )
+        })?;
+        // A whitespace/comment-only file parses to zero certs without
+        // erroring, silently leaving only the default trust store —
+        // reject it so a misconfigured mount fails loudly at startup.
+        anyhow::ensure!(
+            !certs.is_empty(),
+            "extra_ca_cert_path {:?} contained no certificates",
+            idp.extra_ca_cert_path
+        );
+        for cert in certs {
+            builder = builder.add_root_certificate(cert);
+        }
+    }
+    builder.build().context("build OIDC HTTP client")
+}
+
+/// The OIDC client for ONE issuer — holds that issuer's client registration;
+/// builds the `openidconnect` client per op (discovery is a cold-path
+/// login/callback concern). Which instance serves a request is decided by
+/// [`crate::issuers::IssuerSelector`].
 #[derive(Clone)]
 pub struct OidcClient {
     issuer_url: String,
     client_id: String,
     client_secret: String,
+    redirect_uri: String,
     tenant_claim: String,
     default_tenant_id: String,
     external_id_claim: String,
@@ -80,58 +137,10 @@ pub struct OidcClient {
 }
 
 impl OidcClient {
-    /// Build the client from the `idp.*` config. Returns an error if the HTTP
-    /// client can't be built.
-    ///
-    /// # Errors
-    /// Fails when the underlying `reqwest` client cannot be constructed.
-    pub fn new(idp: &IdpConfig) -> anyhow::Result<Self> {
-        // Do not follow redirects: the RP must never chase the IdP's 3xx itself
-        // (SSRF-safety guidance from the openidconnect docs). A total timeout is
-        // mandatory (reqwest has none by default): the background refresher runs
-        // each grant under a 30 s per-session lock, so a hung IdP connection
-        // (half-open TCP, no RST) must fail well before that — otherwise the
-        // request outlives its lock, a second worker re-runs the grant with the
-        // same one-time-use refresh token, and the IdP burns it → false logout.
-        // It also caps semaphore-permit hold time so hung calls can't wedge the
-        // whole refresher (G5).
-        let mut builder = reqwest::Client::builder()
-            .redirect(reqwest::redirect::Policy::none())
-            .timeout(std::time::Duration::from_secs(10))
-            .connect_timeout(std::time::Duration::from_secs(5));
-        // Trust an extra internal/corporate CA for the IdP connection, on
-        // top of whichever trust store this build's TLS backend resolves by
-        // default. Explicit `.add_root_certificate()` works regardless of
-        // whether Cargo's feature unification landed on native-tls (OS trust
-        // store) or rustls (bundled webpki-roots) for this binary — unlike
-        // an OS-level trust-store file/env-var (e.g. SSL_CERT_FILE), which
-        // only applies if native-tls won and cannot be relied on here.
-        if !idp.extra_ca_cert_path.is_empty() {
-            let pem = std::fs::read(&idp.extra_ca_cert_path)
-                .with_context(|| format!("read extra_ca_cert_path {:?}", idp.extra_ca_cert_path))?;
-            // `from_pem_bundle`, not `from_pem`: the file may carry a full
-            // chain (e.g. intermediate + root); `from_pem` only parses the
-            // first certificate in the blob and silently drops the rest.
-            let certs = reqwest::Certificate::from_pem_bundle(&pem).with_context(|| {
-                format!(
-                    "parse PEM cert bundle from extra_ca_cert_path {:?}",
-                    idp.extra_ca_cert_path
-                )
-            })?;
-            // A whitespace/comment-only file parses to zero certs without
-            // erroring, silently leaving only the default trust store —
-            // reject it so a misconfigured mount fails loudly at startup.
-            anyhow::ensure!(
-                !certs.is_empty(),
-                "extra_ca_cert_path {:?} contained no certificates",
-                idp.extra_ca_cert_path
-            );
-            for cert in certs {
-                builder = builder.add_root_certificate(cert);
-            }
-        }
-        let http = builder.build().context("build OIDC HTTP client")?;
-        Ok(Self {
+    /// The single-issuer (degenerate map) client, from the flat `idp.*` fields.
+    #[must_use]
+    pub fn flat(idp: &IdpConfig, redirect_uri: &str, http: reqwest::Client) -> Self {
+        Self {
             // Do NOT normalize a trailing slash: OIDC issuer comparison is a
             // byte-exact string match against the `issuer` field the IdP's
             // own discovery document returns (RFC 8414 / OIDC Discovery
@@ -144,11 +153,35 @@ impl OidcClient {
             issuer_url: idp.issuer_url.clone(),
             client_id: idp.client_id.clone(),
             client_secret: idp.client_secret.clone(),
+            redirect_uri: redirect_uri.to_owned(),
             tenant_claim: idp.tenant_claim.clone(),
             default_tenant_id: idp.default_tenant_id.clone(),
             external_id_claim: idp.external_id_claim.clone(),
             http,
-        })
+        }
+    }
+
+    /// One `idp.hosts` entry's client: the entry supplies the issuer + client
+    /// registration (and optional redirect/tenant overrides); every other
+    /// knob comes from the shared `idp.*` fields.
+    #[must_use]
+    pub fn for_host(
+        idp: &IdpConfig,
+        entry: &HostIdpConfig,
+        default_redirect_uri: &str,
+        http: reqwest::Client,
+    ) -> Self {
+        let pick = |own: &str, shared: &str| if own.is_empty() { shared } else { own }.to_owned();
+        Self {
+            issuer_url: entry.issuer_url.clone(),
+            client_id: entry.client_id.clone(),
+            client_secret: entry.client_secret.clone(),
+            redirect_uri: pick(&entry.redirect_uri, default_redirect_uri),
+            tenant_claim: idp.tenant_claim.clone(),
+            default_tenant_id: pick(&entry.default_tenant_id, &idp.default_tenant_id),
+            external_id_claim: idp.external_id_claim.clone(),
+            http,
+        }
     }
 
     /// Fetch the provider discovery metadata.
@@ -169,11 +202,7 @@ impl OidcClient {
     ///
     /// # Errors
     /// Fails on discovery / URL-construction errors.
-    pub async fn authorize(
-        &self,
-        redirect_uri: &str,
-        scopes: &[String],
-    ) -> anyhow::Result<AuthorizeStart> {
+    pub async fn authorize(&self, scopes: &[String]) -> anyhow::Result<AuthorizeStart> {
         // Built inline (not via a helper) so the endpoint type-state markers
         // from `from_provider_metadata` + `set_redirect_uri` are preserved.
         let client = CoreClient::from_provider_metadata(
@@ -182,7 +211,7 @@ impl OidcClient {
             self.secret(),
         )
         .set_redirect_uri(
-            RedirectUrl::new(redirect_uri.to_owned()).context("invalid redirect_uri")?,
+            RedirectUrl::new(self.redirect_uri.clone()).context("invalid redirect_uri")?,
         );
         let (challenge, verifier) = PkceCodeChallenge::new_random_sha256();
 
@@ -213,7 +242,6 @@ impl OidcClient {
     /// validation failure (signature / iss / aud / nonce / exp).
     pub async fn exchange_code_pkce(
         &self,
-        redirect_uri: &str,
         code: &str,
         pkce_verifier: &str,
         expected_nonce: &str,
@@ -224,7 +252,7 @@ impl OidcClient {
             self.secret(),
         )
         .set_redirect_uri(
-            RedirectUrl::new(redirect_uri.to_owned()).context("invalid redirect_uri")?,
+            RedirectUrl::new(self.redirect_uri.clone()).context("invalid redirect_uri")?,
         );
         let token = client
             .exchange_code(AuthorizationCode::new(code.to_owned()))
@@ -459,8 +487,11 @@ fn extract_external_id(raw_id_token: &str, external_id_claim: &str, sub: &str) -
     payload_string(raw_id_token, external_id_claim).filter(|v| !v.is_empty())
 }
 
-/// Read a string claim from an (already-validated) compact JWT payload.
-fn payload_string(jwt: &str, field: &str) -> Option<String> {
+/// Read a string claim from a compact JWT payload WITHOUT verification — for
+/// claims either already validated by `openidconnect` or, like the
+/// back-channel `iss` peek, used only to SELECT the verifier that then
+/// validates the token in full.
+pub(crate) fn payload_string(jwt: &str, field: &str) -> Option<String> {
     payload(jwt)?
         .get(field)?
         .as_str()

--- a/src/backend/services/authenticator/src/refresher.rs
+++ b/src/backend/services/authenticator/src/refresher.rs
@@ -238,7 +238,26 @@ async fn do_refresh(
         return Ok(());
     };
 
-    match state.oidc.refresh_grant(refresh_token).await {
+    // Sessions pin their issuer; a session whose issuer left the map (config
+    // edit mid-lifetime) is treated as transient — backed off, never revoked
+    // — so a config mistake fixed by the next deploy cannot mass-logout.
+    let Some(oidc) = state.oidc.for_stored_issuer(&record.idp_iss) else {
+        metrics.record("transient");
+        if let Some(failures) = sessions.bump_refresh_failures(session_id).await? {
+            let retry_at = now + backoff_seconds(failures);
+            sessions.reschedule_refresh(session_id, retry_at).await?;
+            tracing::warn!(
+                session_id,
+                issuer = %record.idp_iss,
+                failures,
+                retry_at,
+                "idp refresh: session issuer not in the configured map; backing off (never revoking)"
+            );
+        }
+        return Ok(());
+    };
+
+    match oidc.refresh_grant(refresh_token).await {
         RefreshOutcome::Refreshed {
             new_refresh_token,
             expires_in,

--- a/src/backend/services/authenticator/src/session.rs
+++ b/src/backend/services/authenticator/src/session.rs
@@ -22,6 +22,11 @@ pub struct LoginState {
     pub pkce_verifier: String,
     pub nonce: String,
     pub return_to: String,
+    /// The issuer the login started against (host-keyed selection, ADR-0003):
+    /// the callback exchanges the code with THIS issuer, never re-consulting
+    /// the callback's own `Host`. Empty only in state written by a pre-map
+    /// replica (resolved as the single-issuer degenerate case).
+    pub issuer: String,
     /// View-as target from `__override=<email>` (#1941). Stored only when
     /// `override_enabled`; empty on normal logins.
     pub override_email: String,
@@ -34,6 +39,7 @@ impl LoginState {
             ("pkce_verifier", self.pkce_verifier.clone()),
             ("nonce", self.nonce.clone()),
             ("return_to", self.return_to.clone()),
+            ("issuer", self.issuer.clone()),
             ("override_email", self.override_email.clone()),
         ]
     }
@@ -45,6 +51,7 @@ impl LoginState {
             pkce_verifier: get("pkce_verifier"),
             nonce: get("nonce"),
             return_to: get("return_to"),
+            issuer: get("issuer"),
             override_email: get("override_email"),
         }
     }

--- a/src/backend/services/authenticator/tests/e2e_hostmap.rs
+++ b/src/backend/services/authenticator/tests/e2e_hostmap.rs
@@ -1,0 +1,169 @@
+//! End-to-end host-keyed issuer selection (ADR-0003) against an authenticator
+//! configured with a two-entry `idp.hosts` map in front of two fakeidp
+//! instances, plus the flat-config instance for the degenerate case.
+//!
+//! `#[ignore]` by default (needs the stack up); run-e2e.sh wires it:
+//!
+//! ```text
+//! AUTH_BASE=http://localhost:8087 AUTH_FLAT_BASE=http://localhost:8083 \
+//!   AUTH3_LOG=/tmp/authenticator-e2e-auth3.log \
+//!   FAKEIDP_PUBLIC=http://localhost:8084 FAKEIDP2_PUBLIC=http://localhost:8088 \
+//!   cargo test -p authenticator --test e2e_hostmap -- --ignored --nocapture
+//! ```
+//!
+//! Covers: Host routing at `/auth/login`, unknown-host 403 + audit line,
+//! callback under a different Host, and the flat-config degenerate case.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod common;
+
+const COOKIE: &str = "__Host-sid";
+const HOST_A: &str = "tenant-a.example";
+const HOST_B: &str = "tenant-b.example";
+
+fn env(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_owned())
+}
+
+fn location_of(resp: &reqwest::Response) -> String {
+    resp.headers()[reqwest::header::LOCATION]
+        .to_str()
+        .unwrap()
+        .to_owned()
+}
+
+fn cookie_from(resp: &reqwest::Response) -> Option<String> {
+    for hv in resp.headers().get_all(reqwest::header::SET_COOKIE) {
+        let raw = hv.to_str().ok()?;
+        for part in raw.split(';') {
+            if let Some(v) = part.trim().strip_prefix(&format!("{COOKIE}="))
+                && !v.is_empty()
+            {
+                return Some(v.to_owned());
+            }
+        }
+    }
+    None
+}
+
+#[tokio::test]
+#[ignore = "requires the run-e2e.sh stack (two fakeidps + hosts-map authenticator)"]
+async fn host_selects_the_issuer_and_the_callback_stays_pinned() {
+    let auth_base = env("AUTH_BASE", "http://localhost:8087");
+    let idp_a = env("FAKEIDP_PUBLIC", "http://localhost:8084");
+    let idp_b = env("FAKEIDP2_PUBLIC", "http://localhost:8088");
+    let test_user = env("E2E_USER", "dev@company.nonpresent");
+    let http = common::client();
+
+    // Each configured host is routed to its own issuer's authorize endpoint.
+    for (host, idp) in [(HOST_A, &idp_a), (HOST_B, &idp_b)] {
+        let login = http
+            .get(format!("{auth_base}/auth/login"))
+            .header("Host", host)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(login.status(), 302, "login via {host} should redirect");
+        let authorize = location_of(&login);
+        assert!(
+            authorize.starts_with(idp.as_str()),
+            "Host {host} must select issuer {idp}, got {authorize}"
+        );
+    }
+
+    // Full loop through tenant-a; the callback is presented with tenant-b's
+    // Host to prove the issuer pinned in the login state wins over any Host
+    // ambiguity after login.
+    let login = http
+        .get(format!("{auth_base}/auth/login?return_to=/dashboard"))
+        .header("Host", HOST_A)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(login.status(), 302);
+    let authorize = location_of(&login);
+    let sep = if authorize.contains('?') { '&' } else { '?' };
+    let authorized = http
+        .get(format!("{authorize}{sep}user={test_user}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(authorized.status(), 302, "authorize redirects to callback");
+
+    let cb = http
+        .get(location_of(&authorized))
+        .header("Host", HOST_B)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        cb.status(),
+        302,
+        "callback must complete against the login-pinned issuer regardless of Host"
+    );
+    assert_eq!(location_of(&cb), "/dashboard");
+    let token = cookie_from(&cb).expect("callback must set the session cookie");
+
+    let authz = http
+        .get(format!("{auth_base}/internal/authz"))
+        .header(reqwest::header::COOKIE, format!("{COOKIE}={token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(authz.status(), 200, "the minted session must exchange");
+}
+
+#[tokio::test]
+#[ignore = "requires the run-e2e.sh stack (two fakeidps + hosts-map authenticator)"]
+async fn unknown_host_is_rejected_fail_closed_with_an_audit_event() {
+    let auth_base = env("AUTH_BASE", "http://localhost:8087");
+    let http = common::client();
+
+    let denied = http
+        .get(format!("{auth_base}/auth/login"))
+        .header("Host", "unknown.example")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        denied.status(),
+        403,
+        "a Host matching no configured issuer must be rejected fail-closed"
+    );
+    let body: serde_json::Value = denied.json().await.unwrap();
+    assert_eq!(body["status"], 403, "problem+json body expected: {body}");
+
+    // The denial is audited (`event = "login_denied_unknown_host"`).
+    let log_path = env("AUTH3_LOG", "/tmp/authenticator-e2e-auth3.log");
+    tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+    let log = std::fs::read_to_string(&log_path)
+        .unwrap_or_else(|e| panic!("read authenticator log {log_path}: {e}"));
+    assert!(
+        log.contains("login_denied_unknown_host"),
+        "the unknown-host denial must emit its audit event (log: {log_path})"
+    );
+}
+
+#[tokio::test]
+#[ignore = "requires the run-e2e.sh stack (two fakeidps + hosts-map authenticator)"]
+async fn flat_single_issuer_config_matches_every_host() {
+    let flat_base = env("AUTH_FLAT_BASE", "http://localhost:8083");
+    let idp_a = env("FAKEIDP_PUBLIC", "http://localhost:8084");
+    let http = common::client();
+
+    // The degenerate (map-less) instance serves any Host, exactly as before.
+    for host in ["whatever.example", "another.example:8443"] {
+        let login = http
+            .get(format!("{flat_base}/auth/login"))
+            .header("Host", host)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(login.status(), 302, "flat config must serve Host {host}");
+        assert!(
+            location_of(&login).starts_with(idp_a.as_str()),
+            "flat config always routes to its one issuer"
+        );
+    }
+}

--- a/src/backend/services/authenticator/tests/run-e2e.sh
+++ b/src/backend/services/authenticator/tests/run-e2e.sh
@@ -28,7 +28,11 @@ AUTH_PORT=8083
 TOKEN_PORT=8093
 AUTH2_PORT=8085
 TOKEN2_PORT=8095
+AUTH3_PORT=8087
+TOKEN3_PORT=8097
 IDP_PORT=8084
+# 8086 avoided: a common local-daemon default (InfluxDB) collides with it.
+IDP2_PORT=8088
 IDENTITY_PORT=8092
 REDIS_CT=authenticator-e2e-redis
 pids=()
@@ -40,6 +44,7 @@ cleanup() {
   [[ -n "${KEYS_DIR:-}" ]] && rm -rf "$KEYS_DIR"
   [[ -n "${SVC_KEYS_DIR:-}" ]] && rm -rf "$SVC_KEYS_DIR"
   [[ -n "${AUTH2_CONFIG:-}" ]] && rm -f "$AUTH2_CONFIG"
+  [[ -n "${AUTH3_CONFIG:-}" ]] && rm -f "$AUTH3_CONFIG"
 }
 trap cleanup EXIT
 
@@ -85,6 +90,13 @@ FAKEIDP_ISSUER="http://localhost:$IDP_PORT" FAKEIDP_BIND="0.0.0.0:$IDP_PORT" \
   ./target/release/fakeidp >/tmp/authenticator-e2e-fakeidp.log 2>&1 &
 pids+=($!)
 wait_ready fakeidp "http://localhost:$IDP_PORT/.well-known/openid-configuration"
+
+echo "==> fakeidp #2 :$IDP2_PORT (the second issuer of the host-keyed map, ADR-0003)"
+FAKEIDP_ISSUER="http://localhost:$IDP2_PORT" FAKEIDP_BIND="0.0.0.0:$IDP2_PORT" \
+  FAKEIDP_DEFAULT_AUD=insight-authenticator \
+  ./target/release/fakeidp >/tmp/authenticator-e2e-fakeidp2.log 2>&1 &
+pids+=($!)
+wait_ready fakeidp2 "http://localhost:$IDP2_PORT/.well-known/openid-configuration"
 
 echo "==> identity stub :$IDENTITY_PORT (resolves any email/external-id to a person)"
 python3 "$HERE/identity-stub.py" "127.0.0.1:$IDENTITY_PORT" >/tmp/authenticator-e2e-identity.log 2>&1 &
@@ -143,6 +155,32 @@ if ! wait_ready authenticator2 "http://localhost:$AUTH2_PORT/.well-known/jwks.js
   exit 1
 fi
 
+echo "==> authenticator #3 :$AUTH3_PORT (host-keyed issuer map, ADR-0003)"
+# Two hosts -> two issuers; the flat idp client fields stay empty (map mode
+# replaces them). The map rides ONE env var as a JSON string — exactly the
+# shape a deployment would use.
+AUTH3_CONFIG="$(mktemp "${TMPDIR:-/tmp}/authenticator-e2e-cfg3.XXXXXX")"
+sed -e "s/$AUTH_PORT/$AUTH3_PORT/g" -e "s/$TOKEN_PORT/$TOKEN3_PORT/g" \
+    -e 's#/tmp/authenticator-grpc#/tmp/authenticator-e2e3-grpc#' \
+  services/authenticator/config/insight.yaml > "$AUTH3_CONFIG"
+APP__gears__authenticator__config__redis_url=redis://localhost:6399 \
+APP__gears__authenticator__config__signing_keys_path="$KEYS_DIR" \
+APP__gears__authenticator__config__identity_url="http://localhost:$IDENTITY_PORT" \
+APP__gears__authenticator__config__gateway_issuer=http://localhost:8080 \
+APP__gears__authenticator__config__idp__source_type=faketest \
+APP__gears__authenticator__config__idp__hosts="{\"tenant-a.example\": {\"issuer_url\": \"http://localhost:$IDP_PORT\", \"client_id\": \"insight-authenticator\"}, \"tenant-b.example\": {\"issuer_url\": \"http://localhost:$IDP2_PORT\", \"client_id\": \"insight-authenticator\"}}" \
+APP__gears__authenticator__config__redirect_uri="http://localhost:$AUTH3_PORT/auth/callback" \
+APP__gears__authenticator__config__service_tokens__public_key_dir="$SVC_KEYS_DIR" \
+  ./target/release/authenticator -c "$AUTH3_CONFIG" run \
+  >/tmp/authenticator-e2e-auth3.log 2>&1 &
+pids+=($!)
+
+echo "==> wait for authenticator #3 readiness"
+if ! wait_ready authenticator3 "http://localhost:$AUTH3_PORT/.well-known/jwks.json"; then
+  tail -20 /tmp/authenticator-e2e-auth3.log >&2 || true
+  exit 1
+fi
+
 echo "==> run the login loop"
 AUTH_BASE="http://localhost:$AUTH_PORT" E2E_USER=dev@company.nonpresent \
   cargo test -p authenticator --test e2e_login_loop -- --ignored --nocapture
@@ -163,6 +201,13 @@ echo "==> run the __override view-as loop (#1941)"
 AUTH_BASE="http://localhost:$AUTH_PORT" AUTH_BASE_DISABLED="http://localhost:$AUTH2_PORT" \
   E2E_USER=dev@company.nonpresent \
   cargo test -p authenticator --test e2e_override -- --ignored --nocapture
+
+echo "==> run the host-keyed issuer map loop (ADR-0003)"
+AUTH_BASE="http://localhost:$AUTH3_PORT" AUTH_FLAT_BASE="http://localhost:$AUTH_PORT" \
+  AUTH3_LOG=/tmp/authenticator-e2e-auth3.log \
+  FAKEIDP_PUBLIC="http://localhost:$IDP_PORT" FAKEIDP2_PUBLIC="http://localhost:$IDP2_PORT" \
+  E2E_USER=dev@company.nonpresent \
+  cargo test -p authenticator --test e2e_hostmap -- --ignored --nocapture
 
 echo "==> run the back-channel logout loop (step 10.3)"
 AUTH_BASE="http://localhost:$AUTH_PORT" FAKEIDP_PUBLIC="http://localhost:$IDP_PORT" \


### PR DESCRIPTION
## What

Replaces the authenticator's single-issuer OIDC configuration with a **host-keyed issuer map** (ADR-0003, Keycloak identity broker): the request `Host` header selects the issuer (broker realm) wherever an OIDC flow starts, so one deployment can serve multiple customers, each hostname mapping to its own realm and its own confidential-client registration.

- **Config** (`idp.hosts`, new): a map of `hostname -> {issuer_url, client_id, client_secret, redirect_uri?, default_tenant_id?}`. Per-issuer fields are exactly what legitimately differs per broker realm — the issuer and its client registration (plus optional redirect/tenant overrides); every other `idp.*` knob (tenant/source claims, refresh tuning, extra CA) is broker-wide and stays global. Nested maps don't fit the `APP__…` env layering, so the field also accepts a **JSON string** — one env var (or the config file) carries the whole map; the flat single-issuer env config stays primary.
- **Selection** (`issuers.rs`, new): `IssuerSelector` builds every issuer's `OidcClient` at boot (fail-closed on a bad map, shared HTTP pool) and keys lookups two ways: by normalized request `Host` (lowercased, port-stripped, trailing-dot-stripped; exact match) at `/auth/login`, and by **issuer URL** everywhere the issuer is already pinned server-side — the login state (callback), the session record (background refresher, RP-initiated logout), and the validated `iss` of a back-channel `logout_token`. Host ambiguity after login is therefore harmless: the login state now records the issuer it started against, and sessions already record `idp_iss`.
- **Fail closed**: with a non-empty map, a `/auth/login` whose `Host` matches no entry is rejected 403 (problem+json) with the audit event `login_denied_unknown_host` (tracing `target: "audit"` + the durable Redpanda sink, mirroring `login_denied_unknown_person`). Declared in the OpenAPI doc (regenerated).
- **Back-channel logout** peeks the token's `iss` (unverified) only to select the verifier, which then validates the token in full against that issuer's JWKS/claims — a forged `iss` buys nothing but a rejection.
- **Refresher**: a session whose pinned issuer left the map is backed off (transient), never revoked — a config mistake fixed by the next deploy cannot mass-logout.

## Config compatibility (the degenerate case)

An empty/absent `idp.hosts` is single-issuer mode: the flat `idp.issuer_url`/`client_id`/`client_secret` (today's `APP__gears__authenticator__config__idp__*` env vars) are the one-and-only entry and match **every** Host. Existing deployments see zero change — no chart or gitops edits in this PR, and the chart's secret surface is untouched. With a non-empty map, each entry must be complete (`issuer_url` + `client_id`), keys must be bare hostnames, one issuer may appear under only one host, and the flat client fields become optional (they take no part in selection).

## Tests

- **Unit** (`cargo test -p authenticator`, 69 passing incl. 7 new): host→issuer selection (exact match, unknown-host fail-closed, single-entry matching any host), host normalization (case / port / IPv6 literal / trailing dot), config parsing of both map shapes (native YAML map + JSON-string env), and validation of both modes.
- **e2e** (`tests/run-e2e.sh`, extended): a second fakeidp and a third authenticator instance configured with a two-entry `idp.hosts` map **via a single JSON env var**. New `e2e_hostmap.rs` proves: each Host routes to its own issuer's authorize endpoint; the full login loop completes with the **callback presented under a different Host** (issuer pinned at login wins); an unknown Host is rejected 403 and the `login_denied_unknown_host` audit line is in the log; and the flat-config instance keeps serving any Host. All pre-existing suites (login loop, refresh, sessions, 401 contract, override, back-channel, rate-limit, refresher, service token) pass unchanged; the coverage ledger picks the new requests up through `tests/common`.

<details><summary>Test run tails</summary>

```
$ cargo test -p authenticator --bin authenticator
test config::tests::flat_issuer_fields_required_only_without_a_hosts_map ... ok
test config::tests::idp_hosts_parses_native_map_and_json_string_shapes ... ok
test issuers::tests::normalize_host_strips_port_case_and_trailing_dot ... ok
test issuers::tests::empty_map_is_single_issuer_mode_matching_any_host ... ok
test issuers::tests::host_matching_normalizes_case_and_port ... ok
test issuers::tests::duplicate_issuer_across_hosts_is_rejected ... ok
test issuers::tests::multi_entry_map_selects_by_exact_host_and_fails_closed ... ok
test result: ok. 69 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ src/backend/services/authenticator/tests/run-e2e.sh
==> run the host-keyed issuer map loop (ADR-0003)
running 3 tests
test flat_single_issuer_config_matches_every_host ... ok
test host_selects_the_issuer_and_the_callback_stays_pinned ... ok
test unknown_host_is_rejected_fail_closed_with_an_audit_event ... ok
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.35s
==> PASS (endpoint-coverage ledger: .../observed_authenticator_endpoints.json)

$ api_coverage.py --suite authenticator --spec docs/components/backend/authenticator/openapi.json
Gate: PASS. 13/14 operations exercised · 0 missing · registered-code coverage 88.0% (22/25)
(GET /auth/login now covers 302 + the new fail-closed 403)
```

</details>

Refs #2197
Part of #2193

🤖 Generated with [Claude Code](https://claude.com/claude-code)
