### PR TITLE
feat(frontend): report errors to Sentry

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -837,9 +837,21 @@ jobs:
       # No `file:` — the Dockerfile is at the context root.
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         id: build
+        env:
+          # Both arches emit identical maps under one release, and a
+          # pull_request image is discarded.
+          UPLOAD_SOURCEMAPS: ${{ needs.changes.outputs.should_push == 'true' && matrix.arch == 'amd64' }}
         with:
           context: src/frontend
           platforms: ${{ matrix.platform }}
+          build-args: |
+            VITE_SENTRY_DSN=${{ secrets.FRONTEND_SENTRY_DSN }}
+            VITE_APP_RELEASE=${{ needs.changes.outputs.build_tag }}
+            SENTRY_UPLOAD=${{ env.UPLOAD_SOURCEMAPS }}
+          # Quoted: the value is a multiline dotenv, and the action reads
+          # unquoted newlines as further entries.
+          secrets: |
+            "sentry_env=${{ env.UPLOAD_SOURCEMAPS == 'true' && secrets.SENTRY_BUILD_ENV || '' }}"
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}/insight-frontend,push-by-digest=true,name-canonical=true,push=${{ needs.changes.outputs.should_push == 'true' }}
           cache-from: type=gha,scope=frontend-${{ matrix.arch }}
           cache-to: ${{ needs.changes.outputs.should_push == 'true' && format('type=gha,mode=max,scope=frontend-{0},ignore-error=true', matrix.arch) || '' }}

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -554,3 +554,7 @@ frontend:
     enabled: false
     className: nginx
     host: ""
+  sentry:
+    # Sentry origin the SPA posts to, e.g. "https://sentry.example.com".
+    # Empty leaves it out of the CSP, which blocks every event.
+    connectSrc: ""

--- a/src/frontend/.env.example
+++ b/src/frontend/.env.example
@@ -21,3 +21,8 @@ VITE_ENABLE_MOCKS=false
 # Set during screenshot / demo capture when the banner would intrude on the
 # image. Mocks themselves keep running. No effect when mocks are off.
 # VITE_HIDE_MOCK_BANNER=true
+
+# Sentry DSN. Unset means no reporting — the normal state for local work. A
+# deployed stand also needs the same origin in the chart's `sentry.connectSrc`,
+# or its CSP blocks every event.
+# VITE_SENTRY_DSN=https://<key>@sentry.example.com/<project-id>

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -11,7 +11,17 @@ RUN npm install -g "pnpm@$(node -p 'require("/app/package.json").packageManager.
 RUN pnpm install --frozen-lockfile --ignore-scripts
 
 COPY . .
-RUN pnpm run build
+
+ARG VITE_SENTRY_DSN
+ARG VITE_APP_RELEASE
+# Secret contents are not part of the layer cache key; this is.
+ARG SENTRY_UPLOAD
+
+RUN --mount=type=secret,id=sentry_env \
+    if [ -f /run/secrets/sentry_env ]; then \
+      set -a; . /run/secrets/sentry_env; set +a; \
+    fi; \
+    pnpm run build
 
 # Runtime base: keep this on a currently-maintained nginx line. The 1.27 tag
 # stopped getting Alpine package refreshes, so the published image accumulated
@@ -31,9 +41,8 @@ RUN chmod +x /docker-entrypoint.sh
 
 # nginx config: security-headers snippet (included at server level AND inside
 # any location block that declares its own add_header — nginx replaces rather
-# than merges across levels) + default.conf that the entrypoint copies into
-# conf.d at container start. No runtime templating anymore (the SPA is
-# same-origin only), but the file keeps its .template name and location.
+# than merges across levels) + default.conf that the entrypoint renders into
+# conf.d at container start.
 RUN mkdir -p /etc/nginx/snippets
 COPY nginx/security-headers.conf /etc/nginx/snippets/security-headers.conf
 COPY nginx/default.conf.template /etc/nginx/templates/default.conf.template

