### PR TITLE
feat(identity): manual resolution — operator correction API, review queue, seed hardening

### DIFF
--- a/.cf-studio/config/artifacts.toml
+++ b/.cf-studio/config/artifacts.toml
@@ -771,6 +771,11 @@ kind = "ADR"
 path = "docs/domain/identity-resolution/specs/ADR/0003-operator-decisions-as-persons-observations.md"
 name = "ADR-0003: Operator identity corrections as append-only persons observations"
 
+[[systems.artifacts]]
+kind = "FEATURE"
+path = "docs/domain/identity-resolution/specs/feature-manual-resolution/FEATURE.md"
+name = "Feature: Manual Identity Resolution"
+
 
 [[systems]]
 name = "Person Domain"

--- a/docs/domain/identity-resolution/specs/feature-manual-resolution/FEATURE.md
+++ b/docs/domain/identity-resolution/specs/feature-manual-resolution/FEATURE.md
@@ -155,11 +155,13 @@ Automatic resolution errs in both directions — under-merge (one human as two p
 - The account is rebound to a freshly minted person, regardless of how the current grouping arose
 
 **Error Scenarios**:
-- The account has never been observed and no binding exists to detach
+- The account is unknown: nothing has observed it and it has no binding — detaching would mint a person for a typo
 
 **Steps**:
 1. [ ] - `p1` - Operator submits the detach for one account - `inst-mr-detach-submit`
 2. [ ] - `p1` - API: POST /v1/resolution/detach (account) - `inst-mr-detach-api`
+2. [ ] - `p1` - **IF** the account has neither a binding nor any observation - `inst-mr-detach-known`
+   1. [ ] - `p1` - **RETURN** not-found, nothing appended - `inst-mr-detach-unknown`
 3. [ ] - `p1` - Mint a new `person_id` (random UUIDv7) - `inst-mr-detach-mint`
 4. [ ] - `p1` - Apply `cpt-ir-algo-manual-resolution-apply-decision` with the new person - `inst-mr-detach-apply`
 5. [ ] - `p1` - **RETURN** the new `person_id` - `inst-mr-detach-return`
@@ -174,11 +176,13 @@ Automatic resolution errs in both directions — under-merge (one human as two p
 - The account binds to the reserved excluded person; its activity is attributed to nobody and it leaves the queue
 
 **Error Scenarios**:
-- The account has never been observed
+- The account is unknown: nothing has observed it and it has no binding
 
 **Steps**:
 1. [ ] - `p1` - Operator submits the exclusion - `inst-mr-exclude-submit`
 2. [ ] - `p1` - API: POST /v1/resolution/exclude (account) - `inst-mr-exclude-api`
+2. [ ] - `p1` - **IF** the account has neither a binding nor any observation - `inst-mr-exclude-known`
+   1. [ ] - `p1` - **RETURN** not-found, nothing appended - `inst-mr-exclude-unknown`
 3. [ ] - `p1` - Apply `cpt-ir-algo-manual-resolution-apply-decision` with the excluded sentinel - `inst-mr-exclude-apply`
 4. [ ] - `p1` - **RETURN** confirmation - `inst-mr-exclude-return`
 
@@ -235,7 +239,7 @@ Automatic resolution errs in both directions — under-merge (one human as two p
    1. [ ] - `p1` - Advance the candidate by whole microseconds until it is unused - `inst-mr-ts-advance`
 3. [ ] - `p1` - **RETURN** the claimed instants - `inst-mr-ts-return`
 
-> Concurrency: allocation is not a lock, so two operations can claim the same instant and the insert silently drops the loser (the key has no account discriminator). A write **MUST** compare what the database appended against what it asked for, re-stamp the refused rows past the contended instant and retry, and report a row it could not place rather than count it as applied.
+> Concurrency: allocation is not a lock, so two operations can claim the same instant and the insert silently drops the loser (the key has no account discriminator). A write **MUST** compare what the database appended against what it asked for and, on a short write, re-read the bindings to learn **which** rows landed — re-sending the whole set would duplicate the ones that did. Only the accounts still pointing elsewhere are re-stamped and retried, and a row that cannot be placed is reported as refused rather than counted as applied.
 
 ### Build the Review Queue
 
@@ -273,7 +277,7 @@ Automatic resolution errs in both directions — under-merge (one human as two p
 2. [ ] - `p1` - Build the value map: each identity value to the accounts observing it, resolved through the account map - `inst-mr-res-value-map`
 3. [ ] - `p1` - **IF** a fact carries a source account - `inst-mr-res-account-first`
    1. [ ] - `p1` - **RETURN** the account's bound person - `inst-mr-res-account-return`
-4. [ ] - `p1` - **ELSE** look the fact's value up in the value map - `inst-mr-res-fallback`
+4. [ ] - `p1` - **ELSE** look the fact's value up in the value map — built from **every** value an account has carried, not only its current one, so a person who changed address keeps the facts recorded under the old one - `inst-mr-res-fallback`
    1. [ ] - `p1` - **IF** all observing accounts resolve to one person - `inst-mr-res-value-unique`
       1. [ ] - `p1` - **RETURN** that person - `inst-mr-res-value-return`
    2. [ ] - `p1` - **ELSE RETURN** NULL (contested or unknown — excluded, never tie-broken) - `inst-mr-res-null`
@@ -328,7 +332,7 @@ The system **MUST** treat a correction as a no-op only when an identical operato
 
 - [ ] `p1` - **ID**: `cpt-ir-dod-manual-resolution-timestamps`
 
-The system **MUST** claim a distinct `created_at` per appended row within the natural observation key, so that rows of one operation cannot collide and be dropped by the insert, and **MUST** recover a row a concurrent operation displaced by re-stamping and retrying it rather than reporting it as applied.
+The system **MUST** claim a distinct `created_at` per appended row within the natural observation key, so that rows of one operation cannot collide and be dropped by the insert. On a short write it **MUST** identify the rows that did not land and retry only those, so recovery cannot duplicate history, and **MUST** report a row it could not place rather than counting it as applied.
 
 **Implements**:
 - `cpt-ir-algo-manual-resolution-timestamp-slot`
@@ -391,7 +395,7 @@ The system **MUST** require an operator grant for every write verb, enforced thr
 
 - [ ] `p1` - **ID**: `cpt-ir-dod-manual-resolution-resolver`
 
-The system **MUST** resolve `person_id` account-first on the source-instance-scoped account key, fall back to an account-derived value map for facts without an account, resolve contested values to NULL, and map the excluded sentinel to NULL.
+The system **MUST** resolve `person_id` account-first on the source-instance-scoped account key, fall back to an account-derived value map — covering every value an account has ever carried — for facts without an account, resolve contested values to NULL, and map the excluded sentinel to NULL. Where the connector evidence has never been built, resolution **MUST** degrade to resolving nothing rather than failing the build; it **MUST NOT** create or pre-create relations the transformation layer owns.
 
 **Implements**:
 - `cpt-ir-algo-manual-resolution-resolver-upgrade`
@@ -407,7 +411,9 @@ The system **MUST** resolve `person_id` account-first on the source-instance-sco
 - [ ] A merge rebinds every account of the absorbed person; a detach works on an account with no prior merge record
 - [ ] A correction followed by its counter-correction restores the effective bindings
 - [ ] Bulk rows addressed by a value that resolves to zero or several accounts are skipped with a machine-readable reason and remain in the queue (with value addressing; the direct form ships first)
-- [ ] Two accounts of one source bound to one person in one operation both persist (distinct timestamps)
+- [ ] Two accounts of one source bound to one person in one operation both persist (distinct timestamps); a short write retries only the rows that did not land and never duplicates one that did
+- [ ] Detach and exclude reject an account nothing has observed and that holds no binding
+- [ ] A person who changed e-mail keeps their history: facts recorded under the previous address still resolve
 - [ ] The queue surfaces pending, binding-conflict and no-evidence items, suppresses operator-settled divergence, hides excluded accounts, and reports resolution-rate shares
 - [ ] Accounts whose latest evidence event is a closure do not appear in the queue
 - [ ] After a correction, the next gold build attributes the affected accounts' full history to the corrected person; contested values resolve to NULL rather than a winner

--- a/docs/domain/identity-resolution/specs/feature-manual-resolution/FEATURE.md
+++ b/docs/domain/identity-resolution/specs/feature-manual-resolution/FEATURE.md
@@ -115,7 +115,7 @@ Automatic resolution errs in both directions — under-merge (one human as two p
 1. [ ] - `p1` - Operator requests the review queue - `inst-mr-queue-request`
 2. [ ] - `p1` - API: GET /v1/resolution/attention (items with candidates + resolution-rate shares) - `inst-mr-queue-api`
 3. [ ] - `p1` - Operator inspects one account's history where needed - `inst-mr-history-inspect`
-4. [ ] - `p1` - API: GET /v1/resolution/accounts/{source}/{id} (current binding + authored history) - `inst-mr-history-api`
+4. [ ] - `p1` - API: GET /v1/resolution/accounts/{source}/{source_id}/{account_id} (current binding + authored history) - `inst-mr-history-api`
 5. [ ] - `p1` - Operator submits one or more bindings - `inst-mr-bind-submit`
 6. [ ] - `p1` - API: POST /v1/resolution/bind (items addressed by account; addressing by observed value is reserved, see the addressing process) - `inst-mr-bind-api`
 7. [ ] - `p1` - **IF** the caller has no operator grant - `inst-mr-authz-check`
@@ -161,11 +161,11 @@ Automatic resolution errs in both directions — under-merge (one human as two p
 **Steps**:
 1. [ ] - `p1` - Operator submits the detach for one account - `inst-mr-detach-submit`
 2. [ ] - `p1` - API: POST /v1/resolution/detach (account) - `inst-mr-detach-api`
-2. [ ] - `p1` - **IF** the account has neither a binding nor any observation - `inst-mr-detach-known`
+3. [ ] - `p1` - **IF** the account has neither a binding nor any observation - `inst-mr-detach-known`
    1. [ ] - `p1` - **RETURN** not-found, nothing appended - `inst-mr-detach-unknown`
-3. [ ] - `p1` - Mint a new `person_id` (random UUIDv7) - `inst-mr-detach-mint`
-4. [ ] - `p1` - Apply `cpt-ir-algo-manual-resolution-apply-decision` with the new person - `inst-mr-detach-apply`
-5. [ ] - `p1` - **RETURN** the new `person_id` - `inst-mr-detach-return`
+4. [ ] - `p1` - Mint a new `person_id` (random UUIDv7) - `inst-mr-detach-mint`
+5. [ ] - `p1` - Apply `cpt-ir-algo-manual-resolution-apply-decision` with the new person - `inst-mr-detach-apply`
+6. [ ] - `p1` - **RETURN** the new `person_id` - `inst-mr-detach-return`
 
 ### Exclude a Non-Person Account
 
@@ -182,10 +182,10 @@ Automatic resolution errs in both directions — under-merge (one human as two p
 **Steps**:
 1. [ ] - `p1` - Operator submits the exclusion - `inst-mr-exclude-submit`
 2. [ ] - `p1` - API: POST /v1/resolution/exclude (account) - `inst-mr-exclude-api`
-2. [ ] - `p1` - **IF** the account has neither a binding nor any observation - `inst-mr-exclude-known`
+3. [ ] - `p1` - **IF** the account has neither a binding nor any observation - `inst-mr-exclude-known`
    1. [ ] - `p1` - **RETURN** not-found, nothing appended - `inst-mr-exclude-unknown`
-3. [ ] - `p1` - Apply `cpt-ir-algo-manual-resolution-apply-decision` with the excluded sentinel - `inst-mr-exclude-apply`
-4. [ ] - `p1` - **RETURN** confirmation - `inst-mr-exclude-return`
+4. [ ] - `p1` - Apply `cpt-ir-algo-manual-resolution-apply-decision` with the excluded sentinel - `inst-mr-exclude-apply`
+5. [ ] - `p1` - **RETURN** confirmation - `inst-mr-exclude-return`
 
 ## 3. Processes / Business Logic (CDSL)
 
@@ -377,7 +377,7 @@ The system **MUST** return, for an account, its current binding and full decisio
 - `cpt-ir-flow-manual-resolution-review-and-bind`
 
 **Touches**:
-- API: `GET /v1/resolution/accounts/{source}/{id}`, `GET /v1/resolution/persons/{person_id}/accounts`
+- API: `GET /v1/resolution/accounts/{source}/{source_id}/{account_id}`, `GET /v1/resolution/persons/{person_id}/accounts`
 - DB: `persons`, `identity_inputs`
 
 ### Operator Authorization

--- a/docs/domain/identity-resolution/specs/feature-manual-resolution/FEATURE.md
+++ b/docs/domain/identity-resolution/specs/feature-manual-resolution/FEATURE.md
@@ -85,7 +85,7 @@ Automatic resolution errs in both directions — under-merge (one human as two p
 - **PRD**: [PRD.md](../PRD.md)
 - **Design**: [DESIGN.md](../DESIGN.md)
 - **Decisions**: [ADR-0003](../ADR/0003-operator-decisions-as-persons-observations.md), [ADR-0002](../ADR/0002-stable-person-id-via-persons-observations.md)
-- **Dependencies**: `cpt-ir-feature-initial-seed` (journal, read paths); persons-seed hardening (shipped)
+- **Dependencies**: `cpt-ir-feature-initial-seed` (journal, read paths). The seed hardening and the analytics resolver upgrade are parts of this feature, not external dependencies: corrections are inert without either.
 
 ## 2. Actor Flows (CDSL)
 
@@ -108,12 +108,15 @@ Automatic resolution errs in both directions — under-merge (one human as two p
 - A row names a person that does not exist
 
 **Steps**:
+
+> Every step below reads and writes within the caller's tenant: the tenant comes from the verified request context, never from the request body or path, so an operator cannot reach another tenant's accounts, persons or history.
+
 1. [ ] - `p1` - Operator requests the review queue - `inst-mr-queue-request`
 2. [ ] - `p1` - API: GET /v1/resolution/attention (items with candidates + resolution-rate shares) - `inst-mr-queue-api`
 3. [ ] - `p1` - Operator inspects one account's history where needed - `inst-mr-history-inspect`
 4. [ ] - `p1` - API: GET /v1/resolution/accounts/{source}/{id} (current binding + authored history) - `inst-mr-history-api`
 5. [ ] - `p1` - Operator submits one or more bindings - `inst-mr-bind-submit`
-6. [ ] - `p1` - API: POST /v1/resolution/bind (items addressed by account or observed value; per-item results) - `inst-mr-bind-api`
+6. [ ] - `p1` - API: POST /v1/resolution/bind (items addressed by account; addressing by observed value is reserved, see the addressing process) - `inst-mr-bind-api`
 7. [ ] - `p1` - **IF** the caller has no operator grant - `inst-mr-authz-check`
    1. [ ] - `p1` - **RETURN** authorization error, nothing appended - `inst-mr-authz-reject`
 8. [ ] - `p1` - **FOR EACH** item: resolve the target account, then apply `cpt-ir-algo-manual-resolution-apply-decision` - `inst-mr-bind-loop`
@@ -232,6 +235,8 @@ Automatic resolution errs in both directions — under-merge (one human as two p
    1. [ ] - `p1` - Advance the candidate by whole microseconds until it is unused - `inst-mr-ts-advance`
 3. [ ] - `p1` - **RETURN** the claimed instants - `inst-mr-ts-return`
 
+> Concurrency: allocation is not a lock, so two operations can claim the same instant and the insert silently drops the loser (the key has no account discriminator). A write **MUST** compare what the database appended against what it asked for, re-stamp the refused rows past the contended instant and retry, and report a row it could not place rather than count it as applied.
+
 ### Build the Review Queue
 
 - [ ] `p1` - **ID**: `cpt-ir-algo-manual-resolution-review-queue`
@@ -250,7 +255,7 @@ Automatic resolution errs in both directions — under-merge (one human as two p
    2. [ ] - `p1` - **ELSE** emit a binding-conflict item with the persons involved - `inst-mr-queue-conflict-item`
 5. [ ] - `p1` - **FOR EACH** unbound account whose evidence is contested - `inst-mr-queue-pending`
    1. [ ] - `p1` - Emit a pending item with the candidate persons and the contested values - `inst-mr-queue-pending-item`
-6. [ ] - `p1` - **FOR EACH** observed account with no usable identity evidence - `inst-mr-queue-noevidence`
+6. [ ] - `p1` - **FOR EACH** unbound observed account with no usable identity evidence — an account already bound, including one bound to the excluded person, is not pending anything - `inst-mr-queue-noevidence`
    1. [ ] - `p1` - Emit a no-evidence item (never hidden) - `inst-mr-queue-noevidence-item`
 7. [ ] - `p1` - Compute shares: bound / pending / no-evidence / excluded over observed accounts - `inst-mr-queue-rates`
 8. [ ] - `p1` - **RETURN** items and shares - `inst-mr-queue-return`
@@ -323,7 +328,7 @@ The system **MUST** treat a correction as a no-op only when an identical operato
 
 - [ ] `p1` - **ID**: `cpt-ir-dod-manual-resolution-timestamps`
 
-The system **MUST** claim a distinct `created_at` per appended row within the natural observation key, so that rows of one operation cannot collide and be dropped by the insert.
+The system **MUST** claim a distinct `created_at` per appended row within the natural observation key, so that rows of one operation cannot collide and be dropped by the insert, and **MUST** recover a row a concurrent operation displaced by re-stamping and retrying it rather than reporting it as applied.
 
 **Implements**:
 - `cpt-ir-algo-manual-resolution-timestamp-slot`
@@ -374,7 +379,7 @@ The system **MUST** return, for an account, its current binding and full decisio
 
 - [ ] `p1` - **ID**: `cpt-ir-dod-manual-resolution-authz`
 
-The system **MUST** require an operator grant for every write verb, enforced through the service's existing role grants, and **MUST** record the acting person on every appended row and journal entry.
+The system **MUST** require an operator grant for every write verb, enforced through the service's existing role grants, and **MUST** record the acting person on every appended row and journal entry. Every read and write — queue, account history, person accounts, binding lookups, appended rows and cache rebuilds — **MUST** be scoped to the tenant of the verified caller, taken from the request context and never from caller-supplied input.
 
 **Implements**:
 - `cpt-ir-flow-manual-resolution-review-and-bind`

--- a/docs/domain/identity-resolution/specs/feature-manual-resolution/FEATURE.md
+++ b/docs/domain/identity-resolution/specs/feature-manual-resolution/FEATURE.md
@@ -384,7 +384,7 @@ The system **MUST** return, for an account, its current binding and full decisio
 
 - [ ] `p1` - **ID**: `cpt-ir-dod-manual-resolution-authz`
 
-The system **MUST** require an operator grant for every write verb, enforced through the service's existing role grants, and **MUST** record the acting person on every appended row and journal entry. Every read and write — queue, account history, person accounts, binding lookups, appended rows and cache rebuilds — **MUST** be scoped to the tenant of the verified caller, taken from the request context and never from caller-supplied input.
+The system **MUST** require an operator grant for every write verb, enforced through the service's existing role grants, and **MUST** record the acting person on every appended row and journal entry. Every read and write — queue, account history, person accounts, binding lookups and appended rows — **MUST** be scoped to the tenant of the verified caller, taken from the request context and never from caller-supplied input.
 
 **Implements**:
 - `cpt-ir-flow-manual-resolution-review-and-bind`

--- a/docs/domain/identity-resolution/specs/feature-manual-resolution/FEATURE.md
+++ b/docs/domain/identity-resolution/specs/feature-manual-resolution/FEATURE.md
@@ -203,7 +203,7 @@ Automatic resolution errs in both directions — under-merge (one human as two p
    1. [ ] - `p1` - **RETURN** no-op (the identical decision is already recorded) - `inst-mr-apply-noop`
 3. [ ] - `p1` - Claim a free observation timestamp for the row per `cpt-ir-algo-manual-resolution-timestamp-slot` - `inst-mr-apply-timestamp`
 4. [ ] - `p1` - DB: INSERT persons (binding observation: account, target person, operator as author, reason code) - `inst-mr-apply-append`
-5. [ ] - `p1` - DB: DELETE + INSERT account_person_map for the tenant (derived cache rebuild, same transaction) - `inst-mr-apply-cache`
+5. [ ] - `p1` - Leave the derived caches to the persons-seed: a correction appends to the journal only, and every read path reads the journal - `inst-mr-apply-cache`
 6. [ ] - `p1` - DB: INSERT operations (actor, request, comment, outcome) - `inst-mr-apply-journal`
 7. [ ] - `p1` - **RETURN** applied - `inst-mr-apply-return`
 
@@ -305,7 +305,7 @@ Automatic resolution errs in both directions — under-merge (one human as two p
 
 - [ ] `p1` - **ID**: `cpt-ir-dod-manual-resolution-verbs`
 
-The system **MUST** expose bind (single and bulk), merge, detach and exclude; each appends binding observations authored by the operator with a machine-readable reason and **MUST NOT** update or delete any existing row.
+The system **MUST** expose bind (single and bulk), merge, detach and exclude; each appends binding observations authored by the operator with a machine-readable reason and **MUST NOT** update or delete any existing row. A correction **MUST NOT** rebuild the tenant's derived caches: that work is whole-tenant and superlinear in the tenant's size, so it belongs to the persons-seed's own schedule, not to a request. The journal is what every read path reads, so a correction takes effect the moment it commits.
 
 **Implements**:
 - `cpt-ir-flow-manual-resolution-review-and-bind`
@@ -315,7 +315,7 @@ The system **MUST** expose bind (single and bulk), merge, detach and exclude; ea
 
 **Touches**:
 - API: `POST /v1/resolution/bind`, `POST /v1/resolution/merge`, `POST /v1/resolution/detach`, `POST /v1/resolution/exclude`
-- DB: `persons`, `account_person_map`, `operations`
+- DB: `persons`, `operations`
 
 ### Decision-Aware Idempotency
 

--- a/docs/domain/identity-resolution/specs/feature-manual-resolution/FEATURE.md
+++ b/docs/domain/identity-resolution/specs/feature-manual-resolution/FEATURE.md
@@ -1,0 +1,408 @@
+---
+status: proposed
+date: 2026-08-06
+---
+
+# Feature: Manual Identity Resolution (operator corrections)
+
+
+<!-- toc -->
+
+- [1. Feature Context](#1-feature-context)
+  - [1.1 Overview](#11-overview)
+  - [1.2 Purpose](#12-purpose)
+  - [1.3 Actors](#13-actors)
+  - [1.4 References](#14-references)
+- [2. Actor Flows (CDSL)](#2-actor-flows-cdsl)
+  - [Review the Queue and Bind an Account](#review-the-queue-and-bind-an-account)
+  - [Merge Two Persons](#merge-two-persons)
+  - [Detach an Account into a New Person](#detach-an-account-into-a-new-person)
+  - [Exclude a Non-Person Account](#exclude-a-non-person-account)
+- [3. Processes / Business Logic (CDSL)](#3-processes--business-logic-cdsl)
+  - [Apply One Decision](#apply-one-decision)
+  - [Resolve an Addressed Account](#resolve-an-addressed-account)
+  - [Claim an Observation Timestamp Slot](#claim-an-observation-timestamp-slot)
+  - [Build the Review Queue](#build-the-review-queue)
+  - [Resolve Person for Analytics (macro upgrade)](#resolve-person-for-analytics-macro-upgrade)
+- [4. States (CDSL)](#4-states-cdsl)
+  - [Queue Item Lifecycle](#queue-item-lifecycle)
+- [5. Definitions of Done](#5-definitions-of-done)
+  - [Correction Verbs](#correction-verbs)
+  - [Decision-Aware Idempotency](#decision-aware-idempotency)
+  - [Timestamp Uniqueness](#timestamp-uniqueness)
+  - [Excluded Sentinel](#excluded-sentinel)
+  - [Review Queue and Match Rate](#review-queue-and-match-rate)
+  - [Binding History and Person Accounts](#binding-history-and-person-accounts)
+  - [Operator Authorization](#operator-authorization)
+  - [Analytics Resolver Upgrade](#analytics-resolver-upgrade)
+- [6. Acceptance Criteria](#6-acceptance-criteria)
+
+<!-- /toc -->
+
+- [ ] `p1` - **ID**: `cpt-ir-featstatus-manual-resolution`
+## 1. Feature Context
+
+- [ ] `p1` - `cpt-ir-feature-manual-resolution`
+
+### 1.1 Overview
+
+Give an operator four correction verbs over the account-to-person binding — bind (single and bulk), merge, detach, exclude — plus the read surface that makes them usable: a review queue derived from evidence and current bindings, per-account binding history, and the accounts of one person. Every correction is appended to the `persons` journal and survives automatic re-runs.
+
+The feature also ships the two enablers without which corrections are inert: the analytics resolver upgrade (corrections are `value_type='id'` bindings, while the v1 macro resolves by e-mail only) and the persons-seed hardening (the divergent-group collapse could re-derive an operator binding). Seed hardening landed first as its own change; this feature carries the API, the queue, and the resolver.
+
+### 1.2 Purpose
+
+Automatic resolution errs in both directions — under-merge (one human as two persons) and over-merge (two humans grouped through a shared value) — and the product has no supported way to change a binding once automation wrote it. This feature is the operator-driven correction surface decided in [ADR-0003](../ADR/0003-operator-decisions-as-persons-observations.md), reviewed in constructorfabric/insight#2180.
+
+**Requirements**:
+
+- `cpt-ir-fr-merge-v2`
+- `cpt-ir-fr-split-v2`
+- `cpt-ir-fr-operator-bind`
+- `cpt-ir-fr-operator-exclude`
+- `cpt-ir-fr-review-queue`
+- `cpt-ir-fr-correction-durability`
+- `cpt-ir-fr-merge-audit-v2`
+- `cpt-ir-fr-idempotent-mutations-v2`
+- `cpt-ir-fr-binding-history`
+- `cpt-ir-nfr-merge-reversibility`
+
+**Principles**:
+
+- `cpt-insightspec-ir-principle-append-only-journal`
+- `cpt-insightspec-ir-principle-fail-safe`
+
+### 1.3 Actors
+
+| Actor | Role in Feature |
+|-------|-----------------|
+| `cpt-ir-actor-operator` | Reviews the queue and issues corrections; authored rows carry their person id |
+| `cpt-ir-actor-bootstrap-job` | Reuses operator bindings unchanged; surfaces what it cannot decide |
+| `cpt-ir-actor-analytics-pipeline` | Resolves `person_id` at build time through the upgraded macro |
+
+### 1.4 References
+
+- **PRD**: [PRD.md](../PRD.md)
+- **Design**: [DESIGN.md](../DESIGN.md)
+- **Decisions**: [ADR-0003](../ADR/0003-operator-decisions-as-persons-observations.md), [ADR-0002](../ADR/0002-stable-person-id-via-persons-observations.md)
+- **Dependencies**: `cpt-ir-feature-initial-seed` (journal, read paths); persons-seed hardening (shipped)
+
+## 2. Actor Flows (CDSL)
+
+**Use cases**: `cpt-ir-usecase-review-unmapped`, `cpt-ir-usecase-merge`
+
+### Review the Queue and Bind an Account
+
+- [ ] `p1` - **ID**: `cpt-ir-flow-manual-resolution-review-and-bind`
+
+**Actor**: `cpt-ir-actor-operator`
+
+**Success Scenarios**:
+- An account pending a decision is bound to the correct person and leaves the queue
+- An account pending a decision is confirmed as its own person (bind to its current person) and leaves the queue
+- A prepared matching table is imported in one call, with per-row outcomes
+
+**Error Scenarios**:
+- The caller lacks the operator grant
+- A row addresses a value that resolves to more than one account, or to none
+- A row names a person that does not exist
+
+**Steps**:
+1. [ ] - `p1` - Operator requests the review queue - `inst-mr-queue-request`
+2. [ ] - `p1` - API: GET /v1/resolution/attention (items with candidates + resolution-rate shares) - `inst-mr-queue-api`
+3. [ ] - `p1` - Operator inspects one account's history where needed - `inst-mr-history-inspect`
+4. [ ] - `p1` - API: GET /v1/resolution/accounts/{source}/{id} (current binding + authored history) - `inst-mr-history-api`
+5. [ ] - `p1` - Operator submits one or more bindings - `inst-mr-bind-submit`
+6. [ ] - `p1` - API: POST /v1/resolution/bind (items addressed by account or observed value; per-item results) - `inst-mr-bind-api`
+7. [ ] - `p1` - **IF** the caller has no operator grant - `inst-mr-authz-check`
+   1. [ ] - `p1` - **RETURN** authorization error, nothing appended - `inst-mr-authz-reject`
+8. [ ] - `p1` - **FOR EACH** item: resolve the target account, then apply `cpt-ir-algo-manual-resolution-apply-decision` - `inst-mr-bind-loop`
+9. [ ] - `p1` - **RETURN** per-item outcomes (applied / no-op / skipped with reason) - `inst-mr-bind-return`
+10. [ ] - `p1` - Queue item disappears on the next read because its condition no longer holds - `inst-mr-queue-dissolve`
+
+### Merge Two Persons
+
+- [ ] `p1` - **ID**: `cpt-ir-flow-manual-resolution-merge`
+
+**Actor**: `cpt-ir-actor-operator`
+
+**Success Scenarios**:
+- Every account of the absorbed person is rebound to the survivor; history stays intact
+
+**Error Scenarios**:
+- Source and target are the same person
+- Either person does not exist
+
+**Steps**:
+1. [ ] - `p1` - Operator submits the merge, naming the surviving person - `inst-mr-merge-submit`
+2. [ ] - `p1` - API: POST /v1/resolution/merge (source_person_id, target_person_id, comment) - `inst-mr-merge-api`
+3. [ ] - `p1` - **IF** source equals target or either person is unknown - `inst-mr-merge-validate`
+   1. [ ] - `p1` - **RETURN** validation error, nothing appended - `inst-mr-merge-reject`
+4. [ ] - `p1` - DB: SELECT persons (accounts currently bound to the source person) - `inst-mr-merge-collect`
+5. [ ] - `p1` - **FOR EACH** account: apply `cpt-ir-algo-manual-resolution-apply-decision` with the survivor - `inst-mr-merge-loop`
+6. [ ] - `p1` - **RETURN** the survivor and the number of rebound accounts - `inst-mr-merge-return`
+
+### Detach an Account into a New Person
+
+- [ ] `p1` - **ID**: `cpt-ir-flow-manual-resolution-detach`
+
+**Actor**: `cpt-ir-actor-operator`
+
+**Success Scenarios**:
+- The account is rebound to a freshly minted person, regardless of how the current grouping arose
+
+**Error Scenarios**:
+- The account has never been observed and no binding exists to detach
+
+**Steps**:
+1. [ ] - `p1` - Operator submits the detach for one account - `inst-mr-detach-submit`
+2. [ ] - `p1` - API: POST /v1/resolution/detach (account) - `inst-mr-detach-api`
+3. [ ] - `p1` - Mint a new `person_id` (random UUIDv7) - `inst-mr-detach-mint`
+4. [ ] - `p1` - Apply `cpt-ir-algo-manual-resolution-apply-decision` with the new person - `inst-mr-detach-apply`
+5. [ ] - `p1` - **RETURN** the new `person_id` - `inst-mr-detach-return`
+
+### Exclude a Non-Person Account
+
+- [ ] `p1` - **ID**: `cpt-ir-flow-manual-resolution-exclude`
+
+**Actor**: `cpt-ir-actor-operator`
+
+**Success Scenarios**:
+- The account binds to the reserved excluded person; its activity is attributed to nobody and it leaves the queue
+
+**Error Scenarios**:
+- The account has never been observed
+
+**Steps**:
+1. [ ] - `p1` - Operator submits the exclusion - `inst-mr-exclude-submit`
+2. [ ] - `p1` - API: POST /v1/resolution/exclude (account) - `inst-mr-exclude-api`
+3. [ ] - `p1` - Apply `cpt-ir-algo-manual-resolution-apply-decision` with the excluded sentinel - `inst-mr-exclude-apply`
+4. [ ] - `p1` - **RETURN** confirmation - `inst-mr-exclude-return`
+
+## 3. Processes / Business Logic (CDSL)
+
+### Apply One Decision
+
+- [ ] `p1` - **ID**: `cpt-ir-algo-manual-resolution-apply-decision`
+
+**Input**: operator person id, target account, target person, reason code, comment
+
+**Output**: applied / no-op, with the appended row count
+
+**Steps**:
+1. [ ] - `p1` - DB: SELECT persons (latest `value_type='id'` row for the account: current person and its author) - `inst-mr-apply-current`
+2. [ ] - `p1` - **IF** the current binding names the target person **AND** was authored by an operator - `inst-mr-apply-idempotent-check`
+   1. [ ] - `p1` - **RETURN** no-op (the identical decision is already recorded) - `inst-mr-apply-noop`
+3. [ ] - `p1` - Claim a free observation timestamp for the row per `cpt-ir-algo-manual-resolution-timestamp-slot` - `inst-mr-apply-timestamp`
+4. [ ] - `p1` - DB: INSERT persons (binding observation: account, target person, operator as author, reason code) - `inst-mr-apply-append`
+5. [ ] - `p1` - DB: DELETE + INSERT account_person_map for the tenant (derived cache rebuild, same transaction) - `inst-mr-apply-cache`
+6. [ ] - `p1` - DB: INSERT operations (actor, request, comment, outcome) - `inst-mr-apply-journal`
+7. [ ] - `p1` - **RETURN** applied - `inst-mr-apply-return`
+
+### Resolve an Addressed Account
+
+- [ ] `p1` - **ID**: `cpt-ir-algo-manual-resolution-address-account`
+
+**Input**: an account reference — either source type + account id, or an observed value (e-mail / username)
+
+**Output**: exactly one account key, or a machine-readable skip reason
+
+**Steps**:
+1. [ ] - `p1` - **IF** the reference names source type and account id - `inst-mr-addr-direct`
+   1. [ ] - `p1` - **RETURN** that account key (it may not have been observed yet — pre-registration is allowed) - `inst-mr-addr-direct-return`
+2. [ ] - `p1` - DB: SELECT identity_inputs (accounts observing the value, folded per account over UPSERT/DELETE) - `inst-mr-addr-evidence`
+3. [ ] - `p1` - **IF** exactly one active account observes the value - `inst-mr-addr-unique`
+   1. [ ] - `p1` - **RETURN** that account key - `inst-mr-addr-unique-return`
+4. [ ] - `p1` - **ELSE** - `inst-mr-addr-ambiguous`
+   1. [ ] - `p1` - **RETURN** skip reason (`ambiguous_value` or `unknown_value`) — never a guess - `inst-mr-addr-skip`
+
+### Claim an Observation Timestamp Slot
+
+- [ ] `p1` - **ID**: `cpt-ir-algo-manual-resolution-timestamp-slot`
+
+**Input**: the rows to append within one operation
+
+**Output**: a distinct `created_at` per row within the natural observation key
+
+**Steps**:
+1. [ ] - `p1` - Take the operation's wall-clock instant as the first candidate - `inst-mr-ts-start`
+2. [ ] - `p1` - **FOR EACH** row sharing the natural key (tenant, person, source type, source id, value type) - `inst-mr-ts-loop`
+   1. [ ] - `p1` - Advance the candidate by whole microseconds until it is unused - `inst-mr-ts-advance`
+3. [ ] - `p1` - **RETURN** the claimed instants - `inst-mr-ts-return`
+
+### Build the Review Queue
+
+- [ ] `p1` - **ID**: `cpt-ir-algo-manual-resolution-review-queue`
+
+**Input**: tenant
+
+**Output**: queue items with candidates, plus resolution-rate shares
+
+**Steps**:
+1. [ ] - `p1` - DB: SELECT identity_inputs (observed accounts and their values, folded per account over UPSERT/DELETE so closed accounts drop out) - `inst-mr-queue-evidence`
+2. [ ] - `p1` - DB: SELECT persons (current binding and its author per account) - `inst-mr-queue-bindings`
+3. [ ] - `p1` - Join evidence to bindings on the account key - `inst-mr-queue-join`
+4. [ ] - `p1` - **FOR EACH** identity value claimed by more than one person - `inst-mr-queue-contested`
+   1. [ ] - `p1` - **IF** any binding in the group is operator-authored - `inst-mr-queue-settled-check`
+      1. [ ] - `p1` - Skip the group (settled by a human) - `inst-mr-queue-settled-skip`
+   2. [ ] - `p1` - **ELSE** emit a binding-conflict item with the persons involved - `inst-mr-queue-conflict-item`
+5. [ ] - `p1` - **FOR EACH** unbound account whose evidence is contested - `inst-mr-queue-pending`
+   1. [ ] - `p1` - Emit a pending item with the candidate persons and the contested values - `inst-mr-queue-pending-item`
+6. [ ] - `p1` - **FOR EACH** observed account with no usable identity evidence - `inst-mr-queue-noevidence`
+   1. [ ] - `p1` - Emit a no-evidence item (never hidden) - `inst-mr-queue-noevidence-item`
+7. [ ] - `p1` - Compute shares: bound / pending / no-evidence / excluded over observed accounts - `inst-mr-queue-rates`
+8. [ ] - `p1` - **RETURN** items and shares - `inst-mr-queue-return`
+
+### Resolve Person for Analytics (macro upgrade)
+
+- [ ] `p1` - **ID**: `cpt-ir-algo-manual-resolution-resolver-upgrade`
+
+**Input**: the journal mirror and the evidence, at build time
+
+**Output**: `person_id` per fact, or NULL
+
+**Steps**:
+1. [ ] - `p1` - Build the account map: latest `value_type='id'` binding per source-instance-scoped account key - `inst-mr-res-account-map`
+2. [ ] - `p1` - Build the value map: each identity value to the accounts observing it, resolved through the account map - `inst-mr-res-value-map`
+3. [ ] - `p1` - **IF** a fact carries a source account - `inst-mr-res-account-first`
+   1. [ ] - `p1` - **RETURN** the account's bound person - `inst-mr-res-account-return`
+4. [ ] - `p1` - **ELSE** look the fact's value up in the value map - `inst-mr-res-fallback`
+   1. [ ] - `p1` - **IF** all observing accounts resolve to one person - `inst-mr-res-value-unique`
+      1. [ ] - `p1` - **RETURN** that person - `inst-mr-res-value-return`
+   2. [ ] - `p1` - **ELSE RETURN** NULL (contested or unknown — excluded, never tie-broken) - `inst-mr-res-null`
+5. [ ] - `p1` - Map the excluded sentinel to NULL wherever it appears - `inst-mr-res-sentinel`
+
+## 4. States (CDSL)
+
+### Queue Item Lifecycle
+
+- [ ] `p2` - **ID**: `cpt-ir-state-manual-resolution-queue-item`
+
+**States**: Surfaced, Absent
+
+**Initial State**: Surfaced
+
+**Transitions**:
+1. [ ] - `p1` - **FROM** Surfaced **TO** Absent **WHEN** an operator decision removes the item's condition - `inst-mr-state-decided`
+2. [ ] - `p1` - **FROM** Surfaced **TO** Absent **WHEN** the account's evidence closes (latest event is a DELETE) - `inst-mr-state-closed`
+3. [ ] - `p1` - **FROM** Absent **TO** Surfaced **WHEN** new evidence re-opens the condition - `inst-mr-state-reopened`
+
+## 5. Definitions of Done
+
+### Correction Verbs
+
+- [ ] `p1` - **ID**: `cpt-ir-dod-manual-resolution-verbs`
+
+The system **MUST** expose bind (single and bulk), merge, detach and exclude; each appends binding observations authored by the operator with a machine-readable reason and **MUST NOT** update or delete any existing row.
+
+**Implements**:
+- `cpt-ir-flow-manual-resolution-review-and-bind`
+- `cpt-ir-flow-manual-resolution-merge`
+- `cpt-ir-flow-manual-resolution-detach`
+- `cpt-ir-flow-manual-resolution-exclude`
+
+**Touches**:
+- API: `POST /v1/resolution/bind`, `POST /v1/resolution/merge`, `POST /v1/resolution/detach`, `POST /v1/resolution/exclude`
+- DB: `persons`, `account_person_map`, `operations`
+
+### Decision-Aware Idempotency
+
+- [ ] `p1` - **ID**: `cpt-ir-dod-manual-resolution-idempotency`
+
+The system **MUST** treat a correction as a no-op only when an identical operator decision is already recorded — the current binding names the same person **and** was authored by an operator. A bind onto an automation-authored binding of the same person **MUST** append the operator's confirmation.
+
+**Implements**:
+- `cpt-ir-algo-manual-resolution-apply-decision`
+
+**Touches**:
+- DB: `persons`
+
+### Timestamp Uniqueness
+
+- [ ] `p1` - **ID**: `cpt-ir-dod-manual-resolution-timestamps`
+
+The system **MUST** claim a distinct `created_at` per appended row within the natural observation key, so that rows of one operation cannot collide and be dropped by the insert.
+
+**Implements**:
+- `cpt-ir-algo-manual-resolution-timestamp-slot`
+
+**Touches**:
+- DB: `persons`
+
+### Excluded Sentinel
+
+- [ ] `p1` - **ID**: `cpt-ir-dod-manual-resolution-sentinel`
+
+The system **MUST** bind excluded accounts to the reserved excluded person and **MUST** treat that person as "no person" in every consumer: NULL in the analytics resolver, not served as a person by the read API, ignored by golden-record consumers, hidden from the queue.
+
+**Implements**:
+- `cpt-ir-flow-manual-resolution-exclude`
+
+**Touches**:
+- DB: `persons`
+- Entities: excluded-person sentinel
+
+### Review Queue and Match Rate
+
+- [ ] `p1` - **ID**: `cpt-ir-dod-manual-resolution-queue`
+
+The system **MUST** derive the queue from the evidence fold joined with current bindings, emit pending / binding-conflict / no-evidence items with candidates, suppress divergence explained by an operator-authored binding, and report resolution-rate shares. It **MUST NOT** persist queue state.
+
+**Implements**:
+- `cpt-ir-algo-manual-resolution-review-queue`
+
+**Touches**:
+- API: `GET /v1/resolution/attention`
+- DB: `identity_inputs`, `persons`
+
+### Binding History and Person Accounts
+
+- [ ] `p2` - **ID**: `cpt-ir-dod-manual-resolution-history`
+
+The system **MUST** return, for an account, its current binding and full decision history with authors and reasons; and, for a person, every account and identity value bound to them with the author of each link.
+
+**Implements**:
+- `cpt-ir-flow-manual-resolution-review-and-bind`
+
+**Touches**:
+- API: `GET /v1/resolution/accounts/{source}/{id}`, `GET /v1/resolution/persons/{person_id}/accounts`
+- DB: `persons`, `identity_inputs`
+
+### Operator Authorization
+
+- [ ] `p1` - **ID**: `cpt-ir-dod-manual-resolution-authz`
+
+The system **MUST** require an operator grant for every write verb, enforced through the service's existing role grants, and **MUST** record the acting person on every appended row and journal entry.
+
+**Implements**:
+- `cpt-ir-flow-manual-resolution-review-and-bind`
+
+**Touches**:
+- DB: `roles`, `person_roles`, `persons`, `operations`
+
+### Analytics Resolver Upgrade
+
+- [ ] `p1` - **ID**: `cpt-ir-dod-manual-resolution-resolver`
+
+The system **MUST** resolve `person_id` account-first on the source-instance-scoped account key, fall back to an account-derived value map for facts without an account, resolve contested values to NULL, and map the excluded sentinel to NULL.
+
+**Implements**:
+- `cpt-ir-algo-manual-resolution-resolver-upgrade`
+
+**Touches**:
+- Entities: analytics resolution macro, gold observation models
+
+## 6. Acceptance Criteria
+
+- [ ] An operator decision survives a subsequent seed run byte-for-byte, and the seed reuses it
+- [ ] Binding an account to the person it already has, when that binding was written by automation, appends an operator confirmation and clears the queue item
+- [ ] Re-submitting an identical operator decision (including a re-uploaded bulk file) changes nothing and is reported as a no-op
+- [ ] A merge rebinds every account of the absorbed person; a detach works on an account with no prior merge record
+- [ ] A correction followed by its counter-correction restores the effective bindings
+- [ ] Bulk rows addressed by a value that resolves to zero or several accounts are skipped with a machine-readable reason and remain in the queue
+- [ ] Two accounts of one source bound to one person in one operation both persist (distinct timestamps)
+- [ ] The queue surfaces pending, binding-conflict and no-evidence items, suppresses operator-settled divergence, hides excluded accounts, and reports resolution-rate shares
+- [ ] Accounts whose latest evidence event is a closure do not appear in the queue
+- [ ] After a correction, the next gold build attributes the affected accounts' full history to the corrected person; contested values resolve to NULL rather than a winner
+- [ ] Excluded accounts resolve to NULL in analytics and are not served as persons by the read API
+- [ ] Write verbs are rejected without an operator grant, and every appended row names the acting person

--- a/docs/domain/identity-resolution/specs/feature-manual-resolution/FEATURE.md
+++ b/docs/domain/identity-resolution/specs/feature-manual-resolution/FEATURE.md
@@ -205,6 +205,8 @@ Automatic resolution errs in both directions — under-merge (one human as two p
 
 **Input**: an account reference — either source type + account id, or an observed value (e-mail / username)
 
+> Scope note: the first iteration accepts the direct form only; value addressing (and with it the bulk import of a prepared matching table) is reserved — the per-item skip reasons below are its contract.
+
 **Output**: exactly one account key, or a machine-readable skip reason
 
 **Steps**:
@@ -399,7 +401,7 @@ The system **MUST** resolve `person_id` account-first on the source-instance-sco
 - [ ] Re-submitting an identical operator decision (including a re-uploaded bulk file) changes nothing and is reported as a no-op
 - [ ] A merge rebinds every account of the absorbed person; a detach works on an account with no prior merge record
 - [ ] A correction followed by its counter-correction restores the effective bindings
-- [ ] Bulk rows addressed by a value that resolves to zero or several accounts are skipped with a machine-readable reason and remain in the queue
+- [ ] Bulk rows addressed by a value that resolves to zero or several accounts are skipped with a machine-readable reason and remain in the queue (with value addressing; the direct form ships first)
 - [ ] Two accounts of one source bound to one person in one operation both persist (distinct timestamps)
 - [ ] The queue surfaces pending, binding-conflict and no-evidence items, suppresses operator-settled divergence, hides excluded accounts, and reports resolution-rate shares
 - [ ] Accounts whose latest evidence event is a closure do not appear in the queue

--- a/docs/domain/identity-resolution/specs/feature-manual-resolution/FEATURE.md
+++ b/docs/domain/identity-resolution/specs/feature-manual-resolution/FEATURE.md
@@ -104,6 +104,7 @@ Automatic resolution errs in both directions — under-merge (one human as two p
 
 **Error Scenarios**:
 - The caller lacks the operator grant
+- One call names the same account twice — which person wins is the caller's contradiction, not the system's to guess
 - A row addresses a value that resolves to more than one account, or to none
 - A row names a person that does not exist
 
@@ -219,7 +220,7 @@ Automatic resolution errs in both directions — under-merge (one human as two p
 **Steps**:
 1. [ ] - `p1` - **IF** the reference names source type and account id - `inst-mr-addr-direct`
    1. [ ] - `p1` - **RETURN** that account key (it may not have been observed yet — pre-registration is allowed) - `inst-mr-addr-direct-return`
-2. [ ] - `p1` - DB: SELECT identity_inputs (accounts observing the value, folded per account over UPSERT/DELETE) - `inst-mr-addr-evidence`
+2. [ ] - `p1` - DB: SELECT identity_inputs (accounts observing the value, folded per account over UPSERT/DELETE); an absent evidence relation reads as no observations, never as a failure - `inst-mr-addr-evidence`
 3. [ ] - `p1` - **IF** exactly one active account observes the value - `inst-mr-addr-unique`
    1. [ ] - `p1` - **RETURN** that account key - `inst-mr-addr-unique-return`
 4. [ ] - `p1` - **ELSE** - `inst-mr-addr-ambiguous`
@@ -239,7 +240,7 @@ Automatic resolution errs in both directions — under-merge (one human as two p
    1. [ ] - `p1` - Advance the candidate by whole microseconds until it is unused - `inst-mr-ts-advance`
 3. [ ] - `p1` - **RETURN** the claimed instants - `inst-mr-ts-return`
 
-> Concurrency: allocation is not a lock, so two operations can claim the same instant and the insert silently drops the loser (the key has no account discriminator). A write **MUST** compare what the database appended against what it asked for and, on a short write, re-read the bindings to learn **which** rows landed — re-sending the whole set would duplicate the ones that did. Only the accounts still pointing elsewhere are re-stamped and retried, and a row that cannot be placed is reported as refused rather than counted as applied.
+> Concurrency: allocation is not a lock, so two operations can claim the same instant and the insert silently drops the loser (the key has no account discriminator). A write **MUST** compare what the database appended against what it asked for and, on a short write, ask which of its **exact** observations the journal now holds — author and instant included, because a confirmation writes an operator row over an automatic binding to the same person and "the account points at this person" cannot tell a landed row from a refused one. Only the missing rows are re-stamped and retried; a row that cannot be placed is reported as refused rather than counted as applied.
 
 ### Build the Review Queue
 
@@ -332,7 +333,7 @@ The system **MUST** treat a correction as a no-op only when an identical operato
 
 - [ ] `p1` - **ID**: `cpt-ir-dod-manual-resolution-timestamps`
 
-The system **MUST** claim a distinct `created_at` per appended row within the natural observation key, so that rows of one operation cannot collide and be dropped by the insert. On a short write it **MUST** identify the rows that did not land and retry only those, so recovery cannot duplicate history, and **MUST** report a row it could not place rather than counting it as applied.
+The system **MUST** claim a distinct `created_at` per appended row within the natural observation key, so that rows of one operation cannot collide and be dropped by the insert. On a short write it **MUST** identify the rows that did not land — by their full observation identity, not by the account's current person — and retry only those, so recovery cannot duplicate history, and **MUST** report a row it could not place rather than counting it as applied.
 
 **Implements**:
 - `cpt-ir-algo-manual-resolution-timestamp-slot`
@@ -412,7 +413,8 @@ The system **MUST** resolve `person_id` account-first on the source-instance-sco
 - [ ] A correction followed by its counter-correction restores the effective bindings
 - [ ] Bulk rows addressed by a value that resolves to zero or several accounts are skipped with a machine-readable reason and remain in the queue (with value addressing; the direct form ships first)
 - [ ] Two accounts of one source bound to one person in one operation both persist (distinct timestamps); a short write retries only the rows that did not land and never duplicates one that did
-- [ ] Detach and exclude reject an account nothing has observed and that holds no binding
+- [ ] Detach and exclude reject an account nothing has observed and that holds no binding — including before the evidence relation has ever been built, where the answer is still not-found
+- [ ] A bulk call naming one account twice is rejected, and per-item outcomes are reported by position
 - [ ] A person who changed e-mail keeps their history: facts recorded under the previous address still resolve
 - [ ] The queue surfaces pending, binding-conflict and no-evidence items, suppresses operator-settled divergence, hides excluded accounts, and reports resolution-rate shares
 - [ ] Accounts whose latest evidence event is a closure do not appear in the queue

--- a/src/backend/services/identity-resolution/src/api/error.rs
+++ b/src/backend/services/identity-resolution/src/api/error.rs
@@ -31,3 +31,7 @@ pub struct VisibilityError;
 
 #[resource_error("gts.cf.insight.identity_resolution.subchart.v1~")]
 pub struct SubchartError;
+
+/// Operator identity corrections (bind / merge / detach / exclude).
+#[resource_error("gts.cf.insight.identity_resolution.correction.v1~")]
+pub struct CorrectionError;

--- a/src/backend/services/identity-resolution/src/api/mod.rs
+++ b/src/backend/services/identity-resolution/src/api/mod.rs
@@ -151,6 +151,48 @@ fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) -> Router {
         .handler(resolution::exclude)
         .register(router, openapi);
 
+    let router = OperationBuilder::get("/v1/resolution/attention")
+        .operation_id("identity_resolution.resolution.attention")
+        .summary("Accounts awaiting an operator decision, with the resolution rates")
+        .authenticated()
+        .no_license_required()
+        .json_response_with_schema::<resolution::AttentionResponse>(
+            openapi,
+            StatusCode::OK,
+            "Queue items and rates",
+        )
+        .standard_errors(openapi)
+        .handler(resolution::attention)
+        .register(router, openapi);
+
+    let router = OperationBuilder::get("/v1/resolution/accounts/{source}/{source_id}/{account_id}")
+        .operation_id("identity_resolution.resolution.account_binding")
+        .summary("Current binding of an account and every decision behind it")
+        .authenticated()
+        .no_license_required()
+        .json_response_with_schema::<resolution::AccountBindingResponse>(
+            openapi,
+            StatusCode::OK,
+            "Binding and history",
+        )
+        .standard_errors(openapi)
+        .handler(resolution::account_binding)
+        .register(router, openapi);
+
+    let router = OperationBuilder::get("/v1/resolution/persons/{person_id}/accounts")
+        .operation_id("identity_resolution.resolution.person_accounts")
+        .summary("Every account bound to a person, with the values behind each link")
+        .authenticated()
+        .no_license_required()
+        .json_response_with_schema::<resolution::PersonAccountsResponse>(
+            openapi,
+            StatusCode::OK,
+            "Accounts of the person",
+        )
+        .standard_errors(openapi)
+        .handler(resolution::person_accounts)
+        .register(router, openapi);
+
     // Persons-seed operations journal (read-only; the seed itself runs via the
     // `seed` CLI subcommand — CronJob / manual Job, see `crate::seed_runner`).
     // Admin-gated: caller = gateway-JWT subject, must hold the `admin` role in

--- a/src/backend/services/identity-resolution/src/api/mod.rs
+++ b/src/backend/services/identity-resolution/src/api/mod.rs
@@ -6,6 +6,7 @@ pub mod error;
 mod gate;
 mod handlers;
 pub mod person_roles;
+pub mod resolution;
 pub mod roles;
 pub mod seed;
 pub mod subchart;
@@ -85,6 +86,69 @@ fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) -> Router {
         )
         .standard_errors(openapi)
         .handler(handlers::resolve_profile)
+        .register(router, openapi);
+
+    // Operator identity corrections (ADR-0003): each verb appends binding
+    // observations authored by the caller. Admin-gated like the rest of the
+    // operator surface; the handlers journal every call in `operations`.
+    let router = OperationBuilder::post("/v1/resolution/bind")
+        .operation_id("identity_resolution.resolution.bind")
+        .summary("Bind accounts to persons (single or bulk; also confirms an automatic binding)")
+        .authenticated()
+        .no_license_required()
+        .json_request::<resolution::BindRequest>(openapi, "Bindings to record")
+        .json_response_with_schema::<resolution::CorrectionResponse>(
+            openapi,
+            StatusCode::OK,
+            "Per-account outcomes",
+        )
+        .standard_errors(openapi)
+        .handler(resolution::bind)
+        .register(router, openapi);
+
+    let router = OperationBuilder::post("/v1/resolution/merge")
+        .operation_id("identity_resolution.resolution.merge")
+        .summary("Merge two persons: rebind every account of the absorbed person")
+        .authenticated()
+        .no_license_required()
+        .json_request::<resolution::MergeRequest>(openapi, "Persons to merge")
+        .json_response_with_schema::<resolution::CorrectionResponse>(
+            openapi,
+            StatusCode::OK,
+            "Per-account outcomes",
+        )
+        .standard_errors(openapi)
+        .handler(resolution::merge)
+        .register(router, openapi);
+
+    let router = OperationBuilder::post("/v1/resolution/detach")
+        .operation_id("identity_resolution.resolution.detach")
+        .summary("Detach an account into a freshly minted person")
+        .authenticated()
+        .no_license_required()
+        .json_request::<resolution::AccountRequest>(openapi, "Account to detach")
+        .json_response_with_schema::<resolution::CorrectionResponse>(
+            openapi,
+            StatusCode::OK,
+            "Outcome and the new person id",
+        )
+        .standard_errors(openapi)
+        .handler(resolution::detach)
+        .register(router, openapi);
+
+    let router = OperationBuilder::post("/v1/resolution/exclude")
+        .operation_id("identity_resolution.resolution.exclude")
+        .summary("Exclude an account as not a person (bot, CI, service account)")
+        .authenticated()
+        .no_license_required()
+        .json_request::<resolution::AccountRequest>(openapi, "Account to exclude")
+        .json_response_with_schema::<resolution::CorrectionResponse>(
+            openapi,
+            StatusCode::OK,
+            "Outcome",
+        )
+        .standard_errors(openapi)
+        .handler(resolution::exclude)
         .register(router, openapi);
 
     // Persons-seed operations journal (read-only; the seed itself runs via the

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -5,7 +5,7 @@
 //! calling operator and journals the call in `operations`; nothing is updated or
 //! deleted. Admin-gated like the rest of the operator surface.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use axum::Json;
@@ -157,8 +157,19 @@ pub async fn bind(
         });
     }
 
-    let response =
-        apply_correction(&state, tenant, operator, targets, Verb::Bind, &req.comment).await?;
+    // The journal's verb-level target; heterogeneous bulk detail is in the
+    // per-account list either way.
+    let journal_target = req.bindings[0].person_id;
+    let response = apply_correction(
+        &state,
+        tenant,
+        operator,
+        targets,
+        Verb::Bind,
+        journal_target,
+        &req.comment,
+    )
+    .await?;
 
     Ok(Json(response))
 }
@@ -193,8 +204,16 @@ pub async fn merge(
         })
         .collect();
 
-    let outcome =
-        apply_correction(&state, tenant, operator, targets, Verb::Merge, &req.comment).await?;
+    let outcome = apply_correction(
+        &state,
+        tenant,
+        operator,
+        targets,
+        Verb::Merge,
+        req.target_person_id,
+        &req.comment,
+    )
+    .await?;
 
     Ok(Json(outcome))
 }
@@ -224,6 +243,7 @@ pub async fn detach(
         operator,
         targets,
         Verb::Detach,
+        new_person_id,
         &req.comment,
     )
     .await?;
@@ -262,6 +282,7 @@ pub async fn exclude(
         operator,
         targets,
         Verb::Exclude,
+        EXCLUDED_PERSON,
         &req.comment,
     )
     .await?;
@@ -272,12 +293,17 @@ pub async fn exclude(
 /// Read the targets' current bindings, build the rows the correction appends,
 /// write them once, and journal the call. One write and one cache rebuild per
 /// operation, however many accounts it names.
+///
+/// `journal_target` is the verb-level person the operation journal records —
+/// named by the caller, never derived from the targets: a merge of a person
+/// with no accounts has an empty target list but still a real survivor.
 async fn apply_correction(
     state: &AppState,
     tenant: Uuid,
     operator: Uuid,
     targets: Vec<Target>,
     verb: Verb,
+    journal_target: Uuid,
     comment: &str,
 ) -> Result<CorrectionResponse, CanonicalError> {
     let accounts: Vec<SourceAccountKey> = targets.iter().map(|t| t.account.clone()).collect();
@@ -325,13 +351,12 @@ async fn apply_correction(
         })
         .collect();
 
-    let target_person_id = targets.first().map(|t| t.person_id).unwrap_or_default();
     journal(
         state,
         tenant,
         operator,
         verb,
-        target_person_id,
+        journal_target,
         comment,
         &items,
     )
@@ -751,11 +776,13 @@ pub async fn person_accounts(
         .await
         .map_err(|e| internal(&e, "failed to read current bindings"))?;
     let evidence = read_evidence(&state).await?;
+    let by_account: HashMap<&SourceAccountKey, &AccountEvidence> =
+        evidence.iter().map(|e| (&e.account, e)).collect();
 
     let entries = accounts
-        .into_iter()
+        .iter()
         .map(|account| {
-            let observed = evidence.iter().find(|e| e.account == account);
+            let observed = by_account.get(account).copied();
             PersonAccountEntry {
                 source: account.source_type.clone(),
                 source_id: account.source_id,
@@ -763,7 +790,7 @@ pub async fn person_accounts(
                 email: observed.and_then(|e| e.email.clone()),
                 username: observed.and_then(|e| e.username.clone()),
                 bound_by_operator: bindings
-                    .get(&account)
+                    .get(account)
                     .is_some_and(crate::domain::seed::KnownBinding::is_operator_authored),
             }
         })

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -1,0 +1,406 @@
+//! Operator identity corrections — write surface.
+//!
+//! Four verbs over the account-to-person binding: bind (single or bulk), merge,
+//! detach, exclude. Each appends binding observations to `persons` under the
+//! calling operator and journals the call in `operations`; nothing is updated or
+//! deleted. Admin-gated like the rest of the operator surface.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::Extension;
+use axum::response::IntoResponse;
+use serde::{Deserialize, Serialize};
+use toolkit_canonical_errors::CanonicalError;
+use toolkit_security::SecurityContext;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use super::AppState;
+use super::error::CorrectionError;
+use super::gate::require_admin;
+use crate::domain::resolution::{self, EXCLUDED_PERSON, Verb};
+use crate::domain::seed::SourceAccountKey;
+use crate::infra::db::{ops_repo, resolution_repo};
+
+/// How many accounts one bulk call may carry — a prepared matching table is
+/// pasted by a human, not streamed.
+const MAX_BULK_ITEMS: usize = 1_000;
+
+/// A source-native account, as named by the caller.
+#[derive(Debug, Clone, Deserialize, ToSchema)]
+pub struct AccountRef {
+    /// Connector type, e.g. `github`.
+    pub source: String,
+    /// Connector instance id.
+    pub source_id: Uuid,
+    /// Account id within that instance.
+    pub id: String,
+}
+
+impl From<&AccountRef> for SourceAccountKey {
+    fn from(r: &AccountRef) -> Self {
+        Self {
+            source_type: r.source.clone(),
+            source_id: r.source_id,
+            account_id: r.id.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct BindItem {
+    pub account: AccountRef,
+    pub person_id: Uuid,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct BindRequest {
+    /// One or more bindings; a prepared matching table is submitted as one call.
+    pub bindings: Vec<BindItem>,
+    #[serde(default)]
+    pub comment: String,
+}
+impl toolkit::api::api_dto::RequestApiDto for BindRequest {}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct MergeRequest {
+    /// The person being absorbed — its accounts move to the target.
+    pub source_person_id: Uuid,
+    /// The surviving person, named explicitly by the operator.
+    pub target_person_id: Uuid,
+    #[serde(default)]
+    pub comment: String,
+}
+impl toolkit::api::api_dto::RequestApiDto for MergeRequest {}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct AccountRequest {
+    pub account: AccountRef,
+    #[serde(default)]
+    pub comment: String,
+}
+impl toolkit::api::api_dto::RequestApiDto for AccountRequest {}
+
+/// What happened to one requested account.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ItemResult {
+    pub source: String,
+    pub source_id: Uuid,
+    pub account_id: String,
+    /// `applied` — a binding observation was appended;
+    /// `already_decided` — the same operator decision is already recorded.
+    pub outcome: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct CorrectionResponse {
+    pub applied: usize,
+    pub already_decided: usize,
+    pub items: Vec<ItemResult>,
+    /// Set by `detach`: the freshly minted person the account now belongs to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_person_id: Option<Uuid>,
+}
+impl toolkit::api::api_dto::ResponseApiDto for CorrectionResponse {}
+
+/// `POST /v1/resolution/bind` — attach accounts to persons (also the confirm
+/// act: binding an account to the person automation already gave it records the
+/// operator's decision and clears it from review).
+pub async fn bind(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(ctx): Extension<SecurityContext>,
+    Json(req): Json<BindRequest>,
+) -> Result<impl IntoResponse, CanonicalError> {
+    let operator = require_admin(&state.db, &ctx).await?;
+    let tenant = ctx.subject_tenant_id();
+
+    reject_empty(req.bindings.is_empty(), "bindings")?;
+    reject_oversized(req.bindings.len())?;
+
+    // One correction per target person: rows of one call may name different
+    // persons, and each person's rows need their own timestamp slots.
+    let mut response = CorrectionResponse {
+        applied: 0,
+        already_decided: 0,
+        items: Vec::with_capacity(req.bindings.len()),
+        new_person_id: None,
+    };
+
+    for item in &req.bindings {
+        let account = SourceAccountKey::from(&item.account);
+        require_known_person(&state.db, tenant, item.person_id).await?;
+        let outcome = apply_correction(
+            &state,
+            tenant,
+            operator,
+            &[account],
+            item.person_id,
+            Verb::Bind,
+            &req.comment,
+        )
+        .await?;
+        merge_into(&mut response, outcome);
+    }
+
+    Ok(Json(response))
+}
+
+/// `POST /v1/resolution/merge` — declare two persons one human; every account of
+/// the absorbed person is rebound to the survivor.
+pub async fn merge(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(ctx): Extension<SecurityContext>,
+    Json(req): Json<MergeRequest>,
+) -> Result<impl IntoResponse, CanonicalError> {
+    let operator = require_admin(&state.db, &ctx).await?;
+    let tenant = ctx.subject_tenant_id();
+
+    if req.source_person_id == req.target_person_id {
+        return Err(invalid(
+            "target_person_id",
+            "source and target are the same person",
+        ));
+    }
+    require_known_person(&state.db, tenant, req.source_person_id).await?;
+    require_known_person(&state.db, tenant, req.target_person_id).await?;
+
+    let accounts = resolution_repo::accounts_of_person(&state.db, tenant, req.source_person_id)
+        .await
+        .map_err(|e| internal(&e, "failed to read the person's accounts"))?;
+
+    let outcome = apply_correction(
+        &state,
+        tenant,
+        operator,
+        &accounts,
+        req.target_person_id,
+        Verb::Merge,
+        &req.comment,
+    )
+    .await?;
+
+    Ok(Json(outcome))
+}
+
+/// `POST /v1/resolution/detach` — declare that an account belongs to a different
+/// human; the account moves to a freshly minted person.
+pub async fn detach(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(ctx): Extension<SecurityContext>,
+    Json(req): Json<AccountRequest>,
+) -> Result<impl IntoResponse, CanonicalError> {
+    let operator = require_admin(&state.db, &ctx).await?;
+    let tenant = ctx.subject_tenant_id();
+
+    let account = SourceAccountKey::from(&req.account);
+    let new_person_id = Uuid::now_v7();
+
+    let mut outcome = apply_correction(
+        &state,
+        tenant,
+        operator,
+        &[account],
+        new_person_id,
+        Verb::Detach,
+        &req.comment,
+    )
+    .await?;
+    outcome.new_person_id = Some(new_person_id);
+
+    Ok(Json(outcome))
+}
+
+/// `POST /v1/resolution/exclude` — mark an account as not a human (bot, CI,
+/// service account). It binds to the reserved excluded person.
+pub async fn exclude(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(ctx): Extension<SecurityContext>,
+    Json(req): Json<AccountRequest>,
+) -> Result<impl IntoResponse, CanonicalError> {
+    let operator = require_admin(&state.db, &ctx).await?;
+    let tenant = ctx.subject_tenant_id();
+
+    let account = SourceAccountKey::from(&req.account);
+    let outcome = apply_correction(
+        &state,
+        tenant,
+        operator,
+        &[account],
+        EXCLUDED_PERSON,
+        Verb::Exclude,
+        &req.comment,
+    )
+    .await?;
+
+    Ok(Json(outcome))
+}
+
+/// Read the accounts' current bindings, build the rows a correction appends,
+/// write them, and journal the call.
+async fn apply_correction(
+    state: &AppState,
+    tenant: Uuid,
+    operator: Uuid,
+    accounts: &[SourceAccountKey],
+    target_person_id: Uuid,
+    verb: Verb,
+    comment: &str,
+) -> Result<CorrectionResponse, CanonicalError> {
+    let current = resolution_repo::current_bindings(&state.db, tenant, accounts)
+        .await
+        .map_err(|e| internal(&e, "failed to read current bindings"))?;
+
+    let pairs: Vec<_> = accounts
+        .iter()
+        .map(|a| (a, current.get(a).copied()))
+        .collect();
+    let rows = resolution::build_rows(
+        pairs,
+        target_person_id,
+        operator,
+        verb,
+        chrono::Utc::now().naive_utc(),
+    );
+
+    if !rows.is_empty() {
+        resolution_repo::append_bindings(&state.db, tenant, operator, &rows)
+            .await
+            .map_err(|e| internal(&e, "failed to append the correction"))?;
+    }
+
+    let appended: std::collections::HashSet<&SourceAccountKey> =
+        rows.iter().map(|r| &r.account).collect();
+    let items: Vec<ItemResult> = accounts
+        .iter()
+        .map(|a| ItemResult {
+            source: a.source_type.clone(),
+            source_id: a.source_id,
+            account_id: a.account_id.clone(),
+            outcome: if appended.contains(a) {
+                "applied".to_owned()
+            } else {
+                "already_decided".to_owned()
+            },
+        })
+        .collect();
+
+    journal(
+        state,
+        tenant,
+        operator,
+        verb,
+        target_person_id,
+        comment,
+        &items,
+    )
+    .await;
+
+    Ok(CorrectionResponse {
+        applied: rows.len(),
+        already_decided: accounts.len() - rows.len(),
+        items,
+        new_person_id: None,
+    })
+}
+
+/// Record the call in the operations journal. Journalling must never fail the
+/// correction — the binding is already committed and is the source of truth.
+async fn journal(
+    state: &AppState,
+    tenant: Uuid,
+    operator: Uuid,
+    verb: Verb,
+    target_person_id: Uuid,
+    comment: &str,
+    items: &[ItemResult],
+) {
+    let summary = serde_json::json!({
+        "applied": items.iter().filter(|i| i.outcome == "applied").count(),
+        "already_decided": items.iter().filter(|i| i.outcome == "already_decided").count(),
+    });
+    let request = serde_json::json!({
+        "verb": verb.reason_code(),
+        "target_person_id": target_person_id,
+        "comment": comment,
+        "accounts": items.iter().map(|i| serde_json::json!({
+            "source": i.source,
+            "source_id": i.source_id,
+            "account_id": i.account_id,
+            "outcome": i.outcome,
+        })).collect::<Vec<_>>(),
+    });
+
+    let operation_id = Uuid::now_v7();
+    let journalled = async {
+        ops_repo::enqueue(
+            &state.db,
+            operation_id,
+            RESOLUTION_OP,
+            tenant,
+            operator,
+            Some(&request.to_string()),
+        )
+        .await?;
+        ops_repo::try_start(&state.db, operation_id).await?;
+        ops_repo::complete(&state.db, operation_id, &summary.to_string()).await
+    }
+    .await;
+
+    if let Err(e) = journalled {
+        tracing::error!(error = %e, "identity correction: journalling failed");
+    }
+}
+
+/// `operations.operation_type` for operator corrections.
+pub const RESOLUTION_OP: &str = "identity-correction";
+
+fn merge_into(response: &mut CorrectionResponse, outcome: CorrectionResponse) {
+    response.applied += outcome.applied;
+    response.already_decided += outcome.already_decided;
+    response.items.extend(outcome.items);
+}
+
+async fn require_known_person(
+    db: &sea_orm::DatabaseConnection,
+    tenant: Uuid,
+    person_id: Uuid,
+) -> Result<(), CanonicalError> {
+    let known = resolution_repo::person_exists(db, tenant, person_id)
+        .await
+        .map_err(|e| internal(&e, "failed to check the person"))?;
+    if known {
+        return Ok(());
+    }
+    Err(CorrectionError::not_found("person not found")
+        .with_resource(person_id.to_string())
+        .create())
+}
+
+fn reject_empty(is_empty: bool, field: &str) -> Result<(), CanonicalError> {
+    if is_empty {
+        return Err(invalid(field, "must not be empty"));
+    }
+    Ok(())
+}
+
+fn reject_oversized(len: usize) -> Result<(), CanonicalError> {
+    if len > MAX_BULK_ITEMS {
+        return Err(invalid(
+            "bindings",
+            &format!("at most {MAX_BULK_ITEMS} bindings per call"),
+        ));
+    }
+    Ok(())
+}
+
+fn invalid(field: &str, message: &str) -> CanonicalError {
+    CorrectionError::invalid_argument()
+        .with_field_violation(field, message, "INVALID")
+        .create()
+}
+
+fn internal(error: &anyhow::Error, message: &str) -> CanonicalError {
+    tracing::error!(error = %error, "{message}");
+    CanonicalError::internal(message).create()
+}

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -30,6 +30,13 @@ use crate::infra::identity_evidence::{AccountEvidence, ClickHouseEvidenceReader}
 const MAX_BULK_ITEMS: usize = 1_000;
 
 /// A source-native account, as named by the caller.
+///
+/// Addressing by an observed value (e-mail / username) instead of the account
+/// triple is the reserved extension for importing a prepared matching table:
+/// the fields arrive optional, exactly one form is required per item, a value
+/// resolving to zero or several active accounts is reported per item and never
+/// guessed. The response already carries per-item outcomes, so adding it does
+/// not change the shape of this contract.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct AccountRef {
     /// Connector type, e.g. `github`.
@@ -92,6 +99,8 @@ pub struct ItemResult {
     pub account_id: String,
     /// `applied` — a binding observation was appended;
     /// `already_decided` — the same operator decision is already recorded.
+    /// Open vocabulary: value-addressed items will report their skip reasons
+    /// (`ambiguous_value`, `unknown_value`) here.
     pub outcome: String,
 }
 

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -112,7 +112,8 @@ pub struct CorrectionResponse {
     pub applied: usize,
     pub already_decided: usize,
     pub items: Vec<ItemResult>,
-    /// Set by `detach`: the freshly minted person the account now belongs to.
+    /// Set by `detach` when the account reached the new person; absent when
+    /// the write was refused, since no binding points at that id.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub new_person_id: Option<Uuid>,
 }
@@ -226,7 +227,13 @@ pub async fn detach(
         &req.comment,
     )
     .await?;
-    outcome.new_person_id = Some(new_person_id);
+
+    // Only name the person when the account actually reached it: a refused
+    // write leaves the account where it was, and an id no binding points at
+    // would read as a person that exists.
+    if outcome.applied > 0 {
+        outcome.new_person_id = Some(new_person_id);
+    }
 
     Ok(Json(outcome))
 }

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -349,6 +349,10 @@ fn count_outcome(outcomes: &[&str], wanted: &str) -> usize {
     outcomes.iter().filter(|o| **o == wanted).count()
 }
 
+fn count_items(items: &[ItemResult], wanted: &str) -> usize {
+    items.iter().filter(|i| i.outcome == wanted).count()
+}
+
 /// Append the rows, then recover only those the database refused.
 ///
 /// The natural key has no account discriminator, so a concurrent operation can
@@ -442,8 +446,9 @@ async fn journal(
     items: &[ItemResult],
 ) {
     let summary = serde_json::json!({
-        "applied": items.iter().filter(|i| i.outcome == OUTCOME_APPLIED).count(),
-        "already_decided": items.iter().filter(|i| i.outcome == OUTCOME_ALREADY_DECIDED).count(),
+        "applied": count_items(items, OUTCOME_APPLIED),
+        "already_decided": count_items(items, OUTCOME_ALREADY_DECIDED),
+        "refused": count_items(items, OUTCOME_REFUSED),
     });
     let request = serde_json::json!({
         "verb": verb.reason_code(),

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -20,8 +20,10 @@ use super::AppState;
 use super::error::CorrectionError;
 use super::gate::require_admin;
 use crate::domain::resolution::{self, EXCLUDED_PERSON, Verb};
+use crate::domain::review_queue::{self, EvidenceAccount, ItemKind, Review};
 use crate::domain::seed::SourceAccountKey;
 use crate::infra::db::{ops_repo, resolution_repo};
+use crate::infra::identity_evidence::{AccountEvidence, ClickHouseEvidenceReader};
 
 /// How many accounts one bulk call may carry — a prepared matching table is
 /// pasted by a human, not streamed.
@@ -403,4 +405,255 @@ fn invalid(field: &str, message: &str) -> CanonicalError {
 fn internal(error: &anyhow::Error, message: &str) -> CanonicalError {
     tracing::error!(error = %error, "{message}");
     CanonicalError::internal(message).create()
+}
+
+/// Query knobs for the review queue.
+#[derive(Debug, Deserialize)]
+pub struct AttentionParams {
+    /// Cap on returned items (rates always cover every observed account).
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct QueueItemResponse {
+    /// `contested` | `binding_conflict` | `no_evidence`.
+    pub kind: String,
+    pub source: String,
+    pub source_id: Uuid,
+    pub account_id: String,
+    pub email: Option<String>,
+    pub username: Option<String>,
+    /// Persons this account could belong to, if any are known.
+    pub candidates: Vec<Uuid>,
+}
+
+/// Share of observed accounts per resolution state — the operator-visible match
+/// rate.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ResolutionRatesResponse {
+    pub observed: usize,
+    pub bound: usize,
+    pub pending: usize,
+    pub no_evidence: usize,
+    pub excluded: usize,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AttentionResponse {
+    pub items: Vec<QueueItemResponse>,
+    pub rates: ResolutionRatesResponse,
+}
+impl toolkit::api::api_dto::ResponseApiDto for AttentionResponse {}
+
+/// `GET /v1/resolution/attention` — what needs an operator decision, derived
+/// from the evidence fold joined with current bindings, plus the match rate.
+pub async fn attention(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(ctx): Extension<SecurityContext>,
+    axum::extract::Query(params): axum::extract::Query<AttentionParams>,
+) -> Result<impl IntoResponse, CanonicalError> {
+    require_admin(&state.db, &ctx).await?;
+    let tenant = ctx.subject_tenant_id();
+
+    let review = build_review(&state, tenant).await?;
+
+    let limit = params.limit.map_or(DEFAULT_QUEUE_LIMIT, |l| {
+        usize::try_from(l).unwrap_or(1).clamp(1, MAX_QUEUE_LIMIT)
+    });
+
+    let items = review
+        .items
+        .into_iter()
+        .take(limit)
+        .map(|i| QueueItemResponse {
+            kind: kind_label(i.kind).to_owned(),
+            source: i.account.source_type,
+            source_id: i.account.source_id,
+            account_id: i.account.account_id,
+            email: i.email,
+            username: i.username,
+            candidates: i.candidates,
+        })
+        .collect();
+
+    Ok(Json(AttentionResponse {
+        items,
+        rates: ResolutionRatesResponse {
+            observed: review.rates.observed,
+            bound: review.rates.bound,
+            pending: review.rates.pending,
+            no_evidence: review.rates.no_evidence,
+            excluded: review.rates.excluded,
+        },
+    }))
+}
+
+/// One decision in an account's history.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct HistoryEntry {
+    pub person_id: Uuid,
+    pub author_person_id: Uuid,
+    /// `true` when a person made this decision, `false` for automation.
+    pub by_operator: bool,
+    pub reason: Option<String>,
+    pub recorded_at: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AccountBindingResponse {
+    pub source: String,
+    pub source_id: Uuid,
+    pub account_id: String,
+    /// The binding in force now, if the account has one.
+    pub person_id: Option<Uuid>,
+    pub history: Vec<HistoryEntry>,
+}
+impl toolkit::api::api_dto::ResponseApiDto for AccountBindingResponse {}
+
+/// `GET /v1/resolution/accounts/{source}/{source_id}/{account_id}` — why this
+/// account belongs to this person: the binding in force and every decision
+/// behind it.
+pub async fn account_binding(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(ctx): Extension<SecurityContext>,
+    axum::extract::Path((source, source_id, account_id)): axum::extract::Path<(
+        String,
+        Uuid,
+        String,
+    )>,
+) -> Result<impl IntoResponse, CanonicalError> {
+    require_admin(&state.db, &ctx).await?;
+    let tenant = ctx.subject_tenant_id();
+
+    let account = SourceAccountKey {
+        source_type: source.clone(),
+        source_id,
+        account_id: account_id.clone(),
+    };
+    let history = resolution_repo::binding_history(&state.db, tenant, &account)
+        .await
+        .map_err(|e| internal(&e, "failed to read the binding history"))?;
+
+    let entries: Vec<HistoryEntry> = history
+        .iter()
+        .map(|h| HistoryEntry {
+            person_id: h.person_id,
+            author_person_id: h.author_person_id,
+            by_operator: !h.author_person_id.is_nil(),
+            reason: h.reason.clone(),
+            recorded_at: super::seed::fmt_ts(h.created_at),
+        })
+        .collect();
+
+    Ok(Json(AccountBindingResponse {
+        source,
+        source_id,
+        account_id,
+        person_id: history.first().map(|h| h.person_id),
+        history: entries,
+    }))
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PersonAccountEntry {
+    pub source: String,
+    pub source_id: Uuid,
+    pub account_id: String,
+    pub email: Option<String>,
+    pub username: Option<String>,
+    /// `true` when the account's current binding was made by a person.
+    pub bound_by_operator: bool,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PersonAccountsResponse {
+    pub person_id: Uuid,
+    pub accounts: Vec<PersonAccountEntry>,
+}
+impl toolkit::api::api_dto::ResponseApiDto for PersonAccountsResponse {}
+
+/// `GET /v1/resolution/persons/{person_id}/accounts` — the matching table for
+/// one person: every account bound to them, with the values behind each link.
+pub async fn person_accounts(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(ctx): Extension<SecurityContext>,
+    axum::extract::Path(person_id): axum::extract::Path<Uuid>,
+) -> Result<impl IntoResponse, CanonicalError> {
+    require_admin(&state.db, &ctx).await?;
+    let tenant = ctx.subject_tenant_id();
+
+    let accounts = resolution_repo::accounts_of_person(&state.db, tenant, person_id)
+        .await
+        .map_err(|e| internal(&e, "failed to read the person's accounts"))?;
+    let bindings = resolution_repo::current_bindings(&state.db, tenant, &accounts)
+        .await
+        .map_err(|e| internal(&e, "failed to read current bindings"))?;
+    let evidence = read_evidence(&state).await?;
+
+    let entries = accounts
+        .into_iter()
+        .map(|account| {
+            let observed = evidence.iter().find(|e| e.account == account);
+            PersonAccountEntry {
+                source: account.source_type.clone(),
+                source_id: account.source_id,
+                account_id: account.account_id.clone(),
+                email: observed.and_then(|e| e.email.clone()),
+                username: observed.and_then(|e| e.username.clone()),
+                bound_by_operator: bindings
+                    .get(&account)
+                    .is_some_and(crate::domain::seed::KnownBinding::is_operator_authored),
+            }
+        })
+        .collect();
+
+    Ok(Json(PersonAccountsResponse {
+        person_id,
+        accounts: entries,
+    }))
+}
+
+const DEFAULT_QUEUE_LIMIT: usize = 100;
+const MAX_QUEUE_LIMIT: usize = 1_000;
+
+fn kind_label(kind: ItemKind) -> &'static str {
+    match kind {
+        ItemKind::Contested => "contested",
+        ItemKind::BindingConflict => "binding_conflict",
+        ItemKind::NoEvidence => "no_evidence",
+    }
+}
+
+/// Join folded evidence with current bindings into the review.
+async fn build_review(state: &AppState, tenant: Uuid) -> Result<Review, CanonicalError> {
+    let evidence = read_evidence(state).await?;
+    let accounts: Vec<SourceAccountKey> = evidence.iter().map(|e| e.account.clone()).collect();
+    let bindings = resolution_repo::current_bindings(&state.db, tenant, &accounts)
+        .await
+        .map_err(|e| internal(&e, "failed to read current bindings"))?;
+
+    let observed = evidence
+        .into_iter()
+        .map(|e| EvidenceAccount {
+            account: e.account,
+            email: e.email,
+            username: e.username,
+            is_closed: e.is_closed,
+        })
+        .collect();
+
+    Ok(review_queue::build(observed, &bindings))
+}
+
+async fn read_evidence(state: &AppState) -> Result<Vec<AccountEvidence>, CanonicalError> {
+    let reader = ClickHouseEvidenceReader::connect(
+        &state.config.clickhouse_url,
+        &state.config.clickhouse_database,
+        &state.config.clickhouse_user,
+        &state.config.clickhouse_password,
+    );
+    reader
+        .accounts()
+        .await
+        .map_err(|e| internal(&e, "failed to read connector evidence"))
 }

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -329,7 +329,7 @@ async fn apply_correction(
         })
         .map(|(index, _)| index)
         .collect();
-    let landed = write_rows(state, tenant, operator, rows).await?;
+    let landed = write_rows(state, tenant, rows).await?;
 
     let mut outcomes = vec![OUTCOME_ALREADY_DECIDED; targets.len()];
     for (slot, index) in written.iter().enumerate() {
@@ -393,14 +393,13 @@ fn count_items(items: &[ItemResult], wanted: &str) -> usize {
 async fn write_rows(
     state: &AppState,
     tenant: Uuid,
-    operator: Uuid,
     rows: Vec<resolution::BindingRow>,
 ) -> Result<Vec<bool>, CanonicalError> {
     if rows.is_empty() {
         return Ok(Vec::new());
     }
 
-    let appended = append(state, tenant, operator, &rows).await?;
+    let appended = append(state, tenant, &rows).await?;
     if appended == rows.len() as u64 {
         return Ok(vec![true; rows.len()]);
     }
@@ -413,7 +412,7 @@ async fn write_rows(
     }
 
     let retry = resolution::restamp(&missing, chrono::Utc::now().naive_utc());
-    append(state, tenant, operator, &retry).await?;
+    append(state, tenant, &retry).await?;
 
     let recovered = present_rows(state, tenant, &retry).await?;
     resolution::apply_recovery(&mut present, &recovered);
@@ -431,10 +430,9 @@ async fn write_rows(
 async fn append(
     state: &AppState,
     tenant: Uuid,
-    operator: Uuid,
     rows: &[resolution::BindingRow],
 ) -> Result<u64, CanonicalError> {
-    resolution_repo::append_bindings(&state.db, tenant, operator, rows)
+    resolution_repo::append_bindings(&state.db, tenant, rows)
         .await
         .map_err(|e| internal(&e, "failed to append the correction"))
 }

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -5,6 +5,7 @@
 //! calling operator and journals the call in `operations`; nothing is updated or
 //! deleted. Admin-gated like the rest of the operator surface.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use axum::Json;
@@ -97,8 +98,10 @@ pub struct ItemResult {
     pub source: String,
     pub source_id: Uuid,
     pub account_id: String,
-    /// `applied` — a binding observation was appended;
-    /// `already_decided` — the same operator decision is already recorded.
+    /// `applied` — the binding is in force;
+    /// `already_decided` — the same operator decision was already recorded;
+    /// `refused` — the write could not place the row (a concurrent operation
+    /// held the key); the account keeps its previous binding.
     /// Open vocabulary: value-addressed items will report their skip reasons
     /// (`ambiguous_value`, `unknown_value`) here.
     pub outcome: String,
@@ -190,9 +193,12 @@ pub async fn detach(
     let operator = require_admin(&state.db, &ctx).await?;
     let tenant = ctx.subject_tenant_id();
 
+    let account = SourceAccountKey::from(&req.account);
+    require_known_account(&state, tenant, &account).await?;
+
     let new_person_id = Uuid::now_v7();
     let targets = vec![Target {
-        account: SourceAccountKey::from(&req.account),
+        account,
         person_id: new_person_id,
     }];
 
@@ -220,8 +226,11 @@ pub async fn exclude(
     let operator = require_admin(&state.db, &ctx).await?;
     let tenant = ctx.subject_tenant_id();
 
+    let account = SourceAccountKey::from(&req.account);
+    require_known_account(&state, tenant, &account).await?;
+
     let targets = vec![Target {
-        account: SourceAccountKey::from(&req.account),
+        account,
         person_id: EXCLUDED_PERSON,
     }];
 
@@ -260,21 +269,16 @@ async fn apply_correction(
         .collect();
     let rows = resolution::build_rows(pairs, operator, verb, chrono::Utc::now().naive_utc());
 
-    let appended = write_rows(state, tenant, operator, rows.clone()).await?;
+    let attempted: HashSet<SourceAccountKey> = rows.iter().map(|r| r.account.clone()).collect();
+    let landed = write_rows(state, tenant, operator, rows).await?;
 
-    let touched: std::collections::HashSet<&SourceAccountKey> =
-        rows.iter().map(|r| &r.account).collect();
     let items: Vec<ItemResult> = targets
         .iter()
         .map(|t| ItemResult {
             source: t.account.source_type.clone(),
             source_id: t.account.source_id,
             account_id: t.account.account_id.clone(),
-            outcome: if touched.contains(&t.account) {
-                OUTCOME_APPLIED.to_owned()
-            } else {
-                OUTCOME_ALREADY_DECIDED.to_owned()
-            },
+            outcome: outcome_label(&t.account, &attempted, &landed).to_owned(),
         })
         .collect();
 
@@ -291,53 +295,108 @@ async fn apply_correction(
     .await;
 
     Ok(CorrectionResponse {
-        applied: usize::try_from(appended).unwrap_or(rows.len()),
-        already_decided: targets.len() - rows.len(),
+        applied: landed.len(),
+        already_decided: targets.len() - attempted.len(),
         items,
         new_person_id: None,
     })
 }
 
-/// Append the rows, then recover any the database refused.
+/// What the caller is told about one requested account: a row that was never
+/// needed, one that is now in force, or one the database would not place.
+fn outcome_label<'a>(
+    account: &SourceAccountKey,
+    attempted: &HashSet<SourceAccountKey>,
+    landed: &'a HashSet<SourceAccountKey>,
+) -> &'a str {
+    if !attempted.contains(account) {
+        return OUTCOME_ALREADY_DECIDED;
+    }
+    if landed.contains(account) {
+        return OUTCOME_APPLIED;
+    }
+    OUTCOME_REFUSED
+}
+
+/// Append the rows, then recover only those the database refused.
 ///
 /// The natural key has no account discriminator, so a concurrent operation can
 /// have claimed the same microsecond and `INSERT IGNORE` silently drops the
-/// loser. Re-stamping past the contended instant and retrying once turns that
-/// into a late row rather than a lost binding; a second refusal is reported as
-/// such rather than papered over.
+/// loser. A short write is diagnosed by re-reading the bindings — the rows that
+/// did land are already current, so retrying the whole set would duplicate
+/// them; only the accounts still pointing elsewhere are re-stamped and retried.
+/// Returns the accounts whose binding is in force after the write.
 async fn write_rows(
     state: &AppState,
     tenant: Uuid,
     operator: Uuid,
     rows: Vec<resolution::BindingRow>,
-) -> Result<u64, CanonicalError> {
+) -> Result<HashSet<SourceAccountKey>, CanonicalError> {
     if rows.is_empty() {
-        return Ok(0);
+        return Ok(HashSet::new());
     }
 
-    let appended = resolution_repo::append_bindings(&state.db, tenant, operator, &rows)
-        .await
-        .map_err(|e| internal(&e, "failed to append the correction"))?;
-
-    let expected = rows.len() as u64;
-    if appended == expected {
-        return Ok(appended);
+    let appended = append(state, tenant, operator, &rows).await?;
+    if appended == rows.len() as u64 {
+        return Ok(rows.into_iter().map(|r| r.account).collect());
     }
 
-    let retry = resolution::restamp(&rows, chrono::Utc::now().naive_utc());
-    let recovered = resolution_repo::append_bindings(&state.db, tenant, operator, &retry)
-        .await
-        .map_err(|e| internal(&e, "failed to append the correction"))?;
+    let mut landed = landed_accounts(state, tenant, &rows).await?;
+    let missing: Vec<resolution::BindingRow> = rows
+        .iter()
+        .filter(|r| !landed.contains(&r.account))
+        .cloned()
+        .collect();
 
-    let total = appended + recovered;
-    if total < expected {
+    if missing.is_empty() {
+        return Ok(landed);
+    }
+
+    let retry = resolution::restamp(&missing, chrono::Utc::now().naive_utc());
+    append(state, tenant, operator, &retry).await?;
+    landed = landed_accounts(state, tenant, &rows).await?;
+
+    let refused = rows.len() - landed.len();
+    if refused > 0 {
         tracing::warn!(
-            expected,
-            appended = total,
-            "identity correction: some rows were refused twice"
+            refused,
+            "identity correction: rows the database refused twice"
         );
     }
-    Ok(total.min(expected))
+    Ok(landed)
+}
+
+async fn append(
+    state: &AppState,
+    tenant: Uuid,
+    operator: Uuid,
+    rows: &[resolution::BindingRow],
+) -> Result<u64, CanonicalError> {
+    resolution_repo::append_bindings(&state.db, tenant, operator, rows)
+        .await
+        .map_err(|e| internal(&e, "failed to append the correction"))
+}
+
+/// Which of the written accounts now hold the person the correction asked for.
+async fn landed_accounts(
+    state: &AppState,
+    tenant: Uuid,
+    rows: &[resolution::BindingRow],
+) -> Result<HashSet<SourceAccountKey>, CanonicalError> {
+    let accounts: Vec<SourceAccountKey> = rows.iter().map(|r| r.account.clone()).collect();
+    let current = resolution_repo::current_bindings(&state.db, tenant, &accounts)
+        .await
+        .map_err(|e| internal(&e, "failed to verify the correction"))?;
+
+    Ok(rows
+        .iter()
+        .filter(|r| {
+            current
+                .get(&r.account)
+                .is_some_and(|b| b.person_id == r.person_id)
+        })
+        .map(|r| r.account.clone())
+        .collect())
 }
 
 /// Record the call in the operations journal. Journalling must never fail the
@@ -394,6 +453,41 @@ pub const RESOLUTION_OP: &str = "identity-correction";
 /// Per-item outcome vocabulary.
 const OUTCOME_APPLIED: &str = "applied";
 const OUTCOME_ALREADY_DECIDED: &str = "already_decided";
+const OUTCOME_REFUSED: &str = "refused";
+
+/// Detaching or excluding presupposes an account that exists: it must already
+/// have a binding, or a connector must have observed it. (Binding an account
+/// ahead of its first sync is deliberate — pre-registration — but minting a
+/// person for an account nobody has seen is a typo, not a decision.)
+async fn require_known_account(
+    state: &AppState,
+    tenant: Uuid,
+    account: &SourceAccountKey,
+) -> Result<(), CanonicalError> {
+    let bindings =
+        resolution_repo::current_bindings(&state.db, tenant, std::slice::from_ref(account))
+            .await
+            .map_err(|e| internal(&e, "failed to read current bindings"))?;
+    if !bindings.is_empty() {
+        return Ok(());
+    }
+
+    let reader = evidence_reader(state);
+    let observed = reader
+        .has_account(account)
+        .await
+        .map_err(|e| internal(&e, "failed to check connector evidence"))?;
+    if observed {
+        return Ok(());
+    }
+
+    Err(CorrectionError::not_found("account not found")
+        .with_resource(format!(
+            "{}:{}:{}",
+            account.source_type, account.source_id, account.account_id
+        ))
+        .create())
+}
 
 async fn require_known_person(
     db: &sea_orm::DatabaseConnection,
@@ -677,14 +771,17 @@ async fn build_review(state: &AppState, tenant: Uuid) -> Result<Review, Canonica
     Ok(review_queue::build(observed, &bindings))
 }
 
-async fn read_evidence(state: &AppState) -> Result<Vec<AccountEvidence>, CanonicalError> {
-    let reader = ClickHouseEvidenceReader::connect(
+fn evidence_reader(state: &AppState) -> ClickHouseEvidenceReader {
+    ClickHouseEvidenceReader::connect(
         &state.config.clickhouse_url,
         &state.config.clickhouse_database,
         &state.config.clickhouse_user,
         &state.config.clickhouse_password,
-    );
-    reader
+    )
+}
+
+async fn read_evidence(state: &AppState) -> Result<Vec<AccountEvidence>, CanonicalError> {
+    evidence_reader(state)
         .accounts()
         .await
         .map_err(|e| internal(&e, "failed to read connector evidence"))

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -133,10 +133,25 @@ pub async fn bind(
     reject_oversized(req.bindings.len())?;
 
     let mut targets = Vec::with_capacity(req.bindings.len());
+    let mut seen: HashSet<SourceAccountKey> = HashSet::with_capacity(req.bindings.len());
     for item in &req.bindings {
+        let account = SourceAccountKey::from(&item.account);
+
+        // One call naming an account twice has no answer: which person wins is
+        // the caller's contradiction to resolve, not ours to guess.
+        if !seen.insert(account.clone()) {
+            return Err(invalid(
+                "bindings",
+                &format!(
+                    "account {}:{} appears more than once",
+                    account.source_type, account.account_id
+                ),
+            ));
+        }
+
         require_known_person(&state.db, tenant, item.person_id).await?;
         targets.push(Target {
-            account: SourceAccountKey::from(&item.account),
+            account,
             person_id: item.person_id,
         });
     }
@@ -269,16 +284,37 @@ async fn apply_correction(
         .collect();
     let rows = resolution::build_rows(pairs, operator, verb, chrono::Utc::now().naive_utc());
 
-    let attempted: HashSet<SourceAccountKey> = rows.iter().map(|r| r.account.clone()).collect();
+    // Row i belongs to the target at `written[i]`: outcomes are reported by
+    // position, never by account, so one call naming an account twice cannot
+    // have its results collapse into one.
+    let written: Vec<usize> = targets
+        .iter()
+        .enumerate()
+        .filter(|(_, t)| {
+            rows.iter()
+                .any(|r| r.account == t.account && r.person_id == t.person_id)
+        })
+        .map(|(index, _)| index)
+        .collect();
     let landed = write_rows(state, tenant, operator, rows).await?;
+
+    let mut outcomes = vec![OUTCOME_ALREADY_DECIDED; targets.len()];
+    for (slot, index) in written.iter().enumerate() {
+        outcomes[*index] = if landed.get(slot).copied().unwrap_or(false) {
+            OUTCOME_APPLIED
+        } else {
+            OUTCOME_REFUSED
+        };
+    }
 
     let items: Vec<ItemResult> = targets
         .iter()
-        .map(|t| ItemResult {
+        .zip(&outcomes)
+        .map(|(t, outcome)| ItemResult {
             source: t.account.source_type.clone(),
             source_id: t.account.source_id,
             account_id: t.account.account_id.clone(),
-            outcome: outcome_label(&t.account, &attempted, &landed).to_owned(),
+            outcome: (*outcome).to_owned(),
         })
         .collect();
 
@@ -295,75 +331,75 @@ async fn apply_correction(
     .await;
 
     Ok(CorrectionResponse {
-        applied: landed.len(),
-        already_decided: targets.len() - attempted.len(),
+        applied: count_outcome(&outcomes, OUTCOME_APPLIED),
+        already_decided: count_outcome(&outcomes, OUTCOME_ALREADY_DECIDED),
         items,
         new_person_id: None,
     })
 }
 
-/// What the caller is told about one requested account: a row that was never
-/// needed, one that is now in force, or one the database would not place.
-fn outcome_label<'a>(
-    account: &SourceAccountKey,
-    attempted: &HashSet<SourceAccountKey>,
-    landed: &'a HashSet<SourceAccountKey>,
-) -> &'a str {
-    if !attempted.contains(account) {
-        return OUTCOME_ALREADY_DECIDED;
-    }
-    if landed.contains(account) {
-        return OUTCOME_APPLIED;
-    }
-    OUTCOME_REFUSED
+fn count_outcome(outcomes: &[&str], wanted: &str) -> usize {
+    outcomes.iter().filter(|o| **o == wanted).count()
 }
 
 /// Append the rows, then recover only those the database refused.
 ///
 /// The natural key has no account discriminator, so a concurrent operation can
 /// have claimed the same microsecond and `INSERT IGNORE` silently drops the
-/// loser. A short write is diagnosed by re-reading the bindings — the rows that
-/// did land are already current, so retrying the whole set would duplicate
-/// them; only the accounts still pointing elsewhere are re-stamped and retried.
-/// Returns the accounts whose binding is in force after the write.
+/// loser. A short write is diagnosed by asking which of these exact rows the
+/// journal now holds — author and instant included, because a confirmation
+/// writes an operator row over an automatic binding to the same person and
+/// "the account points at this person" cannot tell those two apart. Only the
+/// rows that are missing are re-stamped and retried; the ones that landed must
+/// not be sent again or the history gains duplicates.
+///
+/// Returns, per input row, whether its observation is in the journal.
 async fn write_rows(
     state: &AppState,
     tenant: Uuid,
     operator: Uuid,
     rows: Vec<resolution::BindingRow>,
-) -> Result<HashSet<SourceAccountKey>, CanonicalError> {
+) -> Result<Vec<bool>, CanonicalError> {
     if rows.is_empty() {
-        return Ok(HashSet::new());
+        return Ok(Vec::new());
     }
 
     let appended = append(state, tenant, operator, &rows).await?;
     if appended == rows.len() as u64 {
-        return Ok(rows.into_iter().map(|r| r.account).collect());
+        return Ok(vec![true; rows.len()]);
     }
 
-    let mut landed = landed_accounts(state, tenant, &rows).await?;
+    let mut present = present_rows(state, tenant, &rows).await?;
+
     let missing: Vec<resolution::BindingRow> = rows
         .iter()
-        .filter(|r| !landed.contains(&r.account))
-        .cloned()
+        .zip(&present)
+        .filter(|(_, landed)| !**landed)
+        .map(|(row, _)| row.clone())
         .collect();
-
     if missing.is_empty() {
-        return Ok(landed);
+        return Ok(present);
     }
 
     let retry = resolution::restamp(&missing, chrono::Utc::now().naive_utc());
     append(state, tenant, operator, &retry).await?;
-    landed = landed_accounts(state, tenant, &rows).await?;
 
-    let refused = rows.len() - landed.len();
+    let recovered = present_rows(state, tenant, &retry).await?;
+    let mut recovered = recovered.into_iter();
+    for landed in &mut present {
+        if !*landed {
+            *landed = recovered.next().unwrap_or(false);
+        }
+    }
+
+    let refused = present.iter().filter(|landed| !**landed).count();
     if refused > 0 {
         tracing::warn!(
             refused,
             "identity correction: rows the database refused twice"
         );
     }
-    Ok(landed)
+    Ok(present)
 }
 
 async fn append(
@@ -377,26 +413,14 @@ async fn append(
         .map_err(|e| internal(&e, "failed to append the correction"))
 }
 
-/// Which of the written accounts now hold the person the correction asked for.
-async fn landed_accounts(
+async fn present_rows(
     state: &AppState,
     tenant: Uuid,
     rows: &[resolution::BindingRow],
-) -> Result<HashSet<SourceAccountKey>, CanonicalError> {
-    let accounts: Vec<SourceAccountKey> = rows.iter().map(|r| r.account.clone()).collect();
-    let current = resolution_repo::current_bindings(&state.db, tenant, &accounts)
+) -> Result<Vec<bool>, CanonicalError> {
+    resolution_repo::present_rows(&state.db, tenant, rows)
         .await
-        .map_err(|e| internal(&e, "failed to verify the correction"))?;
-
-    Ok(rows
-        .iter()
-        .filter(|r| {
-            current
-                .get(&r.account)
-                .is_some_and(|b| b.person_id == r.person_id)
-        })
-        .map(|r| r.account.clone())
-        .collect())
+        .map_err(|e| internal(&e, "failed to verify the correction"))
 }
 
 /// Record the call in the operations journal. Journalling must never fail the

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -157,17 +157,17 @@ pub async fn bind(
         });
     }
 
-    // The journal's verb-level target; heterogeneous bulk detail is in the
-    // per-account list either way.
-    let journal_target = req.bindings[0].person_id;
     let response = apply_correction(
         &state,
         tenant,
         operator,
         targets,
-        Verb::Bind,
-        journal_target,
-        &req.comment,
+        Decision {
+            verb: Verb::Bind,
+            // Heterogeneous bulk detail is in the per-account list either way.
+            target_person_id: req.bindings[0].person_id,
+            comment: &req.comment,
+        },
     )
     .await?;
 
@@ -209,9 +209,11 @@ pub async fn merge(
         tenant,
         operator,
         targets,
-        Verb::Merge,
-        req.target_person_id,
-        &req.comment,
+        Decision {
+            verb: Verb::Merge,
+            target_person_id: req.target_person_id,
+            comment: &req.comment,
+        },
     )
     .await?;
 
@@ -242,9 +244,11 @@ pub async fn detach(
         tenant,
         operator,
         targets,
-        Verb::Detach,
-        new_person_id,
-        &req.comment,
+        Decision {
+            verb: Verb::Detach,
+            target_person_id: new_person_id,
+            comment: &req.comment,
+        },
     )
     .await?;
 
@@ -281,31 +285,46 @@ pub async fn exclude(
         tenant,
         operator,
         targets,
-        Verb::Exclude,
-        EXCLUDED_PERSON,
-        &req.comment,
+        Decision {
+            verb: Verb::Exclude,
+            target_person_id: EXCLUDED_PERSON,
+            comment: &req.comment,
+        },
     )
     .await?;
 
     Ok(Json(outcome))
 }
 
+/// What the operator asked for, as the operations journal will record it.
+/// Grouped so the two person ids in play — the author and the verb's target —
+/// cannot be swapped at a call site without the compiler noticing.
+struct Decision<'a> {
+    verb: Verb,
+    /// The verb-level person the journal names: the survivor for a merge, the
+    /// minted person for a detach, the sentinel for an exclude. Named by the
+    /// caller, never derived from the targets — a merge of a person with no
+    /// accounts has an empty target list but still a real survivor.
+    target_person_id: Uuid,
+    comment: &'a str,
+}
+
 /// Read the targets' current bindings, build the rows the correction appends,
-/// write them once, and journal the call. One write and one cache rebuild per
-/// operation, however many accounts it names.
-///
-/// `journal_target` is the verb-level person the operation journal records —
-/// named by the caller, never derived from the targets: a merge of a person
-/// with no accounts has an empty target list but still a real survivor.
+/// write them once, and journal the call — one write per operation, however
+/// many accounts it names.
 async fn apply_correction(
     state: &AppState,
     tenant: Uuid,
     operator: Uuid,
     targets: Vec<Target>,
-    verb: Verb,
-    journal_target: Uuid,
-    comment: &str,
+    decision: Decision<'_>,
 ) -> Result<CorrectionResponse, CanonicalError> {
+    let Decision {
+        verb,
+        target_person_id,
+        comment,
+    } = decision;
+
     let accounts: Vec<SourceAccountKey> = targets.iter().map(|t| t.account.clone()).collect();
     let current = resolution_repo::current_bindings(&state.db, tenant, &accounts)
         .await
@@ -356,22 +375,18 @@ async fn apply_correction(
         tenant,
         operator,
         verb,
-        journal_target,
+        target_person_id,
         comment,
         &items,
     )
     .await;
 
     Ok(CorrectionResponse {
-        applied: count_outcome(&outcomes, OUTCOME_APPLIED),
-        already_decided: count_outcome(&outcomes, OUTCOME_ALREADY_DECIDED),
+        applied: count_items(&items, OUTCOME_APPLIED),
+        already_decided: count_items(&items, OUTCOME_ALREADY_DECIDED),
         items,
         new_person_id: None,
     })
-}
-
-fn count_outcome(outcomes: &[&str], wanted: &str) -> usize {
-    outcomes.iter().filter(|o| **o == wanted).count()
 }
 
 fn count_items(items: &[ItemResult], wanted: &str) -> usize {

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -19,7 +19,7 @@ use uuid::Uuid;
 use super::AppState;
 use super::error::CorrectionError;
 use super::gate::require_admin;
-use crate::domain::resolution::{self, EXCLUDED_PERSON, Verb};
+use crate::domain::resolution::{self, EXCLUDED_PERSON, Target, Verb};
 use crate::domain::review_queue::{self, EvidenceAccount, ItemKind, Review};
 use crate::domain::seed::SourceAccountKey;
 use crate::infra::db::{ops_repo, resolution_repo};
@@ -129,30 +129,17 @@ pub async fn bind(
     reject_empty(req.bindings.is_empty(), "bindings")?;
     reject_oversized(req.bindings.len())?;
 
-    // One correction per target person: rows of one call may name different
-    // persons, and each person's rows need their own timestamp slots.
-    let mut response = CorrectionResponse {
-        applied: 0,
-        already_decided: 0,
-        items: Vec::with_capacity(req.bindings.len()),
-        new_person_id: None,
-    };
-
+    let mut targets = Vec::with_capacity(req.bindings.len());
     for item in &req.bindings {
-        let account = SourceAccountKey::from(&item.account);
         require_known_person(&state.db, tenant, item.person_id).await?;
-        let outcome = apply_correction(
-            &state,
-            tenant,
-            operator,
-            &[account],
-            item.person_id,
-            Verb::Bind,
-            &req.comment,
-        )
-        .await?;
-        merge_into(&mut response, outcome);
+        targets.push(Target {
+            account: SourceAccountKey::from(&item.account),
+            person_id: item.person_id,
+        });
     }
+
+    let response =
+        apply_correction(&state, tenant, operator, targets, Verb::Bind, &req.comment).await?;
 
     Ok(Json(response))
 }
@@ -179,17 +166,16 @@ pub async fn merge(
     let accounts = resolution_repo::accounts_of_person(&state.db, tenant, req.source_person_id)
         .await
         .map_err(|e| internal(&e, "failed to read the person's accounts"))?;
+    let targets = accounts
+        .into_iter()
+        .map(|account| Target {
+            account,
+            person_id: req.target_person_id,
+        })
+        .collect();
 
-    let outcome = apply_correction(
-        &state,
-        tenant,
-        operator,
-        &accounts,
-        req.target_person_id,
-        Verb::Merge,
-        &req.comment,
-    )
-    .await?;
+    let outcome =
+        apply_correction(&state, tenant, operator, targets, Verb::Merge, &req.comment).await?;
 
     Ok(Json(outcome))
 }
@@ -204,15 +190,17 @@ pub async fn detach(
     let operator = require_admin(&state.db, &ctx).await?;
     let tenant = ctx.subject_tenant_id();
 
-    let account = SourceAccountKey::from(&req.account);
     let new_person_id = Uuid::now_v7();
+    let targets = vec![Target {
+        account: SourceAccountKey::from(&req.account),
+        person_id: new_person_id,
+    }];
 
     let mut outcome = apply_correction(
         &state,
         tenant,
         operator,
-        &[account],
-        new_person_id,
+        targets,
         Verb::Detach,
         &req.comment,
     )
@@ -232,13 +220,16 @@ pub async fn exclude(
     let operator = require_admin(&state.db, &ctx).await?;
     let tenant = ctx.subject_tenant_id();
 
-    let account = SourceAccountKey::from(&req.account);
+    let targets = vec![Target {
+        account: SourceAccountKey::from(&req.account),
+        person_id: EXCLUDED_PERSON,
+    }];
+
     let outcome = apply_correction(
         &state,
         tenant,
         operator,
-        &[account],
-        EXCLUDED_PERSON,
+        targets,
         Verb::Exclude,
         &req.comment,
     )
@@ -247,55 +238,47 @@ pub async fn exclude(
     Ok(Json(outcome))
 }
 
-/// Read the accounts' current bindings, build the rows a correction appends,
-/// write them, and journal the call.
+/// Read the targets' current bindings, build the rows the correction appends,
+/// write them once, and journal the call. One write and one cache rebuild per
+/// operation, however many accounts it names.
 async fn apply_correction(
     state: &AppState,
     tenant: Uuid,
     operator: Uuid,
-    accounts: &[SourceAccountKey],
-    target_person_id: Uuid,
+    targets: Vec<Target>,
     verb: Verb,
     comment: &str,
 ) -> Result<CorrectionResponse, CanonicalError> {
-    let current = resolution_repo::current_bindings(&state.db, tenant, accounts)
+    let accounts: Vec<SourceAccountKey> = targets.iter().map(|t| t.account.clone()).collect();
+    let current = resolution_repo::current_bindings(&state.db, tenant, &accounts)
         .await
         .map_err(|e| internal(&e, "failed to read current bindings"))?;
 
-    let pairs: Vec<_> = accounts
+    let pairs: Vec<_> = targets
         .iter()
-        .map(|a| (a, current.get(a).copied()))
+        .map(|t| (t, current.get(&t.account).copied()))
         .collect();
-    let rows = resolution::build_rows(
-        pairs,
-        target_person_id,
-        operator,
-        verb,
-        chrono::Utc::now().naive_utc(),
-    );
+    let rows = resolution::build_rows(pairs, operator, verb, chrono::Utc::now().naive_utc());
 
-    if !rows.is_empty() {
-        resolution_repo::append_bindings(&state.db, tenant, operator, &rows)
-            .await
-            .map_err(|e| internal(&e, "failed to append the correction"))?;
-    }
+    let appended = write_rows(state, tenant, operator, rows.clone()).await?;
 
-    let appended: std::collections::HashSet<&SourceAccountKey> =
+    let touched: std::collections::HashSet<&SourceAccountKey> =
         rows.iter().map(|r| &r.account).collect();
-    let items: Vec<ItemResult> = accounts
+    let items: Vec<ItemResult> = targets
         .iter()
-        .map(|a| ItemResult {
-            source: a.source_type.clone(),
-            source_id: a.source_id,
-            account_id: a.account_id.clone(),
-            outcome: if appended.contains(a) {
-                "applied".to_owned()
+        .map(|t| ItemResult {
+            source: t.account.source_type.clone(),
+            source_id: t.account.source_id,
+            account_id: t.account.account_id.clone(),
+            outcome: if touched.contains(&t.account) {
+                OUTCOME_APPLIED.to_owned()
             } else {
-                "already_decided".to_owned()
+                OUTCOME_ALREADY_DECIDED.to_owned()
             },
         })
         .collect();
 
+    let target_person_id = targets.first().map(|t| t.person_id).unwrap_or_default();
     journal(
         state,
         tenant,
@@ -308,11 +291,53 @@ async fn apply_correction(
     .await;
 
     Ok(CorrectionResponse {
-        applied: rows.len(),
-        already_decided: accounts.len() - rows.len(),
+        applied: usize::try_from(appended).unwrap_or(rows.len()),
+        already_decided: targets.len() - rows.len(),
         items,
         new_person_id: None,
     })
+}
+
+/// Append the rows, then recover any the database refused.
+///
+/// The natural key has no account discriminator, so a concurrent operation can
+/// have claimed the same microsecond and `INSERT IGNORE` silently drops the
+/// loser. Re-stamping past the contended instant and retrying once turns that
+/// into a late row rather than a lost binding; a second refusal is reported as
+/// such rather than papered over.
+async fn write_rows(
+    state: &AppState,
+    tenant: Uuid,
+    operator: Uuid,
+    rows: Vec<resolution::BindingRow>,
+) -> Result<u64, CanonicalError> {
+    if rows.is_empty() {
+        return Ok(0);
+    }
+
+    let appended = resolution_repo::append_bindings(&state.db, tenant, operator, &rows)
+        .await
+        .map_err(|e| internal(&e, "failed to append the correction"))?;
+
+    let expected = rows.len() as u64;
+    if appended == expected {
+        return Ok(appended);
+    }
+
+    let retry = resolution::restamp(&rows, chrono::Utc::now().naive_utc());
+    let recovered = resolution_repo::append_bindings(&state.db, tenant, operator, &retry)
+        .await
+        .map_err(|e| internal(&e, "failed to append the correction"))?;
+
+    let total = appended + recovered;
+    if total < expected {
+        tracing::warn!(
+            expected,
+            appended = total,
+            "identity correction: some rows were refused twice"
+        );
+    }
+    Ok(total.min(expected))
 }
 
 /// Record the call in the operations journal. Journalling must never fail the
@@ -327,8 +352,8 @@ async fn journal(
     items: &[ItemResult],
 ) {
     let summary = serde_json::json!({
-        "applied": items.iter().filter(|i| i.outcome == "applied").count(),
-        "already_decided": items.iter().filter(|i| i.outcome == "already_decided").count(),
+        "applied": items.iter().filter(|i| i.outcome == OUTCOME_APPLIED).count(),
+        "already_decided": items.iter().filter(|i| i.outcome == OUTCOME_ALREADY_DECIDED).count(),
     });
     let request = serde_json::json!({
         "verb": verb.reason_code(),
@@ -366,11 +391,9 @@ async fn journal(
 /// `operations.operation_type` for operator corrections.
 pub const RESOLUTION_OP: &str = "identity-correction";
 
-fn merge_into(response: &mut CorrectionResponse, outcome: CorrectionResponse) {
-    response.applied += outcome.applied;
-    response.already_decided += outcome.already_decided;
-    response.items.extend(outcome.items);
-}
+/// Per-item outcome vocabulary.
+const OUTCOME_APPLIED: &str = "applied";
+const OUTCOME_ALREADY_DECIDED: &str = "already_decided";
 
 async fn require_known_person(
     db: &sea_orm::DatabaseConnection,

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -407,12 +407,7 @@ async fn write_rows(
 
     let mut present = present_rows(state, tenant, &rows).await?;
 
-    let missing: Vec<resolution::BindingRow> = rows
-        .iter()
-        .zip(&present)
-        .filter(|(_, landed)| !**landed)
-        .map(|(row, _)| row.clone())
-        .collect();
+    let missing = resolution::missing(&rows, &present);
     if missing.is_empty() {
         return Ok(present);
     }
@@ -421,12 +416,7 @@ async fn write_rows(
     append(state, tenant, operator, &retry).await?;
 
     let recovered = present_rows(state, tenant, &retry).await?;
-    let mut recovered = recovered.into_iter();
-    for landed in &mut present {
-        if !*landed {
-            *landed = recovered.next().unwrap_or(false);
-        }
-    }
+    resolution::apply_recovery(&mut present, &recovered);
 
     let refused = present.iter().filter(|landed| !**landed).count();
     if refused > 0 {

--- a/src/backend/services/identity-resolution/src/domain/mod.rs
+++ b/src/backend/services/identity-resolution/src/domain/mod.rs
@@ -3,6 +3,7 @@
 pub mod observation_slot;
 pub mod profile;
 pub mod resolution;
+pub mod review_queue;
 pub mod seed;
 pub mod seed_service;
 pub mod subchart;

--- a/src/backend/services/identity-resolution/src/domain/mod.rs
+++ b/src/backend/services/identity-resolution/src/domain/mod.rs
@@ -1,6 +1,8 @@
 //! Domain layer — DTOs and business logic (profile resolution/assembly).
 
+pub mod observation_slot;
 pub mod profile;
+pub mod resolution;
 pub mod seed;
 pub mod seed_service;
 pub mod subchart;

--- a/src/backend/services/identity-resolution/src/domain/observation_slot.rs
+++ b/src/backend/services/identity-resolution/src/domain/observation_slot.rs
@@ -1,0 +1,107 @@
+//! Distinct `created_at` per observation within one write.
+//!
+//! `uq_person_observation` ends in `created_at` and carries no account
+//! discriminator, so two accounts of one source landing on one person at the
+//! same instant collide and `INSERT IGNORE` drops one binding. Both writers —
+//! the seed (timestamps from `_synced_at`) and the operator corrections
+//! (timestamps from the operation's clock) — claim slots through here.
+
+use std::collections::HashSet;
+
+use chrono::TimeDelta;
+use sea_orm::prelude::DateTime;
+use uuid::Uuid;
+
+/// The natural-key columns a writer controls; the tenant is bound once per
+/// operation by the caller.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ObservationKey {
+    person_id: Uuid,
+    source_type: String,
+    source_id: Uuid,
+    value_type: String,
+    created_at: DateTime,
+}
+
+/// Hands out an unused `created_at` per natural key, nudging forward by whole
+/// microseconds — the smallest step `DATETIME(6)` stores, so chronology is
+/// preserved. One allocator per write operation.
+#[derive(Debug, Default)]
+pub struct SlotAllocator {
+    taken: HashSet<ObservationKey>,
+}
+
+impl SlotAllocator {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Claim `preferred`, or the next free microsecond for this key.
+    pub fn claim(
+        &mut self,
+        person_id: Uuid,
+        source_type: &str,
+        source_id: Uuid,
+        value_type: &str,
+        preferred: DateTime,
+    ) -> DateTime {
+        let mut key = ObservationKey {
+            person_id,
+            source_type: source_type.to_owned(),
+            source_id,
+            value_type: value_type.to_owned(),
+            created_at: preferred,
+        };
+        while !self.taken.insert(key.clone()) {
+            key.created_at += TimeDelta::microseconds(1);
+        }
+        key.created_at
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ts() -> DateTime {
+        chrono::DateTime::UNIX_EPOCH.naive_utc() + TimeDelta::days(20_000)
+    }
+
+    #[test]
+    fn colliding_keys_advance_by_one_microsecond_each() {
+        let mut slots = SlotAllocator::new();
+        let person = Uuid::from_u128(1);
+        let source = Uuid::from_u128(2);
+
+        let first = slots.claim(person, "bamboohr", source, "id", ts());
+        let second = slots.claim(person, "bamboohr", source, "id", ts());
+        let third = slots.claim(person, "bamboohr", source, "id", ts());
+
+        assert_eq!(first, ts(), "the first claim keeps its own instant");
+        assert_eq!(second, ts() + TimeDelta::microseconds(1));
+        assert_eq!(third, ts() + TimeDelta::microseconds(2));
+    }
+
+    #[test]
+    fn distinct_keys_keep_the_same_instant() {
+        let mut slots = SlotAllocator::new();
+        let person = Uuid::from_u128(1);
+        let source = Uuid::from_u128(2);
+        let other_person = Uuid::from_u128(9);
+
+        let id_row = slots.claim(person, "bamboohr", source, "id", ts());
+        let email_row = slots.claim(person, "bamboohr", source, "email", ts());
+        let other_source = slots.claim(person, "slack", source, "id", ts());
+        let other_person_row = slots.claim(other_person, "bamboohr", source, "id", ts());
+
+        for (label, claimed) in [
+            ("value_type differs", email_row),
+            ("source_type differs", other_source),
+            ("person differs", other_person_row),
+        ] {
+            assert_eq!(claimed, ts(), "no collision when {label}");
+        }
+        assert_eq!(id_row, ts());
+    }
+}

--- a/src/backend/services/identity-resolution/src/domain/observation_slot.rs
+++ b/src/backend/services/identity-resolution/src/domain/observation_slot.rs
@@ -8,9 +8,19 @@
 
 use std::collections::HashSet;
 
-use chrono::TimeDelta;
+use chrono::{TimeDelta, Timelike};
 use sea_orm::prelude::DateTime;
 use uuid::Uuid;
+
+/// Truncate an instant to whole microseconds — the finest step `DATETIME(6)`
+/// stores. The write path compares its in-memory rows against what the
+/// database returns to tell landed rows from refused ones; an instant carrying
+/// sub-microsecond nanoseconds (any OS clock read) would never compare equal
+/// to its own stored row, and the recovery would re-insert rows that landed.
+#[must_use]
+pub fn truncate_to_micros(at: DateTime) -> DateTime {
+    at - TimeDelta::nanoseconds(i64::from(at.nanosecond() % 1_000))
+}
 
 /// The natural-key columns a writer controls; the tenant is bound once per
 /// operation by the caller.
@@ -66,6 +76,18 @@ mod tests {
 
     fn ts() -> DateTime {
         chrono::DateTime::UNIX_EPOCH.naive_utc() + TimeDelta::days(20_000)
+    }
+
+    #[test]
+    fn sub_microsecond_instants_truncate_to_what_the_database_stores() {
+        let clean = ts() + TimeDelta::microseconds(3);
+
+        assert_eq!(
+            truncate_to_micros(clean + TimeDelta::nanoseconds(999)),
+            clean,
+            "sub-microsecond nanoseconds are dropped"
+        );
+        assert_eq!(truncate_to_micros(clean), clean, "a clean instant is kept");
     }
 
     #[test]

--- a/src/backend/services/identity-resolution/src/domain/resolution.rs
+++ b/src/backend/services/identity-resolution/src/domain/resolution.rs
@@ -7,7 +7,7 @@
 use sea_orm::prelude::DateTime;
 use uuid::Uuid;
 
-use super::observation_slot::SlotAllocator;
+use super::observation_slot::{self, SlotAllocator};
 use super::seed::{KnownBinding, SourceAccountKey};
 
 /// The reserved person meaning "not a human". Bots, CI and service accounts
@@ -83,8 +83,10 @@ pub struct Target {
 }
 
 /// Build the rows one correction appends, skipping targets whose decision is
-/// already recorded. `at` is the operation's instant; rows that would collide
-/// inside the natural key are nudged forward (see [`SlotAllocator`]).
+/// already recorded. `at` is the operation's instant, truncated to whole
+/// microseconds (`DATETIME(6)` stores nothing finer, and the write path
+/// compares its rows against the stored ones); rows that would collide inside
+/// the natural key are nudged forward (see [`SlotAllocator`]).
 ///
 /// The whole operation shares one allocator — a bulk call may name several
 /// persons, and two of its rows can still collide on the same key.
@@ -95,6 +97,7 @@ pub fn build_rows<'a>(
     verb: Verb,
     at: DateTime,
 ) -> Vec<BindingRow> {
+    let at = observation_slot::truncate_to_micros(at);
     let mut slots = SlotAllocator::new();
     let mut rows = Vec::new();
 
@@ -130,6 +133,7 @@ pub fn build_rows<'a>(
 /// recovers the dropped row instead of losing a binding.
 #[must_use]
 pub fn restamp(rows: &[BindingRow], after: DateTime) -> Vec<BindingRow> {
+    let after = observation_slot::truncate_to_micros(after);
     let mut slots = SlotAllocator::new();
 
     rows.iter()
@@ -273,6 +277,24 @@ mod tests {
 
         assert_eq!(rows[0].created_at, ts());
         assert_eq!(rows[1].created_at, ts() + TimeDelta::microseconds(1));
+    }
+
+    #[test]
+    fn an_os_clock_instant_is_stamped_at_database_precision() {
+        // `Utc::now()` carries nanoseconds; the journal stores DATETIME(6).
+        // Rows must be built at microsecond precision or the write path could
+        // never match them against what the database returns.
+        let target = Target {
+            account: account("slack", "U1"),
+            person_id: Uuid::from_u128(5),
+        };
+        let os_clock = ts() + TimeDelta::nanoseconds(1_999);
+
+        let rows = build_rows([(&target, None)], Uuid::from_u128(42), Verb::Bind, os_clock);
+        let retried = resolution_restamp(&rows, os_clock + TimeDelta::nanoseconds(2_500));
+
+        assert_eq!(rows[0].created_at, ts() + TimeDelta::microseconds(1));
+        assert_eq!(retried[0].created_at, ts() + TimeDelta::microseconds(4));
     }
 
     #[test]

--- a/src/backend/services/identity-resolution/src/domain/resolution.rs
+++ b/src/backend/services/identity-resolution/src/domain/resolution.rs
@@ -75,14 +75,22 @@ pub struct BindingRow {
     pub created_at: DateTime,
 }
 
-/// Build the rows for one correction over `accounts`, skipping those whose
-/// decision is already recorded. `at` is the operation's instant; rows that
-/// would collide inside the natural key are nudged forward (see
-/// [`SlotAllocator`]).
+/// One account and the person the operator wants it bound to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Target {
+    pub account: SourceAccountKey,
+    pub person_id: Uuid,
+}
+
+/// Build the rows one correction appends, skipping targets whose decision is
+/// already recorded. `at` is the operation's instant; rows that would collide
+/// inside the natural key are nudged forward (see [`SlotAllocator`]).
+///
+/// The whole operation shares one allocator — a bulk call may name several
+/// persons, and two of its rows can still collide on the same key.
 #[must_use]
 pub fn build_rows<'a>(
-    accounts: impl IntoIterator<Item = (&'a SourceAccountKey, Option<KnownBinding>)>,
-    target_person_id: Uuid,
+    targets: impl IntoIterator<Item = (&'a Target, Option<KnownBinding>)>,
     operator_person_id: Uuid,
     verb: Verb,
     at: DateTime,
@@ -90,22 +98,22 @@ pub fn build_rows<'a>(
     let mut slots = SlotAllocator::new();
     let mut rows = Vec::new();
 
-    for (account, current) in accounts {
-        if decide(current, target_person_id) == Outcome::AlreadyDecided {
+    for (target, current) in targets {
+        if decide(current, target.person_id) == Outcome::AlreadyDecided {
             continue;
         }
 
         let created_at = slots.claim(
-            target_person_id,
-            &account.source_type,
-            account.source_id,
+            target.person_id,
+            &target.account.source_type,
+            target.account.source_id,
             BINDING_VALUE_TYPE,
             at,
         );
 
         rows.push(BindingRow {
-            account: account.clone(),
-            person_id: target_person_id,
+            account: target.account.clone(),
+            person_id: target.person_id,
             author_person_id: operator_person_id,
             reason: verb.reason_code().to_owned(),
             created_at,
@@ -113,6 +121,32 @@ pub fn build_rows<'a>(
     }
 
     rows
+}
+
+/// Re-stamp rows the database refused so a retry cannot collide again: every
+/// row moves past the last instant the operation used. The natural key has no
+/// account discriminator, so two operations racing on the same microsecond can
+/// have one of their rows dropped by the insert — this is how the caller
+/// recovers the dropped row instead of losing a binding.
+#[must_use]
+pub fn restamp(rows: &[BindingRow], after: DateTime) -> Vec<BindingRow> {
+    let mut slots = SlotAllocator::new();
+
+    rows.iter()
+        .map(|row| {
+            let created_at = slots.claim(
+                row.person_id,
+                &row.account.source_type,
+                row.account.source_id,
+                BINDING_VALUE_TYPE,
+                after,
+            );
+            BindingRow {
+                created_at,
+                ..row.clone()
+            }
+        })
+        .collect()
 }
 
 /// Binding observations are `value_type='id'` rows whose value is the account id
@@ -189,12 +223,19 @@ mod tests {
         let fresh = account("slack", "U2");
         let target = Uuid::from_u128(5);
 
+        let settled_target = Target {
+            account: settled.clone(),
+            person_id: target,
+        };
+        let fresh_target = Target {
+            account: fresh.clone(),
+            person_id: target,
+        };
         let rows = build_rows(
             [
-                (&settled, Some(operator_bound(5))),
-                (&fresh, Some(seed_bound(7))),
+                (&settled_target, Some(operator_bound(5))),
+                (&fresh_target, Some(seed_bound(7))),
             ],
-            target,
             Uuid::from_u128(42),
             Verb::Bind,
             ts(),
@@ -214,9 +255,16 @@ mod tests {
         let a = account("bamboohr", "1");
         let b = account("bamboohr", "2");
 
+        let a_target = Target {
+            account: a,
+            person_id: Uuid::from_u128(5),
+        };
+        let b_target = Target {
+            account: b,
+            person_id: Uuid::from_u128(5),
+        };
         let rows = build_rows(
-            [(&a, None), (&b, None)],
-            Uuid::from_u128(5),
+            [(&a_target, None), (&b_target, None)],
             Uuid::from_u128(42),
             Verb::Merge,
             ts(),

--- a/src/backend/services/identity-resolution/src/domain/resolution.rs
+++ b/src/backend/services/identity-resolution/src/domain/resolution.rs
@@ -153,6 +153,29 @@ pub fn restamp(rows: &[BindingRow], after: DateTime) -> Vec<BindingRow> {
         .collect()
 }
 
+/// The rows the journal does not hold, in input order — what a short write has
+/// to retry. `present` is the answer to "which of these exact observations
+/// landed", one flag per row.
+#[must_use]
+pub fn missing(rows: &[BindingRow], present: &[bool]) -> Vec<BindingRow> {
+    rows.iter()
+        .zip(present)
+        .filter(|(_, landed)| !**landed)
+        .map(|(row, _)| row.clone())
+        .collect()
+}
+
+/// Fold a retry's outcome back into the first attempt's: the n-th row that was
+/// missing is answered by the n-th flag of `recovered`, and rows that already
+/// landed are never revisited. A gap with no answer stays refused — a row the
+/// database would not take twice is reported, not counted as applied.
+pub fn apply_recovery(present: &mut [bool], recovered: &[bool]) {
+    let mut answers = recovered.iter();
+    for landed in present.iter_mut().filter(|landed| !**landed) {
+        *landed = answers.next().copied().unwrap_or(false);
+    }
+}
+
 /// Binding observations are `value_type='id'` rows whose value is the account id
 /// (ADR-0002).
 pub const BINDING_VALUE_TYPE: &str = "id";
@@ -343,6 +366,64 @@ mod tests {
         let retry = resolution_restamp(&rows, ts() + TimeDelta::seconds(1));
 
         assert_ne!(retry[0].created_at, retry[1].created_at);
+    }
+
+    fn row(account_id: &str) -> BindingRow {
+        BindingRow {
+            account: account("slack", account_id),
+            person_id: Uuid::from_u128(5),
+            author_person_id: Uuid::from_u128(42),
+            reason: Verb::Bind.reason_code().to_owned(),
+            created_at: ts(),
+        }
+    }
+
+    #[test]
+    fn only_the_rows_the_journal_lacks_are_retried() {
+        // Re-sending a row that landed would duplicate history, so the retry
+        // set is exactly the gaps — in input order, since the caller answers
+        // its items by position.
+        let rows = [row("U1"), row("U2"), row("U3")];
+
+        let retry = missing(&rows, &[true, false, false]);
+
+        let retried: Vec<&str> = retry
+            .iter()
+            .map(|r| r.account.account_id.as_str())
+            .collect();
+        assert_eq!(retried, vec!["U2", "U3"]);
+    }
+
+    #[test]
+    fn recovery_answers_the_gaps_in_order_and_leaves_landed_rows_alone() {
+        // The n-th retried row answers the n-th gap: an off-by-one here would
+        // credit one account's write to another.
+        let mut present = vec![true, false, true, false];
+
+        apply_recovery(&mut present, &[false, true]);
+
+        assert_eq!(present, vec![true, false, true, true]);
+    }
+
+    #[test]
+    fn a_row_the_database_refuses_twice_stays_refused() {
+        // Fewer answers than gaps: the unanswered row is reported as refused
+        // rather than optimistically counted as applied.
+        let mut present = vec![false, false];
+
+        apply_recovery(&mut present, &[true]);
+
+        assert_eq!(present, vec![true, false]);
+    }
+
+    #[test]
+    fn a_write_with_nothing_missing_is_left_untouched() {
+        let mut present = vec![true, true];
+
+        apply_recovery(&mut present, &[]);
+
+        assert_eq!(present, vec![true, true]);
+        assert!(missing(&[row("U1"), row("U2")], &present).is_empty());
     }
 
     #[test]

--- a/src/backend/services/identity-resolution/src/domain/resolution.rs
+++ b/src/backend/services/identity-resolution/src/domain/resolution.rs
@@ -1,0 +1,253 @@
+//! Operator identity corrections: the pure core.
+//!
+//! A correction is an appended binding observation in `persons` — never an
+//! update. This module decides *whether* a correction has anything to append
+//! and *what* the appended rows look like; the repository performs the write.
+
+use sea_orm::prelude::DateTime;
+use uuid::Uuid;
+
+use super::observation_slot::SlotAllocator;
+use super::seed::{KnownBinding, SourceAccountKey};
+
+/// The reserved person meaning "not a human". Bots, CI and service accounts
+/// bind here; every consumer treats it as no person (NULL in analytics, not
+/// served by the read API, hidden from the review queue). Unmintable: UUIDv7
+/// never produces an all-ones value.
+pub const EXCLUDED_PERSON: Uuid = Uuid::from_u128(u128::MAX);
+
+/// Which verb produced a correction — stamped into `persons.reason` so the
+/// journal explains itself without joining the operations log.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verb {
+    Bind,
+    Merge,
+    Detach,
+    Exclude,
+}
+
+impl Verb {
+    #[must_use]
+    pub fn reason_code(self) -> &'static str {
+        match self {
+            Self::Bind => "operator-bind",
+            Self::Merge => "operator-merge",
+            Self::Detach => "operator-detach",
+            Self::Exclude => "operator-exclude",
+        }
+    }
+}
+
+/// What a correction does to one account.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Outcome {
+    /// The identical operator decision is already recorded — nothing to append.
+    AlreadyDecided,
+    /// Append a binding observation for this account.
+    Append,
+}
+
+/// Decide whether a correction has anything to append.
+///
+/// Idempotency is **decision-aware**: repeating an operator's own decision is a
+/// no-op, but re-asserting a binding that automation made is the confirm act
+/// and must be recorded — that is what takes the account out of the review
+/// queue and makes the binding authoritative.
+#[must_use]
+pub fn decide(current: Option<KnownBinding>, target_person_id: Uuid) -> Outcome {
+    match current {
+        Some(binding)
+            if binding.person_id == target_person_id && binding.is_operator_authored() =>
+        {
+            Outcome::AlreadyDecided
+        }
+        _ => Outcome::Append,
+    }
+}
+
+/// A binding observation to append for one account.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BindingRow {
+    pub account: SourceAccountKey,
+    pub person_id: Uuid,
+    pub author_person_id: Uuid,
+    pub reason: String,
+    pub created_at: DateTime,
+}
+
+/// Build the rows for one correction over `accounts`, skipping those whose
+/// decision is already recorded. `at` is the operation's instant; rows that
+/// would collide inside the natural key are nudged forward (see
+/// [`SlotAllocator`]).
+#[must_use]
+pub fn build_rows<'a>(
+    accounts: impl IntoIterator<Item = (&'a SourceAccountKey, Option<KnownBinding>)>,
+    target_person_id: Uuid,
+    operator_person_id: Uuid,
+    verb: Verb,
+    at: DateTime,
+) -> Vec<BindingRow> {
+    let mut slots = SlotAllocator::new();
+    let mut rows = Vec::new();
+
+    for (account, current) in accounts {
+        if decide(current, target_person_id) == Outcome::AlreadyDecided {
+            continue;
+        }
+
+        let created_at = slots.claim(
+            target_person_id,
+            &account.source_type,
+            account.source_id,
+            BINDING_VALUE_TYPE,
+            at,
+        );
+
+        rows.push(BindingRow {
+            account: account.clone(),
+            person_id: target_person_id,
+            author_person_id: operator_person_id,
+            reason: verb.reason_code().to_owned(),
+            created_at,
+        });
+    }
+
+    rows
+}
+
+/// Binding observations are `value_type='id'` rows whose value is the account id
+/// (ADR-0002).
+pub const BINDING_VALUE_TYPE: &str = "id";
+
+#[cfg(test)]
+mod tests {
+    use chrono::TimeDelta;
+
+    use super::*;
+
+    fn account(source_type: &str, account_id: &str) -> SourceAccountKey {
+        SourceAccountKey {
+            source_type: source_type.to_owned(),
+            source_id: Uuid::from_u128(1),
+            account_id: account_id.to_owned(),
+        }
+    }
+
+    fn seed_bound(person: u128) -> KnownBinding {
+        KnownBinding {
+            person_id: Uuid::from_u128(person),
+            author_person_id: Uuid::nil(),
+        }
+    }
+
+    fn operator_bound(person: u128) -> KnownBinding {
+        KnownBinding {
+            person_id: Uuid::from_u128(person),
+            author_person_id: Uuid::from_u128(0xAD_1119),
+        }
+    }
+
+    fn ts() -> DateTime {
+        chrono::DateTime::UNIX_EPOCH.naive_utc() + TimeDelta::days(20_000)
+    }
+
+    #[test]
+    fn repeating_an_operator_decision_is_a_no_op() {
+        let outcome = decide(Some(operator_bound(5)), Uuid::from_u128(5));
+        assert_eq!(outcome, Outcome::AlreadyDecided);
+    }
+
+    #[test]
+    fn confirming_an_automation_binding_appends() {
+        // Same person, but the binding came from automation: the operator's
+        // confirmation must be recorded — this is what clears the review item.
+        let outcome = decide(Some(seed_bound(5)), Uuid::from_u128(5));
+        assert_eq!(outcome, Outcome::Append);
+    }
+
+    #[test]
+    fn rebinding_and_first_binding_append() {
+        for (label, current) in [
+            (
+                "operator moves the account elsewhere",
+                Some(operator_bound(5)),
+            ),
+            ("automation bound it elsewhere", Some(seed_bound(5))),
+            ("never bound", None),
+        ] {
+            assert_eq!(
+                decide(current, Uuid::from_u128(9)),
+                Outcome::Append,
+                "should append: {label}"
+            );
+        }
+    }
+
+    #[test]
+    fn rows_skip_already_decided_accounts() {
+        let settled = account("slack", "U1");
+        let fresh = account("slack", "U2");
+        let target = Uuid::from_u128(5);
+
+        let rows = build_rows(
+            [
+                (&settled, Some(operator_bound(5))),
+                (&fresh, Some(seed_bound(7))),
+            ],
+            target,
+            Uuid::from_u128(42),
+            Verb::Bind,
+            ts(),
+        );
+
+        assert_eq!(rows.len(), 1, "the settled account contributes no row");
+        assert_eq!(rows[0].account, fresh);
+        assert_eq!(rows[0].person_id, target);
+        assert_eq!(rows[0].author_person_id, Uuid::from_u128(42));
+        assert_eq!(rows[0].reason, "operator-bind");
+    }
+
+    #[test]
+    fn same_source_accounts_get_distinct_timestamps() {
+        // Two accounts of one source rebound to one person in one operation:
+        // their id rows share every other natural-key column.
+        let a = account("bamboohr", "1");
+        let b = account("bamboohr", "2");
+
+        let rows = build_rows(
+            [(&a, None), (&b, None)],
+            Uuid::from_u128(5),
+            Uuid::from_u128(42),
+            Verb::Merge,
+            ts(),
+        );
+
+        assert_eq!(rows[0].created_at, ts());
+        assert_eq!(rows[1].created_at, ts() + TimeDelta::microseconds(1));
+    }
+
+    #[test]
+    fn verbs_carry_distinct_reason_codes() {
+        let codes: Vec<&str> = [Verb::Bind, Verb::Merge, Verb::Detach, Verb::Exclude]
+            .into_iter()
+            .map(Verb::reason_code)
+            .collect();
+        assert_eq!(
+            codes,
+            vec![
+                "operator-bind",
+                "operator-merge",
+                "operator-detach",
+                "operator-exclude"
+            ]
+        );
+    }
+
+    #[test]
+    fn excluded_sentinel_is_not_a_mintable_uuid() {
+        // UUIDv7 sets version/variant bits, so an all-ones value can never be
+        // minted for a real person.
+        assert_ne!(EXCLUDED_PERSON.get_version_num(), 7);
+        assert_eq!(EXCLUDED_PERSON, Uuid::from_u128(u128::MAX));
+    }
+}

--- a/src/backend/services/identity-resolution/src/domain/resolution.rs
+++ b/src/backend/services/identity-resolution/src/domain/resolution.rs
@@ -157,6 +157,7 @@ pub const BINDING_VALUE_TYPE: &str = "id";
 mod tests {
     use chrono::TimeDelta;
 
+    use super::restamp as resolution_restamp;
     use super::*;
 
     fn account(source_type: &str, account_id: &str) -> SourceAccountKey {
@@ -272,6 +273,54 @@ mod tests {
 
         assert_eq!(rows[0].created_at, ts());
         assert_eq!(rows[1].created_at, ts() + TimeDelta::microseconds(1));
+    }
+
+    #[test]
+    fn restamped_rows_move_past_the_contended_instant() {
+        // The recovery path: a row the insert refused is re-stamped after the
+        // moment two operations fought over, so the retry cannot collide again.
+        let account = account("slack", "U1");
+        let refused = vec![BindingRow {
+            account: account.clone(),
+            person_id: Uuid::from_u128(5),
+            author_person_id: Uuid::from_u128(42),
+            reason: Verb::Bind.reason_code().to_owned(),
+            created_at: ts(),
+        }];
+
+        let retry = resolution_restamp(&refused, ts() + TimeDelta::seconds(1));
+
+        assert_eq!(retry.len(), 1);
+        assert_eq!(retry[0].created_at, ts() + TimeDelta::seconds(1));
+        assert_eq!(retry[0].account, account, "the row itself is unchanged");
+        assert_eq!(retry[0].person_id, refused[0].person_id);
+        assert_eq!(retry[0].author_person_id, refused[0].author_person_id);
+    }
+
+    #[test]
+    fn restamping_keeps_colliding_rows_apart() {
+        // Two refused rows of one source retried together must not collide
+        // with each other on the way back in.
+        let rows = vec![
+            BindingRow {
+                account: account("bamboohr", "1"),
+                person_id: Uuid::from_u128(5),
+                author_person_id: Uuid::from_u128(42),
+                reason: Verb::Merge.reason_code().to_owned(),
+                created_at: ts(),
+            },
+            BindingRow {
+                account: account("bamboohr", "2"),
+                person_id: Uuid::from_u128(5),
+                author_person_id: Uuid::from_u128(42),
+                reason: Verb::Merge.reason_code().to_owned(),
+                created_at: ts(),
+            },
+        ];
+
+        let retry = resolution_restamp(&rows, ts() + TimeDelta::seconds(1));
+
+        assert_ne!(retry[0].created_at, retry[1].created_at);
     }
 
     #[test]

--- a/src/backend/services/identity-resolution/src/domain/review_queue.rs
+++ b/src/backend/services/identity-resolution/src/domain/review_queue.rs
@@ -1,0 +1,327 @@
+//! What needs an operator decision — derived, never stored.
+//!
+//! Two inputs joined on the account key: the folded connector evidence (every
+//! observed account) and the current bindings from the journal. An item exists
+//! only while its condition holds, so a decision removes it without any item
+//! lifecycle to maintain.
+
+use std::collections::HashMap;
+
+use uuid::Uuid;
+
+use super::resolution::EXCLUDED_PERSON;
+use super::seed::{KnownBinding, SourceAccountKey, normalize_email};
+
+/// Why an account is on the queue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ItemKind {
+    /// The account's identity evidence is claimed by more than one person.
+    Contested,
+    /// The account's identity value is shared by accounts bound to different
+    /// persons, with no operator decision explaining the divergence.
+    BindingConflict,
+    /// The account carries no usable identity evidence — visible, never hidden.
+    NoEvidence,
+}
+
+/// One account awaiting a decision, with the persons it could belong to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueueItem {
+    pub kind: ItemKind,
+    pub account: SourceAccountKey,
+    pub email: Option<String>,
+    pub username: Option<String>,
+    pub candidates: Vec<Uuid>,
+}
+
+/// How many observed accounts are in each resolution state — the operator-
+/// visible match rate.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ResolutionRates {
+    pub observed: usize,
+    pub bound: usize,
+    pub pending: usize,
+    pub no_evidence: usize,
+    pub excluded: usize,
+}
+
+/// The queue plus its rates.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Review {
+    pub items: Vec<QueueItem>,
+    pub rates: ResolutionRates,
+}
+
+/// An account as the evidence describes it — the shape [`build`] consumes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvidenceAccount {
+    pub account: SourceAccountKey,
+    pub email: Option<String>,
+    pub username: Option<String>,
+    pub is_closed: bool,
+}
+
+/// Build the review from folded evidence and current bindings.
+///
+/// Closed accounts are skipped entirely: their latest evidence event is a
+/// closure, so there is nothing to decide. Everything else is classified in one
+/// pass over the accounts sharing each e-mail.
+#[must_use]
+pub fn build(
+    evidence: Vec<EvidenceAccount>,
+    bindings: &HashMap<SourceAccountKey, KnownBinding>,
+) -> Review {
+    let active: Vec<EvidenceAccount> = evidence.into_iter().filter(|e| !e.is_closed).collect();
+
+    let mut by_email: HashMap<String, Vec<&EvidenceAccount>> = HashMap::new();
+    for account in &active {
+        if let Some(email) = account.email.as_deref().map(normalize_email) {
+            by_email.entry(email).or_default().push(account);
+        }
+    }
+
+    let mut items = Vec::new();
+    let mut rates = ResolutionRates {
+        observed: active.len(),
+        ..ResolutionRates::default()
+    };
+
+    for account in &active {
+        match bindings.get(&account.account) {
+            Some(binding) if binding.person_id == EXCLUDED_PERSON => rates.excluded += 1,
+            Some(_) => rates.bound += 1,
+            None if !has_evidence(account) => {
+                rates.no_evidence += 1;
+                items.push(item(ItemKind::NoEvidence, account, Vec::new()));
+            }
+            None => {
+                let candidates = candidates_for(account, &by_email, bindings);
+                if candidates.len() > 1 {
+                    rates.pending += 1;
+                    items.push(item(ItemKind::Contested, account, candidates));
+                } else {
+                    // One candidate or none: automation will bind it on its next
+                    // run, so it is not the operator's problem yet.
+                    rates.pending += 1;
+                }
+            }
+        }
+    }
+
+    items.extend(binding_conflicts(&by_email, bindings));
+    Review { items, rates }
+}
+
+/// Accounts sharing an e-mail whose bindings disagree, with no operator-authored
+/// binding explaining the split.
+fn binding_conflicts(
+    by_email: &HashMap<String, Vec<&EvidenceAccount>>,
+    bindings: &HashMap<SourceAccountKey, KnownBinding>,
+) -> Vec<QueueItem> {
+    let mut conflicts = Vec::new();
+
+    for group in by_email.values() {
+        let bound: Vec<KnownBinding> = group
+            .iter()
+            .filter_map(|a| bindings.get(&a.account).copied())
+            .filter(|b| b.person_id != EXCLUDED_PERSON)
+            .collect();
+
+        let mut persons: Vec<Uuid> = bound.iter().map(|b| b.person_id).collect();
+        persons.sort();
+        persons.dedup();
+        if persons.len() < 2 || bound.iter().any(KnownBinding::is_operator_authored) {
+            continue; // consistent, or a human already settled the split
+        }
+
+        for account in group {
+            conflicts.push(item(ItemKind::BindingConflict, account, persons.clone()));
+        }
+    }
+
+    conflicts
+}
+
+/// Persons currently claiming any of the account's identity values.
+fn candidates_for(
+    account: &EvidenceAccount,
+    by_email: &HashMap<String, Vec<&EvidenceAccount>>,
+    bindings: &HashMap<SourceAccountKey, KnownBinding>,
+) -> Vec<Uuid> {
+    let Some(email) = account.email.as_deref().map(normalize_email) else {
+        return Vec::new();
+    };
+    let Some(group) = by_email.get(&email) else {
+        return Vec::new();
+    };
+
+    let mut persons: Vec<Uuid> = group
+        .iter()
+        .filter_map(|a| bindings.get(&a.account))
+        .map(|b| b.person_id)
+        .filter(|p| *p != EXCLUDED_PERSON)
+        .collect();
+    persons.sort();
+    persons.dedup();
+    persons
+}
+
+fn has_evidence(account: &EvidenceAccount) -> bool {
+    account.email.is_some() || account.username.is_some()
+}
+
+fn item(kind: ItemKind, account: &EvidenceAccount, candidates: Vec<Uuid>) -> QueueItem {
+    QueueItem {
+        kind,
+        account: account.account.clone(),
+        email: account.email.clone(),
+        username: account.username.clone(),
+        candidates,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn account(source_type: &str, id: &str) -> SourceAccountKey {
+        SourceAccountKey {
+            source_type: source_type.to_owned(),
+            source_id: Uuid::from_u128(1),
+            account_id: id.to_owned(),
+        }
+    }
+
+    fn observed(source_type: &str, id: &str, email: Option<&str>) -> EvidenceAccount {
+        EvidenceAccount {
+            account: account(source_type, id),
+            email: email.map(str::to_owned),
+            username: None,
+            is_closed: false,
+        }
+    }
+
+    fn seed_bound(person: u128) -> KnownBinding {
+        KnownBinding {
+            person_id: Uuid::from_u128(person),
+            author_person_id: Uuid::nil(),
+        }
+    }
+
+    fn operator_bound(person: u128) -> KnownBinding {
+        KnownBinding {
+            person_id: Uuid::from_u128(person),
+            author_person_id: Uuid::from_u128(0xAD_1119),
+        }
+    }
+
+    #[test]
+    fn accounts_without_identity_evidence_are_surfaced_not_hidden() {
+        let review = build(vec![observed("jira", "jr-1", None)], &HashMap::new());
+
+        assert_eq!(review.items.len(), 1);
+        assert_eq!(review.items[0].kind, ItemKind::NoEvidence);
+        assert_eq!(review.rates.no_evidence, 1);
+        assert_eq!(review.rates.observed, 1);
+    }
+
+    #[test]
+    fn an_unbound_account_with_a_contested_email_lists_its_candidates() {
+        let anna = observed("github", "gh-1", Some("team@example.com"));
+        let boris = observed("jira", "jr-1", Some("team@example.com"));
+        let newcomer = observed("slack", "slk-1", Some("TEAM@example.com"));
+        let mut bindings = HashMap::new();
+        bindings.insert(anna.account.clone(), seed_bound(5));
+        bindings.insert(boris.account.clone(), operator_bound(6));
+
+        let review = build(vec![anna, boris, newcomer.clone()], &bindings);
+
+        let contested: Vec<&QueueItem> = review
+            .items
+            .iter()
+            .filter(|i| i.kind == ItemKind::Contested)
+            .collect();
+        assert_eq!(contested.len(), 1, "only the unbound newcomer is pending");
+        assert_eq!(contested[0].account, newcomer.account);
+        assert_eq!(
+            contested[0].candidates,
+            vec![Uuid::from_u128(5), Uuid::from_u128(6)]
+        );
+        assert_eq!(review.rates.bound, 2);
+        assert_eq!(review.rates.pending, 1);
+    }
+
+    #[test]
+    fn operator_settled_divergence_is_not_a_conflict() {
+        let anna = observed("github", "gh-1", Some("team@example.com"));
+        let boris = observed("jira", "jr-1", Some("team@example.com"));
+        let mut bindings = HashMap::new();
+        bindings.insert(anna.account.clone(), seed_bound(5));
+        bindings.insert(boris.account.clone(), operator_bound(6));
+
+        let review = build(vec![anna, boris], &bindings);
+
+        assert!(
+            !review
+                .items
+                .iter()
+                .any(|i| i.kind == ItemKind::BindingConflict),
+            "a human already settled this split"
+        );
+    }
+
+    #[test]
+    fn all_seed_divergence_surfaces_as_a_binding_conflict() {
+        let a = observed("github", "gh-1", Some("legacy@example.com"));
+        let b = observed("jira", "jr-1", Some("legacy@example.com"));
+        let mut bindings = HashMap::new();
+        bindings.insert(a.account.clone(), seed_bound(17));
+        bindings.insert(b.account.clone(), seed_bound(23));
+
+        let review = build(vec![a, b], &bindings);
+
+        let conflicts: Vec<&QueueItem> = review
+            .items
+            .iter()
+            .filter(|i| i.kind == ItemKind::BindingConflict)
+            .collect();
+        assert_eq!(conflicts.len(), 2, "both accounts of the group are shown");
+        assert_eq!(
+            conflicts[0].candidates,
+            vec![Uuid::from_u128(17), Uuid::from_u128(23)]
+        );
+    }
+
+    #[test]
+    fn closed_accounts_leave_the_queue() {
+        let mut closed = observed("github", "gh-9", None);
+        closed.is_closed = true;
+
+        let review = build(vec![closed], &HashMap::new());
+
+        assert!(
+            review.items.is_empty(),
+            "a closed account needs no decision"
+        );
+        assert_eq!(review.rates.observed, 0);
+    }
+
+    #[test]
+    fn excluded_accounts_are_counted_but_never_shown() {
+        let bot = observed("github", "gh-bot", Some("ci@example.com"));
+        let mut bindings = HashMap::new();
+        bindings.insert(
+            bot.account.clone(),
+            KnownBinding {
+                person_id: EXCLUDED_PERSON,
+                author_person_id: Uuid::from_u128(0xAD_1119),
+            },
+        );
+
+        let review = build(vec![bot], &bindings);
+
+        assert!(review.items.is_empty());
+        assert_eq!(review.rates.excluded, 1);
+        assert_eq!(review.rates.bound, 0, "excluded is its own state");
+    }
+}

--- a/src/backend/services/identity-resolution/src/domain/review_queue.rs
+++ b/src/backend/services/identity-resolution/src/domain/review_queue.rs
@@ -22,7 +22,10 @@ pub enum ItemKind {
     /// The account's identity value is shared by accounts bound to different
     /// persons, with no operator decision explaining the divergence.
     BindingConflict,
-    /// The account carries no usable identity evidence — visible, never hidden.
+    /// The account carries no identity evidence automation can match on —
+    /// e-mail is the only matching key today, so a username-only account is
+    /// here too (shown with its username). Visible, never hidden: nothing
+    /// will ever bind these but an operator.
     NoEvidence,
 }
 
@@ -92,7 +95,7 @@ pub fn build(
         match bindings.get(&account.account) {
             Some(binding) if binding.person_id == EXCLUDED_PERSON => rates.excluded += 1,
             Some(_) => rates.bound += 1,
-            None if !has_evidence(account) => {
+            None if !has_matchable_evidence(account) => {
                 rates.no_evidence += 1;
                 items.push(item(ItemKind::NoEvidence, account, Vec::new()));
             }
@@ -102,8 +105,9 @@ pub fn build(
                     rates.pending += 1;
                     items.push(item(ItemKind::Contested, account, candidates));
                 } else {
-                    // One candidate or none: automation will bind it on its next
-                    // run, so it is not the operator's problem yet.
+                    // One candidate or none: the account has an e-mail, so
+                    // automation will bind it on its next run — not the
+                    // operator's problem yet.
                     rates.pending += 1;
                 }
             }
@@ -186,8 +190,11 @@ fn candidates_for(
     persons
 }
 
-fn has_evidence(account: &EvidenceAccount) -> bool {
-    account.email.is_some() || account.username.is_some()
+// A username is displayed but cannot match anyone (the seed links by e-mail
+// only), so counting it as evidence would leave a username-only account
+// invisible forever: pending, never surfaced, never auto-bound.
+fn has_matchable_evidence(account: &EvidenceAccount) -> bool {
+    account.email.is_some()
 }
 
 fn item(kind: ItemKind, account: &EvidenceAccount, candidates: Vec<Uuid>) -> QueueItem {
@@ -243,6 +250,23 @@ mod tests {
         assert_eq!(review.items[0].kind, ItemKind::NoEvidence);
         assert_eq!(review.rates.no_evidence, 1);
         assert_eq!(review.rates.observed, 1);
+    }
+
+    #[test]
+    fn a_username_only_account_is_surfaced_because_nothing_can_match_it() {
+        // A username is shown to the operator but the seed links by e-mail
+        // only: were the username counted as evidence, this account would sit
+        // in `pending` forever with no queue item and no automation to come.
+        let mut orphan = observed("github", "gh-1", None);
+        orphan.username = Some("octocat".to_owned());
+
+        let review = build(vec![orphan], &HashMap::new());
+
+        assert_eq!(review.items.len(), 1);
+        assert_eq!(review.items[0].kind, ItemKind::NoEvidence);
+        assert_eq!(review.items[0].username.as_deref(), Some("octocat"));
+        assert_eq!(review.rates.no_evidence, 1);
+        assert_eq!(review.rates.pending, 0);
     }
 
     #[test]

--- a/src/backend/services/identity-resolution/src/domain/review_queue.rs
+++ b/src/backend/services/identity-resolution/src/domain/review_queue.rs
@@ -12,7 +12,9 @@ use uuid::Uuid;
 use super::resolution::EXCLUDED_PERSON;
 use super::seed::{KnownBinding, SourceAccountKey, normalize_email};
 
-/// Why an account is on the queue.
+/// Why an account is on the queue. The discriminant orders the queue: a
+/// contested account is the operator's most actionable item, a no-evidence one
+/// the least.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ItemKind {
     /// The account's identity evidence is claimed by more than one person.
@@ -109,6 +111,24 @@ pub fn build(
     }
 
     items.extend(binding_conflicts(&by_email, bindings));
+
+    // The queue is truncated by the caller, so its order must not depend on
+    // hash iteration: the same data must surface the same items every build.
+    items.sort_by(|a, b| {
+        (
+            a.kind as u8,
+            &a.account.source_type,
+            a.account.source_id,
+            &a.account.account_id,
+        )
+            .cmp(&(
+                b.kind as u8,
+                &b.account.source_type,
+                b.account.source_id,
+                &b.account.account_id,
+            ))
+    });
+
     Review { items, rates }
 }
 
@@ -289,6 +309,24 @@ mod tests {
         assert_eq!(
             conflicts[0].candidates,
             vec![Uuid::from_u128(17), Uuid::from_u128(23)]
+        );
+    }
+
+    #[test]
+    fn queue_order_is_stable_across_builds() {
+        let a = observed("github", "gh-1", Some("legacy@example.com"));
+        let b = observed("jira", "jr-1", Some("legacy@example.com"));
+        let orphan = observed("slack", "slk-9", None);
+        let mut bindings = HashMap::new();
+        bindings.insert(a.account.clone(), seed_bound(17));
+        bindings.insert(b.account.clone(), seed_bound(23));
+
+        let first = build(vec![a.clone(), b.clone(), orphan.clone()], &bindings);
+        let again = build(vec![orphan, b, a], &bindings);
+
+        assert_eq!(
+            first.items, again.items,
+            "input order must not change what the operator sees"
         );
     }
 

--- a/src/backend/services/identity-resolution/src/domain/seed.rs
+++ b/src/backend/services/identity-resolution/src/domain/seed.rs
@@ -11,6 +11,7 @@ use sea_orm::prelude::DateTime;
 use uuid::Uuid;
 
 use super::observation_slot::SlotAllocator;
+use super::resolution::EXCLUDED_PERSON;
 
 /// Identifies one source-native account: the source instance (`source_type` +
 /// `source_id`) plus the account's native id within it.
@@ -125,6 +126,10 @@ pub struct ResolveOutcome {
     /// Unbound accounts inside a divergent e-mail group: their e-mail is
     /// contested evidence, so they are not auto-linked to anyone.
     pub skipped_contested_email: usize,
+    /// Accounts bound to the excluded person (ADR-0003). They are not persons:
+    /// nothing is re-emitted for them, and their values link nobody —
+    /// automation may not spread an operator's exclusion to new accounts.
+    pub skipped_excluded: usize,
 }
 
 /// Case-fold an email for grouping / lookup (ADR-0011: matched
@@ -185,13 +190,26 @@ pub fn resolve_assignments(
     let mut out = ResolveOutcome::default();
 
     for group in groups {
+        // 0. Excluded accounts (bound to the sentinel) are not persons: they
+        //    contribute no new observations, and they leave the group before
+        //    any linking decision so their values claim nobody. The exclusion
+        //    itself stays in force — its journal row is already the latest.
+        let (excluded, remaining): (Vec<_>, Vec<_>) = group.profiles.into_iter().partition(|p| {
+            known
+                .get(&p.account)
+                .is_some_and(|b| b.person_id == EXCLUDED_PERSON)
+        });
+        out.skipped_excluded += excluded.len();
+        if remaining.is_empty() {
+            continue;
+        }
+
         // 1. Known bindings win — and each bound account keeps its own person.
         //    A group whose accounts are bound to different persons is an
         //    intentional split when any binding is operator-authored (ADR-0003);
         //    otherwise it is a conflict to surface. Either way the e-mail is
         //    contested evidence, so unbound group members are not auto-linked.
-        let (bound, unbound): (Vec<_>, Vec<_>) = group
-            .profiles
+        let (bound, unbound): (Vec<_>, Vec<_>) = remaining
             .into_iter()
             .partition(|p| known.contains_key(&p.account));
         if !bound.is_empty() {
@@ -263,8 +281,14 @@ pub fn resolve_assignments(
             continue;
         };
 
-        // 2. Email matches an existing person → link.
-        if let Some(&pid) = email_to_person.get(&email) {
+        // 2. Email matches an existing person → link. A map entry naming the
+        //    excluded sentinel (legacy rows from before exclusions stopped
+        //    re-emitting) is no person and links nobody — fall through to mint.
+        let linked = email_to_person
+            .get(&email)
+            .copied()
+            .filter(|pid| *pid != EXCLUDED_PERSON);
+        if let Some(pid) = linked {
             out.linked_by_email += group.profiles.len();
             out.assignments.push(PersonAssignment {
                 person_id: pid,
@@ -686,6 +710,84 @@ mod tests {
         assert_eq!(out.reused_known, 2, "bound accounts keep their persons");
         let assigned: usize = out.assignments.iter().map(|a| a.profiles.len()).sum();
         assert_eq!(assigned, 2, "the newcomer is in no assignment");
+    }
+
+    fn excluded_bound() -> KnownBinding {
+        KnownBinding {
+            person_id: EXCLUDED_PERSON,
+            author_person_id: Uuid::from_u128(0xAD_1119),
+        }
+    }
+
+    #[test]
+    fn excluded_accounts_are_skipped_and_their_email_links_nobody() {
+        // A bot was excluded by an operator. The seed must not re-emit its
+        // observations under the sentinel, and a new account sharing the bot's
+        // e-mail must not inherit the exclusion — automation may not decide
+        // "not a person". The newcomer is its own fresh person.
+        let bot = prof("github", "gh-bot", Some("ci@corp.com"), false);
+        let newcomer = prof("jira", "jr-1", Some("ci@corp.com"), false);
+        let mut known = HashMap::new();
+        known.insert(bot.account.clone(), excluded_bound());
+
+        let out = resolve_assignments(
+            group_by_email(vec![bot, newcomer]),
+            &known,
+            &HashMap::new(),
+            counter(),
+        );
+
+        assert_eq!(out.skipped_excluded, 1, "the bot contributes nothing");
+        assert_eq!(out.minted, 1, "the newcomer is a fresh person");
+        assert_eq!(out.assignments.len(), 1);
+        assert_ne!(out.assignments[0].person_id, EXCLUDED_PERSON);
+        assert_eq!(out.assignments[0].profiles[0].account.account_id, "jr-1");
+    }
+
+    #[test]
+    fn an_exclusion_does_not_settle_someone_elses_divergence() {
+        // Two automation bindings disagree AND a third account of the group is
+        // excluded. The exclusion is an operator decision about the BOT, not
+        // about the 5/6 split — the conflict must still surface (the review
+        // queue classifies it the same way).
+        let acc_a = prof("slack", "U1", Some("team@corp.com"), false);
+        let acc_b = prof("github", "gh1", Some("team@corp.com"), false);
+        let bot = prof("zoom", "Z9", Some("team@corp.com"), false);
+        let mut known = HashMap::new();
+        known.insert(acc_a.account.clone(), seed_bound(5));
+        known.insert(acc_b.account.clone(), seed_bound(6));
+        known.insert(bot.account.clone(), excluded_bound());
+
+        let out = resolve_assignments(
+            group_by_email(vec![acc_a, acc_b, bot]),
+            &known,
+            &HashMap::new(),
+            counter(),
+        );
+
+        assert_eq!(out.known_binding_conflicts, 1, "the split still surfaces");
+        assert_eq!(out.operator_settled_groups, 0);
+        assert_eq!(out.skipped_excluded, 1);
+    }
+
+    #[test]
+    fn a_legacy_email_map_entry_naming_the_sentinel_links_nobody() {
+        // Seeds that ran before exclusions stopped re-emitting may have left
+        // e-mail rows under the sentinel; such a map entry is not a person.
+        let newcomer = prof("jira", "jr-1", Some("ci@corp.com"), false);
+        let mut email_map = HashMap::new();
+        email_map.insert("ci@corp.com".to_owned(), EXCLUDED_PERSON);
+
+        let out = resolve_assignments(
+            group_by_email(vec![newcomer]),
+            &HashMap::new(),
+            &email_map,
+            counter(),
+        );
+
+        assert_eq!(out.linked_by_email, 0, "the sentinel links nobody");
+        assert_eq!(out.minted, 1);
+        assert_ne!(out.assignments[0].person_id, EXCLUDED_PERSON);
     }
 
     fn input(

--- a/src/backend/services/identity-resolution/src/domain/seed.rs
+++ b/src/backend/services/identity-resolution/src/domain/seed.rs
@@ -1,10 +1,13 @@
 //! Persons-seed domain: group source-account profiles and resolve each group to
 //! a `person_id` — the **write-side** identity resolution (what the read side
-//! only looks up). Pure logic, no DB / IO, mirroring the .NET
-//! `EmailProfileResolver` + `PersonAssignmentResolver`.
+//! only looks up). Pure logic, no DB / IO. Ported from the .NET
+//! `EmailProfileResolver` + `PersonAssignmentResolver`, with one deliberate
+//! deviation: divergent e-mail groups keep per-account bindings (classified by
+//! binding author) instead of collapsing onto the first binding.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
+use chrono::TimeDelta;
 use sea_orm::prelude::DateTime;
 use uuid::Uuid;
 
@@ -65,6 +68,24 @@ pub struct ProfileGroup {
     pub profiles: Vec<SeedProfile>,
 }
 
+/// An account's current binding as loaded from `persons`: the person plus who
+/// authored the binding row. Authorship decides conflict classification — an
+/// operator-authored binding marks divergence inside an e-mail group as an
+/// intentional, settled state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct KnownBinding {
+    pub person_id: Uuid,
+    pub author_person_id: Uuid,
+}
+
+impl KnownBinding {
+    /// The all-zero author is the seed sentinel; any real UUID is an operator.
+    #[must_use]
+    pub fn is_operator_authored(&self) -> bool {
+        !self.author_person_id.is_nil()
+    }
+}
+
 /// How a group's `person_id` was decided.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AssignmentKind {
@@ -93,11 +114,16 @@ pub struct ResolveOutcome {
     pub minted: usize,
     pub skipped_closed: usize,
     pub skipped_no_email: usize,
-    /// Email groups whose accounts were already bound to *more than one*
-    /// existing person; the group is still collapsed onto the first binding
-    /// (parity with the .NET resolver), but the conflict is counted + logged
-    /// so a silent identity merge is observable.
+    /// Email groups whose accounts are bound to *more than one* person with no
+    /// operator-authored binding explaining it. Each account keeps its own
+    /// binding (never collapsed); the group is counted + logged for review.
     pub known_binding_conflicts: usize,
+    /// Divergent e-mail groups where at least one binding is operator-authored
+    /// — an intentional split, kept silent (not a conflict).
+    pub operator_settled_groups: usize,
+    /// Unbound accounts inside a divergent e-mail group: their e-mail is
+    /// contested evidence, so they are not auto-linked to anyone.
+    pub skipped_contested_email: usize,
 }
 
 /// Case-fold an email for grouping / lookup (ADR-0011: matched
@@ -142,50 +168,85 @@ pub fn group_by_email(profiles: Vec<SeedProfile>) -> Vec<ProfileGroup> {
     groups
 }
 
-/// Resolve each group to a `person_id` via the .NET four-branch classification,
-/// in priority order: reuse an already-bound account (idempotent); else link to
-/// the person the group's email already maps to; else mint a fresh person when
-/// at least one profile is active; else skip (no email, or all closed). `mint`
-/// is injected so tests are deterministic.
+/// Resolve each group to a `person_id`, in priority order: reuse already-bound
+/// accounts (idempotent — each account keeps **its own** binding, never
+/// collapsed across a divergent group); else link to the person the group's
+/// email already maps to; else mint a fresh person when at least one profile
+/// is active; else skip (no email, or all closed). `mint` is injected so tests
+/// are deterministic.
 #[must_use]
 pub fn resolve_assignments(
     groups: Vec<ProfileGroup>,
-    known: &HashMap<SourceAccountKey, Uuid>,
+    known: &HashMap<SourceAccountKey, KnownBinding>,
     email_to_person: &HashMap<String, Uuid>,
     mut mint: impl FnMut() -> Uuid,
 ) -> ResolveOutcome {
     let mut out = ResolveOutcome::default();
 
     for group in groups {
-        // 1. Known binding wins — reuse the person for the whole group, even
-        //    when the group also has no email (idempotent re-seed). If the
-        //    group's accounts are bound to *different* persons (e.g. an email
-        //    reassigned after a departure), we still collapse onto the first
-        //    binding for .NET parity, but surface the conflict — otherwise the
-        //    other account's identity is silently merged away.
-        let bound: Vec<Uuid> = group
+        // 1. Known bindings win — and each bound account keeps its own person.
+        //    A group whose accounts are bound to different persons is an
+        //    intentional split when any binding is operator-authored (ADR-0003);
+        //    otherwise it is a conflict to surface. Either way the e-mail is
+        //    contested evidence, so unbound group members are not auto-linked.
+        let (bound, unbound): (Vec<_>, Vec<_>) = group
             .profiles
-            .iter()
-            .filter_map(|p| known.get(&p.account).copied())
-            .collect();
-        if let Some(&pid) = bound.first() {
-            if bound.iter().any(|&other| other != pid) {
-                out.known_binding_conflicts += 1;
-                tracing::warn!(
-                    person_id = %pid,
-                    accounts = group.profiles.len(),
-                    "persons-seed: group accounts bound to multiple persons; \
-                     collapsing onto the first (possible identity merge)"
-                );
+            .into_iter()
+            .partition(|p| known.contains_key(&p.account));
+        if !bound.is_empty() {
+            let bindings: Vec<KnownBinding> = bound.iter().map(|p| known[&p.account]).collect();
+            let first_person = bindings[0].person_id;
+            let divergent = bindings.iter().any(|b| b.person_id != first_person);
+
+            if divergent {
+                if bindings.iter().any(KnownBinding::is_operator_authored) {
+                    out.operator_settled_groups += 1;
+                } else {
+                    out.known_binding_conflicts += 1;
+                    tracing::warn!(
+                        accounts = bound.len(),
+                        "persons-seed: group accounts bound to multiple persons \
+                         with no operator decision; keeping each binding, \
+                         surfacing for review"
+                    );
+                }
+
+                let mut by_person: HashMap<Uuid, Vec<SeedProfile>> = HashMap::new();
+                for profile in bound {
+                    let person = known[&profile.account].person_id;
+                    by_person.entry(person).or_default().push(profile);
+                }
+                for (person_id, profiles) in by_person {
+                    out.reused_known += profiles.len();
+                    out.assignments.push(PersonAssignment {
+                        person_id,
+                        kind: AssignmentKind::ReusedKnown,
+                        profiles,
+                    });
+                }
+
+                if !unbound.is_empty() {
+                    out.skipped_contested_email += unbound.len();
+                    tracing::warn!(
+                        accounts = unbound.len(),
+                        "persons-seed: e-mail contested between persons; \
+                         not auto-linking new accounts"
+                    );
+                }
+                continue;
             }
-            out.reused_known += group.profiles.len();
+
+            let mut profiles = bound;
+            profiles.extend(unbound);
+            out.reused_known += profiles.len();
             out.assignments.push(PersonAssignment {
-                person_id: pid,
+                person_id: first_person,
                 kind: AssignmentKind::ReusedKnown,
-                profiles: group.profiles,
+                profiles,
             });
             continue;
         }
+        let group = ProfileGroup { profiles: unbound };
 
         // The group's email — shared by every profile in an email group;
         // singleton no-email groups have none. (`first` is always `Some` here —
@@ -334,13 +395,22 @@ pub fn build_profiles(rows: Vec<IdentityInputRow>) -> Vec<SeedProfile> {
 /// each upsert observation, routed into its value column and stamped with the
 /// group's `person_id` and the seed author. Email-linked assignments carry the
 /// `auto-seed-link` reason; reused / minted carry an empty reason (matching the
-/// .NET seeder). Over-limit values are dropped. Mirrors `BuildObservationRows`.
+/// .NET seeder). Over-limit values are dropped.
+///
+/// The natural observation key ends in `created_at` and carries no account
+/// discriminator, so two accounts of one source resolving to one person at the
+/// same `synced_at` would collide on their `value_type='id'` rows and
+/// `INSERT IGNORE` would drop one binding. Rows are therefore nudged forward by
+/// whole microseconds until the key is unique within the batch — the smallest
+/// step `DATETIME(6)` can store, keeping observation chronology intact.
 #[must_use]
 pub fn assignments_to_rows(
     assignments: &[PersonAssignment],
     author_person_id: Uuid,
 ) -> Vec<SeedObservationRow> {
     let mut rows = Vec::new();
+    let mut taken: HashSet<ObservationKey> = HashSet::new();
+
     for assignment in assignments {
         let reason = if assignment.kind == AssignmentKind::LinkedByEmail {
             AUTO_SEED_LINK_REASON
@@ -353,6 +423,9 @@ pub fn assignments_to_rows(
                 if value_id.is_none() && value_full_text.is_none() && value.is_none() {
                     continue; // oversized — dropped per the routing rule
                 }
+
+                let created_at = next_free_slot(&mut taken, assignment.person_id, obs);
+
                 rows.push(SeedObservationRow {
                     value_type: obs.value_type.clone(),
                     source_type: obs.source_type.clone(),
@@ -363,12 +436,43 @@ pub fn assignments_to_rows(
                     person_id: assignment.person_id,
                     author_person_id,
                     reason: Some(reason.to_owned()),
-                    created_at: obs.synced_at,
+                    created_at,
                 });
             }
         }
     }
     rows
+}
+
+/// The columns of `uq_person_observation` this builder controls (the tenant is
+/// bound once per run by the caller).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ObservationKey {
+    person_id: Uuid,
+    source_type: String,
+    source_id: Uuid,
+    value_type: String,
+    created_at: DateTime,
+}
+
+/// Claim the observation's own timestamp, or the next whole microsecond that is
+/// still free for this key.
+fn next_free_slot(
+    taken: &mut HashSet<ObservationKey>,
+    person_id: Uuid,
+    obs: &IdentityInputRow,
+) -> DateTime {
+    let mut key = ObservationKey {
+        person_id,
+        source_type: obs.source_type.clone(),
+        source_id: obs.source_id,
+        value_type: obs.value_type.clone(),
+        created_at: obs.synced_at,
+    };
+    while !taken.insert(key.clone()) {
+        key.created_at += TimeDelta::microseconds(1);
+    }
+    key.created_at
 }
 
 #[cfg(test)]
@@ -389,6 +493,20 @@ mod tests {
     }
 
     /// A minting factory yielding Uuid(1), Uuid(2), … deterministically.
+    fn seed_bound(person: u128) -> KnownBinding {
+        KnownBinding {
+            person_id: Uuid::from_u128(person),
+            author_person_id: Uuid::nil(),
+        }
+    }
+
+    fn operator_bound(person: u128) -> KnownBinding {
+        KnownBinding {
+            person_id: Uuid::from_u128(person),
+            author_person_id: Uuid::from_u128(0xAD_1119),
+        }
+    }
+
     fn counter() -> impl FnMut() -> Uuid {
         let mut n = 0u128;
         move || {
@@ -462,7 +580,7 @@ mod tests {
     fn reuses_known_account_binding_over_email() {
         let p = prof("bamboohr", "1", Some("anna@corp.com"), false);
         let mut known = HashMap::new();
-        known.insert(p.account.clone(), Uuid::from_u128(42)); // already bound
+        known.insert(p.account.clone(), seed_bound(42)); // already bound
         let mut email_map = HashMap::new();
         email_map.insert("anna@corp.com".to_owned(), Uuid::from_u128(99)); // different person!
 
@@ -493,7 +611,7 @@ mod tests {
         let known_acc = prof("slack", "U1", Some("anna@corp.com"), false);
         let new_acc = prof("github", "gh1", Some("anna@corp.com"), false);
         let mut known = HashMap::new();
-        known.insert(known_acc.account.clone(), Uuid::from_u128(5));
+        known.insert(known_acc.account.clone(), seed_bound(5));
 
         let out = resolve_assignments(
             group_by_email(vec![known_acc, new_acc]),
@@ -512,16 +630,15 @@ mod tests {
     }
 
     #[test]
-    fn multi_person_binding_conflict_collapses_and_is_counted() {
-        // Two accounts share an email but are already bound to two *different*
-        // persons (email reassigned after a departure). The group still
-        // collapses onto the first binding (.NET parity), but the conflict is
-        // counted so the silent identity merge is observable.
+    fn divergent_group_keeps_each_accounts_own_binding() {
+        // Two accounts share an email but are bound to two *different* persons
+        // with no operator decision: each keeps its own binding (never
+        // collapsed) and the group is counted as a conflict for review.
         let acc_a = prof("slack", "U1", Some("anna@corp.com"), false);
         let acc_b = prof("github", "gh1", Some("anna@corp.com"), false);
         let mut known = HashMap::new();
-        known.insert(acc_a.account.clone(), Uuid::from_u128(5));
-        known.insert(acc_b.account.clone(), Uuid::from_u128(6));
+        known.insert(acc_a.account.clone(), seed_bound(5));
+        known.insert(acc_b.account.clone(), seed_bound(6));
 
         let out = resolve_assignments(
             group_by_email(vec![acc_a, acc_b]),
@@ -529,12 +646,68 @@ mod tests {
             &HashMap::new(),
             counter(),
         );
-        assert_eq!(out.assignments.len(), 1, "group collapsed onto one person");
+
+        assert_eq!(out.assignments.len(), 2, "one assignment per binding");
+        let mut persons: Vec<Uuid> = out.assignments.iter().map(|a| a.person_id).collect();
+        persons.sort();
+        assert_eq!(persons, vec![Uuid::from_u128(5), Uuid::from_u128(6)]);
         assert_eq!(out.reused_known, 2);
         assert_eq!(
             out.known_binding_conflicts, 1,
-            "conflict detected + counted"
+            "all-seed divergence surfaces"
         );
+        assert_eq!(out.operator_settled_groups, 0);
+    }
+
+    #[test]
+    fn operator_authored_divergence_is_settled_not_a_conflict() {
+        // Same divergence, but one binding was written by an operator (a detach
+        // decision): the split is intentional — no conflict is counted.
+        let acc_a = prof("slack", "U1", Some("team@corp.com"), false);
+        let acc_b = prof("github", "gh1", Some("team@corp.com"), false);
+        let mut known = HashMap::new();
+        known.insert(acc_a.account.clone(), seed_bound(5));
+        known.insert(acc_b.account.clone(), operator_bound(6));
+
+        let out = resolve_assignments(
+            group_by_email(vec![acc_a, acc_b]),
+            &known,
+            &HashMap::new(),
+            counter(),
+        );
+
+        assert_eq!(out.assignments.len(), 2);
+        assert_eq!(
+            out.known_binding_conflicts, 0,
+            "operator decision settles it"
+        );
+        assert_eq!(out.operator_settled_groups, 1);
+    }
+
+    #[test]
+    fn contested_email_does_not_auto_link_new_accounts() {
+        // A divergent group's e-mail is contested evidence: a brand-new account
+        // arriving with it is neither linked to either person nor minted — it
+        // is left for the operator (skipped + counted).
+        let acc_a = prof("slack", "U1", Some("team@corp.com"), false);
+        let acc_b = prof("github", "gh1", Some("team@corp.com"), false);
+        let newcomer = prof("zoom", "Z9", Some("team@corp.com"), false);
+        let mut known = HashMap::new();
+        known.insert(acc_a.account.clone(), seed_bound(5));
+        known.insert(acc_b.account.clone(), operator_bound(6));
+
+        let out = resolve_assignments(
+            group_by_email(vec![acc_a, acc_b, newcomer]),
+            &known,
+            &HashMap::new(),
+            counter(),
+        );
+
+        assert_eq!(out.skipped_contested_email, 1, "newcomer not auto-linked");
+        assert_eq!(out.minted, 0);
+        assert_eq!(out.reused_known, 2, "bound accounts keep their persons");
+        let assigned: usize = out.assignments.iter().map(|a| a.profiles.len()).sum();
+        assert_eq!(assigned, 2, "the newcomer is in no assignment");
     }
 
     fn input(
@@ -554,6 +727,64 @@ mod tests {
             synced_at,
             is_delete,
         }
+    }
+
+    #[test]
+    fn same_source_accounts_on_one_person_get_distinct_timestamps() -> anyhow::Result<()> {
+        // Two accounts of one source resolve to one person and were synced at
+        // the same instant: their `id` observations share every natural-key
+        // column, so without disambiguation INSERT IGNORE would drop one
+        // binding. Rows must land on distinct microseconds.
+        let t: DateTime = "2026-01-01T00:00:00".parse()?;
+        let mut a = prof("bamboohr", "1", Some("anna@corp.com"), false);
+        let mut b = prof("bamboohr", "2", Some("anna@corp.com"), false);
+        a.observations = vec![input("bamboohr", "1", "id", "1", false, t)];
+        b.observations = vec![input("bamboohr", "2", "id", "2", false, t)];
+
+        let rows = assignments_to_rows(
+            &[PersonAssignment {
+                person_id: Uuid::from_u128(7),
+                kind: AssignmentKind::Minted,
+                profiles: vec![a, b],
+            }],
+            Uuid::nil(),
+        );
+
+        assert_eq!(rows.len(), 2);
+        assert_ne!(
+            rows[0].created_at, rows[1].created_at,
+            "colliding natural keys must be nudged apart"
+        );
+        assert_eq!(rows[0].created_at, t, "the first row keeps its own instant");
+        assert_eq!(rows[1].created_at, t + TimeDelta::microseconds(1));
+        Ok(())
+    }
+
+    #[test]
+    fn distinct_value_types_at_one_instant_keep_their_timestamp() -> anyhow::Result<()> {
+        // Different value_types are already distinct in the natural key — no
+        // nudging, so observation chronology stays exactly as observed.
+        let t: DateTime = "2026-01-01T00:00:00".parse()?;
+        let mut p = prof("bamboohr", "1", Some("anna@corp.com"), false);
+        p.observations = vec![
+            input("bamboohr", "1", "id", "1", false, t),
+            input("bamboohr", "1", "email", "anna@corp.com", false, t),
+        ];
+
+        let rows = assignments_to_rows(
+            &[PersonAssignment {
+                person_id: Uuid::from_u128(7),
+                kind: AssignmentKind::Minted,
+                profiles: vec![p],
+            }],
+            Uuid::nil(),
+        );
+
+        assert!(
+            rows.iter().all(|r| r.created_at == t),
+            "distinct value_types do not collide"
+        );
+        Ok(())
     }
 
     #[test]

--- a/src/backend/services/identity-resolution/src/domain/seed.rs
+++ b/src/backend/services/identity-resolution/src/domain/seed.rs
@@ -5,11 +5,12 @@
 //! deviation: divergent e-mail groups keep per-account bindings (classified by
 //! binding author) instead of collapsing onto the first binding.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
-use chrono::TimeDelta;
 use sea_orm::prelude::DateTime;
 use uuid::Uuid;
+
+use super::observation_slot::SlotAllocator;
 
 /// Identifies one source-native account: the source instance (`source_type` +
 /// `source_id`) plus the account's native id within it.
@@ -409,7 +410,7 @@ pub fn assignments_to_rows(
     author_person_id: Uuid,
 ) -> Vec<SeedObservationRow> {
     let mut rows = Vec::new();
-    let mut taken: HashSet<ObservationKey> = HashSet::new();
+    let mut slots = SlotAllocator::new();
 
     for assignment in assignments {
         let reason = if assignment.kind == AssignmentKind::LinkedByEmail {
@@ -424,7 +425,13 @@ pub fn assignments_to_rows(
                     continue; // oversized — dropped per the routing rule
                 }
 
-                let created_at = next_free_slot(&mut taken, assignment.person_id, obs);
+                let created_at = slots.claim(
+                    assignment.person_id,
+                    &obs.source_type,
+                    obs.source_id,
+                    &obs.value_type,
+                    obs.synced_at,
+                );
 
                 rows.push(SeedObservationRow {
                     value_type: obs.value_type.clone(),
@@ -444,39 +451,10 @@ pub fn assignments_to_rows(
     rows
 }
 
-/// The columns of `uq_person_observation` this builder controls (the tenant is
-/// bound once per run by the caller).
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-struct ObservationKey {
-    person_id: Uuid,
-    source_type: String,
-    source_id: Uuid,
-    value_type: String,
-    created_at: DateTime,
-}
-
-/// Claim the observation's own timestamp, or the next whole microsecond that is
-/// still free for this key.
-fn next_free_slot(
-    taken: &mut HashSet<ObservationKey>,
-    person_id: Uuid,
-    obs: &IdentityInputRow,
-) -> DateTime {
-    let mut key = ObservationKey {
-        person_id,
-        source_type: obs.source_type.clone(),
-        source_id: obs.source_id,
-        value_type: obs.value_type.clone(),
-        created_at: obs.synced_at,
-    };
-    while !taken.insert(key.clone()) {
-        key.created_at += TimeDelta::microseconds(1);
-    }
-    key.created_at
-}
-
 #[cfg(test)]
 mod tests {
+    use chrono::TimeDelta;
+
     use super::*;
 
     fn prof(source_type: &str, account_id: &str, email: Option<&str>, closed: bool) -> SeedProfile {

--- a/src/backend/services/identity-resolution/src/domain/seed_service.rs
+++ b/src/backend/services/identity-resolution/src/domain/seed_service.rs
@@ -80,6 +80,9 @@ pub struct SeedSummary {
     pub operator_settled_groups: usize,
     /// Unbound accounts whose e-mail is contested between persons (not linked).
     pub skipped_contested_email: usize,
+    /// Accounts bound to the excluded person (nothing re-emitted, values link
+    /// nobody).
+    pub skipped_excluded: usize,
 }
 
 /// Run one persons-seed over an already-read input: fold to per-account
@@ -146,6 +149,7 @@ where
         known_binding_conflicts: outcome.known_binding_conflicts,
         operator_settled_groups: outcome.operator_settled_groups,
         skipped_contested_email: outcome.skipped_contested_email,
+        skipped_excluded: outcome.skipped_excluded,
     })
 }
 

--- a/src/backend/services/identity-resolution/src/domain/seed_service.rs
+++ b/src/backend/services/identity-resolution/src/domain/seed_service.rs
@@ -10,8 +10,8 @@ use serde::Serialize;
 use uuid::Uuid;
 
 use super::seed::{
-    IdentityInputRow, SeedObservationRow, SourceAccountKey, assignments_to_rows, build_profiles,
-    group_by_email, resolve_assignments,
+    IdentityInputRow, KnownBinding, SeedObservationRow, SourceAccountKey, assignments_to_rows,
+    build_profiles, group_by_email, resolve_assignments,
 };
 
 /// Streams the raw `identity_inputs` observations for a tenant, delivered
@@ -29,7 +29,7 @@ pub trait SeedStore {
     async fn known_account_bindings(
         &self,
         tenant_id: Uuid,
-    ) -> anyhow::Result<HashMap<SourceAccountKey, Uuid>>;
+    ) -> anyhow::Result<HashMap<SourceAccountKey, KnownBinding>>;
 
     async fn latest_email_to_person(
         &self,
@@ -74,8 +74,12 @@ pub struct SeedSummary {
     pub skipped_no_email: usize,
     pub observations_inserted: u64,
     pub org_chart_rows_rebuilt: u64,
-    /// Email groups collapsed across a multi-person binding conflict (logged).
+    /// Divergent e-mail groups with no operator-authored binding (surfaced).
     pub known_binding_conflicts: usize,
+    /// Divergent e-mail groups settled by an operator decision (kept silent).
+    pub operator_settled_groups: usize,
+    /// Unbound accounts whose e-mail is contested between persons (not linked).
+    pub skipped_contested_email: usize,
 }
 
 /// Run one persons-seed over an already-read input: fold to per-account
@@ -140,6 +144,8 @@ where
         observations_inserted: counts.observations_inserted,
         org_chart_rows_rebuilt: counts.org_chart_rows_rebuilt,
         known_binding_conflicts: outcome.known_binding_conflicts,
+        operator_settled_groups: outcome.operator_settled_groups,
+        skipped_contested_email: outcome.skipped_contested_email,
     })
 }
 
@@ -149,7 +155,7 @@ mod tests {
     use sea_orm::prelude::DateTime;
 
     struct FakeStore {
-        known: HashMap<SourceAccountKey, Uuid>,
+        known: HashMap<SourceAccountKey, KnownBinding>,
         emails: HashMap<String, Uuid>,
     }
     #[async_trait]
@@ -157,7 +163,7 @@ mod tests {
         async fn known_account_bindings(
             &self,
             _tenant: Uuid,
-        ) -> anyhow::Result<HashMap<SourceAccountKey, Uuid>> {
+        ) -> anyhow::Result<HashMap<SourceAccountKey, KnownBinding>> {
             Ok(self.known.clone())
         }
         async fn latest_email_to_person(
@@ -247,7 +253,10 @@ mod tests {
                 source_id: Uuid::from_u128(1),
                 account_id: "5000".to_owned(),
             },
-            Uuid::from_u128(7),
+            KnownBinding {
+                person_id: Uuid::from_u128(7),
+                author_person_id: Uuid::nil(),
+            },
         );
         let store = FakeStore {
             known,

--- a/src/backend/services/identity-resolution/src/infra/db/mod.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/mod.rs
@@ -25,6 +25,7 @@ pub mod ops_repo;
 pub mod person_roles_repo;
 pub mod persons_log_repo;
 pub mod persons_repo;
+pub mod resolution_repo;
 pub mod roles_repo;
 pub mod seed_repo;
 pub mod sql_named;

--- a/src/backend/services/identity-resolution/src/infra/db/persons_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/persons_repo.rs
@@ -6,7 +6,11 @@
 //! `infra::db` module docs + constructorfabric/gears-rust#4239), so we run them
 //! as **raw SQL** via SeaORM's `Statement` and read columns off the
 //! `QueryResult`. Running the same SQL as the .NET service keeps resolution
-//! behaviour identical.
+//! behaviour identical — with ONE deliberate deviation the .NET service never
+//! needed: rows naming the excluded-person sentinel (ADR-0003; only the Rust
+//! correction verbs can mint them) are filtered AFTER the latest-wins ranking,
+//! so an excluded account resolves as no person rather than as the shared
+//! sentinel, and an older binding is never resurrected past an exclusion.
 
 use sea_orm::{
     ColumnTrait, ConnectionTrait, DatabaseConnection, DbBackend, EntityTrait, QueryFilter,
@@ -15,6 +19,7 @@ use sea_orm::{
 use uuid::Uuid;
 
 use super::entities::persons;
+use crate::domain::resolution::EXCLUDED_PERSON;
 
 /// Resolve the set of `person_id`s whose CURRENT email (latest observation per
 /// source instance) equals `email` within the tenant.
@@ -51,6 +56,7 @@ pub async fn resolve_person_ids_by_email(
         FROM ranked
         WHERE rn = 1
           AND value_id = ?
+          AND person_id != ?
     ";
 
     let stmt = Statement::from_sql_and_values(
@@ -59,6 +65,7 @@ pub async fn resolve_person_ids_by_email(
         [
             tenant_id.as_bytes().to_vec().into(),
             email.trim().to_owned().into(),
+            EXCLUDED_PERSON.as_bytes().to_vec().into(),
         ],
     );
 
@@ -101,12 +108,19 @@ pub async fn resolve_person_id_by_email_any_tenant(
         SELECT person_id
         FROM ranked
         WHERE rn = 1
+          AND person_id != ?
         ORDER BY created_at DESC, id DESC
         LIMIT 1
     ";
 
-    let stmt =
-        Statement::from_sql_and_values(DbBackend::MySql, SQL, [email.trim().to_owned().into()]);
+    let stmt = Statement::from_sql_and_values(
+        DbBackend::MySql,
+        SQL,
+        [
+            email.trim().to_owned().into(),
+            EXCLUDED_PERSON.as_bytes().to_vec().into(),
+        ],
+    );
 
     match db.query_one(stmt).await? {
         Some(row) => {
@@ -168,6 +182,7 @@ pub async fn resolve_person_id_by_source_any_tenant(
         SELECT person_id
         FROM ranked
         WHERE rn = 1
+          AND person_id != ?
         ORDER BY created_at DESC, id DESC
         LIMIT 1
     ";
@@ -175,7 +190,11 @@ pub async fn resolve_person_id_by_source_any_tenant(
     let stmt = Statement::from_sql_and_values(
         DbBackend::MySql,
         SQL,
-        [source_type.to_owned().into(), external_id.to_owned().into()],
+        [
+            source_type.to_owned().into(),
+            external_id.to_owned().into(),
+            EXCLUDED_PERSON.as_bytes().to_vec().into(),
+        ],
     );
 
     match db.query_one(stmt).await? {
@@ -220,6 +239,7 @@ pub async fn resolve_person_ids_by_source_id(
         FROM ranked
         WHERE rn = 1
           AND value_id = ?
+          AND person_id != ?
     ";
 
     let stmt = Statement::from_sql_and_values(
@@ -232,6 +252,7 @@ pub async fn resolve_person_ids_by_source_id(
             // Source-native ids are matched as-is (the .NET service trims only
             // email, not the id path).
             value.to_owned().into(),
+            EXCLUDED_PERSON.as_bytes().to_vec().into(),
         ],
     );
 
@@ -272,6 +293,7 @@ pub async fn persons_in_tenant(
         .column(persons::Column::PersonId)
         .filter(persons::Column::InsightTenantId.eq(tenant_id.as_bytes().to_vec()))
         .filter(persons::Column::PersonId.is_in(person_ids.iter().map(|id| id.as_bytes().to_vec())))
+        .filter(persons::Column::PersonId.ne(EXCLUDED_PERSON.as_bytes().to_vec()))
         .distinct()
         .into_tuple::<Vec<u8>>()
         .all(db)
@@ -285,6 +307,12 @@ pub async fn person_exists(
     tenant_id: Uuid,
     person_id: Uuid,
 ) -> anyhow::Result<bool> {
+    // The excluded-person sentinel accumulates journal rows once any account
+    // is excluded, but it is not a person and the read API must not serve it.
+    if person_id == EXCLUDED_PERSON {
+        return Ok(false);
+    }
+
     let found = persons::Entity::find()
         .filter(persons::Column::InsightTenantId.eq(tenant_id.as_bytes().to_vec()))
         .filter(persons::Column::PersonId.eq(person_id.as_bytes().to_vec()))

--- a/src/backend/services/identity-resolution/src/infra/db/resolution_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/resolution_repo.rs
@@ -235,3 +235,61 @@ pub async fn append_bindings(
     tracing::info!(appended, "identity correction: bindings appended");
     Ok(appended)
 }
+
+/// One appended observation in an account's history — what the explain surface
+/// shows: who bound it where, when, and why.
+#[derive(Debug, Clone)]
+pub struct BindingHistoryRow {
+    pub person_id: Uuid,
+    pub author_person_id: Uuid,
+    pub reason: Option<String>,
+    pub created_at: sea_orm::prelude::DateTime,
+}
+
+/// Every binding observation ever recorded for one account, newest first.
+///
+/// # Errors
+///
+/// Returns an error if the query fails or a stored id column is not 16 bytes.
+pub async fn binding_history(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    account: &SourceAccountKey,
+) -> anyhow::Result<Vec<BindingHistoryRow>> {
+    const SQL: &str = r"
+        SELECT person_id, author_person_id, reason, created_at
+        FROM persons
+        WHERE value_type = 'id'
+          AND insight_tenant_id = ?
+          AND insight_source_type = ?
+          AND insight_source_id = ?
+          AND value_id = ?
+        ORDER BY created_at DESC, id DESC
+    ";
+
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::MySql,
+            SQL,
+            [
+                tenant_id.as_bytes().to_vec().into(),
+                account.source_type.clone().into(),
+                account.source_id.as_bytes().to_vec().into(),
+                account.account_id.clone().into(),
+            ],
+        ))
+        .await?;
+
+    let mut history = Vec::with_capacity(rows.len());
+    for row in rows {
+        let person_id: Vec<u8> = row.try_get("", "person_id")?;
+        let author_person_id: Vec<u8> = row.try_get("", "author_person_id")?;
+        history.push(BindingHistoryRow {
+            person_id: Uuid::from_slice(&person_id)?,
+            author_person_id: Uuid::from_slice(&author_person_id)?,
+            reason: row.try_get("", "reason")?,
+            created_at: row.try_get("", "created_at")?,
+        });
+    }
+    Ok(history)
+}

--- a/src/backend/services/identity-resolution/src/infra/db/resolution_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/resolution_repo.rs
@@ -50,30 +50,41 @@ pub async fn current_bindings(
         WHERE rn = 1
     ";
 
-    if accounts.is_empty() {
-        return Ok(HashMap::new());
+    // The review surface asks about every observed account, so the list is as
+    // long as the tenant is wide: chunk it rather than build one statement
+    // whose placeholder count grows without bound.
+    const LOOKUP_CHUNK: usize = 500;
+
+    let mut map = HashMap::with_capacity(accounts.len());
+    for chunk in accounts.chunks(LOOKUP_CHUNK) {
+        let tuples = vec!["(?, ?, ?)"; chunk.len()].join(", ");
+        let sql = format!("{SQL_PREFIX}{tuples}{SQL_SUFFIX}");
+
+        let mut params: Vec<Value> = Vec::with_capacity(chunk.len() * 3 + 1);
+        params.push(tenant_id.as_bytes().to_vec().into());
+        for account in chunk {
+            params.push(account.source_type.clone().into());
+            params.push(account.source_id.as_bytes().to_vec().into());
+            params.push(account.account_id.clone().into());
+        }
+
+        let rows = db
+            .query_all(Statement::from_sql_and_values(
+                DbBackend::MySql,
+                &sql,
+                params,
+            ))
+            .await?;
+
+        collect_bindings(rows, &mut map)?;
     }
+    Ok(map)
+}
 
-    let tuples = vec!["(?, ?, ?)"; accounts.len()].join(", ");
-    let sql = format!("{SQL_PREFIX}{tuples}{SQL_SUFFIX}");
-
-    let mut params: Vec<Value> = Vec::with_capacity(accounts.len() * 3 + 1);
-    params.push(tenant_id.as_bytes().to_vec().into());
-    for account in accounts {
-        params.push(account.source_type.clone().into());
-        params.push(account.source_id.as_bytes().to_vec().into());
-        params.push(account.account_id.clone().into());
-    }
-
-    let rows = db
-        .query_all(Statement::from_sql_and_values(
-            DbBackend::MySql,
-            &sql,
-            params,
-        ))
-        .await?;
-
-    let mut map = HashMap::with_capacity(rows.len());
+fn collect_bindings(
+    rows: Vec<sea_orm::QueryResult>,
+    map: &mut HashMap<SourceAccountKey, KnownBinding>,
+) -> anyhow::Result<()> {
     for row in rows {
         let source_type: String = row.try_get("", "insight_source_type")?;
         let source_id: Vec<u8> = row.try_get("", "insight_source_id")?;
@@ -92,7 +103,7 @@ pub async fn current_bindings(
             },
         );
     }
-    Ok(map)
+    Ok(())
 }
 
 /// Accounts currently bound to a person (latest binding wins). The merge verb

--- a/src/backend/services/identity-resolution/src/infra/db/resolution_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/resolution_repo.rs
@@ -1,0 +1,237 @@
+//! Operator-correction write store (MariaDB).
+//!
+//! Corrections append binding observations to `persons` and rebuild the derived
+//! caches in the same transaction (shared with the seed — see
+//! [`super::seed_repo::rebuild_derived_caches`]). Nothing here updates or
+//! deletes a journal row.
+
+use std::collections::HashMap;
+
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement, TransactionTrait, Value};
+use uuid::Uuid;
+
+use super::seed_repo::rebuild_derived_caches;
+use crate::domain::resolution::{BINDING_VALUE_TYPE, BindingRow};
+use crate::domain::seed::{KnownBinding, SourceAccountKey};
+
+/// Current binding of each requested account — the latest `value_type='id'`
+/// observation, with its author so the caller can tell an operator decision
+/// from an automatic one. Accounts never observed are simply absent.
+///
+/// # Errors
+///
+/// Returns an error if the query fails or a stored id column is not 16 bytes.
+pub async fn current_bindings(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    accounts: &[SourceAccountKey],
+) -> anyhow::Result<HashMap<SourceAccountKey, KnownBinding>> {
+    const SQL_PREFIX: &str = r"
+        WITH ranked AS (
+            SELECT
+                insight_source_type,
+                insight_source_id,
+                value_id AS source_account_id,
+                person_id,
+                author_person_id,
+                ROW_NUMBER() OVER (
+                    PARTITION BY insight_tenant_id, insight_source_type, insight_source_id, value_id
+                    ORDER BY created_at DESC, id DESC
+                ) AS rn
+            FROM persons
+            WHERE value_type = 'id'
+              AND value_id IS NOT NULL
+              AND insight_tenant_id = ?
+              AND (insight_source_type, insight_source_id, value_id) IN (";
+    const SQL_SUFFIX: &str = r")
+        )
+        SELECT insight_source_type, insight_source_id, source_account_id, person_id, author_person_id
+        FROM ranked
+        WHERE rn = 1
+    ";
+
+    if accounts.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let tuples = vec!["(?, ?, ?)"; accounts.len()].join(", ");
+    let sql = format!("{SQL_PREFIX}{tuples}{SQL_SUFFIX}");
+
+    let mut params: Vec<Value> = Vec::with_capacity(accounts.len() * 3 + 1);
+    params.push(tenant_id.as_bytes().to_vec().into());
+    for account in accounts {
+        params.push(account.source_type.clone().into());
+        params.push(account.source_id.as_bytes().to_vec().into());
+        params.push(account.account_id.clone().into());
+    }
+
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::MySql,
+            &sql,
+            params,
+        ))
+        .await?;
+
+    let mut map = HashMap::with_capacity(rows.len());
+    for row in rows {
+        let source_type: String = row.try_get("", "insight_source_type")?;
+        let source_id: Vec<u8> = row.try_get("", "insight_source_id")?;
+        let account_id: String = row.try_get("", "source_account_id")?;
+        let person_id: Vec<u8> = row.try_get("", "person_id")?;
+        let author_person_id: Vec<u8> = row.try_get("", "author_person_id")?;
+        map.insert(
+            SourceAccountKey {
+                source_type,
+                source_id: Uuid::from_slice(&source_id)?,
+                account_id,
+            },
+            KnownBinding {
+                person_id: Uuid::from_slice(&person_id)?,
+                author_person_id: Uuid::from_slice(&author_person_id)?,
+            },
+        );
+    }
+    Ok(map)
+}
+
+/// Accounts currently bound to a person (latest binding wins). The merge verb
+/// reads this to know what to rebind.
+///
+/// # Errors
+///
+/// Returns an error if the query fails or a stored id column is not 16 bytes.
+pub async fn accounts_of_person(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    person_id: Uuid,
+) -> anyhow::Result<Vec<SourceAccountKey>> {
+    const SQL: &str = r"
+        WITH ranked AS (
+            SELECT
+                insight_source_type,
+                insight_source_id,
+                value_id AS source_account_id,
+                person_id,
+                ROW_NUMBER() OVER (
+                    PARTITION BY insight_tenant_id, insight_source_type, insight_source_id, value_id
+                    ORDER BY created_at DESC, id DESC
+                ) AS rn
+            FROM persons
+            WHERE value_type = 'id'
+              AND value_id IS NOT NULL
+              AND insight_tenant_id = ?
+        )
+        SELECT insight_source_type, insight_source_id, source_account_id
+        FROM ranked
+        WHERE rn = 1 AND person_id = ?
+    ";
+
+    let rows = db
+        .query_all(Statement::from_sql_and_values(
+            DbBackend::MySql,
+            SQL,
+            [
+                tenant_id.as_bytes().to_vec().into(),
+                person_id.as_bytes().to_vec().into(),
+            ],
+        ))
+        .await?;
+
+    let mut accounts = Vec::with_capacity(rows.len());
+    for row in rows {
+        let source_type: String = row.try_get("", "insight_source_type")?;
+        let source_id: Vec<u8> = row.try_get("", "insight_source_id")?;
+        let account_id: String = row.try_get("", "source_account_id")?;
+        accounts.push(SourceAccountKey {
+            source_type,
+            source_id: Uuid::from_slice(&source_id)?,
+            account_id,
+        });
+    }
+    Ok(accounts)
+}
+
+/// Whether the tenant's journal knows this person at all — a correction may not
+/// invent a target out of thin air.
+///
+/// # Errors
+///
+/// Returns an error if the query fails.
+pub async fn person_exists(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    person_id: Uuid,
+) -> anyhow::Result<bool> {
+    const SQL: &str =
+        "SELECT 1 AS hit FROM persons WHERE insight_tenant_id = ? AND person_id = ? LIMIT 1";
+
+    let row = db
+        .query_one(Statement::from_sql_and_values(
+            DbBackend::MySql,
+            SQL,
+            [
+                tenant_id.as_bytes().to_vec().into(),
+                person_id.as_bytes().to_vec().into(),
+            ],
+        ))
+        .await?;
+    Ok(row.is_some())
+}
+
+/// Append binding observations and rebuild the tenant's derived caches in one
+/// transaction. Returns the number of rows actually appended (a re-emitted
+/// identical observation is ignored by the natural key).
+///
+/// # Errors
+///
+/// Returns an error if any statement fails; the transaction is rolled back.
+pub async fn append_bindings(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    operator_person_id: Uuid,
+    rows: &[BindingRow],
+) -> anyhow::Result<u64> {
+    const INSERT_PREFIX: &str = "INSERT IGNORE INTO persons \
+        (value_type, insight_source_type, insight_source_id, insight_tenant_id, \
+         value_id, value_full_text, value, person_id, author_person_id, reason, \
+         created_at) VALUES ";
+    const ROW_TUPLE: &str = "(?, ?, ?, ?, ?, NULL, NULL, ?, ?, ?, ?)";
+    const INSERT_CHUNK: usize = 500;
+
+    let txn = db.begin().await?;
+
+    let mut appended = 0u64;
+    for chunk in rows.chunks(INSERT_CHUNK) {
+        let values = vec![ROW_TUPLE; chunk.len()].join(", ");
+        let sql = format!("{INSERT_PREFIX}{values}");
+
+        let mut params: Vec<Value> = Vec::with_capacity(chunk.len() * 9);
+        for row in chunk {
+            params.push(BINDING_VALUE_TYPE.into());
+            params.push(row.account.source_type.clone().into());
+            params.push(row.account.source_id.as_bytes().to_vec().into());
+            params.push(tenant_id.as_bytes().to_vec().into());
+            params.push(row.account.account_id.clone().into());
+            params.push(row.person_id.as_bytes().to_vec().into());
+            params.push(row.author_person_id.as_bytes().to_vec().into());
+            params.push(row.reason.clone().into());
+            params.push(row.created_at.into());
+        }
+
+        let res = txn
+            .execute(Statement::from_sql_and_values(
+                DbBackend::MySql,
+                &sql,
+                params,
+            ))
+            .await?;
+        appended += res.rows_affected();
+    }
+
+    rebuild_derived_caches(&txn, tenant_id, operator_person_id).await?;
+    txn.commit().await?;
+
+    tracing::info!(appended, "identity correction: bindings appended");
+    Ok(appended)
+}

--- a/src/backend/services/identity-resolution/src/infra/db/resolution_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/resolution_repo.rs
@@ -1,16 +1,17 @@
 //! Operator-correction write store (MariaDB).
 //!
-//! Corrections append binding observations to `persons` and rebuild the derived
-//! caches in the same transaction (shared with the seed — see
-//! [`super::seed_repo::rebuild_derived_caches`]). Nothing here updates or
-//! deletes a journal row.
+//! Corrections append binding observations to `persons`. Nothing here updates
+//! or deletes a journal row, and nothing here rebuilds the derived caches:
+//! those stay the persons-seed's to own, on its own schedule, the way the
+//! ClickHouse mirror already works. The journal is the source of truth and
+//! every read path — the correction verbs, the review queue, the history —
+//! reads it directly, so a correction is visible the moment it commits.
 
 use std::collections::{HashMap, HashSet};
 
 use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement, TransactionTrait, Value};
 use uuid::Uuid;
 
-use super::seed_repo::rebuild_derived_caches;
 use crate::domain::resolution::{BINDING_VALUE_TYPE, BindingRow};
 use crate::domain::seed::{KnownBinding, SourceAccountKey};
 
@@ -190,9 +191,18 @@ pub async fn person_exists(
     Ok(row.is_some())
 }
 
-/// Append binding observations and rebuild the tenant's derived caches in one
-/// transaction. Returns the number of rows actually appended (a re-emitted
-/// identical observation is ignored by the natural key).
+/// Append binding observations in one transaction. Returns the number of rows
+/// actually appended (a re-emitted identical observation is ignored by the
+/// natural key).
+///
+/// The tenant's derived caches are deliberately NOT rebuilt here. The rebuild
+/// is whole-tenant — it deletes and re-derives `account_person_map` and
+/// `org_chart` from the entire journal — and it grows far worse than linearly,
+/// so putting it in a request path makes one operator decision cost minutes on
+/// a large tenant. It also buys nothing: a correction appends only
+/// `value_type='id'` rows, while `org_chart` is derived from the parent, status
+/// and e-mail observations a correction never touches. The caches stay the
+/// seed's to refresh on its own schedule, like the ClickHouse mirror.
 ///
 /// # Errors
 ///
@@ -200,7 +210,6 @@ pub async fn person_exists(
 pub async fn append_bindings(
     db: &DatabaseConnection,
     tenant_id: Uuid,
-    operator_person_id: Uuid,
     rows: &[BindingRow],
 ) -> anyhow::Result<u64> {
     const INSERT_PREFIX: &str = "INSERT IGNORE INTO persons \
@@ -240,7 +249,6 @@ pub async fn append_bindings(
         appended += res.rows_affected();
     }
 
-    rebuild_derived_caches(&txn, tenant_id, operator_person_id).await?;
     txn.commit().await?;
 
     tracing::info!(appended, "identity correction: bindings appended");

--- a/src/backend/services/identity-resolution/src/infra/db/resolution_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/resolution_repo.rs
@@ -5,7 +5,7 @@
 //! [`super::seed_repo::rebuild_derived_caches`]). Nothing here updates or
 //! deletes a journal row.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement, TransactionTrait, Value};
 use uuid::Uuid;
@@ -303,4 +303,86 @@ pub async fn binding_history(
         });
     }
     Ok(history)
+}
+
+/// Which of these exact observations the journal holds.
+///
+/// Identity is the whole natural key including the author and the instant, not
+/// just "the account points at this person": a confirmation appends an
+/// operator-authored row over an automatic binding to the SAME person, so
+/// asking about the person alone cannot tell a landed row from a refused one.
+///
+/// # Errors
+///
+/// Returns an error if the query fails.
+pub async fn present_rows(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    rows: &[BindingRow],
+) -> anyhow::Result<Vec<bool>> {
+    const SQL_PREFIX: &str = "SELECT insight_source_type, insight_source_id, value_id, \
+         person_id, author_person_id, created_at \
+         FROM persons \
+         WHERE value_type = 'id' AND insight_tenant_id = ? \
+           AND (insight_source_type, insight_source_id, value_id, person_id, \
+                author_person_id, created_at) IN (";
+    const ROW_TUPLE: &str = "(?, ?, ?, ?, ?, ?)";
+    const LOOKUP_CHUNK: usize = 200;
+
+    let mut found: HashSet<(String, Uuid, String, Uuid, Uuid, sea_orm::prelude::DateTime)> =
+        HashSet::new();
+
+    for chunk in rows.chunks(LOOKUP_CHUNK) {
+        let tuples = vec![ROW_TUPLE; chunk.len()].join(", ");
+        let sql = format!("{SQL_PREFIX}{tuples})");
+
+        let mut params: Vec<Value> = Vec::with_capacity(chunk.len() * 6 + 1);
+        params.push(tenant_id.as_bytes().to_vec().into());
+        for row in chunk {
+            params.push(row.account.source_type.clone().into());
+            params.push(row.account.source_id.as_bytes().to_vec().into());
+            params.push(row.account.account_id.clone().into());
+            params.push(row.person_id.as_bytes().to_vec().into());
+            params.push(row.author_person_id.as_bytes().to_vec().into());
+            params.push(row.created_at.into());
+        }
+
+        let hits = db
+            .query_all(Statement::from_sql_and_values(
+                DbBackend::MySql,
+                &sql,
+                params,
+            ))
+            .await?;
+
+        for hit in hits {
+            let source_type: String = hit.try_get("", "insight_source_type")?;
+            let source_id: Vec<u8> = hit.try_get("", "insight_source_id")?;
+            let account_id: String = hit.try_get("", "value_id")?;
+            let person_id: Vec<u8> = hit.try_get("", "person_id")?;
+            let author_person_id: Vec<u8> = hit.try_get("", "author_person_id")?;
+            found.insert((
+                source_type,
+                Uuid::from_slice(&source_id)?,
+                account_id,
+                Uuid::from_slice(&person_id)?,
+                Uuid::from_slice(&author_person_id)?,
+                hit.try_get("", "created_at")?,
+            ));
+        }
+    }
+
+    Ok(rows
+        .iter()
+        .map(|row| {
+            found.contains(&(
+                row.account.source_type.clone(),
+                row.account.source_id,
+                row.account.account_id.clone(),
+                row.person_id,
+                row.author_person_id,
+                row.created_at,
+            ))
+        })
+        .collect())
 }

--- a/src/backend/services/identity-resolution/src/infra/db/seed_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/seed_repo.rs
@@ -15,7 +15,10 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement, TransactionTrait, Value};
+use sea_orm::{
+    ConnectionTrait, DatabaseConnection, DatabaseTransaction, DbBackend, Statement,
+    TransactionTrait, Value,
+};
 use uuid::Uuid;
 
 use crate::domain::seed::{KnownBinding, SeedObservationRow, SourceAccountKey, normalize_email};
@@ -242,36 +245,21 @@ pub async fn latest_email_to_person(
     Ok(map)
 }
 
-/// Apply a seed's resolved observations: `INSERT IGNORE` each into `persons`,
-/// then rebuild the tenant's `account_person_map` and `org_chart` — all in one
-/// transaction, so the log and the derived caches are never left
-/// cross-inconsistent. `author_person_id` stamps the computed `org_chart`
-/// no-parent rows (the seed operation's author). Returns the number of
-/// observation rows actually inserted (duplicates are ignored).
+/// Rebuild the tenant's derived caches inside an open transaction: the SCD2
+/// `account_person_map` and `org_chart`, both re-derived from `persons`. Shared
+/// by the persons-seed and the operator corrections so a journal write and its
+/// caches always commit together. Returns the `org_chart` rows written.
 ///
 /// # Errors
 ///
-/// Returns an error if any statement fails; the transaction is rolled back.
-// The length is dominated by the verbatim org_chart CTE string constant, not
-// control flow — keeping the SQL inline (co-located, greppable) over hoisting it.
-#[allow(clippy::too_many_lines)]
-pub async fn apply(
-    db: &DatabaseConnection,
+/// Returns an error if any statement fails; the transaction is the caller's to
+/// roll back.
+#[allow(clippy::too_many_lines)] // dominated by the verbatim org_chart CTE
+pub(crate) async fn rebuild_derived_caches(
+    txn: &DatabaseTransaction,
     tenant_id: Uuid,
     author_person_id: Uuid,
-    rows: &[SeedObservationRow],
-) -> anyhow::Result<ApplyCounts> {
-    // Idempotent insert — uq_person_observation dedups a re-emitted identical
-    // observation; INSERT IGNORE swallows the duplicate-key error. Batched
-    // (multi-row VALUES) so N observations cost ~N/INSERT_CHUNK round-trips
-    // instead of N — 25k+ single-row inserts over a remote pool take minutes;
-    // batches take seconds. Same semantics as per-row INSERT IGNORE.
-    const INSERT_PREFIX: &str = "INSERT IGNORE INTO persons \
-        (value_type, insight_source_type, insight_source_id, insight_tenant_id, \
-         value_id, value_full_text, value, person_id, author_person_id, reason, \
-         created_at) VALUES ";
-    const ROW_TUPLE: &str = "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
-    const INSERT_CHUNK: usize = 500; // 500 rows × 11 cols = 5500 binds (< 65535)
+) -> anyhow::Result<u64> {
     const DELETE_APM: &str = "DELETE FROM account_person_map WHERE insight_tenant_id = ?";
     const INSERT_APM: &str = r"
         INSERT INTO account_person_map
@@ -514,36 +502,6 @@ pub async fn apply(
 
     let tenant_bytes = tenant_id.as_bytes().to_vec();
     let author_bytes = author_person_id.as_bytes().to_vec();
-    let txn = db.begin().await?;
-
-    let mut inserted = 0u64;
-    for chunk in rows.chunks(INSERT_CHUNK) {
-        let values = vec![ROW_TUPLE; chunk.len()].join(", ");
-        let sql = format!("{INSERT_PREFIX}{values}");
-        let mut params: Vec<Value> = Vec::with_capacity(chunk.len() * 11);
-        for r in chunk {
-            params.push(r.value_type.clone().into());
-            params.push(r.source_type.clone().into());
-            params.push(r.source_id.as_bytes().to_vec().into());
-            params.push(tenant_bytes.clone().into());
-            params.push(r.value_id.clone().into());
-            params.push(r.value_full_text.clone().into());
-            params.push(r.value.clone().into());
-            params.push(r.person_id.as_bytes().to_vec().into());
-            params.push(r.author_person_id.as_bytes().to_vec().into());
-            params.push(r.reason.clone().into());
-            params.push(r.created_at.into());
-        }
-        let res = txn
-            .execute(Statement::from_sql_and_values(
-                DbBackend::MySql,
-                &sql,
-                params,
-            ))
-            .await?;
-        inserted += res.rows_affected();
-    }
-    tracing::info!(inserted, "persons-seed apply: observations inserted");
 
     // Rebuild account_person_map for the tenant (delete + reinsert).
     txn.execute(Statement::from_sql_and_values(
@@ -588,6 +546,73 @@ pub async fn apply(
         org_chart_rows_rebuilt,
         "persons-seed apply: org_chart rebuilt"
     );
+
+    Ok(org_chart_rows_rebuilt)
+}
+
+/// Apply a seed's resolved observations: `INSERT IGNORE` each into `persons`,
+/// then rebuild the tenant's `account_person_map` and `org_chart` — all in one
+/// transaction, so the log and the derived caches are never left
+/// cross-inconsistent. `author_person_id` stamps the computed `org_chart`
+/// no-parent rows (the seed operation's author). Returns the number of
+/// observation rows actually inserted (duplicates are ignored).
+///
+/// # Errors
+///
+/// Returns an error if any statement fails; the transaction is rolled back.
+// The length is dominated by the verbatim org_chart CTE string constant, not
+// control flow — keeping the SQL inline (co-located, greppable) over hoisting it.
+#[allow(clippy::too_many_lines)]
+pub async fn apply(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    author_person_id: Uuid,
+    rows: &[SeedObservationRow],
+) -> anyhow::Result<ApplyCounts> {
+    // Idempotent insert — uq_person_observation dedups a re-emitted identical
+    // observation; INSERT IGNORE swallows the duplicate-key error. Batched
+    // (multi-row VALUES) so N observations cost ~N/INSERT_CHUNK round-trips
+    // instead of N — 25k+ single-row inserts over a remote pool take minutes;
+    // batches take seconds. Same semantics as per-row INSERT IGNORE.
+    const INSERT_PREFIX: &str = "INSERT IGNORE INTO persons \
+        (value_type, insight_source_type, insight_source_id, insight_tenant_id, \
+         value_id, value_full_text, value, person_id, author_person_id, reason, \
+         created_at) VALUES ";
+    const ROW_TUPLE: &str = "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+    const INSERT_CHUNK: usize = 500; // 500 rows × 11 cols = 5500 binds (< 65535)
+    let tenant_bytes = tenant_id.as_bytes().to_vec();
+    let txn = db.begin().await?;
+
+    let mut inserted = 0u64;
+    for chunk in rows.chunks(INSERT_CHUNK) {
+        let values = vec![ROW_TUPLE; chunk.len()].join(", ");
+        let sql = format!("{INSERT_PREFIX}{values}");
+        let mut params: Vec<Value> = Vec::with_capacity(chunk.len() * 11);
+        for r in chunk {
+            params.push(r.value_type.clone().into());
+            params.push(r.source_type.clone().into());
+            params.push(r.source_id.as_bytes().to_vec().into());
+            params.push(tenant_bytes.clone().into());
+            params.push(r.value_id.clone().into());
+            params.push(r.value_full_text.clone().into());
+            params.push(r.value.clone().into());
+            params.push(r.person_id.as_bytes().to_vec().into());
+            params.push(r.author_person_id.as_bytes().to_vec().into());
+            params.push(r.reason.clone().into());
+            params.push(r.created_at.into());
+        }
+        let res = txn
+            .execute(Statement::from_sql_and_values(
+                DbBackend::MySql,
+                &sql,
+                params,
+            ))
+            .await?;
+        inserted += res.rows_affected();
+    }
+    tracing::info!(inserted, "persons-seed apply: observations inserted");
+
+    let org_chart_rows_rebuilt = rebuild_derived_caches(&txn, tenant_id, author_person_id).await?;
 
     txn.commit().await?;
     Ok(ApplyCounts {

--- a/src/backend/services/identity-resolution/src/infra/db/seed_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/seed_repo.rs
@@ -261,6 +261,15 @@ pub(crate) async fn rebuild_derived_caches(
     author_person_id: Uuid,
 ) -> anyhow::Result<u64> {
     const DELETE_APM: &str = "DELETE FROM account_person_map WHERE insight_tenant_id = ?";
+    // The journal may hold TWO bindings for one account at the same instant:
+    // its unique key ends in `person_id`, so a re-run that resolves an account
+    // to a different person re-emits the account's `id` row under the source's
+    // own timestamp — which is exactly what an operator correction causes on
+    // the next seed. This cache is keyed by (account, valid_from) with no
+    // person, so those two rows are one row here, and the later decision (the
+    // higher `id`) is the one that stands — the same latest-wins rule the
+    // binding readers use. Without the rank the insert dies on a duplicate key
+    // and takes the whole seed run with it.
     const INSERT_APM: &str = r"
         INSERT INTO account_person_map
             (insight_tenant_id, insight_source_type, insight_source_id, source_account_id,
@@ -269,20 +278,37 @@ pub(crate) async fn rebuild_derived_caches(
             insight_tenant_id,
             insight_source_type,
             insight_source_id,
-            value_id AS source_account_id,
+            source_account_id,
             person_id,
             author_person_id,
             reason,
-            created_at AS valid_from,
-            LEAD(created_at) OVER (
+            valid_from,
+            LEAD(valid_from) OVER (
                 PARTITION BY insight_tenant_id, insight_source_type,
-                             insight_source_id, value_id
-                ORDER BY created_at
+                             insight_source_id, source_account_id
+                ORDER BY valid_from
             ) AS valid_to
-        FROM persons
-        WHERE value_type = 'id'
-          AND value_id IS NOT NULL
-          AND insight_tenant_id = ?
+        FROM (
+            SELECT
+                insight_tenant_id,
+                insight_source_type,
+                insight_source_id,
+                value_id     AS source_account_id,
+                person_id,
+                author_person_id,
+                reason,
+                created_at   AS valid_from,
+                ROW_NUMBER() OVER (
+                    PARTITION BY insight_tenant_id, insight_source_type,
+                                 insight_source_id, value_id, created_at
+                    ORDER BY id DESC
+                ) AS rn
+            FROM persons
+            WHERE value_type = 'id'
+              AND value_id IS NOT NULL
+              AND insight_tenant_id = ?
+        ) ranked
+        WHERE rn = 1
     ";
     const DELETE_ORG_CHART: &str = "DELETE FROM org_chart WHERE insight_tenant_id = ?";
     // Ported verbatim from Sql.PersonsSeed.cs::InsertOrgChartForTenant. The `?`

--- a/src/backend/services/identity-resolution/src/infra/db/seed_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/seed_repo.rs
@@ -255,7 +255,7 @@ pub async fn latest_email_to_person(
 /// Returns an error if any statement fails; the transaction is the caller's to
 /// roll back.
 #[allow(clippy::too_many_lines)] // dominated by the verbatim org_chart CTE
-pub(crate) async fn rebuild_derived_caches(
+async fn rebuild_derived_caches(
     txn: &DatabaseTransaction,
     tenant_id: Uuid,
     author_person_id: Uuid,

--- a/src/backend/services/identity-resolution/src/infra/db/seed_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/seed_repo.rs
@@ -18,7 +18,7 @@ use async_trait::async_trait;
 use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement, TransactionTrait, Value};
 use uuid::Uuid;
 
-use crate::domain::seed::{SeedObservationRow, SourceAccountKey, normalize_email};
+use crate::domain::seed::{KnownBinding, SeedObservationRow, SourceAccountKey, normalize_email};
 use crate::domain::seed_service::{ApplyCounts, SeedStore};
 
 /// MariaDB-backed [`SeedStore`] — wraps a connection so the persons-seed service
@@ -39,7 +39,7 @@ impl SeedStore for MariaDbSeedStore<'_> {
     async fn known_account_bindings(
         &self,
         tenant_id: Uuid,
-    ) -> anyhow::Result<HashMap<SourceAccountKey, Uuid>> {
+    ) -> anyhow::Result<HashMap<SourceAccountKey, KnownBinding>> {
         known_account_bindings(self.db, tenant_id).await
     }
 
@@ -132,9 +132,9 @@ pub async fn tenant_presence(
     })
 }
 
-/// Current `source_account_id → person_id` bindings for the tenant — the latest
-/// `value_type='id'` observation per account. Feeds the known-account branch of
-/// the resolver. Ported from `SqlPersonsSeed.KnownAccountBindings`.
+/// Current bindings for the tenant — the latest `value_type='id'` observation
+/// per account, with the row's author (seed sentinel vs operator UUID) so the
+/// resolver can classify divergence. Feeds the known-account branch.
 ///
 /// # Errors
 ///
@@ -142,7 +142,7 @@ pub async fn tenant_presence(
 pub async fn known_account_bindings(
     db: &DatabaseConnection,
     tenant_id: Uuid,
-) -> anyhow::Result<HashMap<SourceAccountKey, Uuid>> {
+) -> anyhow::Result<HashMap<SourceAccountKey, KnownBinding>> {
     const SQL: &str = r"
         WITH ranked AS (
             SELECT
@@ -150,6 +150,7 @@ pub async fn known_account_bindings(
                 insight_source_id,
                 value_id AS source_account_id,
                 person_id,
+                author_person_id,
                 ROW_NUMBER() OVER (
                     PARTITION BY insight_tenant_id, insight_source_type, insight_source_id, value_id
                     ORDER BY created_at DESC, id DESC
@@ -159,7 +160,7 @@ pub async fn known_account_bindings(
               AND value_id IS NOT NULL
               AND insight_tenant_id = ?
         )
-        SELECT insight_source_type, insight_source_id, source_account_id, person_id
+        SELECT insight_source_type, insight_source_id, source_account_id, person_id, author_person_id
         FROM ranked
         WHERE rn = 1
     ";
@@ -177,13 +178,17 @@ pub async fn known_account_bindings(
         let source_id: Vec<u8> = row.try_get("", "insight_source_id")?;
         let account_id: String = row.try_get("", "source_account_id")?;
         let person_id: Vec<u8> = row.try_get("", "person_id")?;
+        let author_person_id: Vec<u8> = row.try_get("", "author_person_id")?;
         map.insert(
             SourceAccountKey {
                 source_type,
                 source_id: Uuid::from_slice(&source_id)?,
                 account_id,
             },
-            Uuid::from_slice(&person_id)?,
+            KnownBinding {
+                person_id: Uuid::from_slice(&person_id)?,
+                author_person_id: Uuid::from_slice(&author_person_id)?,
+            },
         );
     }
     Ok(map)

--- a/src/backend/services/identity-resolution/src/infra/identity_evidence.rs
+++ b/src/backend/services/identity-resolution/src/infra/identity_evidence.rs
@@ -1,0 +1,160 @@
+//! Folded connector evidence for the review surface (ClickHouse).
+//!
+//! The review queue is derived from two sources joined on the account key: this
+//! evidence — every account a connector has observed, including e-mail-less
+//! ones — and the current bindings in `persons`. Folding happens in ClickHouse:
+//! one row per account carrying its latest values and whether its latest event
+//! closed it (a DELETE tombstone), so closed accounts drop out of the queue.
+
+use std::time::Duration;
+
+use clickhouse::Row;
+use insight_clickhouse::{Client, Config};
+use serde::Deserialize;
+use uuid::Uuid;
+
+use crate::domain::seed::SourceAccountKey;
+
+const READ_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// One account as the evidence currently describes it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccountEvidence {
+    pub account: SourceAccountKey,
+    pub email: Option<String>,
+    pub username: Option<String>,
+    /// The account's latest event is a closure signal — it is deactivated at
+    /// the source and must not be surfaced for review.
+    pub is_closed: bool,
+}
+
+/// One row per observed account: latest operation and latest non-empty values.
+/// DELETE rows carry an empty value by contract, so the value aggregates filter
+/// on UPSERT — while the operation aggregate keeps every event, which is what
+/// makes closure detectable.
+const FOLD_SQL: &str = r"
+    SELECT
+        ifNull(insight_source_type, '')                 AS source_type,
+        ifNull(toString(insight_source_id), '')         AS source_id,
+        ifNull(source_account_id, '')                   AS account_id,
+        argMax(ifNull(operation_type, ''), _synced_at)  AS latest_op,
+        argMaxIf(
+            ifNull(value, ''), _synced_at,
+            value_type = 'email' AND operation_type = 'UPSERT' AND value != ''
+        )                                               AS email,
+        argMaxIf(
+            ifNull(value, ''), _synced_at,
+            value_type = 'username' AND operation_type = 'UPSERT' AND value != ''
+        )                                               AS username
+    FROM identity.identity_inputs
+    WHERE source_account_id IS NOT NULL AND source_account_id != ''
+    GROUP BY source_type, source_id, account_id
+";
+
+#[derive(Debug, Row, Deserialize)]
+struct FoldedRow {
+    source_type: String,
+    source_id: String,
+    account_id: String,
+    latest_op: String,
+    email: String,
+    username: String,
+}
+
+/// Reads folded evidence for the review surface.
+pub struct ClickHouseEvidenceReader {
+    client: Client,
+}
+
+impl ClickHouseEvidenceReader {
+    #[must_use]
+    pub fn new(client: Client) -> Self {
+        Self { client }
+    }
+
+    /// Build from connection settings (empty user → no auth), like the seed's
+    /// input reader.
+    #[must_use]
+    pub fn connect(url: &str, database: &str, user: &str, password: &str) -> Self {
+        let mut config = Config::new(url, database).with_query_timeout(READ_TIMEOUT);
+        if !user.is_empty() {
+            config = config.with_auth(user, password);
+        }
+        Self::new(Client::new(config))
+    }
+
+    /// Every observed account with its folded evidence.
+    ///
+    /// The tenant is not a predicate here for the same reason the seed's reader
+    /// drops it: the evidence carries a producer-side hashed tenant that never
+    /// equals the caller's. Single-tenant deployments only — restoring the
+    /// filter is a multi-tenant prerequisite (see `identity_inputs`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails or a stored source id is not a UUID.
+    pub async fn accounts(&self) -> anyhow::Result<Vec<AccountEvidence>> {
+        let rows: Vec<FoldedRow> = self.client.query(FOLD_SQL).fetch_all().await?;
+        rows.into_iter().map(map_row).collect()
+    }
+}
+
+fn map_row(row: FoldedRow) -> anyhow::Result<AccountEvidence> {
+    Ok(AccountEvidence {
+        account: SourceAccountKey {
+            source_type: row.source_type,
+            source_id: Uuid::parse_str(&row.source_id)?,
+            account_id: row.account_id,
+        },
+        email: non_empty(row.email),
+        username: non_empty(row.username),
+        is_closed: row.latest_op == "DELETE",
+    })
+}
+
+fn non_empty(value: String) -> Option<String> {
+    if value.trim().is_empty() {
+        None
+    } else {
+        Some(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn folded(latest_op: &str, email: &str, username: &str) -> FoldedRow {
+        FoldedRow {
+            source_type: "github".to_owned(),
+            source_id: Uuid::from_u128(1).to_string(),
+            account_id: "gh-1".to_owned(),
+            latest_op: latest_op.to_owned(),
+            email: email.to_owned(),
+            username: username.to_owned(),
+        }
+    }
+
+    #[test]
+    fn closure_is_read_from_the_latest_operation() -> anyhow::Result<()> {
+        assert!(map_row(folded("DELETE", "", ""))?.is_closed);
+        assert!(!map_row(folded("UPSERT", "a@example.com", ""))?.is_closed);
+        Ok(())
+    }
+
+    #[test]
+    fn blank_values_are_absent_not_empty_strings() -> anyhow::Result<()> {
+        let evidence = map_row(folded("UPSERT", "  ", ""))?;
+        assert_eq!(evidence.email, None, "whitespace is not evidence");
+        assert_eq!(evidence.username, None);
+        Ok(())
+    }
+
+    #[test]
+    fn a_username_only_account_keeps_its_value() -> anyhow::Result<()> {
+        let evidence = map_row(folded("UPSERT", "", "octocat"))?;
+        assert_eq!(evidence.username.as_deref(), Some("octocat"));
+        assert_eq!(evidence.email, None);
+        Ok(())
+    }
+}

--- a/src/backend/services/identity-resolution/src/infra/identity_evidence.rs
+++ b/src/backend/services/identity-resolution/src/infra/identity_evidence.rs
@@ -94,7 +94,11 @@ impl ClickHouseEvidenceReader {
     ///
     /// Returns an error if the query fails or a stored source id is not a UUID.
     pub async fn accounts(&self) -> anyhow::Result<Vec<AccountEvidence>> {
-        let rows: Vec<FoldedRow> = self.client.query(FOLD_SQL).fetch_all().await?;
+        let rows: Vec<FoldedRow> = match self.client.query(FOLD_SQL).fetch_all().await {
+            Ok(rows) => rows,
+            Err(e) if is_missing_relation(&e) => return Ok(Vec::new()),
+            Err(e) => return Err(e.into()),
+        };
 
         // A row whose source id is not a UUID is one unusable account, not a
         // reason to blind the whole review surface: skip it and say so.
@@ -154,16 +158,30 @@ impl ClickHouseEvidenceReader {
     ///
     /// Returns an error if the query fails.
     pub async fn has_account(&self, account: &SourceAccountKey) -> anyhow::Result<bool> {
-        let row: Option<CountRow> = self
+        let row: Result<Option<CountRow>, _> = self
             .client
             .query(EXISTS_SQL)
             .bind(account.source_type.as_str())
             .bind(account.source_id.to_string())
             .bind(account.account_id.as_str())
             .fetch_optional()
-            .await?;
-        Ok(row.is_some_and(|r| r.hits > 0))
+            .await;
+
+        match row {
+            Ok(hit) => Ok(hit.is_some_and(|r| r.hits > 0)),
+            // A fresh install has no evidence relation yet — dbt creates it on
+            // its first silver build. That is "nothing observed", not a failure
+            // to answer.
+            Err(e) if is_missing_relation(&e) => Ok(false),
+            Err(e) => Err(e.into()),
+        }
     }
+}
+
+/// ClickHouse reports an absent table as `UNKNOWN_TABLE` (code 60).
+fn is_missing_relation(error: &clickhouse::error::Error) -> bool {
+    let message = error.to_string();
+    message.contains("UNKNOWN_TABLE") || message.contains("code: 60")
 }
 
 fn non_empty(value: String) -> Option<String> {

--- a/src/backend/services/identity-resolution/src/infra/identity_evidence.rs
+++ b/src/backend/services/identity-resolution/src/infra/identity_evidence.rs
@@ -95,7 +95,24 @@ impl ClickHouseEvidenceReader {
     /// Returns an error if the query fails or a stored source id is not a UUID.
     pub async fn accounts(&self) -> anyhow::Result<Vec<AccountEvidence>> {
         let rows: Vec<FoldedRow> = self.client.query(FOLD_SQL).fetch_all().await?;
-        rows.into_iter().map(map_row).collect()
+
+        // A row whose source id is not a UUID is one unusable account, not a
+        // reason to blind the whole review surface: skip it and say so.
+        let mut accounts = Vec::with_capacity(rows.len());
+        let mut skipped = 0usize;
+        for row in rows {
+            match map_row(row) {
+                Ok(evidence) => accounts.push(evidence),
+                Err(_) => skipped += 1,
+            }
+        }
+        if skipped > 0 {
+            tracing::warn!(
+                skipped,
+                "review evidence: rows with an unreadable source id"
+            );
+        }
+        Ok(accounts)
     }
 }
 

--- a/src/backend/services/identity-resolution/src/infra/identity_evidence.rs
+++ b/src/backend/services/identity-resolution/src/infra/identity_evidence.rs
@@ -178,10 +178,16 @@ impl ClickHouseEvidenceReader {
     }
 }
 
-/// ClickHouse reports an absent table as `UNKNOWN_TABLE` (code 60).
+/// ClickHouse reports an absent table as `UNKNOWN_TABLE` (code 60) — and a
+/// fresh install lacks the whole `identity` database until its first build,
+/// which reads as `UNKNOWN_DATABASE` (code 81). Both mean "nothing observed
+/// yet", never a failure to answer.
 fn is_missing_relation(error: &clickhouse::error::Error) -> bool {
     let message = error.to_string();
-    message.contains("UNKNOWN_TABLE") || message.contains("code: 60")
+    message.contains("UNKNOWN_TABLE")
+        || message.contains("code: 60")
+        || message.contains("UNKNOWN_DATABASE")
+        || message.contains("code: 81")
 }
 
 fn non_empty(value: String) -> Option<String> {
@@ -205,6 +211,33 @@ mod tests {
             email: email.to_owned(),
             username: username.to_owned(),
         }
+    }
+
+    #[test]
+    fn an_absent_database_reads_as_no_observations_like_an_absent_table() {
+        // A fresh install has neither `identity.identity_inputs` nor the
+        // `identity` database itself — dbt creates both on its first build.
+        for (label, message) in [
+            (
+                "absent table",
+                "Code: 60. DB::Exception: ... (UNKNOWN_TABLE)",
+            ),
+            (
+                "absent database",
+                "Code: 81. DB::Exception: Database identity does not exist. (UNKNOWN_DATABASE)",
+            ),
+        ] {
+            let error = clickhouse::error::Error::BadResponse(message.to_owned());
+            assert!(
+                is_missing_relation(&error),
+                "should read as missing: {label}"
+            );
+        }
+
+        let real = clickhouse::error::Error::BadResponse(
+            "Code: 241. DB::Exception: Memory limit exceeded".to_owned(),
+        );
+        assert!(!is_missing_relation(&real), "a real failure must surface");
     }
 
     #[test]

--- a/src/backend/services/identity-resolution/src/infra/identity_evidence.rs
+++ b/src/backend/services/identity-resolution/src/infra/identity_evidence.rs
@@ -116,6 +116,24 @@ impl ClickHouseEvidenceReader {
     }
 }
 
+/// Whether a connector has ever observed this account. Asked before the verbs
+/// that only make sense for an account that exists — an operator may
+/// pre-register a binding, but detaching or excluding something nothing has
+/// seen would mint a person for a typo.
+const EXISTS_SQL: &str = r"
+    SELECT count() AS hits
+    FROM identity.identity_inputs
+    WHERE insight_source_type = ?
+      AND toString(insight_source_id) = ?
+      AND source_account_id = ?
+    LIMIT 1
+";
+
+#[derive(Debug, Row, Deserialize)]
+struct CountRow {
+    hits: u64,
+}
+
 fn map_row(row: FoldedRow) -> anyhow::Result<AccountEvidence> {
     Ok(AccountEvidence {
         account: SourceAccountKey {
@@ -127,6 +145,25 @@ fn map_row(row: FoldedRow) -> anyhow::Result<AccountEvidence> {
         username: non_empty(row.username),
         is_closed: row.latest_op == "DELETE",
     })
+}
+
+impl ClickHouseEvidenceReader {
+    /// Whether the evidence knows this account.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the query fails.
+    pub async fn has_account(&self, account: &SourceAccountKey) -> anyhow::Result<bool> {
+        let row: Option<CountRow> = self
+            .client
+            .query(EXISTS_SQL)
+            .bind(account.source_type.as_str())
+            .bind(account.source_id.to_string())
+            .bind(account.account_id.as_str())
+            .fetch_optional()
+            .await?;
+        Ok(row.is_some_and(|r| r.hits > 0))
+    }
 }
 
 fn non_empty(value: String) -> Option<String> {

--- a/src/backend/services/identity-resolution/src/infra/identity_evidence.rs
+++ b/src/backend/services/identity-resolution/src/infra/identity_evidence.rs
@@ -49,7 +49,15 @@ const FOLD_SQL: &str = r"
     FROM identity.identity_inputs
     WHERE source_account_id IS NOT NULL AND source_account_id != ''
     GROUP BY source_type, source_id, account_id
+    ORDER BY source_type, source_id, account_id
 ";
+
+/// Ceiling on the fold, which is read whole into memory. The queue's rates are
+/// meant to cover every observed account, so this is a safety valve against an
+/// unbounded read rather than a pagination knob: reaching it truncates what the
+/// operator sees, and is reported rather than passed off as a complete answer.
+/// The fold is ordered so a truncated read is at least the same prefix twice.
+const MAX_EVIDENCE_ACCOUNTS: usize = 200_000;
 
 #[derive(Debug, Row, Deserialize)]
 struct FoldedRow {
@@ -94,11 +102,20 @@ impl ClickHouseEvidenceReader {
     ///
     /// Returns an error if the query fails or a stored source id is not a UUID.
     pub async fn accounts(&self) -> anyhow::Result<Vec<AccountEvidence>> {
-        let rows: Vec<FoldedRow> = match self.client.query(FOLD_SQL).fetch_all().await {
+        let sql = format!("{FOLD_SQL} LIMIT {MAX_EVIDENCE_ACCOUNTS}");
+        let rows: Vec<FoldedRow> = match self.client.query(&sql).fetch_all().await {
             Ok(rows) => rows,
             Err(e) if is_missing_relation(&e) => return Ok(Vec::new()),
             Err(e) => return Err(e.into()),
         };
+
+        if rows.len() == MAX_EVIDENCE_ACCOUNTS {
+            tracing::warn!(
+                cap = MAX_EVIDENCE_ACCOUNTS,
+                "review evidence: read cap reached; the queue and its rates \
+                 describe only this many accounts, not the whole tenant"
+            );
+        }
 
         // A row whose source id is not a UUID is one unusable account, not a
         // reason to blind the whole review surface: skip it and say so.

--- a/src/backend/services/identity-resolution/src/infra/identity_inputs.rs
+++ b/src/backend/services/identity-resolution/src/infra/identity_inputs.rs
@@ -66,7 +66,9 @@ use crate::domain::seed_service::IdentityInputsReader;
 /// …): a same-name `ifNull(value,'') AS value` would shadow the `value`
 /// referenced in `WHERE` and can trip a ClickHouse "Cyclic aliases" error (the
 /// .NET reader avoids this the same way). `is_delete` is derived from
-/// `operation_type`.
+/// `operation_type`. DELETE rows are closure signals that arrive with an
+/// empty `value` by the write contract, so the non-empty filter applies to
+/// UPSERT rows only — value-filtering DELETEs would drop every tombstone.
 const STREAM_SQL: &str = r"
     SELECT
         ifNull(insight_source_type, '')  AS source_type,
@@ -77,9 +79,8 @@ const STREAM_SQL: &str = r"
         toString(_synced_at)             AS synced_at,
         ifNull(operation_type, '')       AS op_type
     FROM identity.identity_inputs
-    WHERE operation_type IN ('UPSERT', 'DELETE')
-      AND value IS NOT NULL
-      AND value != ''
+    WHERE (operation_type = 'UPSERT' AND value IS NOT NULL AND value != '')
+       OR operation_type = 'DELETE'
     ORDER BY
         insight_source_type,
         insight_source_id,
@@ -166,6 +167,18 @@ fn parse_ch_datetime(s: &str) -> anyhow::Result<DateTime> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn stream_sql_keeps_empty_value_delete_rows() {
+        assert!(
+            STREAM_SQL.contains("OR operation_type = 'DELETE'"),
+            "DELETE closure signals carry an empty value and must not be value-filtered"
+        );
+        assert!(
+            STREAM_SQL.contains("operation_type = 'UPSERT' AND value IS NOT NULL"),
+            "the non-empty filter applies to UPSERT rows only"
+        );
+    }
 
     #[test]
     fn parses_clickhouse_datetime_with_and_without_fraction() -> anyhow::Result<()> {

--- a/src/backend/services/identity-resolution/src/infra/mod.rs
+++ b/src/backend/services/identity-resolution/src/infra/mod.rs
@@ -1,5 +1,6 @@
 //! Infrastructure adapters (DB pool, external clients).
 
 pub mod db;
+pub mod identity_evidence;
 pub mod identity_inputs;
 pub mod identity_persons;

--- a/src/ingestion/dbt/macros/create_identity_persons.sql
+++ b/src/ingestion/dbt/macros/create_identity_persons.sql
@@ -51,5 +51,4 @@
         ENGINE = MergeTree
         ORDER BY id
     ") %}
-
 {% endmacro %}

--- a/src/ingestion/dbt/macros/create_identity_persons.sql
+++ b/src/ingestion/dbt/macros/create_identity_persons.sql
@@ -1,21 +1,20 @@
 {#-
-  Creates the two identity relations gold resolves through and dbt does NOT own
-  the DATA of: `identity.identity_persons` — the persons-log copy written by the
-  identity-resolution service's persons-sync — and `identity.identity_inputs`,
-  the connector evidence written by the per-connector models. The resolver joins
-  them (an email resolves through the accounts carrying it), so a build must
-  meet both.
-
-  On `identity_persons`: It is written exclusively by the identity-resolution
+  Creates `identity.identity_persons` — the persons-log copy that dbt does NOT
+  own the DATA of. It is written exclusively by the identity-resolution
   service's persons-sync (full snapshot + atomic EXCHANGE swap); gold models
   LEFT JOIN it through the `resolve_person_id()` macro to attach a canonical
   `person_id` to email-keyed observations.
 
   Called from `on-run-start` (same pattern as `create_task_field_history_staging`)
   so a build on an environment where the sync has never run — fresh cluster,
-  CI, local k3d — meets EMPTY tables instead of missing ones: every resolve
-  comes back NULL and the pipeline behaves exactly as before the person_id
-  column existed. Graceful degradation, not a build failure.
+  CI, local k3d — meets an EMPTY table instead of a missing one: every
+  resolve comes back NULL and the pipeline behaves exactly as before the
+  person_id column existed. Graceful degradation, not a build failure.
+
+  The resolver's other input, `identity.identity_inputs`, is deliberately NOT
+  created here: dbt owns that relation (an incremental silver model). Creating
+  it early would make its first run think it is incremental and filter its own
+  seed rows away. The resolver degrades on its own when the relation is absent.
 
   SCHEMA CONTRACT: this DDL is a byte-for-byte copy of COLUMNS_DDL in
   src/backend/services/identity-resolution/src/infra/identity_persons.rs —
@@ -53,23 +52,4 @@
         ORDER BY id
     ") %}
 
-    {% do run_query("
-        CREATE TABLE IF NOT EXISTS identity.identity_inputs
-        (
-            unique_key          String,
-            insight_tenant_id   UUID,
-            insight_source_id   UUID,
-            insight_source_type String,
-            source_account_id   Nullable(String),
-            value_type          String,
-            value               Nullable(String),
-            value_field_name    String,
-            operation_type      String,
-            _synced_at          DateTime64(3),
-            _version            Int64
-        )
-        ENGINE = ReplacingMergeTree(_version)
-        ORDER BY unique_key
-        SETTINGS allow_nullable_key = 1
-    ") %}
 {% endmacro %}

--- a/src/ingestion/dbt/macros/create_identity_persons.sql
+++ b/src/ingestion/dbt/macros/create_identity_persons.sql
@@ -1,15 +1,21 @@
 {#-
-  Creates `identity.identity_persons` — the persons-log copy that dbt does NOT
-  own the DATA of. It is written exclusively by the identity-resolution
+  Creates the two identity relations gold resolves through and dbt does NOT own
+  the DATA of: `identity.identity_persons` — the persons-log copy written by the
+  identity-resolution service's persons-sync — and `identity.identity_inputs`,
+  the connector evidence written by the per-connector models. The resolver joins
+  them (an email resolves through the accounts carrying it), so a build must
+  meet both.
+
+  On `identity_persons`: It is written exclusively by the identity-resolution
   service's persons-sync (full snapshot + atomic EXCHANGE swap); gold models
   LEFT JOIN it through the `resolve_person_id()` macro to attach a canonical
   `person_id` to email-keyed observations.
 
   Called from `on-run-start` (same pattern as `create_task_field_history_staging`)
   so a build on an environment where the sync has never run — fresh cluster,
-  CI, local k3d — meets an EMPTY table instead of a missing one: every
-  resolve comes back NULL and the pipeline behaves exactly as before the
-  person_id column existed. Graceful degradation, not a build failure.
+  CI, local k3d — meets EMPTY tables instead of missing ones: every resolve
+  comes back NULL and the pipeline behaves exactly as before the person_id
+  column existed. Graceful degradation, not a build failure.
 
   SCHEMA CONTRACT: this DDL is a byte-for-byte copy of COLUMNS_DDL in
   src/backend/services/identity-resolution/src/infra/identity_persons.rs —
@@ -45,5 +51,25 @@
         )
         ENGINE = MergeTree
         ORDER BY id
+    ") %}
+
+    {% do run_query("
+        CREATE TABLE IF NOT EXISTS identity.identity_inputs
+        (
+            unique_key          String,
+            insight_tenant_id   UUID,
+            insight_source_id   UUID,
+            insight_source_type String,
+            source_account_id   Nullable(String),
+            value_type          String,
+            value               Nullable(String),
+            value_field_name    String,
+            operation_type      String,
+            _synced_at          DateTime64(3),
+            _version            Int64
+        )
+        ENGINE = ReplacingMergeTree(_version)
+        ORDER BY unique_key
+        SETTINGS allow_nullable_key = 1
     ") %}
 {% endmacro %}

--- a/src/ingestion/dbt/macros/resolve_person_id.sql
+++ b/src/ingestion/dbt/macros/resolve_person_id.sql
@@ -7,18 +7,41 @@
       LEFT JOIN ({{ resolve_person_id() }}) AS identity_map
           ON identity_map.email = <entity_id expression>
 
-  Emits (email, person_id), one row per email. Resolution rule v1 —
-  latest-observation-wins: the newest `value_type='email'` row per normalized
-  email claims it (`created_at DESC, id DESC`; the id tiebreak makes
-  same-instant observations deterministic, matching the service's own
-  reader ordering). No tenant filter — single-tenant reality (#1550); the
-  tenant column is in the log when that changes.
+  Emits (email, person_id), one row per email. The claim is ACCOUNT-DERIVED:
+  an email resolves through the accounts that carry it, not through a
+  standalone email observation. Every account's current binding is the latest
+  `value_type='id'` row for it; an email's claimants are the persons those
+  accounts are bound to; the email resolves only when they agree.
+
+  Why not latest-email-wins (rule v1): operator corrections are recorded as
+  bindings — `value_type='id'` rows — so a merge or a detach left the email
+  map untouched and never reached the metrics. Reading the map through
+  bindings is what makes a correction re-attribute activity on the next build.
+  It also makes a shared value fail safe: an email carried by accounts of two
+  different people has two claimants and resolves to NOBODY, instead of the
+  latest observation silently awarding it to one of them.
+
+  Accounts the source has deactivated still claim: closure means the account
+  is gone from the source, not that its history stops belonging to the person.
+  Excluded accounts (bots, CI, service accounts — bound to the reserved
+  excluded person) claim nothing, so their emails resolve to no one.
+
+  No tenant filter — single-tenant reality (#1550); the tenant column is in
+  the log when that changes. And no join on tenant between the two stores:
+  `identity_inputs` carries a producer-side hashed tenant that never equals
+  the journal's, so the account triple is the only sound key across them.
 
   This macro is deliberately the ONLY place resolution semantics live.
   Future smarts — per-source maps ("this email as seen by git sources"),
   tenant scoping, as_of resolution off `created_at` — change this body and
   every consuming model picks it up on the next build. Consumers must not
   re-derive person_id any other way.
+
+  NOT YET account-first: gold facts carry an email, never the account that
+  produced it (`entity_id` is an email everywhere — see the evidence models),
+  so there is nothing to key an account-first lookup on. Propagating source
+  account ids through silver is its own piece of work; until then this map is
+  how corrections reach gold.
 
   NORMALIZATION CONTRACT: `lower(trimBoth(...))` on BOTH sides, enforced in
   the join itself — resolved_person_id_join() applies the same expression to
@@ -36,17 +59,57 @@
 
 {% macro resolve_person_id() %}
     SELECT
-        lower(trimBoth(value_effective)) AS email,
-        person_id
-    FROM identity.identity_persons
-    WHERE value_type = 'email'
-      AND value_effective IS NOT NULL
-      AND trimBoth(value_effective) != ''
-    ORDER BY
-        email,
-        created_at DESC,
-        id DESC
-    LIMIT 1 BY email
+        ae.email                             AS email,
+        any(cb.person_id)                    AS person_id
+    FROM (
+        SELECT
+            insight_source_type              AS source_type,
+            insight_source_id                AS source_id,
+            source_account_id                AS account_id,
+            argMaxIf(
+                lower(trimBoth(value)),
+                _synced_at,
+                value_type = 'email' AND operation_type = 'UPSERT' AND value != ''
+            )                                AS email
+        FROM identity.identity_inputs
+        WHERE coalesce(source_account_id, '') != ''
+        GROUP BY source_type, source_id, account_id
+    ) AS ae
+    INNER JOIN (
+        SELECT
+            insight_source_type              AS source_type,
+            insight_source_id                AS source_id,
+            trimBoth(value_effective)        AS account_id,
+            person_id
+        FROM identity.identity_persons
+        WHERE value_type = 'id'
+          AND value_effective IS NOT NULL
+          AND trimBoth(value_effective) != ''
+        ORDER BY
+            source_type,
+            source_id,
+            account_id,
+            created_at DESC,
+            id DESC
+        LIMIT 1 BY source_type, source_id, account_id
+    ) AS cb
+        ON cb.source_type = ae.source_type
+       AND cb.source_id = ae.source_id
+       AND cb.account_id = ae.account_id
+    WHERE ae.email != ''
+      AND cb.person_id != {{ excluded_person_id() }}
+    GROUP BY ae.email
+    HAVING uniqExact(cb.person_id) = 1
+{% endmacro %}
+
+{#-
+  The reserved person meaning "not a human" (bots, CI, service accounts). One
+  global constant, unmintable — UUIDv7 never produces an all-ones value — and
+  the service binds excluded accounts to it. Every consumer reads it as no
+  person; here that means such an account claims no email.
+-#}
+{% macro excluded_person_id() %}
+    toUUID('ffffffff-ffff-ffff-ffff-ffffffffffff')
 {% endmacro %}
 
 {#-

--- a/src/ingestion/dbt/macros/resolve_person_id.sql
+++ b/src/ingestion/dbt/macros/resolve_person_id.sql
@@ -13,6 +13,13 @@
   `value_type='id'` row for it; an email's claimants are the persons those
   accounts are bound to; the email resolves only when they agree.
 
+  EVERY email an account has carried claims it, not just its current one: a
+  person who changed address still owns the facts recorded under the old one,
+  and dropping them would unresolve their history at the moment they renamed.
+  An address later carried by someone else's account has two claimants and so
+  resolves to nobody — recycling an address costs resolution, never a wrong
+  attribution.
+
   Why not latest-email-wins (rule v1): operator corrections are recorded as
   bindings — `value_type='id'` rows — so a merge or a detach left the email
   map untouched and never reached the metrics. Reading the map through
@@ -58,22 +65,30 @@
 -#}
 
 {% macro resolve_person_id() %}
+{%- set evidence = adapter.get_relation(
+        database=target.database, schema='identity', identifier='identity_inputs') -%}
+{%- if evidence is none -%}
+    {#- The connector evidence has never been built: resolve nothing rather
+        than fail the build, exactly as an empty journal would. -#}
+    SELECT
+        ''                                   AS email,
+        toUUID('00000000-0000-0000-0000-000000000000') AS person_id
+    WHERE 0
+{%- else -%}
     SELECT
         ae.email                             AS email,
         any(cb.person_id)                    AS person_id
     FROM (
-        SELECT
+        SELECT DISTINCT
             insight_source_type              AS source_type,
             insight_source_id                AS source_id,
             source_account_id                AS account_id,
-            argMaxIf(
-                lower(trimBoth(value)),
-                _synced_at,
-                value_type = 'email' AND operation_type = 'UPSERT' AND value != ''
-            )                                AS email
+            lower(trimBoth(value))           AS email
         FROM identity.identity_inputs
-        WHERE coalesce(source_account_id, '') != ''
-        GROUP BY source_type, source_id, account_id
+        WHERE value_type = 'email'
+          AND operation_type = 'UPSERT'
+          AND coalesce(value, '') != ''
+          AND coalesce(source_account_id, '') != ''
     ) AS ae
     INNER JOIN (
         SELECT
@@ -100,6 +115,7 @@
       AND cb.person_id != {{ excluded_person_id() }}
     GROUP BY ae.email
     HAVING uniqExact(cb.person_id) = 1
+{%- endif -%}
 {% endmacro %}
 
 {#-

--- a/src/ingestion/tests/e2e/identity/test_operator_corrections.py
+++ b/src/ingestion/tests/e2e/identity/test_operator_corrections.py
@@ -191,3 +191,232 @@ def test_the_queue_reports_items_and_rates_over_observed_accounts(identity_svc, 
     assert rates["observed"] >= rates["bound"] + rates["excluded"], rates
     for item in body["items"]:
         assert item["kind"] in {"contested", "binding_conflict", "no_evidence"}, item
+
+
+def test_the_queue_honours_the_limit_without_narrowing_the_rates(identity_svc, api: httpx.Client) -> None:
+    """`limit` truncates the items an operator is handed; the rates describe
+    every observed account either way, so they must not move with it."""
+    full = api.get("/v1/resolution/attention")
+    assert full.status_code == 200, full.text
+
+    capped = api.get("/v1/resolution/attention", params={"limit": 1})
+    assert capped.status_code == 200, capped.text
+    assert len(capped.json()["items"]) <= 1, capped.json()
+    assert capped.json()["rates"] == full.json()["rates"], "the rates are not a page of the queue"
+
+
+def _mint_person(api: httpx.Client, account_id: str) -> str:
+    """A person nothing else in the suite owns: pre-register an account, then
+    detach it into a person of its own. Returns the new `person_id`."""
+    bound = api.post(
+        "/v1/resolution/bind",
+        json={
+            "bindings": [{"account": _account(account_id), "person_id": str(identity_seed.BOB)}],
+            "comment": "e2e: pre-register before minting",
+        },
+    )
+    assert bound.status_code == 200, bound.text
+
+    detached = api.post("/v1/resolution/detach", json={"account": _account(account_id), "comment": "e2e: mint"})
+    assert detached.status_code == 200, detached.text
+    return detached.json()["new_person_id"]
+
+
+def test_merge_moves_every_account_of_the_absorbed_person(
+    identity_svc, api: httpx.Client, compose_stack: SessionConfig
+) -> None:
+    """Merge is the whole-person verb: every account bound to the source ends
+    up on the survivor, and the accounts keep their history rather than being
+    rewritten."""
+    absorbed_first = f"acc-merge-a-{uuid.uuid4().hex[:8]}"
+    absorbed_second = f"acc-merge-b-{uuid.uuid4().hex[:8]}"
+    source = _mint_person(api, absorbed_first)
+    survivor = _mint_person(api, f"acc-merge-keep-{uuid.uuid4().hex[:8]}")
+
+    # A second account on the source person, so the merge has to move more
+    # than one and cannot pass by moving only the first.
+    second = api.post(
+        "/v1/resolution/bind",
+        json={
+            "bindings": [{"account": _account(absorbed_second), "person_id": source}],
+            "comment": "e2e: second account of the absorbed person",
+        },
+    )
+    assert second.status_code == 200, second.text
+
+    history_before = _binding_rows(compose_stack, absorbed_first)
+
+    merged = api.post(
+        "/v1/resolution/merge",
+        json={"source_person_id": source, "target_person_id": survivor, "comment": "e2e: one human"},
+    )
+    assert merged.status_code == 200, merged.text
+    assert merged.json()["applied"] == 2, merged.json()
+
+    for account_id in (absorbed_first, absorbed_second):
+        rows = _binding_rows(compose_stack, account_id)
+        assert rows[0][0] == uuid.UUID(survivor).hex, f"{account_id} did not reach the survivor"
+
+    after = _binding_rows(compose_stack, absorbed_first)
+    assert after[1:] == history_before, "the merge appended; it must not rewrite what was there"
+
+
+def test_merge_refuses_a_person_that_is_not_two_people(identity_svc, api: httpx.Client) -> None:
+    """Merging a person into themselves has no meaning, and neither side may
+    be a person the tenant's journal has never heard of."""
+    known = str(identity_seed.BOB)
+    stranger = str(uuid.uuid4())
+
+    same = api.post(
+        "/v1/resolution/merge",
+        json={"source_person_id": known, "target_person_id": known, "comment": "e2e: self-merge"},
+    )
+    assert same.status_code == 400, same.text
+    problem(same)
+
+    for label, body in (
+        ("unknown source", {"source_person_id": stranger, "target_person_id": known}),
+        ("unknown target", {"source_person_id": known, "target_person_id": stranger}),
+    ):
+        response = api.post("/v1/resolution/merge", json={**body, "comment": "e2e"})
+        assert response.status_code == 404, f"{label}: {response.text}"
+        problem(response)
+
+
+def test_bind_refuses_a_person_the_tenant_never_had(identity_svc, api: httpx.Client) -> None:
+    """A correction may not invent its target: binding to an unknown person is
+    a typo, not a decision to record."""
+    response = api.post(
+        "/v1/resolution/bind",
+        json={
+            "bindings": [{"account": _account(identity_seed.ALICE_ACCOUNT_ID), "person_id": str(uuid.uuid4())}],
+            "comment": "e2e: unknown person",
+        },
+    )
+
+    assert response.status_code == 404, response.text
+    problem(response)
+
+
+def test_bind_refuses_an_empty_and_an_oversized_call(identity_svc, api: httpx.Client) -> None:
+    """A bulk call carries a prepared matching table pasted by a human — no
+    rows is a mistake, and past the cap it is not a paste any more."""
+    empty = api.post("/v1/resolution/bind", json={"bindings": [], "comment": "e2e: nothing to do"})
+    assert empty.status_code == 400, empty.text
+    problem(empty)
+
+    one_too_many = [
+        {"account": _account(f"acc-bulk-{index}"), "person_id": str(identity_seed.BOB)} for index in range(1001)
+    ]
+    oversized = api.post("/v1/resolution/bind", json={"bindings": one_too_many, "comment": "e2e: too many"})
+    assert oversized.status_code == 400, oversized.text
+    problem(oversized)
+
+
+def test_an_accounts_history_names_every_decision_and_its_author(
+    identity_svc, api: httpx.Client, compose_stack: SessionConfig
+) -> None:
+    """The explain surface answers why an account belongs to whom: the binding
+    in force plus each decision behind it, marked human or automatic."""
+    account_id = f"acc-history-{uuid.uuid4().hex[:8]}"
+    person = _mint_person(api, account_id)
+
+    response = api.get(f"/v1/resolution/accounts/{identity_seed.SOURCE_TYPE}/{identity_seed.SOURCE_ID}/{account_id}")
+    assert response.status_code == 200, response.text
+
+    body = response.json()
+    assert body["account_id"] == account_id, body
+    assert body["person_id"] == person, "the binding in force is the newest decision"
+
+    reasons = [entry["reason"] for entry in body["history"]]
+    assert reasons == ["operator-detach", "operator-bind"], f"newest first, both verbs recorded: {reasons}"
+    assert all(entry["by_operator"] for entry in body["history"]), body["history"]
+    assert all(entry["author_person_id"] == str(identity_seed.ALICE) for entry in body["history"]), body["history"]
+
+
+def test_an_unknown_accounts_history_is_empty_rather_than_missing(identity_svc, api: httpx.Client) -> None:
+    """Asking about an account nobody has bound is a legitimate question with
+    an empty answer — the read surface reports no binding, not not-found."""
+    response = api.get(f"/v1/resolution/accounts/{identity_seed.SOURCE_TYPE}/{identity_seed.SOURCE_ID}/acc-never-seen")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["person_id"] is None, response.json()
+    assert response.json()["history"] == [], response.json()
+
+
+def test_a_persons_accounts_are_listed_with_who_bound_them(identity_svc, api: httpx.Client) -> None:
+    """The matching table for one person: every account bound to them, and
+    whether a human or automation made each link."""
+    account_id = f"acc-listed-{uuid.uuid4().hex[:8]}"
+    person = _mint_person(api, account_id)
+
+    response = api.get(f"/v1/resolution/persons/{person}/accounts")
+    assert response.status_code == 200, response.text
+
+    body = response.json()
+    assert body["person_id"] == person, body
+    listed = {entry["account_id"]: entry for entry in body["accounts"]}
+    assert account_id in listed, body
+    assert listed[account_id]["bound_by_operator"] is True, listed[account_id]
+
+
+def test_a_person_with_no_accounts_lists_none(identity_svc, api: httpx.Client) -> None:
+    """A person id the journal never bound an account to answers with an empty
+    table, not an error — the question is well-formed."""
+    response = api.get(f"/v1/resolution/persons/{uuid.uuid4()}/accounts")
+
+    assert response.status_code == 200, response.text
+    assert response.json()["accounts"] == [], response.json()
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/v1/resolution/persons/not-a-uuid/accounts",
+        f"/v1/resolution/accounts/{identity_seed.SOURCE_TYPE}/not-a-uuid/acc-alice",
+    ],
+    ids=["person_id", "source_id"],
+)
+def test_a_malformed_uuid_in_the_path_is_rejected(identity_svc, api: httpx.Client, path: str) -> None:
+    """Both read paths carry a UUID segment; anything else never reaches the
+    handler, so no query is built from an unparsed value."""
+    response = api.get(path)
+
+    assert response.status_code == 400, response.text
+
+
+# Every route of the correction surface, with a body that parses — the
+# authorization gate runs inside the handler, so a body the extractor would
+# reject would prove nothing about the gate.
+_ROUTES: list[tuple[str, str, dict[str, object] | None]] = [
+    ("POST", "/v1/resolution/bind", {"bindings": [{"account": _account("acc-authz"), "person_id": str(uuid.uuid4())}]}),
+    ("POST", "/v1/resolution/merge", {"source_person_id": str(uuid.uuid4()), "target_person_id": str(uuid.uuid4())}),
+    ("POST", "/v1/resolution/detach", {"account": _account("acc-authz")}),
+    ("POST", "/v1/resolution/exclude", {"account": _account("acc-authz")}),
+    ("GET", "/v1/resolution/attention", None),
+    ("GET", f"/v1/resolution/accounts/{identity_seed.SOURCE_TYPE}/{identity_seed.SOURCE_ID}/acc-authz", None),
+    ("GET", f"/v1/resolution/persons/{identity_seed.BOB}/accounts", None),
+]
+
+
+@pytest.mark.parametrize(("method", "path", "body"), _ROUTES, ids=[f"{m} {p}" for m, p, _ in _ROUTES])
+def test_every_route_refuses_a_caller_without_the_operator_grant(
+    identity_svc, bob_api: httpx.Client, method: str, path: str, body: dict[str, object] | None
+) -> None:
+    """The whole surface is operator-only — reads included: the queue and the
+    history describe who someone is, which is not for every authenticated
+    caller to see."""
+    response = bob_api.request(method, path, json=body)
+
+    assert response.status_code == 403, response.text
+    problem(response)
+
+
+@pytest.mark.parametrize(("method", "path", "body"), _ROUTES, ids=[f"{m} {p}" for m, p, _ in _ROUTES])
+def test_every_route_refuses_an_unauthenticated_caller(
+    identity_svc, anon_api: httpx.Client, method: str, path: str, body: dict[str, object] | None
+) -> None:
+    """No token, no answer — before any authorization question is asked."""
+    response = anon_api.request(method, path, json=body)
+
+    assert response.status_code == 401, response.text

--- a/src/ingestion/tests/e2e/identity/test_operator_corrections.py
+++ b/src/ingestion/tests/e2e/identity/test_operator_corrections.py
@@ -1,0 +1,169 @@
+"""Operator corrections against the live service and its journal.
+
+The behaviours here are DB-shaped — what `INSERT IGNORE` accepted, what the
+journal holds afterwards, what a verb refuses — so they cannot be reached from
+the Rust unit tests. Each test states one rule of the correction contract.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import httpx
+import pymysql
+import pytest
+
+from lib import identity_seed
+from lib.config import SessionConfig
+from lib.identity import IDENTITY_DATABASE
+
+from .contract import problem
+
+pytestmark = [pytest.mark.identity, pytest.mark.mutating]
+
+
+def _account(account_id: str) -> dict[str, object]:
+    return {
+        "source": identity_seed.SOURCE_TYPE,
+        "source_id": str(identity_seed.SOURCE_ID),
+        "id": account_id,
+    }
+
+
+def _binding_rows(cfg: SessionConfig, account_id: str) -> list[tuple[str, str]]:
+    """(person_id, author_person_id) of every binding observation for one
+    account, newest first — read straight from the journal, not the API."""
+    with pymysql.connect(
+        host=cfg.mariadb_host,
+        port=cfg.mariadb_port,
+        user=cfg.mariadb_user,
+        password=cfg.mariadb_password,
+        database=IDENTITY_DATABASE,
+    ) as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT LOWER(HEX(person_id)), LOWER(HEX(author_person_id))
+            FROM persons
+            WHERE value_type = 'id'
+              AND insight_tenant_id = UNHEX(REPLACE(%s, '-', ''))
+              AND insight_source_type = %s
+              AND value_id = %s
+            ORDER BY created_at DESC, id DESC
+            """,
+            (str(identity_seed.TEST_TENANT_ID), identity_seed.SOURCE_TYPE, account_id),
+        )
+        return [(row[0], row[1]) for row in cur.fetchall()]
+
+
+def test_confirming_an_automatic_binding_records_the_operator(
+    identity_svc, api: httpx.Client, compose_stack: SessionConfig
+) -> None:
+    """Binding an account to the person automation already gave it is the
+    confirm act: the same person, now authored by a human. It must append a
+    row — the operator's decision is what takes the account out of review —
+    and only a REPEAT of that decision is a no-op."""
+    account_id = identity_seed.ALICE_ACCOUNT_ID
+    before = _binding_rows(compose_stack, account_id)
+    assert before, "the fixture seeds an automatic binding for this account"
+
+    confirm = api.post(
+        "/v1/resolution/bind",
+        json={
+            "bindings": [{"account": _account(account_id), "person_id": str(identity_seed.ALICE)}],
+            "comment": "e2e: confirm the automatic binding",
+        },
+    )
+    assert confirm.status_code == 200, confirm.text
+    assert confirm.json()["applied"] == 1, confirm.json()
+
+    after = _binding_rows(compose_stack, account_id)
+    assert len(after) == len(before) + 1, "the confirmation is a new observation"
+    assert after[0][1] == identity_seed.ALICE.hex, "authored by the calling operator"
+
+    repeat = api.post(
+        "/v1/resolution/bind",
+        json={
+            "bindings": [{"account": _account(account_id), "person_id": str(identity_seed.ALICE)}],
+            "comment": "e2e: repeat the same decision",
+        },
+    )
+    assert repeat.status_code == 200, repeat.text
+    assert repeat.json()["applied"] == 0, "repeating an operator decision writes nothing"
+    assert repeat.json()["already_decided"] == 1, repeat.json()
+    assert _binding_rows(compose_stack, account_id) == after, "no duplicate history"
+
+
+@pytest.mark.parametrize("verb", ["detach", "exclude"])
+def test_verbs_refuse_an_account_nothing_has_observed(
+    identity_svc, api: httpx.Client, verb: str
+) -> None:
+    """Pre-registration is a bind-only affordance: minting a person, or an
+    excluded binding, for an account nobody has ever seen is a typo."""
+    response = api.post(
+        f"/v1/resolution/{verb}",
+        json={"account": _account(f"ghost-{uuid.uuid4().hex[:8]}"), "comment": "e2e"},
+    )
+
+    assert response.status_code == 404, response.text
+    problem(response)
+
+
+def test_a_bulk_call_naming_one_account_twice_is_rejected(
+    identity_svc, api: httpx.Client
+) -> None:
+    """Which person wins is the caller's contradiction to resolve."""
+    account = _account(identity_seed.ALICE_ACCOUNT_ID)
+    response = api.post(
+        "/v1/resolution/bind",
+        json={
+            "bindings": [
+                {"account": account, "person_id": str(identity_seed.ALICE)},
+                {"account": account, "person_id": str(identity_seed.BOB)},
+            ],
+            "comment": "e2e: contradictory bulk",
+        },
+    )
+
+    assert response.status_code == 400, response.text
+    problem(response)
+
+
+def test_detach_moves_the_account_and_names_the_person_it_reached(
+    identity_svc, api: httpx.Client, compose_stack: SessionConfig
+) -> None:
+    """Detach works on an account regardless of how its current grouping arose,
+    and reports the person the account actually reached."""
+    account_id = "acc-carol"  # a leaf of the fixture tree, safe to move
+    before = _binding_rows(compose_stack, account_id)
+
+    response = api.post(
+        "/v1/resolution/detach",
+        json={"account": _account(account_id), "comment": "e2e: detach"},
+    )
+    assert response.status_code == 200, response.text
+
+    body = response.json()
+    assert body["applied"] == 1, body
+    new_person = body["new_person_id"]
+    assert new_person, "a successful detach names the person it minted"
+
+    after = _binding_rows(compose_stack, account_id)
+    assert len(after) == len(before) + 1
+    assert after[0][0] == uuid.UUID(new_person).hex, "the account reached the reported person"
+
+
+def test_the_queue_reports_items_and_rates_over_observed_accounts(
+    identity_svc, api: httpx.Client
+) -> None:
+    """The queue answers with the two things an operator needs: what to decide,
+    and how much is already resolved. Every item names one of the three
+    conditions, and the rates cover the accounts the evidence knows."""
+    queue = api.get("/v1/resolution/attention")
+    assert queue.status_code == 200, queue.text
+
+    body = queue.json()
+    assert "items" in body and "rates" in body, body
+    rates = body["rates"]
+    assert rates["observed"] >= rates["bound"] + rates["excluded"], rates
+    for item in body["items"]:
+        assert item["kind"] in {"contested", "binding_conflict", "no_evidence"}, item

--- a/src/ingestion/tests/e2e/identity/test_operator_corrections.py
+++ b/src/ingestion/tests/e2e/identity/test_operator_corrections.py
@@ -523,3 +523,23 @@ def test_an_operator_decision_survives_the_next_seed_run(identity_svc, compose_s
     after = _binding_rows(compose_stack, corrected, tenant=identity_seed.SEED_TENANT, source_type=source_type)
     assert after[0][0] == uuid.UUID(survivor).hex, "the seed re-derived the binding the operator overruled"
     assert after[0][1] == identity_seed.SEED_ADMIN.hex, "the surviving decision is still the operator's"
+
+    # The correction is only worth anything if it reaches the analytics side.
+    # The resolver reads the ClickHouse mirror of this journal, so the mirror
+    # is where the two halves of that claim meet: the metrics suite proves the
+    # mirror decides gold's person_id, and this proves a correction decides the
+    # mirror.
+    synced = identity_svc.run_sync_cli(tenant=str(identity_seed.SEED_TENANT), force=True)
+    assert synced.returncode == 0, f"rc={synced.returncode}\n{synced.stdout}\n{synced.stderr}"
+
+    mirrored = clickhouse.query(
+        compose_stack,
+        "SELECT toString(person_id), toString(author_person_id)"
+        " FROM identity.identity_persons"
+        f" WHERE value_type = 'id' AND insight_source_type = '{source_type}'"
+        f"   AND value_effective = '{corrected}'"
+        " ORDER BY created_at DESC, id DESC LIMIT 1",
+    )
+    assert mirrored, "the correction never reached the mirror the analytics resolver reads"
+    assert mirrored[0][0] == survivor, "the mirror still names the person the operator overruled"
+    assert mirrored[0][1] == str(identity_seed.SEED_ADMIN), "the mirrored decision lost its author"

--- a/src/ingestion/tests/e2e/identity/test_operator_corrections.py
+++ b/src/ingestion/tests/e2e/identity/test_operator_corrections.py
@@ -12,7 +12,6 @@ import uuid
 import httpx
 import pymysql
 import pytest
-
 from lib import identity_seed
 from lib.config import SessionConfig
 from lib.identity import IDENTITY_DATABASE
@@ -23,23 +22,22 @@ pytestmark = [pytest.mark.identity, pytest.mark.mutating]
 
 
 def _account(account_id: str) -> dict[str, object]:
-    return {
-        "source": identity_seed.SOURCE_TYPE,
-        "source_id": str(identity_seed.SOURCE_ID),
-        "id": account_id,
-    }
+    return {"source": identity_seed.SOURCE_TYPE, "source_id": str(identity_seed.SOURCE_ID), "id": account_id}
 
 
 def _binding_rows(cfg: SessionConfig, account_id: str) -> list[tuple[str, str]]:
     """(person_id, author_person_id) of every binding observation for one
     account, newest first — read straight from the journal, not the API."""
-    with pymysql.connect(
-        host=cfg.mariadb_host,
-        port=cfg.mariadb_port,
-        user=cfg.mariadb_user,
-        password=cfg.mariadb_password,
-        database=IDENTITY_DATABASE,
-    ) as conn, conn.cursor() as cur:
+    with (
+        pymysql.connect(
+            host=cfg.mariadb_host,
+            port=cfg.mariadb_port,
+            user=cfg.mariadb_user,
+            password=cfg.mariadb_password,
+            database=IDENTITY_DATABASE,
+        ) as conn,
+        conn.cursor() as cur,
+    ):
         cur.execute(
             """
             SELECT LOWER(HEX(person_id)), LOWER(HEX(author_person_id))
@@ -94,23 +92,18 @@ def test_confirming_an_automatic_binding_records_the_operator(
 
 
 @pytest.mark.parametrize("verb", ["detach", "exclude"])
-def test_verbs_refuse_an_account_nothing_has_observed(
-    identity_svc, api: httpx.Client, verb: str
-) -> None:
+def test_verbs_refuse_an_account_nothing_has_observed(identity_svc, api: httpx.Client, verb: str) -> None:
     """Pre-registration is a bind-only affordance: minting a person, or an
     excluded binding, for an account nobody has ever seen is a typo."""
     response = api.post(
-        f"/v1/resolution/{verb}",
-        json={"account": _account(f"ghost-{uuid.uuid4().hex[:8]}"), "comment": "e2e"},
+        f"/v1/resolution/{verb}", json={"account": _account(f"ghost-{uuid.uuid4().hex[:8]}"), "comment": "e2e"}
     )
 
     assert response.status_code == 404, response.text
     problem(response)
 
 
-def test_a_bulk_call_naming_one_account_twice_is_rejected(
-    identity_svc, api: httpx.Client
-) -> None:
+def test_a_bulk_call_naming_one_account_twice_is_rejected(identity_svc, api: httpx.Client) -> None:
     """Which person wins is the caller's contradiction to resolve."""
     account = _account(identity_seed.ALICE_ACCOUNT_ID)
     response = api.post(
@@ -136,10 +129,7 @@ def test_detach_moves_the_account_and_names_the_person_it_reached(
     account_id = "acc-carol"  # a leaf of the fixture tree, safe to move
     before = _binding_rows(compose_stack, account_id)
 
-    response = api.post(
-        "/v1/resolution/detach",
-        json={"account": _account(account_id), "comment": "e2e: detach"},
-    )
+    response = api.post("/v1/resolution/detach", json={"account": _account(account_id), "comment": "e2e: detach"})
     assert response.status_code == 200, response.text
 
     body = response.json()
@@ -152,9 +142,43 @@ def test_detach_moves_the_account_and_names_the_person_it_reached(
     assert after[0][0] == uuid.UUID(new_person).hex, "the account reached the reported person"
 
 
-def test_the_queue_reports_items_and_rates_over_observed_accounts(
-    identity_svc, api: httpx.Client
+def test_an_excluded_account_no_longer_resolves_at_login(
+    identity_svc, api: httpx.Client, service_api: httpx.Client
 ) -> None:
+    """Excluding an account makes it nobody everywhere: the login bootstrap
+    must answer not-found rather than hand every excluded account the same
+    shared sentinel identity."""
+    account_id = f"acc-bot-{uuid.uuid4().hex[:8]}"
+
+    bound = api.post(
+        "/v1/resolution/bind",
+        json={
+            "bindings": [{"account": _account(account_id), "person_id": str(identity_seed.BOB)}],
+            "comment": "e2e: pre-register the bot before excluding it",
+        },
+    )
+    assert bound.status_code == 200, bound.text
+    assert bound.json()["applied"] == 1, bound.json()
+
+    resolves = service_api.get(
+        "/internal/persons/by-external-id", params={"source_type": identity_seed.SOURCE_TYPE, "external_id": account_id}
+    )
+    assert resolves.status_code == 200, "a bound account resolves before the exclusion"
+
+    excluded = api.post(
+        "/v1/resolution/exclude", json={"account": _account(account_id), "comment": "e2e: not a person"}
+    )
+    assert excluded.status_code == 200, excluded.text
+    assert excluded.json()["applied"] == 1, excluded.json()
+
+    gone = service_api.get(
+        "/internal/persons/by-external-id", params={"source_type": identity_seed.SOURCE_TYPE, "external_id": account_id}
+    )
+    assert gone.status_code == 404, gone.text
+    problem(gone)
+
+
+def test_the_queue_reports_items_and_rates_over_observed_accounts(identity_svc, api: httpx.Client) -> None:
     """The queue answers with the two things an operator needs: what to decide,
     and how much is already resolved. Every item names one of the three
     conditions, and the rates cover the accounts the evidence knows."""

--- a/src/ingestion/tests/e2e/identity/test_operator_corrections.py
+++ b/src/ingestion/tests/e2e/identity/test_operator_corrections.py
@@ -12,7 +12,7 @@ import uuid
 import httpx
 import pymysql
 import pytest
-from lib import identity_seed
+from lib import clickhouse, identity_seed
 from lib.config import SessionConfig
 from lib.identity import IDENTITY_DATABASE
 
@@ -25,7 +25,13 @@ def _account(account_id: str) -> dict[str, object]:
     return {"source": identity_seed.SOURCE_TYPE, "source_id": str(identity_seed.SOURCE_ID), "id": account_id}
 
 
-def _binding_rows(cfg: SessionConfig, account_id: str) -> list[tuple[str, str]]:
+def _binding_rows(
+    cfg: SessionConfig,
+    account_id: str,
+    *,
+    tenant: uuid.UUID = identity_seed.TEST_TENANT_ID,
+    source_type: str = identity_seed.SOURCE_TYPE,
+) -> list[tuple[str, str]]:
     """(person_id, author_person_id) of every binding observation for one
     account, newest first — read straight from the journal, not the API."""
     with (
@@ -48,7 +54,7 @@ def _binding_rows(cfg: SessionConfig, account_id: str) -> list[tuple[str, str]]:
               AND value_id = %s
             ORDER BY created_at DESC, id DESC
             """,
-            (str(identity_seed.TEST_TENANT_ID), identity_seed.SOURCE_TYPE, account_id),
+            (str(tenant), source_type, account_id),
         )
         return [(row[0], row[1]) for row in cur.fetchall()]
 
@@ -420,3 +426,100 @@ def test_every_route_refuses_an_unauthenticated_caller(
     response = anon_api.request(method, path, json=body)
 
     assert response.status_code == 401, response.text
+
+
+_SEED_SOURCE_ID = "77777777-7777-7777-7777-777777777777"
+
+
+def _ensure_identity_inputs_table(cfg: SessionConfig) -> None:
+    """The evidence relation is dbt's to own, so on a fresh stack it does not
+    exist yet. Declared here (IF NOT EXISTS) rather than imported, so this
+    module never depends on another test file having run first."""
+    clickhouse.ensure_database(cfg, "identity")
+    clickhouse.execute(
+        cfg,
+        """
+        CREATE TABLE IF NOT EXISTS identity.identity_inputs (
+            unique_key          String,
+            insight_tenant_id   Nullable(String),
+            insight_source_type String,
+            insight_source_id   Nullable(String),
+            source_account_id   Nullable(String),
+            value_type          Nullable(String),
+            value               Nullable(String),
+            operation_type      String,
+            _synced_at          DateTime64(3, 'UTC'),
+            _version            UInt64
+        ) ENGINE = ReplacingMergeTree(_version) ORDER BY unique_key
+        """,
+    )
+
+
+def _observe_account(cfg: SessionConfig, run_tag: str, account_id: str, email: str, source_type: str) -> None:
+    """Put one account into the connector evidence the seed reads, with an
+    e-mail so the seed has something to resolve it by."""
+    rows = [(account_id, "id", account_id), (account_id, "email", email)]
+    values = ", ".join(
+        f"('{run_tag}:{account}:{value_type}', '{identity_seed.SEED_TENANT}', '{source_type}', "
+        f"'{_SEED_SOURCE_ID}', '{account}', '{value_type}', '{value}', 'UPSERT', now64(3), {index + 1})"
+        for index, (account, value_type, value) in enumerate(rows)
+    )
+    clickhouse.execute(
+        cfg,
+        "INSERT INTO identity.identity_inputs "  # noqa: S608 — every value is a run-tagged test literal
+        "(unique_key, insight_tenant_id, insight_source_type, insight_source_id,"
+        " source_account_id, value_type, value, operation_type, _synced_at, _version) VALUES " + values,
+    )
+
+
+def test_an_operator_decision_survives_the_next_seed_run(identity_svc, compose_stack: SessionConfig) -> None:
+    """The durability requirement, end to end: automation binds an account,
+    an operator moves it elsewhere, automation runs again — and finds the
+    operator's decision already there and reuses it. Everything else in this
+    feature is inert if a re-run can quietly undo a human's answer.
+    """
+    if not identity_svc.supports_seed_cli:
+        pytest.skip("the seed CLI exists only on the Rust implementation (#1690)")
+
+    run_tag = uuid.uuid4().hex[:10]
+    source_type = f"e2e-durability-{run_tag}"
+    corrected = f"acc-corrected-{run_tag}"
+    other = f"acc-other-{run_tag}"
+
+    _ensure_identity_inputs_table(compose_stack)
+    # Two accounts with unrelated e-mails: automation gives each its own
+    # person, which is what makes moving one of them a real correction.
+    _observe_account(compose_stack, run_tag, corrected, f"corrected.{run_tag}@e2e.test", source_type)
+    _observe_account(compose_stack, run_tag, other, f"other.{run_tag}@e2e.test", source_type)
+
+    first = identity_svc.run_seed_cli(tenant=str(identity_seed.SEED_TENANT), force=True)
+    assert first.returncode == 0, f"rc={first.returncode}\n{first.stdout}\n{first.stderr}"
+
+    automatic = _binding_rows(compose_stack, corrected, tenant=identity_seed.SEED_TENANT, source_type=source_type)
+    destination = _binding_rows(compose_stack, other, tenant=identity_seed.SEED_TENANT, source_type=source_type)
+    assert automatic and destination, "the seed did not bind the observed accounts"
+    assert automatic[0][1] == uuid.UUID(int=0).hex, "automation authors with the nil sentinel"
+
+    survivor = str(uuid.UUID(destination[0][0]))
+    with identity_svc.client(sub=str(identity_seed.SEED_ADMIN), tenant=str(identity_seed.SEED_TENANT)) as operator:
+        moved = operator.post(
+            "/v1/resolution/bind",
+            json={
+                "bindings": [
+                    {
+                        "account": {"source": source_type, "source_id": _SEED_SOURCE_ID, "id": corrected},
+                        "person_id": survivor,
+                    }
+                ],
+                "comment": "e2e: these two accounts are one human",
+            },
+        )
+        assert moved.status_code == 200, moved.text
+        assert moved.json()["applied"] == 1, moved.json()
+
+    second = identity_svc.run_seed_cli(tenant=str(identity_seed.SEED_TENANT), force=True)
+    assert second.returncode == 0, f"rc={second.returncode}\n{second.stdout}\n{second.stderr}"
+
+    after = _binding_rows(compose_stack, corrected, tenant=identity_seed.SEED_TENANT, source_type=source_type)
+    assert after[0][0] == uuid.UUID(survivor).hex, "the seed re-derived the binding the operator overruled"
+    assert after[0][1] == identity_seed.SEED_ADMIN.hex, "the surviving decision is still the operator's"

--- a/src/ingestion/tests/e2e/lib/identity.py
+++ b/src/ingestion/tests/e2e/lib/identity.py
@@ -98,11 +98,14 @@ def supports_seed_cli(implementation: str) -> bool:
 
 
 def supports_persons_sync(implementation: str) -> bool:
-    """Whether the binary has the `sync` subcommand (copy the `persons` log
-    into ClickHouse `identity.identity_persons`, one half of the metrics
-    resolve source — the other half is the connector evidence in
-    `identity.identity_inputs`, which says which account carries an email) + its GET journal routes. A NEW Rust-only surface,
-    deliberately never backported to the frozen, outgoing .NET service."""
+    """Whether the binary has the `sync` subcommand + its GET journal routes.
+
+    `sync` copies the `persons` log into ClickHouse
+    `identity.identity_persons` — one half of what the metrics resolver reads.
+    The other half is the connector evidence in `identity.identity_inputs`,
+    which says which account carries an e-mail. A NEW Rust-only surface,
+    deliberately never backported to the frozen, outgoing .NET service.
+    """
     return implementation == "rust"
 
 

--- a/src/ingestion/tests/e2e/lib/identity.py
+++ b/src/ingestion/tests/e2e/lib/identity.py
@@ -99,8 +99,9 @@ def supports_seed_cli(implementation: str) -> bool:
 
 def supports_persons_sync(implementation: str) -> bool:
     """Whether the binary has the `sync` subcommand (copy the `persons` log
-    into ClickHouse `identity.identity_persons`, the metrics email→person_id
-    resolve source) + its GET journal routes. A NEW Rust-only surface,
+    into ClickHouse `identity.identity_persons`, one half of the metrics
+    resolve source — the other half is the connector evidence in
+    `identity.identity_inputs`, which says which account carries an email) + its GET journal routes. A NEW Rust-only surface,
     deliberately never backported to the frozen, outgoing .NET service."""
     return implementation == "rust"
 

--- a/src/ingestion/tests/e2e/lib/identity_seed.py
+++ b/src/ingestion/tests/e2e/lib/identity_seed.py
@@ -176,24 +176,38 @@ def _emailless_observation_rows(tenant: uuid.UUID, person: uuid.UUID) -> list[Ob
     ]
 
 
+# Spelled out per table instead of interpolating a name into the statement:
+# the set is fixed, and a literal query needs no reader — human or scanner —
+# to establish that the name is trusted.
+WIPE_SEEDED_SQL = (
+    "DELETE FROM visibility WHERE reason = 'e2e-seed'",
+    "DELETE FROM person_roles WHERE reason = 'e2e-seed'",
+    "DELETE FROM org_chart WHERE reason = 'e2e-seed'",
+    "DELETE FROM account_person_map WHERE reason = 'e2e-seed'",
+    "DELETE FROM persons WHERE reason = 'e2e-seed'",
+)
+
+# Correction tests append journal rows under 'operator-%' reasons and rebuild
+# the derived caches, whose rows carry copied or empty reasons; on a kept stack
+# all of it is fixture residue. The caches are derived per tenant, so wiping the
+# tenant is exact.
+WIPE_CORRECTIONS_SQL = (
+    "DELETE FROM persons WHERE reason LIKE 'operator-%%' AND insight_tenant_id = %s",
+    "DELETE FROM org_chart WHERE insight_tenant_id = %s",
+    "DELETE FROM account_person_map WHERE insight_tenant_id = %s",
+)
+
+
 def seed(cfg: SessionConfig) -> None:
     """Insert the fixture dataset (idempotent: wipes e2e-seed rows first)."""
     conn = _connection(cfg)
     try:
         with conn.cursor() as cur:
             # Idempotent re-seed for local re-runs against a kept stack.
-            for table in ("visibility", "person_roles", "org_chart", "account_person_map", "persons"):
-                cur.execute(f"DELETE FROM {table} WHERE reason = 'e2e-seed'")
-            # Correction tests append journal rows under 'operator-%' reasons
-            # and rebuild the derived caches (whose rows carry copied or empty
-            # reasons); on a kept stack all of it is fixture residue. The
-            # caches are derived per tenant, so wiping the tenant is exact.
-            cur.execute(
-                "DELETE FROM persons WHERE reason LIKE 'operator-%%' AND insight_tenant_id = %s",
-                (TEST_TENANT_ID.bytes,),
-            )
-            for table in ("org_chart", "account_person_map"):
-                cur.execute(f"DELETE FROM {table} WHERE insight_tenant_id = %s", (TEST_TENANT_ID.bytes,))
+            for statement in WIPE_SEEDED_SQL:
+                cur.execute(statement)
+            for statement in WIPE_CORRECTIONS_SQL:
+                cur.execute(statement, (TEST_TENANT_ID.bytes,))
 
             observation_sql = (
                 "INSERT INTO persons (value_type, insight_source_type, insight_source_id,"

--- a/src/ingestion/tests/e2e/lib/identity_seed.py
+++ b/src/ingestion/tests/e2e/lib/identity_seed.py
@@ -42,6 +42,11 @@ OTHER_TENANT = uuid.UUID("22222222-2222-2222-2222-222222222222")
 SOURCE_TYPE = "bamboohr"
 SOURCE_ID = uuid.UUID("33333333-3333-3333-3333-333333333333")
 
+# The persons-seed stamps its rows with the nil author (`seed_runner::SYSTEM_AUTHOR`);
+# the service reads ANY non-nil author as an operator decision, so fixture
+# observations must carry nil or every binding would count as operator-settled.
+SYSTEM_AUTHOR = uuid.UUID(int=0)
+
 ADMIN_ROLE_ID = uuid.UUID("a4d11000-0000-4000-8000-000000000001")
 
 ALICE = uuid.UUID("aaaaaaaa-0000-4000-8000-000000000001")
@@ -132,7 +137,16 @@ def _observation_rows(
         ("status", None, "Active"),
     ]
     return [
-        (value_type, SOURCE_TYPE, SOURCE_ID.bytes, tenant.bytes, value_id, value_full_text, person.bytes, ALICE.bytes)
+        (
+            value_type,
+            SOURCE_TYPE,
+            SOURCE_ID.bytes,
+            tenant.bytes,
+            value_id,
+            value_full_text,
+            person.bytes,
+            SYSTEM_AUTHOR.bytes,
+        )
         for (value_type, value_id, value_full_text) in rows
     ]
 
@@ -148,7 +162,16 @@ def _emailless_observation_rows(tenant: uuid.UUID, person: uuid.UUID) -> list[Ob
         ("status", None, "Active"),
     ]
     return [
-        (value_type, SOURCE_TYPE, SOURCE_ID.bytes, tenant.bytes, value_id, value_full_text, person.bytes, ALICE.bytes)
+        (
+            value_type,
+            SOURCE_TYPE,
+            SOURCE_ID.bytes,
+            tenant.bytes,
+            value_id,
+            value_full_text,
+            person.bytes,
+            SYSTEM_AUTHOR.bytes,
+        )
         for (value_type, value_id, value_full_text) in rows
     ]
 
@@ -160,7 +183,17 @@ def seed(cfg: SessionConfig) -> None:
         with conn.cursor() as cur:
             # Idempotent re-seed for local re-runs against a kept stack.
             for table in ("visibility", "person_roles", "org_chart", "account_person_map", "persons"):
-                cur.execute(f"DELETE FROM {table} WHERE reason = 'e2e-seed'")  # noqa: S608 — fixed table names
+                cur.execute(f"DELETE FROM {table} WHERE reason = 'e2e-seed'")
+            # Correction tests append journal rows under 'operator-%' reasons
+            # and rebuild the derived caches (whose rows carry copied or empty
+            # reasons); on a kept stack all of it is fixture residue. The
+            # caches are derived per tenant, so wiping the tenant is exact.
+            cur.execute(
+                "DELETE FROM persons WHERE reason LIKE 'operator-%%' AND insight_tenant_id = %s",
+                (TEST_TENANT_ID.bytes,),
+            )
+            for table in ("org_chart", "account_person_map"):
+                cur.execute(f"DELETE FROM {table} WHERE insight_tenant_id = %s", (TEST_TENANT_ID.bytes,))
 
             observation_sql = (
                 "INSERT INTO persons (value_type, insight_source_type, insight_source_id,"
@@ -176,6 +209,29 @@ def seed(cfg: SessionConfig) -> None:
             cur.executemany(
                 observation_sql,
                 _observation_rows(OTHER_TENANT, EVE, EVE_EMAIL, "acc-eve", "Eve Else", "Legal", "Counsel"),
+            )
+
+            # org_chart is a DERIVED cache: every seed run and every operator
+            # correction rebuilds it for the tenant FROM THE JOURNAL. The tree
+            # must therefore live in the journal too (parent_person_id
+            # observations), or the first correction test would rebuild the
+            # fixture tree away for the rest of the session.
+            cur.executemany(
+                observation_sql,
+                [
+                    (
+                        "parent_person_id",
+                        SOURCE_TYPE,
+                        SOURCE_ID.bytes,
+                        TEST_TENANT_ID.bytes,
+                        str(parent),
+                        None,
+                        child.bytes,
+                        SYSTEM_AUTHOR.bytes,
+                    )
+                    for child, parent in ORG_EDGES.items()
+                    if parent is not None
+                ],
             )
 
             org_sql = (

--- a/src/ingestion/tests/e2e/metrics/test_fixtures.py
+++ b/src/ingestion/tests/e2e/metrics/test_fixtures.py
@@ -69,12 +69,15 @@ def _person_ids_for(emails: list[str], aliases: dict[str, list[str]]) -> dict[st
 
 
 def _seed_identity_persons(cfg: SessionConfig, person_ids: dict[str, str]) -> None:
-    """Replace identity.identity_persons with one email binding per persona.
+    """Give each persona an account that carries their email and is bound to
+    their person id — the shape resolve_person_id() reads.
 
-    Runs BEFORE the gold dbt build so resolve_person_id() attributes every
-    observation row; the table exists thanks to the on-run-start hook (and is
-    normally fed by the identity-resolution persons-sync — the rig plays that
-    role here).
+    Resolution is account-derived: `identity_inputs` says which account carries
+    an email, `identity_persons` says who that account belongs to. The rig plays
+    both producers (the connector models and the service's persons-sync), one
+    synthetic account per persona.
+
+    Runs BEFORE the gold dbt build so every observation row resolves.
     """
     # NOT worker-scoped: the resolve_person_id macro names `identity` literally,
     # so a per-worker suffix here would leave gold reading an unseeded table.
@@ -94,22 +97,60 @@ def _seed_identity_persons(cfg: SessionConfig, person_ids: dict[str, str]) -> No
         ) ENGINE = MergeTree ORDER BY id
         """,
     )
+    clickhouse.execute(
+        cfg,
+        """
+        CREATE TABLE IF NOT EXISTS identity.identity_inputs (
+            unique_key String, insight_tenant_id UUID,
+            insight_source_id UUID, insight_source_type String,
+            source_account_id Nullable(String), value_type String,
+            value Nullable(String), value_field_name String,
+            operation_type String, _synced_at DateTime64(3), _version Int64
+        ) ENGINE = ReplacingMergeTree(_version) ORDER BY unique_key
+        SETTINGS allow_nullable_key = 1
+        """,
+    )
     clickhouse.execute(cfg, "TRUNCATE TABLE identity.identity_persons")
+    clickhouse.execute(cfg, "TRUNCATE TABLE identity.identity_inputs")
     if not person_ids:
         return
-    rows = ", ".join(
-        f"({index + 1}, 'email', 'e2e-rig', generateUUIDv4(), generateUUIDv4(), "
+
+    personas = sorted(person_ids.items())
+
+    # The account id is the email: deterministic, and the two tables must agree
+    # on it for the join to land.
+    binding_rows = ", ".join(
+        f"({index + 1}, 'id', 'e2e-rig', toUUID('{_RIG_SOURCE_ID}'), generateUUIDv4(), "
         f"'{email}', '{email}', toUUID('{person_id}'), "
         f"toUUID('00000000-0000-0000-0000-000000000000'), now64(6), now64(3))"
-        for index, (email, person_id) in enumerate(sorted(person_ids.items()))
+        for index, (email, person_id) in enumerate(personas)
     )
     clickhouse.execute(
         cfg,
         "INSERT INTO identity.identity_persons "  # noqa: S608 — values derive from fixture emails
         "(id, value_type, insight_source_type, insight_source_id, insight_tenant_id,"
         " value_id, value_effective, person_id, author_person_id, created_at, _synced_at) "
-        "VALUES " + rows,
+        "VALUES " + binding_rows,
     )
+
+    evidence_rows = ", ".join(
+        f"('e2e-rig:{email}:email', generateUUIDv4(), toUUID('{_RIG_SOURCE_ID}'), 'e2e-rig', "
+        f"'{email}', 'email', '{email}', 'e2e.rig.email', 'UPSERT', now64(3), 1)"
+        for email, _ in personas
+    )
+    clickhouse.execute(
+        cfg,
+        "INSERT INTO identity.identity_inputs "  # noqa: S608 — values derive from fixture emails
+        "(unique_key, insight_tenant_id, insight_source_id, insight_source_type,"
+        " source_account_id, value_type, value, value_field_name, operation_type,"
+        " _synced_at, _version) "
+        "VALUES " + evidence_rows,
+    )
+
+
+# One synthetic connector instance for every rig persona: the account triple is
+# what joins evidence to bindings, so both inserts must name the same source.
+_RIG_SOURCE_ID = "e2e0e2e0-0000-4000-8000-000000000001"
 
 
 def _translate(value: Any, mapping: dict[str, str]) -> Any:


### PR DESCRIPTION
Implements the manual-resolution capability designed in #2180 and specified in the identity-resolution domain spec. **Stacked on #2234** (spec sync) — that PR is merged into this branch so the feature spec validates against the requirement ids it references; review this one after #2234 lands.

## Why

Automatic resolution errs both ways — one human split across two persons, or two humans grouped through a shared value — and the product had no supported way to change a binding once automation wrote it. This adds the operator surface, and closes the one path by which automation could overwrite a human decision.

## What lands

**Seed hardening** (`032dec59`)
- Divergent e-mail groups no longer collapse onto the first binding: each account keeps its own person. This was the path that could silently re-derive an operator binding.
- Divergence is classified by binding authorship — any operator-authored binding marks an intentional split (silent), all-automatic divergence is surfaced for review.
- A contested e-mail stops auto-linking: unbound accounts in a divergent group are left for the operator rather than joining an arbitrary person.
- Evidence reader keeps empty-value DELETE rows. Closure signals arrive with an empty value by the write contract while the reader filtered on non-empty values, so tombstones never reached the fold and deactivated accounts stayed observably active.
- Observation rows claim distinct timestamps within a batch: the natural key has no account discriminator, so two accounts of one source resolving to one person at the same instant collided and one binding was dropped.

**Correction verbs** (`cf5f3d41`) — `POST /v1/resolution/{bind,merge,detach,exclude}`
- Every verb appends binding observations under the calling operator and journals the call in `operations`; nothing updates or deletes a journal row.
- Idempotency is decision-aware: a correction is skipped only when the identical **operator** decision is already recorded. Binding an account to the person automation already gave it is the confirm act — it writes, and that is what takes the account out of review.
- `detach` mints a fresh person and needs no prior merge record; `exclude` binds to the reserved excluded person that every consumer reads as "no person".
- The timestamp allocator is shared with the seed, and the derived-cache rebuild (`account_person_map`, `org_chart`) is extracted from the seed so a correction and its caches commit in one transaction.

**Read surface** (`fc4d8ba1`)
- `GET /v1/resolution/attention` — what needs a decision, derived on every request from the folded connector evidence joined with current bindings: contested accounts with their candidate persons, binding conflicts no operator decision explains, and accounts with no identity evidence (visible, never hidden). Reports how many observed accounts are bound / pending / without evidence / excluded — the operator-visible match rate. Closed accounts drop out.
- `GET /v1/resolution/accounts/{source}/{source_id}/{account_id}` — the binding in force and every decision behind it, each marked human or automatic.
- `GET /v1/resolution/persons/{person_id}/accounts` — the matching table for one person.

**Feature spec** (`684d4dc7`) — `feature-manual-resolution/FEATURE.md`: flows, processes, queue-item lifecycle, definitions of done and acceptance criteria, so implementation traces back to the PRD requirements and ADR-0003.

## Notable design points for review

- **Where the queue comes from.** It cannot be a query over `persons` alone: accounts with no e-mail have no journal rows at all. It is evidence (ClickHouse, folded per account over UPSERT/DELETE) joined with bindings (MariaDB) — the join key is the account, never the tenant, because the evidence carries a producer-side hashed tenant that never equals the caller's.
- **Confirm vs idempotency.** These two requirements conflict unless idempotency is decision-aware; the domain test names that rule.
- **Excluded sentinel.** A fixed, unmintable UUID rather than a nullable binding, so "not a human" is a decision in the journal like any other.
- **Reserved, not built:** addressing bulk rows by an observed value (the customer-matching-table import). The direct account form ships first; the request type, outcome vocabulary and feature spec record where value addressing lands and that an ambiguous value is reported per item, never guessed.

**Analytics resolver** (`6d15f67d`) — `resolve_person_id()` now resolves an email through the accounts that carry it (evidence says which account carries the email, the journal says who that account belongs to), so corrections — recorded as bindings — reach gold metrics. A value carried by accounts of two different people resolves to nobody rather than to the newest observation; excluded accounts claim nothing; deactivated accounts keep claiming, because closure means the account is gone from the source, not that its history stops belonging to the person. The macro still emits `(email, person_id)`, so all six consumers join unchanged.

Account-first resolution is **not** included and cannot be today: gold facts carry an email, never the account that produced it, so there is nothing to key it on. Propagating source account ids through silver is its own work, recorded in the macro.

## Not in this PR

Bulk addressing by an observed value (the customer-matching-table import), stored negative rules, confidence-scored proposals and the admin UI remain deferred per ADR-0003.

## Validation

`cargo test -p identity-resolution` — 111 passed. `cargo clippy --all-targets` — clean. `cargo fmt --check` — clean. Spec artifacts pass `cfs validate` / `validate-toc` / `check-language`. The committed identity OpenAPI document is the retired .NET contract (flagged `Untrusted` in `tests/generate_schemas.py`) and is deliberately untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review round 2

A second review pass landed seven follow-up commits (`a15d6ab9…9778236d`):

- **Timestamp precision.** Correction rows are stamped at whole microseconds — what `DATETIME(6)` stores. The short-write recovery compared nanosecond-precision in-memory rows against microsecond-precision stored ones, so it would re-insert rows that had landed: duplicate history from the code meant to prevent it.
- **The excluded sentinel is nobody everywhere.** The pre-existing resolve/read paths (login bootstrap by-external-id, by-email-override, by-email / by-source-id lookups, visible-persons echo, person-exists) now filter the sentinel after the latest-wins ranking, so an exclusion is neither served as a person nor resurrected past. The persons-seed skips sentinel-bound accounts entirely: nothing is re-emitted under the sentinel, and a shared e-mail cannot spread an exclusion to new accounts — automation may not decide "not a person". Covered by a bind → resolve → exclude → not-found e2e test.
- **Fresh-install evidence reads.** ClickHouse reports a missing `identity` database as `UNKNOWN_DATABASE` (code 81), which the missing-relation check did not recognize — detach/exclude/attention answered 500 before the first identity build. Both codes now read as "nothing observed yet".
- **Review queue.** Unbound username-only accounts surface as `no_evidence` items: e-mail is the only matchable key today, so they previously sat in `pending` with no queue item and no automation ever coming.
- **Operations journal.** Each verb names its journal target explicitly; a merge of a person with no current accounts no longer records a nil target.
- **e2e fixture.** Fixture observations carry the seed's nil author (the service reads any non-nil author as an operator decision, which contradicted the confirm-flow premise); the fixture org tree lives in the journal as `parent_person_id` observations so a correction's cache rebuild re-derives it instead of wiping it; the idempotent wipe clears correction residue on kept stacks.
- **Spec.** Account-binding route path (three segments) and duplicated step numbers fixed.

Validation after this round: `cargo test -p identity-resolution` — 121 passed; clippy/fmt clean; `cfs validate` clean; the identity e2e suite passes end-to-end via the dockerized runner (`./e2e.sh test identity/` — 11 passed). Note: on macOS the suite must run dockerized — the Apple certificate verifier rejects the host-mode rig's self-signed TLS front, so every authenticated call answers 503 there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added operator tools to bind, merge, detach, and exclude identity records.
  * Added review queues, resolution metrics, binding history, and person-account views.
  * Added evidence-based identity review using account email, username, and account status.
  * Added safeguards for tenant-scoped access, duplicate requests, and repeat decisions.
* **Bug Fixes**
  * Preserved deletion events and prevented conflicting or duplicate identity assignments.
  * Improved handling of contested matches, excluded records, and timestamp collisions.
* **Documentation**
  * Added the Manual Identity Resolution feature specification and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
