### PR TITLE
fix(reconcile): read the migrated definition id back from Airbyte

### DIFF
--- a/src/ingestion/reconcile-connectors/lib/reconcile.sh
+++ b/src/ingestion/reconcile-connectors/lib/reconcile.sh
@@ -244,6 +244,25 @@ reconcile_classify_change() {
 _RECONCILE_MANIFEST_REPO="airbyte/source-declarative-manifest"
 
 # ---------------------------------------------------------------------------
+# reconcile_find_custom_definition_id <workspace_id> <connector_name>
+#
+# The id of the Insight-managed (custom, per ADR-0009) source definition holding
+# this connector's name, or empty. Emits nothing but the id, so it is safe to
+# read with a command substitution — unlike anything that logs, since log_line
+# writes its JSON to stdout.
+# ---------------------------------------------------------------------------
+reconcile_find_custom_definition_id() {
+  local workspace_id="$1" connector_name="$2"
+  ab_list_definitions "${workspace_id}" | python3 -c '
+import sys, json
+target = sys.argv[1]
+for d in json.load(sys.stdin):
+    if d.get("name") == target and d.get("custom") is True:
+        print(d.get("sourceDefinitionId", "")); break
+' "${connector_name}"
+}
+
+# ---------------------------------------------------------------------------
 # reconcile_migrated_state_file <source_name>
 #
 # Path of the state backup taken when reconcile_migrate_definition_kind tore a
@@ -375,7 +394,6 @@ for s in json.load(sys.stdin):
 
   reconcile__log CHANGE "${connector_name}" \
     "migrated to cdk definition ${new_def_id} (${docker_repo}:${docker_tag}); source and connection are rebuilt by the later stages"
-  printf '%s' "${new_def_id}"
 }
 
 # ---------------------------------------------------------------------------
@@ -435,16 +453,7 @@ reconcile_definitions() {
   # @cpt-begin:cpt-insightspec-algo-reconcile-diff-definition-version:p1:inst-ddv-if-none
   local workspace_id
   workspace_id="$(ab_workspace_id)"
-  local defs_json
-  defs_json="$(ab_list_definitions "${workspace_id}")"
-  # custom is True: Insight namespace separation per ADR-0009.
-  definition_id="$(printf '%s' "${defs_json}" | python3 -c '
-import sys, json
-target = sys.argv[1]
-for d in json.load(sys.stdin):
-    if d.get("name") == target and d.get("custom") is True:
-        print(d.get("sourceDefinitionId", "")); break
-' "${connector_name}")"
+  definition_id="$(reconcile_find_custom_definition_id "${workspace_id}" "${connector_name}")"
 
   if [[ -z "${definition_id}" ]]; then
     if [[ "${type}" == "nocode" ]]; then
@@ -621,10 +630,20 @@ for d in json.load(sys.stdin):
         printf 'republish\tpatch\t%s\n' "${definition_id}"
         return 0
       fi
-      local migrated_def_id
-      if ! migrated_def_id="$(reconcile_migrate_definition_kind \
-            "${connector_name}" "${definition_id}" "${cdk_image}")"; then
+      # Called directly, never through a command substitution: it logs, and
+      # log_line writes JSON to stdout, so capturing it would swallow the log
+      # lines into the value. The new id is read back from Airbyte afterwards,
+      # which also confirms the definition really does hold the name now.
+      if ! reconcile_migrate_definition_kind \
+            "${connector_name}" "${definition_id}" "${cdk_image}"; then
         reconcile__log ERROR "${connector_name}" "definition migration failed"
+        return 1
+      fi
+      local migrated_def_id
+      migrated_def_id="$(reconcile_find_custom_definition_id "${workspace_id}" "${connector_name}")"
+      if [[ -z "${migrated_def_id}" ]]; then
+        reconcile__log ERROR "${connector_name}" \
+          "migration reported success but no definition holds the name — the next pass republishes it as a first publish"
         return 1
       fi
       _RECONCILE_CHANGED=$((_RECONCILE_CHANGED + 1))


### PR DESCRIPTION
## Problem

The manifest-backed → CDK definition migration added in #2287 returned the new
definition id on stdout while also logging. `reconcile__log` sends its human line
to stderr, but it also calls `log_line`, which writes the structured JSON to
**stdout** — so the caller's command substitution captured the log lines and the
id together.

`reconcile_definitions` then emitted:

```
republish	patch	{"ts":"…","msg":"deleted source …"}
{"ts":"…","msg":"migrated to cdk definition …"}
d5cdc25a-…
```

`_reconcile_one_connector` parses that with `tail -1 | awk -F'\t' '{print $3}'`.
The last line is the bare id with no tabs, so field 3 is empty, and the run took
the `definition not ready — skipping source and connection setup` branch.

The migration itself had already completed: the old source and definition were
deleted and the CDK definition registered. The connector was left with a valid
definition but **no source and no connection** until a later pass rebuilt them.

Existing functions avoid this because their final `printf` *is* the TSV line, so
`tail -1` lands on it. This one emitted a bare trailing value instead.

## Fix

- Call `reconcile_migrate_definition_kind` directly rather than through a command
  substitution, so its logs go where every other stage's logs go.
- Read the new id back with `reconcile_find_custom_definition_id`, which emits
  nothing but the id. This also confirms a definition really holds the name before
  the caller commits to it, rather than trusting an in-memory value.
- An empty lookup now fails the connector instead of reporting success with no id.

The lookup is the same query `reconcile_definitions` already ran inline at the top;
it is now a shared helper instead of duplicated.

## Verification

The old and new shapes side by side, against the exact production sequence:

```
OLD def_id = []
NEW def_id = [d5cdc25a-143e-47a2-89b2-91af8aa8ba66]
empty-id case: returns failure (good)
```

`bash -n` clean; dry-run coverage audit unchanged at its existing baseline.

Swept the rest of the file for the same shape — a function that logs *and* returns
a value on stdout. `reconcile_resolve_destination_id` is the only other candidate
and is safe: it logs only on the error path, where callers discard the value and
bail. Every other stage terminates in a TSV line.

## Note

`shellcheck` could not be run in this environment (no Docker daemon available), so
it is not part of the evidence above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reconciliation of custom connector definitions.
  * Added validation to ensure migrated definitions are available before proceeding.
  * Improved migration logging and follow-up verification for more reliable setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->