--- a/src/frontend/README.md
+++ b/src/frontend/README.md
@@ -118,6 +118,67 @@ Build-time (Vite, `.env.local`):
 | `VITE_API_PROXY_TARGET` | Dev-only `/api` proxy target (e.g. `http://localhost:8080`). |
 | `VITE_API_BASE` | Override analytics API base URL (default `/api/analytics/v1`). |
 | `VITE_IDENTITY_BASE` | Override identity API base URL (default `/api/identity/v1`). |
+| `VITE_SENTRY_DSN` | Sentry DSN. Unset means Sentry never initializes. |
+| `VITE_APP_RELEASE` | Release attached to events and sourcemaps. Defaults to `local-<git sha>`; CI passes the image tag. |
+
+## Error Reporting and Tracing
+
+[src/sentry.ts](src/sentry.ts) initializes Sentry as the first statement in
+[src/main.tsx](src/main.tsx). The module imports above it — i18n, the query
+client, the router — have already run by then, so a throw while they initialize
+goes unreported.
+
+What leaves the browser:
+
+- Render errors, via `onError` on [app-error-boundary.tsx](src/components/app-error-boundary.tsx).
+- Unhandled exceptions and rejections, from the SDK's own handlers.
+- Performance transactions for 10% of page loads and navigations. Browser
+  tracing also instruments `fetch`/XHR and adds `sentry-trace` and `baggage`
+  headers to same-origin requests.
+
+Events carry the hostname as their `environment` (`local` on localhost) — one
+image serves every stand, so nothing else tells them apart.
+
+Two settings must agree:
+
+1. `VITE_SENTRY_DSN` at build time — a `--build-arg` for the image, or the
+   `FRONTEND_SENTRY_DSN` repository secret in CI.
+2. `sentry.connectSrc` in the deployed chart values, set to the same origin.
+   The container's CSP is rendered from it at start; without it the browser
+   blocks every event and nothing arrives.
+
+The SDK attaches no cookies, IP or headers to events. Session Replay is not
+enabled.
+
+### Sourcemaps
+
+Without uploaded sourcemaps a Sentry stack trace names the minified bundle, not
+your code. The image build uploads them, then deletes them from `dist/` so nginx
+never serves them.
+
+The credentials arrive as one BuildKit secret — a dotenv file mounted at
+`/run/secrets/sentry_env` and sourced only for `pnpm run build`:
+
+```dotenv
+SENTRY_AUTH_TOKEN=sntrys_exampletoken
+SENTRY_URL=https://sentry.example.com
+SENTRY_ORG=example-org
+SENTRY_PROJECT=example-project
+```
+
+The token needs the `project:releases` and `org:read` scopes.
+
+Store it as the `SENTRY_BUILD_ENV` repository secret. A secret rather than build
+args because this job builds PR-authored source and `ARG` values persist in
+builder history.
+
+Without the secret the file is absent and the build skips the upload. A failed
+upload — expired token, Sentry unreachable — logs and continues, so image builds
+do not depend on Sentry being up.
+
+`@sentry/cli` fetches its binary in a postinstall, so `package.json` allowlists
+it under `pnpm.onlyBuiltDependencies`. Everything else stays blocked: pnpm 10
+denies lifecycle scripts by default.
 
 ## Routes
 

--- a/src/frontend/docker-entrypoint.sh
+++ b/src/frontend/docker-entrypoint.sh
@@ -8,7 +8,10 @@ set -e
 # `/api/*` and `/auth/me` same-origin with `credentials: 'include'`.
 
 # Place the nginx config. The build ships it under /etc/nginx/templates, so
-# copy it into conf.d here.
-cp /etc/nginx/templates/default.conf.template /etc/nginx/conf.d/default.conf
+# render it into conf.d here. The explicit variable list keeps envsubst off
+# nginx's own `$sent_http_content_type` / `$csp_header`.
+envsubst '${SENTRY_CONNECT_SRC}' \
+  < /etc/nginx/templates/default.conf.template \
+  > /etc/nginx/conf.d/default.conf
 
 exec "$@"

