### PR TITLE
feat(frontend): add an app favicon

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Insight</title>
   </head>
   <body>

--- a/src/frontend/public/favicon.svg
+++ b/src/frontend/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="7" fill="#262626" />
+  <path
+    d="M10 8h12v3.2h-4.4v9.6H22V24H10v-3.2h4.4v-9.6H10z"
+    fill="#fafafa"
+  />
+</svg>

--- a/src/frontend/public/favicon.svg
+++ b/src/frontend/public/favicon.svg
@@ -1,7 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
   <rect width="32" height="32" rx="7" fill="#262626" />
-  <path
-    d="M10 8h12v3.2h-4.4v9.6H22V24H10v-3.2h4.4v-9.6H10z"
-    fill="#fafafa"
-  />
+  <rect x="13.5" y="8" width="5" height="16" rx="1" fill="#fafafa" />
 </svg>


### PR DESCRIPTION
## What

The browser tab had no icon — the shell document declared none, so browsers fell back to their blank-page glyph.

Adds `src/frontend/public/favicon.svg`: a 32×32 rounded tile in the app's neutral primary (`#262626`) with a white "I" — the same mark the sidebar header renders (`app-sidebar.tsx`, `size-7` + `rounded-md` + `bg-sidebar-primary`). The stem is drawn heavier than the text glyph so it stays visible at 16px.

`index.html` links it with `<link rel="icon" type="image/svg+xml">`.

## Notes

SVG only, no `.ico` fallback — covers Chrome, Edge, Firefox and Safari 16.4+. Happy to add a PNG/ICO fallback or an `apple-touch-icon` if older browsers matter.

## Test

- `pnpm build` copies the file to `dist/favicon.svg` and keeps the tag in `dist/index.html`.
- Served from a local compose stand at `/favicon.svg`.
- Rasterized the SVG to confirm the mark renders as intended and matches the sidebar tile.