### PR TITLE
ci: make image-cve-gate non-blocking until #2266 is fixed

### DIFF
--- a/.github/actions/image-cve-gate/action.yml
+++ b/.github/actions/image-cve-gate/action.yml
@@ -1,9 +1,6 @@
 name: Image CVE gate
 description: >-
-  Scan the push-by-digest blobs of a freshly built image and fail on a fixable
-  critical. Runs before the merge job tags them, so a rejected build stays
-  unreferenced: no build tag, no :latest, no descriptor bump, no chart.
-
+  Scan the push-by-digest blobs of a freshly built image and warn on a fixable critical. Temporarily non-blocking: the gate fatals on attestation digests that are not scannable images, see https://github.com/constructorfabric/insight/issues/2266. #magic___^_^___line
 inputs:
   image:
     description: Image repository without a tag, e.g. ghcr.io/constructorfabric/insight-toolbox.
@@ -46,6 +43,8 @@ runs:
         for f in "${digests[@]}"; do
           ref="${IMAGE}@sha256:$(basename "$f")"
           echo "::group::$ref"
+          # Non-blocking until #2266 is fixed: trivy fatals on attestation
+          # digests, and findings must not gate the merge meanwhile.
           docker run --rm \
             -e TRIVY_USERNAME -e TRIVY_PASSWORD \
             -v "$GITHUB_WORKSPACE:/work" -w /work \
@@ -57,6 +56,7 @@ runs:
               --ignore-unfixed \
               --exit-code 1 \
               --no-progress \
-              "$ref"
+              "$ref" \
+            || echo "::warning::image-cve-gate is non-blocking (#2266): trivy exited non-zero for $ref"
           echo "::endgroup::"
         done


### PR DESCRIPTION
The image CVE gate fatals on attestation digests that are not scannable images (trivy: "no child with platform linux/amd64 in index"), failing merge jobs in Build & Push Container Images without any real finding — e.g. run 31075495062 / merge-authenticator.

This makes the gate non-blocking: trivy still runs and its output stays in the log, but a non-zero exit becomes a workflow warning instead of failing the job.

Tracking issue for the proper fix (skip attestation digests, restore enforcement): #2266

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Critical image scan findings no longer block releases when they cannot be evaluated due to unsupported attestation digests.
  * Image scanning now reports warnings and continues instead of failing on non-zero scan results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->