### PR TITLE
chore: remove leftover .NET traces from CI and docker context

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,6 +1,6 @@
 name: Semgrep SAST
 
-# SAST, report-only (#2020). `--config auto` plus p/rust and p/csharp, which auto covers thinly.
+# SAST, report-only (#2020). `--config auto` plus p/rust, which auto covers thinly.
 # Secrets are excluded here — trufflehog.yml owns them.
 
 on:
@@ -50,7 +50,6 @@ jobs:
             semgrep scan \
               --config auto \
               --config p/rust \
-              --config p/csharp \
               --exclude-rule generic.secrets.security.detected-generic-secret \
               --sarif --output semgrep.sarif
 
@@ -69,7 +68,6 @@ jobs:
             semgrep scan \
               --config auto \
               --config p/rust \
-              --config p/csharp \
               --exclude-rule generic.secrets.security.detected-generic-secret \
               --error \
               --baseline-commit "$BASE_SHA"
@@ -97,7 +95,7 @@ jobs:
           rules = collections.Counter(x.get("ruleId", "?").split(".")[-1] for x in res)
           w = out.write
           w("## Semgrep SAST (report-only)\n\n")
-          w(f"**{total}** finding(s) from `auto` + `p/rust`/`p/csharp` (secrets excluded — TruffleHog owns those). "
+          w(f"**{total}** finding(s) from `auto` + `p/rust` (secrets excluded — TruffleHog owns those). "
             f"This check does **not** block; full details in [Security -> Code scanning]({cs_url}).\n\n")
           if total:
               w("| Severity | Count |\n|---|---:|\n")

--- a/src/backend/.dockerignore
+++ b/src/backend/.dockerignore
@@ -1,23 +1,13 @@
-# Build context = src/backend/ for all three backend services
-# (api-gateway, analytics, identity). This file mirrors the union of
-# the per-service ignore patterns. Without it, host build artifacts leak
-# into the image and Linux builds fail on Windows-built `project.assets.json`
-# or stale Rust target trees.
+# Build context = src/backend/ for all backend services. Without it, host
+# build artifacts leak into the image and Linux builds fail on stale Rust
+# target trees.
 
 # Rust
 **/target
 
-# .NET — critical: leaking Windows bin/obj breaks `dotnet publish` with
-# "Unable to find fallback package folder 'C:\Program Files (x86)\...'".
-**/bin
-**/obj
-
 # IDE state
-**/.vs
 **/.vscode
 **/.idea
-**/*.user
-**/*.suo
 
 # VCS / Docker / repo hygiene
 **/.git
@@ -26,7 +16,6 @@
 **/Dockerfile*
 
 # Caches and node_modules
-**/TestResults
 **/.cache
 **/node_modules
 


### PR DESCRIPTION
The .NET identity service is fully decommissioned and no C# code remains in the repository, but two pieces of tooling still assumed it existed:

- **semgrep workflow**: drop the `p/csharp` ruleset from both scan passes (nothing left for it to match) and update the comment/summary text accordingly.
- **`src/backend/.dockerignore`**: remove the .NET `bin`/`obj` block, Visual Studio state (`.vs`, `*.user`, `*.suo`), and `TestResults`, and fix the stale header that still described the build context as serving the retired api-gateway/analytics/identity trio.

Deliberately **not** touched (load-bearing history/parity documentation): the identity-resolution migration parity comments and frozen `sql/001–013` scripts, the e2e capability shims in `tests/e2e/lib/identity.py`, and historical mentions in specs/ADRs.

Known remaining .NET residue, out of scope here: the committed identity OpenAPI contract is still the .NET document (blocked on identity-resolution growing an `openapi` subcommand, as authenticator did in #2000), and `migration/mod.rs` still states the additive-only-until-decommission rollback policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)