### PR TITLE
fix(analytics): deny metric evidence export for unseen persons

### DIFF
--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -1799,6 +1799,16 @@
             },
             "description": "Unauthorized"
           },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
           "404": {
             "content": {
               "application/problem+json": {

--- a/src/backend/services/analytics/src/api/http_live_tests.rs
+++ b/src/backend/services/analytics/src/api/http_live_tests.rs
@@ -157,6 +157,26 @@ fn metric_results_body(person_ids: &[Uuid]) -> Value {
     })
 }
 
+fn drilldown_body(person_id: Uuid) -> Value {
+    json!({
+        "metric_key": "git.commits",
+        "entity": {"type": "person", "id": person_id.to_string()},
+        "period": {"from": "2026-07-01", "to": "2026-07-28"},
+        "limit": 100
+    })
+}
+
+fn drilldown_export_body(person_id: Uuid) -> Value {
+    json!({
+        "metric_key": "git.commits",
+        "entity": {"type": "person", "id": person_id.to_string()},
+        "period": {"from": "2026-07-01", "to": "2026-07-28"},
+        "filters": [],
+        "display_dimensions": [],
+        "format": "csv"
+    })
+}
+
 /// Seed a `SecurityContext` (subject + tenant) the way `authverify` would.
 async fn inject_host_context(
     axum::extract::State(tenant): axum::extract::State<Uuid>,
@@ -249,6 +269,59 @@ async fn metric_results_does_not_deny_a_person_inside_the_callers_visible_set() 
         StatusCode::INTERNAL_SERVER_ERROR,
         "a visible person must pass the gate and fail only on the unreachable \
          ClickHouse; a 400 would mean the request never got that far"
+    );
+    Ok(())
+}
+
+// Both drilldown routes gate before validation, so neither test needs a
+// `DrilldownFixture`: the metric definition is never loaded. A 404 here would
+// mean the gate had moved back behind validation.
+
+#[tokio::test]
+#[ignore = "requires live MariaDB (INTEGRATION_TESTS_MARIADB_URL)"]
+async fn metric_drilldown_forbids_a_person_outside_the_callers_visible_set() -> TestResult {
+    let Some(db) = connect_or_skip().await else {
+        return Ok(());
+    };
+    let identity = spawn_identity(&[VISIBLE_PERSON]).await?;
+    let app = app_with_identity(db, Uuid::now_v7(), identity);
+
+    let req = json_req(
+        "POST",
+        "/v1/metric-drilldown",
+        &drilldown_body(HIDDEN_PERSON),
+    )?;
+    let resp = app.oneshot(req).await?;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "a person the caller cannot see must not resolve to evidence rows"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires live MariaDB (INTEGRATION_TESTS_MARIADB_URL)"]
+async fn metric_drilldown_export_forbids_a_person_outside_the_callers_visible_set() -> TestResult {
+    let Some(db) = connect_or_skip().await else {
+        return Ok(());
+    };
+    let identity = spawn_identity(&[VISIBLE_PERSON]).await?;
+    let app = app_with_identity(db, Uuid::now_v7(), identity);
+
+    let req = json_req(
+        "POST",
+        "/v1/metric-drilldown/export",
+        &drilldown_export_body(HIDDEN_PERSON),
+    )?;
+    let resp = app.oneshot(req).await?;
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "the export route serves the same per-person evidence as the page route \
+         and must deny the same callers"
     );
     Ok(())
 }
@@ -548,11 +621,15 @@ async fn metric_drilldown_validates_selection_before_clickhouse_error() -> TestR
         return Ok(());
     };
     let fixture = DrilldownFixture::insert(&db, &["git.commits"], &["repository"]).await?;
