### PR TITLE
feat(frontend): a section shows the work, not a second ranking

### DIFF
--- a/src/frontend/src/components/portal/single-group-view.test.tsx
+++ b/src/frontend/src/components/portal/single-group-view.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+/**
+ * One activity class, composed.
+ *
+ * The choices this file makes are all about what NOT to draw: which metrics
+ * earn a detail block, when a whole class collapses to a sentence, and what the
+ * index is allowed to repeat. Each of those is invisible in the output when it
+ * works, which is why they are pinned here.
+ */
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { MetricResult } from "@/api/metric-results-client";
+import { normalizeMetricResults } from "@/lib/metrics/collection";
+
+const mocks = vi.hoisted(() => ({
+  byKey: new Map<string, unknown>(),
+  isPending: false,
+  isError: false,
+  cohort: [] as string[],
+}));
+
+vi.mock("@/queries/metric-results", () => ({
+  useMetricCollection: () => ({
+    byKey: mocks.byKey,
+    previousByKey: null,
+    isPending: mocks.isPending,
+    isFetching: false,
+    isError: mocks.isError,
+    refetch: vi.fn(),
+  }),
+}));
+vi.mock("@/lib/portal/use-person-cohort", () => ({
+  usePersonCohort: () => mocks.cohort,
+}));
+vi.mock("@/hooks/use-portal-period", () => ({
+  usePortalPeriod: () => ({
+    period: "month",
+    dateRange: { from: "2026-03-01", to: "2026-03-31" },
+  }),
+}));
+// The composition blocks are someone else's tests; stubbing them keeps this
+// file about which children get built, not how they paint.
+vi.mock("@/components/widgets/metric-views/collection-drilldown", () => ({
+  CollectionDrilldown: ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="composition">{children}</div>
+  ),
+}));
+vi.mock("@/components/widgets/metric-views/metric-activity", () => ({
+  MetricActivity: ({ metric }: { metric: { label: string } }) => (
+    <div data-testid="activity">{metric.label}</div>
+  ),
+}));
+
+import { SingleGroupView } from "./single-group-view";
+
+const ME = "019e27bc-dec0-7626-81a9-c5524662a6a9";
+
+function metric(key: string, label: string, value: number | null) {
+  return {
+    metric_key: key,
+    label,
+    unit: null,
+    format: "integer",
+    computation: "sum",
+    direction: "higher_is_better",
+    views: [{ view: "period", values: [{ entity_id: ME, value }] }],
+    drilldown: { granularity: ["source_summary"] },
+  } as unknown as MetricResult;
+}
+
+/** Collaboration's headline keys, from the group registry. */
+const HEADLINE = [
+  ["collab.messages_sent", "Messages Sent"],
+  ["collab.meeting_hours", "Meeting Hours"],
+  ["collab.focus_time_pct", "Focus Time"],
+] as const;
+
+function draw() {
+  return render(<SingleGroupView personId={ME} groupId="collaboration" />);
+}
+
+beforeEach(() => {
+  mocks.byKey = new Map();
+  mocks.isPending = false;
+  mocks.isError = false;
+  mocks.cohort = [];
+});
+
+describe("SingleGroupView", () => {
+  it("collapses a class with nothing recorded into one sentence", () => {
+    // Every composition block would otherwise render its own polite
+    // placeholder — a chart, a summary card, a distribution — and a reader
+    // would meet one fact restated four ways down a full page.
+    mocks.byKey = normalizeMetricResults(
+      HEADLINE.map(([k, l]) => metric(k, l, null))
+    );
+    draw();
+    expect(screen.getByText(/Nothing recorded here/)).toBeInTheDocument();
+    expect(screen.queryByTestId("composition")).not.toBeInTheDocument();
+  });
+
+  it("gives a detail block only to the headline metrics that read", () => {
+    mocks.byKey = normalizeMetricResults([
+      metric("collab.messages_sent", "Messages Sent", 400),
+      metric("collab.meeting_hours", "Meeting Hours", null),
+      metric("collab.focus_time_pct", "Focus Time", 81),
+    ]);
+    draw();
+    const shown = screen.getAllByTestId("activity").map((n) => n.textContent);
+    expect(shown).toEqual(["Messages Sent", "Focus Time"]);
+  });
+
+  it("says so once when the class reads but nothing can be broken down", () => {
+    // Stated for the class rather than under every metric: three rows each
+    // saying "no detail" reads as three separate faults.
+    const flat = HEADLINE.map(([k, l]) => {
+      const m = metric(k, l, 5) as unknown as Record<string, unknown>;
+      delete m.drilldown;
+      return m as unknown as MetricResult;
+    });
+    mocks.byKey = normalizeMetricResults(flat);
+    draw();
+    expect(screen.getByText(/report period totals only/)).toBeInTheDocument();
+    expect(screen.queryAllByTestId("activity")).toHaveLength(0);
+  });
+
+  it("shows a spinner while the collection loads, not an empty class", () => {
+    // A class still loading must not be drawn as one with nothing; the reader
+    // would take the sentence for an answer.
+    mocks.isPending = true;
+    const { container } = draw();
+    expect(screen.queryByText(/Nothing recorded here/)).not.toBeInTheDocument();
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("surfaces a failed fetch as retryable rather than as an empty class", () => {
+    mocks.isError = true;
+    draw();
+    expect(screen.queryByText(/Nothing recorded here/)).not.toBeInTheDocument();
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("refuses a group it does not know", () => {
+    render(<SingleGroupView personId={ME} groupId={"not_a_group" as never} />);
+    expect(screen.getByText(/Unknown group/)).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/portal/single-group-view.tsx
+++ b/src/frontend/src/components/portal/single-group-view.tsx
@@ -3,12 +3,19 @@ import { useMemo } from "react";
 import { CenteredSpinner } from "@/components/widgets/centered-spinner";
 import { ComingSoon } from "@/components/widgets/coming-soon";
 import { CollectionDrilldown } from "@/components/widgets/metric-views/collection-drilldown";
+import { MetricActivity } from "@/components/widgets/metric-views/metric-activity";
+import { SectionMetricIndex } from "@/components/widgets/metric-views/section-metric-index";
 import { usePortalPeriod } from "@/hooks/use-portal-period";
+import { groupHasData } from "@/lib/insight/group-data";
 import { GROUPS, type GroupId } from "@/lib/insight/groups";
+import { finestGrain } from "@/lib/insight/metric-grain";
+import { sectionSources } from "@/lib/insight/section-sources";
 import { injectCohortPeer } from "@/lib/insight/within-team-peer";
-import { type MetricCollectionConfig } from "@/lib/metrics/collection";
+import {
+  forEntity,
+  type MetricCollectionConfig,
+} from "@/lib/metrics/collection";
 import { normalizePersonId } from "@/lib/metrics/entity";
-import { useCohortLabel } from "@/lib/portal/use-cohort-label";
 import { usePersonCohort } from "@/lib/portal/use-person-cohort";
 import { useMetricCollection } from "@/queries/metric-results";
 
@@ -16,11 +23,20 @@ const EMPTY_COLLECTION: MetricCollectionConfig = { metrics: [] };
 const CLOSED_ENTITY = { type: "person" as const, ids: [] };
 
 /**
- * A direction lens with a single metric group renders the group's full
- * drilldown inline — no click-to-expand card, since there's only one section.
- * Fetches the full collection (all views) so charts + peer story paint directly.
- * When a slice is active, the person's slice cohort is fetched and its peer
- * stats are injected so the drilldown's peer story reads "vs <slice> median".
+ * One activity class, in as much detail as it can be read.
+ *
+ * The section is not a second, larger ranking. The overview already said
+ * which sections are worth opening, and repeating that judgment here — bigger
+ * and in red — showed a reader the finding that brought them here instead of
+ * explaining it. What a section owes them is the work itself: what was done,
+ * on which days, out of what.
+ *
+ * So the body is the group's declared composition, then each of its headline
+ * metrics rendered at the closest grain that metric declares about itself.
+ * Nothing here is configured per group: a metric that can name its artifacts
+ * lists them, one that reports a daily counter draws its days, one that
+ * carries both sides of a ratio shows the denominator, and one that offers
+ * nothing says so.
  */
 export function SingleGroupView({
   personId,
@@ -29,8 +45,7 @@ export function SingleGroupView({
   personId: string;
   groupId: GroupId;
 }) {
-  const cohortLabel = useCohortLabel();
-  const { dateRange } = usePortalPeriod();
+  const { period, dateRange } = usePortalPeriod();
   const entityId = normalizePersonId(personId);
   const def = GROUPS.find((d) => d.id === groupId) ?? null;
 
@@ -38,6 +53,10 @@ export function SingleGroupView({
     def?.collection ?? EMPTY_COLLECTION,
     def ? { type: "person", ids: [entityId] } : CLOSED_ENTITY,
     dateRange,
+    // The reader's own previous period. It is the comparison they can act on,
+    // and a section that dropped it left them only the cohort's middle —
+    // which they neither chose nor can see inside.
+    { previousPeriod: period },
   );
   const cohortIds = usePersonCohort(entityId);
   const cohortData = useMetricCollection(
@@ -52,6 +71,40 @@ export function SingleGroupView({
     }),
     [data, cohortData.byKey, cohortIds],
   );
+
+  // Metrics the composition above already draws over time. A daily strip
+  // beside a weekly chart of the same counter is the same fact twice, and the
+  // chart is the better of the two — it carries the split by tool or by
+  // repository that a bare strip cannot.
+  //
+  // Event-grade metrics are exempt: a list of the commits themselves is not a
+  // finer drawing of the chart, it is a different kind of answer.
+  const charted = new Set(
+    (def?.drilldown ?? []).flatMap((block) =>
+      block.view === "timeseries" ? block.metrics : [],
+    ),
+  );
+  // Everything the composition already puts on screen in any form — a chart,
+  // a headline card, a distribution. The index below lists what is left, so
+  // it must not restate a number the reader can already see; a bare repeat
+  // adds nothing, unlike a chart and a strip that answer different questions
+  // about the same metric.
+  const composed = new Set(
+    (def?.drilldown ?? []).flatMap((block) => block.metrics),
+  );
+
+  // The metrics that name the class, in the order the def states them. The
+  // rest of a collection is supporting arithmetic over the same events —
+  // rendering every one of them would say the same day twice under different
+  // labels.
+  const headline = (def?.card.preview ?? []).flatMap((key) => {
+    const metric = injectedData.byKey.get(key);
+    if (!metric) return [];
+    const grain = finestGrain(metric);
+    if (grain == null) return [metric];
+    if (grain !== "event" && charted.has(key)) return [];
+    return [metric];
+  });
 
   if (!def) {
     return (
@@ -71,16 +124,88 @@ export function SingleGroupView({
     );
   }
 
+  // Nothing at all for this person in this class. The composition blocks
+  // would each render their own polite placeholder — a chart saying "no data
+  // in this period", a summary card showing a dash, a distribution saying "no
+  // values" — and a reader would meet one fact restated in four wordings down
+  // a full page. One sentence says it once.
+  if (!groupHasData(def, injectedData.byKey, entityId)) {
+    return (
+      <div className="flex flex-col gap-3 p-4 md:p-6">
+        <h1 className="text-xl font-semibold tracking-tight">{def.title}</h1>
+        <p className="text-sm text-muted-foreground">
+          Nothing recorded here for the selected period.
+        </p>
+      </div>
+    );
+  }
+
+  const sources = sectionSources(def, injectedData.byKey, entityId);
+  const readable = headline.filter((metric) => finestGrain(metric) != null);
+  // Nothing to look into is one fact about the class, not one per metric:
+  // three metrics each saying "nothing recorded" reads as three faults.
+  const observed = headline.filter(
+    (metric) => forEntity(metric, entityId).value != null,
+  );
+
   return (
     <div className="flex flex-col gap-4 p-4 md:p-6">
       <h1 className="text-xl font-semibold tracking-tight">{def.title}</h1>
+      {sources.length > 0 ? (
+        // What was being watched, next to what it concluded. A low number
+        // means one thing when the tool everyone uses is connected and
+        // another when it is not, and the reader cannot tell which from the
+        // number alone.
+        <p className="-mt-2 text-xs text-muted-foreground">
+          From {sources.join(", ")}
+        </p>
+      ) : null}
       <CollectionDrilldown
         def={def}
         data={injectedData}
         entityId={entityId}
         range={dateRange}
-        cohortLabel={cohortLabel}
-      />
+      >
+        {headline.length > 0 ? (
+          <div className="rounded-xl border p-4 sm:p-5">
+            <h2 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+              The work behind these numbers
+            </h2>
+            {observed.length === 0 ? (
+              <p className="pt-2 text-xs text-muted-foreground">
+                Nothing recorded in this section for the selected period.
+              </p>
+            ) : readable.length === 0 ? (
+              // Said once at the top rather than repeated under every metric:
+              // when a whole class reports period totals only, that is a fact
+              // about the class, and stating it per metric reads as several
+              // separate faults.
+              <p className="pt-2 text-xs text-muted-foreground">
+                These metrics report period totals only — nothing here can be
+                broken down by day or by item yet.
+              </p>
+            ) : (
+              observed.map((metric) => (
+                <MetricActivity
+                  key={metric.metric_key}
+                  metric={metric}
+                  previous={
+                    injectedData.previousByKey?.get(metric.metric_key) ?? null
+                  }
+                  entityId={entityId}
+                  periodNoun={period}
+                />
+              ))
+            )}
+          </div>
+        ) : null}
+        <SectionMetricIndex
+          collection={def.collection}
+          byKey={injectedData.byKey}
+          entityId={entityId}
+          shown={new Set([...composed, ...observed.map((m) => m.metric_key)])}
+        />
+      </CollectionDrilldown>
     </div>
   );
 }

--- a/src/frontend/src/components/widgets/dashboard/group-drilldown-sheet.tsx
+++ b/src/frontend/src/components/widgets/dashboard/group-drilldown-sheet.tsx
@@ -2,6 +2,8 @@ import { Maximize2, Minimize2, XIcon } from "lucide-react";
 
 import { ComingSoon } from "@/components/widgets/coming-soon";
 import { CollectionDrilldown } from "@/components/widgets/metric-views/collection-drilldown";
+import { PeerStory } from "@/components/widgets/metric-views/peer-story";
+import { buildPeerStoryEntries } from "@/lib/metrics/peer-story";
 import {
   TeamCollectionDrilldown,
   type TeamMemberRef,
@@ -132,8 +134,20 @@ function DrilldownPanel({
             data={metricTarget.data}
             entityId={metricTarget.entityId}
             range={range}
-            cohortLabel={cohortLabel}
-          />
+          >
+            {/* A drilldown opened from a card is answering "how do I
+                compare", so the standing follows the composition here. The
+                section screen reached from the navigation answers a different
+                question and puts the work itself in this slot. */}
+            <PeerStory
+              entries={buildPeerStoryEntries(
+                def.collection,
+                metricTarget.data.byKey,
+                metricTarget.entityId
+              )}
+              cohortLabel={cohortLabel}
+            />
+          </CollectionDrilldown>
         ) : metricTarget?.kind === "team" && range && period ? (
           <TeamCollectionDrilldown
             def={def}

--- a/src/frontend/src/components/widgets/metric-views/collection-drilldown.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/collection-drilldown.test.tsx
@@ -62,7 +62,7 @@ function result(
 }
 
 describe("CollectionDrilldown", () => {
-  it("renders the def's blocks and the peer story from wire data", () => {
+  it("renders the def's blocks from wire data", () => {
     render(
       <CollectionDrilldown
         def={DEF}
@@ -73,10 +73,23 @@ describe("CollectionDrilldown", () => {
     // Breakdown block: composition by tool with response-provided labels.
     expect(screen.getByText("Period total by tool")).toBeInTheDocument();
     expect(screen.getAllByText("Claude Code").length).toBeGreaterThan(0);
-    // Peer story: both fixture metrics are in-pack (no outlier hero), so the
-    // story falls back to the flat grid with one card per metric.
-    expect(screen.getByText("Tool acceptance rate")).toBeInTheDocument();
-    expect(screen.getByText("77%")).toBeInTheDocument();
+  });
+
+  it("says nothing about the numbers on its own", () => {
+    // Composition only. What is said ABOUT a metric — where it stands, what
+    // the person actually did — differs by surface, so it arrives from the
+    // caller and this renders it after the blocks.
+    render(
+      <CollectionDrilldown
+        def={DEF}
+        data={result()}
+        entityId="alice@example.com"
+      >
+        <p>where this stands</p>
+      </CollectionDrilldown>
+    );
+    expect(screen.getByText("where this stands")).toBeInTheDocument();
+    expect(screen.queryByText(/vs peer median/)).not.toBeInTheDocument();
   });
 
   it("dispatches a histogram block to the histogram renderer", () => {

--- a/src/frontend/src/components/widgets/metric-views/collection-drilldown.tsx
+++ b/src/frontend/src/components/widgets/metric-views/collection-drilldown.tsx
@@ -4,15 +4,14 @@ import { MetricBreakdown } from "@/components/widgets/metric-views/metric-breakd
 import { MetricHistogram } from "@/components/widgets/metric-views/metric-histogram";
 import { MetricSummaryCard } from "@/components/widgets/metric-views/metric-summary-card";
 import { MetricTimeseriesView } from "@/components/widgets/metric-views/metric-timeseries-view";
-import { PeerStory } from "@/components/widgets/metric-views/peer-story";
+import type { ReactNode } from "react";
+
 import type { DateRange } from "@/api/period-to-date-range";
 import type { DrilldownBlock, MetricGroup } from "@/lib/insight/groups";
 import {
   forEntity,
   type NormalizedMetricResult,
 } from "@/lib/metrics/collection";
-import { buildPeerStoryEntries } from "@/lib/metrics/peer-story";
-import type { PeerCohortLabel } from "@/lib/peers";
 import type { MetricCollectionResult } from "@/queries/metric-results";
 import { cn } from "@/lib/utils";
 
@@ -21,7 +20,8 @@ export interface CollectionDrilldownProps {
   data: MetricCollectionResult;
   entityId: string;
   range?: DateRange;
-  cohortLabel?: PeerCohortLabel;
+  /** Rendered after the composition blocks — the caller's own answer. */
+  children?: ReactNode;
   className?: string;
 }
 
@@ -63,16 +63,21 @@ function Block({
 }
 
 /**
- * Drilldown body for a metrics-backed group: the def's chart blocks, then
- * the peer story over every collection metric (hero outlier, side cards,
- * chips, supporting fold).
+ * What a group is made of: the def's declared chart, summary, and
+ * distribution blocks for one entity.
+ *
+ * Composition only. What is said ABOUT the numbers — where they stand against
+ * a cohort, what a person actually did — belongs to whoever is rendering the
+ * group, because the answer differs by surface: a drilldown opened from a
+ * card is answering "how do I compare", a section reached from the navigation
+ * is answering "what is this made of".
  */
 export function CollectionDrilldown({
   def,
   data,
   entityId,
   range,
-  cohortLabel = "department",
+  children,
   className,
 }: CollectionDrilldownProps) {
   if (data.isPending) {
@@ -105,7 +110,6 @@ export function CollectionDrilldown({
     );
   }
 
-  const entries = buildPeerStoryEntries(def.collection, data.byKey, entityId);
   // Summary cards get their own wider grid row above the charts;
   // distribution (histogram) charts get their own labeled card below the
   // peer story; everything else pairs into the top chart grid. Filter to
@@ -206,7 +210,7 @@ export function CollectionDrilldown({
           ))}
         </div>
       ) : null}
-      <PeerStory entries={entries} cohortLabel={cohortLabel} />
+      {children}
       {distributionMetrics.length > 0 ? (
         // Each histogram is its own card, dropped straight into the grid like
         // the chart blocks above — no wrapping "Distributions" card.

--- a/src/frontend/src/components/widgets/metric-views/metric-activity.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-activity.test.tsx
@@ -1,0 +1,202 @@
+// @vitest-environment jsdom
+/**
+ * What a person actually did, at the closest grain the metric offers.
+ *
+ * Three grains render three different things from the same component, so what
+ * these tests pin is that each one is drawn as itself: a counter is never
+ * dressed up as a list of things, a ratio shows the denominator it was taken
+ * out of, and a metric with no detail says so rather than leaving a hole that
+ * reads as a failed load.
+ */
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { MetricResult } from "@/api/metric-results-client";
+import { normalizeMetricResults } from "@/lib/metrics/collection";
+
+const detail = vi.hoisted(() => ({
+  state: {
+    isPending: false,
+    isError: false,
+    data: undefined as unknown,
+    refetch: () => {},
+  },
+  calls: [] as unknown[],
+}));
+vi.mock("@/queries/metric-detail", () => ({
+  DETAIL_LIMIT: 200,
+  useMetricDetail: (selection: unknown, enabled?: boolean) => {
+    detail.calls.push({ selection, enabled });
+    return detail.state;
+  },
+}));
+
+import { MetricActivity } from "./metric-activity";
+
+const ME = "019e27bc-dec0-7626-81a9-c5524662a6a9";
+
+function metric(
+  key: string,
+  granularity: string[] | null,
+  value: number | null,
+  over: Partial<MetricResult> = {}
+) {
+  const result = {
+    metric_key: key,
+    label: key === "git.commits" ? "Commits" : "Messages Sent",
+    description: "what this counts",
+    unit: key === "git.commits" ? "commits" : "messages",
+    format: "integer",
+    computation: "sum",
+    direction: "higher_is_better",
+    views: [{ view: "period", values: [{ entity_id: ME, value }] }],
+    selection: {
+      metric_key: key,
+      entity: { type: "person", ids: [ME] },
+      period: { from: "2026-03-01", to: "2026-03-05" },
+      filters: [],
+    },
+    ...(granularity ? { drilldown: { granularity } } : {}),
+    ...over,
+  } as unknown as MetricResult;
+  return normalizeMetricResults([result]).get(key)!;
+}
+
+function draw(m: ReturnType<typeof metric>) {
+  return render(
+    <MetricActivity
+      metric={m}
+      previous={null}
+      entityId={ME}
+      periodNoun="month"
+    />
+  );
+}
+
+beforeEach(() => {
+  detail.calls = [];
+  detail.state = {
+    isPending: false,
+    isError: false,
+    data: undefined,
+    refetch: () => {},
+  };
+});
+
+describe("MetricActivity", () => {
+  it("says a metric offers no detail rather than leaving a hole", () => {
+    // A reader who can open the day of every other metric on the page reads
+    // silence here as a screen that failed to load.
+    draw(metric("git.commits", null, 14));
+    expect(screen.getByText(/reports a period total only/)).toBeInTheDocument();
+  });
+
+  it("does not ask for detail a metric cannot give", () => {
+    draw(metric("git.commits", null, 14));
+    expect(detail.calls).toHaveLength(1);
+    expect((detail.calls[0] as { enabled: boolean }).enabled).toBe(false);
+  });
+
+  it("lists the things themselves at event grain", () => {
+    detail.state.data = {
+      columns: [],
+      rows: [
+        {
+          values: {
+            date: "2026-03-04",
+            title: "Fix the thing\n\nbody",
+            repository: "example/app",
+            ref: "abc",
+          },
+        },
+        {
+          values: {
+            date: "2026-03-02",
+            title: "Another change",
+            repository: "example/app",
+            ref: "def",
+          },
+        },
+      ],
+    };
+    draw(metric("git.commits", ["event"], 14));
+    // Newest first, and only the subject of the message.
+    const rows = screen.getAllByRole("listitem").map((li) => li.textContent);
+    expect(rows[0]).toContain("Fix the thing");
+    expect(rows[0]).not.toContain("body");
+    expect(rows[1]).toContain("Another change");
+  });
+
+  it("draws days at counter grain, and names the days with no reading", () => {
+    detail.state.data = {
+      columns: [
+        { key: "date", label: "Date", type: "date" },
+        { key: "value", label: "Value", type: "number" },
+      ],
+      // Two of the five days in the period are missing entirely.
+      rows: [
+        { values: { date: "2026-03-01", value: 4 } },
+        { values: { date: "2026-03-03", value: 2 } },
+        { values: { date: "2026-03-05", value: 0 } },
+      ],
+    };
+    const { container } = draw(
+      metric("collab.messages_sent", ["source_summary"], 6)
+    );
+    expect(screen.getByText(/2 days with no reading/)).toBeInTheDocument();
+    // Nothing is listed — a counter is not a list of things.
+    expect(container.querySelector("li")).toBeNull();
+  });
+
+  it("names a constant denominator, because that is what a share is argued with", () => {
+    detail.state.data = {
+      columns: [
+        { key: "date", label: "Date", type: "date" },
+        { key: "numerator", label: "Numerator", type: "number" },
+        { key: "denominator", label: "Denominator", type: "number" },
+      ],
+      rows: [
+        { values: { date: "2026-03-01", numerator: 6, denominator: 8 } },
+        { values: { date: "2026-03-02", numerator: 7, denominator: 8 } },
+      ],
+    };
+    draw(metric("collab.focus_time_pct", ["derived_population"], 81));
+    expect(screen.getByText(/measured against 8 per day/)).toBeInTheDocument();
+  });
+
+  it("offers a retry when the detail could not be loaded", () => {
+    detail.state.isError = true;
+    draw(metric("collab.messages_sent", ["source_summary"], 6));
+    expect(
+      screen.getByRole("button", { name: /try again/i })
+    ).toBeInTheDocument();
+  });
+
+  it("describes the strip for anyone not reading it with their eyes", () => {
+    // Thirty-one focusable days per strip is a worse answer for a keyboard
+    // reader than one sentence saying what the shape is.
+    detail.state.data = {
+      columns: [
+        { key: "date", label: "Date", type: "date" },
+        { key: "value", label: "Value", type: "number" },
+      ],
+      rows: [
+        { values: { date: "2026-03-01", value: 4 } },
+        { values: { date: "2026-03-03", value: 9 } },
+      ],
+    };
+    draw(metric("collab.messages_sent", ["source_summary"], 13));
+    const label = screen.getByRole("img").getAttribute("aria-label") ?? "";
+    expect(label).toMatch(/Messages Sent by day/);
+    expect(label).toMatch(/busiest/);
+    expect(label).toMatch(/3 days have no reading/);
+  });
+
+  it("says nothing was recorded rather than drawing an empty chart", () => {
+    detail.state.data = { columns: [], rows: [] };
+    draw(metric("collab.messages_sent", ["source_summary"], 0));
+    expect(
+      screen.getByText(/Nothing recorded in this period/)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
@@ -231,6 +231,39 @@ function dayTitle(metric: NormalizedMetricResult, day: StripDay): string {
   return `${when} — ${value}`;
 }
 
+/**
+ * The strip in words, for anyone not reading it with their eyes.
+ *
+ * States the span, the busiest day and how many days hold no reading — the
+ * three things the drawing is for. The per-day readout stays a pointer
+ * enhancement over this.
+ */
+function stripSummary(
+  metric: NormalizedMetricResult,
+  days: StripDay[],
+  period: { from: string; to: string } | undefined
+): string {
+  const span = period
+    ? `${formatDate(period.from)} to ${formatDate(period.to)}`
+    : `${days.length} days`;
+  const silent = silentDays(days);
+  const busiest = days.reduce<StripDay | null>(
+    (best, day) =>
+      day.value != null && (best?.value == null || day.value > best.value)
+        ? day
+        : best,
+    null
+  );
+  const parts = [`${metric.label} by day, ${span}`];
+  if (busiest?.value != null) parts.push(`busiest ${dayTitle(metric, busiest)}`);
+  parts.push(
+    silent === 0
+      ? "every day has a reading"
+      : `${silent} ${silent === 1 ? "day has" : "days have"} no reading`
+  );
+  return `${parts.join("; ")}.`;
+}
+
 function DayStrip({
   metric,
   rows,
@@ -266,9 +299,17 @@ function DayStrip({
     <div className="flex flex-col gap-1.5">
       {/* Hover reads out in the caption below rather than in a tooltip per
           day: a month is thirty-one triggers, and a floating card that covers
-          its neighbours is the wrong shape for asking "what was that bar". */}
+          its neighbours is the wrong shape for asking "what was that bar".
+
+          The strip carries its own description rather than making each day
+          focusable. Thirty-one tab stops per strip, three strips to a section,
+          is a worse answer for a keyboard reader than one sentence saying what
+          the shape is — and the per-day figure is an enhancement over content
+          the header and caption already state. */}
       <div
         className="flex h-10 items-end gap-px border-b"
+        role="img"
+        aria-label={stripSummary(metric, days, period)}
         onPointerLeave={() => setHovered(null)}
       >
         {days.map((day, index) => (

--- a/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
@@ -1,0 +1,287 @@
+import { useMemo } from "react";
+
+import { evidenceSelection } from "@/api/metric-drilldown-client";
+import { useMetricEvidenceOptional } from "@/components/metric-evidence-context";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { MetricName } from "@/components/widgets/metric-help-tooltip";
+import { silentDays, stripDays, type StripDay } from "@/lib/insight/day-strip";
+import { metricComparisons } from "@/lib/insight/metric-comparison";
+import { metricHelp } from "@/lib/insight/metric-help";
+import {
+  activityEvents,
+  dailyReadings,
+  finestGrain,
+} from "@/lib/insight/metric-grain";
+import { formatDate, formatMetricValue } from "@/lib/format";
+import {
+  forEntity,
+  type NormalizedMetricResult,
+} from "@/lib/metrics/collection";
+import { useMetricDetail } from "@/queries/metric-detail";
+import { cn } from "@/lib/utils";
+
+/** Events listed inline before the rest goes to the evidence dialog. */
+const EVENTS_SHOWN = 8;
+
+/**
+ * What a person actually did, at the closest grain the metric offers.
+ *
+ * A section is where a number is explained, and the explanation a reader
+ * wants is the work behind it: which commits, on which days, against what
+ * denominator. Each metric declares how closely it can be read, so this
+ * renders that and nothing more — a counter is never dressed up as a list of
+ * things, and a metric that offers no detail says so rather than being drawn
+ * as though it had some.
+ */
+export function MetricActivity({
+  metric,
+  previous,
+  entityId,
+  periodNoun,
+}: {
+  metric: NormalizedMetricResult;
+  previous: NormalizedMetricResult | null;
+  entityId: string;
+  /** "month" / "week" — what the change is measured against. */
+  periodNoun: string;
+}) {
+  const grain = finestGrain(metric);
+  const selection = metric.selection
+    ? evidenceSelection(metric.selection, entityId)
+    : null;
+  const detail = useMetricDetail(selection, grain != null);
+  const help = metricHelp(metric);
+  const data = forEntity(metric, entityId);
+  const total = formatMetricValue(data.value, metric.format, metric.unit);
+  const against = metricComparisons(metric, previous, entityId);
+
+  return (
+    <section className="flex flex-col gap-2 border-t py-4 first:border-t-0">
+      <header className="flex items-baseline justify-between gap-4">
+        <div className="min-w-0">
+          <MetricName metric={metric} className="text-sm font-medium" />
+          {help?.description ? (
+            <p className="truncate text-xs text-muted-foreground">
+              {help.description}
+            </p>
+          ) : null}
+        </div>
+        <div className="shrink-0 text-right">
+          <div className="text-sm tabular-nums">{total}</div>
+          {/* Both readings, stated and neither judged. The reader's own last
+              period comes first because it is the one they can act on; the
+              cohort follows, because they did not choose it and cannot see
+              who is in it. No colour either way — this is their own page. */}
+          <div className="text-xs text-muted-foreground">
+            {[
+              against.change
+                ? `${against.change} since last ${periodNoun}`
+                : null,
+              against.median ? `team ${against.median}` : null,
+            ]
+              .filter(Boolean)
+              .join(" · ")}
+          </div>
+        </div>
+      </header>
+      <Body grain={grain} metric={metric} entityId={entityId} detail={detail} />
+    </section>
+  );
+}
+
+function Body({
+  grain,
+  metric,
+  entityId,
+  detail,
+}: {
+  grain: ReturnType<typeof finestGrain>;
+  metric: NormalizedMetricResult;
+  entityId: string;
+  detail: ReturnType<typeof useMetricDetail>;
+}) {
+  if (grain == null) {
+    // Said plainly rather than left blank: a reader who can open the day of
+    // every other metric on the page will otherwise read the silence here as
+    // a screen that failed to load.
+    return (
+      <p className="text-xs text-muted-foreground">
+        This metric reports a period total only — no daily or per-item detail is
+        available for it.
+      </p>
+    );
+  }
+  if (detail.isPending) {
+    return (
+      <div className="flex h-12 items-center">
+        <Spinner className="size-4 text-muted-foreground" />
+      </div>
+    );
+  }
+  if (detail.isError) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        The detail behind this number could not be loaded.{" "}
+        <button
+          type="button"
+          className="underline underline-offset-2"
+          onClick={() => void detail.refetch()}
+        >
+          Try again
+        </button>
+      </p>
+    );
+  }
+  const rows = detail.data?.rows ?? [];
+  const columns = detail.data?.columns ?? [];
+  if (rows.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Nothing recorded in this period.
+      </p>
+    );
+  }
+  if (grain === "event") {
+    return <EventList metric={metric} entityId={entityId} rows={rows} />;
+  }
+  return <DayStrip metric={metric} rows={rows} columns={columns} />;
+}
+
+function EventList({
+  metric,
+  entityId,
+  rows,
+}: {
+  metric: NormalizedMetricResult;
+  entityId: string;
+  rows: NonNullable<ReturnType<typeof useMetricDetail>["data"]>["rows"];
+}) {
+  const evidence = useMetricEvidenceOptional();
+  const selection = evidenceSelection(metric.selection, entityId);
+  const events = useMemo(() => activityEvents(rows), [rows]);
+  const shown = events.slice(0, EVENTS_SHOWN);
+  const rest = events.length - shown.length;
+
+  return (
+    <div className="flex flex-col gap-1">
+      <ul className="flex flex-col">
+        {shown.map((event, index) => (
+          <li
+            key={event.ref ?? `${event.date}-${index}`}
+            className="flex items-baseline gap-3 py-1 text-xs"
+          >
+            <span className="w-14 shrink-0 text-muted-foreground tabular-nums">
+              {formatDate(event.date)}
+            </span>
+            <span className="min-w-0 flex-1 truncate">
+              {event.title ?? <span className="text-muted-foreground">—</span>}
+            </span>
+            {event.context ? (
+              <span className="hidden max-w-[14rem] shrink-0 truncate text-muted-foreground sm:inline">
+                {event.context}
+              </span>
+            ) : null}
+          </li>
+        ))}
+      </ul>
+      {rest > 0 && evidence && selection ? (
+        <Button
+          type="button"
+          variant="link"
+          className="h-auto justify-start p-0 text-xs"
+          onClick={() => evidence.openEvidence(selection, metric.label)}
+        >
+          {rest} more
+        </Button>
+      ) : null}
+    </div>
+  );
+}
+
+/** A ratio's daily value is a fraction; the metric says what to scale it by. */
+function scaled(metric: NormalizedMetricResult, value: number): number {
+  return metric.computation === "ratio" ? value * (metric.scale ?? 1) : value;
+}
+
+function dayTitle(metric: NormalizedMetricResult, day: StripDay): string {
+  const when = formatDate(day.date, "d MMM yyyy");
+  if (day.value == null) return `${when} — no reading`;
+  const value = formatMetricValue(
+    scaled(metric, day.value),
+    metric.format,
+    metric.unit
+  );
+  if (day.numerator != null && day.denominator != null) {
+    return `${when} — ${value} of ${day.denominator}`;
+  }
+  return `${when} — ${value}`;
+}
+
+function DayStrip({
+  metric,
+  rows,
+  columns,
+}: {
+  metric: NormalizedMetricResult;
+  rows: NonNullable<ReturnType<typeof useMetricDetail>["data"]>["rows"];
+  columns: NonNullable<ReturnType<typeof useMetricDetail>["data"]>["columns"];
+}) {
+  const period = metric.selection?.period;
+  const days = useMemo(
+    () =>
+      period
+        ? stripDays(dailyReadings(rows, columns), period.from, period.to)
+        : [],
+    [rows, columns, period]
+  );
+  if (days.length === 0) return null;
+
+  const silent = silentDays(days);
+  // One denominator for the whole period is worth naming: it is the thing a
+  // reader argues with when a share looks wrong, and it is invisible in the
+  // percentage itself.
+  const denominators = new Set(
+    days.flatMap((d) => (d.denominator != null ? [d.denominator] : []))
+  );
+  const constantDenominator =
+    denominators.size === 1 ? [...denominators][0] : null;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex h-10 items-end gap-px border-b">
+        {days.map((day) => (
+          <div
+            key={day.date}
+            title={dayTitle(metric, day)}
+            className="relative flex h-full flex-1 items-end"
+          >
+            {day.height == null ? null : (
+              <div
+                className={cn(
+                  "w-full rounded-t-[1px] bg-foreground/35",
+                  // A measured zero keeps a hairline: without it the day is
+                  // indistinguishable from one the source said nothing about,
+                  // and those mean opposite things.
+                  day.height === 0 && "bg-foreground/20"
+                )}
+                style={{ height: `${Math.max(day.height * 100, 2)}%` }}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+      <div className="flex justify-between text-[0.6875rem] text-muted-foreground">
+        <span>{period ? formatDate(period.from) : null}</span>
+        <span className="text-center">
+          {constantDenominator != null
+            ? `measured against ${constantDenominator} per day`
+            : silent > 0
+              ? `${silent} ${silent === 1 ? "day" : "days"} with no reading`
+              : null}
+        </span>
+        <span>{period ? formatDate(period.to) : null}</span>
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
@@ -5,7 +5,6 @@ import { useMetricEvidenceOptional } from "@/components/metric-evidence-context"
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { MetricName } from "@/components/widgets/metric-help-tooltip";
-import { PeerMark } from "@/components/widgets/metric-views/peer-mark";
 import { silentDays, stripDays, type StripDay } from "@/lib/insight/day-strip";
 import { metricComparisons } from "@/lib/insight/metric-comparison";
 import { metricHelp } from "@/lib/insight/metric-help";
@@ -19,7 +18,6 @@ import {
   forEntity,
   type NormalizedMetricResult,
 } from "@/lib/metrics/collection";
-import { derivePeerStanding } from "@/lib/metrics/peer-standing";
 import { useMetricDetail } from "@/queries/metric-detail";
 import { cn } from "@/lib/utils";
 
@@ -75,25 +73,21 @@ export function MetricActivity({
               period comes first because it is the one they can act on; the
               cohort follows, because they did not choose it and cannot see
               who is in it. */}
-          <div className="flex items-center justify-end gap-2 text-xs text-muted-foreground">
-            <span>
-              {[
-                against.change
-                  ? `${against.change} since last ${periodNoun}`
-                  : null,
-                against.median ? `team ${against.median}` : null,
-              ]
-                .filter(Boolean)
-                .join(" · ")}
-            </span>
-            {/* The same mark the list further down carries, so "how unlike
-                the group am I" is read one way wherever it appears. */}
-            <PeerMark
-              standing={derivePeerStanding(metric.direction, data)}
-              metricLabel={metric.label}
-              format={metric.format}
-              unit={metric.unit}
-            />
+          {/* No standing mark here, though the list below carries one on
+              every row. What makes that mark readable is the shared line the
+              list draws behind it: a dot means something against a visible
+              middle and nothing at all on its own. Three rows would not earn
+              a line of their own either — the mark exists to make fifteen
+              rows scannable, and here both comparisons are already in words. */}
+          <div className="text-xs text-muted-foreground">
+            {[
+              against.change
+                ? `${against.change} since last ${periodNoun}`
+                : null,
+              against.median ? `team ${against.median}` : null,
+            ]
+              .filter(Boolean)
+              .join(" · ")}
           </div>
         </div>
       </header>

--- a/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
@@ -1,10 +1,11 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import { evidenceSelection } from "@/api/metric-drilldown-client";
 import { useMetricEvidenceOptional } from "@/components/metric-evidence-context";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { MetricName } from "@/components/widgets/metric-help-tooltip";
+import { PeerMark } from "@/components/widgets/metric-views/peer-mark";
 import { silentDays, stripDays, type StripDay } from "@/lib/insight/day-strip";
 import { metricComparisons } from "@/lib/insight/metric-comparison";
 import { metricHelp } from "@/lib/insight/metric-help";
@@ -18,6 +19,7 @@ import {
   forEntity,
   type NormalizedMetricResult,
 } from "@/lib/metrics/collection";
+import { derivePeerStanding } from "@/lib/metrics/peer-standing";
 import { useMetricDetail } from "@/queries/metric-detail";
 import { cn } from "@/lib/utils";
 
@@ -72,16 +74,26 @@ export function MetricActivity({
           {/* Both readings, stated and neither judged. The reader's own last
               period comes first because it is the one they can act on; the
               cohort follows, because they did not choose it and cannot see
-              who is in it. No colour either way — this is their own page. */}
-          <div className="text-xs text-muted-foreground">
-            {[
-              against.change
-                ? `${against.change} since last ${periodNoun}`
-                : null,
-              against.median ? `team ${against.median}` : null,
-            ]
-              .filter(Boolean)
-              .join(" · ")}
+              who is in it. */}
+          <div className="flex items-center justify-end gap-2 text-xs text-muted-foreground">
+            <span>
+              {[
+                against.change
+                  ? `${against.change} since last ${periodNoun}`
+                  : null,
+                against.median ? `team ${against.median}` : null,
+              ]
+                .filter(Boolean)
+                .join(" · ")}
+            </span>
+            {/* The same mark the list further down carries, so "how unlike
+                the group am I" is read one way wherever it appears. */}
+            <PeerMark
+              standing={derivePeerStanding(metric.direction, data)}
+              metricLabel={metric.label}
+              format={metric.format}
+              unit={metric.unit}
+            />
           </div>
         </div>
       </header>
@@ -204,8 +216,15 @@ function scaled(metric: NormalizedMetricResult, value: number): number {
   return metric.computation === "ratio" ? value * (metric.scale ?? 1) : value;
 }
 
+/**
+ * One day, in words.
+ *
+ * "No reading" is spelled out rather than shown as a zero, because the whole
+ * point of the gap in the drawing is that those are different — and a reader
+ * checking a suspicious blank is exactly who reaches for this.
+ */
 function dayTitle(metric: NormalizedMetricResult, day: StripDay): string {
-  const when = formatDate(day.date, "d MMM yyyy");
+  const when = formatDate(day.date, "d MMM");
   if (day.value == null) return `${when} — no reading`;
   const value = formatMetricValue(
     scaled(metric, day.value),
@@ -227,6 +246,7 @@ function DayStrip({
   rows: NonNullable<ReturnType<typeof useMetricDetail>["data"]>["rows"];
   columns: NonNullable<ReturnType<typeof useMetricDetail>["data"]>["columns"];
 }) {
+  const [hovered, setHovered] = useState<number | null>(null);
   const period = metric.selection?.period;
   const days = useMemo(
     () =>
@@ -237,6 +257,7 @@ function DayStrip({
   );
   if (days.length === 0) return null;
 
+  const hoveredDay = hovered != null ? (days[hovered] ?? null) : null;
   const silent = silentDays(days);
   // One denominator for the whole period is worth naming: it is the thing a
   // reader argues with when a share looks wrong, and it is invisible in the
@@ -249,11 +270,17 @@ function DayStrip({
 
   return (
     <div className="flex flex-col gap-1.5">
-      <div className="flex h-10 items-end gap-px border-b">
-        {days.map((day) => (
+      {/* Hover reads out in the caption below rather than in a tooltip per
+          day: a month is thirty-one triggers, and a floating card that covers
+          its neighbours is the wrong shape for asking "what was that bar". */}
+      <div
+        className="flex h-10 items-end gap-px border-b"
+        onPointerLeave={() => setHovered(null)}
+      >
+        {days.map((day, index) => (
           <div
             key={day.date}
-            title={dayTitle(metric, day)}
+            onPointerEnter={() => setHovered(index)}
             className="relative flex h-full flex-1 items-end"
           >
             {day.height == null ? null : (
@@ -273,12 +300,19 @@ function DayStrip({
       </div>
       <div className="flex justify-between text-[0.6875rem] text-muted-foreground">
         <span>{period ? formatDate(period.from) : null}</span>
-        <span className="text-center">
-          {constantDenominator != null
-            ? `measured against ${constantDenominator} per day`
-            : silent > 0
-              ? `${silent} ${silent === 1 ? "day" : "days"} with no reading`
-              : null}
+        <span
+          className={cn(
+            "text-center",
+            hoveredDay ? "text-foreground tabular-nums" : null
+          )}
+        >
+          {hoveredDay
+            ? dayTitle(metric, hoveredDay)
+            : constantDenominator != null
+              ? `measured against ${constantDenominator} per day`
+              : silent > 0
+                ? `${silent} ${silent === 1 ? "day" : "days"} with no reading`
+                : null}
         </span>
         <span>{period ? formatDate(period.to) : null}</span>
       </div>

--- a/src/frontend/src/components/widgets/metric-views/metric-summary-card.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-summary-card.tsx
@@ -10,25 +10,16 @@ import {
 } from "@/components/widgets/metric-views/dimension-series";
 import { MetricSublabel } from "@/components/widgets/dashboard/metric-sublabel";
 import { MetricCardActions } from "@/components/widgets/metric-views/metric-card-actions";
-import { useSettings } from "@/hooks/use-settings";
 import {
   formatMetricNumber,
   formatMetricValue,
   metricDisplayUnit,
 } from "@/lib/format";
-import { peerStatusToStatus } from "@/lib/insight/peer-status";
 import {
   forEntity,
   type NormalizedMetricResult,
 } from "@/lib/metrics/collection";
-import { derivePeerStanding } from "@/lib/metrics/peer-standing";
 import { seriesColors } from "@/lib/series-colors";
-import {
-  STATUS_STRIPE_LEFT,
-  STATUS_TEXT_CLASS,
-  applyFocusStatus,
-} from "@/lib/status";
-import { cn } from "@/lib/utils";
 import { evidenceSelection } from "@/api/metric-drilldown-client";
 
 export interface MetricSummaryCardProps {
@@ -37,17 +28,21 @@ export interface MetricSummaryCardProps {
 }
 
 /**
- * Modality headline card: period total with peer status, plus a collapsible
+ * Modality headline card: period total, plus a collapsible
  * proportional breakdown over the metric's dimension groups (ribbon +
  * legend). The breakdown section renders only when at least two groups have
  * data — a single-source metric reads as a plain summary card.
+ *
+ * No standing and no colour. The card says how much of a modality there was
+ * and what it was made of; whether that is good is a judgment the section
+ * around it deliberately does not make, and a coloured card makes it anyway
+ * — louder than any sentence next to it.
  */
 export function MetricSummaryCard({
   metric,
   entityId,
 }: MetricSummaryCardProps) {
   const [open, setOpen] = useState(false);
-  const { focusMode } = useSettings();
   const evidence = metric.drilldown
     ? evidenceSelection(
         metric.selection,
@@ -64,11 +59,6 @@ export function MetricSummaryCard({
   // the quartile rank come from the shared standing derivation — same
   // verdict as the KPI tiles and the peer story by construction: red means
   // bottom quartile, in-pack is normal and stays uncolored.
-  const standing = derivePeerStanding(metric.direction, data);
-  const status = applyFocusStatus(peerStatusToStatus(standing.rank), focusMode);
-  // The status is carried by the stripe and the value color alone — no
-  // status words on the card.
-  const stripeClass = STATUS_STRIPE_LEFT[status];
 
   const rows = data.breakdown
     .filter((row) => (row.value ?? 0) > 0)
@@ -86,7 +76,7 @@ export function MetricSummaryCard({
   const displayUnit = metricDisplayUnit(metric.format, metric.unit);
 
   return (
-    <Card className={cn("relative h-full", stripeClass)}>
+    <Card className="relative h-full">
       <MetricCardActions evidence={evidence} label={metric.label} />
       <CardContent className="flex h-full flex-col gap-3">
         {/* KPI-tile line structure — label, sublabel slot, then the
@@ -104,12 +94,7 @@ export function MetricSummaryCard({
           />
         </div>
         <span className="flex items-baseline gap-1 tabular-nums">
-          <span
-            className={cn(
-              "text-3xl font-semibold",
-              status !== "neutral" && STATUS_TEXT_CLASS[status]
-            )}
-          >
+          <span className="text-3xl font-semibold">
             {value == null
               ? "—"
               : metric.format === "percent"

--- a/src/frontend/src/components/widgets/metric-views/peer-mark.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/peer-mark.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+/**
+ * The mark that says how unlike the group one reading is.
+ *
+ * Its whole job is to be ignorable when the answer is "like everyone else"
+ * and unmissable when it is not, so these tests are about the three ways that
+ * fails: a mark where nothing is comparable, colour where no verdict was
+ * earned, and one extreme reading squashing the axis for every other row.
+ */
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PeerMark } from "@/components/widgets/metric-views/peer-mark";
+import type { PeerStanding } from "@/lib/metrics/peer-standing";
+import type { PeerStatusWithNeutral } from "@/lib/peers";
+
+function standing(
+  overrides: Partial<PeerStanding> & { gapDelta?: number } = {}
+): PeerStanding {
+  return {
+    observed: true,
+    stats: { p25: 8, p50: 10, p75: 12, min: 0, max: 30, n: 20 },
+    eligible: true,
+    reason: "ok",
+    rank: "in_pack" as PeerStatusWithNeutral,
+    gapDelta: 0,
+    gapPct: 0,
+    severity: 0,
+    spreadGap: 0,
+    ...overrides,
+  } as PeerStanding;
+}
+
+function draw(s: PeerStanding) {
+  const { container } = render(
+    <PeerMark standing={s} metricLabel="Commits" format="integer" />
+  );
+  return {
+    dot: container.querySelector("circle"),
+    pin: container.querySelector("path"),
+    svg: container.querySelector('[data-slot="peer-mark"]'),
+    label: container
+      .querySelector('[data-slot="peer-mark"]')
+      ?.getAttribute("aria-label"),
+  };
+}
+
+describe("PeerMark", () => {
+  it("puts a reading at the group's middle on the shared line", () => {
+    // The axis is 112 wide, so the middle is 56 — the same x every row draws
+    // its line at. Ordinary readings are meant to disappear into it.
+    const { dot } = draw(standing({ gapDelta: 0 }));
+    expect(Number(dot?.getAttribute("cx"))).toBe(56);
+  });
+
+  it("measures distance in spreads, not in the metric's own units", () => {
+    // IQR here is 4, so a gap of 4 is one spread — and one spread means the
+    // same thing on a row counting hours and a row counting messages.
+    const { dot, label } = draw(standing({ gapDelta: 4 }));
+    expect(label).toMatch(/1\.0 spreads above/);
+    // One spread of 2.5 on the right half: 56 + (1/2.5) * 51.
+    expect(Number(dot?.getAttribute("cx"))).toBeCloseTo(76.4, 1);
+  });
+
+  it("draws no mark where there is nothing to compare against", () => {
+    // But keeps the element, so the row holds its height and the shared line
+    // behind it stays unbroken. An absent dot means "not comparable" — it
+    // must not be confused with a dot sitting at the middle.
+    const { dot, pin, svg } = draw(
+      standing({ eligible: false, rank: "neutral", gapDelta: 3 })
+    );
+    expect(svg).not.toBeNull();
+    expect(dot).toBeNull();
+    expect(pin).toBeNull();
+  });
+
+  it("pins an extreme reading instead of letting it set the scale", () => {
+    // Eleven spreads out would otherwise compress every other row into the
+    // middle. The shape changes so the edge is not read as a measurement.
+    const { dot, pin, label } = draw(standing({ gapDelta: 44 }));
+    expect(dot).toBeNull();
+    expect(pin).not.toBeNull();
+    expect(label).toMatch(/11\.0 spreads above/);
+  });
+
+  it("colours only what the shared standing calls bottom of the pack", () => {
+    // Standing out is not the same as being wrong: a reading far above the
+    // middle is remarkable on any metric and a problem on almost none.
+    const far = draw(standing({ gapDelta: 8, rank: "top" }));
+    expect(far.dot?.getAttribute("class")).not.toMatch(/destructive/);
+
+    const adverse = draw(standing({ gapDelta: -8, rank: "bottom" }));
+    expect(adverse.dot?.getAttribute("class")).toMatch(/destructive/);
+  });
+});

--- a/src/frontend/src/components/widgets/metric-views/peer-mark.tsx
+++ b/src/frontend/src/components/widgets/metric-views/peer-mark.tsx
@@ -1,0 +1,177 @@
+import type { MetricFormat } from "@/api/metric-results-client";
+import { formatMetricValue } from "@/lib/format";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { peerSpread, type PeerStanding } from "@/lib/metrics/peer-standing";
+import { cn } from "@/lib/utils";
+
+/** Matches the metric-name tooltips beside it, so a sweep stays quiet. */
+const HOVER_DELAY_MS = 400;
+
+/** Half the axis, in cohort spreads. Beyond this a mark pins to the edge. */
+const MAX_SPREADS = 2.5;
+
+const W = 112;
+const H = 20;
+const PAD = 5;
+
+/**
+ * Distance from a row's right edge to the axis middle, for the list that
+ * draws the shared centre line. Ties the rule to this component's geometry so
+ * the two cannot drift apart.
+ */
+export const PEER_MARK_CENTRE = W / 2;
+
+/** Where a deviation of `spreads` sits on the axis. */
+function x(spreads: number): number {
+  const clamped = Math.max(-MAX_SPREADS, Math.min(MAX_SPREADS, spreads));
+  return W / 2 + (clamped / MAX_SPREADS) * (W / 2 - PAD);
+}
+
+/**
+ * How far from the middle of the pool one reading sits, on an axis every
+ * metric shares.
+ *
+ * A list of numbers each followed by its median asks the reader to do the
+ * subtraction nineteen times, and a per-metric bar asks them to learn a new
+ * scale on every row. Measuring the distance in cohort spreads instead —
+ * `(value − median) / IQR` — puts hours, messages and percentages on one axis,
+ * because "eight tenths of a spread below the middle" means the same thing
+ * whatever is being counted.
+ *
+ * The point of the shared axis is the vertical line it makes — drawn once by
+ * the list behind every mark (`PEER_MARK_CENTRE`), not per row, because a line
+ * broken by row padding is just a column of dashes and the effect dies.
+ * Everything ordinary settles onto that line. The blending is deliberate: "I
+ * am like the others here" is the answer that should cost no attention, and
+ * what the eye is left with is the few marks standing off it.
+ *
+ * Lower on the left, higher on the right — never flipped by direction.
+ * Orienting the axis so that "left" means "worse" would smuggle a verdict into
+ * the geometry, and for a metric with no better direction there is no worse to
+ * point at.
+ *
+ * Colour is the one place a verdict is allowed, and only at its narrowest.
+ * Standing out is not the same as being wrong: eleven spreads above the middle
+ * is remarkable on any metric and a problem on almost none. So a mark is grey
+ * unless the shared standing calls this reading bottom-of-pack on a metric
+ * that HAS a wrong direction — the same call the overview makes, in a dot
+ * instead of a red card. Two coloured marks in a list of nineteen is a
+ * finding; nineteen coloured marks is a scoreboard, and the reader did not ask
+ * to be scored on every row.
+ */
+export function PeerMark({
+  standing,
+  metricLabel,
+  format,
+  unit,
+  className,
+}: {
+  standing: PeerStanding;
+  metricLabel: string;
+  /** So the tooltip can state the pool in the units the reader is reading. */
+  format: MetricFormat;
+  unit?: string | null;
+  className?: string;
+}) {
+  const show = (value: number) => formatMetricValue(value, format, unit);
+  // No mark where there is nothing to compare against: too few peers, a pool
+  // with no spread, or a reading the peer view calls unmeasured. An empty
+  // track still draws, so the line stays continuous and the row keeps its
+  // height — an absent dot reads as "not comparable", not as "at the middle".
+  const spreads =
+    standing.eligible && standing.stats
+      ? standing.gapDelta / peerSpread(standing.stats)
+      : null;
+  const pinned = spreads != null && Math.abs(spreads) > MAX_SPREADS;
+  // The overview's own verdict, reused rather than re-derived: a section and
+  // the page that sent the reader to it must not disagree about what counts.
+  const adverse = standing.rank === "bottom";
+  const markClass = adverse ? "text-destructive" : "text-foreground/70";
+
+  const svg = (
+    <svg
+      data-slot="peer-mark"
+      viewBox={`0 0 ${W} ${H}`}
+      width={W}
+      height={H}
+      className={cn("shrink-0 overflow-visible", className)}
+      role="img"
+      aria-label={describe(spreads, metricLabel)}
+    >
+      {/* One spread out, either way — a scale for "far", marked at the foot so
+          it never competes with the reading itself. */}
+      {[-1, 1].map((side) => (
+        <line
+          key={side}
+          x1={x(side)}
+          y1={H - 3}
+          x2={x(side)}
+          y2={H}
+          stroke="currentColor"
+          strokeWidth={1}
+          className="text-foreground/10"
+        />
+      ))}
+      {spreads == null ? null : pinned ? (
+        // Pinned rather than plotted: one metric sitting twelve spreads out
+        // would otherwise squash the axis for the other eighteen. The shape
+        // changes so the edge is not read as a measurement.
+        <path
+          d={
+            spreads > 0
+              ? `M${W - PAD - 4},${H / 2 - 3.5} L${W - PAD + 1},${H / 2} L${W - PAD - 4},${H / 2 + 3.5} Z`
+              : `M${PAD + 4},${H / 2 - 3.5} L${PAD - 1},${H / 2} L${PAD + 4},${H / 2 + 3.5} Z`
+          }
+          fill="currentColor"
+          className={markClass}
+        />
+      ) : (
+        <circle
+          cx={x(spreads)}
+          cy={H / 2}
+          r={3}
+          fill="currentColor"
+          className={markClass}
+        />
+      )}
+    </svg>
+  );
+
+  // A mark says "far from the middle" and nothing about how far in the units
+  // the reader thinks in. The tooltip closes that: the two readings and how
+  // many people the middle was taken over, since a middle of four is a
+  // different claim from a middle of forty.
+  return (
+    <TooltipProvider delay={HOVER_DELAY_MS}>
+      <Tooltip>
+        <TooltipTrigger render={<span className="inline-flex">{svg}</span>} />
+        <TooltipContent
+          side="top"
+          className="flex-col items-start gap-1 text-left leading-relaxed"
+        >
+          <p>{describe(spreads, metricLabel)}</p>
+          {standing.stats ? (
+            <p className="text-background/70">
+              {standing.stats.n} compared · middle {show(standing.stats.p50)} ·
+              middle half {show(standing.stats.p25)}–{show(standing.stats.p75)}
+            </p>
+          ) : null}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+/** What the mark says, for anyone not reading it with their eyes. */
+function describe(spreads: number | null, metricLabel: string): string {
+  if (spreads == null) return `${metricLabel}: nothing comparable in the group`;
+  const size = Math.abs(spreads).toFixed(1);
+  const side = spreads > 0 ? "above" : "below";
+  if (Math.abs(spreads) < 0.05) return `${metricLabel}: at the group's middle`;
+  return `${metricLabel}: ${size} spreads ${side} the group's middle`;
+}

--- a/src/frontend/src/components/widgets/metric-views/section-metric-index.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/section-metric-index.test.tsx
@@ -58,28 +58,25 @@ describe("SectionMetricIndex", () => {
     // declaration order is invisible to a reader.
     renderIndex();
     const names = screen.getAllByRole("term").map((n) => n.textContent);
-    expect(names).toEqual(["Alpha", "Mid", "Zeta"]);
+    expect(names).toEqual(["Alpha", "Zeta"]);
   });
 
-  it("keeps a metric that holds nothing, as a dash", () => {
-    // Dropping it would answer "is this measured at all?" with silence, which
-    // reads as "no such metric" rather than "nothing for you this period".
+  it("leaves out a metric that holds nothing", () => {
+    // A row reading "—" against "median —" costs a line to say nothing. Why
+    // the metric is silent is a fact about the section, stated once at its
+    // top, not repeated down every row that happens to be empty.
     renderIndex();
-    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.queryByText("—")).toBeNull();
   });
 
   it("leaves out what the section already drew", () => {
     renderIndex(["collab.alpha"]);
     const names = screen.getAllByRole("term").map((n) => n.textContent);
-    expect(names).toEqual(["Mid", "Zeta"]);
+    expect(names).toEqual(["Zeta"]);
   });
 
-  it("renders nothing when the section drew everything", () => {
-    const { container } = renderIndex([
-      "collab.alpha",
-      "collab.mid",
-      "collab.zeta",
-    ]);
+  it("renders nothing when the section drew everything that reads", () => {
+    const { container } = renderIndex(["collab.alpha", "collab.zeta"]);
     expect(container).toBeEmptyDOMElement();
   });
 });

--- a/src/frontend/src/components/widgets/metric-views/section-metric-index.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/section-metric-index.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+/**
+ * The list that keeps a section honest about what it measures.
+ *
+ * Before it, a section showed three metrics closely and the other sixteen
+ * were unreachable — so these tests are about completeness and about the two
+ * ways a list of numbers stops being findable: repeating what is already on
+ * screen, and being in no order at all.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type { MetricResult } from "@/api/metric-results-client";
+import { SectionMetricIndex } from "@/components/widgets/metric-views/section-metric-index";
+import { normalizeMetricResults } from "@/lib/metrics/collection";
+
+const ME = "019e27bc-dec0-7626-81a9-c5524662a6a9";
+
+function metric(
+  key: string,
+  label: string,
+  value: number | null
+): MetricResult {
+  return {
+    metric_key: key,
+    label,
+    unit: null,
+    format: "integer",
+    computation: "sum",
+    direction: "higher_is_better",
+    views: [{ view: "period", values: [{ entity_id: ME, value }] }],
+  } as MetricResult;
+}
+
+const RESULTS = [
+  metric("collab.zeta", "Zeta", 3),
+  metric("collab.alpha", "Alpha", 1),
+  metric("collab.mid", "Mid", null),
+];
+const COLLECTION = {
+  metrics: RESULTS.map((r) => ({ key: r.metric_key, views: [] })),
+};
+
+function renderIndex(shown: string[] = []) {
+  return render(
+    <SectionMetricIndex
+      collection={COLLECTION}
+      byKey={normalizeMetricResults(RESULTS)}
+      entityId={ME}
+      shown={new Set(shown)}
+    />
+  );
+}
+
+describe("SectionMetricIndex", () => {
+  it("lists what the section measures in alphabetical order", () => {
+    // The only thing done with this list is looking something up, and
+    // declaration order is invisible to a reader.
+    renderIndex();
+    const names = screen.getAllByRole("term").map((n) => n.textContent);
+    expect(names).toEqual(["Alpha", "Mid", "Zeta"]);
+  });
+
+  it("keeps a metric that holds nothing, as a dash", () => {
+    // Dropping it would answer "is this measured at all?" with silence, which
+    // reads as "no such metric" rather than "nothing for you this period".
+    renderIndex();
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("leaves out what the section already drew", () => {
+    renderIndex(["collab.alpha"]);
+    const names = screen.getAllByRole("term").map((n) => n.textContent);
+    expect(names).toEqual(["Mid", "Zeta"]);
+  });
+
+  it("renders nothing when the section drew everything", () => {
+    const { container } = renderIndex([
+      "collab.alpha",
+      "collab.mid",
+      "collab.zeta",
+    ]);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/frontend/src/components/widgets/metric-views/section-metric-index.tsx
+++ b/src/frontend/src/components/widgets/metric-views/section-metric-index.tsx
@@ -1,0 +1,90 @@
+import { MetricName } from "@/components/widgets/metric-help-tooltip";
+import { formatMetricValue } from "@/lib/format";
+import { metricComparisons } from "@/lib/insight/metric-comparison";
+import {
+  forEntity,
+  type MetricCollectionConfig,
+  type NormalizedMetricResult,
+} from "@/lib/metrics/collection";
+
+/**
+ * Everything else the section measures, named and valued.
+ *
+ * A section shows a few metrics closely, and the rest of its collection would
+ * otherwise be invisible — a person could not find out that the thing was
+ * measured at all, let alone what it read. The list that used to carry them
+ * was folded behind "supporting and on-par metrics", which sorted them by
+ * their standing against a cohort: a reader looking for emails sent had to
+ * know it was unremarkable this period in order to guess where it went.
+ *
+ * So: no ranking, no colour, no fold. Collection order, the value or an
+ * honest dash, and the catalog's own words on hover. A dash here means the
+ * metric exists and holds nothing for this person — which is itself the
+ * answer to "is this being measured?".
+ */
+export function SectionMetricIndex({
+  collection,
+  byKey,
+  entityId,
+  shown,
+}: {
+  collection: MetricCollectionConfig;
+  byKey: Map<string, NormalizedMetricResult>;
+  entityId: string;
+  /** Keys already given their own block above. */
+  shown: ReadonlySet<string>;
+}) {
+  // Alphabetical, because the only thing a reader does with this list is look
+  // something up. Collection order is the order the metrics were declared in
+  // and means nothing on screen; ordering by value or by standing would rank
+  // them, which is the judgment this section deliberately withholds — and
+  // would also make a named metric impossible to find without reading all of
+  // them.
+  const rest = collection.metrics
+    .flatMap((m) => {
+      if (shown.has(m.key)) return [];
+      const metric = byKey.get(m.key);
+      return metric ? [metric] : [];
+    })
+    .sort((a, b) => a.label.localeCompare(b.label));
+  if (rest.length === 0) return null;
+
+  return (
+    <section className="rounded-xl border p-4 sm:p-5">
+      <h2 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+        Also measured here
+      </h2>
+      {/* Multi-column flow rather than a grid: columns fill top to bottom, so
+          the alphabet reads down one column and on to the next like an index.
+          A grid fills across the row and scatters the same list. */}
+      <dl className="gap-x-8 pt-3 sm:columns-2 xl:columns-3">
+        {rest.map((metric) => (
+          <div
+            key={metric.metric_key}
+            className="flex break-inside-avoid items-baseline justify-between gap-3 border-b border-dashed py-1.5"
+          >
+            <dt className="min-w-0 truncate text-xs">
+              <MetricName metric={metric} />
+            </dt>
+            <dd className="flex shrink-0 items-baseline gap-2 text-xs tabular-nums">
+              <span>
+                {formatMetricValue(
+                  forEntity(metric, entityId).value,
+                  metric.format,
+                  metric.unit
+                )}
+              </span>
+              {/* The pool's middle, so a row is readable without opening
+                  anything. Uncoloured: a list of thirty numbers lit up by
+                  quartile is a scoreboard, and the reader did not ask to be
+                  scored on every one of them. */}
+              <span className="w-24 text-right text-muted-foreground">
+                {metricComparisons(metric, null, entityId).median ?? ""}
+              </span>
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}

--- a/src/frontend/src/components/widgets/metric-views/section-metric-index.tsx
+++ b/src/frontend/src/components/widgets/metric-views/section-metric-index.tsx
@@ -22,10 +22,15 @@ import {
  * their standing against a cohort: a reader looking for emails sent had to
  * know it was unremarkable this period in order to guess where it went.
  *
- * So: no ranking, no colour, no fold. Collection order, the value or an
- * honest dash, and the catalog's own words on hover. A dash here means the
- * metric exists and holds nothing for this person — which is itself the
- * answer to "is this being measured?".
+ * So: no ranking, no fold, alphabetical order, the value, the pool's middle,
+ * and the catalog's own words on hover.
+ *
+ * Only rows that read. A metric holding nothing for this person in this
+ * period gives the reader nothing to act on and costs them a line to discover
+ * that; a column of dashes is the fastest way to teach someone to stop
+ * reading a list. Why a metric is silent — a source nobody wired, or a period
+ * this person did none of it — is a question about the section, and belongs
+ * once at the top rather than nineteen times down its body.
  */
 export function SectionMetricIndex({
   collection,
@@ -49,7 +54,13 @@ export function SectionMetricIndex({
     .flatMap((m) => {
       if (shown.has(m.key)) return [];
       const metric = byKey.get(m.key);
-      return metric ? [metric] : [];
+      if (!metric) return [];
+      // A row that reads "—" against "median —" tells the reader nothing they
+      // can use and costs them a line to find that out. Whether the silence
+      // is a missing connector or a period this person did none of it is a
+      // question about the section, answered once at the top, not nineteen
+      // times down a list.
+      return forEntity(metric, entityId).value == null ? [] : [metric];
     })
     .sort((a, b) => a.label.localeCompare(b.label));
   if (rest.length === 0) return null;

--- a/src/frontend/src/components/widgets/metric-views/section-metric-index.tsx
+++ b/src/frontend/src/components/widgets/metric-views/section-metric-index.tsx
@@ -1,6 +1,11 @@
 import { MetricName } from "@/components/widgets/metric-help-tooltip";
+import {
+  PEER_MARK_CENTRE,
+  PeerMark,
+} from "@/components/widgets/metric-views/peer-mark";
 import { formatMetricValue } from "@/lib/format";
 import { metricComparisons } from "@/lib/insight/metric-comparison";
+import { derivePeerStanding } from "@/lib/metrics/peer-standing";
 import {
   forEntity,
   type MetricCollectionConfig,
@@ -54,20 +59,31 @@ export function SectionMetricIndex({
       <h2 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
         Also measured here
       </h2>
-      {/* Multi-column flow rather than a grid: columns fill top to bottom, so
-          the alphabet reads down one column and on to the next like an index.
-          A grid fills across the row and scatters the same list. */}
-      <dl className="gap-x-8 pt-3 sm:columns-2 xl:columns-3">
+      {/* One column, whatever the width. Side-by-side columns of aligned
+          names and numbers read as a table — the eye takes the row first — so
+          an alphabet running down each column is invisible, and the list
+          looks like a heap however carefully it was sorted. Vertical space at
+          the very bottom of a page is the cheapest thing here. */}
+      {/* The axis middle, drawn once behind every mark. Per-row ticks would
+          break at each row's padding and read as a dotted column; the whole
+          point is an unbroken line for the ordinary readings to disappear
+          into. */}
+      <dl className="relative pt-2">
+        <span
+          aria-hidden
+          className="pointer-events-none absolute inset-y-2 w-px bg-foreground/20"
+          style={{ right: PEER_MARK_CENTRE }}
+        />
         {rest.map((metric) => (
           <div
             key={metric.metric_key}
-            className="flex break-inside-avoid items-baseline justify-between gap-3 border-b border-dashed py-1.5"
+            className="flex items-center justify-between gap-4 border-b border-dashed py-1 last:border-b-0"
           >
-            <dt className="min-w-0 truncate text-xs">
+            <dt className="min-w-0 flex-1 truncate text-xs">
               <MetricName metric={metric} />
             </dt>
             <dd className="flex shrink-0 items-baseline gap-2 text-xs tabular-nums">
-              <span>
+              <span className="w-32 text-right">
                 {formatMetricValue(
                   forEntity(metric, entityId).value,
                   metric.format,
@@ -78,9 +94,22 @@ export function SectionMetricIndex({
                   anything. Uncoloured: a list of thirty numbers lit up by
                   quartile is a scoreboard, and the reader did not ask to be
                   scored on every one of them. */}
-              <span className="w-24 text-right text-muted-foreground">
+              <span className="w-28 text-right text-muted-foreground">
                 {metricComparisons(metric, null, entityId).median ?? ""}
               </span>
+              {/* And how far off that middle, on the axis every row shares.
+                  The number answers "what do the others have"; the mark
+                  answers "how unlike them am I", which is the question a
+                  reader cannot do in their head nineteen times. */}
+              <PeerMark
+                standing={derivePeerStanding(
+                  metric.direction,
+                  forEntity(metric, entityId)
+                )}
+                metricLabel={metric.label}
+                format={metric.format}
+                unit={metric.unit}
+              />
             </dd>
           </div>
         ))}

--- a/src/frontend/src/lib/insight/day-strip.test.ts
+++ b/src/frontend/src/lib/insight/day-strip.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { silentDays, stripDays } from "@/lib/insight/day-strip";
+import type { DayReading } from "@/lib/insight/metric-grain";
+
+function reading(date: string, value: number): DayReading {
+  return { date, value, numerator: null, denominator: null };
+}
+
+describe("stripDays", () => {
+  it("walks the calendar, not the rows", () => {
+    // Built from rows alone, four busy days in a month would pack together
+    // and read as a month that was busy throughout.
+    const days = stripDays(
+      [reading("2026-03-01", 4), reading("2026-03-05", 2)],
+      "2026-03-01",
+      "2026-03-05"
+    );
+    expect(days).toHaveLength(5);
+    expect(days.map((d) => d.value)).toEqual([4, null, null, null, 2]);
+  });
+
+  it("keeps a measured zero apart from a day with no reading", () => {
+    // They draw the same and mean opposite things: silence from the source
+    // versus a day this person did none of it.
+    const days = stripDays(
+      [reading("2026-03-01", 0)],
+      "2026-03-01",
+      "2026-03-02"
+    );
+    expect(days[0]?.value).toBe(0);
+    expect(days[0]?.height).toBe(0);
+    expect(days[1]?.value).toBeNull();
+    expect(days[1]?.height).toBeNull();
+  });
+
+  it("scales to the tallest day of the period", () => {
+    const days = stripDays(
+      [reading("2026-03-01", 5), reading("2026-03-02", 10)],
+      "2026-03-01",
+      "2026-03-02"
+    );
+    expect(days.map((d) => d.height)).toEqual([0.5, 1]);
+  });
+
+  it("survives a period where nothing happened at all", () => {
+    const days = stripDays(
+      [reading("2026-03-01", 0), reading("2026-03-02", 0)],
+      "2026-03-01",
+      "2026-03-02"
+    );
+    expect(days.every((d) => d.height === 0)).toBe(true);
+  });
+
+  it("refuses a range it cannot walk", () => {
+    expect(stripDays([], "2026-03-05", "2026-03-01")).toEqual([]);
+    expect(stripDays([], "not-a-date", "2026-03-01")).toEqual([]);
+  });
+
+  it("carries both sides of a ratio through to the day", () => {
+    const days = stripDays(
+      [{ date: "2026-03-01", value: 0.5, numerator: 4, denominator: 8 }],
+      "2026-03-01",
+      "2026-03-01"
+    );
+    expect(days[0]).toMatchObject({ numerator: 4, denominator: 8 });
+  });
+});
+
+describe("silentDays", () => {
+  it("counts the days the source said nothing about", () => {
+    const days = stripDays(
+      [reading("2026-03-01", 1)],
+      "2026-03-01",
+      "2026-03-04"
+    );
+    expect(silentDays(days)).toBe(3);
+  });
+});

--- a/src/frontend/src/lib/insight/day-strip.test.ts
+++ b/src/frontend/src/lib/insight/day-strip.test.ts
@@ -52,6 +52,17 @@ describe("stripDays", () => {
     expect(days.every((d) => d.height === 0)).toBe(true);
   });
 
+  it("scales to the tallest day on the strip, not the tallest reading given", () => {
+    // A reading outside the window sets the height of nothing it is drawn
+    // beside; letting it into the scale makes every visible bar read short.
+    const days = stripDays(
+      [reading("2026-02-14", 100), reading("2026-03-01", 5), reading("2026-03-02", 10)],
+      "2026-03-01",
+      "2026-03-02"
+    );
+    expect(days.map((d) => d.height)).toEqual([0.5, 1]);
+  });
+
   it("refuses a range it cannot walk", () => {
     expect(stripDays([], "2026-03-05", "2026-03-01")).toEqual([]);
     expect(stripDays([], "not-a-date", "2026-03-01")).toEqual([]);

--- a/src/frontend/src/lib/insight/day-strip.ts
+++ b/src/frontend/src/lib/insight/day-strip.ts
@@ -44,8 +44,15 @@ export function stripDays(
   to: string
 ): StripDay[] {
   const byDate = new Map(readings.map((r) => [r.date, r]));
-  const peak = readings.reduce((max, r) => Math.max(max, r.value), 0);
-  return calendar(from, to).map((date) => {
+  const days = calendar(from, to);
+  // Scaled to the tallest day ON THE STRIP, not the tallest reading handed in.
+  // A reading outside the window would otherwise set the height of bars it is
+  // not drawn beside, and every one of them would read as smaller than it is.
+  const peak = days.reduce(
+    (max, date) => Math.max(max, byDate.get(date)?.value ?? 0),
+    0
+  );
+  return days.map((date) => {
     const reading = byDate.get(date);
     if (!reading) {
       return {

--- a/src/frontend/src/lib/insight/day-strip.ts
+++ b/src/frontend/src/lib/insight/day-strip.ts
@@ -1,0 +1,72 @@
+import type { DayReading } from "@/lib/insight/metric-grain";
+
+export interface StripDay {
+  date: string;
+  /** Null where the day has no reading at all — never a stand-in zero. */
+  value: number | null;
+  /** Share of the tallest reading, 0..1; null follows `value`. */
+  height: number | null;
+  numerator: number | null;
+  denominator: number | null;
+}
+
+const DAY_MS = 86_400_000;
+
+/** Every date from `from` to `to`, inclusive. */
+function calendar(from: string, to: string): string[] {
+  const start = Date.parse(`${from}T00:00:00Z`);
+  const end = Date.parse(`${to}T00:00:00Z`);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start)
+    return [];
+  const days: string[] = [];
+  for (let t = start; t <= end; t += DAY_MS) {
+    days.push(new Date(t).toISOString().slice(0, 10));
+  }
+  return days;
+}
+
+/**
+ * The period's days in order, each carrying its reading or nothing.
+ *
+ * Built from the calendar rather than from the rows, because the rows only
+ * cover days something happened on. A strip drawn from rows alone packs the
+ * active days together and hides every quiet one — the shape of a month with
+ * four busy days would be indistinguishable from a month that was busy
+ * throughout.
+ *
+ * A day with no reading stays null and a measured zero stays zero. They look
+ * the same on a bar chart and mean opposite things: one is silence from the
+ * source, the other is a day this person did none of it.
+ */
+export function stripDays(
+  readings: DayReading[],
+  from: string,
+  to: string
+): StripDay[] {
+  const byDate = new Map(readings.map((r) => [r.date, r]));
+  const peak = readings.reduce((max, r) => Math.max(max, r.value), 0);
+  return calendar(from, to).map((date) => {
+    const reading = byDate.get(date);
+    if (!reading) {
+      return {
+        date,
+        value: null,
+        height: null,
+        numerator: null,
+        denominator: null,
+      };
+    }
+    return {
+      date,
+      value: reading.value,
+      height: peak > 0 ? reading.value / peak : 0,
+      numerator: reading.numerator,
+      denominator: reading.denominator,
+    };
+  });
+}
+
+/** How many days of the period carry no reading. */
+export function silentDays(days: StripDay[]): number {
+  return days.filter((d) => d.value == null).length;
+}

--- a/src/frontend/src/lib/insight/groups.ts
+++ b/src/frontend/src/lib/insight/groups.ts
@@ -166,7 +166,14 @@ const GIT_OUTPUT_COLLECTION: MetricCollectionConfig = {
   metrics: [
     {
       key: "git.commits",
-      views: [{ view: "period" }, { view: "peer" }],
+      // The forge split is asked for so the section can name what it was
+      // watching. One breakdown per class is enough for that line, and this
+      // is the metric every git source reports.
+      views: [
+        { view: "period" },
+        { view: "peer" },
+        { view: "breakdown", dimensions: ["source"] },
+      ],
     },
     {
       key: "git.prs_merged",

--- a/src/frontend/src/lib/insight/metric-comparison.ts
+++ b/src/frontend/src/lib/insight/metric-comparison.ts
@@ -1,0 +1,51 @@
+import { formatMetricNumber, formatMetricValue } from "@/lib/format";
+import { computeDelta, formatTileDelta } from "@/lib/metrics/delta";
+import {
+  forEntity,
+  type NormalizedMetricResult,
+} from "@/lib/metrics/collection";
+
+export interface MetricComparisons {
+  /** "+17%" against this person's own previous period. */
+  change: string | null;
+  /** "median 512" over the comparison pool. */
+  median: string | null;
+}
+
+/**
+ * The two things a number can be read against, as plain text.
+ *
+ * Context, not a verdict. A section states both and colours neither: the
+ * reader is looking at their own work, and a red number is an accusation the
+ * screen is in no position to make — it knows the count, not why.
+ *
+ * The same pair the headline tiles carry, built the same way, so a metric
+ * does not appear to mean one thing on the overview and another one screen
+ * deeper.
+ */
+export function metricComparisons(
+  metric: NormalizedMetricResult,
+  previous: NormalizedMetricResult | null | undefined,
+  entityId: string
+): MetricComparisons {
+  const data = forEntity(metric, entityId);
+  const previousValue = previous ? forEntity(previous, entityId).value : null;
+  const delta = computeDelta(
+    data.value,
+    previousValue,
+    metric.computation,
+    metric.format
+  );
+  const median = data.peer?.median ?? null;
+  return {
+    change: delta ? formatTileDelta(delta) : null,
+    median:
+      median != null
+        ? `median ${
+            metric.format === "percent"
+              ? formatMetricValue(median, metric.format, metric.unit)
+              : formatMetricNumber(median, metric.format)
+          }`
+        : null,
+  };
+}

--- a/src/frontend/src/lib/insight/metric-grain.test.ts
+++ b/src/frontend/src/lib/insight/metric-grain.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+
+import type { MetricResult } from "@/api/metric-results-client";
+import { normalizeMetricResults } from "@/lib/metrics/collection";
+import {
+  activityEvents,
+  dailyReadings,
+  finestGrain,
+} from "@/lib/insight/metric-grain";
+
+function metric(granularity?: string[]): MetricResult | undefined {
+  return {
+    metric_key: "git.commits",
+    label: "Commits",
+    unit: null,
+    format: "integer",
+    computation: "sum",
+    direction: "higher_is_better",
+    views: [],
+    ...(granularity ? { drilldown: { granularity } } : {}),
+  } as unknown as MetricResult;
+}
+
+function normalized(granularity?: string[]) {
+  return normalizeMetricResults([metric(granularity)!]).get("git.commits");
+}
+
+const DAY_COLUMNS = [
+  { key: "date", label: "Date", type: "date" as const },
+  { key: "value", label: "Value", type: "number" as const },
+];
+const RATIO_COLUMNS = [
+  { key: "date", label: "Date", type: "date" as const },
+  { key: "numerator", label: "Numerator", type: "number" as const },
+  { key: "denominator", label: "Denominator", type: "number" as const },
+];
+
+function rows(values: Record<string, unknown>[]) {
+  return values.map((v) => ({ values: v }));
+}
+
+describe("finestGrain", () => {
+  it("takes the closest look a metric offers", () => {
+    expect(finestGrain(normalized(["event", "source_summary"]))).toBe("event");
+    expect(finestGrain(normalized(["source_summary"]))).toBe("source_summary");
+    expect(finestGrain(normalized(["derived_population"]))).toBe(
+      "derived_population"
+    );
+  });
+
+  it("says a metric offers none rather than guessing one", () => {
+    // A metric with no declared detail must render as having none. Falling
+    // back to a default would draw a daily picture for something the API
+    // cannot break down at all.
+    expect(finestGrain(normalized())).toBeNull();
+    expect(finestGrain(undefined)).toBeNull();
+    expect(finestGrain(normalized([]))).toBeNull();
+  });
+});
+
+describe("dailyReadings", () => {
+  it("adds up the rows a day was split across", () => {
+    // The wire splits a day per dimension and returns the dimension only when
+    // asked for it, so unsummed rows read as duplicates of the same date.
+    expect(
+      dailyReadings(
+        rows([
+          { date: "2026-03-02", value: 30 },
+          { date: "2026-03-02", value: 12 },
+          { date: "2026-03-01", value: 5 },
+        ]),
+        DAY_COLUMNS
+      )
+    ).toEqual([
+      { date: "2026-03-01", value: 5, numerator: null, denominator: null },
+      { date: "2026-03-02", value: 42, numerator: null, denominator: null },
+    ]);
+  });
+
+  it("divides a ratio once, on summed sides", () => {
+    // Averaging daily shares would weight a day holding one meeting the same
+    // as a day holding eight.
+    const days = dailyReadings(
+      rows([
+        { date: "2026-03-01", numerator: 2, denominator: 8 },
+        { date: "2026-03-01", numerator: 2, denominator: 0 },
+      ]),
+      RATIO_COLUMNS
+    );
+    expect(days).toEqual([
+      { date: "2026-03-01", value: 0.5, numerator: 4, denominator: 8 },
+    ]);
+  });
+
+  it("leaves a day with no denominator alone rather than dividing by zero", () => {
+    const days = dailyReadings(
+      rows([{ date: "2026-03-01", numerator: 3, denominator: 0 }]),
+      RATIO_COLUMNS
+    );
+    expect(days[0]?.value).toBe(0);
+    expect(Number.isFinite(days[0]?.value ?? NaN)).toBe(true);
+  });
+
+  it("drops a row that names no day", () => {
+    expect(dailyReadings(rows([{ value: 4 }]), DAY_COLUMNS)).toEqual([]);
+  });
+});
+
+describe("activityEvents", () => {
+  it("keeps the subject of a title and leaves the body behind", () => {
+    // A commit message carries its reasoning after the first line; in a list
+    // being scanned that reasoning is noise, and in the export it is intact.
+    const events = activityEvents(
+      rows([
+        {
+          date: "2026-03-01",
+          ref: "abc123",
+          title: "Fix the thing\n\nThe long why, several paragraphs of it.\n",
+          repository: "example/app",
+        },
+      ])
+    );
+    expect(events[0]?.title).toBe("Fix the thing");
+    expect(events[0]?.context).toBe("example/app");
+    expect(events[0]?.ref).toBe("abc123");
+  });
+
+  it("puts the newest first — a section is read from now backwards", () => {
+    const events = activityEvents(
+      rows([
+        { date: "2026-03-01", title: "older" },
+        { date: "2026-03-09", title: "newest" },
+        { date: "2026-03-05", title: "middle" },
+      ])
+    );
+    expect(events.map((e) => e.title)).toEqual(["newest", "middle", "older"]);
+  });
+
+  it("survives a source that reports no title, ref, or place", () => {
+    // Not every event-grade source names its things; the row still happened
+    // and must not be dropped for missing a label.
+    const events = activityEvents(rows([{ date: "2026-03-01", value: 3 }]));
+    expect(events).toEqual([
+      {
+        date: "2026-03-01",
+        ref: null,
+        title: null,
+        context: null,
+        value: 3,
+      },
+    ]);
+  });
+});

--- a/src/frontend/src/lib/insight/metric-grain.ts
+++ b/src/frontend/src/lib/insight/metric-grain.ts
@@ -1,0 +1,143 @@
+import type {
+  MetricEvidenceColumn,
+  MetricEvidenceRow,
+} from "@/api/metric-drilldown-client";
+import type { NormalizedMetricResult } from "@/lib/metrics/collection";
+
+/**
+ * How closely a metric can be looked at.
+ *
+ * Every metric declares this about itself in the results response, so a
+ * section never has to be told per group what its detail looks like: it asks
+ * each metric how closely it can be read and renders that. A metric that
+ * gains detail later gains it on screen without a layout change, and one that
+ * has none says so instead of being drawn as though it did.
+ */
+export type MetricGrain = "event" | "derived_population" | "source_summary";
+
+/** Closest first — what a metric can show at best. */
+const GRAIN_ORDER: MetricGrain[] = [
+  "event",
+  "derived_population",
+  "source_summary",
+];
+
+/**
+ * The closest look a metric offers, or null when it offers none.
+ *
+ * `event` names the things themselves. `derived_population` names the daily
+ * readings a ratio was built from, and carries both sides of it — for a share
+ * of the day that is the most explanatory of the three, because the argument
+ * a reader has with a percentage is almost always about its denominator.
+ * `source_summary` is a daily counter and can say when, not what.
+ */
+export function finestGrain(
+  metric: NormalizedMetricResult | undefined
+): MetricGrain | null {
+  const declared = metric?.drilldown?.granularity ?? [];
+  return GRAIN_ORDER.find((grain) => declared.includes(grain)) ?? null;
+}
+
+export interface DayReading {
+  date: string;
+  value: number;
+  /** Both sides of a ratio, when the metric reports them. */
+  numerator: number | null;
+  denominator: number | null;
+}
+
+function num(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * One reading per day, oldest first.
+ *
+ * The wire splits a day across rows whenever the metric carries a dimension,
+ * and returns the dimension itself only when it was asked for — so rows read
+ * as duplicates unless they are added up. Summing here is what makes a day a
+ * day, whatever split produced it.
+ *
+ * A ratio is summed on each side and divided once, never averaged across
+ * days: the mean of daily shares weights a day with one meeting the same as a
+ * day with eight.
+ */
+export function dailyReadings(
+  rows: MetricEvidenceRow[],
+  columns: MetricEvidenceColumn[]
+): DayReading[] {
+  const hasRatio = columns.some((c) => c.key === "numerator");
+  const byDate = new Map<string, DayReading>();
+  for (const row of rows) {
+    const date = row.values.date;
+    if (typeof date !== "string") continue;
+    const day = byDate.get(date) ?? {
+      date,
+      value: 0,
+      numerator: hasRatio ? 0 : null,
+      denominator: hasRatio ? 0 : null,
+    };
+    day.value += num(row.values.value) ?? 0;
+    if (hasRatio) {
+      day.numerator = (day.numerator ?? 0) + (num(row.values.numerator) ?? 0);
+      day.denominator =
+        (day.denominator ?? 0) + (num(row.values.denominator) ?? 0);
+    }
+    byDate.set(date, day);
+  }
+  const days = [...byDate.values()].sort((a, b) =>
+    a.date.localeCompare(b.date)
+  );
+  // A ratio's daily value is its own two sides, not whatever the wire put in
+  // `value` — which for a share of the day is a rounded percentage.
+  return days.map((day) =>
+    day.denominator != null && day.denominator > 0
+      ? { ...day, value: (day.numerator ?? 0) / day.denominator }
+      : day
+  );
+}
+
+export interface ActivityEvent {
+  /** Stable identity of the thing — a commit hash, a page id. */
+  ref: string | null;
+  /** What it is called. Absent for sources that report no title. */
+  title: string | null;
+  /** Where it happened — a repository, a space. */
+  context: string | null;
+  date: string;
+  /** The metric's own reading for this event, when it has one. */
+  value: number | null;
+}
+
+/** Everything after the first line — a commit body, not its subject. */
+function firstLine(title: string): string {
+  return title.split("\n", 1)[0]?.trim() ?? "";
+}
+
+/**
+ * The things themselves, newest first.
+ *
+ * Only the first line of a title survives. A commit message carries its
+ * reasoning in the body, and that belongs in the export or the dialog, not in
+ * a list a reader is scanning.
+ */
+export function activityEvents(rows: MetricEvidenceRow[]): ActivityEvent[] {
+  return rows
+    .flatMap((row) => {
+      const date = row.values.date;
+      if (typeof date !== "string") return [];
+      const title = row.values.title;
+      const context = row.values.repository ?? row.values.space;
+      const ref = row.values.ref;
+      return [
+        {
+          ref: typeof ref === "string" ? ref : null,
+          title: typeof title === "string" ? firstLine(title) || null : null,
+          context: typeof context === "string" ? context : null,
+          date,
+          value: num(row.values.value),
+        },
+      ];
+    })
+    .sort((a, b) => b.date.localeCompare(a.date));
+}

--- a/src/frontend/src/lib/insight/section-sources.test.ts
+++ b/src/frontend/src/lib/insight/section-sources.test.ts
@@ -1,0 +1,127 @@
+/**
+ * The line naming what a section was watching.
+ *
+ * Its value is entirely in what it refuses to say: a dimension that describes
+ * the thing being counted is not a system, and a system that produced nothing
+ * cannot be told apart from one nobody wired — so neither is claimed.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { MetricResult } from "@/api/metric-results-client";
+import type { MetricGroup } from "@/lib/insight/groups";
+import { sectionSources } from "@/lib/insight/section-sources";
+import { normalizeMetricResults } from "@/lib/metrics/collection";
+
+const ME = "019e27bc-dec0-7626-81a9-c5524662a6a9";
+
+/** One metric with a breakdown over `dimension`, as the wire delivers it. */
+function metric(
+  key: string,
+  dimension: string,
+  rows: Array<[value: string, label: string | null, amount: number]>
+): MetricResult {
+  return {
+    metric_key: key,
+    label: key,
+    unit: null,
+    format: "integer",
+    computation: "sum",
+    direction: "higher_is_better",
+    views: [
+      {
+        view: "breakdown",
+        dimensions: [dimension],
+        values: rows.map(([value, label, amount]) => ({
+          entity_id: ME,
+          dimensions: [{ key: dimension, value, label: label ?? undefined }],
+          value: amount,
+        })),
+      },
+    ],
+  } as unknown as MetricResult;
+}
+
+function group(keys: string[]): MetricGroup {
+  return {
+    id: "collaboration",
+    title: "Collaboration",
+    collection: { metrics: keys.map((key) => ({ key, views: [] })) },
+    card: { preview: [] },
+    drilldown: [],
+  } as unknown as MetricGroup;
+}
+
+describe("sectionSources", () => {
+  it("names the systems behind the numbers, alphabetically and once each", () => {
+    const results = [
+      metric("collab.messages_sent", "tool", [
+        ["zulip", "Zulip", 400],
+        ["m365", "Microsoft Teams", 20],
+      ]),
+      metric("collab.meeting_hours", "tool", [
+        ["zoom", "Zoom", 27],
+        ["m365", "Microsoft Teams", 13],
+      ]),
+    ];
+    expect(
+      sectionSources(
+        group(["collab.messages_sent", "collab.meeting_hours"]),
+        normalizeMetricResults(results),
+        ME
+      )
+    ).toEqual(["Microsoft Teams", "Zoom", "Zulip"]);
+  });
+
+  it("ignores dimensions that describe the work rather than the system", () => {
+    // "Internal" and "external" are properties of a shared file, not products.
+    // Naming them here would claim a connector that does not exist.
+    const results = [
+      metric("collab.files_shared", "scope", [
+        ["internal", "Internal", 9],
+        ["external", "External", 1],
+      ]),
+    ];
+    expect(
+      sectionSources(
+        group(["collab.files_shared"]),
+        normalizeMetricResults(results),
+        ME
+      )
+    ).toEqual([]);
+  });
+
+  it("leaves out a system that produced nothing", () => {
+    // A zero means either "this person did not use it" or "nobody wired it",
+    // and this line cannot tell those apart — so it claims neither.
+    const results = [
+      metric("ai.accepted_lines", "tool", [
+        ["claude_code", "Claude Code", 164],
+        ["codex", "Codex", 0],
+      ]),
+    ];
+    expect(
+      sectionSources(
+        group(["ai.accepted_lines"]),
+        normalizeMetricResults(results),
+        ME
+      )
+    ).toEqual(["Claude Code"]);
+  });
+
+  it("falls back to the raw value when the wire sends no label", () => {
+    const results = [metric("git.commits", "source", [["gitlab", null, 14]])];
+    expect(
+      sectionSources(
+        group(["git.commits"]),
+        normalizeMetricResults(results),
+        ME
+      )
+    ).toEqual(["gitlab"]);
+  });
+
+  it("says nothing when no metric carries a breakdown", () => {
+    // A section whose metrics were fetched without a system split states no
+    // sources rather than guessing from the metric keys.
+    expect(sectionSources(group(["git.commits"]), new Map(), ME)).toEqual([]);
+  });
+});

--- a/src/frontend/src/lib/insight/section-sources.ts
+++ b/src/frontend/src/lib/insight/section-sources.ts
@@ -1,0 +1,50 @@
+import type { MetricGroup } from "@/lib/insight/groups";
+import {
+  forEntity,
+  type NormalizedMetricResult,
+} from "@/lib/metrics/collection";
+
+/**
+ * Dimension keys that name a system rather than a property of the work.
+ *
+ * `tool` and `source` say which product the reading came out of. `scope`
+ * (internal / external), `type`, `category` and the rest describe the thing
+ * being counted, not where it was observed, and putting them in the same
+ * sentence would claim a connector that does not exist.
+ */
+const SYSTEM_DIMENSIONS = new Set(["tool", "source"]);
+
+/**
+ * The systems this section's numbers actually came out of, named.
+ *
+ * A section says how much someone collaborated; it should also say what it
+ * was watching when it decided that. Without the line, a reader has no way to
+ * tell a low number that means "little happened" from one that means "the
+ * chat tool everybody uses is not connected" — and the second is not their
+ * problem to answer for.
+ *
+ * Built from breakdowns the section already fetched, so it costs nothing.
+ * Only systems that produced something are listed: a tool with a zero reading
+ * is either unused by this person or unwired, and this line cannot tell those
+ * apart — so it does not claim to.
+ */
+export function sectionSources(
+  def: MetricGroup,
+  byKey: Map<string, NormalizedMetricResult>,
+  entityId: string
+): string[] {
+  const names = new Set<string>();
+  for (const m of def.collection.metrics) {
+    const metric = byKey.get(m.key);
+    if (!metric) continue;
+    for (const row of forEntity(metric, entityId).breakdown) {
+      if ((row.value ?? 0) <= 0) continue;
+      for (const dimension of row.dimensions) {
+        if (!SYSTEM_DIMENSIONS.has(dimension.key)) continue;
+        const name = dimension.label ?? dimension.value;
+        if (name) names.add(name);
+      }
+    }
+  }
+  return [...names].sort((a, b) => a.localeCompare(b));
+}

--- a/src/frontend/src/queries/metric-detail.test.tsx
+++ b/src/frontend/src/queries/metric-detail.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * The rows behind one metric, fetched for showing inline.
+ *
+ * What matters here is when it does NOT fetch. A section renders one of these
+ * per headline metric, so a hook that asks anyway — with no session, with no
+ * selection, or for a metric that offers no detail — turns one screen into
+ * several pointless round trips.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as drilldown from "@/api/metric-drilldown-client";
+import type { MetricEvidenceSelection } from "@/api/metric-drilldown-client";
+
+vi.mock("@/api/metric-drilldown-client");
+
+const session = vi.hoisted(() => ({ value: { scope: "tenant-a" } as unknown }));
+vi.mock("@/auth/use-auth", () => ({
+  useAuth: () => ({ session: session.value }),
+}));
+vi.mock("@/auth/session-scope", () => ({
+  sessionAuthorizationScope: (s: unknown) =>
+    s == null ? null : (s as { scope: string }).scope,
+}));
+
+import { DETAIL_LIMIT, useMetricDetail } from "./metric-detail";
+
+const SELECTION: MetricEvidenceSelection = {
+  metric_key: "git.commits",
+  entity: { type: "person", id: "019e27bc-dec0-7626-81a9-c5524662a6a9" },
+  period: { from: "2026-03-01", to: "2026-03-31" },
+  filters: [],
+  display_dimensions: [],
+};
+
+function harness() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { wrapper };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  session.value = { scope: "tenant-a" };
+});
+
+describe("useMetricDetail", () => {
+  it("asks for one page, bounded", async () => {
+    // A section is a first look, not an export: it takes what one request
+    // returns rather than paging until the source runs out.
+    vi.mocked(drilldown.queryMetricDrilldown).mockResolvedValue({
+      selection: SELECTION,
+      columns: [{ key: "date", label: "Date", type: "date" }],
+      rows: [{ values: { date: "2026-03-01" } }],
+      next_cursor: "there-is-more",
+    });
+    const { wrapper } = harness();
+    const { result } = renderHook(() => useMetricDetail(SELECTION), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(drilldown.queryMetricDrilldown).toHaveBeenCalledTimes(1);
+    expect(
+      vi.mocked(drilldown.queryMetricDrilldown).mock.calls[0][0]
+    ).toMatchObject({
+      metric_key: "git.commits",
+      limit: DETAIL_LIMIT,
+    });
+    expect(result.current.data?.rows).toHaveLength(1);
+  });
+
+  it("does not fetch for a metric that offers no detail", async () => {
+    // The caller passes `enabled: false` for a metric declaring no grain.
+    // Asking anyway would spend a request to be told there is nothing.
+    const { wrapper } = harness();
+    renderHook(() => useMetricDetail(SELECTION, false), { wrapper });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(drilldown.queryMetricDrilldown).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch without a selection", async () => {
+    const { wrapper } = harness();
+    renderHook(() => useMetricDetail(null), { wrapper });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(drilldown.queryMetricDrilldown).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch before a session exists", async () => {
+    // On a cold load the session resolves after the first render. Firing then
+    // produces a 401 the screen would have to explain, for a request that was
+    // never going to work.
+    session.value = null;
+    const { wrapper } = harness();
+    renderHook(() => useMetricDetail(SELECTION), { wrapper });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(drilldown.queryMetricDrilldown).not.toHaveBeenCalled();
+  });
+
+  it("keeps two different selections apart", async () => {
+    // The key carries the selection, so a second metric does not read the
+    // first one's rows out of the cache.
+    vi.mocked(drilldown.queryMetricDrilldown).mockResolvedValue({
+      selection: SELECTION,
+      columns: [],
+      rows: [],
+      next_cursor: null,
+    });
+    const { wrapper } = harness();
+    const { result, rerender } = renderHook(
+      ({ s }: { s: MetricEvidenceSelection }) => useMetricDetail(s),
+      { wrapper, initialProps: { s: SELECTION } }
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    rerender({ s: { ...SELECTION, metric_key: "git.prs_merged" } });
+    await waitFor(() =>
+      expect(drilldown.queryMetricDrilldown).toHaveBeenCalledTimes(2)
+    );
+  });
+});

--- a/src/frontend/src/queries/metric-detail.ts
+++ b/src/frontend/src/queries/metric-detail.ts
@@ -1,0 +1,49 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { AnalyticsApiError } from "@/api/analytics-client";
+import {
+  queryMetricDrilldown,
+  type MetricEvidenceSelection,
+} from "@/api/metric-drilldown-client";
+import { sessionAuthorizationScope } from "@/auth/session-scope";
+import { useAuth } from "@/auth/use-auth";
+
+/**
+ * How many rows a section's inline detail asks for.
+ *
+ * Enough to show a period's shape at day grain without paging, and far short
+ * of what the evidence dialog is for. A section is a first look, not an
+ * export.
+ */
+export const DETAIL_LIMIT = 200;
+
+/**
+ * The rows behind one metric, for showing inline rather than in a dialog.
+ *
+ * Shares the dialog's query key so the two never fetch the same page twice:
+ * opening the full evidence for a metric already shown in a section starts
+ * from cache.
+ */
+export function useMetricDetail(
+  selection: MetricEvidenceSelection | null | undefined,
+  enabled = true
+) {
+  const { session } = useAuth();
+  const sessionScope = sessionAuthorizationScope(session);
+  return useQuery({
+    // The dialog keys on the same shape with its own page size, so the two
+    // stay distinct entries rather than one clobbering the other's rows.
+    queryKey: ["metric-drilldown", sessionScope, selection, DETAIL_LIMIT],
+    queryFn: ({ signal }) => {
+      if (!selection) throw new Error("Metric detail selection is missing");
+      return queryMetricDrilldown(
+        { ...selection, limit: DETAIL_LIMIT },
+        signal
+      );
+    },
+    enabled: enabled && sessionScope != null && selection != null,
+    retry: (failureCount, error) =>
+      failureCount < 1 &&
+      (!(error instanceof AnalyticsApiError) || error.status >= 500),
+  });
+}


### PR DESCRIPTION
## What a section is for

The section screen and the drilldown sheet were the same component — the sheet
lifted onto a page with a heading added. A modal answering a click and a
destination reached from the navigation are not the same job, and the seam
showed.

The overview had already said which sections were worth opening. The section
then repeated that judgment, bigger and in red: a hero card labelled TOP ISSUE
above three coloured outliers, most of which the overview had just named. A
reader who came in because Focus Time needed attention was shown Focus Time
needing attention. Every comparison on the screen was against the cohort, so
the screen one level deeper had dropped the only comparison the reader owns.
And most of the class was behind a fold titled by its statistical standing, so
finding a metric meant knowing in advance how it had ranked.

A section is where a number is explained, and the explanation a reader wants is
the work behind it.

## The rule the body follows

Every metric declares, in the results response, how closely it can be read:
the things themselves, the daily readings a ratio was built from, or a daily
counter. Nothing on screen used that. So the section asks each metric and
renders what it gets — commits listed as commits, counters drawn as days, a
share of the day drawn with the denominator it was taken out of, and a plain
statement where a metric offers nothing.

Nothing here is configured per group. A metric that gains detail later gains it
on screen without a layout change.

## What that produced

**The work behind these numbers.** Per headline metric, at its own grain. The
day strip walks the calendar rather than the rows, so quiet days keep their
place — drawn from rows alone, four busy days in a month pack together and read
as a month that was busy throughout. A day with no reading stays a gap and a
measured zero stays a zero; they draw alike and mean opposite things. Hover
reads out in the caption already under the strip, rather than in a native title
on each of thirty-one bars.

**Also measured here.** The rest of the class, alphabetical, in one column.
Three aligned columns read as a table — the eye takes the row first — so an
alphabet running down each column is invisible and the list still looks like a
heap. Rows that hold nothing for this person are left out: a column of dashes
is the fastest way to teach someone to stop reading a list.

**A standing mark on one shared axis.** Distance in cohort spreads —
(value − median) / IQR — puts hours, messages and percentages on one axis. The
axis line is drawn once behind every row, not per row, so everything ordinary
settles onto it and blends. That blending is the point: "I am like the others
here" should cost no attention, and what the eye is left with is the few marks
standing off the line.

**From <systems>.** What the section was watching, assembled from breakdowns it
had already fetched. A low number means one thing when the tool everyone uses is
connected and another when it is not, and nothing on the screen let a reader
tell those apart.

**Composition, and no verdict.** The headline cards keep their totals and their
breakdowns and lose their status stripe and coloured value. In a section that
withholds judgment, a coloured card makes the judgment anyway — louder than any
sentence beside it, because colour is read before words are.

## Deliberate refusals

- The axis is **never flipped by direction**. Lower left, higher right. Orienting
  it so that left means worse would put the verdict back in through the
  geometry, and a metric with no better direction has no worse to point at.
- **Colour only where the shared standing already calls a reading bottom of the
  pack.** Standing out is not being wrong: eleven spreads above the middle is
  remarkable on any metric and a problem on almost none. Two coloured marks in a
  list of nineteen is a finding; nineteen is a scoreboard.
- **An extreme reading pins to the edge in a different shape** rather than
  setting the scale for every other row.
- **Where nothing is comparable there is no mark**, though the element still
  renders — so an absent dot cannot be misread as a dot at the middle.
- **No mark in the headline blocks.** It reads against the line the list draws
  behind it; three rows that already state both comparisons in words are not the
  problem it solves.
- **A metric a chart already draws over time gets no strip beside it** — the
  chart carries the split a strip cannot. Event-grade metrics are exempt: a list
  of the things themselves is a different answer, not a finer drawing.

## Empty sections

A class with nothing recorded said so once per metric, in four wordings, down a
full page of placeholders. It now says it once, and skips composition entirely.

## Verification

966 tests across both projects, `tsc -b` and eslint clean. Checked against a
running stand on every section, for people with data in most classes and for
people with none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detailed metric activity views with daily trends, event evidence, comparison text, and empty-state messaging.
  - Added peer-comparison markers showing median, spread, and relative standing.
  - Added an index of additional measured metrics with values and peer comparisons.
  - Added source attribution and “work behind these numbers” activity sections.
  - Added clearer period, loading, error, and no-data states.
- **Improvements**
  - Refined drilldowns to support explanatory content and more relevant metric filtering.
  - Removed status-based coloring from metric summary cards for a more consistent presentation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->