### PR TITLE
fix(ci): publish frontend image as insight-frontend, add frontend-only manual build

### DIFF
--- a/.env.compose.example
+++ b/.env.compose.example
@@ -33,7 +33,7 @@ ENABLE_AUTO_RELOAD=true
 FRONTEND_MODE=dev
 
 # Override the published image for FRONTEND_MODE=ghcr. Leave blank for
-# the default (ghcr.io/constructorfabric/insight-front:latest).
+# the default (ghcr.io/constructorfabric/insight/frontend:latest).
 FRONTEND_IMAGE=
 
 # ── Auth mode ──────────────────────────────────────────────────────────

--- a/.env.compose.example
+++ b/.env.compose.example
@@ -33,7 +33,7 @@ ENABLE_AUTO_RELOAD=true
 FRONTEND_MODE=dev
 
 # Override the published image for FRONTEND_MODE=ghcr. Leave blank for
-# the default (ghcr.io/constructorfabric/insight/frontend:latest).
+# the default (ghcr.io/constructorfabric/insight-frontend:latest).
 FRONTEND_IMAGE=
 
 # ── Auth mode ──────────────────────────────────────────────────────────

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -784,7 +784,7 @@ jobs:
 
   # ─── Frontend build ────────────────────────────────────────────────────────
   # Per-arch on native runners so `pnpm build` never runs under QEMU. The image
-  # is `insight/frontend` — a package created and owned by THIS repository.
+  # is `insight-frontend` — a package created and owned by THIS repository.
   # The old `insight-front` package belongs to the retired insight-front
   # repo's Actions ACL, so this repo's GITHUB_TOKEN cannot push it (#2247).
   #
@@ -829,7 +829,7 @@ jobs:
         with:
           context: src/frontend
           platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/insight/frontend,push-by-digest=true,name-canonical=true,push=${{ needs.changes.outputs.should_push == 'true' }}
+          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/insight-frontend,push-by-digest=true,name-canonical=true,push=${{ needs.changes.outputs.should_push == 'true' }}
           cache-from: type=gha,scope=frontend-${{ matrix.arch }}
           cache-to: ${{ needs.changes.outputs.should_push == 'true' && format('type=gha,mode=max,scope=frontend-{0},ignore-error=true', matrix.arch) || '' }}
       - name: Export digest
@@ -883,7 +883,7 @@ jobs:
       - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         id: meta
         with:
-          images: ${{ env.IMAGE_PREFIX }}/insight/frontend
+          images: ${{ env.IMAGE_PREFIX }}/insight-frontend
           tags: |
             type=raw,value=${{ needs.changes.outputs.build_tag }}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
@@ -893,7 +893,7 @@ jobs:
       - name: Fail on a fixable critical before any tag points here
         uses: ./.github/actions/image-cve-gate
         with:
-          image: ${{ env.IMAGE_PREFIX }}/insight/frontend
+          image: ${{ env.IMAGE_PREFIX }}/insight-frontend
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create multi-arch manifest and push
@@ -901,24 +901,24 @@ jobs:
         run: |
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.IMAGE_PREFIX }}/insight/frontend@sha256:%s ' *)
+            $(printf '${{ env.IMAGE_PREFIX }}/insight-frontend@sha256:%s ' *)
       - name: Inspect manifest digest
         id: inspect
         run: |
           DIGEST=$(docker buildx imagetools inspect \
-            ${{ env.IMAGE_PREFIX }}/insight/frontend:${{ needs.changes.outputs.build_tag }} \
+            ${{ env.IMAGE_PREFIX }}/insight-frontend:${{ needs.changes.outputs.build_tag }} \
             --format '{{json .Manifest}}' | jq -r .digest)
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
       - name: Attest build provenance
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
-          subject-name: ${{ env.IMAGE_PREFIX }}/insight/frontend
+          subject-name: ${{ env.IMAGE_PREFIX }}/insight-frontend
           subject-digest: ${{ steps.inspect.outputs.digest }}
           push-to-registry: true
       # Copy-pastable pushed ref on the run's Summary page (#1994).
       - name: Report pushed image
         run: |
