### PR TITLE
fix(dev-compose): prune dangling ghcr pulls by digest

### DIFF
--- a/dev-compose.sh
+++ b/dev-compose.sh
@@ -1283,8 +1283,16 @@ EOF
   # Image removal is a separate question — re-pulling is slow.
   if ask_yes_no "Also remove pulled ghcr.io/constructorfabric/insight-* images?" "n"; then
     local imgs
-    imgs=$(docker images --format '{{.Repository}}:{{.Tag}}' 2>/dev/null \
-           | grep -E '^ghcr\.io/constructorfabric/insight-' || true)
+    # A pull whose tag was since taken over by a newer image is listed as
+    # `repo:<none>` — not a valid reference for `docker rmi`. Address those as
+    # `repo@digest`, which removes only the ghcr association: unlike the image
+    # ID, it leaves any other tag on the same image (the e2e rig's
+    # `*:e2e-prebuilt` retags) in place. Tagged pulls keep the repo:tag form.
+    imgs=$(docker images --digests --format '{{.Repository}}:{{.Tag}} {{.Repository}}@{{.Digest}}' 2>/dev/null \
+           | awk '$1 ~ /^ghcr\.io\/constructorfabric\/insight-/ {
+               if ($1 !~ /:<none>$/)      print $1
+               else if ($2 !~ /@<none>$/) print $2
+             }' || true)
     if [[ -z "$imgs" ]]; then
       echo "  No matching images present."
     else


### PR DESCRIPTION
Follow-up to #2320. The prune's opt-in ghcr image removal builds its list as `{{.Repository}}:{{.Tag}}`, so a pull whose tag was since taken over by a newer image renders as `repo:<none>` — not a valid reference, and `docker rmi` refuses it with `invalid reference format`, leaving the layers behind.

Address untagged pulls as `repo@digest` (via `docker images --digests`) rather than by image ID: the digest reference removes only the ghcr association, so an image the e2e rig also holds under an `*:e2e-prebuilt` retag is untagged from ghcr but keeps its local tag — where an ID reference either refuses ("image is referenced in multiple repositories") or, forced, would tear the local tag down too. Tagged pulls keep the readable `repo:tag` form.

Verified against a daemon holding two dangling insight pulls that were also retagged `e2e-prebuilt`: `docker rmi repo@digest` untagged the ghcr reference and left the local tags in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)