### PR TITLE
fix(stand): pin the frontend to the insight-frontend package

### DIFF
--- a/dev-compose.sh
+++ b/dev-compose.sh
@@ -1436,8 +1436,15 @@ test_stand_pinned_image() {
   printf 'ghcr.io/constructorfabric/insight-%s:%s' "$name" "$version"
 }
 
+# `frontend`, not `front`: build-images.yml publishes this repo's frontend as
+# the flat `insight-frontend` package. The `insight-front` package belongs to a
+# retired repository whose Actions ACL this repo's GITHUB_TOKEN cannot push
+# (#2247), so it stopped gaining tags — every appVersion minted after the rename
+# names an `insight-front` tag that was never published, and `up` dies on
+# `manifest unknown` before a single test runs. Unrelated to the `insight-front`
+# SERVICE hostname in docker-compose.yml, which is not an image reference.
 test_stand_frontend_image() {
-  test_stand_pinned_image src/frontend/helm/Chart.yaml front
+  test_stand_pinned_image src/frontend/helm/Chart.yaml frontend
 }
 
 # The backend services the stand runs from published images rather than from

--- a/dev-compose.sh
+++ b/dev-compose.sh
@@ -1436,13 +1436,6 @@ test_stand_pinned_image() {
   printf 'ghcr.io/constructorfabric/insight-%s:%s' "$name" "$version"
 }
 
-# `frontend`, not `front`: build-images.yml publishes this repo's frontend as
-# the flat `insight-frontend` package. The `insight-front` package belongs to a
-# retired repository whose Actions ACL this repo's GITHUB_TOKEN cannot push
-# (#2247), so it stopped gaining tags — every appVersion minted after the rename
-# names an `insight-front` tag that was never published, and `up` dies on
-# `manifest unknown` before a single test runs. Unrelated to the `insight-front`
-# SERVICE hostname in docker-compose.yml, which is not an image reference.
 test_stand_frontend_image() {
   test_stand_pinned_image src/frontend/helm/Chart.yaml frontend
 }


### PR DESCRIPTION
## Problem

`./dev-compose.sh test-stand up` fails while pulling images, so **both** stand lanes die before any test runs:

```
step 5: Bring the stand up
 insight-front-ghcr Error manifest unknown
ERROR: stack startup failed.
```

`test_stand_frontend_image` resolved `insight-front:<appVersion>`, but `build-images.yml` publishes this repo's frontend as the flat `insight-frontend` package. As its own comment records, the old package belongs to a retired repository whose Actions ACL this repo's `GITHUB_TOKEN` cannot push (#2247):

> The image is `insight-frontend` — a package created and owned by THIS repository. The old `insight-front` package belongs to the retired insight-front repo's Actions ACL, so this repo's GITHUB_TOKEN cannot push it (#2247).

So `insight-front` stopped gaining tags at the rename, while `appVersion` kept advancing:

| tag | `insight-front` | `insight-frontend` |
|---|---|---|
| `2026.08.05.04.32-7302d55` | pullable | absent |
| `2026.08.06.08.20-849a40c` | absent | pullable |
| `2026.08.06.08.44-32b375b` | absent | pullable |

This also breaks the invariant asserted just above the resolver — *"bump-descriptors writes these on every successful main push, so an appVersion names an image that provably exists"* — for the frontend specifically.

The stand cannot recover on its own: each release bumps the pin further past the last tag the old package ever received.

## Impact

Every `E2E — Compose stand` run that reaches `up` fails, including `merge_group` runs, so the merge queue is blocked. Affected runs: [`31087011630`](https://github.com/constructorfabric/insight/actions/runs/31087011630), [`31088255808`](https://github.com/constructorfabric/insight/actions/runs/31088255808), [`31088339732`](https://github.com/constructorfabric/insight/actions/runs/31088339732).

The last green run was the 05:39 nightly, which pulled `insight-front:2026.08.05.04.32-7302d55` — the final tag published under the old name.

## Fix

One argument, `front` → `frontend`, plus a comment recording why the frontend's suffix differs from the backends' and why the similarly-named service hostname must not follow.

## Verification

Resolved with the script's own `test_stand_pinned_image` / `test_stand_frontend_image`, checked against the registry:

```
after:   ghcr.io/constructorfabric/insight-frontend:2026.08.06.08.44-32b375b   pullable
before:  ghcr.io/constructorfabric/insight-front:2026.08.06.08.44-32b375b      manifest unknown
```

`bash -n dev-compose.sh` clean. `docker-compose.yml`'s `FRONTEND_IMAGE` default already used the correct package; only this pinned path was stale.

## Deliberately untouched

`insight-front` also appears as a **service hostname** in `docker-compose.yml` (`GATEWAY_FRONT_URL`), `deploy/seed/manifest.py` and `gateway.yml` (`--add-host`). Those are container names, not image references, and renaming them would break the gateway's upstream.

## Note

This unblocks the stack from starting. A separate, pre-existing failure in `stand/ui/test_collaboration_card_evidence.py::test_collaboration_card_menu_opens_and_exports_supporting_data` (Playwright strict-mode violation — the locator resolves to 2 elements) was failing before this breakage masked it, and is expected to resurface once `up` succeeds. Not addressed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the test environment’s frontend image reference to use the correct published image name, improving container startup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->