### PR TITLE
feat(gitops): provision grafana_ro with Grafana, not with ingestion

### DIFF
--- a/deploy/gitops/Makefile
+++ b/deploy/gitops/Makefile
@@ -612,10 +612,20 @@ system-alloy: vpn-up kube-ctx
 		$(call _system_values_args,alloy) \
 		--wait --timeout 5m
 
+# Grafana's ClickHouse datasource needs a ClickHouse login, and this is the
+# only place that knows Grafana is being installed at all — the umbrella must
+# not provision it, because ingestion ships to every instance and Grafana does
+# not. Runs after the sealed secrets land (it reads the password from one) and
+# before helm, so the datasource authenticates on first start. Idempotent, and
+# it degrades to a warning rather than failing the install when ClickHouse is
+# external or the password has not been sealed yet.
 .PHONY: system-grafana
 system-grafana: vpn-up kube-ctx
 	@$(call _helm_repo_add,grafana,https://grafana.github.io/helm-charts)
 	$(call _apply_optional_system_secrets,grafana)
+	@echo "$(C_GRN)→$(C_RST) provisioning grafana_ro in ClickHouse"
+	@NAMESPACE=$(NS_INFRA) KUBE_CTX=$(KUBE_CTX) \
+		bash system/grafana/provision-clickhouse-user.sh
 	helm upgrade --install $(GRAFANA_RELEASE) $(GRAFANA_CHART) \
 		--namespace $(NS_INFRA) --create-namespace \
 		--version $(GRAFANA_VERSION) $(HELM_EXTRA_FLAGS) \

--- a/deploy/gitops/system/grafana/SECRETS.md
+++ b/deploy/gitops/system/grafana/SECRETS.md
@@ -1,0 +1,114 @@
+# Grafana — Secrets
+
+Grafana itself needs no credentials to install. This file covers the one
+optional Secret it does read: the ClickHouse login behind the `ClickHouse`
+datasource in `values.yaml`.
+
+## `grafana-clickhouse` — the ClickHouse datasource login
+
+Grafana charts warehouse volume straight out of `bronze_*`, which needs a
+ClickHouse user. It must not be the admin (`clickhouse.auth.username`, which
+holds `CREATE USER` / `DROP TABLE` / `INSERT`) — a dashboard has no business
+carrying any of that. So `make system-grafana` provisions a dedicated
+`grafana_ro`:
+
+```
+make system-grafana
+  ├── apply environments/<env>/sealed-secrets/insight-infra/grafana*-sealedsecret.yaml
+  ├── system/grafana/provision-clickhouse-user.sh   ← role + user in ClickHouse
+  └── helm upgrade --install grafana
+```
+
+**Why here and not in the umbrella chart.** The umbrella already provisions
+ClickHouse users at deploy time (the `presentation` user for analytics), and
+putting `grafana_ro` there would have been less code. It would also have been
+backwards: ingestion ships to every instance, Grafana is optional
+(`inventory.system.grafana`). A cluster without Grafana should carry no
+`grafana_ro`, and the thing that installs Grafana is the thing that should
+create its user.
+
+### Required keys
+
+| Key | Used for |
+|---|---|
+| `username` | the ClickHouse user Grafana connects as — always `grafana_ro` |
+| `password` | its password; the provisioning script sets the same value in ClickHouse |
+
+### Everything is optional, and degrades rather than fails
+
+- no `grafana-clickhouse` Secret → the script provisions the role and no
+  user, Grafana installs, and only the ClickHouse datasource fails its health
+  check. The Loki dashboards are unaffected.
+- ClickHouse not in this namespace (external / managed) → the script says so
+  and skips; provision `grafana_ro` out-of-band with `clickhouse-role.sql`
+  plus a `CREATE USER`, then seal the Secret.
+- admin without `access_management` → same, warns and skips.
+
+So the order of operations does not matter: install Grafana first and seal the
+password later, or the reverse. Re-running `make system-grafana` converges.
+
+### Adding it to an environment
+
+```bash
+# 1. Generate. Alphanumeric on purpose: the script refuses a password with a
+#    quote, backslash or semicolon, because the value rides the SQL body of
+#    the CREATE USER statement.
+GRAFANA_PW="$(openssl rand -base64 30 | tr -d /=+ | head -c 32)"
+
+# 2. Put it in your secret store as insight-<env>-grafana-clickhouse, as
+#    single-line JSON (Passbolt's password field is single-line):
+jq -cn --arg p "$GRAFANA_PW" \
+  '{apiVersion:"v1",kind:"Secret",
+    metadata:{name:"grafana-clickhouse",namespace:"insight-infra"},
+    type:"Opaque",
+    stringData:{username:"grafana_ro",password:$p}}'
+
+# 3. Seal and deploy:
+make seal-secret ENV=<env> NAMESPACE=insight-infra NAME=grafana-clickhouse
+make system-grafana ENV=<env>
+```
+
+### Rotation
+
+Update the secret-store entry, re-seal, re-run `make system-grafana`. The
+script's `ALTER USER` converges ClickHouse to the new password in the same
+run that hands it to Grafana, so there is no window where the two disagree —
+unlike a credential split across two deploy pipelines.
+
+### Verify
+
+```bash
+GRAFANA_PW="$(kubectl -n insight-infra get secret grafana-clickhouse \
+  -o jsonpath='{.data.password}' | base64 -d)"
+
+kubectl -n insight-infra exec clickhouse-shard0-0 -- \
+  clickhouse-client --user grafana_ro --password "$GRAFANA_PW" \
+  -q "SELECT currentUser(), count() FROM system.tables"
+# writes must be refused (expect ACCESS_DENIED):
+kubectl -n insight-infra exec clickhouse-shard0-0 -- \
+  clickhouse-client --user grafana_ro --password "$GRAFANA_PW" \
+  -q "CREATE TABLE default.evil (a Int) ENGINE=Memory"
+```
+
+The grant matrix is pinned by `tests/test_clickhouse_role.py` beside this
+file — opt-in, runs the real script against a throwaway ClickHouse:
+
+```bash
+docker run -d --rm --name ch -p 38211:8123 \
+  -e CLICKHOUSE_USER=insight -e CLICKHOUSE_PASSWORD=insight \
+  -e CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1 \
+  clickhouse/clickhouse-server:25.7.5
+GRAFANA_ROLE_TEST_CH_URL=http://localhost:38211 \
+GRAFANA_ROLE_TEST_CH_USER=insight \
+GRAFANA_ROLE_TEST_CH_PASSWORD=insight \
+  python -m pytest system/grafana/tests -q
+```
+
+### Why the role grants `SELECT ON *.*`
+
+Unlike the umbrella's `presentation_ro`, which enumerates its contract
+databases, `grafana_ro` takes a wildcard. Every connector onboarding creates a
+new `bronze_<name>` database, and a fixed list would silently drop that
+connector out of the dashboards until someone noticed the gap.
+Read-only-by-construction still holds: `SELECT` and `SHOW` are the only
+privileges, so the wildcard only discloses data the dashboards exist to show.

--- a/deploy/gitops/system/grafana/clickhouse-role.sql
+++ b/deploy/gitops/system/grafana/clickhouse-role.sql
@@ -1,0 +1,15 @@
+-- grafana_ro: read-only role for Grafana's ClickHouse datasource, which charts
+-- warehouse load volume from `_airbyte_extracted_at`. Idempotent. Needs an
+-- admin with access_management. The user that carries this role is created by
+-- provision-clickhouse-user.sh (needs a password → not static DDL).
+
+CREATE ROLE IF NOT EXISTS grafana_ro;
+
+-- SELECT on everything rather than an enumerated contract list: every
+-- connector onboarding creates a new `bronze_<name>` database, and a fixed
+-- list would silently drop the new connector out of the dashboards until
+-- someone noticed. Read-only-by-construction still holds — SELECT and SHOW are
+-- the only privileges here, so the wildcard only discloses data the dashboards
+-- exist to display.
+GRANT SELECT ON *.* TO grafana_ro;
+GRANT SHOW   ON *.* TO grafana_ro;

--- a/deploy/gitops/system/grafana/provision-clickhouse-user.sh
+++ b/deploy/gitops/system/grafana/provision-clickhouse-user.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Provision Grafana's ClickHouse access: the read-only `grafana_ro` role
+# (clickhouse-role.sql) plus the grant-less user of the same name that the
+# provisioned datasource connects as. Called by `make system-grafana`.
+#
+# This lives with Grafana rather than with the umbrella's ClickHouse
+# migrations on purpose. Ingestion is always installed; Grafana is optional
+# (inventory.system.grafana). A cluster without Grafana should carry no
+# grafana_ro, and the thing that installs Grafana is the thing that should
+# create it.
+#
+# Idempotent — `make system-grafana` re-runs it on every invocation and it
+# converges an existing user (password and settings) rather than failing.
+#
+# Two modes:
+#   cluster (default) — resolves credentials from Secrets in NAMESPACE and
+#                       reaches ClickHouse through a temporary port-forward
+#   direct            — set CLICKHOUSE_URL (plus USER/PASSWORD/GRAFANA_PASSWORD)
+#                       and no kubectl is used at all; this is the path
+#                       tests/test_clickhouse_role.py drives
+#
+# Env:
+#   CLICKHOUSE_URL              http://host:8123 — enables direct mode
+#   CLICKHOUSE_USER/_PASSWORD   admin, needs access_management
+#   CLICKHOUSE_GRAFANA_PASSWORD the grafana_ro password
+#   NAMESPACE                   cluster mode, default insight-infra
+#   KUBE_CTX                    cluster mode, optional
+#   CH_SECRET/CH_SECRET_KEY     cluster mode, where the admin password lives
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+NAMESPACE="${NAMESPACE:-insight-infra}"
+CH_SECRET="${CH_SECRET:-clickhouse-creds}"
+GRAFANA_SECRET="${GRAFANA_SECRET:-grafana-clickhouse}"
+PORT_FORWARD_PID=""
+
+cleanup() {
+  [[ -z "$PORT_FORWARD_PID" ]] && return 0
+  kill "$PORT_FORWARD_PID" 2>/dev/null || true
+  wait "$PORT_FORWARD_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+kube() { kubectl ${KUBE_CTX:+--context "$KUBE_CTX"} -n "$NAMESPACE" "$@"; }
+
+# Secret value or empty string — a missing Secret is a skip, not a failure.
+secret_value() {
+  kube get secret "$1" -o "jsonpath={.data.$2}" 2>/dev/null | base64 -d 2>/dev/null || true
+}
+
+if [[ -z "${CLICKHOUSE_URL:-}" ]]; then
+  # The admin password key differs between deployments (the shared baseline
+  # names it in system/clickhouse/values.yaml), so read it from there rather
+  # than hardcoding, and let the caller override.
+  if [[ -z "${CH_SECRET_KEY:-}" ]]; then
+    CH_SECRET_KEY="$(yq -r '.auth.existingSecretKey // "admin-password"' \
+      "$SCRIPT_DIR/../clickhouse/values.yaml" 2>/dev/null || echo admin-password)"
+  fi
+  CLICKHOUSE_USER="${CLICKHOUSE_USER:-$(yq -r '.auth.username // "insight"' \
+    "$SCRIPT_DIR/../clickhouse/values.yaml" 2>/dev/null || echo insight)}"
+  CLICKHOUSE_PASSWORD="${CLICKHOUSE_PASSWORD:-$(secret_value "$CH_SECRET" "$CH_SECRET_KEY")}"
+  CLICKHOUSE_GRAFANA_PASSWORD="${CLICKHOUSE_GRAFANA_PASSWORD:-$(secret_value "$GRAFANA_SECRET" password)}"
+
+  if [[ -z "$CLICKHOUSE_PASSWORD" ]]; then
+    echo "  NOTE: no $CH_SECRET/$CH_SECRET_KEY in $NAMESPACE; skipping grafana_ro provisioning"
+    exit 0
+  fi
+  if ! kube get svc clickhouse >/dev/null 2>&1; then
+    echo "  NOTE: no svc/clickhouse in $NAMESPACE (external ClickHouse?); skipping grafana_ro provisioning"
+    echo "        Provision it out-of-band — see system/grafana/SECRETS.md."
+    exit 0
+  fi
+
+  # An ephemeral local port: the operator's machine may already be forwarding
+  # something, and this must not collide with a long-lived tunnel.
+  LOCAL_PORT="${LOCAL_PORT:-$(( 20000 + RANDOM % 20000 ))}"
+  # Deliberately not through the `kube` helper: backgrounding a shell function
+  # makes $! the subshell's pid, and the real kubectl survives as its child —
+  # the tunnel then outlives this script.
+  kubectl ${KUBE_CTX:+--context "$KUBE_CTX"} -n "$NAMESPACE" \
+    port-forward svc/clickhouse "${LOCAL_PORT}:8123" >/dev/null 2>&1 &
+  PORT_FORWARD_PID=$!
+  CLICKHOUSE_URL="http://127.0.0.1:${LOCAL_PORT}"
+
+  for _ in $(seq 1 40); do
+    curl -sf -o /dev/null "${CLICKHOUSE_URL}/ping" && break
+    sleep 0.25
+  done
+  if ! curl -sf -o /dev/null "${CLICKHOUSE_URL}/ping"; then
+    echo "  ERROR: port-forward to svc/clickhouse in $NAMESPACE never became ready"
+    exit 1
+  fi
+fi
+
+: "${CLICKHOUSE_USER:?CLICKHOUSE_USER must be set}"
+: "${CLICKHOUSE_PASSWORD:?CLICKHOUSE_PASSWORD must be set}"
+
+ch_query() {
+  curl -sS --fail-with-body "${CLICKHOUSE_URL}/" \
+    -H "X-ClickHouse-User: ${CLICKHOUSE_USER}" \
+    -H "X-ClickHouse-Key: ${CLICKHOUSE_PASSWORD}" \
+    --data-binary @-
+}
+
+# Statement-at-a-time: the HTTP interface takes one per request.
+ch_script() {
+  local statement
+  while IFS= read -r -d ';' statement; do
+    [[ -z "${statement//[[:space:]]/}" ]] && continue
+    printf '%s' "$statement" | ch_query >/dev/null
+  done
+}
+
+# CREATE ROLE fails without access_management.
+if ! printf 'CREATE ROLE IF NOT EXISTS grafana_ro' | ch_query >/dev/null 2>&1; then
+  echo "  WARN: ClickHouse admin lacks access_management; skipping grafana_ro"
+  exit 0
+fi
+
+grep -v '^[[:space:]]*--' "$SCRIPT_DIR/clickhouse-role.sql" | ch_script
+echo "  grafana_ro role ready"
+
+if [[ -z "${CLICKHOUSE_GRAFANA_PASSWORD:-}" ]]; then
+  echo "  NOTE: no $GRAFANA_SECRET/password; role only, no user"
+  echo "        Grafana's ClickHouse datasource will fail its health check until"
+  echo "        that Secret exists — see system/grafana/SECRETS.md."
+  exit 0
+fi
+
+# The password rides the SQL body, so reject characters that could break out of
+# the IDENTIFIED BY '...' literal.
+case "${CLICKHOUSE_GRAFANA_PASSWORD}" in
+  *"'"* | *"\\"* | *";"*)
+    echo "  WARN: grafana_ro password has a quote/backslash/semicolon; skipping user (use alphanumeric)"
+    exit 0
+    ;;
+esac
+
+# Grant-less user: every privilege arrives via grafana_ro. readonly=2 is
+# belt-and-braces on top of the SELECT-only role — it blocks writes and DDL at
+# the settings level while still allowing SET, which the Grafana ClickHouse
+# plugin needs. max_execution_time matches the datasource's queryTimeout in
+# values.yaml, so a runaway panel query dies here instead of outliving the HTTP
+# request that already gave up on it.
+USER_SETTINGS="readonly = 2, max_execution_time = 60, max_result_rows = 2000000, result_overflow_mode = 'throw'"
+
+ch_script <<SQL
+CREATE USER IF NOT EXISTS grafana_ro IDENTIFIED BY '${CLICKHOUSE_GRAFANA_PASSWORD}' SETTINGS ${USER_SETTINGS};
+ALTER USER grafana_ro IDENTIFIED BY '${CLICKHOUSE_GRAFANA_PASSWORD}' SETTINGS ${USER_SETTINGS};
+GRANT grafana_ro TO grafana_ro;
+ALTER USER grafana_ro DEFAULT ROLE grafana_ro;
+SQL
+echo "  grafana_ro user ready"

--- a/deploy/gitops/system/grafana/tests/test_clickhouse_role.py
+++ b/deploy/gitops/system/grafana/tests/test_clickhouse_role.py
@@ -1,0 +1,171 @@
+"""Opt-in integration test: the `grafana_ro` role grant matrix.
+
+Pins the read-only guarantee for Grafana's ClickHouse datasource against a real
+ClickHouse: run provision-clickhouse-user.sh in direct mode, then assert the
+user it creates can read every database — including a `bronze_*` created after
+the grant, which is the whole reason the grant is a wildcard — and cannot
+write, alter or drop anything anywhere.
+
+Skipped unless a server is offered, so CI and local `pytest` stay dependency-
+free. The admin must have access_management (to CREATE ROLE / CREATE USER):
+
+    docker run -d --rm --name ch -p 38211:8123 \\
+        -e CLICKHOUSE_USER=insight -e CLICKHOUSE_PASSWORD=insight \\
+        -e CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1 \\
+        clickhouse/clickhouse-server:25.7.5
+    GRAFANA_ROLE_TEST_CH_URL=http://localhost:38211 \\
+    GRAFANA_ROLE_TEST_CH_USER=insight \\
+    GRAFANA_ROLE_TEST_CH_PASSWORD=insight \\
+        python -m pytest deploy/gitops/system/grafana/tests -q
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+CH_URL = os.environ.get("GRAFANA_ROLE_TEST_CH_URL")
+CH_USER = os.environ.get("GRAFANA_ROLE_TEST_CH_USER", "default")
+CH_PASSWORD = os.environ.get("GRAFANA_ROLE_TEST_CH_PASSWORD", "")
+
+pytestmark = pytest.mark.skipif(not CH_URL, reason="set GRAFANA_ROLE_TEST_CH_URL (admin with access_management) to run")
+
+PROVISION_SCRIPT = Path(__file__).resolve().parent.parent / "provision-clickhouse-user.sh"
+
+GRAFANA_USER = "grafana_ro"
+GRAFANA_PASSWORD = "grafanaRoTest1"
+
+# `silver` and `insight` stand in for the fixed databases; the bronze ones
+# exercise the wildcard grant — LATE_DB is created after the role is granted,
+# which an enumerated grant list would miss.
+SEEDED_DBS = ("silver", "insight", "bronze_probe")
+LATE_DB = "bronze_onboarded_later"
+
+
+def _query(sql: str, *, user: str, password: str) -> tuple[bool, str]:
+    """POST one statement over the HTTP interface. Returns (ok, body)."""
+    url = CH_URL.rstrip("/") + "/"
+    # Pin the scheme: urllib honours file:// etc. CH_URL is an operator-supplied
+    # test endpoint, but reject anything but http(s) so a stray value can't read
+    # local files.
+    if urllib.parse.urlparse(url).scheme not in ("http", "https"):
+        raise ValueError(f"GRAFANA_ROLE_TEST_CH_URL must be http(s), got {CH_URL!r}")
+    req = urllib.request.Request(
+        url, data=sql.encode(), headers={"X-ClickHouse-User": user, "X-ClickHouse-Key": password}
+    )
+    try:
+        # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
+        with urllib.request.urlopen(req) as resp:  # noqa: S310 (scheme pinned to http(s) above)
+            return True, resp.read().decode()
+    except urllib.error.HTTPError as e:
+        return False, e.read().decode()
+
+
+def _admin(sql: str) -> tuple[bool, str]:
+    return _query(sql, user=CH_USER, password=CH_PASSWORD)
+
+
+def _seed(db: str) -> None:
+    assert _admin(f"CREATE DATABASE IF NOT EXISTS {db}")[0]
+    assert _admin(f"CREATE TABLE IF NOT EXISTS {db}.probe (x UInt8) ENGINE=MergeTree ORDER BY x")[0]
+    assert _admin(f"INSERT INTO {db}.probe VALUES (1)")[0]
+
+
+def _provision(*, with_password: bool) -> subprocess.CompletedProcess[str]:
+    """Run the script in direct mode — CLICKHOUSE_URL set, so it never touches kubectl."""
+    env = {**os.environ, "CLICKHOUSE_URL": CH_URL, "CLICKHOUSE_USER": CH_USER, "CLICKHOUSE_PASSWORD": CH_PASSWORD}
+    if with_password:
+        env["CLICKHOUSE_GRAFANA_PASSWORD"] = GRAFANA_PASSWORD
+    else:
+        env.pop("CLICKHOUSE_GRAFANA_PASSWORD", None)
+    return subprocess.run(["bash", str(PROVISION_SCRIPT)], env=env, capture_output=True, text=True, timeout=60)
+
+
+@pytest.fixture(scope="module")
+def grafana_user():
+    if not (shutil.which("bash") and shutil.which("curl")):
+        pytest.skip("provision-clickhouse-user.sh needs bash + curl")
+
+    for db in SEEDED_DBS:
+        _seed(db)
+
+    result = _provision(with_password=True)
+    assert result.returncode == 0, f"provisioning failed: {result.stdout}\n{result.stderr}"
+    assert "grafana_ro user ready" in result.stdout, result.stdout
+
+    def _query_as_grafana(sql: str) -> tuple[bool, str]:
+        return _query(sql, user=GRAFANA_USER, password=GRAFANA_PASSWORD)
+
+    try:
+        yield _query_as_grafana
+    finally:
+        for db in (*SEEDED_DBS, LATE_DB):
+            _admin(f"DROP DATABASE IF EXISTS {db}")
+        _admin(f"DROP USER IF EXISTS {GRAFANA_USER}")
+
+
+@pytest.mark.parametrize("db", SEEDED_DBS)
+def test_every_database_is_readable(grafana_user, db: str) -> None:
+    assert grafana_user(f"SELECT count() FROM {db}.probe")[0], f"{db} SELECT must be allowed"
+
+
+def test_database_created_after_the_grant_is_readable(grafana_user) -> None:
+    """A connector onboarded after provisioning must not need a re-grant — the
+    reason grafana_ro holds SELECT ON *.* rather than an enumerated list."""
+    _seed(LATE_DB)
+    assert grafana_user(f"SELECT count() FROM {LATE_DB}.probe")[0]
+
+
+@pytest.mark.parametrize("db", SEEDED_DBS)
+def test_writes_are_refused_everywhere(grafana_user, db: str) -> None:
+    for sql in (
+        f"INSERT INTO {db}.probe VALUES (2)",
+        f"DROP TABLE {db}.probe",
+        f"ALTER TABLE {db}.probe ADD COLUMN y UInt8",
+        f"TRUNCATE TABLE {db}.probe",
+        f"CREATE TABLE {db}.evil (x UInt8) ENGINE=MergeTree ORDER BY x",
+    ):
+        ok, resp = grafana_user(sql)
+        assert not ok, f"{db} must reject: {sql!r}"
+        assert "ACCESS_DENIED" in resp or "READONLY" in resp, resp
+
+
+def test_cannot_escalate_its_own_access(grafana_user) -> None:
+    """readonly=2 plus a SELECT-only role: no access management, and no lifting
+    the readonly setting for the session."""
+    for sql in ("CREATE USER escalated IDENTIFIED BY 'x'", "GRANT INSERT ON *.* TO grafana_ro", "SET readonly = 0"):
+        ok, _ = grafana_user(sql)
+        assert not ok, f"must reject: {sql!r}"
+
+
+def test_rerun_converges_an_existing_user(grafana_user) -> None:
+    """`make system-grafana` re-runs this on every deploy, against a cluster
+    where the user already exists."""
+    result = _provision(with_password=True)
+    assert result.returncode == 0, f"re-run failed: {result.stdout}\n{result.stderr}"
+    assert grafana_user("SELECT 1")[0], "user must still authenticate after a re-run"
+
+
+def test_role_only_when_password_unset() -> None:
+    """No grafana-clickhouse Secret yet → the role exists and the user does not,
+    so installing Grafana before sealing the password degrades rather than fails."""
+    assert _admin(f"DROP USER IF EXISTS {GRAFANA_USER}")[0]
+
+    result = _provision(with_password=False)
+    assert result.returncode == 0, result.stderr
+    assert "role only" in result.stdout, result.stdout
+
+    try:
+        ok, users = _admin(f"SELECT count() FROM system.users WHERE name = '{GRAFANA_USER}'")
+        assert ok and users.strip() == "0", f"user must not be created: {users!r}"
+        ok, roles = _admin(f"SELECT count() FROM system.roles WHERE name = '{GRAFANA_USER}'")
+        assert ok and roles.strip() == "1", f"role must exist: {roles!r}"
+    finally:
+        _admin(f"DROP ROLE IF EXISTS {GRAFANA_USER}")

--- a/deploy/gitops/system/grafana/values.yaml
+++ b/deploy/gitops/system/grafana/values.yaml
@@ -33,8 +33,37 @@ persistence:
 initChownData:
   enabled: false
 
+# ─── Plugins ────────────────────────────────────────────────────────────
+# Downloaded from grafana.com by the chart's init container on every pod
+# start (there is no PVC — see above), so the pod needs egress to
+# grafana.com. On an air-gapped cluster, bake them into a custom image
+# instead and drop this block.
+plugins:
+  - grafana-clickhouse-datasource
+
+# ─── Datasource credentials ─────────────────────────────────────────────
+# The ClickHouse password comes from the `grafana-clickhouse` Secret, which
+# `make system-grafana` applies from
+# environments/<env>/sealed-secrets/insight-infra/ (the optional-secrets
+# helper globs grafana*-sealedsecret.yaml) and whose ClickHouse-side user is
+# created by system/grafana/provision-clickhouse-user.sh in the same target.
+# Grafana expands $CLICKHOUSE_PASSWORD in the provisioning file below, so no
+# secret lands in this repo. Both are optional: without them the ClickHouse
+# datasource simply fails its health check and the Loki dashboards carry on.
+envValueFrom:
+  CLICKHOUSE_USER:
+    secretKeyRef:
+      name: grafana-clickhouse
+      key: username
+      optional: true
+  CLICKHOUSE_PASSWORD:
+    secretKeyRef:
+      name: grafana-clickhouse
+      key: password
+      optional: true
+
 # Loki wired as the default datasource so Explore works out of the box.
-# Fixed uid so provisioned dashboards can reference it. Tempo/Mimir get
+# Fixed uids so provisioned dashboards can reference them. Tempo/Mimir get
 # added here in the tracing/metrics phases; `derivedFields` will then map
 # `trace_id` → a Tempo link for log↔trace correlation.
 datasources:
@@ -49,6 +78,30 @@ datasources:
         isDefault: true
         jsonData:
           maxLines: 1000
+
+      # The warehouse itself, for dashboards that chart data volume rather
+      # than pod behaviour — row counts bucketed by `_airbyte_extracted_at`,
+      # which no log or container metric can answer. Native protocol (9000)
+      # rather than HTTP (8123): both are exposed by svc/clickhouse, native
+      # is cheaper for the wide GROUP BY scans those panels do. The
+      # grafana_ro user is SELECT-only with readonly=2 and a matching 60s
+      # server-side timeout — see system/grafana/SECRETS.md.
+      - name: ClickHouse
+        uid: clickhouse
+        type: grafana-clickhouse-datasource
+        access: proxy
+        isDefault: false
+        jsonData:
+          host: clickhouse.insight-infra.svc.cluster.local
+          port: 9000
+          protocol: native
+          secure: false
+          username: $CLICKHOUSE_USER
+          tlsSkipVerify: false
+          dialTimeout: 10
+          queryTimeout: 60
+        secureJsonData:
+          password: $CLICKHOUSE_PASSWORD
 
 # ─── Dashboards as code ─────────────────────────────────────────────────
 # Provisioned into the "Insight" folder. Sources are LOG-based (LogQL over


### PR DESCRIPTION
Grafana's ClickHouse datasource needs a ClickHouse login to chart connector load volume out of `bronze_*` — the connector dashboards can say whether a sync ran and what it cost, but nothing except the warehouse can say whether it moved any data. That login must not be the admin user, which holds `CREATE USER` / `DROP TABLE` / `INSERT`.

> **Rewritten.** The first version of this PR created the user from the umbrella's clickhouse-migrate Hook, next to `presentation` (#1963/#1964) — less code, wrong dependency direction. Ingestion ships to every instance; Grafana is optional (`inventory.system.grafana`). A cluster without Grafana should carry no `grafana_ro`, and nothing under `src/ingestion` should exist because of a dashboard. This version touches neither `src/ingestion` nor `charts/`.

## Shape

Grafana owns its own user. `make system-grafana` gains one step:

```
make system-grafana
  ├── apply environments/<env>/sealed-secrets/insight-infra/grafana*-sealedsecret.yaml
  ├── system/grafana/provision-clickhouse-user.sh   ← role + user in ClickHouse
  └── helm upgrade --install grafana
```

| File | Role |
|---|---|
| `system/grafana/clickhouse-role.sql` | role + grants |
| `system/grafana/provision-clickhouse-user.sh` | the grant-less user |
| `system/grafana/SECRETS.md` | operator contract |
| `system/grafana/tests/test_clickhouse_role.py` | grant-matrix pin |

The ordering is deliberate: the Secret lands first (the script reads the password from it), the user exists before helm, so the datasource authenticates on first start rather than after a restart.

## Everything degrades, nothing fails

- no `grafana-clickhouse` Secret → role, no user
- external / managed ClickHouse → skips with a note
- admin without `access_management` → skips with a warning

In each case Grafana installs and only its ClickHouse datasource is unhealthy; the Loki dashboards are untouched. Re-running converges. Both `envValueFrom` keys are `optional`, so a missing Secret is a degraded datasource rather than a pod that will not start.

## Why the role grants `SELECT ON *.*`

Unlike `presentation_ro`, which enumerates its contract databases, this one takes a wildcard: every connector onboarding creates a new `bronze_<name>`, and a fixed list would silently drop that connector out of the dashboards until someone noticed. Read-only-by-construction still holds — `SELECT` and `SHOW` are the only privileges, and the wildcard only discloses data the dashboards exist to display. On top of the role the user carries `readonly = 2` and `max_execution_time = 60`, matching the datasource's `queryTimeout`.

## Verification

The script has two modes so it stays testable: cluster mode resolves credentials from Secrets and reaches ClickHouse over a temporary port-forward; setting `CLICKHOUSE_URL` bypasses kubectl entirely. `tests/test_clickhouse_role.py` drives the second — 10 tests, green against ClickHouse 25.7.5:

- every database is readable
- **a database created *after* the grant is readable** — the point of the wildcard
- every write and DDL refused, in every database
- self-escalation refused, including `SET readonly = 0`
- a re-run converges an existing user
- the role-only path when no password is supplied

Cluster mode was run against a live stand, and it earned its keep: the port-forward leaked. Backgrounding a shell function makes `$!` the subshell's pid, so the real `kubectl` survived as its child and the tunnel outlived the script. It now invokes `kubectl` directly. That path is not covered by the tests — only the live run found it.

## Operator side

insight-gitops!67 carries the same four files for the internal deployment, plus the dashboards and panels that use the datasource.

Not ported here: the five extra dashboards and the loaded-volume panels live only in the internal copy for now. This PR adds the mechanism (plugin, datasource, user), not the content.
