### PR TITLE
ci: gate stand e2e and k3s smoke on the merge queue, not on every PR push

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -52,10 +52,12 @@ on:
         default: false
 
 # One in-flight chart-publish per branch. Prevents two merges from racing
-# the auto-commit-back step.
+# the auto-commit-back step. PR builds have no publish to protect, and a new
+# push obsoletes the matrix in flight — cancel it rather than let a stale
+# build keep burning runners next to the fresh one it queues behind.
 concurrency:
   group: build-images-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/e2e-stand.yml
+++ b/.github/workflows/e2e-stand.yml
@@ -21,8 +21,11 @@ name: E2E — Compose stand
 #                published ui-tests image.
 #
 # Neither is required on its own. The `Stand E2E` umbrella below is the check
-# meant to be required once it has a track record — see the wall-clock and
-# flake rate in .cf-studio/.plans/stage1-compose-e2e-suite/out/ci-wiring.md.
+# meant to be required in branch protection, and the whole workflow is a
+# merge-queue gate rather than a per-push one: on pull_request every job here
+# skips (branch protection counts a skipped job as a pass), and the lanes run
+# once per queue batch on merge_group. Wall-clock and flake history are in
+# .cf-studio/.plans/stage1-compose-e2e-suite/out/ci-wiring.md.
 #
 # Every stand operation goes through ./dev-compose.sh test-stand — never the
 # bare up/down/seed a human developer uses. The pinned frontend, Keycloak auth
@@ -33,11 +36,11 @@ name: E2E — Compose stand
 on:
   pull_request:
     branches: [main]
-    # Deliberately NO `paths:` filter. This workflow emits a REQUIRED check,
-    # and GitHub reports a required check whose workflow never ran as pending
-    # rather than passed — a path filter here would block every PR that did not
-    # happen to touch one of the listed directories. Relevance is decided by
-    # the `changes` job below instead, which is cheap and always reports.
+    # Deliberately NO `paths:` filter, even though every job below skips on
+    # pull_request: a required check whose workflow never triggers at all
+    # reports as pending forever and would block queue entry, while a
+    # triggered run whose jobs all skip counts as a pass. The trigger must
+    # therefore keep firing on every PR — it just costs no runner time.
   # Merge-queue builds: the queue's gh-readonly-queue/* branches emit
   # merge_group, and a required check must report there or every queued PR
   # times out and is evicted.
@@ -56,10 +59,12 @@ on:
         options: [compose]
         default: compose
 
-# One run per PR. A rebase or a force-push obsoletes whatever is in flight.
+# One run per PR; a rebase or a force-push obsoletes whatever is in flight.
+# Merge-queue builds get a unique group instead — cancelling a batch mid-run
+# is the queue's own call, never this workflow's.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'merge_group' && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 permissions:
   contents: read
@@ -84,6 +89,10 @@ jobs:
   # has to run the stand or the gate is decorative.
   changes:
     name: changes
+    # Not on pull_request: the stand gates the merge queue, not every push.
+    # Skipping here cascades — every downstream job skips with it, and a
+    # skipped job satisfies the required check on the PR.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -431,10 +440,10 @@ jobs:
           ./dev-compose.sh test-stand down
 
   # ─── the required check ───────────────────────────────────────────────────
-  # One stable context name for branch protection, and the only job here that
-  # runs unconditionally. That is the whole point: a required check must report
-  # on EVERY pull request, including ones that touch nothing this suite covers
-  # and ones where `changes` skipped the lanes.
+  # One stable context name for branch protection. On pull_request it skips
+  # with everything else — the skip IS the passing report. On merge-queue
+  # builds it runs whenever the run wasn't cancelled, so it still reports when
+  # `changes` deemed the batch irrelevant and the lanes were skipped.
   #
   # `skipped` is therefore a PASS here, unlike in e2e-bronze-to-api.yml's
   # umbrella where it is a failure. The difference is what the skip means: there
