### PR TITLE
fix(ci): scan platform manifests, not the index, in the image gate (#2266)

### DIFF
--- a/.github/actions/image-cve-gate/action.yml
+++ b/.github/actions/image-cve-gate/action.yml
@@ -1,21 +1,20 @@
 name: Image CVE gate
 description: >-
-  Scan the push-by-digest blobs of a freshly built image and fail on a fixable
-  critical. Runs before the merge job tags them, so a rejected build stays
-  unreferenced: no build tag, no :latest, no descriptor bump, no chart.
+  Fail on a fixable critical in a freshly built image, before the merge job tags
+  it — a rejected build stays unreferenced: no tag, no descriptor, no chart.
 
 inputs:
   image:
     description: Image repository without a tag, e.g. ghcr.io/constructorfabric/insight-toolbox.
     required: true
   registry-username:
-    description: Registry user for pulling the digests under scan.
+    description: Registry user, for pulling the digests.
     required: true
   registry-password:
-    description: Registry token for pulling the digests under scan.
+    description: Registry token, for pulling the digests.
     required: true
   digests-dir:
-    description: Directory holding one empty file per pushed digest, named by the digest.
+    description: Directory with one empty file per pushed digest, named by it.
     default: /tmp/digests
   severity:
     description: Severities that fail the build.
@@ -45,9 +44,8 @@ runs:
         fi
         scanned=0
         for f in "${digests[@]}"; do
-          # Each build publishes an index — a platform manifest plus an attestation
-          # child — and trivy resolves an index against the runner's own platform,
-          # so the arm64 one fatals. Scan the platform manifests by their digest.
+          # trivy resolves an index against the runner's platform, so it fatals on the
+          # arm64 one — scan the platform manifests inside it instead (see #2266).
           targets="$(docker buildx imagetools inspect --raw "${IMAGE}@sha256:$(basename "$f")" | jq -r '
             if .manifests then
               .manifests[]

--- a/.github/actions/image-cve-gate/action.yml
+++ b/.github/actions/image-cve-gate/action.yml
@@ -1,6 +1,9 @@
 name: Image CVE gate
 description: >-
-  Scan the push-by-digest blobs of a freshly built image and warn on a fixable critical. Temporarily non-blocking: the gate fatals on attestation digests that are not scannable images, see https://github.com/constructorfabric/insight/issues/2266. #magic___^_^___line
+  Scan the push-by-digest blobs of a freshly built image and fail on a fixable
+  critical. Runs before the merge job tags them, so a rejected build stays
+  unreferenced: no build tag, no :latest, no descriptor bump, no chart.
+
 inputs:
   image:
     description: Image repository without a tag, e.g. ghcr.io/constructorfabric/insight-toolbox.
@@ -40,23 +43,38 @@ runs:
           echo "::error::no digests in $DIGESTS_DIR — nothing was scanned"
           exit 1
         fi
+        scanned=0
         for f in "${digests[@]}"; do
-          ref="${IMAGE}@sha256:$(basename "$f")"
-          echo "::group::$ref"
-          # Non-blocking until #2266 is fixed: trivy fatals on attestation
-          # digests, and findings must not gate the merge meanwhile.
-          docker run --rm \
-            -e TRIVY_USERNAME -e TRIVY_PASSWORD \
-            -v "$GITHUB_WORKSPACE:/work" -w /work \
-            -v /tmp/trivy-cache:/root/.cache \
-            "$TRIVY_IMAGE" image \
-              --scanners vuln \
-              --severity "$SEVERITY" \
-              --pkg-types os,library \
-              --ignore-unfixed \
-              --exit-code 1 \
-              --no-progress \
-              "$ref" \
-            || echo "::warning::image-cve-gate is non-blocking (#2266): trivy exited non-zero for $ref"
-          echo "::endgroup::"
+          # Each build publishes an index — a platform manifest plus an attestation
+          # child — and trivy resolves an index against the runner's own platform,
+          # so the arm64 one fatals. Scan the platform manifests by their digest.
+          targets="$(docker buildx imagetools inspect --raw "${IMAGE}@sha256:$(basename "$f")" | jq -r '
+            if .manifests then
+              .manifests[]
+              | select(.platform.os != "unknown")
+              | select(.annotations["vnd.docker.reference.type"] != "attestation-manifest")
+              | .digest
+            else empty end')"
+          [ -n "$targets" ] || targets="sha256:$(basename "$f")"
+          for t in $targets; do
+            echo "::group::${IMAGE}@${t}"
+            docker run --rm \
+              -e TRIVY_USERNAME -e TRIVY_PASSWORD \
+              -v "$GITHUB_WORKSPACE:/work" -w /work \
+              -v /tmp/trivy-cache:/root/.cache \
+              "$TRIVY_IMAGE" image \
+                --scanners vuln \
+                --severity "$SEVERITY" \
+                --pkg-types os,library \
+                --ignore-unfixed \
+                --exit-code 1 \
+                --no-progress \
+                "${IMAGE}@${t}"
+            echo "::endgroup::"
+            scanned=$((scanned + 1))
+          done
         done
+        if [ "$scanned" -eq 0 ]; then
+          echo "::error::no image manifest was scanned"
+          exit 1
+        fi


### PR DESCRIPTION
Fixes #2266 and supersedes #2267 — with this in, the gate no longer needs to be non-blocking.

## What actually breaks

Not attestation manifests. I pulled both digests from the failing job and looked them up in the registry:

```
52b63ee7…  oci.image.index   children: linux/amd64  +  unknown/unknown
818f534b…  oci.image.index   children: linux/arm64  +  unknown/unknown
```

`Export digest` writes `steps.build.outputs.digest`, and with provenance on, buildx returns the digest of an **index**, not of a manifest. There is one such index per architecture, and each already contains an attestation child.

Trivy runs on an amd64 runner and resolves an index against the host platform. The amd64 index has the child it wants and scanned clean — that is the "first digest scanned clean" in the issue. The arm64 index has no `linux/amd64` child, hence the fatal. The attestation child sits in both indexes, including the one that scanned fine, so it is not what trivy chokes on.

## The fix

Expand each index and scan the platform manifests by their own digest. No `--platform` to derive, and the attestation children fall out of the same filter:

```
.manifests[]
| select(.platform.os != "unknown")
| select(.annotations["vnd.docker.reference.type"] != "attestation-manifest")
| .digest
```

Both predicates are kept deliberately. On our images they are equivalent, but they fail differently: the platform one covers an attestation child that ever declares a real platform, the annotation one covers a platform child that ever loses its platform. Media type is not usable as a discriminator here — the image child and the attestation child are both `application/vnd.oci.image.manifest.v1+json`.

A digest that is already a plain manifest falls back to being scanned as-is, so a build with provenance disabled keeps working. A `scanned` counter fails the step if expansion yields nothing, extending the existing "a gate that scanned nothing is not a pass" guard from the empty-directory case to the empty-expansion one.

## Test plan

Ran the action's script verbatim, against the live registry.

- [x] The two digests from the failing run (`52b63ee7…`, `818f534b…`): both scan, debian 12.15 detected, 91 packages each, exit 0. Previously the second one fatalled.
- [x] Multi-arch index (`insight-front:latest`, 2 platform + 2 attestation children): 2 scans, 2 OS detections, attestation children skipped.
- [x] Findings still block: `alpine:3.10` index at `HIGH,CRITICAL` → exit 1.
- [x] Fallback: the same image's amd64 child digest, which has no `.manifests` → scanned as-is, exit 1.
- [x] Empty digests directory still errors and exits 1.
- [x] `insight-toolbox` (2 platforms, 10 fixable HIGH after #2168): `CRITICAL` → exit 0 on both, `HIGH` → exit 1 on both.
- [x] Merge order: simulated #2267 landing first. Two conflict hunks, both with its temporary wording wholly on one side; taking this branch's side yields a file byte-identical to it — no `non-blocking` text survives and `--exit-code 1` is back.
- [x] `actionlint`: 7 findings on the base, 7 on the branch, identical set.
- [ ] First `main` build after merge tags images again.

## Cost note

Scanning `insight-toolbox` pulls Trivy's Java DB (~1.4 GB) on top of the vulnerability DB, because the image carries Java artifacts and the Java analyzer runs even under `--scanners vuln`. Each merge job is a fresh runner, so `merge-toolbox` pays that download every build — roughly a minute beyond the 30–45 s estimated in #2238. The other six jobs are unaffected.

## Sequencing

#2267 makes the gate non-blocking as a stop-gap and is in the merge queue. If it lands first I will rebase and drop its `|| echo ::warning::` line; if this lands first, #2267 can be closed unmerged. Either order works, they just should not both end up on `main` — the enforcement has to come back on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container image security scans to inspect each supported platform image individually.
  * Excluded non-runnable and attestation-only manifests from vulnerability scanning.
  * Added a fallback scan when platform details are unavailable.
  * Builds now fail clearly when no image manifest can be scanned, helping prevent incomplete security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