-          echo '- `${{ env.IMAGE_PREFIX }}/insight/frontend:${{ needs.changes.outputs.build_tag }}`' >> "$GITHUB_STEP_SUMMARY"
+          echo '- `${{ env.IMAGE_PREFIX }}/insight-frontend:${{ needs.changes.outputs.build_tag }}`' >> "$GITHUB_STEP_SUMMARY"
 
   # ─── Toolbox build (with dbt parse smoke) ──────────────────────────────────
   # Toolbox is special — it bakes every connector's descriptor.yaml and dbt

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -39,9 +39,17 @@ on:
       - ".github/workflows/build-images.yml"
       - ".github/workflows/scripts/discover-image-matrix.py"
       - ".github/workflows/scripts/bump-service-appversions.sh"
-  # A manual dispatch is a full rebuild: every service and connector image is
-  # rebuilt regardless of changed paths, and publish-chart pins them all.
+  # A manual dispatch is a full rebuild by default: every service and
+  # connector image is rebuilt regardless of changed paths, and publish-chart
+  # pins them all. With `frontend_only` checked it instead builds and pushes
+  # JUST the frontend image from the dispatched ref (main or a branch) —
+  # no backend/connector builds, no descriptor bumps, no chart publish.
   workflow_dispatch:
+    inputs:
+      frontend_only:
+        description: "Build and push only the frontend image (skip everything else)"
+        type: boolean
+        default: false
 
 # One in-flight chart-publish per branch. Prevents two merges from racing
 # the auto-commit-back step.
@@ -206,8 +214,11 @@ jobs:
   # itself fired image rebuilds, we'd loop forever.
   # 
   # `workflow_dispatch` (full rebuild) emits every entry; PR runs use the same
-  # path-filter logic as push runs.
+  # path-filter logic as push runs. A frontend-only dispatch skips discovery
+  # entirely — build-image, merge-image and bump-descriptors all key off
+  # `outputs.any`, so they cascade-skip with it.
   discover-images:
+    if: github.event_name != 'workflow_dispatch' || !inputs.frontend_only
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.scan.outputs.matrix }}
@@ -287,7 +298,7 @@ jobs:
     needs: changes
     if: |
       needs.changes.outputs.analytics == 'true'
-      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'workflow_dispatch' && !inputs.frontend_only)
     strategy:
       fail-fast: false
       matrix:
@@ -419,7 +430,7 @@ jobs:
     needs: changes
     if: |
       needs.changes.outputs.authenticator == 'true'
-      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'workflow_dispatch' && !inputs.frontend_only)
     strategy:
       fail-fast: false
       matrix:
@@ -533,7 +544,7 @@ jobs:
     needs: changes
     if: |
       needs.changes.outputs.gateway == 'true'
-      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'workflow_dispatch' && !inputs.frontend_only)
     strategy:
       fail-fast: false
       matrix:
@@ -648,7 +659,7 @@ jobs:
     needs: changes
     if: |
       needs.changes.outputs.identity_resolution == 'true'
-      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'workflow_dispatch' && !inputs.frontend_only)
     strategy:
       fail-fast: false
       matrix:
@@ -773,8 +784,9 @@ jobs:
 
   # ─── Frontend build ────────────────────────────────────────────────────────
   # Per-arch on native runners so `pnpm build` never runs under QEMU. The image
-  # name stays `insight-front` — every chart, values file and overlay resolves it,
-  # so it must not drift to match the `src/frontend` path.
+  # is `insight/frontend` — a package created and owned by THIS repository.
+  # The old `insight-front` package belongs to the retired insight-front
+  # repo's Actions ACL, so this repo's GITHUB_TOKEN cannot push it (#2247).
   #
   # The workflow_dispatch clause is load-bearing: bump-service-appversions.sh pins
   # this subchart on dispatch (FULL_REBUILD), so without it publish-chart would
@@ -817,7 +829,7 @@ jobs:
         with:
           context: src/frontend
           platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/insight-front,push-by-digest=true,name-canonical=true,push=${{ needs.changes.outputs.should_push == 'true' }}
+          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/insight/frontend,push-by-digest=true,name-canonical=true,push=${{ needs.changes.outputs.should_push == 'true' }}
           cache-from: type=gha,scope=frontend-${{ matrix.arch }}
           cache-to: ${{ needs.changes.outputs.should_push == 'true' && format('type=gha,mode=max,scope=frontend-{0},ignore-error=true', matrix.arch) || '' }}
       - name: Export digest
@@ -871,7 +883,7 @@ jobs:
       - uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         id: meta
         with:
