### PR TITLE
feat(identity-resolution): govern discovered person attributes

### DIFF
--- a/.github/workflows/openapi-specs.yml
+++ b/.github/workflows/openapi-specs.yml
@@ -94,6 +94,44 @@ jobs:
           if [ "$rc" -ne 0 ]; then echo "::error::Authenticator OpenAPI spec drift — $AUTHENTICATOR_SPEC is stale. Regenerate: (cd src/backend && cargo run -p authenticator --bin authenticator -- openapi) > dump.json && python3 scripts/ci/openapi_spec.py update --file $AUTHENTICATOR_SPEC --live-file dump.json"; fi
           exit "$rc"
 
+  # ─── identity-resolution — offline emit via the `openapi` subcommand ──────
+  identity-resolution:
+    name: Identity-resolution OpenAPI spec drift gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - name: Install protoc
+        # protobuf-compiler: grpc-hub -> prost-build (same host gear set as
+        # the analytics service).
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: src/backend -> target
+          key: identity-resolution-openapi
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+      - name: Generate the OpenAPI doc offline and drift-check it
+        env:
+          IDENTITY_RESOLUTION_SPEC: docs/components/backend/identity-resolution/openapi.json
+        run: |
+          # `identity-resolution openapi` builds offline and prints the doc; a
+          # build failure here should abort loudly under the runner's `set -e`.
+          (cd src/backend && cargo run --quiet -p identity-resolution -- openapi) > identity-resolution.openapi.live.json
+          # Relax errexit from here: we capture the drift-check rc ourselves,
+          # write the committed-vs-generated diff to the step summary, and emit a
+          # friendly ::error:: before exiting non-zero.
+          set +e
+          python3 scripts/ci/openapi_spec.py check --file "$IDENTITY_RESOLUTION_SPEC" --live-file identity-resolution.openapi.live.json | tee identity_resolution_openapi_drift.txt
+          rc=${PIPESTATUS[0]}
+          if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then { echo '```'; cat identity_resolution_openapi_drift.txt; echo '```'; } >> "$GITHUB_STEP_SUMMARY"; fi
+          if [ "$rc" -ne 0 ]; then echo "::error::Identity-resolution OpenAPI spec drift — $IDENTITY_RESOLUTION_SPEC is stale. Regenerate: (cd src/backend && cargo run -p identity-resolution -- openapi) > dump.json && python3 scripts/ci/openapi_spec.py update --file $IDENTITY_RESOLUTION_SPEC --live-file dump.json"; fi
+          exit "$rc"
+
   # ─── the models generated FROM those documents ────────────────────────────
   # `tests/stand/api/schemas/` is generated from the same committed documents
   # the two jobs above gate, so it belongs in this workflow rather than beside

--- a/docs/components/backend/identity-resolution/openapi.json
+++ b/docs/components/backend/identity-resolution/openapi.json
@@ -1,35 +1,121 @@
 {
   "components": {
     "schemas": {
-      "CreatePersonRoleCommandModel": {
+      "AttributeReconcileListResponse": {
+        "description": "List response wrapper (typed for OpenAPI); `next_cursor` is declared but\nalways `null`, same non-paginating contract as the other journals.",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/AttributeReconcileOperationResponse"
+            },
+            "type": "array"
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "type": "object"
+      },
+      "AttributeReconcileOperationResponse": {
+        "description": "One reconcile operation's status.",
+        "properties": {
+          "author_person_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "completed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "error_message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "insight_tenant_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "operation_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "operation_type": {
+            "type": "string"
+          },
+          "request": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "started_at": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "summary": {
+            "description": "On completion: the [`ReconcileSummary`] — discovered / created /\nrefreshed / `skipped_invalid` counts.\n\n[`ReconcileSummary`]: crate::domain::attribute_reconcile::ReconcileSummary",
+            "type": [
+              "object",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "operation_id",
+          "operation_type",
+          "status",
+          "insight_tenant_id",
+          "author_person_id",
+          "started_at"
+        ],
+        "type": "object"
+      },
+      "CreatePersonRoleRequest": {
+        "description": "Body of `POST /v1/person-roles` — grant a role to a person.",
         "properties": {
           "person_id": {
             "format": "uuid",
             "type": "string"
           },
           "reason": {
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "role_id": {
             "format": "uuid",
             "type": "string"
           },
           "valid_from": {
+            "description": "Optional assignment start; defaults to now when omitted. Accepts RFC-3339\n(`Z`/offset), zone-less, or date-only, normalised to naive-UTC.",
             "format": "date-time",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [
           "person_id",
-          "role_id",
-          "valid_from",
-          "reason"
+          "role_id"
         ],
         "type": "object"
       },
-      "CreateRoleCommandModel": {
+      "CreateRoleRequest": {
+        "description": "Body of `POST /v1/roles`.",
         "properties": {
           "name": {
             "type": "string"
@@ -40,21 +126,29 @@
         ],
         "type": "object"
       },
-      "CreateVisibilityCommandModel": {
+      "CreateVisibilityRequest": {
+        "description": "Body of `POST /v1/visibility` — grant a viewer visibility over a target\n(or the whole tree when `viewed_person_id` is omitted).",
         "properties": {
           "reason": {
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "valid_from": {
+            "description": "Optional grant start; defaults to now when omitted. Accepts RFC-3339\n(`Z`/offset), zone-less, or date-only, normalised to naive-UTC.",
             "format": "date-time",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "viewed_person_id": {
             "format": "uuid",
-            "nullable": true,
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "viewer_person_id": {
             "format": "uuid",
@@ -62,82 +156,892 @@
           }
         },
         "required": [
-          "viewer_person_id",
-          "viewed_person_id",
-          "valid_from",
-          "reason"
+          "viewer_person_id"
         ],
         "type": "object"
       },
-      "PersonsSeedRequest": {
-        "nullable": true,
+      "PersonAttributeListResponse": {
+        "description": "List response wrapper (typed for OpenAPI).",
         "properties": {
-          "mode": {
-            "nullable": true,
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/PersonAttributeResponse"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "type": "object"
+      },
+      "PersonAttributeResponse": {
+        "description": "One attribute definition with its current policy.",
+        "properties": {
+          "first_observed_at": {
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "last_observed_at": {
+            "type": "string"
+          },
+          "policy": {
+            "$ref": "#/components/schemas/PolicyResponse"
+          },
+          "source_field_id": {
+            "type": "string"
+          },
+          "source_instance": {
+            "type": "string"
+          },
+          "source_type": {
             "type": "string"
           }
         },
         "required": [
-          "mode"
+          "id",
+          "source_type",
+          "source_instance",
+          "source_field_id",
+          "first_observed_at",
+          "last_observed_at",
+          "policy"
         ],
         "type": "object"
       },
-      "ResolveProfileCommandModel": {
+      "PersonResponse": {
+        "description": "A person node in the org tree (subordinate of a profile), matching the .NET\n`PersonResponse`. Unlike `ProfileResponse`, the attribute fields are plain\nstrings (empty when absent, not omitted) and the `supervisor_*`/`parent_*`\nfields serialize as `null` rather than being dropped.",
+        "properties": {
+          "department": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "division": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "first_name": {
+            "type": "string"
+          },
+          "job_title": {
+            "type": "string"
+          },
+          "last_name": {
+            "type": "string"
+          },
+          "parent_email": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "parent_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "parent_person_id": {
+            "format": "uuid",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "person_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "subordinates": {
+            "items": {
+              "$ref": "#/components/schemas/PersonResponse"
+            },
+            "type": "array"
+          },
+          "supervisor_email": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "supervisor_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "person_id",
+          "email",
+          "display_name",
+          "first_name",
+          "last_name",
+          "department",
+          "division",
+          "job_title",
+          "status",
+          "subordinates"
+        ],
+        "type": "object"
+      },
+      "PersonRoleListResponse": {
+        "description": "List wrapper.",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/PersonRoleResponse"
+            },
+            "type": "array"
+          },
+          "next_cursor": {
+            "description": "Wire parity with the .NET `ListResponse`: the cursor is declared\nbut pagination is not implemented — always `null` (both\nimplementations return every row; consumers already tolerate it).",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "type": "object"
+      },
+      "PersonRoleResponse": {
+        "description": "One role assignment.",
+        "properties": {
+          "author_person_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "insight_tenant_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "person_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "person_role_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "role_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "valid_from": {
+            "type": "string"
+          },
+          "valid_to": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "person_role_id",
+          "insight_tenant_id",
+          "person_id",
+          "role_id",
+          "valid_from",
+          "author_person_id",
+          "created_at"
+        ],
+        "type": "object"
+      },
+      "PersonsSeedListResponse": {
+        "description": "List response wrapper (typed for OpenAPI).",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/PersonsSeedOperationResponse"
+            },
+            "type": "array"
+          },
+          "next_cursor": {
+            "description": "Wire parity with the .NET `ListResponse`: the cursor is declared\nbut pagination is not implemented — always `null` (both\nimplementations return every row; consumers already tolerate it).",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "type": "object"
+      },
+      "PersonsSeedOperationResponse": {
+        "description": "One operation's status. Wire shape mirrors the .NET\n`PersonsSeedOperationResponse`: `request` and `summary` are surfaced as\nparsed JSON (not double-encoded strings), the tenant/author ids are\nincluded, timestamps are ISO-8601, and null fields are emitted (the .NET\nserializer does not drop nulls).",
+        "properties": {
+          "author_person_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "completed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "error_message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "insight_tenant_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "operation_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "operation_type": {
+            "type": "string"
+          },
+          "request": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "started_at": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "summary": {
+            "type": [
+              "object",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "operation_id",
+          "operation_type",
+          "status",
+          "insight_tenant_id",
+          "author_person_id",
+          "started_at"
+        ],
+        "type": "object"
+      },
+      "PersonsSyncListResponse": {
+        "description": "List response wrapper (typed for OpenAPI). `next_cursor` is declared but\nalways `null` — same non-paginating contract as the seed journal.",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/PersonsSyncOperationResponse"
+            },
+            "type": "array"
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "type": "object"
+      },
+      "PersonsSyncOperationResponse": {
+        "description": "One operation's status. Wire shape matches the seed journal's:\n`request` and `summary` surfaced as parsed JSON, ISO-8601 timestamps,\nnull fields emitted.",
+        "properties": {
+          "author_person_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "completed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "error_message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "insight_tenant_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "operation_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "operation_type": {
+            "type": "string"
+          },
+          "request": {
+            "type": [
+              "object",
+              "null"
+            ]
+          },
+          "started_at": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "summary": {
+            "description": "On completion: the [`SyncSummary`] — rows copied, `max_id` /\n`max_created_at` watermarks, `synced_at`.\n\n[`SyncSummary`]: crate::domain::sync_service::SyncSummary",
+            "type": [
+              "object",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "operation_id",
+          "operation_type",
+          "status",
+          "insight_tenant_id",
+          "author_person_id",
+          "started_at"
+        ],
+        "type": "object"
+      },
+      "PolicyResponse": {
+        "description": "The current policy revision of one definition.",
+        "properties": {
+          "actor_person_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "comparison_enabled": {
+            "type": "boolean"
+          },
+          "grouping_enabled": {
+            "type": "boolean"
+          },
+          "label_override": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "reason": {
+            "type": "string"
+          },
+          "retired": {
+            "type": "boolean"
+          },
+          "revision": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "sensitivity_class": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value_mode": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "revision",
+          "grouping_enabled",
+          "comparison_enabled",
+          "value_mode",
+          "retired",
+          "actor_person_id",
+          "reason"
+        ],
+        "type": "object"
+      },
+      "PolicyUpdateRequest": {
+        "description": "Full policy body for the next revision. `expected_revision` is the\nrevision the caller read; a stale value yields 409.",
+        "properties": {
+          "comparison_enabled": {
+            "type": "boolean"
+          },
+          "expected_revision": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "grouping_enabled": {
+            "type": "boolean"
+          },
+          "label_override": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "reason": {
+            "type": "string"
+          },
+          "retired": {
+            "type": "boolean"
+          },
+          "sensitivity_class": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value_mode": {
+            "$ref": "#/components/schemas/ValueModeDto"
+          }
+        },
+        "required": [
+          "expected_revision",
+          "grouping_enabled",
+          "comparison_enabled",
+          "value_mode",
+          "retired",
+          "reason"
+        ],
+        "type": "object"
+      },
+      "Problem": {
+        "description": "RFC 9457 problem+json. `context` varies by error category.",
+        "properties": {
+          "context": {
+            "type": "object"
+          },
+          "detail": {
+            "type": "string"
+          },
+          "instance": {
+            "type": "string"
+          },
+          "status": {
+            "format": "int32",
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "trace_id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "title",
+          "status",
+          "detail",
+          "context"
+        ],
+        "type": "object"
+      },
+      "ProfileIdEntry": {
+        "description": "One source-native account id bound to the person — the latest\n`value_type='id'` observation per source instance. Ported from the .NET\n`ProfileIdEntry`.",
         "properties": {
           "insight_source_id": {
             "format": "uuid",
-            "nullable": true,
             "type": "string"
           },
           "insight_source_type": {
-            "nullable": true,
             "type": "string"
           },
           "value": {
-            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": [
+          "insight_source_type",
+          "insight_source_id",
+          "value"
+        ],
+        "type": "object"
+      },
+      "ProfileResponse": {
+        "description": "Response body of `POST /v1/profiles` — the resolved person's profile:\ncurrent attributes, the org tree (`supervisor_*` / `parent_*` /\n`subordinates[]`), and every current source-native id (`ids[]`). Null\nattribute fields are omitted from JSON; `subordinates`/`ids` are always\npresent (empty when none), matching the .NET contract.",
+        "properties": {
+          "department": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "display_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "division": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "email": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "employee_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "first_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "ids": {
+            "description": "Every current source-native id for the person (one per source instance).\nAlways serialized — an empty array when the person has no ids — matching\nthe .NET contract (unlike the attributes above, which are omitted).",
+            "items": {
+              "$ref": "#/components/schemas/ProfileIdEntry"
+            },
+            "type": "array"
+          },
+          "insight_tenant_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "job_title": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "last_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "parent_email": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "parent_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "parent_person_id": {
+            "format": "uuid",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "person_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "status": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subordinates": {
+            "description": "Recursive subordinates subtree (direct reports and their reports), on the\nconfigured `org_chart` source. Always serialized (empty when none).",
+            "items": {
+              "$ref": "#/components/schemas/PersonResponse"
+            },
+            "type": "array"
+          },
+          "supervisor_email": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "supervisor_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "username": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "person_id",
+          "insight_tenant_id",
+          "subordinates",
+          "ids"
+        ],
+        "type": "object"
+      },
+      "ResolveProfileRequest": {
+        "description": "Body of `POST /v1/profiles`. `value_type = \"email\"` matches across all\nsources for the tenant; `value_type = \"id\"` matches a source-native account\nid within one source instance (needs `insight_source_type` + `insight_source_id`);\n`value_type = \"person_id\"` takes the canonical person UUID itself — the key\nthe metrics runtime and its routes use since the identity cutover.",
+        "properties": {
+          "insight_source_id": {
+            "description": "Required when `value_type = \"id\"`.",
+            "format": "uuid",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "insight_source_type": {
+            "description": "Required when `value_type = \"id\"` — the source instance to scope to.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value": {
             "type": "string"
           },
           "value_type": {
-            "description": "Which key `value` carries: an email (tenant-wide), a source-native account id (needs both source fields), or the canonical person UUID.",
-            "enum": [
-              "email",
-              "id",
-              "person_id"
-            ],
-            "nullable": true,
             "type": "string"
           }
         },
         "required": [
           "value_type",
-          "value",
-          "insight_source_type",
-          "insight_source_id"
+          "value"
         ],
         "type": "object"
       },
-      "RevokeReasonModel": {
-        "nullable": true,
+      "RoleListResponse": {
+        "description": "List wrapper.",
         "properties": {
-          "reason": {
-            "nullable": true,
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/RoleResponse"
+            },
+            "type": "array"
+          },
+          "next_cursor": {
+            "description": "Wire parity with the .NET `ListResponse`: the cursor is declared\nbut pagination is not implemented — always `null` (both\nimplementations return every row; consumers already tolerate it).",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "type": "object"
+      },
+      "RoleResponse": {
+        "description": "One role in the catalogue.",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "role_id": {
+            "format": "uuid",
             "type": "string"
           }
         },
         "required": [
-          "reason"
+          "role_id",
+          "name"
         ],
         "type": "object"
       },
-      "VisiblePersonsCommandModel": {
+      "SubchartForestResponse": {
+        "description": "`{ \"roots\": [ … ] }` — forest wrapper (#344). Empty when the caller has no\nvisible-in-source membership.",
+        "properties": {
+          "roots": {
+            "items": {
+              "$ref": "#/components/schemas/SubchartNode"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "roots"
+        ],
+        "type": "object"
+      },
+      "SubchartNode": {
+        "description": "One node in the org subchart tree.",
+        "properties": {
+          "display_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "email": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "job_title": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "person_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "status": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subordinates": {
+            "items": {
+              "$ref": "#/components/schemas/SubchartNode"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "person_id",
+          "subordinates"
+        ],
+        "type": "object"
+      },
+      "SubchartResponse": {
+        "description": "`{ \"root\": { … } }` — single-root wrapper (locked by the #348 acceptance\ncriteria so the response can gain sibling fields without breaking clients).",
+        "properties": {
+          "root": {
+            "$ref": "#/components/schemas/SubchartNode"
+          }
+        },
+        "required": [
+          "root"
+        ],
+        "type": "object"
+      },
+      "ValueModeDto": {
+        "description": "Declared value mode of an attribute, as an OpenAPI enum.",
+        "enum": [
+          "single",
+          "multi"
+        ],
+        "type": "string"
+      },
+      "VisibilityListResponse": {
+        "description": "List wrapper.",
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/VisibilityResponse"
+            },
+            "type": "array"
+          },
+          "next_cursor": {
+            "description": "Wire parity with the .NET `ListResponse`: the cursor is declared\nbut pagination is not implemented — always `null` (both\nimplementations return every row; consumers already tolerate it).",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "items"
+        ],
+        "type": "object"
+      },
+      "VisibilityResponse": {
+        "description": "One visibility grant.",
+        "properties": {
+          "author_person_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "insight_tenant_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "valid_from": {
+            "type": "string"
+          },
+          "valid_to": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "viewed_person_id": {
+            "format": "uuid",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "viewer_person_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "visibility_id": {
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "visibility_id",
+          "insight_tenant_id",
+          "viewer_person_id",
+          "valid_from",
+          "author_person_id",
+          "created_at"
+        ],
+        "type": "object"
+      },
+      "VisiblePersonsRequest": {
+        "description": "Canonical person UUIDs to check (the metric runtime's key since the\nidentity cutover — the earlier email-based draft of this endpoint never\nshipped).",
         "properties": {
           "person_ids": {
             "items": {
               "format": "uuid",
               "type": "string"
             },
-            "maxItems": 1000,
-            "minItems": 1,
             "type": "array"
           }
         },
@@ -161,482 +1065,2015 @@
         ],
         "type": "object"
       }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "bearerFormat": "JWT",
+        "scheme": "bearer",
+        "type": "http"
+      }
     }
   },
   "info": {
-    "description": "Resolves people, org-chart parent/subordinates, roles, and row-level visibility for Insight. Backed by MariaDB (identity tables) with a ClickHouse-sourced bulk re-seed. Fronted by the API Gateway.",
-    "title": "Identity API",
+    "description": "Identity governance service: person profiles, roles and visibility administration, persons-seed/sync journals, and the person-attribute registry. The API Gateway mounts this service at /api/identity-resolution.",
+    "title": "Identity Resolution API",
     "version": "1.0.0"
   },
-  "openapi": "3.0.1",
+  "openapi": "3.1.0",
   "paths": {
-    "/health": {
+    "/v1/person-attributes": {
       "get": {
+        "operationId": "identity_resolution.person_attributes.list",
         "responses": {
           "200": {
-            "description": "OK"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PersonAttributeListResponse"
+                }
+              }
+            },
+            "description": "Person attributes"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
-        "tags": [
-          "Insight.Identity.Api"
-        ]
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "List discovered person attributes with their current policy (admin)"
       }
     },
-    "/healthz": {
+    "/v1/person-attributes-reconcile": {
       "get": {
+        "operationId": "identity_resolution.person_attributes_reconcile.list",
         "responses": {
           "200": {
-            "description": "OK"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttributeReconcileListResponse"
+                }
+              }
+            },
+            "description": "Operations"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
-        "tags": [
-          "Insight.Identity.Api"
-        ]
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "List attribute-reconcile operations"
+      }
+    },
+    "/v1/person-attributes-reconcile/{id}": {
+      "get": {
+        "operationId": "identity_resolution.person_attributes_reconcile.get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttributeReconcileOperationResponse"
+                }
+              }
+            },
+            "description": "Operation status"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Poll one attribute-reconcile operation"
+      }
+    },
+    "/v1/person-attributes/{id}": {
+      "get": {
+        "operationId": "identity_resolution.person_attributes.get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PersonAttributeResponse"
+                }
+              }
+            },
+            "description": "Person attribute"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "One person attribute with its current policy (admin)"
+      }
+    },
+    "/v1/person-attributes/{id}/policy": {
+      "put": {
+        "operationId": "identity_resolution.person_attributes.put_policy",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PolicyUpdateRequest"
+              }
+            }
+          },
+          "description": "Next policy revision",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PersonAttributeResponse"
+                }
+              }
+            },
+            "description": "Person attribute with the appended policy"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Append the next policy revision of a person attribute (admin)"
       }
     },
     "/v1/person-roles": {
       "get": {
-        "parameters": [
-          {
-            "in": "query",
-            "name": "person",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "role",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "active",
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "schema": {
-              "format": "int32",
-              "type": "integer"
-            }
-          }
-        ],
+        "operationId": "identity_resolution.person_roles.list",
         "responses": {
           "200": {
-            "description": "OK"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PersonRoleListResponse"
+                }
+              }
+            },
+            "description": "Assignments"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
-        "tags": [
-          "Insight.Identity.Api"
-        ]
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "List role assignments (admin)"
       },
       "post": {
+        "operationId": "identity_resolution.person_roles.create",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreatePersonRoleCommandModel"
+                "$ref": "#/components/schemas/CreatePersonRoleRequest"
               }
             }
           },
+          "description": "Assignment to create",
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "OK"
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PersonRoleResponse"
+                }
+              }
+            },
+            "description": "Created assignment"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
-        "tags": [
-          "Insight.Identity.Api"
-        ]
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Grant a role to a person (admin)"
       }
     },
     "/v1/person-roles/{id}": {
       "delete": {
-        "parameters": [
+        "operationId": "identity_resolution.person_roles.delete",
+        "responses": {
+          "204": {
+            "description": "Assignment revoked"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
           {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
+            "bearerAuth": []
           }
         ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RevokeReasonModel"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        },
-        "tags": [
-          "Insight.Identity.Api"
-        ]
+        "summary": "Revoke a role assignment (admin)"
       }
     },
     "/v1/persons-seed": {
       "get": {
-        "parameters": [
-          {
-            "in": "query",
-            "name": "status",
-            "schema": {
-              "type": "string"
-            }
+        "operationId": "identity_resolution.persons_seed.list",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PersonsSeedListResponse"
+                }
+              }
+            },
+            "description": "Operations"
           },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
           {
-            "in": "query",
-            "name": "limit",
-            "schema": {
-              "format": "int32",
-              "type": "integer"
-            }
+            "bearerAuth": []
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        },
-        "tags": [
-          "Insight.Identity.Api"
-        ]
-      },
-      "post": {
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/PersonsSeedRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        },
-        "tags": [
-          "Insight.Identity.Api"
-        ]
+        "summary": "List persons-seed operations"
       }
     },
     "/v1/persons-seed/{id}": {
       "get": {
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
+        "operationId": "identity_resolution.persons_seed.get",
         "responses": {
           "200": {
-            "description": "OK"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PersonsSeedOperationResponse"
+                }
+              }
+            },
+            "description": "Operation status"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
-        "tags": [
-          "Insight.Identity.Api"
-        ]
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Get a persons-seed operation"
       }
     },