@@ -444,7 +453,7 @@ jobs:
   stand-suite:
     name: Stand E2E
     needs: [changes, api-smoke, ui-journeys]
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/functional-k3s.yml
+++ b/.github/workflows/functional-k3s.yml
@@ -8,13 +8,20 @@ name: Functional K3s Smoke
 
 on:
   workflow_dispatch:
+  # Merge-queue builds are where the cluster actually comes up. The
+  # pull_request trigger stays so the check reports on every PR — the job
+  # below skips there, and branch protection counts a skipped job as a pass —
+  # but the deploy smoke itself runs once per queue batch, not on every push.
+  merge_group:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
 
+# One run per PR; merge-queue builds get a unique group so a queue rebuild
+# can never cancel a batch mid-run.
 concurrency:
-  group: functional-k3s-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  group: functional-k3s-${{ github.event_name == 'merge_group' && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 permissions:
   contents: read
@@ -38,6 +45,8 @@ env:
 jobs:
   cluster-smoke:
     name: K3s GitOps Deploy
+    # Skipped on pull_request by design — see the trigger comment above.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/openapi-specs.yml
+++ b/.github/workflows/openapi-specs.yml
@@ -20,6 +20,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# A new push obsoletes any run still in flight for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # ─── analytics — offline emit via the `openapi` subcommand ───────────────
   analytics:


### PR DESCRIPTION
## What

Moves the two heaviest advisory suites off the per-push PR lane and onto the merge queue, and closes the remaining cancel-in-progress gaps.

- **e2e-stand** (~8–14 runner-min per PR push): every job now skips on `pull_request` and runs on `merge_group` (scoped by the existing `changes` job). The `pull_request` trigger stays — a skipped job satisfies a required check, so PRs report "Stand E2E" at zero runner cost, while a workflow that never triggered would hang on "Expected" and block queue entry.
- **functional-k3s** (~4 min per PR push, was advisory-only): gains the `merge_group` trigger; `cluster-smoke` skips on `pull_request` the same way.
- Both workflows give merge-queue runs a unique concurrency group (`run_id`) and never cancel them — eviction is the queue's call.
- **build-images**: superseded `pull_request` runs (13–15 runner-min per stale matrix) are now cancelled; `push` runs keep `cancel-in-progress: false` to protect the chart auto-commit-back.
- **openapi-specs**: adds the standard per-ref concurrency block it was missing.

## After merge (admin step, ORDER MATTERS)

Add the two contexts to the `main` ruleset's required status checks **only after this lands on main** — before that, queued PRs whose merge group lacks the new `functional-k3s` `merge_group` trigger would time out and be evicted:

```
gh api -X PUT repos/constructorfabric/insight/rulesets/17457293 \
  --input - <<'JSON'
{"rules":[{"type":"deletion"},{"type":"non_fast_forward"},{"type":"pull_request","parameters":{"allowed_merge_methods":["merge","squash","rebase"],"dismiss_stale_reviews_on_push":false,"dismissal_restriction":{"allowed_actors":[],"enabled":false},"require_code_owner_review":true,"require_last_push_approval":true,"required_approving_review_count":1,"required_review_thread_resolution":false,"required_reviewers":[]}},{"type":"required_status_checks","parameters":{"strict_required_status_checks_policy":true,"do_not_enforce_on_create":false,"required_status_checks":[{"context":"Run E2E suite","integration_id":15368},{"context":"Stand E2E","integration_id":15368},{"context":"K3s GitOps Deploy","integration_id":15368}]}},{"type":"merge_queue","parameters":{"check_response_timeout_minutes":60,"grouping_strategy":"ALLGREEN","max_entries_to_build":5,"max_entries_to_merge":5,"merge_method":"MERGE","min_entries_to_merge":1,"min_entries_to_merge_wait_minutes":5}}]}
JSON
```

## Why

Runner pressure: PR pushes competed with merge-queue jobs for the shared hosted-runner quota. This cuts ~12–18 runner-minutes from every PR push and replaces them with one run per queue entry, and the two suites become actual merge gates instead of advisory noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)