### PR TITLE
test(authenticator): migrate the e2e rig to a container-imported Keycloak realm

### DIFF
--- a/.github/workflows/authenticator.yml
+++ b/.github/workflows/authenticator.yml
@@ -1,7 +1,7 @@
 name: Authenticator — e2e, endpoint coverage
 
-# The authenticator's end-to-end suite (tests/run-e2e.sh: Redis in docker,
-# fakeidp + two authenticator instances as local release binaries, the eight
+# The authenticator's end-to-end suite (tests/run-e2e.sh: Redis + Keycloak in
+# docker, three authenticator instances as local release binaries, the ten
 # e2e_*.rs loops) plus the endpoint coverage gate on top of it: the suite's
 # shared client (tests/common/mod.rs) records every request against the
 # authenticator into a ledger, and the gate job matches that ledger against
@@ -14,8 +14,11 @@ on:
     branches: [main]
     paths:
       - "src/backend/services/authenticator/**"
-      - "src/backend/services/fakeidp/**"
       - "src/backend/libs/authenticator-sdk/**"
+      # The e2e stack imports the generated compose realm (run-e2e.sh), which
+      # gen-realm.py builds from the seed roster.
+      - "deploy/compose/keycloak/**"
+      - "deploy/seed/profiles.py"
       # A workspace-wide dependency bump can break the authenticator build
       # without touching its sources (reqwest 0.12 -> 0.13 did, via
       # openidconnect's pinned HTTP-client impls).
@@ -59,8 +62,9 @@ jobs:
           key: authenticator-e2e
 
       - name: Run the authenticator e2e suite
-        # run-e2e.sh builds fakeidp + authenticator (release), boots the stack,
-        # runs every e2e_*.rs loop serially, and leaves the coverage ledger at
+        # run-e2e.sh builds the authenticator (release), boots the stack
+        # (Redis + Keycloak with the imported generated realm), runs every
+        # e2e_*.rs loop serially, and leaves the coverage ledger at
         # $E2E_COVERAGE_LEDGER (tests/common/mod.rs writes it per response).
         env:
           E2E_COVERAGE_LEDGER: ${{ github.workspace }}/observed_authenticator_endpoints.json

--- a/src/backend/services/authenticator/tests/common/kc.rs
+++ b/src/backend/services/authenticator/tests/common/kc.rs
@@ -245,15 +245,36 @@ pub async fn set_user_enabled(email: &str, enabled: bool) {
     );
 }
 
-/// Freeze / thaw the IdP container: requests hang until the client's own
-/// timeout and fail as transport errors — a transient outage, the
-/// real-IdP equivalent of fakeidp's `/_control/outage` hook.
-pub fn set_idp_outage(outage: bool) {
+/// Freeze the IdP container until the returned guard drops: requests hang
+/// until the client's own timeout and fail as transport errors — a transient
+/// outage, the real-IdP equivalent of fakeidp's `/_control/outage` hook.
+/// The guard thaws on drop, panic included, so a failed assertion mid-outage
+/// cannot leave the shared container paused for whoever runs next.
+pub fn idp_outage() -> IdpOutage {
     let container = env("E2E_KC_CONTAINER", "authenticator-e2e-keycloak");
-    let action = if outage { "pause" } else { "unpause" };
     let status = Command::new("docker")
-        .args([action, &container])
+        .args(["pause", &container])
         .status()
         .expect("docker must be runnable");
-    assert!(status.success(), "docker {action} {container} must succeed");
+    assert!(status.success(), "docker pause {container} must succeed");
+    IdpOutage { container }
+}
+
+pub struct IdpOutage {
+    container: String,
+}
+
+impl Drop for IdpOutage {
+    fn drop(&mut self) {
+        // Best effort only: this runs during unwinding, where a panic aborts.
+        let thawed = Command::new("docker")
+            .args(["unpause", &self.container])
+            .status()
+            .is_ok_and(|status| status.success());
+        assert!(
+            thawed || std::thread::panicking(),
+            "docker unpause {} must succeed",
+            self.container
+        );
+    }
 }

--- a/src/backend/services/authenticator/tests/common/kc.rs
+++ b/src/backend/services/authenticator/tests/common/kc.rs
@@ -1,0 +1,259 @@
+//! Keycloak-side helpers for the e2e rig: drive the realm's login form and
+//! the admin API — the seams fakeidp's `/_control/*` hooks used to provide.
+//!
+//! `run-e2e.sh` provides the coordinates: `E2E_KC_BASE` (the container's
+//! published origin), `E2E_KC_REALM`, `E2E_KC_CONTAINER` (for the docker
+//! pause/unpause outage seam), `E2E_KC_ADMIN_USER`/`E2E_KC_ADMIN_PASSWORD`
+//! (the bootstrap admin), and `E2E_USER_PASSWORD` (every realm user's dev
+//! password). All carry localhost defaults matching run-e2e.sh.
+
+use std::process::Command;
+
+fn env(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_owned())
+}
+
+pub fn base() -> String {
+    env("E2E_KC_BASE", "http://localhost:8084")
+}
+
+pub fn realm() -> String {
+    env("E2E_KC_REALM", "insight")
+}
+
+pub fn user_password() -> String {
+    env("E2E_USER_PASSWORD", "insight-dev")
+}
+
+/// Redirects OFF, like the suites' own client: the 302 back to the RP is the
+/// observation, not something to follow.
+fn http() -> reqwest::Client {
+    reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("reqwest client must build")
+}
+
+/// Drive the Keycloak login form at `authorize_url` as `user`; returns the
+/// redirect back to the RP (the authenticator's callback URL, code + state).
+pub async fn authorize(authorize_url: &str, user: &str) -> String {
+    let http = http();
+
+    let page = http.get(authorize_url).send().await.unwrap();
+    assert_eq!(
+        page.status(),
+        200,
+        "the authorize endpoint must serve the login form"
+    );
+    let auth_cookies: Vec<String> = page
+        .headers()
+        .get_all(reqwest::header::SET_COOKIE)
+        .iter()
+        .filter_map(|h| h.to_str().ok())
+        .filter_map(|raw| raw.split(';').next())
+        .map(str::to_owned)
+        .collect();
+    let body = page.text().await.unwrap();
+    let form_action = login_form_action(&body);
+
+    let submitted = http
+        .post(&form_action)
+        .header(reqwest::header::COOKIE, auth_cookies.join("; "))
+        .form(&[
+            ("username", user),
+            ("password", &user_password()),
+            ("credentialId", ""),
+        ])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        submitted.status(),
+        302,
+        "the credential POST for {user} must redirect to the RP; page said: {}",
+        submitted
+            .text()
+            .await
+            .unwrap_or_default()
+            .chars()
+            .take(500)
+            .collect::<String>()
+    );
+    submitted.headers()[reqwest::header::LOCATION]
+        .to_str()
+        .unwrap()
+        .to_owned()
+}
+
+/// The full login loop as `user`: `/auth/login` → realm login form →
+/// `/auth/callback`. Returns the `__Host-sid` session cookie token. The
+/// authenticator hops ride the suite's ledger-recording client; the IdP form
+/// hops deliberately do not.
+pub async fn login(http: &super::Client, auth_base: &str, user: &str) -> String {
+    let login = http
+        .get(format!("{auth_base}/auth/login"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        login.status(),
+        302,
+        "GET /auth/login must redirect to the IdP"
+    );
+    let authorize_url = login.headers()[reqwest::header::LOCATION]
+        .to_str()
+        .unwrap()
+        .to_owned();
+
+    let callback = authorize(&authorize_url, user).await;
+
+    let cb = http.get(&callback).send().await.unwrap();
+    assert_eq!(
+        cb.status(),
+        302,
+        "callback must set the cookie and redirect"
+    );
+    session_cookie(&cb).expect("callback must set __Host-sid")
+}
+
+/// The `__Host-sid` value from a response's `Set-Cookie` headers.
+pub fn session_cookie(resp: &reqwest::Response) -> Option<String> {
+    for hv in resp.headers().get_all(reqwest::header::SET_COOKIE) {
+        let raw = hv.to_str().ok()?;
+        for part in raw.split(';') {
+            if let Some(v) = part.trim().strip_prefix("__Host-sid=")
+                && !v.is_empty()
+            {
+                return Some(v.to_owned());
+            }
+        }
+    }
+    None
+}
+
+/// The login form's POST target. Keycloak escapes `&` in the attribute value.
+fn login_form_action(page: &str) -> String {
+    let from = page.find("id=\"kc-form-login\"").unwrap_or(0);
+    let action_at = page[from..]
+        .find("action=\"")
+        .expect("the authorize page must contain the login form action")
+        + from
+        + "action=\"".len();
+    let action = &page[action_at
+        ..action_at
+            + page[action_at..]
+                .find('"')
+                .expect("unterminated action attribute")];
+    action.replace("&amp;", "&")
+}
+
+async fn admin_token(http: &reqwest::Client) -> String {
+    let resp = http
+        .post(format!(
+            "{}/realms/master/protocol/openid-connect/token",
+            base()
+        ))
+        .form(&[
+            ("grant_type", "password"),
+            ("client_id", "admin-cli"),
+            ("username", &env("E2E_KC_ADMIN_USER", "admin")),
+            ("password", &env("E2E_KC_ADMIN_PASSWORD", "admin")),
+        ])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        200,
+        "the Keycloak admin token grant must succeed"
+    );
+    resp.json::<serde_json::Value>().await.unwrap()["access_token"]
+        .as_str()
+        .unwrap()
+        .to_owned()
+}
+
+async fn user_representation(
+    http: &reqwest::Client,
+    token: &str,
+    email: &str,
+) -> serde_json::Value {
+    let resp = http
+        .get(format!("{}/admin/realms/{}/users", base(), realm()))
+        .query(&[("email", email), ("exact", "true")])
+        .bearer_auth(token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "the admin user lookup must succeed");
+    let mut users: Vec<serde_json::Value> = resp.json().await.unwrap();
+    assert_eq!(
+        users.len(),
+        1,
+        "exactly one realm user expected for {email}"
+    );
+    users.remove(0)
+}
+
+/// Log the user out at the IdP (every session). With the client's
+/// back-channel logout URL registered, Keycloak fires a signed
+/// `logout_token` per session at the authenticator — the real-IdP
+/// equivalent of fakeidp's `/_control/backchannel/{email}` hook.
+pub async fn logout_user(email: &str) {
+    let http = http();
+    let token = admin_token(&http).await;
+    let user = user_representation(&http, &token, email).await;
+    let id = user["id"].as_str().unwrap();
+    let resp = http
+        .post(format!(
+            "{}/admin/realms/{}/users/{id}/logout",
+            base(),
+            realm()
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_success(),
+        "the admin logout for {email} must succeed, got {}",
+        resp.status()
+    );
+}
+
+/// Enable or disable the user at the IdP. A disabled user's next refresh
+/// gets a definitive `invalid_grant` — the real-IdP equivalent of
+/// fakeidp's `/_control/revoke/{user}` hook, without the back-channel
+/// side-channel an admin logout would also fire.
+pub async fn set_user_enabled(email: &str, enabled: bool) {
+    let http = http();
+    let token = admin_token(&http).await;
+    let mut user = user_representation(&http, &token, email).await;
+    let id = user["id"].as_str().unwrap().to_owned();
+    user["enabled"] = serde_json::Value::Bool(enabled);
+    let resp = http
+        .put(format!("{}/admin/realms/{}/users/{id}", base(), realm()))
+        .bearer_auth(&token)
+        .json(&user)
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        resp.status().is_success(),
+        "setting enabled={enabled} for {email} must succeed, got {}",
+        resp.status()
+    );
+}
+
+/// Freeze / thaw the IdP container: requests hang until the client's own
+/// timeout and fail as transport errors — a transient outage, the
+/// real-IdP equivalent of fakeidp's `/_control/outage` hook.
+pub fn set_idp_outage(outage: bool) {
+    let container = env("E2E_KC_CONTAINER", "authenticator-e2e-keycloak");
+    let action = if outage { "pause" } else { "unpause" };
+    let status = Command::new("docker")
+        .args([action, &container])
+        .status()
+        .expect("docker must be runnable");
+    assert!(status.success(), "docker {action} {container} must succeed");
+}