--- a/src/frontend/helm/templates/deployment.yaml
+++ b/src/frontend/helm/templates/deployment.yaml
@@ -41,6 +41,9 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          env:
+            - name: SENTRY_CONNECT_SRC
+              value: {{ .Values.sentry.connectSrc | quote }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/src/frontend/helm/values.yaml
+++ b/src/frontend/helm/values.yaml
@@ -17,6 +17,11 @@ ingress:
   annotations: {}
   host: ""
 
+sentry:
+  # Sentry origin the SPA posts to, e.g. "https://sentry.example.com".
+  # Empty leaves it out of the CSP, which blocks every event.
+  connectSrc: ""
+
 resources:
   requests:
     cpu: 50m

--- a/src/frontend/nginx/default.conf.template
+++ b/src/frontend/nginx/default.conf.template
@@ -1,5 +1,5 @@
 map $sent_http_content_type $csp_header {
-    default "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self'; frame-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; object-src 'none'";
+    default "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ${SENTRY_CONNECT_SRC}; frame-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; object-src 'none'";
 }
 
 server {
@@ -15,9 +15,8 @@ server {
     # location block that declares its own add_header (nginx replaces rather
     # than merges across levels). CSP: 'unsafe-inline' for style-src is
     # required for React inline styles + recharts; tighten via nonce in a
-    # later iteration. The SPA is same-origin only (it calls /api/* and
-    # /auth/* through the gateway that fronts this container), so connect-src
-    # and frame-src stay at 'self'.
+    # later iteration. The SPA reaches /api/* and /auth/* through the gateway
+    # that fronts this container, so 'self' covers them.
     include /etc/nginx/snippets/security-headers.conf;
 
     # MSW service worker ships in dist/ from public/ but is inert without

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@base-ui/react": "1.4.1",
     "@fontsource-variable/inter": "5.2.8",
+    "@sentry/react": "10.69.0",
     "@tanstack/react-query": "5.100.9",
     "@tanstack/react-router": "1.169.2",
     "@tanstack/react-virtual": "3.13.12",
@@ -52,6 +53,7 @@
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@rolldown/plugin-babel": "0.2.3",
+    "@sentry/vite-plugin": "5.4.0",
     "@storybook/addon-a11y": "10.4.6",
     "@storybook/addon-docs": "10.4.6",
     "@storybook/addon-themes": "10.4.6",

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@fontsource-variable/inter':
         specifier: 5.2.8
         version: 5.2.8
+      '@sentry/react':
+        specifier: 10.69.0
+        version: 10.69.0(react@19.2.6)
       '@tanstack/react-query':
         specifier: 5.100.9
         version: 5.100.9(react@19.2.6)
@@ -94,6 +97,9 @@ importers:
       '@rolldown/plugin-babel':
         specifier: 0.2.3
         version: 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0))
+      '@sentry/vite-plugin':
+        specifier: 5.4.0
+        version: 5.4.0
       '@storybook/addon-a11y':
         specifier: 10.4.6
         version: 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))