-    "/v1/persons/{email}": {
+    "/v1/persons-sync": {
       "get": {
-        "parameters": [
-          {
-            "in": "path",
-            "name": "email",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
+        "operationId": "identity_resolution.persons_sync.list",
         "responses": {
           "200": {
-            "description": "OK"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PersonsSyncListResponse"
+                }
+              }
+            },
+            "description": "Operations"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
-        "tags": [
-          "Insight.Identity.Api"
-        ]
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "List persons-sync operations"
+      }
+    },
+    "/v1/persons-sync/{id}": {
+      "get": {
+        "operationId": "identity_resolution.persons_sync.get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PersonsSyncOperationResponse"
+                }
+              }
+            },
+            "description": "Operation status"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Get a persons-sync operation"
       }
     },
     "/v1/profiles": {
       "post": {
+        "operationId": "identity_resolution.profiles.resolve",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ResolveProfileCommandModel"
+                "$ref": "#/components/schemas/ResolveProfileRequest"
               }
             }
           },
+          "description": "Identity to resolve",
           "required": true
         },
         "responses": {
           "200": {
-            "description": "OK"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileResponse"
+                }
+              }
+            },
+            "description": "Resolved person"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
-        "tags": [
-          "Insight.Identity.Api"
-        ]
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Resolve a profile by email or source-native id"
       }
     },
     "/v1/roles": {
       "get": {
+        "operationId": "identity_resolution.roles.list",
         "responses": {
           "200": {
-            "description": "OK"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoleListResponse"
+                }
+              }
+            },
+            "description": "Roles"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
-        "tags": [
-          "Insight.Identity.Api"
-        ]
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "List roles (admin)"
       },
       "post": {
+        "operationId": "identity_resolution.roles.create",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateRoleCommandModel"
+                "$ref": "#/components/schemas/CreateRoleRequest"
               }
             }
           },