-          images: ${{ env.IMAGE_PREFIX }}/insight-front
+          images: ${{ env.IMAGE_PREFIX }}/insight/frontend
           tags: |
             type=raw,value=${{ needs.changes.outputs.build_tag }}
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
@@ -881,7 +893,7 @@ jobs:
       - name: Fail on a fixable critical before any tag points here
         uses: ./.github/actions/image-cve-gate
         with:
-          image: ${{ env.IMAGE_PREFIX }}/insight-front
+          image: ${{ env.IMAGE_PREFIX }}/insight/frontend
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
       - name: Create multi-arch manifest and push
@@ -889,24 +901,24 @@ jobs:
         run: |
           docker buildx imagetools create \
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
-            $(printf '${{ env.IMAGE_PREFIX }}/insight-front@sha256:%s ' *)
+            $(printf '${{ env.IMAGE_PREFIX }}/insight/frontend@sha256:%s ' *)
       - name: Inspect manifest digest
         id: inspect
         run: |
           DIGEST=$(docker buildx imagetools inspect \
-            ${{ env.IMAGE_PREFIX }}/insight-front:${{ needs.changes.outputs.build_tag }} \
+            ${{ env.IMAGE_PREFIX }}/insight/frontend:${{ needs.changes.outputs.build_tag }} \
             --format '{{json .Manifest}}' | jq -r .digest)
           echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
       - name: Attest build provenance
         uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
         with:
-          subject-name: ${{ env.IMAGE_PREFIX }}/insight-front
+          subject-name: ${{ env.IMAGE_PREFIX }}/insight/frontend
           subject-digest: ${{ steps.inspect.outputs.digest }}
           push-to-registry: true
       # Copy-pastable pushed ref on the run's Summary page (#1994).
       - name: Report pushed image
         run: |
-          echo '- `${{ env.IMAGE_PREFIX }}/insight-front:${{ needs.changes.outputs.build_tag }}`' >> "$GITHUB_STEP_SUMMARY"
+          echo '- `${{ env.IMAGE_PREFIX }}/insight/frontend:${{ needs.changes.outputs.build_tag }}`' >> "$GITHUB_STEP_SUMMARY"
 
   # ─── Toolbox build (with dbt parse smoke) ──────────────────────────────────
   # Toolbox is special — it bakes every connector's descriptor.yaml and dbt
@@ -920,7 +932,7 @@ jobs:
     needs: changes
     if: |
       needs.changes.outputs.toolbox == 'true'
-      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'workflow_dispatch' && !inputs.frontend_only)
     strategy:
       fail-fast: false
       matrix:
@@ -1104,7 +1116,7 @@ jobs:
     needs: changes
     if: |
       needs.changes.outputs.ui_tests == 'true'
-      || github.event_name == 'workflow_dispatch'
+      || (github.event_name == 'workflow_dispatch' && !inputs.frontend_only)
     strategy:
       fail-fast: false
       matrix:
@@ -1579,6 +1591,7 @@ jobs:
     if: |
       always()
       && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+      && !(github.event_name == 'workflow_dispatch' && inputs.frontend_only)
       && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release-'))
       && (needs.merge-analytics.result == 'success' || needs.merge-analytics.result == 'skipped')
       && (needs.merge-authenticator.result == 'success' || needs.merge-authenticator.result == 'skipped')

--- a/.github/workflows/e2e-stand.yml
+++ b/.github/workflows/e2e-stand.yml
@@ -63,7 +63,7 @@ concurrency:
 
 permissions:
   contents: read
-  packages: read # pulls insight/frontend (via compose) and insight-ui-tests
+  packages: read # pulls insight-frontend (via compose) and insight-ui-tests
 
 env:
   # Built and published by build-images.yml's ui-tests job. Pulled here, never

--- a/.github/workflows/e2e-stand.yml
+++ b/.github/workflows/e2e-stand.yml
@@ -63,7 +63,7 @@ concurrency:
 
 permissions:
   contents: read
-  packages: read # pulls insight-front (via compose) and insight-ui-tests
+  packages: read # pulls insight/frontend (via compose) and insight-ui-tests
 
 env:
   # Built and published by build-images.yml's ui-tests job. Pulled here, never

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -6,8 +6,7 @@ name: GHCR cleanup
 #     weeks on a daily schedule, keeping the 15 newest per package as a
 #     backstop. `latest` and the branch-suffixed tags never match the glob,
 #     and `image-names: insight-*` never matches the `charts/insight`
