### PR TITLE
ci(e2e): gate bronze-to-api on a relevance check

### DIFF
--- a/.github/workflows/e2e-bronze-to-api.yml
+++ b/.github/workflows/e2e-bronze-to-api.yml
@@ -126,7 +126,19 @@ jobs:
             echo "no base sha — running"
             exit 0
           fi
-          changed="$(git diff --name-only "$BASE" "$HEAD")"
+          # Diff from the MERGE BASE, not from the base branch's tip. A two-dot
+          # `git diff BASE HEAD` reports every file that differs between the
+          # two commits, which includes everything that landed on the base
+          # branch since this branch forked — attributed to this PR. Any branch
+          # not freshly rebased would then look like it touched the data path
+          # and the gate would never skip anything.
+          base_point="$(git merge-base "$BASE" "$HEAD" 2>/dev/null || true)"
+          if [ -z "$base_point" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "no merge base between $BASE and $HEAD — running"
+            exit 0
+          fi
+          changed="$(git diff --name-only "$base_point" "$HEAD")"
           echo "$changed" | sed 's/^/  /'
           if echo "$changed" | grep -qE '^(src/ingestion/|src/backend/|\.github/workflows/e2e-bronze-to-api\.yml|\.github/workflows/build-images\.yml)'; then
             echo "relevant=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/e2e-bronze-to-api.yml
+++ b/.github/workflows/e2e-bronze-to-api.yml
@@ -15,7 +15,9 @@ name: E2E — Bronze to API
 # here is what only this rig can do — bronze → dbt → ClickHouse → analytics
 # response, over fixtures it seeds itself.
 #
-# Topology: a shared upstream `build` job assembles the runner image ONCE —
+# Topology: a cheap `changes` job decides whether the diff can reach the data
+# path at all and everything expensive hangs off it; a shared upstream `build`
+# job assembles the runner image ONCE —
 # on PRs from the component images build-images.yml already built (or the
 # published :latest for path-skipped components), elsewhere by compiling
 # analytics + each connector's enrich binary via build-only services — and
@@ -32,11 +34,16 @@ name: E2E — Bronze to API
 # Code:  src/ingestion/tests/e2e/
 
 on:
-  # PR-only (+ manual dispatch). Runs on every PR against main, regardless of
-  # which paths changed — no path filtering. workflow_dispatch remains for
-  # manual reruns against main.
+  # PR-only (+ manual dispatch). workflow_dispatch remains for manual reruns
+  # against main.
   pull_request:
     branches: [main]
+    # Deliberately NO `paths:` filter. This workflow emits a REQUIRED check
+    # ("Run E2E suite"), and GitHub reports a required check whose workflow
+    # never ran as pending rather than passed — a path filter here would block
+    # every PR that did not happen to touch one of the listed directories.
+    # Relevance is decided by the `changes` job below instead, which is cheap
+    # and always reports. Same pattern as e2e-stand.yml.
   # Merge-queue builds: the queue's gh-readonly-queue/* branches emit merge_group,
   # and the required "Run E2E suite" check must report there or every queued PR
   # times out and is evicted.
@@ -62,13 +69,77 @@ permissions:
 jobs:
   # `e2e-suite` emits the "Run E2E suite" status check the `main` ruleset
   # requires, so branch protection needs no change when lanes come and go —
-  # only this file's `needs:` does. If `build` fails, `e2e-metrics` is skipped
-  # by default `needs` semantics (a red build must not run the lane), and
-  # GitHub reports a required check's skipped job as failed rather than green.
+  # only this file's `needs:` does. It is the one job here that runs
+  # unconditionally — a required check must report on EVERY pull request,
+  # including the ones `changes` decided are irrelevant.
+  #
+  # Skipping cascades by default `needs` semantics: `changes` says irrelevant →
+  # `build` skips → `e2e-metrics` skips → `metric-coverage-gate` skips. A red
+  # `build` produces the same cascade, so the umbrella distinguishes the two
+  # cases from `changes`'s own output rather than from the lane results.
+
+  # ─── changes ──────────────────────────────────────────────────────────────
+  # What an `on: paths:` filter would have done, moved into a job so the
+  # workflow ALWAYS runs and the umbrella below can always report.
+  #
+  # The list is deliberately over-inclusive: a false positive costs one
+  # unnecessary suite run — today's behaviour for every PR — while a false
+  # negative greens a required check over untested data-path changes. It covers
+  # everything the runner image bakes in or the suite reads at run time:
+  #
+  #   src/ingestion/  the rig itself (tests/e2e), dbt models, the migration and
+  #                   connectors-ddl scripts, and every connector's enrich
+  #                   source (jira-enrich is baked into the runner image)
+  #   src/backend/    analytics and identity-resolution — compiled from their
+  #                   own Dockerfiles into the runner image, and the analytics
+  #                   HTTP response is the last hop every metric fixture
+  #                   asserts on
+  #   build-images.yml  the PR path consumes its e2e-prebuilt-* artifacts by
+  #                   name, so a change there can break this workflow's build
+  #
+  # src/frontend/, deploy/, tests/ (the deployed-stand suite) and docs/ are
+  # absent on purpose: nothing in this rig loads them.
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          # The diff needs both endpoints; the default shallow fetch has
+          # neither the base nor enough history to reach a merge base.
+          fetch-depth: 0
+          persist-credentials: false
+      - id: filter
+        env:
+          BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          # No base to diff against (a merge_group without one, or a manual
+          # dispatch): assume relevant rather than skipping a required gate on
+          # a guess.
+          if [ -z "${BASE:-}" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "no base sha — running"
+            exit 0
+          fi
+          changed="$(git diff --name-only "$BASE" "$HEAD")"
+          echo "$changed" | sed 's/^/  /'
+          if echo "$changed" | grep -qE '^(src/ingestion/|src/backend/|\.github/workflows/e2e-bronze-to-api\.yml|\.github/workflows/build-images\.yml)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "nothing on the bronze → dbt → ClickHouse → analytics path changed"
+          fi
 
   # ─── Build the runner image once, shared by both lanes ────────────────────
   build:
     name: Build runner image
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
     # This compile-only job keeps the old combined job's full ceiling: a cold
     # GHA cache (Cargo.lock bump, the 7-day cache eviction, or the 10 GB
@@ -326,11 +397,11 @@ jobs:
   # artifact, and reads plain files. No Docker, no analytics boot.
   # `!cancelled()` so they still report when the suite itself failed (the
   # artifacts are usually present). The `needs.<lane>.result != 'skipped'`
-  # clause guards the other case: a lane is SKIPPED (not failed) when the
-  # upstream `build` job fails, and in that case there's no artifact to
-  # download at all — without this clause the gate would still run and fail
-  # noisily on a missing artifact instead of just skipping cleanly alongside
-  # its lane.
+  # clause guards the other case: a lane is SKIPPED (not failed) when `changes`
+  # found nothing relevant or when the upstream `build` job fails, and in
+  # neither case is there an artifact to download — without this clause the
+  # gate would still run and fail noisily on a missing artifact instead of just
+  # skipping cleanly alongside its lane.
 
   metric-coverage-gate:
     name: Metric coverage gate
@@ -373,6 +444,7 @@ jobs:
     # a broken service image can't be merged even though that workflow's own
     # checks aren't in the ruleset.
     needs:
+      - changes
       - build
       - e2e-metrics
     if: ${{ !cancelled() }}
@@ -381,16 +453,48 @@ jobs:
     # poll a straggling build-images run for up to 10 more.
     timeout-minutes: 15
     steps:
+      # A skipped lane now has two possible meanings, and they are opposites:
+      # `changes` decided the diff cannot reach the data path (a pass), or the
+      # upstream build went red and took the lane with it (a failure). So the
+      # lane results are read one at a time through the environment rather than
+      # collapsed with `contains(needs.*.result, 'skipped')` — that expression
+      # cannot tell the two apart, and it would also fold in `changes`'s own
+      # result now that it is a `needs` entry.
       - name: Require the build and the data-path lane to have succeeded
+        env:
+          CHANGES: ${{ needs.changes.result }}
+          RELEVANT: ${{ needs.changes.outputs.relevant }}
+          BUILD: ${{ needs.build.result }}
+          METRICS: ${{ needs.e2e-metrics.result }}
         run: |
-          echo "build=${{ needs.build.result }}"
-          echo "metrics=${{ needs.e2e-metrics.result }}"
-          if [ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}" = "true" ]; then
-            echo "::error::E2E suite did not fully pass — the build or the metrics lane failed, was cancelled, or was skipped."
+          set -euo pipefail
+          echo "changes=$CHANGES relevant=$RELEVANT build=$BUILD metrics=$METRICS"
+
+          # Fail closed. A `changes` job that did not succeed leaves `relevant`
+          # empty, which would otherwise read as "irrelevant" and green a
+          # required check that proved nothing.
+          if [ "$CHANGES" != "success" ]; then
+            echo "::error::the changes job did not succeed ($CHANGES) — relevance is unknown, so the data path is unproven."
             exit 1
           fi
-          echo "E2E suite passed: build + the metrics lane succeeded."
 
+          if [ "$RELEVANT" != "true" ]; then
+            echo "nothing on the bronze → dbt → ClickHouse → analytics path changed — nothing to prove."
+          else
+            for lane in "build=$BUILD" "metrics=$METRICS"; do
+              if [ "${lane#*=}" != "success" ]; then
+                echo "::error::${lane%%=*} did not pass (${lane#*=}) — the E2E suite did not fully run for this change."
+                exit 1
+              fi
+            done
+            echo "E2E suite passed: build + the metrics lane succeeded."
+          fi
+
+      # Unconditional, including on a PR `changes` found irrelevant: this gate
+      # guards the service images rather than the data path, and a PR touching
+      # only src/frontend/ can still break a build this required check is the
+      # sole ruleset-visible reporter for.
+      #
       # build-images.yml is a separate workflow, so `needs:` can't reach it;
       # ask the API for this SHA's run instead. Absent (path-skipped, or a
       # merge_group SHA — that workflow has no merge_group trigger) passes;


### PR DESCRIPTION
Closes #2269

## Problem

`E2E — Bronze to API` triggered on every PR against `main` with no path filtering and no relevance check. A PR touching only docs or unrelated CI config still paid for the runner-image build, the stack boot and the whole metrics suite.

## Change

Adopts the pattern `e2e-stand.yml` already uses.

- **`changes` job** — cheap diff of `base.sha…head.sha` emitting a `relevant` output. The workflow keeps triggering unconditionally: a required check whose workflow never ran reports *pending* rather than passed, so an `on: paths:` filter would block every PR that missed the list.
- **`build`** is gated on `relevant == 'true'`. The skip cascades to `e2e-metrics` (default `needs` semantics) and `metric-coverage-gate` (its existing `result != 'skipped'` guard) for free.
- **`Run E2E suite`** (the ruleset-required umbrella) now reads lane results individually instead of through `contains(needs.*.result, 'skipped')`. A skipped lane has two opposite meanings — the diff cannot reach the data path (a pass) or the build went red (a failure) — and that expression cannot tell them apart, nor exclude `changes`'s own result now that it is a `needs` entry.
- The umbrella **fails closed** when `changes` itself did not succeed: an empty `relevant` output would otherwise read as irrelevant and green a required check having proved nothing.
- The **image-build gate step stays unconditional** — it guards the service images rather than the data path, and this check is the only ruleset-visible reporter for a `build-images` failure on, say, a frontend-only PR.

## Relevant paths

Derived from what the runner image bakes in (`compose/docker-compose.runner.yml` build contexts) and what the rig reads at run time (repo paths in `src/ingestion/tests/e2e/lib/`):

```
src/ingestion/                            rig, dbt models, migrations, connectors-ddl, connector enrich sources
src/backend/                              analytics + identity-resolution, each compiled from its own Dockerfile
.github/workflows/e2e-bronze-to-api.yml
.github/workflows/build-images.yml        the PR path consumes its e2e-prebuilt-* artifacts by name
```

`src/frontend/`, `deploy/`, `tests/` (the deployed-stand suite) and `docs/` are excluded — nothing in this rig loads them.

The list is deliberately over-inclusive: a false positive costs one unnecessary run (today's behaviour for every PR), a false negative greens a required check over untested data-path changes.

## Verification

- Filter checked against synthetic changed-file lists and real commit diffs: docs, `ci.yml`, frontend, `tests/stand`, `deploy/compose` skip; dbt models, migrations, enrich source, `Cargo.lock` and the rig itself run.
Both branches of the gate were run in CI on this branch.

**`relevant=true`** — run [`31081881256`](https://github.com/constructorfabric/insight/actions/runs/31081881256), green end to end. This PR edits the workflow, which is in the path list, so the normal path is exercised by the PR itself:

```
changes=success relevant=true build=success metrics=success
E2E suite passed: build + the metrics lane succeeded.
```

**`relevant=false`** — run [`31084284631`](https://github.com/constructorfabric/insight/actions/runs/31084284631), green with every expensive job skipped:

```
changes: success        relevant=false
Build runner image:     skipped
metrics:                skipped
Metric coverage gate:   skipped
Run E2E suite:          success
  → nothing on the bronze → dbt → ClickHouse → analytics path changed — nothing to prove.
  → No image-build run for <sha> — builds were path-skipped.
```

3m06s versus 21m34s for the full run — the saving #2269 asked for. The image-build gate still executed on the skip path, as intended.

That second run needed a temporary probe commit, since the gate diffs the PR's *whole* contribution (`merge-base…HEAD`) and this branch's contribution already contains the workflow file — a PR editing the workflow cannot produce a diff the workflow calls irrelevant. The probe dropped the workflow's own path from the pattern and added a docs file. It has been reverted; the branch is back to `816331f0` with the pattern intact. The probe therefore proves the *wiring* (skip cascade + green umbrella), not the path list, which is verified separately by matching it against changed-file lists.

## Open question

`src/backend/` is broad: it also catches `authenticator`, `gateway`, `fakeidp` and `keycloak`, none of which are baked into the runner image. Kept broad to match `e2e-stand.yml` and because a false negative on a required check is the worse failure. Narrowing to what the rig actually compiles would be:

```
src/backend/(services/(analytics|identity-resolution)/|libs/|Cargo\.(toml|lock))
```

Happy to narrow if reviewers prefer.

## Caught by the first CI run: diff from the merge base

The gate's first run reported **15 changed files** for a branch holding a single one-file commit. A two-dot `git diff BASE HEAD` reports everything that differs between the two commits, so every change that landed on `main` after this branch forked was attributed to this PR — including one under `src/backend/`, enough on its own to force `relevant=true`.

A freshly-cut branch is unaffected — with no divergence, two-dot and three-dot agree — but the gate misfires as soon as the base branch gains a commit under one of the listed paths, which for `src/ingestion/` and `src/backend/` is a matter of hours. Fixed in `816331f0` by diffing from `git merge-base BASE HEAD`. An absent merge base resolves to `relevant=true` rather than failing the job — an unprovable relevance decision should run the suite, not block on it.

Local check on this branch, after the fix:

```
two-dot   (before)  15 files, incl. src/backend/... and tests/stand/...
three-dot (after)    1 file: .github/workflows/e2e-bronze-to-api.yml
```

> [!NOTE]
> `.github/workflows/e2e-stand.yml`, the reference implementation this pattern was copied from, has the same two-dot diff and therefore the same defect. It is not hypothetical: on this PR its gate attributed 15 files to the branch — including `tests/stand/ui/test_collaboration_card_evidence.py`, which arrived on `main` after the fork point — ran both stand lanes, and reported that test's failure against a PR whose only change is a CI file. A merge-base diff would have skipped both lanes.
>
> Left untouched here to keep this PR to its subject; worth its own issue.