--- a/src/backend/services/authenticator/tests/common/mod.rs
+++ b/src/backend/services/authenticator/tests/common/mod.rs
@@ -10,7 +10,7 @@
 //!
 //! Only requests whose origin matches `$AUTH_BASE` / `$AUTH_BASE_DISABLED`
 //! (the two authenticator instances) are recorded: the same client also talks
-//! to fakeidp and the service-token listener, and those must not pollute the
+//! to Keycloak and the service-token listener, and those must not pollute the
 //! ledger the authenticator spec is matched against. Each `cargo test --test
 //! e2e_*` invocation is its own process, and run-e2e.sh runs them serially, so
 //! the read-merge-write below needs no cross-process locking; the in-process
@@ -19,6 +19,8 @@
 // Each integration-test crate compiles its own copy of this module and none
 // uses the full surface.
 #![allow(dead_code)]
+
+pub mod kc;
 
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Mutex;

--- a/src/backend/services/authenticator/tests/e2e_backchannel.rs
+++ b/src/backend/services/authenticator/tests/e2e_backchannel.rs
@@ -1,24 +1,25 @@
 //! End-to-end OIDC back-channel logout against a running authenticator +
-//! fakeidp + Redis (nginx+auth step 10, item 3).
-//!
-//! `#[ignore]` by default (needs the stack up with
-//! `FAKEIDP_BACKCHANNEL_URL` pointing at the authenticator; `run-e2e.sh`
-//! wires it):
+//! Keycloak + Redis (nginx+auth step 10, item 3). The realm registers the
+//! authenticator's `/auth/oidc/back-channel-logout` as the client's
+//! back-channel logout URL (`run-e2e.sh` wires it via kc-realm-overlay.py):
 //!
 //! ```text
-//! AUTH_BASE=http://localhost:8083 FAKEIDP_PUBLIC=http://localhost:8084 \
+//! AUTH_BASE=http://localhost:8083 \
 //!   cargo test -p authenticator --test e2e_backchannel -- --ignored --nocapture
 //! ```
 //!
-//! Drives fakeidp's `POST /_control/backchannel/{email}` hook: the fake IdP
-//! fires a signed `logout_token` at the authenticator, and every session of
-//! that user dies through the standard revoke pipeline.
+//! An admin-triggered IdP logout makes Keycloak fire a signed `logout_token`
+//! per session at the authenticator, and every session of that user dies
+//! through the standard revoke pipeline.
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::doc_markdown)]
 
 mod common;
 
 const COOKIE: &str = "__Host-sid";