+          "description": "Role to create",
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "OK"
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoleResponse"
+                }
+              }
+            },
+            "description": "Created role"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
-        "tags": [
-          "Insight.Identity.Api"
-        ]
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Create a role (admin)"
       }
     },
     "/v1/roles/{id}": {
       "delete": {
-        "parameters": [
-          {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
+        "operationId": "identity_resolution.roles.delete",
         "responses": {
-          "200": {
-            "description": "OK"
+          "204": {
+            "description": "Role deleted"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
-        "tags": [
-          "Insight.Identity.Api"
-        ]
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Delete a role (admin)"
       }
     },
     "/v1/subchart": {
       "get": {
-        "parameters": [
-          {
-            "in": "query",
-            "name": "depth",
-            "schema": {
-              "format": "int32",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "valid_at",
-            "schema": {
-              "format": "date-time",
-              "type": "string"
-            }
-          }
-        ],
+        "operationId": "identity_resolution.subchart.forest",
         "responses": {
           "200": {
-            "description": "OK"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubchartForestResponse"
+                }
+              }
+            },
+            "description": "Visible forest"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
-        "tags": [
-          "Insight.Identity.Api"
-        ]
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Org forest the caller can see"
       }
     },
-    "/v1/subchart/{personId}": {
+    "/v1/subchart/{person_id}": {
       "get": {
-        "parameters": [
-          {
-            "in": "path",
-            "name": "personId",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "depth",
-            "schema": {
-              "format": "int32",
-              "type": "integer"
-            }
-          },
-          {
-            "in": "query",
-            "name": "valid_at",
-            "schema": {
-              "format": "date-time",
-              "type": "string"
-            }
-          }
-        ],
+        "operationId": "identity_resolution.subchart.get",
         "responses": {
           "200": {
-            "description": "OK"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubchartResponse"
+                }
+              }
+            },
+            "description": "Subchart"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
-        "tags": [
-          "Insight.Identity.Api"
-        ]
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Depth-bounded org subtree rooted at a person"
       }
     },
     "/v1/visibility": {
       "get": {
-        "parameters": [
-          {
-            "in": "query",
-            "name": "viewer",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "viewed",
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "active",
-            "schema": {
-              "type": "boolean"
-            }
-          },
-          {
-            "in": "query",
-            "name": "limit",
-            "schema": {
-              "format": "int32",
-              "type": "integer"
-            }
-          }
-        ],
+        "operationId": "identity_resolution.visibility.list",
         "responses": {
           "200": {
-            "description": "OK"
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VisibilityListResponse"
+                }
+              }
+            },
+            "description": "Grants"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
-        "tags": [
-          "Insight.Identity.Api"
-        ]
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "List visibility grants (admin)"
       },
       "post": {
+        "operationId": "identity_resolution.visibility.create",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateVisibilityCommandModel"
+                "$ref": "#/components/schemas/CreateVisibilityRequest"
               }
             }
           },
+          "description": "Grant to create",
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "OK"
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VisibilityResponse"
+                }
+              }
+            },
+            "description": "Created grant"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
-        "tags": [
-          "Insight.Identity.Api"
-        ]
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Create a visibility grant (admin)"
       }
     },
     "/v1/visibility/{id}": {
       "delete": {
-        "parameters": [
+        "operationId": "identity_resolution.visibility.delete",
+        "responses": {
+          "204": {
+            "description": "Grant revoked"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
           {
-            "in": "path",
-            "name": "id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
+            "bearerAuth": []
           }
         ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/RevokeReasonModel"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "OK"
-          }
-        },
-        "tags": [
-          "Insight.Identity.Api"
-        ]
+        "summary": "Revoke a visibility grant (admin)"
       }
     },
     "/v1/visible-persons": {
       "post": {
+        "operationId": "identity_resolution.visible_persons.create",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/VisiblePersonsCommandModel"
+                "$ref": "#/components/schemas/VisiblePersonsRequest"
               }
             }
           },
+          "description": "Person ids to check",
           "required": true
         },
         "responses": {
@@ -648,18 +3085,86 @@
                 }
               }
             },
-            "description": "OK"
+            "description": "Visible subset"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
           }
         },
-        "tags": [
-          "Insight.Identity.Api"
-        ]
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Filter person ids to the ones the caller may see"
       }
     }
-  },
-  "tags": [
-    {
-      "name": "Insight.Identity.Api"
-    }
-  ]
+  }
 }

--- a/src/backend/services/identity-resolution/helm/templates/reconcile-attributes-cronjob.yaml
+++ b/src/backend/services/identity-resolution/helm/templates/reconcile-attributes-cronjob.yaml
@@ -1,0 +1,101 @@
+{{- if .Values.reconcileAttributes.enabled }}
+# Scheduled attribute reconcile: registers person-attribute fields discovered
+# in the warehouse claim relation (`silver.class_person_attribute_claims`)
+# into the MariaDB registry (definition + default revision-1 policy:
+# grouping allowed, comparison denied). Scheduled after the connector syncs
+# so freshly ingested fields register the same day.
+#
+# Same image/config/secret wiring as the seed/sync CronJobs; the
+# `reconcile-attributes` subcommand runs once and exits (exit codes: 0 ok /
+# 1 failed / 2 lock busy / 3 guard — the guard also covers a warehouse where
+# the claims relation does not exist yet, so this chart can deploy ahead of
+# the ingestion release). Runs serialize on a MariaDB advisory lock, so
+# `concurrencyPolicy: Forbid` is belt-and-braces for cron-vs-cron only.
+#
+# Manual run:
+#   kubectl create job --from=cronjob/{{ include "insight-identity-resolution.fullname" . }}-reconcile-attributes reconcile-manual-$USER
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "insight-identity-resolution.fullname" . }}-reconcile-attributes
+  labels:
+    {{- include "insight-identity-resolution.labels" . | nindent 4 }}
+    app.kubernetes.io/component: attribute-reconcile
+spec:
+  schedule: {{ .Values.reconcileAttributes.schedule | quote }}
+  concurrencyPolicy: {{ .Values.reconcileAttributes.concurrencyPolicy }}
+  successfulJobsHistoryLimit: {{ .Values.reconcileAttributes.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.reconcileAttributes.failedJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      # Retries for transient connect blips; the advisory lock + the
+      # snapshot-swap idempotency make a repeated run safe. The deadline caps
+      # a wedged pod well past the in-binary 5-minute reconcile timeout.
+      backoffLimit: {{ .Values.reconcileAttributes.backoffLimit }}
+      activeDeadlineSeconds: {{ .Values.reconcileAttributes.activeDeadlineSeconds }}
+      template:
+        metadata:
+          # NOT the shared selectorLabels: the Service selects on
+          # name+instance alone, and a job pod carrying them would enter the
+          # Service's endpoints (it listens on nothing).
+          labels:
+            app.kubernetes.io/name: identity-resolution-attribute-reconcile
+            app.kubernetes.io/instance: {{ .Release.Name }}
+            app.kubernetes.io/component: attribute-reconcile
+        spec:
+          {{- with .Values.global }}
+          {{- with .imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+          enableServiceLinks: false
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            fsGroup: 1000
+          containers:
+            - name: attribute-reconcile
+              image: "{{ required "image.repository is required" .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              command: ["/app/identity-resolution"]
+              args: ["-c", "/app/config/insight.yaml", "reconcile-attributes"]
+              volumeMounts:
+                - name: identity-resolution-config
+                  mountPath: /app/config/insight.yaml
+                  subPath: insight.yaml
+                  readOnly: true
+                # The gears host creates `server.home_dir` at boot; the
+                # subcommand never starts grpc-hub, so /app/data is the only
+                # writable path it needs under a read-only root.
+                - name: data
+                  mountPath: /app/data
+              envFrom:
+                # Same Secret as the deployment: database_url, clickhouse_*,
+                # tenant_default_id — everything the reconcile needs. The
+                # ClickHouse user additionally needs SELECT on the `silver`
+                # database (the claims read path).
+                - secretRef:
+                    name: {{ required "existingSecret is required (umbrella provides `insight-identity-resolution-config`; standalone installs supply their own)" .Values.existingSecret | quote }}
+              {{- with .Values.reconcileAttributes.tenantDefaultId }}
+              env:
+                # Explicit tenant for the JOURNAL row (the copy itself is
+                # tenant-agnostic). Same override semantics as the seed's.
+                - name: APP__gears__identity_resolution__config__tenant_default_id
+                  value: {{ . | quote }}
+              {{- end }}
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: ["ALL"]
+              resources:
+                {{- toYaml .Values.reconcileAttributes.resources | nindent 16 }}
+          volumes:
+            - name: identity-resolution-config
+              configMap:
+                name: {{ include "insight-identity-resolution.fullname" . }}-gears-config
+            - name: data
+              emptyDir: {}
+{{- end }}

--- a/src/backend/services/identity-resolution/helm/tests/test_seed_cronjob_contract.py
+++ b/src/backend/services/identity-resolution/helm/tests/test_seed_cronjob_contract.py
@@ -43,10 +43,13 @@ UMBRELLA = REPO_ROOT / "charts" / "insight"
 
 TENANT = "3e1d5a65-434c-95b4-8c1b-eb8f53a39bab"
 
-# name suffix -> (schedule, subcommand) — the per-job contract facts.
+# name suffix -> (schedule, subcommand, values key) — the per-job contract
+# facts. The values key differs from the name suffix only where the suffix
+# has a hyphen (values keys stay camelCase for clean `.Values.` template refs).
 JOBS = {
-    "seed": ("30 6 * * *", "seed"),
-    "sync": ("45 6 * * *", "sync"),
+    "seed": ("30 6 * * *", "seed", "seed"),
+    "sync": ("45 6 * * *", "sync", "sync"),
+    "reconcile-attributes": ("0 7 * * *", "reconcile-attributes", "reconcileAttributes"),
 }
 
 # Minimum viable subchart install (mirrors the umbrella's wiring).
@@ -168,7 +171,7 @@ def _job_container(cronjob: dict) -> dict:
     return container
 
 
-def test_default_render_ships_exactly_the_two_documented_cronjobs(default_docs) -> None:
+def test_default_render_ships_exactly_the_documented_cronjobs(default_docs) -> None:
     names = sorted(_cronjobs(default_docs))
     assert len(names) == len(JOBS), names
     for job in JOBS:
@@ -217,7 +220,7 @@ def test_tenant_value_overrides_the_secret_via_env(default_docs, job: str) -> No
     container = _job_container(_cronjob(default_docs, job))
     assert "env" not in container, container.get("env")
 
-    docs = _subchart_docs("--set", f"{job}.tenantDefaultId={TENANT}")
+    docs = _subchart_docs("--set", f"{JOBS[job][2]}.tenantDefaultId={TENANT}")
     container = _job_container(_cronjob(docs, job))
     env = {e["name"]: e["value"] for e in container["env"]}
     assert env == {"APP__gears__identity_resolution__config__tenant_default_id": TENANT}
@@ -225,12 +228,12 @@ def test_tenant_value_overrides_the_secret_via_env(default_docs, job: str) -> No
 
 @pytest.mark.parametrize("job", JOBS)
 def test_disabling_one_job_removes_only_that_cronjob(job: str) -> None:
-    docs = _subchart_docs("--set", f"{job}.enabled=false")
+    docs = _subchart_docs("--set", f"{JOBS[job][2]}.enabled=false")
     jobs = _cronjobs(docs)
     assert f"contract-test-identity-resolution-{job}" not in jobs, sorted(jobs)
-    # The sibling CronJob and the rest of the chart are untouched.
-    (other,) = [j for j in JOBS if j != job]
-    _cronjob(docs, other)
+    # The sibling CronJobs and the rest of the chart are untouched.
+    for other in (j for j in JOBS if j != job):
+        _cronjob(docs, other)
     _the(docs, "Deployment")
     _the(docs, "Service")
 

--- a/src/backend/services/identity-resolution/helm/values.yaml
+++ b/src/backend/services/identity-resolution/helm/values.yaml
@@ -123,6 +123,33 @@ sync:
       cpu: 500m
       memory: 512Mi
 
+reconcileAttributes:
+  enabled: true
+  # Journal-row tenant (UUID); same override semantics as seed.tenantDefaultId
+  # (the run spans every tenant present in claims — this only scopes the
+  # operations journal the admin GET routes read).
+  tenantDefaultId: ""
+  # Daily, after the sync's 06:45 run — freshly synced connector fields
+  # register the same morning.
+  schedule: "0 7 * * *"
+  # Belt-and-braces for cron-vs-cron only — manual Jobs and other instances
+  # serialize on the MariaDB advisory lock regardless.
+  concurrencyPolicy: Forbid
+  # Retries for transient connect blips; the lock + insert-only idempotency
+  # make a repeated run safe.
+  backoffLimit: 2
+  # Caps a wedged pod well past the in-binary 5-minute reconcile timeout.
+  activeDeadlineSeconds: 600
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
 # TCP gate before start: the service connects to MariaDB at boot. Same
 # busybox wait as the .NET identity chart.
 waitForMariadb:

--- a/src/backend/services/identity-resolution/src/api/attribute_reconcile.rs
+++ b/src/backend/services/identity-resolution/src/api/attribute_reconcile.rs
@@ -1,0 +1,135 @@
+//! Attribute-reconcile operations journal — read-only HTTP surface.
+//!
+//! The reconcile itself is CLI-only (`identity-resolution
+//! reconcile-attributes`, run by the Helm `CronJob` or a manual Job — see
+//! `crate::attribute_reconcile_runner`); these GETs are the observability
+//! window over its `operations` rows: status, summary (discovered / created /
+//! refreshed / skipped counts), error per run. Same wire conventions and
+//! admin gate as the seed and sync journals.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Extension, Path, Query};
+use axum::response::IntoResponse;
+use serde::Serialize;
+use toolkit_canonical_errors::CanonicalError;
+use toolkit_security::SecurityContext;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use super::AppState;
+use super::error::PersonAttributeError;
+use super::gate::require_admin;
+use super::seed::ListParams;
+use crate::infra::db::ops_repo::{self, Operation, PERSON_ATTRIBUTES_RECONCILE_OP};
+
+const LIST_DEFAULT_LIMIT: u64 = 50;
+const LIST_MAX_LIMIT: u64 = 500;
+
+/// One reconcile operation's status.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AttributeReconcileOperationResponse {
+    pub operation_id: Uuid,
+    pub operation_type: String,
+    pub status: String,
+    pub insight_tenant_id: Uuid,
+    pub author_person_id: Uuid,
+    #[schema(value_type = Option<Object>)]
+    pub request: Option<serde_json::Value>,
+    /// On completion: the [`ReconcileSummary`] — discovered / created /
+    /// refreshed / `skipped_invalid` counts.
+    ///
+    /// [`ReconcileSummary`]: crate::domain::attribute_reconcile::ReconcileSummary
+    #[schema(value_type = Option<Object>)]
+    pub summary: Option<serde_json::Value>,
+    pub error_message: Option<String>,
+    pub started_at: String,
+    pub completed_at: Option<String>,
+}
+impl toolkit::api::api_dto::ResponseApiDto for AttributeReconcileOperationResponse {}
+
+impl From<Operation> for AttributeReconcileOperationResponse {
+    fn from(op: Operation) -> Self {
+        Self {
+            operation_id: op.operation_id,
+            operation_type: op.operation_type,
+            status: op.status.as_db().to_owned(),
+            insight_tenant_id: op.insight_tenant_id,
+            author_person_id: op.author_person_id,
+            request: super::seed::parse_or_null(op.request_json.as_deref()),
+            summary: super::seed::parse_or_null(op.summary_json.as_deref()),
+            error_message: op.error_message,
+            started_at: super::seed::fmt_ts(op.started_at),
+            completed_at: op.completed_at.map(super::seed::fmt_ts),
+        }
+    }
+}
+
+/// List response wrapper (typed for OpenAPI); `next_cursor` is declared but
+/// always `null`, same non-paginating contract as the other journals.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct AttributeReconcileListResponse {
+    pub items: Vec<AttributeReconcileOperationResponse>,
+    pub next_cursor: Option<String>,
+}
+impl toolkit::api::api_dto::ResponseApiDto for AttributeReconcileListResponse {}
+
+/// `GET /v1/person-attributes-reconcile/{id}` — poll one operation.
+pub async fn get_attribute_reconcile(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(ctx): Extension<SecurityContext>,
+    Path(id): Path<Uuid>,
+) -> Result<impl IntoResponse, CanonicalError> {
+    let tenant = ctx.subject_tenant_id();
+    require_admin(&state.db, &ctx).await?;
+    let op = ops_repo::get_by_id(&state.db, tenant, id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "get operation failed");
+            CanonicalError::internal("failed to read operation").create()
+        })?
+        .filter(|o| o.operation_type == PERSON_ATTRIBUTES_RECONCILE_OP)
+        .ok_or_else(|| {
+            PersonAttributeError::not_found("operation not found")
+                .with_resource(id.to_string())
+                .create()
+        })?;
+    Ok(Json(AttributeReconcileOperationResponse::from(op)))
+}
+
+/// `GET /v1/person-attributes-reconcile` — list reconcile operations.
+/// Optional `?status=` (unknown values ignored) and `?limit=` (default 50,
+/// capped 500), same semantics as the seed and sync journals.
+pub async fn list_attribute_reconcile(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(ctx): Extension<SecurityContext>,
+    Query(params): Query<ListParams>,
+) -> Result<impl IntoResponse, CanonicalError> {
+    let tenant = ctx.subject_tenant_id();
+    require_admin(&state.db, &ctx).await?;
+    let status = super::seed::status_filter(params.status.as_deref());
+    let limit = params.limit.map_or(LIST_DEFAULT_LIMIT, |l| {
+        u64::try_from(l).unwrap_or(1).clamp(1, LIST_MAX_LIMIT)
+    });
+    let ops = ops_repo::list(
+        &state.db,
+        tenant,
+        Some(PERSON_ATTRIBUTES_RECONCILE_OP),
+        status,
+        limit,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!(error = %e, "list operations failed");
+        CanonicalError::internal("failed to list operations").create()
+    })?;
+    let items = ops
+        .into_iter()
+        .map(AttributeReconcileOperationResponse::from)
+        .collect();
+    Ok(Json(AttributeReconcileListResponse {
+        items,
+        next_cursor: None,
+    }))
+}