-#     package, so charts are untouched. The frontend package `insight/frontend`
-#     is nested, so it is listed by exact name next to the glob.
+#     package, so charts are untouched.
 #   • branch tags (`…-sha7.<sanitized-branch>`, #1994) — deleted when their
 #     branch is deleted. `release-*` branches are excluded: their images are
 #     kept forever (customer-release pins).
@@ -44,7 +43,7 @@ jobs:
         with:
           account: constructorfabric
           token: ${{ secrets.GITHUB_TOKEN }}
-          image-names: "insight-* insight/frontend"
+          image-names: "insight-*"
           # Fixed-length trunk format only: branch tags carry a `.suffix`
           # (longer), `latest` doesn't match either.
           image-tags: "2???.??.??.??.??-???????"
@@ -74,7 +73,7 @@ jobs:
         with:
           account: constructorfabric
           token: ${{ secrets.GITHUB_TOKEN }}
-          image-names: "insight-* insight/frontend"
+          image-names: "insight-*"
           image-tags: "*.${{ steps.suffix.outputs.safe }}"
           cut-off: 0s
           dry-run: true

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -6,7 +6,8 @@ name: GHCR cleanup
 #     weeks on a daily schedule, keeping the 15 newest per package as a
 #     backstop. `latest` and the branch-suffixed tags never match the glob,
 #     and `image-names: insight-*` never matches the `charts/insight`
-#     package, so charts are untouched.
+#     package, so charts are untouched. The frontend package `insight/frontend`
+#     is nested, so it is listed by exact name next to the glob.
 #   • branch tags (`…-sha7.<sanitized-branch>`, #1994) — deleted when their
 #     branch is deleted. `release-*` branches are excluded: their images are
 #     kept forever (customer-release pins).
@@ -43,7 +44,7 @@ jobs:
         with:
           account: constructorfabric
           token: ${{ secrets.GITHUB_TOKEN }}
-          image-names: "insight-*"
+          image-names: "insight-* insight/frontend"
           # Fixed-length trunk format only: branch tags carry a `.suffix`
           # (longer), `latest` doesn't match either.
           image-tags: "2???.??.??.??.??-???????"
@@ -73,7 +74,7 @@ jobs:
         with:
           account: constructorfabric
           token: ${{ secrets.GITHUB_TOKEN }}
-          image-names: "insight-*"
+          image-names: "insight-* insight/frontend"
           image-tags: "*.${{ steps.suffix.outputs.safe }}"
           cut-off: 0s
           dry-run: true

--- a/.github/workflows/trivy-images.yml
+++ b/.github/workflows/trivy-images.yml
@@ -41,7 +41,7 @@ jobs:
           - insight-gateway
           - insight-identity-resolution
           # Frontend (nginx + the Vite bundle)
-          - insight/frontend
+          - insight-frontend
           # Python tooling
           - insight-toolbox
           - insight-jira-enrich

--- a/.github/workflows/trivy-images.yml
+++ b/.github/workflows/trivy-images.yml
@@ -41,7 +41,7 @@ jobs:
           - insight-gateway
           - insight-identity-resolution
           # Frontend (nginx + the Vite bundle)
-          - insight-front
+          - insight/frontend
           # Python tooling
           - insight-toolbox
           - insight-jira-enrich

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ First-run wizard prompts (Enter accepts defaults):
 | Use local MariaDB? | Y | Compose starts mariadb on :3306 |
 | Use local ClickHouse? | Y | Compose starts clickhouse on :8123 |
 | `DEV_USER_EMAIL` | `dev@company.nonpresent` | FakeIdP login and dev-team lead in the seed roster |