+// Dedicated realm user (kc-realm-overlay.py): the IdP-side logout must never
+// reach another suite's live sessions.
+const USER: &str = "backchannel@example.com";
 
 fn env(key: &str, default: &str) -> String {
     std::env::var(key).unwrap_or_else(|_| default.to_owned())
@@ -26,55 +27,6 @@ fn env(key: &str, default: &str) -> String {
 
 fn client() -> common::Client {
     common::client()
-}
-
-fn rewrite_host(url: &str) -> String {
-    match (
-        std::env::var("FAKEIDP_REWRITE_FROM"),
-        std::env::var("FAKEIDP_REWRITE_TO"),
-    ) {
-        (Ok(from), Ok(to)) if !from.is_empty() => url.replace(&from, &to),
-        _ => url.to_owned(),
-    }
-}
-
-fn cookie_from(resp: &reqwest::Response) -> Option<String> {
-    for hv in resp.headers().get_all(reqwest::header::SET_COOKIE) {
-        let raw = hv.to_str().ok()?;
-        for part in raw.split(';') {
-            if let Some(v) = part.trim().strip_prefix(&format!("{COOKIE}="))
-                && !v.is_empty()
-            {
-                return Some(v.to_owned());
-            }
-        }
-    }
-    None
-}
-
-async fn login(http: &common::Client, auth_base: &str, user: &str) -> String {
-    let login = http
-        .get(format!("{auth_base}/auth/login"))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(login.status(), 302);
-    let authorize = rewrite_host(login.headers()[reqwest::header::LOCATION].to_str().unwrap());
-    let sep = if authorize.contains('?') { '&' } else { '?' };
-    let authorized = http
-        .get(format!("{authorize}{sep}user={user}"))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(authorized.status(), 302);
-    let callback = rewrite_host(
-        authorized.headers()[reqwest::header::LOCATION]
-            .to_str()
-            .unwrap(),
-    );
-    let cb = http.get(&callback).send().await.unwrap();
-    assert_eq!(cb.status(), 302);
-    cookie_from(&cb).expect("callback must set __Host-sid")
 }
 
 async fn authz_status(http: &common::Client, auth_base: &str, token: &str) -> u16 {
@@ -88,44 +40,37 @@ async fn authz_status(http: &common::Client, auth_base: &str, token: &str) -> u1
 }
 
 #[tokio::test]
-#[ignore = "requires a running authenticator + fakeidp + Redis stack"]
+#[ignore = "requires a running authenticator + Keycloak + Redis stack"]
 async fn back_channel_logout_kills_the_users_sessions() {
     let auth_base = env("AUTH_BASE", "http://localhost:8083");
-    let idp_public = env("FAKEIDP_PUBLIC", "http://localhost:8084");
-    let test_user = env("E2E_USER", "dev@company.nonpresent");
     let http = client();
 
     // Two devices, both alive.
-    let token_a = login(&http, &auth_base, &test_user).await;
-    let token_b = login(&http, &auth_base, &test_user).await;
+    let token_a = common::kc::login(&http, &auth_base, USER).await;
+    let token_b = common::kc::login(&http, &auth_base, USER).await;
     assert_eq!(authz_status(&http, &auth_base, &token_a).await, 200);
     assert_eq!(authz_status(&http, &auth_base, &token_b).await, 200);
 
-    // The IdP fires a back-channel logout_token at the authenticator.
-    let fired = http
-        .post(format!("{idp_public}/_control/backchannel/{test_user}"))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(fired.status(), 200, "fakeidp control hook must succeed");
-    let body: serde_json::Value = fired.json().await.unwrap();
-    assert_eq!(
-        body["rp_status"], 200,
-        "the authenticator must answer the logout_token with 200, got {body}"
-    );
+    // The IdP-side logout: Keycloak fires a signed logout_token per session
+    // at the registered back-channel URL. Each device logged in separately,
+    // so each has its own OIDC `sid` — both sid-index revokes must land.
+    common::kc::logout_user(USER).await;
 
-    // fakeidp's users have ONE OIDC sid per user (users.yaml), so the sid-index
-    // path revokes every session created under it: both devices die.
-    assert_eq!(
-        authz_status(&http, &auth_base, &token_a).await,
-        401,
-        "device A must be logged out by back-channel logout"
-    );
-    assert_eq!(
-        authz_status(&http, &auth_base, &token_b).await,
-        401,
-        "device B must be logged out by back-channel logout"
-    );
+    // Delivery is the IdP's side of the contract and asynchronous; poll
+    // briefly rather than assert the first read.
+    for (device, token) in [("A", &token_a), ("B", &token_b)] {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+        loop {
+            if authz_status(&http, &auth_base, token).await == 401 {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "device {device} must be logged out by back-channel logout"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        }
+    }
 
     // A rejected (unsigned garbage) token is a 400, not a revoke.
     let bad = http

--- a/src/backend/services/authenticator/tests/e2e_hostmap.rs
+++ b/src/backend/services/authenticator/tests/e2e_hostmap.rs
@@ -1,13 +1,14 @@
 //! End-to-end host-keyed issuer selection (ADR-0003) against an authenticator
-//! configured with a two-entry `idp.hosts` map in front of two fakeidp
-//! instances, plus the flat-config instance for the degenerate case.
+//! configured with a two-entry `idp.hosts` map in front of two realms of the
+//! one Keycloak, plus the flat-config instance for the degenerate case.
 //!
 //! `#[ignore]` by default (needs the stack up); run-e2e.sh wires it:
 //!
 //! ```text
 //! AUTH_BASE=http://localhost:8087 AUTH_FLAT_BASE=http://localhost:8083 \
 //!   AUTH3_LOG=/tmp/authenticator-e2e-auth3.log \
-//!   FAKEIDP_PUBLIC=http://localhost:8084 FAKEIDP2_PUBLIC=http://localhost:8088 \
+//!   E2E_IDP_ISSUER=http://localhost:8084/realms/insight \
+//!   E2E_IDP2_ISSUER=http://localhost:8084/realms/insight-b \
 //!   cargo test -p authenticator --test e2e_hostmap -- --ignored --nocapture
 //! ```
 //!
@@ -48,11 +49,11 @@ fn cookie_from(resp: &reqwest::Response) -> Option<String> {
 }
 
 #[tokio::test]
-#[ignore = "requires the run-e2e.sh stack (two fakeidps + hosts-map authenticator)"]
+#[ignore = "requires the run-e2e.sh stack (two realms + hosts-map authenticator)"]
 async fn host_selects_the_issuer_and_the_callback_stays_pinned() {
     let auth_base = env("AUTH_BASE", "http://localhost:8087");
-    let idp_a = env("FAKEIDP_PUBLIC", "http://localhost:8084");
-    let idp_b = env("FAKEIDP2_PUBLIC", "http://localhost:8088");
+    let idp_a = env("E2E_IDP_ISSUER", "http://localhost:8084/realms/insight");
+    let idp_b = env("E2E_IDP2_ISSUER", "http://localhost:8084/realms/insight-b");
     let test_user = env("E2E_USER", "dev@company.nonpresent");
     let http = common::client();
 
@@ -83,16 +84,10 @@ async fn host_selects_the_issuer_and_the_callback_stays_pinned() {
         .unwrap();
     assert_eq!(login.status(), 302);
     let authorize = location_of(&login);
-    let sep = if authorize.contains('?') { '&' } else { '?' };
-    let authorized = http
-        .get(format!("{authorize}{sep}user={test_user}"))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(authorized.status(), 302, "authorize redirects to callback");
+    let callback = common::kc::authorize(&authorize, &test_user).await;
 
     let cb = http
-        .get(location_of(&authorized))
+        .get(&callback)
         .header("Host", HOST_B)
         .send()
         .await
@@ -115,7 +110,7 @@ async fn host_selects_the_issuer_and_the_callback_stays_pinned() {
 }
 
 #[tokio::test]
-#[ignore = "requires the run-e2e.sh stack (two fakeidps + hosts-map authenticator)"]
+#[ignore = "requires the run-e2e.sh stack (two realms + hosts-map authenticator)"]
 async fn unknown_host_is_rejected_fail_closed_with_an_audit_event() {
     let auth_base = env("AUTH_BASE", "http://localhost:8087");
     let http = common::client();
@@ -146,10 +141,10 @@ async fn unknown_host_is_rejected_fail_closed_with_an_audit_event() {
 }
 
 #[tokio::test]
-#[ignore = "requires the run-e2e.sh stack (two fakeidps + hosts-map authenticator)"]
+#[ignore = "requires the run-e2e.sh stack (two realms + hosts-map authenticator)"]
 async fn flat_single_issuer_config_matches_every_host() {
     let flat_base = env("AUTH_FLAT_BASE", "http://localhost:8083");
-    let idp_a = env("FAKEIDP_PUBLIC", "http://localhost:8084");
+    let idp_a = env("E2E_IDP_ISSUER", "http://localhost:8084/realms/insight");
     let http = common::client();
 
     // The degenerate (map-less) instance serves any Host, exactly as before.

--- a/src/backend/services/authenticator/tests/e2e_login_loop.rs
+++ b/src/backend/services/authenticator/tests/e2e_login_loop.rs
@@ -1,22 +1,15 @@
-//! End-to-end login loop against a running authenticator + fakeidp + Redis.
-//!
-//! `#[ignore]` by default (needs the stack up). Run it against docker-compose or
-//! a local process stack:
+//! End-to-end login loop against a running authenticator + Keycloak + Redis
+//! (`run-e2e.sh` boots the stack):
 //!
 //! ```text
-//! AUTH_BASE=http://localhost:8083 FAKEIDP_PUBLIC=http://localhost:8084 \
+//! AUTH_BASE=http://localhost:8083 \
 //!   cargo test -p authenticator --test e2e_login_loop -- --ignored --nocapture
 //! ```
 //!
-//! It drives the full loop: `/auth/login` -> fakeidp `/authorize` ->
+//! It drives the full loop: `/auth/login` -> the realm's login form ->
 //! `/auth/callback` (session + cookie) -> `/internal/authz` (JWT, verified
 //! against the published JWKS) -> `/auth/me` -> `/auth/logout` -> `/internal/authz`
 //! returns 401.
-//!
-//! Networking: in a docker-compose run the authenticator advertises fakeidp's
-//! authorize URL as `http://fakeidp:8084/...`, unreachable from the host — set
-//! `FAKEIDP_REWRITE_FROM=http://fakeidp:8084` and `FAKEIDP_REWRITE_TO=http://localhost:8084`
-//! to rewrite it. In an all-localhost process stack no rewrite is needed.
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::too_many_lines)]
 
@@ -33,16 +26,6 @@ fn env(key: &str, default: &str) -> String {
 
 fn client() -> common::Client {
     common::client()
-}
-
-fn rewrite_host(url: &str) -> String {
-    match (
-        std::env::var("FAKEIDP_REWRITE_FROM"),
-        std::env::var("FAKEIDP_REWRITE_TO"),
-    ) {
-        (Ok(from), Ok(to)) if !from.is_empty() => url.replace(&from, &to),
-        _ => url.to_owned(),
-    }
 }
 
 fn cookie_from(resp: &reqwest::Response) -> Option<String> {
@@ -83,7 +66,7 @@ struct Claims {
 }
 
 #[tokio::test]
-#[ignore = "requires a running authenticator + fakeidp + Redis stack"]
+#[ignore = "requires a running authenticator + Keycloak + Redis stack"]
 async fn full_login_exchange_logout_loop() {
     let auth_base = env("AUTH_BASE", "http://localhost:8083");
     let test_user = env("E2E_USER", "dev@company.nonpresent");
@@ -96,25 +79,13 @@ async fn full_login_exchange_logout_loop() {
         .await
         .unwrap();
     assert_eq!(login.status(), 302, "login should redirect to the IdP");
-    let authorize = rewrite_host(login.headers()[reqwest::header::LOCATION].to_str().unwrap());
+    let authorize = login.headers()[reqwest::header::LOCATION]
+        .to_str()
+        .unwrap()
+        .to_owned();
 
-    // 2. Follow authorize with an explicit test user -> 302 back to the callback.
-    let sep = if authorize.contains('?') { '&' } else { '?' };
-    let authorized = http
-        .get(format!("{authorize}{sep}user={test_user}"))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(
-        authorized.status(),
-        302,
-        "authorize should redirect to callback"
-    );
-    let callback = rewrite_host(
-        authorized.headers()[reqwest::header::LOCATION]
-            .to_str()
-            .unwrap(),
-    );
+    // 2. Authenticate on the realm's login form -> redirect to the callback.
+    let callback = common::kc::authorize(&authorize, &test_user).await;
 
     // 3. Follow the callback -> session created, cookie set, 302 to return_to.
     let cb = http.get(&callback).send().await.unwrap();
@@ -253,7 +224,7 @@ async fn full_login_exchange_logout_loop() {
 /// `default_return_to` with a fixed `auth_error=<reason>` the SPA consumes to
 /// restart the flow.
 #[tokio::test]
-#[ignore = "requires a running authenticator + fakeidp + Redis stack"]
+#[ignore = "requires a running authenticator + Keycloak + Redis stack"]
 async fn failed_callback_redirects_into_the_spa_with_auth_error() {
     let auth_base = env("AUTH_BASE", "http://localhost:8083");
     let http = client();

--- a/src/backend/services/authenticator/tests/e2e_override.rs
+++ b/src/backend/services/authenticator/tests/e2e_override.rs
@@ -1,5 +1,5 @@
 //! End-to-end `__override` (view-as, #1941) against a running authenticator +
-//! fakeidp + Redis + identity stub.
+//! Keycloak + Redis + identity stub.
 //!
 //! `#[ignore]` by default (needs the stack up; `run-e2e.sh` drives it):
 //!
@@ -12,6 +12,13 @@
 //! person (JWT `sub`, `/auth/me` user/email) with the real principal recorded
 //! (`impersonator_email`); an unknown target is 403; and against an instance
 //! with `override_enabled` at its default (`false`) the parameter is inert.
+//!
+//! Each test owns a disjoint {impersonator + targets} set of users
+//! (kc-realm-overlay.py provisions the ones that log in): view-as sessions
+//! are indexed under BOTH persons, so sharing either side would let one
+//! test's revoke-all kill a sibling's session under cargo's default parallel
+//! execution. Targets that never log in need no realm user — the identity
+//! stub resolves them from the email alone.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -44,7 +51,7 @@ fn cookie_from(resp: &reqwest::Response) -> Option<String> {
     None
 }
 
-/// Run the fakeidp login loop as `user`, optionally with `__override=<email>`
+/// Run the login loop as `user`, optionally with `__override=<email>`
 /// on `/auth/login`. Returns the callback response (302 + cookie on success,
 /// the error status otherwise).
 async fn login_flow(
@@ -63,17 +70,7 @@ async fn login_flow(
         .to_str()
         .unwrap()
         .to_owned();
-    let sep = if authorize.contains('?') { '&' } else { '?' };
-    let authorized = http
-        .get(format!("{authorize}{sep}user={user}"))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(authorized.status(), 302, "fakeidp /authorize must redirect");
-    let callback = authorized.headers()[reqwest::header::LOCATION]
-        .to_str()
-        .unwrap()
-        .to_owned();
+    let callback = common::kc::authorize(&authorize, user).await;
     http.get(&callback).send().await.unwrap()
 }
 
@@ -112,8 +109,9 @@ async fn jwt_sub(http: &common::Client, auth_base: &str, token: &str) -> String 
 #[ignore = "needs the e2e stack (run-e2e.sh)"]
 async fn override_mints_the_session_for_the_target_person() {
     let auth_base = env("AUTH_BASE", "http://localhost:8083");
-    let user = env("E2E_USER", "dev@company.nonpresent");
-    let target = "bob@example.com";
+    let user = "viewer-mints@example.com";
+    // The baseline below logs in AS the target, so it needs a realm user too.
+    let target = "target-mints@example.com";
     let http = client();
 
     // Baseline: a normal login AS the target — its person id is the reference
@@ -129,7 +127,7 @@ async fn override_mints_the_session_for_the_target_person() {
     );
 
     // The override login: authenticate as `user`, view as `target`.
-    let cb = login_flow(&http, &auth_base, &user, Some(target)).await;
+    let cb = login_flow(&http, &auth_base, user, Some(target)).await;
     assert_eq!(cb.status(), 302, "override callback must succeed");
     let token = cookie_from(&cb).expect("override callback must set the cookie");
 
@@ -148,7 +146,7 @@ async fn override_mints_the_session_for_the_target_person() {
     // The view-as session is reachable through the REAL principal: it is
     // indexed under both persons, so the impersonator's own "log out
     // everywhere" must kill it.
-    let cb = login_flow(&http, &auth_base, &user, None).await;
+    let cb = login_flow(&http, &auth_base, user, None).await;
     assert_eq!(cb.status(), 302);
     let own_token = cookie_from(&cb).expect("normal login must set the cookie");
     let csrf = csrf_token(&http, &auth_base, &own_token).await;
@@ -199,15 +197,24 @@ async fn csrf_token(http: &common::Client, auth_base: &str, token: &str) -> Stri
 #[ignore = "needs the e2e stack (run-e2e.sh)"]
 async fn override_relogin_swaps_the_target_and_kills_the_old_session() {
     let auth_base = env("AUTH_BASE", "http://localhost:8083");
-    let user = env("E2E_USER", "dev@company.nonpresent");
+    let user = "viewer-relogin@example.com";
     let http = client();
 
-    // 1. Login viewing as alice.
-    let cb = login_flow(&http, &auth_base, &user, Some("alice@example.com")).await;
+    // 1. Login viewing as the first target.
+    let cb = login_flow(
+        &http,
+        &auth_base,
+        user,
+        Some("target-relogin-a@example.com"),
+    )
+    .await;
     assert_eq!(cb.status(), 302);
     let token_a = cookie_from(&cb).expect("first override callback must set the cookie");
     let me_a = me(&http, &auth_base, &token_a).await;
-    assert_eq!(me_a["email"].as_str().unwrap(), "alice@example.com");
+    assert_eq!(
+        me_a["email"].as_str().unwrap(),
+        "target-relogin-a@example.com"
+    );
     let sub_a = jwt_sub(&http, &auth_base, &token_a).await;
 
     // 2. Logout.
@@ -247,8 +254,14 @@ async fn override_relogin_swaps_the_target_and_kills_the_old_session() {
         "the exchange must refuse the revoked credential (nothing for nginx to re-cache)"
     );
 
-    // 3. Login viewing as bob — a fresh credential and a fresh identity.
-    let cb = login_flow(&http, &auth_base, &user, Some("bob@example.com")).await;
+    // 3. Login viewing as the second target — a fresh credential and identity.
+    let cb = login_flow(
+        &http,
+        &auth_base,
+        user,
+        Some("target-relogin-b@example.com"),
+    )
+    .await;
     assert_eq!(cb.status(), 302);
     let token_b = cookie_from(&cb).expect("second override callback must set the cookie");
     assert_ne!(
@@ -257,7 +270,10 @@ async fn override_relogin_swaps_the_target_and_kills_the_old_session() {
     );
 
     let me_b = me(&http, &auth_base, &token_b).await;
-    assert_eq!(me_b["email"].as_str().unwrap(), "bob@example.com");
+    assert_eq!(
+        me_b["email"].as_str().unwrap(),
+        "target-relogin-b@example.com"
+    );
     assert_eq!(me_b["impersonator_email"].as_str().unwrap(), user);
     let sub_b = jwt_sub(&http, &auth_base, &token_b).await;
     assert_ne!(
@@ -279,17 +295,18 @@ async fn override_relogin_swaps_the_target_and_kills_the_old_session() {
 #[ignore = "needs the e2e stack (run-e2e.sh)"]
 async fn override_switch_without_logout_revokes_the_presented_session() {
     let auth_base = env("AUTH_BASE", "http://localhost:8083");
-    let user = env("E2E_USER", "dev@company.nonpresent");
+    let user = "viewer-switch@example.com";
     let http = client();
 
-    let cb = login_flow(&http, &auth_base, &user, Some("bob@example.com")).await;
+    let cb = login_flow(&http, &auth_base, user, Some("target-switch-a@example.com")).await;
     assert_eq!(cb.status(), 302);
     let token_b = cookie_from(&cb).expect("first override callback must set the cookie");
 
-    // Browser-style switch to alice: the bob cookie rides along.
+    // Browser-style switch to the second target: the first session's cookie
+    // rides along.
     let login = http
         .get(format!(
-            "{auth_base}/auth/login?__override=alice%40example.com"
+            "{auth_base}/auth/login?__override=target-switch-b%40example.com"
         ))
         .header(reqwest::header::COOKIE, format!("{COOKIE}={token_b}"))
         .send()
@@ -300,17 +317,7 @@ async fn override_switch_without_logout_revokes_the_presented_session() {
         .to_str()
         .unwrap()
         .to_owned();
-    let sep = if authorize.contains('?') { '&' } else { '?' };
-    let authorized = http
-        .get(format!("{authorize}{sep}user={user}"))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(authorized.status(), 302);
-    let callback = authorized.headers()[reqwest::header::LOCATION]
-        .to_str()
-        .unwrap()
-        .to_owned();
+    let callback = common::kc::authorize(&authorize, user).await;
     let cb = http
         .get(&callback)
         .header(reqwest::header::COOKIE, format!("{COOKIE}={token_b}"))
@@ -322,7 +329,10 @@ async fn override_switch_without_logout_revokes_the_presented_session() {
     assert_ne!(token_b, token_c);
 
     let me_c = me(&http, &auth_base, &token_c).await;
-    assert_eq!(me_c["email"].as_str().unwrap(), "alice@example.com");
+    assert_eq!(
+        me_c["email"].as_str().unwrap(),
+        "target-switch-b@example.com"
+    );
     assert_eq!(me_c["impersonator_email"].as_str().unwrap(), user);
     let stale = http
         .get(format!("{auth_base}/internal/authz"))
@@ -333,7 +343,7 @@ async fn override_switch_without_logout_revokes_the_presented_session() {
     assert_eq!(
         stale.status(),
         401,
-        "the fixation guard must have revoked the presented bob session"
+        "the fixation guard must have revoked the presented first session"
     );
 }
 
@@ -341,13 +351,13 @@ async fn override_switch_without_logout_revokes_the_presented_session() {
 #[ignore = "needs the e2e stack (run-e2e.sh)"]
 async fn override_with_unknown_target_is_denied() {
     let auth_base = env("AUTH_BASE", "http://localhost:8083");
-    let user = env("E2E_USER", "dev@company.nonpresent");
+    let user = "viewer-unknown@example.com";
     let http = client();
 
     // The identity stub 404s emails prefixed `unknown-` (test seam). The
     // denial is an auth_error bounce back into the SPA (#2032), never a
     // fallback to the caller's own identity.
-    let cb = login_flow(&http, &auth_base, &user, Some("unknown-nobody@example.com")).await;
+    let cb = login_flow(&http, &auth_base, user, Some("unknown-nobody@example.com")).await;
     assert_eq!(
         cb.status(),
         302,
@@ -365,10 +375,10 @@ async fn override_with_unknown_target_is_denied() {
 async fn override_is_inert_when_disabled() {
     // The second instance runs with `override_enabled` at its default (false).
     let auth_base = env("AUTH_BASE_DISABLED", "http://localhost:8085");
-    let user = env("E2E_USER", "dev@company.nonpresent");
+    let user = "viewer-disabled@example.com";
     let http = client();
 
-    let cb = login_flow(&http, &auth_base, &user, Some("bob@example.com")).await;
+    let cb = login_flow(&http, &auth_base, user, Some("target-disabled@example.com")).await;
     assert_eq!(cb.status(), 302, "login itself must still succeed");
     let token = cookie_from(&cb).expect("callback must set the cookie");
 

--- a/src/backend/services/authenticator/tests/e2e_ratelimit.rs
+++ b/src/backend/services/authenticator/tests/e2e_ratelimit.rs
@@ -1,5 +1,5 @@
 //! End-to-end layer-2 rate limiting (nginx+auth step 10, item 6) against a
-//! running authenticator + fakeidp + Redis.
+//! running authenticator + Keycloak + Redis.
 //!
 //! ```text
 //! AUTH_BASE=http://localhost:8083 \
@@ -26,53 +26,12 @@ fn client() -> common::Client {
     common::client()
 }
 
-fn rewrite_host(url: &str) -> String {
-    match (
-        std::env::var("FAKEIDP_REWRITE_FROM"),
-        std::env::var("FAKEIDP_REWRITE_TO"),
-    ) {
-        (Ok(from), Ok(to)) if !from.is_empty() => url.replace(&from, &to),
-        _ => url.to_owned(),
-    }
-}
-
 fn cookie_from(resp: &reqwest::Response) -> Option<String> {
-    for hv in resp.headers().get_all(reqwest::header::SET_COOKIE) {
-        let raw = hv.to_str().ok()?;
-        for part in raw.split(';') {
-            if let Some(v) = part.trim().strip_prefix(&format!("{COOKIE}="))
-                && !v.is_empty()
-            {
-                return Some(v.to_owned());
-            }
-        }
-    }
-    None
+    common::kc::session_cookie(resp)
 }
 
 async fn login(http: &common::Client, auth_base: &str, user: &str) -> String {
-    let login = http
-        .get(format!("{auth_base}/auth/login"))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(login.status(), 302);
-    let authorize = rewrite_host(login.headers()[reqwest::header::LOCATION].to_str().unwrap());
-    let sep = if authorize.contains('?') { '&' } else { '?' };
-    let authorized = http
-        .get(format!("{authorize}{sep}user={user}"))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(authorized.status(), 302);
-    let callback = rewrite_host(
-        authorized.headers()[reqwest::header::LOCATION]
-            .to_str()
-            .unwrap(),
-    );
-    let cb = http.get(&callback).send().await.unwrap();
-    assert_eq!(cb.status(), 302);
-    cookie_from(&cb).expect("callback must set __Host-sid")
+    common::kc::login(http, auth_base, user).await
 }
 
 async fn get_csrf(http: &common::Client, auth_base: &str, token: &str) -> String {
@@ -110,7 +69,7 @@ async fn refresh(
 }
 
 #[tokio::test]
-#[ignore = "requires a running authenticator + fakeidp + Redis stack"]
+#[ignore = "requires a running authenticator + Keycloak + Redis stack"]
 async fn refresh_and_callback_buckets_trip_past_burst() {
     let auth_base = env("AUTH_BASE", "http://localhost:8083");
     let test_user = env("E2E_USER", "dev@company.nonpresent");

--- a/src/backend/services/authenticator/tests/e2e_refresh.rs
+++ b/src/backend/services/authenticator/tests/e2e_refresh.rs
@@ -1,5 +1,5 @@
 //! End-to-end `/auth/refresh` rotation-with-grace against a running
-//! authenticator + fakeidp + Redis (nginx+auth step 10, item 1).
+//! authenticator + Keycloak + Redis (nginx+auth step 10, item 1).
 //!
 //! `#[ignore]` by default (needs the stack up):
 //!
@@ -29,54 +29,8 @@ fn client() -> common::Client {
     common::client()
 }
 
-fn rewrite_host(url: &str) -> String {
-    match (
-        std::env::var("FAKEIDP_REWRITE_FROM"),
-        std::env::var("FAKEIDP_REWRITE_TO"),
-    ) {
-        (Ok(from), Ok(to)) if !from.is_empty() => url.replace(&from, &to),
-        _ => url.to_owned(),
-    }
-}
-
 fn cookie_from(resp: &reqwest::Response) -> Option<String> {
-    for hv in resp.headers().get_all(reqwest::header::SET_COOKIE) {
-        let raw = hv.to_str().ok()?;
-        for part in raw.split(';') {
-            if let Some(v) = part.trim().strip_prefix(&format!("{COOKIE}="))
-                && !v.is_empty()
-            {
-                return Some(v.to_owned());
-            }
-        }
-    }
-    None
-}
-
-/// Run the full fakeidp login loop; returns the session cookie token.
-async fn login(http: &common::Client, auth_base: &str, user: &str) -> String {
-    let login = http
-        .get(format!("{auth_base}/auth/login"))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(login.status(), 302);
-    let authorize = rewrite_host(login.headers()[reqwest::header::LOCATION].to_str().unwrap());
-    let sep = if authorize.contains('?') { '&' } else { '?' };
-    let authorized = http
-        .get(format!("{authorize}{sep}user={user}"))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(authorized.status(), 302);
-    let callback = rewrite_host(
-        authorized.headers()[reqwest::header::LOCATION]
-            .to_str()
-            .unwrap(),
-    );
-    let cb = http.get(&callback).send().await.unwrap();
-    assert_eq!(cb.status(), 302);
-    cookie_from(&cb).expect("callback must set __Host-sid")
+    common::kc::session_cookie(resp)
 }
 
 /// Fetch the session's CSRF token (state-changing /auth/* requires it, 10.5).
@@ -137,13 +91,13 @@ async fn authz_sid(http: &common::Client, auth_base: &str, token: &str) -> Optio
 }
 
 #[tokio::test]
-#[ignore = "requires a running authenticator + fakeidp + Redis stack"]
+#[ignore = "requires a running authenticator + Keycloak + Redis stack"]
 async fn refresh_rotates_with_grace_and_stable_session() {
     let auth_base = env("AUTH_BASE", "http://localhost:8083");
     let test_user = env("E2E_USER", "dev@company.nonpresent");
     let http = client();
 
-    let old_token = login(&http, &auth_base, &test_user).await;
+    let old_token = common::kc::login(&http, &auth_base, &test_user).await;
     let sid_before = authz_sid(&http, &auth_base, &old_token)
         .await
         .expect("fresh session exchanges");

--- a/src/backend/services/authenticator/tests/e2e_refresher.rs
+++ b/src/backend/services/authenticator/tests/e2e_refresher.rs
@@ -76,7 +76,8 @@ async fn refresher_outage_survives_and_invalid_grant_kills() {
     // 1. Outage: the IdP container is paused, so refresh attempts hang until
     //    the OIDC client's own timeout and fail TRANSIENTLY for ~12 s (several
     //    due cycles at the fast lifecycle) — nobody may be logged out by a blip.
-    common::kc::set_idp_outage(true);
+    //    The guard unpauses on drop even if an assertion fails mid-outage.
+    let outage = common::kc::idp_outage();
     tokio::time::sleep(Duration::from_secs(12)).await;
     assert_eq!(
         authz_status(&http, &auth_base, &victim_token).await,
@@ -84,7 +85,7 @@ async fn refresher_outage_survives_and_invalid_grant_kills() {
         "an IdP outage must not log users out (fail open on transport)"
     );
     assert_eq!(authz_status(&http, &auth_base, &survivor_token).await, 200);
-    common::kc::set_idp_outage(false);
+    drop(outage);
 
     // 2. Definitive verdict: disable the victim at the IdP. The next scheduled
     //    refresh gets invalid_grant and the session dies through the standard

--- a/src/backend/services/authenticator/tests/e2e_refresher.rs
+++ b/src/backend/services/authenticator/tests/e2e_refresher.rs
@@ -1,18 +1,18 @@
 //! End-to-end IdP background refresher (nginx+auth step 10, item 4) against a
-//! running authenticator + fakeidp + Redis with a FAST refresh lifecycle
-//! (`run-e2e.sh` sets `FAKEIDP_TOKEN_TTL=15`, margin 10 s, tick 1 s, jitter
-//! ±1 s, so a session's IdP tokens refresh every ~5 s).
+//! running authenticator + Keycloak + Redis with a FAST refresh lifecycle
+//! (`run-e2e.sh` pairs the realm's 15 s access-token lifespan with margin
+//! 10 s, tick 1 s, jitter ±1 s, so a session's IdP tokens refresh every ~5 s).
 //!
 //! ```text
-//! AUTH_BASE=http://localhost:8083 FAKEIDP_PUBLIC=http://localhost:8084 \
+//! AUTH_BASE=http://localhost:8083 \
 //!   cargo test -p authenticator --test e2e_refresher -- --ignored --nocapture
 //! ```
 //!
-//! Drives fakeidp's control hooks (the reason fakeidp exists, G6):
-//! `/_control/outage` — transient failures must log nobody out; and
-//! `/_control/revoke/{user}` — the definitive `invalid_grant` verdict must
-//! kill the user's sessions on the next scheduled refresh, while another
-//! user's session survives.
+//! Drives the two IdP failure modes through real-IdP seams (tests/common/kc.rs;
+//! what fakeidp's `/_control/*` hooks used to simulate): a paused container —
+//! transient failures must log nobody out; and an admin-disabled user — the
+//! definitive `invalid_grant` verdict must kill the user's sessions on the
+//! next scheduled refresh, while another user's session survives.
 
 #![allow(clippy::unwrap_used, clippy::expect_used, clippy::doc_markdown)]
 
@@ -30,55 +30,6 @@ fn client() -> common::Client {
     common::client()
 }
 
-fn rewrite_host(url: &str) -> String {
-    match (
-        std::env::var("FAKEIDP_REWRITE_FROM"),
-        std::env::var("FAKEIDP_REWRITE_TO"),
-    ) {
-        (Ok(from), Ok(to)) if !from.is_empty() => url.replace(&from, &to),
-        _ => url.to_owned(),
-    }
-}
-
-fn cookie_from(resp: &reqwest::Response) -> Option<String> {
-    for hv in resp.headers().get_all(reqwest::header::SET_COOKIE) {
-        let raw = hv.to_str().ok()?;
-        for part in raw.split(';') {
-            if let Some(v) = part.trim().strip_prefix(&format!("{COOKIE}="))
-                && !v.is_empty()
-            {
-                return Some(v.to_owned());
-            }
-        }
-    }
-    None
-}
-
-async fn login(http: &common::Client, auth_base: &str, user: &str) -> String {
-    let login = http
-        .get(format!("{auth_base}/auth/login"))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(login.status(), 302);
-    let authorize = rewrite_host(login.headers()[reqwest::header::LOCATION].to_str().unwrap());
-    let sep = if authorize.contains('?') { '&' } else { '?' };
-    let authorized = http
-        .get(format!("{authorize}{sep}user={user}"))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(authorized.status(), 302);
-    let callback = rewrite_host(
-        authorized.headers()[reqwest::header::LOCATION]
-            .to_str()
-            .unwrap(),
-    );
-    let cb = http.get(&callback).send().await.unwrap();
-    assert_eq!(cb.status(), 302);
-    cookie_from(&cb).expect("callback must set __Host-sid")
-}
-
 async fn authz_status(http: &common::Client, auth_base: &str, token: &str) -> u16 {
     http.get(format!("{auth_base}/internal/authz"))
         .header(reqwest::header::COOKIE, format!("{COOKIE}={token}"))
@@ -87,20 +38,6 @@ async fn authz_status(http: &common::Client, auth_base: &str, token: &str) -> u1
         .unwrap()
         .status()
         .as_u16()
-}
-
-async fn control(http: &common::Client, idp: &str, path: &str, body: Option<serde_json::Value>) {
-    let req = http.post(format!("{idp}{path}"));
-    let req = match body {
-        Some(json) => req.json(&json),
-        None => req,
-    };
-    let resp = req.send().await.unwrap();
-    assert!(
-        resp.status().is_success(),
-        "control hook {path} failed: {}",
-        resp.status()
-    );
 }
 
 /// Poll `authz` until it returns `expected` or the deadline passes.
@@ -125,26 +62,21 @@ async fn wait_for_status(
 #[ignore = "requires the fast-lifecycle e2e stack (run-e2e.sh)"]
 async fn refresher_outage_survives_and_invalid_grant_kills() {
     let auth_base = env("AUTH_BASE", "http://localhost:8083");
-    let idp = env("FAKEIDP_PUBLIC", "http://localhost:8084");
-    let victim = "alice@example.com";
-    let survivor = "bob@example.com";
+    // Dedicated realm users (kc-realm-overlay.py): the victim stays disabled
+    // at the IdP after this test, so no other suite may share it.
+    let victim = "refresh-victim@example.com";
+    let survivor = "refresh-survivor@example.com";
     let http = client();
 
-    let victim_token = login(&http, &auth_base, victim).await;
-    let survivor_token = login(&http, &auth_base, survivor).await;
+    let victim_token = common::kc::login(&http, &auth_base, victim).await;
+    let survivor_token = common::kc::login(&http, &auth_base, survivor).await;
     assert_eq!(authz_status(&http, &auth_base, &victim_token).await, 200);
     assert_eq!(authz_status(&http, &auth_base, &survivor_token).await, 200);
 
-    // 1. Outage: the IdP token endpoint returns 5xx. Refresh attempts fail
-    //    TRANSIENTLY for ~12 s (several due cycles at the fast lifecycle) —
-    //    nobody may be logged out by a blip.
-    control(
-        &http,
-        &idp,
-        "/_control/outage",
-        Some(serde_json::json!({"mode": "5xx"})),
-    )
-    .await;
+    // 1. Outage: the IdP container is paused, so refresh attempts hang until
+    //    the OIDC client's own timeout and fail TRANSIENTLY for ~12 s (several
+    //    due cycles at the fast lifecycle) — nobody may be logged out by a blip.
+    common::kc::set_idp_outage(true);
     tokio::time::sleep(Duration::from_secs(12)).await;
     assert_eq!(
         authz_status(&http, &auth_base, &victim_token).await,
@@ -152,19 +84,15 @@ async fn refresher_outage_survives_and_invalid_grant_kills() {
         "an IdP outage must not log users out (fail open on transport)"
     );
     assert_eq!(authz_status(&http, &auth_base, &survivor_token).await, 200);
-    control(
-        &http,
-        &idp,
-        "/_control/outage",
-        Some(serde_json::json!({"mode": "off"})),
-    )
-    .await;
+    common::kc::set_idp_outage(false);
 
-    // 2. Definitive verdict: revoke the victim at the IdP. The next scheduled
+    // 2. Definitive verdict: disable the victim at the IdP. The next scheduled
     //    refresh gets invalid_grant and the session dies through the standard
-    //    pipeline. Generous deadline: the outage above pushed the session into
+    //    pipeline. (An admin logout would ALSO fire back-channel logout — the
+    //    disable keeps the kill on the refresher path this test pins.)
+    //    Generous deadline: the outage above pushed the session into
     //    exponential backoff (~15–40 s).
-    control(&http, &idp, &format!("/_control/revoke/{victim}"), None).await;
+    common::kc::set_user_enabled(victim, false).await;
     let died = wait_for_status(
         &http,
         &auth_base,

--- a/src/backend/services/authenticator/tests/e2e_sessions.rs
+++ b/src/backend/services/authenticator/tests/e2e_sessions.rs
@@ -1,4 +1,4 @@
-//! End-to-end session management against a running authenticator + fakeidp +
+//! End-to-end session management against a running authenticator + Keycloak +
 //! Redis (nginx+auth step 10, item 2).
 //!
 //! `#[ignore]` by default (needs the stack up; `run-e2e.sh` drives it):
@@ -29,28 +29,8 @@ fn client() -> common::Client {
     common::client()
 }
 
-fn rewrite_host(url: &str) -> String {
-    match (
-        std::env::var("FAKEIDP_REWRITE_FROM"),
-        std::env::var("FAKEIDP_REWRITE_TO"),
-    ) {
-        (Ok(from), Ok(to)) if !from.is_empty() => url.replace(&from, &to),
-        _ => url.to_owned(),
-    }
-}
-
 fn cookie_from(resp: &reqwest::Response) -> Option<String> {
-    for hv in resp.headers().get_all(reqwest::header::SET_COOKIE) {
-        let raw = hv.to_str().ok()?;
-        for part in raw.split(';') {
-            if let Some(v) = part.trim().strip_prefix(&format!("{COOKIE}="))
-                && !v.is_empty()
-            {
-                return Some(v.to_owned());
-            }
-        }
-    }
-    None
+    common::kc::session_cookie(resp)
 }
 
 /// Fetch the session's CSRF token (state-changing /auth/* requires it, 10.5).
@@ -69,7 +49,8 @@ async fn get_csrf(http: &common::Client, auth_base: &str, token: &str) -> String
     resp.json::<CsrfBody>().await.unwrap().csrf_token
 }
 
-/// Run the full fakeidp login loop; returns the session cookie token.
+/// Run the full login loop with this suite's user-agent (the list surfaces
+/// the attribution captured at login); returns the session cookie token.
 async fn login(http: &common::Client, auth_base: &str, user: &str) -> String {
     let login = http
         .get(format!("{auth_base}/auth/login"))
@@ -78,19 +59,13 @@ async fn login(http: &common::Client, auth_base: &str, user: &str) -> String {
         .await
         .unwrap();
     assert_eq!(login.status(), 302);
-    let authorize = rewrite_host(login.headers()[reqwest::header::LOCATION].to_str().unwrap());
-    let sep = if authorize.contains('?') { '&' } else { '?' };
-    let authorized = http
-        .get(format!("{authorize}{sep}user={user}"))
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(authorized.status(), 302);
-    let callback = rewrite_host(
-        authorized.headers()[reqwest::header::LOCATION]
-            .to_str()
-            .unwrap(),
-    );
+    let authorize = login.headers()[reqwest::header::LOCATION]
+        .to_str()
+        .unwrap()
+        .to_owned();
+
+    let callback = common::kc::authorize(&authorize, user).await;
+
     let cb = http
         .get(&callback)
         .header(reqwest::header::USER_AGENT, "e2e-sessions-test")
@@ -129,7 +104,7 @@ async fn list(http: &common::Client, auth_base: &str, token: &str) -> Vec<Sessio
 }
 
 #[tokio::test]
-#[ignore = "requires a running authenticator + fakeidp + Redis stack"]
+#[ignore = "requires a running authenticator + Keycloak + Redis stack"]
 async fn sessions_list_revoke_and_logout_everywhere() {
     let auth_base = env("AUTH_BASE", "http://localhost:8083");
     let test_user = env("E2E_USER", "dev@company.nonpresent");

--- a/src/backend/services/authenticator/tests/e2e_unauthorized.rs
+++ b/src/backend/services/authenticator/tests/e2e_unauthorized.rs
@@ -37,7 +37,7 @@ const SESSION_ROUTES: &[(Method, &str)] = &[
 ];
 
 #[tokio::test]
-#[ignore = "requires a running authenticator + fakeidp + Redis stack"]
+#[ignore = "requires a running authenticator + Keycloak + Redis stack"]
 async fn session_routes_reject_missing_cookie_with_401() {
     let auth_base = env("AUTH_BASE", "http://localhost:8083");
     let http = common::client();
@@ -62,7 +62,7 @@ async fn session_routes_reject_missing_cookie_with_401() {
 }
 
 #[tokio::test]
-#[ignore = "requires a running authenticator + fakeidp + Redis stack"]
+#[ignore = "requires a running authenticator + Keycloak + Redis stack"]
 async fn session_routes_reject_unknown_session_token_with_401() {
     let auth_base = env("AUTH_BASE", "http://localhost:8083");
     let http = common::client();

--- a/src/backend/services/authenticator/tests/identity-stub.py
+++ b/src/backend/services/authenticator/tests/identity-stub.py
@@ -30,19 +30,6 @@ def person_id_for(*parts: str) -> str:
     return str(uuid.UUID(bytes=digest[:16]))
 
 
-# fakeidp's users.yaml `sub` -> `email`, so an external-id lookup (the login
-# path) and an email lookup (the `__override` path) resolve to the SAME
-# person for the SAME fakeidp user — a real identity-resolution service would
-# converge the same way (one `persons` person_id, two value_type observations).
-# Keep in sync with services/fakeidp/users.yaml.
-FAKEIDP_USERS = {
-    "fakeidp|dev": "dev@company.nonpresent",
-    "fakeidp|alice": "alice@example.com",
-    "fakeidp|bob": "bob@example.com",
-    "fakeidp|carol": "carol@example.com",
-}
-
-
 class Handler(BaseHTTPRequestHandler):
     BY_EXTERNAL_ID_PATH = "/internal/persons/by-external-id"
     BY_EMAIL_OVERRIDE_PATH = "/internal/persons/by-email-override"
@@ -58,11 +45,13 @@ class Handler(BaseHTTPRequestHandler):
                 self.send_response(400)
                 self.end_headers()
                 return
-            # A known fakeidp sub resolves to the same key as that user's
-            # email lookup (see FAKEIDP_USERS); an unrecognized one still gets
-            # a deterministic (but path-specific) id.
-            mapped_email = FAKEIDP_USERS.get(external_id)
-            key = ("email", mapped_email) if mapped_email else ("id", source_type, external_id)
+            # The rig configures `idp.external_id_claim: email`, so a login's
+            # external id IS the email — keyed identically to the `__override`
+            # email lookup, both paths resolve the same user to the SAME
+            # person (a real identity-resolution service converges the same
+            # way: one `persons` person_id, two value_type observations). A
+            # non-email external id still gets a deterministic path-specific id.
+            key = ("email", external_id) if "@" in external_id else ("id", source_type, external_id)
             value_type, value = "id", external_id
         elif split.path == self.BY_EMAIL_OVERRIDE_PATH:
             email = (query.get("email") or [""])[0]

--- a/src/backend/services/authenticator/tests/kc-realm-overlay.py
+++ b/src/backend/services/authenticator/tests/kc-realm-overlay.py
@@ -80,10 +80,7 @@ def main() -> None:
 
     (client,) = [c for c in realm["clients"] if c["clientId"] == "insight-authenticator"]
     client.setdefault("attributes", {}).update(
-        {
-            "backchannel.logout.url": args.backchannel_url,
-            "backchannel.logout.session.required": "true",
-        }
+        {"backchannel.logout.url": args.backchannel_url, "backchannel.logout.session.required": "true"}
     )
 
     seed_user = realm["users"][0]

--- a/src/backend/services/authenticator/tests/kc-realm-overlay.py
+++ b/src/backend/services/authenticator/tests/kc-realm-overlay.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Turn the generated compose realm into the e2e rig's Keycloak import set.
+
+Input is `gen-realm.py` output (the roster realm the compose stack imports).
+The rig needs the same realm plus what only the e2e suites care about:
+
+- a short access-token lifespan, so the authenticator's background refresher
+  cycles in seconds (`e2e_refresher`) instead of minutes;
+- the client's back-channel logout registration, pointing back at the
+  authenticator running on the docker host (`e2e_backchannel`);
+- dedicated test users, so no two suites (and no two tests inside the
+  parallel `e2e_override` suite) share a principal — one test's revoke-all
+  or admin disable must never reach a sibling's live session;
+- a second, user-less realm (`--second-realm`) as the second issuer of the
+  host-keyed map (`e2e_hostmap`). User-less because Keycloak's user ids are
+  globally unique across realms, so importing the roster twice collides.
+
+Passwords and tenant ids are read off the input realm rather than restated,
+so this script cannot drift from the generator.
+
+Usage:
+    python3 kc-realm-overlay.py --realm realm-insight.generated.json \
+        --out-dir .artifacts/keycloak-import --second-realm insight-b \
+        --backchannel-url http://host.docker.internal:8083/auth/oidc/back-channel-logout \
+        --access-token-lifespan 15
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+from pathlib import Path
+
+# One user per concern. The e2e_override suite runs its five tests in
+# parallel, and view-as sessions are indexed under both the impersonator and
+# the target — sharing either side lets one test's revoke-all kill another
+# test's session mid-flight. Impersonators authenticate against Keycloak;
+# override *targets* are resolved by the identity stub from the email alone
+# and only need a realm user when the test also logs in as them.
+TEST_USERS = [
+    "backchannel@example.com",  # e2e_backchannel: admin logout kills its sessions
+    "refresh-victim@example.com",  # e2e_refresher: disabled mid-test (invalid_grant)
+    "refresh-survivor@example.com",  # e2e_refresher: must outlive the victim
+    "viewer-mints@example.com",  # e2e_override: override_mints_the_session…
+    "target-mints@example.com",  # e2e_override: its baseline logs in AS the target
+    "viewer-relogin@example.com",  # e2e_override: override_relogin_swaps…
+    "viewer-switch@example.com",  # e2e_override: override_switch_without_logout…
+    "viewer-unknown@example.com",  # e2e_override: override_with_unknown_target…
+    "viewer-disabled@example.com",  # e2e_override: override_is_inert_when_disabled
+]
+
+
+def _test_user(email: str, password: str, tenant_id: str) -> dict:
+    local = email.split("@", 1)[0]
+    return {
+        "username": email,
+        "email": email,
+        "firstName": local,
+        "lastName": "e2e",
+        "enabled": True,
+        "emailVerified": True,
+        "credentials": [{"type": "password", "value": password, "temporary": False}],
+        "attributes": {"org_unit": ["development"], "tenant_id": [tenant_id]},
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--realm", required=True, help="gen-realm.py output JSON")
+    parser.add_argument("--out-dir", required=True, help="Keycloak import directory")
+    parser.add_argument("--second-realm", required=True, help="Name of the user-less second realm")
+    parser.add_argument("--backchannel-url", required=True, help="insight-authenticator back-channel logout URL")
+    parser.add_argument("--access-token-lifespan", type=int, required=True, help="Realm access-token lifespan, seconds")
+    args = parser.parse_args()
+
+    realm = json.loads(Path(args.realm).read_text())
+
+    realm["accessTokenLifespan"] = args.access_token_lifespan
+
+    (client,) = [c for c in realm["clients"] if c["clientId"] == "insight-authenticator"]
+    client.setdefault("attributes", {}).update(
+        {
+            "backchannel.logout.url": args.backchannel_url,
+            "backchannel.logout.session.required": "true",
+        }
+    )
+
+    seed_user = realm["users"][0]
+    password = seed_user["credentials"][0]["value"]
+    tenant_id = seed_user["attributes"]["tenant_id"][0]
+    realm["users"].extend(_test_user(email, password, tenant_id) for email in TEST_USERS)
+
+    second = copy.deepcopy(realm)
+    second["realm"] = args.second_realm
+    second["users"] = []
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "realm-insight.json").write_text(json.dumps(realm, indent=2, sort_keys=True) + "\n")
+    (out_dir / f"realm-{args.second_realm}.json").write_text(json.dumps(second, indent=2, sort_keys=True) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/backend/services/authenticator/tests/run-e2e.sh
+++ b/src/backend/services/authenticator/tests/run-e2e.sh
@@ -1,17 +1,25 @@
 #!/usr/bin/env bash
 # End-to-end login-loop smoke test for the authenticator (nginx+auth step 04).
 #
-# Spins up the minimal stack — Redis (docker), fakeidp + authenticator (local
-# release binaries) — and runs the ignored `e2e_login_loop` integration test:
-#   /auth/login -> fakeidp /authorize -> /auth/callback (cookie) ->
+# Spins up the minimal stack — Redis + Keycloak (docker), authenticator (local
+# release binaries) — and runs the ignored `e2e_*` integration suites:
+#   /auth/login -> Keycloak login form -> /auth/callback (cookie) ->
 #   /internal/authz (JWT verified against JWKS) -> /auth/me -> /auth/logout ->
 #   /internal/authz returns 401.
+#
+# The IdP is a real Keycloak importing the generated compose realm
+# (deploy/compose/keycloak/gen-realm.py) with the rig's overlay on top
+# (tests/kc-realm-overlay.py: test users, fast token lifespan, back-channel
+# registration, and a second realm for the host-keyed issuer map). What the
+# retired fakeidp offered as `/_control/*` hooks the suites now drive through
+# the Keycloak admin API and `docker pause` (tests/common/kc.rs).
 #
 # Everything runs on localhost, so no IdP-URL rewriting is needed. Usage:
 #   src/backend/services/authenticator/tests/run-e2e.sh
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$HERE/../../../../.." && pwd)"   # the repo root
 cd "$HERE/../../.."   # -> src/backend (the cargo workspace root)
 
 # Endpoint-coverage ledger: tests/common/mod.rs records every test-client
@@ -24,25 +32,37 @@ cd "$HERE/../../.."   # -> src/backend (the cargo workspace root)
 export E2E_COVERAGE_LEDGER="${E2E_COVERAGE_LEDGER:-$HERE/.artifacts/observed_authenticator_endpoints.json}"
 rm -f "$E2E_COVERAGE_LEDGER"
 
-AUTH_PORT=8083
-TOKEN_PORT=8093
-AUTH2_PORT=8085
-TOKEN2_PORT=8095
-AUTH3_PORT=8087
-TOKEN3_PORT=8097
-IDP_PORT=8084
-# 8086 avoided: a common local-daemon default (InfluxDB) collides with it.
-IDP2_PORT=8088
-IDENTITY_PORT=8092
+# Env-overridable so the rig can run next to a compose stack, which holds
+# several of the defaults (8083/8085/8093).
+AUTH_PORT="${AUTH_PORT:-8083}"
+TOKEN_PORT="${TOKEN_PORT:-8093}"
+AUTH2_PORT="${AUTH2_PORT:-8085}"
+TOKEN2_PORT="${TOKEN2_PORT:-8095}"
+AUTH3_PORT="${AUTH3_PORT:-8087}"
+TOKEN3_PORT="${TOKEN3_PORT:-8097}"
+KC_PORT="${KC_PORT:-8084}"
+IDENTITY_PORT="${IDENTITY_PORT:-8092}"
 REDIS_CT=authenticator-e2e-redis
+KC_CT=authenticator-e2e-keycloak
+# Same image the compose stack pins for its realm (docker-compose.yml).
+KC_IMAGE=quay.io/keycloak/keycloak:26.4
+KC_REALM=insight
+KC_REALM_B=insight-b
+KC_ADMIN_USER=admin
+KC_ADMIN_PASSWORD=admin
+E2E_USER=dev@company.nonpresent
 pids=()
 
 cleanup() {
   set +e
   for p in "${pids[@]:-}"; do kill "$p" 2>/dev/null; done
-  docker rm -f "$REDIS_CT" >/dev/null 2>&1
+  # A failed e2e_refresher can leave the container paused; a paused container
+  # cannot be force-removed.
+  docker unpause "$KC_CT" >/dev/null 2>&1
+  docker rm -f "$KC_CT" "$REDIS_CT" >/dev/null 2>&1
   [[ -n "${KEYS_DIR:-}" ]] && rm -rf "$KEYS_DIR"
   [[ -n "${SVC_KEYS_DIR:-}" ]] && rm -rf "$SVC_KEYS_DIR"
+  [[ -n "${AUTH_CONFIG:-}" ]] && rm -f "$AUTH_CONFIG"
   [[ -n "${AUTH2_CONFIG:-}" ]] && rm -f "$AUTH2_CONFIG"
   [[ -n "${AUTH3_CONFIG:-}" ]] && rm -f "$AUTH3_CONFIG"
 }
@@ -67,12 +87,54 @@ echo "==> Redis"
 docker rm -f "$REDIS_CT" >/dev/null 2>&1 || true
 docker run -d --name "$REDIS_CT" -p 6399:6379 redis:7-alpine >/dev/null
 
-echo "==> build fakeidp + authenticator"
-cargo build --release --bin fakeidp --bin authenticator
+echo "==> generate the Keycloak import set (roster realm + e2e overlay)"
+# Inside the repo (not mktemp) so docker file-sharing covers it on macOS;
+# .artifacts/ is gitignored.
+KC_IMPORT_DIR="$HERE/.artifacts/keycloak-import"
+rm -rf "$KC_IMPORT_DIR" && mkdir -p "$KC_IMPORT_DIR"
+# The redirect URIs are the three authenticator instances below; the compose
+# defaults would deregister them (--authenticator-redirect REPLACES, not
+# appends).
+python3 "$ROOT_DIR/deploy/compose/keycloak/gen-realm.py" \
+  --dev-email "$E2E_USER" \
+  --authenticator-redirect "http://localhost:$AUTH_PORT/auth/callback" \
+  --authenticator-redirect "http://localhost:$AUTH2_PORT/auth/callback" \
+  --authenticator-redirect "http://localhost:$AUTH3_PORT/auth/callback" \
+  --out "$KC_IMPORT_DIR/realm-insight.generated.json"
+# host.docker.internal: the container must reach the authenticator process on
+# the docker host (docker run maps it via host-gateway below).
+python3 "$HERE/kc-realm-overlay.py" \
+  --realm "$KC_IMPORT_DIR/realm-insight.generated.json" \
+  --out-dir "$KC_IMPORT_DIR" \
+  --second-realm "$KC_REALM_B" \
+  --backchannel-url "http://host.docker.internal:$AUTH_PORT/auth/oidc/back-channel-logout" \
+  --access-token-lifespan 15
+rm -f "$KC_IMPORT_DIR/realm-insight.generated.json"
 
-# Wait for an HTTP endpoint to answer, or fail loudly.
-wait_ready() { # name url
-  for _ in $(seq 1 30); do
+echo "==> Keycloak :$KC_PORT (realms $KC_REALM + $KC_REALM_B, --import-realm)"
+docker rm -f "$KC_CT" >/dev/null 2>&1 || true
+# KC_HOSTNAME pins the advertised issuer (and the `iss` of back-channel
+# logout tokens) to the host-published origin, so what the authenticator
+# discovers is also what admin-triggered logout tokens carry.
+docker run -d --name "$KC_CT" -p "$KC_PORT:8080" \
+  --add-host=host.docker.internal:host-gateway \
+  -e KC_BOOTSTRAP_ADMIN_USERNAME="$KC_ADMIN_USER" \
+  -e KC_BOOTSTRAP_ADMIN_PASSWORD="$KC_ADMIN_PASSWORD" \
+  -e KC_HOSTNAME="http://localhost:$KC_PORT" \
+  -e JAVA_OPTS_APPEND="-Xms256m -Xmx512m" \
+  -v "$KC_IMPORT_DIR:/opt/keycloak/data/import:ro" \
+  "$KC_IMAGE" start-dev --import-realm >/dev/null
+
+KC_BASE="http://localhost:$KC_PORT"
+ISSUER="$KC_BASE/realms/$KC_REALM"
+ISSUER_B="$KC_BASE/realms/$KC_REALM_B"
+
+echo "==> build the authenticator"
+cargo build --release --bin authenticator
+
+# Wait for an HTTP endpoint to answer, or fail loudly. Tries default to 30.
+wait_ready() { # name url [tries]
+  for _ in $(seq 1 "${3:-30}"); do
     curl -fsS -o /dev/null "$2" && return 0
     sleep 1
   done
@@ -80,23 +142,14 @@ wait_ready() { # name url
   return 1
 }
 
-echo "==> fakeidp :$IDP_PORT"
-# Short IdP token TTL so the background refresher (step 10.4) cycles within
-# seconds instead of minutes; see the matching margin/tick overrides below.
-FAKEIDP_ISSUER="http://localhost:$IDP_PORT" FAKEIDP_BIND="0.0.0.0:$IDP_PORT" \
-  FAKEIDP_DEFAULT_AUD=insight-authenticator \
-  FAKEIDP_BACKCHANNEL_URL="http://localhost:$AUTH_PORT/auth/oidc/back-channel-logout" \
-  FAKEIDP_TOKEN_TTL=15 \
-  ./target/release/fakeidp >/tmp/authenticator-e2e-fakeidp.log 2>&1 &
-pids+=($!)
-wait_ready fakeidp "http://localhost:$IDP_PORT/.well-known/openid-configuration"
-
-echo "==> fakeidp #2 :$IDP2_PORT (the second issuer of the host-keyed map, ADR-0003)"
-FAKEIDP_ISSUER="http://localhost:$IDP2_PORT" FAKEIDP_BIND="0.0.0.0:$IDP2_PORT" \
-  FAKEIDP_DEFAULT_AUD=insight-authenticator \
-  ./target/release/fakeidp >/tmp/authenticator-e2e-fakeidp2.log 2>&1 &
-pids+=($!)
-wait_ready fakeidp2 "http://localhost:$IDP2_PORT/.well-known/openid-configuration"
+echo "==> wait for Keycloak realm import"
+# Keycloak start + realm import runs tens of seconds; the realm discovery
+# document answers only once its import committed.
+if ! wait_ready keycloak "$ISSUER/.well-known/openid-configuration" 120; then
+  docker logs --tail 40 "$KC_CT" >&2 || true
+  exit 1
+fi
+wait_ready keycloak-b "$ISSUER_B/.well-known/openid-configuration" 30
 
 echo "==> identity stub :$IDENTITY_PORT (resolves any email/external-id to a person)"
 python3 "$HERE/identity-stub.py" "127.0.0.1:$IDENTITY_PORT" >/tmp/authenticator-e2e-identity.log 2>&1 &
@@ -104,22 +157,35 @@ pids+=($!)
 wait_ready identity-stub "http://localhost:$IDENTITY_PORT/internal/persons/by-external-id?source_type=faketest&external_id=probe"
 
 echo "==> authenticator :$AUTH_PORT"
+# The config's own bind addrs are the default 8083/8093; rewrite them like the
+# other instances so the port overrides above reach instance #1 too.
+AUTH_CONFIG="$(mktemp "${TMPDIR:-/tmp}/authenticator-e2e-cfg.XXXXXX")"
+sed -e "s/8083/$AUTH_PORT/g" -e "s/8093/$TOKEN_PORT/g" \
+    -e 's#/tmp/authenticator-grpc#/tmp/authenticator-e2e1-grpc#' \
+  services/authenticator/config/insight.yaml > "$AUTH_CONFIG"
 # override_enabled exercises the `__override` view-as loop (e2e_override); the
 # parameter is inert for every other test (nothing else sends it).
+# external_id_claim=email: the realm users' `sub` is a Keycloak uuid, and the
+# identity stub keys logins and `__override` targets by email so both resolve
+# to the same person. The fast refresh lifecycle (margin 10 s, tick 1 s,
+# jitter ±1 s) pairs with the realm's 15 s access-token lifespan
+# (kc-realm-overlay.py), so a session's IdP tokens refresh every ~5 s.
 APP__gears__authenticator__config__override_enabled=true \
 APP__gears__authenticator__config__redis_url=redis://localhost:6399 \
 APP__gears__authenticator__config__signing_keys_path="$KEYS_DIR" \
 APP__gears__authenticator__config__identity_url="http://localhost:$IDENTITY_PORT" \
 APP__gears__authenticator__config__gateway_issuer=http://localhost:8080 \
-APP__gears__authenticator__config__idp__issuer_url="http://localhost:$IDP_PORT" \
+APP__gears__authenticator__config__idp__issuer_url="$ISSUER" \
 APP__gears__authenticator__config__idp__client_id=insight-authenticator \
+APP__gears__authenticator__config__idp__client_secret=insight-authenticator-dev-secret \
 APP__gears__authenticator__config__idp__source_type=faketest \
+APP__gears__authenticator__config__idp__external_id_claim=email \
 APP__gears__authenticator__config__redirect_uri="http://localhost:$AUTH_PORT/auth/callback" \
 APP__gears__authenticator__config__service_tokens__public_key_dir="$SVC_KEYS_DIR" \
 APP__gears__authenticator__config__idp__refresh_safety_margin_seconds=10 \
 APP__gears__authenticator__config__idp__refresh_due_jitter_seconds=1 \
 APP__gears__authenticator__config__idp__refresher_tick_seconds=1 \
-  ./target/release/authenticator -c services/authenticator/config/insight.yaml run \
+  ./target/release/authenticator -c "$AUTH_CONFIG" run \
   >/tmp/authenticator-e2e-auth.log 2>&1 &
 pids+=($!)
 
@@ -133,16 +199,18 @@ echo "==> authenticator #2 :$AUTH2_PORT (override_enabled at its default: false)
 # Same stack (Redis/keys/IdP/identity), own ports + grpc socket. This instance
 # proves the `__override` parameter is inert unless an environment opts in.
 AUTH2_CONFIG="$(mktemp "${TMPDIR:-/tmp}/authenticator-e2e-cfg2.XXXXXX")"
-sed -e "s/$AUTH_PORT/$AUTH2_PORT/g" -e "s/$TOKEN_PORT/$TOKEN2_PORT/g" \
+sed -e "s/8083/$AUTH2_PORT/g" -e "s/8093/$TOKEN2_PORT/g" \
     -e 's#/tmp/authenticator-grpc#/tmp/authenticator-e2e2-grpc#' \
   services/authenticator/config/insight.yaml > "$AUTH2_CONFIG"
 APP__gears__authenticator__config__redis_url=redis://localhost:6399 \
 APP__gears__authenticator__config__signing_keys_path="$KEYS_DIR" \
 APP__gears__authenticator__config__identity_url="http://localhost:$IDENTITY_PORT" \
 APP__gears__authenticator__config__gateway_issuer=http://localhost:8080 \
-APP__gears__authenticator__config__idp__issuer_url="http://localhost:$IDP_PORT" \
+APP__gears__authenticator__config__idp__issuer_url="$ISSUER" \
 APP__gears__authenticator__config__idp__client_id=insight-authenticator \
+APP__gears__authenticator__config__idp__client_secret=insight-authenticator-dev-secret \
 APP__gears__authenticator__config__idp__source_type=faketest \
+APP__gears__authenticator__config__idp__external_id_claim=email \
 APP__gears__authenticator__config__redirect_uri="http://localhost:$AUTH2_PORT/auth/callback" \
 APP__gears__authenticator__config__service_tokens__public_key_dir="$SVC_KEYS_DIR" \
   ./target/release/authenticator -c "$AUTH2_CONFIG" run \
@@ -156,11 +224,11 @@ if ! wait_ready authenticator2 "http://localhost:$AUTH2_PORT/.well-known/jwks.js
 fi
 
 echo "==> authenticator #3 :$AUTH3_PORT (host-keyed issuer map, ADR-0003)"
-# Two hosts -> two issuers; the flat idp client fields stay empty (map mode
-# replaces them). The map rides ONE env var as a JSON string — exactly the
-# shape a deployment would use.
+# Two hosts -> two realms of the one Keycloak; the flat idp client fields stay
+# empty (map mode replaces them). The map rides ONE env var as a JSON string —
+# exactly the shape a deployment would use.
 AUTH3_CONFIG="$(mktemp "${TMPDIR:-/tmp}/authenticator-e2e-cfg3.XXXXXX")"
-sed -e "s/$AUTH_PORT/$AUTH3_PORT/g" -e "s/$TOKEN_PORT/$TOKEN3_PORT/g" \
+sed -e "s/8083/$AUTH3_PORT/g" -e "s/8093/$TOKEN3_PORT/g" \
     -e 's#/tmp/authenticator-grpc#/tmp/authenticator-e2e3-grpc#' \
   services/authenticator/config/insight.yaml > "$AUTH3_CONFIG"
 APP__gears__authenticator__config__redis_url=redis://localhost:6399 \
@@ -168,7 +236,8 @@ APP__gears__authenticator__config__signing_keys_path="$KEYS_DIR" \
 APP__gears__authenticator__config__identity_url="http://localhost:$IDENTITY_PORT" \
 APP__gears__authenticator__config__gateway_issuer=http://localhost:8080 \
 APP__gears__authenticator__config__idp__source_type=faketest \
-APP__gears__authenticator__config__idp__hosts="{\"tenant-a.example\": {\"issuer_url\": \"http://localhost:$IDP_PORT\", \"client_id\": \"insight-authenticator\"}, \"tenant-b.example\": {\"issuer_url\": \"http://localhost:$IDP2_PORT\", \"client_id\": \"insight-authenticator\"}}" \
+APP__gears__authenticator__config__idp__external_id_claim=email \
+APP__gears__authenticator__config__idp__hosts="{\"tenant-a.example\": {\"issuer_url\": \"$ISSUER\", \"client_id\": \"insight-authenticator\", \"client_secret\": \"insight-authenticator-dev-secret\"}, \"tenant-b.example\": {\"issuer_url\": \"$ISSUER_B\", \"client_id\": \"insight-authenticator\", \"client_secret\": \"insight-authenticator-dev-secret\"}}" \
 APP__gears__authenticator__config__redirect_uri="http://localhost:$AUTH3_PORT/auth/callback" \
 APP__gears__authenticator__config__service_tokens__public_key_dir="$SVC_KEYS_DIR" \
   ./target/release/authenticator -c "$AUTH3_CONFIG" run \
@@ -181,16 +250,25 @@ if ! wait_ready authenticator3 "http://localhost:$AUTH3_PORT/.well-known/jwks.js
   exit 1
 fi
 
+# Keycloak coordinates for the suites (tests/common/kc.rs): the login form
+# password and the admin-API/docker seams that replaced fakeidp's hooks.
+export E2E_KC_BASE="$KC_BASE"
+export E2E_KC_REALM="$KC_REALM"
+export E2E_KC_CONTAINER="$KC_CT"
+export E2E_KC_ADMIN_USER="$KC_ADMIN_USER"
+export E2E_KC_ADMIN_PASSWORD="$KC_ADMIN_PASSWORD"
+export E2E_USER_PASSWORD=insight-dev
+
 echo "==> run the login loop"
-AUTH_BASE="http://localhost:$AUTH_PORT" E2E_USER=dev@company.nonpresent \
+AUTH_BASE="http://localhost:$AUTH_PORT" E2E_USER="$E2E_USER" \
   cargo test -p authenticator --test e2e_login_loop -- --ignored --nocapture
 
 echo "==> run the refresh rotation-with-grace loop (step 10.1)"
-AUTH_BASE="http://localhost:$AUTH_PORT" E2E_USER=dev@company.nonpresent \
+AUTH_BASE="http://localhost:$AUTH_PORT" E2E_USER="$E2E_USER" \
   cargo test -p authenticator --test e2e_refresh -- --ignored --nocapture
 
 echo "==> run the session-management loop (step 10.2)"
-AUTH_BASE="http://localhost:$AUTH_PORT" E2E_USER=dev@company.nonpresent \
+AUTH_BASE="http://localhost:$AUTH_PORT" E2E_USER="$E2E_USER" \
   cargo test -p authenticator --test e2e_sessions -- --ignored --nocapture
 
 echo "==> run the 401 contract for the session-cookie surface"
@@ -198,31 +276,29 @@ AUTH_BASE="http://localhost:$AUTH_PORT" \
   cargo test -p authenticator --test e2e_unauthorized -- --ignored --nocapture
 
 echo "==> run the __override view-as loop (#1941)"
-# --test-threads=1: every test impersonates as the same principal, and one of
-# them exercises DELETE /auth/sessions (revoke-all), which by design reaches
-# the sibling tests' view-as sessions when they run concurrently.
+# Each test owns a disjoint {impersonator + targets} set of realm users
+# (kc-realm-overlay.py), so the suite is safe under cargo's default parallel
+# execution — one test's revoke-all can never reach a sibling's session.
 AUTH_BASE="http://localhost:$AUTH_PORT" AUTH_BASE_DISABLED="http://localhost:$AUTH2_PORT" \
-  E2E_USER=dev@company.nonpresent \
-  cargo test -p authenticator --test e2e_override -- --ignored --nocapture --test-threads=1
+  cargo test -p authenticator --test e2e_override -- --ignored --nocapture
 
 echo "==> run the host-keyed issuer map loop (ADR-0003)"
 AUTH_BASE="http://localhost:$AUTH3_PORT" AUTH_FLAT_BASE="http://localhost:$AUTH_PORT" \
   AUTH3_LOG=/tmp/authenticator-e2e-auth3.log \
-  FAKEIDP_PUBLIC="http://localhost:$IDP_PORT" FAKEIDP2_PUBLIC="http://localhost:$IDP2_PORT" \
-  E2E_USER=dev@company.nonpresent \
+  E2E_IDP_ISSUER="$ISSUER" E2E_IDP2_ISSUER="$ISSUER_B" \
+  E2E_USER="$E2E_USER" \
   cargo test -p authenticator --test e2e_hostmap -- --ignored --nocapture
 
 echo "==> run the back-channel logout loop (step 10.3)"
-AUTH_BASE="http://localhost:$AUTH_PORT" FAKEIDP_PUBLIC="http://localhost:$IDP_PORT" \
-  E2E_USER=dev@company.nonpresent \
+AUTH_BASE="http://localhost:$AUTH_PORT" \
   cargo test -p authenticator --test e2e_backchannel -- --ignored --nocapture
 
 echo "==> run the layer-2 rate-limit loop (step 10.6)"
-AUTH_BASE="http://localhost:$AUTH_PORT" E2E_USER=dev@company.nonpresent \
+AUTH_BASE="http://localhost:$AUTH_PORT" E2E_USER="$E2E_USER" \
   cargo test -p authenticator --test e2e_ratelimit -- --ignored --nocapture
 
 echo "==> run the IdP background-refresher loop (step 10.4: outage + invalid_grant)"
-AUTH_BASE="http://localhost:$AUTH_PORT" FAKEIDP_PUBLIC="http://localhost:$IDP_PORT" \
+AUTH_BASE="http://localhost:$AUTH_PORT" \
   cargo test -p authenticator --test e2e_refresher -- --ignored --nocapture
 
 echo "==> run the service-token loop (step 06)"

--- a/src/backend/services/authenticator/tests/run-e2e.sh
+++ b/src/backend/services/authenticator/tests/run-e2e.sh
@@ -135,7 +135,7 @@ cargo build --release --bin authenticator
 # Wait for an HTTP endpoint to answer, or fail loudly. Tries default to 30.
 wait_ready() { # name url [tries]
   for _ in $(seq 1 "${3:-30}"); do
-    curl -fsS -o /dev/null "$2" && return 0
+    curl --connect-timeout 2 --max-time 5 -fsS -o /dev/null "$2" && return 0
     sleep 1
   done
   echo "ERROR: $1 did not become ready ($2)" >&2


### PR DESCRIPTION
Part of #2198 (ADR-0003): the in-process integration rig moves off fakeidp onto a container-imported generated realm. fakeidp itself stays until the compose default flips — this is the prerequisite for that deletion, scoped so it does not touch any file #2253 rewrites.

## What changed

**The rig's IdP is now a real Keycloak.** `run-e2e.sh` boots one Keycloak 26.4 container (the image compose already pins) with `--import-realm`, importing the generated compose realm (`gen-realm.py`, dev user anchored at the suite's `E2E_USER`) plus a new e2e overlay, `tests/kc-realm-overlay.py`: dedicated per-suite test users, a 15 s access-token lifespan so the background refresher cycles in seconds, the client's back-channel logout registration (pointing at the authenticator on the docker host), and a user-less second realm as the host-keyed map's second issuer (user-less because Keycloak user ids are globally unique across realms).

**fakeidp's `/_control/*` hooks become real-IdP seams** (`tests/common/kc.rs`):
- login: the realm's actual login form, driven by the shared helper;
- back-channel logout: admin-API user logout — Keycloak fires a signed `logout_token` per session; the test polls both devices to 401 instead of trusting a synchronous `rp_status`;
- definitive `invalid_grant`: admin user disable — kills via the refresher path without the back-channel side-channel an admin logout would also fire;
- transient outage: `docker pause`/`unpause` — requests hang until the OIDC client's own 10 s timeout and fail as transport errors.

**`e2e_override` runs parallel again** (the re-fixture #2198's note asks for): each of the five tests owns a disjoint {impersonator + targets} user set, so one test's revoke-all can never reach a sibling's view-as session. No `--test-threads=1`.

**Person resolution keys on email** (`idp.external_id_claim=email`): the realm's `sub` is a Keycloak uuid, and the identity stub resolves logins and `__override` targets to the same person from the email alone — its fakeidp sub→email table is gone.

**Rig ports are env-overridable** (defaults unchanged, so CI is untouched): the historical defaults collide with a running compose stack (8083/8085/8093), and the overrides let the suite run beside one.

The workflow trigger drops the fakeidp path and gains the realm generator's (`deploy/compose/keycloak/**`, `deploy/seed/profiles.py`).

## Sequencing vs #2253

Zero file overlap. When #2253 lands, the only touch-point here is the one `gen-realm.py` invocation in `run-e2e.sh` (it becomes the seed package's installed entry point) plus the two workflow trigger paths above.

## Verification

- `run-e2e.sh` end to end on this branch: 10 suites, 18 tests, PASS — including the override suite 5/5 under default parallel execution, back-channel logout killing both devices via container→host delivery, and the refresher surviving a 12 s paused-container outage then dying on the disabled user's `invalid_grant`.
- Endpoint coverage gate on the produced ledger: 13/14 operations exercised, 0 missing (same BLOCKED profile as before).
- `cargo check` / `clippy` / `fmt` clean; suite also verified green with all ports overridden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * End-to-end authentication testing now runs against Keycloak-based identity-provider scenarios.
  * Added coverage for multiple realms, session refresh and revocation, back-channel logout, rate limiting, login loops, user status changes, and identity-provider outages.
  * Expanded scenarios for target switching, host mapping, authorization failures, and concurrent authenticator instances.

* **Documentation**
  * Updated test setup guidance and workflow descriptions to reflect the new authentication stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->