### PR TITLE
fix(frontend): build the image on the Node major .nvmrc pins

### DIFF
--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:25-bookworm-slim AS builder
+FROM node:24-bookworm-slim AS builder
 
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
-# Not corepack: node:25 dropped it, and its package collides with the yarn bins
-# this image already holds.
+# Not corepack: node images past 24 no longer ship it, and its package collides
+# with the yarn bins this image already holds.
 RUN npm install -g "pnpm@$(node -p 'require("/app/package.json").packageManager.split("@")[1]')"
 
 RUN pnpm install --frozen-lockfile --ignore-scripts

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -4,6 +4,9 @@
   "version": "0.0.1",
   "type": "module",
   "packageManager": "pnpm@10.33.0",
+  "engines": {
+    "node": "24.x"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",

--- a/src/frontend/pnpm-workspace.yaml
+++ b/src/frontend/pnpm-workspace.yaml
@@ -4,3 +4,5 @@ minimumReleaseAge: 10080
 
 # Save exact versions when installing dependencies.
 saveExact: true
+
+engineStrict: true


### PR DESCRIPTION
Closes #2352

## What

The frontend builder stage ran `node:25-bookworm-slim` while `.nvmrc`, `ci.yml` and the README all name 24, so `pnpm run build` produced the shipped bundle on a runtime no gate exercises.

Nothing chose 25 — a base-image bump landed it in the `Dockerfile` alone. Node 25 is a Current line: it never becomes LTS and reached end of life on 2026-06-01 (`nodejs/Release` `schedule.json`). Node 24 is Active LTS, maintenance until 2026-10-20, EOL 2028-04-30.

## Changes

- `src/frontend/Dockerfile` — builder stage back to `node:24-bookworm-slim`. The `Dockerfile:7` comment named node:25 explicitly, so it is reworded to state the version-independent reason corepack is not used.
- `src/frontend/package.json` — `"engines": { "node": "24.x" }`.
- `src/frontend/pnpm-workspace.yaml` — `engineStrict: true`.

`pnpm install` now refuses a Node major outside `engines.node`, so a base that drifts off `.nvmrc` fails the image build instead of passing silently. `.nvmrc`, `ci.yml`, the README and `docker-compose.yml` already name 24 and are untouched.

`corepack enable` is deliberately not restored: node images past 24 no longer ship corepack, so reverting to it would break again at the next major. pnpm stays pinned by `packageManager`.

No dependabot `ignore` entry was added. A future bump now fails the image build in `build-images.yml`, which makes moving the Node major a deliberate change touching every source at once rather than silent drift in one file.

## Verification

- `docker build --target builder src/frontend` on Node 24 — exit 0; `tsc -b` and `vite build` both pass and `dist/` is produced.
- Same Dockerfile with the tag flipped to `node:25-bookworm-slim` — fails at `pnpm install`, before any bundle exists:

  ```
  ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)
  Expected version: 24.x
  Got: v25.9.0
  ```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the frontend runtime on Node.js 24.
  * Added validation to ensure installations use the supported Node.js version.
  * Updated package configuration to enforce the declared runtime requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->