-| Frontend mode | `1` (ghcr) | Pulls the published `insight/frontend:latest` image |
+| Frontend mode | `1` (ghcr) | Pulls the published `insight-frontend:latest` image |
 
 Then the script builds host artefacts, brings up the stack, auto-seeds
 the demo dataset (25 persons + ~24k ClickHouse rows across 16 silver
@@ -89,7 +89,7 @@ builder container.
 **K8s path** — also `kubectl`, `helm`, `kubeseal`, `yq`, `jq`, plus a
 local cluster (OrbStack with Kubernetes / k3d / kind / minikube). No
 frontend checkout needed — the umbrella chart pulls
-`ghcr.io/constructorfabric/insight/frontend:<tag>` from GHCR.
+`ghcr.io/constructorfabric/insight-frontend:<tag>` from GHCR.
 
 **Frontend checkout** — only needed for compose with
 `FRONTEND_MODE=dev` (Vite HMR) or `built` (host-built dist). The

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ First-run wizard prompts (Enter accepts defaults):
 | Use local MariaDB? | Y | Compose starts mariadb on :3306 |
 | Use local ClickHouse? | Y | Compose starts clickhouse on :8123 |
 | `DEV_USER_EMAIL` | `dev@company.nonpresent` | FakeIdP login and dev-team lead in the seed roster |
-| Frontend mode | `1` (ghcr) | Pulls the published `insight-front:latest` image |
+| Frontend mode | `1` (ghcr) | Pulls the published `insight/frontend:latest` image |
 
 Then the script builds host artefacts, brings up the stack, auto-seeds
 the demo dataset (25 persons + ~24k ClickHouse rows across 16 silver
@@ -89,7 +89,7 @@ builder container.
 **K8s path** — also `kubectl`, `helm`, `kubeseal`, `yq`, `jq`, plus a
 local cluster (OrbStack with Kubernetes / k3d / kind / minikube). No
 frontend checkout needed — the umbrella chart pulls
-`ghcr.io/constructorfabric/insight-front:<tag>` from GHCR.
+`ghcr.io/constructorfabric/insight/frontend:<tag>` from GHCR.
 
 **Frontend checkout** — only needed for compose with
 `FRONTEND_MODE=dev` (Vite HMR) or `built` (host-built dist). The

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ cd insight
 ./dev-compose.sh up        # first-run wizard, then builds + seeds the stack
 ```
 
-The wizard prompts for local-vs-external MariaDB / ClickHouse, a dev-user email, and the frontend mode (defaults pull the published `insight/frontend` image). First `up` auto-seeds a demo dataset; open <http://localhost:3000>.
+The wizard prompts for local-vs-external MariaDB / ClickHouse, a dev-user email, and the frontend mode (defaults pull the published `insight-frontend` image). First `up` auto-seeds a demo dataset; open <http://localhost:3000>.
 
 The compose stack does **not** ship Airbyte or Argo Workflows — for ingestion work use the Kubernetes path below. See [CONTRIBUTING.md](CONTRIBUTING.md) for the edit-build loop, frontend modes, seeding, and the `.env.compose` settings reference.
 
@@ -320,7 +320,7 @@ For cluster deployments image tags flow through automatically: the umbrella char
 | `insight-analytics` | this repo | https://github.com/constructorfabric/insight/pkgs/container/insight-analytics |
 | `insight-identity-resolution` | this repo | https://github.com/constructorfabric/insight/pkgs/container/insight-identity-resolution |
 | `insight-toolbox` | this repo | https://github.com/constructorfabric/insight/pkgs/container/insight-toolbox |
-| `insight/frontend` | this repo | https://github.com/constructorfabric/insight/pkgs/container/insight%2Ffrontend |
+| `insight-frontend` | this repo | https://github.com/constructorfabric/insight/pkgs/container/insight-frontend |
 | `insight-jira-enrich` | **separate** `constructorfabric/insight-jira-enrich` | https://github.com/constructorfabric/insight/pkgs/container/insight-jira-enrich |
 
 > **Note**: jira-enrich lives in its own repo with an independent release cadence — a tag from this repo (e.g. `2026.04.28.10.34-b08b460`) does **not** exist for `insight-jira-enrich`. Pick the latest tag in that repo separately.

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ cd insight
 ./dev-compose.sh up        # first-run wizard, then builds + seeds the stack
 ```
 
-The wizard prompts for local-vs-external MariaDB / ClickHouse, a dev-user email, and the frontend mode (defaults pull the published `insight-front` image). First `up` auto-seeds a demo dataset; open <http://localhost:3000>.
+The wizard prompts for local-vs-external MariaDB / ClickHouse, a dev-user email, and the frontend mode (defaults pull the published `insight/frontend` image). First `up` auto-seeds a demo dataset; open <http://localhost:3000>.
 
 The compose stack does **not** ship Airbyte or Argo Workflows — for ingestion work use the Kubernetes path below. See [CONTRIBUTING.md](CONTRIBUTING.md) for the edit-build loop, frontend modes, seeding, and the `.env.compose` settings reference.
 
@@ -320,7 +320,7 @@ For cluster deployments image tags flow through automatically: the umbrella char
 | `insight-analytics` | this repo | https://github.com/constructorfabric/insight/pkgs/container/insight-analytics |
 | `insight-identity-resolution` | this repo | https://github.com/constructorfabric/insight/pkgs/container/insight-identity-resolution |
 | `insight-toolbox` | this repo | https://github.com/constructorfabric/insight/pkgs/container/insight-toolbox |
-| `insight-front` | this repo | https://github.com/constructorfabric/insight/pkgs/container/insight-front |
+| `insight/frontend` | this repo | https://github.com/constructorfabric/insight/pkgs/container/insight%2Ffrontend |
 | `insight-jira-enrich` | **separate** `constructorfabric/insight-jira-enrich` | https://github.com/constructorfabric/insight/pkgs/container/insight-jira-enrich |
 
 > **Note**: jira-enrich lives in its own repo with an independent release cadence — a tag from this repo (e.g. `2026.04.28.10.34-b08b460`) does **not** exist for `insight-jira-enrich`. Pick the latest tag in that repo separately.

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -547,7 +547,7 @@ frontend:
   deploy: true
   replicaCount: 1
   image:
-    repository: ghcr.io/constructorfabric/insight-front
+    repository: ghcr.io/constructorfabric/insight/frontend
     tag: "" # MUST be set (e.g. "0.1.0")
     pullPolicy: IfNotPresent
   resources:

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -547,7 +547,7 @@ frontend:
   deploy: true
   replicaCount: 1
   image:
-    repository: ghcr.io/constructorfabric/insight/frontend
+    repository: ghcr.io/constructorfabric/insight-frontend
     tag: "" # MUST be set (e.g. "0.1.0")
     pullPolicy: IfNotPresent
   resources:

--- a/deploy/compose/front-ghcr-patch-conf.sh
+++ b/deploy/compose/front-ghcr-patch-conf.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Compose-only patch for the insight-front ghcr image.
+# Compose-only patch for the published frontend ghcr image.
 #
 # The published image's nginx config deliberately has no /api proxy — in k8s
 # the cluster ingress routes /api/* straight to the gateway pod, so the FE pod

--- a/deploy/gitops/environments/local/values.yaml.template
+++ b/deploy/gitops/environments/local/values.yaml.template
@@ -214,7 +214,7 @@ identityResolution:
     limits:   { cpu: 500m, memory: 512Mi }
 
 frontend:
-  # The SPA image is pulled from ghcr (ghcr.io/constructorfabric/insight-front,
+  # The SPA image is pulled from ghcr (ghcr.io/constructorfabric/insight/frontend,
   # chart appVersion tag) — no local build needed. It deploys but may not fully
   # work against the current backend yet.
   deploy: true

--- a/deploy/gitops/environments/local/values.yaml.template
+++ b/deploy/gitops/environments/local/values.yaml.template
@@ -214,7 +214,7 @@ identityResolution:
     limits:   { cpu: 500m, memory: 512Mi }
 
 frontend:
-  # The SPA image is pulled from ghcr (ghcr.io/constructorfabric/insight/frontend,
+  # The SPA image is pulled from ghcr (ghcr.io/constructorfabric/insight-frontend,
   # chart appVersion tag) — no local build needed. It deploys but may not fully
   # work against the current backend yet.
   deploy: true

--- a/deploy/preview/values.yaml
+++ b/deploy/preview/values.yaml
@@ -15,7 +15,7 @@ podAnnotations: {}
 
 # The FE image. Only the FE varies per experiment; the backend never does.
 image:
-  repository: ghcr.io/constructorfabric/insight/frontend
+  repository: ghcr.io/constructorfabric/insight-frontend
   tag: "" # REQUIRED per experiment (a build tag; rendered as repository:tag). No `:latest` default.
   pullPolicy: IfNotPresent
 

--- a/deploy/preview/values.yaml
+++ b/deploy/preview/values.yaml
@@ -15,7 +15,7 @@ podAnnotations: {}
 
 # The FE image. Only the FE varies per experiment; the backend never does.
 image:
-  repository: ghcr.io/constructorfabric/insight-front
+  repository: ghcr.io/constructorfabric/insight/frontend
   tag: "" # REQUIRED per experiment (a build tag; rendered as repository:tag). No `:latest` default.
   pullPolicy: IfNotPresent
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -608,7 +608,7 @@ services:
     profiles: ["front-ghcr"]
     # No platform pin: the published tags are multi-arch manifests covering
     # linux/amd64 and linux/arm64, so Apple-silicon hosts pull arm64 natively.
-    image: ${FRONTEND_IMAGE:-ghcr.io/constructorfabric/insight/frontend:latest}
+    image: ${FRONTEND_IMAGE:-ghcr.io/constructorfabric/insight-frontend:latest}
     container_name: ${COMPOSE_PROJECT_NAME:-insight}-front
     networks:
       insight:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -608,7 +608,7 @@ services:
     profiles: ["front-ghcr"]
     # No platform pin: the published tags are multi-arch manifests covering
     # linux/amd64 and linux/arm64, so Apple-silicon hosts pull arm64 natively.
-    image: ${FRONTEND_IMAGE:-ghcr.io/constructorfabric/insight-front:latest}
+    image: ${FRONTEND_IMAGE:-ghcr.io/constructorfabric/insight/frontend:latest}
     container_name: ${COMPOSE_PROJECT_NAME:-insight}-front
     networks:
       insight:

--- a/src/frontend/helm/values.yaml
+++ b/src/frontend/helm/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 podAnnotations: {}
 
 image:
-  repository: ghcr.io/constructorfabric/insight-front
+  repository: ghcr.io/constructorfabric/insight/frontend
   tag: "" # MUST be set by the operator. No `:latest` default.
   pullPolicy: IfNotPresent
 

--- a/src/frontend/helm/values.yaml
+++ b/src/frontend/helm/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 podAnnotations: {}
 
 image:
-  repository: ghcr.io/constructorfabric/insight/frontend
+  repository: ghcr.io/constructorfabric/insight-frontend
   tag: "" # MUST be set by the operator. No `:latest` default.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## What

Closes #2247 via the "new package" path: the frontend image is now published as `ghcr.io/constructorfabric/insight-frontend` instead of `ghcr.io/constructorfabric/insight-front`. The old package's Actions access list belongs to the retired `insight-front` repository (hence the `write_package` denial on every `main` publish); a package this repository first-pushes is created with this repo on its ACL — same mechanism that makes `insight-analytics` and the other sibling images work. The flat name matches those siblings, the `insight-frontend` subchart, and the existing `insight-*` cleanup/scan globs.

Also adds a **manual frontend-only build**: `build-images.yml` gains a `frontend_only` workflow_dispatch input. Checked, it builds and pushes just the frontend image from the dispatched ref (main or any branch); everything else — backend/connector/toolbox/ui-tests builds, descriptor bumps, chart publish — is skipped. Unchecked dispatches keep the existing full-rebuild semantics.

## Changes

- `build-images.yml`: image renamed in the `frontend`/`merge-frontend` jobs; `frontend_only` input; non-frontend build jobs, `discover-images` and `publish-chart` gated on it (`build-image`/`merge-image`/`bump-descriptors` cascade-skip via `discover-images.outputs.any`).
- Image reference updated in `charts/insight/values.yaml`, `src/frontend/helm/values.yaml`, `deploy/preview/values.yaml`, `docker-compose.yml` (`front-ghcr` default), local gitops template, README/CONTRIBUTING/.env example.
- `trivy-images.yml`: matrix entry `insight-front` → `insight-frontend`.
- `ghcr-cleanup.yml` needs no change — the new name matches the `insight-*` glob.

## After merge (operational)

1. The first `main` push creates the `insight-frontend` package. New GHCR packages default to **private** — set it to public in package settings so anonymous compose/helm pulls keep working (the old package was public).
2. The old `insight-front` package stays as-is with its tag history; it simply stops receiving tags. Charts pinned to old tags keep resolving.

## Verification

- All edited YAML parses; workflow gating reviewed job-by-job (frontend job runs on any dispatch; `frontend_only` skips the rest including chart publish, so no appVersion can be pinned to a tag that was never pushed).
- Real proof is the first dispatch/merge run — acceptance criteria of #2247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)