--- a/src/backend/services/identity-resolution/src/api/error.rs
+++ b/src/backend/services/identity-resolution/src/api/error.rs
@@ -15,6 +15,9 @@ pub struct PersonsSeedError;
 #[resource_error("gts.cf.insight.identity_resolution.persons_sync.v1~")]
 pub struct PersonsSyncError;
 
+#[resource_error("gts.cf.insight.identity_resolution.person_attribute.v1~")]
+pub struct PersonAttributeError;
+
 /// Shared admin-gate errors (401 no caller / 403 not admin), used by every
 /// admin-gated endpoint via [`crate::api::gate`].
 #[resource_error("gts.cf.insight.identity_resolution.access.v1~")]

--- a/src/backend/services/identity-resolution/src/api/mod.rs
+++ b/src/backend/services/identity-resolution/src/api/mod.rs
@@ -1,10 +1,12 @@
 //! HTTP API layer — shared state, route table, extractors.
 
+pub mod attribute_reconcile;
 pub(crate) mod canonical_json;
 pub(crate) mod datetime;
 pub mod error;
 mod gate;
 mod handlers;
+pub mod person_attributes;
 pub mod person_roles;
 pub mod roles;
 pub mod seed;
@@ -19,7 +21,7 @@ use axum::Extension;
 use axum::Router;
 use axum::http::StatusCode;
 use sea_orm::DatabaseConnection;
-use toolkit::api::{OpenApiRegistry, OperationBuilder};
+use toolkit::api::{OpenApiInfo, OpenApiRegistry, OpenApiRegistryImpl, OperationBuilder};
 
 use crate::config::GearConfig;
 use crate::domain::profile;
@@ -148,6 +150,79 @@ fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) -> Router {
         )
         .standard_errors(openapi)
         .handler(sync::list_persons_sync)
+        .register(router, openapi);
+
+    // Person-attribute registry (admin-gated; discovery is CLI-only, see
+    // `crate::attribute_reconcile_runner`).
+    let router = OperationBuilder::get("/v1/person-attributes")
+        .operation_id("identity_resolution.person_attributes.list")
+        .summary("List discovered person attributes with their current policy (admin)")
+        .authenticated()
+        .no_license_required()
+        .json_response_with_schema::<person_attributes::PersonAttributeListResponse>(
+            openapi,
+            StatusCode::OK,
+            "Person attributes",
+        )
+        .standard_errors(openapi)
+        .handler(person_attributes::list_person_attributes)
+        .register(router, openapi);
+
+    let router = OperationBuilder::get("/v1/person-attributes/{id}")
+        .operation_id("identity_resolution.person_attributes.get")
+        .summary("One person attribute with its current policy (admin)")
+        .authenticated()
+        .no_license_required()
+        .json_response_with_schema::<person_attributes::PersonAttributeResponse>(
+            openapi,
+            StatusCode::OK,
+            "Person attribute",
+        )
+        .standard_errors(openapi)
+        .handler(person_attributes::get_person_attribute)
+        .register(router, openapi);
+
+    let router = OperationBuilder::put("/v1/person-attributes/{id}/policy")
+        .operation_id("identity_resolution.person_attributes.put_policy")
+        .summary("Append the next policy revision of a person attribute (admin)")
+        .authenticated()
+        .no_license_required()
+        .json_request::<person_attributes::PolicyUpdateRequest>(openapi, "Next policy revision")
+        .json_response_with_schema::<person_attributes::PersonAttributeResponse>(
+            openapi,
+            StatusCode::OK,
+            "Person attribute with the appended policy",
+        )
+        .standard_errors(openapi)
+        .handler(person_attributes::put_person_attribute_policy)
+        .register(router, openapi);
+
+    let router = OperationBuilder::get("/v1/person-attributes-reconcile/{id}")
+        .operation_id("identity_resolution.person_attributes_reconcile.get")
+        .summary("Poll one attribute-reconcile operation")
+        .authenticated()
+        .no_license_required()
+        .json_response_with_schema::<attribute_reconcile::AttributeReconcileOperationResponse>(
+            openapi,
+            StatusCode::OK,
+            "Operation status",
+        )
+        .standard_errors(openapi)
+        .handler(attribute_reconcile::get_attribute_reconcile)
+        .register(router, openapi);
+
+    let router = OperationBuilder::get("/v1/person-attributes-reconcile")
+        .operation_id("identity_resolution.person_attributes_reconcile.list")
+        .summary("List attribute-reconcile operations")
+        .authenticated()
+        .no_license_required()
+        .json_response_with_schema::<attribute_reconcile::AttributeReconcileListResponse>(
+            openapi,
+            StatusCode::OK,
+            "Operations",
+        )
+        .standard_errors(openapi)
+        .handler(attribute_reconcile::list_attribute_reconcile)
         .register(router, openapi);
 
     // Roles catalogue (admin-gated CRUD over the global `roles` table).
@@ -309,4 +384,46 @@ fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) -> Router {
         .standard_errors(openapi)
         .handler(visible_persons::filter_visible_persons)
         .register(router, openapi)
+}
+
+fn openapi_info() -> OpenApiInfo {
+    OpenApiInfo {
+        title: "Identity Resolution API".to_owned(),
+        version: "1.0.0".to_owned(),
+        description: Some(
+            "Identity governance service: person profiles, roles and \
+             visibility administration, persons-seed/sync journals, and the \
+             person-attribute registry. The API Gateway mounts this service \
+             at /api/identity-resolution."
+                .to_owned(),
+        ),
+        servers: Vec::new(),
+    }
+}
+
+/// Build the identity-resolution `OpenAPI` document **offline** — no
+/// `AppState`, DB, or HTTP listener. Backs the `openapi` subcommand
+/// (committed-doc regeneration + drift gate), reusing the exact
+/// `build_operations` route table the live gear serves, so the two can never
+/// diverge.
+///
+/// # Errors
+///
+/// Returns an error when the registry cannot assemble the document.
+pub fn openapi_document() -> anyhow::Result<utoipa::openapi::OpenApi> {
+    let openapi = OpenApiRegistryImpl::new();
+    let _ = build_operations(Router::new(), &openapi);
+    openapi
+        .build_openapi(&openapi_info())
+        .map_err(|e| anyhow::anyhow!("failed to build identity-resolution OpenAPI document: {e}"))
+}
+
+#[cfg(test)]
+mod openapi_tests {
+    /// The `openapi` subcommand's input: the document must build offline.
+    #[test]
+    fn openapi_document_builds_offline() {
+        let doc = super::openapi_document();
+        assert!(doc.is_ok(), "document must build: {:?}", doc.err());
+    }
 }

--- a/src/backend/services/identity-resolution/src/api/person_attributes.rs
+++ b/src/backend/services/identity-resolution/src/api/person_attributes.rs
@@ -1,0 +1,234 @@
+//! Person-attribute registry — admin HTTP surface.
+//!
+//! Definitions are discovered by the `reconcile-attributes` CLI run (see
+//! `crate::attribute_reconcile_runner`); this surface reads them and revises
+//! their policy. A policy revision is append-only: `PUT …/policy` writes the
+//! next revision, never mutates one, and carries the caller as its actor.
+//! Concurrency is optimistic — the request names the revision it saw, and a
+//! stale value is a 409 `aborted` (the canonical model has no 422; see the
+//! divergence note in `super::error`).
+//!
+//! Tenant scope: definitions store the RAW warehouse tenant string; the
+//! caller's gateway-JWT tenant UUID is matched against it in canonical
+//! string form.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Extension, Path};
+use axum::response::IntoResponse;
+use serde::{Deserialize, Serialize};
+use toolkit_canonical_errors::CanonicalError;
+use toolkit_security::SecurityContext;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use super::AppState;
+use super::error::PersonAttributeError;
+use super::gate::require_admin;
+use crate::infra::db::person_attributes_repo::{
+    self, DefinitionWithPolicy, PolicyInput, ValueMode,
+};
+
+/// One attribute definition with its current policy.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PersonAttributeResponse {
+    pub id: Uuid,
+    pub source_type: String,
+    pub source_instance: String,
+    pub source_field_id: String,
+    pub first_observed_at: String,
+    pub last_observed_at: String,
+    pub policy: PolicyResponse,
+}
+impl toolkit::api::api_dto::ResponseApiDto for PersonAttributeResponse {}
+
+/// The current policy revision of one definition.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PolicyResponse {
+    pub revision: i32,
+    pub label_override: Option<String>,
+    pub sensitivity_class: Option<String>,
+    pub grouping_enabled: bool,
+    pub comparison_enabled: bool,
+    pub value_mode: String,
+    pub retired: bool,
+    pub actor_person_id: Uuid,
+    pub reason: String,
+}
+
+/// List response wrapper (typed for OpenAPI).
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PersonAttributeListResponse {
+    pub items: Vec<PersonAttributeResponse>,
+}
+impl toolkit::api::api_dto::ResponseApiDto for PersonAttributeListResponse {}
+
+/// Declared value mode of an attribute, as an OpenAPI enum.
+#[derive(Debug, Clone, Copy, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ValueModeDto {
+    Single,
+    Multi,
+}
+
+impl From<ValueModeDto> for ValueMode {
+    fn from(v: ValueModeDto) -> Self {
+        match v {
+            ValueModeDto::Single => Self::Single,
+            ValueModeDto::Multi => Self::Multi,
+        }
+    }
+}
+
+/// Full policy body for the next revision. `expected_revision` is the
+/// revision the caller read; a stale value yields 409.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct PolicyUpdateRequest {
+    pub expected_revision: i32,
+    pub label_override: Option<String>,
+    pub sensitivity_class: Option<String>,
+    pub grouping_enabled: bool,
+    pub comparison_enabled: bool,
+    pub value_mode: ValueModeDto,
+    pub retired: bool,
+    pub reason: String,
+}
+impl toolkit::api::api_dto::RequestApiDto for PolicyUpdateRequest {}
+
+fn to_policy_input(body: PolicyUpdateRequest) -> PolicyInput {
+    PolicyInput {
+        label_override: body.label_override,
+        sensitivity_class: body.sensitivity_class,
+        grouping_enabled: body.grouping_enabled,
+        comparison_enabled: body.comparison_enabled,
+        value_mode: body.value_mode.into(),
+        retired: body.retired,
+        reason: body.reason,
+    }
+}
+
+fn to_response(d: DefinitionWithPolicy) -> PersonAttributeResponse {
+    PersonAttributeResponse {
+        id: d.id,
+        source_type: d.key.insight_source_type,
+        source_instance: d.key.insight_source_id,
+        source_field_id: d.key.source_field_id,
+        first_observed_at: d.first_observed_at,
+        last_observed_at: d.last_observed_at,
+        policy: PolicyResponse {
+            revision: d.policy.revision,
+            label_override: d.policy.label_override,
+            sensitivity_class: d.policy.sensitivity_class,
+            grouping_enabled: d.policy.grouping_enabled,
+            comparison_enabled: d.policy.comparison_enabled,
+            value_mode: d.policy.value_mode.as_db().to_owned(),
+            retired: d.policy.retired,
+            actor_person_id: d.policy.actor_person_id,
+            reason: d.policy.reason,
+        },
+    }
+}
+
+/// `GET /v1/person-attributes` — list the tenant's discovered attribute
+/// definitions with their current policy.
+pub async fn list_person_attributes(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(ctx): Extension<SecurityContext>,
+) -> Result<impl IntoResponse, CanonicalError> {
+    require_admin(&state.db, &ctx).await?;
+
+    let tenant = ctx.subject_tenant_id().to_string();
+    let items = person_attributes_repo::list_definitions(&state.db, &tenant)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "list person attributes failed");
+            CanonicalError::internal("failed to list person attributes").create()
+        })?
+        .into_iter()
+        .map(to_response)
+        .collect();
+    Ok(Json(PersonAttributeListResponse { items }))
+}
+
+/// `GET /v1/person-attributes/{id}` — one definition with its current policy.
+pub async fn get_person_attribute(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(ctx): Extension<SecurityContext>,
+    Path(id): Path<Uuid>,
+) -> Result<impl IntoResponse, CanonicalError> {
+    require_admin(&state.db, &ctx).await?;
+
+    let tenant = ctx.subject_tenant_id().to_string();
+    let definition = person_attributes_repo::get_definition(&state.db, &tenant, id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "get person attribute failed");
+            CanonicalError::internal("failed to read person attribute").create()
+        })?
+        .ok_or_else(|| {
+            PersonAttributeError::not_found("person attribute not found")
+                .with_resource(id.to_string())
+                .create()
+        })?;
+    Ok(Json(to_response(definition)))
+}
+
+/// `PUT /v1/person-attributes/{id}/policy` — append the next policy revision.
+/// The 200 body re-reads the current state, which a concurrent append may
+/// already have advanced past the revision this call wrote — acceptable
+/// under optimistic concurrency (the response always shows current truth).
+pub async fn put_person_attribute_policy(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(ctx): Extension<SecurityContext>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<PolicyUpdateRequest>,
+) -> Result<impl IntoResponse, CanonicalError> {
+    require_admin(&state.db, &ctx).await?;
+
+    if body.expected_revision < 1 {
+        return Err(PersonAttributeError::invalid_argument()
+            .with_field_violation(
+                "expected_revision",
+                "expected_revision must be >= 1",
+                "RANGE",
+            )
+            .create());
+    }
+
+    let tenant = ctx.subject_tenant_id().to_string();
+    let expected_revision = body.expected_revision;
+    let appended = person_attributes_repo::append_policy_revision(
+        &state.db,
+        &tenant,
+        id,
+        expected_revision,
+        &to_policy_input(body),
+        ctx.subject_id(),
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!(error = %e, "append policy revision failed");
+        CanonicalError::internal("failed to update person attribute policy").create()
+    })?;
+    if !appended {
+        return Err(PersonAttributeError::aborted(
+            "expected_revision is stale or the person attribute does not exist",
+        )
+        .with_reason("STALE_REVISION")
+        .create());
+    }
+
+    let updated = person_attributes_repo::get_definition(&state.db, &tenant, id)
+        .await
+        .map_err(|e| {
+            tracing::error!(error = %e, "re-read after policy update failed");
+            CanonicalError::internal("failed to read person attribute").create()
+        })?
+        .ok_or_else(|| {
+            PersonAttributeError::not_found("person attribute not found")
+                .with_resource(id.to_string())
+                .create()
+        })?;
+    Ok(Json(to_response(updated)))
+}

