### PR TITLE
feat(portal): organizational analytics portal behind the insight.portal flag

### DIFF
--- a/src/frontend/src/api/metric-definitions-client.ts
+++ b/src/frontend/src/api/metric-definitions-client.ts
@@ -19,7 +19,7 @@ import type {
 const BASE =
   (import.meta.env.VITE_API_BASE as string | undefined) ?? "/api/analytics/v1";
 
-type MetricDefinitionSchemaStatus = "ok" | "error" | "unchecked";
+export type MetricDefinitionSchemaStatus = "ok" | "error" | "unchecked";
 
 export interface MetricDefinition {
   metric_key: string;

--- a/src/frontend/src/api/metric-results-client.test.ts
+++ b/src/frontend/src/api/metric-results-client.test.ts
@@ -33,6 +33,15 @@ function response(init: {
 describe("queryMetricResults", () => {
   beforeEach(() => mockFetch.mockReset());
 
+  it("refuses an empty entity list instead of letting the server 400", async () => {
+    // The backend answers `entity.ids must not be empty`; a caller that got
+    // here has a gating bug, and a network error hides that.
+    await expect(
+      queryMetricResults({ ...REQUEST, entity: { type: "person", ids: [] } }),
+    ).rejects.toThrow(/empty entity list/);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("returns the parsed response on success", async () => {
     mockFetch.mockResolvedValue(
       response({ ok: true, json: async () => METRIC_RESULTS_RESPONSE_FIXTURE }),

--- a/src/frontend/src/api/metric-results-client.ts
+++ b/src/frontend/src/api/metric-results-client.ts
@@ -183,6 +183,15 @@ export interface MetricResultsResponse {
 export async function queryMetricResults(
   body: MetricResultsRequest
 ): Promise<MetricResultsResponse> {
+  // Refuse a request the backend is guaranteed to reject (400 invalid_argument,
+  // "entity.ids must not be empty"). Callers are expected to keep the query
+  // disabled until they have entities; failing here names the real cause
+  // instead of surfacing a server validation error in the network log.
+  if (body.entity.ids.length === 0) {
+    throw new Error(
+      "metric-results: refusing to request an empty entity list — the caller should stay disabled until the roster resolves",
+    );
+  }
   const res = await fetchWithAuth(`${BASE}/metric-results`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/src/frontend/src/components/app-sidebar-footer.tsx
+++ b/src/frontend/src/components/app-sidebar-footer.tsx
@@ -1,0 +1,83 @@
+import { Link, useRouterState } from "@tanstack/react-router";
+import { BookOpenText, Megaphone } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { useViewer } from "@/auth";
+import { SidebarSettings } from "@/components/sidebar-settings";
+import { ThemeSwitcher } from "@/components/theme-switcher";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar";
+import { getInitials } from "@/lib/insight/get-initials";
+import { useIcPerson } from "@/queries/ic-dashboard";
+
+/**
+ * Shared footer for the sidebar chrome: metric catalog, What's new, view
+ * settings (portal / focus / explanations), theme switch, and the viewer
+ * identity block. Extracted from AppSidebar so the portal shell can surface
+ * the same controls (from the rail's settings popover) without duplicating them.
+ */
+export function AppSidebarFooter() {
+  const { t } = useTranslation();
+  const { email: viewerEmail, personId: viewerPersonId } = useViewer();
+  const viewerQ = useIcPerson(viewerPersonId ?? "");
+  const viewer = viewerQ.data ?? null;
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+
+  const primaryEmail = viewer?.email ?? viewerEmail;
+  const primary = viewer?.display_name || primaryEmail;
+  const showSecondary = primary !== primaryEmail;
+
+  return (
+    <>
+      <SidebarMenu>
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            isActive={pathname === "/metrics"}
+            render={<Link to="/metrics" />}
+          >
+            <BookOpenText />
+            <span>{t("metric_definitions.nav_label")}</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            isActive={pathname === "/whats-new"}
+            render={<Link to="/whats-new" />}
+          >
+            <Megaphone />
+            <span>{t("whats_new.nav_label")}</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+      <SidebarSettings />
+      <ThemeSwitcher />
+      {viewerEmail ? (
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton size="lg" className="cursor-default">
+              <Avatar className="size-8 shrink-0">
+                <AvatarFallback className="bg-sidebar-primary text-xs font-semibold text-sidebar-primary-foreground">
+                  {getInitials(primary) || "?"}
+                </AvatarFallback>
+              </Avatar>
+              <div className="flex min-w-0 flex-1 flex-col leading-tight">
+                <span className="truncate text-sm font-medium text-sidebar-foreground">
+                  {primary}
+                </span>
+                {showSecondary ? (
+                  <span className="truncate text-xs text-sidebar-foreground/60">
+                    {primaryEmail}
+                  </span>
+                ) : null}
+              </div>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      ) : null}
+    </>
+  );
+}

--- a/src/frontend/src/components/app-sidebar.tsx
+++ b/src/frontend/src/components/app-sidebar.tsx
@@ -21,6 +21,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import { personIdFromPath } from "@/lib/metrics/entity";
 import { useIcPerson } from "@/queries/ic-dashboard";
 import type { IdentityPerson } from "@/types/insight";
 
@@ -106,8 +107,8 @@ export function AppSidebar() {
   // The URL segment is the person id since the identity cutover; a legacy
   // email URL simply highlights nothing for the moment its redirect takes.
   const activePersonId = useMemo(() => {
-    const m = /^\/ic\/([^/]+)/.exec(pathname);
-    if (m) return decodeURIComponent(m[1]!);
+    const fromPath = personIdFromPath(pathname);
+    if (fromPath) return fromPath;
     if (pathname === "/" && viewerPersonId) return viewerPersonId;
     return null;
   }, [pathname, viewerPersonId]);

--- a/src/frontend/src/components/mock-banner.test.tsx
+++ b/src/frontend/src/components/mock-banner.test.tsx
@@ -1,19 +1,25 @@
 import { render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import "@/i18n";
 
 import { MockBanner } from "@/components/mock-banner";
 
-// `isVisible()` also requires import.meta.env.DEV, which vitest sets to true,
-// so the mock flags below are the only knobs the tests need to turn.
+// `isVisible()` also requires import.meta.env.DEV, which vitest sets to true.
+// Both mock flags are stubbed to a known baseline first: vite loads the
+// developer's own `.env.local`, so a machine with VITE_HIDE_MOCK_BANNER=true
+// would otherwise fail the visible case while CI (no `.env.local`) passes.
 describe("MockBanner", () => {
+  beforeEach(() => {
+    vi.stubEnv("VITE_ENABLE_MOCKS", "false");
+    vi.stubEnv("VITE_HIDE_MOCK_BANNER", "");
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
   it("renders nothing when mocks are not enabled", () => {
-    vi.stubEnv("VITE_ENABLE_MOCKS", "false");
     const { container } = render(<MockBanner />);
     expect(container).toBeEmptyDOMElement();
   });

--- a/src/frontend/src/components/org-tree.tsx
+++ b/src/frontend/src/components/org-tree.tsx
@@ -1,33 +1,21 @@
 import { Link, useRouterState } from "@tanstack/react-router";
-import {
-  ChevronDown,
-  ChevronRight,
-  User,
-  Users,
-} from "lucide-react";
+import { ChevronDown, ChevronRight, User, Users } from "lucide-react";
 import { useMemo } from "react";
-import { useTranslation } from "react-i18next";
 
 import { useViewer } from "@/auth";
-import { AppSidebarFooter } from "@/components/app-sidebar-footer";
 import {
-  Sidebar,
-  SidebarContent,
-  SidebarFooter,
-  SidebarGroup,
-  SidebarGroupContent,
-  SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import {
+  usePortalNavActions,
+} from "@/lib/portal/portal-nav";
 import { useIcPerson } from "@/queries/ic-dashboard";
 import type { IdentityPerson } from "@/types/insight";
 
-// The identity contract admits people with no email and no display name (a
-// person whose log carries neither). Their node still has to be clickable.
-const UNNAMED_PERSON = "Unnamed person";
-
+// Person ids, not emails: the identity cutover made the id the key the route
+// segment, `?scope=` and the metric entity ids all carry.
 function personIdEq(a: string, b: string): boolean {
   return a.toLowerCase() === b.toLowerCase();
 }
@@ -41,11 +29,15 @@ function PersonNode({
   node,
   depth,
   activePersonId,
+  leadsToTeam,
 }: {
   node: IdentityPerson;
   depth: number;
   activePersonId: string | null;
+  /** Lead (has reports) links to their team roster instead of their own page. */
+  leadsToTeam: boolean;
 }) {
+  const { setScope } = usePortalNavActions();
   const hasReports = node.subordinates.length > 0;
   const isActive = activePersonId
     ? personIdEq(activePersonId, node.person_id)
@@ -55,17 +47,26 @@ function PersonNode({
       ? node.subordinates.some((s) => containsPerson(s, activePersonId))
       : false;
   const open = depth === 0 || isActive || hasActiveDescendant;
+  // A lead's name lands on their team; an IC's on their own page. (The two
+  // literal `to`s keep the typed router happy vs. a computed path.) Drilling
+  // into a lead also *sets the org scope* (design §6) so the topbar badge and
+  // every org zone follow the node you just clicked.
+  const link =
+    hasReports && leadsToTeam ? (
+      <Link
+        to="/ic/$person/team"
+        params={{ person: node.person_id }}
+        onClick={() => setScope({ root: node.person_id })}
+      />
+    ) : (
+      <Link to="/ic/$person/personal" params={{ person: node.person_id }} />
+    );
   return (
     <>
       <SidebarMenuItem>
         <SidebarMenuButton
           isActive={isActive}
-          render={
-            <Link
-              to="/ic/$person/personal"
-              params={{ person: node.person_id }}
-            />
-          }
+          render={link}
           style={{ paddingLeft: `${0.5 + depth * 0.875}rem` }}
         >
           {hasReports ? (
@@ -78,9 +79,7 @@ function PersonNode({
             <span className="w-4 shrink-0" />
           )}
           {hasReports ? <Users /> : <User />}
-          <span className="truncate">
-            {node.display_name || node.email || UNNAMED_PERSON}
-          </span>
+          <span className="truncate">{node.display_name || node.email}</span>
         </SidebarMenuButton>
       </SidebarMenuItem>
       {hasReports && open
@@ -90,6 +89,7 @@ function PersonNode({
               node={sub}
               depth={depth + 1}
               activePersonId={activePersonId}
+              leadsToTeam={leadsToTeam}
             />
           ))
         : null}
@@ -97,14 +97,16 @@ function PersonNode({
   );
 }
 
-export function AppSidebar() {
-  const { t } = useTranslation();
+/**
+ * Recursive org-chart navigation, rooted at the viewer. Extracted from
+ * AppSidebar so the portal shell's context pane can reuse the same tree
+ * without duplicating the traversal / active-node logic.
+ */
+export function OrgTree({ leadsToTeam = false }: { leadsToTeam?: boolean } = {}) {
   const { personId: viewerPersonId } = useViewer();
   const viewerQ = useIcPerson(viewerPersonId ?? "");
   const viewer = viewerQ.data ?? null;
   const pathname = useRouterState({ select: (s) => s.location.pathname });
-  // The URL segment is the person id since the identity cutover; a legacy
-  // email URL simply highlights nothing for the moment its redirect takes.
   const activePersonId = useMemo(() => {
     const m = /^\/ic\/([^/]+)/.exec(pathname);
     if (m) return decodeURIComponent(m[1]!);
@@ -112,32 +114,16 @@ export function AppSidebar() {
     return null;
   }, [pathname, viewerPersonId]);
 
+  if (!viewer) return null;
+
   return (
-    <Sidebar>
-      <SidebarHeader>
-        <div className="flex items-center gap-2 px-2 py-1.5">
-          <div className="flex size-7 items-center justify-center rounded-md bg-sidebar-primary font-semibold text-sidebar-primary-foreground">
-            I
-          </div>
-          <span className="font-semibold tracking-tight text-sidebar-foreground">
-            {t("common.app_name")}
-          </span>
-        </div>
-      </SidebarHeader>
-      <SidebarContent>
-        <SidebarGroup>
-          <SidebarGroupContent>
-            {viewer ? (
-              <SidebarMenu>
-                <PersonNode node={viewer} depth={0} activePersonId={activePersonId} />
-              </SidebarMenu>
-            ) : null}
-          </SidebarGroupContent>
-        </SidebarGroup>
-      </SidebarContent>
-      <SidebarFooter>
-        <AppSidebarFooter />
-      </SidebarFooter>
-    </Sidebar>
+    <SidebarMenu>
+      <PersonNode
+        node={viewer}
+        depth={0}
+        activePersonId={activePersonId}
+        leadsToTeam={leadsToTeam}
+      />
+    </SidebarMenu>
   );
 }

--- a/src/frontend/src/components/org-tree.tsx
+++ b/src/frontend/src/components/org-tree.tsx
@@ -11,6 +11,7 @@ import {
 import {
   usePortalNavActions,
 } from "@/lib/portal/portal-nav";
+import { personIdFromPath } from "@/lib/metrics/entity";
 import { useIcPerson } from "@/queries/ic-dashboard";
 import type { IdentityPerson } from "@/types/insight";
 
@@ -108,8 +109,8 @@ export function OrgTree({ leadsToTeam = false }: { leadsToTeam?: boolean } = {})
   const viewer = viewerQ.data ?? null;
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   const activePersonId = useMemo(() => {
-    const m = /^\/ic\/([^/]+)/.exec(pathname);
-    if (m) return decodeURIComponent(m[1]!);
+    const fromPath = personIdFromPath(pathname);
+    if (fromPath) return fromPath;
     if (pathname === "/" && viewerPersonId) return viewerPersonId;
     return null;
   }, [pathname, viewerPersonId]);

--- a/src/frontend/src/components/portal/ai-cost-view.test.tsx
+++ b/src/frontend/src/components/portal/ai-cost-view.test.tsx
@@ -1,0 +1,211 @@
+// @vitest-environment jsdom
+/**
+ * AI & Cost zone semantics: the Claude-only cost caveat ("not tracked" is
+ * never $0), adoption math (active users, funnel stage cuts), per-tool
+ * aggregation from the breakdown view, by-unit rollups under a slice, and
+ * honest ComingSoon for unwired pane items.
+ */
+vi.mock("@tanstack/react-router", async () => {
+  const { portalRouterMock } = await import("@/test/portal-router");
+  return portalRouterMock();
+});
+
+import { portalRouter } from "@/test/portal-router";
+
+import { act, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { NormalizedMetricResult } from "@/lib/metrics/collection";
+import { identityPerson, pid } from "@/test/identity";
+import type { IdentityPerson, TeamMember } from "@/types/insight";
+
+const mocks = vi.hoisted(() => ({
+  personId: null as string | null,
+  tree: undefined as IdentityPerson | undefined,
+  members: [] as TeamMember[],
+  grid: {
+    byKey: new Map<string, NormalizedMetricResult>(),
+    previousByKey: new Map<string, NormalizedMetricResult>(),
+    isPending: false,
+    isFetching: false,
+    isError: false,
+    refetch: vi.fn(),
+  },
+  tools: {
+    byKey: new Map<string, NormalizedMetricResult>(),
+    previousByKey: null,
+    isPending: false,
+    isFetching: false,
+    isError: false,
+    refetch: vi.fn(),
+  },
+}));
+
+vi.mock("@/auth", () => ({
+  useViewer: () => ({ email: "boss@x", personId: mocks.personId }),
+}));
+vi.mock("@/lib/portal/use-cohort-label", () => ({
+  useCohortLabel: () => "team",
+}));
+vi.mock("@/queries/ic-dashboard", () => ({
+  useIcPerson: () => ({ data: mocks.tree, isPending: false, isLoading: false, isError: false, refetch: vi.fn() }),
+}));
+vi.mock("@/queries/team-view", () => ({
+  useTeamMembers: () => ({ data: mocks.members, isPending: false, isLoading: false, isError: false, refetch: vi.fn() }),
+}));
+vi.mock("@/queries/member-grid", () => ({ useMemberGridData: () => mocks.grid }));
+vi.mock("@/queries/metric-results", () => ({ useMetricCollection: () => mocks.tools }));
+vi.mock("@/hooks/use-portal-period", () => ({
+  usePortalPeriod: () => ({ period: "week", dateRange: { start: "2026-07-20", end: "2026-07-26" } }),
+}));
+
+
+import { AiCostView } from "./ai-cost-view";
+
+const person = (
+  label: string,
+  over: Partial<IdentityPerson> = {},
+  subs: IdentityPerson[] = [],
+): IdentityPerson => identityPerson(label, over, subs);
+
+const member = (id: string): TeamMember =>
+  ({ person_id: id, name: `Name ${id.split("@")[0]}` }) as unknown as TeamMember;
+
+function metric(
+  key: string,
+  period: Array<[string, number | null]>,
+  over: Partial<NormalizedMetricResult> = {},
+): NormalizedMetricResult {
+  return {
+    metric_key: key,
+    label: key,
+    unit: null,
+    computation: "sum",
+    format: "integer",
+    direction: "higher_is_better",
+    period: { view: "period", values: period.map(([entity_id, value]) => ({ entity_id, value })) },
+    peer: { view: "peer", values: period.map(([entity_id, value]) => ({ entity_id, target_value: value })) },
+    ...over,
+  } as unknown as NormalizedMetricResult;
+}
+
+function toolBreakdown(
+  key: string,
+  rows: Array<[string, string, number]>,
+): NormalizedMetricResult {
+  return {
+    ...metric(key, []),
+    breakdown: {
+      view: "breakdown",
+      values: rows.map(([entity_id, tool, value]) => ({
+        entity_id,
+        dimensions: [{ key: "tool", value: tool }],
+        value,
+      })),
+    },
+  } as unknown as NormalizedMetricResult;
+}
+
+// Roster entity ids are person UUIDs (identity cutover).
+const LABELS = ["a", "b", "c", "d"];
+const IDS = LABELS.map(pid);
+
+beforeEach(() => {
+  mocks.personId = pid("boss");
+  mocks.tree = person("boss", {}, LABELS.map((l) => person(l)));
+  mocks.members = IDS.map(member);
+  mocks.grid.isPending = false;
+  mocks.grid.isError = false;
+  mocks.tools.isError = false;
+  // 3 of 4 use AI; costs are Claude-only.
+  mocks.grid.byKey = new Map([
+    ["ai.cost", metric("ai.cost", [[pid("a"), 100], [pid("b"), 50], [pid("c"), 0], [pid("d"), 0]], { format: "currency", unit: "USD" } as never)],
+    ["ai.active_days", metric("ai.active_days", [[pid("a"), 5], [pid("b"), 3], [pid("c"), 1], [pid("d"), 0]])],
+    ["ai.accepted_lines", metric("ai.accepted_lines", [[pid("a"), 700], [pid("b"), 200], [pid("c"), 100], [pid("d"), 0]])],
+  ]);
+  mocks.grid.previousByKey = new Map();
+  mocks.tools.byKey = new Map([
+    ["ai.cost", toolBreakdown("ai.cost", [[pid("a"), "claude_code", 100], [pid("b"), "claude_code", 50]])],
+    ["ai.accepted_lines", toolBreakdown("ai.accepted_lines", [
+      [pid("a"), "claude_code", 600],
+      [pid("b"), "chatgpt", 300],
+      [pid("c"), "chatgpt", 100],
+    ])],
+  ]);
+  act(() => {
+    portalRouter.set({ slice: undefined });
+    portalRouter.set({ scope: undefined, direct: false });
+  });
+});
+
+describe("AiCostView", () => {
+  it("renders headline KPIs: Claude-only cost, active users, org lines", () => {
+    render(<AiCostView item={null} />);
+    expect(screen.getByText("AI cost")).toBeInTheDocument();
+    expect(screen.getByText("Claude Code only")).toBeInTheDocument();
+    // 3 of 4 members have active days > 0
+    expect(screen.getByText("Active AI users")).toBeInTheDocument();
+    expect(screen.getByText("75% of 4")).toBeInTheDocument();
+    expect(screen.getByText(/1[,  ]?000/)).toBeInTheDocument(); // 700+200+100 lines
+  });
+
+  it("shows per-tool cards where untracked cost reads 'not tracked', never $0", () => {
+    render(<AiCostView item={null} />);
+    expect(screen.getAllByText("Claude Code").length).toBeGreaterThan(0);
+    expect(screen.getByText("ChatGPT")).toBeInTheDocument();
+    // ChatGPT reports lines but no cost
+    expect(screen.getByText("cost not tracked")).toBeInTheDocument();
+    expect(screen.getByText(/2 users · 400 lines/)).toBeInTheDocument();
+    // the caveat is spelled out for the reader
+    expect(screen.getByText(/Only Claude Code is usage-metered/)).toBeInTheDocument();
+  });
+
+  it("computes the adoption funnel with data-relative stage cuts", () => {
+    render(<AiCostView item="adoption-funnel" />);
+    expect(screen.getByText("Adoption funnel")).toBeInTheDocument();
+    expect(screen.getByText("In org")).toBeInTheDocument();
+    expect(screen.getByText("Used AI (≥1 day)")).toBeInTheDocument();
+    // users days = [1,3,5] → median 3 → active = {3,5} = 2; p75 = 4 → heavy = {5} = 1
+    expect(screen.getByText(/Active \(≥3 days · median\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Heavy \(≥4 days · top quartile\)/)).toBeInTheDocument();
+  });
+
+  it("surfaces a failed per-tool breakdown instead of calling it empty", () => {
+    // "No per-tool breakdown for this period" over a failed request states a
+    // fact about the org that was never measured.
+    mocks.tools.isError = true;
+    render(<AiCostView item={null} />);
+    expect(screen.getByText("Unable to load the per-tool breakdown")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/No per-tool breakdown for this period/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders an honest ComingSoon for unwired pane items", () => {
+    render(<AiCostView item="autofix" />);
+    expect(screen.getByText(/no autofix signal ingested/i)).toBeInTheDocument();
+    // no fabricated KPI cards behind it
+    expect(screen.queryByText("AI cost")).not.toBeInTheDocument();
+  });
+
+  it("groups cost and adoption by unit when a slice is active", () => {
+    mocks.tree = person("boss", {}, [
+      person("a", { division: "R&D" } as never),
+      person("b", { division: "R&D" } as never),
+      person("c", { division: "Sales" } as never),
+      person("d", { division: "Sales" } as never),
+    ]);
+    act(() => portalRouter.set({ slice: "division" }));
+    render(<AiCostView item="by-unit-role" />);
+    expect(screen.getByText("R&D")).toBeInTheDocument();
+    expect(screen.getByText("Sales")).toBeInTheDocument();
+  });
+
+  it("gates on an empty scope instead of rendering zero KPIs", () => {
+    mocks.members = [];
+    mocks.tree = person("boss");
+    render(<AiCostView item={null} />);
+    expect(screen.getByText(/No people in the current scope/)).toBeInTheDocument();
+    expect(screen.queryByText("AI cost")).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/portal/ai-cost-view.tsx
+++ b/src/frontend/src/components/portal/ai-cost-view.tsx
@@ -337,7 +337,11 @@ export function AiCostView({ item }: { item: string | null }) {
         />
         <Tile
           label="Avg cost / active user"
-          value={formatMetricValue(avgCost, "currency", "USD")}
+          value={formatMetricValue(
+            avgCost,
+            costR?.format ?? "currency",
+            costR?.unit ?? null,
+          )}
           sub="Claude Code"
         />
       </div>

--- a/src/frontend/src/components/portal/ai-cost-view.tsx
+++ b/src/frontend/src/components/portal/ai-cost-view.tsx
@@ -1,0 +1,550 @@
+import { useMemo } from "react";
+
+import { CenteredSpinner } from "@/components/widgets/centered-spinner";
+import { ComingSoon } from "@/components/widgets/coming-soon";
+import { orgScopeGate } from "@/components/portal/org-scope-gate";
+import { MembersGrid } from "@/components/widgets/dashboard/members-grid";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { usePortalPeriod } from "@/hooks/use-portal-period";
+import { formatMetricValue } from "@/lib/format";
+import { GROUPS } from "@/lib/insight/groups";
+import {
+  availableSlices,
+  cohortKey,
+  collectRosterAttrs,
+  PLANNED_SLICES,
+  type SliceDim,
+} from "@/lib/insight/slices";
+import { quantile, withinCohortPeer } from "@/lib/insight/within-team-peer";
+import {
+  forEntity,
+  type MetricCollectionConfig,
+  type NormalizedMetricResult,
+} from "@/lib/metrics/collection";
+import { normalizePersonId } from "@/lib/metrics/entity";
+import {
+  usePortalSlice,
+} from "@/lib/portal/portal-nav";
+import type { TeamMember } from "@/types/insight";
+import { useCohortLabel } from "@/lib/portal/use-cohort-label";
+import { useOrgScope } from "@/lib/portal/use-org-scope";
+import { useMemberGridData } from "@/queries/member-grid";
+import { useMetricCollection } from "@/queries/metric-results";
+
+const EMPTY_COLLECTION: MetricCollectionConfig = { metrics: [] };
+const COST_KEY = "ai.cost";
+const LINES_KEY = "ai.accepted_lines";
+const DAYS_KEY = "ai.active_days";
+/** Grid columns for the cost-leaders scan. */
+const GRID_KEYS = [COST_KEY, DAYS_KEY, LINES_KEY, "ai.dev_conversations"];
+/** Pane items with no dedicated data-backed view yet — honest ComingSoon. */
+const COMING_SOON: Record<string, string> = {
+  "per-tool":
+    "Per-tool detail — the tool split is summarised on Overview → By tool; a standalone per-tool drilldown is pending.",
+  autofix: "Autofix — no autofix signal ingested.",
+  "ai-audit": "AI Audit — pending the diagnosis circuit.",
+  "spend-by-tool":
+    "Spend by tool — see Overview → By tool; a dedicated spend breakdown is pending.",
+  "cost-by-unit":
+    "Cost by unit / user — unit rollup is under “By unit / role”, per-user is on Overview; a combined view is pending.",
+  "idle-seats":
+    "Idle seats — the seat roster lives in bronze (52 ChatGPT seats) but isn't exposed through the analytics API yet.",
+  credits: "Credits burn-down — no credit/quota feed ingested.",
+  "ai-pricing": "AI pricing config — not wired.",
+};
+
+const TOOL_LABEL: Record<string, string> = {
+  claude_code: "Claude Code",
+  codex: "Codex",
+  chatgpt: "ChatGPT",
+};
+
+interface ToolRow {
+  tool: string;
+  users: number;
+  lines: number;
+  cost: number;
+  costTracked: boolean;
+}
+
+/** Sum a breakdown metric across members, grouped by the `tool` dimension. */
+function aggregateByTool(
+  result: NormalizedMetricResult | undefined,
+  memberIds: readonly string[],
+): Map<string, { sum: number; users: Set<string> }> {
+  const out = new Map<string, { sum: number; users: Set<string> }>();
+  if (!result) return out;
+  for (const id of memberIds) {
+    for (const row of forEntity(result, id).breakdown) {
+      const tool = row.dimensions.find((d) => d.key === "tool")?.value;
+      if (!tool || row.value == null) continue;
+      const bucket = out.get(tool) ?? { sum: 0, users: new Set<string>() };
+      bucket.sum += row.value;
+      if (row.value > 0) bucket.users.add(id);
+      out.set(tool, bucket);
+    }
+  }
+  return out;
+}
+
+const PLANNED_KEYS = new Set(PLANNED_SLICES.map((d) => d.key));
+
+/**
+ * AI & Cost — org-level adoption + spend across the active org scope (set in
+ * the topbar). Shows what's actually ingested; everything unavailable is an
+ * explicit ComingSoon rather than a fabricated or zero-filled panel.
+ *
+ * Honest data caveats surfaced in the UI:
+ *  - only Claude Code is usage-metered → the cost total is Claude-only;
+ *  - ChatGPT/Codex report usage but no per-user cost (subscription / token
+ *    billing isn't ingested), so their cost reads "not tracked", never $0.
+ */
+export function AiCostView({ item }: { item: string | null }) {
+  const cohortLabel = useCohortLabel();
+  const { period, dateRange } = usePortalPeriod();
+
+  const orgScope = useOrgScope();
+  const { pivot, roster } = orgScope;
+
+  // The roster IS the member list: identity owns who is on the team and
+  // every metric for them comes from `/v1/metric-results`. There is no second
+  // source to reconcile — the legacy per-member batch this used to call was
+  // removed upstream with the rest of the old metric UI.
+  const members = useMemo<TeamMember[]>(
+    () =>
+      (roster ?? []).map((entry) => ({
+        person_id: entry.person_id,
+        name: entry.display_name,
+      })),
+    [roster],
+  );
+  const memberIds = useMemo(
+    () => members.map((m) => normalizePersonId(m.person_id)),
+    [members],
+  );
+
+  const aiGroup = useMemo(
+    () => GROUPS.find((g) => g.id === "ai_adoption") ?? null,
+    [],
+  );
+  const gridCollection = useMemo<MetricCollectionConfig>(
+    () => ({
+      metrics: (aiGroup?.collection.metrics ?? []).filter((m) =>
+        GRID_KEYS.includes(m.key),
+      ),
+    }),
+    [aiGroup],
+  );
+  const toolCollection = useMemo<MetricCollectionConfig>(
+    () => ({
+      metrics: [COST_KEY, LINES_KEY].map((key) => ({
+        key,
+        views: [{ view: "breakdown" as const, dimensions: ["tool"] }],
+      })),
+    }),
+    [],
+  );
+
+  const grid = useMemberGridData(
+    memberIds.length ? gridCollection : EMPTY_COLLECTION,
+    { type: "person", ids: memberIds },
+    dateRange,
+    period,
+  );
+  const toolData = useMetricCollection(
+    memberIds.length ? toolCollection : EMPTY_COLLECTION,
+    { type: "person", ids: memberIds },
+    dateRange,
+  );
+
+  const teamName = orgScope.label;
+
+  const sum = (key: string) => {
+    const r = grid.byKey.get(key);
+    if (!r) return 0;
+    return memberIds.reduce((acc, id) => {
+      const v = forEntity(r, id).value;
+      return acc + (v != null && Number.isFinite(v) ? v : 0);
+    }, 0);
+  };
+  const activeUsers = useMemo(() => {
+    const r = grid.byKey.get(DAYS_KEY);
+    if (!r) return 0;
+    return memberIds.filter((id) => (forEntity(r, id).value ?? 0) > 0).length;
+  }, [grid.byKey, memberIds]);
+
+  const toolRows = useMemo<ToolRow[]>(() => {
+    const cost = aggregateByTool(toolData.byKey.get(COST_KEY), memberIds);
+    const lines = aggregateByTool(toolData.byKey.get(LINES_KEY), memberIds);
+    const tools = new Set([...cost.keys(), ...lines.keys()]);
+    return [...tools]
+      .map((tool) => {
+        const c = cost.get(tool);
+        const l = lines.get(tool);
+        return {
+          tool,
+          users: (l?.users.size ?? 0) || (c?.users.size ?? 0),
+          lines: l?.sum ?? 0,
+          cost: c?.sum ?? 0,
+          costTracked: (c?.sum ?? 0) > 0,
+        };
+      })
+      .sort((a, b) => b.lines - a.lines);
+  }, [toolData.byKey, memberIds]);
+
+  // Data-driven slice options + the active slice's cohort accessor. The slice
+  // is global (portal-store) so it re-cohorts every view at once.
+  const attrByEntity = useMemo(
+    () => collectRosterAttrs(pivot, normalizePersonId),
+    [pivot],
+  );
+  const sliceDims = useMemo<SliceDim[]>(
+    () => availableSlices(attrByEntity.values()),
+    [attrByEntity],
+  );
+  const slice = usePortalSlice();
+  const cohortOf = useMemo(
+    () => (id: string) => cohortKey(attrByEntity.get(id), slice),
+    [attrByEntity, slice],
+  );
+
+  // Grid heat / attention rank each person within their active-slice cohort
+  // (whole roster when no slice is set).
+  const heatByKey = useMemo(() => {
+    const m = new Map<string, NormalizedMetricResult>();
+    for (const k of GRID_KEYS) {
+      const r = grid.byKey.get(k);
+      if (r) m.set(k, withinCohortPeer(r, memberIds, cohortOf));
+    }
+    return m;
+  }, [grid.byKey, memberIds, cohortOf]);
+
+  // "By unit" groups the roster by the active slice attribute.
+  const unitRows = useMemo(() => {
+    if (!slice || PLANNED_KEYS.has(slice)) return [];
+    const costR = grid.byKey.get(COST_KEY);
+    const linesR = grid.byKey.get(LINES_KEY);
+    const daysR = grid.byKey.get(DAYS_KEY);
+    const val = (r: NormalizedMetricResult | undefined, id: string) =>
+      r ? (forEntity(r, id).value ?? 0) : 0;
+    const map = new Map<
+      string,
+      { unit: string; people: number; active: number; cost: number; lines: number }
+    >();
+    for (const id of memberIds) {
+      const unit = attrByEntity.get(id)?.[slice]?.value ?? "—";
+      const b = map.get(unit) ?? { unit, people: 0, active: 0, cost: 0, lines: 0 };
+      b.people += 1;
+      if (val(daysR, id) > 0) b.active += 1;
+      b.cost += val(costR, id);
+      b.lines += val(linesR, id);
+      map.set(unit, b);
+    }
+    return [...map.values()].sort((a, b) => b.cost - a.cost || b.lines - a.lines);
+  }, [grid.byKey, memberIds, attrByEntity, slice]);
+
+  // Adoption funnel from active-days: org → any use → active → heavy. Stage
+  // cuts are data-relative (median / top-quartile among AI users), so they hold
+  // regardless of the selected period length.
+  const funnel = useMemo(() => {
+    const daysR = grid.byKey.get(DAYS_KEY);
+    const days = memberIds.map((id) => (daysR ? (forEntity(daysR, id).value ?? 0) : 0));
+    const users = days.filter((d) => d > 0).sort((a, b) => a - b);
+    // Rounded ONCE and reused for both the label and the comparison, so the
+    // stage count always matches the threshold the label promises.
+    const med = users.length ? Math.round(quantile(users, 0.5)) : 0;
+    const p75 = users.length ? Math.round(quantile(users, 0.75)) : 0;
+    return [
+      { label: "In org", n: memberIds.length },
+      { label: "Used AI (≥1 day)", n: users.length },
+      { label: `Active (≥${med} days · median)`, n: days.filter((d) => d > 0 && d >= med).length },
+      { label: `Heavy (≥${p75} days · top quartile)`, n: days.filter((d) => d > 0 && d >= p75).length },
+    ];
+  }, [grid.byKey, memberIds]);
+
+  if (item && COMING_SOON[item])
+    return (
+      <div className="mx-auto w-full max-w-md p-8">
+        <ComingSoon variant="card" state="empty" label={COMING_SOON[item]} />
+      </div>
+    );
+
+  const gate = orgScopeGate({
+    viewerLoading: orgScope.isLoading,
+    viewerError: orgScope.isError,
+    membersLoading: false,
+    membersError: false,
+    memberCount: members.length,
+    gridPending: grid.isPending,
+    gridError: grid.isError,
+    emptyLabel: "No people in the current scope — pick a different scope in the topbar.",
+    onRetry: () => {
+      orgScope.refetch();
+      grid.refetch();
+    },
+  });
+  if (gate) return gate;
+
+  const costR = grid.byKey.get(COST_KEY);
+  const linesR = grid.byKey.get(LINES_KEY);
+  const totalCost = sum(COST_KEY);
+  const totalLines = sum(LINES_KEY);
+  const adoptionPct = members.length
+    ? Math.round((activeUsers / members.length) * 100)
+    : 0;
+  const avgCost = activeUsers ? totalCost / activeUsers : 0;
+
+  const shownGridKeys = GRID_KEYS.filter((k) => {
+    const r = grid.byKey.get(k);
+    return (
+      !!r &&
+      memberIds.some((id) => {
+        const v = forEntity(r, id).value;
+        return v != null && Number.isFinite(v);
+      })
+    );
+  });
+
+  return (
+    <div className="flex flex-col gap-6 p-4 md:p-6">
+      <div>
+        <h1 className="text-xl font-semibold tracking-tight">AI &amp; Cost</h1>
+        <p className="text-sm text-muted-foreground">
+          {teamName ? `${teamName}'s org` : "Org"} · {orgScope.count} people
+        </p>
+      </div>
+
+      {/* Headline */}
+      <div className="grid grid-cols-[repeat(auto-fit,minmax(11rem,1fr))] gap-3">
+        <Tile
+          label="AI cost"
+          value={formatMetricValue(totalCost, costR?.format ?? "currency", costR?.unit ?? "USD")}
+          sub="Claude Code only"
+        />
+        <Tile label="Active AI users" value={String(activeUsers)} sub={`${adoptionPct}% of ${members.length}`} />
+        <Tile
+          label="AI-accepted lines"
+          value={formatMetricValue(totalLines, linesR?.format ?? "integer", linesR?.unit ?? null)}
+          sub="org total"
+        />
+        <Tile
+          label="Avg cost / active user"
+          value={formatMetricValue(avgCost, "currency", "USD")}
+          sub="Claude Code"
+        />
+      </div>
+
+      {item === "adoption-funnel" ? (
+        <FunnelSection funnel={funnel} />
+      ) : item === "by-unit-role" ? (
+        <UnitSection
+          rows={unitRows}
+          costR={costR}
+          linesR={linesR}
+          dim={[...sliceDims, ...PLANNED_SLICES].find((d) => d.key === slice) ?? null}
+        />
+      ) : (
+        <>
+      {/* By tool */}
+      <section className="flex flex-col gap-3">
+        <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+          By tool
+        </p>
+        {toolData.isError ? (
+          // A failed breakdown is not an empty one: reporting "nothing for this
+          // period" would hide exactly the failure the scope gate exists to
+          // surface, and the reader would take a broken request for a fact
+          // about their org.
+          <ComingSoon state="error" label="Unable to load the per-tool breakdown" />
+        ) : toolData.isPending ? (
+          <CenteredSpinner className="min-h-32" />
+        ) : toolRows.length ? (
+          <div className="grid grid-cols-[repeat(auto-fit,minmax(13rem,1fr))] gap-3">
+            {toolRows.map((t) => (
+              <Card key={t.tool}>
+                <CardContent className="flex flex-col gap-1 p-4">
+                  <div className="text-sm font-semibold">
+                    {TOOL_LABEL[t.tool] ?? t.tool}
+                  </div>
+                  <div className="text-2xl font-semibold tabular-nums">
+                    {t.costTracked
+                      ? formatMetricValue(t.cost, "currency", "USD")
+                      : "—"}
+                  </div>
+                  <div className="text-xs text-muted-foreground">
+                    {t.costTracked ? "cost" : "cost not tracked"}
+                  </div>
+                  <div className="mt-1 text-xs text-muted-foreground">
+                    {t.users} users · {formatMetricValue(t.lines, "integer", null)} lines
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        ) : (
+          <ComingSoon variant="card" state="empty" label="No per-tool breakdown for this period." />
+        )}
+        <p className="text-xs text-muted-foreground">
+          Only Claude Code is usage-metered. ChatGPT (per-seat subscription) and
+          Codex (token-based) report usage but no per-user cost yet — shown as
+          “not tracked”, not $0.
+        </p>
+      </section>
+
+      {/* Cost leaders */}
+      <section className="flex flex-col gap-3">
+        <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+          Cost &amp; usage by person
+        </p>
+        <Card>
+          <CardContent className="p-0">
+            <MembersGrid
+              members={members.map((m) => ({
+                entityId: normalizePersonId(m.person_id),
+                displayName: m.name,
+                personId: m.person_id,
+              }))}
+              metricKeys={shownGridKeys}
+              byKey={heatByKey}
+              previousByKey={grid.previousByKey}
+              caption={`${teamName} — AI usage & cost by person`}
+              cohortLabel={cohortLabel}
+            />
+          </CardContent>
+        </Card>
+      </section>
+        </>
+      )}
+    </div>
+  );
+}
+
+/** Adoption funnel — successive stages as proportional bars. */
+function FunnelSection({ funnel }: { funnel: { label: string; n: number }[] }) {
+  const top = funnel[0]?.n || 1;
+  return (
+    <section className="flex flex-col gap-3">
+      <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+        Adoption funnel
+      </p>
+      <Card>
+        <CardContent className="flex flex-col gap-2 p-4">
+          {funnel.map((s) => {
+            const pct = Math.round((s.n / top) * 100);
+            return (
+              <div key={s.label} className="flex items-center gap-3">
+                <div className="w-56 shrink-0 text-sm">{s.label}</div>
+                <div className="relative h-7 flex-1 overflow-hidden rounded bg-muted">
+                  <div
+                    className="h-full rounded bg-primary/25"
+                    style={{ width: `${pct}%` }}
+                  />
+                  <span className="absolute inset-y-0 left-2 flex items-center text-xs font-medium tabular-nums">
+                    {s.n} · {pct}%
+                  </span>
+                </div>
+              </div>
+            );
+          })}
+        </CardContent>
+      </Card>
+      <p className="text-xs text-muted-foreground">
+        Stages from AI active-days; “active”/“heavy” cuts are the median and
+        top-quartile day counts among people who used AI this period.
+      </p>
+    </section>
+  );
+}
+
+/** AI cost + adoption grouped by the active slice (driven by the header SliceSelect). */
+function UnitSection({
+  rows,
+  costR,
+  linesR,
+  dim,
+}: {
+  rows: { unit: string; people: number; active: number; cost: number; lines: number }[];
+  costR: NormalizedMetricResult | undefined;
+  linesR: NormalizedMetricResult | undefined;
+  dim: SliceDim | null;
+}) {
+  const dimLabel = dim?.label ?? "Unit";
+  return (
+    <section className="flex flex-col gap-3">
+      <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+        {dim ? `By ${dimLabel.toLowerCase()}` : "By unit"}
+      </p>
+      {!dim ? (
+        <ComingSoon
+          variant="card"
+          state="empty"
+          label="Pick a slice in the header (Division / Department / Title / Manager) to group the org."
+        />
+      ) : dim.planned ? (
+        <ComingSoon
+          variant="card"
+          state="empty"
+          label="Functional teams — derived team detection (co-commit clustering) isn't built yet; only reporting-line slices (division / department / manager) and title are available."
+        />
+      ) : (
+      <div className="overflow-x-auto rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>{dimLabel}</TableHead>
+              <TableHead className="text-right">People</TableHead>
+              <TableHead className="text-right">AI users</TableHead>
+              <TableHead className="text-right">AI cost</TableHead>
+              <TableHead className="text-right">Accepted lines</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((r) => (
+              <TableRow key={r.unit}>
+                <TableCell className="font-medium">{r.unit}</TableCell>
+                <TableCell className="text-right tabular-nums text-muted-foreground">
+                  {r.people}
+                </TableCell>
+                <TableCell className="text-right tabular-nums text-muted-foreground">
+                  {r.active}
+                </TableCell>
+                <TableCell className="text-right tabular-nums">
+                  {formatMetricValue(r.cost, costR?.format ?? "currency", costR?.unit ?? "USD")}
+                </TableCell>
+                <TableCell className="text-right tabular-nums text-muted-foreground">
+                  {formatMetricValue(r.lines, linesR?.format ?? "integer", linesR?.unit ?? null)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      )}
+      {dim && !dim.planned ? (
+        <p className="text-xs text-muted-foreground">
+          Cost is Claude Code only (the usage-metered tool).
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+function Tile({ label, value, sub }: { label: string; value: string; sub: string }) {
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <div className="text-xs font-medium text-muted-foreground">{label}</div>
+        <div className="mt-1 text-2xl font-semibold tabular-nums">{value}</div>
+        <div className="text-xs text-muted-foreground">{sub}</div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/frontend/src/components/portal/attention-list.test.tsx
+++ b/src/frontend/src/components/portal/attention-list.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+vi.mock("@tanstack/react-router", async () => {
+  const { portalRouterMock } = await import("@/test/portal-router");
+  return portalRouterMock();
+});
+
+import { portalRouter } from "@/test/portal-router";
+
+import { act, render, renderHook, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { AttentionFlag } from "@/lib/insight/attention-flags";
+import {
+  usePortalZone,
+} from "@/lib/portal/portal-nav";
+
+
+import { AttentionList } from "./attention-list";
+
+// Person ids, not emails: rows link by the identity-cutover key.
+const ID = (n: number) => `0000000${n}-1111-4111-8111-111111111111`;
+
+function flag(over: Partial<AttentionFlag>): AttentionFlag {
+  return {
+    personId: ID(0),
+    name: "Person",
+    metricKey: "t.metric",
+    metricLabel: "Commits",
+    kind: "outlier",
+    valueText: "2",
+    reason: "unusually low · team median 10",
+    severity: 1,
+    ...over,
+  };
+}
+
+const FLAGS = Array.from({ length: 5 }, (_, i) =>
+  flag({ personId: ID(i), name: `Person ${i}`, severity: 5 - i }),
+);
+
+describe("AttentionList", () => {
+  it("renders the summary, people label and flag rows with reasons", () => {
+    render(
+      <AttentionList
+        flags={FLAGS.slice(0, 2)}
+        summary="2 of 8 people need a look — most flags on Commits (2)."
+        peopleLabel="2 of 8 people"
+      />,
+    );
+    expect(screen.getByText(/2 of 8 people need a look/)).toBeInTheDocument();
+    expect(screen.getByText("Person 0")).toBeInTheDocument();
+    expect(screen.getAllByText("unusually low · team median 10")).toHaveLength(2);
+  });
+
+  it("links every row to that person's personal page", () => {
+    render(<AttentionList flags={[flag({ personId: ID(7) })]} summary="s" />);
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      `/ic/${ID(7)}/personal`,
+    );
+  });
+
+  it("clears the pinned zone on click so the route-driven Person zone wins", async () => {
+    act(() => portalRouter.set({ zone: "overview" }));
+    const { result } = renderZone();
+    render(<AttentionList flags={[flag({})]} summary="s" />);
+    await userEvent.click(screen.getByRole("link"));
+    expect(result.current).toBeNull();
+  });
+
+  it("shows the steady note when there are no flags", () => {
+    render(<AttentionList flags={[]} summary="All steady." />);
+    expect(screen.getByText(/No outliers, declines, or collapses/)).toBeInTheDocument();
+  });
+
+  it("collapses to max rows and expands on '+N more', then collapses back", async () => {
+    render(<AttentionList flags={FLAGS} summary="s" max={2} />);
+    expect(screen.getAllByRole("link")).toHaveLength(2);
+
+    await userEvent.click(screen.getByRole("button", { name: "+3 more" }));
+    expect(screen.getAllByRole("link")).toHaveLength(5);
+
+    await userEvent.click(screen.getByRole("button", { name: "Show less" }));
+    expect(screen.getAllByRole("link")).toHaveLength(2);
+    expect(screen.getByRole("button", { name: "+3 more" })).toBeInTheDocument();
+  });
+});
+
+// Small helper: observe the portal zone through the public hook.
+function renderZone() {
+  return renderHook(() => usePortalZone());
+}

--- a/src/frontend/src/components/portal/attention-list.test.tsx
+++ b/src/frontend/src/components/portal/attention-list.test.tsx
@@ -16,14 +16,14 @@ import {
 } from "@/lib/portal/portal-nav";
 
 
+import { pid } from "@/test/identity";
+
 import { AttentionList } from "./attention-list";
 
-// Person ids, not emails: rows link by the identity-cutover key.
-const ID = (n: number) => `0000000${n}-1111-4111-8111-111111111111`;
 
 function flag(over: Partial<AttentionFlag>): AttentionFlag {
   return {
-    personId: ID(0),
+    personId: pid("p0"),
     name: "Person",
     metricKey: "t.metric",
     metricLabel: "Commits",
@@ -36,7 +36,7 @@ function flag(over: Partial<AttentionFlag>): AttentionFlag {
 }
 
 const FLAGS = Array.from({ length: 5 }, (_, i) =>
-  flag({ personId: ID(i), name: `Person ${i}`, severity: 5 - i }),
+  flag({ personId: pid(`p${i}`), name: `Person ${i}`, severity: 5 - i }),
 );
 
 describe("AttentionList", () => {
@@ -54,10 +54,10 @@ describe("AttentionList", () => {
   });
 
   it("links every row to that person's personal page", () => {
-    render(<AttentionList flags={[flag({ personId: ID(7) })]} summary="s" />);
+    render(<AttentionList flags={[flag({ personId: pid("who") })]} summary="s" />);
     expect(screen.getByRole("link")).toHaveAttribute(
       "href",
-      `/ic/${ID(7)}/personal`,
+      `/ic/${pid("who")}/personal`,
     );
   });
 

--- a/src/frontend/src/components/portal/attention-list.tsx
+++ b/src/frontend/src/components/portal/attention-list.tsx
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { AlertTriangle, ArrowDownRight, Sparkles, TrendingDown } from "lucide-react";
+
+import { Card, CardContent } from "@/components/ui/card";
+import type { AttentionFlag, FlagKind } from "@/lib/insight/attention-flags";
+import {
+  usePortalNavActions,
+} from "@/lib/portal/portal-nav";
+import { cn } from "@/lib/utils";
+
+const FLAG_ICON: Record<FlagKind, typeof AlertTriangle> = {
+  outlier: ArrowDownRight,
+  decline: TrendingDown,
+  collapse: AlertTriangle,
+};
+
+/**
+ * Shared "needs attention" panel: a rule-based summary line (placeholder for a
+ * future AI insight) plus the ranked flag rows, each linking into that person.
+ * Used by the team-state roster and the org overview.
+ */
+export function AttentionList({
+  flags,
+  summary,
+  peopleLabel,
+  max = 12,
+}: {
+  flags: AttentionFlag[];
+  summary: string;
+  /** e.g. "3 of 16 people" — shown top-right; omit to hide. */
+  peopleLabel?: string;
+  max?: number;
+}) {
+  const { setZone } = usePortalNavActions();
+  const [expanded, setExpanded] = useState(false);
+  const shown = expanded ? flags : flags.slice(0, max);
+  return (
+    <section className="flex flex-col gap-3">
+      <div className="flex items-center justify-between">
+        <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+          Needs attention
+        </p>
+        {peopleLabel ? (
+          <span className="text-xs text-muted-foreground">{peopleLabel}</span>
+        ) : null}
+      </div>
+
+      <Card>
+        <CardContent className="flex items-start gap-2 p-3 text-sm">
+          <Sparkles className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+          <div>
+            <span className="text-foreground">{summary}</span>
+            <span className="ml-1 text-xs text-muted-foreground">· rule-based</span>
+          </div>
+        </CardContent>
+      </Card>
+
+      {shown.length > 0 ? (
+        <div className="flex flex-col gap-1.5">
+          {shown.map((f) => {
+            const Icon = FLAG_ICON[f.kind];
+            return (
+              <Link
+                key={`${f.personId}-${f.metricKey}`}
+                to="/ic/$person/personal"
+                params={{ person: f.personId }}
+                // A pinned theme zone (Overview, Manage) wins over the route in
+                // `useActiveZone` — clear it so the navigation actually lands
+                // on the Person zone (same pattern as the rail).
+                onClick={() => setZone(null)}
+                className="flex items-center gap-3 rounded-lg border bg-card px-3 py-2 text-sm transition-colors hover:bg-accent"
+              >
+                <Icon
+                  className={cn(
+                    "size-4 shrink-0",
+                    f.kind === "collapse" ? "text-destructive" : "text-warning",
+                  )}
+                />
+                <span className="w-40 shrink-0 truncate font-medium">{f.name}</span>
+                <span className="w-32 shrink-0 truncate text-muted-foreground">
+                  {f.metricLabel}
+                </span>
+                <span className="shrink-0 font-medium tabular-nums">{f.valueText}</span>
+                <span className="truncate text-xs text-muted-foreground">{f.reason}</span>
+              </Link>
+            );
+          })}
+          {flags.length > max ? (
+            <button
+              type="button"
+              onClick={() => setExpanded((v) => !v)}
+              className="self-start px-3 pt-1 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+            >
+              {expanded ? "Show less" : `+${flags.length - max} more`}
+            </button>
+          ) : null}
+        </div>
+      ) : (
+        <div className="rounded-lg border bg-card p-4 text-sm text-muted-foreground">
+          No outliers, declines, or collapses in this period — steady.
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/frontend/src/components/portal/context-pane.test.tsx
+++ b/src/frontend/src/components/portal/context-pane.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+/**
+ * ContextPane semantics: the second navigation level follows the active zone
+ * (theme items for Overview, direction→lens tree for Directions, roster/org
+ * items for People, catalog items for Manage), and clicking writes the
+ * portal-store selection the content area renders from.
+ */
+vi.mock("@tanstack/react-router", async () => {
+  const { portalRouterMock } = await import("@/test/portal-router");
+  return portalRouterMock();
+});
+
+import { portalRouter } from "@/test/portal-router";
+
+import { act, render, renderHook, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  zone: { activeZone: "overview", activePerson: "boss@x" },
+}));
+
+vi.mock("@/lib/portal/use-active-zone", () => ({ useActiveZone: () => mocks.zone }));
+vi.mock("@/components/org-tree", () => ({
+  OrgTree: () => <div data-testid="org-tree" />,
+}));
+
+import {
+  usePortalDir,
+  usePortalItem,
+  usePortalLens,
+} from "@/lib/portal/portal-nav";
+import { SidebarProvider } from "@/components/ui/sidebar";
+import { ContextPane } from "./context-pane";
+
+const pane = () => render(<SidebarProvider><ContextPane /></SidebarProvider>);
+
+beforeEach(() => {
+  window.matchMedia ??= ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+  mocks.zone = { activeZone: "overview", activePerson: "boss@x" };
+  act(() => {
+    portalRouter.set({ zone: undefined });
+    portalRouter.set({ item: undefined });
+    portalRouter.set({ dir: "dev" });
+    portalRouter.set({ lens: "Delivery" });
+  });
+});
+
+describe("ContextPane", () => {
+  it("lists the Overview theme items and writes the selection on click", async () => {
+    pane();
+    expect(screen.getByText("Overview")).toBeInTheDocument();
+    expect(screen.getByText("Cross-functional org rollup")).toBeInTheDocument();
+    const item = renderHook(() => usePortalItem());
+    await userEvent.click(screen.getByText("Health radar"));
+    expect(item.result.current).toBe("health");
+  });
+
+  it("shows the direction catalog with lenses and drives dir+lens state", async () => {
+    mocks.zone = { activeZone: "directions", activePerson: "boss@x" };
+    pane();
+    expect(screen.getByText("Functional domains")).toBeInTheDocument();
+    expect(screen.getByText("Development")).toBeInTheDocument();
+    expect(screen.getByText("Collaboration")).toBeInTheDocument();
+
+    const dir = renderHook(() => usePortalDir());
+    const lens = renderHook(() => usePortalLens());
+    // dev is the active dir → its lens list is expanded
+    await userEvent.click(screen.getByText("Git output"));
+    expect(dir.result.current).toBe("dev");
+    expect(lens.result.current).toBe("Git output");
+  });
+
+  it("switches direction when another domain is clicked", async () => {
+    mocks.zone = { activeZone: "directions", activePerson: "boss@x" };
+    pane();
+    const dir = renderHook(() => usePortalDir());
+    await userEvent.click(screen.getByText("Knowledge / Wiki"));
+    expect(dir.result.current).toBe("wiki");
+  });
+
+  it("renders the People zone with the org tree and roster items", () => {
+    mocks.zone = { activeZone: "people", activePerson: "boss@x" };
+    pane();
+    expect(screen.getByText("Roster & org structure")).toBeInTheDocument();
+    expect(screen.getByTestId("org-tree")).toBeInTheDocument();
+  });
+
+  it("renders Manage items", () => {
+    mocks.zone = { activeZone: "manage", activePerson: "boss@x" };
+    pane();
+    expect(screen.getByText("Catalog, identity & governance")).toBeInTheDocument();
+    expect(screen.getByText(/Metric catalog/i)).toBeInTheDocument();
+  });
+
+  it("renders the person's sections nav in the Person zone", () => {
+    mocks.zone = { activeZone: "person", activePerson: "boss@x" };
+    pane();
+    expect(screen.getByText("Pick a person")).toBeInTheDocument();
+    expect(screen.getByText("At a glance")).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/portal/context-pane.tsx
+++ b/src/frontend/src/components/portal/context-pane.tsx
@@ -1,0 +1,521 @@
+import { ChevronRight, Layers, LayoutGrid, Settings2 } from "lucide-react";
+import { useState } from "react";
+
+import { AppSidebarFooter } from "@/components/app-sidebar-footer";
+import { OrgTree } from "@/components/org-tree";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { GROUPS } from "@/lib/insight/groups";
+import { lensEntry } from "@/lib/portal/lens-configs";
+import { useShellLayout } from "@/lib/portal/use-shell-layout";
+import { useZoneNav } from "@/lib/portal/use-zone-nav";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  useSidebar,
+} from "@/components/ui/sidebar";
+import {
+  DIRECTIONS,
+  MANAGE_ITEMS,
+  PEOPLE_ITEMS,
+  PLANNED_GROUP_LABEL,
+  partitionByReadiness,
+  ZONE_SECTIONS,
+  zoneById,
+  type Direction,
+  type PaneItem,
+} from "@/lib/portal/nav-model";
+import {
+  usePortalShowPlanned,
+} from "@/lib/portal/portal-store";
+import {
+  usePortalDir,
+  usePortalItem,
+  usePortalLens,
+  usePortalNavActions,
+} from "@/lib/portal/portal-nav";
+import { useActiveZone } from "@/lib/portal/use-active-zone";
+import { cn } from "@/lib/utils";
+
+const ZONE_SUB: Record<string, string> = {
+  overview: "Cross-functional org rollup",
+  directions: "Functional domains",
+  person: "Pick a person",
+  people: "Roster & org structure",
+  aicost: "Adoption funnel & cost",
+  scorecard: "Unit × quarter × QoQ",
+  reports: "Generated & custom",
+  manage: "Catalog, identity & governance",
+};
+
+const BADGE_TONE: Record<string, string> = {
+  warn: "bg-warning/15 text-warning",
+  new: "bg-primary/10 text-foreground",
+  error: "bg-destructive/15 text-destructive",
+};
+
+/**
+ * Zone-contextual secondary navigation, driven by the active rail zone.
+ *
+ * On a phone this is the ONLY navigation surface: the icon rail hides itself
+ * (two fixed sidebars left ~60px for content), so the pane becomes an
+ * off-canvas drawer — opened by the topbar trigger — and carries the zone list
+ * and the settings menu that normally live in the rail. Desktop is unchanged:
+ * `collapsible="none"`, in normal flow, zones in the rail beside it.
+ */
+export function ContextPane() {
+  const layout = useShellLayout();
+  // A phone hides the rail, so the drawer inherits its duties. A tablet keeps
+  // the rail — the drawer there is only the pane itself, collapsed to give the
+  // content its 256px back.
+  const isPhone = layout === "phone";
+  const drawer = layout !== "wide";
+  const { activeZone } = useActiveZone();
+  const zone = zoneById(activeZone);
+  const title = zone?.label ?? "Insight";
+
+  return (
+    <Sidebar collapsible={drawer ? "offcanvas" : "none"} className="border-e">
+      {/* The drawer's zone row already names the zone, so repeating it in a
+          header would cost two of the ~14 rows a phone has. */}
+      {isPhone ? null : (
+        <SidebarHeader>
+          <div className="flex flex-col px-2 py-1.5">
+            <span className="text-sm font-semibold tracking-tight text-sidebar-foreground">
+              {title}
+            </span>
+            <span className="text-xs text-muted-foreground">
+              {ZONE_SUB[activeZone] ?? ""}
+            </span>
+          </div>
+        </SidebarHeader>
+      )}
+      <SidebarContent>
+        {isPhone ? <MobileZoneNav /> : null}
+        {activeZone === "directions" ? (
+          <DirectionsNav />
+        ) : activeZone === "people" ? (
+          <PeopleNav />
+        ) : activeZone === "manage" ? (
+          <ItemsNav items={MANAGE_ITEMS} groupLabel="Manage" />
+        ) : activeZone === "person" ? (
+          <PersonSectionsNav />
+        ) : (
+          <ThemeNav zoneId={activeZone} />
+        )}
+      </SidebarContent>
+      {isPhone ? (
+        <SidebarFooter>
+          {/* One row, not six: inline the settings menu and it takes a third of
+              the drawer, crowding out the sections that are the point of it.
+              Same affordance the rail gives desktop — an icon that opens the
+              menu on demand. */}
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <Popover>
+                <PopoverTrigger
+                  render={
+                    <SidebarMenuButton>
+                      <Settings2 aria-hidden />
+                      <span>Settings</span>
+                    </SidebarMenuButton>
+                  }
+                />
+                <PopoverContent side="top" align="start" className="w-60 gap-0 p-1">
+                  <AppSidebarFooter />
+                </PopoverContent>
+              </Popover>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarFooter>
+      ) : null}
+    </Sidebar>
+  );
+}
+
+/**
+ * Dismiss the mobile drawer after a LEAF pick (a section / lens / group): on a
+ * phone the pane is the drawer, so leaving it open would hide the very view the
+ * reader just chose. Zone picks deliberately keep it open — the zone's items
+ * render right below, so zone-then-item is one pass. No-op on desktop, where
+ * the pane is always-visible chrome.
+ */
+function useDismissDrawer(): () => void {
+  const layout = useShellLayout();
+  const { setOpen, setOpenMobile } = useSidebar();
+  return () => {
+    // Below 768 the pane is a Sheet (`openMobile`); on a tablet it is an
+    // off-canvas panel (`open`). Wide keeps it in flow — nothing to dismiss.
+    if (layout === "phone") setOpenMobile(false);
+    else if (layout === "narrow") setOpen(false);
+  };
+}
+
+/**
+ * Zone switcher for the mobile drawer, standing in for the hidden icon rail.
+ *
+ * Collapsed to a SINGLE row by default — the full list is eight zones tall, and
+ * expanded it pushed the zone's own sections below the fold, so picking a zone
+ * looked like it did nothing. Collapsed, the sections start right under this row:
+ * changing section (the common move) costs no scrolling, and switching zone
+ * costs one extra tap that also re-collapses the list.
+ */
+function MobileZoneNav() {
+  const { zones, activeZone, selectZone } = useZoneNav();
+  const [expanded, setExpanded] = useState(false);
+  const current = zones.find((z) => z.id === activeZone);
+  const CurrentIcon = current?.icon;
+
+  return (
+    <SidebarGroup>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              onClick={() => setExpanded((v) => !v)}
+              aria-expanded={expanded}
+            >
+              {CurrentIcon ? <CurrentIcon aria-hidden /> : null}
+              <span className="font-medium">{current?.label ?? "Zones"}</span>
+              <ChevronRight
+                className={cn(
+                  "ms-auto transition-transform",
+                  expanded && "rotate-90",
+                )}
+                aria-hidden
+              />
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          {expanded
+            ? zones.map((z) => (
+                <SidebarMenuItem key={z.id}>
+                  <SidebarMenuButton
+                    isActive={activeZone === z.id}
+                    onClick={() => {
+                      selectZone(z);
+                      setExpanded(false);
+                    }}
+                    className="ps-4"
+                  >
+                    <z.icon aria-hidden />
+                    <span>{z.label}</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))
+            : null}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}
+
+/* ── Theme zones (Overview / AI & Cost / Scorecard / Reports) ────────── */
+
+function ThemeNav({ zoneId }: { zoneId: string }) {
+  const groups = ZONE_SECTIONS[zoneId] ?? [];
+  const active = usePortalItem();
+  const showPlanned = usePortalShowPlanned();
+  // Everything not yet real is pulled out of its original group and collected
+  // under one demoted "Planned" group at the bottom, so the working menu reads
+  // clean and roadmap items stay honest instead of masquerading as features.
+  const split = groups.map((g) => partitionByReadiness(g.items, showPlanned));
+  const planned = split.flatMap((s) => s.planned);
+  return (
+    <>
+      {groups.map((g, i) =>
+        split[i]!.live.length ? (
+          <SidebarGroup key={g.label ?? i}>
+            {g.label ? <SidebarGroupLabel>{g.label}</SidebarGroupLabel> : null}
+            <SidebarGroupContent>
+              <SidebarMenu>
+                {split[i]!.live.map((it) => (
+                  <ItemButton key={it.id} item={it} active={active === it.id} />
+                ))}
+              </SidebarMenu>
+            </SidebarGroupContent>
+          </SidebarGroup>
+        ) : null,
+      )}
+      {planned.length ? (
+        <SidebarGroup>
+          <SidebarGroupLabel>{PLANNED_GROUP_LABEL}</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {planned.map((it) => (
+                <ItemButton key={it.id} item={it} active={active === it.id} planned />
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      ) : null}
+    </>
+  );
+}
+
+function ItemsNav({
+  items,
+  groupLabel,
+}: {
+  items: readonly PaneItem[];
+  groupLabel: string;
+}) {
+  const active = usePortalItem();
+  const showPlanned = usePortalShowPlanned();
+  const { live, planned } = partitionByReadiness(items, showPlanned);
+  return (
+    <>
+      <SidebarGroup>
+        <SidebarGroupLabel>{groupLabel}</SidebarGroupLabel>
+        <SidebarGroupContent>
+          <SidebarMenu>
+            {live.map((it) => (
+              <ItemButton key={it.id} item={it} active={active === it.id} />
+            ))}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
+      {planned.length ? (
+        <SidebarGroup>
+          <SidebarGroupLabel>{PLANNED_GROUP_LABEL}</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {planned.map((it) => (
+                <ItemButton key={it.id} item={it} active={active === it.id} planned />
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      ) : null}
+    </>
+  );
+}
+
+function ItemButton({
+  item,
+  active,
+  planned = false,
+}: {
+  item: PaneItem;
+  active: boolean;
+  /** Demoted rendering: same affordance, visibly lighter weight. */
+  planned?: boolean;
+}) {
+  const { setItem } = usePortalNavActions();
+  const Icon = item.icon;
+  const dismiss = useDismissDrawer();
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        isActive={active}
+        onClick={() => {
+          setItem(item.id);
+          dismiss();
+        }}
+        className={planned ? "text-muted-foreground" : undefined}
+      >
+        <Icon />
+        <span>{item.label}</span>
+        {item.badge ? (
+          <span
+            className={cn(
+              "ml-auto rounded-full px-1.5 py-0.5 text-[9px] font-semibold",
+              BADGE_TONE[item.badge.tone],
+            )}
+          >
+            {item.badge.text}
+          </span>
+        ) : null}
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  );
+}
+
+/* ── Directions zone ─────────────────────────────────────────────────── */
+
+function DirectionsNav() {
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>
+        Directions
+        <span className="ml-1 text-[10px] font-normal text-muted-foreground">
+          · catalog · {DIRECTIONS.length}
+        </span>
+      </SidebarGroupLabel>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          {DIRECTIONS.map((d) => (
+            <DirectionItem key={d.id} direction={d} />
+          ))}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}
+
+function DirectionItem({ direction }: { direction: Direction }) {
+  const { setDir, setItem, setLens } = usePortalNavActions();
+  const dismiss = useDismissDrawer();
+  const activeDir = usePortalDir();
+  const activeLens = usePortalLens();
+  const showPlanned = usePortalShowPlanned();
+  const expanded = activeDir === direction.id;
+  const Icon = direction.icon;
+  // A lens we simply have not built yet is hidden unless the viewer asked for
+  // planned work; a lens waiting on the product stays listed (dimmed) because
+  // it tells the reader the domain exists in our model.
+  const lenses = direction.lenses.filter((lens) => {
+    const entry = lensEntry(direction.id, lens);
+    if (!entry || !("comingSoon" in entry)) return true;
+    return entry.readiness === "planned" || showPlanned;
+  });
+
+  function toggle() {
+    if (expanded) {
+      setDir("");
+    } else {
+      setDir(direction.id);
+      setLens(lenses[0] ?? direction.lenses[0]!);
+    }
+  }
+
+  return (
+    <>
+      <SidebarMenuItem>
+        <SidebarMenuButton isActive={expanded} onClick={toggle} aria-expanded={expanded}>
+          <Icon />
+          <span>{direction.name}</span>
+          {direction.source === "bullet" ? (
+            <span className="ml-auto rounded-full bg-warning/15 px-1.5 py-0.5 text-[9px] font-semibold text-warning">
+              bullet
+            </span>
+          ) : null}
+          <ChevronRight
+            className={cn(
+              "size-4 text-muted-foreground transition-transform",
+              direction.source === "bullet" ? "ml-1" : "ml-auto",
+              expanded && "rotate-90",
+            )}
+          />
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+
+      {expanded ? (
+        <>
+          <SidebarMenuSub>
+            {lenses.map((lens) => {
+              const entry = lensEntry(direction.id, lens);
+              const roadmap = !!entry && "comingSoon" in entry;
+              return (
+                <SidebarMenuSubItem key={lens}>
+                  <SidebarMenuSubButton
+                    isActive={activeLens === lens}
+                    className={roadmap ? "text-muted-foreground" : undefined}
+                    onClick={() => {
+                      setLens(lens);
+                      setItem(null);
+                      dismiss();
+                    }}
+                  >
+                    <span>{lens}</span>
+                  </SidebarMenuSubButton>
+                </SidebarMenuSubItem>
+              );
+            })}
+          </SidebarMenuSub>
+        </>
+      ) : null}
+    </>
+  );
+}
+
+/* ── People / Person zones ───────────────────────────────────────────── */
+
+function PeopleNav() {
+  const active = usePortalItem();
+  return (
+    <>
+      <SidebarGroup>
+        <SidebarGroupLabel>Views</SidebarGroupLabel>
+        <SidebarGroupContent>
+          <SidebarMenu>
+            {PEOPLE_ITEMS.map((it) => (
+              <ItemButton key={it.id} item={it} active={active === it.id} />
+            ))}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
+      <WorkChart />
+    </>
+  );
+}
+
+function WorkChart() {
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>WorkChart</SidebarGroupLabel>
+      <SidebarGroupContent>
+        <OrgTree leadsToTeam />
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}
+
+/* ── Person zone: one person, section switcher (no WorkChart, no modal) ─── */
+
+function PersonSectionsNav() {
+  const { setItem } = usePortalNavActions();
+  const dismiss = useDismissDrawer();
+  const active = usePortalItem();
+  const groups = GROUPS;
+  const groupIds = groups.map((g) => g.id) as string[];
+  const glance = active == null || !groupIds.includes(active);
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>Sections</SidebarGroupLabel>
+      <SidebarGroupContent>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton
+              isActive={glance}
+              onClick={() => {
+                setItem(null);
+                dismiss();
+              }}
+            >
+              <LayoutGrid />
+              <span>At a glance</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          {groups.map((g) => (
+            <SidebarMenuItem key={g.id}>
+              <SidebarMenuButton
+                isActive={active === g.id}
+                onClick={() => {
+                  setItem(g.id);
+                  dismiss();
+                }}
+              >
+                <Layers />
+                <span>{g.title}</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          ))}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}

--- a/src/frontend/src/components/portal/context-pane.tsx
+++ b/src/frontend/src/components/portal/context-pane.tsx
@@ -278,16 +278,21 @@ function ItemsNav({
   const { live, planned } = partitionByReadiness(items, showPlanned);
   return (
     <>
-      <SidebarGroup>
-        <SidebarGroupLabel>{groupLabel}</SidebarGroupLabel>
-        <SidebarGroupContent>
-          <SidebarMenu>
-            {live.map((it) => (
-              <ItemButton key={it.id} item={it} active={active === it.id} />
-            ))}
-          </SidebarMenu>
-        </SidebarGroupContent>
-      </SidebarGroup>
+      {/* Skipped when empty, as ThemeNav does: with planned items hidden a
+          zone can have no live items, and a bare heading reads as a load
+          failure rather than as a filter. */}
+      {live.length ? (
+        <SidebarGroup>
+          <SidebarGroupLabel>{groupLabel}</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {live.map((it) => (
+                <ItemButton key={it.id} item={it} active={active === it.id} />
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      ) : null}
       {planned.length ? (
         <SidebarGroup>
           <SidebarGroupLabel>{PLANNED_GROUP_LABEL}</SidebarGroupLabel>

--- a/src/frontend/src/components/portal/direction-view.tsx
+++ b/src/frontend/src/components/portal/direction-view.tsx
@@ -1,0 +1,30 @@
+import { useMemo } from "react";
+
+import { DomainLensView, Pending } from "@/components/portal/domain-lens-view";
+import { directionMetricKeys, lensEntry } from "@/lib/portal/lens-configs";
+import { DIRECTIONS } from "@/lib/portal/nav-model";
+
+/**
+ * Directions content — every direction/lens resolves through the lens-config
+ * registry: a section config renders DomainLensView; a roadmap entry renders
+ * its honest ComingSoon note (design D1). The grid fetch is direction-scoped
+ * (union of the direction's lens keys) so switching lenses never re-spins.
+ */
+export function DirectionView({ dir, lens }: { dir: string; lens: string }) {
+  const entry = lensEntry(dir, lens);
+  const direction = DIRECTIONS.find((d) => d.id === dir);
+  const gridKeys = useMemo(() => directionMetricKeys(dir), [dir]);
+  // Collapsing a direction in the pane clears `dir`, so there is no direction
+  // to talk about — say "pick one" instead of blaming the lens for not
+  // existing in a direction the reader never named.
+  if (!direction) {
+    return <Pending label="Pick a direction to see its metrics." />;
+  }
+  if (!entry) {
+    return (
+      <Pending label={`“${lens}” isn't a metric family in ${direction.name} yet.`} />
+    );
+  }
+  if ("comingSoon" in entry) return <Pending label={entry.comingSoon} />;
+  return <DomainLensView config={entry} gridKeys={gridKeys} />;
+}

--- a/src/frontend/src/components/portal/domain-lens-view.test.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.test.tsx
@@ -34,6 +34,7 @@ const mocks = vi.hoisted(() => ({
     isError: false,
     refetch: vi.fn(),
   },
+  call: 0,
   collections: [] as Array<{
     byKey: Map<string, NormalizedMetricResult>;
     isPending: boolean;
@@ -58,16 +59,15 @@ vi.mock("@/queries/member-grid", () => ({
   useMemberGridData: () => mocks.grid,
 }));
 // DomainLensView calls useMetricCollection three times (trend, composition,
-// event-histogram) in that order on every render.
+// event-histogram) in that order on every render. The counter is reset per test
+// (see beforeEach): left running, each caller's slot would depend on how many
+// renders every earlier test happened to do.
 vi.mock("@/queries/metric-results", () => ({
-  useMetricCollection: (() => {
-    let call = 0;
-    return () => {
-      const r = mocks.collections[call % 3] ?? emptyCollection();
-      call += 1;
-      return r;
-    };
-  })(),
+  useMetricCollection: () => {
+    const r = mocks.collections[mocks.call % 3] ?? emptyCollection();
+    mocks.call += 1;
+    return r;
+  },
 }));
 vi.mock("@/hooks/use-portal-period", () => ({
   usePortalPeriod: () => ({
@@ -155,6 +155,7 @@ const HEADLINE_CONFIG: LensConfig = {
 };
 
 beforeEach(() => {
+  mocks.call = 0;
   seedHappyOrg();
   mocks.grid.isPending = false;
   mocks.grid.isError = false;

--- a/src/frontend/src/components/portal/domain-lens-view.test.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.test.tsx
@@ -1,0 +1,448 @@
+// @vitest-environment jsdom
+/**
+ * Behavioral tests for DomainLensView — the single renderer behind every
+ * Directions lens and Overview item. Data enters through the query hooks
+ * (viewer tree, roster, member grid, timeseries), which are stubbed at the
+ * module boundary with REALISTIC payloads; every assertion is about what a
+ * manager actually reads on screen: per-capita numbers, deltas, honest
+ * not-ingested/suppression states, framing copy and roll-up math.
+ */
+vi.mock("@tanstack/react-router", async () => {
+  const { portalRouterMock } = await import("@/test/portal-router");
+  return portalRouterMock();
+});
+
+import { portalRouter } from "@/test/portal-router";
+
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { NormalizedMetricResult } from "@/lib/metrics/collection";
+import { identityPerson, pid } from "@/test/identity";
+import type { IdentityPerson } from "@/types/insight";
+
+/* ── module mocks ────────────────────────────────────────────────────── */
+
+const mocks = vi.hoisted(() => ({
+  personId: null as string | null,
+  tree: undefined as IdentityPerson | undefined,
+  grid: {
+    byKey: new Map<string, NormalizedMetricResult>(),
+    previousByKey: new Map<string, NormalizedMetricResult>(),
+    isPending: false,
+    isFetching: false,
+    isError: false,
+    refetch: vi.fn(),
+  },
+  collections: [] as Array<{
+    byKey: Map<string, NormalizedMetricResult>;
+    isPending: boolean;
+    isError: boolean;
+    refetch: () => void;
+  }>,
+}));
+
+vi.mock("@/auth", () => ({
+  useViewer: () => ({ email: "boss@x", personId: mocks.personId }),
+}));
+vi.mock("@/queries/ic-dashboard", () => ({
+  useIcPerson: () => ({
+    data: mocks.tree,
+    isPending: false,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  }),
+}));
+vi.mock("@/queries/member-grid", () => ({
+  useMemberGridData: () => mocks.grid,
+}));
+// DomainLensView calls useMetricCollection three times (trend, composition,
+// event-histogram) in that order on every render.
+vi.mock("@/queries/metric-results", () => ({
+  useMetricCollection: (() => {
+    let call = 0;
+    return () => {
+      const r = mocks.collections[call % 3] ?? emptyCollection();
+      call += 1;
+      return r;
+    };
+  })(),
+}));
+vi.mock("@/hooks/use-portal-period", () => ({
+  usePortalPeriod: () => ({
+    period: "week",
+    dateRange: { start: "2026-07-20", end: "2026-07-26" },
+  }),
+}));
+// Charts are exercised by the browser/storybook project; here they'd render
+// into a 0×0 jsdom box. Stub them with introspectable placeholders.
+vi.mock("@/components/portal/section-trend", () => ({
+  SectionTrend: ({ series }: { series: unknown[] }) => (
+    <div data-testid="section-trend" data-series={JSON.stringify(series ?? []).length} />
+  ),
+}));
+
+
+import type { LensConfig } from "@/lib/portal/lens-configs";
+import { DomainLensView } from "./domain-lens-view";
+
+/* ── fixtures ────────────────────────────────────────────────────────── */
+
+function emptyCollection() {
+  return {
+    byKey: new Map<string, NormalizedMetricResult>(),
+    previousByKey: null,
+    isPending: false,
+    isFetching: false,
+    isError: false,
+    refetch: vi.fn(),
+  };
+}
+
+function metric(
+  key: string,
+  period: Array<[string, number | null]>,
+  over: Partial<NormalizedMetricResult> = {},
+): NormalizedMetricResult {
+  return {
+    metric_key: key,
+    label: over.label ?? key,
+    unit: null,
+    computation: "sum",
+    format: "integer",
+    direction: "higher_is_better",
+    period: {
+      view: "period",
+      values: period.map(([entity_id, value]) => ({ entity_id, value })),
+    },
+    peer: {
+      view: "peer",
+      values: period.map(([entity_id, value]) => ({ entity_id, target_value: value })),
+    },
+    ...over,
+  } as unknown as NormalizedMetricResult;
+}
+
+const person = (
+  label: string,
+  over: Partial<IdentityPerson> = {},
+  subordinates: IdentityPerson[] = [],
+): IdentityPerson => identityPerson(label, over, subordinates);
+
+
+// Roster entity ids are person UUIDs (identity cutover); labels stay legible.
+const LABELS = ["a", "b", "c", "d"];
+const IDS = LABELS.map(pid);
+
+function seedHappyOrg() {
+  mocks.personId = pid("boss");
+  mocks.tree = person("boss", {}, LABELS.map((l) => person(l)));
+  // 4 members, 10+20+30+40 = 100 commits; everyone active.
+  mocks.grid.byKey = new Map([
+    ["t.commits", metric("t.commits", [[pid("a"), 10], [pid("b"), 20], [pid("c"), 30], [pid("d"), 40]], { short_label: "Commits", unit: "commits" })],
+  ]);
+  mocks.grid.previousByKey = new Map([
+    ["t.commits", metric("t.commits", [[pid("a"), 20], [pid("b"), 40], [pid("c"), 60], [pid("d"), 80]])],
+  ]);
+  mocks.collections = [emptyCollection(), emptyCollection(), emptyCollection()];
+}
+
+const HEADLINE_CONFIG: LensConfig = {
+  title: "Dev · Test",
+  tagline: "test lens",
+  sections: [{ kind: "headline", metrics: ["t.commits"] }],
+};
+
+beforeEach(() => {
+  seedHappyOrg();
+  mocks.grid.isPending = false;
+  mocks.grid.isError = false;
+  act(() => {
+    portalRouter.set({ slice: undefined });
+    portalRouter.set({ scope: undefined, direct: false });
+  });
+});
+
+afterEach(() => vi.clearAllMocks());
+
+/* ── tests ───────────────────────────────────────────────────────────── */
+
+describe("headline (rules 1–2: per-capita + PoP delta)", () => {
+  it("shows the per-active-person value, the team total and the delta", () => {
+    render(<DomainLensView config={HEADLINE_CONFIG} />);
+    // 100 commits over 4 active people = 25/person; halved vs last period.
+    expect(screen.getByText("25 commits")).toBeInTheDocument();
+    expect(screen.getByText(/100 commits team total/)).toBeInTheDocument();
+    expect(screen.getByText("-50%")).toBeInTheDocument();
+    // header carries the scope size + tagline
+    expect(screen.getByText(/4 members · test lens/)).toBeInTheDocument();
+  });
+
+  it("divides by ACTIVE people only — zeros don't dilute the denominator", () => {
+    mocks.grid.byKey = new Map([
+      ["t.commits", metric("t.commits", [[pid("a"), 0], [pid("b"), 0], [pid("c"), 30], [pid("d"), 70]], { short_label: "Commits", unit: "commits" })],
+    ]);
+    mocks.grid.previousByKey = new Map();
+    render(<DomainLensView config={HEADLINE_CONFIG} />);
+    // 100 total / 2 active = 50, not 25
+    expect(screen.getByText("50 commits")).toBeInTheDocument();
+  });
+});
+
+describe("rule 6: honest not-ingested gate", () => {
+  it("renders the family not-ingested note when nothing was ever observed", () => {
+    mocks.grid.byKey = new Map([
+      ["t.commits", metric("t.commits", IDS.map((id) => [id, 0]), {
+        peer: { view: "peer", values: [] },
+      } as never)],
+    ]);
+    mocks.grid.previousByKey = new Map();
+    render(
+      <DomainLensView
+        config={{ ...HEADLINE_CONFIG, notIngested: "Git source isn't wired for this org yet." }}
+      />,
+    );
+    expect(screen.getByText("Git source isn't wired for this org yet.")).toBeInTheDocument();
+    expect(screen.queryByText(/team total/)).not.toBeInTheDocument();
+  });
+});
+
+describe("org-scope gates", () => {
+  it("shows the empty-roster label instead of a fabricated dashboard", () => {
+    mocks.tree = person("boss");
+    render(<DomainLensView config={HEADLINE_CONFIG} />);
+    expect(screen.getByText(/No team in the current scope/)).toBeInTheDocument();
+  });
+
+  it("surfaces a grid failure as retryable error", () => {
+    mocks.grid.isError = true;
+    render(<DomainLensView config={HEADLINE_CONFIG} />);
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+});
+
+describe("stat-tiles (medians, never sums)", () => {
+  it("renders the cohort median for ratio metrics under a section title", () => {
+    mocks.grid.byKey.set(
+      "t.cycle",
+      metric("t.cycle", [[pid("a"), 10], [pid("b"), 20], [pid("c"), 30], [pid("d"), 40]], {
+        computation: "avg",
+        label: "PR cycle",
+        format: "float",
+      } as never),
+    );
+    render(
+      <DomainLensView
+        config={{
+          title: "T",
+          sections: [{ kind: "stat-tiles", title: "Flow health", metrics: ["t.cycle"] }],
+        }}
+      />,
+    );
+    expect(screen.getByText("Flow health")).toBeInTheDocument();
+    // median of 10,20,30,40 = 25
+    expect(screen.getByText("25")).toBeInTheDocument();
+    expect(screen.getByText(/median \/ person/)).toBeInTheDocument();
+  });
+});
+
+describe("distribution (rule 4: integer 1/2/5 bins, self-suppressing)", () => {
+  it("suppresses a degenerate single-bin distribution entirely", () => {
+    mocks.grid.byKey = new Map([
+      ["t.commits", metric("t.commits", [[pid("a"), 5], [pid("b"), 5], [pid("c"), 5], [pid("d"), 5]], { short_label: "Commits" })],
+    ]);
+    render(
+      <DomainLensView
+        config={{
+          title: "T",
+          sections: [
+            { kind: "headline", metrics: ["t.commits"] },
+            { kind: "distribution", metric: "t.commits", title: "Spread", caption: "spread", unitLabel: "commits per person" },
+          ],
+        }}
+      />,
+    );
+    expect(screen.queryByText("Spread")).not.toBeInTheDocument();
+  });
+});
+
+describe("concentration (rule 5: top-decile share with framing)", () => {
+  it("frames git concentration as bus-factor risk with the share and count", () => {
+    render(
+      <DomainLensView
+        config={{
+          title: "T",
+          sections: [{ kind: "concentration", metrics: ["t.commits"], framing: "bus-factor" }],
+        }}
+      />,
+    );
+    // top 10% of 4 people = busiest 1 of 4 → 40 of 100 = 40%
+    expect(screen.getByText("40%")).toBeInTheDocument();
+    expect(screen.getByText(/carried by the busiest 1 of 4/)).toBeInTheDocument();
+    expect(screen.getByText(/continuity risk/)).toBeInTheDocument();
+  });
+
+  it("frames collaboration concentration as load balance, not risk", () => {
+    render(
+      <DomainLensView
+        config={{
+          title: "T",
+          sections: [{ kind: "concentration", metrics: ["t.commits"], framing: "load-balance" }],
+        }}
+      />,
+    );
+    expect(screen.queryByText(/continuity risk/)).not.toBeInTheDocument();
+    expect(screen.getByText(/load/i)).toBeInTheDocument();
+  });
+});
+
+describe("composition (rule 7: only real server dimensions)", () => {
+  it("renders breakdown bars with shares from the composition query", () => {
+    const comp = emptyCollection();
+    comp.byKey.set("t.commits", {
+      ...metric("t.commits", []),
+      breakdown: {
+        view: "breakdown",
+        values: IDS.flatMap((id) => [
+          { entity_id: id, dimensions: [{ key: "category", value: "docs" }], value: 30 },
+          { entity_id: id, dimensions: [{ key: "category", value: "code" }], value: 10 },
+        ]),
+      },
+    } as never);
+    mocks.collections = [emptyCollection(), comp, emptyCollection()];
+    render(
+      <DomainLensView
+        config={{
+          title: "T",
+          sections: [
+            { kind: "headline", metrics: ["t.commits"] },
+            { kind: "composition", metric: "t.commits", dimension: "category", title: "Lines by category" },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByText("Lines by category")).toBeInTheDocument();
+    expect(screen.getByText("docs")).toBeInTheDocument();
+    // docs 120 of 160 total = 75%
+    expect(screen.getByText(/75%/)).toBeInTheDocument();
+  });
+
+  it("shows a retryable error card when the breakdown request fails", () => {
+    const comp = emptyCollection();
+    comp.isError = true;
+    mocks.collections = [emptyCollection(), comp, emptyCollection()];
+    render(
+      <DomainLensView
+        config={{
+          title: "T",
+          sections: [
+            { kind: "headline", metrics: ["t.commits"] },
+            { kind: "composition", metric: "t.commits", dimension: "category", title: "Lines by category" },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByText(/unable to load/i)).toBeInTheDocument();
+  });
+});
+
+describe("participation (rule 8 variant: N of M active)", () => {
+  it("counts members with a non-zero value and shows the share", () => {
+    mocks.grid.byKey.set(
+      "t.active",
+      metric("t.active", [[pid("a"), 3], [pid("b"), 0], [pid("c"), 2], [pid("d"), 0]], { label: "Active days" }),
+    );
+    render(
+      <DomainLensView
+        config={{
+          title: "T",
+          sections: [
+            { kind: "participation", metrics: ["t.active"], title: "AI adoption", noun: "People using AI" },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByText("People using AI")).toBeInTheDocument();
+    expect(screen.getByText("2 of 4")).toBeInTheDocument();
+    expect(screen.getByText(/50% of the team/)).toBeInTheDocument();
+  });
+});
+
+describe("by-unit auto-section (rule 7: slice cohorts inside scope)", () => {
+  const CONFIG: LensConfig = {
+    title: "T",
+    sections: [{ kind: "headline", metrics: ["t.commits"] }],
+  };
+
+  function seedSliced() {
+    // Two divisions of 4 people each with very different output.
+    const labels = ["a1", "a2", "a3", "a4", "b1", "b2", "b3", "b4"];
+    mocks.tree = person("boss", {}, labels.map((l) =>
+      person(l, { division: l.startsWith("a") ? "R&D" : "Sales" } as never),
+    ));
+    mocks.grid.byKey = new Map([
+      ["t.commits", metric("t.commits", labels.map((l) => [pid(l), l.startsWith("a") ? 10 : 30]), { short_label: "Commits" })],
+    ]);
+    mocks.grid.previousByKey = new Map();
+  }
+
+  it("renders per-active-person unit bars when a slice is active", () => {
+    seedSliced();
+    act(() => portalRouter.set({ slice: "division" }));
+    render(<DomainLensView config={CONFIG} />);
+    expect(screen.getByText(/by Division/)).toBeInTheDocument();
+    expect(screen.getByText(/R&D · 4/)).toBeInTheDocument();
+    expect(screen.getByText(/Sales · 4/)).toBeInTheDocument();
+  });
+
+  it("stays silent without a slice", () => {
+    seedSliced();
+    render(<DomainLensView config={CONFIG} />);
+    expect(screen.queryByText(/by Division/)).not.toBeInTheDocument();
+  });
+
+  it("explains itself when units are too small to compare (never silent)", () => {
+    act(() => portalRouter.set({ slice: "division" }));
+    // default org: 4 people all WITHOUT division values → no comparable units
+    render(<DomainLensView config={CONFIG} />);
+    expect(screen.getByText(/No comparable units/)).toBeInTheDocument();
+  });
+});
+
+describe("direction-cards / coverage-radar / attention sections", () => {
+  it("renders attention rows for cohort outliers, named and linked (O3)", () => {
+    // 7 healthy + 1 collapsed member
+    const labels = ["m1", "m2", "m3", "m4", "m5", "m6", "m7", "z"];
+    mocks.tree = person("boss", {}, labels.map((l) => person(l)));
+    mocks.grid.byKey = new Map([
+      ["t.commits", metric("t.commits", labels.map((l) => [pid(l), l === "z" ? 0 : 10]), { label: "Commits" })],
+    ]);
+    mocks.grid.previousByKey = new Map();
+    render(
+      <DomainLensView
+        config={{
+          title: "T",
+          sections: [{ kind: "attention", metrics: ["t.commits"], max: 8 }],
+        }}
+      />,
+    );
+    expect(screen.getByText(/1 of 8 people need a look/)).toBeInTheDocument();
+    // Identity owns the display name now.
+    expect(screen.getByText("z")).toBeInTheDocument();
+    expect(screen.getByText(/no commits/)).toBeInTheDocument();
+  });
+
+  it("suppresses the coverage radar below the minimum cohort", () => {
+    mocks.tree = person("boss", {}, [person("a"), person("b")]);
+    render(
+      <DomainLensView
+        config={{ title: "T", sections: [
+          { kind: "headline", metrics: ["t.commits"] },
+          { kind: "coverage-radar" },
+        ] }}
+      />,
+    );
+    expect(screen.queryByText("Health radar")).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/portal/domain-lens-view.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.tsx
@@ -440,28 +440,36 @@ function ParticipationSection({
       return r != null && (forEntity(r, id).value ?? 0) > 0;
     });
 
-  const active = memberIds.filter((id) => isActive(grid.byKey, id)).length;
-  const prevActive = memberIds.filter((id) => isActive(grid.previousByKey, id)).length;
-  if (memberIds.length === 0) return null;
-
   // Active people per trend bucket (client count over the fetched timeseries).
-  const byDate = new Map<string, Set<string>>();
-  for (const key of spec.metrics) {
-    const r = trend.byKey.get(key);
-    if (!r) continue;
-    for (const id of memberIds) {
-      for (const s of forEntity(r, id).series) {
-        for (const p of s.points) {
-          if ((p.value ?? 0) > 0) {
-            (byDate.get(p.bucket_start) ?? byDate.set(p.bucket_start, new Set()).get(p.bucket_start)!).add(id);
+  // Memoised: the scan is metrics × roster × buckets, and at org scope every
+  // parent re-render — a slice or period change — repeated all of it.
+  const data = useMemo(() => {
+    const byDate = new Map<string, Set<string>>();
+    for (const key of spec.metrics) {
+      const r = trend.byKey.get(key);
+      if (!r) continue;
+      for (const id of memberIds) {
+        for (const s of forEntity(r, id).series) {
+          for (const p of s.points) {
+            if ((p.value ?? 0) > 0) {
+              let ids = byDate.get(p.bucket_start);
+              if (!ids) byDate.set(p.bucket_start, (ids = new Set()));
+              ids.add(id);
+            }
           }
         }
       }
     }
-  }
-  const data = [...byDate.entries()]
-    .map(([date, ids]) => ({ date, active: ids.size }))
-    .sort((a, b) => a.date.localeCompare(b.date));
+    return [...byDate.entries()]
+      .map(([date, ids]) => ({ date, active: ids.size }))
+      .sort((a, b) => a.date.localeCompare(b.date));
+  }, [spec.metrics, trend.byKey, memberIds]);
+
+  const active = memberIds.filter((id) => isActive(grid.byKey, id)).length;
+  const prevActive = memberIds.filter((id) => isActive(grid.previousByKey, id)).length;
+  // After the hook: an early return above it would make the hook conditional.
+  if (memberIds.length === 0) return null;
+
 
   return (
     <section className="flex flex-col gap-3">

--- a/src/frontend/src/components/portal/domain-lens-view.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.tsx
@@ -1,0 +1,1297 @@
+import { useMemo, useState } from "react";
+import { ArrowDownRight, ArrowUpRight } from "lucide-react";
+import {
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+  ResponsiveContainer,
+} from "recharts";
+
+import { AttentionList } from "@/components/portal/attention-list";
+import { ComingSoon } from "@/components/widgets/coming-soon";
+import { orgScopeGate } from "@/components/portal/org-scope-gate";
+import { SectionTrend } from "@/components/portal/section-trend";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  BarChart,
+  CartesianGrid,
+  ChartBar,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  XAxis,
+  YAxis,
+  type ChartConfig,
+} from "@/components/ui/chart";
+import { usePortalPeriod } from "@/hooks/use-portal-period";
+import {
+  attentionSummary,
+  computeAttentionFlags,
+} from "@/lib/insight/attention-flags";
+import { GROUPS } from "@/lib/insight/groups";
+import { availableSlices, cohortKey, collectRosterAttrs, PLANNED_SLICES } from "@/lib/insight/slices";
+import { MIN_COHORT } from "@/lib/insight/within-team-peer";
+import {
+  forEntity,
+  type MetricCollectionConfig,
+  type NormalizedMetricResult,
+} from "@/lib/metrics/collection";
+import type { MetricBucket, MetricDirection } from "@/api/metric-results-client";
+import { normalizePersonId } from "@/lib/metrics/entity";
+import { formatMetricValue } from "@/lib/format";
+import { mergeEventHistogram } from "@/lib/portal/event-histogram";
+import {
+  distribution,
+  familyObserved,
+  fmtCompact,
+  groupCoverage,
+  medianAcross,
+  perCapita,
+  representative,
+  topDecileShare,
+} from "@/lib/portal/metric-stats";
+import {
+  lensEntry,
+  sectionMetricKeys,
+  type ConcentrationFraming,
+  type LensConfig,
+  type SectionSpec,
+} from "@/lib/portal/lens-configs";
+import { DIRECTIONS } from "@/lib/portal/nav-model";
+import { buildTrendData, pickTrendBucket } from "@/lib/portal/trend-data";
+import {
+  usePortalNavActions,
+  usePortalSlice,
+} from "@/lib/portal/portal-nav";
+import type { TeamMember } from "@/types/insight";
+import { useOrgScope } from "@/lib/portal/use-org-scope";
+import { useMetricCollection } from "@/queries/metric-results";
+import { useMemberGridData } from "@/queries/member-grid";
+
+const EMPTY_COLLECTION: MetricCollectionConfig = { metrics: [] };
+
+/**
+ * One renderer for every Directions lens (design §4): sections come from the
+ * lens config, values follow the metric grammar (§3), each section
+ * self-suppresses on degenerate data (rule 11), the whole tab collapses to an
+ * honest "not ingested" state when no metric of the family is observed
+ * (rule 6), and no individual is ever named (rule 10).
+ */
+export function DomainLensView({
+  config,
+  gridKeys: gridKeysProp,
+}: {
+  config: LensConfig;
+  /**
+   * Direction-wide metric key union (see `directionMetricKeys`). When
+   * provided, the fetched member grid requests this stable set instead of
+   * the lens's own keys, so switching lenses within a direction reuses the
+   * same query key instead of minting a new one on every switch (which would
+   * otherwise re-trip the full loading gate). The rule-6 observed-gate and
+   * every section below still read only the lens's OWN keys
+   * (`sectionMetricKeys(config)`) — widening is fetch-only.
+   */
+  gridKeys?: readonly string[];
+}) {
+  const { period, dateRange } = usePortalPeriod();
+
+  const orgScope = useOrgScope();
+  const { pivot, roster } = orgScope;
+  // The roster IS the member list: identity owns who is on the team and
+  // every metric for them comes from `/v1/metric-results`. There is no second
+  // source to reconcile — the legacy per-member batch this used to call was
+  // removed upstream with the rest of the old metric UI.
+  const members = useMemo<TeamMember[]>(
+    () =>
+      (roster ?? []).map((entry) => ({
+        person_id: entry.person_id,
+        name: entry.display_name,
+      })),
+    [roster],
+  );
+  const memberIds = useMemo(
+    () => members.map((m) => normalizePersonId(m.person_id)),
+    [members],
+  );
+
+  // Lens's own keys drive the rule-6 observed-gate and every section below.
+  const lensKeys = useMemo(() => sectionMetricKeys(config), [config]);
+  // The FETCH collection may widen to the whole direction's key union (see
+  // `gridKeys` prop) so switching lenses within a direction never mints a new
+  // grid query key — only the request widens, nothing downstream does.
+  const fetchKeys = useMemo(
+    () => (gridKeysProp ? [...gridKeysProp] : lensKeys),
+    [gridKeysProp, lensKeys],
+  );
+  const gridCollection = useMemo<MetricCollectionConfig>(
+    () => ({
+      metrics: fetchKeys.map((key) => ({
+        key,
+        views: [{ view: "period" as const }, { view: "peer" as const }],
+      })),
+    }),
+    [fetchKeys],
+  );
+  const grid = useMemberGridData(
+    gridCollection.metrics.length ? gridCollection : EMPTY_COLLECTION,
+    { type: "person", ids: memberIds },
+    dateRange,
+    period,
+  );
+
+  // Trend: bucket coarsened to the roster so org scope never trips the row limit.
+  const trendKeys = useMemo(
+    () =>
+      config.sections
+        .filter((s): s is Extract<SectionSpec, { kind: "trend" }> => s.kind === "trend")
+        .flatMap((s) => s.metrics),
+    [config],
+  );
+  const trendBucket = useMemo(
+    () => pickTrendBucket(memberIds.length, trendKeys.length, dateRange),
+    [memberIds.length, trendKeys.length, dateRange],
+  );
+  const trendCollection = useMemo<MetricCollectionConfig>(
+    () => ({
+      // No bucket fits → no request. Sending one anyway earns a 400 the reader
+      // then has to interpret as "the trend is broken" rather than "this window
+      // is too wide for this many people".
+      metrics: trendBucket
+        ? trendKeys.map((key) => ({
+            key,
+            views: [{ view: "timeseries" as const, bucket: trendBucket }],
+          }))
+        : [],
+    }),
+    [trendKeys, trendBucket],
+  );
+  const trend = useMetricCollection(
+    trendCollection.metrics.length && memberIds.length ? trendCollection : EMPTY_COLLECTION,
+    trendCollection.metrics.length && memberIds.length
+      ? { type: "person", ids: memberIds }
+      : { type: "person", ids: [] },
+    dateRange,
+  );
+
+  // Composition: one breakdown request covering every composition section.
+  const compSections = useMemo(
+    () =>
+      config.sections.filter(
+        (s): s is Extract<SectionSpec, { kind: "composition" }> => s.kind === "composition",
+      ),
+    [config],
+  );
+  const compCollection = useMemo<MetricCollectionConfig>(
+    () => ({
+      metrics: compSections.map((s) => ({
+        key: s.metric,
+        views: [{ view: "breakdown" as const, dimensions: [s.dimension] }],
+      })),
+    }),
+    [compSections],
+  );
+  const compData = useMetricCollection(
+    compSections.length && memberIds.length ? compCollection : EMPTY_COLLECTION,
+    compSections.length && memberIds.length
+      ? { type: "person", ids: memberIds }
+      : { type: "person", ids: [] },
+    dateRange,
+  );
+
+  // Event histograms: per-entity server bins, merged org-side only when edges
+  // align across every member (design §7 open question — probed, not assumed).
+  const eventSections = useMemo(
+    () =>
+      config.sections.filter(
+        (s): s is Extract<SectionSpec, { kind: "event-histogram" }> => s.kind === "event-histogram",
+      ),
+    [config],
+  );
+  const eventCollection = useMemo<MetricCollectionConfig>(
+    () => ({
+      metrics: eventSections.map((s) => ({ key: s.metric, views: [{ view: "histogram" as const }] })),
+    }),
+    [eventSections],
+  );
+  const eventData = useMetricCollection(
+    eventSections.length && memberIds.length ? eventCollection : EMPTY_COLLECTION,
+    eventSections.length && memberIds.length
+      ? { type: "person", ids: memberIds }
+      : { type: "person", ids: [] },
+    dateRange,
+  );
+
+  // Slice → by-unit auto-section (rule 7).
+  const slice = usePortalSlice();
+  const attrByEntity = useMemo(() => collectRosterAttrs(pivot, normalizePersonId), [pivot]);
+  const sliceDims = useMemo(() => availableSlices(attrByEntity.values()), [attrByEntity]);
+  const sliceLabel = slice
+    ? (sliceDims.find((d) => d.key === slice)?.label ?? slice)
+    : null;
+
+  const nameByEntity = useMemo(
+    () => new Map(members.map((m) => [normalizePersonId(m.person_id), m.name])),
+    [members],
+  );
+  const personIdByEntity = useMemo(
+    () => new Map(members.map((m) => [normalizePersonId(m.person_id), m.person_id])),
+    [members],
+  );
+  const cohortOf = useMemo(
+    () => (id: string) => cohortKey(attrByEntity.get(id), slice),
+    [attrByEntity, slice],
+  );
+  const cohortLabel = slice ? (sliceLabel ?? "cohort").toLowerCase() : "team";
+
+  const gate = orgScopeGate({
+    viewerLoading: orgScope.isLoading,
+    viewerError: orgScope.isError,
+    membersLoading: false,
+    membersError: false,
+    memberCount: members.length,
+    gridPending: grid.isPending,
+    gridError: grid.isError,
+    emptyLabel:
+      "No team in the current scope — a Direction shows a domain across a team; pick a different scope in the topbar.",
+    onRetry: () => {
+      orgScope.refetch();
+      grid.refetch();
+    },
+  });
+  if (gate) return gate;
+
+  // Rule 6: nothing in this family was ever observed → the source isn't wired.
+  if (!familyObserved(grid.byKey, lensKeys, memberIds)) {
+    return (
+      <Pending
+        label={config.notIngested ?? `${config.title} — source isn't ingested for this org yet.`}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6 p-4 md:p-6">
+      <div>
+        <h1 className="text-xl font-semibold tracking-tight">{config.title}</h1>
+        <p className="text-sm text-muted-foreground">
+          {orgScope.count} members · {config.tagline ?? "trend & balance"}
+        </p>
+      </div>
+
+      {config.sections.map((s, i) => (
+        <Section
+          key={`${s.kind}-${i}`}
+          spec={s}
+          grid={grid}
+          trend={trend}
+          trendBucket={trendBucket}
+          compData={compData.byKey}
+          compIsError={compData.isError}
+          compRefetch={compData.refetch}
+          eventByKey={eventData.byKey}
+          eventIsError={eventData.isError}
+          memberIds={memberIds}
+          cohortOf={cohortOf}
+          cohortLabel={cohortLabel}
+          nameByEntity={nameByEntity}
+          personIdByEntity={personIdByEntity}
+        />
+      ))}
+
+      {slice ? (
+        <ByUnitSection
+          config={config}
+          grid={grid.byKey}
+          memberIds={memberIds}
+          keyOf={(id) => attrByEntity.get(id)?.[slice]?.value ?? null}
+          sliceKey={slice}
+          sliceLabel={sliceLabel ?? slice}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+/* ── Section dispatch ────────────────────────────────────────────────── */
+
+interface GridData {
+  byKey: Map<string, NormalizedMetricResult>;
+  previousByKey: Map<string, NormalizedMetricResult>;
+}
+interface TrendData {
+  byKey: Map<string, NormalizedMetricResult>;
+  isPending: boolean;
+  isError: boolean;
+  refetch: () => void;
+}
+
+function Section({
+  spec,
+  grid,
+  trend,
+  trendBucket,
+  compData,
+  compIsError,
+  compRefetch,
+  eventByKey,
+  eventIsError,
+  memberIds,
+  cohortOf,
+  cohortLabel,
+  nameByEntity,
+  personIdByEntity,
+}: {
+  spec: SectionSpec;
+  grid: GridData;
+  trend: TrendData;
+  trendBucket: MetricBucket | null;
+  compData: Map<string, NormalizedMetricResult>;
+  compIsError: boolean;
+  compRefetch: () => void;
+  eventByKey: Map<string, NormalizedMetricResult>;
+  eventIsError: boolean;
+  memberIds: readonly string[];
+  nameByEntity: Map<string, string>;
+  personIdByEntity: Map<string, string>;
+  cohortOf: (id: string) => string | null;
+  cohortLabel: string;
+}) {
+  switch (spec.kind) {
+    case "headline":
+      return <HeadlineSection metrics={spec.metrics} grid={grid} memberIds={memberIds} />;
+    case "stat-tiles":
+      return (
+        <StatTilesSection title={spec.title} metrics={spec.metrics} grid={grid} memberIds={memberIds} />
+      );
+    case "trend":
+      return (
+        trendBucket ? (
+          <TrendSection metrics={spec.metrics} grid={grid} trend={trend} bucket={trendBucket} memberIds={memberIds} />
+        ) : (
+          // Say which of the two dials to turn — a bare "no data" would read as
+          // an ingestion gap rather than a request nobody can answer.
+          <Pending label="Trend needs a narrower period or a smaller scope — this many people over this window exceeds one request." />
+        )
+      );
+    case "distribution":
+      return <DistributionSection spec={spec} grid={grid} memberIds={memberIds} />;
+    case "concentration":
+      return <ConcentrationSection spec={spec} grid={grid} memberIds={memberIds} />;
+    case "composition":
+      return (
+        <CompositionSection
+          spec={spec}
+          compData={compData}
+          compIsError={compIsError}
+          compRefetch={compRefetch}
+          grid={grid}
+          memberIds={memberIds}
+        />
+      );
+    case "participation":
+      return <ParticipationSection spec={spec} grid={grid} trend={trend} memberIds={memberIds} />;
+    case "event-histogram":
+      return (
+        <EventHistogramSection
+          spec={spec}
+          grid={grid}
+          eventByKey={eventByKey}
+          eventIsError={eventIsError}
+          memberIds={memberIds}
+        />
+      );
+    case "attention":
+      return (
+        <AttentionSection
+          spec={spec}
+          grid={grid}
+          memberIds={memberIds}
+          cohortOf={cohortOf}
+          cohortLabel={cohortLabel}
+          nameByEntity={nameByEntity}
+          personIdByEntity={personIdByEntity}
+        />
+      );
+    case "direction-cards":
+      return <DirectionCardsSection variant={spec.variant} grid={grid} memberIds={memberIds} />;
+    case "coverage-radar":
+      return <CoverageRadarSection grid={grid} memberIds={memberIds} />;
+  }
+}
+
+/* ── participation (rule 8 variant — "N of M are active") ────────────── */
+
+function ParticipationSection({
+  spec,
+  grid,
+  trend,
+  memberIds,
+}: {
+  spec: Extract<SectionSpec, { kind: "participation" }>;
+  grid: GridData;
+  trend: TrendData;
+  memberIds: readonly string[];
+}) {
+  const isActive = (byKey: Map<string, NormalizedMetricResult>, id: string) =>
+    spec.metrics.some((key) => {
+      const r = byKey.get(key);
+      return r != null && (forEntity(r, id).value ?? 0) > 0;
+    });
+
+  const active = memberIds.filter((id) => isActive(grid.byKey, id)).length;
+  const prevActive = memberIds.filter((id) => isActive(grid.previousByKey, id)).length;
+  if (memberIds.length === 0) return null;
+
+  // Active people per trend bucket (client count over the fetched timeseries).
+  const byDate = new Map<string, Set<string>>();
+  for (const key of spec.metrics) {
+    const r = trend.byKey.get(key);
+    if (!r) continue;
+    for (const id of memberIds) {
+      for (const s of forEntity(r, id).series) {
+        for (const p of s.points) {
+          if ((p.value ?? 0) > 0) {
+            (byDate.get(p.bucket_start) ?? byDate.set(p.bucket_start, new Set()).get(p.bucket_start)!).add(id);
+          }
+        }
+      }
+    }
+  }
+  const data = [...byDate.entries()]
+    .map(([date, ids]) => ({ date, active: ids.size }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  return (
+    <section className="flex flex-col gap-3">
+      <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+        {spec.title}
+      </p>
+      <div className="grid grid-cols-[repeat(auto-fit,minmax(14rem,1fr))] gap-3">
+        <Card>
+          <CardContent className="p-4">
+            <div className="flex items-center justify-between gap-2">
+              <div className="text-xs font-medium text-muted-foreground">{spec.noun}</div>
+              <Delta now={active} prev={prevActive || null} direction="higher_is_better" />
+            </div>
+            <div className="mt-1 text-2xl font-semibold tabular-nums">
+              {active} of {memberIds.length}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {Math.round((active / memberIds.length) * 100)}% of the team this period
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+      {data.length > 1 ? (
+        <SectionTrend
+          title="Active people over time"
+          series={[{ key: "active", label: spec.noun, type: "line" }]}
+          data={data}
+          isPending={trend.isPending}
+        />
+      ) : null}
+    </section>
+  );
+}
+
+/* ── headline (rules 1-2) ────────────────────────────────────────────── */
+
+function HeadlineSection({
+  metrics,
+  grid,
+  memberIds,
+}: {
+  metrics: readonly string[];
+  grid: GridData;
+  memberIds: readonly string[];
+}) {
+  const cards = metrics
+    .map((key) => {
+      const r = grid.byKey.get(key);
+      if (!r) return null;
+      const now = representative(r, memberIds);
+      if (now == null) return null;
+      const prev = representative(grid.previousByKey.get(key), memberIds);
+      const isSum = r.computation === "sum";
+      return { key, r, now, prev, isSum };
+    })
+    .filter((x): x is NonNullable<typeof x> => x != null);
+  if (!cards.length) return null;
+
+  return (
+    <section className="flex flex-col gap-3">
+      <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+        Per person · vs previous period
+      </p>
+      <div className="grid grid-cols-[repeat(auto-fit,minmax(12rem,1fr))] gap-3">
+        {cards.map((c) => (
+          <Card key={c.key}>
+            <CardContent className="p-4">
+              <div className="flex items-center justify-between gap-2">
+                <div className="text-xs font-medium text-muted-foreground">
+                  {c.r.short_label ?? c.r.label}
+                </div>
+                <Delta now={c.now} prev={c.prev} direction={c.r.direction} />
+              </div>
+              <div className="mt-1 text-2xl font-semibold tabular-nums">
+                {formatMetricValue(c.isSum ? perCapita(c.r, memberIds) : c.now, c.r.format, c.r.unit)}
+              </div>
+              <div className="text-xs text-muted-foreground">
+                {c.isSum
+                  ? `per active person · ${formatMetricValue(c.now, c.r.format, c.r.unit)} team total`
+                  : "median / person"}
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/* ── stat-tiles (rule 2, with deltas) ────────────────────────────────── */
+
+function StatTilesSection({
+  title,
+  metrics,
+  grid,
+  memberIds,
+}: {
+  title: string;
+  metrics: readonly string[];
+  grid: GridData;
+  memberIds: readonly string[];
+}) {
+  const tiles = metrics
+    .map((key) => {
+      const r = grid.byKey.get(key);
+      if (!r) return null;
+      const median = medianAcross(r, memberIds);
+      if (median == null) return null;
+      const prev = medianAcross(grid.previousByKey.get(key), memberIds);
+      return { key, r, median, prev };
+    })
+    .filter((x): x is NonNullable<typeof x> => x != null);
+  if (!tiles.length) return null;
+
+  return (
+    <section className="flex flex-col gap-3">
+      <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">{title}</p>
+      <div className="grid grid-cols-[repeat(auto-fit,minmax(11rem,1fr))] gap-3">
+        {tiles.map((t) => (
+          <Card key={t.key}>
+            <CardContent className="p-4">
+              <div className="flex items-center justify-between gap-2">
+                <div className="text-xs font-medium text-muted-foreground">
+                  {t.r.short_label ?? t.r.label}
+                </div>
+                <Delta now={t.median} prev={t.prev} direction={t.r.direction} />
+              </div>
+              <div className="mt-1 text-2xl font-semibold tabular-nums">
+                {formatMetricValue(t.median, t.r.format, t.r.unit)}
+              </div>
+              <div className="text-xs text-muted-foreground">median / person</div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/* ── trend (rule 8) ──────────────────────────────────────────────────── */
+
+function TrendSection({
+  metrics,
+  grid,
+  trend,
+  bucket,
+  memberIds,
+}: {
+  metrics: readonly string[];
+  grid: GridData;
+  trend: TrendData;
+  bucket: MetricBucket;
+  memberIds: readonly string[];
+}) {
+  const series = metrics
+    .map((key) => {
+      const r = grid.byKey.get(key);
+      if (!r || r.computation !== "sum") return null;
+      return { key, label: r.short_label ?? r.label };
+    })
+    .filter((x): x is NonNullable<typeof x> => x != null)
+    .map((s, i) => ({
+      key: s.key,
+      label: s.label,
+      type: "line" as const,
+      yAxisId: (i === 0 ? "left" : "right") as "left" | "right",
+    }));
+  const data = buildTrendData(series.map((s) => s.key), trend.byKey, memberIds);
+
+  if (series.length === 0) return null;
+  if (trend.isError)
+    return (
+      <SectionTrend
+        title="Activity over time"
+        series={series}
+        data={[]}
+        isError
+        onRetry={trend.refetch}
+      />
+    );
+  if (data.length < 2) return null;
+  return (
+    <SectionTrend
+      title="Activity over time"
+      description={`Team totals · per ${bucket}`}
+      series={series}
+      data={data}
+      rightAxis={series.some((s) => s.yAxisId === "right")}
+      isPending={trend.isPending}
+    />
+  );
+}
+
+/* ── distribution (rules 3, 11) ──────────────────────────────────────── */
+
+const DIST_CONFIG: ChartConfig = { count: { label: "People" } };
+
+function DistributionSection({
+  spec,
+  grid,
+  memberIds,
+}: {
+  spec: Extract<SectionSpec, { kind: "distribution" }>;
+  grid: GridData;
+  memberIds: readonly string[];
+}) {
+  const r = grid.byKey.get(spec.metric);
+  const values = r
+    ? memberIds
+        .map((id) => forEntity(r, id).value)
+        .filter((v): v is number => v != null && Number.isFinite(v) && v >= 0)
+    : [];
+  const fmt =
+    r?.format === "percent" ? (n: number) => formatMetricValue(n, "percent", null) : fmtCompact;
+  const rows = distribution(values, fmt);
+  if (!rows.length) return null;
+
+  return (
+    <section className="flex flex-col gap-3">
+      <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+        {spec.title} · {values.length} people
+      </p>
+      <Card>
+        <CardContent className="p-4">
+          <p className="mb-3 text-xs text-muted-foreground">{spec.caption}</p>
+          <ChartContainer config={DIST_CONFIG} className="h-56 w-full">
+            <BarChart data={rows} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+              <CartesianGrid vertical={false} strokeDasharray="3 3" stroke="var(--border)" />
+              <XAxis
+                dataKey="label"
+                tick={{ fontSize: 10, fill: "var(--muted-foreground)" }}
+                tickLine={false}
+                axisLine={false}
+                interval="preserveStartEnd"
+              />
+              <YAxis
+                allowDecimals={false}
+                width={28}
+                tick={{ fontSize: 10, fill: "var(--muted-foreground)" }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <ChartTooltip
+                content={
+                  <ChartTooltipContent
+                    className="min-w-40"
+                    labelFormatter={(_, p) =>
+                      (p?.[0]?.payload as { range?: string } | undefined)?.range ?? ""
+                    }
+                  />
+                }
+              />
+              <ChartBar dataKey="count" name="People" radius={[2, 2, 0, 0]} fill="var(--chart-1)" />
+            </BarChart>
+          </ChartContainer>
+          <p className="mt-1 text-center text-[10px] text-muted-foreground">{spec.unitLabel}</p>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}
+
+/* ── event-histogram (design §7 — bin-aligned merge, honest fallback) ── */
+
+/**
+ * Org-wide event histogram assembled from per-entity server bins. This is an
+ * enhancement probe, not a guaranteed capability: org-wide bin alignment
+ * across entities is unknown until observed (design §7 open question). When
+ * `mergeEventHistogram` can't align edges (or errors on the underlying
+ * fetch), this section renders nothing — the Flow stat-tiles above still
+ * carry the tab, and a missing chart here reads as "not available", never as
+ * a fabricated or wrong distribution.
+ */
+function EventHistogramSection({
+  spec,
+  grid,
+  eventByKey,
+  eventIsError,
+  memberIds,
+}: {
+  spec: Extract<SectionSpec, { kind: "event-histogram" }>;
+  grid: GridData;
+  eventByKey: Map<string, NormalizedMetricResult>;
+  eventIsError: boolean;
+  memberIds: readonly string[];
+}) {
+  if (eventIsError) return null;
+  const r = grid.byKey.get(spec.metric);
+  const bins = mergeEventHistogram(eventByKey.get(spec.metric), memberIds);
+  if (!bins) return null;
+
+  const fmt =
+    r?.format === "percent" ? (n: number) => formatMetricValue(n, "percent", null) : fmtCompact;
+  const rows = bins.map((bin) => ({
+    label: fmt(bin.lo),
+    range: `${fmt(bin.lo)}–${fmt(bin.hi)}`,
+    count: bin.count,
+  }));
+  const total = bins.reduce((sum, bin) => sum + bin.count, 0);
+
+  return (
+    <section className="flex flex-col gap-3">
+      <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+        {spec.title} · {total} events
+      </p>
+      <Card>
+        <CardContent className="p-4">
+          <p className="mb-3 text-xs text-muted-foreground">
+            Distribution of events (every PR), not people.
+          </p>
+          <ChartContainer config={DIST_CONFIG} className="h-56 w-full">
+            <BarChart data={rows} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+              <CartesianGrid vertical={false} strokeDasharray="3 3" stroke="var(--border)" />
+              <XAxis
+                dataKey="label"
+                tick={{ fontSize: 10, fill: "var(--muted-foreground)" }}
+                tickLine={false}
+                axisLine={false}
+                interval="preserveStartEnd"
+              />
+              <YAxis
+                allowDecimals={false}
+                width={28}
+                tick={{ fontSize: 10, fill: "var(--muted-foreground)" }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <ChartTooltip
+                content={
+                  <ChartTooltipContent
+                    className="min-w-40"
+                    labelFormatter={(_, p) =>
+                      (p?.[0]?.payload as { range?: string } | undefined)?.range ?? ""
+                    }
+                  />
+                }
+              />
+              <ChartBar dataKey="count" name="Events" radius={[2, 2, 0, 0]} fill="var(--chart-1)" />
+            </BarChart>
+          </ChartContainer>
+          <p className="mt-1 text-center text-[10px] text-muted-foreground">
+            {r?.short_label ?? r?.label ?? spec.metric}
+            {r?.unit ? ` (${r.unit})` : ""}
+          </p>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}
+
+/* ── concentration (rules 4, 10 — aggregate only, framed per domain) ─── */
+
+const FRAMING_COPY: Record<ConcentrationFraming, { heading: string; note: string }> = {
+  "bus-factor": {
+    heading: "Bus factor · top 10% of contributors",
+    note: "high concentration = continuity risk",
+  },
+  "load-balance": {
+    heading: "Load concentration · top 10% of contributors",
+    note: "even share ≈ 10%",
+  },
+};
+
+function ConcentrationSection({
+  spec,
+  grid,
+  memberIds,
+}: {
+  spec: Extract<SectionSpec, { kind: "concentration" }>;
+  grid: GridData;
+  memberIds: readonly string[];
+}) {
+  const cards = spec.metrics
+    .map((key) => {
+      const r = grid.byKey.get(key);
+      if (!r) return null;
+      const vals = memberIds
+        .map((id) => forEntity(r, id).value)
+        .filter((v): v is number => v != null && Number.isFinite(v) && v > 0);
+      const share = topDecileShare(vals);
+      if (share == null) return null;
+      return { key, label: r.short_label ?? r.label, share, contributors: vals.length };
+    })
+    .filter((x): x is NonNullable<typeof x> => x != null);
+  if (!cards.length) return null;
+  const copy = FRAMING_COPY[spec.framing];
+
+  return (
+    <section className="flex flex-col gap-3">
+      <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+        {copy.heading}
+      </p>
+      <div className="grid grid-cols-[repeat(auto-fit,minmax(14rem,1fr))] gap-3">
+        {cards.map((c) => (
+          <Card key={c.key}>
+            <CardContent className="p-4">
+              <div className="text-xs font-medium text-muted-foreground">{c.label}</div>
+              <div className="mt-1 text-2xl font-semibold tabular-nums">
+                {Math.round(c.share * 100)}%
+              </div>
+              <div className="text-xs text-muted-foreground">
+                carried by the busiest {Math.max(1, Math.ceil(c.contributors * 0.1))} of{" "}
+                {c.contributors} · {copy.note}
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/* ── composition (rule 5) ────────────────────────────────────────────── */
+
+function CompositionSection({
+  spec,
+  compData,
+  compIsError,
+  compRefetch,
+  grid,
+  memberIds,
+}: {
+  spec: Extract<SectionSpec, { kind: "composition" }>;
+  compData: Map<string, NormalizedMetricResult>;
+  compIsError: boolean;
+  compRefetch: () => void;
+  grid: GridData;
+  memberIds: readonly string[];
+}) {
+  if (compIsError) {
+    return (
+      <section className="flex flex-col gap-3">
+        <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+          {spec.title}
+        </p>
+        <ComingSoon
+          variant="card"
+          state="error"
+          label={`${spec.title} — unable to load`}
+          onRetry={compRefetch}
+        />
+      </section>
+    );
+  }
+
+  const r = grid.byKey.get(spec.metric);
+  const bd = compData.get(spec.metric);
+  const bucket = new Map<string, number>();
+  if (bd) {
+    for (const id of memberIds) {
+      for (const row of forEntity(bd, id).breakdown) {
+        const val = row.dimensions.find((d) => d.key === spec.dimension)?.value;
+        if (!val || row.value == null || row.value <= 0) continue;
+        bucket.set(val, (bucket.get(val) ?? 0) + row.value);
+      }
+    }
+  }
+  const rows = toBarRows(bucket);
+  // A single 100%-share bar is an empty shell (rule 11), same as ByUnitSection.
+  if (rows.length < 2) return null;
+
+  return (
+    <BarList title={spec.title} rows={rows} format={r?.format ?? "integer"} unit={r?.unit ?? null} />
+  );
+}
+
+/* ── attention (Overview design O3: the ONLY section that names people —
+      actionable pointers into Person, not a leaderboard) ───────────────── */
+
+function AttentionSection({
+  spec,
+  grid,
+  memberIds,
+  cohortOf,
+  cohortLabel,
+  nameByEntity,
+  personIdByEntity,
+}: {
+  spec: Extract<SectionSpec, { kind: "attention" }>;
+  grid: GridData;
+  memberIds: readonly string[];
+  cohortOf: (id: string) => string | null;
+  cohortLabel: string;
+  nameByEntity: Map<string, string>;
+  personIdByEntity: Map<string, string>;
+}) {
+  const flags = useMemo(
+    () =>
+      computeAttentionFlags({
+        headlineKeys: spec.metrics,
+        byKey: grid.byKey,
+        previousByKey: grid.previousByKey,
+        memberIds,
+        cohortOf,
+        nameOf: (id) => nameByEntity.get(id) ?? id,
+        personIdOf: (id) => personIdByEntity.get(id) ?? id,
+        cohortLabel,
+      }),
+    [spec.metrics, grid.byKey, grid.previousByKey, memberIds, cohortOf, cohortLabel, nameByEntity, personIdByEntity],
+  );
+  if (!memberIds.length) return null;
+  const flaggedPeople = new Set(flags.map((f) => f.personId)).size;
+  return (
+    <AttentionList
+      flags={flags}
+      summary={attentionSummary(flags, flaggedPeople, memberIds.length)}
+      peopleLabel={flags.length ? `${flaggedPeople} of ${memberIds.length} people` : undefined}
+      max={spec.max}
+    />
+  );
+}
+
+/* ── direction-cards (Overview design O4: cards derive from DIRECTION_LENSES,
+      click routes into the Directions zone) ─────────────────────────────── */
+
+function DirectionCardsSection({
+  variant,
+  grid,
+  memberIds,
+}: {
+  variant: "compact" | "full";
+  grid: GridData;
+  memberIds: readonly string[];
+}) {
+  const { setDir, setLens, setZone } = usePortalNavActions();
+  const cards = DIRECTIONS.map((d) => {
+    const entry = lensEntry(d.id, "Overview");
+    if (!entry || "comingSoon" in entry) return null;
+    const headline = entry.sections.find(
+      (s): s is Extract<SectionSpec, { kind: "headline" }> => s.kind === "headline",
+    );
+    if (!headline) return null;
+    const keys = variant === "compact" ? headline.metrics.slice(0, 2) : headline.metrics;
+    const observed = familyObserved(grid.byKey, sectionMetricKeys(entry), memberIds);
+    return { id: d.id, name: d.name, keys, observed };
+  }).filter((c): c is NonNullable<typeof c> => c != null);
+  if (!cards.length) return null;
+
+  const go = (dir: string) => {
+    setDir(dir);
+    setLens("Overview");
+    setZone("directions");
+  };
+
+  return (
+    <section className="flex flex-col gap-3">
+      <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+        By direction
+      </p>
+      <div className="grid grid-cols-[repeat(auto-fit,minmax(16rem,1fr))] gap-3">
+        {cards.map((c) => (
+          <button
+            key={c.id}
+            type="button"
+            onClick={() => go(c.id)}
+            className="rounded-xl border bg-card text-left transition-colors hover:bg-accent"
+          >
+            <div className="flex flex-col gap-2 p-4">
+              <div className="text-sm font-semibold">{c.name}</div>
+              {c.observed ? (
+                c.keys.map((key) => {
+                  const r = grid.byKey.get(key);
+                  if (!r) return null;
+                  const now = representative(r, memberIds);
+                  if (now == null) return null;
+                  const prev = representative(grid.previousByKey.get(key), memberIds);
+                  const isSum = r.computation === "sum";
+                  return (
+                    <div key={key} className="flex items-center justify-between gap-2 text-sm">
+                      <span className="truncate text-muted-foreground">
+                        {r.short_label ?? r.label}
+                      </span>
+                      <span className="flex items-center gap-2">
+                        <span className="font-medium tabular-nums">
+                          {formatMetricValue(isSum ? perCapita(r, memberIds) : now, r.format, r.unit)}
+                        </span>
+                        <Delta now={now} prev={prev} direction={r.direction} />
+                      </span>
+                    </div>
+                  );
+                })
+              ) : (
+                <span className="text-xs text-muted-foreground">
+                  source isn&apos;t ingested for this org yet
+                </span>
+              )}
+            </div>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+/* ── coverage-radar (Overview design O5: coverage = share of members with ≥1
+      OBSERVED metric per group — entityObserved, never zero-filled sums) ── */
+
+function CoverageRadarSection({
+  grid,
+  memberIds,
+}: {
+  grid: GridData;
+  memberIds: readonly string[];
+}) {
+  if (memberIds.length < MIN_COHORT) return null;
+  const data = GROUPS.map((g) => ({
+    domain: g.title,
+    coverage: Math.round((groupCoverage(grid.byKey, g.card.preview, memberIds) ?? 0) * 100),
+  }));
+  if (data.every((d) => d.coverage === 0)) return null;
+
+  return (
+    <section className="flex flex-col gap-3">
+      <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+        Health radar
+      </p>
+      <Card>
+        <CardContent className="p-4">
+          <div className="h-72 w-full">
+            <ResponsiveContainer width="100%" height="100%">
+              <RadarChart data={data} outerRadius="70%">
+                <PolarGrid />
+                <PolarAngleAxis dataKey="domain" tick={{ fontSize: 12 }} />
+                {/* Percent scale is absolute: full edge = 100% coverage, not
+                    the period's max — and the explicit axis gives recharts a
+                    radius scale (without one the polygon collapses to center). */}
+                <PolarRadiusAxis domain={[0, 100]} tick={false} axisLine={false} />
+                <Radar
+                  dataKey="coverage"
+                  stroke="var(--primary)"
+                  fill="var(--primary)"
+                  fillOpacity={0.25}
+                  isAnimationActive={false}
+                />
+              </RadarChart>
+            </ResponsiveContainer>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Coverage — % of people in scope with any observed activity in each domain this
+            period.
+          </p>
+        </CardContent>
+      </Card>
+    </section>
+  );
+}
+
+/* ── by-unit auto-section (rule 7) ───────────────────────────────────── */
+
+const NO_COMPARABLE_UNITS_NOTE =
+  "No comparable units for this lens at this slice (needs a summable headline metric and ≥2 units of ≥4 people).";
+
+function ByUnitSection({
+  config,
+  grid,
+  memberIds,
+  keyOf,
+  sliceKey,
+  sliceLabel,
+}: {
+  config: LensConfig;
+  grid: Map<string, NormalizedMetricResult>;
+  memberIds: readonly string[];
+  keyOf: (id: string) => string | null;
+  sliceKey: string;
+  sliceLabel: string;
+}) {
+  // A declared-but-unfed dimension (e.g. functional team) can never produce
+  // by-unit data — say so plainly rather than fall through to the generic
+  // "no comparable units" note, which would wrongly suggest a data quirk.
+  const planned = PLANNED_SLICES.find((d) => d.key === sliceKey);
+  if (planned) {
+    return <SliceNote text={`The ${planned.label} dimension isn't ingested yet.`} />;
+  }
+
+  // Compare units on the lens's first headline counter, per active person.
+  const headline = config.sections.find(
+    (s): s is Extract<SectionSpec, { kind: "headline" }> => s.kind === "headline",
+  );
+  // No headline → by-unit was never promised for this lens; stay silent.
+  if (!headline) return null;
+  const key = headline.metrics.find((k) => grid.get(k)?.computation === "sum");
+  const r = key ? grid.get(key) : undefined;
+  if (!r) return <SliceNote text={NO_COMPARABLE_UNITS_NOTE} />;
+
+  const byUnit = new Map<string, string[]>();
+  for (const id of memberIds) {
+    const unit = keyOf(id);
+    if (!unit) continue;
+    (byUnit.get(unit) ?? byUnit.set(unit, []).get(unit)!).push(id);
+  }
+  const bucket = new Map<string, number>();
+  for (const [unit, ids] of byUnit) {
+    if (ids.length < MIN_COHORT) continue; // small-cohort suppression
+    const v = perCapita(r, ids);
+    if (v > 0) bucket.set(`${unit} · ${ids.length}`, v);
+  }
+  const rows = toBarRows(bucket);
+  if (rows.length < 2) return <SliceNote text={NO_COMPARABLE_UNITS_NOTE} />;
+
+  return (
+    <BarList
+      title={`${r.short_label ?? r.label} per active person · by ${sliceLabel}`}
+      rows={rows}
+      format={r.format}
+      unit={r.unit}
+      showShare={false}
+    />
+  );
+}
+
+/* ── shared bits ─────────────────────────────────────────────────────── */
+
+interface BarRow {
+  label: string;
+  value: number;
+  pct: number;
+}
+
+function toBarRows(bucket: Map<string, number>): BarRow[] {
+  const total = [...bucket.values()].reduce((a, b) => a + b, 0) || 1;
+  return [...bucket.entries()]
+    .map(([label, value]) => ({ label, value, pct: Math.round((value / total) * 100) }))
+    .sort((a, b) => b.value - a.value);
+}
+
+/** Rows shown before the reader opts into the full list. */
+const BAR_LIST_COLLAPSED = 12;
+
+function BarList({
+  title,
+  rows,
+  format,
+  unit,
+  showShare = true,
+}: {
+  title: string;
+  rows: BarRow[];
+  format: NormalizedMetricResult["format"];
+  unit: string | null;
+  /** False for per-capita values, where a share-of-total percent would mislead. */
+  showShare?: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const visible = expanded ? rows : rows.slice(0, BAR_LIST_COLLAPSED);
+  const max = rows[0]?.value || 1;
+  // Collapsed view is a sample, not the full picture — the title says so,
+  // and the "+N more" button below hands over the rest on demand.
+  const displayTitle =
+    !expanded && rows.length > BAR_LIST_COLLAPSED
+      ? `${title} · top ${BAR_LIST_COLLAPSED}`
+      : title;
+  return (
+    <section className="flex flex-col gap-3">
+      <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+        {displayTitle}
+      </p>
+      <Card>
+        <CardContent className="flex flex-col gap-2 p-4">
+          {visible.map((row) => (
+            <div key={row.label} className="flex items-center gap-3">
+              <div className="w-44 shrink-0 truncate text-sm">{row.label}</div>
+              <div className="relative h-6 flex-1 overflow-hidden rounded bg-muted">
+                <div
+                  className="h-full rounded bg-primary/25"
+                  style={{ width: `${Math.round((row.value / max) * 100)}%` }}
+                />
+                <span className="absolute inset-y-0 left-2 flex items-center text-xs font-medium tabular-nums">
+                  {formatMetricValue(row.value, format, unit)}
+                  {showShare ? ` · ${row.pct}%` : ""}
+                </span>
+              </div>
+            </div>
+          ))}
+          {rows.length > BAR_LIST_COLLAPSED ? (
+            <button
+              type="button"
+              onClick={() => setExpanded((v) => !v)}
+              className="self-start pt-1 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+            >
+              {expanded ? "Show less" : `+${rows.length - BAR_LIST_COLLAPSED} more`}
+            </button>
+          ) : null}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}
+
+function SliceNote({ text }: { text: string }) {
+  return (
+    <p className="rounded-md border border-dashed bg-muted/30 p-3 text-xs text-muted-foreground">
+      {text}
+    </p>
+  );
+}
+
+function Delta({
+  now,
+  prev,
+  direction,
+}: {
+  now: number;
+  prev: number | null;
+  direction: MetricDirection;
+}) {
+  if (prev == null || prev === 0) return null;
+  const diff = now - prev;
+  if (Math.abs(diff) / Math.abs(prev) < 0.01) {
+    return <span className="text-xs text-muted-foreground tabular-nums">±0%</span>;
+  }
+  const up = diff > 0;
+  const good = direction === "neutral" ? null : direction === "higher_is_better" ? up : !up;
+  const color =
+    good == null ? "text-muted-foreground" : good ? "text-success" : "text-destructive";
+  const Icon = up ? ArrowUpRight : ArrowDownRight;
+  const pct = Math.round((diff / Math.abs(prev)) * 100);
+  return (
+    <span className={`flex items-center gap-0.5 text-xs font-medium tabular-nums ${color}`}>
+      <Icon className="h-3.5 w-3.5" />
+      {up ? "+" : ""}
+      {pct}%
+    </span>
+  );
+}
+
+export function Pending({ label }: { label: string }) {
+  return (
+    <div className="mx-auto w-full max-w-md p-8">
+      <ComingSoon variant="card" state="empty" label={label} />
+    </div>
+  );
+}

--- a/src/frontend/src/components/portal/employees-view.test.tsx
+++ b/src/frontend/src/components/portal/employees-view.test.tsx
@@ -39,6 +39,7 @@ const person = (
 ): IdentityPerson => identityPerson(label, over, subs);
 
 beforeEach(() => {
+  mocks.ic.refetch.mockClear();
   mocks.personId = pid("boss");
   mocks.ic.isPending = false;
   mocks.ic.isError = false;

--- a/src/frontend/src/components/portal/employees-view.test.tsx
+++ b/src/frontend/src/components/portal/employees-view.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+vi.mock("@tanstack/react-router", async () => {
+  const { portalRouterMock } = await import("@/test/portal-router");
+  return portalRouterMock();
+});
+/**
+ * Employees directory semantics: the org tree flattens into a de-duplicated,
+ * sorted roster; search filters across name/title/department; rows link into
+ * Person; identity failures surface as a retryable error.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { identityPerson, pid } from "@/test/identity";
+import type { IdentityPerson } from "@/types/insight";
+
+const mocks = vi.hoisted(() => ({
+  personId: null as string | null,
+  ic: {
+    data: undefined as IdentityPerson | undefined,
+    isPending: false,
+    isError: false,
+    refetch: vi.fn(),
+  },
+}));
+
+vi.mock("@/auth", () => ({
+  useViewer: () => ({ email: "boss@x", personId: mocks.personId }),
+}));
+vi.mock("@/queries/ic-dashboard", () => ({ useIcPerson: () => mocks.ic }));
+
+import { EmployeesView } from "./employees-view";
+
+const person = (
+  label: string,
+  over: Partial<IdentityPerson> = {},
+  subs: IdentityPerson[] = [],
+): IdentityPerson => identityPerson(label, over, subs);
+
+beforeEach(() => {
+  mocks.personId = pid("boss");
+  mocks.ic.isPending = false;
+  mocks.ic.isError = false;
+  mocks.ic.data = person("boss", { display_name: "Boss", job_title: "Director" }, [
+    person("zoe", { display_name: "Zoe", job_title: "QA Engineer", department: "Quality" } as never),
+    person("adam", { display_name: "Adam", job_title: "Backend Dev" } as never, [
+      // the same person deeper in the tree must NOT double a row
+      person("zoe", { display_name: "Zoe" } as never),
+    ]),
+  ]);
+});
+
+describe("EmployeesView", () => {
+  it("flattens the tree, de-duplicates and sorts by display name", () => {
+    render(<EmployeesView />);
+    const rows = screen.getAllByRole("link").map((a) => a.textContent);
+    expect(rows).toEqual(["Adam", "Boss", "Zoe"]);
+    expect(screen.getByText(/3 people/)).toBeInTheDocument();
+  });
+
+  it("links each row into that person's Person view", () => {
+    render(<EmployeesView />);
+    expect(screen.getAllByRole("link")[2]).toHaveAttribute(
+      "href",
+      `/ic/${pid("zoe")}/personal`,
+    );
+  });
+
+  it("filters across name / title / department and shows the filtered count", async () => {
+    render(<EmployeesView />);
+    await userEvent.type(screen.getByRole("textbox"), "quality");
+    expect(screen.getAllByRole("link").map((a) => a.textContent)).toEqual(["Zoe"]);
+    expect(screen.getByText(/1 of 3/)).toBeInTheDocument();
+  });
+
+  it("surfaces an identity failure as a retryable error", async () => {
+    mocks.ic.data = undefined;
+    mocks.ic.isError = true;
+    render(<EmployeesView />);
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(mocks.ic.refetch).toHaveBeenCalledOnce();
+  });
+});

--- a/src/frontend/src/components/portal/employees-view.tsx
+++ b/src/frontend/src/components/portal/employees-view.tsx
@@ -1,0 +1,186 @@
+import { Link } from "@tanstack/react-router";
+import { Search } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { useViewer } from "@/auth";
+import { CenteredSpinner } from "@/components/widgets/centered-spinner";
+import { ComingSoon } from "@/components/widgets/coming-soon";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  usePortalNavActions,
+} from "@/lib/portal/portal-nav";
+import { useIcPerson } from "@/queries/ic-dashboard";
+import type { IdentityPerson } from "@/types/insight";
+import { cn } from "@/lib/utils";
+
+// Mirrors the rail: a person with neither display name nor email is still a row.
+const UNNAMED_PERSON = "Unnamed person";
+
+interface EmployeeRow {
+  personId: string;
+  displayName: string;
+  jobTitle: string;
+  department: string;
+  division: string;
+  supervisorName: string;
+  status: string;
+}
+
+/** Flatten the org tree (root + every descendant) into a de-duplicated roster. */
+function collectEmployees(root: IdentityPerson): EmployeeRow[] {
+  // Keyed by person id, not email: the identity contract admits people with no
+  // email, and their row still has to be listed and clickable.
+  const byId = new Map<string, EmployeeRow>();
+  const walk = (node: IdentityPerson) => {
+    if (node.person_id) {
+      const key = node.person_id.toLowerCase();
+      if (!byId.has(key)) {
+        byId.set(key, {
+          personId: node.person_id,
+          displayName: node.display_name || node.email || UNNAMED_PERSON,
+          jobTitle: node.job_title ?? "",
+          department: node.department ?? "",
+          division: node.division ?? "",
+          supervisorName: node.supervisor_name ?? "",
+          status: node.status ?? "",
+        });
+      }
+    }
+    node.subordinates.forEach(walk);
+  };
+  walk(root);
+  return [...byId.values()].sort((a, b) =>
+    a.displayName.localeCompare(b.displayName),
+  );
+}
+
+/**
+ * Employees directory — every person in the viewer's org (flattened org tree),
+ * searchable, each row linking into their Person view. Sourced entirely from
+ * the identity profile tree (`getPerson` recurses), so no metric queries and no
+ * new endpoint: it's a live people index, not a scaffold.
+ */
+export function EmployeesView() {
+  const { setZone } = usePortalNavActions();
+  const { personId: viewerPersonId } = useViewer();
+  const { data, isPending, isError, refetch } = useIcPerson(viewerPersonId ?? "");
+  const [query, setQuery] = useState("");
+
+  const employees = useMemo(
+    () => (data ? collectEmployees(data) : []),
+    [data],
+  );
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return employees;
+    return employees.filter((e) =>
+      [e.displayName, e.jobTitle, e.department, e.division, e.supervisorName]
+        .join(" ")
+        .toLowerCase()
+        .includes(q),
+    );
+  }, [employees, query]);
+
+  if (isPending) return <CenteredSpinner className="min-h-[60vh]" />;
+  if (isError || !data)
+    return (
+      <div className="mx-auto w-full max-w-md p-8">
+        <ComingSoon variant="card" state="error" onRetry={refetch} />
+      </div>
+    );
+
+  return (
+    <div className="flex flex-col gap-3 p-4 md:p-6">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold tracking-tight">Employees</h1>
+          <p className="text-sm text-muted-foreground">
+            {filtered.length}
+            {filtered.length !== employees.length ? ` of ${employees.length}` : ""}{" "}
+            people · live from the identity directory
+          </p>
+        </div>
+        <div className="relative w-full max-w-xs">
+          <Search className="absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search name, title, department…"
+            className="pl-8"
+          />
+        </div>
+      </div>
+
+      <div className="overflow-x-auto rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+              <TableHead>Title</TableHead>
+              <TableHead>Department</TableHead>
+              <TableHead>Division</TableHead>
+              <TableHead>Manager</TableHead>
+              <TableHead>Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.map((e) => (
+              <TableRow key={e.personId}>
+                <TableCell>
+                  <Link
+                    to="/ic/$person/personal"
+                    params={{ person: e.personId }}
+                    // Clear the pinned Manage zone so the route-driven Person
+                    // zone takes over (same pattern as the rail).
+                    onClick={() => setZone(null)}
+                    className="font-medium hover:underline"
+                  >
+                    {e.displayName}
+                  </Link>
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {e.jobTitle || "—"}
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {e.department || "—"}
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {e.division || "—"}
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {e.supervisorName || "—"}
+                </TableCell>
+                <TableCell>
+                  {e.status ? (
+                    <Badge
+                      variant="secondary"
+                      className={cn(
+                        "font-medium",
+                        e.status.toLowerCase() === "active"
+                          ? "bg-success/15 text-success"
+                          : "bg-muted text-muted-foreground",
+                      )}
+                    >
+                      {e.status}
+                    </Badge>
+                  ) : (
+                    "—"
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/components/portal/lens-rail.tsx
+++ b/src/frontend/src/components/portal/lens-rail.tsx
@@ -1,0 +1,107 @@
+import { Settings2 } from "lucide-react";
+
+import { AppSidebarFooter } from "@/components/app-sidebar-footer";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+} from "@/components/ui/sidebar";
+import { type Zone } from "@/lib/portal/nav-model";
+import { useShellLayout } from "@/lib/portal/use-shell-layout";
+import { useZoneNav } from "@/lib/portal/use-zone-nav";
+
+/**
+ * Portal primary rail: a bounded set of zone icons. Entity zones (Person /
+ * People) link to the existing dashboard routes and clear the theme-zone
+ * selection; other zones set the active zone so the context pane switches.
+ * Zones the active role can't see are filtered out (permission layer — FE
+ * stub over the future role_section_visibility entity). Rendered as a
+ * `collapsible="none"` sidebar so it sits in normal flow beside the pane.
+ *
+ * Below 768px the rail renders nothing: 56px of icons plus a 256px pane left a
+ * phone with ~60px of content. The same zones (labelled, not icon-only) live in
+ * the context pane's drawer instead — see `ContextPane`. On a tablet the rail
+ * stays: 56px is affordable, and it is the pane that collapses.
+ */
+export function LensRail() {
+  const layout = useShellLayout();
+  const { zones, activeZone, selectZone } = useZoneNav();
+
+  if (layout === "phone") return null;
+
+  return (
+    <Sidebar collapsible="none" className="w-14! border-e">
+      <SidebarHeader className="items-center">
+        <div className="flex size-8 items-center justify-center rounded-md bg-sidebar-primary text-sm font-bold text-sidebar-primary-foreground">
+          I
+        </div>
+      </SidebarHeader>
+      <SidebarContent>
+        <SidebarMenu className="items-center gap-1">
+          {zones.map((z) => (
+            <ZoneItem
+              key={z.id}
+              zone={z}
+              active={activeZone === z.id}
+              onSelect={selectZone}
+            />
+          ))}
+        </SidebarMenu>
+      </SidebarContent>
+      <SidebarFooter className="items-center gap-1">
+        <Popover>
+          <PopoverTrigger
+            render={
+              <button
+                type="button"
+                title="Settings"
+                className="flex size-10 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+              >
+                <Settings2 className="size-[19px]" aria-hidden />
+                <span className="sr-only">Settings</span>
+              </button>
+            }
+          />
+          <PopoverContent side="right" align="end" className="w-56 gap-0 p-1">
+            <AppSidebarFooter />
+          </PopoverContent>
+        </Popover>
+      </SidebarFooter>
+    </Sidebar>
+  );
+}
+
+function ZoneItem({
+  zone,
+  active,
+  onSelect,
+}: {
+  zone: Zone;
+  active: boolean;
+  onSelect: (zone: Zone) => void;
+}) {
+  const Icon = zone.icon;
+
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        isActive={active}
+        title={zone.label}
+        className="size-10 justify-center p-0"
+        onClick={() => onSelect(zone)}
+      >
+        <Icon />
+        <span className="sr-only">{zone.label}</span>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  );
+}

--- a/src/frontend/src/components/portal/manage-view.test.tsx
+++ b/src/frontend/src/components/portal/manage-view.test.tsx
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+/**
+ * Manage-zone surfaces read the UNIFIED registry, not the legacy catalog:
+ * the table lists `metric_key`s `/v1/metric-results` actually serves, spells
+ * out an unobserved definition as "no data yet" rather than hiding it, and
+ * Data health separates "schema checks out" from "has ever produced a row".
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { MetricDefinition } from "@/api/metric-definitions-client";
+import type { MetricDefinitionGroup } from "@/queries/metric-definitions";
+
+const mocks = vi.hoisted(() => ({
+  q: {
+    data: undefined as MetricDefinitionGroup[] | undefined,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  },
+}));
+
+vi.mock("@/queries/metric-definitions", () => ({
+  useMetricDefinitions: () => mocks.q,
+}));
+
+import { ManageView } from "./manage-view";
+
+function def(over: Partial<MetricDefinition>): MetricDefinition {
+  return {
+    metric_key: "git.commits",
+    label: "Commits",
+    short_label: null,
+    description: null,
+    explanation: null,
+    unit: "commits",
+    format: "integer",
+    direction: "higher_is_better",
+    dimensions: [],
+    is_enabled: true,
+    schema_status: "ok",
+    schema_error_code: null,
+    last_observed_date: "2026-07-26",
+    ...over,
+  } as MetricDefinition;
+}
+
+beforeEach(() => {
+  mocks.q.isLoading = false;
+  mocks.q.isError = false;
+  mocks.q.data = [
+    {
+      prefix: "git",
+      metrics: [
+        def({
+          metric_key: "git.prs_merged",
+          label: "Pull requests merged",
+          short_label: "PRs merged",
+          dimensions: ["repository", "project"],
+        }),
+        def({ metric_key: "git.commits" }),
+      ],
+    },
+    {
+      prefix: "tasks",
+      metrics: [
+        def({
+          metric_key: "tasks.closed",
+          label: "Tasks closed",
+          unit: null,
+          direction: "higher_is_better",
+          schema_status: "error",
+          schema_error_code: "table_not_found",
+          last_observed_date: null,
+        }),
+      ],
+    },
+  ];
+});
+
+describe("Manage · Metric catalog", () => {
+  it("lists unified metric keys, sorted, with the endpoint it came from", () => {
+    render(<ManageView item="metric-catalog" />);
+    expect(screen.getByText("/v1/metric-definitions")).toBeInTheDocument();
+    expect(screen.getByText("3 metrics", { exact: false })).toBeInTheDocument();
+    const keys = screen
+      .getAllByText(/^(git|tasks)\./)
+      .map((el) => el.textContent);
+    expect(keys).toEqual(["git.commits", "git.prs_merged", "tasks.closed"]);
+  });
+
+  it("prefers the short label and renders dimensions and direction", () => {
+    render(<ManageView item="metric-catalog" />);
+    expect(screen.getByText("PRs merged")).toBeInTheDocument();
+    expect(screen.getByText("repository · project")).toBeInTheDocument();
+    expect(screen.getAllByText("higher is better").length).toBe(3);
+  });
+
+  it("says 'no data yet' for a definition with no observation", () => {
+    render(<ManageView item="metric-catalog" />);
+    expect(screen.getByText("no data yet")).toBeInTheDocument();
+    // the two observed definitions keep their date
+    expect(screen.getAllByText("2026-07-26")).toHaveLength(2);
+  });
+
+  it("shows the schema error code next to a failing status", () => {
+    render(<ManageView item="metric-catalog" />);
+    expect(screen.getByText(/error · table_not_found/)).toBeInTheDocument();
+  });
+
+  it("offers retry when the registry request fails", async () => {
+    mocks.q.isError = true;
+    render(<ManageView item="metric-catalog" />);
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(mocks.q.refetch).toHaveBeenCalledOnce();
+  });
+});
+
+describe("Manage · Data health", () => {
+  it("counts schema statuses and, separately, definitions with no data", () => {
+    render(<ManageView item="data-health" />);
+    expect(screen.getByText(/across 3 metrics/)).toBeInTheDocument();
+    // 2 ok · 1 error · 0 unchecked · 1 without any observation
+    const tile = (label: string) =>
+      screen.getByText(label).closest("div")?.parentElement?.textContent ?? "";
+    expect(tile("ok")).toMatch(/^2/);
+    expect(tile("error")).toMatch(/^1/);
+    expect(tile("unchecked")).toMatch(/^0/);
+    expect(tile("no data yet")).toMatch(/^1/);
+  });
+});
+
+describe("Manage · unwired items", () => {
+  it("renders an honest placeholder instead of a fake admin screen", () => {
+    render(<ManageView item="identities" />);
+    expect(screen.getByText(/not wired yet/i)).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/portal/manage-view.test.tsx
+++ b/src/frontend/src/components/portal/manage-view.test.tsx
@@ -47,6 +47,7 @@ function def(over: Partial<MetricDefinition>): MetricDefinition {
 }
 
 beforeEach(() => {
+  mocks.q.refetch.mockClear();
   mocks.q.isLoading = false;
   mocks.q.isError = false;
   mocks.q.data = [

--- a/src/frontend/src/components/portal/manage-view.tsx
+++ b/src/frontend/src/components/portal/manage-view.tsx
@@ -1,0 +1,189 @@
+import { useMemo } from "react";
+
+import { CenteredSpinner } from "@/components/widgets/centered-spinner";
+import { ComingSoon } from "@/components/widgets/coming-soon";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type {
+  MetricDefinitionSchemaStatus,
+  MetricDefinition,
+} from "@/api/metric-definitions-client";
+import { useMetricDefinitions } from "@/queries/metric-definitions";
+import { cn } from "@/lib/utils";
+
+const STATUS_STYLE: Record<MetricDefinitionSchemaStatus, string> = {
+  ok: "bg-success/15 text-success",
+  error: "bg-destructive/15 text-destructive",
+  unchecked: "bg-muted text-muted-foreground",
+};
+
+/**
+ * Manage-zone surfaces backed by live data (Metric catalog, Data health).
+ *
+ * Both read the **unified** registry (`GET /v1/metric-definitions`) — the set
+ * of metrics `/v1/metric-results` actually serves. The legacy
+ * `/catalog/get_metrics` surface describes a disjoint, pre-catalog key
+ * namespace (`*_bullet_rows.*`), so listing it here showed an admin a catalog
+ * no portal surface reads (constructorfabric/insight#1988).
+ */
+export function ManageView({ item }: { item: string | null }) {
+  if (item === "metric-catalog") return <MetricCatalogTable />;
+  if (item === "data-health") return <DataHealth />;
+  return (
+    <div className="mx-auto w-full max-w-md p-8">
+      <ComingSoon
+        variant="card"
+        state="empty"
+        label="Admin surface — not wired yet"
+      />
+    </div>
+  );
+}
+
+/** Flatten the prefix-grouped query result into one key-sorted list. */
+function useFlatDefinitions() {
+  const q = useMetricDefinitions();
+  const metrics = useMemo<MetricDefinition[]>(
+    () =>
+      (q.data ?? [])
+        .flatMap((g) => g.metrics)
+        .sort((a, b) => a.metric_key.localeCompare(b.metric_key)),
+    [q.data],
+  );
+  return { metrics, isLoading: q.isLoading, isError: q.isError, refetch: q.refetch };
+}
+
+const DIRECTION_LABEL: Record<MetricDefinition["direction"], string> = {
+  higher_is_better: "higher is better",
+  lower_is_better: "lower is better",
+  neutral: "neutral",
+};
+
+function MetricCatalogTable() {
+  const { metrics, isLoading, isError, refetch } = useFlatDefinitions();
+  if (isLoading) return <CenteredSpinner className="min-h-[60vh]" />;
+  if (isError)
+    return (
+      <div className="mx-auto w-full max-w-md p-8">
+        <ComingSoon variant="card" state="error" onRetry={() => refetch()} />
+      </div>
+    );
+
+  return (
+    <div className="flex flex-col gap-3 p-4 md:p-6">
+      <div>
+        <h1 className="text-xl font-semibold tracking-tight">Metric catalog</h1>
+        <p className="text-sm text-muted-foreground">
+          {metrics.length} metrics · live from{" "}
+          <code className="text-xs">/v1/metric-definitions</code>
+        </p>
+      </div>
+      <div className="overflow-x-auto rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Metric key</TableHead>
+              <TableHead>Label</TableHead>
+              <TableHead>Unit</TableHead>
+              <TableHead>Direction</TableHead>
+              <TableHead>Dimensions</TableHead>
+              <TableHead>Last observed</TableHead>
+              <TableHead>Schema</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {metrics.map((m) => (
+              <TableRow key={m.metric_key}>
+                <TableCell className="font-mono text-xs">{m.metric_key}</TableCell>
+                <TableCell>{m.short_label ?? m.label}</TableCell>
+                <TableCell className="text-muted-foreground">
+                  {m.unit || "—"}
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {DIRECTION_LABEL[m.direction]}
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {m.dimensions.length ? m.dimensions.join(" · ") : "—"}
+                </TableCell>
+                {/* A definition can exist with no observation for this tenant —
+                    that is a data state, not an error. Say so plainly. */}
+                <TableCell className="text-muted-foreground">
+                  {m.last_observed_date ?? "no data yet"}
+                </TableCell>
+                <TableCell>
+                  <Badge
+                    variant="secondary"
+                    className={cn("font-medium", STATUS_STYLE[m.schema_status])}
+                  >
+                    {m.schema_status}
+                    {m.schema_error_code ? ` · ${m.schema_error_code}` : ""}
+                  </Badge>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}
+
+function DataHealth() {
+  const { metrics, isLoading, isError, refetch } = useFlatDefinitions();
+  if (isLoading) return <CenteredSpinner className="min-h-[60vh]" />;
+  if (isError)
+    return (
+      <div className="mx-auto w-full max-w-md p-8">
+        <ComingSoon variant="card" state="error" onRetry={() => refetch()} />
+      </div>
+    );
+
+  const counts: Record<MetricDefinitionSchemaStatus, number> = {
+    ok: 0,
+    error: 0,
+    unchecked: 0,
+  };
+  for (const m of metrics) counts[m.schema_status] += 1;
+  // A definition whose schema checks out can still have never produced a row
+  // for this tenant — two separate questions, so show both answers.
+  const noData = metrics.filter((m) => m.last_observed_date == null).length;
+
+  return (
+    <div className="flex flex-col gap-4 p-4 md:p-6">
+      <div>
+        <h1 className="text-xl font-semibold tracking-tight">Data health</h1>
+        <p className="text-sm text-muted-foreground">
+          Schema-check status across {metrics.length} metrics
+        </p>
+      </div>
+      <div className="grid grid-cols-[repeat(auto-fit,minmax(11rem,1fr))] gap-3">
+        {(["ok", "error", "unchecked"] as const).map((s) => (
+          <div key={s} className="rounded-lg border bg-card p-4">
+            <div className="text-3xl font-semibold tabular-nums">{counts[s]}</div>
+            <div
+              className={cn(
+                "mt-1 inline-flex rounded-full px-2 py-0.5 text-xs font-medium",
+                STATUS_STYLE[s],
+              )}
+            >
+              {s}
+            </div>
+          </div>
+        ))}
+        <div className="rounded-lg border bg-card p-4">
+          <div className="text-3xl font-semibold tabular-nums">{noData}</div>
+          <div className="mt-1 inline-flex rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+            no data yet
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/components/portal/metric-groups-view.test.tsx
+++ b/src/frontend/src/components/portal/metric-groups-view.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+vi.mock("@/lib/portal/use-cohort-label", () => ({
+  useCohortLabel: () => "team",
+}));
+/**
+ * MetricGroupsView routing/gating semantics: honest empty + error + loading
+ * states, KPI-row gating via showKpis, section-card wiring and the
+ * inline-select vs modal-drilldown split. The v2 leaf widgets (KpiTile,
+ * MetricGroupCard, drilldown) predate this PR and are stubbed; assertions
+ * target THIS view's own decisions.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { GroupId } from "@/lib/insight/groups";
+
+const mocks = vi.hoisted(() => ({
+  collection: {
+    byKey: new Map(),
+    previousByKey: new Map(),
+    isPending: false,
+    isFetching: false,
+    isError: false,
+    refetch: vi.fn(),
+  },
+  set: new Map<string, { byKey: Map<string, never>; isPending: boolean; isError: boolean; refetch: () => void }>(),
+  cohort: [] as string[],
+}));
+
+vi.mock("@/queries/metric-results", () => ({
+  useMetricCollection: () => mocks.collection,
+  useMetricCollectionSet: () => mocks.set,
+  collectionSetPending: (set: Map<string, { isPending: boolean }>) =>
+    [...set.values()].some((r) => r.isPending),
+}));
+vi.mock("@/lib/portal/use-person-cohort", () => ({
+  usePersonCohort: () => mocks.cohort,
+}));
+vi.mock("@/hooks/use-portal-period", () => ({
+  usePortalPeriod: () => ({ period: "week", dateRange: { start: "2026-07-20", end: "2026-07-26" } }),
+}));
+vi.mock("@/hooks/use-settings", () => ({ useSettings: () => ({ focusMode: false }) }));
+vi.mock("@/components/widgets/dashboard/kpi-tile", () => ({
+  KpiTile: ({ tile }: { tile: { key: string } }) => <div data-testid="kpi-tile">{tile.key}</div>,
+  KpiTilePlaceholder: () => <div data-testid="kpi-placeholder" />,
+}));
+vi.mock("@/components/widgets/dashboard/ic-needs-attention", () => ({
+  IcNeedsAttention: () => <div data-testid="needs-attention" />,
+}));
+vi.mock("@/components/widgets/metric-views/metric-group-card", () => ({
+  MetricGroupCard: ({ def, onOpen }: { def: { id: string; title: string }; onOpen: () => void }) => (
+    <button data-testid={`group-card-${def.id}`} onClick={onOpen}>
+      {def.title}
+    </button>
+  ),
+}));
+vi.mock("@/components/widgets/dashboard/group-drilldown-sheet", () => ({
+  GroupDrilldownSheet: ({ open, def }: { open: boolean; def: { id: string } }) =>
+    open ? <div data-testid={`drilldown-${def.id}`} /> : null,
+}));
+
+import { MetricGroupsView } from "./metric-groups-view";
+
+const GROUPS: readonly GroupId[] = ["git_output", "collaboration"];
+
+function seedSet(over: Partial<{ isPending: boolean; isError: boolean }> = {}) {
+  mocks.set = new Map(
+    GROUPS.map((id) => [
+      id as string,
+      { byKey: new Map<string, never>(), isPending: false, isError: false, refetch: vi.fn() as () => void, ...over },
+    ]),
+  );
+}
+
+beforeEach(() => {
+  mocks.collection.isPending = false;
+  mocks.collection.isError = false;
+  mocks.cohort = [];
+  seedSet();
+});
+
+describe("MetricGroupsView", () => {
+  it("renders an honest note when no group is in the semantic layer", () => {
+    render(<MetricGroupsView personId="p@x" groupIds={[]} />);
+    expect(screen.getByText(/Not in the semantic layer yet/)).toBeInTheDocument();
+  });
+
+  it("spins while any group collection is pending", () => {
+    seedSet({ isPending: true });
+    const { container } = render(<MetricGroupsView personId="p@x" groupIds={GROUPS} />);
+    expect(screen.queryByTestId("group-card-git_output")).not.toBeInTheDocument();
+    expect(container.querySelector(".animate-spin")).not.toBeNull();
+  });
+
+  it("surfaces a group failure as a retryable error, not empty cards", async () => {
+    seedSet({ isError: true });
+    render(<MetricGroupsView personId="p@x" groupIds={GROUPS} />);
+    expect(screen.queryByTestId("group-card-git_output")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(mocks.set.get("git_output")!.refetch).toHaveBeenCalled();
+  });
+
+  it("renders a section card per requested group", () => {
+    render(<MetricGroupsView personId="p@x" groupIds={GROUPS} />);
+    expect(screen.getByTestId("group-card-git_output")).toBeInTheDocument();
+    expect(screen.getByTestId("group-card-collaboration")).toBeInTheDocument();
+    // KPI row is opt-in and off here
+    expect(screen.queryByTestId("needs-attention")).not.toBeInTheDocument();
+  });
+
+  it("shows the KPI row + needs-attention only with showKpis", () => {
+    render(<MetricGroupsView personId="p@x" groupIds={GROUPS} showKpis />);
+    expect(screen.getByText("At a glance")).toBeInTheDocument();
+    expect(screen.getByTestId("needs-attention")).toBeInTheDocument();
+  });
+
+  it("routes a card through onSelectGroup instead of the modal when provided", async () => {
+    const onSelect = vi.fn();
+    render(<MetricGroupsView personId="p@x" groupIds={GROUPS} onSelectGroup={onSelect} />);
+    await userEvent.click(screen.getByTestId("group-card-git_output"));
+    expect(onSelect).toHaveBeenCalledWith("git_output");
+    expect(screen.queryByTestId("drilldown-git_output")).not.toBeInTheDocument();
+  });
+
+  it("opens the drilldown modal when no inline selector is wired", async () => {
+    render(<MetricGroupsView personId="p@x" groupIds={GROUPS} />);
+    await userEvent.click(screen.getByTestId("group-card-git_output"));
+    expect(screen.getByTestId("drilldown-git_output")).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/portal/metric-groups-view.tsx
+++ b/src/frontend/src/components/portal/metric-groups-view.tsx
@@ -41,6 +41,7 @@ const CLOSED_DRILLDOWN_DATA = {
   refetch: () => {},
 } as const;
 
+/** The person and catalogue slice a metric-groups screen renders. */
 export interface MetricGroupsViewProps {
   /** Person id the lens is scoped to (org-level rollup is a backend follow-up). */
   personId: string;

--- a/src/frontend/src/components/portal/metric-groups-view.tsx
+++ b/src/frontend/src/components/portal/metric-groups-view.tsx
@@ -1,0 +1,268 @@
+import { useState } from "react";
+
+import { CenteredSpinner } from "@/components/widgets/centered-spinner";
+import { ComingSoon } from "@/components/widgets/coming-soon";
+import { GroupDrilldownSheet } from "@/components/widgets/dashboard/group-drilldown-sheet";
+import { IcNeedsAttention } from "@/components/widgets/dashboard/ic-needs-attention";
+import { KpiTile, KpiTilePlaceholder } from "@/components/widgets/dashboard/kpi-tile";
+import { MetricGroupCard } from "@/components/widgets/metric-views/metric-group-card";
+import { usePortalPeriod } from "@/hooks/use-portal-period";
+import { useSettings } from "@/hooks/use-settings";
+import { metricAttentionItems } from "@/lib/insight/attention";
+import {
+  KPI_ROW,
+  KPI_ROW_COLLECTION,
+  GROUPS,
+  type GroupId,
+} from "@/lib/insight/groups";
+import { metricKpiTiles, type KpiTileData } from "@/lib/insight/kpi-row";
+import { injectCohortPeer } from "@/lib/insight/within-team-peer";
+import {
+  projectViews,
+  type MetricCollectionConfig,
+} from "@/lib/metrics/collection";
+import { normalizePersonId } from "@/lib/metrics/entity";
+import { useCohortLabel } from "@/lib/portal/use-cohort-label";
+import { usePersonCohort } from "@/lib/portal/use-person-cohort";
+import {
+  collectionSetPending,
+  useMetricCollection,
+  useMetricCollectionSet,
+} from "@/queries/metric-results";
+
+const EMPTY_COLLECTION: MetricCollectionConfig = { metrics: [] };
+const CLOSED_ENTITY = { type: "person" as const, ids: [] };
+const CLOSED_DRILLDOWN_DATA = {
+  byKey: new Map(),
+  previousByKey: null,
+  isPending: true,
+  isFetching: false,
+  isError: false,
+  refetch: () => {},
+} as const;
+
+export interface MetricGroupsViewProps {
+  /** Person id the lens is scoped to (org-level rollup is a backend follow-up). */
+  personId: string;
+  /** Which metric-family groups to render; empty ⇒ nothing available yet. */
+  groupIds: readonly GroupId[];
+  /** Overview renders the KPI row + needs-attention; direction lenses don't. */
+  showKpis?: boolean;
+  /**
+   * When set, a group card selects the group via this callback (e.g. to expand
+   * it inline in a second sidebar level) instead of opening the drilldown
+   * modal. Passing it also suppresses the modal sheets entirely.
+   */
+  onSelectGroup?: (id: GroupId) => void;
+  /**
+   * Render the per-group section cards. Off ⇒ a general glance (KPI row +
+   * needs-attention only) with sections reached from the sidebar instead.
+   */
+  showSections?: boolean;
+}
+
+/**
+ * Catalog-driven metric-group screen — the reusable body behind the portal's
+ * Overview and Direction lenses. Reuses the v2 dashboard widgets
+ * (KpiTile / MetricGroupCard / GroupDrilldownSheet) and the `/metric-results`
+ * collection queries, parameterised by the set of groups to show.
+ */
+export function MetricGroupsView({
+  personId,
+  groupIds,
+  showKpis = false,
+  onSelectGroup,
+  showSections = true,
+}: MetricGroupsViewProps) {
+  const cohortLabel = useCohortLabel();
+  const { period, dateRange } = usePortalPeriod();
+  const { focusMode } = useSettings();
+  const entityId = normalizePersonId(personId);
+  const entity = { type: "person" as const, ids: [entityId] };
+
+  const defs = GROUPS.filter((d) => groupIds.includes(d.id));
+
+  const kpiData = useMetricCollection(
+    showKpis ? KPI_ROW_COLLECTION : EMPTY_COLLECTION,
+    showKpis ? entity : CLOSED_ENTITY,
+    dateRange,
+    { previousPeriod: period },
+  );
+  const groupData = useMetricCollectionSet(
+    defs.map((def) => ({
+      key: def.id,
+      collection: projectViews(def.collection, ["period", "peer"]),
+    })),
+    entity,
+    dateRange,
+  );
+
+  // Slice cohort: the people who share this person's active-slice attribute
+  // value. Only fetched when a slice is picked — otherwise the person's own
+  // numbers stand alone (no cohort, tiles show "no peer data" as before).
+  const cohortIds = usePersonCohort(entityId);
+  const cohortEntity =
+    cohortIds.length ? { type: "person" as const, ids: cohortIds } : CLOSED_ENTITY;
+  const cohortKpi = useMetricCollection(
+    cohortIds.length && showKpis ? KPI_ROW_COLLECTION : EMPTY_COLLECTION,
+    // Entity gated on the SAME condition as the collection — a live entity
+    // with an empty collection still issues a useless network request.
+    cohortIds.length && showKpis ? cohortEntity : CLOSED_ENTITY,
+    dateRange,
+  );
+  const cohortGroup = useMetricCollectionSet(
+    cohortIds.length
+      ? defs.map((def) => ({
+          key: def.id,
+          collection: projectViews(def.collection, ["period"]),
+        }))
+      : [],
+    cohortEntity,
+    dateRange,
+  );
+
+  const [openGroup, setOpenGroup] = useState<GroupId | null>(null);
+  // With `onSelectGroup` a card/alert navigates to the section inline; without
+  // it, it opens the drilldown modal.
+  const openOrSelect = onSelectGroup ?? setOpenGroup;
+  const openDef =
+    openGroup != null ? (defs.find((d) => d.id === openGroup) ?? null) : null;
+  const drilldownData = useMetricCollection(
+    openDef?.collection ?? EMPTY_COLLECTION,
+    openDef ? entity : CLOSED_ENTITY,
+    dateRange,
+  );
+
+  const [prevPersonId, setPrevPersonId] = useState(personId);
+  if (personId !== prevPersonId) {
+    setPrevPersonId(personId);
+    setOpenGroup(null);
+  }
+
+  if (defs.length === 0) {
+    return (
+      <div className="mx-auto w-full max-w-md p-8">
+        <ComingSoon
+          variant="card"
+          state="empty"
+          label="Not in the semantic layer yet — bullet-only direction"
+        />
+      </div>
+    );
+  }
+
+  const isLoading = (showKpis && kpiData.isPending) || collectionSetPending(groupData);
+  if (isLoading) return <CenteredSpinner className="min-h-[60vh]" />;
+
+  // Surface a backend failure as a retryable error, not empty section cards.
+  const isError =
+    (showKpis && kpiData.isError) || [...groupData.values()].some((r) => r.isError);
+  if (isError)
+    return (
+      <div className="mx-auto w-full max-w-md p-8">
+        <ComingSoon
+          variant="card"
+          state="error"
+          onRetry={() => {
+            kpiData.refetch();
+            groupData.forEach((r) => r.refetch());
+          }}
+        />
+      </div>
+    );
+
+  // Cohort-injected views: with a slice active, the person's results carry
+  // their cohort's peer stats so tiles/cards/attention read "vs <slice> median".
+  const kpiByKey = injectCohortPeer(kpiData.byKey, cohortKpi.byKey, cohortIds);
+  const groupResult = (id: GroupId) => {
+    const r = groupData.get(id);
+    if (!r) return undefined;
+    const cr = cohortGroup.get(id);
+    if (!cohortIds.length || !cr) return r;
+    return { ...r, byKey: injectCohortPeer(r.byKey, cr.byKey, cohortIds) };
+  };
+
+  const tiles = showKpis
+    ? metricKpiTiles(kpiByKey, kpiData.previousByKey, entityId, focusMode)
+    : [];
+  const tilesByKey = new Map<string, KpiTileData>(
+    tiles.map((tile) => [tile.key, tile]),
+  );
+  const attentionItems = showKpis
+    ? defs.flatMap((def) =>
+        metricAttentionItems(def, groupResult(def.id)?.byKey ?? new Map(), entityId),
+      )
+    : [];
+
+  return (
+    <>
+      <main className="flex flex-1 flex-col gap-8 p-4 md:p-6">
+        {showKpis ? (
+          <>
+            <section className="flex flex-col gap-3">
+              <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+                At a glance
+              </p>
+              <div className="grid grid-cols-[repeat(auto-fit,minmax(13rem,1fr))] gap-3">
+                {/* KPI_ROW is a plain metric-key list upstream now — the
+                    legacy/metric tile split died with the legacy data path. */}
+                {KPI_ROW.map((key) => {
+                  const tile = tilesByKey.get(key);
+                  if (tile)
+                    return (
+                      <KpiTile key={key} tile={tile} onOpenGroup={openOrSelect} />
+                    );
+                  return <KpiTilePlaceholder key={key} />;
+                })}
+              </div>
+            </section>
+            <IcNeedsAttention items={attentionItems} onOpenGroup={openOrSelect} />
+          </>
+        ) : null}
+
+        {showSections ? (
+          <section className="flex flex-col gap-3">
+            <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+              Sections
+            </p>
+            <div className="grid grid-cols-[repeat(auto-fit,minmax(18rem,1fr))] gap-3">
+              {defs.map((def) => {
+                const result = groupResult(def.id);
+                if (!result) return null;
+                return (
+                  <MetricGroupCard
+                    key={def.id}
+                    def={def}
+                    data={result}
+                    entityId={entityId}
+                    onOpen={() => openOrSelect(def.id)}
+                  />
+                );
+              })}
+            </div>
+          </section>
+        ) : null}
+      </main>
+
+      {onSelectGroup || !showSections
+        ? null
+        : defs.map((def) => (
+            <GroupDrilldownSheet
+              key={def.id}
+              open={openGroup === def.id}
+              onOpenChange={(o) => setOpenGroup(o ? def.id : null)}
+              def={def}
+              metricTarget={{
+                kind: "person",
+                entityId,
+                data:
+                  def.id === openGroup ? drilldownData : CLOSED_DRILLDOWN_DATA,
+              }}
+              range={dateRange}
+              period={period}
+              cohortLabel={cohortLabel}
+            />
+          ))}
+    </>
+  );
+}

--- a/src/frontend/src/components/portal/org-scope-gate.test.tsx
+++ b/src/frontend/src/components/portal/org-scope-gate.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { orgScopeGate, type OrgScopeGateArgs } from "./org-scope-gate";
+
+function args(over: Partial<OrgScopeGateArgs>): OrgScopeGateArgs {
+  return {
+    viewerLoading: false,
+    viewerError: false,
+    membersLoading: false,
+    membersError: false,
+    memberCount: 5,
+    gridPending: false,
+    gridError: false,
+    emptyLabel: "No team here.",
+    onRetry: vi.fn(),
+    ...over,
+  };
+}
+
+describe("orgScopeGate", () => {
+  it("returns null when everything is resolved — the view proceeds", () => {
+    expect(orgScopeGate(args({}))).toBeNull();
+  });
+
+  it("spins while the viewer identity or roster is loading", () => {
+    expect(orgScopeGate(args({ viewerLoading: true }))).not.toBeNull();
+    expect(orgScopeGate(args({ membersLoading: true }))).not.toBeNull();
+  });
+
+  it("surfaces a backend failure as a retryable error, not an empty team", async () => {
+    const onRetry = vi.fn();
+    render(<>{orgScopeGate(args({ membersError: true, onRetry }))}</>);
+    const retry = screen.getByRole("button", { name: /retry/i });
+    await userEvent.click(retry);
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it("shows the empty label when the roster genuinely resolved to nobody", () => {
+    render(<>{orgScopeGate(args({ memberCount: 0 }))}</>);
+    expect(screen.getByText("No team here.")).toBeInTheDocument();
+  });
+
+  it("prioritises the error state over the empty state", () => {
+    // A 500 must never masquerade as "this manager has no team".
+    render(<>{orgScopeGate(args({ viewerError: true, memberCount: 0 }))}</>);
+    expect(screen.queryByText("No team here.")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("gates on a pending metric grid after the roster resolves", () => {
+    expect(orgScopeGate(args({ gridPending: true }))).not.toBeNull();
+  });
+
+  it("gates on a failed metric grid with retry", () => {
+    render(<>{orgScopeGate(args({ gridError: true }))}</>);
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/portal/org-scope-gate.tsx
+++ b/src/frontend/src/components/portal/org-scope-gate.tsx
@@ -1,0 +1,65 @@
+/* eslint-disable react-refresh/only-export-components -- this is a render
+   helper (returns the gate element or null for an early return), not a
+   hot-reloadable component; the org views call it, they don't mount it. */
+import type { ReactNode } from "react";
+
+import { CenteredSpinner } from "@/components/widgets/centered-spinner";
+import { ComingSoon } from "@/components/widgets/coming-soon";
+
+export interface OrgScopeGateArgs {
+  /** Viewer identity query — `isLoading` (not `isPending`), so a disabled query
+   * (viewer email still unresolved) doesn't spin forever. */
+  viewerLoading: boolean;
+  viewerError: boolean;
+  membersLoading: boolean;
+  membersError: boolean;
+  memberCount: number;
+  gridPending: boolean;
+  gridError: boolean;
+  /** Shown when the roster resolved but is empty. */
+  emptyLabel: string;
+  onRetry: () => void;
+}
+
+/**
+ * Loading / error / empty gate shared by the org-scoped portal views (Overview,
+ * People, Directions, AI & Cost, Collaboration). Returns the element to render
+ * in place of the view, or `null` to proceed.
+ *
+ * Centralising this keeps the views' gating identical and — the reason it
+ * exists — surfaces backend failures (`isError`) as an explicit retry state
+ * instead of masking a 500 as "this manager has no team" (empty roster) or a
+ * fabricated all-zero dashboard (empty metric grid). A disabled query reports
+ * `isPending: true` forever, so callers pass `isLoading` for the viewer/members
+ * queries; the metric grid already gates its own `isPending` on `enabled`.
+ */
+export function orgScopeGate(a: OrgScopeGateArgs): ReactNode | null {
+  if (a.viewerLoading || a.membersLoading)
+    return <CenteredSpinner className="min-h-[60vh]" />;
+  if (a.viewerError || a.membersError) return <GateCard error onRetry={a.onRetry} />;
+  if (a.memberCount === 0) return <GateCard label={a.emptyLabel} />;
+  if (a.gridPending) return <CenteredSpinner className="min-h-[60vh]" />;
+  if (a.gridError) return <GateCard error onRetry={a.onRetry} />;
+  return null;
+}
+
+function GateCard({
+  error,
+  label,
+  onRetry,
+}: {
+  error?: boolean;
+  label?: string;
+  onRetry?: () => void;
+}) {
+  return (
+    <div className="mx-auto w-full max-w-md p-8">
+      <ComingSoon
+        variant="card"
+        state={error ? "error" : "empty"}
+        label={label}
+        onRetry={onRetry}
+      />
+    </div>
+  );
+}

--- a/src/frontend/src/components/portal/org-scope-gate.tsx
+++ b/src/frontend/src/components/portal/org-scope-gate.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from "react";
 import { CenteredSpinner } from "@/components/widgets/centered-spinner";
 import { ComingSoon } from "@/components/widgets/coming-soon";
 
+/** What the gate needs to decide between loading, empty, failed, and ready. */
 export interface OrgScopeGateArgs {
   /** Viewer identity query — `isLoading` (not `isPending`), so a disabled query
    * (viewer email still unresolved) doesn't spin forever. */

--- a/src/frontend/src/components/portal/overview-view.tsx
+++ b/src/frontend/src/components/portal/overview-view.tsx
@@ -1,0 +1,23 @@
+import { useMemo } from "react";
+
+import { DomainLensView, Pending } from "@/components/portal/domain-lens-view";
+import {
+  DEFAULT_OVERVIEW_ITEM,
+  OVERVIEW_ITEMS,
+  overviewMetricKeys,
+} from "@/lib/portal/overview-configs";
+
+/**
+ * Overview content — every pane item resolves through the overview-configs
+ * registry and renders DomainLensView, exactly like Directions (Overview
+ * design O2). The grid fetch is zone-scoped (union across all items) so
+ * switching items never re-spins the loading gate.
+ */
+export function OverviewView({ item }: { item: string | null }) {
+  const gridKeys = useMemo(() => overviewMetricKeys(), []);
+  const entry = OVERVIEW_ITEMS[item ?? DEFAULT_OVERVIEW_ITEM];
+  if (!entry) {
+    return <Pending label={`“${item}” isn't an Overview view yet.`} />;
+  }
+  return <DomainLensView config={entry} gridKeys={gridKeys} />;
+}

--- a/src/frontend/src/components/portal/people-view.tsx
+++ b/src/frontend/src/components/portal/people-view.tsx
@@ -1,0 +1,64 @@
+import { useEffect } from "react";
+
+import { EmployeesView } from "@/components/portal/employees-view";
+import { TeamStateView } from "@/components/portal/team-state-view";
+import { ComingSoon } from "@/components/widgets/coming-soon";
+import {
+  usePortalNavActions,
+} from "@/lib/portal/portal-nav";
+
+/**
+ * Module-scoped, deliberately NOT a ref: the guard must outlive this component.
+ * A per-mount ref would re-fire the route sync every time the user leaves the
+ * People zone and comes back, silently reverting a scope they picked in the
+ * topbar. Keyed by person, so an actual route change still syncs.
+ */
+let lastRouteSync: string | null = null;
+
+/**
+ * People zone content, driven by the selected pane item. The roster is a
+ * lead-facing team-state dashboard (state → attention → member scan); the
+ * individual view lives in the dedicated Person rail zone (drill into any
+ * name), not here. Median-by-Role is an honest scaffold pending the cohort
+ * pipeline; Employees is a live identity directory.
+ *
+ * The People route is the one place where a route still *sets* the org scope:
+ * landing on /ic/<person_id>/team (a link, a drill, or a pasted URL) makes that
+ * node the visible scope, after which every org zone reads it from the URL.
+ */
+export function PeopleView({
+  person,
+  item,
+}: {
+  person: string;
+  item: string | null;
+}) {
+  const { replaceScope } = usePortalNavActions();
+  // Sync route → scope once per person, not on every render or remount: the
+  // effect must not fight a scope the user then changes from the topbar.
+  useEffect(() => {
+    if (person && lastRouteSync !== person) {
+      lastRouteSync = person;
+      replaceScope({ root: person });
+    }
+  }, [person, replaceScope]);
+
+  if (item === "median-by-role") {
+    return (
+      <Pending label="Cohort role medians — pending the two-axis cohort pipeline" />
+    );
+  }
+  if (item === "employees") {
+    return <EmployeesView />;
+  }
+  // Default (roster): the team-state dashboard over the active org scope.
+  return <TeamStateView />;
+}
+
+function Pending({ label }: { label: string }) {
+  return (
+    <div className="mx-auto w-full max-w-md p-8">
+      <ComingSoon variant="card" state="empty" label={label} />
+    </div>
+  );
+}

--- a/src/frontend/src/components/portal/people-view.tsx
+++ b/src/frontend/src/components/portal/people-view.tsx
@@ -3,17 +3,11 @@ import { useEffect } from "react";
 import { EmployeesView } from "@/components/portal/employees-view";
 import { TeamStateView } from "@/components/portal/team-state-view";
 import { ComingSoon } from "@/components/widgets/coming-soon";
+import { normalizePersonId } from "@/lib/metrics/entity";
 import {
   usePortalNavActions,
 } from "@/lib/portal/portal-nav";
-
-/**
- * Module-scoped, deliberately NOT a ref: the guard must outlive this component.
- * A per-mount ref would re-fire the route sync every time the user leaves the
- * People zone and comes back, silently reverting a scope they picked in the
- * topbar. Keyed by person, so an actual route change still syncs.
- */
-let lastRouteSync: string | null = null;
+import { claimScopeSync } from "@/lib/portal/route-scope-sync";
 
 /**
  * People zone content, driven by the selected pane item. The roster is a
@@ -37,10 +31,11 @@ export function PeopleView({
   // Sync route → scope once per person, not on every render or remount: the
   // effect must not fight a scope the user then changes from the topbar.
   useEffect(() => {
-    if (person && lastRouteSync !== person) {
-      lastRouteSync = person;
-      replaceScope({ root: person });
-    }
+    // Normalised before the guard sees it: the same person arrives from a link,
+    // an identity record or a hand-edited URL in either case, and an
+    // unnormalised compare re-syncs the scope on a casing difference alone.
+    const id = person ? normalizePersonId(person) : "";
+    if (claimScopeSync(id)) replaceScope({ root: id });
   }, [person, replaceScope]);
 
   if (item === "median-by-role") {

--- a/src/frontend/src/components/portal/person-header.tsx
+++ b/src/frontend/src/components/portal/person-header.tsx
@@ -115,11 +115,11 @@ export function PersonHeader({ person }: { person: string }) {
                 </DropdownMenuLabel>
                 {peers.map((p) => {
                   const active =
-                    p.email.toLowerCase() === data.email.toLowerCase();
+                    p.person_id.toLowerCase() === data.person_id.toLowerCase();
                   return (
                     <DropdownMenuItem
-                      key={p.email}
-                      onClick={() => goPerson(p.email)}
+                      key={p.person_id}
+                      onClick={() => goPerson(p.person_id)}
                       className={cn(active && "font-medium")}
                     >
                       <Check

--- a/src/frontend/src/components/portal/person-header.tsx
+++ b/src/frontend/src/components/portal/person-header.tsx
@@ -1,0 +1,174 @@
+import { useNavigate } from "@tanstack/react-router";
+import { Check, ChevronsUpDown, ChevronUp, Users } from "lucide-react";
+import { useMemo } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useIcPerson } from "@/queries/ic-dashboard";
+import {
+  usePortalNavActions,
+} from "@/lib/portal/portal-nav";
+import { useOrgScope } from "@/lib/portal/use-org-scope";
+import { cn } from "@/lib/utils";
+
+/**
+ * Person-zone header — the "climb up" + lateral half of the Person ↔ People
+ * model. The name is a peer switcher: it lists the person's teammates (their
+ * manager's direct reports) so you can hop between people without bouncing back
+ * to People. The supervisor chip drills sideways into the manager; "Team" jumps
+ * to People — scoped to the person's own reports if they're a manager, else to
+ * their manager's team — and that jump also sets the global org scope, so it only
+ * renders when the target is a node the scope can actually reach. Everything is
+ * route-driven (clears the pinned zone) and sourced from the identity profile;
+ * absent fields render nothing.
+ */
+export function PersonHeader({ person }: { person: string }) {
+  const { setScope, setZone } = usePortalNavActions();
+  const navigate = useNavigate();
+  const { data } = useIcPerson(person);
+  // Ids, not emails, since the identity cutover: the same key the route
+  // segment, `?scope=` and the metric entity ids carry.
+  const supervisorPersonId = data?.parent_person_id ?? null;
+  // Fetch the manager to enumerate siblings; the query self-disables on "".
+  const { data: manager } = useIcPerson(supervisorPersonId ?? "");
+  // Every node the org scope can actually resolve to — identity serves the
+  // viewer only their own subtree, so anything outside it is unreachable.
+  const { managerNodes } = useOrgScope();
+  const scopeRoots = useMemo(
+    () => new Set(managerNodes.map((n) => n.person_id.toLowerCase())),
+    [managerNodes],
+  );
+
+  if (!data) return null;
+
+  const subtitle = [data.job_title, data.department]
+    .filter((s) => s && s.trim())
+    .join(" · ");
+  const supervisorName = data.supervisor_name ?? null;
+  const isManager = data.subordinates.length > 0;
+  // Manager → their own team; IC → their manager's team (peers).
+  const teamTarget = isManager ? data.person_id : supervisorPersonId;
+  // An IC viewer's own supervisor sits ABOVE them, outside the subtree identity
+  // serves — scoping there resolves to the viewer's (empty) org and the People
+  // zone would render "no people". Hide the button instead of dead-ending,
+  // matching the IC-aware shell where org zones don't exist at all.
+  const canScopeToTeam = teamTarget
+    ? scopeRoots.has(teamTarget.toLowerCase())
+    : false;
+
+  const peers = [...(manager?.subordinates ?? [])]
+    .filter((p) => p.person_id)
+    .sort((a, b) =>
+      (a.display_name || a.email).localeCompare(b.display_name || b.email),
+    );
+  const hasPeers = peers.length > 1;
+
+  function goPerson(personId: string) {
+    setZone(null);
+    void navigate({ to: "/ic/$person/personal", params: { person: personId } });
+  }
+  function goTeam(personId: string) {
+    setZone(null);
+    // Jumping to a team makes that node the visible org scope (design §6), so
+    // the topbar badge and every org zone agree with where you just landed.
+    setScope({ root: personId });
+    void navigate({ to: "/ic/$person/team", params: { person: personId } });
+  }
+
+  const title = (
+    <h1 className="truncate text-lg font-semibold tracking-tight">
+      {data.display_name || data.email}
+    </h1>
+  );
+
+  return (
+    <header className="flex flex-wrap items-center gap-x-4 gap-y-2 border-b px-4 py-3 md:px-6">
+      <div className="flex min-w-0 flex-col">
+        {hasPeers ? (
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              render={
+                <button
+                  type="button"
+                  className="flex min-w-0 items-center gap-1 rounded-md text-left hover:opacity-80"
+                  title="Switch teammate"
+                >
+                  {title}
+                  <ChevronsUpDown className="size-4 shrink-0 text-muted-foreground" />
+                </button>
+              }
+            />
+            <DropdownMenuContent
+              align="start"
+              className="max-h-80 w-64 overflow-y-auto"
+            >
+              <DropdownMenuGroup>
+                <DropdownMenuLabel className="text-xs text-muted-foreground">
+                  {supervisorName ? `${supervisorName}'s team` : "Team"}
+                </DropdownMenuLabel>
+                {peers.map((p) => {
+                  const active =
+                    p.email.toLowerCase() === data.email.toLowerCase();
+                  return (
+                    <DropdownMenuItem
+                      key={p.email}
+                      onClick={() => goPerson(p.email)}
+                      className={cn(active && "font-medium")}
+                    >
+                      <Check
+                        className={cn(
+                          "size-4",
+                          active ? "opacity-100" : "opacity-0",
+                        )}
+                      />
+                      <span className="truncate">
+                        {p.display_name || p.email}
+                      </span>
+                    </DropdownMenuItem>
+                  );
+                })}
+              </DropdownMenuGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        ) : (
+          title
+        )}
+        {subtitle ? (
+          <p className="truncate text-xs text-muted-foreground">{subtitle}</p>
+        ) : null}
+      </div>
+
+      <div className="ml-auto flex items-center gap-2">
+        {supervisorPersonId && supervisorName ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 gap-1 text-muted-foreground"
+            onClick={() => goPerson(supervisorPersonId)}
+          >
+            <ChevronUp className="size-3.5" />
+            <span className="max-w-40 truncate">{supervisorName}</span>
+          </Button>
+        ) : null}
+        {teamTarget && canScopeToTeam ? (
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-8 gap-1.5"
+            onClick={() => goTeam(teamTarget)}
+          >
+            <Users className="size-3.5" />
+            {isManager ? "Team" : "Peers"}
+          </Button>
+        ) : null}
+      </div>
+    </header>
+  );
+}

--- a/src/frontend/src/components/portal/person-view.tsx
+++ b/src/frontend/src/components/portal/person-view.tsx
@@ -1,0 +1,43 @@
+import { MetricGroupsView } from "@/components/portal/metric-groups-view";
+import { PersonHeader } from "@/components/portal/person-header";
+import { SingleGroupView } from "@/components/portal/single-group-view";
+import { GROUPS, type GroupId } from "@/lib/insight/groups";
+import {
+  usePortalItem,
+  usePortalNavActions,
+} from "@/lib/portal/portal-nav";
+
+const PERSON_GROUP_IDS: readonly GroupId[] = GROUPS.map((g) => g.id);
+
+/**
+ * Person zone: one specific person (like the reporting tool's Person page).
+ * The second sidebar level lists the person's sections; selecting a section
+ * expands it into the full content area inline (rich drilldown) — no modal.
+ * "At a glance" is a health dashboard: KPI row + needs-attention + per-section
+ * status cards, all routing into the relevant section inline so a problem
+ * points straight at its section.
+ */
+export function PersonView({ person }: { person: string }) {
+  const { setItem } = usePortalNavActions();
+  const item = usePortalItem();
+  const isSection = item != null && (PERSON_GROUP_IDS as string[]).includes(item);
+
+  return (
+    <>
+      <PersonHeader person={person} />
+      {isSection ? (
+        <SingleGroupView personId={person} groupId={item as GroupId} />
+      ) : (
+        // "At a glance" — a health dashboard: general KPIs + needs-attention +
+        // per-section status cards. Everything routes into the relevant section
+        // inline (no modal), so a problem points you straight at its section.
+        <MetricGroupsView
+          personId={person}
+          groupIds={PERSON_GROUP_IDS}
+          showKpis
+          onSelectGroup={(id) => setItem(id)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/frontend/src/components/portal/portal-layout.tsx
+++ b/src/frontend/src/components/portal/portal-layout.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useRef } from "react";
+
+import { MockBanner } from "@/components/mock-banner";
+import { ViewAsBanner } from "@/components/view-as-banner";
+import { ContextPane } from "@/components/portal/context-pane";
+import { LensRail } from "@/components/portal/lens-rail";
+import { PortalTopBar } from "@/components/portal/portal-topbar";
+import { ZoneContent } from "@/components/portal/zone-content";
+import { SidebarInset, SidebarProvider, useSidebar } from "@/components/ui/sidebar";
+import {
+  usePortalNavActions,
+  usePortalZone,
+} from "@/lib/portal/portal-nav";
+import { useShellLayout, type ShellLayout } from "@/lib/portal/use-shell-layout";
+import { useViewerIsManager } from "@/lib/portal/use-viewer-is-manager";
+
+/**
+ * Portal shell (Phase 1 buildout), behind the `insight.portal` flag so the
+ * default app is untouched. Composition (one SidebarProvider, all normal flow):
+ *   [ lens rail ] [ zone-contextual pane ] [ content ]
+ * Every zone renders through `<ZoneContent/>` (Person / People / Directions /
+ * Overview / … all portal-native); the route only carries the active person.
+ */
+export function PortalLayout() {
+  const { replaceZone } = usePortalNavActions();
+  // Pin the landing zone exactly once, when the viewer's manager status first
+  // resolves: a manager lands on the Overview org rollup; an IC has no subtree,
+  // so we leave the zone route-driven (null) → their own Person page. The rail
+  // stays interactive while the status resolves, so honour a zone the user
+  // already picked: a manager's choice is never overridden, and an IC who
+  // landed on an org zone (now hidden for them) is reset to route-driven.
+  const { isManager, isPending } = useViewerIsManager();
+  const zone = usePortalZone();
+  const landed = useRef(false);
+  useEffect(() => {
+    if (isPending || landed.current) return;
+    landed.current = true;
+    if (isManager) {
+      if (zone == null) replaceZone("overview");
+    } else if (zone != null && zone !== "person") {
+      replaceZone(null);
+    }
+  }, [isPending, isManager, zone, replaceZone]);
+
+  return (
+    <SidebarProvider className="h-svh overflow-hidden">
+      <PaneStateForLayout />
+      <LensRail />
+      <ContextPane />
+      <SidebarInset className="min-w-0 overflow-x-clip overflow-y-auto">
+        <MockBanner />
+        {/* The impersonation indicator: it names whose data is on screen and
+            carries the way out. Missing it left a view-as operator with no sign
+            they were not looking at their own org, and no exit. */}
+        <ViewAsBanner />
+        <PortalTopBar />
+        <ZoneContent />
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}
+
+/**
+ * The pane is in normal flow only on a wide screen; narrower, it is off-canvas
+ * and must START collapsed, or a tablet is back to 312px of chrome. The
+ * provider's `open` defaults to true and survives a resize, so a layout change
+ * has to reset it.
+ *
+ * Guarded on the layout actually CHANGING: `setOpen` from the provider is a new
+ * function on every open-state change, so an unguarded effect would re-fire and
+ * slam the pane shut the instant the reader opened it.
+ */
+function PaneStateForLayout() {
+  const layout = useShellLayout();
+  const { setOpen } = useSidebar();
+  const previous = useRef<ShellLayout | null>(null);
+  useEffect(() => {
+    if (previous.current === layout) return;
+    previous.current = layout;
+    setOpen(layout === "wide");
+  }, [layout, setOpen]);
+  return null;
+}

--- a/src/frontend/src/components/portal/portal-shell.test.tsx
+++ b/src/frontend/src/components/portal/portal-shell.test.tsx
@@ -1,0 +1,279 @@
+// @vitest-environment jsdom
+/**
+ * Shell + router semantics: which view each zone/item/lens resolves to, the
+ * manager-vs-IC landing decision, the route→scope one-shot sync and the
+ * global slice control. Heavy leaf views are stubbed — their own behavior is
+ * covered in their dedicated test files; here we assert the ROUTING.
+ */
+vi.mock("@tanstack/react-router", async () => {
+  const { portalRouterMock } = await import("@/test/portal-router");
+  return portalRouterMock();
+});
+
+import { portalRouter } from "@/test/portal-router";
+
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  email: "boss@x" as string | null,
+  isManager: true,
+  isPending: false,
+  zone: { activeZone: "overview", activePerson: "boss@x" },
+}));
+
+vi.mock("@/auth", () => ({ useViewer: () => ({ email: mocks.email }) }));
+vi.mock("@/lib/portal/use-viewer-is-manager", () => ({
+  useViewerIsManager: () => ({ isManager: mocks.isManager, isPending: mocks.isPending }),
+}));
+vi.mock("@/lib/portal/use-active-zone", () => ({
+  useActiveZone: () => mocks.zone,
+}));
+vi.mock("@/lib/portal/use-cohort-label", () => ({
+  useCohortLabel: () => "team",
+}));
+vi.mock("@/queries/ic-dashboard", () => ({
+  useIcPerson: () => ({ data: undefined, isPending: false, isLoading: false, isError: false, refetch: vi.fn() }),
+}));
+
+// Leaf views become labelled placeholders so routing is observable.
+vi.mock("@/components/portal/domain-lens-view", () => ({
+  DomainLensView: ({ config }: { config: { title: string } }) => (
+    <div data-testid="domain-lens">{config.title}</div>
+  ),
+  Pending: ({ label }: { label: string }) => <div data-testid="pending">{label}</div>,
+}));
+vi.mock("@/components/portal/ai-cost-view", () => ({
+  AiCostView: () => <div data-testid="ai-cost" />,
+}));
+vi.mock("@/components/portal/manage-view", () => ({
+  ManageView: () => <div data-testid="manage" />,
+}));
+vi.mock("@/components/portal/team-state-view", () => ({
+  TeamStateView: () => <div data-testid="team-state" />,
+}));
+vi.mock("@/components/portal/employees-view", () => ({
+  EmployeesView: () => <div data-testid="employees" />,
+}));
+vi.mock("@/components/portal/metric-groups-view", () => ({
+  MetricGroupsView: ({ personId }: { personId: string }) => (
+    <div data-testid="metric-groups">{personId}</div>
+  ),
+}));
+vi.mock("@/components/portal/single-group-view", () => ({
+  SingleGroupView: ({ groupId }: { groupId: string }) => (
+    <div data-testid="single-group">{groupId}</div>
+  ),
+}));
+vi.mock("@/components/portal/person-header", () => ({
+  PersonHeader: ({ person }: { person: string }) => (
+    <div data-testid="person-header">{person}</div>
+  ),
+}));
+vi.mock("@/components/portal/lens-rail", () => ({ LensRail: () => <div /> }));
+vi.mock("@/components/portal/context-pane", () => ({ ContextPane: () => <div /> }));
+vi.mock("@/components/portal/portal-topbar", () => ({ PortalTopBar: () => <div /> }));
+vi.mock("@/components/mock-banner", () => ({ MockBanner: () => <div /> }));
+vi.mock("@/components/view-as-banner", () => ({
+  ViewAsBanner: () => <div data-testid="view-as-banner" />,
+}));
+
+import {
+  usePortalScope,
+  usePortalSlice,
+  usePortalZone,
+} from "@/lib/portal/portal-nav";
+import { renderHook } from "@testing-library/react";
+
+import { DirectionView } from "./direction-view";
+import { OverviewView } from "./overview-view";
+import { PeopleView } from "./people-view";
+import { PersonView } from "./person-view";
+import { PortalLayout } from "./portal-layout";
+import { SliceSelect } from "./slice-select";
+import { ZoneContent } from "./zone-content";
+
+// SidebarProvider (inside PortalLayout) reads a media query; jsdom has none.
+beforeEach(() => {
+  window.matchMedia ??= ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+  mocks.isManager = true;
+  mocks.isPending = false;
+  mocks.zone = { activeZone: "overview", activePerson: "boss@x" };
+  act(() => {
+    portalRouter.set({ zone: undefined });
+    portalRouter.set({ item: undefined });
+    portalRouter.set({ dir: "dev" });
+    portalRouter.set({ lens: "Delivery" });
+    portalRouter.set({ slice: undefined });
+    portalRouter.set({ scope: undefined, direct: false });
+  });
+});
+
+describe("ZoneContent routing", () => {
+  const cases: Array<[string, string]> = [
+    ["person", "person-header"],
+    ["overview", "domain-lens"],
+    ["directions", "domain-lens"],
+    ["aicost", "ai-cost"],
+    ["people", "team-state"],
+    ["manage", "manage"],
+  ];
+  it.each(cases)("zone %s renders its view", (zone, testid) => {
+    mocks.zone = { activeZone: zone, activePerson: "boss@x" };
+    render(<ZoneContent />);
+    expect(screen.getByTestId(testid)).toBeInTheDocument();
+  });
+
+  it("scorecard renders an honest scaffold, not a fake dashboard", () => {
+    mocks.zone = { activeZone: "scorecard", activePerson: "boss@x" };
+    render(<ZoneContent />);
+    expect(screen.getByText("Scorecard")).toBeInTheDocument();
+    expect(screen.getByText(/org snapshots/)).toBeInTheDocument();
+  });
+});
+
+describe("DirectionView", () => {
+  it("routes a configured lens to DomainLensView", () => {
+    render(<DirectionView dir="dev" lens="Overview" />);
+    expect(screen.getByTestId("domain-lens")).toBeInTheDocument();
+  });
+
+  it("renders the roadmap note for a ComingSoon lens", () => {
+    render(<DirectionView dir="dev" lens="Repositories" />);
+    expect(screen.getByTestId("pending").textContent).toMatch(/Repository-level rollups/);
+  });
+
+  it("names the direction in the unknown-lens note", () => {
+    render(<DirectionView dir="dev" lens="Nope" />);
+    expect(screen.getByTestId("pending").textContent).toMatch(
+      /“Nope” isn't a metric family in Development yet/,
+    );
+  });
+
+  it("asks for a direction when the pane collapsed the selection", () => {
+    // Collapsing a direction clears `dir`; blaming the lens for missing from
+    // a direction the reader never picked reads like a bug.
+    render(<DirectionView dir="" lens="Delivery" />);
+    expect(screen.getByTestId("pending").textContent).toMatch(/Pick a direction/);
+  });
+});
+
+describe("OverviewView", () => {
+  it("defaults a null item to At a glance", () => {
+    render(<OverviewView item={null} />);
+    expect(screen.getByTestId("domain-lens")).toHaveTextContent("Overview");
+  });
+
+  it("resolves a named item through the registry", () => {
+    render(<OverviewView item="contribution" />);
+    expect(screen.getByTestId("domain-lens")).toHaveTextContent(
+      "Overview · Contribution breakdown",
+    );
+  });
+
+  it("renders Pending for an unknown item instead of crashing", () => {
+    render(<OverviewView item="nope" />);
+    expect(screen.getByTestId("pending").textContent).toMatch(/isn't an Overview view yet/);
+  });
+});
+
+describe("PersonView", () => {
+  it("defaults to the at-a-glance dashboard with the person's header", () => {
+    render(<PersonView person="a@x" />);
+    expect(screen.getByTestId("person-header")).toHaveTextContent("a@x");
+    expect(screen.getByTestId("metric-groups")).toHaveTextContent("a@x");
+  });
+
+  it("expands a selected metric group inline", () => {
+    act(() => portalRouter.set({ item: "git_output" }));
+    render(<PersonView person="a@x" />);
+    expect(screen.getByTestId("single-group")).toHaveTextContent("git_output");
+    expect(screen.queryByTestId("metric-groups")).not.toBeInTheDocument();
+  });
+});
+
+describe("PeopleView", () => {
+  it("routes items: roster (default), employees, median-by-role scaffold", () => {
+    const { rerender } = render(<PeopleView person="p1@x" item={null} />);
+    expect(screen.getByTestId("team-state")).toBeInTheDocument();
+    rerender(<PeopleView person="p1@x" item="employees" />);
+    expect(screen.getByTestId("employees")).toBeInTheDocument();
+    rerender(<PeopleView person="p1@x" item="median-by-role" />);
+    expect(screen.getByText(/Cohort role medians/)).toBeInTheDocument();
+  });
+
+  it("syncs the route person into the org scope ONCE, then defers to the user", () => {
+    const scope = renderHook(() => usePortalScope());
+    render(<PeopleView person="p2@x" item={null} />);
+    expect(scope.result.current.root).toBe("p2@x");
+    // The user re-picks a scope from the topbar…
+    act(() => portalRouter.set({ scope: "other@x" }));
+    // …and a remount for the SAME person must NOT revert it.
+    render(<PeopleView person="p2@x" item={null} />);
+    expect(scope.result.current.root).toBe("other@x");
+  });
+});
+
+describe("PortalLayout landing", () => {
+  it("pins a manager's landing zone to Overview once resolved", () => {
+    const zone = renderHook(() => usePortalZone());
+    render(<PortalLayout />);
+    expect(zone.result.current).toBe("overview");
+  });
+
+  it("leaves an IC route-driven (their own Person page)", () => {
+    mocks.isManager = false;
+    const zone = renderHook(() => usePortalZone());
+    render(<PortalLayout />);
+    expect(zone.result.current).toBeNull();
+  });
+
+  it("never overrides a zone the manager picked while their role resolved", () => {
+    act(() => portalRouter.set({ zone: "directions" }));
+    const zone = renderHook(() => usePortalZone());
+    render(<PortalLayout />);
+    expect(zone.result.current).toBe("directions");
+  });
+
+  it("resets an IC stranded on an org zone (hidden for them) to route-driven", () => {
+    mocks.isManager = false;
+    act(() => portalRouter.set({ zone: "overview" }));
+    const zone = renderHook(() => usePortalZone());
+    render(<PortalLayout />);
+    expect(zone.result.current).toBeNull();
+  });
+});
+
+describe("SliceSelect", () => {
+  it("shows the active dimension and writes the store on change", async () => {
+    const slice = renderHook(() => usePortalSlice());
+    render(<SliceSelect dims={[{ key: "division", label: "Division" }]} />);
+    // "Slice:" is a separate, md-only span now, so match the value itself.
+    expect(screen.getByRole("combobox", { name: "Slice by" })).toHaveTextContent(
+      "Team (all)",
+    );
+
+    await userEvent.click(screen.getByRole("combobox", { name: "Slice by" }));
+    await userEvent.click(await screen.findByRole("option", { name: "Division" }));
+    expect(slice.result.current).toBe("division");
+  });
+
+  it("maps the team sentinel back to an empty slice", async () => {
+    act(() => portalRouter.set({ slice: "division" }));
+    render(<SliceSelect dims={[{ key: "division", label: "Division" }]} />);
+    const slice = renderHook(() => usePortalSlice());
+    await userEvent.click(screen.getByRole("combobox", { name: "Slice by" }));
+    await userEvent.click(await screen.findByRole("option", { name: "Team (all)" }));
+    expect(slice.result.current).toBe("");
+  });
+});

--- a/src/frontend/src/components/portal/portal-shell.test.tsx
+++ b/src/frontend/src/components/portal/portal-shell.test.tsx
@@ -10,6 +10,8 @@ vi.mock("@tanstack/react-router", async () => {
   return portalRouterMock();
 });
 
+import { resetRouteScopeSync } from "@/lib/portal/route-scope-sync";
+import { pid } from "@/test/identity";
 import { portalRouter } from "@/test/portal-router";
 
 import { act, render, screen } from "@testing-library/react";
@@ -17,13 +19,15 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  email: "boss@x" as string | null,
+  personId: null as string | null,
   isManager: true,
   isPending: false,
-  zone: { activeZone: "overview", activePerson: "boss@x" },
+  zone: { activeZone: "overview", activePerson: "" },
 }));
 
-vi.mock("@/auth", () => ({ useViewer: () => ({ email: mocks.email }) }));
+vi.mock("@/auth", () => ({
+  useViewer: () => ({ email: "boss@x", personId: mocks.personId }),
+}));
 vi.mock("@/lib/portal/use-viewer-is-manager", () => ({
   useViewerIsManager: () => ({ isManager: mocks.isManager, isPending: mocks.isPending }),
 }));
@@ -108,7 +112,9 @@ beforeEach(() => {
   })) as unknown as typeof window.matchMedia;
   mocks.isManager = true;
   mocks.isPending = false;
-  mocks.zone = { activeZone: "overview", activePerson: "boss@x" };
+  mocks.personId = pid("boss");
+  resetRouteScopeSync();
+  mocks.zone = { activeZone: "overview", activePerson: pid("boss") };
   act(() => {
     portalRouter.set({ zone: undefined });
     portalRouter.set({ item: undefined });
@@ -129,13 +135,13 @@ describe("ZoneContent routing", () => {
     ["manage", "manage"],
   ];
   it.each(cases)("zone %s renders its view", (zone, testid) => {
-    mocks.zone = { activeZone: zone, activePerson: "boss@x" };
+    mocks.zone = { activeZone: zone, activePerson: pid("boss") };
     render(<ZoneContent />);
     expect(screen.getByTestId(testid)).toBeInTheDocument();
   });
 
   it("scorecard renders an honest scaffold, not a fake dashboard", () => {
-    mocks.zone = { activeZone: "scorecard", activePerson: "boss@x" };
+    mocks.zone = { activeZone: "scorecard", activePerson: pid("boss") };
     render(<ZoneContent />);
     expect(screen.getByText("Scorecard")).toBeInTheDocument();
     expect(screen.getByText(/org snapshots/)).toBeInTheDocument();
@@ -189,14 +195,14 @@ describe("OverviewView", () => {
 
 describe("PersonView", () => {
   it("defaults to the at-a-glance dashboard with the person's header", () => {
-    render(<PersonView person="a@x" />);
-    expect(screen.getByTestId("person-header")).toHaveTextContent("a@x");
-    expect(screen.getByTestId("metric-groups")).toHaveTextContent("a@x");
+    render(<PersonView person={pid("a")} />);
+    expect(screen.getByTestId("person-header")).toHaveTextContent(pid("a"));
+    expect(screen.getByTestId("metric-groups")).toHaveTextContent(pid("a"));
   });
 
   it("expands a selected metric group inline", () => {
     act(() => portalRouter.set({ item: "git_output" }));
-    render(<PersonView person="a@x" />);
+    render(<PersonView person={pid("a")} />);
     expect(screen.getByTestId("single-group")).toHaveTextContent("git_output");
     expect(screen.queryByTestId("metric-groups")).not.toBeInTheDocument();
   });
@@ -204,23 +210,25 @@ describe("PersonView", () => {
 
 describe("PeopleView", () => {
   it("routes items: roster (default), employees, median-by-role scaffold", () => {
-    const { rerender } = render(<PeopleView person="p1@x" item={null} />);
+    const { rerender } = render(<PeopleView person={pid("p1")} item={null} />);
     expect(screen.getByTestId("team-state")).toBeInTheDocument();
-    rerender(<PeopleView person="p1@x" item="employees" />);
+    rerender(<PeopleView person={pid("p1")} item="employees" />);
     expect(screen.getByTestId("employees")).toBeInTheDocument();
-    rerender(<PeopleView person="p1@x" item="median-by-role" />);
+    rerender(<PeopleView person={pid("p1")} item="median-by-role" />);
     expect(screen.getByText(/Cohort role medians/)).toBeInTheDocument();
   });
 
   it("syncs the route person into the org scope ONCE, then defers to the user", () => {
     const scope = renderHook(() => usePortalScope());
-    render(<PeopleView person="p2@x" item={null} />);
-    expect(scope.result.current.root).toBe("p2@x");
+    const first = render(<PeopleView person={pid("p2")} item={null} />);
+    expect(scope.result.current.root).toBe(pid("p2"));
     // The user re-picks a scope from the topbar…
-    act(() => portalRouter.set({ scope: "other@x" }));
-    // …and a remount for the SAME person must NOT revert it.
-    render(<PeopleView person="p2@x" item={null} />);
-    expect(scope.result.current.root).toBe("other@x");
+    act(() => portalRouter.set({ scope: pid("other") }));
+    // …and leaving the zone and coming back must NOT revert it. Unmounted for
+    // real, so this is the remount case and not two live instances.
+    first.unmount();
+    render(<PeopleView person={pid("p2")} item={null} />);
+    expect(scope.result.current.root).toBe(pid("other"));
   });
 });
 

--- a/src/frontend/src/components/portal/portal-topbar.tsx
+++ b/src/frontend/src/components/portal/portal-topbar.tsx
@@ -1,0 +1,59 @@
+import { useMemo } from "react";
+
+import { useViewer } from "@/auth";
+import { ScopeSelect } from "@/components/portal/scope-select";
+import { SliceSelect } from "@/components/portal/slice-select";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { PeriodSelectorBar } from "@/components/widgets/period-selector-bar";
+import { usePortalPeriod } from "@/hooks/use-portal-period";
+import { availableSlices } from "@/lib/insight/slices";
+import { collectRosterAttrs } from "@/lib/insight/slices";
+import { normalizePersonId } from "@/lib/metrics/entity";
+import { useIcPerson } from "@/queries/ic-dashboard";
+
+/**
+ * Global portal bar — the two cross-cutting controls live here so every zone
+ * shares one consistent position: the **period** filter and the **slice**
+ * (grouping + peer cohort). Both back global state (usePeriod / portal.slice),
+ * so all views react. Slice dimensions are derived once from the viewer's whole
+ * org (attributes are org-wide, not per-view), keeping the control universal.
+ */
+export function PortalTopBar() {
+  const { period, customRange, setPeriod, setCustomRange } = usePortalPeriod();
+  const { personId } = useViewer();
+  const tree = useIcPerson(personId ?? "").data ?? null;
+  const dims = useMemo(
+    () => availableSlices(collectRosterAttrs(tree, normalizePersonId).values()),
+    [tree],
+  );
+
+  return (
+    // Sticky to the scroll container (`SidebarInset` owns the overflow): scope,
+    // slice and period apply to whatever is on screen, so they have to stay
+    // reachable while reading down a long zone. Opaque background — content
+    // scrolling underneath a translucent bar makes both unreadable.
+    <div className="sticky top-0 z-20 flex items-center gap-2 border-b bg-background px-4 py-2 md:px-6">
+      {/* Opens the context pane wherever it is collapsed — the drawer is the
+          only way to reach navigation on a phone (no rail at all), and the only
+          way to reach sections on a tablet. Outside the scroller below, so it
+          stays put while the controls slide. */}
+      <SidebarTrigger className="shrink-0 lg:hidden" />
+      {/* Narrow screens keep the three controls on ONE scrollable row: wrapped,
+          they stack three deep and a sticky bar then holds 17% of a phone
+          viewport for good. Wide screens wrap as before — there is room. */}
+      {/* `justify-end` only once there is room to wrap: inside a horizontal
+          scroller it pushes the overflow off the START edge, where no scroll
+          gesture can reach it — Scope and Slice became unreachable. */}
+      <div className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto md:flex-wrap md:justify-end md:overflow-x-visible">
+        <ScopeSelect />
+        <SliceSelect dims={dims} />
+        <PeriodSelectorBar
+          period={period}
+          customRange={customRange}
+          onPeriodChange={setPeriod}
+          onRangeChange={setCustomRange}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/components/portal/scope-select.tsx
+++ b/src/frontend/src/components/portal/scope-select.tsx
@@ -1,0 +1,80 @@
+import { Check, ChevronDown } from "lucide-react";
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Switch } from "@/components/ui/switch";
+import {
+  usePortalNavActions,
+  usePortalScope,
+} from "@/lib/portal/portal-nav";
+import { useOrgScope } from "@/lib/portal/use-org-scope";
+import { cn } from "@/lib/utils";
+
+/**
+ * Global org-scope control (design §6): pick any manager node of the viewer's
+ * subtree; optionally narrow to direct reports. The active scope is the frame
+ * every org zone (Overview / Directions / AI & Cost / People) computes in.
+ *
+ * Options carry person ids since the identity cutover — the same key the routes
+ * and the metric requests use. `pivotPersonId` and `managerNodes[].person_id`
+ * come from one identity tree walk in `useOrgScope`, so a plain `===` is safe.
+ */
+export function ScopeSelect() {
+  const { setScope } = usePortalNavActions();
+  const scope = usePortalScope();
+  const { label, count, managerNodes, pivotPersonId, canDirectOnly } = useOrgScope();
+  if (!managerNodes.length) return null;
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        render={
+          <button
+            type="button"
+            className="flex h-9 items-center gap-1.5 rounded-md border bg-background px-3 text-sm shadow-xs hover:bg-accent"
+          >
+            {/* Narrow screens keep only the identity of the scope: the word
+                "Scope" and the head-count are recoverable from the popover, and
+                the sticky bar has ~300px for three controls. */}
+            <span className="hidden text-muted-foreground md:inline">Scope:</span>
+            <span className="max-w-28 truncate font-medium md:max-w-40">{label}</span>
+            <span className="hidden text-muted-foreground md:inline">· {count}</span>
+            <ChevronDown className="size-4 text-muted-foreground" aria-hidden />
+          </button>
+        }
+      />
+      <PopoverContent align="end" className="w-72 p-1">
+        <div className="max-h-80 overflow-y-auto">
+          {managerNodes.map((m) => (
+            <button
+              key={m.person_id}
+              type="button"
+              onClick={() => setScope({ root: m.depth === 0 ? null : m.person_id })}
+              className={cn(
+                "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm hover:bg-accent",
+                m.person_id === pivotPersonId && "bg-accent/60",
+              )}
+              style={{ paddingLeft: `${0.5 + m.depth * 0.875}rem` }}
+            >
+              <span className="min-w-0 flex-1 truncate">{m.name}</span>
+              <span className="text-xs text-muted-foreground">{m.teamSize}</span>
+              {m.person_id === pivotPersonId ? <Check className="size-4" aria-hidden /> : null}
+            </button>
+          ))}
+        </div>
+        {canDirectOnly ? (
+          <label className="flex cursor-pointer items-center justify-between gap-2 border-t px-2 py-2 text-sm select-none">
+            <span>Direct reports only</span>
+            <Switch
+              checked={scope.directOnly}
+              onCheckedChange={(v) => setScope({ directOnly: v })}
+            />
+          </label>
+        ) : null}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/frontend/src/components/portal/section-trend.test.tsx
+++ b/src/frontend/src/components/portal/section-trend.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+/**
+ * The shared trend card. Two things here are load-bearing and invisible when
+ * they break: metric keys are remapped to CSS-safe aliases (a dot in a custom
+ * property name silently yields no colour, and recharts reads it as a nested
+ * path), and a right-axis series needs its axis to exist or recharts drops the
+ * series without a word. The rest is the honest set of states.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  SectionTrend,
+  type SectionTrendPoint,
+  type SectionTrendSeries,
+} from "./section-trend";
+
+// Recharts needs a real layout; the assertions here are about what SectionTrend
+// hands it, so the chart primitives report their props as data attributes.
+vi.mock("@/components/ui/chart", () => ({
+  ChartContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="chart">{children}</div>
+  ),
+  ComposedChart: ({
+    data,
+    children,
+  }: {
+    data: unknown[];
+    children: React.ReactNode;
+  }) => (
+    <div data-testid="plot" data-rows={JSON.stringify(data)}>
+      {children}
+    </div>
+  ),
+  ChartLine: ({ dataKey, yAxisId }: { dataKey: string; yAxisId: string }) => (
+    <div data-testid="line" data-key={dataKey} data-axis={yAxisId} />
+  ),
+  ChartArea: ({
+    dataKey,
+    stackId,
+  }: {
+    dataKey: string;
+    stackId?: string;
+  }) => <div data-testid="area" data-key={dataKey} data-stack={stackId ?? ""} />,
+  YAxis: ({ yAxisId }: { yAxisId: string }) => (
+    <div data-testid={`y-${yAxisId}`} />
+  ),
+  XAxis: () => <div data-testid="x" />,
+  CartesianGrid: () => null,
+  ChartLegend: () => null,
+  ChartLegendContent: () => null,
+  ChartTooltip: () => null,
+  ChartTooltipContent: () => null,
+  ReferenceLine: ({ y }: { y: number }) => (
+    <div data-testid="target" data-y={y} />
+  ),
+}));
+
+const SERIES: SectionTrendSeries[] = [
+  { key: "collab.messages_sent", label: "Messages" },
+  { key: "collab.meeting_hours", label: "Meeting hours", yAxisId: "right" },
+];
+
+const DATA: SectionTrendPoint[] = [
+  { date: "2026-07-01", "collab.messages_sent": 10, "collab.meeting_hours": 2 },
+  { date: "2026-07-02", "collab.messages_sent": 20 },
+];
+
+function renderTrend(props: Partial<Parameters<typeof SectionTrend>[0]> = {}) {
+  return render(
+    <SectionTrend title="Collaboration" series={SERIES} data={DATA} {...props} />,
+  );
+}
+
+describe("SectionTrend", () => {
+  it("remaps metric keys to CSS-safe aliases in both series and rows", () => {
+    renderTrend();
+    const keys = screen
+      .getAllByTestId(/line|area/)
+      .map((el) => el.getAttribute("data-key"));
+    expect(keys.every((k) => k && !k.includes("."))).toBe(true);
+    // The rows must be rewritten to the same aliases, or every point is
+    // undefined and the chart renders empty with no error.
+    const rows = JSON.parse(
+      screen.getByTestId("plot").getAttribute("data-rows")!,
+    ) as Array<Record<string, unknown>>;
+    for (const key of keys) expect(rows[0]).toHaveProperty(key!);
+    expect(rows[0]).not.toHaveProperty("collab.messages_sent");
+  });
+
+  it("drops a null reading instead of rewriting it as zero", () => {
+    renderTrend();
+    const rows = JSON.parse(
+      screen.getByTestId("plot").getAttribute("data-rows")!,
+    ) as Array<Record<string, unknown>>;
+    // Day two has no meeting hours: the key is absent, so the line shows a gap
+    // rather than a measured zero.
+    expect(Object.keys(rows[1]!)).toHaveLength(2);
+  });
+
+  it("renders the right axis when a series asks for it, without the prop", () => {
+    renderTrend();
+    expect(screen.getByTestId("y-right")).toBeInTheDocument();
+  });
+
+  it("omits the right axis when no series uses it", () => {
+    renderTrend({ series: [SERIES[0]!] });
+    expect(screen.queryByTestId("y-right")).not.toBeInTheDocument();
+  });
+
+  it("keeps the right axis when a caller pins it", () => {
+    renderTrend({ series: [SERIES[0]!], rightAxis: true });
+    expect(screen.getByTestId("y-right")).toBeInTheDocument();
+  });
+
+  it("stacks only a stacked-area series", () => {
+    renderTrend({
+      series: [
+        { key: "a.b", label: "A", type: "stacked-area" },
+        { key: "c.d", label: "C", type: "area" },
+      ],
+      data: [{ date: "2026-07-01", "a.b": 1, "c.d": 2 }] as SectionTrendPoint[],
+    });
+    const stacks = screen
+      .getAllByTestId("area")
+      .map((el) => el.getAttribute("data-stack"));
+    expect(stacks).toEqual(["stack", ""]);
+  });
+
+  it("shows a skeleton while pending, and no chart", () => {
+    renderTrend({ isPending: true });
+    expect(screen.queryByTestId("chart")).not.toBeInTheDocument();
+  });
+
+  it("offers a retry on failure instead of an empty chart", () => {
+    const onRetry = vi.fn();
+    renderTrend({ isError: true, onRetry });
+    expect(screen.getByText(/unable to load/)).toBeInTheDocument();
+    expect(screen.queryByTestId("chart")).not.toBeInTheDocument();
+  });
+
+  it("says there is no data yet rather than drawing an empty plot", () => {
+    renderTrend({ data: [] });
+    expect(screen.getByText("No trend data yet.")).toBeInTheDocument();
+    expect(screen.queryByTestId("chart")).not.toBeInTheDocument();
+  });
+
+  it("draws the target line at the given value", () => {
+    renderTrend({ targetLine: { value: 8, label: "target" } });
+    expect(screen.getByTestId("target")).toHaveAttribute("data-y", "8");
+  });
+});

--- a/src/frontend/src/components/portal/section-trend.tsx
+++ b/src/frontend/src/components/portal/section-trend.tsx
@@ -1,0 +1,199 @@
+import { ComingSoon } from "@/components/widgets/coming-soon";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  CartesianGrid,
+  ChartArea,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartLine,
+  ChartTooltip,
+  ChartTooltipContent,
+  ComposedChart,
+  ReferenceLine,
+  type ChartConfig,
+  XAxis,
+  YAxis,
+} from "@/components/ui/chart";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export type SectionTrendSeries = {
+  key: string;
+  label: string;
+  type?: "line" | "area" | "stacked-area";
+  yAxisId?: "left" | "right";
+};
+
+export type SectionTrendPoint = {
+  date: string;
+  [seriesKey: string]: number | string;
+};
+
+export interface SectionTrendProps {
+  title: string;
+  description?: string;
+  series: SectionTrendSeries[];
+  data: SectionTrendPoint[];
+  targetLine?: { value: number; label: string };
+  rightAxis?: boolean;
+  height?: number;
+  isPending?: boolean;
+  isError?: boolean;
+  onRetry?: () => void;
+}
+
+const DEFAULT_CHART_KEYS = ["chart-1", "chart-2", "chart-3", "chart-4", "chart-5"];
+
+export function SectionTrend({
+  title,
+  description,
+  series,
+  data,
+  targetLine,
+  rightAxis,
+  height = 180,
+  isPending,
+  isError,
+  onRetry,
+}: SectionTrendProps) {
+  if (isPending) {
+    return <Skeleton className="h-48 w-full rounded-lg" />;
+  }
+  if (isError) {
+    return (
+      <ComingSoon
+        state="error"
+        label={`${title} — unable to load`}
+        onRetry={onRetry}
+      />
+    );
+  }
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-semibold">{title}</CardTitle>
+          <CardDescription>No trend data yet.</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  // Series keys are metric keys like "collab.messages_sent". A dot is illegal
+  // in a CSS custom-property name (so `--color-<key>` never resolves → invisible
+  // strokes) and makes recharts treat the dataKey as a nested path. Remap every
+  // series to a safe, collision-free alias and rewrite the data rows to match.
+  const safeKeys = series.map((s, i) => `s${i}_${s.key.replace(/[^a-zA-Z0-9_-]/g, "_")}`);
+  const safeSeries = series.map((s, i) => ({ ...s, key: safeKeys[i] }));
+  const safeData = data.map((row) => {
+    const next: SectionTrendPoint = { date: row.date as string };
+    series.forEach((s, i) => {
+      const v = row[s.key];
+      if (v != null) next[safeKeys[i]] = v;
+    });
+    return next;
+  });
+
+  const config: ChartConfig = Object.fromEntries(
+    safeSeries.map((s, i) => [
+      s.key,
+      { label: s.label, color: `var(--${DEFAULT_CHART_KEYS[i % DEFAULT_CHART_KEYS.length]})` },
+    ]),
+  );
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-semibold">{title}</CardTitle>
+        {description ? (
+          <CardDescription className="text-xs">{description}</CardDescription>
+        ) : null}
+      </CardHeader>
+      <CardContent>
+        <ChartContainer
+          config={config}
+          className="w-full"
+          style={{ height }}
+        >
+          <ComposedChart data={safeData} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+            <XAxis
+              dataKey="date"
+              tick={{ fontSize: 10, fill: "var(--muted-foreground)" }}
+              tickLine={false}
+              axisLine={false}
+              interval="preserveStartEnd"
+            />
+            <YAxis
+              yAxisId="left"
+              tick={{ fontSize: 10, fill: "var(--muted-foreground)" }}
+              tickLine={false}
+              axisLine={false}
+            />
+            {rightAxis ? (
+              <YAxis
+                yAxisId="right"
+                orientation="right"
+                tick={{ fontSize: 10, fill: "var(--muted-foreground)" }}
+                tickLine={false}
+                axisLine={false}
+                width={28}
+              />
+            ) : null}
+            <ChartTooltip content={<ChartTooltipContent />} />
+            <ChartLegend content={<ChartLegendContent />} />
+            {targetLine ? (
+              <ReferenceLine
+                yAxisId="left"
+                y={targetLine.value}
+                stroke="var(--success)"
+                strokeDasharray="4 4"
+                label={{
+                  value: targetLine.label,
+                  position: "right",
+                  fontSize: 10,
+                  fill: "var(--success)",
+                }}
+              />
+            ) : null}
+            {safeSeries.map((s) => {
+              const yAxisId = s.yAxisId ?? "left";
+              const color = `var(--color-${s.key})`;
+              if (s.type === "area" || s.type === "stacked-area") {
+                return (
+                  <ChartArea
+                    key={s.key}
+                    yAxisId={yAxisId}
+                    dataKey={s.key}
+                    name={s.label}
+                    stackId={s.type === "stacked-area" ? "stack" : undefined}
+                    stroke={color}
+                    fill={color}
+                    fillOpacity={0.25}
+                    strokeWidth={2}
+                  />
+                );
+              }
+              return (
+                <ChartLine
+                  key={s.key}
+                  yAxisId={yAxisId}
+                  dataKey={s.key}
+                  name={s.label}
+                  stroke={color}
+                  strokeWidth={2}
+                />
+              );
+            })}
+          </ComposedChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/frontend/src/components/portal/section-trend.tsx
+++ b/src/frontend/src/components/portal/section-trend.tsx
@@ -23,6 +23,7 @@ import {
 } from "@/components/ui/chart";
 import { Skeleton } from "@/components/ui/skeleton";
 
+/** One plotted series: its metric key, its label, and how to draw it. */
 export type SectionTrendSeries = {
   key: string;
   label: string;
@@ -30,6 +31,10 @@ export type SectionTrendSeries = {
   yAxisId?: "left" | "right";
 };
 
+/**
+ * One bucket. A series key is ABSENT when that series has no reading for the
+ * bucket — never zero, so the line shows a gap instead of a measurement.
+ */
 export type SectionTrendPoint = {
   date: string;
   [seriesKey: string]: number | string;
@@ -55,6 +60,7 @@ export interface SectionTrendProps {
 
 const DEFAULT_CHART_KEYS = ["chart-1", "chart-2", "chart-3", "chart-4", "chart-5"];
 
+/** The shared trend card: one chart, the same states, wherever a trend appears. */
 export function SectionTrend({
   title,
   description,

--- a/src/frontend/src/components/portal/section-trend.tsx
+++ b/src/frontend/src/components/portal/section-trend.tsx
@@ -41,6 +41,11 @@ export interface SectionTrendProps {
   series: SectionTrendSeries[];
   data: SectionTrendPoint[];
   targetLine?: { value: number; label: string };
+  /**
+   * Force the right axis on. Normally unnecessary — it is rendered whenever a
+   * series asks for it — but a caller can pin it so the plot area does not
+   * shift when a right-axis series drops out of the data.
+   */
   rightAxis?: boolean;
   height?: number;
   isPending?: boolean;
@@ -100,6 +105,11 @@ export function SectionTrend({
     return next;
   });
 
+  // Derived, not just taken from the prop: a series with `yAxisId: "right"`
+  // and no right YAxis rendered is dropped by recharts without a word.
+  const needsRightAxis =
+    rightAxis || safeSeries.some((s) => s.yAxisId === "right");
+
   const config: ChartConfig = Object.fromEntries(
     safeSeries.map((s, i) => [
       s.key,
@@ -136,7 +146,7 @@ export function SectionTrend({
               tickLine={false}
               axisLine={false}
             />
-            {rightAxis ? (
+            {needsRightAxis ? (
               <YAxis
                 yAxisId="right"
                 orientation="right"

--- a/src/frontend/src/components/portal/shell-layout.test.tsx
+++ b/src/frontend/src/components/portal/shell-layout.test.tsx
@@ -1,0 +1,287 @@
+// @vitest-environment jsdom
+/**
+ * Mobile shell semantics. Two fixed sidebars (56px rail + 256px pane) left a
+ * 375px phone ~60px of content, so below the breakpoint the rail hides and the
+ * pane becomes the single off-canvas drawer. These tests pin the parts that
+ * make that usable: the rail really disappears, the drawer carries the zones
+ * (collapsed, so the zone's own sections stay above the fold) and the settings
+ * menu, a zone pick keeps the drawer open while a section pick closes it, and
+ * NOTHING of this leaks into the desktop layout.
+ */
+vi.mock("@tanstack/react-router", async () => {
+  const { portalRouterMock } = await import("@/test/portal-router");
+  return portalRouterMock();
+});
+
+import { portalRouter } from "@/test/portal-router";
+
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  layout: "phone" as "phone" | "narrow" | "wide",
+  zone: { activeZone: "overview", activePerson: "boss@x" },
+  isManager: true,
+}));
+
+vi.mock("@/hooks/use-mobile", () => ({ useIsMobile: () => mocks.layout === "phone" }));
+vi.mock("@/lib/portal/use-shell-layout", () => ({ useShellLayout: () => mocks.layout }));
+vi.mock("@/lib/portal/use-active-zone", () => ({ useActiveZone: () => mocks.zone }));
+vi.mock("@/lib/portal/use-viewer-is-manager", () => ({
+  useViewerIsManager: () => ({ isManager: mocks.isManager, isPending: false }),
+}));
+
+vi.mock("@/components/org-tree", () => ({ OrgTree: () => <div /> }));
+vi.mock("@/components/mock-banner", () => ({ MockBanner: () => <div /> }));
+vi.mock("@/components/view-as-banner", () => ({
+  ViewAsBanner: () => <div data-testid="view-as-banner" />,
+}));
+vi.mock("@/components/portal/zone-content", () => ({ ZoneContent: () => <div /> }));
+vi.mock("@/lib/portal/use-viewer-is-manager", () => ({
+  useViewerIsManager: () => ({ isManager: true, isPending: false }),
+}));
+vi.mock("@/components/portal/scope-select", () => ({ ScopeSelect: () => <div /> }));
+vi.mock("@/components/portal/slice-select", () => ({ SliceSelect: () => <div /> }));
+vi.mock("@/components/widgets/period-selector-bar", () => ({
+  PeriodSelectorBar: () => <div />,
+}));
+vi.mock("@/queries/ic-dashboard", () => ({
+  useIcPerson: () => ({ data: null }),
+}));
+vi.mock("@/hooks/use-portal-period", () => ({
+  usePortalPeriod: () => ({
+    period: "month",
+    customRange: null,
+    setPeriod: vi.fn(),
+    setCustomRange: vi.fn(),
+  }),
+}));
+vi.mock("@/auth", () => ({ useViewer: () => ({ email: "boss@x" }) }));
+// The settings menu pulls in viewer/theme/i18n plumbing; its presence is what
+// matters here — on a phone it is only reachable through this drawer.
+vi.mock("@/components/app-sidebar-footer", () => ({
+  AppSidebarFooter: () => <div data-testid="settings-menu" />,
+}));
+
+import { SidebarProvider, SidebarTrigger } from "@/components/ui/sidebar";
+import {
+  usePortalItem,
+  usePortalZone,
+} from "@/lib/portal/portal-nav";
+import { act, renderHook } from "@testing-library/react";
+
+import { ContextPane } from "./context-pane";
+import { LensRail } from "./lens-rail";
+
+/** The real shell wiring: trigger in the topbar, pane as the drawer. */
+function Shell() {
+  return (
+    <SidebarProvider>
+      <LensRail />
+      <SidebarTrigger />
+      <ContextPane />
+    </SidebarProvider>
+  );
+}
+
+beforeEach(() => {
+  mocks.layout = "phone";
+  mocks.zone = { activeZone: "overview", activePerson: "boss@x" };
+  mocks.isManager = true;
+  act(() => {
+    portalRouter.set({ item: undefined });
+  });
+  window.matchMedia ??= ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  })) as unknown as typeof window.matchMedia;
+});
+
+const openDrawer = async () => {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: /sidebar/i }));
+  return user;
+};
+
+describe("shell layout: phone", () => {
+  it("hides the icon rail — it would eat 56px of a 375px screen", () => {
+    const { container } = render(
+      <SidebarProvider>
+        <LensRail />
+      </SidebarProvider>,
+    );
+    // The provider wrapper is all that renders; the rail itself contributes no
+    // sidebar element.
+    expect(container.querySelector('[data-slot="sidebar"]')).toBeNull();
+  });
+
+  it("keeps the rail on a tablet — 56px is affordable there", () => {
+    mocks.layout = "narrow";
+    const { container } = render(
+      <SidebarProvider>
+        <LensRail />
+      </SidebarProvider>,
+    );
+    expect(container.querySelector('[data-slot="sidebar"]')).not.toBeNull();
+  });
+
+  it("keeps the rail on desktop", () => {
+    mocks.layout = "wide";
+    const { container } = render(
+      <SidebarProvider>
+        <LensRail />
+      </SidebarProvider>,
+    );
+    expect(container.querySelector('[data-slot="sidebar"]')).not.toBeNull();
+  });
+
+  it("keeps the pane closed until the topbar trigger opens it", async () => {
+    render(<Shell />);
+    expect(screen.queryByText("At a glance")).not.toBeInTheDocument();
+    await openDrawer();
+    expect(screen.getByText("At a glance")).toBeInTheDocument();
+  });
+
+  it("shows the zone switcher collapsed, so sections stay above the fold", async () => {
+    render(<Shell />);
+    await openDrawer();
+    // One row for the active zone; the other zones are not listed yet.
+    expect(screen.getByRole("button", { name: "Overview", expanded: false })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "AI & Cost" })).not.toBeInTheDocument();
+    // …and the zone's own sections are already there.
+    expect(screen.getByText("Trend")).toBeInTheDocument();
+  });
+
+  it("expands the zone list on demand and re-collapses after a pick", async () => {
+    render(<Shell />);
+    const user = await openDrawer();
+    const zoneState = renderHook(() => usePortalZone());
+
+    await user.click(screen.getByRole("button", { name: "Overview", expanded: false }));
+    const aiCost = screen.getByRole("button", { name: "AI & Cost" });
+
+    await user.click(aiCost);
+    expect(zoneState.result.current).toBe("aicost");
+    // Collapsed again: "Manage" only exists while the list is expanded, so its
+    // absence is the collapse. The drawer itself stays open — the Settings row
+    // is still there — so the new zone's sections are what the reader sees next.
+    expect(screen.queryByRole("button", { name: "Manage" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Settings" })).toBeInTheDocument();
+  });
+
+  it("closes the drawer when a section is picked — otherwise it hides the view", async () => {
+    render(<Shell />);
+    const user = await openDrawer();
+    const itemState = renderHook(() => usePortalItem());
+
+    await user.click(screen.getByText("Trend"));
+
+    expect(itemState.result.current).toBe("trend");
+    expect(screen.queryByText("Trend")).not.toBeInTheDocument();
+  });
+
+  it("keeps the settings menu one tap away instead of inline", async () => {
+    // Inline it costs six of the ~14 rows a phone has, which is what the
+    // sections need. Behind one row it costs one — the same trade the desktop
+    // rail makes with its settings icon.
+    render(<Shell />);
+    const user = await openDrawer();
+    expect(screen.queryByTestId("settings-menu")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Settings" }));
+    expect(screen.getByTestId("settings-menu")).toBeInTheDocument();
+  });
+
+  it("drops the header — the zone row already names the zone", async () => {
+    render(<Shell />);
+    await openDrawer();
+    expect(screen.queryByText("Cross-functional org rollup")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Overview", expanded: false })).toBeInTheDocument();
+  });
+
+  it("adds neither the zone switcher nor the settings menu on desktop", () => {
+    mocks.layout = "wide";
+    render(
+      <SidebarProvider>
+        <ContextPane />
+      </SidebarProvider>,
+    );
+    // Desktop keeps its header, and the rail's duties stay in the rail.
+    const pane = screen.getByText("Cross-functional org rollup").closest("[data-slot='sidebar']");
+    expect(screen.getByText("At a glance")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Settings" })).not.toBeInTheDocument();
+    expect(
+      within(pane as HTMLElement).queryByRole("button", { name: "Overview", expanded: false }),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe("shell layout: narrow (tablet)", () => {
+  beforeEach(() => {
+    mocks.layout = "narrow";
+  });
+
+  it("collapses the pane off-canvas instead of Sheeting it", () => {
+    // The rail is still there, so the pane must NOT take over the rail's duties
+    // — no zone list, no settings row, and the header stays.
+    render(<Shell />);
+    const pane = screen
+      .getByText("Cross-functional org rollup")
+      .closest("[data-slot='sidebar']") as HTMLElement;
+    // Settings still exist — in the RAIL, where they belong at this width.
+    expect(within(pane).queryByRole("button", { name: "Settings" })).not.toBeInTheDocument();
+    expect(
+      within(pane).queryByRole("button", { name: "Overview", expanded: false }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("closes the pane after a section pick, same as the phone drawer", async () => {
+    const user = userEvent.setup();
+    render(<Shell />);
+    const itemState = renderHook(() => usePortalItem());
+
+    // The pane starts expanded in this bare harness (no PaneStateForLayout), so
+    // the sections are reachable; picking one must collapse it.
+    await user.click(screen.getByText("Trend"));
+
+    expect(itemState.result.current).toBe("trend");
+    expect(document.querySelector('[data-state="collapsed"]')).not.toBeNull();
+  });
+});
+
+describe("the global controls stay reachable while reading", () => {
+  it("pins the topbar to the scroll container, opaquely", async () => {
+    const { PortalTopBar } = await import("./portal-topbar");
+    const { container } = render(
+      <SidebarProvider>
+        <PortalTopBar />
+      </SidebarProvider>,
+    );
+    const bar = container.querySelector("div.sticky");
+    // Sticky alone is not enough: content scrolling under a transparent bar
+    // makes both unreadable, and a bar below the cards' stacking order is
+    // covered by them.
+    expect(bar?.className).toContain("top-0");
+    expect(bar?.className).toContain("bg-background");
+    expect(bar?.className).toMatch(/z-\d+/);
+  });
+});
+
+describe("what the shell must never drop", () => {
+  it("renders the impersonation banner — a view-as session needs its exit", async () => {
+    // It went missing when the portal became the shell: an operator viewing as
+    // someone else saw no indication whose data was on screen, and no way back.
+    // The banner's own behaviour is covered by its tests; this pins that the
+    // shell still composes it in.
+    const { PortalLayout } = await import("./portal-layout");
+    render(<PortalLayout />);
+    expect(screen.getByTestId("view-as-banner")).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/portal/shell-layout.test.tsx
+++ b/src/frontend/src/components/portal/shell-layout.test.tsx
@@ -38,9 +38,6 @@ vi.mock("@/components/view-as-banner", () => ({
   ViewAsBanner: () => <div data-testid="view-as-banner" />,
 }));
 vi.mock("@/components/portal/zone-content", () => ({ ZoneContent: () => <div /> }));
-vi.mock("@/lib/portal/use-viewer-is-manager", () => ({
-  useViewerIsManager: () => ({ isManager: true, isPending: false }),
-}));
 vi.mock("@/components/portal/scope-select", () => ({ ScopeSelect: () => <div /> }));
 vi.mock("@/components/portal/slice-select", () => ({ SliceSelect: () => <div /> }));
 vi.mock("@/components/widgets/period-selector-bar", () => ({

--- a/src/frontend/src/components/portal/single-group-view.tsx
+++ b/src/frontend/src/components/portal/single-group-view.tsx
@@ -1,0 +1,86 @@
+import { useMemo } from "react";
+
+import { CenteredSpinner } from "@/components/widgets/centered-spinner";
+import { ComingSoon } from "@/components/widgets/coming-soon";
+import { CollectionDrilldown } from "@/components/widgets/metric-views/collection-drilldown";
+import { usePortalPeriod } from "@/hooks/use-portal-period";
+import { GROUPS, type GroupId } from "@/lib/insight/groups";
+import { injectCohortPeer } from "@/lib/insight/within-team-peer";
+import { type MetricCollectionConfig } from "@/lib/metrics/collection";
+import { normalizePersonId } from "@/lib/metrics/entity";
+import { useCohortLabel } from "@/lib/portal/use-cohort-label";
+import { usePersonCohort } from "@/lib/portal/use-person-cohort";
+import { useMetricCollection } from "@/queries/metric-results";
+
+const EMPTY_COLLECTION: MetricCollectionConfig = { metrics: [] };
+const CLOSED_ENTITY = { type: "person" as const, ids: [] };
+
+/**
+ * A direction lens with a single metric group renders the group's full
+ * drilldown inline — no click-to-expand card, since there's only one section.
+ * Fetches the full collection (all views) so charts + peer story paint directly.
+ * When a slice is active, the person's slice cohort is fetched and its peer
+ * stats are injected so the drilldown's peer story reads "vs <slice> median".
+ */
+export function SingleGroupView({
+  personId,
+  groupId,
+}: {
+  personId: string;
+  groupId: GroupId;
+}) {
+  const cohortLabel = useCohortLabel();
+  const { dateRange } = usePortalPeriod();
+  const entityId = normalizePersonId(personId);
+  const def = GROUPS.find((d) => d.id === groupId) ?? null;
+
+  const data = useMetricCollection(
+    def?.collection ?? EMPTY_COLLECTION,
+    def ? { type: "person", ids: [entityId] } : CLOSED_ENTITY,
+    dateRange,
+  );
+  const cohortIds = usePersonCohort(entityId);
+  const cohortData = useMetricCollection(
+    def && cohortIds.length ? def.collection : EMPTY_COLLECTION,
+    cohortIds.length ? { type: "person", ids: cohortIds } : CLOSED_ENTITY,
+    dateRange,
+  );
+  const injectedData = useMemo(
+    () => ({
+      ...data,
+      byKey: injectCohortPeer(data.byKey, cohortData.byKey, cohortIds),
+    }),
+    [data, cohortData.byKey, cohortIds],
+  );
+
+  if (!def) {
+    return (
+      <div className="mx-auto w-full max-w-md p-8">
+        <ComingSoon variant="card" state="empty" label="Unknown group" />
+      </div>
+    );
+  }
+  if (data.isPending) return <CenteredSpinner className="min-h-[60vh]" />;
+  // A failed fetch must surface as a retryable error, not a drilldown
+  // rendered over an empty dataset (same policy as MetricGroupsView).
+  if (data.isError) {
+    return (
+      <div className="mx-auto w-full max-w-md p-8">
+        <ComingSoon variant="card" state="error" onRetry={() => data.refetch()} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-4 md:p-6">
+      <h1 className="text-xl font-semibold tracking-tight">{def.title}</h1>
+      <CollectionDrilldown
+        def={def}
+        data={injectedData}
+        entityId={entityId}
+        range={dateRange}
+        cohortLabel={cohortLabel}
+      />
+    </div>
+  );
+}

--- a/src/frontend/src/components/portal/slice-select.tsx
+++ b/src/frontend/src/components/portal/slice-select.tsx
@@ -17,9 +17,12 @@ import {
 /**
  * "No slice" — the whole roster is one cohort and views stay per-person. The
  * store keeps this as `""`; the Select uses a non-empty sentinel because Base
- * UI treats an empty-string value as "no selection" (blank trigger).
+ * UI treats an empty-string value as "no selection" (blank trigger). The
+ * sentinel is underscored so a roster attribute literally named `team` cannot
+ * collide with it — that collision duplicated a React key and made the real
+ * dimension unselectable, because picking it read as "no slice".
  */
-const TEAM_KEY = "team";
+const TEAM_KEY = "__team__";
 const TEAM_SLICE = { key: TEAM_KEY, label: "Team (all)" };
 
 /**
@@ -52,7 +55,7 @@ export function SliceSelect({ dims }: { dims: SliceDim[] }) {
             Slice by
           </SelectLabel>
           {all.map((d) => (
-            <SelectItem key={d.key || "team"} value={d.key}>
+            <SelectItem key={d.key} value={d.key}>
               {d.label}
             </SelectItem>
           ))}

--- a/src/frontend/src/components/portal/slice-select.tsx
+++ b/src/frontend/src/components/portal/slice-select.tsx
@@ -1,0 +1,63 @@
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { SliceDim } from "@/lib/insight/slices";
+import { PLANNED_SLICES } from "@/lib/insight/slices";
+import {
+  usePortalNavActions,
+  usePortalSlice,
+} from "@/lib/portal/portal-nav";
+
+/**
+ * "No slice" — the whole roster is one cohort and views stay per-person. The
+ * store keeps this as `""`; the Select uses a non-empty sentinel because Base
+ * UI treats an empty-string value as "no selection" (blank trigger).
+ */
+const TEAM_KEY = "team";
+const TEAM_SLICE = { key: TEAM_KEY, label: "Team (all)" };
+
+/**
+ * The one shared slice control. Writes the global `portal.slice`, so picking a
+ * dimension re-cohorts every view (roster heat, attention, AI cost, …) at once.
+ * `dims` are the data-derived slices for the current roster; planned dims are
+ * appended (and render ComingSoon in the consuming view).
+ */
+export function SliceSelect({ dims }: { dims: SliceDim[] }) {
+  const { setSlice } = usePortalNavActions();
+  const slice = usePortalSlice();
+  const all = [TEAM_SLICE, ...dims, ...PLANNED_SLICES];
+  const current = slice || TEAM_KEY;
+  const value = all.some((d) => d.key === current) ? current : TEAM_KEY;
+  const label = all.find((d) => d.key === value)?.label ?? "Team (all)";
+  return (
+    <Select
+      value={value}
+      onValueChange={(v) => setSlice(v && v !== TEAM_KEY ? v : "")}
+    >
+      <SelectTrigger size="sm" aria-label="Slice by" className="w-32 md:w-48">
+        <SelectValue>
+          <span className="hidden md:inline">Slice: </span>
+          {label}
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent align="end">
+        <SelectGroup>
+          <SelectLabel className="text-xs text-muted-foreground">
+            Slice by
+          </SelectLabel>
+          {all.map((d) => (
+            <SelectItem key={d.key || "team"} value={d.key}>
+              {d.label}
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/frontend/src/components/portal/team-state-view.test.tsx
+++ b/src/frontend/src/components/portal/team-state-view.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+/**
+ * Team-state dashboard semantics: honest KPI roll-ups (totals for counters,
+ * medians for ratios), all-empty columns dropped instead of zero-painted,
+ * attention wired to the roster, and the org-scope gate in front of it all.
+ * Data arrives via the same stubbed query boundary as the real view.
+ */
+vi.mock("@tanstack/react-router", async () => {
+  const { portalRouterMock } = await import("@/test/portal-router");
+  return portalRouterMock();
+});
+
+import { portalRouter } from "@/test/portal-router";
+
+import { act, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { NormalizedMetricResult } from "@/lib/metrics/collection";
+import { identityPerson, pid } from "@/test/identity";
+import type { IdentityPerson } from "@/types/insight";
+
+const mocks = vi.hoisted(() => ({
+  personId: null as string | null,
+  tree: undefined as IdentityPerson | undefined,
+  grid: {
+    byKey: new Map<string, NormalizedMetricResult>(),
+    previousByKey: new Map<string, NormalizedMetricResult>(),
+    isPending: false,
+    isFetching: false,
+    isError: false,
+    refetch: vi.fn(),
+  },
+}));
+
+vi.mock("@/auth", () => ({
+  useViewer: () => ({ email: "boss@x", personId: mocks.personId }),
+}));
+vi.mock("@/lib/portal/use-cohort-label", () => ({
+  useCohortLabel: () => "team",
+}));
+vi.mock("@/queries/ic-dashboard", () => ({
+  useIcPerson: () => ({ data: mocks.tree, isPending: false, isLoading: false, isError: false, refetch: vi.fn() }),
+}));
+vi.mock("@/queries/member-grid", () => ({ useMemberGridData: () => mocks.grid }));
+vi.mock("@/hooks/use-portal-period", () => ({
+  usePortalPeriod: () => ({ period: "week", dateRange: { start: "2026-07-20", end: "2026-07-26" } }),
+}));
+
+
+import { TeamStateView } from "./team-state-view";
+
+const person = (label: string, subs: IdentityPerson[] = []): IdentityPerson =>
+  identityPerson(label, {}, subs);
+
+
+function metric(
+  key: string,
+  period: Array<[string, number | null]>,
+  over: Partial<NormalizedMetricResult> = {},
+): NormalizedMetricResult {
+  return {
+    metric_key: key,
+    label: over.label ?? key,
+    unit: null,
+    computation: "sum",
+    format: "integer",
+    direction: "higher_is_better",
+    period: { view: "period", values: period.map(([entity_id, value]) => ({ entity_id, value })) },
+    peer: { view: "peer", values: period.map(([entity_id, value]) => ({ entity_id, target_value: value })) },
+    ...over,
+  } as unknown as NormalizedMetricResult;
+}
+
+// Roster entity ids: person UUIDs, the same key the metric grid returns.
+const LABELS = ["a", "b", "c", "d"];
+const IDS = LABELS.map(pid);
+
+beforeEach(() => {
+  mocks.personId = pid("boss");
+  mocks.tree = person("boss", LABELS.map((l) => person(l)));
+  mocks.grid.isPending = false;
+  mocks.grid.isError = false;
+  // git.commits is a real headline key (GROUPS card.preview) — the view
+  // only renders columns from that set.
+  mocks.grid.byKey = new Map([
+    ["git.commits", metric("git.commits", [[pid("a"), 10], [pid("b"), 20], [pid("c"), 30], [pid("d"), 40]], { label: "Commits" })],
+    // a ratio metric: must roll up as MEDIAN, not a summed percentage
+    ["collab.focus_time_pct", metric("collab.focus_time_pct", [[pid("a"), 40], [pid("b"), 50], [pid("c"), 60], [pid("d"), 70]], {
+      computation: "avg",
+      label: "Focus Time",
+      format: "percent",
+    } as never)],
+    // ingested nowhere → its column must disappear, not paint zeros
+    ["tasks.closed", metric("tasks.closed", IDS.map((id) => [id, null]), { label: "Tasks closed" })],
+  ]);
+  mocks.grid.previousByKey = new Map();
+  act(() => {
+    portalRouter.set({ slice: undefined });
+    portalRouter.set({ scope: undefined, direct: false });
+  });
+});
+
+describe("TeamStateView", () => {
+  it("renders the scope header and every member row", () => {
+    render(<TeamStateView />);
+    expect(screen.getByText("boss's team")).toBeInTheDocument();
+    expect(screen.getByText(/4 people · state & attention/)).toBeInTheDocument();
+    // Names come from identity now — the roster is the member list.
+    for (const label of LABELS) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it("sums counters into a team total and medians ratios — never the reverse", () => {
+    render(<TeamStateView />);
+    expect(screen.getByText("100")).toBeInTheDocument();
+    expect(screen.getAllByText("team total").length).toBeGreaterThan(0);
+    // median of 40,50,60,70 = 55%, NOT the 220% a sum would fabricate
+    expect(screen.getByText("55%")).toBeInTheDocument();
+    expect(screen.getAllByText("team median").length).toBeGreaterThan(0);
+  });
+
+  it("drops a column that has no data for anyone (honest, not zero-filled)", () => {
+    render(<TeamStateView />);
+    expect(screen.queryByText("Tasks closed")).not.toBeInTheDocument();
+  });
+
+  it("keeps the steady attention note when nobody diverges", () => {
+    render(<TeamStateView />);
+    expect(screen.getByText("All 4 people are within their usual range this period.")).toBeInTheDocument();
+    expect(screen.getByText(/No outliers, declines, or collapses/)).toBeInTheDocument();
+  });
+
+  it("gates on the empty roster with the People-specific label", () => {
+    mocks.tree = person("boss"); // a manager with nobody under them
+    render(<TeamStateView />);
+    expect(
+      screen.getByText(
+        "No people in the current scope — pick a different scope in the topbar.",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/portal/team-state-view.tsx
+++ b/src/frontend/src/components/portal/team-state-view.tsx
@@ -88,9 +88,9 @@ export function TeamStateView() {
 
   // Headline metrics only (card.preview): the set a lead scans, and — crucially —
   // small enough to stay under the API's 50-metrics-per-request cap when the full
-  // metric catalog across every group would blow past it. `GROUPS` is
-  // called INSIDE the memo — it returns a fresh array per call, and a fresh
-  // dependency would defeat the memo and re-key the grid query every render.
+  // metric catalog across every group would blow past it. `GROUPS` is a module
+  // constant, so it is read inside the memo and left out of the dependency
+  // list — listing it would be noise, not safety.
   const headlineKeys = useMemo(() => headlineMetricKeys(), []);
   const gridCollection = useMemo<MetricCollectionConfig>(() => {
     const want = new Set(headlineKeys);
@@ -256,7 +256,7 @@ export function TeamStateView() {
               metricKeys={shownKeys}
               byKey={heatByKey}
               previousByKey={grid.previousByKey}
-              caption={`${teamName} — members × metrics`}
+              caption={`${teamName || "Team"} — members × metrics`}
               cohortLabel={cohortLabel}
             />
           </CardContent>

--- a/src/frontend/src/components/portal/team-state-view.tsx
+++ b/src/frontend/src/components/portal/team-state-view.tsx
@@ -1,0 +1,267 @@
+import { useMemo } from "react";
+
+import { AttentionList } from "@/components/portal/attention-list";
+import { orgScopeGate } from "@/components/portal/org-scope-gate";
+import { MembersGrid } from "@/components/widgets/dashboard/members-grid";
+import { Card, CardContent } from "@/components/ui/card";
+import { usePortalPeriod } from "@/hooks/use-portal-period";
+import { formatMetricValue } from "@/lib/format";
+import {
+  attentionSummary,
+  computeAttentionFlags,
+} from "@/lib/insight/attention-flags";
+import { headlineMetricKeys, GROUPS } from "@/lib/insight/groups";
+import {
+  cohortKey,
+  collectRosterAttrs,
+} from "@/lib/insight/slices";
+import { quantile, withinCohortPeer } from "@/lib/insight/within-team-peer";
+import {
+  forEntity,
+  type MetricCollectionConfig,
+  type NormalizedMetricResult,
+} from "@/lib/metrics/collection";
+import { normalizePersonId } from "@/lib/metrics/entity";
+import {
+  usePortalSlice,
+} from "@/lib/portal/portal-nav";
+import type { TeamMember } from "@/types/insight";
+import { useCohortLabel } from "@/lib/portal/use-cohort-label";
+import { useOrgScope } from "@/lib/portal/use-org-scope";
+import { useMemberGridData } from "@/queries/member-grid";
+
+const EMPTY_COLLECTION: MetricCollectionConfig = { metrics: [] };
+
+/**
+ * Team-state dashboard — the People roster reframed for a lead: "what's the
+ * overall state, and where do I look?". Peer-cohort stats aren't computed yet,
+ * so signals are honest and self-contained:
+ *   • outlier — a member in the worse quartile *within this team*;
+ *   • decline — a member's metric materially worse than last period;
+ *   • collapse — zero on an activity the team otherwise shows.
+ * The AI summary is rule-based for now (a real insights endpoint would slot in).
+ * The roster is the active org scope (topbar) — the view owns no scoping of its
+ * own.
+ */
+export function TeamStateView() {
+  const { period, dateRange } = usePortalPeriod();
+
+  const orgScope = useOrgScope();
+  const { pivot, roster } = orgScope;
+
+  // The roster IS the member list: identity owns who is on the team and
+  // every metric for them comes from `/v1/metric-results`. There is no second
+  // source to reconcile — the legacy per-member batch this used to call was
+  // removed upstream with the rest of the old metric UI.
+  const members = useMemo<TeamMember[]>(
+    () =>
+      (roster ?? []).map((entry) => ({
+        person_id: entry.person_id,
+        name: entry.display_name,
+      })),
+    [roster],
+  );
+  const memberIds = useMemo(
+    () => members.map((m) => normalizePersonId(m.person_id)),
+    [members],
+  );
+  const nameByEntity = useMemo(
+    () => new Map(members.map((m) => [normalizePersonId(m.person_id), m.name])),
+    [members],
+  );
+  const personIdByEntity = useMemo(
+    () => new Map(members.map((m) => [normalizePersonId(m.person_id), m.person_id])),
+    [members],
+  );
+
+  // Active slice → each person's peer cohort (whole roster when no slice set).
+  const attrByEntity = useMemo(
+    () => collectRosterAttrs(pivot, normalizePersonId),
+    [pivot],
+  );
+  const slice = usePortalSlice();
+  const cohortOf = useMemo(
+    () => (id: string) => cohortKey(attrByEntity.get(id), slice),
+    [attrByEntity, slice],
+  );
+  const cohortLabel = useCohortLabel();
+
+  // Headline metrics only (card.preview): the set a lead scans, and — crucially —
+  // small enough to stay under the API's 50-metrics-per-request cap when the full
+  // metric catalog across every group would blow past it. `GROUPS` is
+  // called INSIDE the memo — it returns a fresh array per call, and a fresh
+  // dependency would defeat the memo and re-key the grid query every render.
+  const headlineKeys = useMemo(() => headlineMetricKeys(), []);
+  const gridCollection = useMemo<MetricCollectionConfig>(() => {
+    const want = new Set(headlineKeys);
+    const byKey = new Map<string, MetricCollectionConfig["metrics"][number]>();
+    for (const g of GROUPS) {
+      for (const m of g.collection.metrics) {
+        if (want.has(m.key) && !byKey.has(m.key)) byKey.set(m.key, m);
+      }
+    }
+    return { metrics: [...byKey.values()] };
+  }, [headlineKeys]);
+
+  const grid = useMemberGridData(
+    gridCollection.metrics.length ? gridCollection : EMPTY_COLLECTION,
+    { type: "person", ids: memberIds },
+    dateRange,
+    period,
+  );
+
+  const teamName = orgScope.label;
+
+  // ── Headline: team totals (summable) / medians (everything else) ──
+  const summary = useMemo(() => {
+    return headlineKeys
+      .map((key) => grid.byKey.get(key))
+      .filter((r): r is NormalizedMetricResult => Boolean(r))
+      .map((r) => {
+        const vals = memberIds
+          .map((id) => forEntity(r, id).value)
+          .filter((v): v is number => v != null && Number.isFinite(v));
+        if (vals.length === 0) return null;
+        const isSum = r.computation === "sum";
+        const value = isSum
+          ? vals.reduce((a, b) => a + b, 0)
+          : quantile([...vals].sort((a, b) => a - b), 0.5);
+        return {
+          key: r.metric_key,
+          label: r.short_label ?? r.label,
+          text: formatMetricValue(value, r.format, r.unit),
+          kind: isSum ? "team total" : "team median",
+        };
+      })
+      .filter((x): x is NonNullable<typeof x> => x != null)
+      .slice(0, 6);
+  }, [headlineKeys, grid.byKey, memberIds]);
+
+  // ── Attention: shared within-cohort outliers + declines + collapses ──
+  const flags = useMemo(
+    () =>
+      computeAttentionFlags({
+        headlineKeys,
+        byKey: grid.byKey,
+        previousByKey: grid.previousByKey,
+        memberIds,
+        cohortOf,
+        nameOf: (id) => nameByEntity.get(id) ?? id,
+        personIdOf: (id) => personIdByEntity.get(id) ?? id,
+        cohortLabel,
+      }),
+    [
+      headlineKeys,
+      grid.byKey,
+      grid.previousByKey,
+      memberIds,
+      nameByEntity,
+      personIdByEntity,
+      cohortOf,
+      cohortLabel,
+    ],
+  );
+
+  // Columns with data for at least one member (drop all-empty ones, e.g. the
+  // un-ingested task metrics), and a within-team heat overlay for the grid.
+  const shownKeys = useMemo(
+    () =>
+      headlineKeys.filter((k) => {
+        const r = grid.byKey.get(k);
+        return (
+          !!r &&
+          memberIds.some((id) => {
+            const v = forEntity(r, id).value;
+            return v != null && Number.isFinite(v);
+          })
+        );
+      }),
+    [headlineKeys, grid.byKey, memberIds],
+  );
+  const heatByKey = useMemo(() => {
+    const m = new Map<string, NormalizedMetricResult>();
+    for (const k of shownKeys) {
+      const r = grid.byKey.get(k);
+      if (r) m.set(k, withinCohortPeer(r, memberIds, cohortOf));
+    }
+    return m;
+  }, [shownKeys, grid.byKey, memberIds, cohortOf]);
+
+  const gate = orgScopeGate({
+    viewerLoading: orgScope.isLoading,
+    viewerError: orgScope.isError,
+    membersLoading: false,
+    membersError: false,
+    memberCount: members.length,
+    gridPending: grid.isPending,
+    gridError: grid.isError,
+    emptyLabel: "No people in the current scope — pick a different scope in the topbar.",
+    onRetry: () => {
+      orgScope.refetch();
+      grid.refetch();
+    },
+  });
+  if (gate) return gate;
+
+  const flaggedPeople = new Set(flags.map((f) => f.personId)).size;
+
+  return (
+    <div className="flex flex-col gap-6 p-4 md:p-6">
+      <div>
+        <h1 className="text-xl font-semibold tracking-tight">
+          {teamName ? `${teamName}'s team` : "Team"}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {orgScope.count} people · state &amp; attention
+        </p>
+      </div>
+
+      {/* Team state at a glance */}
+      {summary.length > 0 ? (
+        <div className="grid grid-cols-[repeat(auto-fit,minmax(10rem,1fr))] gap-3">
+          {summary.map((s) => (
+            <Card key={s.key}>
+              <CardContent className="p-4">
+                <div className="text-xs font-medium text-muted-foreground">{s.label}</div>
+                <div className="mt-1 text-2xl font-semibold tabular-nums">{s.text}</div>
+                <div className="text-xs text-muted-foreground">{s.kind}</div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      ) : null}
+
+      {/* What to look at — shared with the org Overview */}
+      <AttentionList
+        flags={flags}
+        summary={attentionSummary(flags, flaggedPeople, members.length)}
+        peopleLabel={
+          flags.length > 0 ? `${flaggedPeople} of ${members.length} people` : undefined
+        }
+      />
+
+      {/* Detailed scan */}
+      <section className="flex flex-col gap-3">
+        <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
+          Members
+        </p>
+        <Card>
+          <CardContent className="p-0">
+            <MembersGrid
+              members={members.map((m) => ({
+                entityId: normalizePersonId(m.person_id),
+                displayName: m.name,
+                personId: m.person_id,
+              }))}
+              metricKeys={shownKeys}
+              byKey={heatByKey}
+              previousByKey={grid.previousByKey}
+              caption={`${teamName} — members × metrics`}
+              cohortLabel={cohortLabel}
+            />
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  );
+}

--- a/src/frontend/src/components/portal/zone-content.tsx
+++ b/src/frontend/src/components/portal/zone-content.tsx
@@ -49,11 +49,17 @@ export function ZoneContent() {
   }
 }
 
+const PENDING_BY_ZONE: Record<string, string> = {
+  scorecard: "org snapshots + unit × quarter aggregation",
+  reports: "diagnosis circuit + report builder",
+};
+
 function ZoneScaffold({ zone }: { zone: string }) {
+  // Keyed, not defaulted: an unrecognised zone from the URL used to read
+  // "pending: diagnosis circuit + report builder", which names work that has
+  // nothing to do with it.
   const pending =
-    zone === "scorecard"
-      ? "org snapshots + unit × quarter aggregation"
-      : "diagnosis circuit + report builder";
+    PENDING_BY_ZONE[zone] ?? "this lens";
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8">
       <div className="flex flex-col items-center gap-1 text-center">

--- a/src/frontend/src/components/portal/zone-content.tsx
+++ b/src/frontend/src/components/portal/zone-content.tsx
@@ -1,0 +1,72 @@
+import { ComingSoon } from "@/components/widgets/coming-soon";
+import { AiCostView } from "@/components/portal/ai-cost-view";
+import { DirectionView } from "@/components/portal/direction-view";
+import { OverviewView } from "@/components/portal/overview-view";
+import { ManageView } from "@/components/portal/manage-view";
+import { PeopleView } from "@/components/portal/people-view";
+import { PersonView } from "@/components/portal/person-view";
+import { zoneById } from "@/lib/portal/nav-model";
+import {
+  usePortalDir,
+  usePortalItem,
+  usePortalLens,
+} from "@/lib/portal/portal-nav";
+import { useActiveZone } from "@/lib/portal/use-active-zone";
+
+/**
+ * Content for the non-entity portal zones. Overview rolls the org up; Directions
+ * route each lens to a focused domain view or an honest ComingSoon; Manage reads
+ * the live catalog; Scorecard / Reports are honest scaffolds.
+ *
+ * Org zones take no person prop — they read the global org scope (design §6) via
+ * `useOrgScope`, so the topbar badge and every org subtitle always agree. Only
+ * the entity lenses (Person / People) stay route-driven.
+ */
+export function ZoneContent() {
+  const { activeZone, activePerson } = useActiveZone();
+  const dir = usePortalDir();
+  const lens = usePortalLens();
+  const item = usePortalItem();
+
+  switch (activeZone) {
+    case "person":
+      return <PersonView person={activePerson} />;
+    case "overview":
+      return <OverviewView item={item} />;
+    case "directions":
+      return <DirectionView dir={dir} lens={lens} />;
+    case "aicost":
+      return <AiCostView item={item} />;
+    case "people":
+      return <PeopleView person={activePerson} item={item} />;
+    case "manage":
+      return <ManageView item={item} />;
+    case "scorecard":
+    case "reports":
+      return <ZoneScaffold zone={activeZone} />;
+    default:
+      return <ZoneScaffold zone={activeZone} />;
+  }
+}
+
+function ZoneScaffold({ zone }: { zone: string }) {
+  const pending =
+    zone === "scorecard"
+      ? "org snapshots + unit × quarter aggregation"
+      : "diagnosis circuit + report builder";
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8">
+      <div className="flex flex-col items-center gap-1 text-center">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          {zoneById(zone)?.label ?? "Portal"}
+        </h1>
+        <p className="max-w-md text-sm text-muted-foreground">
+          Portal lens — structure in place, wiring pending.
+        </p>
+      </div>
+      <div className="w-full max-w-md">
+        <ComingSoon variant="card" state="empty" label={`Pending: ${pending}`} />
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/components/sidebar-settings.tsx
+++ b/src/frontend/src/components/sidebar-settings.tsx
@@ -1,4 +1,4 @@
-import { HelpCircle } from "lucide-react";
+import { HelpCircle, PanelsTopLeft, Wrench } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -10,6 +10,12 @@ import { Switch } from "@/components/ui/switch";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { useSettings } from "@/hooks/use-settings";
 import type { FocusMode } from "@/lib/peers";
+import {
+  setPortalEnabled,
+  setPortalShowPlanned,
+  usePortalEnabled,
+  usePortalShowPlanned,
+} from "@/lib/portal/portal-store";
 
 const FOCUS_MODES: ReadonlyArray<FocusMode> = [
   "critical",
@@ -20,11 +26,53 @@ const FOCUS_MODES: ReadonlyArray<FocusMode> = [
 
 export function SidebarSettings() {
   const { t } = useTranslation();
+  const portal = usePortalEnabled();
+  const showPlanned = usePortalShowPlanned();
   const { focusMode, showExplanations, setFocusMode, setShowExplanations } =
     useSettings();
 
   return (
     <SidebarMenu>
+      <SidebarMenuItem>
+        <SidebarMenuButton
+          onClick={() => setPortalEnabled(!portal)}
+          aria-pressed={portal}
+          className="justify-between"
+        >
+          <span className="flex items-center gap-2">
+            <PanelsTopLeft className="size-4" />
+            <span>Portal (preview)</span>
+          </span>
+          <Switch
+            checked={portal}
+            onCheckedChange={setPortalEnabled}
+            size="sm"
+            tabIndex={-1}
+          />
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+      {/* Only meaningful inside the portal, so it hides with it. Shows the
+          zones and views we have scaffolded but not built. */}
+      {portal ? (
+        <SidebarMenuItem>
+          <SidebarMenuButton
+            onClick={() => setPortalShowPlanned(!showPlanned)}
+            aria-pressed={showPlanned}
+            className="justify-between"
+          >
+            <span className="flex items-center gap-2">
+              <Wrench className="size-4" />
+              <span>Show planned sections</span>
+            </span>
+            <Switch
+              checked={showPlanned}
+              onCheckedChange={setPortalShowPlanned}
+              size="sm"
+              tabIndex={-1}
+            />
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      ) : null}
       <SidebarMenuItem className="flex flex-col items-stretch gap-1.5 p-1">
         <span className="px-1 text-[10px] font-medium uppercase tracking-wider text-sidebar-foreground/60">
           {t("settings.focus_mode.label")}

--- a/src/frontend/src/components/ui/chart-line-defaults.test.tsx
+++ b/src/frontend/src/components/ui/chart-line-defaults.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+/**
+ * The central line defaults every chart inherits: straight segments between
+ * real readings (no invented curve), dots while they are readable, and an
+ * always-visible dot for a lone value that would otherwise draw no line.
+ */
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  ChartContainer,
+  ChartLine,
+  DOT_DENSITY_LIMIT,
+  LineChart,
+  YAxis,
+  type ChartConfig,
+} from "./chart";
+
+const CONFIG: ChartConfig = { v: { label: "V", color: "#f00" } };
+
+function renderSeries(data: Array<{ d: string; v: number | null }>) {
+  return render(
+    <ChartContainer config={CONFIG} className="h-40 w-96">
+      <LineChart data={data} width={384} height={160}>
+        <ChartLine dataKey="v" stroke="#f00" />
+      </LineChart>
+    </ChartContainer>,
+  );
+}
+
+const series = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({ d: `2026-07-${i + 1}`, v: i + 1 }));
+
+describe("ChartLine defaults", () => {
+  it("draws a dot per reading on a short series", () => {
+    const { container } = renderSeries(series(7));
+    expect(container.querySelectorAll("circle")).toHaveLength(7);
+  });
+
+  it("drops per-point dots once the series gets dense", () => {
+    const { container } = renderSeries(series(DOT_DENSITY_LIMIT + 10));
+    expect(container.querySelectorAll("circle")).toHaveLength(0);
+  });
+
+  it("keeps the boundary readable — exactly at the limit dots still show", () => {
+    const { container } = renderSeries(series(DOT_DENSITY_LIMIT));
+    expect(container.querySelectorAll("circle")).toHaveLength(DOT_DENSITY_LIMIT);
+  });
+
+  it("always marks a lone reading between gaps, however dense the series", () => {
+    // One value surrounded by nulls draws no line segment at all: without a dot
+    // the chart would look empty rather than "one measurement".
+    const data = Array.from({ length: DOT_DENSITY_LIMIT + 20 }, (_, i) => ({
+      d: `d${i}`,
+      v: i === 15 ? 42 : null,
+    }));
+    const { container } = renderSeries(data);
+    expect(container.querySelectorAll("circle")).toHaveLength(1);
+  });
+
+  it("renders no dot for a null value", () => {
+    const { container } = renderSeries([
+      { d: "a", v: 1 },
+      { d: "b", v: null },
+      { d: "c", v: 3 },
+    ]);
+    // a and c are dotted; b contributes nothing.
+    expect(container.querySelectorAll("circle")).toHaveLength(2);
+  });
+
+  it("joins readings with straight segments, not an interpolated curve", () => {
+    const { container } = renderSeries(series(4));
+    const path = container.querySelector("path.recharts-line-curve");
+    // A monotone curve emits cubic commands ("C"); linear segments only "L".
+    expect(path?.getAttribute("d")).not.toMatch(/C/);
+    expect(path?.getAttribute("d")).toMatch(/L/);
+  });
+
+  it("lets a caller override the curve for step-like counters", () => {
+    const { container } = render(
+      <ChartContainer config={CONFIG} className="h-40 w-96">
+        <LineChart data={series(4)} width={384} height={160}>
+          <ChartLine dataKey="v" stroke="#f00" type="stepAfter" />
+        </LineChart>
+      </ChartContainer>,
+    );
+    const d = container.querySelector("path.recharts-line-curve")?.getAttribute("d");
+    // stepAfter holds a value then jumps: horizontal then vertical segments.
+    expect(d).toMatch(/L/);
+    expect(d).not.toMatch(/C/);
+  });
+});
+
+describe("YAxis defaults", () => {
+  const renderAxis = (domainMax: number) =>
+    render(
+      <ChartContainer config={CONFIG} className="h-40 w-96">
+        <LineChart
+          data={[
+            { d: "a", v: 0 },
+            { d: "b", v: domainMax },
+          ]}
+          width={384}
+          height={160}
+        >
+          <YAxis />
+          <ChartLine dataKey="v" stroke="#f00" />
+        </LineChart>
+      </ChartContainer>,
+    );
+
+  const ticks = (c: HTMLElement) =>
+    [...c.querySelectorAll(".recharts-cartesian-axis-tick-value")].map(
+      (t) => t.textContent ?? "",
+    );
+
+  it("abbreviates large ticks so they fit the axis gutter", () => {
+    const { container } = renderAxis(40_000);
+    // Whatever ticks recharts picks, none of them is a raw five-digit number.
+    expect(ticks(container).some((t) => t.endsWith("k"))).toBe(true);
+    expect(ticks(container).every((t) => !/^\d{5}/.test(t))).toBe(true);
+  });
+
+  it("leaves small ticks literal", () => {
+    const { container } = renderAxis(300);
+    expect(ticks(container).every((t) => !t.includes("k"))).toBe(true);
+  });
+
+  it("lets a caller keep raw numbers", () => {
+    const { container } = render(
+      <ChartContainer config={CONFIG} className="h-40 w-96">
+        <LineChart data={[{ d: "a", v: 0 }, { d: "b", v: 40_000 }]} width={384} height={160}>
+          <YAxis tickFormatter={(v: number) => String(v)} />
+          <ChartLine dataKey="v" stroke="#f00" />
+        </LineChart>
+      </ChartContainer>,
+    );
+    expect(ticks(container).some((t) => /^\d{5}$/.test(t))).toBe(true);
+  });
+});

--- a/src/frontend/src/components/ui/chart.tsx
+++ b/src/frontend/src/components/ui/chart.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import * as RechartsPrimitive from "recharts";
 import type { TooltipValueType } from "recharts";
 
+import { formatAxisTick } from "@/lib/format";
 import { cn } from "@/lib/utils";
 
 // Format: { THEME_NAME: CSS_SELECTOR }
@@ -118,7 +119,23 @@ const LineChart = RechartsPrimitive.LineChart;
 const ComposedChart = RechartsPrimitive.ComposedChart;
 const CartesianGrid = RechartsPrimitive.CartesianGrid;
 const XAxis = RechartsPrimitive.XAxis;
-const YAxis = RechartsPrimitive.YAxis;
+
+/**
+ * Value axis with abbreviated ticks by default (36000 → "36k"). A raw five-digit
+ * label needs more room than the ~28px gutter charts give the axis, so it was
+ * being clipped by the chart's own edge on a narrow screen — and any series can
+ * cross that threshold as the org grows. Callers that need literal numbers can
+ * still pass their own `tickFormatter`.
+ *
+ * Category axes are left alone: a non-numeric tick passes through untouched.
+ */
+function YAxis({
+  tickFormatter = (value: unknown) =>
+    typeof value === "number" ? formatAxisTick(value) : String(value),
+  ...props
+}: React.ComponentProps<typeof RechartsPrimitive.YAxis>) {
+  return <RechartsPrimitive.YAxis tickFormatter={tickFormatter} {...props} />;
+}
 const ReferenceArea = RechartsPrimitive.ReferenceArea;
 const ReferenceLine = RechartsPrimitive.ReferenceLine;
 const ResponsiveContainer = RechartsPrimitive.ResponsiveContainer;
@@ -133,21 +150,70 @@ function ChartBar({
   );
 }
 
+/**
+ * Above this many buckets per-point dots stop being readable and turn the line
+ * into noise, so they collapse to hover-only (`activeDot`).
+ */
+export const DOT_DENSITY_LIMIT = 31;
+
+/**
+ * The shared dot rule for every line/area in the app.
+ *
+ * Two jobs: mark the actual measurements while there are few enough of them to
+ * see, and ALWAYS mark a value whose neighbours are null — a lone reading in a
+ * gappy series draws no line segment at all, so without a dot the series looks
+ * like it has no data rather than one data point.
+ */
+function AdaptiveDot({
+  cx,
+  cy,
+  index,
+  points,
+  stroke,
+  value,
+}: RechartsPrimitive.DotItemDotProps) {
+  if (value == null || cx == null || cy == null) return null;
+  const isolated =
+    points[index - 1]?.value == null && points[index + 1]?.value == null;
+  if (!isolated && points.length > DOT_DENSITY_LIMIT) return null;
+  return <circle cx={cx} cy={cy} r={isolated ? 3 : 2.5} fill={stroke} />;
+}
+
+/**
+ * `type="linear"` on purpose: a monotone curve interpolates between buckets,
+ * inventing a shape for days we never measured. Straight segments say "these
+ * are the readings, joined" — and for step-like counters a caller can still
+ * pass `type="stepAfter"`.
+ */
 function ChartLine({
   isAnimationActive = false,
+  type = "linear",
+  dot = AdaptiveDot,
+  activeDot = { r: 4 },
   ...props
 }: React.ComponentProps<typeof RechartsPrimitive.Line>) {
   return (
-    <RechartsPrimitive.Line isAnimationActive={isAnimationActive} {...props} />
+    <RechartsPrimitive.Line
+      isAnimationActive={isAnimationActive}
+      type={type}
+      dot={dot}
+      activeDot={activeDot}
+      {...props}
+    />
   );
 }
 
 function ChartArea({
   isAnimationActive = false,
+  type = "linear",
   ...props
 }: React.ComponentProps<typeof RechartsPrimitive.Area>) {
   return (
-    <RechartsPrimitive.Area isAnimationActive={isAnimationActive} {...props} />
+    <RechartsPrimitive.Area
+      isAnimationActive={isAnimationActive}
+      type={type}
+      {...props}
+    />
   );
 }
 

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-chart.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-chart.tsx
@@ -1,5 +1,4 @@
 import { format } from "date-fns";
-import type { DotItemDotProps } from "recharts";
 
 import {
   BarChart,
@@ -41,21 +40,6 @@ function dateLabel(value: string, pattern: string): string {
   const [year, month, day] = value.split("-").map(Number);
   if (!year || !month || !day) return value;
   return format(new Date(year, month - 1, day), pattern);
-}
-
-function IsolatedPoint({
-  cx,
-  cy,
-  index,
-  points,
-  stroke,
-  value,
-}: DotItemDotProps) {
-  if (value == null || cx == null || cy == null) return null;
-  if (points[index - 1]?.value != null || points[index + 1]?.value != null) {
-    return null;
-  }
-  return <circle cx={cx} cy={cy} r={3} fill={stroke} />;
 }
 
 function TimeseriesXAxis({
@@ -225,11 +209,14 @@ export function MetricTimeseriesChart({
             {chartModel.series.map((series) => (
               <ChartLine
                 key={series.key}
-                type="monotone"
                 dataKey={series.key}
                 stroke={`var(--color-${series.key})`}
                 strokeWidth={2}
-                dot={IsolatedPoint}
+                // No local `dot`: ChartLine's AdaptiveDot generalises what the
+                // local IsolatedPoint did (always mark a reading whose
+                // neighbours are null) across every chart. `connectNulls` is a
+                // separate concern and stays — a gap must read as a gap, not as
+                // a straight line drawn across it.
                 connectNulls={false}
                 name={series.label}
                 onClick={(point) => openPoint(series, point)}

--- a/src/frontend/src/components/widgets/period-selector-bar.tsx
+++ b/src/frontend/src/components/widgets/period-selector-bar.tsx
@@ -125,7 +125,9 @@ export function PeriodSelectorBar({
             render={
               <ToggleGroupItem value="custom" className="gap-1.5">
                 <CalendarIcon className="size-3.5" />
-                <span>{activeRangeLabel}</span>
+                {/* The range spells out to ~140px; below `sm` the calendar icon
+                    stands in for it and the popover shows the actual dates. */}
+                <span className="hidden sm:inline">{activeRangeLabel}</span>
                 <TooltipProvider delay={200}>
                   <Tooltip>
                     <TooltipTrigger

--- a/src/frontend/src/components/widgets/period-selector-bar.tsx
+++ b/src/frontend/src/components/widgets/period-selector-bar.tsx
@@ -123,7 +123,13 @@ export function PeriodSelectorBar({
         <Popover open={calOpen} onOpenChange={handleOpenChange}>
           <PopoverTrigger
             render={
-              <ToggleGroupItem value="custom" className="gap-1.5">
+              <ToggleGroupItem
+                value="custom"
+                className="gap-1.5"
+                // Below `sm` the label is hidden and only the icon remains, so
+                // without this the control has no accessible name at all.
+                aria-label={`Custom date range: ${activeRangeLabel}`}
+              >
                 <CalendarIcon className="size-3.5" />
                 {/* The range spells out to ~140px; below `sm` the calendar icon
                     stands in for it and the popover shows the actual dates. */}

--- a/src/frontend/src/hooks/use-period.ts
+++ b/src/frontend/src/hooks/use-period.ts
@@ -100,6 +100,19 @@ function getSnapshot(): PersistedState {
   return state;
 }
 
+/** The remembered default for a URL that names no period (see usePortalPeriod). */
+export function readPeriodPreference(): PeriodValue {
+  return readPeriod();
+}
+
+export function writePeriodPreference(period: PeriodValue): void {
+  try {
+    window.localStorage.setItem(PERIOD_KEY, period);
+  } catch {
+    // localStorage may be unavailable (private mode, quota exceeded).
+  }
+}
+
 export function usePeriod(): {
   period: PeriodValue;
   customRange: CustomRange | null;

--- a/src/frontend/src/hooks/use-period.ts
+++ b/src/frontend/src/hooks/use-period.ts
@@ -100,17 +100,24 @@ function getSnapshot(): PersistedState {
   return state;
 }
 
-/** The remembered default for a URL that names no period (see usePortalPeriod). */
-export function readPeriodPreference(): PeriodValue {
-  return readPeriod();
+/**
+ * The remembered default for a URL that names no period (see usePortalPeriod),
+ * SUBSCRIBED rather than read during render: reading localStorage in a render
+ * body is an impure read of a mutable external store, and under concurrent
+ * rendering two components in the same pass can disagree after a write. The
+ * store below already has the primitive, so use it.
+ */
+export function usePeriodPreference(): PeriodValue {
+  return useSyncExternalStore(
+    subscribe,
+    () => state.period,
+    () => state.period,
+  );
 }
 
+/** Persist the default AND notify, so every reader sees the same value at once. */
 export function writePeriodPreference(period: PeriodValue): void {
-  try {
-    window.localStorage.setItem(PERIOD_KEY, period);
-  } catch {
-    // localStorage may be unavailable (private mode, quota exceeded).
-  }
+  setState({ period });
 }
 
 export function usePeriod(): {

--- a/src/frontend/src/hooks/use-portal-period.test.tsx
+++ b/src/frontend/src/hooks/use-portal-period.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+/**
+ * The period lives in the URL like the rest of the portal's navigation state,
+ * with one exception: the LAST preset a reader picked is remembered, so a link
+ * that names no period opens on their habit rather than on a hardcoded week.
+ * A custom range that is not a range at all must degrade, not throw.
+ */
+vi.mock("@tanstack/react-router", async () => {
+  const { portalRouterMock } = await import("@/test/portal-router");
+  return portalRouterMock();
+});
+
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { portalRouter } from "@/test/portal-router";
+
+import { usePortalPeriod } from "./use-portal-period";
+
+beforeEach(() => {
+  act(() => portalRouter.reset());
+  window.localStorage.clear();
+});
+
+describe("usePortalPeriod", () => {
+  it("puts a chosen preset in the URL and clears any custom range", () => {
+    const { result } = renderHook(() => usePortalPeriod());
+    act(() => result.current.setPeriod("month"));
+    expect(portalRouter.search.period).toBe("month");
+    expect(portalRouter.search.from).toBeUndefined();
+    expect(portalRouter.search.to).toBeUndefined();
+  });
+
+  it("writes a valid custom range to the URL", () => {
+    const { result } = renderHook(() => usePortalPeriod());
+    act(() => result.current.setCustomRange({ from: "2026-07-01", to: "2026-07-15" }));
+    expect(portalRouter.search.from).toBe("2026-07-01");
+    expect(portalRouter.search.to).toBe("2026-07-15");
+  });
+
+  it("drops an inverted range instead of throwing out of the handler", () => {
+    // This runs in an event handler, where no error boundary is watching: a
+    // throw here takes the screen down. The picker keeps its own message.
+    const { result } = renderHook(() => usePortalPeriod());
+    expect(() =>
+      act(() => result.current.setCustomRange({ from: "2026-07-30", to: "2026-01-01" })),
+    ).not.toThrow();
+    expect(portalRouter.search.from).toBeUndefined();
+    expect(portalRouter.search.to).toBeUndefined();
+  });
+});

--- a/src/frontend/src/hooks/use-portal-period.test.tsx
+++ b/src/frontend/src/hooks/use-portal-period.test.tsx
@@ -16,11 +16,18 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { portalRouter } from "@/test/portal-router";
 
+import { writePeriodPreference } from "./use-period";
 import { usePortalPeriod } from "./use-portal-period";
 
 beforeEach(() => {
-  act(() => portalRouter.reset());
   window.localStorage.clear();
+  act(() => {
+    portalRouter.reset();
+    // The preference is an in-memory store as well as a storage key, so
+    // clearing localStorage alone leaves the previous test's choice behind and
+    // the next test inherits it as the default for a URL naming no period.
+    writePeriodPreference("week");
+  });
 });
 
 describe("usePortalPeriod", () => {

--- a/src/frontend/src/hooks/use-portal-period.ts
+++ b/src/frontend/src/hooks/use-portal-period.ts
@@ -1,0 +1,51 @@
+import {
+  resolveDateRange,
+  validateDateRange,
+  type DateRange,
+} from "@/api/period-to-date-range";
+import { usePortalSearch, useSetPortalSearch } from "@/lib/portal/portal-search";
+import { readPeriodPreference, writePeriodPreference } from "@/hooks/use-period";
+import type { CustomRange, PeriodValue } from "@/types/insight";
+
+/**
+ * The period, read from the URL.
+ *
+ * A link has to reproduce the whole picture, and the period is half of any
+ * number on screen — "63 commits" means nothing without the window it covers.
+ * So `?period=` (plus `?from=`/`?to=` for a custom range) is the truth, and
+ * localStorage keeps only the DEFAULT for a URL that names none: a reader's
+ * habitual window survives between sessions without leaking into a link they
+ * send someone else.
+ */
+export function usePortalPeriod(): {
+  period: PeriodValue;
+  customRange: CustomRange | null;
+  dateRange: DateRange;
+  setPeriod: (period: PeriodValue) => void;
+  setCustomRange: (range: CustomRange | null) => void;
+} {
+  const search = usePortalSearch();
+  const setSearch = useSetPortalSearch();
+
+  const period = search.period ?? readPeriodPreference();
+  const customRange =
+    search.from && search.to ? { from: search.from, to: search.to } : null;
+
+  return {
+    period,
+    customRange,
+    dateRange: resolveDateRange(period, customRange),
+    setPeriod: (next) => {
+      // Remember the choice as the default for a link that names no period,
+      // then put it in the URL where it belongs.
+      writePeriodPreference(next);
+      setSearch({ period: next, from: undefined, to: undefined });
+    },
+    setCustomRange: (range) => {
+      if (range && !validateDateRange(range).valid) {
+        throw new Error(`Invalid date range: from=${range.from} to=${range.to}`);
+      }
+      setSearch({ from: range?.from, to: range?.to });
+    },
+  };
+}

--- a/src/frontend/src/hooks/use-portal-period.ts
+++ b/src/frontend/src/hooks/use-portal-period.ts
@@ -42,9 +42,11 @@ export function usePortalPeriod(): {
       setSearch({ period: next, from: undefined, to: undefined });
     },
     setCustomRange: (range) => {
-      if (range && !validateDateRange(range).valid) {
-        throw new Error(`Invalid date range: from=${range.from} to=${range.to}`);
-      }
+      // Drop an invalid range instead of throwing: this runs in an event
+      // handler, where no error boundary is watching, and the same policy the
+      // URL validator follows (degrade to the preset) has to hold here too.
+      // The picker does its own validation and keeps its own message.
+      if (range && !validateDateRange(range).valid) return;
       setSearch({ from: range?.from, to: range?.to });
     },
   };

--- a/src/frontend/src/hooks/use-portal-period.ts
+++ b/src/frontend/src/hooks/use-portal-period.ts
@@ -1,10 +1,12 @@
+import { useCallback, useMemo } from "react";
+
 import {
   resolveDateRange,
   validateDateRange,
   type DateRange,
 } from "@/api/period-to-date-range";
 import { usePortalSearch, useSetPortalSearch } from "@/lib/portal/portal-search";
-import { readPeriodPreference, writePeriodPreference } from "@/hooks/use-period";
+import { usePeriodPreference, writePeriodPreference } from "@/hooks/use-period";
 import type { CustomRange, PeriodValue } from "@/types/insight";
 
 /**
@@ -26,22 +28,31 @@ export function usePortalPeriod(): {
 } {
   const search = usePortalSearch();
   const setSearch = useSetPortalSearch();
+  const preference = usePeriodPreference();
 
-  const period = search.period ?? readPeriodPreference();
-  const customRange =
-    search.from && search.to ? { from: search.from, to: search.to } : null;
+  const period = search.period ?? preference;
+  // Memoised: these land in the dependency arrays of every metric query, so a
+  // fresh object per render re-keys the queries on an unrelated re-render.
+  const customRange = useMemo(
+    () => (search.from && search.to ? { from: search.from, to: search.to } : null),
+    [search.from, search.to],
+  );
+  const dateRange = useMemo(
+    () => resolveDateRange(period, customRange),
+    [period, customRange],
+  );
 
-  return {
-    period,
-    customRange,
-    dateRange: resolveDateRange(period, customRange),
-    setPeriod: (next) => {
+  const setPeriod = useCallback(
+    (next: PeriodValue) => {
       // Remember the choice as the default for a link that names no period,
       // then put it in the URL where it belongs.
       writePeriodPreference(next);
       setSearch({ period: next, from: undefined, to: undefined });
     },
-    setCustomRange: (range) => {
+    [setSearch],
+  );
+  const setCustomRange = useCallback(
+    (range: CustomRange | null) => {
       // Drop an invalid range instead of throwing: this runs in an event
       // handler, where no error boundary is watching, and the same policy the
       // URL validator follows (degrade to the preset) has to hold here too.
@@ -49,5 +60,11 @@ export function usePortalPeriod(): {
       if (range && !validateDateRange(range).valid) return;
       setSearch({ from: range?.from, to: range?.to });
     },
-  };
+    [setSearch],
+  );
+
+  return useMemo(
+    () => ({ period, customRange, dateRange, setPeriod, setCustomRange }),
+    [period, customRange, dateRange, setPeriod, setCustomRange],
+  );
 }

--- a/src/frontend/src/lib/format.axis.test.ts
+++ b/src/frontend/src/lib/format.axis.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { formatAxisTick } from "./format";
+
+/**
+ * Tick labels have two jobs that pull against each other: fit the ~28px axis
+ * gutter, and not lie about where the gridline sits.
+ */
+describe("formatAxisTick", () => {
+  it("keeps four digits literal — they fit, and they are exact", () => {
+    // A tick at 2250 labelled "2.3k" would misplace the gridline it sits on.
+    expect(formatAxisTick(2250)).toBe("2250");
+    expect(formatAxisTick(9000)).toBe("9000");
+    expect(formatAxisTick(750)).toBe("750");
+    expect(formatAxisTick(0)).toBe("0");
+  });
+
+  it("abbreviates from five digits, where the literal no longer fits", () => {
+    expect(formatAxisTick(10_000)).toBe("10k");
+    expect(formatAxisTick(36_000)).toBe("36k");
+    expect(formatAxisTick(102_806)).toBe("103k");
+  });
+
+  it("switches to millions before k labels grow long again", () => {
+    expect(formatAxisTick(1_000_000)).toBe("1M");
+    expect(formatAxisTick(2_400_000)).toBe("2.4M");
+  });
+
+  it("survives negatives (deltas, net change axes)", () => {
+    expect(formatAxisTick(-2250)).toBe("-2250");
+    expect(formatAxisTick(-36_000)).toBe("-36k");
+  });
+
+  it("does not print a trailing .0", () => {
+    expect(formatAxisTick(1500)).toBe("1500");
+    expect(formatAxisTick(3)).toBe("3");
+    expect(formatAxisTick(2.5)).toBe("2.5");
+  });
+
+  it("stays inside the gutter: no label longer than four characters", () => {
+    for (const v of [0, 7.5, 750, 2250, 9000, 10_000, 36_000, 999_000, 2_400_000]) {
+      expect(formatAxisTick(v).length, `${v}`).toBeLessThanOrEqual(4);
+    }
+  });
+});

--- a/src/frontend/src/lib/format.ts
+++ b/src/frontend/src/lib/format.ts
@@ -81,3 +81,24 @@ export function formatDate(iso: string, pattern = "d MMM"): string {
   return format(parseISO(iso), pattern, { locale: enUS });
 }
 
+/** "1.0k" reads worse than "1k" on an axis. */
+function trimTrailingZero(s: string): string {
+  return s.endsWith(".0") ? s.slice(0, -2) : s;
+}
+
+/**
+ * Axis tick labels. Kept short on purpose: an axis gutter is ~28px, while
+ * "36000" at the 10px tick font needs 31px and gets clipped by the chart's own
+ * edge. Abbreviating makes the width independent of the magnitude, so a series
+ * that grows an order of magnitude does not silently start truncating.
+ *
+ * The 10k threshold is where abbreviation stops costing accuracy: a tick sits on
+ * a gridline, so "2.3k" for a line drawn at 2250 is a label that lies. Four
+ * digits still fit; five do not.
+ */
+export function formatAxisTick(v: number): string {
+  const abs = Math.abs(v);
+  if (abs >= 1_000_000) return `${trimTrailingZero((v / 1_000_000).toFixed(1))}M`;
+  if (abs >= 10_000) return `${Math.round(v / 1000)}k`;
+  return trimTrailingZero((Math.round(v * 10) / 10).toFixed(1));
+}

--- a/src/frontend/src/lib/format.ts
+++ b/src/frontend/src/lib/format.ts
@@ -99,6 +99,12 @@ function trimTrailingZero(s: string): string {
 export function formatAxisTick(v: number): string {
   const abs = Math.abs(v);
   if (abs >= 1_000_000) return `${trimTrailingZero((v / 1_000_000).toFixed(1))}M`;
-  if (abs >= 10_000) return `${Math.round(v / 1000)}k`;
+  if (abs >= 10_000) {
+    const k = Math.round(v / 1000);
+    // 999_600 rounds to 1000k — a tick that names a magnitude the scale below
+    // it already covers. Roll it over rather than print a fourth digit.
+    if (Math.abs(k) >= 1000) return `${trimTrailingZero((k / 1000).toFixed(1))}M`;
+    return `${k}k`;
+  }
   return trimTrailingZero((Math.round(v * 10) / 10).toFixed(1));
 }

--- a/src/frontend/src/lib/insight/attention-flags.test.ts
+++ b/src/frontend/src/lib/insight/attention-flags.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from "vitest";
+
+import type { NormalizedMetricResult } from "@/lib/metrics/collection";
+import {
+  attentionSummary,
+  computeAttentionFlags,
+  type FlagParams,
+} from "./attention-flags";
+
+function fixture(
+  period: Array<[string, number | null]>,
+  opts?: Partial<Pick<NormalizedMetricResult, "direction" | "label" | "format">>,
+): NormalizedMetricResult {
+  return {
+    metric_key: "t.metric",
+    label: opts?.label ?? "Commits",
+    unit: null,
+    computation: "sum",
+    format: opts?.format ?? "integer",
+    direction: opts?.direction ?? "higher_is_better",
+    period: {
+      view: "period",
+      values: period.map(([entity_id, value]) => ({ entity_id, value })),
+    },
+  } as unknown as NormalizedMetricResult;
+}
+
+/** 7 well-behaved members around 10, plus one member under test. */
+const BASE: Array<[string, number]> = [
+  ["m1", 9], ["m2", 10], ["m3", 10], ["m4", 11], ["m5", 10], ["m6", 9], ["m7", 11],
+];
+const IDS = [...BASE.map(([id]) => id), "x"];
+
+function params(over: Partial<FlagParams>): FlagParams {
+  return {
+    headlineKeys: ["t.metric"],
+    byKey: new Map(),
+    previousByKey: new Map(),
+    memberIds: IDS,
+    cohortOf: () => "team",
+    nameOf: (id) => `Name ${id}`,
+    personIdOf: (id) => `person-${id}`,
+    cohortLabel: "team",
+    ...over,
+  };
+}
+
+describe("computeAttentionFlags", () => {
+  it("flags a collapse when a member has zero against a positive median", () => {
+    const flags = computeAttentionFlags(
+      params({ byKey: new Map([["t.metric", fixture([...BASE, ["x", 0]])]]) }),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]).toMatchObject({
+      kind: "collapse",
+      personId: "person-x",
+      name: "Name x",
+    });
+    expect(flags[0]!.reason).toContain("no commits");
+    expect(flags[0]!.reason).toContain("team median 10");
+  });
+
+  it("flags a low outlier below the Tukey fence on a higher-is-better metric", () => {
+    const flags = computeAttentionFlags(
+      params({ byKey: new Map([["t.metric", fixture([...BASE, ["x", 2]])]]) }),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.kind).toBe("outlier");
+    expect(flags[0]!.reason).toContain("unusually low");
+  });
+
+  it("flags a HIGH outlier when lower is better (e.g. meeting hours)", () => {
+    const flags = computeAttentionFlags(
+      params({
+        byKey: new Map([
+          ["t.metric", fixture([...BASE, ["x", 40]], { direction: "lower_is_better" })],
+        ]),
+      }),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.kind).toBe("outlier");
+    expect(flags[0]!.reason).toContain("unusually high");
+  });
+
+  it("does not flag anyone in a tight, healthy cohort", () => {
+    const flags = computeAttentionFlags(
+      params({ byKey: new Map([["t.metric", fixture([...BASE, ["x", 10]])]]) }),
+    );
+    expect(flags).toEqual([]);
+  });
+
+  it("skips neutral-direction metrics entirely", () => {
+    const flags = computeAttentionFlags(
+      params({
+        byKey: new Map([
+          ["t.metric", fixture([...BASE, ["x", 0]], { direction: "neutral" })],
+        ]),
+      }),
+    );
+    expect(flags).toEqual([]);
+  });
+
+  it("stays silent when the cohort is too small to judge", () => {
+    const flags = computeAttentionFlags(
+      params({
+        byKey: new Map([["t.metric", fixture([["m1", 10], ["m2", 10], ["x", 0]])]]),
+        memberIds: ["m1", "m2", "x"],
+      }),
+    );
+    expect(flags).toEqual([]);
+  });
+
+  it("flags an adverse period-over-period decline", () => {
+    const flags = computeAttentionFlags(
+      params({
+        byKey: new Map([["t.metric", fixture([...BASE, ["x", 8]])]]),
+        previousByKey: new Map([["t.metric", fixture([...BASE, ["x", 16]])]]),
+      }),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.kind).toBe("decline");
+    expect(flags[0]!.reason).toBe("down 50% vs last period");
+  });
+
+  it("treats an INCREASE as adverse when lower is better", () => {
+    // x=12 stays inside the Tukey fence (so the outlier branch, which is
+    // checked first and wins, stays quiet) but is +50% vs last period.
+    const flags = computeAttentionFlags(
+      params({
+        byKey: new Map([
+          ["t.metric", fixture([...BASE, ["x", 12]], { direction: "lower_is_better" })],
+        ]),
+        previousByKey: new Map([
+          ["t.metric", fixture([...BASE, ["x", 8]], { direction: "lower_is_better" })],
+        ]),
+      }),
+    );
+    expect(flags).toHaveLength(1);
+    expect(flags[0]!.kind).toBe("decline");
+    expect(flags[0]!.reason).toBe("up 50% vs last period");
+  });
+
+  it("judges members within their own cohort, not the whole roster", () => {
+    // Cohort A hovers at 10; cohort B at 1000. x belongs to B with 900 —
+    // fine within B, catastrophic vs the global median. Must NOT flag.
+    const period: Array<[string, number]> = [
+      ["a1", 9], ["a2", 10], ["a3", 11], ["a4", 10],
+      ["b1", 990], ["b2", 1000], ["b3", 1010], ["b4", 1000], ["x", 995],
+    ];
+    const flags = computeAttentionFlags(
+      params({
+        byKey: new Map([["t.metric", fixture(period)]]),
+        memberIds: period.map(([id]) => id),
+        cohortOf: (id) => (id.startsWith("a") ? "A" : "B"),
+      }),
+    );
+    expect(flags).toEqual([]);
+  });
+
+  it("keeps only the strongest flag per person+metric and ranks by severity", () => {
+    // x collapses (0 vs median) AND declined vs last period — collapse wins.
+    const flags = computeAttentionFlags(
+      params({
+        byKey: new Map([["t.metric", fixture([...BASE, ["x", 0], ["y", 2]])]]),
+        previousByKey: new Map([["t.metric", fixture([...BASE, ["x", 10], ["y", 2]])]]),
+        memberIds: [...IDS, "y"],
+      }),
+    );
+    const x = flags.filter((f) => f.personId === "person-x");
+    expect(x).toHaveLength(1);
+    expect(x[0]!.kind).toBe("collapse");
+    // collapse severity (1 + relGap) outranks y's outlier severity (relGap)
+    expect(flags[0]!.personId).toBe("person-x");
+  });
+});
+
+describe("attentionSummary", () => {
+  it("reports steady when there are no flags", () => {
+    expect(attentionSummary([], 0, 12)).toBe(
+      "All 12 people are within their usual range this period.",
+    );
+  });
+
+  it("names the top metric themes with counts", () => {
+    const flags = computeAttentionFlags(
+      params({ byKey: new Map([["t.metric", fixture([...BASE, ["x", 0]])]]) }),
+    );
+    expect(attentionSummary(flags, 1, 8)).toBe(
+      "1 of 8 people need a look — most flags on Commits (1).",
+    );
+  });
+});
+
+describe("severity is scale-free", () => {
+  /** Flags for a single metric over `values`, every value multiplied by `factor`. */
+  function flagsFor(values: Array<[string, number]>, factor = 1, cohortOf?: (id: string) => string) {
+    const scaled = values.map(([id, v]) => [id, v * factor] as [string, number]);
+    return computeAttentionFlags(
+      params({
+        byKey: new Map([["t.metric", fixture(scaled)]]),
+        memberIds: scaled.map(([id]) => id),
+        ...(cohortOf ? { cohortOf } : {}),
+      }),
+    );
+  }
+
+  // A cohort with real spread and one member at zero.
+  const SPREAD: Array<[string, number]> = [
+    ["m1", 10], ["m2", 11], ["m3", 12], ["m4", 13], ["m5", 14], ["m6", 15], ["x", 0],
+  ];
+
+  it("ranks identically when every value is scaled by 1000", () => {
+    const order = (fs: ReturnType<typeof flagsFor>) => fs.map((f) => f.personId).join(",");
+    expect(order(flagsFor(SPREAD, 1000))).toBe(order(flagsFor(SPREAD)));
+  });
+
+  it("gives the same severity for the same shape at any magnitude", () => {
+    const [small] = flagsFor(SPREAD);
+    const [big] = flagsFor(SPREAD, 1000);
+    expect(small).toBeDefined();
+    expect(big!.severity).toBeCloseTo(small!.severity, 6);
+  });
+
+  it("separates collapses instead of tying them at a constant", () => {
+    // Two cohorts, each with a zero. The tight cohort's zero sits further out
+    // in IQRs, so it must outrank the scattered cohort's zero — under the old
+    // constant both scored exactly 2 and the order was arbitrary.
+    const values: Array<[string, number]> = [
+      ["t1", 10], ["t2", 10], ["t3", 10], ["t4", 11], ["t0", 0],
+      ["w1", 2], ["w2", 20], ["w3", 40], ["w4", 60], ["w0", 0],
+    ];
+    const collapses = flagsFor(values, 1, (id) => (id.startsWith("t") ? "tight" : "wide")).filter(
+      (f) => f.kind === "collapse",
+    );
+    expect(collapses.map((f) => f.personId)).toEqual(["person-t0", "person-w0"]);
+    expect(collapses[0]!.severity).toBeGreaterThan(collapses[1]!.severity);
+  });
+
+  it("raises nothing for a cohort with no scale at all", () => {
+    // Everyone identical and at zero: nothing is unusual, and no scale exists to
+    // rank by. A flag here would carry a number that means something else.
+    expect(flagsFor([["m1", 0], ["m2", 0], ["m3", 0], ["m4", 0]])).toEqual([]);
+  });
+});

--- a/src/frontend/src/lib/insight/attention-flags.ts
+++ b/src/frontend/src/lib/insight/attention-flags.ts
@@ -202,6 +202,11 @@ export function computeAttentionFlags({
   return [...best.values()].sort((a, b) => b.severity - a.severity);
 }
 
+/** "1 person" / "3 people" — a scope of one is a real case (a lead with one report). */
+function people(n: number): string {
+  return `${n} ${n === 1 ? "person" : "people"}`;
+}
+
 /** Deterministic one-liner over the flag set — placeholder for a future AI insight. */
 export function attentionSummary(
   flags: AttentionFlag[],
@@ -209,10 +214,10 @@ export function attentionSummary(
   teamSize: number,
 ): string {
   if (flags.length === 0)
-    return `All ${teamSize} people are within their usual range this period.`;
+    return `All ${people(teamSize)} are within their usual range this period.`;
   const byMetric = new Map<string, number>();
   for (const f of flags) byMetric.set(f.metricLabel, (byMetric.get(f.metricLabel) ?? 0) + 1);
   const top = [...byMetric.entries()].sort((a, b) => b[1] - a[1]).slice(0, 2);
   const themes = top.map(([label, n]) => `${label} (${n})`).join(", ");
-  return `${flaggedPeople} of ${teamSize} people need a look — most flags on ${themes}.`;
+  return `${flaggedPeople} of ${people(teamSize)} need a look — most flags on ${themes}.`;
 }

--- a/src/frontend/src/lib/insight/attention-flags.ts
+++ b/src/frontend/src/lib/insight/attention-flags.ts
@@ -5,6 +5,7 @@ import {
   type NormalizedMetricResult,
 } from "@/lib/metrics/collection";
 
+/** Why a person was flagged: apart from their cohort, moving adversely, or at zero. */
 export type FlagKind = "outlier" | "decline" | "collapse";
 
 export interface AttentionFlag {

--- a/src/frontend/src/lib/insight/attention-flags.ts
+++ b/src/frontend/src/lib/insight/attention-flags.ts
@@ -1,0 +1,218 @@
+import { formatMetricValue } from "@/lib/format";
+import { MIN_COHORT, quantile } from "@/lib/insight/within-team-peer";
+import {
+  forEntity,
+  type NormalizedMetricResult,
+} from "@/lib/metrics/collection";
+
+export type FlagKind = "outlier" | "decline" | "collapse";
+
+export interface AttentionFlag {
+  /** Person id (the identity-cutover key), not an email. */
+  personId: string;
+  name: string;
+  metricKey: string;
+  metricLabel: string;
+  kind: FlagKind;
+  valueText: string;
+  reason: string;
+  severity: number;
+}
+
+/** A member is flagged only when the divergence clears this fraction of the median. */
+const OUTLIER_MIN_REL_GAP = 0.25;
+/** Adverse period-over-period move that trips a "declining" flag. */
+const DELTA_MIN = 0.25;
+
+export interface FlagParams {
+  headlineKeys: readonly string[];
+  byKey: Map<string, NormalizedMetricResult>;
+  previousByKey: Map<string, NormalizedMetricResult>;
+  memberIds: readonly string[];
+  /** Cohort key per member — flags are computed within each person's cohort. */
+  cohortOf: (id: string) => string | null;
+  nameOf: (id: string) => string;
+  personIdOf: (id: string) => string;
+  /** How the cohort is named in reasons ("team" / "division" / …). */
+  cohortLabel: string;
+}
+
+/**
+ * The shared "needs attention" scan: per headline metric, judge each person
+ * against their own cohort (Tukey outliers + period declines + collapses).
+ * Used by the team-state roster and the org overview so the logic lives once.
+ */
+/**
+ * Severity in units of the cohort's own spread.
+ *
+ * One ranked list mixes metrics measured in commits, hours and dollars, so the
+ * number that orders them cannot carry a unit. Dividing an adverse distance by
+ * the cohort's IQR (or |median| when the cohort is flat) makes the result
+ * dimensionless: multiply every value of a metric by 1000 and nothing moves.
+ *
+ * `null` when the cohort offers no scale — a flag that cannot be compared is
+ * not raised, rather than raised with a number that means something else.
+ */
+function severityIn(scale: number | null, adverseDistance: number): number | null {
+  if (scale == null || !(scale > 1e-9)) return null;
+  const sev = adverseDistance / scale;
+  return Number.isFinite(sev) && sev > 0 ? sev : null;
+}
+
+export function computeAttentionFlags({
+  headlineKeys,
+  byKey,
+  previousByKey,
+  memberIds,
+  cohortOf,
+  nameOf,
+  personIdOf,
+  cohortLabel,
+}: FlagParams): AttentionFlag[] {
+  const out: AttentionFlag[] = [];
+  for (const key of headlineKeys) {
+    const r = byKey.get(key);
+    if (!r || r.direction === "neutral") continue;
+    const prev = previousByKey.get(key);
+    const higherIsBetter = r.direction !== "lower_is_better";
+    const points = memberIds
+      .map((id) => ({ id, v: forEntity(r, id).value, c: cohortOf(id) }))
+      .filter(
+        (pt): pt is { id: string; v: number; c: string } =>
+          pt.v != null && Number.isFinite(pt.v) && pt.c != null,
+      );
+    if (points.length < MIN_COHORT) continue;
+
+    const byCohort = new Map<string, number[]>();
+    for (const pt of points)
+      (byCohort.get(pt.c) ?? byCohort.set(pt.c, []).get(pt.c)!).push(pt.v);
+    const stats = new Map<
+      string,
+      {
+        p50: number;
+        loFence: number;
+        hiFence: number;
+        iqr: number;
+        denom: number;
+        /**
+         * The unit severity is measured in. IQR first — a robust spread that
+         * carries the metric's own scale, so "two IQRs from the median" means
+         * the same thing for hours and for commits. |median| is the fallback
+         * for a cohort with no dispersion; `null` means the cohort offers no
+         * scale at all (everyone identical AND at zero), and a flag with no
+         * scale cannot be ranked, so it is not raised.
+         */
+        scale: number | null;
+        medianText: string;
+      }
+    >();
+    for (const [c, vals] of byCohort) {
+      if (vals.length < MIN_COHORT) continue;
+      const sorted = [...vals].sort((a, b) => a - b);
+      const p50 = quantile(sorted, 0.5);
+      const p25 = quantile(sorted, 0.25);
+      const p75 = quantile(sorted, 0.75);
+      const iqr = p75 - p25;
+      stats.set(c, {
+        p50,
+        iqr,
+        loFence: p25 - 1.5 * iqr,
+        hiFence: p75 + 1.5 * iqr,
+        denom: Math.abs(p50) > 1e-9 ? Math.abs(p50) : 1,
+        scale: iqr > 1e-9 ? iqr : Math.abs(p50) > 1e-9 ? Math.abs(p50) : null,
+        medianText: formatMetricValue(p50, r.format, r.unit),
+      });
+    }
+
+    for (const { id, v, c } of points) {
+      const st = stats.get(c);
+      const name = nameOf(id);
+      const personId = personIdOf(id);
+      const valueText = formatMetricValue(v, r.format, r.unit);
+      const label = r.short_label ?? r.label;
+      const relGap = st
+        ? higherIsBetter
+          ? (st.p50 - v) / st.denom
+          : (v - st.p50) / st.denom
+        : 0;
+
+      if (higherIsBetter && v === 0 && st && st.p50 > 0) {
+        // A collapse is the extreme of the same measure, not a separate scale:
+        // how far below the cohort this person sits, in IQRs. Ranking them all
+        // at a constant made every collapse tie and flood the top of the list
+        // — and on a partly-adopted metric everyone at zero is a collapse.
+        const sev = severityIn(st.scale, st.p50 - v);
+        if (sev != null) {
+          out.push({
+            personId, name, metricKey: key, metricLabel: label, kind: "collapse",
+            valueText, reason: `no ${label.toLowerCase()} (${cohortLabel} median ${st.medianText})`,
+            severity: sev,
+          });
+        }
+        continue;
+      }
+      if (
+        st &&
+        st.iqr > 1e-9 &&
+        (higherIsBetter ? v < st.loFence : v > st.hiFence) &&
+        relGap >= OUTLIER_MIN_REL_GAP
+      ) {
+        const sev = severityIn(st.scale, higherIsBetter ? st.p50 - v : v - st.p50);
+        if (sev != null) {
+          out.push({
+            personId, name, metricKey: key, metricLabel: label, kind: "outlier",
+            valueText,
+            reason: `${higherIsBetter ? "unusually low" : "unusually high"} · ${cohortLabel} median ${st.medianText}`,
+            severity: sev,
+          });
+        }
+        continue;
+      }
+      if (prev) {
+        const pv = forEntity(prev, id).value;
+        if (pv != null && Number.isFinite(pv) && Math.abs(pv) > 1e-9) {
+          const change = (v - pv) / Math.abs(pv);
+          const adverse = higherIsBetter ? -change : change;
+          if (adverse >= DELTA_MIN) {
+            // The trigger stays a percentage of the person's own past — that is
+            // the question a decline answers. Severity converts the MOVE into
+            // cohort IQRs so it can share a ranking with the other two kinds;
+            // without a cohort scale there is nothing to compare against, so
+            // fall back to the fractional change and keep the flag.
+            const moved = higherIsBetter ? pv - v : v - pv;
+            const sev = st ? severityIn(st.scale, moved) : null;
+            out.push({
+              personId, name, metricKey: key, metricLabel: label, kind: "decline",
+              valueText,
+              reason: `${higherIsBetter ? "down" : "up"} ${Math.round(adverse * 100)}% vs last period`,
+              severity: sev ?? adverse,
+            });
+          }
+        }
+      }
+    }
+  }
+  // Strongest flag per (person, metric); ranked by severity.
+  const best = new Map<string, AttentionFlag>();
+  for (const f of out) {
+    const k = `${f.personId}::${f.metricKey}`;
+    const cur = best.get(k);
+    if (!cur || f.severity > cur.severity) best.set(k, f);
+  }
+  return [...best.values()].sort((a, b) => b.severity - a.severity);
+}
+
+/** Deterministic one-liner over the flag set — placeholder for a future AI insight. */
+export function attentionSummary(
+  flags: AttentionFlag[],
+  flaggedPeople: number,
+  teamSize: number,
+): string {
+  if (flags.length === 0)
+    return `All ${teamSize} people are within their usual range this period.`;
+  const byMetric = new Map<string, number>();
+  for (const f of flags) byMetric.set(f.metricLabel, (byMetric.get(f.metricLabel) ?? 0) + 1);
+  const top = [...byMetric.entries()].sort((a, b) => b[1] - a[1]).slice(0, 2);
+  const themes = top.map(([label, n]) => `${label} (${n})`).join(", ");
+  return `${flaggedPeople} of ${teamSize} people need a look — most flags on ${themes}.`;
+}

--- a/src/frontend/src/lib/insight/groups.ts
+++ b/src/frontend/src/lib/insight/groups.ts
@@ -512,6 +512,11 @@ export const KPI_ROW_COLLECTION: MetricCollectionConfig = {
 };
 
 /** KPI tiles navigate to the group that owns their metric. */
+/** Every group's card-preview keys, deduped — the cross-domain headline set. */
+export function headlineMetricKeys(): string[] {
+  return [...new Set(GROUPS.flatMap((g) => g.card.preview))];
+}
+
 export function groupIdForMetricKey(metricKey: string): GroupId | null {
   for (const def of GROUPS) {
     if (def.collection.metrics.some((m) => m.key === metricKey)) return def.id;

--- a/src/frontend/src/lib/insight/slices.test.ts
+++ b/src/frontend/src/lib/insight/slices.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import type { IdentityPerson } from "@/types/insight";
+import {
+  availableSlices,
+  cohortKey,
+  collectRosterAttrs,
+  personAttributes,
+  type SliceAttr,
+} from "./slices";
+
+function person(over: Partial<IdentityPerson>): IdentityPerson {
+  return {
+    person_id: "00000000-0000-4000-8000-000000000001",
+    email: "p@t",
+    display_name: "P",
+    department: "",
+    division: "",
+    job_title: "",
+    subordinates: [],
+    ...over,
+  } as unknown as IdentityPerson;
+}
+
+function attrs(division?: string, title?: string): Record<string, SliceAttr> {
+  const out: Record<string, SliceAttr> = {};
+  if (division) out.division = { key: "division", label: "Division", value: division };
+  if (title) out.title = { key: "title", label: "Title", value: title };
+  return out;
+}
+
+describe("personAttributes", () => {
+  it("maps filled identity fields and drops empty/whitespace ones", () => {
+    const p = person({ division: "R&D", department: "  ", job_title: "Engineer" });
+    const a = personAttributes(p);
+    expect(a.division).toEqual({ key: "division", label: "Division", value: "R&D" });
+    expect(a.title?.value).toBe("Engineer");
+    expect(a.department).toBeUndefined();
+  });
+});
+
+describe("availableSlices — data-driven gates", () => {
+  it("hides a single-valued dimension (slices nothing)", () => {
+    // Everyone in the same division: division must NOT be offered.
+    const rosters = ["a", "b", "c", "d"].map(() => attrs("R&D", undefined));
+    expect(availableSlices(rosters).map((d) => d.key)).toEqual([]);
+  });
+
+  it("offers a dimension that genuinely splits the roster", () => {
+    const rosters = [attrs("R&D"), attrs("R&D"), attrs("Sales"), attrs("Sales")];
+    expect(availableSlices(rosters)).toEqual([{ key: "division", label: "Division" }]);
+  });
+
+  it("hides a near-unique dimension (effectively an id)", () => {
+    // 10 people, 10 distinct titles → unique ratio 1.0 ≥ 0.9 → hidden.
+    const rosters = Array.from({ length: 10 }, (_, i) => attrs(undefined, `T${i}`));
+    expect(availableSlices(rosters).map((d) => d.key)).toEqual([]);
+  });
+
+  it("keeps a repeating dimension under the unique-ratio ceiling", () => {
+    // 10 people, 5 titles ×2 → ratio 0.5 → offered.
+    const rosters = Array.from({ length: 10 }, (_, i) => attrs(undefined, `T${i % 5}`));
+    expect(availableSlices(rosters).map((d) => d.key)).toEqual(["title"]);
+  });
+
+  it("preserves first-appearance order across dimensions", () => {
+    const rosters = [
+      attrs("R&D", "Dev"), attrs("Sales", "QA"),
+      attrs("R&D", "Dev"), attrs("Sales", "QA"),
+    ];
+    expect(availableSlices(rosters).map((d) => d.key)).toEqual(["division", "title"]);
+  });
+});
+
+describe("collectRosterAttrs", () => {
+  it("walks the whole subtree and keys entities via keyOf", () => {
+    // Keys are person ids (upper-cased here to prove `keyOf` is applied), not
+    // emails — the map feeds metric entity lookups.
+    const root = person({
+      person_id: "AAAAAAAA-0000-4000-8000-000000000001",
+      division: "R&D",
+      subordinates: [
+        person({
+          person_id: "bbbbbbbb-0000-4000-8000-000000000002",
+          division: "Sales",
+        }),
+      ],
+    });
+    const m = collectRosterAttrs(root, (id) => id.toLowerCase());
+    expect(m.get("aaaaaaaa-0000-4000-8000-000000000001")?.division?.value).toBe(
+      "R&D",
+    );
+    expect(m.get("bbbbbbbb-0000-4000-8000-000000000002")?.division?.value).toBe(
+      "Sales",
+    );
+  });
+
+  it("returns an empty map for a null root", () => {
+    expect(collectRosterAttrs(null, (e) => e).size).toBe(0);
+  });
+});
+
+describe("cohortKey", () => {
+  const a = attrs("R&D");
+  it("is 'all' when no slice is active", () => expect(cohortKey(a, "")).toBe("all"));
+  it("is the attribute value under an active slice", () =>
+    expect(cohortKey(a, "division")).toBe("R&D"));
+  it("is null when the member lacks the attribute (excluded, not faked)", () => {
+    expect(cohortKey(a, "title")).toBeNull();
+    expect(cohortKey(undefined, "division")).toBeNull();
+  });
+});

--- a/src/frontend/src/lib/insight/slices.ts
+++ b/src/frontend/src/lib/insight/slices.ts
@@ -1,0 +1,137 @@
+import type { IdentityPerson } from "@/types/insight";
+
+/**
+ * Slices — grouping a roster and defining peer cohorts by a person attribute.
+ * The machinery is **attribute-agnostic**: it works over a generic
+ * `{ key → {label, value} }` map, so new identity attributes become sliceable
+ * with no change here or downstream. The ONE place attribute names live is
+ * `ATTR_FIELDS` below — the interim adapter from the fixed `IdentityPerson`
+ * shape. Once identity exposes attributes generically (see constructorfabric/
+ * insight#1881), `personAttributes` reads that list and `ATTR_FIELDS` disappears.
+ *
+ * There is no slice catalog in the analytics API yet, so `availableSlices()`
+ * discovers dimensions from the data itself and gates them by presence and
+ * cardinality — junk attributes (unique-per-person like email/employee_id, or
+ * single-valued) never show; good ones (division, seniority, location, …) show
+ * automatically. `PLANNED_SLICES` are declared-but-unfed dims (functional team).
+ */
+
+export interface SliceAttr {
+  key: string;
+  label: string;
+  value: string;
+}
+
+export interface SliceDim {
+  key: string;
+  label: string;
+  /** No data path yet — render an honest ComingSoon. */
+  planned?: boolean;
+}
+
+/** A slice is usable only if it splits people without being near-unique. */
+const MIN_DISTINCT = 2;
+const MAX_DISTINCT = 60;
+/** Above this distinct/people ratio the attribute is effectively an id, not a slice. */
+const MAX_UNIQUE_RATIO = 0.9;
+
+/**
+ * Interim identity→attributes adapter — the only code that names attributes.
+ * Replace its body with the profile's generic `attributes[]` when #1881 lands.
+ */
+const ATTR_FIELDS: readonly {
+  key: string;
+  label: string;
+  get: (p: IdentityPerson) => string | null | undefined;
+}[] = [
+  { key: "division", label: "Division", get: (p) => p.division },
+  { key: "department", label: "Department", get: (p) => p.department },
+  { key: "title", label: "Title", get: (p) => p.job_title },
+  // Keyed by EMAIL, not display name: two managers sharing a name must not
+  // merge into one cohort. The email doubles as the visible unit label — less
+  // pretty, but unambiguous; a display-label lookup is a follow-up.
+  { key: "manager", label: "Manager", get: (p) => p.supervisor_email },
+];
+
+/** A person's sliceable attributes as a generic key→attr map (empty values dropped). */
+export function personAttributes(p: IdentityPerson): Record<string, SliceAttr> {
+  const out: Record<string, SliceAttr> = {};
+  for (const f of ATTR_FIELDS) {
+    const value = (f.get(p) ?? "").trim();
+    if (value) out[f.key] = { key: f.key, label: f.label, value };
+  }
+  return out;
+}
+
+/**
+ * Dimensions declared in the product but not backed by ingested data yet.
+ * Empty today — "Functional team" was removed as speculative (no source is
+ * even planned near-term); add entries here only when a real dimension has a
+ * committed data path, and the by-unit section will render an honest
+ * ComingSoon note for it until the data lands.
+ */
+export const PLANNED_SLICES: readonly SliceDim[] = [];
+
+/**
+ * Discover usable slice dimensions from a roster of attribute maps: present,
+ * multi-valued, not near-unique, not absurdly high-cardinality. Order follows
+ * first appearance so the adapter's order is preserved.
+ */
+export function availableSlices(
+  rosters: Iterable<Record<string, SliceAttr>>,
+): SliceDim[] {
+  const label = new Map<string, string>();
+  const order: string[] = [];
+  const distinct = new Map<string, Set<string>>();
+  const count = new Map<string, number>();
+
+  for (const attrs of rosters) {
+    for (const key of Object.keys(attrs)) {
+      const a = attrs[key]!;
+      if (!label.has(key)) {
+        label.set(key, a.label);
+        order.push(key);
+        distinct.set(key, new Set());
+      }
+      distinct.get(key)!.add(a.value);
+      count.set(key, (count.get(key) ?? 0) + 1);
+    }
+  }
+
+  return order
+    .filter((key) => {
+      const d = distinct.get(key)!.size;
+      const n = count.get(key) ?? 0;
+      return d >= MIN_DISTINCT && d <= MAX_DISTINCT && d / n < MAX_UNIQUE_RATIO;
+    })
+    .map((key) => ({ key, label: label.get(key)! }));
+}
+
+/** Walk an org tree into `entityId → attribute map` (entity id via `keyOf`). */
+export function collectRosterAttrs(
+  root: IdentityPerson | null,
+  keyOf: (personId: string) => string,
+): Map<string, Record<string, SliceAttr>> {
+  const m = new Map<string, Record<string, SliceAttr>>();
+  const walk = (n: IdentityPerson) => {
+    // Keyed by person id (the metric entity id), not email: a person with no
+    // email still belongs to a cohort.
+    if (n.person_id) m.set(keyOf(n.person_id), personAttributes(n));
+    n.subordinates.forEach(walk);
+  };
+  if (root) walk(root);
+  return m;
+}
+
+/**
+ * Cohort key for a member under the active slice: the attribute's value, or
+ * "all" when no slice is active (whole roster = one cohort), or null when the
+ * member has no value for that attribute (excluded from cohort stats).
+ */
+export function cohortKey(
+  attrs: Record<string, SliceAttr> | undefined,
+  slice: string,
+): string | null {
+  if (!slice) return "all";
+  return attrs?.[slice]?.value ?? null;
+}

--- a/src/frontend/src/lib/insight/slices.ts
+++ b/src/frontend/src/lib/insight/slices.ts
@@ -22,6 +22,7 @@ export interface SliceAttr {
   value: string;
 }
 
+/** A sliceable dimension the roster actually supports (see `availableSlices`). */
 export interface SliceDim {
   key: string;
   label: string;

--- a/src/frontend/src/lib/insight/within-team-peer.test.ts
+++ b/src/frontend/src/lib/insight/within-team-peer.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import type { NormalizedMetricResult } from "@/lib/metrics/collection";
+import { forEntity } from "@/lib/metrics/collection";
+import {
+  injectCohortPeer,
+  MIN_COHORT,
+  quantile,
+  withinCohortPeer,
+  withinTeamPeer,
+} from "./within-team-peer";
+
+function fixture(period: Array<[string, number | null]>): NormalizedMetricResult {
+  return {
+    metric_key: "t.metric",
+    label: "T",
+    unit: null,
+    computation: "sum",
+    format: "integer",
+    direction: "higher_is_better",
+    period: {
+      view: "period",
+      values: period.map(([entity_id, value]) => ({ entity_id, value })),
+    },
+  } as unknown as NormalizedMetricResult;
+}
+
+describe("quantile", () => {
+  it("returns NaN on empty input", () => expect(quantile([], 0.5)).toBeNaN());
+  it("returns the single element regardless of q", () =>
+    expect(quantile([7], 0.9)).toBe(7));
+  it("interpolates the median of an even-length array", () =>
+    expect(quantile([1, 2, 3, 4], 0.5)).toBe(2.5));
+  it("interpolates p25 linearly", () =>
+    // pos = 3 * 0.25 = 0.75 → 1 + (2-1) * 0.75 = 1.75
+    expect(quantile([1, 2, 3, 4], 0.25)).toBe(1.75));
+  it("hits exact ends", () => {
+    expect(quantile([1, 2, 3], 0)).toBe(1);
+    expect(quantile([1, 2, 3], 1)).toBe(3);
+  });
+});
+
+describe("withinTeamPeer", () => {
+  it("computes median/p25/p75 for every member from the whole roster", () => {
+    const ids = ["a", "b", "c", "d"];
+    const r = withinTeamPeer(fixture([["a", 1], ["b", 2], ["c", 3], ["d", 4]]), ids);
+    const a = forEntity(r, "a").peer!;
+    expect(a.median).toBe(2.5);
+    expect(a.p25).toBe(1.75);
+    expect(a.p75).toBe(3.25);
+    expect(a.n).toBe(4);
+    // target_value stays the member's own reading
+    expect(a.target_value).toBe(1);
+    expect(forEntity(r, "d").peer!.target_value).toBe(4);
+  });
+
+  it("gives no stats when fewer than MIN_COHORT values are measured", () => {
+    const ids = ["a", "b", "c", "d"];
+    // only 3 finite values — below MIN_COHORT
+    const r = withinTeamPeer(fixture([["a", 1], ["b", 2], ["c", 3], ["d", null]]), ids);
+    expect(MIN_COHORT).toBe(4);
+    expect(forEntity(r, "a").peer!.median).toBeNull();
+    expect(forEntity(r, "a").peer!.n).toBe(0);
+  });
+});
+
+describe("withinCohortPeer", () => {
+  const ids = ["a1", "a2", "a3", "a4", "b1", "b2"];
+  const r = fixture([
+    ["a1", 10], ["a2", 20], ["a3", 30], ["a4", 40],
+    ["b1", 1000], ["b2", 2000],
+  ]);
+  const cohortOf = (id: string) => (id.startsWith("a") ? "A" : "B");
+
+  it("ranks each member against their OWN cohort only", () => {
+    const out = withinCohortPeer(r, ids, cohortOf);
+    // cohort A median = 25, untouched by B's thousands
+    expect(forEntity(out, "a1").peer!.median).toBe(25);
+    expect(forEntity(out, "a1").peer!.min).toBe(10);
+    expect(forEntity(out, "a1").peer!.max).toBe(40);
+  });
+
+  it("suppresses small cohorts instead of faking a comparison", () => {
+    const out = withinCohortPeer(r, ids, cohortOf);
+    // cohort B has 2 members < MIN_COHORT → neutral
+    expect(forEntity(out, "b1").peer!.median).toBeNull();
+    expect(forEntity(out, "b1").peer!.n).toBe(0);
+    // but the member still carries their own value
+    expect(forEntity(out, "b1").peer!.target_value).toBe(1000);
+  });
+
+  it("excludes members whose cohort resolves to null", () => {
+    const out = withinCohortPeer(r, ids, (id) => (id === "a1" ? null : cohortOf(id)));
+    // a1 excluded → cohort A has 3 measured values < MIN_COHORT → suppressed
+    expect(forEntity(out, "a2").peer!.median).toBeNull();
+  });
+
+  it("does not mutate the input result", () => {
+    withinCohortPeer(r, ids, cohortOf);
+    expect(r.peer).toBeUndefined();
+  });
+});
+
+describe("injectCohortPeer", () => {
+  const cohortIds = ["a", "b", "c", "d"];
+  const cohortR = fixture([["a", 1], ["b", 2], ["c", 3], ["d", 4]]);
+  const personR = fixture([["a", 1]]);
+
+  it("overlays the person's result with cohort-derived peer stats", () => {
+    const out = injectCohortPeer(
+      new Map([["t.metric", personR]]),
+      new Map([["t.metric", cohortR]]),
+      cohortIds,
+    );
+    const merged = out.get("t.metric")!;
+    expect(forEntity(merged, "a").peer!.median).toBe(2.5);
+    // the person's own period view is preserved
+    expect(forEntity(merged, "a").value).toBe(1);
+  });
+
+  it("keeps the person's result untouched when the cohort lacks that metric", () => {
+    const out = injectCohortPeer(
+      new Map([["t.metric", personR]]),
+      new Map(),
+      cohortIds,
+    );
+    expect(out.get("t.metric")).toBe(personR);
+  });
+
+  it("is a no-op on an empty cohort", () => {
+    const byKey = new Map([["t.metric", personR]]);
+    expect(injectCohortPeer(byKey, new Map([["t.metric", cohortR]]), [])).toBe(byKey);
+  });
+});

--- a/src/frontend/src/lib/insight/within-team-peer.ts
+++ b/src/frontend/src/lib/insight/within-team-peer.ts
@@ -1,0 +1,128 @@
+import {
+  forEntity,
+  type NormalizedMetricResult,
+} from "@/lib/metrics/collection";
+
+/** Linear-interpolated quantile over a pre-sorted ascending array. */
+export function quantile(sorted: number[], q: number): number {
+  if (sorted.length === 0) return NaN;
+  if (sorted.length === 1) return sorted[0]!;
+  const pos = (sorted.length - 1) * q;
+  const lo = Math.floor(pos);
+  const hi = Math.ceil(pos);
+  return sorted[lo]! + (sorted[hi]! - sorted[lo]!) * (pos - lo);
+}
+
+/** A cohort needs at least this many measured members for a meaningful median. */
+export const MIN_COHORT = 4;
+
+interface CohortStats {
+  p25: number;
+  median: number;
+  p75: number;
+  min: number;
+  max: number;
+  n: number;
+}
+
+function statsOf(values: number[]): CohortStats | null {
+  const finite = values.filter((v) => Number.isFinite(v));
+  if (finite.length < MIN_COHORT) return null;
+  const sorted = [...finite].sort((a, b) => a - b);
+  return {
+    p25: quantile(sorted, 0.25),
+    median: quantile(sorted, 0.5),
+    p75: quantile(sorted, 0.75),
+    min: sorted[0]!,
+    max: sorted[sorted.length - 1]!,
+    n: sorted.length,
+  };
+}
+
+/**
+ * Peer stats aren't computed by the backend yet, so the shared members grid
+ * paints every cell neutral ("no peer data"). Synthesize a peer view where each
+ * member is ranked **within their own cohort** — the group of members sharing
+ * `cohortOf(id)` (e.g. same division / title / manager). This drives the grid
+ * heat, attention outliers, and the Person "vs your <slice> median" framing off
+ * a single, honest, client-side computation.
+ *
+ * `cohortOf` returns the cohort key for a member (or null to exclude). Members
+ * whose cohort has fewer than `MIN_COHORT` measured values get no peer stats
+ * (neutral) — no fake comparison against a 1–2 person group.
+ */
+export function withinCohortPeer(
+  result: NormalizedMetricResult,
+  memberIds: readonly string[],
+  cohortOf: (id: string) => string | null,
+): NormalizedMetricResult {
+  // Bucket member values by cohort key.
+  const byCohort = new Map<string, number[]>();
+  for (const id of memberIds) {
+    const key = cohortOf(id);
+    if (key == null) continue;
+    const v = forEntity(result, id).value;
+    if (v == null || !Number.isFinite(v)) continue;
+    (byCohort.get(key) ?? byCohort.set(key, []).get(key)!).push(v);
+  }
+  const statsByCohort = new Map<string, CohortStats>();
+  for (const [key, vals] of byCohort) {
+    const s = statsOf(vals);
+    if (s) statsByCohort.set(key, s);
+  }
+
+  return {
+    ...result,
+    peer: {
+      view: "peer",
+      values: memberIds.map((id) => {
+        const key = cohortOf(id);
+        const stats = key != null ? statsByCohort.get(key) : undefined;
+        return {
+          entity_id: id,
+          target_value: forEntity(result, id).value,
+          p25: stats?.p25 ?? null,
+          median: stats?.median ?? null,
+          p75: stats?.p75 ?? null,
+          min: stats?.min ?? null,
+          max: stats?.max ?? null,
+          n: stats?.n ?? 0,
+        };
+      }),
+    },
+  };
+}
+
+/**
+ * The whole roster as a single cohort — the default when no slice is active.
+ * Thin wrapper over `withinCohortPeer`.
+ */
+export function withinTeamPeer(
+  result: NormalizedMetricResult,
+  memberIds: readonly string[],
+): NormalizedMetricResult {
+  return withinCohortPeer(result, memberIds, () => "all");
+}
+
+/**
+ * Overlay a person's own metric results with peer stats computed from their
+ * slice cohort (a single "all" bucket over `cohortIds`), so the existing
+ * "vs peer" widgets read "vs <slice> median". No-op when the cohort is empty.
+ */
+export function injectCohortPeer(
+  personByKey: Map<string, NormalizedMetricResult>,
+  cohortByKey: Map<string, NormalizedMetricResult>,
+  cohortIds: readonly string[],
+): Map<string, NormalizedMetricResult> {
+  if (!cohortIds.length) return personByKey;
+  const out = new Map(personByKey);
+  for (const [key, personR] of personByKey) {
+    const cohortR = cohortByKey.get(key);
+    if (!cohortR) continue;
+    out.set(key, {
+      ...personR,
+      peer: withinCohortPeer(cohortR, cohortIds, () => "all").peer,
+    });
+  }
+  return out;
+}

--- a/src/frontend/src/lib/metrics/collection.test.ts
+++ b/src/frontend/src/lib/metrics/collection.test.ts
@@ -7,6 +7,8 @@ import {
 } from "@/mocks/metric-results-fixtures";
 import {
   buildMetricCollectionRequest,
+  entityObserved,
+  type NormalizedMetricResult,
   chunkEntityIds,
   entityChunkSize,
   forEntity,
@@ -315,5 +317,73 @@ describe("forEntity", () => {
     )!;
     expect(forEntity(ratio, "bob@example.com").value).toBeNull();
     expect(forEntity(ratio, "nobody@example.com").value).toBeNull();
+  });
+});
+
+/**
+ * Every "source isn't ingested" gate in the portal rides on this predicate, and
+ * it rests on a backend guarantee: the peer view's `target_value` is NULL
+ * exactly when the entity was not observed. That holds because the peer query
+ * ends with `SETTINGS join_use_nulls = 1` — without it ClickHouse would fill
+ * unmatched rows with 0 and an un-ingested domain would render an all-zero
+ * dashboard instead of the honest empty state.
+ *
+ * These cases pin BOTH sides of that contract, so a regression in the backend
+ * setting shows up as a failing expectation here rather than as fabricated
+ * zeros in front of a customer.
+ */
+describe("entityObserved", () => {
+  const withPeer = (target: number | null, value: number | null) =>
+    ({
+      metric_key: "m",
+      label: "M",
+      unit: null,
+      computation: "sum",
+      format: "integer",
+      direction: "higher_is_better",
+      period: { view: "period", values: [{ entity_id: "a@x", value }] },
+      peer: {
+        view: "peer",
+        values: [{ entity_id: "a@x", target_value: target, median: 5, n: 9 }],
+      },
+    }) as unknown as NormalizedMetricResult;
+
+  it("treats a null peer target as unobserved, whatever the period value says", () => {
+    // The period view zero-fills every requested entity, so a 0 there proves
+    // nothing on its own.
+    expect(entityObserved(withPeer(null, 0), "a@x")).toBe(false);
+  });
+
+  it("treats a ZERO peer target as observed — a measured zero is data", () => {
+    // The case the null-only fixtures never covered: if the backend ever
+    // zero-filled instead of nulling, this is what would silently flip every
+    // gate from "not ingested" to "all zeros".
+    expect(entityObserved(withPeer(0, 0), "a@x")).toBe(true);
+  });
+
+  it("falls back to a non-zero period value when there is no peer row", () => {
+    const noPeer = {
+      metric_key: "m",
+      label: "M",
+      unit: null,
+      computation: "sum",
+      format: "integer",
+      direction: "higher_is_better",
+      period: { view: "period", values: [{ entity_id: "a@x", value: 7 }] },
+    } as unknown as NormalizedMetricResult;
+    expect(entityObserved(noPeer, "a@x")).toBe(true);
+  });
+
+  it("does not count a zero-filled period value as observation without a peer row", () => {
+    const noPeer = {
+      metric_key: "m",
+      label: "M",
+      unit: null,
+      computation: "sum",
+      format: "integer",
+      direction: "higher_is_better",
+      period: { view: "period", values: [{ entity_id: "a@x", value: 0 }] },
+    } as unknown as NormalizedMetricResult;
+    expect(entityObserved(noPeer, "a@x")).toBe(false);
   });
 });

--- a/src/frontend/src/lib/metrics/collection.ts
+++ b/src/frontend/src/lib/metrics/collection.ts
@@ -222,7 +222,7 @@ export function forEntity(
  * all-or-nothing limit (5000). Headroom below that so period+peer chunking
  * never sits exactly on the cliff.
  */
-const MAX_PROJECTED_ROWS = 4500;
+export const MAX_PROJECTED_ROWS = 4500;
 
 /**
  * How many entities fit in one request for this collection, or null when the
@@ -302,6 +302,23 @@ export function mergeNormalizedResults(
     }
   }
   return out;
+}
+
+/**
+ * Whether the entity has any observations for this metric. Period views
+ * zero-fill sums for requested entities, so a zero alone cannot distinguish
+ * "measured zero" from "unmeasured" — the peer view's `target_value` can
+ * (null exactly when unobserved). Without a peer row (no peer view, or no
+ * cohort membership), a non-null non-zero period value still proves
+ * observation; a zero-filled one does not.
+ */
+export function entityObserved(
+  result: NormalizedMetricResult,
+  entityId: string
+): boolean {
+  const data = forEntity(result, entityId);
+  if (data.peer) return data.peer.target_value != null;
+  return data.value != null && data.value !== 0;
 }
 
 function toRequestView(

--- a/src/frontend/src/lib/metrics/entity.test.ts
+++ b/src/frontend/src/lib/metrics/entity.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isPersonId, normalizePersonId } from "./entity";
+import { isPersonId, normalizePersonId, personIdFromPath } from "./entity";
 
 describe("normalizePersonId", () => {
   it("trims and lowercases so a route param and an identity record compare equal", () => {
@@ -33,4 +33,25 @@ describe("isPersonId", () => {
       expect(isPersonId(value)).toBe(false);
     },
   );
+});
+
+describe("personIdFromPath", () => {
+  const ID = "019e27bc-dec0-7626-81a9-c5524662a6a9";
+
+  it("reads the person id a /ic/ path names, encoded or not", () => {
+    expect(personIdFromPath(`/ic/${ID}/personal`)).toBe(ID);
+    expect(personIdFromPath(`/ic/${ID}/team/`)).toBe(ID);
+    expect(personIdFromPath("/ic/who%40x/personal")).toBe("who@x");
+  });
+
+  it("is null for a path that names no person", () => {
+    expect(personIdFromPath("/")).toBeNull();
+    expect(personIdFromPath("/metrics")).toBeNull();
+  });
+
+  it("survives a malformed percent-sequence instead of throwing", () => {
+    // The pathname is reader-editable text; decoding it raw during render
+    // raises URIError and takes the shell down over a typo'd link.
+    expect(personIdFromPath("/ic/%E0%A4%A/personal")).toBeNull();
+  });
 });

--- a/src/frontend/src/lib/metrics/entity.ts
+++ b/src/frontend/src/lib/metrics/entity.ts
@@ -26,3 +26,23 @@ export function isPersonId(value: string): boolean {
   const normalized = normalizePersonId(value);
   return UUID_RE.test(normalized) && normalized !== NIL_UUID;
 }
+
+const PERSON_PATH = /^\/ic\/([^/]+)/;
+
+/**
+ * The person id a `/ic/<id>/...` path names, or null for any other path.
+ *
+ * `decodeURIComponent` THROWS a URIError on a malformed percent-sequence, and
+ * the pathname is reader-editable text — decoding it raw during render crashes
+ * the shell on a typo'd link. An undecodable segment is treated as "no person"
+ * so the caller falls back (to the viewer, to no highlight) instead.
+ */
+export function personIdFromPath(pathname: string): string | null {
+  const m = PERSON_PATH.exec(pathname);
+  if (!m) return null;
+  try {
+    return decodeURIComponent(m[1]!);
+  } catch {
+    return null;
+  }
+}

--- a/src/frontend/src/lib/peers.ts
+++ b/src/frontend/src/lib/peers.ts
@@ -10,7 +10,14 @@ export type PeerStats = {
 export type PeerStatus = "top" | "in_pack" | "bottom"
 export type PeerStatusWithNeutral = PeerStatus | "neutral"
 
-export type PeerCohortLabel = "team" | "org" | "department"
+/**
+ * The noun a peer comparison is phrased against ("top 25% in <label>").
+ * The three literals are the common cases and keep autocomplete useful; the
+ * open branch admits a slice-derived cohort noun (division, title, …) now that
+ * peer cohorts follow the active slice. Consumers only interpolate this — no
+ * exhaustive switching depends on the closed set.
+ */
+export type PeerCohortLabel = "team" | "org" | "department" | (string & {})
 
 export type FocusMode = "all" | "critical" | "rewards" | "neutral"
 
@@ -77,4 +84,3 @@ export function peerStatusVsQuartiles(
   if (value >= stats.p75 && value > stats.p50) return "bottom"
   return "in_pack"
 }
-

--- a/src/frontend/src/lib/portal/event-histogram.test.ts
+++ b/src/frontend/src/lib/portal/event-histogram.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import type { NormalizedMetricResult } from "@/lib/metrics/collection";
+import { mergeEventHistogram } from "./event-histogram";
+
+const result = (
+  values: Array<{ entity_id: string; bins: Array<{ lo: number; hi: number; count: number }> }>,
+) => ({ metric_key: "m", histogram: { view: "histogram", values } }) as unknown as NormalizedMetricResult;
+
+describe("mergeEventHistogram", () => {
+  it("sums counts when bin edges align across entities", () => {
+    const r = result([
+      { entity_id: "a", bins: [{ lo: 0, hi: 1, count: 2 }, { lo: 1, hi: 2, count: 1 }] },
+      { entity_id: "b", bins: [{ lo: 0, hi: 1, count: 3 }, { lo: 1, hi: 2, count: 0 }] },
+    ]);
+    expect(mergeEventHistogram(r, ["a", "b"])).toEqual([
+      { lo: 0, hi: 1, count: 5 },
+      { lo: 1, hi: 2, count: 1 },
+    ]);
+  });
+  it("returns null when edges differ (per-entity bins are not summable)", () => {
+    const r = result([
+      { entity_id: "a", bins: [{ lo: 0, hi: 1, count: 2 }] },
+      { entity_id: "b", bins: [{ lo: 0, hi: 5, count: 3 }] },
+    ]);
+    expect(mergeEventHistogram(r, ["a", "b"])).toBeNull();
+  });
+  it("returns null when nothing is there", () => {
+    expect(mergeEventHistogram(undefined, ["a"])).toBeNull();
+  });
+});

--- a/src/frontend/src/lib/portal/event-histogram.ts
+++ b/src/frontend/src/lib/portal/event-histogram.ts
@@ -1,0 +1,39 @@
+import { forEntity, type NormalizedMetricResult } from "@/lib/metrics/collection";
+
+export interface EventBin {
+  lo: number;
+  hi: number;
+  count: number;
+}
+
+/**
+ * Merge per-entity server histograms into one org event histogram — valid
+ * only when every entity shares identical bin edges (design §7 open
+ * question). Returns null when edges differ, no data, or an entity has an
+ * anomalous bin count; the caller falls back honestly (no chart) rather than
+ * summing incomparable bins.
+ */
+export function mergeEventHistogram(
+  result: NormalizedMetricResult | undefined,
+  memberIds: readonly string[],
+): EventBin[] | null {
+  if (!result?.histogram) return null;
+  let reference: EventBin[] | null = null;
+  const totals: number[] = [];
+  for (const id of memberIds) {
+    const bins = forEntity(result, id).histogram[0]?.bins;
+    if (!bins?.length) continue;
+    if (!reference) {
+      reference = bins.map((b) => ({ lo: b.lo, hi: b.hi, count: 0 }));
+      totals.length = bins.length;
+      totals.fill(0);
+    }
+    if (bins.length !== reference.length) return null;
+    for (let i = 0; i < bins.length; i++) {
+      if (bins[i]!.lo !== reference[i]!.lo || bins[i]!.hi !== reference[i]!.hi) return null;
+      totals[i] += bins[i]!.count;
+    }
+  }
+  if (!reference) return null;
+  return reference.map((b, i) => ({ ...b, count: totals[i]! }));
+}

--- a/src/frontend/src/lib/portal/event-histogram.ts
+++ b/src/frontend/src/lib/portal/event-histogram.ts
@@ -8,10 +8,14 @@ export interface EventBin {
 
 /**
  * Merge per-entity server histograms into one org event histogram — valid
- * only when every entity shares identical bin edges (design §7 open
- * question). Returns null when edges differ, no data, or an entity has an
- * anomalous bin count; the caller falls back honestly (no chart) rather than
- * summing incomparable bins.
+ * only when every entity that HAS bins shares identical bin edges (design §7
+ * open question). Returns null when edges differ, when an entity has an
+ * anomalous bin count, or when nobody has bins at all; the caller falls back
+ * honestly (no chart) rather than summing incomparable bins.
+ *
+ * A member with no bins is skipped, not a reason to bail: they simply had no
+ * events in the period, which is a normal reading on any real roster. Bailing
+ * would blank the chart for the whole org whenever one person was inactive.
  */
 export function mergeEventHistogram(
   result: NormalizedMetricResult | undefined,

--- a/src/frontend/src/lib/portal/event-histogram.ts
+++ b/src/frontend/src/lib/portal/event-histogram.ts
@@ -1,5 +1,6 @@
 import { forEntity, type NormalizedMetricResult } from "@/lib/metrics/collection";
 
+/** One merged histogram bar: a half-open [lo, hi) band and how many events fell in it. */
 export interface EventBin {
   lo: number;
   hi: number;

--- a/src/frontend/src/lib/portal/lens-configs.test.ts
+++ b/src/frontend/src/lib/portal/lens-configs.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import { GROUPS } from "@/lib/insight/groups";
+import { DIRECTIONS } from "@/lib/portal/nav-model";
+import {
+  DIRECTION_LENSES,
+  directionMetricKeys,
+  lensEntry,
+  sectionMetricKeys,
+  type SectionSpec,
+} from "./lens-configs";
+
+const KNOWN_KEYS = new Set(
+  GROUPS.flatMap((g) => g.collection.metrics.map((m) => m.key)),
+);
+
+describe("DIRECTION_LENSES registry", () => {
+  it("covers every direction and lens declared in nav-model", () => {
+    for (const d of DIRECTIONS) {
+      for (const lens of d.lenses) {
+        expect(lensEntry(d.id, lens), `${d.id}/${lens}`).toBeDefined();
+      }
+    }
+  });
+
+  it("references only metric keys that exist in the groups registry", () => {
+    for (const [dir, lenses] of Object.entries(DIRECTION_LENSES)) {
+      for (const [lens, entry] of Object.entries(lenses)) {
+        if ("comingSoon" in entry) continue;
+        for (const key of sectionMetricKeys(entry)) {
+          expect(KNOWN_KEYS.has(key), `${dir}/${lens}: ${key}`).toBe(true);
+        }
+      }
+    }
+  });
+
+  it("stays under the API metric cap per lens", () => {
+    for (const lenses of Object.values(DIRECTION_LENSES)) {
+      for (const entry of Object.values(lenses)) {
+        if ("comingSoon" in entry) continue;
+        expect(sectionMetricKeys(entry).length).toBeLessThanOrEqual(50);
+      }
+    }
+  });
+
+  it("has no orphan configs — every registry dir/lens exists in nav-model", () => {
+    const navLenses: Record<string, Set<string>> = {};
+    for (const d of DIRECTIONS) navLenses[d.id] = new Set(d.lenses);
+    for (const [dir, lenses] of Object.entries(DIRECTION_LENSES)) {
+      for (const lens of Object.keys(lenses)) {
+        expect(navLenses[dir]?.has(lens), `${dir}/${lens}`).toBe(true);
+      }
+    }
+  });
+
+  it("gives every non-comingSoon entry at least one section", () => {
+    for (const [dir, lenses] of Object.entries(DIRECTION_LENSES)) {
+      for (const [lens, entry] of Object.entries(lenses)) {
+        if ("comingSoon" in entry) continue;
+        expect(entry.sections.length, `${dir}/${lens}`).toBeGreaterThanOrEqual(1);
+      }
+    }
+  });
+
+  it("never has two composition sections sharing the same metric (compData is keyed by metric)", () => {
+    for (const [dir, lenses] of Object.entries(DIRECTION_LENSES)) {
+      for (const [lens, entry] of Object.entries(lenses)) {
+        if ("comingSoon" in entry) continue;
+        const compMetrics = entry.sections
+          .filter(
+            (s): s is Extract<SectionSpec, { kind: "composition" }> => s.kind === "composition",
+          )
+          .map((s) => s.metric);
+        expect(new Set(compMetrics).size, `${dir}/${lens}`).toBe(compMetrics.length);
+      }
+    }
+  });
+});
+
+describe("directionMetricKeys", () => {
+  it("stays under the API metric cap per direction — the union must stay requestable in one grid", () => {
+    for (const dir of Object.keys(DIRECTION_LENSES)) {
+      expect(directionMetricKeys(dir).length, dir).toBeLessThanOrEqual(50);
+    }
+  });
+
+  it("spans every lens of the direction, not just one (dev has both git.* and tasks.*)", () => {
+    const keys = directionMetricKeys("dev");
+    expect(keys.some((k) => k.startsWith("git."))).toBe(true);
+    expect(keys.some((k) => k.startsWith("tasks."))).toBe(true);
+  });
+});
+
+describe("sectionMetricKeys — Overview section kinds", () => {
+  it("collects attention metrics", () => {
+    const keys = sectionMetricKeys({
+      title: "t",
+      sections: [{ kind: "attention", metrics: ["git.commits", "wiki.edits"], max: 8 }],
+    });
+    expect(keys.sort()).toEqual(["git.commits", "wiki.edits"]);
+  });
+  it("derives direction-cards keys from every configured Overview lens headline", () => {
+    const keys = sectionMetricKeys({
+      title: "t",
+      sections: [{ kind: "direction-cards", variant: "full" }],
+    });
+    expect(keys).toContain("git.commits");
+    expect(keys).toContain("collab.messages_sent");
+    expect(keys).toContain("wiki.pages_created");
+  });
+  it("derives coverage-radar keys from every group's card preview", () => {
+    const keys = new Set(
+      sectionMetricKeys({ title: "t", sections: [{ kind: "coverage-radar" }] }),
+    );
+    for (const g of GROUPS) {
+      for (const k of g.card.preview) expect(keys.has(k), k).toBe(true);
+    }
+  });
+});

--- a/src/frontend/src/lib/portal/lens-configs.ts
+++ b/src/frontend/src/lib/portal/lens-configs.ts
@@ -49,8 +49,10 @@ export interface LensRoadmap {
   readiness: Readiness;
 }
 
+/** Either a lens we render or one we only name — the pane treats the two differently. */
 export type LensEntry = LensConfig | LensRoadmap;
 
+/** The registry entry for a direction's lens — a config, a roadmap note, or nothing. */
 export function lensEntry(dir: string, lens: string): LensEntry | undefined {
   return DIRECTION_LENSES[dir]?.[lens];
 }

--- a/src/frontend/src/lib/portal/lens-configs.ts
+++ b/src/frontend/src/lib/portal/lens-configs.ts
@@ -1,0 +1,435 @@
+import { headlineMetricKeys } from "@/lib/insight/groups";
+import type { Readiness } from "@/lib/portal/nav-model";
+
+/**
+ * The Directions registry: every direction × lens maps to either a LensConfig
+ * (rendered by DomainLensView from typed sections) or an honest ComingSoon
+ * note naming what would enable it (design D1, rule 9).
+ *
+ * Metric MEANING stays server-owned; configs carry keys + section composition
+ * only. No named individuals anywhere (design D4/rule 10).
+ */
+
+export type ConcentrationFraming = "bus-factor" | "load-balance";
+
+export type SectionSpec =
+  | { kind: "headline"; metrics: readonly string[] }
+  | { kind: "stat-tiles"; title: string; metrics: readonly string[] }
+  | { kind: "trend"; metrics: readonly string[] }
+  | { kind: "distribution"; metric: string; title: string; caption: string; unitLabel: string }
+  | { kind: "concentration"; metrics: readonly string[]; framing: ConcentrationFraming }
+  | { kind: "composition"; metric: string; dimension: string; title: string }
+  // Flow-depth sections: event-histogram merges per-entity server bins when
+  // edges align (they don't on the current API — honest fallback, see design §7);
+  // participation counts active people.
+  | { kind: "event-histogram"; metric: string; title: string }
+  | { kind: "participation"; metrics: readonly string[]; title: string; noun: string }
+  // Overview-motivated, zone-agnostic sections (design DESIGN-2026-07-27-overview §4).
+  | { kind: "attention"; metrics: readonly string[]; max: number }
+  | { kind: "direction-cards"; variant: "compact" | "full" }
+  | { kind: "coverage-radar" };
+
+export interface LensConfig {
+  title: string;
+  /** Subtitle tail after "N members · " (defaults to "trend & balance"). */
+  tagline?: string;
+  sections: readonly SectionSpec[];
+  /** Whole-tab message when no metric of the lens is observed (rule 6). */
+  notIngested?: string;
+}
+
+/**
+ * A lens that renders nothing yet, and WHY — the two causes must not look
+ * alike. `planned`: the product does not model this metric family yet (same
+ * for every tenant). `unbuilt`: the data path exists and the screen is ours to
+ * build. See `Readiness` in nav-model.
+ */
+export interface LensRoadmap {
+  comingSoon: string;
+  readiness: Readiness;
+}
+
+export type LensEntry = LensConfig | LensRoadmap;
+
+export function lensEntry(dir: string, lens: string): LensEntry | undefined {
+  return DIRECTION_LENSES[dir]?.[lens];
+}
+
+/** Unique metric keys a config needs in its period+peer grid. */
+export function sectionMetricKeys(config: LensConfig): string[] {
+  const keys = new Set<string>();
+  for (const s of config.sections) {
+    switch (s.kind) {
+      case "headline":
+      case "stat-tiles":
+      case "trend":
+      case "concentration":
+      case "participation":
+      case "attention":
+        for (const k of s.metrics) keys.add(k);
+        break;
+      case "distribution":
+      case "composition":
+      case "event-histogram":
+        keys.add(s.metric);
+        break;
+      case "direction-cards":
+        // Cards derive from every configured direction Overview lens (design O4).
+        for (const lenses of Object.values(DIRECTION_LENSES)) {
+          const overview = lenses["Overview"];
+          if (!overview || "comingSoon" in overview) continue;
+          for (const sec of overview.sections) {
+            if (sec.kind === "headline") for (const k of sec.metrics) keys.add(k);
+          }
+        }
+        break;
+      case "coverage-radar":
+        for (const k of headlineMetricKeys()) keys.add(k);
+        break;
+      default: {
+        const _exhaustive: never = s;
+        throw new Error(`Unhandled section kind: ${JSON.stringify(_exhaustive)}`);
+      }
+    }
+  }
+  return [...keys];
+}
+
+/* ── Development ─────────────────────────────────────────────────────── */
+
+/** Product-side gap: the metric family is not in the semantic layer yet. */
+const DEV_PLANNED = (what: string): LensRoadmap => ({
+  comingSoon: `${what} — not in the semantic layer yet. This tab lights up when its metric family ships.`,
+  readiness: "planned",
+});
+
+/**
+ * Our gap: the dimensions this needs already ride on the git observations
+ * (repository / project / file_extension / change_type), so this is frontend
+ * work we owe, not a data request. Worded so nobody schedules a metric task.
+ */
+const DEV_UNBUILT = (what: string): LensRoadmap => ({
+  comingSoon: `${what} — the data is there (git observations carry the dimensions); this view is still in development.`,
+  readiness: "unbuilt",
+});
+
+const DEV: Record<string, LensEntry> = {
+  Overview: {
+    title: "Development",
+    tagline: "output, flow & balance",
+    sections: [
+      { kind: "headline", metrics: ["git.commits", "git.prs_merged", "git.lines_added"] },
+      {
+        kind: "stat-tiles",
+        title: "Flow health · median",
+        metrics: ["git.pr_cycle_time_h", "git.pr_size", "git.merge_rate"],
+      },
+      { kind: "trend", metrics: ["git.commits", "git.prs_merged"] },
+      { kind: "concentration", metrics: ["git.commits"], framing: "bus-factor" },
+      {
+        kind: "composition",
+        metric: "git.lines_added",
+        dimension: "category",
+        title: "Lines by category",
+      },
+    ],
+  },
+  "Git output": {
+    title: "Development · Git output",
+    sections: [
+      {
+        kind: "headline",
+        metrics: ["git.commits", "git.prs_created", "git.prs_merged", "git.code_lines"],
+      },
+      { kind: "trend", metrics: ["git.commits", "git.prs_merged"] },
+      {
+        kind: "distribution",
+        metric: "git.commits",
+        title: "Commit-volume distribution",
+        caption:
+          "How many people fall in each commit-count band — a long right tail means a few people produce most of the commits.",
+        unitLabel: "commits per person",
+      },
+      { kind: "concentration", metrics: ["git.commits"], framing: "bus-factor" },
+      {
+        kind: "composition",
+        metric: "git.lines_added",
+        dimension: "repository",
+        title: "Lines by repository",
+      },
+    ],
+  },
+  Flow: {
+    title: "Development · Flow",
+    tagline: "how smoothly work moves",
+    sections: [
+      {
+        kind: "stat-tiles",
+        title: "Flow health · median",
+        metrics: [
+          "git.pr_cycle_time_h",
+          "git.pr_size",
+          "git.commit_size",
+          "git.merge_rate",
+          "git.commits_per_active_day",
+        ],
+      },
+      {
+        kind: "event-histogram",
+        metric: "git.pr_cycle_time_h",
+        title: "PR cycle-time distribution (events)",
+      },
+    ],
+  },
+  Delivery: {
+    title: "Development · Delivery",
+    notIngested: "Task source (Jira) isn't ingested for this org yet.",
+    sections: [
+      { kind: "headline", metrics: ["tasks.closed", "tasks.bugs_fixed"] },
+      {
+        kind: "stat-tiles",
+        title: "Delivery health · median",
+        metrics: ["tasks.resolution_time", "tasks.pickup_time", "tasks.dev_time"],
+      },
+      { kind: "trend", metrics: ["tasks.closed", "tasks.bugs_fixed"] },
+      {
+        kind: "distribution",
+        metric: "tasks.closed",
+        title: "Task-throughput distribution",
+        caption: "How many people fall in each tasks-closed band.",
+        unitLabel: "tasks closed per person",
+      },
+    ],
+  },
+  Activity: DEV_PLANNED("Per-person activity-day metrics"),
+  Quality: DEV_PLANNED("Review / reopen quality metrics"),
+  Continuity: DEV_PLANNED("Longitudinal continuity metrics"),
+  Repositories: DEV_UNBUILT("Repository-level rollups"),
+  Elements: DEV_UNBUILT("Element-level (file/module) analytics"),
+};
+
+/* ── Collaboration (ported unchanged from ModalityView configs) ──────── */
+
+const COLLAB: Record<string, LensEntry> = {
+  Overview: {
+    title: "Collaboration",
+    sections: [
+      {
+        kind: "headline",
+        metrics: ["collab.messages_sent", "collab.meeting_hours", "collab.focus_time_pct"],
+      },
+      { kind: "trend", metrics: ["collab.messages_sent", "collab.meeting_hours"] },
+      {
+        kind: "distribution",
+        metric: "collab.meeting_hours",
+        title: "Meeting-load distribution",
+        caption:
+          "How many people fall in each meeting-hours band — a long right tail means a few people carry an outsized meeting load.",
+        unitLabel: "meeting hours per person",
+      },
+      {
+        kind: "concentration",
+        metrics: ["collab.meeting_hours", "collab.messages_sent"],
+        framing: "load-balance",
+      },
+    ],
+  },
+  Messaging: {
+    title: "Messaging",
+    sections: [
+      {
+        kind: "headline",
+        metrics: ["collab.messages_sent", "collab.msgs_per_active_day", "collab.active_days"],
+      },
+      { kind: "trend", metrics: ["collab.messages_sent"] },
+      {
+        kind: "distribution",
+        metric: "collab.messages_sent",
+        title: "Messaging-load distribution",
+        caption:
+          "How many people fall in each message-volume band — a long right tail means a few people account for most of the chatter.",
+        unitLabel: "messages per person",
+      },
+      { kind: "concentration", metrics: ["collab.messages_sent"], framing: "load-balance" },
+    ],
+  },
+  Meetings: {
+    title: "Meetings",
+    sections: [
+      {
+        kind: "headline",
+        metrics: ["collab.meeting_hours", "collab.meetings_count", "collab.meeting_free_days"],
+      },
+      { kind: "trend", metrics: ["collab.meeting_hours"] },
+      {
+        kind: "distribution",
+        metric: "collab.meeting_hours",
+        title: "Meeting-load distribution",
+        caption:
+          "How many people fall in each meeting-hours band — a long right tail means a few people carry an outsized meeting load.",
+        unitLabel: "meeting hours per person",
+      },
+      { kind: "concentration", metrics: ["collab.meeting_hours"], framing: "load-balance" },
+    ],
+  },
+  // emails_received deliberately omitted: distribution-list/CI noise (see git history).
+  Email: {
+    title: "Email",
+    sections: [
+      { kind: "headline", metrics: ["collab.emails_sent", "collab.emails_read"] },
+      { kind: "trend", metrics: ["collab.emails_sent"] },
+      {
+        kind: "distribution",
+        metric: "collab.emails_sent",
+        title: "Email-volume distribution",
+        caption:
+          "How many people fall in each sent-email band — a long right tail means a few people send most of the email.",
+        unitLabel: "emails sent per person",
+      },
+      { kind: "concentration", metrics: ["collab.emails_sent"], framing: "load-balance" },
+    ],
+  },
+  "Focus time": {
+    title: "Focus time",
+    sections: [
+      { kind: "headline", metrics: ["collab.focus_time_pct", "collab.meeting_free_days"] },
+      {
+        kind: "distribution",
+        metric: "collab.focus_time_pct",
+        title: "Focus-time distribution",
+        caption:
+          "How many people fall in each focus-time band — a cluster on the left means many people have little uninterrupted focus time.",
+        unitLabel: "focus time (share of working time) per person",
+      },
+    ],
+  },
+  "Files & sharing": {
+    title: "Files & sharing",
+    sections: [
+      {
+        kind: "headline",
+        metrics: ["collab.files_shared", "collab.files_engaged", "collab.files_shared_external"],
+      },
+      { kind: "trend", metrics: ["collab.files_shared"] },
+      {
+        kind: "distribution",
+        metric: "collab.files_shared",
+        title: "File-sharing distribution",
+        caption:
+          "How many people fall in each files-shared band — a long right tail means a few people do most of the sharing.",
+        unitLabel: "files shared per person",
+      },
+      { kind: "concentration", metrics: ["collab.files_shared"], framing: "load-balance" },
+    ],
+  },
+};
+
+/* ── Knowledge / Wiki ────────────────────────────────────────────────── */
+
+const WIKI: Record<string, LensEntry> = {
+  Overview: {
+    title: "Knowledge / Wiki",
+    sections: [
+      { kind: "headline", metrics: ["wiki.pages_created", "wiki.edits", "wiki.comments"] },
+      { kind: "trend", metrics: ["wiki.pages_created", "wiki.edits"] },
+      {
+        kind: "distribution",
+        metric: "wiki.edits",
+        title: "Edit-volume distribution",
+        caption:
+          "How many people fall in each wiki-edits band — a long right tail means knowledge writing is concentrated in a few hands.",
+        unitLabel: "wiki edits per person",
+      },
+      { kind: "concentration", metrics: ["wiki.edits"], framing: "bus-factor" },
+    ],
+  },
+  Authoring: {
+    title: "Wiki · Authoring",
+    sections: [
+      { kind: "headline", metrics: ["wiki.pages_created", "wiki.pages_edited"] },
+      {
+        kind: "distribution",
+        metric: "wiki.pages_created",
+        title: "Authoring distribution",
+        caption: "How many people fall in each pages-created band.",
+        unitLabel: "pages created per person",
+      },
+      { kind: "concentration", metrics: ["wiki.pages_created"], framing: "bus-factor" },
+    ],
+  },
+  "Edits & comments": {
+    title: "Wiki · Edits & comments",
+    sections: [
+      { kind: "headline", metrics: ["wiki.edits", "wiki.comments"] },
+      { kind: "trend", metrics: ["wiki.edits", "wiki.comments"] },
+      {
+        kind: "distribution",
+        metric: "wiki.edits",
+        title: "Edit-volume distribution",
+        caption: "How many people fall in each wiki-edits band.",
+        unitLabel: "wiki edits per person",
+      },
+    ],
+  },
+  "Active authors": {
+    title: "Wiki · Active authors",
+    tagline: "who writes at all",
+    sections: [
+      {
+        kind: "participation",
+        metrics: ["wiki.pages_created", "wiki.edits", "wiki.comments"],
+        title: "Participation",
+        noun: "Active authors",
+      },
+      // Participation's per-bucket count reads the trend query; wiki.edits
+      // dominates wiki activity, so the trend fetch keys off it alone — do NOT
+      // add all three (row budget at org scope). The headline "N of M" uses the
+      // period grid over all three metrics.
+      { kind: "trend", metrics: ["wiki.edits"] },
+    ],
+  },
+};
+
+/* ── Sales / Support (bullet-only directions) ────────────────────────── */
+
+const SALES_NOTE: LensRoadmap = {
+  comingSoon: "HubSpot isn't in the semantic layer yet — bullet-only direction.",
+  readiness: "planned",
+};
+const SUPPORT_NOTE: LensRoadmap = {
+  comingSoon: "Zendesk isn't in the semantic layer yet — bullet-only direction.",
+  readiness: "planned",
+};
+
+const SALES: Record<string, LensEntry> = Object.fromEntries(
+  ["Pipeline", "Deal flow", "Activity", "Velocity & quality"].map((l) => [
+    l,
+    SALES_NOTE,
+  ]),
+);
+const SUPPORT: Record<string, LensEntry> = Object.fromEntries(
+  ["Tickets", "CSAT", "Knowledge base", "Comments & updates"].map((l) => [
+    l,
+    SUPPORT_NOTE,
+  ]),
+);
+
+export const DIRECTION_LENSES: Record<string, Record<string, LensEntry>> = {
+  dev: DEV,
+  collab: COLLAB,
+  wiki: WIKI,
+  sales: SALES,
+  support: SUPPORT,
+};
+
+/** Union of metric keys across every configured lens of a direction — one
+ * stable grid collection per direction so switching lenses never changes the
+ * query key (no spinner). ComingSoon entries contribute nothing. */
+export function directionMetricKeys(dir: string): string[] {
+  const keys = new Set<string>();
+  for (const entry of Object.values(DIRECTION_LENSES[dir] ?? {})) {
+    if ("comingSoon" in entry) continue;
+    for (const k of sectionMetricKeys(entry)) keys.add(k);
+  }
+  return [...keys];
+}

--- a/src/frontend/src/lib/portal/metric-stats.test.ts
+++ b/src/frontend/src/lib/portal/metric-stats.test.ts
@@ -104,6 +104,12 @@ describe("medianAcross", () => {
 describe("fmtCompact", () => {
   it("abbreviates thousands", () => expect(fmtCompact(1500)).toBe("1.5k"));
   it("keeps small integers", () => expect(fmtCompact(10)).toBe("10"));
+  // Without the million step a large bin edge read "1000k", which names a
+  // magnitude the reader has to decode.
+  it("abbreviates millions", () => {
+    expect(fmtCompact(1_500_000)).toBe("1.5M");
+    expect(fmtCompact(2_000_000)).toBe("2M");
+  });
 });
 
 describe("groupCoverage", () => {

--- a/src/frontend/src/lib/portal/metric-stats.test.ts
+++ b/src/frontend/src/lib/portal/metric-stats.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+
+import type { NormalizedMetricResult } from "@/lib/metrics/collection";
+import {
+  chooseStep,
+  distribution,
+  familyObserved,
+  fmtCompact,
+  groupCoverage,
+  medianAcross,
+  perCapita,
+  representative,
+  topDecileShare,
+} from "./metric-stats";
+
+/** Minimal NormalizedMetricResult fixture: period values + peer target_values. */
+function fixture(opts: {
+  computation?: NormalizedMetricResult["computation"];
+  period: Array<[string, number | null]>;
+  peerTargets?: Array<[string, number | null]>;
+}): NormalizedMetricResult {
+  return {
+    metric_key: "t.metric",
+    label: "T",
+    unit: null,
+    computation: opts.computation ?? "sum",
+    format: "integer",
+    direction: "higher_is_better",
+    period: {
+      view: "period",
+      values: opts.period.map(([entity_id, value]) => ({ entity_id, value })),
+    },
+    peer: opts.peerTargets
+      ? {
+          view: "peer",
+          values: opts.peerTargets.map(([entity_id, target_value]) => ({
+            entity_id,
+            target_value,
+          })),
+        }
+      : undefined,
+  } as unknown as NormalizedMetricResult;
+}
+
+describe("chooseStep", () => {
+  it("keeps small maxima at step 1", () => expect(chooseStep(6, 14)).toBe(1));
+  it("climbs the 1/2/5 ladder", () => expect(chooseStep(70, 14)).toBe(5));
+  it("scales into hundreds", () => expect(chooseStep(4500, 14)).toBe(500));
+});
+
+describe("distribution", () => {
+  it("suppresses below 4 observations", () =>
+    expect(distribution([1, 2, 3], String)).toEqual([]));
+  it("suppresses when all mass lands in one bin", () =>
+    expect(distribution([5, 5, 5, 5], String)).toEqual([]));
+  it("bins a real spread", () => {
+    const rows = distribution([1, 2, 3, 9], String);
+    expect(rows.length).toBeGreaterThan(1);
+    expect(rows.reduce((a, r) => a + r.count, 0)).toBe(4);
+  });
+});
+
+describe("topDecileShare", () => {
+  it("needs at least 4 values", () => expect(topDecileShare([1, 2, 3])).toBeNull());
+  it("computes the busiest-decile share", () => {
+    const share = topDecileShare([10, 1, 1, 1, 1, 1, 1, 1, 1, 1]);
+    expect(share).toBeCloseTo(10 / 19, 3);
+  });
+});
+
+describe("perCapita / representative", () => {
+  it("perCapita divides by ACTIVE people only", () => {
+    const r = fixture({ period: [["a", 10], ["b", 0], ["c", 20]] });
+    expect(perCapita(r, ["a", "b", "c"])).toBe(15);
+  });
+  it("representative sums counters and medians ratios", () => {
+    const sum = fixture({ period: [["a", 1], ["b", 2]] });
+    expect(representative(sum, ["a", "b"])).toBe(3);
+    const med = fixture({ computation: "ratio", period: [["a", 10], ["b", 30]] });
+    expect(representative(med, ["a", "b"])).toBe(20);
+  });
+});
+
+describe("familyObserved", () => {
+  it("false when every peer target is null (zero-filled sums don't count)", () => {
+    const r = fixture({ period: [["a", 0]], peerTargets: [["a", null]] });
+    expect(familyObserved(new Map([["t.metric", r]]), ["t.metric"], ["a"])).toBe(false);
+  });
+  it("true when any entity is observed", () => {
+    const r = fixture({ period: [["a", 0], ["b", 7]], peerTargets: [["a", null], ["b", 7]] });
+    expect(familyObserved(new Map([["t.metric", r]]), ["t.metric"], ["a", "b"])).toBe(true);
+  });
+});
+
+describe("medianAcross", () => {
+  it("medians a summable metric instead of summing it (unlike representative)", () => {
+    const r = fixture({ computation: "sum", period: [["a", 10], ["b", 20], ["c", 30]] });
+    expect(medianAcross(r, ["a", "b", "c"])).toBe(20);
+    expect(representative(r, ["a", "b", "c"])).toBe(60);
+  });
+  it("null when the metric is missing", () => expect(medianAcross(undefined, ["a"])).toBeNull());
+});
+
+describe("fmtCompact", () => {
+  it("abbreviates thousands", () => expect(fmtCompact(1500)).toBe("1.5k"));
+  it("keeps small integers", () => expect(fmtCompact(10)).toBe("10"));
+});
+
+describe("groupCoverage", () => {
+  it("counts only entityObserved members (zero-filled sums excluded)", () => {
+    const r = fixture({
+      period: [["a", 0], ["b", 7], ["c", 3]],
+      peerTargets: [["a", null], ["b", 7], ["c", 3]],
+    });
+    const byKey = new Map([["t.metric", r]]);
+    expect(groupCoverage(byKey, ["t.metric"], ["a", "b", "c"])).toBeCloseTo(2 / 3, 5);
+  });
+  it("returns null for an empty roster", () => {
+    expect(groupCoverage(new Map(), ["t.metric"], [])).toBeNull();
+  });
+  it("returns 0 when the group has no observations", () => {
+    const r = fixture({ period: [["a", 0]], peerTargets: [["a", null]] });
+    expect(groupCoverage(new Map([["t.metric", r]]), ["t.metric"], ["a"])).toBe(0);
+  });
+});

--- a/src/frontend/src/lib/portal/metric-stats.ts
+++ b/src/frontend/src/lib/portal/metric-stats.ts
@@ -89,7 +89,10 @@ export function distribution(
   const nBins = Math.max(1, Math.ceil(max / step));
   const counts = new Array(nBins).fill(0) as number[];
   for (const v of values) {
-    counts[Math.min(nBins - 1, Math.floor(v / step))] += 1;
+    // Clamped at both ends: a negative value (a delta-shaped metric, a bad
+    // row) would index counts[-1], which lands on a property outside the array
+    // and drops the person from the distribution silently.
+    counts[Math.min(nBins - 1, Math.max(0, Math.floor(v / step)))] += 1;
   }
   if (counts.filter((c) => c > 0).length < 2) return [];
   return counts.map((count, i) => ({
@@ -122,12 +125,23 @@ export function topDecileShare(values: readonly number[]): number | null {
   return top / total;
 }
 
-/** Compact axis number: 1500 → "1.5k", 10 → "10", 2.5 → "2.5". */
+/**
+ * Compact bin label: 1500 → "1.5k", 1_500_000 → "1.5M", 10 → "10", 2.5 → "2.5".
+ *
+ * Deliberately NOT `formatAxisTick`, which only abbreviates from 10k: a tick
+ * marks a gridline, so "1.5k" there would name a position the line is not
+ * exactly on. A bin edge is an exact value off the 1/2/5 ladder, so abbreviating
+ * from a thousand loses nothing. The million step exists because without it a
+ * million-level bin read "1000k".
+ */
 export function fmtCompact(n: number): string {
-  if (Math.abs(n) >= 1000) {
-    const k = n / 1000;
-    return `${Number.isInteger(k) ? k : k.toFixed(1)}k`;
-  }
+  const abs = Math.abs(n);
+  if (abs >= 1_000_000) return `${trim(n / 1_000_000)}M`;
+  if (abs >= 1000) return `${trim(n / 1000)}k`;
+  return trim(n);
+}
+
+function trim(n: number): string {
   return Number.isInteger(n) ? String(n) : n.toFixed(1);
 }
 

--- a/src/frontend/src/lib/portal/metric-stats.ts
+++ b/src/frontend/src/lib/portal/metric-stats.ts
@@ -1,0 +1,175 @@
+import {
+  entityObserved,
+  forEntity,
+  type NormalizedMetricResult,
+} from "@/lib/metrics/collection";
+import { quantile } from "@/lib/insight/within-team-peer";
+
+/**
+ * Pure stats used by the Directions section library (design §3 rules 1-4, 11).
+ * All functions are roster-scoped: callers pass the member-id list of the
+ * active scope, never the whole org implicitly.
+ */
+
+/** Representative period value: total for sums, median across people otherwise. */
+export function representative(
+  r: NormalizedMetricResult | undefined,
+  ids: readonly string[],
+): number | null {
+  if (!r) return null;
+  const vals = ids
+    .map((id) => forEntity(r, id).value)
+    .filter((v): v is number => v != null && Number.isFinite(v));
+  if (!vals.length) return null;
+  if (r.computation === "sum") return vals.reduce((a, b) => a + b, 0);
+  return quantile([...vals].sort((a, b) => a - b), 0.5);
+}
+
+/**
+ * Median across people, regardless of the result's own `computation` kind.
+ * Unlike `representative`, this never sums — useful for stat-tile sections
+ * that want a per-person median health read on a metric that's normally
+ * summed (e.g. a counter's per-person spread), without re-wrapping the
+ * result to fake a different computation kind.
+ */
+export function medianAcross(
+  r: NormalizedMetricResult | undefined,
+  ids: readonly string[],
+): number | null {
+  if (!r) return null;
+  const vals = ids
+    .map((id) => forEntity(r, id).value)
+    .filter((v): v is number => v != null && Number.isFinite(v));
+  if (!vals.length) return null;
+  return quantile([...vals].sort((a, b) => a - b), 0.5);
+}
+
+/** Per-active-person mean for a summable metric (denominator = value > 0). */
+export function perCapita(r: NormalizedMetricResult, ids: readonly string[]): number {
+  let total = 0;
+  let active = 0;
+  for (const id of ids) {
+    const v = forEntity(r, id).value;
+    if (v != null && Number.isFinite(v) && v > 0) {
+      total += v;
+      active += 1;
+    }
+  }
+  return active ? total / active : 0;
+}
+
+/**
+ * Not exported: nothing outside this module imports the type by name.
+ * `DomainLensView` consumes `distribution()`'s return structurally (it reads
+ * `.label`/`.range`/`.count` off the inferred row type without naming
+ * `DistRow`) — re-export only if a future consumer needs to name the shape.
+ */
+interface DistRow {
+  /** Compact lower-edge tick, e.g. "10" or "1.5k". */
+  label: string;
+  /** Full band for the tooltip, e.g. "10–15". */
+  range: string;
+  count: number;
+}
+
+/**
+ * Frequency distribution of per-person values into evenly-spaced bands.
+ * Self-suppression (design rule 11): returns [] below 4 observations, when
+ * the maximum is not positive, or when all mass lands in a single bin — a
+ * correct-but-meaningless histogram is worse than none.
+ */
+export function distribution(
+  values: readonly number[],
+  fmt: (n: number) => string,
+): DistRow[] {
+  if (values.length < 4) return [];
+  const max = Math.max(...values);
+  if (max <= 0) return [];
+  const step = chooseStep(max, 14);
+  const nBins = Math.max(1, Math.ceil(max / step));
+  const counts = new Array(nBins).fill(0) as number[];
+  for (const v of values) {
+    counts[Math.min(nBins - 1, Math.floor(v / step))] += 1;
+  }
+  if (counts.filter((c) => c > 0).length < 2) return [];
+  return counts.map((count, i) => ({
+    label: fmt(i * step),
+    range: `${fmt(i * step)}–${fmt((i + 1) * step)}`,
+    count,
+  }));
+}
+
+/** Smallest whole 1/2/5·10ⁿ step whose bin count stays at or under `maxBins`. */
+export function chooseStep(max: number, maxBins: number): number {
+  const mults = [1, 2, 5];
+  for (let pow = 0; pow < 12; pow++) {
+    for (const m of mults) {
+      const step = m * Math.pow(10, pow);
+      if (Math.ceil(max / step) <= maxBins) return step;
+    }
+  }
+  return max;
+}
+
+/** Share of the total held by the busiest 10% of contributors. */
+export function topDecileShare(values: readonly number[]): number | null {
+  if (values.length < 4) return null;
+  const sorted = [...values].sort((a, b) => b - a);
+  const total = sorted.reduce((a, b) => a + b, 0);
+  if (total <= 0) return null;
+  const topN = Math.max(1, Math.ceil(sorted.length * 0.1));
+  const top = sorted.slice(0, topN).reduce((a, b) => a + b, 0);
+  return top / total;
+}
+
+/** Compact axis number: 1500 → "1.5k", 10 → "10", 2.5 → "2.5". */
+export function fmtCompact(n: number): string {
+  if (Math.abs(n) >= 1000) {
+    const k = n / 1000;
+    return `${Number.isInteger(k) ? k : k.toFixed(1)}k`;
+  }
+  return Number.isInteger(n) ? String(n) : n.toFixed(1);
+}
+
+/**
+ * Whether ANY metric of a lens family has ANY observed entity (design rule 6).
+ * Uses `entityObserved` (peer target_value), never zero-filled period sums —
+ * this is what distinguishes "measured zero" from "source not ingested".
+ */
+export function familyObserved(
+  byKey: Map<string, NormalizedMetricResult>,
+  metricKeys: readonly string[],
+  ids: readonly string[],
+): boolean {
+  for (const key of metricKeys) {
+    const r = byKey.get(key);
+    if (!r) continue;
+    for (const id of ids) {
+      if (entityObserved(r, id)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Domain coverage (Overview design O5): the share of members with at least one
+ * OBSERVED metric among `groupKeys` — via `entityObserved` (peer target when
+ * present; non-zero period value otherwise, so zero-filled sums never count as
+ * observed). Null on an empty roster so callers can suppress.
+ */
+export function groupCoverage(
+  byKey: Map<string, NormalizedMetricResult>,
+  groupKeys: readonly string[],
+  ids: readonly string[],
+): number | null {
+  if (!ids.length) return null;
+  let covered = 0;
+  for (const id of ids) {
+    const has = groupKeys.some((k) => {
+      const r = byKey.get(k);
+      return r != null && entityObserved(r, id);
+    });
+    if (has) covered += 1;
+  }
+  return covered / ids.length;
+}

--- a/src/frontend/src/lib/portal/nav-model.ts
+++ b/src/frontend/src/lib/portal/nav-model.ts
@@ -1,0 +1,294 @@
+import {
+  Activity,
+  AlertTriangle,
+  BarChart3,
+  BookOpen,
+  Boxes,
+  Clock,
+  DollarSign,
+  FileText,
+  Filter,
+  Fingerprint,
+  GitPullRequest,
+  LayoutGrid,
+  Layers,
+  Megaphone,
+  MessageSquare,
+  Plus,
+  Radar,
+  Server,
+  Settings2,
+  ShieldCheck,
+  Sparkles,
+  Ticket,
+  TrendingUp,
+  User,
+  Users,
+  type LucideIcon,
+} from "lucide-react";
+
+
+/**
+ * Portal navigation model (Phase 1 buildout — mirrors the design mockup).
+ *
+ * This is the static composition the mockup demonstrates. Directions, their
+ * lenses and the connector chips are hand-declared here for now; a later phase
+ * derives them from the Analytics API metric catalog (see _work/portal-nav/SPEC.md).
+ * Meaning stays server-owned; this file only carries structure + presentation.
+ */
+
+/* ── Rail zones ──────────────────────────────────────────────────────── */
+
+export type ZoneKind = "person" | "directions" | "theme" | "manage" | "people";
+
+/**
+ * Why a navigation entry has nothing behind it. Three genuinely different
+ * causes that must not look alike to the reader:
+ *
+ * - **absent** (the default, no marker) — the surface is built and backed by
+ *   data. If it still renders empty, that is a per-tenant data gap and the
+ *   view says which source is missing. Always visible: the gap IS the signal.
+ * - **`planned`** — the product does not model this yet (a metric family is
+ *   not in the semantic layer). Identical for every tenant. Kept visible but
+ *   demoted, because it tells a reader the domain exists in our model.
+ * - **`unbuilt`** — WE have not built the screen yet, though the data path
+ *   exists. This is our backlog, not roadmap communication: hidden unless the
+ *   viewer opts into seeing planned work.
+ *
+ * Rendering a tenant data gap and our own unfinished UI the same way is what
+ * makes both meaningless, which is why the distinction is in the model rather
+ * than in prose.
+ */
+export type Readiness = "planned" | "unbuilt";
+
+export interface Zone {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  kind: ZoneKind;
+  readiness?: Readiness;
+}
+
+export const ZONES: readonly Zone[] = [
+  { id: "overview", label: "Overview", icon: LayoutGrid, kind: "theme" },
+  { id: "directions", label: "Directions", icon: Layers, kind: "directions" },
+  { id: "person", label: "Person", icon: User, kind: "person" },
+  { id: "people", label: "People", icon: Users, kind: "people" },
+  { id: "aicost", label: "AI & Cost", icon: DollarSign, kind: "theme" },
+  // Pure scaffolds: no view, no data path. Our backlog, not a tenant gap.
+  { id: "scorecard", label: "Scorecard", icon: BarChart3, kind: "theme", readiness: "unbuilt" },
+  { id: "reports", label: "Reports", icon: FileText, kind: "theme", readiness: "unbuilt" },
+  { id: "manage", label: "Manage", icon: Settings2, kind: "manage" },
+];
+
+export function zoneById(id: string | null): Zone | undefined {
+  if (!id) return undefined;
+  return ZONES.find((z) => z.id === id);
+}
+
+/* ── Directions (catalog-driven family list) ─────────────────────────── */
+
+export type DirectionSource = "semantic" | "bullet";
+
+export interface Direction {
+  id: string;
+  name: string;
+  icon: LucideIcon;
+  source: DirectionSource;
+  lenses: readonly string[];
+}
+
+export const DIRECTIONS: readonly Direction[] = [
+  {
+    id: "dev",
+    name: "Development",
+    icon: GitPullRequest,
+    source: "semantic",
+    lenses: [
+      "Overview",
+      "Git output",
+      "Delivery",
+      "Activity",
+      "Flow",
+      "Quality",
+      "Continuity",
+      "Repositories",
+      "Elements",
+    ],
+  },
+  {
+    id: "collab",
+    name: "Collaboration",
+    icon: MessageSquare,
+    source: "semantic",
+    lenses: ["Overview", "Messaging", "Meetings", "Email", "Focus time", "Files & sharing"],
+  },
+  {
+    id: "wiki",
+    name: "Knowledge / Wiki",
+    icon: BookOpen,
+    source: "semantic",
+    lenses: ["Overview", "Authoring", "Edits & comments", "Active authors"],
+  },
+  {
+    id: "sales",
+    name: "Sales / CRM",
+    icon: DollarSign,
+    source: "bullet",
+    lenses: ["Pipeline", "Deal flow", "Activity", "Velocity & quality"],
+  },
+  {
+    id: "support",
+    name: "Support",
+    icon: Ticket,
+    source: "bullet",
+    lenses: ["Tickets", "CSAT", "Knowledge base", "Comments & updates"],
+  },
+];
+
+/* ── Theme-zone section lists ────────────────────────────────────────── */
+
+export interface PaneItem {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  badge?: { text: string; tone: "warn" | "new" | "error" };
+  /** See {@link Readiness}. Absent = built and data-backed. */
+  readiness?: Readiness;
+}
+
+export interface PaneGroup {
+  label?: string;
+  items: readonly PaneItem[];
+}
+
+/** The label the pane uses for the demoted group of planned entries. */
+export const PLANNED_GROUP_LABEL = "Planned";
+
+/**
+ * Split entries into what a reader should always see and what belongs under
+ * the demoted "Planned" group. `unbuilt` entries drop out entirely unless the
+ * viewer opted in — showing our own unfinished screens next to honest tenant
+ * data gaps teaches people that empty means nothing in particular.
+ */
+export function partitionByReadiness<T extends { readiness?: Readiness }>(
+  entries: readonly T[],
+  showPlanned: boolean,
+): { live: T[]; planned: T[] } {
+  const live: T[] = [];
+  const planned: T[] = [];
+  for (const e of entries) {
+    if (e.readiness == null) live.push(e);
+    // `planned` is roadmap the reader benefits from seeing; `unbuilt` is ours
+    // and only appears when the viewer asked for planned work.
+    else if (e.readiness === "planned" || showPlanned) planned.push(e);
+  }
+  return { live, planned };
+}
+
+export const ZONE_SECTIONS: Record<string, readonly PaneGroup[]> = {
+  overview: [
+    {
+      label: "Themes",
+      items: [
+        { id: "at-a-glance", label: "At a glance", icon: LayoutGrid },
+        { id: "by-direction", label: "By direction", icon: Layers },
+        { id: "trend", label: "Trend", icon: TrendingUp },
+        { id: "attention", label: "Attention needed", icon: AlertTriangle },
+        { id: "health", label: "Health radar", icon: Radar },
+        { id: "contribution", label: "Contribution breakdown", icon: Users },
+      ],
+    },
+  ],
+  // Lean, data-honest menu: Overview is the live dashboard (adoption + by-tool
+  // + cost-by-person in one scroll); the second group is capabilities that need
+  // data we don't ingest yet (kept visible as honest ComingSoon, not padded out
+  // into a dozen dead tabs).
+  // Full intended IA. Overview / Adoption funnel / By unit are backed by real
+  // data; the rest render an honest ComingSoon (see AiCostView.COMING_SOON) —
+  // the menu shows the roadmap, but nothing fabricates data it doesn't have.
+  aicost: [
+    {
+      items: [{ id: "overview", label: "Overview", icon: LayoutGrid }],
+    },
+    {
+      label: "AI adoption",
+      items: [
+        { id: "adoption-funnel", label: "Adoption funnel", icon: Activity },
+        { id: "by-unit-role", label: "By unit / role", icon: Layers },
+        { id: "per-tool", label: "Per-tool", icon: Sparkles, readiness: "unbuilt" },
+        { id: "autofix", label: "Autofix", icon: Activity, readiness: "planned" },
+        { id: "ai-audit", label: "AI Audit", icon: Radar, readiness: "planned" },
+      ],
+    },
+    {
+      label: "Cost",
+      items: [
+        { id: "spend-by-tool", label: "Spend by tool", icon: DollarSign, readiness: "unbuilt" },
+        { id: "cost-by-unit", label: "Cost by unit / user", icon: Users, readiness: "unbuilt" },
+        { id: "idle-seats", label: "Idle seats", icon: Clock, readiness: "planned" },
+        { id: "credits", label: "Credits burn-down", icon: TrendingUp, readiness: "planned" },
+        {
+          id: "ai-pricing",
+          label: "AI pricing",
+          icon: DollarSign,
+          badge: { text: "ai.cost", tone: "error" },
+          readiness: "planned",
+        },
+      ],
+    },
+  ],
+  scorecard: [
+    {
+      items: [
+        { id: "fixed", label: "Fixed scorecard", icon: LayoutGrid, readiness: "unbuilt" },
+        { id: "detailed", label: "Detailed (drill)", icon: Layers, readiness: "unbuilt" },
+        { id: "quarterly", label: "Quarterly QoQ", icon: TrendingUp, readiness: "unbuilt" },
+      ],
+    },
+  ],
+  reports: [
+    {
+      label: "Generated (diagnosis)",
+      items: [
+        { id: "delivery-trend", label: "Delivery trend v3", icon: FileText, readiness: "unbuilt" },
+        { id: "ttm", label: "TTM report", icon: FileText, readiness: "unbuilt" },
+      ],
+    },
+    {
+      label: "Custom",
+      items: [
+        { id: "report-builder", label: "Report builder", icon: LayoutGrid, readiness: "unbuilt" },
+        { id: "dashboards", label: "Saved dashboards", icon: Layers, readiness: "unbuilt" },
+        { id: "new-report", label: "New report", icon: Plus, readiness: "unbuilt" },
+      ],
+    },
+  ],
+};
+
+/* ── People zone ─────────────────────────────────────────────────────── */
+
+// No "Person" item here — the individual view is the dedicated Person rail
+// zone (reached by drilling into any name); listing it again would duplicate it.
+export const PEOPLE_ITEMS: readonly PaneItem[] = [
+  { id: "roster", label: "People (roster)", icon: Users },
+  { id: "median-by-role", label: "Median by Role", icon: BarChart3, readiness: "planned" },
+  { id: "employees", label: "Employees", icon: Fingerprint },
+];
+
+/* ── Manage zone ─────────────────────────────────────────────────────── */
+
+export const MANAGE_ITEMS: readonly PaneItem[] = [
+  { id: "metric-catalog", label: "Metric catalog", icon: LayoutGrid },
+  { id: "identities", label: "Identities", icon: Fingerprint, readiness: "unbuilt" },
+  { id: "taxonomy", label: "Roles & taxonomy", icon: Boxes, readiness: "unbuilt" },
+  { id: "exclusions", label: "Data exclusions", icon: Filter, readiness: "unbuilt" },
+  { id: "snapshots", label: "Org snapshots", icon: Clock, readiness: "unbuilt" },
+  { id: "group-mgmt", label: "Group management", icon: Users, readiness: "unbuilt" },
+  { id: "scorecard-mgmt", label: "Scorecard management", icon: BarChart3, readiness: "unbuilt" },
+  { id: "data-health", label: "Data health", icon: ShieldCheck },
+  { id: "platform-usage", label: "Platform usage", icon: Activity, readiness: "unbuilt" },
+  { id: "mcp", label: "MCP servers", icon: Server, readiness: "unbuilt" },
+  { id: "config", label: "Config & setup", icon: Settings2, readiness: "unbuilt" },
+  { id: "whats-new", label: "What's new", icon: Megaphone, readiness: "unbuilt" },
+];

--- a/src/frontend/src/lib/portal/nav-model.ts
+++ b/src/frontend/src/lib/portal/nav-model.ts
@@ -81,6 +81,7 @@ export const ZONES: readonly Zone[] = [
   { id: "manage", label: "Manage", icon: Settings2, kind: "manage" },
 ];
 
+/** The zone a URL names, or undefined for an id no longer in the rail. */
 export function zoneById(id: string | null): Zone | undefined {
   if (!id) return undefined;
   return ZONES.find((z) => z.id === id);

--- a/src/frontend/src/lib/portal/overview-configs.test.ts
+++ b/src/frontend/src/lib/portal/overview-configs.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+import { GROUPS } from "@/lib/insight/groups";
+import { ZONE_SECTIONS } from "@/lib/portal/nav-model";
+import { sectionMetricKeys } from "@/lib/portal/lens-configs";
+import { DEFAULT_OVERVIEW_ITEM, OVERVIEW_ITEMS, overviewMetricKeys } from "./overview-configs";
+
+const KNOWN_KEYS = new Set(
+  GROUPS.flatMap((g) => g.collection.metrics.map((m) => m.key)),
+);
+const NAV_ITEM_IDS = (ZONE_SECTIONS.overview ?? []).flatMap((group) =>
+  group.items.map((i) => i.id),
+);
+
+describe("OVERVIEW_ITEMS registry", () => {
+  it("covers every Overview pane item declared in nav-model", () => {
+    for (const id of NAV_ITEM_IDS) {
+      expect(OVERVIEW_ITEMS[id], id).toBeDefined();
+    }
+  });
+  it("has no orphan items missing from nav-model", () => {
+    for (const id of Object.keys(OVERVIEW_ITEMS)) {
+      expect(NAV_ITEM_IDS.includes(id), id).toBe(true);
+    }
+  });
+  it("references only metric keys that exist, per item and in total", () => {
+    for (const [id, config] of Object.entries(OVERVIEW_ITEMS)) {
+      const keys = sectionMetricKeys(config);
+      expect(keys.length, id).toBeLessThanOrEqual(50);
+      for (const k of keys) expect(KNOWN_KEYS.has(k), `${id}: ${k}`).toBe(true);
+    }
+    expect(overviewMetricKeys().length).toBeLessThanOrEqual(50);
+  });
+  it("spans multiple metric families in the union (zone-stable grid)", () => {
+    const union = overviewMetricKeys();
+    expect(union.some((k) => k.startsWith("git."))).toBe(true);
+    expect(union.some((k) => k.startsWith("collab."))).toBe(true);
+    expect(union.some((k) => k.startsWith("ai."))).toBe(true);
+  });
+  it("gives every item at least one section", () => {
+    for (const [id, config] of Object.entries(OVERVIEW_ITEMS)) {
+      expect(config.sections.length, id).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it("keeps the router default item present", () => {
+    expect(OVERVIEW_ITEMS[DEFAULT_OVERVIEW_ITEM]).toBeDefined();
+  });
+
+  it("the at-a-glance headline spans code, delivery, comms and cost", () => {
+    // The headline used to be git + comms + cost only, so an org whose people
+    // work in tickets rather than repos read as idle at the top level — and the
+    // gap was invisible on a dataset where every git tile happened to have data.
+    const headline = OVERVIEW_ITEMS[DEFAULT_OVERVIEW_ITEM]!.sections.find(
+      (s) => s.kind === "headline",
+    );
+    const metrics = headline && "metrics" in headline ? headline.metrics : [];
+    for (const family of ["git.", "tasks.", "collab.", "ai."]) {
+      expect(
+        metrics.some((m) => m.startsWith(family)),
+        `headline is missing the ${family} family`,
+      ).toBe(true);
+    }
+  });
+
+  it("direction-cards keys are variant-independent", () => {
+    const compact = sectionMetricKeys({
+      title: "t",
+      sections: [{ kind: "direction-cards", variant: "compact" }],
+    });
+    const full = sectionMetricKeys({
+      title: "t",
+      sections: [{ kind: "direction-cards", variant: "full" }],
+    });
+    expect([...compact].sort()).toEqual([...full].sort());
+  });
+});

--- a/src/frontend/src/lib/portal/overview-configs.ts
+++ b/src/frontend/src/lib/portal/overview-configs.ts
@@ -1,0 +1,100 @@
+import { headlineMetricKeys } from "@/lib/insight/groups";
+import { sectionMetricKeys, type LensConfig } from "@/lib/portal/lens-configs";
+
+/**
+ * The Overview zone registry: each pane item (nav-model ZONE_SECTIONS.overview)
+ * maps to a LensConfig rendered by DomainLensView — same pattern as
+ * DIRECTION_LENSES (design DESIGN-2026-07-27-overview §3/§5). Item ids must
+ * match nav-model verbatim (pinned by overview-configs.test.ts).
+ */
+
+/** Attention scans the cross-domain headline set — every group's card preview. */
+const ATTENTION_KEYS: readonly string[] = headlineMetricKeys();
+
+/** The item the router renders when no pane item is selected. */
+export const DEFAULT_OVERVIEW_ITEM = "at-a-glance";
+
+export const OVERVIEW_ITEMS: Record<string, LensConfig> = {
+  [DEFAULT_OVERVIEW_ITEM]: {
+    title: "Overview",
+    tagline: "cross-functional org rollup",
+    sections: [
+      {
+        kind: "headline",
+        // Task throughput belongs in a cross-functional headline: without it
+        // the org's top line was three-quarters code and cost, and the work
+        // that never touches a repo went unrepresented.
+        metrics: [
+          "git.commits",
+          "git.prs_merged",
+          "tasks.closed",
+          "collab.messages_sent",
+          "ai.cost",
+        ],
+      },
+      // The old header's "N using AI" stat, now an honest participation card
+      // (count + share + delta). No trend section here → card renders chartless.
+      {
+        kind: "participation",
+        metrics: ["ai.active_days"],
+        title: "AI adoption",
+        noun: "People using AI",
+      },
+      { kind: "attention", metrics: ATTENTION_KEYS, max: 8 },
+      { kind: "direction-cards", variant: "compact" },
+    ],
+  },
+  "by-direction": {
+    title: "Overview · By direction",
+    tagline: "where to look next",
+    sections: [{ kind: "direction-cards", variant: "full" }],
+  },
+  trend: {
+    title: "Overview · Trend",
+    tagline: "org totals over time",
+    sections: [
+      { kind: "trend", metrics: ["git.commits", "git.prs_merged", "collab.messages_sent"] },
+    ],
+  },
+  attention: {
+    title: "Overview · Attention needed",
+    tagline: "who to look at",
+    sections: [{ kind: "attention", metrics: ATTENTION_KEYS, max: 30 }],
+  },
+  health: {
+    title: "Overview · Health radar",
+    tagline: "domain coverage",
+    sections: [{ kind: "coverage-radar" }],
+  },
+  contribution: {
+    title: "Overview · Contribution breakdown",
+    tagline: "who carries the output — shape, not leaderboard",
+    sections: [
+      // Headline gives the per-capita + delta rollup AND feeds the automatic
+      // by-unit comparison when a slice is active (review decision).
+      { kind: "headline", metrics: ["git.commits"] },
+      { kind: "concentration", metrics: ["git.commits"], framing: "bus-factor" },
+      {
+        kind: "distribution",
+        metric: "git.commits",
+        title: "Commit-volume distribution",
+        caption:
+          "How many people fall in each commit-count band — a long right tail means a few people produce most of the commits.",
+        unitLabel: "commits per person",
+      },
+    ],
+  },
+};
+
+/**
+ * Union of metric keys across every Overview item — one stable grid query for
+ * the whole zone, so switching pane items never re-spins (mirror of
+ * directionMetricKeys).
+ */
+export function overviewMetricKeys(): string[] {
+  const keys = new Set<string>();
+  for (const config of Object.values(OVERVIEW_ITEMS)) {
+    for (const k of sectionMetricKeys(config)) keys.add(k);
+  }
+  return [...keys];
+}

--- a/src/frontend/src/lib/portal/portal-hooks.test.tsx
+++ b/src/frontend/src/lib/portal/portal-hooks.test.tsx
@@ -1,0 +1,196 @@
+// @vitest-environment jsdom
+/**
+ * Hook-level tests for the small portal hooks that glue viewer identity,
+ * router state and the portal store together: useActiveZone,
+ * useViewerIsManager, usePersonCohort and the useOrgScope wrapper.
+ * Identity/auth/router dependencies are stubbed at the module boundary;
+ * assertions are about the derived semantics, not the wiring.
+ */
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { IdentityPerson } from "@/types/insight";
+import { portalRouter } from "@/test/portal-router";
+
+// Person ids are canonical UUIDs since the identity cutover (see
+// `lib/metrics/entity.ts`); the fixtures use real UUID shapes so a test can
+// never pass on a value the route guard and the metrics API would reject.
+const BOSS = "11111111-1111-4111-8111-111111111111";
+const A = "aaaaaaaa-1111-4111-8111-111111111111";
+const B = "bbbbbbbb-1111-4111-8111-111111111111";
+const C = "cccccccc-1111-4111-8111-111111111111";
+
+const mocks = vi.hoisted(() => ({
+  personId: "11111111-1111-4111-8111-111111111111" as string | null,
+  pathname: "/" as string,
+  ic: {
+    data: undefined as IdentityPerson | undefined,
+    isPending: false,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  },
+}));
+
+vi.mock("@/auth", () => ({
+  useViewer: () => ({ email: "viewer@x", personId: mocks.personId }),
+}));
+vi.mock("@/queries/ic-dashboard", () => ({ useIcPerson: () => mocks.ic }));
+vi.mock("@tanstack/react-router", async () => {
+  const { portalRouterMock } = await import("@/test/portal-router");
+  return portalRouterMock();
+});
+
+import { useActiveZone } from "./use-active-zone";
+import { useOrgScope } from "./use-org-scope";
+import { usePersonCohort } from "./use-person-cohort";
+import { useViewerIsManager } from "./use-viewer-is-manager";
+
+const person = (
+  personId: string,
+  name: string,
+  over: Partial<IdentityPerson> = {},
+  subordinates: IdentityPerson[] = [],
+): IdentityPerson =>
+  ({
+    person_id: personId,
+    email: `${name}@x`,
+    display_name: name,
+    subordinates,
+    ...over,
+  }) as unknown as IdentityPerson;
+
+const TREE = person(BOSS, "boss", { division: "R&D" }, [
+  person(A, "a", { division: "R&D" }),
+  person(B, "b", { division: "Sales" }),
+  person(C, "c", { division: "R&D" }),
+]);
+
+beforeEach(() => {
+  mocks.personId = BOSS;
+  portalRouter.go("/");
+  mocks.ic.data = TREE;
+  mocks.ic.isPending = false;
+  mocks.ic.isLoading = false;
+  mocks.ic.isError = false;
+  act(() => {
+    portalRouter.reset();
+  });
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("useActiveZone", () => {
+  it("follows the route when no zone is pinned: /personal → person", () => {
+    portalRouter.go(`/ic/${A}/personal`);
+    const { result } = renderHook(() => useActiveZone());
+    expect(result.current).toEqual({ activeZone: "person", activePerson: A });
+  });
+
+  it("maps /team routes to the people zone", () => {
+    portalRouter.go(`/ic/${A}/team`);
+    expect(renderHook(() => useActiveZone()).result.current.activeZone).toBe("people");
+  });
+
+  it("only the trailing /team segment means People", () => {
+    // The person key lives in the path, so a substring check would hijack any
+    // route whose id or a stale pre-cutover email happens to contain "team".
+    portalRouter.go("/ic/teamlead%40x/personal");
+    expect(renderHook(() => useActiveZone()).result.current).toEqual({
+      activeZone: "person",
+      activePerson: "teamlead@x",
+    });
+  });
+
+  it("tolerates a trailing slash on the team route", () => {
+    portalRouter.go(`/ic/${A}/team/`);
+    expect(renderHook(() => useActiveZone()).result.current.activeZone).toBe("people");
+  });
+
+  it("the path wins over a stale ?zone= — the URL cannot contradict itself", () => {
+    // The old shell let a pinned zone override the route, so a person link
+    // could navigate while the screen stayed on Overview. With the URL as the
+    // source of truth that state is unrepresentable: on a person path the zone
+    // IS person, whatever an older param says.
+    portalRouter.go(`/ic/${A}/personal`);
+    act(() => portalRouter.set({ zone: "overview" }));
+    expect(renderHook(() => useActiveZone()).result.current.activeZone).toBe("person");
+  });
+
+  it("uses ?zone= when the path names no zone", () => {
+    portalRouter.go("/portal");
+    act(() => portalRouter.set({ zone: "overview" }));
+    expect(renderHook(() => useActiveZone()).result.current.activeZone).toBe("overview");
+  });
+
+  it("falls back to the viewer for a non-person route", () => {
+    portalRouter.go("/metrics");
+    expect(renderHook(() => useActiveZone()).result.current.activePerson).toBe(BOSS);
+  });
+});
+
+describe("useViewerIsManager", () => {
+  it("is a manager when the viewer's node has subordinates", () => {
+    expect(renderHook(() => useViewerIsManager()).result.current).toEqual({
+      isManager: true,
+      isPending: false,
+    });
+  });
+
+  it("is not a manager for a leaf node (IC shell)", () => {
+    mocks.personId = A;
+    expect(renderHook(() => useViewerIsManager()).result.current.isManager).toBe(false);
+  });
+
+  it("reports pending while identity resolves (callers assume manager)", () => {
+    mocks.ic.data = undefined;
+    mocks.ic.isPending = true;
+    const { result } = renderHook(() => useViewerIsManager());
+    expect(result.current).toEqual({ isManager: false, isPending: true });
+  });
+});
+
+describe("usePersonCohort", () => {
+  it("is empty when no slice is active", () => {
+    expect(renderHook(() => usePersonCohort(A)).result.current).toEqual([]);
+  });
+
+  it("returns everyone sharing the person's slice value", () => {
+    act(() => portalRouter.set({ slice: "division" }));
+    const { result } = renderHook(() => usePersonCohort(A));
+    expect(result.current.sort()).toEqual([A, BOSS, C].sort());
+  });
+
+  it("is empty when the person has no value for the slice attribute", () => {
+    act(() => portalRouter.set({ slice: "title" }));
+    expect(renderHook(() => usePersonCohort(A)).result.current).toEqual([]);
+  });
+});
+
+describe("useOrgScope", () => {
+  it("resolves the viewer's subtree with counts and pivot id", () => {
+    const { result } = renderHook(() => useOrgScope());
+    // count = people under the pivot, the pivot itself excluded
+    expect(result.current.count).toBe(3);
+    expect(result.current.pivotPersonId).toBe(BOSS);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("narrows to a scoped root inside the subtree", () => {
+    act(() => portalRouter.set({ scope: B }));
+    const { result } = renderHook(() => useOrgScope());
+    expect(result.current.pivotPersonId).toBe(B);
+    // a leaf has no reports — org zones will gate on the empty roster
+    expect(result.current.count).toBe(0);
+  });
+
+  it("surfaces identity errors and delegates refetch", () => {
+    mocks.ic.data = undefined;
+    mocks.ic.isError = true;
+    const { result } = renderHook(() => useOrgScope());
+    expect(result.current.isError).toBe(true);
+    expect(result.current.pivot).toBeNull();
+    result.current.refetch();
+    expect(mocks.ic.refetch).toHaveBeenCalledOnce();
+  });
+});

--- a/src/frontend/src/lib/portal/portal-nav.ts
+++ b/src/frontend/src/lib/portal/portal-nav.ts
@@ -25,22 +25,27 @@ export function usePortalZone(): string | null {
   return zone ?? null;
 }
 
+/** The selected item within a zone; null when the zone shows its default. */
 export function usePortalItem(): string | null {
   return usePortalSearch().item ?? null;
 }
 
+/** The expanded direction, or "" when none is open. */
 export function usePortalDir(): string {
   return usePortalSearch().dir ?? "";
 }
 
+/** The active lens inside the open direction, or "" before one is picked. */
 export function usePortalLens(): string {
   return usePortalSearch().lens ?? "";
 }
 
+/** The active slice attribute, or "" when the roster is one undivided cohort. */
 export function usePortalSlice(): string {
   return usePortalSearch().slice ?? "";
 }
 
+/** The org scope the URL names: a root person id (absent = the viewer) + direct-only. */
 export function usePortalScope(): OrgScope {
   const { scope, direct } = usePortalSearch();
   // Memoised on the primitives: `useOrgScope` lists this object in a dependency
@@ -52,6 +57,10 @@ export function usePortalScope(): OrgScope {
   );
 }
 
+/**
+ * Writers for the navigation state. `set*` pushes a history entry (a reader
+ * moved); `replace*` corrects the URL without one (an effect did).
+ */
 export interface PortalNavActions {
   /** Correct the URL without adding a history entry (effects, not clicks). */
   replaceZone: (zone: string | null) => void;
@@ -64,6 +73,7 @@ export interface PortalNavActions {
   setScope: (patch: Partial<OrgScope>) => void;
 }
 
+/** Stable navigation writers — safe to list in an effect's dependencies. */
 export function usePortalNavActions(): PortalNavActions {
   const setSearch = useSetPortalSearch();
   // Memoised so callers can list these in effect dependencies: a fresh object

--- a/src/frontend/src/lib/portal/portal-nav.ts
+++ b/src/frontend/src/lib/portal/portal-nav.ts
@@ -1,6 +1,7 @@
 import { useRouterState } from "@tanstack/react-router";
 import { useMemo } from "react";
 
+import { normalizePersonId } from "@/lib/metrics/entity";
 import type { OrgScope } from "@/lib/portal/portal-store";
 import { usePortalSearch, useSetPortalSearch } from "@/lib/portal/portal-search";
 
@@ -93,7 +94,8 @@ export function usePortalNavActions(): PortalNavActions {
           // the root itself moves and the caller did not say otherwise.
           ...("root" in patch &&
           !("directOnly" in patch) &&
-          patch.root !== prev.scope
+          normalizePersonId(patch.root ?? "") !==
+            normalizePersonId(prev.scope ?? "")
             ? { direct: undefined }
             : {}),
         })),

--- a/src/frontend/src/lib/portal/portal-nav.ts
+++ b/src/frontend/src/lib/portal/portal-nav.ts
@@ -42,7 +42,13 @@ export function usePortalSlice(): string {
 
 export function usePortalScope(): OrgScope {
   const { scope, direct } = usePortalSearch();
-  return { root: scope ?? null, directOnly: direct ?? false };
+  // Memoised on the primitives: `useOrgScope` lists this object in a dependency
+  // array, and a fresh literal per render would re-walk the whole identity tree
+  // (flattenSubordinates per manager node) on every render of every org zone.
+  return useMemo(
+    () => ({ root: scope ?? null, directOnly: direct ?? false }),
+    [scope, direct],
+  );
 }
 
 export interface PortalNavActions {

--- a/src/frontend/src/lib/portal/portal-nav.ts
+++ b/src/frontend/src/lib/portal/portal-nav.ts
@@ -1,0 +1,97 @@
+import { useRouterState } from "@tanstack/react-router";
+import { useMemo } from "react";
+
+import type { OrgScope } from "@/lib/portal/portal-store";
+import { usePortalSearch, useSetPortalSearch } from "@/lib/portal/portal-search";
+
+/**
+ * Portal navigation, read from and written to the URL.
+ *
+ * These replace the in-memory store the shell used to keep: reloading no
+ * longer resets the view, a link reproduces it, and every zone/lens change is
+ * a history entry, so Back goes where a reader expects. The one asymmetry is
+ * deliberate — Person and People come from the PATH (`/ic/<email>/personal`,
+ * `/ic/<email>/team`) because they are about a person, while theme zones ride
+ * in `?zone=`. A path-driven zone therefore always wins over a stale param.
+ */
+
+/** Zone from the route when the path names one, else from `?zone=`. */
+export function usePortalZone(): string | null {
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const { zone } = usePortalSearch();
+  if (/^\/ic\/[^/]+\/team\/?$/.test(pathname)) return "people";
+  if (/^\/ic\/[^/]+\/personal\/?$/.test(pathname)) return "person";
+  return zone ?? null;
+}
+
+export function usePortalItem(): string | null {
+  return usePortalSearch().item ?? null;
+}
+
+export function usePortalDir(): string {
+  return usePortalSearch().dir ?? "";
+}
+
+export function usePortalLens(): string {
+  return usePortalSearch().lens ?? "";
+}
+
+export function usePortalSlice(): string {
+  return usePortalSearch().slice ?? "";
+}
+
+export function usePortalScope(): OrgScope {
+  const { scope, direct } = usePortalSearch();
+  return { root: scope ?? null, directOnly: direct ?? false };
+}
+
+export interface PortalNavActions {
+  /** Correct the URL without adding a history entry (effects, not clicks). */
+  replaceZone: (zone: string | null) => void;
+  replaceScope: (patch: Partial<OrgScope>) => void;
+  setZone: (zone: string | null) => void;
+  setItem: (item: string | null) => void;
+  setDir: (dir: string) => void;
+  setLens: (lens: string) => void;
+  setSlice: (slice: string) => void;
+  setScope: (patch: Partial<OrgScope>) => void;
+}
+
+export function usePortalNavActions(): PortalNavActions {
+  const setSearch = useSetPortalSearch();
+  // Memoised so callers can list these in effect dependencies: a fresh object
+  // per render would re-run the landing-zone and scope-sync effects forever.
+  return useMemo(
+    () => ({
+      // A zone change drops the item with it: `item` is per-zone, and carrying
+      // it across renders a fallback view while the pane highlights nothing.
+      setZone: (zone) => setSearch({ zone: zone ?? undefined, item: undefined }),
+      replaceZone: (zone) =>
+        setSearch({ zone: zone ?? undefined, item: undefined }, { replace: true }),
+      replaceScope: (patch) =>
+        setSearch(
+          { ...("root" in patch ? { scope: patch.root ?? undefined } : {}) },
+          { replace: true },
+        ),
+      setItem: (item) => setSearch({ item: item ?? undefined }),
+      setDir: (dir) => setSearch({ dir: dir || undefined }),
+      setLens: (lens) => setSearch({ lens: lens || undefined }),
+      setSlice: (slice) => setSearch({ slice: slice || undefined }),
+      setScope: (patch) =>
+        // Derived from the PREVIOUS search rather than a captured render value,
+        // which is what keeps this callback stable.
+        setSearch((prev) => ({
+          ...("root" in patch ? { scope: patch.root ?? undefined } : {}),
+          ...("directOnly" in patch ? { direct: patch.directOnly } : {}),
+          // A direct-only narrowing rarely survives a new root: reset it when
+          // the root itself moves and the caller did not say otherwise.
+          ...("root" in patch &&
+          !("directOnly" in patch) &&
+          patch.root !== prev.scope
+            ? { direct: undefined }
+            : {}),
+        })),
+    }),
+    [setSearch],
+  );
+}

--- a/src/frontend/src/lib/portal/portal-routes.test.ts
+++ b/src/frontend/src/lib/portal/portal-routes.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { isPortalShellPath } from "./portal-routes";
+
+describe("isPortalShellPath", () => {
+  it("claims the org zones and the person screens", () => {
+    expect(isPortalShellPath("/portal")).toBe(true);
+    expect(isPortalShellPath("/ic/019e27bc-dec0-7626-81a9-c5524662a6a9/personal")).toBe(true);
+    expect(isPortalShellPath("/ic/019e27bc-dec0-7626-81a9-c5524662a6a9/team")).toBe(true);
+    expect(isPortalShellPath("/ic/019e27bc-dec0-7626-81a9-c5524662a6a9/team/")).toBe(true);
+  });
+
+  it("leaves the rest of the app its own chrome", () => {
+    // An earlier "the portal replaces the app" branch swallowed these.
+    for (const path of ["/", "/metrics", "/queries", "/whats-new"]) {
+      expect(isPortalShellPath(path)).toBe(false);
+    }
+  });
+
+  it("does not claim a person route it has no screen for", () => {
+    // A future /ic/<id>/something renders through the app chrome rather than
+    // silently handing the screen to a shell that would show nothing.
+    expect(isPortalShellPath("/ic/019e27bc-dec0-7626-81a9-c5524662a6a9")).toBe(false);
+    expect(isPortalShellPath("/ic/019e27bc-dec0-7626-81a9-c5524662a6a9/reports")).toBe(false);
+  });
+
+  it("is not fooled by a prefix", () => {
+    expect(isPortalShellPath("/portal-admin")).toBe(false);
+    expect(isPortalShellPath("/not/portal")).toBe(false);
+  });
+});

--- a/src/frontend/src/lib/portal/portal-routes.ts
+++ b/src/frontend/src/lib/portal/portal-routes.ts
@@ -1,0 +1,16 @@
+/**
+ * Which paths the portal shell claims.
+ *
+ * The root layout has to know whether to render the app chrome or hand the
+ * whole screen to the portal, but *which* paths are the portal's is portal
+ * knowledge — kept here so the route file only asks the question.
+ *
+ * `/portal` carries the org zones; a person route carries Person and People.
+ * Anything else (/metrics, /whats-new, /queries) keeps the app chrome, which an
+ * earlier "the portal replaces the app" branch used to swallow.
+ */
+const PERSON_SHELL = /^\/ic\/[^/]+\/(personal|team)\/?$/;
+
+export function isPortalShellPath(pathname: string): boolean {
+  return pathname === "/portal" || PERSON_SHELL.test(pathname);
+}

--- a/src/frontend/src/lib/portal/portal-search.test.ts
+++ b/src/frontend/src/lib/portal/portal-search.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { validatePortalSearch } from "./portal-search";
+
+/**
+ * Search params are user-editable text and arrive from links other people
+ * wrote. The contract is to DEGRADE — drop what makes no sense and fall back to
+ * a computed default — never to error, because the alternative is an error
+ * boundary in place of a dashboard over one mistyped character.
+ */
+describe("validatePortalSearch", () => {
+  it("keeps the navigation keys it recognises", () => {
+    expect(
+      validatePortalSearch({ zone: "directions", dir: "dev", lens: "Delivery" }),
+    ).toMatchObject({ zone: "directions", dir: "dev", lens: "Delivery" });
+  });
+
+  it("lowercases the scope — an email is case-insensitive but our keys are not", () => {
+    expect(validatePortalSearch({ scope: "Head@X.COM" }).scope).toBe("head@x.com");
+  });
+
+  it("drops empty and non-string values rather than passing them on", () => {
+    const out = validatePortalSearch({ zone: "", item: 42, dir: null });
+    expect(out.zone).toBeUndefined();
+    expect(out.item).toBeUndefined();
+    expect(out.dir).toBeUndefined();
+  });
+
+  it("omits `direct` unless it is truthy — no defaults in a shared URL", () => {
+    expect(validatePortalSearch({ direct: "false" })).not.toHaveProperty("direct");
+    expect(validatePortalSearch({})).not.toHaveProperty("direct");
+    expect(validatePortalSearch({ direct: "true" }).direct).toBe(true);
+  });
+
+  it("ignores an unknown period preset", () => {
+    expect(validatePortalSearch({ period: "fortnight" }).period).toBeUndefined();
+    expect(validatePortalSearch({ period: "quarter" }).period).toBe("quarter");
+  });
+
+  describe("custom range", () => {
+    it("keeps a well-formed, correctly ordered pair", () => {
+      const out = validatePortalSearch({ from: "2026-01-01", to: "2026-01-31" });
+      expect(out).toMatchObject({ from: "2026-01-01", to: "2026-01-31" });
+    });
+
+    it("drops an INVERTED pair instead of letting it reach the range assert", () => {
+      // Well-formed and nonsensical: this used to pass validation and throw
+      // downstream, turning a bad link into an error boundary.
+      expect(
+        validatePortalSearch({ from: "2026-07-30", to: "2026-01-01" }),
+      ).not.toHaveProperty("from");
+    });
+
+    it("drops a pair that exceeds the maximum span", () => {
+      expect(
+        validatePortalSearch({ from: "2000-01-01", to: "2026-01-01" }),
+      ).not.toHaveProperty("from");
+    });
+
+    it("drops a half-specified range — one bound cannot resolve a window", () => {
+      expect(validatePortalSearch({ from: "2026-01-01" })).not.toHaveProperty("from");
+      expect(validatePortalSearch({ to: "2026-01-31" })).not.toHaveProperty("to");
+    });
+
+    it("drops malformed dates", () => {
+      expect(
+        validatePortalSearch({ from: "01/01/2026", to: "31/01/2026" }),
+      ).not.toHaveProperty("from");
+      expect(
+        validatePortalSearch({ from: "2026-13-45", to: "2026-13-46" }),
+      ).not.toHaveProperty("from");
+    });
+  });
+});

--- a/src/frontend/src/lib/portal/portal-search.ts
+++ b/src/frontend/src/lib/portal/portal-search.ts
@@ -102,6 +102,7 @@ export const PORTAL_SEARCH_KEYS = [
   "to",
 ] satisfies Array<keyof PortalSearch>;
 
+/** The validated portal params for the current route. */
 export function usePortalSearch(): PortalSearch {
   // `strict: false` so the same hook serves both portal route families
   // (/portal and /ic/$person/*) without a per-route generic.

--- a/src/frontend/src/lib/portal/portal-search.ts
+++ b/src/frontend/src/lib/portal/portal-search.ts
@@ -1,0 +1,153 @@
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import { useCallback } from "react";
+
+import { validateDateRange } from "@/api/period-to-date-range";
+import type { PeriodValue } from "@/types/insight";
+
+/**
+ * The portal's navigation state, carried in the URL.
+ *
+ * Everything that answers "what am I looking at" lives here rather than in a
+ * store: a reload restores the same screen, a link reproduces it for someone
+ * else, and Back means what it says. Only true preferences — is the portal on,
+ * are planned sections shown — stay in localStorage, because they describe the
+ * reader, not the view.
+ *
+ * All fields are optional and the defaults are computed, not stored: an absent
+ * `zone` means "the landing zone for this viewer", an absent `scope` means "the
+ * viewer's own subtree". That keeps a shared link honest — it pins what the
+ * sender actually chose and lets everything else resolve for the recipient.
+ */
+export interface PortalSearch {
+  /** Theme zone (overview / directions / aicost / manage). Person and People
+   *  come from the route instead, so they are never in here. */
+  zone?: string;
+  /** Selected item within a zone (an Overview view, a Manage surface). */
+  item?: string;
+  /** Expanded direction + its active lens, within the Directions zone. */
+  dir?: string;
+  lens?: string;
+  /** Org-scope root: a manager's person id. Absent = the viewer's own subtree. */
+  scope?: string;
+  /** Narrow the scope to direct reports only. */
+  direct?: boolean;
+  /** Person-attribute that groups rosters and defines peer cohorts. */
+  slice?: string;
+  /** Period preset. A custom range rides in `from`/`to` beside it. */
+  period?: PeriodValue;
+  from?: string;
+  to?: string;
+}
+
+const PERIODS = new Set<string>(["week", "month", "quarter", "year"]);
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+function str(v: unknown): string | undefined {
+  return typeof v === "string" && v !== "" ? v : undefined;
+}
+
+/**
+ * Validate rather than trust: search params are user-editable text, and a
+ * malformed one must not reach a metric request or a date range. Anything
+ * unrecognised is dropped, which degrades to the computed default instead of
+ * rendering an error for a link someone mistyped.
+ */
+export function validatePortalSearch(raw: Record<string, unknown>): PortalSearch {
+  const period = str(raw.period);
+  const from = str(raw.from);
+  const to = str(raw.to);
+  // Format alone is not enough: `?from=2026-07-30&to=2026-01-01` is
+  // well-formed, inverted, and used to reach `assertDateRange`, which throws
+  // into the error boundary — breaking this validator's own promise to degrade
+  // rather than error. Run the real check (ordering AND maximum span) and drop
+  // the pair when it fails, falling back to the period preset.
+  const custom =
+    from &&
+    to &&
+    ISO_DATE.test(from) &&
+    ISO_DATE.test(to) &&
+    validateDateRange({ from, to }).valid;
+  return {
+    zone: str(raw.zone),
+    item: str(raw.item),
+    dir: str(raw.dir),
+    lens: str(raw.lens),
+    // Lower-cased to match `normalizePersonId`: the same id reaches us from a
+    // link, an identity record or a hand-edited URL, and the resolver compares
+    // it as a string. An id outside the viewer's subtree (or a pre-cutover
+    // email) resolves to nothing and the scope falls back to the viewer.
+    scope: str(raw.scope)?.toLowerCase(),
+    // Omit rather than serialise `false`: a default has no business in a URL
+    // people read and share.
+    ...(raw.direct === true || raw.direct === "true" || raw.direct === 1
+      ? { direct: true as const }
+      : {}),
+    slice: str(raw.slice),
+    period: period && PERIODS.has(period) ? (period as PeriodValue) : undefined,
+    ...(custom ? { from, to } : {}),
+  };
+}
+
+/** Keys the portal owns — used to carry state across a route change. */
+export const PORTAL_SEARCH_KEYS = [
+  "zone",
+  "item",
+  "dir",
+  "lens",
+  "scope",
+  "direct",
+  "slice",
+  "period",
+  "from",
+  "to",
+] satisfies Array<keyof PortalSearch>;
+
+export function usePortalSearch(): PortalSearch {
+  // `strict: false` so the same hook serves both portal route families
+  // (/portal and /ic/$person/*) without a per-route generic.
+  return useSearch({ strict: false }) as PortalSearch;
+}
+
+/**
+ * Patch the portal's search params. `undefined` in the patch CLEARS a key —
+ * an explicit erase, distinct from "leave it alone" (omit it), which matters
+ * for zone changes that must drop a now-meaningless item.
+ */
+export type PortalSearchPatch =
+  | Partial<PortalSearch>
+  | ((prev: PortalSearch) => Partial<PortalSearch>);
+
+/**
+ * `replace` exists because not every write is a navigation the reader made.
+ * An effect that pins the landing zone or syncs the scope from the route is
+ * CORRECTING the URL, not moving through the app — pushing those makes Back
+ * step into a half-built address (bare `/portal`, or a team URL with no scope).
+ */
+export function useSetPortalSearch(): (
+  patch: PortalSearchPatch,
+  opts?: { replace?: boolean },
+) => void {
+  const navigate = useNavigate();
+  // Stable across renders — `navigate` is, and the patch may be a function of
+  // the previous search, so nothing else needs to be captured. Callers put this
+  // in effect dependency lists, where a fresh identity per render would loop.
+  return useCallback(
+    (patch, opts) => {
+      void navigate({
+        to: ".",
+        search: (prev: Record<string, unknown>) => {
+          const resolved =
+            typeof patch === "function" ? patch(prev as PortalSearch) : patch;
+          const next = { ...prev };
+          for (const [k, v] of Object.entries(resolved)) {
+            if (v === undefined || v === "" || v === false) delete next[k];
+            else next[k] = v;
+          }
+          return next;
+        },
+        replace: opts?.replace ?? false,
+      });
+    },
+    [navigate],
+  );
+}

--- a/src/frontend/src/lib/portal/portal-store.test.ts
+++ b/src/frontend/src/lib/portal/portal-store.test.ts
@@ -6,7 +6,7 @@
  * or reveal the scaffolding they never asked to see.
  */
 import { act, renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   setPortalEnabled,
@@ -56,6 +56,25 @@ describe("portal preferences", () => {
       "setPortalScope",
     ]) {
       expect(store, gone).not.toHaveProperty(gone);
+    }
+  });
+});
+
+describe("blocked storage", () => {
+  it("reading a preference survives a throwing localStorage", async () => {
+    // A sandboxed iframe or blocked third-party storage raises on property
+    // access, not by returning null. The readers run at module scope, so an
+    // unguarded throw would take the whole bundle down over a preview flag.
+    const getItem = vi
+      .spyOn(window.localStorage, "getItem")
+      .mockImplementation(() => {
+        throw new DOMException("blocked", "SecurityError");
+      });
+    try {
+      const { readPortalEnabled } = await import("./portal-store");
+      expect(readPortalEnabled()).toBe(false);
+    } finally {
+      getItem.mockRestore();
     }
   });
 });

--- a/src/frontend/src/lib/portal/portal-store.test.ts
+++ b/src/frontend/src/lib/portal/portal-store.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+/**
+ * What is left in the store after navigation moved to the URL: the two
+ * PREFERENCES. They belong here precisely because they describe the reader
+ * rather than the view — a shared link must not turn someone else's portal on,
+ * or reveal the scaffolding they never asked to see.
+ */
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  setPortalEnabled,
+  setPortalShowPlanned,
+  usePortalEnabled,
+  usePortalShowPlanned,
+} from "./portal-store";
+
+beforeEach(() => {
+  act(() => {
+    setPortalEnabled(false);
+    setPortalShowPlanned(true);
+  });
+  window.localStorage.clear();
+});
+
+describe("portal preferences", () => {
+  it("enabled round-trips and persists", () => {
+    const { result } = renderHook(() => usePortalEnabled());
+    expect(result.current).toBe(false);
+    act(() => setPortalEnabled(true));
+    expect(result.current).toBe(true);
+    expect(window.localStorage.getItem("insight.portal")).toBe("true");
+  });
+
+  it("show-planned defaults ON when the key is absent", () => {
+    window.localStorage.removeItem("insight.portal.showPlanned");
+    const { result } = renderHook(() => usePortalShowPlanned());
+    expect(result.current).toBe(true);
+  });
+
+  it("show-planned round-trips and persists", () => {
+    const { result } = renderHook(() => usePortalShowPlanned());
+    act(() => setPortalShowPlanned(false));
+    expect(result.current).toBe(false);
+    expect(window.localStorage.getItem("insight.portal.showPlanned")).toBe("false");
+  });
+
+  it("keeps no navigation state — that lives in the URL", async () => {
+    const store = await import("./portal-store");
+    for (const gone of [
+      "setPortalZone",
+      "setPortalItem",
+      "setPortalDir",
+      "setPortalLens",
+      "setPortalSlice",
+      "setPortalScope",
+    ]) {
+      expect(store, gone).not.toHaveProperty(gone);
+    }
+  });
+});

--- a/src/frontend/src/lib/portal/portal-store.ts
+++ b/src/frontend/src/lib/portal/portal-store.ts
@@ -93,18 +93,21 @@ function persist(key: string, value: string): void {
   }
 }
 
+/** Turn the portal preview on or off for this reader. */
 export function setPortalEnabled(enabled: boolean): void {
   state = { ...state, enabled };
   persist(ENABLED_KEY, enabled ? "true" : "false");
   emit();
 }
 
+/** Show or hide the not-yet-built sections for this reader. */
 export function setPortalShowPlanned(show: boolean): void {
   state = { ...state, showPlanned: show };
   persist(SHOW_PLANNED_KEY, show ? "true" : "false");
   emit();
 }
 
+/** Whether this reader has the portal preview on. */
 export function usePortalEnabled(): boolean {
   return useSyncExternalStore(
     subscribe,
@@ -113,6 +116,7 @@ export function usePortalEnabled(): boolean {
   );
 }
 
+/** Whether this reader wants planned sections listed. */
 export function usePortalShowPlanned(): boolean {
   return useSyncExternalStore(
     subscribe,

--- a/src/frontend/src/lib/portal/portal-store.ts
+++ b/src/frontend/src/lib/portal/portal-store.ts
@@ -1,0 +1,109 @@
+import { useSyncExternalStore } from "react";
+
+/**
+ * Portal PREFERENCES (feature-flagged behind `insight.portal`).
+ *
+ * `enabled` persists to localStorage (mirrors the metrics-v2 flag pattern in
+ * feature-flags.ts). `zone` is in-memory navigation state: `null` means "follow
+ * the route" (the entity lenses — Person / People — render the existing
+ * dashboard `<Outlet/>`); a zone id means an org-level lens is selected and the
+ * content area shows its scaffold.
+ */
+
+/**
+ * Org scope — WHO is counted in every org zone (design §6). `root` is the
+ * email of a manager node inside the viewer's subtree (null = the viewer's
+ * whole org); `directOnly` narrows to direct reports. Phase 2 reserves
+ * `attrFilter` (attribute-value cut across the tree) — no UI yet.
+ */
+export interface OrgScope {
+  root: string | null;
+  directOnly: boolean;
+  attrFilter?: { key: string; value: string };
+}
+
+const ENABLED_KEY = "insight.portal";
+const SHOW_PLANNED_KEY = "insight.portal.showPlanned";
+
+interface PortalState {
+  enabled: boolean;
+  /**
+   * Whether navigation shows entries we have not built yet (`unbuilt` in the
+   * nav model). Default ON while the whole portal is itself a preview: for us
+   * and for demos the dead entries ARE the roadmap. Turn it off — or flip the
+   * default — the day the portal stops being opt-in, so a customer never has
+   * to tell our backlog apart from their own missing data.
+   */
+  showPlanned: boolean;
+}
+
+/** Router-safe read: `beforeLoad` runs outside React, so it cannot use a hook. */
+export function readPortalEnabled(): boolean {
+  return readEnabled();
+}
+
+function readEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.localStorage.getItem(ENABLED_KEY) === "true";
+}
+
+/** Absent key = default ON (see `showPlanned`); only an explicit "false" hides. */
+function readShowPlanned(): boolean {
+  if (typeof window === "undefined") return true;
+  return window.localStorage.getItem(SHOW_PLANNED_KEY) !== "false";
+}
+
+let state: PortalState = {
+  enabled: readEnabled(),
+  showPlanned: readShowPlanned(),
+};
+
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const fn of listeners) fn();
+}
+
+function subscribe(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}
+
+function persist(key: string, value: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // localStorage unavailable — in-memory state still updated.
+  }
+}
+
+export function setPortalEnabled(enabled: boolean): void {
+  state = { ...state, enabled };
+  persist(ENABLED_KEY, enabled ? "true" : "false");
+  emit();
+}
+
+export function setPortalShowPlanned(show: boolean): void {
+  state = { ...state, showPlanned: show };
+  persist(SHOW_PLANNED_KEY, show ? "true" : "false");
+  emit();
+}
+
+export function usePortalEnabled(): boolean {
+  return useSyncExternalStore(
+    subscribe,
+    () => state.enabled,
+    () => false,
+  );
+}
+
+export function usePortalShowPlanned(): boolean {
+  return useSyncExternalStore(
+    subscribe,
+    () => state.showPlanned,
+    () => true,
+  );
+}

--- a/src/frontend/src/lib/portal/portal-store.ts
+++ b/src/frontend/src/lib/portal/portal-store.ts
@@ -42,15 +42,28 @@ export function readPortalEnabled(): boolean {
   return readEnabled();
 }
 
+/**
+ * Reading storage can THROW, not just return null: a sandboxed iframe or
+ * blocked third-party storage raises SecurityError on property access. These
+ * readers run at module scope, so an unguarded throw escapes before any
+ * component mounts and takes the whole bundle down over a preview flag.
+ */
+function readKey(key: string): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
 function readEnabled(): boolean {
-  if (typeof window === "undefined") return false;
-  return window.localStorage.getItem(ENABLED_KEY) === "true";
+  return readKey(ENABLED_KEY) === "true";
 }
 
 /** Absent key = default ON (see `showPlanned`); only an explicit "false" hides. */
 function readShowPlanned(): boolean {
-  if (typeof window === "undefined") return true;
-  return window.localStorage.getItem(SHOW_PLANNED_KEY) !== "false";
+  return readKey(SHOW_PLANNED_KEY) !== "false";
 }
 
 let state: PortalState = {

--- a/src/frontend/src/lib/portal/portal-store.ts
+++ b/src/frontend/src/lib/portal/portal-store.ts
@@ -3,16 +3,16 @@ import { useSyncExternalStore } from "react";
 /**
  * Portal PREFERENCES (feature-flagged behind `insight.portal`).
  *
- * `enabled` persists to localStorage (mirrors the metrics-v2 flag pattern in
- * feature-flags.ts). `zone` is in-memory navigation state: `null` means "follow
- * the route" (the entity lenses — Person / People — render the existing
- * dashboard `<Outlet/>`); a zone id means an org-level lens is selected and the
- * content area shows its scaffold.
+ * `enabled` and `showPlanned` persist to localStorage (mirroring the metrics-v2
+ * flag pattern in feature-flags.ts). Nothing else lives here: every piece of
+ * navigation state — zone, item, scope, slice, period — rides in the URL
+ * (`portal-search.ts`, `portal-nav.ts`), because it describes the view rather
+ * than the reader.
  */
 
 /**
  * Org scope — WHO is counted in every org zone (design §6). `root` is the
- * email of a manager node inside the viewer's subtree (null = the viewer's
+ * person id of a manager node inside the viewer's subtree (null = the viewer's
  * whole org); `directOnly` narrows to direct reports. Phase 2 reserves
  * `attrFilter` (attribute-value cut across the tree) — no UI yet.
  */

--- a/src/frontend/src/lib/portal/readiness.test.ts
+++ b/src/frontend/src/lib/portal/readiness.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+
+import { DIRECTION_LENSES, lensEntry } from "./lens-configs";
+import {
+  MANAGE_ITEMS,
+  PEOPLE_ITEMS,
+  partitionByReadiness,
+  ZONES,
+  ZONE_SECTIONS,
+} from "./nav-model";
+
+describe("partitionByReadiness", () => {
+  const entries = [
+    { id: "live" },
+    { id: "planned", readiness: "planned" as const },
+    { id: "unbuilt", readiness: "unbuilt" as const },
+  ];
+
+  it("keeps unmarked entries live and never demotes them", () => {
+    for (const show of [true, false]) {
+      const { live } = partitionByReadiness(entries, show);
+      expect(live.map((e) => e.id)).toEqual(["live"]);
+    }
+  });
+
+  it("always lists product-side gaps, demoted — they are roadmap, not noise", () => {
+    const { planned } = partitionByReadiness(entries, false);
+    expect(planned.map((e) => e.id)).toEqual(["planned"]);
+  });
+
+  it("hides our own unbuilt screens until the viewer opts in", () => {
+    expect(partitionByReadiness(entries, false).planned.map((e) => e.id)).not.toContain(
+      "unbuilt",
+    );
+    expect(partitionByReadiness(entries, true).planned.map((e) => e.id)).toEqual([
+      "planned",
+      "unbuilt",
+    ]);
+  });
+
+  it("returns everything exactly once — nothing is dropped silently", () => {
+    const { live, planned } = partitionByReadiness(entries, true);
+    expect([...live, ...planned]).toHaveLength(entries.length);
+  });
+});
+
+describe("nav classification invariants", () => {
+  it("hiding planned work still leaves every zone the portal can render", () => {
+    const { live } = partitionByReadiness(ZONES, false);
+    // The five zones with real views must survive the strictest filter.
+    expect(live.map((z) => z.id)).toEqual([
+      "overview",
+      "directions",
+      "person",
+      "people",
+      "aicost",
+      "manage",
+    ]);
+  });
+
+  it("Manage keeps exactly the two surfaces that read live data", () => {
+    const { live } = partitionByReadiness(MANAGE_ITEMS, false);
+    expect(live.map((i) => i.id)).toEqual(["metric-catalog", "data-health"]);
+  });
+
+  it("every Overview item is live — that zone has no placeholders", () => {
+    const items = (ZONE_SECTIONS.overview ?? []).flatMap((g) => g.items);
+    expect(items.every((i) => i.readiness == null)).toBe(true);
+  });
+
+  it("People marks the cohort-pipeline item as planned, not unbuilt", () => {
+    const median = PEOPLE_ITEMS.find((i) => i.id === "median-by-role");
+    expect(median?.readiness).toBe("planned");
+  });
+
+  it("no zone or item is marked with an unknown readiness value", () => {
+    const all = [
+      ...ZONES,
+      ...MANAGE_ITEMS,
+      ...PEOPLE_ITEMS,
+      ...Object.values(ZONE_SECTIONS).flatMap((groups) =>
+        groups.flatMap((g) => g.items),
+      ),
+    ];
+    for (const e of all) {
+      if (e.readiness != null) {
+        expect(["planned", "unbuilt"]).toContain(e.readiness);
+      }
+    }
+  });
+});
+
+describe("lens roadmap entries carry a reason", () => {
+  const roadmap = Object.entries(DIRECTION_LENSES).flatMap(([dir, lenses]) =>
+    Object.keys(lenses)
+      .map((lens) => ({ dir, lens, entry: lensEntry(dir, lens)! }))
+      .filter((x) => "comingSoon" in x.entry),
+  );
+
+  it("finds roadmap lenses to check", () => expect(roadmap.length).toBeGreaterThan(5));
+
+  it("every roadmap lens declares whether it waits on the product or on us", () => {
+    for (const { dir, lens, entry } of roadmap) {
+      expect(["planned", "unbuilt"], `${dir}/${lens}`).toContain(
+        (entry as { readiness: string }).readiness,
+      );
+    }
+  });
+
+  it("wording matches the reason — a product gap never reads as in-development", () => {
+    for (const { dir, lens, entry } of roadmap) {
+      const e = entry as { comingSoon: string; readiness: string };
+      if (e.readiness === "planned") {
+        expect(e.comingSoon, `${dir}/${lens}`).toMatch(/semantic layer/i);
+        expect(e.comingSoon, `${dir}/${lens}`).not.toMatch(/in development/i);
+      } else {
+        expect(e.comingSoon, `${dir}/${lens}`).toMatch(/in development/i);
+      }
+    }
+  });
+
+  it("Repositories and Elements are ours to build, not a data request", () => {
+    for (const lens of ["Repositories", "Elements"]) {
+      const entry = lensEntry("dev", lens) as { readiness: string };
+      expect(entry.readiness, lens).toBe("unbuilt");
+    }
+  });
+
+  it("Sales and Support wait on the product, so they stay listed", () => {
+    for (const dir of ["sales", "support"]) {
+      for (const lens of Object.keys(DIRECTION_LENSES[dir]!)) {
+        expect((lensEntry(dir, lens) as { readiness: string }).readiness, dir).toBe(
+          "planned",
+        );
+      }
+    }
+  });
+});

--- a/src/frontend/src/lib/portal/route-scope-sync.test.ts
+++ b/src/frontend/src/lib/portal/route-scope-sync.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { claimScopeSync, resetRouteScopeSync } from "./route-scope-sync";
+
+const A = "aaaaaaaa-1111-4111-8111-111111111111";
+const B = "bbbbbbbb-1111-4111-8111-111111111111";
+
+beforeEach(() => resetRouteScopeSync());
+
+describe("claimScopeSync", () => {
+  it("claims a person once, so a re-render or remount does not re-sync", () => {
+    expect(claimScopeSync(A)).toBe(true);
+    expect(claimScopeSync(A)).toBe(false);
+    expect(claimScopeSync(A)).toBe(false);
+  });
+
+  it("claims again after the person changes — A then B then A", () => {
+    // Deliberate, not an oversight: arriving at a person's team IS a
+    // navigation. A reader who visits A, picks a different scope, looks at B
+    // and then clicks back to A's team must get A's roster. Remembering every
+    // person ever seen would leave the scope on B while the route said A.
+    expect(claimScopeSync(A)).toBe(true);
+    expect(claimScopeSync(B)).toBe(true);
+    expect(claimScopeSync(A)).toBe(true);
+    // …and still only once per arrival.
+    expect(claimScopeSync(A)).toBe(false);
+  });
+
+  it("never claims an empty person", () => {
+    expect(claimScopeSync("")).toBe(false);
+  });
+
+  it("resets, so a test mounting the same person again is not a no-op", () => {
+    expect(claimScopeSync(A)).toBe(true);
+    resetRouteScopeSync();
+    expect(claimScopeSync(A)).toBe(true);
+  });
+});

--- a/src/frontend/src/lib/portal/route-scope-sync.ts
+++ b/src/frontend/src/lib/portal/route-scope-sync.ts
@@ -1,0 +1,29 @@
+/**
+ * The one-shot guard behind the route → org-scope sync.
+ *
+ * Module-scoped, deliberately NOT a ref: the guard has to outlive the People
+ * view. A per-mount ref would re-fire the sync every time the reader leaves the
+ * zone and comes back, silently reverting a scope they had picked in the topbar.
+ * Keyed by person, so an actual route change still syncs.
+ *
+ * It lives in its own module for two reasons: a component file cannot export
+ * helpers without breaking fast refresh, and tests need the reset — vitest gives
+ * one module registry per file, so without it the first case that mounts a given
+ * person consumes the guard and every later case sees no sync at all.
+ */
+let lastSynced: string | null = null;
+
+/**
+ * True at most once per person: the caller may sync the scope, and the guard
+ * records that it did.
+ */
+export function claimScopeSync(personId: string): boolean {
+  if (!personId || lastSynced === personId) return false;
+  lastSynced = personId;
+  return true;
+}
+
+/** Tests only — see the note above. */
+export function resetRouteScopeSync(): void {
+  lastSynced = null;
+}

--- a/src/frontend/src/lib/portal/route-scope-sync.ts
+++ b/src/frontend/src/lib/portal/route-scope-sync.ts
@@ -4,7 +4,12 @@
  * Module-scoped, deliberately NOT a ref: the guard has to outlive the People
  * view. A per-mount ref would re-fire the sync every time the reader leaves the
  * zone and comes back, silently reverting a scope they had picked in the topbar.
- * Keyed by person, so an actual route change still syncs.
+ * Keyed by the LATEST person, not by a set of every person ever seen: arriving
+ * at a person's team is a navigation, and the reader who clicks "A's team"
+ * after visiting B has to get A's roster. Remembering every person would leave
+ * the scope on B while the route said A — a disagreement between the address
+ * and the screen, which is what this whole migration was about avoiding. The
+ * guard's job is narrower: absorb re-renders and remounts of the SAME person.
  *
  * It lives in its own module for two reasons: a component file cannot export
  * helpers without breaking fast refresh, and tests need the reset — vitest gives

--- a/src/frontend/src/lib/portal/trend-data.test.ts
+++ b/src/frontend/src/lib/portal/trend-data.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import type { NormalizedMetricResult } from "@/lib/metrics/collection";
+import { buildTrendData, pickTrendBucket } from "./trend-data";
+
+const RANGE_30D = { from: "2026-06-24", to: "2026-07-23" };
+
+describe("pickTrendBucket", () => {
+  it("keeps daily buckets for a small team", () =>
+    expect(pickTrendBucket(5, 2, RANGE_30D)).toBe("day"));
+  it("coarsens to weekly for the org root (152×2×30 > row limit)", () =>
+    expect(pickTrendBucket(152, 2, RANGE_30D)).toBe("week"));
+  it("falls to monthly for a year at org scale", () =>
+    expect(pickTrendBucket(152, 2, { from: "2025-07-24", to: "2026-07-23" })).toBe("month"));
+
+  it("gives up when the roster alone exceeds one bucket", () => {
+    // 4000 × 2 = 8000 rows before any time dimension. A `Math.max(1, …)` floor
+    // used to pretend one bucket always fits and answer "week" here.
+    expect(pickTrendBucket(4000, 2, { from: "2026-01-01", to: "2026-01-07" })).toBeNull();
+  });
+
+  it("gives up when even monthly does not fit", () => {
+    // 4000 people over a year is ~12 buckets × 4000 × 2 metrics = 96k rows
+    // against a 4500 limit. The old version answered "month" and the request
+    // 400'd; there is no bucket to answer with, so say so.
+    expect(pickTrendBucket(4000, 2, { from: "2025-07-24", to: "2026-07-23" })).toBeNull();
+  });
+
+  it("never claims a bucket whose projection exceeds the limit", () => {
+    // The property behind all four outcomes, checked across scales rather than
+    // at the two thresholds a hand-picked example happens to sit on.
+    const perBucketDays = { day: 1, week: 7, month: 30.44 };
+    for (const members of [1, 10, 152, 900, 4000]) {
+      for (const days of [7, 30, 180, 365, 1000]) {
+        const range = {
+          from: "2026-01-01",
+          to: new Date(Date.UTC(2026, 0, days)).toISOString().slice(0, 10),
+        };
+        const bucket = pickTrendBucket(members, 2, range);
+        if (bucket === null) continue;
+        const buckets = Math.ceil(days / perBucketDays[bucket]);
+        expect(members * 2 * buckets, `${members}p/${days}d → ${bucket}`).toBeLessThanOrEqual(4500);
+      }
+    }
+  });
+});
+
+describe("buildTrendData", () => {
+  it("sums per-bucket points across members and sorts by date", () => {
+    const r = {
+      metric_key: "m",
+      computation: "sum",
+      timeseries: {
+        view: "timeseries",
+        bucket: "week",
+        series: [
+          { entity_id: "a", points: [{ bucket_start: "2026-07-06", value: 2 }] },
+          { entity_id: "b", points: [{ bucket_start: "2026-07-06", value: 3 }, { bucket_start: "2026-06-29", value: 1 }] },
+        ],
+      },
+    } as unknown as NormalizedMetricResult;
+    const data = buildTrendData(["m"], new Map([["m", r]]), ["a", "b"]);
+    expect(data).toEqual([
+      { date: "2026-06-29", m: 1 },
+      { date: "2026-07-06", m: 5 },
+    ]);
+  });
+});

--- a/src/frontend/src/lib/portal/trend-data.ts
+++ b/src/frontend/src/lib/portal/trend-data.ts
@@ -1,0 +1,75 @@
+import type { MetricBucket } from "@/api/metric-results-client";
+import type { SectionTrendPoint } from "@/components/portal/section-trend";
+import {
+  forEntity,
+  MAX_PROJECTED_ROWS,
+  type NormalizedMetricResult,
+} from "@/lib/metrics/collection";
+
+/**
+ * Finest bucket (day → week → month) whose projected rows
+ * (members × metrics × buckets) fit the backend's all-or-nothing row limit —
+ * so a large org still gets a coarser trend rather than a failed request.
+ *
+ * `null` is the fourth outcome and the important one: past a certain
+ * members × metrics × months, even monthly does not fit, and returning "month"
+ * anyway just sends a request the backend is guaranteed to reject. A suppressed
+ * trend with a stated reason beats a 400 the reader has to interpret.
+ */
+export function pickTrendBucket(
+  members: number,
+  metrics: number,
+  range: { from: string; to: string },
+): MetricBucket | null {
+  const days = Math.max(1, daysBetween(range.from, range.to));
+  const perBucket = Math.max(1, members * Math.max(1, metrics));
+  // Headroom below the hard limit so we never sit exactly on the cliff.
+  // NO `Math.max(1, …)` floor here: it used to claim that one bucket always
+  // fits, which is false once the roster alone exceeds the limit — 4000 people
+  // × 2 metrics is 8000 rows in a SINGLE bucket. That floor turned "impossible"
+  // into a confident "week" and a guaranteed 400.
+  const maxBuckets = Math.floor((MAX_PROJECTED_ROWS * 0.85) / perBucket);
+  if (maxBuckets < 1) return null;
+  if (days <= maxBuckets) return "day";
+  if (Math.ceil(days / 7) <= maxBuckets) return "week";
+  // ~30.44 days per month: overestimating buckets here is the safe direction.
+  if (Math.ceil(days / 30.44) <= maxBuckets) return "month";
+  return null;
+}
+
+function daysBetween(from: string, to: string): number {
+  const a = Date.parse(`${from}T00:00:00Z`);
+  const b = Date.parse(`${to}T00:00:00Z`);
+  if (Number.isNaN(a) || Number.isNaN(b) || b < a) return 1;
+  return Math.floor((b - a) / 86_400_000) + 1;
+}
+
+/**
+ * Sum each metric's per-bucket timeseries points across a roster into a single
+ * org/team series per bucket, sorted by date. Shared by every portal view that
+ * draws a "team totals over time" chart (Overview, Directions, Collaboration)
+ * so the aggregation stays in one place.
+ */
+export function buildTrendData(
+  keys: readonly string[],
+  byKey: Map<string, NormalizedMetricResult>,
+  memberIds: readonly string[],
+): SectionTrendPoint[] {
+  const byDate = new Map<string, SectionTrendPoint>();
+  for (const key of keys) {
+    const r = byKey.get(key);
+    if (!r) continue;
+    for (const id of memberIds) {
+      for (const s of forEntity(r, id).series) {
+        for (const p of s.points) {
+          const row = byDate.get(p.bucket_start) ?? { date: p.bucket_start };
+          row[key] = ((row[key] as number | undefined) ?? 0) + (p.value ?? 0);
+          byDate.set(p.bucket_start, row);
+        }
+      }
+    }
+  }
+  return [...byDate.values()].sort((a, b) =>
+    String(a.date).localeCompare(String(b.date)),
+  );
+}

--- a/src/frontend/src/lib/portal/use-active-zone.ts
+++ b/src/frontend/src/lib/portal/use-active-zone.ts
@@ -1,0 +1,29 @@
+import { useRouterState } from "@tanstack/react-router";
+import { useMemo } from "react";
+
+import { useViewer } from "@/auth";
+
+import { usePortalZone } from "./portal-nav";
+
+/**
+ * Resolves the active portal zone and the person the entity lenses point at.
+ * The zone itself comes from the URL (`usePortalZone`: the path for
+ * Person/People, `?zone=` for theme zones); this hook adds the person the
+ * route names (its person id), so the rail and the context pane highlight in
+ * sync.
+ */
+export function useActiveZone(): { activeZone: string; activePerson: string } {
+  const zone = usePortalZone();
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const { personId } = useViewer();
+
+  return useMemo(() => {
+    // The path segment is a person id since the identity cutover, so this is
+    // the id every portal surface keys on — not an email.
+    const m = /^\/ic\/([^/]+)/.exec(pathname);
+    const activePerson = m ? decodeURIComponent(m[1]!) : (personId ?? "");
+    // No zone anywhere yet (a bare /portal before the landing pin) → the
+    // person view is the only thing that renders without an org rollup.
+    return { activeZone: zone ?? "person", activePerson };
+  }, [zone, pathname, personId]);
+}

--- a/src/frontend/src/lib/portal/use-active-zone.ts
+++ b/src/frontend/src/lib/portal/use-active-zone.ts
@@ -2,6 +2,7 @@ import { useRouterState } from "@tanstack/react-router";
 import { useMemo } from "react";
 
 import { useViewer } from "@/auth";
+import { personIdFromPath } from "@/lib/metrics/entity";
 
 import { usePortalZone } from "./portal-nav";
 
@@ -20,8 +21,7 @@ export function useActiveZone(): { activeZone: string; activePerson: string } {
   return useMemo(() => {
     // The path segment is a person id since the identity cutover, so this is
     // the id every portal surface keys on — not an email.
-    const m = /^\/ic\/([^/]+)/.exec(pathname);
-    const activePerson = m ? decodeURIComponent(m[1]!) : (personId ?? "");
+    const activePerson = personIdFromPath(pathname) ?? personId ?? "";
     // No zone anywhere yet (a bare /portal before the landing pin) → the
     // person view is the only thing that renders without an org rollup.
     return { activeZone: zone ?? "person", activePerson };

--- a/src/frontend/src/lib/portal/use-cohort-label.test.tsx
+++ b/src/frontend/src/lib/portal/use-cohort-label.test.tsx
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+/**
+ * The noun a peer comparison uses. Three surfaces hardcoded it while injecting
+ * stats from the slice cohort, so "vs department median" could sit over
+ * manager-cohort numbers — a comparison naming the wrong pool of people, which
+ * is worse than one naming none.
+ */
+vi.mock("@tanstack/react-router", async () => {
+  const { portalRouterMock } = await import("@/test/portal-router");
+  return portalRouterMock();
+});
+
+import { renderHook } from "@testing-library/react";
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { identityPerson, pid } from "@/test/identity";
+import type { IdentityPerson } from "@/types/insight";
+
+const mocks = vi.hoisted(() => ({ tree: undefined as IdentityPerson | undefined }));
+
+vi.mock("@/auth", () => ({
+  useViewer: () => ({ email: "boss@x", personId: pid("boss") }),
+}));
+vi.mock("@/queries/ic-dashboard", () => ({
+  useIcPerson: () => ({ data: mocks.tree }),
+}));
+
+import { portalRouter } from "@/test/portal-router";
+
+import { useCohortLabel } from "./use-cohort-label";
+
+const person = (
+  label: string,
+  attrs: Partial<IdentityPerson> = {},
+  subs: IdentityPerson[] = [],
+): IdentityPerson => identityPerson(label, attrs, subs);
+
+beforeEach(() => {
+  portalRouter.reset();
+  // A roster that offers two real dimensions, so a slice has something to name.
+  mocks.tree = person("boss", {}, [
+    person("a", { division: "R&D", job_title: "Engineer" }),
+    person("b", { division: "Sales", job_title: "Rep" }),
+    person("c", { division: "R&D", job_title: "Engineer" }),
+  ]);
+});
+
+describe("useCohortLabel", () => {
+  it("says 'team' when the roster is one undivided cohort", () => {
+    expect(renderHook(() => useCohortLabel()).result.current).toBe("team");
+  });
+
+  it("names the active slice's own dimension", () => {
+    act(() => portalRouter.set({ slice: "division" }));
+    expect(renderHook(() => useCohortLabel()).result.current).toBe("division");
+  });
+
+  it("falls back to 'cohort' for a slice the roster cannot offer", () => {
+    // A shared link may name a dimension this org does not have. Saying
+    // "cohort" is honest; echoing the unknown key would invent a group.
+    act(() => portalRouter.set({ slice: "office" }));
+    expect(renderHook(() => useCohortLabel()).result.current).toBe("cohort");
+  });
+
+  it("never returns a capitalised label — it reads mid-sentence", () => {
+    act(() => portalRouter.set({ slice: "division" }));
+    const label = renderHook(() => useCohortLabel()).result.current;
+    expect(label).toBe(label.toLowerCase());
+  });
+});

--- a/src/frontend/src/lib/portal/use-cohort-label.ts
+++ b/src/frontend/src/lib/portal/use-cohort-label.ts
@@ -1,0 +1,32 @@
+import { useMemo } from "react";
+
+import { useViewer } from "@/auth";
+import { availableSlices, collectRosterAttrs } from "@/lib/insight/slices";
+import { normalizePersonId } from "@/lib/metrics/entity";
+import { usePortalSlice } from "@/lib/portal/portal-nav";
+import { useIcPerson } from "@/queries/ic-dashboard";
+
+/**
+ * The noun a peer comparison should use: the active slice's own label, or
+ * "team" when the roster is one undivided cohort.
+ *
+ * It exists because three surfaces hardcoded a label while injecting peer stats
+ * from whatever cohort the slice defined — so with slice=Manager the UI read
+ * "vs department median" over manager-cohort numbers. A comparison that names
+ * the wrong pool is worse than one that names none: the reader draws a
+ * conclusion about the wrong group of people.
+ *
+ * Derived from the viewer's whole org, like the slice control itself, so every
+ * surface says the same thing about the same slice.
+ */
+export function useCohortLabel(): string {
+  const slice = usePortalSlice();
+  const { personId } = useViewer();
+  const tree = useIcPerson(personId ?? "").data ?? null;
+  const dims = useMemo(
+    () => availableSlices(collectRosterAttrs(tree, normalizePersonId).values()),
+    [tree],
+  );
+  if (!slice) return "team";
+  return (dims.find((d) => d.key === slice)?.label ?? "cohort").toLowerCase();
+}

--- a/src/frontend/src/lib/portal/use-cohort-label.ts
+++ b/src/frontend/src/lib/portal/use-cohort-label.ts
@@ -19,6 +19,16 @@ import { useIcPerson } from "@/queries/ic-dashboard";
  * Derived from the viewer's whole org, like the slice control itself, so every
  * surface says the same thing about the same slice.
  */
+/**
+ * The label reads mid-sentence ("above the division median"), so a plain
+ * capitalised word is lowered. Anything else is left as authored: identity
+ * attribute labels are becoming generic (constructorfabric/insight#1881), and
+ * lowering them blindly turns "R&D area" into "r&d area".
+ */
+function midSentence(label: string): string {
+  return /^[A-Z][a-z]*$/.test(label) ? label.toLowerCase() : label;
+}
+
 export function useCohortLabel(): string {
   const slice = usePortalSlice();
   const { personId } = useViewer();
@@ -28,5 +38,5 @@ export function useCohortLabel(): string {
     [tree],
   );
   if (!slice) return "team";
-  return (dims.find((d) => d.key === slice)?.label ?? "cohort").toLowerCase();
+  return midSentence(dims.find((d) => d.key === slice)?.label ?? "cohort");
 }

--- a/src/frontend/src/lib/portal/use-cohort-label.ts
+++ b/src/frontend/src/lib/portal/use-cohort-label.ts
@@ -29,6 +29,10 @@ function midSentence(label: string): string {
   return /^[A-Z][a-z]*$/.test(label) ? label.toLowerCase() : label;
 }
 
+/**
+ * The noun every peer comparison uses: the slice's own dimension when one is
+ * active, "team" otherwise. One source, so no two surfaces name it differently.
+ */
 export function useCohortLabel(): string {
   const slice = usePortalSlice();
   const { personId } = useViewer();

--- a/src/frontend/src/lib/portal/use-org-scope.test.ts
+++ b/src/frontend/src/lib/portal/use-org-scope.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import type { IdentityPerson } from "@/types/insight";
+import { resolveScopeRoster } from "./use-org-scope";
+
+// Ids deliberately look nothing like emails: the scope resolver keys on
+// `person_id` since the identity cutover, and an email-shaped fixture would
+// hide a regression that reads the wrong field.
+const person = (
+  personId: string,
+  name: string,
+  subordinates: IdentityPerson[] = [],
+): IdentityPerson =>
+  ({
+    person_id: personId,
+    email: `${name.toLowerCase().replace(/ /g, ".")}@x`,
+    display_name: name,
+    subordinates,
+  }) as unknown as IdentityPerson;
+
+//        ao
+//   ┌────┴─────┐
+//  lead1      ic3
+//  ┌──┴──┐
+// ic1   lead2
+//        │
+//       ic2
+const TREE = person("p-ao", "Ao", [
+  person("p-lead1", "Lead One", [
+    person("p-ic1", "IC One"),
+    person("p-lead2", "Lead Two", [person("p-ic2", "IC Two")]),
+  ]),
+  person("p-ic3", "IC Three"),
+]);
+
+describe("resolveScopeRoster", () => {
+  it("defaults to the viewer's whole subtree", () => {
+    const s = resolveScopeRoster(TREE, "p-ao", { root: null, directOnly: false });
+    expect(s.label).toBe("Ao");
+    expect(s.count).toBe(5);
+  });
+  it("scopes to a sub-lead's subtree", () => {
+    const s = resolveScopeRoster(TREE, "p-ao", { root: "p-lead1", directOnly: false });
+    expect(s.label).toBe("Lead One");
+    expect(s.roster?.map((r) => r.person_id).sort()).toEqual([
+      "p-ic1",
+      "p-ic2",
+      "p-lead2",
+    ]);
+  });
+  it("narrows to direct reports", () => {
+    const s = resolveScopeRoster(TREE, "p-ao", { root: "p-lead1", directOnly: true });
+    expect(s.roster?.map((r) => r.person_id).sort()).toEqual(["p-ic1", "p-lead2"]);
+  });
+  it("falls back to the viewer when root is outside the tree", () => {
+    const s = resolveScopeRoster(TREE, "p-ao", { root: "p-stranger", directOnly: false });
+    expect(s.label).toBe("Ao");
+  });
+  it("does not resolve a root outside the VIEWER's own subtree", () => {
+    // lead2 viewing with root=lead1: lead1 exists in the full tree but not in
+    // lead2's own subtree — the permission boundary must win, falling back
+    // to the viewer (lead2), not resolving to lead1.
+    const s = resolveScopeRoster(TREE, "p-lead2", { root: "p-lead1", directOnly: false });
+    expect(s.label).toBe("Lead Two");
+  });
+  it("directOnly is a no-op when the pivot has no indirect reports", () => {
+    const s = resolveScopeRoster(TREE, "p-ao", { root: "p-lead2", directOnly: true });
+    expect(s.roster?.map((r) => r.person_id)).toEqual(["p-ic2"]);
+    expect(s.canDirectOnly).toBe(false);
+  });
+  it("lists manager nodes for the picker, depth-annotated", () => {
+    const s = resolveScopeRoster(TREE, "p-ao", { root: null, directOnly: false });
+    expect(s.managerNodes.map((m) => `${"·".repeat(m.depth)}${m.person_id}`)).toEqual([
+      "p-ao",
+      "·p-lead1",
+      "··p-lead2",
+    ]);
+    expect(s.managerNodes.map((m) => m.teamSize)).toEqual([5, 3, 1]);
+  });
+});

--- a/src/frontend/src/lib/portal/use-org-scope.test.ts
+++ b/src/frontend/src/lib/portal/use-org-scope.test.ts
@@ -77,4 +77,23 @@ describe("resolveScopeRoster", () => {
     ]);
     expect(s.managerNodes.map((m) => m.teamSize)).toEqual([5, 3, 1]);
   });
+
+  it("keeps the picker in outline order across branches, not by depth", () => {
+    // Two leads at the same level, each with a lead under them: the picker is
+    // read as an org chart, so a lead's own leads follow it rather than all
+    // depth-1 nodes coming before all depth-2 nodes.
+    const tree = person("p-top", "Top", [
+      person("p-l1", "Lead 1", [person("p-l1a", "Lead 1A", [person("p-x", "X")])]),
+      person("p-l2", "Lead 2", [person("p-l2a", "Lead 2A", [person("p-y", "Y")])]),
+    ]);
+    const s = resolveScopeRoster(tree, "p-top", { root: null, directOnly: false });
+    expect(s.managerNodes.map((m) => m.person_id)).toEqual([
+      "p-top",
+      "p-l1",
+      "p-l1a",
+      "p-l2",
+      "p-l2a",
+    ]);
+    expect(s.managerNodes.map((m) => m.teamSize)).toEqual([6, 2, 1, 2, 1]);
+  });
 });

--- a/src/frontend/src/lib/portal/use-org-scope.ts
+++ b/src/frontend/src/lib/portal/use-org-scope.ts
@@ -17,6 +17,7 @@ import {
 import { useIcPerson } from "@/queries/ic-dashboard";
 import type { IdentityPerson } from "@/types/insight";
 
+/** One option in the scope picker: a manager, their depth, and their team size. */
 export interface ManagerNode {
   /** Canonical person id — what links, `?scope=` and metric ids all carry. */
   person_id: string;
@@ -25,6 +26,7 @@ export interface ManagerNode {
   teamSize: number;
 }
 
+/** The scope resolved against the viewer's own subtree — the permission boundary. */
 export interface ResolvedScope {
   /** The scope pivot (root manager node); null while the tree loads. */
   pivot: IdentityPerson | null;

--- a/src/frontend/src/lib/portal/use-org-scope.ts
+++ b/src/frontend/src/lib/portal/use-org-scope.ts
@@ -62,16 +62,27 @@ export function resolveScopeRoster(
   const roster = scopeRosterToDirectReports(full, canDirectOnly && scope.directOnly);
 
   const managerNodes: ManagerNode[] = [];
-  const walk = (node: IdentityPerson, depth: number): void => {
-    if (node.subordinates.length > 0) {
-      managerNodes.push({
-        person_id: node.person_id,
-        name: node.display_name || node.email,
-        depth,
-        teamSize: flattenSubordinates(node).length,
-      });
-    }
-    for (const sub of node.subordinates) walk(sub, depth + 1);
+  // One pass: each call returns its own subtree size, so a team size costs one
+  // visit per node. Flattening per manager node re-walked that manager's whole
+  // subtree — O(n · depth), which degrades on a deep reporting chain.
+  //
+  // The entry is pushed BEFORE recursing and its size filled in after, so the
+  // picker keeps its depth-first outline order (a lead, then that lead's leads).
+  const walk = (node: IdentityPerson, depth: number): number => {
+    const entry =
+      node.subordinates.length > 0
+        ? {
+            person_id: node.person_id,
+            name: node.display_name || node.email,
+            depth,
+            teamSize: 0,
+          }
+        : null;
+    if (entry) managerNodes.push(entry);
+    let size = 0;
+    for (const sub of node.subordinates) size += 1 + walk(sub, depth + 1);
+    if (entry) entry.teamSize = size;
+    return size;
   };
   walk(viewerNode, 0);
 

--- a/src/frontend/src/lib/portal/use-org-scope.ts
+++ b/src/frontend/src/lib/portal/use-org-scope.ts
@@ -1,0 +1,110 @@
+import { useMemo } from "react";
+
+import { useViewer } from "@/auth";
+import {
+  findIdentityNode,
+  flattenSubordinates,
+  hasIndirectReports,
+  scopeRosterToDirectReports,
+  type RosterEntry,
+} from "@/lib/insight/identity-tree";
+import {
+  type OrgScope,
+} from "@/lib/portal/portal-store";
+import {
+  usePortalScope,
+} from "@/lib/portal/portal-nav";
+import { useIcPerson } from "@/queries/ic-dashboard";
+import type { IdentityPerson } from "@/types/insight";
+
+export interface ManagerNode {
+  /** Canonical person id — what links, `?scope=` and metric ids all carry. */
+  person_id: string;
+  name: string;
+  depth: number;
+  teamSize: number;
+}
+
+export interface ResolvedScope {
+  /** The scope pivot (root manager node); null while the tree loads. */
+  pivot: IdentityPerson | null;
+  /** Everyone inside the scope (subtree or direct reports). */
+  roster: RosterEntry[] | null;
+  label: string;
+  count: number;
+  /** All manager nodes of the viewer's tree, for the ScopeSelect picker. */
+  managerNodes: ManagerNode[];
+  /** Whether directOnly can change anything at this pivot. */
+  canDirectOnly: boolean;
+}
+
+/**
+ * Pure scope resolution (design §6): pivot = scope.root within the viewer's
+ * tree (permission boundary — identity only serves the viewer their subtree),
+ * falling back to the viewer; roster = subtree, optionally direct-only.
+ */
+export function resolveScopeRoster(
+  tree: IdentityPerson | null,
+  viewerPersonId: string | null,
+  scope: OrgScope,
+): ResolvedScope {
+  if (!tree) {
+    return { pivot: null, roster: null, label: "", count: 0, managerNodes: [], canDirectOnly: false };
+  }
+  // Person id, not email: since the identity cutover that is the only key the
+  // tree, the routes and the metric entity ids agree on.
+  const viewerNode =
+    (viewerPersonId ? findIdentityNode(tree, viewerPersonId) : null) ?? tree;
+  const pivot =
+    (scope.root ? findIdentityNode(viewerNode, scope.root) : null) ?? viewerNode;
+  const full = flattenSubordinates(pivot);
+  const canDirectOnly = hasIndirectReports(full);
+  const roster = scopeRosterToDirectReports(full, canDirectOnly && scope.directOnly);
+
+  const managerNodes: ManagerNode[] = [];
+  const walk = (node: IdentityPerson, depth: number): void => {
+    if (node.subordinates.length > 0) {
+      managerNodes.push({
+        person_id: node.person_id,
+        name: node.display_name || node.email,
+        depth,
+        teamSize: flattenSubordinates(node).length,
+      });
+    }
+    for (const sub of node.subordinates) walk(sub, depth + 1);
+  };
+  walk(viewerNode, 0);
+
+  return {
+    pivot,
+    roster,
+    label: pivot.display_name || pivot.email,
+    count: roster?.length ?? 0,
+    managerNodes,
+    canDirectOnly,
+  };
+}
+
+/** The one hook every org zone uses to know WHO it is looking at. */
+export function useOrgScope(): ResolvedScope & {
+  isLoading: boolean;
+  isError: boolean;
+  refetch: () => void;
+  /** The pivot's person id — the roster key every org query is built from. */
+  pivotPersonId: string;
+} {
+  const { personId } = useViewer();
+  const viewerQ = useIcPerson(personId ?? "");
+  const scope = usePortalScope();
+  const resolved = useMemo(
+    () => resolveScopeRoster(viewerQ.data ?? null, personId, scope),
+    [viewerQ.data, personId, scope],
+  );
+  return {
+    ...resolved,
+    isLoading: viewerQ.isLoading,
+    isError: viewerQ.isError,
+    refetch: () => viewerQ.refetch(),
+    pivotPersonId: resolved.pivot?.person_id ?? personId ?? "",
+  };
+}

--- a/src/frontend/src/lib/portal/use-person-cohort.ts
+++ b/src/frontend/src/lib/portal/use-person-cohort.ts
@@ -1,0 +1,36 @@
+import { useMemo } from "react";
+
+import { useViewer } from "@/auth";
+import { cohortKey, collectRosterAttrs } from "@/lib/insight/slices";
+import { normalizePersonId } from "@/lib/metrics/entity";
+import {
+  usePortalSlice,
+} from "@/lib/portal/portal-nav";
+import { useIcPerson } from "@/queries/ic-dashboard";
+
+/**
+ * The entity ids of a person's slice cohort — everyone in the viewer's org who
+ * shares that person's value for the active slice attribute. Empty when no
+ * slice is active (so callers skip the cohort fetch and show the person's own
+ * numbers alone). Shared by every person-scoped view so slice support is wired
+ * once, not re-derived per screen.
+ */
+export function usePersonCohort(entityId: string): string[] {
+  const slice = usePortalSlice();
+  const { personId } = useViewer();
+  const tree = useIcPerson(personId ?? "").data ?? null;
+  const attrByEntity = useMemo(
+    () => collectRosterAttrs(tree, normalizePersonId),
+    [tree],
+  );
+  return useMemo(() => {
+    if (!slice) return [];
+    // Membership via the shared `cohortKey` predicate so this hook can never
+    // drift from how every other surface derives cohorts.
+    const own = cohortKey(attrByEntity.get(entityId), slice);
+    if (own == null) return [];
+    return [...attrByEntity.entries()]
+      .filter(([, a]) => cohortKey(a, slice) === own)
+      .map(([id]) => id);
+  }, [attrByEntity, slice, entityId]);
+}

--- a/src/frontend/src/lib/portal/use-shell-layout.ts
+++ b/src/frontend/src/lib/portal/use-shell-layout.ts
@@ -1,0 +1,48 @@
+import * as React from "react";
+
+/**
+ * How much chrome the viewport can afford. The portal shell has two fixed
+ * sidebars — a 56px icon rail and a 256px context pane — which is fine on a
+ * wide screen and ruinous on a narrow one.
+ *
+ * - `wide` (>= 1024px): both in normal flow, as designed.
+ * - `narrow` (768–1023px): the rail stays (56px is cheap and keeps zone
+ *   switching one tap away), the pane collapses off-canvas behind the topbar
+ *   trigger. 312px of chrome on a 900px window left the content 588px.
+ * - `phone` (< 768px): neither fits. The rail hides and the pane becomes the
+ *   only navigation surface, so it also carries the rail's zone list and
+ *   settings menu.
+ *
+ * The lower bound deliberately matches `useIsMobile` (768), because that is the
+ * breakpoint at which the sidebar primitive itself switches from an off-canvas
+ * panel to a Sheet — one boundary, two consequences, no third opinion. Which
+ * collapse mechanism is live matters to callers: below 768 the pane is a Sheet
+ * driven by `openMobile`, above it an off-canvas panel driven by `open`.
+ */
+export type ShellLayout = "phone" | "narrow" | "wide";
+
+const PHONE_MQ = "(max-width: 767px)";
+const NARROW_MQ = "(min-width: 768px) and (max-width: 1023px)";
+
+function subscribe(cb: () => void): () => void {
+  const queries = [window.matchMedia(PHONE_MQ), window.matchMedia(NARROW_MQ)];
+  for (const q of queries) q.addEventListener("change", cb);
+  return () => {
+    for (const q of queries) q.removeEventListener("change", cb);
+  };
+}
+
+function getSnapshot(): ShellLayout {
+  if (window.matchMedia(PHONE_MQ).matches) return "phone";
+  if (window.matchMedia(NARROW_MQ).matches) return "narrow";
+  return "wide";
+}
+
+// SSR fallback — assume the roomy case. Hydration corrects on first mount.
+function getServerSnapshot(): ShellLayout {
+  return "wide";
+}
+
+export function useShellLayout(): ShellLayout {
+  return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/src/frontend/src/lib/portal/use-shell-layout.ts
+++ b/src/frontend/src/lib/portal/use-shell-layout.ts
@@ -43,6 +43,7 @@ function getServerSnapshot(): ShellLayout {
   return "wide";
 }
 
+/** The layout tier the shell is in — one source, so rail and pane agree. */
 export function useShellLayout(): ShellLayout {
   return React.useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/src/frontend/src/lib/portal/use-viewer-is-manager.ts
+++ b/src/frontend/src/lib/portal/use-viewer-is-manager.ts
@@ -1,0 +1,29 @@
+import { useMemo } from "react";
+
+import { useViewer } from "@/auth";
+import { findIdentityNode } from "@/lib/insight/identity-tree";
+import { useIcPerson } from "@/queries/ic-dashboard";
+
+/**
+ * Whether the current viewer manages anyone. The portal's org zones (Overview,
+ * People, Directions, AI & Cost, …) all roll up the viewer's subtree, so they
+ * only mean something for a manager. An individual contributor has no subtree,
+ * so those zones would be empty — the shell collapses to their Person page
+ * instead (see LensRail / PortalLayout).
+ *
+ * `isPending` is true only until the viewer's own identity resolves; callers
+ * should treat pending as "assume manager" to avoid hiding zones on a flash.
+ */
+export function useViewerIsManager(): { isManager: boolean; isPending: boolean } {
+  const { personId } = useViewer();
+  const q = useIcPerson(personId ?? "");
+
+  const isManager = useMemo(() => {
+    const tree = q.data ?? null;
+    if (!tree || !personId) return false;
+    const node = findIdentityNode(tree, personId) ?? tree;
+    return (node.subordinates?.length ?? 0) > 0;
+  }, [q.data, personId]);
+
+  return { isManager, isPending: q.isPending };
+}

--- a/src/frontend/src/lib/portal/use-viewer-is-manager.ts
+++ b/src/frontend/src/lib/portal/use-viewer-is-manager.ts
@@ -25,5 +25,8 @@ export function useViewerIsManager(): { isManager: boolean; isPending: boolean }
     return (node.subordinates?.length ?? 0) > 0;
   }, [q.data, personId]);
 
-  return { isManager, isPending: q.isPending };
+  // `q.data == null` covers the error case too: with no tree we do not know,
+  // and callers treat unresolved as "assume manager" so the org zone can show
+  // the identity failure instead of the shell quietly demoting the viewer.
+  return { isManager, isPending: q.isPending || q.data == null };
 }

--- a/src/frontend/src/lib/portal/use-zone-nav.ts
+++ b/src/frontend/src/lib/portal/use-zone-nav.ts
@@ -1,0 +1,70 @@
+import { useNavigate } from "@tanstack/react-router";
+
+import { ZONES, type Zone } from "@/lib/portal/nav-model";
+import {
+  usePortalShowPlanned,
+} from "@/lib/portal/portal-store";
+import { useActiveZone } from "@/lib/portal/use-active-zone";
+import { useViewerIsManager } from "@/lib/portal/use-viewer-is-manager";
+
+/**
+ * Zones that still make sense when the viewer manages no one — everything else
+ * rolls up a (non-existent) subtree. An IC's portal collapses to these.
+ */
+const IC_ZONES = new Set(["person"]);
+
+/**
+ * The zone list the viewer may see plus the selection behaviour, shared by the
+ * desktop icon rail and the mobile drawer so both offer exactly the same zones
+ * and route the same way. Two zones are route-driven (Person / People): they
+ * navigate and clear the pinned zone, which is what lets a person-name click
+ * inside a roster drill straight into Person; the rest pin the zone.
+ */
+export function useZoneNav(): {
+  zones: Zone[];
+  activeZone: string;
+  selectZone: (zone: Zone) => void;
+} {
+  const navigate = useNavigate();
+  const { activeZone, activePerson } = useActiveZone();
+  const { isManager, isPending: mgrPending } = useViewerIsManager();
+  // Zones we have not built are hidden unless the viewer opted into seeing
+  // planned work — a rail of scaffolds makes the built zones look unreliable.
+  const showPlanned = usePortalShowPlanned();
+  // An IC (no reports) has no subtree to roll up, so org zones are hidden — the
+  // shell collapses to Person. While the viewer's identity is still resolving,
+  // assume manager so the nav doesn't flash a collapsed state.
+  const orgZonesVisible = isManager || mgrPending;
+
+  const zones = ZONES.filter(
+    (z) =>
+      (orgZonesVisible || IC_ZONES.has(z.id)) &&
+      (z.readiness !== "unbuilt" || showPlanned),
+  );
+
+  function selectZone(zone: Zone) {
+    // ONE navigation per click. Three separate writes (clear item, clear zone,
+    // change path) meant three history entries, so Back walked through
+    // half-states nobody chose.
+    const entity = zone.kind === "person" || zone.kind === "people";
+    if (entity && !activePerson) return;
+    void navigate({
+      ...(entity
+        ? {
+            to: zone.kind === "person" ? "/ic/$person/personal" : "/ic/$person/team",
+            params: { person: activePerson },
+          }
+        : { to: "/portal" }),
+      // `item` is per-zone: carrying it over renders a fallback view while the
+      // pane highlights nothing. The path carries the zone for entity zones, so
+      // a lingering `?zone=` there would only contradict it.
+      search: (prev: Record<string, unknown>) => ({
+        ...prev,
+        ...(activeZone !== zone.id ? { item: undefined } : {}),
+        zone: entity ? undefined : zone.id,
+      }),
+    });
+  }
+
+  return { zones, activeZone, selectZone };
+}

--- a/src/frontend/src/queries/metric-results.test.tsx
+++ b/src/frontend/src/queries/metric-results.test.tsx
@@ -183,3 +183,88 @@ describe("collectionSetPending", () => {
     expect(collectionSetPending(new Map())).toBe(false);
   });
 });
+
+/**
+ * Reported from the review environment: `/v1/metric-results` answering 400
+ * `entity.ids must not be empty`. The request was ours — `refetch()` ignores
+ * `enabled`, so a Retry on a view whose roster had not resolved posted an empty
+ * entity list, and the resulting error then latched the view into a hard-error
+ * card that no further Retry could clear.
+ */
+describe("a disabled collection has nothing to retry", () => {
+  beforeEach(() => {
+    mock.mockReset();
+    mock.mockImplementation((req: MetricResultsRequest) =>
+      Promise.resolve(respond(req)),
+    );
+  });
+
+  it("sends nothing while the entity list is empty", () => {
+    renderHook(
+      () => useMetricCollection(COLLECTION, { type: "person", ids: [] }, RANGE),
+      { wrapper: wrapper() },
+    );
+    expect(mock).not.toHaveBeenCalled();
+  });
+
+  it("ignores refetch instead of posting an entity-less request", async () => {
+    const { result } = renderHook(
+      () => useMetricCollection(COLLECTION, { type: "person", ids: [] }, RANGE),
+      { wrapper: wrapper() },
+    );
+
+    result.current.refetch();
+
+    // A short settle window: the failure mode is a request that DOES go out.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(mock).not.toHaveBeenCalled();
+  });
+
+  it("ignores refetch on a set of chunked collections too", async () => {
+    const { result } = renderHook(
+      () =>
+        useMetricCollectionSet(
+          [{ key: "g", collection: COLLECTION }],
+          { type: "person", ids: [] },
+          RANGE,
+        ),
+      { wrapper: wrapper() },
+    );
+
+    result.current.get("g")?.refetch();
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(mock).not.toHaveBeenCalled();
+  });
+
+  it("still retries once there is something to ask for", async () => {
+    const { result } = renderHook(
+      () =>
+        useMetricCollection(COLLECTION, { type: "person", ids: ["a@x"] }, RANGE),
+      { wrapper: wrapper() },
+    );
+    await waitFor(() => expect(mock).toHaveBeenCalledTimes(1));
+
+    result.current.refetch();
+    await waitFor(() => expect(mock).toHaveBeenCalledTimes(2));
+  });
+
+  it("does not carry a failure across into a resolved roster", async () => {
+    // The failure was recorded against the entity list that produced it (ids
+    // ride in the query key), so once the roster resolves the view starts from
+    // a clean query rather than inheriting "Unable to load".
+    mock.mockRejectedValue(new Error("400 invalid_argument"));
+    const { result, rerender } = renderHook(
+      ({ ids }: { ids: string[] }) =>
+        useMetricCollection(COLLECTION, { type: "person", ids }, RANGE),
+      { wrapper: wrapper(), initialProps: { ids: ["a@x"] } },
+    );
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    mock.mockImplementation((req: MetricResultsRequest) =>
+      Promise.resolve(respond(req)),
+    );
+    rerender({ ids: ["a@x", "b@x"] });
+    await waitFor(() => expect(result.current.isError).toBe(false));
+  });
+});

--- a/src/frontend/src/queries/metric-results.ts
+++ b/src/frontend/src/queries/metric-results.ts
@@ -81,6 +81,10 @@ export function useMetricCollection(
     { type: entity.type, ids },
     range
   );
+  // An empty entity list is not a request the backend can answer — it rejects
+  // `entity.ids: []` with 400 invalid_argument. So the query stays disabled,
+  // and because `refetch()` bypasses `enabled`, the `refetch` and `isError`
+  // this hook returns have to respect the same flag.
   const enabled = ids.length > 0 && Boolean(range.from && range.to);
 
   const current = useQuery({
@@ -136,8 +140,16 @@ export function useMetricCollection(
     previousByKey,
     isPending: current.isPending && enabled,
     isFetching: current.isFetching || (hasPrevious && previous.isFetching),
-    isError: current.isError,
+    // Defensive: `ids` and `range` both ride in the query key, so today a
+    // disabled query cannot be holding an error from an enabled one. Kept so
+    // that a future key change cannot resurrect "Unable to load" for a
+    // collection we are deliberately not asking about.
+    isError: enabled && current.isError,
     refetch: () => {
+      // `refetch()` ignores `enabled` in react-query, so this guard is what
+      // stops a Retry on an unresolved roster from POSTing `entity.ids: []` —
+      // see the note on `enabled` above.
+      if (!enabled) return;
       void current.refetch();
       if (hasPrevious) void previous.refetch();
     },
@@ -208,13 +220,17 @@ export function useMetricCollectionSet(
     maps.push(normalizeMetricResults(query.data?.metrics));
     chunkMaps.set(key, maps);
     const existing = out.get(key);
-    const refetch = () => void query.refetch();
+    // Same guard as the single-collection hook: a disabled chunk has no valid
+    // request to send, and `refetch()` would send it anyway.
+    const refetch = () => {
+      if (enabled) void query.refetch();
+    };
     out.set(key, {
       byKey: new Map(),
       previousByKey: null,
       isPending: (existing?.isPending ?? false) || (query.isPending && enabled),
       isFetching: (existing?.isFetching ?? false) || query.isFetching,
-      isError: (existing?.isError ?? false) || query.isError,
+      isError: (existing?.isError ?? false) || (enabled && query.isError),
       // Chunks of the same collection share a key; refetch fans out to all.
       refetch: existing
         ? () => {

--- a/src/frontend/src/routeTree.gen.ts
+++ b/src/frontend/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as WhatsNewRouteImport } from './routes/whats-new'
 import { Route as QueriesRouteImport } from './routes/queries'
+import { Route as PortalRouteImport } from './routes/portal'
 import { Route as MetricsRouteImport } from './routes/metrics'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as IcPersonRouteImport } from './routes/ic.$person'
@@ -26,6 +27,11 @@ const WhatsNewRoute = WhatsNewRouteImport.update({
 const QueriesRoute = QueriesRouteImport.update({
   id: '/queries',
   path: '/queries',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const PortalRoute = PortalRouteImport.update({
+  id: '/portal',
+  path: '/portal',
   getParentRoute: () => rootRouteImport,
 } as any)
 const MetricsRoute = MetricsRouteImport.update({
@@ -62,6 +68,7 @@ const IcPersonPersonalRoute = IcPersonPersonalRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/metrics': typeof MetricsRoute
+  '/portal': typeof PortalRoute
   '/queries': typeof QueriesRoute
   '/whats-new': typeof WhatsNewRoute
   '/ic/$person': typeof IcPersonRouteWithChildren
@@ -72,6 +79,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/metrics': typeof MetricsRoute
+  '/portal': typeof PortalRoute
   '/queries': typeof QueriesRoute
   '/whats-new': typeof WhatsNewRoute
   '/ic/$person/personal': typeof IcPersonPersonalRoute
@@ -82,6 +90,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/metrics': typeof MetricsRoute
+  '/portal': typeof PortalRoute
   '/queries': typeof QueriesRoute
   '/whats-new': typeof WhatsNewRoute
   '/ic/$person': typeof IcPersonRouteWithChildren
@@ -94,6 +103,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/metrics'
+    | '/portal'
     | '/queries'
     | '/whats-new'
     | '/ic/$person'
@@ -104,6 +114,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/metrics'
+    | '/portal'
     | '/queries'
     | '/whats-new'
     | '/ic/$person/personal'
@@ -113,6 +124,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/metrics'
+    | '/portal'
     | '/queries'
     | '/whats-new'
     | '/ic/$person'
@@ -124,6 +136,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   MetricsRoute: typeof MetricsRoute
+  PortalRoute: typeof PortalRoute
   QueriesRoute: typeof QueriesRoute
   WhatsNewRoute: typeof WhatsNewRoute
   IcPersonRoute: typeof IcPersonRouteWithChildren
@@ -143,6 +156,13 @@ declare module '@tanstack/react-router' {
       path: '/queries'
       fullPath: '/queries'
       preLoaderRoute: typeof QueriesRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/portal': {
+      id: '/portal'
+      path: '/portal'
+      fullPath: '/portal'
+      preLoaderRoute: typeof PortalRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/metrics': {
@@ -209,6 +229,7 @@ const IcPersonRouteWithChildren = IcPersonRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   MetricsRoute: MetricsRoute,
+  PortalRoute: PortalRoute,
   QueriesRoute: QueriesRoute,
   WhatsNewRoute: WhatsNewRoute,
   IcPersonRoute: IcPersonRouteWithChildren,

--- a/src/frontend/src/routes/__root.tsx
+++ b/src/frontend/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import { Outlet, createRootRoute } from "@tanstack/react-router";
+import { Outlet, createRootRoute, useRouterState } from "@tanstack/react-router";
 
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { getPerson } from "@/api/identity-client";
@@ -9,6 +9,8 @@ import { CenteredSpinner } from "@/components/widgets/centered-spinner";
 import { MockBanner } from "@/components/mock-banner";
 import { ViewAsBanner } from "@/components/view-as-banner";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
+import { PortalLayout } from "@/components/portal/portal-layout";
+import { usePortalEnabled } from "@/lib/portal/portal-store";
 import { normalizePersonId } from "@/lib/metrics/entity";
 import { queryClient } from "@/query-client";
 import { MetricEvidenceDialogProvider } from "@/components/metric-evidence-dialog-provider";
@@ -51,18 +53,34 @@ function RootPending() {
 }
 
 function RootLayout() {
+  const portal = usePortalEnabled();
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  // The portal is a ROUTE now, so it renders through the Outlet like anything
+  // else — otherwise its navigation could never live in the URL. It still owns
+  // the whole shell on the routes it claims (/portal and the person pages);
+  // everywhere else (/metrics, /whats-new) the app chrome stays, which the
+  // old "portal replaces the app" branch used to swallow.
+  const portalRoute =
+    pathname === "/portal" || /^\/ic\/[^/]+\/(personal|team)\/?$/.test(pathname);
   return (
     <TooltipProvider>
+      {/* Upstream's evidence-dialog provider wraps everything; the portal
+          branch lives inside it, so a drilldown opened from a portal surface
+          finds the same provider the legacy screens use. */}
       <MetricEvidenceDialogProvider>
         <AuthGate>
-          <SidebarProvider>
-            <AppSidebar />
-            <SidebarInset className="min-w-0 overflow-x-clip">
-              <MockBanner />
-              <ViewAsBanner />
-              <Outlet />
-            </SidebarInset>
-          </SidebarProvider>
+          {portal && portalRoute ? (
+            <PortalLayout />
+          ) : (
+            <SidebarProvider>
+              <AppSidebar />
+              <SidebarInset className="min-w-0 overflow-x-clip">
+                <MockBanner />
+                <ViewAsBanner />
+                <Outlet />
+              </SidebarInset>
+            </SidebarProvider>
+          )}
         </AuthGate>
       </MetricEvidenceDialogProvider>
     </TooltipProvider>

--- a/src/frontend/src/routes/__root.tsx
+++ b/src/frontend/src/routes/__root.tsx
@@ -10,6 +10,7 @@ import { MockBanner } from "@/components/mock-banner";
 import { ViewAsBanner } from "@/components/view-as-banner";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { PortalLayout } from "@/components/portal/portal-layout";
+import { isPortalShellPath } from "@/lib/portal/portal-routes";
 import { usePortalEnabled } from "@/lib/portal/portal-store";
 import { normalizePersonId } from "@/lib/metrics/entity";
 import { queryClient } from "@/query-client";
@@ -57,11 +58,8 @@ function RootLayout() {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
   // The portal is a ROUTE now, so it renders through the Outlet like anything
   // else — otherwise its navigation could never live in the URL. It still owns
-  // the whole shell on the routes it claims (/portal and the person pages);
-  // everywhere else (/metrics, /whats-new) the app chrome stays, which the
-  // old "portal replaces the app" branch used to swallow.
-  const portalRoute =
-    pathname === "/portal" || /^\/ic\/[^/]+\/(personal|team)\/?$/.test(pathname);
+  // the whole shell on the routes it claims; `isPortalShellPath` owns that list.
+  const portalRoute = isPortalShellPath(pathname);
   return (
     <TooltipProvider>
       {/* Upstream's evidence-dialog provider wraps everything; the portal

--- a/src/frontend/src/routes/ic.$person.tsx
+++ b/src/frontend/src/routes/ic.$person.tsx
@@ -1,5 +1,20 @@
-import { createFileRoute, Outlet } from "@tanstack/react-router";
+import { createFileRoute, Outlet, retainSearchParams } from "@tanstack/react-router";
+
+import {
+  PORTAL_SEARCH_KEYS,
+  validatePortalSearch,
+} from "@/lib/portal/portal-search";
 
 export const Route = createFileRoute("/ic/$person")({
+  // Person and People are portal zones too: the scope, slice and period a
+  // reader picked must survive the drill into a person and the climb back out.
+  validateSearch: validatePortalSearch,
+  search: {
+    // Retain the portal's own keys across every navigation, including the jump
+    // between /portal and a person route. Passing `search` by hand at each call
+    // site is how they got dropped in the first place — five links, one of them
+    // missed, and the scope silently resets.
+    middlewares: [retainSearchParams(PORTAL_SEARCH_KEYS)],
+  },
   component: () => <Outlet />,
 });

--- a/src/frontend/src/routes/index.tsx
+++ b/src/frontend/src/routes/index.tsx
@@ -1,10 +1,17 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, redirect } from "@tanstack/react-router";
 
 import { useViewer } from "@/auth";
+import { readPortalEnabled } from "@/lib/portal/portal-store";
 import { FullScreenLoading } from "@/components/full-screen-loading";
 import { DashboardScreen } from "@/screens/dashboard";
 
 export const Route = createFileRoute("/")({
+  // With the portal on, "/" is not a page — it is a redirect into the portal,
+  // so the address bar names a real destination from the first paint and Back
+  // out of the portal leaves the app rather than looping.
+  beforeLoad: () => {
+    if (readPortalEnabled()) throw redirect({ to: "/portal" });
+  },
   component: IndexRoute,
 });
 

--- a/src/frontend/src/routes/portal.test.tsx
+++ b/src/frontend/src/routes/portal.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment jsdom
+/**
+ * The /portal route is reachable by URL, so the preview flag has to be enforced
+ * there and not only in the shell that usually renders the portal. A pasted
+ * link — or a viewer who turns the preview off while standing on it — must not
+ * paint the portal.
+ */
+vi.mock("@tanstack/react-router", async () => {
+  const { portalRouterMock } = await import("@/test/portal-router");
+  return {
+    ...portalRouterMock(),
+    retainSearchParams: () => () => ({}),
+    // The real one registers the route in the generated tree; here it just
+    // hands the options back so the test can render the component.
+    createFileRoute: () => (options: Record<string, unknown>) => options,
+  };
+});
+vi.mock("@/components/portal/portal-layout", () => ({
+  PortalLayout: () => <div data-testid="portal-layout" />,
+}));
+
+import { render, screen } from "@testing-library/react";
+import { act } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setPortalEnabled } from "@/lib/portal/portal-store";
+import { portalRouter } from "@/test/portal-router";
+
+import { Route } from "./portal";
+
+const Component = (Route as unknown as { component: () => React.ReactNode })
+  .component;
+
+beforeEach(() => {
+  act(() => {
+    setPortalEnabled(false);
+    portalRouter.reset();
+  });
+});
+
+describe("/portal", () => {
+  it("redirects home when the preview is off", () => {
+    render(<Component />);
+    expect(screen.queryByTestId("portal-layout")).not.toBeInTheDocument();
+    expect(portalRouter.navigations).toEqual([{ to: "/", replace: true }]);
+  });
+
+  it("renders the portal when the preview is on", () => {
+    act(() => setPortalEnabled(true));
+    render(<Component />);
+    expect(screen.getByTestId("portal-layout")).toBeInTheDocument();
+    expect(portalRouter.navigations).toEqual([]);
+  });
+});

--- a/src/frontend/src/routes/portal.tsx
+++ b/src/frontend/src/routes/portal.tsx
@@ -1,10 +1,11 @@
-import { createFileRoute, retainSearchParams } from "@tanstack/react-router";
+import { Navigate, createFileRoute, retainSearchParams } from "@tanstack/react-router";
 
 import { PortalLayout } from "@/components/portal/portal-layout";
 import {
   PORTAL_SEARCH_KEYS,
   validatePortalSearch,
 } from "@/lib/portal/portal-search";
+import { usePortalEnabled } from "@/lib/portal/portal-store";
 
 /**
  * The portal's org zones (Overview / Directions / AI & Cost / Manage).
@@ -22,5 +23,14 @@ export const Route = createFileRoute("/portal")({
     // missed, and the scope silently resets.
     middlewares: [retainSearchParams(PORTAL_SEARCH_KEYS)],
   },
-  component: PortalLayout,
+  component: PortalRoute,
 });
+
+function PortalRoute() {
+  // The root shell swaps in PortalLayout for this route while the preview is
+  // on, so this component only mounts with it OFF — a pasted /portal URL, or a
+  // viewer who turned the preview off while standing here. Either way the
+  // portal must not render: send them to the app they do have.
+  if (!usePortalEnabled()) return <Navigate to="/" replace />;
+  return <PortalLayout />;
+}

--- a/src/frontend/src/routes/portal.tsx
+++ b/src/frontend/src/routes/portal.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute, retainSearchParams } from "@tanstack/react-router";
+
+import { PortalLayout } from "@/components/portal/portal-layout";
+import {
+  PORTAL_SEARCH_KEYS,
+  validatePortalSearch,
+} from "@/lib/portal/portal-search";
+
+/**
+ * The portal's org zones (Overview / Directions / AI & Cost / Manage).
+ *
+ * Person and People are NOT here: they are about one person, so they keep
+ * their own `/ic/$person/*` routes and carry the same search params. The zone
+ * therefore comes from the route on those, and from `?zone=` here.
+ */
+export const Route = createFileRoute("/portal")({
+  validateSearch: validatePortalSearch,
+  search: {
+    // Retain the portal's own keys across every navigation, including the jump
+    // between /portal and a person route. Passing `search` by hand at each call
+    // site is how they got dropped in the first place — five links, one of them
+    // missed, and the scope silently resets.
+    middlewares: [retainSearchParams(PORTAL_SEARCH_KEYS)],
+  },
+  component: PortalLayout,
+});

--- a/src/frontend/src/test/identity.ts
+++ b/src/frontend/src/test/identity.ts
@@ -1,0 +1,46 @@
+import type { IdentityPerson } from "@/types/insight";
+
+/**
+ * Identity fixtures for portal tests.
+ *
+ * Person keys are canonical UUIDs since the identity cutover — the route guard
+ * (`lib/metrics/entity.ts`) redirects anything else and the metrics API rejects
+ * it — which makes hand-written fixtures unreadable. `pid("lead")` mints a
+ * stable, valid UUID from a short label so tests stay legible while still
+ * exercising the real key shape, and `identityPerson` builds the tree nodes
+ * every org view resolves its roster from.
+ */
+
+/** A deterministic, valid person UUID for a short fixture label. */
+export function pid(label: string): string {
+  const hex = [...label]
+    .map((c) => c.charCodeAt(0).toString(16).padStart(2, "0"))
+    .join("");
+  const body = (hex + "1".repeat(32)).slice(0, 32);
+  return [
+    body.slice(0, 8),
+    body.slice(8, 12),
+    body.slice(12, 16),
+    body.slice(16, 20),
+    body.slice(20, 32),
+  ].join("-");
+}
+
+/**
+ * An identity tree node keyed by `pid(label)`, with the label doubling as the
+ * display name and the local part of the email (emails still exist on the
+ * profile — they are just no longer the key).
+ */
+export function identityPerson(
+  label: string,
+  over: Partial<IdentityPerson> = {},
+  subordinates: IdentityPerson[] = [],
+): IdentityPerson {
+  return {
+    person_id: pid(label),
+    email: `${label}@x`,
+    display_name: label,
+    subordinates,
+    ...over,
+  } as unknown as IdentityPerson;
+}

--- a/src/frontend/src/test/portal-router.tsx
+++ b/src/frontend/src/test/portal-router.tsx
@@ -1,0 +1,145 @@
+import { useSyncExternalStore } from "react";
+import { vi } from "vitest";
+
+import type { PortalSearch } from "@/lib/portal/portal-search";
+
+/**
+ * Portal navigation lives in the URL, so a component test needs a URL rather
+ * than a store to say "the reader is on Directions, sliced by division".
+ *
+ * A full memory router would drag the whole route tree into every component
+ * test; this stubs the router hooks the portal actually reads and records the
+ * navigations a component issues — which IS the behaviour now, not an
+ * implementation detail worth hiding.
+ *
+ * Usage (the async factory is what lets a shared helper back a `vi.mock`,
+ * since mock factories are hoisted above the file's own imports):
+ *
+ * ```ts
+ * vi.mock("@tanstack/react-router", async () => {
+ *   const { portalRouterMock } = await import("@/test/portal-router");
+ *   return portalRouterMock();
+ * });
+ * import { portalRouter } from "@/test/portal-router";
+ * ```
+ *
+ * The state is a per-file singleton — vitest gives each test file its own
+ * module registry — so `portalRouter.reset()` in `beforeEach` is enough.
+ */
+const listeners = new Set<() => void>();
+function emit(): void {
+  for (const fn of listeners) fn();
+}
+
+export const portalRouter = {
+  search: {} as PortalSearch,
+  pathname: "/portal",
+  /** Every `navigate()` a component issued, newest last. */
+  navigations: [] as Array<Record<string, unknown>>,
+
+  /** Patch the query string, as a link or a control would. */
+  set(next: Partial<PortalSearch>): void {
+    const merged: Record<string, unknown> = { ...this.search, ...next };
+    for (const [k, v] of Object.entries(next)) {
+      if (v === undefined) delete merged[k];
+    }
+    this.search = merged as PortalSearch;
+    emit();
+  },
+
+  /** Move to a path, as a route change would. */
+  go(pathname: string): void {
+    this.pathname = pathname;
+    emit();
+  },
+
+  reset(pathname = "/portal"): void {
+    this.search = {};
+    this.pathname = pathname;
+    this.navigations = [];
+    emit();
+  },
+};
+
+function subscribe(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => listeners.delete(cb);
+}
+
+export function portalRouterMock(): Record<string, unknown> {
+  const navigate = vi.fn((opts: Record<string, unknown>) => {
+    portalRouter.navigations.push(opts);
+    if (typeof opts.search === "function") {
+      portalRouter.search = (
+        opts.search as (p: unknown) => Record<string, unknown>
+      )(portalRouter.search) as PortalSearch;
+      emit();
+    } else if (opts.search) {
+      portalRouter.search = opts.search as PortalSearch;
+      emit();
+    }
+    if (typeof opts.to === "string" && opts.to !== ".") {
+      const params = (opts.params ?? {}) as Record<string, string>;
+      portalRouter.go(
+        opts.to.replace(/\$(\w+)/g, (_, k: string) =>
+          encodeURIComponent(params[k] ?? ""),
+        ),
+      );
+    }
+  });
+  return {
+    useNavigate: () => navigate,
+    // Subscribed, not snapshot-read: a component must re-render when the URL
+    // changes, which is the behaviour the portal now depends on entirely.
+    useSearch: () =>
+      useSyncExternalStore(
+        subscribe,
+        () => portalRouter.search,
+        () => portalRouter.search,
+      ),
+    useRouterState: ({ select }: { select: (s: unknown) => unknown }) => {
+      const path = useSyncExternalStore(
+        subscribe,
+        () => portalRouter.pathname,
+        () => portalRouter.pathname,
+      );
+      const search = useSyncExternalStore(
+        subscribe,
+        () => portalRouter.search,
+        () => portalRouter.search,
+      );
+      return select({ location: { pathname: path, search } });
+    },
+    // A real href, not a bare <a>: without it there is no link role to query,
+    // and the point of this migration is that a link CARRIES the state — so a
+    // test can assert what a shared URL would contain.
+    Link: ({
+      to,
+      params,
+      search,
+      children,
+      ...rest
+    }: {
+      to?: string;
+      params?: Record<string, string>;
+      search?: Record<string, unknown> | ((prev: unknown) => Record<string, unknown>);
+      children: React.ReactNode;
+    } & Record<string, unknown>) => {
+      const path = (to ?? "").replace(/\$(\w+)/g, (_, k: string) =>
+        encodeURIComponent(params?.[k] ?? ""),
+      );
+      const resolved =
+        typeof search === "function" ? search(portalRouter.search) : search;
+      const qs = new URLSearchParams(
+        Object.entries(resolved ?? {})
+          .filter(([, v]) => v !== undefined && v !== "" && v !== false)
+          .map(([k, v]) => [k, String(v)]),
+      ).toString();
+      return (
+        <a href={qs ? `${path}?${qs}` : path} {...rest}>
+          {children}
+        </a>
+      );
+    },
+  };
+}

--- a/src/frontend/src/test/portal-router.tsx
+++ b/src/frontend/src/test/portal-router.tsx
@@ -69,14 +69,18 @@ function subscribe(cb: () => void): () => void {
 export function portalRouterMock(): Record<string, unknown> {
   const navigate = vi.fn((opts: Record<string, unknown>) => {
     portalRouter.navigations.push(opts);
+    // Routed through `set` so a cleared key is DELETED rather than left as
+    // `undefined`: the real router drops it from the URL, and a fake that keeps
+    // it makes `toEqual` assertions disagree with what a shared link contains.
     if (typeof opts.search === "function") {
-      portalRouter.search = (
-        opts.search as (p: unknown) => Record<string, unknown>
-      )(portalRouter.search) as PortalSearch;
-      emit();
+      const next = (opts.search as (p: unknown) => Record<string, unknown>)(
+        portalRouter.search,
+      );
+      portalRouter.search = {} as PortalSearch;
+      portalRouter.set(next as Partial<PortalSearch>);
     } else if (opts.search) {
-      portalRouter.search = opts.search as PortalSearch;
-      emit();
+      portalRouter.search = {} as PortalSearch;
+      portalRouter.set(opts.search as Partial<PortalSearch>);
     }
     if (typeof opts.to === "string" && opts.to !== ".") {
       const params = (opts.params ?? {}) as Record<string, string>;

--- a/src/frontend/src/test/portal-router.tsx
+++ b/src/frontend/src/test/portal-router.tsx
@@ -1,4 +1,4 @@
-import { useSyncExternalStore } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 import { vi } from "vitest";
 
 import type { PortalSearch } from "@/lib/portal/portal-search";
@@ -109,6 +109,14 @@ export function portalRouterMock(): Record<string, unknown> {
         () => portalRouter.search,
       );
       return select({ location: { pathname: path, search } });
+    },
+    // A guard's redirect is a navigation too — recorded so a test can assert
+    // that a disabled preview or an invalid param sends the reader away.
+    Navigate: ({ to, replace }: { to: string; replace?: boolean }) => {
+      useEffect(() => {
+        portalRouter.navigations.push({ to, replace: replace ?? false });
+      }, [to, replace]);
+      return null;
     },
     // A real href, not a bare <a>: without it there is no link role to query,
     // and the point of this migration is that a link CARRIES the state — so a

--- a/src/frontend/src/test/portal-router.tsx
+++ b/src/frontend/src/test/portal-router.tsx
@@ -66,6 +66,10 @@ function subscribe(cb: () => void): () => void {
   return () => listeners.delete(cb);
 }
 
+/**
+ * The router module replacement: subscribed hooks, a `Link` that emits a real
+ * href, and a `Navigate` that records the redirect a guard fires.
+ */
 export function portalRouterMock(): Record<string, unknown> {
   const navigate = vi.fn((opts: Record<string, unknown>) => {
     portalRouter.navigations.push(opts);


### PR DESCRIPTION
## What

An organizational analytics **portal** — a manager-first shell over the existing metric system — gated behind the `insight.portal` localStorage flag (default off; nothing changes for current users). New code lives under `src/frontend/src/components/portal/` and `src/frontend/src/lib/portal/`, plus a few shared libs extracted with tests.

Turn it on: `localStorage.setItem("insight.portal", "true")` and reload (the flag is compared against the literal `"true"`).

**This replaces constructorfabric/insight-front#221**, re-based onto the monorepo now that the frontend lives at `src/frontend`. Same tree, re-cut as five logical commits (charts, metric grammar, URL navigation, shell, zone views); the granular per-task history stays on `dzarlax/insight-front-cf@feat/portal-shell` for anyone who wants the step-by-step.

## Why

The current dashboard is person-centric. Managers need the opposite entry point: the org first (their subtree), domains second, people last. The portal is that shell — and it doubles as a testbed for a **uniform metric grammar**, so every tab renders honestly from whatever connector set a tenant actually has (validated against two real datasets with very different coverage).

## Structure

- **Zones** (left rail): Overview / Directions / Person / People / AI & Cost / Manage.
- **Global topbar**: `Scope` (any node of the viewer's subtree plus a direct-only switch — the permission boundary is the viewer's own tree), `Slice` (dimensions discovered from identity attributes; single-valued and near-unique ones are hidden automatically), and the period selector. The bar is sticky, so the three global controls stay reachable from anywhere in a long dashboard.
- **IC-aware**: a viewer with no reports gets a Person-only shell.

## Everything is in the URL

Navigation state used to live in memory. A reload reset the screen, Back went somewhere unrelated, and a link or a bookmark could not reproduce a view — the main objection in review on the previous PR.

Now: `/portal?zone=&item=&dir=&lens=&scope=&direct=&slice=&period=&from=&to=` plus `/ic/$person/personal|team`. Only true reader preferences (is the portal on, are planned sections shown) remain in localStorage.

- Params are validated, not trusted: an unrecognised value is dropped so a mistyped link degrades to the computed default, and an inverted or over-long custom range falls back to the preset instead of throwing into the error boundary.
- Effect-driven corrections (pinning the landing zone, syncing scope from the route) use `replace`, so Back never steps into a half-built address.
- The path wins over a stale `?zone=` — the URL cannot contradict itself.
- Defaults stay computed rather than serialised, so a shared link pins what the sender actually chose and lets the rest resolve for the recipient.

## Keyed on person ids

Person keys are canonical person ids everywhere: the `/ic/$person/*` route segment (guarded by `isPersonId`, which redirects a pre-cutover email URL instead of sending it to the API as an unactionable 400), `?scope=`, the roster maps, and the metric entity ids. No email-to-id bridge — the frontend and metrics are on ids on dev, and a translation layer would outlive its reason to exist.

Two consequences worth naming: cohorts are keyed by id, so a person with no email still belongs to one and still appears in the employees directory; and the manager step in the person header uses `parent_person_id`.

## The metric grammar (the core of the PR)

Directions and Overview render through ONE config-driven renderer (`DomainLensView`) over a typed section library (`SectionSpec`): headline, stat-tiles, trend, distribution, concentration, composition, participation, event-histogram, attention, direction-cards, coverage-radar. Registries (`DIRECTION_LENSES`, `OVERVIEW_ITEMS`) declare every tab; invariant tests pin nav/registry coverage both ways and the metric-key budget.

Rules the renderer enforces everywhere:

- counters render per-active-person with a period-over-period delta coloured by the server-owned `direction`; ratios and medians are never summed;
- distributions use integer 1/2/5-ladder bins; concentration is a top-decile share with explicit framing (bus-factor risk for git, load balance for collaboration);
- **honest data-gating**: a family never observed for the scope renders a not-ingested state, never zeros (`entityObserved` reads the peer view's nulls, which the backend guarantees via `join_use_nulls = 1`, so zero-filled sums do not count as data);
- self-suppression on degenerate data (cohorts below four, single-bin histograms, single-valued slices), always with a sentence saying why rather than going silent;
- org zones never rank named individuals; names appear only in "needs attention" as click-through pointers into Person;
- trend requests coarsen their bucket (day to week to month) from roster size, and when no bucket fits the row budget the section says so instead of firing a request the API rejects;
- **no status without a threshold.** Deltas are coloured by `direction`, but nothing is labelled good or bad: the unified metric keys carry no threshold rows, and hardcoding good/warn in a component would turn a product decision into invisible frontend trivia. Status lights up the moment the catalog carries values (constructorfabric/insight#1974).

## Charts

Line charts were configured per call site, so the same reading looked different depending on the screen. `ChartLine` now owns the defaults: linear interpolation (a chart must not draw a value nobody measured), adaptive dots (dropped above 31 points, but an isolated reading between two nulls is always marked so a single point is never invisible), and gaps that read as gaps. `ChartYAxis` abbreviates ticks from 10k — the point where four digits still fit the gutter and five clip — and stays exact below it, because a tick sits on a gridline and "2.3k" for 2250 is a label that lies.

## Three layout tiers

`useShellLayout` resolves phone (<768) / narrow (768-1023) / wide (>=1024) in one place: the rail is a drawer on a phone, collapsible on narrow, pinned on wide, and pane state resets when the tier changes instead of restoring a mode that no longer exists. On a phone the drawer shows a one-row zone switcher and folds settings behind a single row — the expanded list pushed the sections below the fold, which is the content the reader opened the drawer to reach.

## Tests

785 unit tests over the new code, semantics-first rather than snapshot-first:

- **libs**: attention flags (outliers, collapses, adverse deltas, cohort isolation, scale-free severity in cohort IQRs, dedup to the strongest flag per person and metric), slice discovery gates, peer quantiles with small-cohort suppression, per-active-person maths, trend bucket selection including the no-bucket-fits case;
- **hooks**: URL-vs-path zone resolution, manager detection, person cohorts, org-scope resolution inside the viewer's own subtree;
- **components**: the section renderer (per-capita and deltas, active-only denominators, not-ingested gate, distribution suppression, concentration framing, composition shares and error card, participation, by-unit under a slice, attention rows, radar suppression), team state (totals vs medians, empty columns dropped), AI & Cost (Claude-only cost caveat, "not tracked" never $0), metric groups, context pane, shell routing across the three tiers, attention list, org-scope gate (an error never masquerades as an empty team), employees directory, Manage.

`src/test/portal-router` is a reactive router fake so navigation is asserted as real hrefs and recorded navigations; `src/test/identity` mints valid person UUIDs from short labels, so fixtures stay readable without drifting from the real key shape.

Verified in the ported tree: `pnpm typecheck` clean, `eslint --max-warnings 0` clean, 785 unit tests pass. The two Storybook browser suites are unchanged by this PR.

## Verified live

Walked every zone and tab at org scope (150+ people) and at narrowed scopes on two real datasets with different connector sets: full coverage on one; the other missing task and git freshness — every gap rendered as an explicit not-ingested state instead of fabricated zeros, which is exactly the behaviour this PR is after.

## Out of scope / follow-ups

- Server-side by-unit aggregation and an org-level histogram with shared bin edges (constructorfabric/insight#1984 — the client merges per-entity bins only when edges align, and falls back honestly otherwise).
- Threshold column with provenance, then editing via `/v1/admin/metric-thresholds` (blocked on values existing: constructorfabric/insight#1974, #1682).
- Analytics authorization for viewing a person above you in the org chart (constructorfabric/insight#1995).
- Development / Repositories / Elements — frontend work on dimensions that already exist (`repository`, `project`, `file_extension`, `change_type`).
- Phase-2 filter model (persistent attribute filters on top of scope and slice).
- Scorecard and Reports zones are ComingSoon scaffolds.

All five commits are signed off (DCO).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a responsive Portal experience with navigation, organization scoping, team and employee views, personal dashboards, metric groups, trends, attention insights, and AI cost reporting.
  * Added configurable overview, direction, and metric-management views with loading, error, empty, and Coming Soon states.
  * Added portal settings for enabling the experience and showing planned sections.
  * Added responsive charts, compact axis labels, period and slice selectors, and persistent period preferences.
* **Bug Fixes**
  * Prevented metric requests when entity lists or date ranges are incomplete.
  * Improved chart handling for sparse and isolated data points.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->