### PR TITLE
fix(dev-compose): never trust a stale locally-built image

### DIFF
--- a/dev-compose.sh
+++ b/dev-compose.sh
@@ -1168,6 +1168,7 @@ The main pass removes:
   • all stack containers (insight-*)
   • named volumes: mariadb-data, clickhouse-data, clickhouse-logs,
     redis-data, redpanda-data, rust-target, frontend-node-modules
+  • locally-built images (seed-sample, build containers, ...)
   • host-side build artefacts under deploy/compose/build/
   • the generated authenticator dev signing key
     (deploy/compose/authenticator-dev-keys/)
@@ -1197,6 +1198,7 @@ This will permanently remove Docker state for Compose instance
 $COMPOSE_PROJECT_NAME:
   • containers
   • named volumes
+  • the instance's locally-built images
   • the instance network
 
 Worktree-level build artefacts, generated config, keys, and .env.compose
@@ -1209,6 +1211,7 @@ This will permanently remove the local Insight stack state:
   • containers (insight-*)
   • named volumes (mariadb-data, clickhouse-data, redis-data,
     redpanda-data, rust-target, frontend-node-modules, ...)
+  • locally-built images (seed-sample, build containers, ...)
   • deploy/compose/build/ artefacts
   • deploy/compose/authenticator-dev-keys/ (dev signing key)
   • deploy/compose/override.generated.yml
@@ -1237,13 +1240,19 @@ EOF
   local compose_cmd=(docker compose --project-name "$COMPOSE_PROJECT_NAME" --env-file "$env_file" -f docker-compose.yml)
   [[ -f "$override" ]] && compose_cmd+=(-f "$override")
 
-  echo "=== docker compose down --volumes --remove-orphans ==="
+  # --rmi local: also drop the images compose built for this project (they
+  # carry no custom `image:` tag, which is what "local" matches — the pulled
+  # ghcr images keep their separate question below). A locally-built image
+  # that outlives a prune is worse than a stale volume: the next `run`
+  # silently reuses it even after the source tree it was built from has
+  # moved, and the layer cache makes the rebuild cheap anyway.
+  echo "=== docker compose down --volumes --rmi local --remove-orphans ==="
   "${compose_cmd[@]}" \
     --profile front-dev --profile front-built --profile front-ghcr \
     --profile auth-keycloak \
     --profile build --profile seed \
     --profile local-mariadb --profile local-clickhouse \
-    down --volumes --remove-orphans || true
+    down --volumes --rmi local --remove-orphans || true
 
   if [[ -z "$instance" && -d deploy/compose/build ]]; then
     echo "Removing deploy/compose/build/..."

--- a/dev-compose.sh
+++ b/dev-compose.sh
@@ -1124,7 +1124,13 @@ cmd_seed() {
 
   # Run the seed step itself. NOT `exec` — we still want to bounce
   # analytics after silver/all completes (see cf/insight#1307).
-  "${compose_cmd[@]}" --profile seed run --rm seed-sample "${args[@]}"
+  #
+  # --build: `compose run` reuses whatever image the tag currently holds, and a
+  # seed image left over from an older checkout runs the wrong entrypoint from
+  # the wrong directory — it surfaces as an EACCES on /app/manifest.json after
+  # the whole seed has run. The source is bind-mounted anyway, so the rebuild
+  # is layer-cached and only refreshes entrypoint/WORKDIR/deps.
+  "${compose_cmd[@]}" --profile seed run --build --rm seed-sample "${args[@]}"
   local seed_status=$?
   if [[ $seed_status -ne 0 ]]; then
     return $seed_status


### PR DESCRIPTION
## Problem

`compose run` reuses whatever image the local tag currently holds. After the seeder moved from `deploy/seed` to `src/ingestion/tools/seed`, a seed image built from the old tree kept running the old `python seed.py` entrypoint with `WORKDIR /app`. Nothing mounts `/app` anymore, the image tree belongs to its build-time uid while the container runs as the host uid, so the run does all of its seeding work and then dies with a misleading `PermissionError: [Errno 13] /app/manifest.json` — which reads as a read-only-mount problem and isn't one.

`prune` doesn't defend against this either: `down --volumes` never touches images, and the opt-in image-removal question only matches pulled `ghcr.io/constructorfabric/insight-*` images, so locally-built images survive even a full wipe.

## Fix

- `cmd_seed`: run `compose run --build`, so the seed image always tracks the checkout. The source is bind-mounted anyway; the rebuild is layer-cached.
- `cmd_prune`: pass `--rmi local` to `down`, removing exactly the images compose built for the project (no custom `image:` tag). Pulled ghcr images stay behind the existing separate question. Help/confirmation texts updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)