### PR TITLE
ci(security): stop the secrets gate failing PRs on other branches' commits

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -43,11 +43,15 @@ jobs:
       - name: TruffleHog scan (commits added by this PR)
         # `pull_request.base.sha` lags main, so it pulls unrelated commits into range (#2025).
         # The merge ref's first parent is the current base tip — that is the PR's own range.
+        # `--since-commit` alone only prunes what the base can reach: with fetch-depth 0 the
+        # checkout carries every branch, and commits on unmerged ones are scanned too, so an
+        # unrelated branch fails this PR. `--branch` confines the walk to the merge ref.
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
           set -euo pipefail
           SINCE="$(git rev-parse 'HEAD^1' 2>/dev/null || echo "$BASE_SHA")"
+          HEAD_SHA="$(git rev-parse HEAD)"
           echo "Scanning ${SINCE}..HEAD"
           docker run --rm \
             -v "${{ github.workspace }}:/src:ro" \
@@ -57,6 +61,7 @@ jobs:
               --json \
               --no-update \
               --since-commit "$SINCE" \
+              --branch "$HEAD_SHA" \
               --results=verified,unknown,unverified,filtered_unverified \
             > trufflehog-findings.jsonl
 

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -10,6 +10,8 @@ name: TruffleHog Secrets
 #   - `--results=verified,unknown,unverified,filtered_unverified` — the default hides findings
 #     whose verification failed, which on a public repository is still a leak.
 #   - no `--filter-entropy` — it suppresses AWS access key IDs.
+#   - `--exclude-detectors lob` — a Lob key is `test_` followed by 35 characters, the same shape
+#     as this repository's long `test_*` function names, and Lob is not a dependency here.
 #   - raw values never reach a log, summary or artifact — this repository is public.
 
 on:
@@ -62,6 +64,7 @@ jobs:
               --no-update \
               --since-commit "$SINCE" \
               --branch "$HEAD_SHA" \
+              --exclude-detectors lob \
               --results=verified,unknown,unverified,filtered_unverified \
             > trufflehog-findings.jsonl
 
@@ -154,6 +157,7 @@ jobs:
             git file:///src \
               --json \
               --no-update \
+              --exclude-detectors lob \
               --results=verified,unknown,unverified,filtered_unverified \
             > trufflehog-findings.jsonl
 
@@ -255,6 +259,7 @@ jobs:
               --include-wikis \
               --json \
               --no-update \
+              --exclude-detectors lob \
               --results=verified,unknown,unverified,filtered_unverified \
             > trufflehog-api-findings.jsonl
 


### PR DESCRIPTION
Closes #2025.

`secrets (diff)` fails pull requests on findings they do not introduce. Two independent causes, one commit each.

**The scan reaches unmerged branches.** `--since-commit` prunes only what the base commit can reach, and `fetch-depth: 0` puts every branch in the checkout, so TruffleHog walks their commits too. A pull request touching five markdown files (#2289) was scanned over 203 chunks / 258 339 bytes and failed on a commit from an unrelated branch, `feat/bamboohr-cdk-fetch-all`. `--branch "$HEAD_SHA"` confines the walk to the merge ref; the same scan then reads 9 chunks / 1 898 bytes.

**The Lob detector matches test function names.** A Lob key is `test_` followed by 35 characters. `test_a_deprecated_field_is_not_requested` is exactly that shape, and Lob's sandbox accepts any `test_`-prefixed key, so the finding arrives as `verified: true` with `environment: test`. 33 names across 27 files match the pattern today, and each one fails the gate on the pull request that adds it. Lob is a direct-mail API and is not a dependency here, so the detector can only produce false positives. Dropped in all three jobs.

Reviewer note: the two halves are separable. Drop the second commit if you would rather keep the detector and annotate individual lines with `trufflehog:ignore` — that costs 33 annotations today and one per future long test name.

## Test plan

- [x] Failure reproduced locally against run 31097123275's merge ref, same image and arguments: `203 chunks / 258 339 bytes / 2 verified` — identical to attempt 3 in CI
- [x] `--branch` alone, detached HEAD as in CI: `9 chunks / 1 898 bytes`, 0 findings
- [x] `--exclude-detectors lob` alone: 0 findings, scan volume unchanged
- [x] Positive control: scanning the branch that does carry the match, with `--branch` and without the Lob exclusion, still reports both findings — confining the range does not blind the gate
- [x] `actionlint .github/workflows/trufflehog.yml` — exit 0
- [ ] `secrets (diff)` passes on this pull request
- [ ] The next nightly `secrets (full history)` reports without the Lob rows

The last two need CI runs and are unchecked until they exist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull-request security scans to focus on the relevant branch and avoid unrelated history.
  * Excluded a detector that could incorrectly flag repository test names, reducing false positives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->