--- a/src/backend/services/identity-resolution/src/attribute_reconcile_runner.rs
+++ b/src/backend/services/identity-resolution/src/attribute_reconcile_runner.rs
@@ -1,0 +1,233 @@
+//! CLI attribute-reconcile runner — the engine behind the
+//! `reconcile-attributes` subcommand.
+//!
+//! Discovers person-attribute fields in the warehouse claim relation and
+//! registers them in the MariaDB registry (definition + default revision-1
+//! policy: grouping allowed, comparison denied). Same execution model as the
+//! seed/sync runners: a Helm `CronJob` / manual Job runs
+//! `identity-resolution reconcile-attributes`; only GET journal routes exist
+//! on the API.
+//!
+//! One run: advisory lock → zombie sweep → `operations` journal row →
+//! discover → guards → register → journal completed/failed.
+//!
+//! Guards (exit code 3, journalled as `failed` so the journal explains why
+//! nothing was registered):
+//! - the claims relation does not exist — this service can deploy ahead of
+//!   the ingestion release that creates it; refusing beats a red `CronJob`
+//!   that alerts until the other repo ships.
+//! - fields were discovered but every one had empty key components — a run
+//!   that green-completes registering nothing would hide a broken claims
+//!   contract indefinitely (see `domain::attribute_reconcile`).
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use sea_orm::DatabaseConnection;
+use uuid::Uuid;
+
+use crate::config::GearConfig;
+use crate::domain::attribute_reconcile::{
+    FieldRegistrar, ReconcileError, ReconcileSummary, run_reconcile,
+};
+use crate::infra::attribute_claims::{ClickHouseDiscoveredFieldsReader, DiscoverOutcome};
+use crate::infra::db::person_attributes_repo::{self, DefinitionKey, RegisterOutcome};
+use crate::infra::db::{self, ops_repo, seed_repo};
+use crate::seed_runner::{SYSTEM_AUTHOR, resolve_tenant};
+
+const RECONCILE_TIMEOUT: Duration = Duration::from_mins(5);
+const RUN_TIMEOUT: Duration = Duration::from_mins(7);
+const ZOMBIE_CUTOFF_HOURS: i64 = 1;
+
+/// Why a reconcile run did not complete — mapped to the shared exit-code
+/// scheme (0 ok / 1 failed / 2 lock busy / 3 guard).
+#[derive(Debug)]
+pub enum ReconcileRunError {
+    LockBusy,
+    Guard(String),
+    Failed(anyhow::Error),
+}
+
+impl From<anyhow::Error> for ReconcileRunError {
+    fn from(e: anyhow::Error) -> Self {
+        Self::Failed(e)
+    }
+}
+
+/// Run one CLI attribute reconciliation end to end.
+///
+/// # Errors
+///
+/// [`ReconcileRunError`] — lock busy, guard refusal, or a failed run.
+pub async fn run(config: &GearConfig) -> Result<ReconcileSummary, ReconcileRunError> {
+    let db = db::connect(&config.database_url).await?;
+
+    // The run spans every tenant present in claims, but its journal row needs
+    // one real tenant (the GET journal routes are tenant-scoped) — same
+    // resolution rule as seed/sync.
+    let distinct = seed_repo::distinct_tenants(&db, 2).await?;
+    let tenant = match resolve_tenant(&config.tenant_default_id, &distinct) {
+        Ok(t) => t,
+        Err(msg) => return Err(ReconcileRunError::Failed(anyhow::anyhow!(msg))),
+    };
+
+    let Some(lock) = db::ReconcileLockGuard::try_acquire(&config.database_url).await? else {
+        return Err(ReconcileRunError::LockBusy);
+    };
+
+    let result = tokio::time::timeout(RUN_TIMEOUT, run_locked(&db, config, tenant))
+        .await
+        .unwrap_or_else(|_| {
+            Err(ReconcileRunError::Failed(anyhow::anyhow!(
+                "attribute reconcile timed out after {}s inside the lock-held critical section",
+                RUN_TIMEOUT.as_secs()
+            )))
+        });
+
+    lock.release().await;
+    result
+}
+
+async fn run_locked(
+    db: &DatabaseConnection,
+    config: &GearConfig,
+    tenant: Uuid,
+) -> Result<ReconcileSummary, ReconcileRunError> {
+    let cutoff = chrono::Utc::now().naive_utc() - chrono::Duration::hours(ZOMBIE_CUTOFF_HOURS);
+    match ops_repo::sweep_zombies(db, cutoff).await {
+        Ok(n) if n > 0 => {
+            tracing::warn!(
+                swept = n,
+                "attribute-reconcile: reclaimed zombie operations"
+            );
+        }
+        Ok(_) => {}
+        Err(e) => tracing::error!(error = %e, "attribute-reconcile: zombie sweep failed"),
+    }
+
+    let operation_id = Uuid::now_v7();
+    let request_json = serde_json::json!({ "trigger": "cli" }).to_string();
+    ops_repo::enqueue(
+        db,
+        operation_id,
+        ops_repo::PERSON_ATTRIBUTES_RECONCILE_OP,
+        tenant,
+        SYSTEM_AUTHOR,
+        Some(&request_json),
+    )
+    .await?;
+    ops_repo::try_start(db, operation_id).await?;
+    tracing::info!(%operation_id, %tenant, "attribute-reconcile: cli run started");
+
+    match guarded_reconcile(db, config).await {
+        Ok(summary) => {
+            if summary.non_canonical_tenants > 0 {
+                tracing::warn!(
+                    count = summary.non_canonical_tenants,
+                    "attribute-reconcile: fields registered under non-canonical tenant \
+                     strings; the admin API cannot address them"
+                );
+            }
+            let summary_json = serde_json::to_string(&summary).unwrap_or_else(|_| "{}".to_owned());
+            ops_repo::complete(db, operation_id, &summary_json).await?;
+            tracing::info!(%operation_id, ?summary, "attribute-reconcile: completed");
+            Ok(summary)
+        }
+        Err(ReconcileRunError::Guard(msg)) => {
+            tracing::warn!(%operation_id, %msg, "attribute-reconcile: refused by guard");
+            if let Err(e) = ops_repo::fail(db, operation_id, &msg).await {
+                tracing::error!(error = %e, %operation_id, "fail update failed");
+            }
+            Err(ReconcileRunError::Guard(msg))
+        }
+        Err(e) => {
+            if let Err(e2) =
+                ops_repo::fail(db, operation_id, "attribute reconcile failed; see job logs").await
+            {
+                tracing::error!(error = %e2, %operation_id, "fail update failed");
+            }
+            Err(e)
+        }
+    }
+}
+
+struct RepoRegistrar<'a> {
+    db: &'a DatabaseConnection,
+}
+
+#[async_trait]
+impl FieldRegistrar for RepoRegistrar<'_> {
+    async fn register(
+        &self,
+        key: &DefinitionKey,
+        observed_at: &str,
+    ) -> anyhow::Result<RegisterOutcome> {
+        person_attributes_repo::register_discovered(self.db, key, observed_at, SYSTEM_AUTHOR).await
+    }
+}
+
+async fn guarded_reconcile(
+    db: &DatabaseConnection,
+    config: &GearConfig,
+) -> Result<ReconcileSummary, ReconcileRunError> {
+    let reader = ClickHouseDiscoveredFieldsReader::connect(
+        &config.clickhouse_url,
+        &config.clickhouse_database,
+        &config.clickhouse_user,
+        &config.clickhouse_password,
+    );
+
+    let run = async {
+        match reader.discover_or_missing().await? {
+            DiscoverOutcome::ClaimsRelationMissing => Err(ReconcileRunError::Guard(
+                "silver.class_person_attribute_claims does not exist on this warehouse yet; \
+                 deploy the ingestion release that creates it, then re-run"
+                    .to_owned(),
+            )),
+            DiscoverOutcome::Fields(fields) => {
+                let registrar = RepoRegistrar { db };
+                run_reconcile(&PreRead(fields), &registrar)
+                    .await
+                    .map_err(|e| match e {
+                        ReconcileError::Guard(msg) => ReconcileRunError::Guard(msg),
+                        ReconcileError::Failed(e) => ReconcileRunError::Failed(e),
+                    })
+            }
+        }
+    };
+
+    tokio::time::timeout(RECONCILE_TIMEOUT, run)
+        .await
+        .unwrap_or_else(|_| {
+            Err(ReconcileRunError::Failed(anyhow::anyhow!(
+                "attribute reconcile timed out after {}s",
+                RECONCILE_TIMEOUT.as_secs()
+            )))
+        })
+}
+
+/// Adapter feeding already-read fields through the domain reader port, so the
+/// missing-relation classification stays in the infra layer while the domain
+/// loop keeps a single entry point.
+struct PreRead(Vec<crate::domain::attribute_reconcile::DiscoveredField>);
+
+#[async_trait]
+impl crate::domain::attribute_reconcile::DiscoveredFieldsReader for PreRead {
+    async fn discover(
+        &self,
+    ) -> anyhow::Result<Vec<crate::domain::attribute_reconcile::DiscoveredField>> {
+        Ok(self.0.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn default_config_fails_cleanly() {
+        let cfg = crate::config::GearConfig::default();
+        let err = run(&cfg).await;
+        assert!(matches!(err, Err(ReconcileRunError::Failed(_))));
+    }
+}

--- a/src/backend/services/identity-resolution/src/domain/attribute_reconcile.rs
+++ b/src/backend/services/identity-resolution/src/domain/attribute_reconcile.rs
@@ -1,0 +1,264 @@
+//! Attribute reconciliation core: turns fields discovered in the warehouse
+//! claim relations into registry registrations. Pure over its two ports —
+//! a reader of discovered fields and a registrar — so the loop, its guards
+//! and its accounting are testable without a database.
+
+use async_trait::async_trait;
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::infra::db::person_attributes_repo::{DefinitionKey, RegisterOutcome};
+
+/// One distinct (tenant, source type, source instance, field) seen in claims,
+/// with its latest observation instant (warehouse-formatted timestamp).
+#[derive(Debug, Clone)]
+pub struct DiscoveredField {
+    pub insight_tenant_id: String,
+    pub insight_source_type: String,
+    pub insight_source_id: String,
+    pub source_field_id: String,
+    pub last_observed_at: String,
+}
+
+/// Port: reads the distinct discovered fields from the warehouse.
+#[async_trait]
+pub trait DiscoveredFieldsReader {
+    async fn discover(&self) -> anyhow::Result<Vec<DiscoveredField>>;
+}
+
+/// Port: registers one discovered field in the registry.
+#[async_trait]
+pub trait FieldRegistrar {
+    async fn register(
+        &self,
+        key: &DefinitionKey,
+        observed_at: &str,
+    ) -> anyhow::Result<RegisterOutcome>;
+}
+
+/// Accounting of one reconciliation run, journalled as `summary_json`.
+#[derive(Debug, Default, Serialize, PartialEq, Eq)]
+pub struct ReconcileSummary {
+    pub discovered: usize,
+    pub created: usize,
+    pub refreshed: usize,
+    pub skipped_invalid: usize,
+    /// Fields registered under a tenant string that is not a canonical UUID.
+    /// They persist and reconcile fine but no gateway JWT can ever address
+    /// them through the admin API, which matches tenants in canonical form —
+    /// a nonzero count is the only signal of that mismatch.
+    pub non_canonical_tenants: usize,
+}
+
+/// Why a reconciliation run refused to proceed.
+#[derive(Debug)]
+pub enum ReconcileError {
+    /// Guard refusal with an operator-facing message (journalled verbatim).
+    Guard(String),
+    Failed(anyhow::Error),
+}
+
+impl From<anyhow::Error> for ReconcileError {
+    fn from(e: anyhow::Error) -> Self {
+        Self::Failed(e)
+    }
+}
+
+fn is_canonical_uuid(tenant: &str) -> bool {
+    Uuid::parse_str(tenant).is_ok_and(|u| u.to_string() == tenant)
+}
+
+/// A field is registrable only when every key component is non-empty; claims
+/// normalize absent values to `''`, and an empty component would mint a
+/// definition no request could ever address.
+fn to_key(field: &DiscoveredField) -> Option<DefinitionKey> {
+    let all_present = !field.insight_tenant_id.is_empty()
+        && !field.insight_source_type.is_empty()
+        && !field.insight_source_id.is_empty()
+        && !field.source_field_id.is_empty();
+    all_present.then(|| DefinitionKey {
+        insight_tenant_id: field.insight_tenant_id.clone(),
+        insight_source_type: field.insight_source_type.clone(),
+        insight_source_id: field.insight_source_id.clone(),
+        source_field_id: field.source_field_id.clone(),
+    })
+}
+
+/// Register every valid discovered field. Guards rather than completes when
+/// fields were read but none was registrable — a green run that registered
+/// nothing would hide a broken contract indefinitely. An EMPTY read is fine
+/// (no claims yet), distinct from an all-invalid read.
+///
+/// # Errors
+///
+/// [`ReconcileError::Guard`] on the all-invalid case; `Failed` when a port
+/// fails.
+pub async fn run_reconcile(
+    reader: &dyn DiscoveredFieldsReader,
+    registrar: &dyn FieldRegistrar,
+) -> Result<ReconcileSummary, ReconcileError> {
+    let fields = reader.discover().await?;
+
+    let mut summary = ReconcileSummary {
+        discovered: fields.len(),
+        ..ReconcileSummary::default()
+    };
+    for field in &fields {
+        let Some(key) = to_key(field) else {
+            summary.skipped_invalid += 1;
+            continue;
+        };
+        if !is_canonical_uuid(&key.insight_tenant_id) {
+            summary.non_canonical_tenants += 1;
+        }
+        match registrar.register(&key, &field.last_observed_at).await? {
+            RegisterOutcome::Created => summary.created += 1,
+            RegisterOutcome::Refreshed => summary.refreshed += 1,
+        }
+    }
+
+    if summary.discovered > 0 && summary.created + summary.refreshed == 0 {
+        return Err(ReconcileError::Guard(format!(
+            "all {} discovered fields had empty key components; refusing to \
+             complete a run that registered nothing — the claims contract is \
+             likely broken",
+            summary.discovered
+        )));
+    }
+    Ok(summary)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    struct FakeReader(Vec<DiscoveredField>);
+
+    #[async_trait]
+    impl DiscoveredFieldsReader for FakeReader {
+        async fn discover(&self) -> anyhow::Result<Vec<DiscoveredField>> {
+            Ok(self.0.clone())
+        }
+    }
+
+    struct FakeRegistrar {
+        seen: Mutex<Vec<DefinitionKey>>,
+        outcome: RegisterOutcome,
+    }
+
+    #[async_trait]
+    impl FieldRegistrar for FakeRegistrar {
+        async fn register(
+            &self,
+            key: &DefinitionKey,
+            _observed_at: &str,
+        ) -> anyhow::Result<RegisterOutcome> {
+            self.seen
+                .lock()
+                .map_err(|_| anyhow::anyhow!("poisoned"))?
+                .push(key.clone());
+            Ok(self.outcome)
+        }
+    }
+
+    fn field(tenant: &str, field_id: &str) -> DiscoveredField {
+        DiscoveredField {
+            insight_tenant_id: tenant.to_owned(),
+            insight_source_type: "bamboohr".to_owned(),
+            insight_source_id: "hr-main".to_owned(),
+            source_field_id: field_id.to_owned(),
+            last_observed_at: "2026-01-01 00:00:00.000".to_owned(),
+        }
+    }
+
+    #[tokio::test]
+    async fn registers_every_valid_field_and_counts_outcomes() {
+        let reader = FakeReader(vec![field("t", "jobTitle"), field("t", "department")]);
+        let registrar = FakeRegistrar {
+            seen: Mutex::new(vec![]),
+            outcome: RegisterOutcome::Created,
+        };
+
+        let summary = run_reconcile(&reader, &registrar).await.ok();
+
+        assert_eq!(
+            summary,
+            Some(ReconcileSummary {
+                discovered: 2,
+                created: 2,
+                refreshed: 0,
+                skipped_invalid: 0,
+                non_canonical_tenants: 2,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_key_components_are_skipped_not_registered() {
+        let reader = FakeReader(vec![field("", "jobTitle"), field("t", "department")]);
+        let registrar = FakeRegistrar {
+            seen: Mutex::new(vec![]),
+            outcome: RegisterOutcome::Refreshed,
+        };
+
+        let summary = run_reconcile(&reader, &registrar).await.ok();
+
+        assert_eq!(
+            summary,
+            Some(ReconcileSummary {
+                discovered: 2,
+                created: 0,
+                refreshed: 1,
+                skipped_invalid: 1,
+                non_canonical_tenants: 1,
+            })
+        );
+    }
+
+    #[tokio::test]
+    async fn all_invalid_fields_refuse_instead_of_completing_green() {
+        let reader = FakeReader(vec![field("", "jobTitle")]);
+        let registrar = FakeRegistrar {
+            seen: Mutex::new(vec![]),
+            outcome: RegisterOutcome::Created,
+        };
+
+        let refusal = run_reconcile(&reader, &registrar).await;
+
+        assert!(matches!(refusal, Err(ReconcileError::Guard(_))));
+    }
+
+    #[tokio::test]
+    async fn canonical_uuid_tenants_are_not_flagged() {
+        let mut f = field("0193e6ae-7c2d-7b1a-9e4f-0a1b2c3d4e5f", "jobTitle");
+        f.insight_tenant_id = f.insight_tenant_id.to_lowercase();
+        let reader = FakeReader(vec![f]);
+        let registrar = FakeRegistrar {
+            seen: Mutex::new(vec![]),
+            outcome: RegisterOutcome::Created,
+        };
+
+        let summary = run_reconcile(&reader, &registrar).await.ok();
+
+        assert_eq!(
+            summary.map(|s| s.non_canonical_tenants),
+            Some(0),
+            "canonical lowercase UUID must not be flagged"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_discovery_completes_as_noop() {
+        let reader = FakeReader(vec![]);
+        let registrar = FakeRegistrar {
+            seen: Mutex::new(vec![]),
+            outcome: RegisterOutcome::Created,
+        };
+
+        let summary = run_reconcile(&reader, &registrar).await.ok();
+
+        assert_eq!(summary, Some(ReconcileSummary::default()));
+    }
+}

--- a/src/backend/services/identity-resolution/src/domain/mod.rs
+++ b/src/backend/services/identity-resolution/src/domain/mod.rs
@@ -1,5 +1,6 @@
 //! Domain layer — DTOs and business logic (profile resolution/assembly).
 
+pub mod attribute_reconcile;
 pub mod profile;
 pub mod seed;
 pub mod seed_service;

--- a/src/backend/services/identity-resolution/src/gear.rs
+++ b/src/backend/services/identity-resolution/src/gear.rs
@@ -130,6 +130,31 @@ pub async fn run_sync(
     Ok(())
 }
 
+/// `reconcile-attributes` subcommand: register warehouse-discovered
+/// person-attribute fields in the MariaDB registry once and exit. Same shape
+/// as [`run_seed`].
+///
+/// # Errors
+///
+/// [`crate::attribute_reconcile_runner::ReconcileRunError`] — the caller maps
+/// each variant to a distinct process exit code.
+pub async fn run_reconcile_attributes(
+    app: &toolkit::bootstrap::AppConfig,
+) -> Result<(), crate::attribute_reconcile_runner::ReconcileRunError> {
+    let cfg = extract_gear_config(app)
+        .map_err(crate::attribute_reconcile_runner::ReconcileRunError::Failed)?;
+    if cfg.database_url.is_empty() {
+        return Err(
+            crate::attribute_reconcile_runner::ReconcileRunError::Failed(anyhow::anyhow!(
+                "`gears.identity-resolution.config.database_url` is required for reconcile-attributes"
+            )),
+        );
+    }
+    let summary = crate::attribute_reconcile_runner::run(&cfg).await?;
+    tracing::info!(?summary, "attribute-reconcile run finished");
+    Ok(())
+}
+
 impl RestApiCapability for IdentityResolutionGear {
     fn register_rest(
         &self,

--- a/src/backend/services/identity-resolution/src/infra/attribute_claims.rs
+++ b/src/backend/services/identity-resolution/src/infra/attribute_claims.rs
@@ -1,0 +1,129 @@
+//! ClickHouse reader for `silver.class_person_attribute_claims` — discovers
+//! which source fields exist so the attribute reconciliation can register
+//! them. Aggregate-only read: one row per distinct
+//! (tenant, source type, source instance, field) with its latest observation.
+//!
+//! Multi-tenant raw scan, same posture as `identity_inputs.rs`: claims carry
+//! RAW connector-config tenant strings, deployments are single-tenant, and
+//! the registry stores the raw string (see `sql/015_person_attributes.sql`).
+//!
+//! `silver.` is fully qualified because the client's configured database is
+//! `identity`; the deployed ClickHouse user therefore needs a `silver` grant.
+//! Aliases differ from source column names (ClickHouse "Cyclic aliases"
+//! gotcha, same as `identity_inputs.rs`). FINAL is required: the relation is
+//! `ReplacingMergeTree` and pre-merge duplicates would be harmless for
+//! `max()` but not for future aggregate changes — keep the read canonical.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use clickhouse::Row;
+use insight_clickhouse::{Client, Config};
+use serde::Deserialize;
+
+use crate::domain::attribute_reconcile::{DiscoveredField, DiscoveredFieldsReader};
+
+const READ_TIMEOUT: Duration = Duration::from_mins(5);
+
+const DISCOVER_SQL: &str = r"
+    SELECT
+        ifNull(insight_tenant_id, '')            AS tenant,
+        ifNull(insight_source_type, '')          AS source_type,
+        ifNull(insight_source_id, '')            AS source_instance,
+        ifNull(field_id, '')                     AS field,
+        toString(max(observed_at))               AS last_observed
+    FROM silver.class_person_attribute_claims FINAL
+    GROUP BY tenant, source_type, source_instance, field
+    ORDER BY tenant, source_type, source_instance, field
+";
+
+/// ClickHouse exception token for a missing table — the pre-ingestion-release
+/// deploy case the runner turns into a guard refusal rather than a failure.
+/// Matched as the named token, not the numeric code: a bare "Code: 60"
+/// substring would also match codes 600-609.
+const UNKNOWN_TABLE_TOKEN: &str = "UNKNOWN_TABLE";
+
+#[derive(Debug, Row, Deserialize)]
+struct FieldRow {
+    tenant: String,
+    source_type: String,
+    source_instance: String,
+    field: String,
+    last_observed: String,
+}
+
+/// Reads discovered attribute fields from ClickHouse via the shared client.
+pub struct ClickHouseDiscoveredFieldsReader {
+    client: Client,
+}
+
+impl ClickHouseDiscoveredFieldsReader {
+    #[must_use]
+    pub fn new(client: Client) -> Self {
+        Self { client }
+    }
+
+    /// Build a reader from connection settings (empty user → no auth).
+    #[must_use]
+    pub fn connect(url: &str, database: &str, user: &str, password: &str) -> Self {
+        let mut config = Config::new(url, database).with_query_timeout(READ_TIMEOUT);
+        if !user.is_empty() {
+            config = config.with_auth(user, password);
+        }
+        Self::new(Client::new(config))
+    }
+}
+
+/// Read outcome distinguishing "relation absent" from real failures.
+pub enum DiscoverOutcome {
+    Fields(Vec<DiscoveredField>),
+    ClaimsRelationMissing,
+}
+
+#[async_trait]
+impl DiscoveredFieldsReader for ClickHouseDiscoveredFieldsReader {
+    async fn discover(&self) -> anyhow::Result<Vec<DiscoveredField>> {
+        let rows: Vec<FieldRow> = self.client.query(DISCOVER_SQL).fetch_all().await?;
+        Ok(rows.into_iter().map(map_row).collect())
+    }
+}
+
+impl ClickHouseDiscoveredFieldsReader {
+    /// Like [`DiscoveredFieldsReader::discover`], but classifies a missing
+    /// claims relation as its own outcome so the runner can refuse (guard)
+    /// instead of failing: this service can deploy ahead of the ingestion
+    /// release that creates the relation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for any ClickHouse failure other than the missing
+    /// relation.
+    pub async fn discover_or_missing(&self) -> anyhow::Result<DiscoverOutcome> {
+        match self
+            .client
+            .query(DISCOVER_SQL)
+            .fetch_all::<FieldRow>()
+            .await
+        {
+            Ok(rows) => Ok(DiscoverOutcome::Fields(
+                rows.into_iter().map(map_row).collect(),
+            )),
+            Err(err) if is_unknown_table(&err) => Ok(DiscoverOutcome::ClaimsRelationMissing),
+            Err(err) => Err(err.into()),
+        }
+    }
+}
+
+fn is_unknown_table(err: &clickhouse::error::Error) -> bool {
+    matches!(err, clickhouse::error::Error::BadResponse(msg) if msg.contains(UNKNOWN_TABLE_TOKEN))
+}
+
+fn map_row(r: FieldRow) -> DiscoveredField {
+    DiscoveredField {
+        insight_tenant_id: r.tenant,
+        insight_source_type: r.source_type,
+        insight_source_id: r.source_instance,
+        source_field_id: r.field,
+        last_observed_at: r.last_observed,
+    }
+}

--- a/src/backend/services/identity-resolution/src/infra/db/mod.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/mod.rs
@@ -22,6 +22,7 @@
 pub mod bootstrap;
 pub mod entities;
 pub mod ops_repo;
+pub mod person_attributes_repo;
 pub mod person_roles_repo;
 pub mod persons_log_repo;
 pub mod persons_repo;
@@ -200,6 +201,57 @@ impl SyncLockGuard {
                 DbBackend::MySql,
                 "SELECT RELEASE_LOCK(?)",
                 [SYNC_LOCK.into()],
+            ))
+            .await;
+    }
+}
+
+/// Name of the GLOBAL advisory lock serializing attribute-reconcile runs —
+/// same lifetime semantics as [`SyncLockGuard`], distinct name so a reconcile
+/// never contends with a sync.
+const ATTRIBUTE_RECONCILE_LOCK: &str = "person-attributes-reconcile";
+
+/// RAII holder of the attribute-reconcile advisory lock.
+pub struct ReconcileLockGuard {
+    conn: DatabaseConnection,
+}
+
+impl ReconcileLockGuard {
+    /// Try to take the reconcile lock without waiting; `None` when another
+    /// run holds it.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the connection or the query fails.
+    pub async fn try_acquire(database_url: &str) -> anyhow::Result<Option<Self>> {
+        use sea_orm::{ConnectionTrait, DbBackend, Statement};
+        let conn = connect_single(database_url).await?;
+        let acquired: Option<i8> = conn
+            .query_one(Statement::from_sql_and_values(
+                DbBackend::MySql,
+                "SELECT GET_LOCK(?, 0)",
+                [ATTRIBUTE_RECONCILE_LOCK.into()],
+            ))
+            .await?
+            .map(|r| r.try_get_by_index::<Option<i8>>(0))
+            .transpose()?
+            .flatten();
+        if acquired == Some(1) {
+            Ok(Some(Self { conn }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Explicit best-effort release; dropping the session releases anyway.
+    pub async fn release(self) {
+        use sea_orm::{ConnectionTrait, DbBackend, Statement};
+        let _ = self
+            .conn
+            .execute(Statement::from_sql_and_values(
+                DbBackend::MySql,
+                "SELECT RELEASE_LOCK(?)",
+                [ATTRIBUTE_RECONCILE_LOCK.into()],
             ))
             .await;
     }

--- a/src/backend/services/identity-resolution/src/infra/db/ops_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/ops_repo.rs
@@ -20,6 +20,8 @@ use uuid::Uuid;
 pub const PERSONS_SEED_OP: &str = "persons-seed";
 /// Operation type of the persons→ClickHouse sync (`sync` subcommand).
 pub const PERSONS_SYNC_OP: &str = "persons-sync";
+/// Operation type of the attribute-reconcile runner.
+pub const PERSON_ATTRIBUTES_RECONCILE_OP: &str = "person-attributes-reconcile";
 
 /// Lifecycle phase of an operation. DB column is a `VARCHAR(16)`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/backend/services/identity-resolution/src/infra/db/person_attributes_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/person_attributes_repo.rs
@@ -1,0 +1,351 @@
+//! Person-attribute registry: connector-discovered attribute definitions and
+//! their append-only policy revisions.
+//!
+//! Definitions are keyed by the RAW string identifiers the warehouse claim
+//! relations carry (see the deviation note in `sql/015_person_attributes.sql`).
+//! Policy revisions never mutate; the current policy is the row with the
+//! highest revision per definition, and every revision carries its actor.
+
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, SqlErr, Statement};
+use uuid::Uuid;
+
+/// Stable identity of one discovered source field.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DefinitionKey {
+    pub insight_tenant_id: String,
+    pub insight_source_type: String,
+    pub insight_source_id: String,
+    pub source_field_id: String,
+}
+
+/// One registry row joined with its current (highest-revision) policy.
+#[derive(Debug, Clone)]
+pub struct DefinitionWithPolicy {
+    pub id: Uuid,
+    pub key: DefinitionKey,
+    pub first_observed_at: String,
+    pub last_observed_at: String,
+    pub policy: PolicyRevision,
+}
+
+/// One immutable policy revision (read model).
+#[derive(Debug, Clone)]
+pub struct PolicyRevision {
+    pub revision: i32,
+    pub label_override: Option<String>,
+    pub sensitivity_class: Option<String>,
+    pub grouping_enabled: bool,
+    pub comparison_enabled: bool,
+    pub value_mode: ValueMode,
+    pub retired: bool,
+    pub actor_person_id: Uuid,
+    pub reason: String,
+}
+
+/// Policy fields a caller may set; revision and actor are assigned by the
+/// append itself.
+#[derive(Debug, Clone)]
+pub struct PolicyInput {
+    pub label_override: Option<String>,
+    pub sensitivity_class: Option<String>,
+    pub grouping_enabled: bool,
+    pub comparison_enabled: bool,
+    pub value_mode: ValueMode,
+    pub retired: bool,
+    pub reason: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValueMode {
+    Single,
+    Multi,
+}
+
+impl ValueMode {
+    #[must_use]
+    pub fn as_db(self) -> &'static str {
+        match self {
+            Self::Single => "single",
+            Self::Multi => "multi",
+        }
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error for a value outside the `value_mode` enum.
+    pub fn from_db(s: &str) -> anyhow::Result<Self> {
+        match s {
+            "single" => Ok(Self::Single),
+            "multi" => Ok(Self::Multi),
+            other => anyhow::bail!("unknown value_mode: {other}"),
+        }
+    }
+}
+
+/// Outcome of registering one discovered field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegisterOutcome {
+    Created,
+    Refreshed,
+}
+
+/// Register a discovered field: insert the definition plus its revision-1
+/// default policy (grouping allowed, comparison denied) when the key is new;
+/// otherwise only advance `last_observed_at`. Idempotent per key.
+///
+/// The insert and its revision-1 row are two statements without a wrapping
+/// transaction: a crash between them leaves a definition whose revision 1 is
+/// re-inserted by the next run (the `INSERT IGNORE` below), never a definition
+/// that reconciliation refuses to touch again.
+///
+/// The outcome is classified from the `INSERT IGNORE` (1 row = the field had
+/// no revision 1, so it registers as created): the definition insert's
+/// affected-rows count is unreliable under `CLIENT_FOUND_ROWS`, which the
+/// driver enables — a duplicate-key no-op reports 1 there, not 0.
+///
+/// # Errors
+///
+/// Returns an error if a statement fails.
+pub async fn register_discovered(
+    db: &DatabaseConnection,
+    key: &DefinitionKey,
+    observed_at: &str,
+    system_actor: Uuid,
+) -> anyhow::Result<RegisterOutcome> {
+    const INSERT_DEFINITION: &str = r"
+        INSERT INTO person_attribute_definitions
+            (id, insight_tenant_id, insight_source_type, insight_source_id,
+             source_field_id, first_observed_at, last_observed_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        ON DUPLICATE KEY UPDATE
+            last_observed_at = GREATEST(last_observed_at, VALUES(last_observed_at))
+    ";
+    const INSERT_INITIAL_POLICY: &str = r"
+        INSERT IGNORE INTO person_attribute_policy_revisions
+            (id, definition_id, revision, actor_person_id, reason)
+        SELECT ?, d.id, 1, ?, 'registered by attribute reconciliation'
+        FROM person_attribute_definitions d
+        WHERE d.insight_tenant_id   = ?
+          AND d.insight_source_type = ?
+          AND d.insight_source_id   = ?
+          AND d.source_field_id     = ?
+    ";
+
+    let definition_id = Uuid::now_v7();
+    let insert = Statement::from_sql_and_values(
+        DbBackend::MySql,
+        INSERT_DEFINITION,
+        [
+            definition_id.as_bytes().to_vec().into(),
+            key.insight_tenant_id.clone().into(),
+            key.insight_source_type.clone().into(),
+            key.insight_source_id.clone().into(),
+            key.source_field_id.clone().into(),
+            observed_at.into(),
+            observed_at.into(),
+        ],
+    );
+    db.execute(insert).await?;
+
+    let policy = Statement::from_sql_and_values(
+        DbBackend::MySql,
+        INSERT_INITIAL_POLICY,
+        [
+            Uuid::now_v7().as_bytes().to_vec().into(),
+            system_actor.as_bytes().to_vec().into(),
+            key.insight_tenant_id.clone().into(),
+            key.insight_source_type.clone().into(),
+            key.insight_source_id.clone().into(),
+            key.source_field_id.clone().into(),
+        ],
+    );
+    let policy_result = db.execute(policy).await?;
+
+    Ok(if policy_result.rows_affected() == 1 {
+        RegisterOutcome::Created
+    } else {
+        RegisterOutcome::Refreshed
+    })
+}
+
+/// Append the next policy revision iff the caller saw the current one.
+/// Returns `false` when `expected_revision` is stale (or the definition does
+/// not exist / belongs to another tenant) — the API maps that to 409. The
+/// guarded `INSERT ... SELECT` makes check-and-insert one statement; if two
+/// writers still race past it, `uq_definition_revision` rejects the loser,
+/// which is reported as the same stale-revision outcome rather than an error.
+///
+/// # Errors
+///
+/// Returns an error if the statement fails for any reason other than the
+/// revision uniqueness key.
+pub async fn append_policy_revision(
+    db: &DatabaseConnection,
+    tenant_id: &str,
+    definition_id: Uuid,
+    expected_revision: i32,
+    policy: &PolicyInput,
+    actor_person_id: Uuid,
+) -> anyhow::Result<bool> {
+    const SQL: &str = r"
+        INSERT INTO person_attribute_policy_revisions
+            (id, definition_id, revision, label_override, sensitivity_class,
+             grouping_enabled, comparison_enabled, value_mode, retired,
+             actor_person_id, reason)
+        SELECT ?, d.id, ?, ?, ?, ?, ?, ?, ?, ?, ?
+        FROM person_attribute_definitions d
+        WHERE d.id = ?
+          AND d.insight_tenant_id = ?
+          AND ? = (SELECT MAX(r.revision)
+                   FROM person_attribute_policy_revisions r
+                   WHERE r.definition_id = d.id)
+    ";
+
+    let next = expected_revision
+        .checked_add(1)
+        .ok_or_else(|| anyhow::anyhow!("revision overflow"))?;
+    let stmt = Statement::from_sql_and_values(
+        DbBackend::MySql,
+        SQL,
+        [
+            Uuid::now_v7().as_bytes().to_vec().into(),
+            next.into(),
+            policy.label_override.clone().into(),
+            policy.sensitivity_class.clone().into(),
+            policy.grouping_enabled.into(),
+            policy.comparison_enabled.into(),
+            policy.value_mode.as_db().into(),
+            policy.retired.into(),
+            actor_person_id.as_bytes().to_vec().into(),
+            policy.reason.clone().into(),
+            definition_id.as_bytes().to_vec().into(),
+            tenant_id.into(),
+            expected_revision.into(),
+        ],
+    );
+
+    match db.execute(stmt).await {
+        Ok(result) => Ok(result.rows_affected() == 1),
+        Err(err) if is_duplicate_key(&err) => Ok(false),
+        Err(err) => Err(err.into()),
+    }
+}
+
+fn is_duplicate_key(err: &sea_orm::DbErr) -> bool {
+    matches!(err.sql_err(), Some(SqlErr::UniqueConstraintViolation(_)))
+}
+
+/// List a tenant's definitions with their current policy, ordered by source
+/// then field for stable presentation.
+///
+/// # Errors
+///
+/// Returns an error if the query fails.
+pub async fn list_definitions(
+    db: &DatabaseConnection,
+    tenant_id: &str,
+) -> anyhow::Result<Vec<DefinitionWithPolicy>> {
+    let stmt = Statement::from_sql_and_values(
+        DbBackend::MySql,
+        format!(
+            "{SELECT_WITH_POLICY} WHERE d.insight_tenant_id = ? ORDER BY d.insight_source_type, d.insight_source_id, d.source_field_id"
+        ),
+        [tenant_id.into()],
+    );
+    let rows = db.query_all(stmt).await?;
+    rows.iter().map(row_to_definition).collect()
+}
+
+/// One definition with its current policy, tenant-scoped.
+///
+/// # Errors
+///
+/// Returns an error if the query fails.
+pub async fn get_definition(
+    db: &DatabaseConnection,
+    tenant_id: &str,
+    definition_id: Uuid,
+) -> anyhow::Result<Option<DefinitionWithPolicy>> {
+    let stmt = Statement::from_sql_and_values(
+        DbBackend::MySql,
+        format!("{SELECT_WITH_POLICY} WHERE d.insight_tenant_id = ? AND d.id = ?"),
+        [tenant_id.into(), definition_id.as_bytes().to_vec().into()],
+    );
+    let row = db.query_one(stmt).await?;
+    row.as_ref().map(row_to_definition).transpose()
+}
+
+const SELECT_WITH_POLICY: &str = r"
+    SELECT
+        d.id                    AS definition_id,
+        d.insight_tenant_id     AS tenant_id,
+        d.insight_source_type   AS source_type,
+        d.insight_source_id     AS source_instance,
+        d.source_field_id       AS field_id,
+        CAST(d.first_observed_at AS CHAR) AS first_observed,
+        CAST(d.last_observed_at  AS CHAR) AS last_observed,
+        r.revision              AS revision,
+        r.label_override        AS label_override,
+        r.sensitivity_class     AS sensitivity_class,
+        r.grouping_enabled      AS grouping_enabled,
+        r.comparison_enabled    AS comparison_enabled,
+        r.value_mode            AS value_mode,
+        r.retired               AS retired,
+        r.actor_person_id       AS actor_person_id,
+        r.reason                AS reason
+    FROM person_attribute_definitions d
+    JOIN person_attribute_policy_revisions r
+        ON r.definition_id = d.id
+        AND r.revision = (SELECT MAX(r2.revision)
+                          FROM person_attribute_policy_revisions r2
+                          WHERE r2.definition_id = d.id)
+";
+
+fn row_to_definition(row: &sea_orm::QueryResult) -> anyhow::Result<DefinitionWithPolicy> {
+    let id: Vec<u8> = row.try_get("", "definition_id")?;
+    let actor: Vec<u8> = row.try_get("", "actor_person_id")?;
+    let value_mode: String = row.try_get("", "value_mode")?;
+    Ok(DefinitionWithPolicy {
+        id: Uuid::from_slice(&id)?,
+        key: DefinitionKey {
+            insight_tenant_id: row.try_get("", "tenant_id")?,
+            insight_source_type: row.try_get("", "source_type")?,
+            insight_source_id: row.try_get("", "source_instance")?,
+            source_field_id: row.try_get("", "field_id")?,
+        },
+        first_observed_at: row.try_get("", "first_observed")?,
+        last_observed_at: row.try_get("", "last_observed")?,
+        policy: PolicyRevision {
+            revision: row.try_get("", "revision")?,
+            label_override: row.try_get("", "label_override")?,
+            sensitivity_class: row.try_get("", "sensitivity_class")?,
+            grouping_enabled: row.try_get("", "grouping_enabled")?,
+            comparison_enabled: row.try_get("", "comparison_enabled")?,
+            value_mode: ValueMode::from_db(&value_mode)?,
+            retired: row.try_get("", "retired")?,
+            actor_person_id: Uuid::from_slice(&actor)?,
+            reason: row.try_get("", "reason")?,
+        },
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ValueMode;
+
+    #[test]
+    fn value_mode_round_trips_through_db_representation() {
+        for mode in [ValueMode::Single, ValueMode::Multi] {
+            assert_eq!(
+                ValueMode::from_db(mode.as_db()).ok(),
+                Some(mode),
+                "should round-trip: {mode:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn value_mode_rejects_unknown_values() {
+        assert!(ValueMode::from_db("plural").is_err());
+    }
+}

--- a/src/backend/services/identity-resolution/src/infra/mod.rs
+++ b/src/backend/services/identity-resolution/src/infra/mod.rs
@@ -1,5 +1,6 @@
 //! Infrastructure adapters (DB pool, external clients).
 
+pub mod attribute_claims;
 pub mod db;
 pub mod identity_inputs;
 pub mod identity_persons;

--- a/src/backend/services/identity-resolution/src/main.rs
+++ b/src/backend/services/identity-resolution/src/main.rs
@@ -10,6 +10,7 @@
 //! external id).
 
 mod api;
+mod attribute_reconcile_runner;
 mod config;
 mod domain;
 mod gear;
@@ -83,6 +84,17 @@ enum Commands {
         #[arg(long)]
         force: bool,
     },
+    /// Print the OpenAPI document to stdout and exit. Built offline from the
+    /// route table — no database, no HTTP listener, no config needed. Used to
+    /// regenerate docs/components/backend/identity-resolution/openapi.json and
+    /// to drift-check it in CI.
+    Openapi,
+    /// Register person-attribute fields discovered in the warehouse claim
+    /// relation into the MariaDB registry and exit. Same execution model as
+    /// `seed`/`sync` — Helm `CronJob` / manual Job. Exit codes: 0 ok /
+    /// 1 failed / 2 another run holds the lock / 3 refused by a guard
+    /// (claims relation absent, or a broken claims contract).
+    ReconcileAttributes,
 }
 
 /// Exit codes of the `seed` / `sync` subcommands (one shared scheme),
@@ -140,7 +152,35 @@ async fn main() -> Result<()> {
                 }
             }
         }
+        Commands::Openapi => print_openapi(),
+        Commands::ReconcileAttributes => {
+            init_subcommand_logging();
+            match gear::run_reconcile_attributes(&config).await {
+                Ok(()) => Ok(()),
+                Err(attribute_reconcile_runner::ReconcileRunError::LockBusy) => {
+                    tracing::warn!("another attribute-reconcile run holds the lock; exiting");
+                    std::process::exit(EXIT_SEED_LOCK_BUSY);
+                }
+                Err(attribute_reconcile_runner::ReconcileRunError::Guard(msg)) => {
+                    tracing::error!(%msg, "attribute reconcile refused by guard");
+                    std::process::exit(EXIT_SEED_GUARD);
+                }
+                Err(attribute_reconcile_runner::ReconcileRunError::Failed(e)) => {
+                    tracing::error!(error = %format!("{e:#}"), "attribute reconcile failed");
+                    std::process::exit(EXIT_SEED_FAILED);
+                }
+            }
+        }
     }
+}
+
+/// Print the OpenAPI document built offline by [`api::openapi_document`]. No
+/// config or backends are touched, and no logging subscriber is initialized
+/// on this path, so stdout stays pure JSON.
+fn print_openapi() -> Result<()> {
+    let doc = api::openapi_document()?;
+    println!("{}", serde_json::to_string_pretty(&doc)?);
+    Ok(())
 }
 
 /// Plain stdout logging for the `migrate` / `seed` subcommands. The bootstrap

--- a/src/backend/services/identity-resolution/src/migration/m20260806_000015_person_attributes.rs
+++ b/src/backend/services/identity-resolution/src/migration/m20260806_000015_person_attributes.rs
@@ -1,0 +1,33 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        super::apply_sql(manager, include_str!("sql/015_person_attributes.sql")).await
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        Err(super::irreversible())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    const SCRIPT: &str = include_str!("sql/015_person_attributes.sql");
+
+    #[test]
+    fn ddl_declares_every_constraint_and_enum_variant() {
+        for required in [
+            "uq_definition",
+            "uq_definition_revision",
+            "chk_person_attribute_policy_revision_positive CHECK (revision >= 1)",
+            "ENUM('single','multi')",
+            "COLLATE utf8mb4_bin",
+        ] {
+            assert!(SCRIPT.contains(required), "missing from DDL: {required}");
+        }
+    }
+}

--- a/src/backend/services/identity-resolution/src/migration/mod.rs
+++ b/src/backend/services/identity-resolution/src/migration/mod.rs
@@ -43,6 +43,7 @@ mod m20260724_000011_operations;
 mod m20260724_000012_org_chart_nullable_parent;
 mod m20260724_000013_persons_email_any_tenant_idx;
 mod m20260724_000014_account_person_map_datetime;
+mod m20260806_000015_person_attributes;
 
 use sea_orm_migration::prelude::*;
 use sea_orm_migration::sea_orm::ConnectionTrait;
@@ -67,6 +68,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260724_000012_org_chart_nullable_parent::Migration),
             Box::new(m20260724_000013_persons_email_any_tenant_idx::Migration),
             Box::new(m20260724_000014_account_person_map_datetime::Migration),
+            Box::new(m20260806_000015_person_attributes::Migration),
         ]
     }
 }
@@ -140,6 +142,7 @@ mod tests {
             (include_str!("sql/012_org_chart_nullable_parent.sql"), 3),
             (include_str!("sql/013_persons_email_any_tenant_idx.sql"), 1),
             (include_str!("sql/014_account_person_map_datetime.sql"), 2),
+            (include_str!("sql/015_person_attributes.sql"), 2),
         ];
         for (i, (script, expected)) in cases.iter().enumerate() {
             let stmts = split_statements(script);

--- a/src/backend/services/identity-resolution/src/migration/sql/015_person_attributes.sql
+++ b/src/backend/services/identity-resolution/src/migration/sql/015_person_attributes.sql
@@ -1,0 +1,46 @@
+-- Person-attribute registry: connector-discovered attribute definitions and
+-- their immutable, actor-attributed policy revisions.
+--
+-- Key representation: definitions are keyed by the RAW string identifiers the
+-- warehouse claim relations carry (tenant, source type, source instance,
+-- source field). This deviates from the BINARY(16) convention of `persons`
+-- deliberately: the policy snapshot published back to ClickHouse must join
+-- claims on byte-equal keys, and the BINARY(16) values in `persons` exist
+-- only because the identity_inputs producer pre-hashes free-form ids into
+-- UUIDs (documented temporary, #1550). Hashing here would make the registry
+-- unjoinable to the very relations it governs.
+CREATE TABLE IF NOT EXISTS person_attribute_definitions (
+    id                  BINARY(16)   NOT NULL,
+    insight_tenant_id   VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    insight_source_type VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    insight_source_id   VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    source_field_id     VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL,
+    first_observed_at   DATETIME(6)  NOT NULL,
+    last_observed_at    DATETIME(6)  NOT NULL,
+    created_at          DATETIME(6)  NOT NULL DEFAULT (UTC_TIMESTAMP(6)),
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_definition (insight_tenant_id, insight_source_type,
+                              insight_source_id, source_field_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- Append-only: a policy change inserts the next revision; rows never mutate.
+-- The revision rows ARE the audit trail (actor + reason on every row), the
+-- pattern of analytics' semantic_definition_revisions.
+CREATE TABLE IF NOT EXISTS person_attribute_policy_revisions (
+    id                 BINARY(16)   NOT NULL,
+    definition_id      BINARY(16)   NOT NULL,
+    revision           INT          NOT NULL,
+    label_override     VARCHAR(255) NULL,
+    sensitivity_class  VARCHAR(64)  NULL,
+    grouping_enabled   BOOLEAN      NOT NULL DEFAULT TRUE,
+    comparison_enabled BOOLEAN      NOT NULL DEFAULT FALSE,
+    value_mode         ENUM('single','multi') NOT NULL DEFAULT 'single',
+    retired            BOOLEAN      NOT NULL DEFAULT FALSE,
+    actor_person_id    BINARY(16)   NOT NULL,
+    reason             TEXT         NOT NULL,
+    created_at         DATETIME(6)  NOT NULL DEFAULT (UTC_TIMESTAMP(6)),
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_definition_revision (definition_id, revision),
+    INDEX idx_definition (definition_id, revision),
+    CONSTRAINT chk_person_attribute_policy_revision_positive CHECK (revision >= 1)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## Problem

Discovered person attributes have no governed home. Analytics needs
tenant-curated policy per attribute — label, sensitivity, whether it may
group or drive comparison — with an audit trail, and a registry that learns
new fields as connectors deliver them. Nothing owns that today.

## Change

Person-attribute registry in the identity-resolution service.

- `person_attribute_definitions` — one row per discovered
  (tenant, source type, source instance, field), keyed by the raw warehouse
  strings so the policy snapshot joins claims byte-equal.
- `person_attribute_policy_revisions` — append-only, actor and reason on
  every row; the revisions are the audit trail. Defaults: grouping allowed,
  comparison denied until an admin enables it.
- `reconcile-attributes` subcommand and CronJob register discovered fields
  (advisory lock, operations journal). Guards refuse — exit 3, journalled —
  when the claims relation is absent (deployable ahead of the ingestion
  release) or when a run would register nothing.
- Admin API: `GET /v1/person-attributes[/{id}]`, `PUT …/{id}/policy`
  (optimistic concurrency, stale revision → 409), journal GETs under
  `/v1/person-attributes-reconcile`. All behind the existing admin gate.
- `openapi` subcommand and CI drift job; the committed spec was
  hand-maintained and stale, now generated from the route table.

## Out of scope

Publishing policy and assignment snapshots to the analytical store (next PR),
the attribute catalog, grouping and comparison APIs, named groups,
manager-source authority.

## Validation

- 98 unit tests; clippy pedantic clean; helm render-contract 23 green.
- Migrations and the exact repository SQL exercised against MariaDB 11.4:
  the guarded self-referencing INSERT is legal, a stale revision inserts zero
  rows, a race loser hits the unique key, the CHECK fires, and a refresh keeps
  `first_observed_at` while advancing `last_observed_at`.
- OpenAPI drift gate passes on the regenerated spec.

## Notes

- `first_observed_at` records when a field was first registered, not the
  earliest claim ever observed for it.
- A warehouse tenant string that is not a canonical UUID registers normally
  but cannot be addressed through the admin API; the reconcile summary counts
  those so the mismatch is visible rather than silent.

Closes constructorfabric/insight#2284