@@ -1220,6 +1226,108 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
+  '@sentry/browser-utils@10.69.0':
+    resolution: {integrity: sha512-e/u1Abj0zRPwR/deGZAP3GOULrsx67/XXnM5Skniqs4uxTsdNtPek1Nef0tpxwaQJYxwh6pWdhswLPPbbPOgBQ==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@10.69.0':
+    resolution: {integrity: sha512-8391tnm96YbR7b8SYfEA/NEIZuyb2r3SZrtAT0bhZtjlujcYWjo7gugQvk8sWLU9cAa/euD00eJoIoJvNfpd7Q==}
+    engines: {node: '>=18'}
+
+  '@sentry/bundler-plugins@10.69.0':
+    resolution: {integrity: sha512-I1otnSJIH4IOugLp+kcBbT0Kcex+J8xnHuUyzMAwCYSpZ0FMVvA723uNmkMdW0PxRRw0oEhe0qDB+t+ZjHxUiA==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      rollup: '>=3.2.0'
+      webpack: '>=5.0.0'
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+      webpack:
+        optional: true
+
+  '@sentry/cli-darwin@2.58.6':
+    resolution: {integrity: sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==}
+    engines: {node: '>=10'}
+    os: [darwin]
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    resolution: {integrity: sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-arm@2.58.6':
+    resolution: {integrity: sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==}
+    engines: {node: '>=10'}
+    cpu: [arm]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-i686@2.58.6':
+    resolution: {integrity: sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-linux-x64@2.58.6':
+    resolution: {integrity: sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [linux, freebsd, android]
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    resolution: {integrity: sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==}
+    engines: {node: '>=10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@sentry/cli-win32-i686@2.58.6':
+    resolution: {integrity: sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==}
+    engines: {node: '>=10'}
+    cpu: [x86, ia32]
+    os: [win32]
+
+  '@sentry/cli-win32-x64@2.58.6':
+    resolution: {integrity: sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==}
+    engines: {node: '>=10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@sentry/cli@2.58.6':
+    resolution: {integrity: sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
+  '@sentry/conventions@0.16.0':
+    resolution: {integrity: sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==}
+    engines: {node: '>=14'}
+
+  '@sentry/core@10.69.0':
+    resolution: {integrity: sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg==}
+    engines: {node: '>=18'}
+
+  '@sentry/feedback@10.69.0':
+    resolution: {integrity: sha512-qrGz5Qaw93/IhMjlFN6uIaXeHwgHDaKGa6FkTAP6PonpkvSbGGqan6xfsENxzj9HUVoli1lZ6tMRDnt2qtSPhg==}
+    engines: {node: '>=18'}
+
+  '@sentry/react@10.69.0':
+    resolution: {integrity: sha512-f0Il/JMteHjdWPNZQB3rtp1Pcj2Leb3p0KSZuv3rh0EUril9CbWtQVy5zJhoAppi+MWWmgRWa+6BpHbQf+ABQA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: 19.2.6
+
+  '@sentry/replay-canvas@10.69.0':
+    resolution: {integrity: sha512-VF6nXvSninHcc7dC1Zme0RjkC7VgRMCixs6jKaQX5zTNeqTW3dZGSefSOVv+ZteRi3hJvVORq985VjUC9Z/0+A==}
+    engines: {node: '>=18'}
+
+  '@sentry/replay@10.69.0':
+    resolution: {integrity: sha512-uRhmNhtFGPOlM0iniVmWKAX3KVXI0le41yYK/iKdPjinT9jA3ZrmykO/Fv1v/KI5znOtwa9D6eHRnDTTMRxFrg==}
+    engines: {node: '>=18'}
+
+  '@sentry/vite-plugin@5.4.0':
+    resolution: {integrity: sha512-fFJgCxs5hDyAm9BbZJ+LbA+LK2tjX5OoD0v0ARU4StR6KQmGUduoPs69yJ9AfqZ0om3Rlp5JDliiwFcNkasORA==}
+    engines: {node: '>= 18'}
+
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
@@ -1792,6 +1900,10 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -2659,6 +2771,10 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
@@ -3199,6 +3315,15 @@ packages:
     engines: {node: '>=10.5.0'}
     deprecated: Use your platform's native DOMException instead
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3459,6 +3584,10 @@ packages:
   process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
 
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -3466,6 +3595,9 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3918,6 +4050,9 @@ packages:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
     engines: {node: '>=16'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
@@ -4134,6 +4269,9 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webidl-conversions@8.0.1:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
@@ -4148,6 +4286,9 @@ packages:
   whatwg-url@16.0.1:
     resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -5111,6 +5252,113 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
+  '@sentry/browser-utils@10.69.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.69.0
+
+  '@sentry/browser@10.69.0':
+    dependencies:
+      '@sentry/browser-utils': 10.69.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.69.0
+      '@sentry/feedback': 10.69.0
+      '@sentry/replay': 10.69.0
+      '@sentry/replay-canvas': 10.69.0
+
+  '@sentry/bundler-plugins@10.69.0':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@sentry/cli': 2.58.6
+      '@sentry/core': 10.69.0
+      dotenv: 17.4.2
+      find-up: 5.0.0
+      glob: 13.0.6
+      magic-string: 0.30.21
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/cli-darwin@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-arm@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-linux-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-arm64@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-i686@2.58.6':
+    optional: true
+
+  '@sentry/cli-win32-x64@2.58.6':
+    optional: true
+
+  '@sentry/cli@2.58.6':
+    dependencies:
+      https-proxy-agent: 5.0.1
+      node-fetch: 2.7.0
+      progress: 2.0.3
+      proxy-from-env: 1.1.0
+      which: 2.0.2
+    optionalDependencies:
+      '@sentry/cli-darwin': 2.58.6
+      '@sentry/cli-linux-arm': 2.58.6
+      '@sentry/cli-linux-arm64': 2.58.6
+      '@sentry/cli-linux-i686': 2.58.6
+      '@sentry/cli-linux-x64': 2.58.6
+      '@sentry/cli-win32-arm64': 2.58.6
+      '@sentry/cli-win32-i686': 2.58.6
+      '@sentry/cli-win32-x64': 2.58.6
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@sentry/conventions@0.16.0': {}
+
+  '@sentry/core@10.69.0':
+    dependencies:
+      '@sentry/conventions': 0.16.0
+
+  '@sentry/feedback@10.69.0':
+    dependencies:
+      '@sentry/core': 10.69.0
+
+  '@sentry/react@10.69.0(react@19.2.6)':
+    dependencies:
+      '@sentry/browser': 10.69.0
+      '@sentry/conventions': 0.16.0
+      '@sentry/core': 10.69.0
+      react: 19.2.6
+
+  '@sentry/replay-canvas@10.69.0':
+    dependencies:
+      '@sentry/core': 10.69.0
+      '@sentry/replay': 10.69.0
+
+  '@sentry/replay@10.69.0':
+    dependencies:
+      '@sentry/browser-utils': 10.69.0
+      '@sentry/core': 10.69.0
+
+  '@sentry/vite-plugin@5.4.0':
+    dependencies:
+      '@sentry/bundler-plugins': 10.69.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+      - webpack
+
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -5768,6 +6016,12 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   agent-base@7.1.4: {}
 
@@ -6689,6 +6943,13 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -7118,6 +7379,10 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-fetch@3.3.2:
     dependencies:
       data-uri-to-buffer: 4.0.1
@@ -7352,6 +7617,8 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
+  progress@2.0.3: {}
+
   prompts@2.4.2:
     dependencies:
       kleur: 3.0.3
@@ -7361,6 +7628,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
 
@@ -7873,6 +8142,8 @@ snapshots:
     dependencies:
       tldts: 7.0.30
 
+  tr46@0.0.3: {}
+
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
@@ -8056,6 +8327,8 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  webidl-conversions@3.0.1: {}
+
   webidl-conversions@8.0.1: {}
 
   webpack-virtual-modules@0.6.2: {}
@@ -8069,6 +8342,11 @@ snapshots:
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which@2.0.2:
     dependencies:

--- a/src/frontend/src/components/app-error-boundary.test.tsx
+++ b/src/frontend/src/components/app-error-boundary.test.tsx
@@ -1,0 +1,34 @@
+import * as Sentry from "@sentry/react";
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+import "@/i18n";
+
+import { AppErrorBoundary } from "@/components/app-error-boundary";
+
+vi.mock("@sentry/react", () => ({ captureReactException: vi.fn() }));
+
+function BrokenChild(): React.ReactElement {
+  throw new Error("render failed");
+}
+
+beforeEach(() => {
+  // React logs every caught error through console.error.
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+it("reports a render error with its component stack", () => {
+  render(
+    <AppErrorBoundary>
+      <BrokenChild />
+    </AppErrorBoundary>
+  );
+
+  expect(screen.getByText("render failed")).toBeInTheDocument();
+  const [, info] = vi.mocked(Sentry.captureReactException).mock.calls[0];
+  expect(info.componentStack).toContain("BrokenChild");
+});

--- a/src/frontend/src/components/app-error-boundary.tsx
+++ b/src/frontend/src/components/app-error-boundary.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from "@sentry/react";
 import { QueryErrorResetBoundary } from "@tanstack/react-query";
 import { type ReactNode } from "react";
 import { ErrorBoundary } from "react-error-boundary";
@@ -12,7 +13,11 @@ export function AppErrorBoundary({
   return (
     <QueryErrorResetBoundary>
       {({ reset }) => (
-        <ErrorBoundary FallbackComponent={ErrorFallback} onReset={reset}>
+        <ErrorBoundary
+          FallbackComponent={ErrorFallback}
+          onReset={reset}
+          onError={Sentry.captureReactException}
+        >
           {children}
         </ErrorBoundary>
       )}

--- a/src/frontend/src/components/error-fallback.test.tsx
+++ b/src/frontend/src/components/error-fallback.test.tsx
@@ -22,12 +22,12 @@ describe("ErrorFallback", () => {
   it("renders an Error's message", () => {
     render(
       <ErrorFallback
-        error={new Error("boom")}
+        error={new Error("render failed")}
         resetErrorBoundary={() => {}}
       />,
     );
     expect(screen.getByText("Something went wrong")).toBeInTheDocument();
-    expect(screen.getByText("boom")).toBeInTheDocument();
+    expect(screen.getByText("render failed")).toBeInTheDocument();
   });
 
   it("renders string errors and falls back for unknown shapes", () => {

--- a/src/frontend/src/components/widgets/metrics-console/metric-detail.test.tsx
+++ b/src/frontend/src/components/widgets/metrics-console/metric-detail.test.tsx
@@ -66,7 +66,7 @@ beforeEach(() => vi.resetAllMocks());
 describe("MetricDetail", () => {
   it("shows a load error when the metric fails to fetch", async () => {
     vi.mocked(metricsClient.getCustomMetric).mockRejectedValue(
-      new Error("boom")
+      new Error("request failed")
     );
     renderDetail();
     expect(

--- a/src/frontend/src/lib/query-console/api-error.test.ts
+++ b/src/frontend/src/lib/query-console/api-error.test.ts
@@ -19,7 +19,9 @@ describe("apiErrorReason", () => {
   });
 
   it("falls back when the error is not an AnalyticsApiError", () => {
-    expect(apiErrorReason(new Error("boom"), FALLBACK)).toBe(FALLBACK);
+    expect(apiErrorReason(new Error("unexpected failure"), FALLBACK)).toBe(
+      FALLBACK
+    );
     expect(apiErrorReason("nope", FALLBACK)).toBe(FALLBACK);
   });
 

--- a/src/frontend/src/main.tsx
+++ b/src/frontend/src/main.tsx
@@ -18,6 +18,7 @@ import { LoginError } from "@/components/login-error";
 import { ThemeProvider } from "@/components/theme-provider";
 import i18n from "@/i18n";
 import { queryClient } from "@/query-client";
+import { initSentry } from "@/sentry";
 import { router } from "./router";
 
 async function enableMocking(): Promise<void> {
@@ -26,6 +27,8 @@ async function enableMocking(): Promise<void> {
   const { worker } = await import("@/mocks/browser");
   await worker.start({ onUnhandledRequest: "bypass" });
 }
+
+initSentry(router);
 
 // `?__override=<email>` (view-as, insight#1941) bounces straight into the
 // login flow — before mocks, session probe, or the router touch anything.

--- a/src/frontend/src/queries/metric-results.test.tsx
+++ b/src/frontend/src/queries/metric-results.test.tsx
@@ -146,7 +146,7 @@ describe("useMetricCollection", () => {
   });
 
   it("surfaces errors and leaves byKey empty", async () => {
-    mock.mockRejectedValue(new Error("boom"));
+    mock.mockRejectedValue(new Error("request failed"));
     const { result } = renderHook(
       () => useMetricCollection(COLLECTION, ENTITY, RANGE),
       { wrapper: wrapper() },

--- a/src/frontend/src/sentry.test.ts
+++ b/src/frontend/src/sentry.test.ts
@@ -1,0 +1,48 @@
+import * as Sentry from "@sentry/react";
+import type { BrowserOptions } from "@sentry/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { initSentry } from "./sentry";
+
+vi.mock("@sentry/react", () => ({
+  init: vi.fn(),
+  tanstackRouterBrowserTracingIntegration: vi.fn(),
+}));
+
+const DSN = "https://public@sentry.example.com/1";
+const ROUTER = { id: "router" };
+
+function initWith(): BrowserOptions {
+  vi.stubEnv("VITE_SENTRY_DSN", DSN);
+  initSentry(ROUTER);
+  return vi.mocked(Sentry.init).mock.calls[0][0]!;
+}
+
+beforeEach(() => {
+  vi.mocked(Sentry.init).mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+});
+
+describe("initSentry", () => {
+  it("does nothing without a DSN", () => {
+    vi.stubEnv("VITE_SENTRY_DSN", "");
+
+    initSentry(ROUTER);
+
+    expect(Sentry.init).not.toHaveBeenCalled();
+  });
+
+  it("labels the environment with the hostname off localhost", () => {
+    vi.stubGlobal("location", new URL("https://stand.example.com/ic"));
+
+    expect(initWith().environment).toBe("stand.example.com");
+  });
+
+  it("labels localhost as local", () => {
+    expect(initWith().environment).toBe("local");
+  });
+});

--- a/src/frontend/src/sentry.ts
+++ b/src/frontend/src/sentry.ts
@@ -1,0 +1,23 @@
+import * as Sentry from "@sentry/react";
+
+const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "[::1]"]);
+
+export function initSentry(router: unknown): void {
+  const dsn = import.meta.env.VITE_SENTRY_DSN;
+  if (!dsn) return;
+
+  Sentry.init({
+    dsn,
+    environment: resolveEnvironment(),
+    release: import.meta.env.VITE_APP_RELEASE || undefined,
+    // Route pattern rather than resolved URL, so ids stay out of event names.
+    integrations: [Sentry.tanstackRouterBrowserTracingIntegration(router)],
+    tracesSampleRate: 0.1,
+  });
+}
+
+/** One image serves every stand, so the hostname is the only label it has. */
+function resolveEnvironment(): string {
+  const { hostname } = window.location;
+  return LOCAL_HOSTNAMES.has(hostname) ? "local" : hostname;
+}

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -1,9 +1,27 @@
 import babel from "@rolldown/plugin-babel";
+import { sentryVitePlugin } from "@sentry/vite-plugin";
 import tailwindcss from "@tailwindcss/vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import react, { reactCompilerPreset } from "@vitejs/plugin-react";
+import { execSync } from "child_process";
 import path from "path";
 import { defineConfig, loadEnv } from "vite";
+
+// CI passes the image tag as VITE_APP_RELEASE. Everywhere else, name the
+// release after the commit built from. `.dockerignore` drops `.git`, so this
+// finds nothing inside the image build.
+function localRelease(): string | undefined {
+  try {
+    const sha = execSync("git rev-parse --short HEAD", {
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+      .toString()
+      .trim();
+    return `local-${sha}`;
+  } catch {
+    return undefined;
+  }
+}
 
 export default defineConfig(({ mode, command }) => {
   const env = loadEnv(mode, process.cwd(), "");
@@ -13,13 +31,37 @@ export default defineConfig(({ mode, command }) => {
   const proxyTarget =
     env.VITE_API_PROXY_TARGET ||
     (command === "serve" ? "http://localhost:8080" : undefined);
+  const release = env.VITE_APP_RELEASE || localRelease();
+  // Without a release, sentry-cli is handed the string "undefined".
+  const uploadSourcemaps =
+    command === "build" &&
+    Boolean(
+      release && env.SENTRY_AUTH_TOKEN && env.SENTRY_ORG && env.SENTRY_PROJECT
+    );
+  // Assigning undefined would store the literal string "undefined".
+  if (release) process.env.VITE_APP_RELEASE = release;
   return {
     plugins: [
       tanstackRouter({ target: "react", autoCodeSplitting: true }),
       react(),
       babel({ presets: [reactCompilerPreset()] }),
       tailwindcss(),
+      uploadSourcemaps &&
+        sentryVitePlugin({
+          // Unset for sentry.io; a self-hosted instance needs its base URL.
+          url: env.SENTRY_URL || undefined,
+          org: env.SENTRY_ORG,
+          project: env.SENTRY_PROJECT,
+          authToken: env.SENTRY_AUTH_TOKEN,
+          release: { name: release },
+          sourcemaps: { filesToDeleteAfterUpload: ["./dist/**/*.map"] },
+        }),
     ],
+    build: {
+      // "hidden": emit maps for the upload without a sourceMappingURL comment
+      // pointing browsers at files that are deleted once uploaded.
+      sourcemap: uploadSourcemaps ? "hidden" : false,
+    },
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "./src"),

--- a/src/frontend/vitest.config.ts
+++ b/src/frontend/vitest.config.ts
@@ -102,6 +102,7 @@ export default defineConfig({
             "@base-ui/react/separator",
             "@base-ui/react/switch",
             "@base-ui/react/tooltip",
+            "@sentry/react",
             "@tanstack/react-virtual",
             "react-day-picker",
             "react-error-boundary",


### PR DESCRIPTION
Part of #2354.

## What

Adds Sentry error reporting to the SPA. Inert until a DSN is configured, so nothing changes until the settings below are set.

## How it reports

- **Render errors** — `onError={Sentry.captureReactException}` on the app error boundary, which attaches the React component stack.
- **Unhandled errors and rejections** — the SDK's own global handlers.

Query failures are deliberately **not** reported from the browser — a screen renders its own error state and the exception never reaches either path.

`src/sentry.ts` is 23 lines: a DSN gate, the environment label, the release, and the TanStack Router tracing integration at a 0.1 sample rate. Initialization runs from `main.tsx` at boot, before the view-as redirect is consumed, so a failure in that redirect path is still covered.

## Configuration

The DSN is compiled into the bundle; the environment label is resolved in the browser from the hostname, so one image can serve several stands.

| Setting | Where | Effect if unset |
|---|---|---|
| `FRONTEND_SENTRY_DSN` | repository secret → `--build-arg` | no reporting at all |
| `frontend.sentry.connectSrc` | chart values | CSP blocks every event |
| `SENTRY_BUILD_ENV` | repository secret → BuildKit secret | no sourcemap upload |

`release` is the image tag (`build_tag`), so an issue in Sentry names the exact image it came from.

`docker-entrypoint.sh` renders the nginx config with `envsubst` over a single variable rather than copying it, so the CSP can name the ingest origin per stand. nginx's own `$sent_http_content_type` and `$csp_header` are outside the substitution list and unaffected.

## Sourcemaps

Without them a stack trace names the minified bundle. The upload runs during `pnpm run build` inside the image, and the maps are deleted from `dist/` before the runtime stage copies it — verified: the published image contains no `.map` files and no `sourceMappingURL` comments, while 28 files carry debug IDs.

Credentials arrive as one BuildKit secret rather than build args, since that job builds PR-authored source. The upload is gated to pushed builds on a single architecture: both arches emit byte-identical maps under the same release, and a `pull_request` image is discarded.

A failed upload logs and continues, so image builds do not depend on Sentry being reachable.

## Privacy

`sendDefaultPii` is left at its default, so no cookies, IP or request headers are attached. Session Replay is not enabled. Transactions are named by route pattern rather than resolved URL.

## Testing

`typecheck`, `lint` and the unit suite pass; the image was built repeatedly to verify the build-arg, secret, sourcemap and CSP paths end to end, with the variables both set and unset.

## After merge

The configuration steps live in #2354 — the token, the two repository secrets, the per-stand CSP origin, and one end-to-end confirmation. Every one fails silently when missing, so that last confirmation is the only real signal the chain works.

### Known follow-ups

- Query failures are not reported from the browser, and no backend reporting is planned, so an API 500 is currently seen by nobody.
- The SPA has no runtime-config channel, which is why the environment is derived from the hostname and why the Sentry origin is stated twice (baked DSN, chart `connectSrc`). Serving a small generated config file from the nginx config the entrypoint already renders would collapse both. Deliberately out of scope here.
- #2352 — the image builds on Node 25 while `.nvmrc`, CI and the README pin Node 24.
