### PR TITLE
fix(github-directory): tag dbt models with the connector slug

### DIFF
--- a/src/ingestion/connectors/git/github-directory/dbt/github_directory__bronze_promoted.sql
+++ b/src/ingestion/connectors/git/github-directory/dbt/github_directory__bronze_promoted.sql
@@ -11,7 +11,7 @@
 {{ config(
     materialized='view',
     schema='staging',
-    tags=['github_directory']
+    tags=['github-directory']
 ) }}
 
 {% do promote_bronze_to_rmt(table='bronze_github_directory.org_members', order_by='unique_key') %}

--- a/src/ingestion/connectors/git/github-directory/dbt/github_directory__identity_inputs.sql
+++ b/src/ingestion/connectors/git/github-directory/dbt/github_directory__identity_inputs.sql
@@ -2,7 +2,7 @@
     materialized='incremental',
     incremental_strategy='append',
     schema='staging',
-    tags=['github_directory', 'silver', 'silver:identity_inputs']
+    tags=['github-directory', 'silver', 'silver:identity_inputs']
 ) }}
 
 -- Identity-resolution inputs for the GitHub account roster; unioned into

--- a/src/ingestion/connectors/git/github-directory/dbt/github_directory__org_members_fields_history.sql
+++ b/src/ingestion/connectors/git/github-directory/dbt/github_directory__org_members_fields_history.sql
@@ -2,7 +2,7 @@
 {{ config(
     materialized='table',
     schema='staging',
-    tags=['github_directory', 'silver']
+    tags=['github-directory', 'silver']
 ) }}
 
 -- Field-level change log of the GitHub member profile, derived from the

--- a/src/ingestion/connectors/git/github-directory/dbt/github_directory__org_members_snapshot.sql
+++ b/src/ingestion/connectors/git/github-directory/dbt/github_directory__org_members_snapshot.sql
@@ -3,7 +3,7 @@
     materialized='incremental',
     incremental_strategy='append',
     schema='staging',
-    tags=['github_directory']
+    tags=['github-directory']
 ) }}
 
 -- SCD2 snapshot of the GitHub organization roster — appends a new version only

--- a/src/ingestion/connectors/git/github-directory/descriptor.yaml
+++ b/src/ingestion/connectors/git/github-directory/descriptor.yaml
@@ -20,7 +20,7 @@ type: nocode
 schedule: "30 3 * * *"       # 03:30 UTC daily
 workflow: sync               # Argo workflow template: ingestion-pipeline
 
-dbt_select: "tag:github_directory+"
+dbt_select: "tag:github-directory+"
 
 connection:
   namespace: "bronze_github_directory"


### PR DESCRIPTION
## Problem

`ingestion-pipeline` derives the dbt selector from the connector slug as `tag:<data_source>+` and ignores the `dbt_select` it is passed (non-jira path). Models were tagged `github_directory`, slug is `github-directory` — selector matched nothing, rows stopped at bronze.

dbt exits 0 on an empty selection, so the step reported success.

## Fix

Retag the 4 models to `github-directory`. Align `descriptor.dbt_select` with the selector actually used.

## Scope

Fixes the `github-directory` half of #2362. dbt exiting 0 on an empty selection is untouched — until that fails loudly, the next mismatch is equally invisible.

## Verification

`connector_wiring.py` green, `validate-strict` passes, 8 mock tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized the GitHub Directory data pipeline tag format from `github_directory` to `github-directory`.
  * Applied the updated tag consistently across related models, snapshots, and selection configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->