+    let identity = spawn_identity(&[VISIBLE_PERSON]).await?;
     let result: anyhow::Result<()> = async {
-        let app = app(db.clone(), fixture.tenant_id);
+        // A visible person: the gate admits, so what these assertions pin is
+        // validation reaching the unreachable ClickHouse snapshot probe. A 403
+        // would mean the gate denied a person it was told is visible.
+        let app = app_with_identity(db.clone(), fixture.tenant_id, identity);
         let body = json!({
             "metric_key": "git.commits",
-            "entity": {"type": "person", "id": "019e2830-0000-7000-8000-000000000001"},
+            "entity": {"type": "person", "id": VISIBLE_PERSON.to_string()},
             "period": {"from": "2026-07-01", "to": "2026-07-28"},
             "filters": [{"dimension": "repository", "values": ["org/repo"]}],
             "display_dimensions": ["repository"],
@@ -563,6 +640,17 @@ async fn metric_drilldown_validates_selection_before_clickhouse_error() -> TestR
             .oneshot(json_req("POST", "/v1/metric-drilldown", &body)?)
             .await?;
         anyhow::ensure!(resp.status() == StatusCode::BAD_REQUEST);
+        let resp = app
+            .clone()
+            .oneshot(json_req(
+                "POST",
+                "/v1/metric-drilldown/export",
+                &drilldown_export_body(VISIBLE_PERSON),
+            )?)
+            .await?;
+        anyhow::ensure!(resp.status() == StatusCode::BAD_REQUEST);
+        // The pre-cutover email shape fails in the entity parse, which runs
+        // ahead of the gate — so it stays a 400 rather than becoming a 403.
         let export = json!({
             "metric_key": "git.commits",
             "entity": {"type": "person", "id": "person@example.com"},
@@ -588,7 +676,11 @@ async fn metric_drilldown_rejects_invalid_selection_without_clickhouse() -> Test
     let Some(db) = connect_or_skip().await else {
         return Ok(());
     };
-    let app = app(db, Uuid::now_v7());
+    // Only the reversed-period case carries a parseable person id and so reaches
+    // the gate; the rest fail in the entity parse ahead of it. The identity has
+    // to be real either way, or that one case would fail closed with a 500.
+    let identity = spawn_identity(&[VISIBLE_PERSON]).await?;
+    let app = app_with_identity(db, Uuid::now_v7(), identity);
     for body in [
         json!({
             "metric_key": "git.commits",
@@ -604,7 +696,7 @@ async fn metric_drilldown_rejects_invalid_selection_without_clickhouse() -> Test
         }),
         json!({
             "metric_key": "git.commits",
-            "entity": {"type": "person", "id": "019e2830-0000-7000-8000-000000000001"},
+            "entity": {"type": "person", "id": VISIBLE_PERSON.to_string()},
             "period": {"from": "2026-07-28", "to": "2026-07-01"},
             "limit": 100
         }),

--- a/src/backend/services/analytics/src/api/metric_drilldown.rs
+++ b/src/backend/services/analytics/src/api/metric_drilldown.rs
@@ -5,7 +5,7 @@ use axum::Json;
 use axum::body::Body;
 use axum::extract::Extension;
 use axum::http::header::{CONTENT_DISPOSITION, CONTENT_TYPE};
-use axum::http::{HeaderValue, Response};
+use axum::http::{HeaderMap, HeaderValue, Response};
 use tokio::sync::Semaphore;
 use toolkit_canonical_errors::CanonicalError;
 use toolkit_security::SecurityContext;
@@ -14,11 +14,12 @@ use super::AppState;
 use crate::api::error::MetricError;
 use crate::domain::metric_drilldown::{
     EVIDENCE_QUERY_TIMEOUT_SECS, EvidenceQueryRow, MAX_EXPORT_BYTES, MAX_EXPORT_ROWS,
-    MetricDrilldownColumn, MetricDrilldownExportFormat, MetricDrilldownExportRequest,
-    MetricDrilldownRequest, MetricDrilldownResponse, MetricDrilldownRow, ValidatedMetricDrilldown,
-    build_export, build_response, compile_query, decode_evidence_rows, evidence_unavailable,
-    export_filename, export_internal, export_limit, presentation, validate_export_request,
-    validate_request, verify_evidence_snapshot, with_evidence_query_limits,
+    MetricDrilldownColumn, MetricDrilldownEntity, MetricDrilldownExportFormat,
+    MetricDrilldownExportRequest, MetricDrilldownRequest, MetricDrilldownResponse,
+    MetricDrilldownRow, ValidatedMetricDrilldown, build_export, build_response, compile_query,
+    decode_evidence_rows, evidence_unavailable, export_filename, export_internal, export_limit,
+    parse_person_entity, presentation, validate_export_request, validate_request,
+    verify_evidence_snapshot, with_evidence_query_limits,
 };
 use crate::domain::person_visibility::authorize_entity_ids;
 
@@ -36,25 +37,14 @@ static QUERY_SEMAPHORE: LazyLock<Semaphore> =
 pub async fn query_metric_drilldown(
     Extension(state): Extension<Arc<AppState>>,
     Extension(ctx): Extension<SecurityContext>,
-    headers: axum::http::HeaderMap,
+    headers: HeaderMap,
     Json(req): Json<MetricDrilldownRequest>,
 ) -> Result<Json<MetricDrilldownResponse>, CanonicalError> {
     let started = Instant::now();
+    authorize_person_entity(&state, &ctx, &headers, &req.entity).await?;
+
     let mut req = validate_request(&state.db, &state.ch, ctx.subject_tenant_id(), req).await?;
     req.enforce_tenant_scope = state.config.metric_catalog.enforce_tenant_scope;
-
-    // Visibility gate BEFORE any ClickHouse work, same predicate and failure
-    // matrix as `/v1/metric-results`: this endpoint serves per-person evidence
-    // rows — names, record labels, contributions — so an unchecked id here is
-    // the same IDOR the sibling endpoint answers 403 for.
-    authorize_entity_ids(
-        &state.identity,
-        &ctx,
-        super::forwarded_authorization(&headers),
-        &req.selection.entity.r#type,
-        &[req.person_id],
-    )
-    .await?;
 
     let log_comment = format!("metric-drilldown:page:{}", req.plan.definition.key());
     let rows = fetch_rows(&state, &req, &log_comment).await?;
@@ -75,9 +65,14 @@ pub async fn query_metric_drilldown(
 pub async fn export_metric_drilldown(
     Extension(state): Extension<Arc<AppState>>,
     Extension(ctx): Extension<SecurityContext>,
+    headers: HeaderMap,
     Json(req): Json<MetricDrilldownExportRequest>,
 ) -> Result<Response<Body>, CanonicalError> {
     let started = Instant::now();
+    // Ahead of the permit: a caller who may not see this person must not occupy
+    // one of MAX_CONCURRENT_EXPORTS slots.
+    authorize_person_entity(&state, &ctx, &headers, &req.entity).await?;
+
     let permit = acquire_export_permit().await?;
     let deadline = tokio::time::Instant::now() + EXPORT_TIMEOUT;
 
@@ -116,6 +111,29 @@ pub async fn export_metric_drilldown(
     );
 
     attachment_response(body, content_type, &export_name(&validated, extension))
+}
+
+// INVARIANT: both drilldown routes call this before validation touches MariaDB
+// or ClickHouse. They serve per-person evidence — names, record labels,
+// contributions — so an unchecked id is the IDOR `/v1/metric-results` answers
+// 403 for. Gating ahead of validation also stops its error codes (404 unknown
+// metric, 400 unhealthy evidence) from describing a person the caller cannot see.
+async fn authorize_person_entity(
+    state: &AppState,
+    ctx: &SecurityContext,
+    headers: &HeaderMap,
+    entity: &MetricDrilldownEntity,
+) -> Result<(), CanonicalError> {
+    let (entity_type, person_id) = parse_person_entity(entity)?;
+
+    authorize_entity_ids(
+        &state.identity,
+        ctx,
+        super::forwarded_authorization(headers),
+        &entity_type,
+        &[person_id],
+    )
+    .await
 }
 
 async fn acquire_export_permit() -> Result<tokio::sync::SemaphorePermit<'static>, CanonicalError> {

--- a/src/backend/services/analytics/src/api/mod.rs
+++ b/src/backend/services/analytics/src/api/mod.rs
@@ -241,6 +241,7 @@ fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) -> Router {
         )
         .error_400(openapi)
         .error_401(openapi)
+        .error_403(openapi)
         .error_404(openapi)
         .error_415(openapi)
         .error_429(openapi)

--- a/src/backend/services/analytics/src/domain/metric_drilldown/dto.rs
+++ b/src/backend/services/analytics/src/domain/metric_drilldown/dto.rs
@@ -120,9 +120,6 @@ impl toolkit::api::api_dto::ResponseApiDto for MetricDrilldownResponse {}
 #[derive(Debug)]
 pub struct ValidatedMetricDrilldown {
     pub selection: MetricDrilldownSelection,
-    /// Canonical person id parsed from `selection.entity.id` — what the
-    /// visibility gate authorizes and the compiler binds to `entity_id`.
-    pub person_id: uuid::Uuid,
     pub tenant_id: uuid::Uuid,
     /// Same runtime policy switch as metric-results (#1967): the evidence read
     /// leads with `tenant_id = ?` when set, degrades to match-all otherwise.

--- a/src/backend/services/analytics/src/domain/metric_drilldown/mod.rs
+++ b/src/backend/services/analytics/src/domain/metric_drilldown/mod.rs
@@ -13,14 +13,15 @@ pub(crate) use compiler::{compile_query, decode_evidence_rows};
 pub(crate) use cursor::verify_evidence_snapshot;
 pub(crate) use dto::{
     EVIDENCE_QUERY_TIMEOUT_SECS, EvidenceQueryRow, MAX_EXPORT_ROWS, MetricDrilldownCapability,
-    MetricDrilldownColumn, MetricDrilldownExportFormat, MetricDrilldownExportRequest,
-    MetricDrilldownRequest, MetricDrilldownResponse, MetricDrilldownRow, ValidatedMetricDrilldown,
+    MetricDrilldownColumn, MetricDrilldownEntity, MetricDrilldownExportFormat,
+    MetricDrilldownExportRequest, MetricDrilldownRequest, MetricDrilldownResponse,
+    MetricDrilldownRow, ValidatedMetricDrilldown,
 };
 pub(crate) use error::{evidence_unavailable, export_internal, export_limit};
 pub(crate) use export::{MAX_EXPORT_BYTES, build_export, export_filename};
 pub(crate) use presentation::{build_response, presentation};
 pub(crate) use query_limits::with_evidence_query_limits;
-pub(crate) use validation::{validate_export_request, validate_request};
+pub(crate) use validation::{parse_person_entity, validate_export_request, validate_request};
 
 #[cfg(test)]
 mod test_support;

--- a/src/backend/services/analytics/src/domain/metric_drilldown/test_support.rs
+++ b/src/backend/services/analytics/src/domain/metric_drilldown/test_support.rs
@@ -101,7 +101,6 @@ pub(super) fn validated(plan: EvidencePlan) -> ValidatedMetricDrilldown {
         display_dimensions: vec!["category".to_owned()],
     };
     ValidatedMetricDrilldown {
-        person_id: TEST_PERSON,
         tenant_id: TEST_TENANT,
         enforce_tenant_scope: true,
         fingerprint: selection_fingerprint(Uuid::nil(), &selection)

--- a/src/backend/services/analytics/src/domain/metric_drilldown/validation.rs
+++ b/src/backend/services/analytics/src/domain/metric_drilldown/validation.rs
@@ -87,6 +87,31 @@ pub async fn validate_export_request(
     .await
 }
 
+// Canonical person id, like every other person-keyed route since the identity
+// cutover; the pre-cutover email shape (and the nil UUID, which parses but is
+// never a person) is a loud 400.
+//
+// INVARIANT: this runs before the visibility gate on both drilldown handlers,
+// so it must not reach any backend — an unauthorized caller gets no further.
+pub(crate) fn parse_person_entity(
+    entity: &MetricDrilldownEntity,
+) -> Result<(String, Uuid), CanonicalError> {
+    let entity_type = normalize_entity_type(&entity.r#type)?;
+    if entity_type != "person" {
+        return Err(invalid_error(
+            "entity.type",
+            "only person entities are supported",
+        ));
+    }
+
+    let person_id = Uuid::parse_str(entity.id.trim())
+        .ok()
+        .filter(|id| !id.is_nil())
+        .ok_or_else(|| invalid_error("entity.id", "entity.id must be a person UUID"))?;
+
+    Ok((entity_type, person_id))
+}
+
 async fn validate_common(
     db: &DatabaseConnection,
     ch: &insight_clickhouse::Client,
@@ -104,19 +129,7 @@ async fn validate_common(
         cursor,
     } = request;
     let metric_key = normalize_metric_key("metric_key", &metric_key)?;
-    let entity_type = normalize_entity_type(&entity.r#type)?;
-    if entity_type != "person" {
-        return invalid("entity.type", "only person entities are supported");
-    }
-    // Canonical person id, like every other person-keyed route since the
-    // identity cutover; the pre-cutover email shape (and the nil UUID, which
-    // parses but is never a person) is a loud 400. The compiler translates the
-    // id back to the person's source emails, because the evidence relations
-    // deliberately stay email-keyed (coverage measures the gap from them).
-    let person_id = uuid::Uuid::parse_str(entity.id.trim())
-        .ok()
-        .filter(|id| !id.is_nil())
-        .ok_or_else(|| invalid_error("entity.id", "entity.id must be a person UUID"))?;
+    let (entity_type, person_id) = parse_person_entity(&entity)?;
     let entity_id = person_id.to_string();
     if limit == 0 || limit > max_limit {
         return invalid("limit", format!("limit must be between 1 and {max_limit}"));
@@ -173,7 +186,6 @@ async fn validate_common(
     };
     Ok(ValidatedMetricDrilldown {
         selection,
-        person_id,
         tenant_id,
         // The handler overwrites this from config; false is the runtime-wide
         // default (#1967) so tests compile queries in the degraded form.


### PR DESCRIPTION
`POST /v1/metric-drilldown/export` had no visibility gate. It served per-person evidence rows for whatever `entity.id` the caller named, filtered only by tenant — the IDOR `POST /v1/metric-results` and `POST /v1/metric-drilldown` both answer 403 for. Both routes are called from the SPA.

## Change

- Export gates on the caller's visible set, ahead of the concurrency permit — an unauthorized caller no longer occupies one of two export slots.
- Both drilldown routes now gate **before** validation. Previously a denied caller still drove a definition load, an evidence-plan join and a ClickHouse snapshot probe, and validation's own codes (404 unknown metric, 400 unhealthy evidence) described a person the caller could not see.
- `parse_person_entity` extracted from `validate_common`; one parse rule, unchanged errors.
- `/v1/metric-drilldown` declares the 403 it could already return; spec regenerated.
- `ValidatedMetricDrilldown.person_id` removed — the old gate was its only reader.

## Behaviour

For a person the caller cannot see, a parseable drilldown request answers 403 where it previously answered 400 or 404. Malformed `entity.type`/`entity.id` still answer 400; the parse runs ahead of the gate.

## Tests

`metric_drilldown_forbids_*` and `metric_drilldown_export_forbids_*` added. The export case was checked against a reverted gate: 400 without the fix, 403 with it.

Two existing tests build the app with an unreachable identity and now reach the gate first, so they take a real loopback identity.

Refs #2109
