### PR TITLE
feat(keycloak): expose only the OIDC surface at the ingress

### DIFF
--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -405,6 +405,9 @@ keycloak:
   # Advertised issuer BASE (must end in /kc) — the URL browser AND
   # authenticator reach, e.g. https://<host>/kc.
   hostname: ""
+  # Admin console base. The ingress exposes only /kc/realms + /kc/resources;
+  # the console rides a port-forward (empty = http://localhost:<port>/kc).
+  adminHostname: ""
   # Bootstrap-admin Secret (keys username/password) and DB connection.
   admin:
     existingSecret: ""

--- a/src/backend/services/keycloak/helm/templates/deployment.yaml
+++ b/src/backend/services/keycloak/helm/templates/deployment.yaml
@@ -65,6 +65,11 @@ spec:
             # in-cluster caller works alongside the advertised issuer.
             - name: KC_HOSTNAME_BACKCHANNEL_DYNAMIC
               value: "true"
+            # Admin console base. The ingress does not expose /kc/admin, so
+            # the console is advertised on the port-forward URL (default
+            # localhost:<service.port>) instead of KC_HOSTNAME.
+            - name: KC_HOSTNAME_ADMIN
+              value: {{ default (printf "http://localhost:%v/kc" .Values.service.port) .Values.adminHostname | quote }}
             - name: KC_HTTP_ENABLED
               value: "true"
             - name: KC_HTTP_PORT

--- a/src/backend/services/keycloak/helm/templates/ingress.yaml
+++ b/src/backend/services/keycloak/helm/templates/ingress.yaml
@@ -2,6 +2,13 @@
 # Cluster ingress -> Keycloak at the /kc prefix. Keycloak serves under /kc
 # natively (--http-relative-path) and discovery emits absolute URLs off
 # KC_HOSTNAME (= .Values.hostname), so no rewrite.
+#
+# Only the browser/OIDC surface is exposed: /kc/realms (discovery, auth,
+# tokens, broker callbacks, account console) and /kc/resources (theme
+# assets). The admin console and admin REST API (/kc/admin, plus the /kc
+# welcome redirect to it) stay cluster-internal — reach them with
+#   kubectl port-forward svc/<release>-keycloak {{ .Values.service.port }}
+# (adminHostname in values.yaml advertises that URL to the console).
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -22,7 +29,14 @@ spec:
       {{- end }}
       http:
         paths:
-          - path: /kc
+          - path: /kc/realms
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "insight-keycloak.fullname" . }}
+                port:
+                  name: http
+          - path: /kc/resources
             pathType: Prefix
             backend:
               service:

--- a/src/backend/services/keycloak/helm/values.yaml
+++ b/src/backend/services/keycloak/helm/values.yaml
@@ -18,6 +18,12 @@ service:
 # advertised issuer.
 hostname: ""
 
+# Admin console base URL. The ingress never exposes /kc/admin — admin access
+# is `kubectl port-forward svc/<release>-keycloak <service.port>`, and this
+# is the URL the console advertises for that. Empty = derived as
+# http://localhost:<service.port>/kc.
+adminHostname: ""
+
 # Secret with keys `username`/`password` (bootstrap admin).
 admin:
   existingSecret: ""
@@ -30,8 +36,9 @@ database:
   username: ""
   passwordSecret: {name: "", key: ""}
 
-# Optional ingress at the /kc prefix (Keycloak serves under /kc natively —
-# no rewrite).
+# Optional ingress exposing only /kc/realms and /kc/resources (Keycloak
+# serves under /kc natively — no rewrite). /kc/admin stays cluster-internal;
+# see adminHostname.
 ingress:
   enabled: false
   className: nginx


### PR DESCRIPTION
The `/kc` ingress now routes only `/kc/realms` (discovery, auth, tokens, broker callbacks, account console) and `/kc/resources` (theme assets). The admin console and admin REST API (`/kc/admin`, plus the `/kc` welcome redirect to it) are no longer reachable from outside the cluster.

Admin access moves to `kubectl port-forward svc/<release>-keycloak 8085`; `KC_HOSTNAME_ADMIN` advertises that URL (new `adminHostname` value, default `http://localhost:<service.port>/kc`) so the console's own OIDC round-trip stays on the port-forward.

External IdP return paths land on `/kc/realms/<realm>/broker/<alias>/endpoint` and are unaffected.

Deployments whose keycloak-config-cli Job targets the public `/kc` URL must switch `keycloakConfig.url` to the in-cluster service (it uses the admin REST API) — gitops MR insight-gitops!65 does this for dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)