### PR TITLE
feat(connectors/git): nocode GitHub, GitLab and Bitbucket connectors on the git-cli-proxy

### DIFF
--- a/deploy/CONNECTORS.md
+++ b/deploy/CONNECTORS.md
@@ -220,6 +220,7 @@ type: Opaque
 stringData:
   github_token:         "ghp_CHANGE_ME"   # repo, read:org
   github_organizations: '["myorg"]'       # JSON array
+  github_start_date:    "2026-01-01"
   git_proxy_url:        "http://insight-git-cli-proxy:8085"
   git_proxy_token:      "CHANGE_ME"       # must match the proxy's own Secret
 ```
@@ -237,6 +238,7 @@ stringData:
   gitlab_url:      "https://gitlab.example.com"
   gitlab_token:    "CHANGE_ME"            # read_api + read_repository
   gitlab_groups:   '["mygroup"]'          # JSON array of full group paths
+  gitlab_start_date: "2026-01-01"
   git_proxy_url:   "http://insight-git-cli-proxy:8085"
   git_proxy_token: "CHANGE_ME"
 ```
@@ -254,6 +256,7 @@ stringData:
   bitbucket_username:   "bot@example.com" # for API tokens; omit for workspace access tokens
   bitbucket_token:      "CHANGE_ME"
   bitbucket_workspaces: '["myworkspace"]' # JSON array
+  bitbucket_start_date: "2026-01-01"
   git_proxy_url:        "http://insight-git-cli-proxy:8085"
   git_proxy_token:      "CHANGE_ME"
 ```

--- a/deploy/CONNECTORS.md
+++ b/deploy/CONNECTORS.md
@@ -15,7 +15,7 @@ Connectors pull data from your tools — Jira issues, Slack messages, GitHub pul
 - [Prerequisites](#prerequisites)
 - [Contents](#contents)
 - [Anatomy of a connector Secret](#anatomy-of-a-connector-secret)
-- [The 19 available connectors](#the-19-available-connectors)
+- [The 22 available connectors](#the-22-available-connectors)
 - [Example Secret for every connector](#example-secret-for-every-connector)
   - [AI & coding assistants](#ai--coding-assistants)
   - [Source control & CI](#source-control--ci)
@@ -52,11 +52,11 @@ stringData:
   jira_api_token:    "ATATT-CHANGE_ME"
 ```
 
-## The 19 available connectors
+## The 22 available connectors
 
 Replace `CHANGE_ME` (and any other placeholder) values in whichever connector files you need, under `connectors/`:
 
-`jira`, `slack`, `github-v2`, `gitlab`, `m365`, `zoom`, `confluence`, `zendesk`, `bamboohr`, `ms-entra`, `outline`, `hubspot`, `cursor`, `chatgpt-team`, `claude-team`, `claude-enterprise`, `bitbucket-cloud`, `zulip-proxy`, `github-directory`.
+`jira`, `slack`, `github-v2`, `gitlab`, `m365`, `zoom`, `confluence`, `zendesk`, `bamboohr`, `ms-entra`, `outline`, `hubspot`, `cursor`, `chatgpt-team`, `claude-team`, `claude-enterprise`, `bitbucket-cloud`, `zulip-proxy`, `github-directory`, `github-nocode`, `gitlab-nocode`, `bitbucket-nocode`.
 
 Apply all of them at once, or one at a time:
 
@@ -201,6 +201,61 @@ type: Opaque
 stringData:
   github_token:         "ghp_CHANGE_ME"   # read:org (+ user:email for member emails)
   github_organizations: '["myorg"]'       # JSON array
+```
+
+```yaml
+# Declarative git connectors on the git-cli-proxy: commit-level data comes
+# from a bare clone served by the proxy instead of one vendor API call per
+# commit. All three need the proxy deployed (gitClIProxy.deploy: true) and
+# git_proxy_token equal to APP__gears__git_cli_proxy__config__proxy_token in
+# the umbrella-composed insight-git-cli-proxy-config Secret.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-github-nocode-main
+  namespace: insight
+  labels: { app.kubernetes.io/part-of: insight }
+  annotations: { insight.cyberfabric.com/connector: github-nocode, insight.cyberfabric.com/source-id: github-nocode-main }
+type: Opaque
+stringData:
+  github_token:         "ghp_CHANGE_ME"   # repo, read:org
+  github_organizations: '["myorg"]'       # JSON array
+  git_proxy_url:        "http://insight-git-cli-proxy:8085"
+  git_proxy_token:      "CHANGE_ME"       # must match the proxy's own Secret
+```
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-gitlab-nocode-main
+  namespace: insight
+  labels: { app.kubernetes.io/part-of: insight }
+  annotations: { insight.cyberfabric.com/connector: gitlab-nocode, insight.cyberfabric.com/source-id: gitlab-nocode-main }
+type: Opaque
+stringData:
+  gitlab_url:      "https://gitlab.example.com"
+  gitlab_token:    "CHANGE_ME"            # read_api + read_repository
+  gitlab_groups:   '["mygroup"]'          # JSON array of full group paths
+  git_proxy_url:   "http://insight-git-cli-proxy:8085"
+  git_proxy_token: "CHANGE_ME"
+```
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-bitbucket-nocode-main
+  namespace: insight
+  labels: { app.kubernetes.io/part-of: insight }
+  annotations: { insight.cyberfabric.com/connector: bitbucket-nocode, insight.cyberfabric.com/source-id: bitbucket-nocode-main }
+type: Opaque
+stringData:
+  bitbucket_username:   "bot@example.com" # for API tokens; omit for workspace access tokens
+  bitbucket_token:      "CHANGE_ME"
+  bitbucket_workspaces: '["myworkspace"]' # JSON array
+  git_proxy_url:        "http://insight-git-cli-proxy:8085"
+  git_proxy_token:      "CHANGE_ME"
 ```
 
 ### Issue tracking & docs

--- a/deploy/CONNECTORS.md
+++ b/deploy/CONNECTORS.md
@@ -61,7 +61,7 @@ Replace `CHANGE_ME` (and any other placeholder) values in whichever connector fi
 Apply all of them at once, or one at a time:
 
 ```sh
-kubectl -n insight apply -f connectors/      # all 19 connectors at once
+kubectl -n insight apply -f connectors/      # all 22 connectors at once
 # or one at a time:
 kubectl -n insight apply -f connectors/jira.yaml
 ```

--- a/deploy/CONNECTORS.md
+++ b/deploy/CONNECTORS.md
@@ -237,7 +237,7 @@ type: Opaque
 stringData:
   gitlab_url:      "https://gitlab.example.com"
   gitlab_token:    "CHANGE_ME"            # read_api + read_repository
-  gitlab_groups:   '["mygroup"]'          # JSON array of full group paths
+  gitlab_groups:   '["mygroup"]'          # JSON array; [] = full instance (self-hosted only)
   gitlab_start_date: "2026-01-01"
   git_proxy_url:   "http://insight-git-cli-proxy:8085"
   git_proxy_token: "CHANGE_ME"

--- a/scripts/ci/components.py
+++ b/scripts/ci/components.py
@@ -218,7 +218,12 @@ COMPONENTS = [
         "pytest_args": "--suites-only",
         "cover": False,
         "triggered_by": ["connector-tests-harness"],
-        "paths": ["src/ingestion/connectors/task-tracking/jira"],
+        "paths": [
+            "src/ingestion/connectors/task-tracking/jira",
+            "src/ingestion/connectors/git/gitlab-nocode",
+            "src/ingestion/connectors/git/bitbucket-nocode",
+            "src/ingestion/connectors/git/github-nocode",
+        ],
     },
     # `src/frontend/helm` falls under this path but has no measured lines, so it
     # never moves the number.

--- a/scripts/ci/connector_wiring.py
+++ b/scripts/ci/connector_wiring.py
@@ -28,6 +28,12 @@ Checks
   4. cast-types — contributors MUST NOT explicitly cast the same class_people
                   column to different types; `union_by_tag` UNION ALLs the
                   branches and ClickHouse raises Code 386 NO_COMMON_TYPE.
+  5. builder    — a declarative `connector.yaml` MUST NOT carry the Airbyte
+                  Builder's `#magic___^_^___line` marker. Inside a `>-` folded
+                  scalar it is CONTENT, not a comment, so a round-trip through
+                  the Builder silently appends it to whatever value it landed
+                  in — including `unique_key`, which is the declared
+                  primary_key and the ReplacingMergeTree order_by.
 
 Empty `images.<key>.image` refs are reported as warnings, never errors: a
 brand-new CDK connector legitimately ships with `image: ""` and is patched by
@@ -38,6 +44,9 @@ Exit:  0 clean (warnings allowed), 1 on any error.
 """
 
 # ruff: noqa: T201  — stdout/stderr IS this script's CI report (cf. changed.py).
+
+# Scoped to connector.yaml on purpose: the same marker appears legitimately in
+# prose (dbt model descriptions, test-case docs), and an ignore-list would rot.
 from __future__ import annotations
 
 import argparse
@@ -50,6 +59,7 @@ import yaml
 # Strict semver per semver.org §2, identical to classify_bump.py and
 # bump-descriptor-version.sh: numeric identifiers MUST NOT carry leading
 # zeroes, which is what keeps `2026.05.04` distinguishable from a real triplet.
+BUILDER_MARKER = "#magic___"
 SEMVER_RE = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 
 CLASS_PEOPLE_TAG = "silver:class_people"
@@ -159,6 +169,20 @@ def main(argv: list[str]) -> int:
                 "(see #2048). Add the entry with "
                 f"`./generate-connectors-config.sh '{rel}'`."
             )
+
+        # ── 5. Airbyte Builder marker ───────────────────────────────────────
+        # Read as RAW TEXT: after yaml.safe_load the marker is indistinguishable
+        # from any other substring, which is exactly the problem.
+        manifest = connector_dir / "connector.yaml"
+        if manifest.is_file():
+            for lineno, line in enumerate(manifest.read_text().splitlines(), start=1):
+                if BUILDER_MARKER in line:
+                    errors.append(
+                        f"{rel}/connector.yaml:{lineno}: contains "
+                        f"{BUILDER_MARKER!r}. Inside a `>-` folded scalar this is "
+                        "CONTENT, not a comment — it is appended to the value. "
+                        "Strip it after every Builder round-trip."
+                    )
 
         # ── 3-4. class_people contributors only ─────────────────────────────
         if not models:

--- a/src/ingestion/connections/example-tenant.yaml.example
+++ b/src/ingestion/connections/example-tenant.yaml.example
@@ -1,0 +1,15 @@
+# Tenant config for the LOCAL declarative-connector runner
+# (tools/declarative-connector/source.sh). Not used by the deployed reconcile
+# loop, which reads the tenant from the connector Secret in the cluster.
+#
+# Copy to {tenant-name}.yaml (e.g. acme.yaml) and pass that name as the
+# <tenant> argument:
+#
+#   cp example-tenant.yaml.example acme.yaml
+#   ./tools/declarative-connector/source.sh check git/github-nocode acme
+#
+# Contains ONLY tenant_id — every credential comes from the connector Secret
+# in secrets/connectors/<connector>.yaml, and insight_source_id from that
+# Secret's insight.cyberfabric.com/source-id annotation.
+
+tenant_id: example_tenant

--- a/src/ingestion/connectors/git/bitbucket-nocode/README.md
+++ b/src/ingestion/connectors/git/bitbucket-nocode/README.md
@@ -1,0 +1,150 @@
+# Bitbucket Cloud (git-cli-proxy) Connector
+
+Declarative Bitbucket Cloud connector that extracts commit-level data through
+the [git-cli-proxy](../../../../../docs/components/connectors/git/git-cli-proxy/specs/DESIGN.md)
+instead of the vendor API. Bitbucket is where the per-commit API cost hurts
+most: the CDK connector calls `diffstat/{sha}` once per commit against a
+~1000 req/h budget, so a 50k-commit repository is a multi-day backfill. The
+proxy serves the same rows from a bare clone.
+
+Repository discovery still uses the Bitbucket API — one call per page of
+repositories, not per commit.
+
+Auth: an Atlassian API token used as HTTP basic `username:token`, both for the
+API and (forwarded per request, never stored) for the clone the proxy performs.
+
+## Prerequisites
+
+1. A Bitbucket API token with `repository:read`, plus the account username or
+   email it belongs to.
+2. A reachable git-cli-proxy deployment and its bearer token. In-cluster the
+   umbrella composes both (`insight-git-cli-proxy-config`); the proxy accepts
+   traffic only from the namespaces its NetworkPolicy allows.
+
+## K8s Secret
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-bitbucket-nocode-main
+  labels:
+    app.kubernetes.io/part-of: insight
+  annotations:
+    insight.cyberfabric.com/connector: bitbucket-nocode
+    insight.cyberfabric.com/source-id: bitbucket-nocode-main
+type: Opaque
+stringData:
+  bitbucket_username: "CHANGE_ME"
+  bitbucket_token: "CHANGE_ME"
+  bitbucket_workspaces: '["acme"]'
+  git_proxy_url: "http://insight-git-cli-proxy:8085"
+  git_proxy_token: "CHANGE_ME"
+  bitbucket_start_date: "2020-01-01"
+```
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `bitbucket_username` | Yes | Atlassian account username or email |
+| `bitbucket_git_username` | No | Username presented when CLONING over https, which is NOT the API credential. Default `x-bitbucket-api-token-auth` works for personal API tokens; use the account's short username for a workspace or repository access token |
+| `bitbucket_token` | Yes | API token with `repository:read` |
+| `bitbucket_workspaces` | Yes | JSON array of workspace slugs |
+| `git_proxy_url` | Yes | git-cli-proxy base URL. No default — a wrong value must fail `check`, not fall back |
+| `git_proxy_token` | Yes | Bearer token the proxy requires on every `/v1` request |
+| `bitbucket_api_base_url` | No | API base URL (default `https://api.bitbucket.org/2.0`) |
+| `bitbucket_start_date` | No | Earliest date for the initial sync (default `2020-01-01`) |
+| `bitbucket_page_size` | No | Bitbucket API page size, max 100 |
+| `proxy_page_size` | No | Rows per proxy page (default 500) |
+| `bitbucket_include_patch` | No | Store per-file diff text (default true) |
+| `bitbucket_lookback_window` | No | ISO-8601 duration re-enumerated below the cursor each sync, so a rebase does not strand commits dated below it (default `P1M`) |
+| `bitbucket_max_patch_bytes` | No | Truncation cap per file diff (default 1 MiB) |
+
+### Automatically injected
+
+| Field | Source |
+|-------|--------|
+| `insight_tenant_id` | `tenant_id` from tenant YAML |
+| `insight_source_id` | `insight.cyberfabric.com/source-id` annotation |
+
+### Local development
+
+```bash
+cp src/ingestion/secrets/connectors/bitbucket-nocode.yaml.example src/ingestion/secrets/connectors/bitbucket-nocode.yaml
+# fill in real values, then:
+kubectl apply -f src/ingestion/secrets/connectors/bitbucket-nocode.yaml
+```
+
+## Streams
+
+| Stream | Upstream | Sync Mode | Cursor |
+|--------|----------|-----------|--------|
+| `repositories` | Bitbucket `/2.0/repositories/{workspace}` | incremental | `updated_on` |
+| `commits` | proxy `/v1/commits` | incremental, per repository | `committed_date` |
+| `commit_files` | proxy `/v1/file-changes` | incremental, per repository | `committed_date` |
+| `repo_branches` | proxy `/v1/branches` | full refresh, per repository | — |
+
+### How the streams fit together
+
+`repositories` fans out over the configured workspaces (`ListPartitionRouter`)
+and is the incremental **parent**: the commit streams route through
+`SubstreamPartitionRouter` with `incremental_dependency: true`, so a sync visits
+only repositories whose `updated_on` advanced. The CDK persists parent state
+only when the child stream is incremental — `commits` and `commit_files` are.
+
+The proxy routes on a **flat** `clone_url` field, but Bitbucket nests clone
+links in an array (`links.clone[]`, one entry per protocol). Every repositories
+stream therefore hoists the `https` entry to a top-level `clone_url` in a
+transformation. The API link is used rather than a URL derived from
+`full_name`: deriving would duplicate knowledge of the host layout.
+
+The streams are otherwise independent: each carries its own cursor and asks the
+proxy for its own window. They join downstream by `sha`.
+
+`repo_branches` is full refresh — bronze keeps the latest state per branch, and
+head-movement history is derived by the `snapshot` / `fields_history` dbt
+macros. Its `unique_key` excludes `head_sha`, so the ReplacingMergeTree
+collapses to current state and a head move is a tracked-column change.
+
+### Bitbucket-specific behaviours
+
+- **Pagination** is cursor-style: the response carries an absolute `next` URL,
+  consumed via `RequestPath`.
+- **`fields=`** trims the response to the used properties; the full repository
+  object is large and most of it is unused here.
+- **No server-side "updated after" filter** exists on `/repositories`, so the
+  cursor filters client-side. The listing is requested `sort=updated_on`
+  (ascending) so the cursor still advances monotonically across pages.
+
+### Cold repositories
+
+The first request for an uncached repository gets `429` + `Retry-After` while
+the proxy clones it in the background; every proxy stream retries on `429`.
+`409` (the pinned snapshot was superseded) and `413` (repository over the
+proxy's size cap) fail the stream instead — retrying the same page token would
+loop.
+
+## Open question: partial clone support
+
+The proxy clones with `--filter=blob:none`. Whether Bitbucket Cloud honours it
+is **unverified** — it is open question #2 in the design and needs a live
+credential to settle. Git degrades gracefully if the server does not support
+filtering (it warns and performs a full clone), so the connector works either
+way; what changes is the proxy's first-clone cost and disk profile, since the
+`repack --filter=blob:none` purge still returns the entry to a blobless
+skeleton afterwards. Measure before sizing the cache volume for Bitbucket.
+
+## Silver Targets
+
+Not wired yet — same position as `git/gitlab-nocode`. The silver models must
+match the CDK `git/bitbucket-cloud` connector's column types exactly
+(`union_by_tag` UNION ALLs the branches; one mismatched type raises
+`Code: 386 NO_COMMON_TYPE` and breaks the shared class for every source). Until
+they land this connector is bronze-only.
+
+## Not ported
+
+Pull requests and their children (comments, reviewers, commits, diffstat) stay
+on the vendor API — that data does not exist in git. Porting them is a
+mechanical translation of the CDK connector's streams and is tracked separately.

--- a/src/ingestion/connectors/git/bitbucket-nocode/README.md
+++ b/src/ingestion/connectors/git/bitbucket-nocode/README.md
@@ -82,8 +82,8 @@ kubectl apply -f src/ingestion/secrets/connectors/bitbucket-nocode.yaml
 |--------|----------|-----------|--------|
 | `repositories` | Bitbucket `/2.0/repositories/{workspace}` | incremental | `updated_on` |
 | `commits` | proxy `/v1/commits` | incremental, per repository | `committed_date` |
-| `commit_files` | proxy `/v1/file-changes` | incremental, per repository | `committed_date` |
-| `repo_branches` | proxy `/v1/branches` | full refresh, per repository | — |
+| `file_changes` | proxy `/v1/file-changes` | incremental, per repository | `committed_date` |
+| `branches` | proxy `/v1/branches` | full refresh, per repository | — |
 
 ### How the streams fit together
 
@@ -91,7 +91,7 @@ kubectl apply -f src/ingestion/secrets/connectors/bitbucket-nocode.yaml
 and is the incremental **parent**: the commit streams route through
 `SubstreamPartitionRouter` with `incremental_dependency: true`, so a sync visits
 only repositories whose `updated_on` advanced. The CDK persists parent state
-only when the child stream is incremental — `commits` and `commit_files` are.
+only when the child stream is incremental — `commits` and `file_changes` are.
 
 The proxy routes on a **flat** `clone_url` field, but Bitbucket nests clone
 links in an array (`links.clone[]`, one entry per protocol). Every repositories
@@ -102,7 +102,7 @@ transformation. The API link is used rather than a URL derived from
 The streams are otherwise independent: each carries its own cursor and asks the
 proxy for its own window. They join downstream by `sha`.
 
-`repo_branches` is full refresh — bronze keeps the latest state per branch, and
+`branches` is full refresh — bronze keeps the latest state per branch, and
 head-movement history is derived by the `snapshot` / `fields_history` dbt
 macros. Its `unique_key` excludes `head_sha`, so the ReplacingMergeTree
 collapses to current state and a head move is a tracked-column change.

--- a/src/ingestion/connectors/git/bitbucket-nocode/README.md
+++ b/src/ingestion/connectors/git/bitbucket-nocode/README.md
@@ -125,15 +125,14 @@ the proxy clones it in the background; every proxy stream retries on `429`.
 proxy's size cap) fail the stream instead — retrying the same page token would
 loop.
 
-## Open question: partial clone support
+## Partial clone support: settled
 
-The proxy clones with `--filter=blob:none`. Whether Bitbucket Cloud honours it
-is **unverified** — it is open question #2 in the design and needs a live
-credential to settle. Git degrades gracefully if the server does not support
-filtering (it warns and performs a full clone), so the connector works either
-way; what changes is the proxy's first-clone cost and disk profile, since the
-`repack --filter=blob:none` purge still returns the entry to a blobless
-skeleton afterwards. Measure before sizing the cache volume for Bitbucket.
+Bitbucket Cloud honours `--filter=blob:none` (verified live — git-cli-proxy
+PLAN §9.2). One sizing consequence remains: with `include_patch=true` the
+first backfill lazily pulls essentially every blob while paging history, so
+the proxy cache should be sized for roughly full-clone weight per Bitbucket
+repository during backfill; the post-serve purge returns entries to the
+blobless skeleton afterwards.
 
 ## Silver Targets
 

--- a/src/ingestion/connectors/git/bitbucket-nocode/README.md
+++ b/src/ingestion/connectors/git/bitbucket-nocode/README.md
@@ -78,6 +78,13 @@ kubectl apply -f src/ingestion/secrets/connectors/bitbucket-nocode.yaml
 | `commits` | proxy `/v1/commits` | incremental, per repository | `committed_date` |
 | `file_changes` | proxy `/v1/file-changes` | incremental, per repository | `committed_date` |
 | `branches` | proxy `/v1/branches` | full refresh, per repository | — |
+| `pull_requests` | Bitbucket `/pullrequests` (all states) | incremental | `updated_on` |
+| `pull_request_comments` | `/pullrequests/{id}/comments` | windowed PR parent, full refresh per PR | — |
+| `pull_request_commits` | `/pullrequests/{id}/commits` | windowed PR parent, full refresh per PR | — |
+| `pull_request_activity` | `/pullrequests/{id}/activity` | windowed PR parent, full refresh per PR | — |
+| `workspace_members` | `/workspaces/{w}/members` | full refresh | — |
+| `pipelines` | `/repositories/{r}/pipelines` | newest-first data feed | `created_on` |
+| `deployments` | `/repositories/{r}/deployments` | newest-first data feed | `created_on` |
 
 ### How the streams fit together
 

--- a/src/ingestion/connectors/git/bitbucket-nocode/README.md
+++ b/src/ingestion/connectors/git/bitbucket-nocode/README.md
@@ -81,6 +81,7 @@ kubectl apply -f src/ingestion/secrets/connectors/bitbucket-nocode.yaml
 | `pull_requests` | Bitbucket `/pullrequests` (all states) | incremental | `updated_on` |
 | `pull_request_comments` | `/pullrequests/{id}/comments` | windowed PR parent, full refresh per PR | — |
 | `pull_request_commits` | `/pullrequests/{id}/commits` | windowed PR parent, full refresh per PR | — |
+| `pull_request_diffstat` | `/pullrequests/{id}/diffstat` | windowed PR parent, full refresh per PR | — |
 | `pull_request_activity` | `/pullrequests/{id}/activity` | windowed PR parent, full refresh per PR | — |
 | `workspace_members` | `/workspaces/{w}/members` | full refresh | — |
 | `pipelines` | `/repositories/{r}/pipelines` | newest-first data feed | `created_on` |
@@ -134,6 +135,16 @@ first backfill lazily pulls essentially every blob while paging history, so
 the proxy cache should be sized for roughly full-clone weight per Bitbucket
 repository during backfill; the post-serve purge returns entries to the
 blobless skeleton afterwards.
+
+### PR size
+
+`pull_request_diffstat` is the only source of pull-request line counts:
+Bitbucket has no GraphQL API and carries no diff totals on the pull request
+itself, so the per-file diffstat rows are it. Grain therefore differs from the
+GitHub and GitLab diff-stat streams, which get pull-request-level totals in one
+query — silver sums these rows per pull request. A pull request whose branches
+share no history has no computable diff and answers 400; that pull request is
+skipped, the rest continue.
 
 ## Silver Targets
 

--- a/src/ingestion/connectors/git/bitbucket-nocode/README.md
+++ b/src/ingestion/connectors/git/bitbucket-nocode/README.md
@@ -47,19 +47,13 @@ stringData:
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `bitbucket_username` | Yes | Atlassian account username or email |
-| `bitbucket_git_username` | No | Username presented when CLONING over https, which is NOT the API credential. Default `x-bitbucket-api-token-auth` works for personal API tokens; use the account's short username for a workspace or repository access token |
+| `bitbucket_username` | No | Atlassian account email/username. Set for personal API tokens (Basic `username:token`); leave empty for workspace/repository access tokens (Bearer). The clone username the proxy presents is derived from the same choice |
 | `bitbucket_token` | Yes | API token with `repository:read` |
 | `bitbucket_workspaces` | Yes | JSON array of workspace slugs |
 | `git_proxy_url` | Yes | git-cli-proxy base URL. No default — a wrong value must fail `check`, not fall back |
 | `git_proxy_token` | Yes | Bearer token the proxy requires on every `/v1` request |
 | `bitbucket_api_base_url` | No | API base URL (default `https://api.bitbucket.org/2.0`) |
-| `bitbucket_start_date` | No | Earliest date for the initial sync (default `2020-01-01`) |
-| `bitbucket_page_size` | No | Bitbucket API page size, max 100 |
-| `proxy_page_size` | No | Rows per proxy page (default 500) |
-| `bitbucket_include_patch` | No | Store per-file diff text (default true) |
-| `bitbucket_lookback_window` | No | ISO-8601 duration re-enumerated below the cursor each sync, so a rebase does not strand commits dated below it (default `P1M`) |
-| `bitbucket_max_patch_bytes` | No | Truncation cap per file diff (default 1 MiB) |
+| `bitbucket_start_date` | Yes | Earliest date for incremental sync (YYYY-MM-DD); bounds the first-sync cost |
 
 ### Automatically injected
 
@@ -128,7 +122,7 @@ loop.
 ## Partial clone support: settled
 
 Bitbucket Cloud honours `--filter=blob:none` (verified live — git-cli-proxy
-PLAN §9.2). One sizing consequence remains: with `include_patch=true` the
+PLAN §9.2). One sizing consequence remains: because patch text is stored, the
 first backfill lazily pulls essentially every blob while paging history, so
 the proxy cache should be sized for roughly full-clone weight per Bitbucket
 repository during backfill; the post-serve purge returns entries to the

--- a/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
@@ -16,8 +16,8 @@ type: DeclarativeSource
 #
 #   repositories     -> Bitbucket /2.0/repositories/{ws} incremental (updated_on)
 #   commits          -> proxy /v1/commits              incremental (committed_date), per repo
-#   commit_files     -> proxy /v1/file-changes         incremental (committed_date), per repo
-#   repo_branches    -> proxy /v1/branches             full refresh, per repo
+#   file_changes     -> proxy /v1/file-changes         incremental (committed_date), per repo
+#   branches         -> proxy /v1/branches             full refresh, per repo
 #
 # The proxy answers 429 + Retry-After while a cold repository is being cloned
 # in the background, so every proxy stream retries on 429 and fails fast on the
@@ -362,7 +362,7 @@ streams:
 
   # ── Per-file changes (git-cli-proxy) ────────────────────────────────────
   - type: DeclarativeStream
-    name: commit_files
+    name: file_changes
     primary_key:
       - unique_key
     schema_loader:
@@ -578,7 +578,7 @@ streams:
   # history is derived downstream by the snapshot/fields_history dbt macros —
   # the same pattern user profiles use.
   - type: DeclarativeStream
-    name: repo_branches
+    name: branches
     primary_key:
       - unique_key
     schema_loader:
@@ -1491,7 +1491,7 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['repo_full_name'] | replace(':', '%3A') }}:{{ stream_partition.pr_id }}:{{ 'approval' if record.get('approval') else 'changes_requested' if record.get('changes_requested') else 'update' if record.get('update') else 'comment' }}:{{ ((record.get('approval') or {}).get('date') or (record.get('changes_requested') or {}).get('date') or (record.get('update') or {}).get('date') or (record.get('comment') or {}).get('created_on') or '') | replace(':', '%3A') }}:{{ (((record.get('approval') or {}).get('user') or {}).get('uuid') or ((record.get('changes_requested') or {}).get('user') or {}).get('uuid') or ((record.get('update') or {}).get('author') or {}).get('uuid') or ((record.get('comment') or {}).get('user') or {}).get('uuid') or '') | replace(':', '%3A') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['repo_full_name'] | replace(':', '%3A') }}:{{ stream_partition.pr_id }}:{{ 'approval' if record.get('approval') else 'changes_requested' if record.get('changes_requested') else 'update' if record.get('update') else 'comment' }}:{{ ((record.get('approval') or {}).get('date') or (record.get('changes_requested') or {}).get('date') or (record.get('update') or {}).get('date') or (record.get('comment') or {}).get('created_on') or '') | replace(':', '%3A') }}:{{ (((record.get('approval') or {}).get('user') or {}).get('uuid') or ((record.get('changes_requested') or {}).get('user') or {}).get('uuid') or ((record.get('update') or {}).get('author') or {}).get('uuid') or ((record.get('comment') or {}).get('user') or {}).get('uuid') or '') | replace(':', '%3A') }}:{{ (record.get('comment') or {}).get('id') or '' }}
       - type: RemoveFields
         # Hoisted above; the nested originals stay out of bronze.
         field_pointers:
@@ -2204,8 +2204,8 @@ metadata:
   autoImportSchema:
     repositories: false
     commits: false
-    commit_files: false
-    repo_branches: false
+    file_changes: false
+    branches: false
     pull_requests: false
     pull_request_comments: false
     pull_request_activity: false

--- a/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
@@ -1594,6 +1594,280 @@ streams:
           - [repository]
           - [rendered]
 
+  # ── Pull request diffstat (Bitbucket API) ───────────────────────────────
+  # Bitbucket has no GraphQL API and carries no diff totals on the pull
+  # request itself (VERIFIED against the live REST reference), so per-file
+  # diffstat rows are the only source of PR size — one call per PR in the
+  # window. Grain therefore differs from the GitHub and GitLab diff-stat
+  # streams, which get PR-level totals in one query: silver sums these rows.
+  - type: DeclarativeStream
+    name: pull_request_diffstat
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          pr_id: {type: [integer, "null"]}
+          repo_full_name: {type: [string, "null"]}
+          file_path: {type: [string, "null"]}
+          old_path: {type: [string, "null"]}
+          status: {type: [string, "null"]}
+          lines_added: {type: [integer, "null"]}
+          lines_removed: {type: [integer, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+        authenticator:
+          type: ApiKeyAuthenticator
+          inject_into:
+            type: RequestOption
+            inject_into: header
+            field_name: Authorization
+          # Personal API tokens are Basic username:token; workspace access
+          # tokens are Bearer and must leave bitbucket_username empty.
+          api_token: >-
+            {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
+        path: "/repositories/{{ stream_slice.extra_fields['repo_full_name'] }}/pullrequests/{{ stream_partition.pr_id }}/diffstat"
+        http_method: GET
+        request_parameters:
+          pagelen: "100"
+        error_handler:
+          type: DefaultErrorHandler
+          backoff_strategies:
+            # Bitbucket sometimes sends Retry-After as an HTTP date, which this
+            # strategy cannot parse; the exponential fallback covers that case.
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+            - type: ExponentialBackoffStrategy
+              factor: 5
+          response_filters:
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RATE_LIMITED
+              error_message: Bitbucket hourly rate budget exhausted
+            # A PR whose branches share no history has no computable diff, and
+            # Bitbucket reports that as a 400 rather than an empty diffstat.
+            # It is a property of that pull request, not a broken request.
+            - type: HttpResponseFilter
+              http_codes: [400]
+              action: IGNORE
+              predicate: "{{ 'no common ancestor' in ((response.get('error') or {}).get('message') or '') | lower }}"
+              error_message: >-
+                Diff not computable for this pull request; other pull requests continue.
+            - type: HttpResponseFilter
+              http_codes: [403, 404]
+              action: IGNORE
+              error_message: >-
+                PR gone or not accessible; other pull requests continue.
+            - type: HttpResponseFilter
+              http_codes: [401]
+              action: FAIL
+              failure_type: config_error
+              error_message: >-
+                Bitbucket rejected the credentials. Personal API tokens need
+                bitbucket_username set (Basic auth); workspace access tokens must
+                NOT set it (Bearer). Mixing the two is the most common cause.
+            - type: HttpResponseFilter
+              http_codes: [500, 502, 503, 504]
+              action: RETRY
+              error_message: Transient Bitbucket error
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [values]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response.get('next', '') }}"
+          stop_condition: "{{ not response.get('next') }}"
+        page_token_option:
+          type: RequestPath
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: id
+            partition_field: pr_id
+            extra_fields:
+              - [repo_full_name]
+            stream:
+              type: DeclarativeStream
+              name: pull_requests_for_diffstat
+              primary_key:
+                - id
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/schema#
+                  properties:
+                    id: {type: [integer, "null"]}
+                    repo_full_name: {type: [string, "null"]}
+                    updated_on: {type: [string, "null"]}
+                  additionalProperties: true
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+                  authenticator:
+                    type: ApiKeyAuthenticator
+                    inject_into:
+                      type: RequestOption
+                      inject_into: header
+                      field_name: Authorization
+                    # Personal API tokens are Basic username:token; workspace access
+                    # tokens are Bearer and must leave bitbucket_username empty.
+                    api_token: >-
+                      {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
+                  path: "/repositories/{{ stream_partition.repo_full_name }}/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED"
+                  http_method: GET
+                  request_parameters:
+                    # pagelen HARD CAP on /pullrequests is 50 (400 above).
+                    pagelen: "50"
+                    sort: updated_on
+                    # Stateless sliding window: the children have no cursor of their
+                    # own, so parent state would never persist. RMT dedups the
+                    # re-read window.
+                    q: >-
+                      updated_on >= "{{ format_datetime(now_utc() - duration('P30D'), '%Y-%m-%dT%H:%M:%SZ') }}"
+                    fields: next,values.id,values.updated_on
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: [values]
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: CursorPagination
+                    cursor_value: "{{ response.get('next', '') }}"
+                    stop_condition: "{{ not response.get('next') }}"
+                  page_token_option:
+                    type: RequestPath
+                partition_router:
+                  type: SubstreamPartitionRouter
+                  parent_stream_configs:
+                    - type: ParentStreamConfig
+                      parent_key: full_name
+                      partition_field: repo_full_name
+                      stream:
+                        type: DeclarativeStream
+                        name: pull_requests_for_diffstat_repos
+                        primary_key:
+                          - uuid
+                        schema_loader:
+                          type: InlineSchemaLoader
+                          schema:
+                            type: object
+                            $schema: http://json-schema.org/schema#
+                            properties:
+                              uuid: {type: [string, "null"]}
+                              full_name: {type: [string, "null"]}
+                              updated_on: {type: [string, "null"]}
+                            additionalProperties: true
+                        retriever:
+                          type: SimpleRetriever
+                          requester:
+                            type: HttpRequester
+                            url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+                            authenticator:
+                              type: ApiKeyAuthenticator
+                              inject_into:
+                                type: RequestOption
+                                inject_into: header
+                                field_name: Authorization
+                              # Personal API tokens are Basic username:token; workspace access
+                              # tokens are Bearer and must leave bitbucket_username empty.
+                              api_token: >-
+                                {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
+                            path: "/repositories/{{ stream_partition.workspace }}"
+                            http_method: GET
+                            request_parameters:
+                              pagelen: "100"
+                              fields: next,values.uuid,values.full_name,values.updated_on
+                          record_selector:
+                            type: RecordSelector
+                            extractor:
+                              type: DpathExtractor
+                              field_path: [values]
+                          paginator:
+                            type: DefaultPaginator
+                            pagination_strategy:
+                              type: CursorPagination
+                              cursor_value: "{{ response.get('next', '') }}"
+                              stop_condition: "{{ not response.get('next') }}"
+                            page_token_option:
+                              type: RequestPath
+                          partition_router:
+                            type: ListPartitionRouter
+                            values: "{{ config['bitbucket_workspaces'] }}"
+                            cursor_field: workspace
+              transformations:
+                - type: AddFields
+                  fields:
+                    - type: AddedFieldDefinition
+                      path: [repo_full_name]
+                      value: "{{ stream_partition.repo_full_name }}"
+                      value_type: string
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_bitbucket_nocode
+          - type: AddedFieldDefinition
+            path: [collected_at]
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          - type: AddedFieldDefinition
+            path: [pr_id]
+            value: "{{ stream_partition.pr_id }}"
+          - type: AddedFieldDefinition
+            path: [repo_full_name]
+            value: "{{ stream_slice.extra_fields['repo_full_name'] }}"
+            value_type: string
+          # A removed file has no `new`, an added file has no `old`.
+          - type: AddedFieldDefinition
+            path: [file_path]
+            value: "{{ (record.get('new') or {}).get('path') or (record.get('old') or {}).get('path') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [old_path]
+            value: "{{ (record.get('old') or {}).get('path') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['repo_full_name'] | replace(':', '%3A') }}:{{ stream_partition.pr_id }}:{{ ((record.get('new') or {}).get('path') or (record.get('old') or {}).get('path') or '') | replace(':', '%3A') }}
+      - type: RemoveFields
+        # Hoisted above; the nested originals stay out of bronze.
+        field_pointers:
+          - [type]
+          - [old]
+          - [new]
+
   # ── Pull request activity (Bitbucket API) ───────────────────────────────
   # The ONLY source of approvals, changes-requested and merge/decline
   # transitions on Bitbucket — there is no reviews endpoint. Entries carry no
@@ -2567,6 +2841,7 @@ metadata:
     pull_requests: false
     pull_request_comments: false
     pull_request_commits: false
+    pull_request_diffstat: false
     pull_request_activity: false
     workspace_members: false
     pipelines: false

--- a/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
@@ -1,0 +1,885 @@
+version: 7.0.4
+
+type: DeclarativeSource
+
+# Bitbucket Cloud connector built on the git-cli-proxy (issue #2224).
+#
+# Two upstreams in ONE manifest, which is the whole point: repository discovery
+# talks to the Bitbucket API, while commit-level extraction talks to the proxy,
+# which serves it from a bare blobless clone instead of one API call per commit.
+# `url_base` is a per-requester property, so mixing them needs no special
+# machinery.
+#
+# The manifest is FULLY INLINED (no $ref, no definitions.linked): the Builder
+# strict validator resolves no $ref, so a shared authenticator or url_base is
+# rejected. Duplication here is the price of Builder compatibility.
+#
+#   repositories     -> Bitbucket /2.0/repositories/{ws} incremental (updated_on)
+#   commits          -> proxy /v1/commits              incremental (committed_date), per repo
+#   commit_files     -> proxy /v1/file-changes         incremental (committed_date), per repo
+#   repo_branches    -> proxy /v1/branches             full refresh, per repo
+#
+# The proxy answers 429 + Retry-After while a cold repository is being cloned
+# in the background, so every proxy stream retries on 429 and fails fast on the
+# permanent ones (409 superseded snapshot, 413 oversized repository).
+#
+# NOT ported here: pull requests and their children (comments, reviewers,
+# commits, diffstat). That data does not exist in git, so it stays on the vendor
+# API — a mechanical port of the CDK connector's streams, tracked separately.
+#
+# Bitbucket is where the per-commit API cost hurts most: the CDK connector calls
+# `diffstat/{sha}` once per commit against a ~1000 req/h budget.
+
+check:
+  type: CheckStream
+  stream_names:
+    - repositories
+
+streams:
+  # ── Repository discovery (GitLab API) ───────────────────────────────────
+  # The incremental parent: only repositories whose last_activity_at advanced
+  # are visited by the commit streams below.
+  - type: DeclarativeStream
+    name: repositories
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          repository_uuid: {type: [string, "null"]}
+          clone_url: {type: [string, "null"]}
+          slug: {type: [string, "null"]}
+          name: {type: [string, "null"]}
+          full_name: {type: [string, "null"]}
+          is_private: {type: [boolean, "null"]}
+          language: {type: [string, "null"]}
+          size: {type: [integer, "null"]}
+          created_on: {type: [string, "null"]}
+          updated_on: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+        authenticator:
+          type: BasicHttpAuthenticator
+          username: "{{ config['bitbucket_username'] }}"
+          password: "{{ config['bitbucket_token'] }}"
+        path: "/repositories/{{ stream_partition.workspace }}"
+        http_method: GET
+        request_parameters:
+          pagelen: "{{ config.get('bitbucket_page_size', 100) }}"
+          # Ascending, so the cursor advances monotonically across pages.
+          sort: updated_on
+          # Trim the payload: the full repository object is large and only
+          # these fields are used (identity, cursor, clone link).
+          fields: >-
+            next,values.uuid,values.slug,values.name,values.full_name,values.is_private,values.language,values.size,values.created_on,values.updated_on,values.mainbranch.name,values.workspace.slug,values.links.clone
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [values]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response.get('next', '') }}"
+          stop_condition: "{{ not response.get('next') }}"
+        page_token_option:
+          type: RequestPath
+      partition_router:
+        type: ListPartitionRouter
+        values: "{{ config['bitbucket_workspaces'] }}"
+        cursor_field: workspace
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: updated_on
+      datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S.%f%z"
+        - "%Y-%m-%dT%H:%M:%S%z"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('bitbucket_start_date', '2020-01-01') }}"
+        datetime_format: "%Y-%m-%d"
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_bitbucket_nocode
+          - type: AddedFieldDefinition
+            path: [repository_uuid]
+            value: "{{ record['uuid'] }}"
+          - type: AddedFieldDefinition
+            path: [clone_url]
+            # Bitbucket nests clone links in an array; the proxy routes on a
+            # flat field, and the API link is authoritative — deriving the URL
+            # from full_name would duplicate knowledge of the host layout.
+            value: >-
+              {{ (record['links']['clone'] | selectattr('name', 'equalto', 'https') | map(attribute='href') | list | first) }}
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ record['uuid'] | string | replace(':', '%3A') }}
+  # ── Commits (git-cli-proxy) ─────────────────────────────────────────────
+  - type: DeclarativeStream
+    name: commits
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          repository: {type: [string, "null"]}
+          sha: {type: [string, "null"]}
+          message: {type: [string, "null"]}
+          authored_date: {type: [string, "null"]}
+          committed_date: {type: [string, "null"]}
+          author_name: {type: [string, "null"]}
+          author_email: {type: [string, "null"]}
+          committer_name: {type: [string, "null"]}
+          committer_email: {type: [string, "null"]}
+          parent_hashes: {type: [array, "null"], items: {type: string}}
+          is_merge: {type: [boolean, "null"]}
+          additions: {type: [integer, "null"]}
+          deletions: {type: [integer, "null"]}
+          changed_files: {type: [integer, "null"]}
+          is_in_default_branch: {type: [boolean, "null"]}
+          patch_id: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['git_proxy_url'] }}"
+        authenticator:
+          type: BearerAuthenticator
+          api_token: "{{ config['git_proxy_token'] }}"
+        request_headers:
+          X-Tenant-Id: "{{ config['insight_tenant_id'] }}"
+          X-Source-Id: "{{ config['insight_source_id'] }}"
+          X-Git-Username: "{{ config.get('bitbucket_git_username', 'x-bitbucket-api-token-auth') }}"
+          X-Git-Token: "{{ config['bitbucket_token'] }}"
+        path: /v1/commits
+        http_method: GET
+        request_parameters:
+          repo: "{{ stream_partition.repo_clone_url }}"
+          page_size: "{{ config.get('proxy_page_size', 500) }}"
+        error_handler:
+          type: DefaultErrorHandler
+          backoff_strategies:
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+          response_filters:
+            # The repository is being cloned in the background: the proxy is
+            # working, the caller waits.
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RETRY
+              error_message: Repository is being prepared by the proxy
+            # Both are permanent for THIS repository and harmless for the rest,
+            # so the partition is skipped rather than the whole stream failed.
+            # A rising git_proxy_admission_rejects_total is the alert: a 413
+            # means a repository is silently absent from bronze until an
+            # operator raises cache.maxRepoBytes.
+            - type: HttpResponseFilter
+              http_codes: [404, 413]
+              action: IGNORE
+              error_message: >-
+                Skipping this repository: gone at origin (404), or larger than
+                cache.maxRepoBytes (413). Other repositories continue.
+            # The pinned snapshot was superseded mid-walk. RETRY would replay
+            # the same dead page token and 409 again; a response filter cannot
+            # reset it. Rerunning the sync resumes each partition from its own
+            # stored cursor against a fresh snapshot.
+            - type: HttpResponseFilter
+              http_codes: [409]
+              action: FAIL
+              error_message: >-
+                Proxy snapshot changed mid-walk; rerun the sync to resume from the stored cursor
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [items]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response['next_page_token'] }}"
+          stop_condition: "{{ not response.get('next_page_token') }}"
+        page_token_option:
+          type: RequestOption
+          field_name: page_token
+          inject_into: request_parameter
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: clone_url
+            partition_field: repo_clone_url
+            # `incremental_dependency` is what keeps the sync proportional to
+            # activity: the parent is itself incremental, so only repositories
+            # touched since the last sync are visited. The CDK persists parent
+            # state ONLY when the child is incremental — which this stream is.
+            incremental_dependency: true
+            # Inlined: the Builder strict validator rejects a whole-object
+            # $ref for a substream parent.
+            stream:
+              type: DeclarativeStream
+              name: repositories_for_commits
+              primary_key:
+                - uuid
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/schema#
+                  properties:
+                    uuid: {type: [string, "null"]}
+                    clone_url: {type: [string, "null"]}
+                    updated_on: {type: [string, "null"]}
+                  additionalProperties: true
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+                  authenticator:
+                    type: BasicHttpAuthenticator
+                    username: "{{ config['bitbucket_username'] }}"
+                    password: "{{ config['bitbucket_token'] }}"
+                  path: "/repositories/{{ stream_partition.workspace }}"
+                  http_method: GET
+                  request_parameters:
+                    pagelen: "{{ config.get('bitbucket_page_size', 100) }}"
+                    sort: updated_on
+                    fields: >-
+                      next,values.uuid,values.slug,values.updated_on,values.links.clone
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: [values]
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: CursorPagination
+                    cursor_value: "{{ response.get('next', '') }}"
+                    stop_condition: "{{ not response.get('next') }}"
+                  page_token_option:
+                    type: RequestPath
+              partition_router:
+                type: ListPartitionRouter
+                values: "{{ config['bitbucket_workspaces'] }}"
+                cursor_field: workspace
+              incremental_sync:
+                type: DatetimeBasedCursor
+                cursor_field: updated_on
+                datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
+                cursor_datetime_formats:
+                  - "%Y-%m-%dT%H:%M:%S.%f%z"
+                  - "%Y-%m-%dT%H:%M:%S%z"
+                start_datetime:
+                  type: MinMaxDatetime
+                  datetime: "{{ config.get('bitbucket_start_date', '2020-01-01') }}"
+                  datetime_format: "%Y-%m-%d"
+              transformations:
+                - type: AddFields
+                  fields:
+                    - type: AddedFieldDefinition
+                      path: [clone_url]
+                      value: >-
+                        {{ (record['links']['clone'] | selectattr('name', 'equalto', 'https') | map(attribute='href') | list | first) }}
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: committed_date
+      datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+      # `git log --since` is a traversal cutoff: after a rebase the
+      # replacement commits can carry dates BELOW the stored cursor and
+      # would never be visited again. Re-enumerating one window each
+      # sync recovers them; bronze dedups the re-read rows. This is a
+      # heuristic, not a guarantee — a rewrite older than the window is
+      # still lost, and nothing detects it.
+      lookback_window: "{{ config.get('bitbucket_lookback_window', 'P1M') }}"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S%z"
+        - "%Y-%m-%dT%H:%M:%SZ"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('bitbucket_start_date', '2020-01-01') }}"
+        datetime_format: "%Y-%m-%d"
+      start_time_option:
+        type: RequestOption
+        field_name: since
+        inject_into: request_parameter
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_bitbucket_nocode
+          - type: AddedFieldDefinition
+            path: [repository]
+            value: "{{ stream_partition.repo_clone_url }}"
+          # Repository identity is REQUIRED in the key: forks share commit
+          # SHAs, so tenant+source+sha alone would let the ReplacingMergeTree
+          # collapse commits from different repositories into one row.
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | string | replace(':', '%3A') }}:{{ record['sha'] | string | replace(':', '%3A') }}
+
+  # ── Per-file changes (git-cli-proxy) ────────────────────────────────────
+  - type: DeclarativeStream
+    name: commit_files
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          repository: {type: [string, "null"]}
+          sha: {type: [string, "null"]}
+          committed_date: {type: [string, "null"]}
+          filename: {type: [string, "null"]}
+          previous_filename: {type: [string, "null"]}
+          status: {type: [string, "null"]}
+          additions: {type: [integer, "null"]}
+          deletions: {type: [integer, "null"]}
+          changes: {type: [integer, "null"]}
+          is_binary: {type: [boolean, "null"]}
+          patch: {type: [string, "null"]}
+          patch_truncated: {type: [boolean, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['git_proxy_url'] }}"
+        authenticator:
+          type: BearerAuthenticator
+          api_token: "{{ config['git_proxy_token'] }}"
+        request_headers:
+          X-Tenant-Id: "{{ config['insight_tenant_id'] }}"
+          X-Source-Id: "{{ config['insight_source_id'] }}"
+          X-Git-Username: "{{ config.get('bitbucket_git_username', 'x-bitbucket-api-token-auth') }}"
+          X-Git-Token: "{{ config['bitbucket_token'] }}"
+        path: /v1/file-changes
+        http_method: GET
+        request_parameters:
+          repo: "{{ stream_partition.repo_clone_url }}"
+          page_size: "{{ config.get('proxy_page_size', 500) }}"
+          include_patch: "{{ config.get('bitbucket_include_patch', true) | lower }}"
+          max_patch_bytes: "{{ config.get('bitbucket_max_patch_bytes', 1048576) }}"
+        error_handler:
+          type: DefaultErrorHandler
+          backoff_strategies:
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+          response_filters:
+            # The repository is being cloned in the background: the proxy is
+            # working, the caller waits.
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RETRY
+              error_message: Repository is being prepared by the proxy
+            # Both are permanent for THIS repository and harmless for the rest,
+            # so the partition is skipped rather than the whole stream failed.
+            # A rising git_proxy_admission_rejects_total is the alert: a 413
+            # means a repository is silently absent from bronze until an
+            # operator raises cache.maxRepoBytes.
+            - type: HttpResponseFilter
+              http_codes: [404, 413]
+              action: IGNORE
+              error_message: >-
+                Skipping this repository: gone at origin (404), or larger than
+                cache.maxRepoBytes (413). Other repositories continue.
+            # The pinned snapshot was superseded mid-walk. RETRY would replay
+            # the same dead page token and 409 again; a response filter cannot
+            # reset it. Rerunning the sync resumes each partition from its own
+            # stored cursor against a fresh snapshot.
+            - type: HttpResponseFilter
+              http_codes: [409]
+              action: FAIL
+              error_message: >-
+                Proxy snapshot changed mid-walk; rerun the sync to resume from the stored cursor
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [items]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response['next_page_token'] }}"
+          stop_condition: "{{ not response.get('next_page_token') }}"
+        page_token_option:
+          type: RequestOption
+          field_name: page_token
+          inject_into: request_parameter
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: clone_url
+            partition_field: repo_clone_url
+            incremental_dependency: true
+            stream:
+              type: DeclarativeStream
+              name: repositories_for_files
+              primary_key:
+                - uuid
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/schema#
+                  properties:
+                    uuid: {type: [string, "null"]}
+                    clone_url: {type: [string, "null"]}
+                    updated_on: {type: [string, "null"]}
+                  additionalProperties: true
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+                  authenticator:
+                    type: BasicHttpAuthenticator
+                    username: "{{ config['bitbucket_username'] }}"
+                    password: "{{ config['bitbucket_token'] }}"
+                  path: "/repositories/{{ stream_partition.workspace }}"
+                  http_method: GET
+                  request_parameters:
+                    pagelen: "{{ config.get('bitbucket_page_size', 100) }}"
+                    sort: updated_on
+                    fields: >-
+                      next,values.uuid,values.slug,values.updated_on,values.links.clone
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: [values]
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: CursorPagination
+                    cursor_value: "{{ response.get('next', '') }}"
+                    stop_condition: "{{ not response.get('next') }}"
+                  page_token_option:
+                    type: RequestPath
+              partition_router:
+                type: ListPartitionRouter
+                values: "{{ config['bitbucket_workspaces'] }}"
+                cursor_field: workspace
+              incremental_sync:
+                type: DatetimeBasedCursor
+                cursor_field: updated_on
+                datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
+                cursor_datetime_formats:
+                  - "%Y-%m-%dT%H:%M:%S.%f%z"
+                  - "%Y-%m-%dT%H:%M:%S%z"
+                start_datetime:
+                  type: MinMaxDatetime
+                  datetime: "{{ config.get('bitbucket_start_date', '2020-01-01') }}"
+                  datetime_format: "%Y-%m-%d"
+              transformations:
+                - type: AddFields
+                  fields:
+                    - type: AddedFieldDefinition
+                      path: [clone_url]
+                      value: >-
+                        {{ (record['links']['clone'] | selectattr('name', 'equalto', 'https') | map(attribute='href') | list | first) }}
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: committed_date
+      datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+      # `git log --since` is a traversal cutoff: after a rebase the
+      # replacement commits can carry dates BELOW the stored cursor and
+      # would never be visited again. Re-enumerating one window each
+      # sync recovers them; bronze dedups the re-read rows. This is a
+      # heuristic, not a guarantee — a rewrite older than the window is
+      # still lost, and nothing detects it.
+      lookback_window: "{{ config.get('bitbucket_lookback_window', 'P1M') }}"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S%z"
+        - "%Y-%m-%dT%H:%M:%SZ"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('bitbucket_start_date', '2020-01-01') }}"
+        datetime_format: "%Y-%m-%d"
+      start_time_option:
+        type: RequestOption
+        field_name: since
+        inject_into: request_parameter
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_bitbucket_nocode
+          - type: AddedFieldDefinition
+            path: [repository]
+            value: "{{ stream_partition.repo_clone_url }}"
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | string | replace(':', '%3A') }}:{{ record['sha'] | string | replace(':', '%3A') }}:{{ record['filename'] | string | replace(':', '%3A') }}
+
+  # ── Branch heads (git-cli-proxy) ────────────────────────────────────────
+  # Full refresh: bronze keeps the LATEST state per branch, and head-movement
+  # history is derived downstream by the snapshot/fields_history dbt macros —
+  # the same pattern user profiles use.
+  - type: DeclarativeStream
+    name: repo_branches
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          repository: {type: [string, "null"]}
+          name: {type: [string, "null"]}
+          head_sha: {type: [string, "null"]}
+          head_committed_date: {type: [string, "null"]}
+          is_default: {type: [boolean, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['git_proxy_url'] }}"
+        authenticator:
+          type: BearerAuthenticator
+          api_token: "{{ config['git_proxy_token'] }}"
+        request_headers:
+          X-Tenant-Id: "{{ config['insight_tenant_id'] }}"
+          X-Source-Id: "{{ config['insight_source_id'] }}"
+          X-Git-Username: "{{ config.get('bitbucket_git_username', 'x-bitbucket-api-token-auth') }}"
+          X-Git-Token: "{{ config['bitbucket_token'] }}"
+        path: /v1/branches
+        http_method: GET
+        request_parameters:
+          repo: "{{ stream_partition.repo_clone_url }}"
+          page_size: "{{ config.get('proxy_page_size', 500) }}"
+        error_handler:
+          type: DefaultErrorHandler
+          backoff_strategies:
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+          response_filters:
+            # The repository is being cloned in the background: the proxy is
+            # working, the caller waits.
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RETRY
+              error_message: Repository is being prepared by the proxy
+            # Both are permanent for THIS repository and harmless for the rest,
+            # so the partition is skipped rather than the whole stream failed.
+            # A rising git_proxy_admission_rejects_total is the alert: a 413
+            # means a repository is silently absent from bronze until an
+            # operator raises cache.maxRepoBytes.
+            - type: HttpResponseFilter
+              http_codes: [404, 413]
+              action: IGNORE
+              error_message: >-
+                Skipping this repository: gone at origin (404), or larger than
+                cache.maxRepoBytes (413). Other repositories continue.
+            # The pinned snapshot was superseded mid-walk. RETRY would replay
+            # the same dead page token and 409 again; a response filter cannot
+            # reset it. Rerunning the sync resumes each partition from its own
+            # stored cursor against a fresh snapshot.
+            - type: HttpResponseFilter
+              http_codes: [409]
+              action: FAIL
+              error_message: >-
+                Proxy snapshot changed mid-walk; rerun the sync to resume from the stored cursor
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [items]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response['next_page_token'] }}"
+          stop_condition: "{{ not response.get('next_page_token') }}"
+        page_token_option:
+          type: RequestOption
+          field_name: page_token
+          inject_into: request_parameter
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: clone_url
+            partition_field: repo_clone_url
+            # No `incremental_dependency` here: this stream is full refresh, so
+            # the CDK would not persist parent state anyway. Branch heads are
+            # cheap and must be re-read for every repository each sync.
+            stream:
+              type: DeclarativeStream
+              name: repositories_for_branches
+              primary_key:
+                - uuid
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/schema#
+                  properties:
+                    uuid: {type: [string, "null"]}
+                    clone_url: {type: [string, "null"]}
+                  additionalProperties: true
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+                  authenticator:
+                    type: BasicHttpAuthenticator
+                    username: "{{ config['bitbucket_username'] }}"
+                    password: "{{ config['bitbucket_token'] }}"
+                  path: "/repositories/{{ stream_partition.workspace }}"
+                  http_method: GET
+                  request_parameters:
+                    pagelen: "{{ config.get('bitbucket_page_size', 100) }}"
+                    fields: >-
+                      next,values.uuid,values.slug,values.links.clone
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: [values]
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: CursorPagination
+                    cursor_value: "{{ response.get('next', '') }}"
+                    stop_condition: "{{ not response.get('next') }}"
+                  page_token_option:
+                    type: RequestPath
+              partition_router:
+                type: ListPartitionRouter
+                values: "{{ config['bitbucket_workspaces'] }}"
+                cursor_field: workspace
+              transformations:
+                - type: AddFields
+                  fields:
+                    - type: AddedFieldDefinition
+                      path: [clone_url]
+                      value: >-
+                        {{ (record['links']['clone'] | selectattr('name', 'equalto', 'https') | map(attribute='href') | list | first) }}
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_bitbucket_nocode
+          - type: AddedFieldDefinition
+            path: [repository]
+            value: "{{ stream_partition.repo_clone_url }}"
+          # No head_sha in the key: the key identifies the BRANCH, so the RMT
+          # collapses to its latest state and a head move is a change the
+          # downstream snapshot macro can see.
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | string | replace(':', '%3A') }}:{{ record['name'] | string | replace(':', '%3A') }}
+
+concurrency_level:
+  type: ConcurrencyLevel
+  # Never 1: the concurrent CDK self-deadlocks at a single worker once a sync
+  # generates ~10k partitions.
+  default_concurrency: 4
+
+spec:
+  type: Spec
+  connection_specification:
+    type: object
+    $schema: http://json-schema.org/draft-07/schema#
+    title: Bitbucket Cloud (git-cli-proxy) Spec
+    required:
+      - insight_tenant_id
+      - insight_source_id
+      - bitbucket_username
+      - bitbucket_token
+      - bitbucket_workspaces
+      - git_proxy_url
+      - git_proxy_token
+    properties:
+      insight_tenant_id:
+        type: string
+        description: Insight tenant identifier stamped onto every emitted record.
+        title: Insight Tenant ID
+        order: 0
+      insight_source_id:
+        type: string
+        description: >-
+          Instance discriminator for multi-instance support (e.g. bitbucket-acme).
+        title: Insight Source ID
+        order: 1
+      bitbucket_username:
+        type: string
+        description: >-
+          Atlassian account username or email. Personal API tokens authenticate as HTTP basic `username:token`, both against the API and against the clone the proxy performs.
+        title: Username / Email
+        order: 2
+      bitbucket_git_username:
+        type: string
+        description: >-
+          Username the proxy presents when CLONING over https, which is NOT the API credential. `x-token-auth` is reserved for workspace/repository access tokens and is rejected for a personal API token; the default works for personal API tokens, and the account's short username works for access tokens.
+        title: Git Clone Username
+        default: x-bitbucket-api-token-auth
+        order: 3
+      bitbucket_token:
+        type: string
+        description: >-
+          Bitbucket API token with `repository:read`. Forwarded to the proxy per request for the clone and never stored there.
+        title: API Token
+        airbyte_secret: true
+        order: 3
+      bitbucket_workspaces:
+        type: array
+        items:
+          type: string
+        description: Workspace slugs to sync.
+        title: Workspaces
+        order: 4
+      git_proxy_url:
+        type: string
+        description: >-
+          Base URL of the git-cli-proxy service (cluster-internal, e.g. http://insight-git-cli-proxy:8085). No default: a wrong or absent value must fail the check, not fall back somewhere.
+        title: Git Proxy URL
+        order: 5
+      git_proxy_token:
+        type: string
+        description: Bearer token the git-cli-proxy requires on every /v1 request.
+        title: Git Proxy Token
+        airbyte_secret: true
+        order: 6
+      bitbucket_api_base_url:
+        type: string
+        description: Bitbucket API base URL.
+        title: API Base URL
+        default: "https://api.bitbucket.org/2.0"
+        order: 7
+      bitbucket_start_date:
+        type: string
+        description: Earliest date for incremental sync (YYYY-MM-DD).
+        title: Start Date
+        format: date
+        default: "2020-01-01"
+        order: 8
+      bitbucket_page_size:
+        type: integer
+        description: Bitbucket API page size (max 100).
+        title: Bitbucket Page Size
+        default: 100
+        minimum: 1
+        maximum: 100
+        order: 9
+      proxy_page_size:
+        type: integer
+        description: Rows per page requested from the git-cli-proxy.
+        title: Proxy Page Size
+        default: 500
+        minimum: 1
+        maximum: 10000
+        order: 10
+      bitbucket_include_patch:
+        type: boolean
+        description: >-
+          Store per-file diff text. Keep enabled to allow recomputing line counts later under different filters; disable to cut bronze volume.
+        title: Include Patch Text
+        default: true
+        order: 11
+      bitbucket_max_patch_bytes:
+        type: integer
+        description: >-
+          Truncation cap for a single file's diff. Truncated rows are flagged with patch_truncated so downstream never mistakes them for complete.
+        title: Max Patch Bytes
+        default: 1048576
+        minimum: 1024
+        order: 12
+      bitbucket_lookback_window:
+        type: string
+        description: >-
+          ISO-8601 duration re-enumerated below the stored cursor on every sync. `git log --since` is a traversal cutoff, so after a rebase the replacement commits can carry dates below the cursor and would never be visited again. Bronze dedups the re-read rows, so the cost is one window per sync. A rewrite older than the window is still lost.
+        title: Rebase Lookback Window
+        default: P1M
+        order: 13
+    additionalProperties: true
+
+metadata:
+  autoImportSchema:
+    repositories: false
+    commits: false
+    commit_files: false
+    repo_branches: false

--- a/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
@@ -23,9 +23,11 @@ type: DeclarativeSource
 # in the background, so every proxy stream retries on 429 and fails fast on the
 # permanent ones (409 superseded snapshot, 413 oversized repository).
 #
-# Vendor-API streams (pull requests, comments, activity, workspace members,
-# pipelines, deployments) live in this same manifest: that data does not
-# exist in git. Issues and projects are deliberately not synced.
+# Vendor-API streams (pull requests, comments, commits, activity, workspace
+# members, pipelines, deployments) live in this same manifest: that data does
+# not exist in git — a PR's commit list included, since a squash-merged PR
+# leaves its original commits unreachable from every ref the proxy clones.
+# Issues and projects are deliberately not synced.
 
 check:
   type: CheckStream
@@ -1329,6 +1331,269 @@ streams:
           - [inline]
           - [content]
 
+  # ── Pull request commits (Bitbucket API) ────────────────────────────────
+  # PR<->commit membership is vendor metadata: it does not exist in git, and a
+  # squash-merged PR leaves its original commits unreachable from every ref
+  # the proxy clones. One light call per PR in the window — the commit
+  # payloads themselves stay on the proxy path, so this stream stores only the
+  # edge.
+  - type: DeclarativeStream
+    name: pull_request_commits
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          sha: {type: [string, "null"]}
+          pr_id: {type: [integer, "null"]}
+          repo_full_name: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+        authenticator:
+          type: ApiKeyAuthenticator
+          inject_into:
+            type: RequestOption
+            inject_into: header
+            field_name: Authorization
+          # Personal API tokens are Basic username:token; workspace access
+          # tokens are Bearer and must leave bitbucket_username empty.
+          api_token: >-
+            {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
+        path: "/repositories/{{ stream_slice.extra_fields['repo_full_name'] }}/pullrequests/{{ stream_partition.pr_id }}/commits"
+        http_method: GET
+        request_parameters:
+          pagelen: "100"
+        error_handler:
+          type: DefaultErrorHandler
+          backoff_strategies:
+            # Bitbucket sometimes sends Retry-After as an HTTP date, which this
+            # strategy cannot parse; the exponential fallback covers that case.
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+            - type: ExponentialBackoffStrategy
+              factor: 5
+          response_filters:
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RATE_LIMITED
+              error_message: Bitbucket hourly rate budget exhausted
+            - type: HttpResponseFilter
+              http_codes: [403, 404]
+              action: IGNORE
+              error_message: >-
+                PR gone or not accessible; other pull requests continue.
+            - type: HttpResponseFilter
+              http_codes: [401]
+              action: FAIL
+              failure_type: config_error
+              error_message: >-
+                Bitbucket rejected the credentials. Personal API tokens need
+                bitbucket_username set (Basic auth); workspace access tokens must
+                NOT set it (Bearer). Mixing the two is the most common cause.
+            - type: HttpResponseFilter
+              http_codes: [500, 502, 503, 504]
+              action: RETRY
+              error_message: Transient Bitbucket error
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [values]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response.get('next', '') }}"
+          stop_condition: "{{ not response.get('next') }}"
+        page_token_option:
+          type: RequestPath
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: id
+            partition_field: pr_id
+            extra_fields:
+              - [repo_full_name]
+            stream:
+              type: DeclarativeStream
+              name: pull_requests_for_commits
+              primary_key:
+                - id
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/schema#
+                  properties:
+                    id: {type: [integer, "null"]}
+                    repo_full_name: {type: [string, "null"]}
+                    updated_on: {type: [string, "null"]}
+                  additionalProperties: true
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+                  authenticator:
+                    type: ApiKeyAuthenticator
+                    inject_into:
+                      type: RequestOption
+                      inject_into: header
+                      field_name: Authorization
+                    # Personal API tokens are Basic username:token; workspace access
+                    # tokens are Bearer and must leave bitbucket_username empty.
+                    api_token: >-
+                      {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
+                  path: "/repositories/{{ stream_partition.repo_full_name }}/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED"
+                  http_method: GET
+                  request_parameters:
+                    # pagelen HARD CAP on /pullrequests is 50 (400 above).
+                    pagelen: "50"
+                    sort: updated_on
+                    # Stateless sliding window: the children have no cursor of their
+                    # own, so parent state would never persist. RMT dedups the
+                    # re-read window.
+                    q: >-
+                      updated_on >= "{{ format_datetime(now_utc() - duration('P30D'), '%Y-%m-%dT%H:%M:%SZ') }}"
+                    fields: next,values.id,values.updated_on
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: [values]
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: CursorPagination
+                    cursor_value: "{{ response.get('next', '') }}"
+                    stop_condition: "{{ not response.get('next') }}"
+                  page_token_option:
+                    type: RequestPath
+                partition_router:
+                  type: SubstreamPartitionRouter
+                  parent_stream_configs:
+                    - type: ParentStreamConfig
+                      parent_key: full_name
+                      partition_field: repo_full_name
+                      stream:
+                        type: DeclarativeStream
+                        name: pull_requests_for_commits_repos
+                        primary_key:
+                          - uuid
+                        schema_loader:
+                          type: InlineSchemaLoader
+                          schema:
+                            type: object
+                            $schema: http://json-schema.org/schema#
+                            properties:
+                              uuid: {type: [string, "null"]}
+                              full_name: {type: [string, "null"]}
+                              updated_on: {type: [string, "null"]}
+                            additionalProperties: true
+                        retriever:
+                          type: SimpleRetriever
+                          requester:
+                            type: HttpRequester
+                            url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+                            authenticator:
+                              type: ApiKeyAuthenticator
+                              inject_into:
+                                type: RequestOption
+                                inject_into: header
+                                field_name: Authorization
+                              # Personal API tokens are Basic username:token; workspace access
+                              # tokens are Bearer and must leave bitbucket_username empty.
+                              api_token: >-
+                                {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
+                            path: "/repositories/{{ stream_partition.workspace }}"
+                            http_method: GET
+                            request_parameters:
+                              pagelen: "100"
+                              fields: next,values.uuid,values.full_name,values.updated_on
+                          record_selector:
+                            type: RecordSelector
+                            extractor:
+                              type: DpathExtractor
+                              field_path: [values]
+                          paginator:
+                            type: DefaultPaginator
+                            pagination_strategy:
+                              type: CursorPagination
+                              cursor_value: "{{ response.get('next', '') }}"
+                              stop_condition: "{{ not response.get('next') }}"
+                            page_token_option:
+                              type: RequestPath
+                          partition_router:
+                            type: ListPartitionRouter
+                            values: "{{ config['bitbucket_workspaces'] }}"
+                            cursor_field: workspace
+              transformations:
+                - type: AddFields
+                  fields:
+                    - type: AddedFieldDefinition
+                      path: [repo_full_name]
+                      value: "{{ stream_partition.repo_full_name }}"
+                      value_type: string
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_bitbucket_nocode
+          - type: AddedFieldDefinition
+            path: [collected_at]
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          - type: AddedFieldDefinition
+            path: [pr_id]
+            value: "{{ stream_partition.pr_id }}"
+          - type: AddedFieldDefinition
+            path: [repo_full_name]
+            value: "{{ stream_slice.extra_fields['repo_full_name'] }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [sha]
+            value: "{{ record.get('hash') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['repo_full_name'] | replace(':', '%3A') }}:{{ stream_partition.pr_id }}:{{ record['hash'] }}
+      - type: RemoveFields
+        # The commit payload comes from the proxy; only the edge is stored.
+        field_pointers:
+          - [hash]
+          - [type]
+          - [date]
+          - [message]
+          - [summary]
+          - [author]
+          - [parents]
+          - [links]
+          - [repository]
+          - [rendered]
+
   # ── Pull request activity (Bitbucket API) ───────────────────────────────
   # The ONLY source of approvals, changes-requested and merge/decline
   # transitions on Bitbucket — there is no reviews endpoint. Entries carry no
@@ -2301,6 +2566,7 @@ metadata:
     branches: false
     pull_requests: false
     pull_request_comments: false
+    pull_request_commits: false
     pull_request_activity: false
     workspace_members: false
     pipelines: false

--- a/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
@@ -312,10 +312,13 @@ streams:
                     stop_condition: "{{ not response.get('next') }}"
                   page_token_option:
                     type: RequestPath
-              partition_router:
-                type: ListPartitionRouter
-                values: "{{ config['bitbucket_workspaces'] }}"
-                cursor_field: workspace
+                partition_router:
+                  # INSIDE `retriever`: at stream level the CDK silently
+                  # ignores it — one empty partition, an empty workspace in
+                  # the path, and a 410 from the deprecated global listing.
+                  type: ListPartitionRouter
+                  values: "{{ config['bitbucket_workspaces'] }}"
+                  cursor_field: workspace
               incremental_sync:
                 type: DatetimeBasedCursor
                 cursor_field: updated_on
@@ -538,10 +541,13 @@ streams:
                     stop_condition: "{{ not response.get('next') }}"
                   page_token_option:
                     type: RequestPath
-              partition_router:
-                type: ListPartitionRouter
-                values: "{{ config['bitbucket_workspaces'] }}"
-                cursor_field: workspace
+                partition_router:
+                  # INSIDE `retriever`: at stream level the CDK silently
+                  # ignores it — one empty partition, an empty workspace in
+                  # the path, and a 410 from the deprecated global listing.
+                  type: ListPartitionRouter
+                  values: "{{ config['bitbucket_workspaces'] }}"
+                  cursor_field: workspace
               incremental_sync:
                 type: DatetimeBasedCursor
                 cursor_field: updated_on
@@ -751,10 +757,13 @@ streams:
                     stop_condition: "{{ not response.get('next') }}"
                   page_token_option:
                     type: RequestPath
-              partition_router:
-                type: ListPartitionRouter
-                values: "{{ config['bitbucket_workspaces'] }}"
-                cursor_field: workspace
+                partition_router:
+                  # INSIDE `retriever`: at stream level the CDK silently
+                  # ignores it — one empty partition, an empty workspace in
+                  # the path, and a 410 from the deprecated global listing.
+                  type: ListPartitionRouter
+                  values: "{{ config['bitbucket_workspaces'] }}"
+                  cursor_field: workspace
               transformations:
                 - type: AddFields
                   fields:
@@ -2580,11 +2589,12 @@ streams:
         path: "/repositories/{{ stream_partition.repo_full_name }}/deployments/"
         http_method: GET
         request_parameters:
+          # No sort and no q: deploy-service rejects `created_on` as a sort
+          # attribute (VERIFIED live, 400), accepts only `state.started_on`,
+          # which is null until a deployment starts — so no ordering is safe
+          # to lean an incremental stop on. Full refresh per repository; the
+          # ReplacingMergeTree absorbs the re-emission.
           pagelen: "100"
-          # Newest first + data-feed stop: `q` is NOT implemented on the
-          # pipelines-module endpoints, so ascending with a server filter is
-          # impossible and plain ascending would rescan all history each sync.
-          sort: -created_on
         error_handler:
           type: DefaultErrorHandler
           backoff_strategies:
@@ -2688,26 +2698,6 @@ streams:
                   type: ListPartitionRouter
                   values: "{{ config['bitbucket_workspaces'] }}"
                   cursor_field: workspace
-    incremental_sync:
-      type: DatetimeBasedCursor
-      cursor_field: created_on
-      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
-      cursor_datetime_formats:
-        - "%Y-%m-%dT%H:%M:%S.%f%z"
-        - "%Y-%m-%dT%H:%M:%S%z"
-      # created_on is immutable, so no lookback; descending order + data-feed
-      # stop is what makes each sync O(new records).
-      # VERIFIED against the CDK: the data-feed stop halts pagination at the
-      # first record older than the slice start, but the boundary PAGE's tail
-      # still emits — up to one page of pre-start_date rows per partition
-      # lands in bronze. Do NOT "fix" this with a record_filter: the stop
-      # condition evaluates POST-filter records, so filtering the old tail
-      # away would keep pagination walking through all history instead.
-      is_data_feed: true
-      start_datetime:
-        type: MinMaxDatetime
-        datetime: "{{ config['bitbucket_start_date'] }}"
-        datetime_format: "%Y-%m-%d"
     transformations:
       - type: AddFields
         fields:

--- a/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
@@ -29,6 +29,48 @@ type: DeclarativeSource
 # leaves its original commits unreachable from every ref the proxy clones.
 # Issues and projects are deliberately not synced.
 
+definitions:
+  proxy_error_handler: &proxy_error_handler
+    type: DefaultErrorHandler
+    # Generous on purpose: a cold blobless clone of a large repository runs
+    # for many Retry-After cycles before the first page can be served.
+    max_retries: 100
+    backoff_strategies:
+      - type: WaitTimeFromHeader
+        header: Retry-After
+        max_waiting_time_in_seconds: 600
+    response_filters:
+      # The repository is being cloned in the background: the proxy is
+      # working, the caller waits.
+      - type: HttpResponseFilter
+        http_codes: [429]
+        action: RETRY
+        error_message: Repository is being prepared by the proxy
+      # Both are permanent for THIS repository and harmless for the rest,
+      # so the partition is skipped rather than the whole stream failed.
+      # A rising git_proxy_admission_rejects_total is the alert: a 413
+      # means a repository is silently absent from bronze until an
+      # operator raises cache.maxRepoBytes.
+      - type: HttpResponseFilter
+        http_codes: [404, 413]
+        action: IGNORE
+        error_message: >-
+          Skipping this repository: gone at origin (404), or larger than
+          cache.maxRepoBytes (413). Other repositories continue.
+      # The pinned snapshot was superseded mid-walk. RETRY would replay
+      # the same dead page token and 409 again; a response filter cannot
+      # reset it. Rerunning the sync resumes each partition from its own
+      # stored cursor against a fresh snapshot.
+      - type: HttpResponseFilter
+        http_codes: [409]
+        action: FAIL
+        error_message: >-
+          Proxy snapshot changed mid-walk; rerun the sync to resume from the stored cursor
+      - type: HttpResponseFilter
+        http_codes: [500, 502, 503, 504]
+        action: RETRY
+        error_message: Transient proxy error (the origin can reset a clone mid-transfer)
+
 check:
   type: CheckStream
   stream_names:
@@ -205,39 +247,7 @@ streams:
         request_parameters:
           repo: "{{ stream_partition.repo_clone_url }}"
           page_size: "500"
-        error_handler:
-          type: DefaultErrorHandler
-          backoff_strategies:
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
-          response_filters:
-            # The repository is being cloned in the background: the proxy is
-            # working, the caller waits.
-            - type: HttpResponseFilter
-              http_codes: [429]
-              action: RETRY
-              error_message: Repository is being prepared by the proxy
-            # Both are permanent for THIS repository and harmless for the rest,
-            # so the partition is skipped rather than the whole stream failed.
-            # A rising git_proxy_admission_rejects_total is the alert: a 413
-            # means a repository is silently absent from bronze until an
-            # operator raises cache.maxRepoBytes.
-            - type: HttpResponseFilter
-              http_codes: [404, 413]
-              action: IGNORE
-              error_message: >-
-                Skipping this repository: gone at origin (404), or larger than
-                cache.maxRepoBytes (413). Other repositories continue.
-            # The pinned snapshot was superseded mid-walk. RETRY would replay
-            # the same dead page token and 409 again; a response filter cannot
-            # reset it. Rerunning the sync resumes each partition from its own
-            # stored cursor against a fresh snapshot.
-            - type: HttpResponseFilter
-              http_codes: [409]
-              action: FAIL
-              error_message: >-
-                Proxy snapshot changed mid-walk; rerun the sync to resume from the stored cursor
+        error_handler: *proxy_error_handler
       record_selector:
         type: RecordSelector
         extractor:
@@ -442,39 +452,7 @@ streams:
           page_size: "500"
           include_patch: "true"
           max_patch_bytes: "1048576"
-        error_handler:
-          type: DefaultErrorHandler
-          backoff_strategies:
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
-          response_filters:
-            # The repository is being cloned in the background: the proxy is
-            # working, the caller waits.
-            - type: HttpResponseFilter
-              http_codes: [429]
-              action: RETRY
-              error_message: Repository is being prepared by the proxy
-            # Both are permanent for THIS repository and harmless for the rest,
-            # so the partition is skipped rather than the whole stream failed.
-            # A rising git_proxy_admission_rejects_total is the alert: a 413
-            # means a repository is silently absent from bronze until an
-            # operator raises cache.maxRepoBytes.
-            - type: HttpResponseFilter
-              http_codes: [404, 413]
-              action: IGNORE
-              error_message: >-
-                Skipping this repository: gone at origin (404), or larger than
-                cache.maxRepoBytes (413). Other repositories continue.
-            # The pinned snapshot was superseded mid-walk. RETRY would replay
-            # the same dead page token and 409 again; a response filter cannot
-            # reset it. Rerunning the sync resumes each partition from its own
-            # stored cursor against a fresh snapshot.
-            - type: HttpResponseFilter
-              http_codes: [409]
-              action: FAIL
-              error_message: >-
-                Proxy snapshot changed mid-walk; rerun the sync to resume from the stored cursor
+        error_handler: *proxy_error_handler
       record_selector:
         type: RecordSelector
         extractor:
@@ -660,39 +638,7 @@ streams:
         request_parameters:
           repo: "{{ stream_partition.repo_clone_url }}"
           page_size: "500"
-        error_handler:
-          type: DefaultErrorHandler
-          backoff_strategies:
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
-          response_filters:
-            # The repository is being cloned in the background: the proxy is
-            # working, the caller waits.
-            - type: HttpResponseFilter
-              http_codes: [429]
-              action: RETRY
-              error_message: Repository is being prepared by the proxy
-            # Both are permanent for THIS repository and harmless for the rest,
-            # so the partition is skipped rather than the whole stream failed.
-            # A rising git_proxy_admission_rejects_total is the alert: a 413
-            # means a repository is silently absent from bronze until an
-            # operator raises cache.maxRepoBytes.
-            - type: HttpResponseFilter
-              http_codes: [404, 413]
-              action: IGNORE
-              error_message: >-
-                Skipping this repository: gone at origin (404), or larger than
-                cache.maxRepoBytes (413). Other repositories continue.
-            # The pinned snapshot was superseded mid-walk. RETRY would replay
-            # the same dead page token and 409 again; a response filter cannot
-            # reset it. Rerunning the sync resumes each partition from its own
-            # stored cursor against a fresh snapshot.
-            - type: HttpResponseFilter
-              http_codes: [409]
-              action: FAIL
-              error_message: >-
-                Proxy snapshot changed mid-walk; rerun the sync to resume from the stored cursor
+        error_handler: *proxy_error_handler
       record_selector:
         type: RecordSelector
         extractor:

--- a/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
@@ -71,6 +71,56 @@ definitions:
         action: RETRY
         error_message: Transient proxy error (the origin can reset a clone mid-transfer)
 
+  # Bitbucket sometimes sends Retry-After as an HTTP date, which this strategy
+  # cannot parse; the exponential fallback covers that case and the 5xx that
+  # carry no header at all.
+  vendor_backoff: &vendor_backoff
+    - type: WaitTimeFromHeader
+      header: Retry-After
+      max_waiting_time_in_seconds: 600
+    - type: ExponentialBackoffStrategy
+      factor: 5
+
+  # Repository discovery is the parent every other stream partitions on, so a
+  # throttle or a bad token here must classify, not surface as a generic error.
+  # No 403/404 IGNORE: on the listing itself that would silently yield an empty
+  # workspace instead of failing.
+  discovery_error_handler: &discovery_error_handler
+    type: DefaultErrorHandler
+    max_retries: 5
+    backoff_strategies: *vendor_backoff
+    response_filters:
+      - type: HttpResponseFilter
+        http_codes: [429]
+        action: RATE_LIMITED
+        error_message: Bitbucket hourly rate budget exhausted
+      - type: HttpResponseFilter
+        http_codes: [401]
+        action: FAIL
+        failure_type: config_error
+        error_message: >-
+          Bitbucket rejected the credentials. Personal API tokens need
+          bitbucket_username set (Basic auth); workspace access tokens must
+          NOT set it (Bearer). Mixing the two is the most common cause.
+      - type: HttpResponseFilter
+        http_codes: [500, 502, 503, 504]
+        action: RETRY
+        error_message: Transient Bitbucket error
+
+  proxy_requester: &proxy_requester
+    type: HttpRequester
+    url_base: "{{ config['git_proxy_url'] }}"
+    http_method: GET
+    authenticator:
+      type: BearerAuthenticator
+      api_token: "{{ config['git_proxy_token'] }}"
+    request_headers:
+      X-Tenant-Id: "{{ config['insight_tenant_id'] }}"
+      X-Source-Id: "{{ config['insight_source_id'] }}"
+      X-Git-Username: "{{ 'x-bitbucket-api-token-auth' if config.get('bitbucket_username') else 'x-token-auth' }}"
+      X-Git-Token: "{{ config['bitbucket_token'] }}"
+    error_handler: *proxy_error_handler
+
 check:
   type: CheckStream
   stream_names:
@@ -133,6 +183,7 @@ streams:
           # these fields are used (identity, cursor, clone link).
           fields: >-
             next,values.uuid,values.slug,values.name,values.full_name,values.is_private,values.language,values.size,values.created_on,values.updated_on,values.mainbranch.name,values.workspace.slug,values.links.clone
+        error_handler: *discovery_error_handler
       record_selector:
         type: RecordSelector
         extractor:
@@ -232,22 +283,11 @@ streams:
     retriever:
       type: SimpleRetriever
       requester:
-        type: HttpRequester
-        url_base: "{{ config['git_proxy_url'] }}"
-        authenticator:
-          type: BearerAuthenticator
-          api_token: "{{ config['git_proxy_token'] }}"
-        request_headers:
-          X-Tenant-Id: "{{ config['insight_tenant_id'] }}"
-          X-Source-Id: "{{ config['insight_source_id'] }}"
-          X-Git-Username: "{{ 'x-bitbucket-api-token-auth' if config.get('bitbucket_username') else 'x-token-auth' }}"
-          X-Git-Token: "{{ config['bitbucket_token'] }}"
+        <<: *proxy_requester
         path: /v1/commits
-        http_method: GET
         request_parameters:
           repo: "{{ stream_partition.repo_clone_url }}"
           page_size: "500"
-        error_handler: *proxy_error_handler
       record_selector:
         type: RecordSelector
         extractor:
@@ -435,24 +475,13 @@ streams:
     retriever:
       type: SimpleRetriever
       requester:
-        type: HttpRequester
-        url_base: "{{ config['git_proxy_url'] }}"
-        authenticator:
-          type: BearerAuthenticator
-          api_token: "{{ config['git_proxy_token'] }}"
-        request_headers:
-          X-Tenant-Id: "{{ config['insight_tenant_id'] }}"
-          X-Source-Id: "{{ config['insight_source_id'] }}"
-          X-Git-Username: "{{ 'x-bitbucket-api-token-auth' if config.get('bitbucket_username') else 'x-token-auth' }}"
-          X-Git-Token: "{{ config['bitbucket_token'] }}"
+        <<: *proxy_requester
         path: /v1/file-changes
-        http_method: GET
         request_parameters:
           repo: "{{ stream_partition.repo_clone_url }}"
           page_size: "500"
           include_patch: "true"
           max_patch_bytes: "1048576"
-        error_handler: *proxy_error_handler
       record_selector:
         type: RecordSelector
         extractor:
@@ -623,22 +652,11 @@ streams:
     retriever:
       type: SimpleRetriever
       requester:
-        type: HttpRequester
-        url_base: "{{ config['git_proxy_url'] }}"
-        authenticator:
-          type: BearerAuthenticator
-          api_token: "{{ config['git_proxy_token'] }}"
-        request_headers:
-          X-Tenant-Id: "{{ config['insight_tenant_id'] }}"
-          X-Source-Id: "{{ config['insight_source_id'] }}"
-          X-Git-Username: "{{ 'x-bitbucket-api-token-auth' if config.get('bitbucket_username') else 'x-token-auth' }}"
-          X-Git-Token: "{{ config['bitbucket_token'] }}"
+        <<: *proxy_requester
         path: /v1/branches
-        http_method: GET
         request_parameters:
           repo: "{{ stream_partition.repo_clone_url }}"
           page_size: "500"
-        error_handler: *proxy_error_handler
       record_selector:
         type: RecordSelector
         extractor:
@@ -819,14 +837,8 @@ streams:
             next,values.id,values.title,values.state,values.draft,values.author.uuid,values.author.display_name,values.created_on,values.updated_on,values.merge_commit.hash,values.closed_by.uuid,values.source.branch.name,values.source.commit.hash,values.destination.branch.name,values.comment_count,values.task_count
         error_handler:
           type: DefaultErrorHandler
-          backoff_strategies:
-            # Bitbucket sometimes sends Retry-After as an HTTP date, which this
-            # strategy cannot parse; the exponential fallback covers that case.
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
-            - type: ExponentialBackoffStrategy
-              factor: 5
+          max_retries: 5
+          backoff_strategies: *vendor_backoff
           response_filters:
             - type: HttpResponseFilter
               http_codes: [429]
@@ -1066,14 +1078,8 @@ streams:
             next,values.id,values.user.uuid,values.user.display_name,values.created_on,values.updated_on,values.deleted,values.parent.id,values.inline.path
         error_handler:
           type: DefaultErrorHandler
-          backoff_strategies:
-            # Bitbucket sometimes sends Retry-After as an HTTP date, which this
-            # strategy cannot parse; the exponential fallback covers that case.
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
-            - type: ExponentialBackoffStrategy
-              factor: 5
+          max_retries: 5
+          backoff_strategies: *vendor_backoff
           response_filters:
             - type: HttpResponseFilter
               http_codes: [429]
@@ -1344,14 +1350,8 @@ streams:
           pagelen: "100"
         error_handler:
           type: DefaultErrorHandler
-          backoff_strategies:
-            # Bitbucket sometimes sends Retry-After as an HTTP date, which this
-            # strategy cannot parse; the exponential fallback covers that case.
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
-            - type: ExponentialBackoffStrategy
-              factor: 5
+          max_retries: 5
+          backoff_strategies: *vendor_backoff
           response_filters:
             - type: HttpResponseFilter
               http_codes: [429]
@@ -1611,14 +1611,8 @@ streams:
           pagelen: "100"
         error_handler:
           type: DefaultErrorHandler
-          backoff_strategies:
-            # Bitbucket sometimes sends Retry-After as an HTTP date, which this
-            # strategy cannot parse; the exponential fallback covers that case.
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
-            - type: ExponentialBackoffStrategy
-              factor: 5
+          max_retries: 5
+          backoff_strategies: *vendor_backoff
           response_filters:
             - type: HttpResponseFilter
               http_codes: [429]
@@ -1887,14 +1881,8 @@ streams:
           pagelen: "50"
         error_handler:
           type: DefaultErrorHandler
-          backoff_strategies:
-            # Bitbucket sometimes sends Retry-After as an HTTP date, which this
-            # strategy cannot parse; the exponential fallback covers that case.
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
-            - type: ExponentialBackoffStrategy
-              factor: 5
+          max_retries: 5
+          backoff_strategies: *vendor_backoff
           response_filters:
             - type: HttpResponseFilter
               http_codes: [429]
@@ -2168,14 +2156,8 @@ streams:
             next,values.user.account_id,values.user.display_name,values.user.nickname,values.user.uuid
         error_handler:
           type: DefaultErrorHandler
-          backoff_strategies:
-            # Bitbucket sometimes sends Retry-After as an HTTP date, which this
-            # strategy cannot parse; the exponential fallback covers that case.
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
-            - type: ExponentialBackoffStrategy
-              factor: 5
+          max_retries: 5
+          backoff_strategies: *vendor_backoff
           response_filters:
             - type: HttpResponseFilter
               http_codes: [429]
@@ -2318,14 +2300,8 @@ streams:
           sort: -created_on
         error_handler:
           type: DefaultErrorHandler
-          backoff_strategies:
-            # Bitbucket sometimes sends Retry-After as an HTTP date, which this
-            # strategy cannot parse; the exponential fallback covers that case.
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
-            - type: ExponentialBackoffStrategy
-              factor: 5
+          max_retries: 5
+          backoff_strategies: *vendor_backoff
           response_filters:
             - type: HttpResponseFilter
               http_codes: [429]
@@ -2553,14 +2529,8 @@ streams:
           pagelen: "100"
         error_handler:
           type: DefaultErrorHandler
-          backoff_strategies:
-            # Bitbucket sometimes sends Retry-After as an HTTP date, which this
-            # strategy cannot parse; the exponential fallback covers that case.
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
-            - type: ExponentialBackoffStrategy
-              factor: 5
+          max_retries: 5
+          backoff_strategies: *vendor_backoff
           response_filters:
             - type: HttpResponseFilter
               http_codes: [429]

--- a/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
@@ -2463,6 +2463,12 @@ streams:
         - "%Y-%m-%dT%H:%M:%S%z"
       # created_on is immutable, so no lookback; descending order + data-feed
       # stop is what makes each sync O(new records).
+      # VERIFIED against the CDK: the data-feed stop halts pagination at the
+      # first record older than the slice start, but the boundary PAGE's tail
+      # still emits — up to one page of pre-start_date rows per partition
+      # lands in bronze. Do NOT "fix" this with a record_filter: the stop
+      # condition evaluates POST-filter records, so filtering the old tail
+      # away would keep pagination walking through all history instead.
       is_data_feed: true
       start_datetime:
         type: MinMaxDatetime
@@ -2691,6 +2697,12 @@ streams:
         - "%Y-%m-%dT%H:%M:%S%z"
       # created_on is immutable, so no lookback; descending order + data-feed
       # stop is what makes each sync O(new records).
+      # VERIFIED against the CDK: the data-feed stop halts pagination at the
+      # first record older than the slice start, but the boundary PAGE's tail
+      # still emits — up to one page of pre-start_date rows per partition
+      # lands in bronze. Do NOT "fix" this with a record_filter: the stop
+      # condition evaluates POST-filter records, so filtering the old tail
+      # away would keep pagination walking through all history instead.
       is_data_feed: true
       start_datetime:
         type: MinMaxDatetime

--- a/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
@@ -69,13 +69,19 @@ streams:
         type: HttpRequester
         url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
         authenticator:
-          type: BasicHttpAuthenticator
-          username: "{{ config['bitbucket_username'] }}"
-          password: "{{ config['bitbucket_token'] }}"
+          type: ApiKeyAuthenticator
+          inject_into:
+            type: RequestOption
+            inject_into: header
+            field_name: Authorization
+          # Personal API tokens are Basic username:token; workspace access
+          # tokens are Bearer and must leave bitbucket_username empty.
+          api_token: >-
+            {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
         path: "/repositories/{{ stream_partition.workspace }}"
         http_method: GET
         request_parameters:
-          pagelen: "{{ config.get('bitbucket_page_size', 100) }}"
+          pagelen: "100"
           # Ascending, so the cursor advances monotonically across pages.
           sort: updated_on
           # Trim the payload: the full repository object is large and only
@@ -108,7 +114,7 @@ streams:
         - "%Y-%m-%dT%H:%M:%S%z"
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config.get('bitbucket_start_date', '2020-01-01') }}"
+        datetime: "{{ config['bitbucket_start_date'] }}"
         datetime_format: "%Y-%m-%d"
     transformations:
       - type: AddFields
@@ -181,13 +187,13 @@ streams:
         request_headers:
           X-Tenant-Id: "{{ config['insight_tenant_id'] }}"
           X-Source-Id: "{{ config['insight_source_id'] }}"
-          X-Git-Username: "{{ config.get('bitbucket_git_username', 'x-bitbucket-api-token-auth') }}"
+          X-Git-Username: "{{ 'x-bitbucket-api-token-auth' if config.get('bitbucket_username') else 'x-token-auth' }}"
           X-Git-Token: "{{ config['bitbucket_token'] }}"
         path: /v1/commits
         http_method: GET
         request_parameters:
           repo: "{{ stream_partition.repo_clone_url }}"
-          page_size: "{{ config.get('proxy_page_size', 500) }}"
+          page_size: "500"
         error_handler:
           type: DefaultErrorHandler
           backoff_strategies:
@@ -270,13 +276,19 @@ streams:
                   type: HttpRequester
                   url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
                   authenticator:
-                    type: BasicHttpAuthenticator
-                    username: "{{ config['bitbucket_username'] }}"
-                    password: "{{ config['bitbucket_token'] }}"
+                    type: ApiKeyAuthenticator
+                    inject_into:
+                      type: RequestOption
+                      inject_into: header
+                      field_name: Authorization
+                    # Personal API tokens are Basic username:token; workspace access
+                    # tokens are Bearer and must leave bitbucket_username empty.
+                    api_token: >-
+                      {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                   path: "/repositories/{{ stream_partition.workspace }}"
                   http_method: GET
                   request_parameters:
-                    pagelen: "{{ config.get('bitbucket_page_size', 100) }}"
+                    pagelen: "100"
                     sort: updated_on
                     fields: >-
                       next,values.uuid,values.slug,values.updated_on,values.links.clone
@@ -306,7 +318,7 @@ streams:
                   - "%Y-%m-%dT%H:%M:%S%z"
                 start_datetime:
                   type: MinMaxDatetime
-                  datetime: "{{ config.get('bitbucket_start_date', '2020-01-01') }}"
+                  datetime: "{{ config['bitbucket_start_date'] }}"
                   datetime_format: "%Y-%m-%d"
               transformations:
                 - type: AddFields
@@ -325,13 +337,13 @@ streams:
       # sync recovers them; bronze dedups the re-read rows. This is a
       # heuristic, not a guarantee — a rewrite older than the window is
       # still lost, and nothing detects it.
-      lookback_window: "{{ config.get('bitbucket_lookback_window', 'P1M') }}"
+      lookback_window: "P1M"
       cursor_datetime_formats:
         - "%Y-%m-%dT%H:%M:%S%z"
         - "%Y-%m-%dT%H:%M:%SZ"
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config.get('bitbucket_start_date', '2020-01-01') }}"
+        datetime: "{{ config['bitbucket_start_date'] }}"
         datetime_format: "%Y-%m-%d"
       start_time_option:
         type: RequestOption
@@ -401,15 +413,15 @@ streams:
         request_headers:
           X-Tenant-Id: "{{ config['insight_tenant_id'] }}"
           X-Source-Id: "{{ config['insight_source_id'] }}"
-          X-Git-Username: "{{ config.get('bitbucket_git_username', 'x-bitbucket-api-token-auth') }}"
+          X-Git-Username: "{{ 'x-bitbucket-api-token-auth' if config.get('bitbucket_username') else 'x-token-auth' }}"
           X-Git-Token: "{{ config['bitbucket_token'] }}"
         path: /v1/file-changes
         http_method: GET
         request_parameters:
           repo: "{{ stream_partition.repo_clone_url }}"
-          page_size: "{{ config.get('proxy_page_size', 500) }}"
-          include_patch: "{{ config.get('bitbucket_include_patch', true) | lower }}"
-          max_patch_bytes: "{{ config.get('bitbucket_max_patch_bytes', 1048576) }}"
+          page_size: "500"
+          include_patch: "true"
+          max_patch_bytes: "1048576"
         error_handler:
           type: DefaultErrorHandler
           backoff_strategies:
@@ -486,13 +498,19 @@ streams:
                   type: HttpRequester
                   url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
                   authenticator:
-                    type: BasicHttpAuthenticator
-                    username: "{{ config['bitbucket_username'] }}"
-                    password: "{{ config['bitbucket_token'] }}"
+                    type: ApiKeyAuthenticator
+                    inject_into:
+                      type: RequestOption
+                      inject_into: header
+                      field_name: Authorization
+                    # Personal API tokens are Basic username:token; workspace access
+                    # tokens are Bearer and must leave bitbucket_username empty.
+                    api_token: >-
+                      {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                   path: "/repositories/{{ stream_partition.workspace }}"
                   http_method: GET
                   request_parameters:
-                    pagelen: "{{ config.get('bitbucket_page_size', 100) }}"
+                    pagelen: "100"
                     sort: updated_on
                     fields: >-
                       next,values.uuid,values.slug,values.updated_on,values.links.clone
@@ -522,7 +540,7 @@ streams:
                   - "%Y-%m-%dT%H:%M:%S%z"
                 start_datetime:
                   type: MinMaxDatetime
-                  datetime: "{{ config.get('bitbucket_start_date', '2020-01-01') }}"
+                  datetime: "{{ config['bitbucket_start_date'] }}"
                   datetime_format: "%Y-%m-%d"
               transformations:
                 - type: AddFields
@@ -541,13 +559,13 @@ streams:
       # sync recovers them; bronze dedups the re-read rows. This is a
       # heuristic, not a guarantee — a rewrite older than the window is
       # still lost, and nothing detects it.
-      lookback_window: "{{ config.get('bitbucket_lookback_window', 'P1M') }}"
+      lookback_window: "P1M"
       cursor_datetime_formats:
         - "%Y-%m-%dT%H:%M:%S%z"
         - "%Y-%m-%dT%H:%M:%SZ"
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config.get('bitbucket_start_date', '2020-01-01') }}"
+        datetime: "{{ config['bitbucket_start_date'] }}"
         datetime_format: "%Y-%m-%d"
       start_time_option:
         type: RequestOption
@@ -610,13 +628,13 @@ streams:
         request_headers:
           X-Tenant-Id: "{{ config['insight_tenant_id'] }}"
           X-Source-Id: "{{ config['insight_source_id'] }}"
-          X-Git-Username: "{{ config.get('bitbucket_git_username', 'x-bitbucket-api-token-auth') }}"
+          X-Git-Username: "{{ 'x-bitbucket-api-token-auth' if config.get('bitbucket_username') else 'x-token-auth' }}"
           X-Git-Token: "{{ config['bitbucket_token'] }}"
         path: /v1/branches
         http_method: GET
         request_parameters:
           repo: "{{ stream_partition.repo_clone_url }}"
-          page_size: "{{ config.get('proxy_page_size', 500) }}"
+          page_size: "500"
         error_handler:
           type: DefaultErrorHandler
           backoff_strategies:
@@ -694,13 +712,19 @@ streams:
                   type: HttpRequester
                   url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
                   authenticator:
-                    type: BasicHttpAuthenticator
-                    username: "{{ config['bitbucket_username'] }}"
-                    password: "{{ config['bitbucket_token'] }}"
+                    type: ApiKeyAuthenticator
+                    inject_into:
+                      type: RequestOption
+                      inject_into: header
+                      field_name: Authorization
+                    # Personal API tokens are Basic username:token; workspace access
+                    # tokens are Bearer and must leave bitbucket_username empty.
+                    api_token: >-
+                      {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                   path: "/repositories/{{ stream_partition.workspace }}"
                   http_method: GET
                   request_parameters:
-                    pagelen: "{{ config.get('bitbucket_page_size', 100) }}"
+                    pagelen: "100"
                     fields: >-
                       next,values.uuid,values.slug,values.links.clone
                 record_selector:
@@ -795,9 +819,15 @@ streams:
         type: HttpRequester
         url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
         authenticator:
-          type: BasicHttpAuthenticator
-          username: "{{ config['bitbucket_username'] }}"
-          password: "{{ config['bitbucket_token'] }}"
+          type: ApiKeyAuthenticator
+          inject_into:
+            type: RequestOption
+            inject_into: header
+            field_name: Authorization
+          # Personal API tokens are Basic username:token; workspace access
+          # tokens are Bearer and must leave bitbucket_username empty.
+          api_token: >-
+            {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
         path: "/repositories/{{ stream_partition.repo_full_name }}/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED"
         http_method: GET
         request_parameters:
@@ -880,13 +910,19 @@ streams:
                   type: HttpRequester
                   url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
                   authenticator:
-                    type: BasicHttpAuthenticator
-                    username: "{{ config['bitbucket_username'] }}"
-                    password: "{{ config['bitbucket_token'] }}"
+                    type: ApiKeyAuthenticator
+                    inject_into:
+                      type: RequestOption
+                      inject_into: header
+                      field_name: Authorization
+                    # Personal API tokens are Basic username:token; workspace access
+                    # tokens are Bearer and must leave bitbucket_username empty.
+                    api_token: >-
+                      {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                   path: "/repositories/{{ stream_partition.workspace }}"
                   http_method: GET
                   request_parameters:
-                    pagelen: "{{ config.get('bitbucket_page_size', 100) }}"
+                    pagelen: "100"
                     fields: next,values.uuid,values.full_name,values.updated_on
                 record_selector:
                   type: RecordSelector
@@ -915,7 +951,7 @@ streams:
       lookback_window: P1D
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config.get('bitbucket_start_date', '2020-01-01') }}"
+        datetime: "{{ config['bitbucket_start_date'] }}"
         datetime_format: "%Y-%m-%d"
     transformations:
       - type: AddFields
@@ -1014,9 +1050,15 @@ streams:
         type: HttpRequester
         url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
         authenticator:
-          type: BasicHttpAuthenticator
-          username: "{{ config['bitbucket_username'] }}"
-          password: "{{ config['bitbucket_token'] }}"
+          type: ApiKeyAuthenticator
+          inject_into:
+            type: RequestOption
+            inject_into: header
+            field_name: Authorization
+          # Personal API tokens are Basic username:token; workspace access
+          # tokens are Bearer and must leave bitbucket_username empty.
+          api_token: >-
+            {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
         path: "/repositories/{{ stream_slice.extra_fields['repo_full_name'] }}/pullrequests/{{ stream_partition.pr_id }}/comments"
         http_method: GET
         request_parameters:
@@ -1097,9 +1139,15 @@ streams:
                   type: HttpRequester
                   url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
                   authenticator:
-                    type: BasicHttpAuthenticator
-                    username: "{{ config['bitbucket_username'] }}"
-                    password: "{{ config['bitbucket_token'] }}"
+                    type: ApiKeyAuthenticator
+                    inject_into:
+                      type: RequestOption
+                      inject_into: header
+                      field_name: Authorization
+                    # Personal API tokens are Basic username:token; workspace access
+                    # tokens are Bearer and must leave bitbucket_username empty.
+                    api_token: >-
+                      {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                   path: "/repositories/{{ stream_partition.repo_full_name }}/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED"
                   http_method: GET
                   request_parameters:
@@ -1110,7 +1158,7 @@ streams:
                     # own, so parent state would never persist. RMT dedups the
                     # re-read window.
                     q: >-
-                      updated_on >= "{{ format_datetime(now_utc() - duration('P' ~ config.get('bitbucket_pr_child_window_days', 30) ~ 'D'), '%Y-%m-%dT%H:%M:%SZ') }}"
+                      updated_on >= "{{ format_datetime(now_utc() - duration('P30D'), '%Y-%m-%dT%H:%M:%SZ') }}"
                     fields: next,values.id,values.updated_on
                 record_selector:
                   type: RecordSelector
@@ -1152,13 +1200,19 @@ streams:
                             type: HttpRequester
                             url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
                             authenticator:
-                              type: BasicHttpAuthenticator
-                              username: "{{ config['bitbucket_username'] }}"
-                              password: "{{ config['bitbucket_token'] }}"
+                              type: ApiKeyAuthenticator
+                              inject_into:
+                                type: RequestOption
+                                inject_into: header
+                                field_name: Authorization
+                              # Personal API tokens are Basic username:token; workspace access
+                              # tokens are Bearer and must leave bitbucket_username empty.
+                              api_token: >-
+                                {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                             path: "/repositories/{{ stream_partition.workspace }}"
                             http_method: GET
                             request_parameters:
-                              pagelen: "{{ config.get('bitbucket_page_size', 100) }}"
+                              pagelen: "100"
                               fields: next,values.uuid,values.full_name,values.updated_on
                           record_selector:
                             type: RecordSelector
@@ -1270,9 +1324,15 @@ streams:
         type: HttpRequester
         url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
         authenticator:
-          type: BasicHttpAuthenticator
-          username: "{{ config['bitbucket_username'] }}"
-          password: "{{ config['bitbucket_token'] }}"
+          type: ApiKeyAuthenticator
+          inject_into:
+            type: RequestOption
+            inject_into: header
+            field_name: Authorization
+          # Personal API tokens are Basic username:token; workspace access
+          # tokens are Bearer and must leave bitbucket_username empty.
+          api_token: >-
+            {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
         path: "/repositories/{{ stream_slice.extra_fields['repo_full_name'] }}/pullrequests/{{ stream_partition.pr_id }}/activity"
         http_method: GET
         request_parameters:
@@ -1352,9 +1412,15 @@ streams:
                   type: HttpRequester
                   url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
                   authenticator:
-                    type: BasicHttpAuthenticator
-                    username: "{{ config['bitbucket_username'] }}"
-                    password: "{{ config['bitbucket_token'] }}"
+                    type: ApiKeyAuthenticator
+                    inject_into:
+                      type: RequestOption
+                      inject_into: header
+                      field_name: Authorization
+                    # Personal API tokens are Basic username:token; workspace access
+                    # tokens are Bearer and must leave bitbucket_username empty.
+                    api_token: >-
+                      {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                   path: "/repositories/{{ stream_partition.repo_full_name }}/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED"
                   http_method: GET
                   request_parameters:
@@ -1365,7 +1431,7 @@ streams:
                     # own, so parent state would never persist. RMT dedups the
                     # re-read window.
                     q: >-
-                      updated_on >= "{{ format_datetime(now_utc() - duration('P' ~ config.get('bitbucket_pr_child_window_days', 30) ~ 'D'), '%Y-%m-%dT%H:%M:%SZ') }}"
+                      updated_on >= "{{ format_datetime(now_utc() - duration('P30D'), '%Y-%m-%dT%H:%M:%SZ') }}"
                     fields: next,values.id,values.updated_on
                 record_selector:
                   type: RecordSelector
@@ -1407,13 +1473,19 @@ streams:
                             type: HttpRequester
                             url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
                             authenticator:
-                              type: BasicHttpAuthenticator
-                              username: "{{ config['bitbucket_username'] }}"
-                              password: "{{ config['bitbucket_token'] }}"
+                              type: ApiKeyAuthenticator
+                              inject_into:
+                                type: RequestOption
+                                inject_into: header
+                                field_name: Authorization
+                              # Personal API tokens are Basic username:token; workspace access
+                              # tokens are Bearer and must leave bitbucket_username empty.
+                              api_token: >-
+                                {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                             path: "/repositories/{{ stream_partition.workspace }}"
                             http_method: GET
                             request_parameters:
-                              pagelen: "{{ config.get('bitbucket_page_size', 100) }}"
+                              pagelen: "100"
                               fields: next,values.uuid,values.full_name,values.updated_on
                           record_selector:
                             type: RecordSelector
@@ -1532,9 +1604,15 @@ streams:
         type: HttpRequester
         url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
         authenticator:
-          type: BasicHttpAuthenticator
-          username: "{{ config['bitbucket_username'] }}"
-          password: "{{ config['bitbucket_token'] }}"
+          type: ApiKeyAuthenticator
+          inject_into:
+            type: RequestOption
+            inject_into: header
+            field_name: Authorization
+          # Personal API tokens are Basic username:token; workspace access
+          # tokens are Bearer and must leave bitbucket_username empty.
+          api_token: >-
+            {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
         path: "/workspaces/{{ stream_partition.workspace }}/members"
         http_method: GET
         request_parameters:
@@ -1673,9 +1751,15 @@ streams:
         type: HttpRequester
         url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
         authenticator:
-          type: BasicHttpAuthenticator
-          username: "{{ config['bitbucket_username'] }}"
-          password: "{{ config['bitbucket_token'] }}"
+          type: ApiKeyAuthenticator
+          inject_into:
+            type: RequestOption
+            inject_into: header
+            field_name: Authorization
+          # Personal API tokens are Basic username:token; workspace access
+          # tokens are Bearer and must leave bitbucket_username empty.
+          api_token: >-
+            {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
         # Trailing slash is load-bearing: without it this endpoint 404s.
         path: "/repositories/{{ stream_partition.repo_full_name }}/pipelines/"
         http_method: GET
@@ -1757,13 +1841,19 @@ streams:
                   type: HttpRequester
                   url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
                   authenticator:
-                    type: BasicHttpAuthenticator
-                    username: "{{ config['bitbucket_username'] }}"
-                    password: "{{ config['bitbucket_token'] }}"
+                    type: ApiKeyAuthenticator
+                    inject_into:
+                      type: RequestOption
+                      inject_into: header
+                      field_name: Authorization
+                    # Personal API tokens are Basic username:token; workspace access
+                    # tokens are Bearer and must leave bitbucket_username empty.
+                    api_token: >-
+                      {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                   path: "/repositories/{{ stream_partition.workspace }}"
                   http_method: GET
                   request_parameters:
-                    pagelen: "{{ config.get('bitbucket_page_size', 100) }}"
+                    pagelen: "100"
                     fields: next,values.uuid,values.full_name,values.updated_on
                 record_selector:
                   type: RecordSelector
@@ -1794,7 +1884,7 @@ streams:
       is_data_feed: true
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config.get('bitbucket_start_date', '2020-01-01') }}"
+        datetime: "{{ config['bitbucket_start_date'] }}"
         datetime_format: "%Y-%m-%d"
     transformations:
       - type: AddFields
@@ -1889,9 +1979,15 @@ streams:
         type: HttpRequester
         url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
         authenticator:
-          type: BasicHttpAuthenticator
-          username: "{{ config['bitbucket_username'] }}"
-          password: "{{ config['bitbucket_token'] }}"
+          type: ApiKeyAuthenticator
+          inject_into:
+            type: RequestOption
+            inject_into: header
+            field_name: Authorization
+          # Personal API tokens are Basic username:token; workspace access
+          # tokens are Bearer and must leave bitbucket_username empty.
+          api_token: >-
+            {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
         # Trailing slash is load-bearing: without it this endpoint 404s.
         path: "/repositories/{{ stream_partition.repo_full_name }}/deployments/"
         http_method: GET
@@ -1973,13 +2069,19 @@ streams:
                   type: HttpRequester
                   url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
                   authenticator:
-                    type: BasicHttpAuthenticator
-                    username: "{{ config['bitbucket_username'] }}"
-                    password: "{{ config['bitbucket_token'] }}"
+                    type: ApiKeyAuthenticator
+                    inject_into:
+                      type: RequestOption
+                      inject_into: header
+                      field_name: Authorization
+                    # Personal API tokens are Basic username:token; workspace access
+                    # tokens are Bearer and must leave bitbucket_username empty.
+                    api_token: >-
+                      {{ ('Basic ' ~ ((config['bitbucket_username'] ~ ':' ~ config['bitbucket_token']) | base64encode)) if config.get('bitbucket_username') else ('Bearer ' ~ config['bitbucket_token']) }}
                   path: "/repositories/{{ stream_partition.workspace }}"
                   http_method: GET
                   request_parameters:
-                    pagelen: "{{ config.get('bitbucket_page_size', 100) }}"
+                    pagelen: "100"
                     fields: next,values.uuid,values.full_name,values.updated_on
                 record_selector:
                   type: RecordSelector
@@ -2010,7 +2112,7 @@ streams:
       is_data_feed: true
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config.get('bitbucket_start_date', '2020-01-01') }}"
+        datetime: "{{ config['bitbucket_start_date'] }}"
         datetime_format: "%Y-%m-%d"
     transformations:
       - type: AddFields
@@ -2080,11 +2182,11 @@ spec:
     required:
       - insight_tenant_id
       - insight_source_id
-      - bitbucket_username
       - bitbucket_token
       - bitbucket_workspaces
       - git_proxy_url
       - git_proxy_token
+      - bitbucket_start_date
     properties:
       insight_tenant_id:
         type: string
@@ -2100,16 +2202,12 @@ spec:
       bitbucket_username:
         type: string
         description: >-
-          Atlassian account username or email. Personal API tokens authenticate as HTTP basic `username:token`, both against the API and against the clone the proxy performs.
-        title: Username / Email
+          Atlassian account email/username. Set it for personal API tokens
+          (HTTP Basic username:token, both against the API and the clone the
+          proxy performs). Leave empty for workspace/repository access tokens,
+          which authenticate as Bearer.
+        title: Username / Email (personal API tokens only)
         order: 2
-      bitbucket_git_username:
-        type: string
-        description: >-
-          Username the proxy presents when CLONING over https, which is NOT the API credential. `x-token-auth` is reserved for workspace/repository access tokens and is rejected for a personal API token; the default works for personal API tokens, and the account's short username works for access tokens.
-        title: Git Clone Username
-        default: x-bitbucket-api-token-auth
-        order: 3
       bitbucket_token:
         type: string
         description: >-
@@ -2141,63 +2239,15 @@ spec:
         description: Bitbucket API base URL.
         title: API Base URL
         default: "https://api.bitbucket.org/2.0"
-        order: 8
+        order: 9
       bitbucket_start_date:
         type: string
-        description: Earliest date for incremental sync (YYYY-MM-DD).
+        description: >-
+          Earliest date for incremental sync (YYYY-MM-DD). Required: it bounds
+          the first-sync cost, so choosing it is a deployment decision.
         title: Start Date
         format: date
-        default: "2020-01-01"
-        order: 9
-      bitbucket_page_size:
-        type: integer
-        description: Bitbucket API page size (max 100).
-        title: Bitbucket Page Size
-        default: 100
-        minimum: 1
-        maximum: 100
-        order: 10
-      proxy_page_size:
-        type: integer
-        description: Rows per page requested from the git-cli-proxy.
-        title: Proxy Page Size
-        default: 500
-        minimum: 1
-        maximum: 10000
-        order: 11
-      bitbucket_include_patch:
-        type: boolean
-        description: >-
-          Store per-file diff text. Keep enabled to allow recomputing line counts later under different filters; disable to cut bronze volume.
-        title: Include Patch Text
-        default: true
-        order: 12
-      bitbucket_max_patch_bytes:
-        type: integer
-        description: >-
-          Truncation cap for a single file's diff. Truncated rows are flagged with patch_truncated so downstream never mistakes them for complete.
-        title: Max Patch Bytes
-        default: 1048576
-        minimum: 1024
-        order: 13
-      bitbucket_lookback_window:
-        type: string
-        description: >-
-          ISO-8601 duration re-enumerated below the stored cursor on every sync. `git log --since` is a traversal cutoff, so after a rebase the replacement commits can carry dates below the cursor and would never be visited again. Bronze dedups the re-read rows, so the cost is one window per sync. A rewrite older than the window is still lost.
-        title: Rebase Lookback Window
-        default: P1M
-        order: 14
-      bitbucket_pr_child_window_days:
-        type: integer
-        description: >-
-          Sliding window, in days, of pull requests whose comments and
-          activity are re-read each sync. The children have no cursor of
-          their own, so the window bounds their cost; edits on PRs older
-          than the window are not picked up.
-        title: PR Child Window (days)
-        default: 30
-        minimum: 1
-        order: 15
+        order: 8
     additionalProperties: true
 
 metadata:

--- a/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
@@ -60,6 +60,7 @@ streams:
           size: {type: [integer, "null"]}
           created_on: {type: [string, "null"]}
           updated_on: {type: [string, "null"]}
+          description: {type: [string, "null"]}
         required:
           - unique_key
         additionalProperties: true
@@ -138,6 +139,10 @@ streams:
             # from full_name would duplicate knowledge of the host layout.
             value: >-
               {{ (record['links']['clone'] | selectattr('name', 'equalto', 'https') | map(attribute='href') | list | first) }}
+          - type: AddedFieldDefinition
+            path: [description]
+            value: "{{ (record.get('description') or '')[:1024] }}"
+            value_type: string
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
@@ -367,6 +372,10 @@ streams:
           # Repository identity is REQUIRED in the key: forks share commit
           # SHAs, so tenant+source+sha alone would let the ReplacingMergeTree
           # collapse commits from different repositories into one row.
+          - type: AddedFieldDefinition
+            path: [message]
+            value: "{{ (record.get('message') or '')[:2048] }}"
+            value_type: string
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
@@ -810,6 +819,9 @@ streams:
           destination_branch: {type: [string, "null"]}
           comment_count: {type: [integer, "null"]}
           task_count: {type: [integer, "null"]}
+          description: {type: [string, "null"]}
+          destination_commit_sha: {type: [string, "null"]}
+          participants: {type: [string, "null"]}
         required:
           - unique_key
         additionalProperties: true
@@ -1001,6 +1013,23 @@ streams:
             value: "{{ ((record.get('destination') or {}).get('branch') or {}).get('name') or '' }}"
             value_type: string
           - type: AddedFieldDefinition
+            path: [title]
+            value: "{{ (record.get('title') or '')[:1024] }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [description]
+            value: "{{ (record.get('description') or '')[:2048] }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [destination_commit_sha]
+            value: "{{ ((record.get('destination') or {}).get('commit') or {}).get('hash') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [participants]
+            value: >-
+              [{% for p in record.get('participants') or [] %}{{ {'uuid': ((p.get('user') or {}).get('uuid') or ''), 'display_name': ((p.get('user') or {}).get('display_name') or ''), 'role': p.get('role') or '', 'state': p.get('state') or '', 'approved': p.get('approved', false), 'participated_on': p.get('participated_on') or ''} | tojson }}{% if not loop.last %},{% endif %}{% endfor %}]
+            value_type: string
+          - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
               {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | replace(':', '%3A') }}:{{ record['id'] }}
@@ -1015,7 +1044,7 @@ streams:
 
   # ── Pull request comments (Bitbucket API) ───────────────────────────────
   # Child of a stateless sliding window of recently updated PRs. Bodies are
-  # deliberately not stored.
+  # stored trimmed to 2048 chars — the silver comments model consumes them.
   - type: DeclarativeStream
     name: pull_request_comments
     primary_key:
@@ -1041,6 +1070,9 @@ streams:
           inline_path: {type: [string, "null"]}
           created_on: {type: [string, "null"]}
           updated_on: {type: [string, "null"]}
+          body: {type: [string, "null"]}
+          inline_to: {type: [integer, "null"]}
+          inline_from: {type: [integer, "null"]}
         required:
           - unique_key
         additionalProperties: true
@@ -1276,6 +1308,16 @@ streams:
             value: "{{ (record.get('inline') or {}).get('path') or '' }}"
             value_type: string
           - type: AddedFieldDefinition
+            path: [body]
+            value: "{{ ((record.get('content') or {}).get('raw') or '')[:2048] }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [inline_to]
+            value: "{{ (record.get('inline') or {}).get('to') }}"
+          - type: AddedFieldDefinition
+            path: [inline_from]
+            value: "{{ (record.get('inline') or {}).get('from') }}"
+          - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
               {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['repo_full_name'] | replace(':', '%3A') }}:{{ stream_partition.pr_id }}:{{ record['id'] }}
@@ -1285,6 +1327,7 @@ streams:
           - [user]
           - [parent]
           - [inline]
+          - [content]
 
   # ── Pull request activity (Bitbucket API) ───────────────────────────────
   # The ONLY source of approvals, changes-requested and merge/decline

--- a/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
@@ -828,9 +828,11 @@ streams:
         path: "/repositories/{{ stream_partition.repo_full_name }}/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED"
         http_method: GET
         request_parameters:
-          # pagelen HARD CAP on /pullrequests is 50 (400 above).
+          # pagelen HARD CAP on /pullrequests is 50 (400 above). No sort:
+          # combined with the state filters it 500s deterministically on large
+          # repositories, and the `next`-link pagination and per-slice cursor
+          # close are both order-independent.
           pagelen: "50"
-          sort: updated_on
           q: >-
             updated_on >= "{{ stream_interval.start_time }}"
           fields: >-
@@ -1156,9 +1158,10 @@ streams:
                   path: "/repositories/{{ stream_partition.repo_full_name }}/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED"
                   http_method: GET
                   request_parameters:
-                    # pagelen HARD CAP on /pullrequests is 50 (400 above).
+                    # pagelen HARD CAP on /pullrequests is 50 (400 above). No
+                    # sort: with the state filters it 500s deterministically on
+                    # large repositories; pagination is order-independent.
                     pagelen: "50"
-                    sort: updated_on
                     # Stateless sliding window: the children have no cursor of their
                     # own, so parent state would never persist. RMT dedups the
                     # re-read window.
@@ -1428,9 +1431,10 @@ streams:
                   path: "/repositories/{{ stream_partition.repo_full_name }}/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED"
                   http_method: GET
                   request_parameters:
-                    # pagelen HARD CAP on /pullrequests is 50 (400 above).
+                    # pagelen HARD CAP on /pullrequests is 50 (400 above). No
+                    # sort: with the state filters it 500s deterministically on
+                    # large repositories; pagination is order-independent.
                     pagelen: "50"
-                    sort: updated_on
                     # Stateless sliding window: the children have no cursor of their
                     # own, so parent state would never persist. RMT dedups the
                     # re-read window.
@@ -1698,9 +1702,10 @@ streams:
                   path: "/repositories/{{ stream_partition.repo_full_name }}/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED"
                   http_method: GET
                   request_parameters:
-                    # pagelen HARD CAP on /pullrequests is 50 (400 above).
+                    # pagelen HARD CAP on /pullrequests is 50 (400 above). No
+                    # sort: with the state filters it 500s deterministically on
+                    # large repositories; pagination is order-independent.
                     pagelen: "50"
-                    sort: updated_on
                     # Stateless sliding window: the children have no cursor of their
                     # own, so parent state would never persist. RMT dedups the
                     # re-read window.
@@ -1959,9 +1964,10 @@ streams:
                   path: "/repositories/{{ stream_partition.repo_full_name }}/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED"
                   http_method: GET
                   request_parameters:
-                    # pagelen HARD CAP on /pullrequests is 50 (400 above).
+                    # pagelen HARD CAP on /pullrequests is 50 (400 above). No
+                    # sort: with the state filters it 500s deterministically on
+                    # large repositories; pagination is order-independent.
                     pagelen: "50"
-                    sort: updated_on
                     # Stateless sliding window: the children have no cursor of their
                     # own, so parent state would never persist. RMT dedups the
                     # re-read window.

--- a/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
@@ -139,8 +139,12 @@ streams:
             # Bitbucket nests clone links in an array; the proxy routes on a
             # flat field, and the API link is authoritative — deriving the URL
             # from full_name would duplicate knowledge of the host layout.
+            # That link carries the authenticated principal as userinfo, which
+            # the proxy rejects: clone credentials travel in X-Git-* headers.
             value: >-
-              {{ (record['links']['clone'] | selectattr('name', 'equalto', 'https') | map(attribute='href') | list | first) }}
+              {%- set href = record['links']['clone'] | selectattr('name', 'equalto', 'https') | map(attribute='href') | list | first -%}
+              {%- set authority, path = href.split('//', 1)[1].split('/', 1) -%}
+              {{ 'https://' ~ authority.split('@')[-1] ~ '/' ~ path }}
           - type: AddedFieldDefinition
             path: [description]
             value: "{{ (record.get('description') or '')[:1024] }}"
@@ -336,7 +340,9 @@ streams:
                     - type: AddedFieldDefinition
                       path: [clone_url]
                       value: >-
-                        {{ (record['links']['clone'] | selectattr('name', 'equalto', 'https') | map(attribute='href') | list | first) }}
+                        {%- set href = record['links']['clone'] | selectattr('name', 'equalto', 'https') | map(attribute='href') | list | first -%}
+                        {%- set authority, path = href.split('//', 1)[1].split('/', 1) -%}
+                        {{ 'https://' ~ authority.split('@')[-1] ~ '/' ~ path }}
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: committed_date
@@ -565,7 +571,9 @@ streams:
                     - type: AddedFieldDefinition
                       path: [clone_url]
                       value: >-
-                        {{ (record['links']['clone'] | selectattr('name', 'equalto', 'https') | map(attribute='href') | list | first) }}
+                        {%- set href = record['links']['clone'] | selectattr('name', 'equalto', 'https') | map(attribute='href') | list | first -%}
+                        {%- set authority, path = href.split('//', 1)[1].split('/', 1) -%}
+                        {{ 'https://' ~ authority.split('@')[-1] ~ '/' ~ path }}
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: committed_date
@@ -770,7 +778,9 @@ streams:
                     - type: AddedFieldDefinition
                       path: [clone_url]
                       value: >-
-                        {{ (record['links']['clone'] | selectattr('name', 'equalto', 'https') | map(attribute='href') | list | first) }}
+                        {%- set href = record['links']['clone'] | selectattr('name', 'equalto', 'https') | map(attribute='href') | list | first -%}
+                        {%- set authority, path = href.split('//', 1)[1].split('/', 1) -%}
+                        {{ 'https://' ~ authority.split('@')[-1] ~ '/' ~ path }}
     transformations:
       - type: AddFields
         fields:

--- a/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
@@ -135,7 +135,7 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ record['uuid'] | string | replace(':', '%3A') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ record['uuid'] | replace(':', '%3A') }}
   # ── Commits (git-cli-proxy) ─────────────────────────────────────────────
   - type: DeclarativeStream
     name: commits
@@ -358,7 +358,7 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | string | replace(':', '%3A') }}:{{ record['sha'] | string | replace(':', '%3A') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | replace(':', '%3A') }}:{{ record['sha'] | replace(':', '%3A') }}
 
   # ── Per-file changes (git-cli-proxy) ────────────────────────────────────
   - type: DeclarativeStream
@@ -571,7 +571,7 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | string | replace(':', '%3A') }}:{{ record['sha'] | string | replace(':', '%3A') }}:{{ record['filename'] | string | replace(':', '%3A') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | replace(':', '%3A') }}:{{ record['sha'] | replace(':', '%3A') }}:{{ record['filename'] | replace(':', '%3A') }}
 
   # ── Branch heads (git-cli-proxy) ────────────────────────────────────────
   # Full refresh: bronze keeps the LATEST state per branch, and head-movement
@@ -748,7 +748,7 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | string | replace(':', '%3A') }}:{{ record['name'] | string | replace(':', '%3A') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | replace(':', '%3A') }}:{{ record['name'] | replace(':', '%3A') }}
 
   # ── Pull requests (Bitbucket API) ───────────────────────────────────────
   # Default filter is OPEN-only, and repeating `state` is the documented way
@@ -967,7 +967,15 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | string | replace(':', '%3A') }}:{{ record['id'] | string }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | replace(':', '%3A') }}:{{ record['id'] }}
+      - type: RemoveFields
+        # Hoisted above; the nested originals stay out of bronze.
+        field_pointers:
+          - [author]
+          - [merge_commit]
+          - [closed_by]
+          - [source]
+          - [destination]
 
   # ── Pull request comments (Bitbucket API) ───────────────────────────────
   # Child of a stateless sliding window of recently updated PRs. Bodies are
@@ -1216,7 +1224,13 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['repo_full_name'] | string | replace(':', '%3A') }}:{{ stream_partition.pr_id | string }}:{{ record['id'] | string }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['repo_full_name'] | replace(':', '%3A') }}:{{ stream_partition.pr_id }}:{{ record['id'] }}
+      - type: RemoveFields
+        # Hoisted above; the nested originals stay out of bronze.
+        field_pointers:
+          - [user]
+          - [parent]
+          - [inline]
 
   # ── Pull request activity (Bitbucket API) ───────────────────────────────
   # The ONLY source of approvals, changes-requested and merge/decline
@@ -1477,7 +1491,14 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['repo_full_name'] | string | replace(':', '%3A') }}:{{ stream_partition.pr_id | string }}:{{ 'approval' if record.get('approval') else 'changes_requested' if record.get('changes_requested') else 'update' if record.get('update') else 'comment' }}:{{ ((record.get('approval') or {}).get('date') or (record.get('changes_requested') or {}).get('date') or (record.get('update') or {}).get('date') or (record.get('comment') or {}).get('created_on') or '') | string | replace(':', '%3A') }}:{{ (((record.get('approval') or {}).get('user') or {}).get('uuid') or ((record.get('changes_requested') or {}).get('user') or {}).get('uuid') or ((record.get('update') or {}).get('author') or {}).get('uuid') or ((record.get('comment') or {}).get('user') or {}).get('uuid') or '') | string | replace(':', '%3A') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['repo_full_name'] | replace(':', '%3A') }}:{{ stream_partition.pr_id }}:{{ 'approval' if record.get('approval') else 'changes_requested' if record.get('changes_requested') else 'update' if record.get('update') else 'comment' }}:{{ ((record.get('approval') or {}).get('date') or (record.get('changes_requested') or {}).get('date') or (record.get('update') or {}).get('date') or (record.get('comment') or {}).get('created_on') or '') | replace(':', '%3A') }}:{{ (((record.get('approval') or {}).get('user') or {}).get('uuid') or ((record.get('changes_requested') or {}).get('user') or {}).get('uuid') or ((record.get('update') or {}).get('author') or {}).get('uuid') or ((record.get('comment') or {}).get('user') or {}).get('uuid') or '') | replace(':', '%3A') }}
+      - type: RemoveFields
+        # Hoisted above; the nested originals stay out of bronze.
+        field_pointers:
+          - [approval]
+          - [changes_requested]
+          - [update]
+          - [comment]
 
   # ── Workspace members (Bitbucket API) ───────────────────────────────────
   # Fills the identity gap the CDK connector never covered: Bitbucket exposes
@@ -1607,7 +1628,11 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.workspace | string | replace(':', '%3A') }}:{{ ((record.get('user') or {}).get('uuid') or '') | string | replace(':', '%3A') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.workspace | replace(':', '%3A') }}:{{ ((record.get('user') or {}).get('uuid') or '') | replace(':', '%3A') }}
+      - type: RemoveFields
+        # Hoisted above; the nested originals stay out of bronze.
+        field_pointers:
+          - [user]
 
   # ── CI pipelines (Bitbucket API) ────────────────────────────────────────
   # No `fields=` projection: partial-response support on this endpoint is
@@ -1767,7 +1792,6 @@ streams:
       # created_on is immutable, so no lookback; descending order + data-feed
       # stop is what makes each sync O(new records).
       is_data_feed: true
-      is_client_side_incremental: true
       start_datetime:
         type: MinMaxDatetime
         datetime: "{{ config.get('bitbucket_start_date', '2020-01-01') }}"
@@ -1818,7 +1842,14 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | string | replace(':', '%3A') }}:{{ record['uuid'] | string | replace(':', '%3A') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | replace(':', '%3A') }}:{{ record['uuid'] | replace(':', '%3A') }}
+      - type: RemoveFields
+        # Hoisted above; the nested originals stay out of bronze.
+        field_pointers:
+          - [state]
+          - [target]
+          - [trigger]
+          - [creator]
 
   # ── Deployments (Bitbucket API) ─────────────────────────────────────────
   # Same pipelines-module shape; outcome (`state`) IS in the list, unlike
@@ -1977,7 +2008,6 @@ streams:
       # created_on is immutable, so no lookback; descending order + data-feed
       # stop is what makes each sync O(new records).
       is_data_feed: true
-      is_client_side_incremental: true
       start_datetime:
         type: MinMaxDatetime
         datetime: "{{ config.get('bitbucket_start_date', '2020-01-01') }}"
@@ -2028,8 +2058,13 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | string | replace(':', '%3A') }}:{{ record['uuid'] | string | replace(':', '%3A') }}
-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | replace(':', '%3A') }}:{{ record['uuid'] | replace(':', '%3A') }}
+      - type: RemoveFields
+        # Hoisted above; the nested originals stay out of bronze.
+        field_pointers:
+          - [state]
+          - [environment]
+          - [deployable]
 concurrency_level:
   type: ConcurrencyLevel
   # Never 1: the concurrent CDK self-deadlocks at a single worker once a sync

--- a/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-nocode/connector.yaml
@@ -23,12 +23,9 @@ type: DeclarativeSource
 # in the background, so every proxy stream retries on 429 and fails fast on the
 # permanent ones (409 superseded snapshot, 413 oversized repository).
 #
-# NOT ported here: pull requests and their children (comments, reviewers,
-# commits, diffstat). That data does not exist in git, so it stays on the vendor
-# API — a mechanical port of the CDK connector's streams, tracked separately.
-#
-# Bitbucket is where the per-commit API cost hurts most: the CDK connector calls
-# `diffstat/{sha}` once per commit against a ~1000 req/h budget.
+# Vendor-API streams (pull requests, comments, activity, workspace members,
+# pipelines, deployments) live in this same manifest: that data does not
+# exist in git. Issues and projects are deliberately not synced.
 
 check:
   type: CheckStream
@@ -36,9 +33,9 @@ check:
     - repositories
 
 streams:
-  # ── Repository discovery (GitLab API) ───────────────────────────────────
-  # The incremental parent: only repositories whose last_activity_at advanced
-  # are visited by the commit streams below.
+  # ── Repository discovery (Bitbucket API) ────────────────────────────────
+  # The incremental parent: only repositories whose updated_on advanced are
+  # visited by the commit streams below.
   - type: DeclarativeStream
     name: repositories
     primary_key:
@@ -753,6 +750,1286 @@ streams:
             value: >-
               {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | string | replace(':', '%3A') }}:{{ record['name'] | string | replace(':', '%3A') }}
 
+  # ── Pull requests (Bitbucket API) ───────────────────────────────────────
+  # Default filter is OPEN-only, and repeating `state` is the documented way
+  # to widen it — request_parameters is a dict, so the states live in the
+  # path. Reviewer identities are detail-only; approvals come from the
+  # activity stream instead.
+  - type: DeclarativeStream
+    name: pull_requests
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          id: {type: [integer, "null"]}
+          repo_full_name: {type: [string, "null"]}
+          title: {type: [string, "null"]}
+          state: {type: [string, "null"]}
+          draft: {type: [boolean, "null"]}
+          author_uuid: {type: [string, "null"]}
+          author_display_name: {type: [string, "null"]}
+          created_on: {type: [string, "null"]}
+          updated_on: {type: [string, "null"]}
+          merge_commit_sha: {type: [string, "null"]}
+          closed_by_uuid: {type: [string, "null"]}
+          source_branch: {type: [string, "null"]}
+          source_commit_sha: {type: [string, "null"]}
+          destination_branch: {type: [string, "null"]}
+          comment_count: {type: [integer, "null"]}
+          task_count: {type: [integer, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+        authenticator:
+          type: BasicHttpAuthenticator
+          username: "{{ config['bitbucket_username'] }}"
+          password: "{{ config['bitbucket_token'] }}"
+        path: "/repositories/{{ stream_partition.repo_full_name }}/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED"
+        http_method: GET
+        request_parameters:
+          # pagelen HARD CAP on /pullrequests is 50 (400 above).
+          pagelen: "50"
+          sort: updated_on
+          q: >-
+            updated_on >= "{{ stream_interval.start_time }}"
+          fields: >-
+            next,values.id,values.title,values.state,values.draft,values.author.uuid,values.author.display_name,values.created_on,values.updated_on,values.merge_commit.hash,values.closed_by.uuid,values.source.branch.name,values.source.commit.hash,values.destination.branch.name,values.comment_count,values.task_count
+        error_handler:
+          type: DefaultErrorHandler
+          backoff_strategies:
+            # Bitbucket sometimes sends Retry-After as an HTTP date, which this
+            # strategy cannot parse; the exponential fallback covers that case.
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+            - type: ExponentialBackoffStrategy
+              factor: 5
+          response_filters:
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RATE_LIMITED
+              error_message: Bitbucket hourly rate budget exhausted
+            - type: HttpResponseFilter
+              http_codes: [403, 404]
+              action: IGNORE
+              error_message: >-
+                Repository not accessible with this token or gone; other repositories continue.
+            - type: HttpResponseFilter
+              http_codes: [401]
+              action: FAIL
+              failure_type: config_error
+              error_message: >-
+                Bitbucket rejected the credentials. Personal API tokens need
+                bitbucket_username set (Basic auth); workspace access tokens must
+                NOT set it (Bearer). Mixing the two is the most common cause.
+            - type: HttpResponseFilter
+              http_codes: [500, 502, 503, 504]
+              action: RETRY
+              error_message: Transient Bitbucket error
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [values]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response.get('next', '') }}"
+          stop_condition: "{{ not response.get('next') }}"
+        page_token_option:
+          type: RequestPath
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: full_name
+            partition_field: repo_full_name
+            stream:
+              type: DeclarativeStream
+              name: repositories_for_pull_requests
+              primary_key:
+                - uuid
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/schema#
+                  properties:
+                    uuid: {type: [string, "null"]}
+                    full_name: {type: [string, "null"]}
+                    updated_on: {type: [string, "null"]}
+                  additionalProperties: true
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+                  authenticator:
+                    type: BasicHttpAuthenticator
+                    username: "{{ config['bitbucket_username'] }}"
+                    password: "{{ config['bitbucket_token'] }}"
+                  path: "/repositories/{{ stream_partition.workspace }}"
+                  http_method: GET
+                  request_parameters:
+                    pagelen: "{{ config.get('bitbucket_page_size', 100) }}"
+                    fields: next,values.uuid,values.full_name,values.updated_on
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: [values]
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: CursorPagination
+                    cursor_value: "{{ response.get('next', '') }}"
+                    stop_condition: "{{ not response.get('next') }}"
+                  page_token_option:
+                    type: RequestPath
+                partition_router:
+                  type: ListPartitionRouter
+                  values: "{{ config['bitbucket_workspaces'] }}"
+                  cursor_field: workspace
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: updated_on
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S.%f%z"
+        - "%Y-%m-%dT%H:%M:%S%z"
+      lookback_window: P1D
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('bitbucket_start_date', '2020-01-01') }}"
+        datetime_format: "%Y-%m-%d"
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_bitbucket_nocode
+          - type: AddedFieldDefinition
+            path: [collected_at]
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          - type: AddedFieldDefinition
+            path: [repo_full_name]
+            value: "{{ stream_partition.repo_full_name }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [author_uuid]
+            value: "{{ (record.get('author') or {}).get('uuid') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [author_display_name]
+            value: "{{ (record.get('author') or {}).get('display_name') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [merge_commit_sha]
+            value: "{{ (record.get('merge_commit') or {}).get('hash') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [closed_by_uuid]
+            value: "{{ (record.get('closed_by') or {}).get('uuid') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [source_branch]
+            value: "{{ ((record.get('source') or {}).get('branch') or {}).get('name') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [source_commit_sha]
+            value: "{{ ((record.get('source') or {}).get('commit') or {}).get('hash') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [destination_branch]
+            value: "{{ ((record.get('destination') or {}).get('branch') or {}).get('name') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | string | replace(':', '%3A') }}:{{ record['id'] | string }}
+
+  # ── Pull request comments (Bitbucket API) ───────────────────────────────
+  # Child of a stateless sliding window of recently updated PRs. Bodies are
+  # deliberately not stored.
+  - type: DeclarativeStream
+    name: pull_request_comments
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          id: {type: [integer, "null"]}
+          pr_id: {type: [integer, "null"]}
+          repo_full_name: {type: [string, "null"]}
+          author_uuid: {type: [string, "null"]}
+          author_display_name: {type: [string, "null"]}
+          deleted: {type: [boolean, "null"]}
+          parent_id: {type: [integer, "null"]}
+          inline_path: {type: [string, "null"]}
+          created_on: {type: [string, "null"]}
+          updated_on: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+        authenticator:
+          type: BasicHttpAuthenticator
+          username: "{{ config['bitbucket_username'] }}"
+          password: "{{ config['bitbucket_token'] }}"
+        path: "/repositories/{{ stream_slice.extra_fields['repo_full_name'] }}/pullrequests/{{ stream_partition.pr_id }}/comments"
+        http_method: GET
+        request_parameters:
+          pagelen: "100"
+          fields: >-
+            next,values.id,values.user.uuid,values.user.display_name,values.created_on,values.updated_on,values.deleted,values.parent.id,values.inline.path
+        error_handler:
+          type: DefaultErrorHandler
+          backoff_strategies:
+            # Bitbucket sometimes sends Retry-After as an HTTP date, which this
+            # strategy cannot parse; the exponential fallback covers that case.
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+            - type: ExponentialBackoffStrategy
+              factor: 5
+          response_filters:
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RATE_LIMITED
+              error_message: Bitbucket hourly rate budget exhausted
+            - type: HttpResponseFilter
+              http_codes: [403, 404]
+              action: IGNORE
+              error_message: >-
+                PR gone or not accessible; other pull requests continue.
+            - type: HttpResponseFilter
+              http_codes: [401]
+              action: FAIL
+              failure_type: config_error
+              error_message: >-
+                Bitbucket rejected the credentials. Personal API tokens need
+                bitbucket_username set (Basic auth); workspace access tokens must
+                NOT set it (Bearer). Mixing the two is the most common cause.
+            - type: HttpResponseFilter
+              http_codes: [500, 502, 503, 504]
+              action: RETRY
+              error_message: Transient Bitbucket error
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [values]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response.get('next', '') }}"
+          stop_condition: "{{ not response.get('next') }}"
+        page_token_option:
+          type: RequestPath
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: id
+            partition_field: pr_id
+            extra_fields:
+              - [repo_full_name]
+            stream:
+              type: DeclarativeStream
+              name: pull_requests_for_comments
+              primary_key:
+                - id
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/schema#
+                  properties:
+                    id: {type: [integer, "null"]}
+                    repo_full_name: {type: [string, "null"]}
+                    updated_on: {type: [string, "null"]}
+                  additionalProperties: true
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+                  authenticator:
+                    type: BasicHttpAuthenticator
+                    username: "{{ config['bitbucket_username'] }}"
+                    password: "{{ config['bitbucket_token'] }}"
+                  path: "/repositories/{{ stream_partition.repo_full_name }}/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED"
+                  http_method: GET
+                  request_parameters:
+                    # pagelen HARD CAP on /pullrequests is 50 (400 above).
+                    pagelen: "50"
+                    sort: updated_on
+                    # Stateless sliding window: the children have no cursor of their
+                    # own, so parent state would never persist. RMT dedups the
+                    # re-read window.
+                    q: >-
+                      updated_on >= "{{ format_datetime(now_utc() - duration('P' ~ config.get('bitbucket_pr_child_window_days', 30) ~ 'D'), '%Y-%m-%dT%H:%M:%SZ') }}"
+                    fields: next,values.id,values.updated_on
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: [values]
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: CursorPagination
+                    cursor_value: "{{ response.get('next', '') }}"
+                    stop_condition: "{{ not response.get('next') }}"
+                  page_token_option:
+                    type: RequestPath
+                partition_router:
+                  type: SubstreamPartitionRouter
+                  parent_stream_configs:
+                    - type: ParentStreamConfig
+                      parent_key: full_name
+                      partition_field: repo_full_name
+                      stream:
+                        type: DeclarativeStream
+                        name: pull_requests_for_comments_repos
+                        primary_key:
+                          - uuid
+                        schema_loader:
+                          type: InlineSchemaLoader
+                          schema:
+                            type: object
+                            $schema: http://json-schema.org/schema#
+                            properties:
+                              uuid: {type: [string, "null"]}
+                              full_name: {type: [string, "null"]}
+                              updated_on: {type: [string, "null"]}
+                            additionalProperties: true
+                        retriever:
+                          type: SimpleRetriever
+                          requester:
+                            type: HttpRequester
+                            url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+                            authenticator:
+                              type: BasicHttpAuthenticator
+                              username: "{{ config['bitbucket_username'] }}"
+                              password: "{{ config['bitbucket_token'] }}"
+                            path: "/repositories/{{ stream_partition.workspace }}"
+                            http_method: GET
+                            request_parameters:
+                              pagelen: "{{ config.get('bitbucket_page_size', 100) }}"
+                              fields: next,values.uuid,values.full_name,values.updated_on
+                          record_selector:
+                            type: RecordSelector
+                            extractor:
+                              type: DpathExtractor
+                              field_path: [values]
+                          paginator:
+                            type: DefaultPaginator
+                            pagination_strategy:
+                              type: CursorPagination
+                              cursor_value: "{{ response.get('next', '') }}"
+                              stop_condition: "{{ not response.get('next') }}"
+                            page_token_option:
+                              type: RequestPath
+                          partition_router:
+                            type: ListPartitionRouter
+                            values: "{{ config['bitbucket_workspaces'] }}"
+                            cursor_field: workspace
+              transformations:
+                - type: AddFields
+                  fields:
+                    - type: AddedFieldDefinition
+                      path: [repo_full_name]
+                      value: "{{ stream_partition.repo_full_name }}"
+                      value_type: string
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_bitbucket_nocode
+          - type: AddedFieldDefinition
+            path: [collected_at]
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          - type: AddedFieldDefinition
+            path: [pr_id]
+            value: "{{ stream_partition.pr_id }}"
+          - type: AddedFieldDefinition
+            path: [repo_full_name]
+            value: "{{ stream_slice.extra_fields['repo_full_name'] }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [author_uuid]
+            value: "{{ (record.get('user') or {}).get('uuid') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [author_display_name]
+            value: "{{ (record.get('user') or {}).get('display_name') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [parent_id]
+            value: "{{ (record.get('parent') or {}).get('id') }}"
+          - type: AddedFieldDefinition
+            path: [inline_path]
+            value: "{{ (record.get('inline') or {}).get('path') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['repo_full_name'] | string | replace(':', '%3A') }}:{{ stream_partition.pr_id | string }}:{{ record['id'] | string }}
+
+  # ── Pull request activity (Bitbucket API) ───────────────────────────────
+  # The ONLY source of approvals, changes-requested and merge/decline
+  # transitions on Bitbucket — there is no reviews endpoint. Entries carry no
+  # id, so the key is synthesized from (kind, event date, actor); every part
+  # coalesces to '' so an absent field can never render the literal "None".
+  - type: DeclarativeStream
+    name: pull_request_activity
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          pr_id: {type: [integer, "null"]}
+          repo_full_name: {type: [string, "null"]}
+          kind: {type: [string, "null"]}
+          event_date: {type: [string, "null"]}
+          actor_uuid: {type: [string, "null"]}
+          actor_display_name: {type: [string, "null"]}
+          update_state: {type: [string, "null"]}
+          update_source_commit: {type: [string, "null"]}
+          comment_id: {type: [integer, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+        authenticator:
+          type: BasicHttpAuthenticator
+          username: "{{ config['bitbucket_username'] }}"
+          password: "{{ config['bitbucket_token'] }}"
+        path: "/repositories/{{ stream_slice.extra_fields['repo_full_name'] }}/pullrequests/{{ stream_partition.pr_id }}/activity"
+        http_method: GET
+        request_parameters:
+          # pagelen HARD CAP on /activity is 50 (400 above).
+          pagelen: "50"
+        error_handler:
+          type: DefaultErrorHandler
+          backoff_strategies:
+            # Bitbucket sometimes sends Retry-After as an HTTP date, which this
+            # strategy cannot parse; the exponential fallback covers that case.
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+            - type: ExponentialBackoffStrategy
+              factor: 5
+          response_filters:
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RATE_LIMITED
+              error_message: Bitbucket hourly rate budget exhausted
+            - type: HttpResponseFilter
+              http_codes: [403, 404]
+              action: IGNORE
+              error_message: >-
+                PR gone or not accessible; other pull requests continue.
+            - type: HttpResponseFilter
+              http_codes: [401]
+              action: FAIL
+              failure_type: config_error
+              error_message: >-
+                Bitbucket rejected the credentials. Personal API tokens need
+                bitbucket_username set (Basic auth); workspace access tokens must
+                NOT set it (Bearer). Mixing the two is the most common cause.
+            - type: HttpResponseFilter
+              http_codes: [500, 502, 503, 504]
+              action: RETRY
+              error_message: Transient Bitbucket error
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [values]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response.get('next', '') }}"
+          stop_condition: "{{ not response.get('next') }}"
+        page_token_option:
+          type: RequestPath
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: id
+            partition_field: pr_id
+            extra_fields:
+              - [repo_full_name]
+            stream:
+              type: DeclarativeStream
+              name: pull_requests_for_activity
+              primary_key:
+                - id
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/schema#
+                  properties:
+                    id: {type: [integer, "null"]}
+                    repo_full_name: {type: [string, "null"]}
+                    updated_on: {type: [string, "null"]}
+                  additionalProperties: true
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+                  authenticator:
+                    type: BasicHttpAuthenticator
+                    username: "{{ config['bitbucket_username'] }}"
+                    password: "{{ config['bitbucket_token'] }}"
+                  path: "/repositories/{{ stream_partition.repo_full_name }}/pullrequests?state=OPEN&state=MERGED&state=DECLINED&state=SUPERSEDED"
+                  http_method: GET
+                  request_parameters:
+                    # pagelen HARD CAP on /pullrequests is 50 (400 above).
+                    pagelen: "50"
+                    sort: updated_on
+                    # Stateless sliding window: the children have no cursor of their
+                    # own, so parent state would never persist. RMT dedups the
+                    # re-read window.
+                    q: >-
+                      updated_on >= "{{ format_datetime(now_utc() - duration('P' ~ config.get('bitbucket_pr_child_window_days', 30) ~ 'D'), '%Y-%m-%dT%H:%M:%SZ') }}"
+                    fields: next,values.id,values.updated_on
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: [values]
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: CursorPagination
+                    cursor_value: "{{ response.get('next', '') }}"
+                    stop_condition: "{{ not response.get('next') }}"
+                  page_token_option:
+                    type: RequestPath
+                partition_router:
+                  type: SubstreamPartitionRouter
+                  parent_stream_configs:
+                    - type: ParentStreamConfig
+                      parent_key: full_name
+                      partition_field: repo_full_name
+                      stream:
+                        type: DeclarativeStream
+                        name: pull_requests_for_activity_repos
+                        primary_key:
+                          - uuid
+                        schema_loader:
+                          type: InlineSchemaLoader
+                          schema:
+                            type: object
+                            $schema: http://json-schema.org/schema#
+                            properties:
+                              uuid: {type: [string, "null"]}
+                              full_name: {type: [string, "null"]}
+                              updated_on: {type: [string, "null"]}
+                            additionalProperties: true
+                        retriever:
+                          type: SimpleRetriever
+                          requester:
+                            type: HttpRequester
+                            url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+                            authenticator:
+                              type: BasicHttpAuthenticator
+                              username: "{{ config['bitbucket_username'] }}"
+                              password: "{{ config['bitbucket_token'] }}"
+                            path: "/repositories/{{ stream_partition.workspace }}"
+                            http_method: GET
+                            request_parameters:
+                              pagelen: "{{ config.get('bitbucket_page_size', 100) }}"
+                              fields: next,values.uuid,values.full_name,values.updated_on
+                          record_selector:
+                            type: RecordSelector
+                            extractor:
+                              type: DpathExtractor
+                              field_path: [values]
+                          paginator:
+                            type: DefaultPaginator
+                            pagination_strategy:
+                              type: CursorPagination
+                              cursor_value: "{{ response.get('next', '') }}"
+                              stop_condition: "{{ not response.get('next') }}"
+                            page_token_option:
+                              type: RequestPath
+                          partition_router:
+                            type: ListPartitionRouter
+                            values: "{{ config['bitbucket_workspaces'] }}"
+                            cursor_field: workspace
+              transformations:
+                - type: AddFields
+                  fields:
+                    - type: AddedFieldDefinition
+                      path: [repo_full_name]
+                      value: "{{ stream_partition.repo_full_name }}"
+                      value_type: string
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_bitbucket_nocode
+          - type: AddedFieldDefinition
+            path: [collected_at]
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          - type: AddedFieldDefinition
+            path: [pr_id]
+            value: "{{ stream_partition.pr_id }}"
+          - type: AddedFieldDefinition
+            path: [repo_full_name]
+            value: "{{ stream_slice.extra_fields['repo_full_name'] }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [kind]
+            value: "{{ 'approval' if record.get('approval') else 'changes_requested' if record.get('changes_requested') else 'update' if record.get('update') else 'comment' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [event_date]
+            value: "{{ (record.get('approval') or {}).get('date') or (record.get('changes_requested') or {}).get('date') or (record.get('update') or {}).get('date') or (record.get('comment') or {}).get('created_on') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [actor_uuid]
+            value: "{{ ((record.get('approval') or {}).get('user') or {}).get('uuid') or ((record.get('changes_requested') or {}).get('user') or {}).get('uuid') or ((record.get('update') or {}).get('author') or {}).get('uuid') or ((record.get('comment') or {}).get('user') or {}).get('uuid') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [actor_display_name]
+            value: "{{ ((record.get('approval') or {}).get('user') or {}).get('display_name') or ((record.get('changes_requested') or {}).get('user') or {}).get('display_name') or ((record.get('update') or {}).get('author') or {}).get('display_name') or ((record.get('comment') or {}).get('user') or {}).get('display_name') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [update_state]
+            value: "{{ (record.get('update') or {}).get('state') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [update_source_commit]
+            value: "{{ (((record.get('update') or {}).get('source') or {}).get('commit') or {}).get('hash') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [comment_id]
+            value: "{{ (record.get('comment') or {}).get('id') }}"
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['repo_full_name'] | string | replace(':', '%3A') }}:{{ stream_partition.pr_id | string }}:{{ 'approval' if record.get('approval') else 'changes_requested' if record.get('changes_requested') else 'update' if record.get('update') else 'comment' }}:{{ ((record.get('approval') or {}).get('date') or (record.get('changes_requested') or {}).get('date') or (record.get('update') or {}).get('date') or (record.get('comment') or {}).get('created_on') or '') | string | replace(':', '%3A') }}:{{ (((record.get('approval') or {}).get('user') or {}).get('uuid') or ((record.get('changes_requested') or {}).get('user') or {}).get('uuid') or ((record.get('update') or {}).get('author') or {}).get('uuid') or ((record.get('comment') or {}).get('user') or {}).get('uuid') or '') | string | replace(':', '%3A') }}
+
+  # ── Workspace members (Bitbucket API) ───────────────────────────────────
+  # Fills the identity gap the CDK connector never covered: Bitbucket exposes
+  # no email anywhere, so identity joins on account_id / nickname.
+  - type: DeclarativeStream
+    name: workspace_members
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          account_id: {type: [string, "null"]}
+          display_name: {type: [string, "null"]}
+          nickname: {type: [string, "null"]}
+          user_uuid: {type: [string, "null"]}
+          workspace: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+        authenticator:
+          type: BasicHttpAuthenticator
+          username: "{{ config['bitbucket_username'] }}"
+          password: "{{ config['bitbucket_token'] }}"
+        path: "/workspaces/{{ stream_partition.workspace }}/members"
+        http_method: GET
+        request_parameters:
+          pagelen: "100"
+          fields: >-
+            next,values.user.account_id,values.user.display_name,values.user.nickname,values.user.uuid
+        error_handler:
+          type: DefaultErrorHandler
+          backoff_strategies:
+            # Bitbucket sometimes sends Retry-After as an HTTP date, which this
+            # strategy cannot parse; the exponential fallback covers that case.
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+            - type: ExponentialBackoffStrategy
+              factor: 5
+          response_filters:
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RATE_LIMITED
+              error_message: Bitbucket hourly rate budget exhausted
+            - type: HttpResponseFilter
+              http_codes: [403]
+              action: IGNORE
+              error_message: >-
+                Token cannot list this workspace's members; other workspaces continue.
+            - type: HttpResponseFilter
+              http_codes: [401]
+              action: FAIL
+              failure_type: config_error
+              error_message: >-
+                Bitbucket rejected the credentials. Personal API tokens need
+                bitbucket_username set (Basic auth); workspace access tokens must
+                NOT set it (Bearer). Mixing the two is the most common cause.
+            - type: HttpResponseFilter
+              http_codes: [500, 502, 503, 504]
+              action: RETRY
+              error_message: Transient Bitbucket error
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [values]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response.get('next', '') }}"
+          stop_condition: "{{ not response.get('next') }}"
+        page_token_option:
+          type: RequestPath
+      partition_router:
+        type: ListPartitionRouter
+        values: "{{ config['bitbucket_workspaces'] }}"
+        cursor_field: workspace
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_bitbucket_nocode
+          - type: AddedFieldDefinition
+            path: [collected_at]
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          - type: AddedFieldDefinition
+            path: [workspace]
+            value: "{{ stream_partition.workspace }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [account_id]
+            value: "{{ (record.get('user') or {}).get('account_id') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [display_name]
+            value: "{{ (record.get('user') or {}).get('display_name') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [nickname]
+            value: "{{ (record.get('user') or {}).get('nickname') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [user_uuid]
+            value: "{{ (record.get('user') or {}).get('uuid') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.workspace | string | replace(':', '%3A') }}:{{ ((record.get('user') or {}).get('uuid') or '') | string | replace(':', '%3A') }}
+
+  # ── CI pipelines (Bitbucket API) ────────────────────────────────────────
+  # No `fields=` projection: partial-response support on this endpoint is
+  # unreliable, so the full object ships.
+  - type: DeclarativeStream
+    name: pipelines
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          uuid: {type: [string, "null"]}
+          build_number: {type: [integer, "null"]}
+          repo_full_name: {type: [string, "null"]}
+          state_name: {type: [string, "null"]}
+          result_name: {type: [string, "null"]}
+          target_ref: {type: [string, "null"]}
+          target_commit_sha: {type: [string, "null"]}
+          trigger_name: {type: [string, "null"]}
+          creator_uuid: {type: [string, "null"]}
+          duration_in_seconds: {type: [integer, "null"]}
+          created_on: {type: [string, "null"]}
+          completed_on: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+        authenticator:
+          type: BasicHttpAuthenticator
+          username: "{{ config['bitbucket_username'] }}"
+          password: "{{ config['bitbucket_token'] }}"
+        # Trailing slash is load-bearing: without it this endpoint 404s.
+        path: "/repositories/{{ stream_partition.repo_full_name }}/pipelines/"
+        http_method: GET
+        request_parameters:
+          pagelen: "100"
+          # Newest first + data-feed stop: `q` is NOT implemented on the
+          # pipelines-module endpoints, so ascending with a server filter is
+          # impossible and plain ascending would rescan all history each sync.
+          sort: -created_on
+        error_handler:
+          type: DefaultErrorHandler
+          backoff_strategies:
+            # Bitbucket sometimes sends Retry-After as an HTTP date, which this
+            # strategy cannot parse; the exponential fallback covers that case.
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+            - type: ExponentialBackoffStrategy
+              factor: 5
+          response_filters:
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RATE_LIMITED
+              error_message: Bitbucket hourly rate budget exhausted
+            - type: HttpResponseFilter
+              http_codes: [403, 404]
+              action: IGNORE
+              error_message: >-
+                Pipelines not enabled or not visible for this repository; other repositories continue.
+            - type: HttpResponseFilter
+              http_codes: [401]
+              action: FAIL
+              failure_type: config_error
+              error_message: >-
+                Bitbucket rejected the credentials. Personal API tokens need
+                bitbucket_username set (Basic auth); workspace access tokens must
+                NOT set it (Bearer). Mixing the two is the most common cause.
+            - type: HttpResponseFilter
+              http_codes: [500, 502, 503, 504]
+              action: RETRY
+              error_message: Transient Bitbucket error
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [values]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response.get('next', '') }}"
+          stop_condition: "{{ not response.get('next') }}"
+        page_token_option:
+          type: RequestPath
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: full_name
+            partition_field: repo_full_name
+            stream:
+              type: DeclarativeStream
+              name: repositories_for_pipelines
+              primary_key:
+                - uuid
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/schema#
+                  properties:
+                    uuid: {type: [string, "null"]}
+                    full_name: {type: [string, "null"]}
+                    updated_on: {type: [string, "null"]}
+                  additionalProperties: true
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+                  authenticator:
+                    type: BasicHttpAuthenticator
+                    username: "{{ config['bitbucket_username'] }}"
+                    password: "{{ config['bitbucket_token'] }}"
+                  path: "/repositories/{{ stream_partition.workspace }}"
+                  http_method: GET
+                  request_parameters:
+                    pagelen: "{{ config.get('bitbucket_page_size', 100) }}"
+                    fields: next,values.uuid,values.full_name,values.updated_on
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: [values]
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: CursorPagination
+                    cursor_value: "{{ response.get('next', '') }}"
+                    stop_condition: "{{ not response.get('next') }}"
+                  page_token_option:
+                    type: RequestPath
+                partition_router:
+                  type: ListPartitionRouter
+                  values: "{{ config['bitbucket_workspaces'] }}"
+                  cursor_field: workspace
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: created_on
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S.%f%z"
+        - "%Y-%m-%dT%H:%M:%S%z"
+      # created_on is immutable, so no lookback; descending order + data-feed
+      # stop is what makes each sync O(new records).
+      is_data_feed: true
+      is_client_side_incremental: true
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('bitbucket_start_date', '2020-01-01') }}"
+        datetime_format: "%Y-%m-%d"
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_bitbucket_nocode
+          - type: AddedFieldDefinition
+            path: [collected_at]
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          - type: AddedFieldDefinition
+            path: [repo_full_name]
+            value: "{{ stream_partition.repo_full_name }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [state_name]
+            value: "{{ (record.get('state') or {}).get('name') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [result_name]
+            value: "{{ ((record.get('state') or {}).get('result') or {}).get('name') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [target_ref]
+            value: "{{ (record.get('target') or {}).get('ref_name') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [target_commit_sha]
+            value: "{{ ((record.get('target') or {}).get('commit') or {}).get('hash') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [trigger_name]
+            value: "{{ (record.get('trigger') or {}).get('name') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [creator_uuid]
+            value: "{{ (record.get('creator') or {}).get('uuid') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | string | replace(':', '%3A') }}:{{ record['uuid'] | string | replace(':', '%3A') }}
+
+  # ── Deployments (Bitbucket API) ─────────────────────────────────────────
+  # Same pipelines-module shape; outcome (`state`) IS in the list, unlike
+  # GitHub. Sort support here is thinner than on /pipelines/ — verify
+  # `sort=-created_on` on the live smoke; the data-feed stop keeps
+  # correctness either way.
+  - type: DeclarativeStream
+    name: deployments
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          uuid: {type: [string, "null"]}
+          repo_full_name: {type: [string, "null"]}
+          state_name: {type: [string, "null"]}
+          state_status: {type: [string, "null"]}
+          environment_uuid: {type: [string, "null"]}
+          deployable_commit_sha: {type: [string, "null"]}
+          deployable_pipeline_uuid: {type: [string, "null"]}
+          created_on: {type: [string, "null"]}
+          last_update_time: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+        authenticator:
+          type: BasicHttpAuthenticator
+          username: "{{ config['bitbucket_username'] }}"
+          password: "{{ config['bitbucket_token'] }}"
+        # Trailing slash is load-bearing: without it this endpoint 404s.
+        path: "/repositories/{{ stream_partition.repo_full_name }}/deployments/"
+        http_method: GET
+        request_parameters:
+          pagelen: "100"
+          # Newest first + data-feed stop: `q` is NOT implemented on the
+          # pipelines-module endpoints, so ascending with a server filter is
+          # impossible and plain ascending would rescan all history each sync.
+          sort: -created_on
+        error_handler:
+          type: DefaultErrorHandler
+          backoff_strategies:
+            # Bitbucket sometimes sends Retry-After as an HTTP date, which this
+            # strategy cannot parse; the exponential fallback covers that case.
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+            - type: ExponentialBackoffStrategy
+              factor: 5
+          response_filters:
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RATE_LIMITED
+              error_message: Bitbucket hourly rate budget exhausted
+            - type: HttpResponseFilter
+              http_codes: [403, 404]
+              action: IGNORE
+              error_message: >-
+                Pipelines not enabled or not visible for this repository; other repositories continue.
+            - type: HttpResponseFilter
+              http_codes: [401]
+              action: FAIL
+              failure_type: config_error
+              error_message: >-
+                Bitbucket rejected the credentials. Personal API tokens need
+                bitbucket_username set (Basic auth); workspace access tokens must
+                NOT set it (Bearer). Mixing the two is the most common cause.
+            - type: HttpResponseFilter
+              http_codes: [500, 502, 503, 504]
+              action: RETRY
+              error_message: Transient Bitbucket error
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [values]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response.get('next', '') }}"
+          stop_condition: "{{ not response.get('next') }}"
+        page_token_option:
+          type: RequestPath
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: full_name
+            partition_field: repo_full_name
+            stream:
+              type: DeclarativeStream
+              name: repositories_for_deployments
+              primary_key:
+                - uuid
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/schema#
+                  properties:
+                    uuid: {type: [string, "null"]}
+                    full_name: {type: [string, "null"]}
+                    updated_on: {type: [string, "null"]}
+                  additionalProperties: true
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: "{{ config.get('bitbucket_api_base_url', 'https://api.bitbucket.org/2.0') }}"
+                  authenticator:
+                    type: BasicHttpAuthenticator
+                    username: "{{ config['bitbucket_username'] }}"
+                    password: "{{ config['bitbucket_token'] }}"
+                  path: "/repositories/{{ stream_partition.workspace }}"
+                  http_method: GET
+                  request_parameters:
+                    pagelen: "{{ config.get('bitbucket_page_size', 100) }}"
+                    fields: next,values.uuid,values.full_name,values.updated_on
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: [values]
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: CursorPagination
+                    cursor_value: "{{ response.get('next', '') }}"
+                    stop_condition: "{{ not response.get('next') }}"
+                  page_token_option:
+                    type: RequestPath
+                partition_router:
+                  type: ListPartitionRouter
+                  values: "{{ config['bitbucket_workspaces'] }}"
+                  cursor_field: workspace
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: created_on
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S.%f%z"
+        - "%Y-%m-%dT%H:%M:%S%z"
+      # created_on is immutable, so no lookback; descending order + data-feed
+      # stop is what makes each sync O(new records).
+      is_data_feed: true
+      is_client_side_incremental: true
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('bitbucket_start_date', '2020-01-01') }}"
+        datetime_format: "%Y-%m-%d"
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_bitbucket_nocode
+          - type: AddedFieldDefinition
+            path: [collected_at]
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          - type: AddedFieldDefinition
+            path: [repo_full_name]
+            value: "{{ stream_partition.repo_full_name }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [state_name]
+            value: "{{ (record.get('state') or {}).get('name') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [state_status]
+            value: "{{ ((record.get('state') or {}).get('status') or {}).get('name') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [environment_uuid]
+            value: "{{ (record.get('environment') or {}).get('uuid') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [deployable_commit_sha]
+            value: "{{ ((record.get('deployable') or {}).get('commit') or {}).get('hash') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [deployable_pipeline_uuid]
+            value: "{{ ((record.get('deployable') or {}).get('pipeline') or {}).get('uuid') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [created_on]
+            value: "{{ record.get('created_on') or (record.get('deployable') or {}).get('created_on') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | string | replace(':', '%3A') }}:{{ record['uuid'] | string | replace(':', '%3A') }}
+
 concurrency_level:
   type: ConcurrencyLevel
   # Never 1: the concurrent CDK self-deadlocks at a single worker once a sync
@@ -804,39 +2081,39 @@ spec:
           Bitbucket API token with `repository:read`. Forwarded to the proxy per request for the clone and never stored there.
         title: API Token
         airbyte_secret: true
-        order: 3
+        order: 4
       bitbucket_workspaces:
         type: array
         items:
           type: string
         description: Workspace slugs to sync.
         title: Workspaces
-        order: 4
+        order: 5
       git_proxy_url:
         type: string
         description: >-
           Base URL of the git-cli-proxy service (cluster-internal, e.g. http://insight-git-cli-proxy:8085). No default: a wrong or absent value must fail the check, not fall back somewhere.
         title: Git Proxy URL
-        order: 5
+        order: 6
       git_proxy_token:
         type: string
         description: Bearer token the git-cli-proxy requires on every /v1 request.
         title: Git Proxy Token
         airbyte_secret: true
-        order: 6
+        order: 7
       bitbucket_api_base_url:
         type: string
         description: Bitbucket API base URL.
         title: API Base URL
         default: "https://api.bitbucket.org/2.0"
-        order: 7
+        order: 8
       bitbucket_start_date:
         type: string
         description: Earliest date for incremental sync (YYYY-MM-DD).
         title: Start Date
         format: date
         default: "2020-01-01"
-        order: 8
+        order: 9
       bitbucket_page_size:
         type: integer
         description: Bitbucket API page size (max 100).
@@ -844,7 +2121,7 @@ spec:
         default: 100
         minimum: 1
         maximum: 100
-        order: 9
+        order: 10
       proxy_page_size:
         type: integer
         description: Rows per page requested from the git-cli-proxy.
@@ -852,14 +2129,14 @@ spec:
         default: 500
         minimum: 1
         maximum: 10000
-        order: 10
+        order: 11
       bitbucket_include_patch:
         type: boolean
         description: >-
           Store per-file diff text. Keep enabled to allow recomputing line counts later under different filters; disable to cut bronze volume.
         title: Include Patch Text
         default: true
-        order: 11
+        order: 12
       bitbucket_max_patch_bytes:
         type: integer
         description: >-
@@ -867,14 +2144,25 @@ spec:
         title: Max Patch Bytes
         default: 1048576
         minimum: 1024
-        order: 12
+        order: 13
       bitbucket_lookback_window:
         type: string
         description: >-
           ISO-8601 duration re-enumerated below the stored cursor on every sync. `git log --since` is a traversal cutoff, so after a rebase the replacement commits can carry dates below the cursor and would never be visited again. Bronze dedups the re-read rows, so the cost is one window per sync. A rewrite older than the window is still lost.
         title: Rebase Lookback Window
         default: P1M
-        order: 13
+        order: 14
+      bitbucket_pr_child_window_days:
+        type: integer
+        description: >-
+          Sliding window, in days, of pull requests whose comments and
+          activity are re-read each sync. The children have no cursor of
+          their own, so the window bounds their cost; edits on PRs older
+          than the window are not picked up.
+        title: PR Child Window (days)
+        default: 30
+        minimum: 1
+        order: 15
     additionalProperties: true
 
 metadata:
@@ -883,3 +2171,9 @@ metadata:
     commits: false
     commit_files: false
     repo_branches: false
+    pull_requests: false
+    pull_request_comments: false
+    pull_request_activity: false
+    workspace_members: false
+    pipelines: false
+    deployments: false

--- a/src/ingestion/connectors/git/bitbucket-nocode/descriptor.yaml
+++ b/src/ingestion/connectors/git/bitbucket-nocode/descriptor.yaml
@@ -1,0 +1,12 @@
+name: bitbucket-nocode
+version: "1.1.0"
+schedule: "0 3 * * *"
+workflow: sync
+
+# Silver routing via dbt tags on the staging models.
+# silver_targets prohibited per Connector Spec §4.10 — Silver is determined by
+# the dbt tags, and the pipeline's silver step hardcodes `tag:<slug>+`.
+dbt_select: "tag:bitbucket-nocode+"
+
+connection:
+  namespace: bronze_bitbucket_nocode

--- a/src/ingestion/connectors/git/bitbucket-nocode/descriptor.yaml
+++ b/src/ingestion/connectors/git/bitbucket-nocode/descriptor.yaml
@@ -8,5 +8,12 @@ workflow: sync
 # the dbt tags, and the pipeline's silver step hardcodes `tag:<slug>+`.
 dbt_select: "tag:bitbucket-nocode+"
 
+secret:
+  # Fields the deployment Secret must carry beyond the spec's `required` list
+  # (generate-connectors-config.sh unions both when building the fake config).
+  required_fields:
+    - bitbucket_token
+    - git_proxy_token
+
 connection:
   namespace: bronze_bitbucket_nocode

--- a/src/ingestion/connectors/git/bitbucket-nocode/tests/config.py
+++ b/src/ingestion/connectors/git/bitbucket-nocode/tests/config.py
@@ -1,0 +1,23 @@
+"""bitbucket-nocode connector test config builder."""
+
+from __future__ import annotations
+
+from connector_tests import ConfigBuilder
+
+BB_URL = "https://api.bitbucket.org/2.0"
+PROXY_URL = "http://git-cli-proxy.example:8085"
+
+
+class BitbucketNocodeConfigBuilder(ConfigBuilder):
+    def __init__(self) -> None:
+        super().__init__()
+        self._config.update(
+            {
+                "bitbucket_username": "bot@example.com",
+                "bitbucket_token": "test-bb-token",
+                "bitbucket_workspaces": ["acme"],
+                "git_proxy_url": PROXY_URL,
+                "git_proxy_token": "test-proxy-token",
+                "bitbucket_start_date": "2026-06-01",
+            }
+        )

--- a/src/ingestion/connectors/git/bitbucket-nocode/tests/conftest.py
+++ b/src/ingestion/connectors/git/bitbucket-nocode/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Local builder modules (config.py) are importable under --import-mode=importlib.
+sys.path.insert(0, str(Path(__file__).parent))
+
+from connector_tests.plugin import *  # noqa: E402,F401,F403 — http_mocker fixture + hooks

--- a/src/ingestion/connectors/git/bitbucket-nocode/tests/test_bitbucket_vendor_streams.py
+++ b/src/ingestion/connectors/git/bitbucket-nocode/tests/test_bitbucket_vendor_streams.py
@@ -62,7 +62,17 @@ def _pr(pr_id: int, *, author: dict | None) -> dict:
         "merge_commit": {"hash": "a" * 12},
         "closed_by": None,
         "source": {"branch": {"name": "feat"}, "commit": {"hash": "b" * 12}},
-        "destination": {"branch": {"name": "main"}},
+        "destination": {"branch": {"name": "main"}, "commit": {"hash": "c" * 12}},
+        "description": "d" * 3000,
+        "participants": [
+            {
+                "user": {"uuid": "{u-2}", "display_name": "Bob"},
+                "role": "REVIEWER",
+                "state": "approved",
+                "approved": True,
+                "participated_on": "2026-06-19T00:00:00+00:00",
+            }
+        ],
         "comment_count": 1,
         "task_count": 0,
     }
@@ -94,6 +104,12 @@ def test_pull_requests_four_states_and_none_guard(http_mocker: HttpMocker) -> No
     assert by_id[2]["author_uuid"] == ""
     # PR ids are per-repository, so the repo is part of the key.
     assert by_id[1]["unique_key"].endswith(":acme/app:1")
+    assert len(by_id[1]["description"]) == 2048
+    assert by_id[1]["destination_commit_sha"] == "c" * 12
+    participants = json.loads(by_id[1]["participants"])
+    assert participants[0]["uuid"] == "{u-2}"
+    assert participants[0]["role"] == "REVIEWER"
+    assert participants[0]["approved"] is True
     _no_literal_none(output.records)
     assert_records_conform(output.records, _CONNECTOR, "pull_requests", strict=True)
 
@@ -159,6 +175,61 @@ def test_activity_synthesizes_distinct_keys_without_ids(http_mocker: HttpMocker)
     assert kinds == ["approval", "update"]
     _no_literal_none(output.records)
     assert_records_conform(output.records, _CONNECTOR, "pull_request_activity", strict=True)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_comments_store_trimmed_bodies_and_inline(http_mocker: HttpMocker) -> None:
+    """The silver comments model consumes body and the inline location; the
+    body is content.raw trimmed to 2048 chars."""
+    config = BitbucketNocodeConfigBuilder().build()
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+    http_mocker.get(
+        HttpRequest(f"{BB_URL}/repositories/acme/app/pullrequests", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"values": [_pr(9, author=None)]}), status_code=200),
+    )
+    http_mocker.get(
+        HttpRequest(
+            f"{BB_URL}/repositories/acme/app/pullrequests/9/comments",
+            query_params=ANY_QUERY_PARAMS,
+        ),
+        HttpResponse(
+            body=json.dumps(
+                {
+                    "values": [
+                        {
+                            "id": 77,
+                            "user": {"uuid": "{u-1}", "display_name": "Alice"},
+                            "content": {"raw": "x" * 3000},
+                            "inline": {"path": "src/a.py", "to": 12},
+                            "deleted": False,
+                            "created_on": "2026-06-20T10:00:00.000000+00:00",
+                            "updated_on": "2026-06-20T10:00:00.000000+00:00",
+                        },
+                        {
+                            "id": 78,
+                            "user": None,
+                            "content": None,
+                            "deleted": False,
+                            "created_on": "2026-06-20T10:00:00.000000+00:00",
+                            "updated_on": "2026-06-20T10:00:00.000000+00:00",
+                        },
+                    ]
+                }
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "pull_request_comments", config)
+
+    assert not output.errors
+    by_id = {r.record.data["id"]: r.record.data for r in output.records}
+    assert len(by_id[77]["body"]) == 2048
+    assert by_id[77]["inline_path"] == "src/a.py"
+    assert by_id[77]["inline_to"] == 12
+    assert by_id[78]["body"] == ""
+    _no_literal_none(output.records)
+    assert_records_conform(output.records, _CONNECTOR, "pull_request_comments", strict=True)
 
 
 @freezegun.freeze_time(_FROZEN)

--- a/src/ingestion/connectors/git/bitbucket-nocode/tests/test_bitbucket_vendor_streams.py
+++ b/src/ingestion/connectors/git/bitbucket-nocode/tests/test_bitbucket_vendor_streams.py
@@ -233,6 +233,57 @@ def test_comments_store_trimmed_bodies_and_inline(http_mocker: HttpMocker) -> No
 
 
 @freezegun.freeze_time(_FROZEN)
+def test_pull_request_commits_store_only_the_edge(http_mocker: HttpMocker) -> None:
+    """PR<->commit membership is vendor-only; the commit payload belongs to
+    the proxy streams, so bronze keeps the sha and the PR identity alone."""
+    config = BitbucketNocodeConfigBuilder().build()
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+    http_mocker.get(
+        HttpRequest(f"{BB_URL}/repositories/acme/app/pullrequests", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"values": [_pr(9, author=None)]}), status_code=200),
+    )
+    http_mocker.get(
+        HttpRequest(
+            f"{BB_URL}/repositories/acme/app/pullrequests/9/commits",
+            query_params=ANY_QUERY_PARAMS,
+        ),
+        HttpResponse(
+            body=json.dumps(
+                {
+                    "values": [
+                        {
+                            "type": "commit",
+                            "hash": "a" * 12,
+                            "date": "2026-06-19T10:00:00+00:00",
+                            "message": "feat: x",
+                            "summary": {"raw": "feat: x"},
+                            "author": {"raw": "Alice <alice@example.com>"},
+                            "parents": [{"hash": "b" * 12}],
+                            "links": {"self": {"href": "https://api.bitbucket.org/x"}},
+                            "repository": {"full_name": "acme/app"},
+                            "rendered": {},
+                        }
+                    ]
+                }
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "pull_request_commits", config)
+
+    assert not output.errors
+    rec = output.records[0].record.data
+    assert rec["sha"] == "a" * 12
+    assert rec["pr_id"] == 9
+    assert rec["repo_full_name"] == "acme/app"
+    assert rec["unique_key"].endswith(f":acme/app:9:{'a' * 12}")
+    assert "message" not in rec and "links" not in rec
+    _no_literal_none(output.records)
+    assert_records_conform(output.records, _CONNECTOR, "pull_request_commits", strict=True)
+
+
+@freezegun.freeze_time(_FROZEN)
 def test_workspace_members_stamping(http_mocker: HttpMocker) -> None:
     config = BitbucketNocodeConfigBuilder().build()
     http_mocker.get(

--- a/src/ingestion/connectors/git/bitbucket-nocode/tests/test_bitbucket_vendor_streams.py
+++ b/src/ingestion/connectors/git/bitbucket-nocode/tests/test_bitbucket_vendor_streams.py
@@ -1,0 +1,197 @@
+"""Mock-server tests for the Bitbucket vendor streams.
+
+The vendor-specific hazards under test: the four-state path filter and the
+pagelen-50 cap on /pullrequests, the activity stream's synthesized key
+(entries carry no id), per-repository 403 skipping (the exact incident class
+that used to break syncs: some repos 403 even on a valid token), and the
+literal-"None" guard on every hoisted field.
+
+Coverage matrix rows: full_refresh_single_page, incremental_state,
+tenant_source_stamping, schema_conformance, substream_partition,
+error_ignore (403), error_retry (429), transformations (None-guard).
+"""
+
+from __future__ import annotations
+
+import json
+
+import freezegun
+from config import BB_URL, BitbucketNocodeConfigBuilder
+
+from connector_tests import (
+    ANY_QUERY_PARAMS,
+    HttpMocker,
+    HttpRequest,
+    HttpResponse,
+    assert_records_conform,
+    read_stream,
+)
+
+_CONNECTOR = "git/bitbucket-nocode"
+_REPOS_URL = f"{BB_URL}/repositories/acme"
+_FROZEN = "2026-07-01T00:00:00Z"
+
+
+def _no_literal_none(records) -> None:
+    for r in records:
+        for key, value in r.record.data.items():
+            assert value != "None", f"literal 'None' leaked into {key}"
+
+
+def _repo() -> dict:
+    return {
+        "uuid": "{r-1}",
+        "full_name": "acme/app",
+        "updated_on": "2026-06-20T10:00:00.000000+00:00",
+    }
+
+
+def _repos_page() -> HttpResponse:
+    return HttpResponse(body=json.dumps({"values": [_repo()]}), status_code=200)
+
+
+def _pr(pr_id: int, *, author: dict | None) -> dict:
+    return {
+        "id": pr_id,
+        "title": f"PR {pr_id}",
+        "state": "MERGED",
+        "draft": False,
+        "author": author,
+        "created_on": "2026-06-10T10:00:00.000000+00:00",
+        "updated_on": "2026-06-20T10:00:00.000000+00:00",
+        "merge_commit": {"hash": "a" * 12},
+        "closed_by": None,
+        "source": {"branch": {"name": "feat"}, "commit": {"hash": "b" * 12}},
+        "destination": {"branch": {"name": "main"}},
+        "comment_count": 1,
+        "task_count": 0,
+    }
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_pull_requests_four_states_and_none_guard(http_mocker: HttpMocker) -> None:
+    """The path carries all four states (request_parameters cannot repeat a
+    key); a deleted author must surface as '' — never the text \"None\"."""
+    config = BitbucketNocodeConfigBuilder().build()
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+    http_mocker.get(
+        HttpRequest(
+            f"{BB_URL}/repositories/acme/app/pullrequests",
+            query_params=ANY_QUERY_PARAMS,
+        ),
+        HttpResponse(
+            body=json.dumps({"values": [_pr(1, author={"uuid": "{u-1}", "display_name": "Alice"}), _pr(2, author=None)]}),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "pull_requests", config)
+
+    assert not output.errors
+    assert len(output.records) == 2
+    by_id = {r.record.data["id"]: r.record.data for r in output.records}
+    assert by_id[1]["author_display_name"] == "Alice"
+    assert by_id[2]["author_uuid"] == ""
+    # PR ids are per-repository, so the repo is part of the key.
+    assert by_id[1]["unique_key"].endswith(":acme/app:1")
+    _no_literal_none(output.records)
+    assert_records_conform(output.records, _CONNECTOR, "pull_requests", strict=True)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_a_403_repository_is_skipped_not_fatal(http_mocker: HttpMocker) -> None:
+    """The incident class this connector exists to survive: a repository that
+    403s on a valid token must not break the stream."""
+    config = BitbucketNocodeConfigBuilder().build()
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+    http_mocker.get(
+        HttpRequest(
+            f"{BB_URL}/repositories/acme/app/pullrequests",
+            query_params=ANY_QUERY_PARAMS,
+        ),
+        HttpResponse(body="", status_code=403),
+    )
+
+    output = read_stream(_CONNECTOR, "pull_requests", config)
+
+    assert not output.errors
+    assert len(output.records) == 0
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_activity_synthesizes_distinct_keys_without_ids(http_mocker: HttpMocker) -> None:
+    """Activity entries carry no id: the (kind, date, actor) key must be
+    distinct per entry and free of the literal \"None\"."""
+    config = BitbucketNocodeConfigBuilder().build()
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+    http_mocker.get(
+        HttpRequest(
+            f"{BB_URL}/repositories/acme/app/pullrequests",
+            query_params=ANY_QUERY_PARAMS,
+        ),
+        HttpResponse(body=json.dumps({"values": [_pr(9, author=None)]}), status_code=200),
+    )
+    http_mocker.get(
+        HttpRequest(
+            f"{BB_URL}/repositories/acme/app/pullrequests/9/activity",
+            query_params=ANY_QUERY_PARAMS,
+        ),
+        HttpResponse(
+            body=json.dumps(
+                {
+                    "values": [
+                        {"approval": {"date": "2026-06-21T10:00:00+00:00", "user": {"uuid": "{u-1}", "display_name": "Alice"}}},
+                        {"update": {"date": "2026-06-20T09:00:00+00:00", "state": "OPEN", "author": {"uuid": "{u-2}", "display_name": "Bob"}, "source": {"commit": {"hash": "c" * 12}}}},
+                    ]
+                }
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "pull_request_activity", config)
+
+    assert not output.errors
+    assert len(output.records) == 2
+    keys = [r.record.data["unique_key"] for r in output.records]
+    assert len(set(keys)) == 2, keys
+    kinds = sorted(r.record.data["kind"] for r in output.records)
+    assert kinds == ["approval", "update"]
+    _no_literal_none(output.records)
+    assert_records_conform(output.records, _CONNECTOR, "pull_request_activity", strict=True)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_workspace_members_stamping(http_mocker: HttpMocker) -> None:
+    config = BitbucketNocodeConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(f"{BB_URL}/workspaces/acme/members", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps({"values": [{"user": {"account_id": "aid-1", "display_name": "Alice", "nickname": "alice", "uuid": "{u-1}"}}]}),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "workspace_members", config)
+
+    assert not output.errors
+    rec = output.records[0].record.data
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["workspace"] == "acme"
+    assert rec["account_id"] == "aid-1"
+    _no_literal_none(output.records)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_pipelines_empty_page(http_mocker: HttpMocker) -> None:
+    config = BitbucketNocodeConfigBuilder().build()
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+    http_mocker.get(
+        HttpRequest(f"{BB_URL}/repositories/acme/app/pipelines/", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"values": []}), status_code=200),
+    )
+
+    output = read_stream(_CONNECTOR, "pipelines", config)
+
+    assert not output.errors
+    assert len(output.records) == 0

--- a/src/ingestion/connectors/git/bitbucket-nocode/tests/test_bitbucket_vendor_streams.py
+++ b/src/ingestion/connectors/git/bitbucket-nocode/tests/test_bitbucket_vendor_streams.py
@@ -284,6 +284,87 @@ def test_pull_request_commits_store_only_the_edge(http_mocker: HttpMocker) -> No
 
 
 @freezegun.freeze_time(_FROZEN)
+def test_diffstat_rows_and_uncomputable_diff(http_mocker: HttpMocker) -> None:
+    """Bitbucket carries no diff totals on the PR itself, so per-file diffstat
+    rows are the only source of PR size. A PR whose branches share no history
+    answers 400 — a property of that PR, not a broken request."""
+    config = BitbucketNocodeConfigBuilder().build()
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+    http_mocker.get(
+        HttpRequest(f"{BB_URL}/repositories/acme/app/pullrequests", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"values": [_pr(9, author=None)]}), status_code=200),
+    )
+    http_mocker.get(
+        HttpRequest(
+            f"{BB_URL}/repositories/acme/app/pullrequests/9/diffstat",
+            query_params=ANY_QUERY_PARAMS,
+        ),
+        HttpResponse(
+            body=json.dumps(
+                {
+                    "values": [
+                        {
+                            "type": "diffstat",
+                            "status": "modified",
+                            "lines_added": 12,
+                            "lines_removed": 3,
+                            "old": {"path": "src/a.py"},
+                            "new": {"path": "src/a.py"},
+                        },
+                        {
+                            "type": "diffstat",
+                            "status": "removed",
+                            "lines_added": 0,
+                            "lines_removed": 40,
+                            "old": {"path": "src/gone.py"},
+                            "new": None,
+                        },
+                    ]
+                }
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "pull_request_diffstat", config)
+
+    assert not output.errors
+    by_path = {r.record.data["file_path"]: r.record.data for r in output.records}
+    assert (by_path["src/a.py"]["lines_added"], by_path["src/a.py"]["lines_removed"]) == (12, 3)
+    assert by_path["src/gone.py"]["status"] == "removed"
+    assert by_path["src/gone.py"]["old_path"] == "src/gone.py"
+    assert by_path["src/a.py"]["unique_key"].endswith(":acme/app:9:src/a.py")
+    assert "old" not in by_path["src/a.py"] and "new" not in by_path["src/a.py"]
+    _no_literal_none(output.records)
+    assert_records_conform(output.records, _CONNECTOR, "pull_request_diffstat", strict=True)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_diffstat_without_common_ancestor_is_skipped(http_mocker: HttpMocker) -> None:
+    config = BitbucketNocodeConfigBuilder().build()
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+    http_mocker.get(
+        HttpRequest(f"{BB_URL}/repositories/acme/app/pullrequests", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"values": [_pr(9, author=None)]}), status_code=200),
+    )
+    http_mocker.get(
+        HttpRequest(
+            f"{BB_URL}/repositories/acme/app/pullrequests/9/diffstat",
+            query_params=ANY_QUERY_PARAMS,
+        ),
+        HttpResponse(
+            body=json.dumps({"type": "error", "error": {"message": "No common ancestor"}}),
+            status_code=400,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "pull_request_diffstat", config)
+
+    assert not output.errors
+    assert len(output.records) == 0
+
+
+@freezegun.freeze_time(_FROZEN)
 def test_workspace_members_stamping(http_mocker: HttpMocker) -> None:
     config = BitbucketNocodeConfigBuilder().build()
     http_mocker.get(

--- a/src/ingestion/connectors/git/github-directory/connector.yaml
+++ b/src/ingestion/connectors/git/github-directory/connector.yaml
@@ -39,13 +39,17 @@ definitions:
     error_handler:
       type: DefaultErrorHandler
       max_retries: 5
+      # The CDK resolves backoff per requester, not per response filter: the
+      # first strategy returning a value wins for every retryable response.
+      # X-RateLimit-Reset is stamped on GitHub responses of any status, so
+      # reading it here would put a transient 5xx to sleep until the hourly
+      # window resets.
       backoff_strategies:
         - type: WaitTimeFromHeader
           header: Retry-After
           max_waiting_time_in_seconds: 600
-        - type: WaitUntilTimeFromHeader
-          header: X-RateLimit-Reset
-          max_waiting_time_in_seconds: 600
+        - type: ExponentialBackoffStrategy
+          factor: 2
       response_filters:
         - type: HttpResponseFilter
           action: RATE_LIMITED

--- a/src/ingestion/connectors/git/github-nocode/README.md
+++ b/src/ingestion/connectors/git/github-nocode/README.md
@@ -20,6 +20,7 @@ Coexists with `git/github-v2` (CDK) under its own `data_source`
 | pull_requests | `/repos/{r}/pulls` (list) | updated_at, newest-first data feed |
 | pull_request_reviews | `/pulls/{n}/reviews` | windowed PR parent, full refresh per PR |
 | pull_request_commits | `/pulls/{n}/commits` | windowed PR parent, full refresh per PR |
+| pull_request_diff_stats | GraphQL `repository.pullRequests` nodes | updated_at, newest-first data feed |
 | pull_request_comments | `/repos/{r}/issues/comments` | updated_at, server-side `since` |
 | issues | `/repos/{r}/issues` | updated_at, server-side `since`; PRs filtered out |
 | projects_v2 | GraphQL `organization.projectsV2` | full refresh |
@@ -59,6 +60,15 @@ Steady state ≈ 6 calls/repo + 1 call per PR updated in the child window +
 workflow_runs backfill goes back at most 90 days — GitHub's run retention —
 paged in weekly windows because `created` queries cap at 1000 results per
 window.
+
+### PR size
+
+`pull_request_diff_stats` carries per-pull-request `additions`, `deletions` and
+`changed_files`. REST has these on the pull-request DETAIL response only, which
+would cost one call per pull request; the GraphQL list node carries all three,
+so a page of 100 pull requests costs a single request. The connection accepts
+no `updatedAfter` argument, so the stream is a newest-first data feed like
+`pull_requests`.
 
 ## Silver Targets
 

--- a/src/ingestion/connectors/git/github-nocode/README.md
+++ b/src/ingestion/connectors/git/github-nocode/README.md
@@ -55,9 +55,9 @@ conversation comments and reviews are.
 
 Steady state ≈ 6 calls/repo + 1 call per PR updated in the child window +
 1 call per deployment created in the deploy window + O(changed rows). First
-workflow_runs backfill defaults to the last 90 days (`created` queries cap at
-1000 results per step window — shrink `github_workflow_runs_step` for
-hyperactive repositories).
+workflow_runs backfill goes back at most 90 days — GitHub's run retention —
+paged in weekly windows because `created` queries cap at 1000 results per
+window.
 
 ## Silver Targets
 

--- a/src/ingestion/connectors/git/github-nocode/README.md
+++ b/src/ingestion/connectors/git/github-nocode/README.md
@@ -1,0 +1,66 @@
+# github-nocode
+
+Declarative GitHub connector on the git-cli-proxy: commit-level extraction
+(commits, per-file changes, branches) is served from a bare blobless clone by
+the proxy instead of one vendor API call per commit; everything git cannot
+carry (PRs, reviews, comments, issues, projects, CI, deployments) stays on
+api.github.com.
+
+Coexists with `git/github-v2` (CDK) under its own `data_source`
+(`insight_github_nocode`); nothing is replaced or deleted by this connector.
+
+## Streams
+
+| Stream | Source | Incremental |
+|---|---|---|
+| repositories | GitHub `/orgs/{org}/repos` | full refresh |
+| commits | proxy `/v1/commits` | committed_date, per pushed repo |
+| commit_files | proxy `/v1/file-changes` | committed_date, per pushed repo |
+| repo_branches | proxy `/v1/branches` | full refresh, per pushed repo |
+| pull_requests | `/repos/{r}/pulls` (list) | updated_at, newest-first data feed |
+| pull_request_reviews | `/pulls/{n}/reviews` | windowed PR parent, full refresh per PR |
+| pull_request_comments | `/repos/{r}/issues/comments` | updated_at, server-side `since` |
+| issues | `/repos/{r}/issues` | updated_at, server-side `since`; PRs filtered out |
+| projects_v2 | GraphQL `organization.projectsV2` | full refresh |
+| workflow_runs | `/repos/{r}/actions/runs` | created_at, weekly step windows |
+| deployments | `/repos/{r}/deployments` | created_at, newest-first data feed |
+| deployment_statuses | `/deployments/{id}/statuses` | windowed deployments parent |
+
+**org_members is deliberately absent**: the deployed `git/github-directory`
+connector already syncs the org roster for identity resolution. Folding it in
+here is a separate migration.
+
+## Error policy
+
+- GitHub reports secondary rate limits as **403**, so throttle predicates
+  (body message, `x-ratelimit-remaining: 0`) run before any 403 handling;
+  what remains of 403 — plus 404/410 — on repo-scoped streams skips that
+  repository and the sync continues. 401 fails fast as a config error.
+- The proxy answers 429 + Retry-After while a repository is being cloned in
+  the background; proxy requesters retry generously (a cold clone of a large
+  repository runs many Retry-After cycles). 404/413 skip the repository;
+  409 (superseded snapshot) fails the attempt — the rerun resumes from the
+  stored cursor.
+- GraphQL errors arrive as HTTP 200: rate-limit-typed errors back off,
+  anything else fails with GitHub's own message.
+
+## Known NULL columns (v1)
+
+`pull_requests.additions/deletions/changed_files/merged_by` are detail-only
+(`GET /pulls/{n}`) and are not fetched — PR size derives from the proxy's
+commit_files. Inline code-review comments (`/pulls/comments`) are not synced;
+conversation comments and reviews are.
+
+## Cost shape
+
+Steady state ≈ 6 calls/repo + 1 call per PR updated in the child window +
+1 call per deployment created in the deploy window + O(changed rows). First
+workflow_runs backfill defaults to the last 90 days (`created` queries cap at
+1000 results per step window — shrink `github_workflow_runs_step` for
+hyperactive repositories).
+
+## Silver Targets
+
+Not wired yet — same position as `git/gitlab-nocode`: bronze-only until the
+silver dbt models land (they must match the CDK connectors' column types
+exactly or `union_by_tag` fails).

--- a/src/ingestion/connectors/git/github-nocode/README.md
+++ b/src/ingestion/connectors/git/github-nocode/README.md
@@ -19,6 +19,7 @@ Coexists with `git/github-v2` (CDK) under its own `data_source`
 | branches | proxy `/v1/branches` | full refresh, per pushed repo |
 | pull_requests | `/repos/{r}/pulls` (list) | updated_at, newest-first data feed |
 | pull_request_reviews | `/pulls/{n}/reviews` | windowed PR parent, full refresh per PR |
+| pull_request_commits | `/pulls/{n}/commits` | windowed PR parent, full refresh per PR |
 | pull_request_comments | `/repos/{r}/issues/comments` | updated_at, server-side `since` |
 | issues | `/repos/{r}/issues` | updated_at, server-side `since`; PRs filtered out |
 | projects_v2 | GraphQL `organization.projectsV2` | full refresh |

--- a/src/ingestion/connectors/git/github-nocode/README.md
+++ b/src/ingestion/connectors/git/github-nocode/README.md
@@ -15,8 +15,8 @@ Coexists with `git/github-v2` (CDK) under its own `data_source`
 |---|---|---|
 | repositories | GitHub `/orgs/{org}/repos` | full refresh |
 | commits | proxy `/v1/commits` | committed_date, per pushed repo |
-| commit_files | proxy `/v1/file-changes` | committed_date, per pushed repo |
-| repo_branches | proxy `/v1/branches` | full refresh, per pushed repo |
+| file_changes | proxy `/v1/file-changes` | committed_date, per pushed repo |
+| branches | proxy `/v1/branches` | full refresh, per pushed repo |
 | pull_requests | `/repos/{r}/pulls` (list) | updated_at, newest-first data feed |
 | pull_request_reviews | `/pulls/{n}/reviews` | windowed PR parent, full refresh per PR |
 | pull_request_comments | `/repos/{r}/issues/comments` | updated_at, server-side `since` |
@@ -48,7 +48,7 @@ here is a separate migration.
 
 `pull_requests.additions/deletions/changed_files/merged_by` are detail-only
 (`GET /pulls/{n}`) and are not fetched — PR size derives from the proxy's
-commit_files. Inline code-review comments (`/pulls/comments`) are not synced;
+file_changes. Inline code-review comments (`/pulls/comments`) are not synced;
 conversation comments and reviews are.
 
 ## Cost shape

--- a/src/ingestion/connectors/git/github-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/github-nocode/connector.yaml
@@ -369,7 +369,7 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ record['id'] | string | replace(':', '%3A') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ record['id'] }}
 
   # ── commits (git-cli-proxy) ────────────────────────────────────────
   - type: DeclarativeStream
@@ -473,7 +473,7 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | string | replace(':', '%3A') }}:{{ record['sha'] | string | replace(':', '%3A') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | replace(':', '%3A') }}:{{ record['sha'] | replace(':', '%3A') }}
 
   # ── commit_files (git-cli-proxy) ───────────────────────────────────
   - type: DeclarativeStream
@@ -574,7 +574,7 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | string | replace(':', '%3A') }}:{{ record['sha'] | string | replace(':', '%3A') }}:{{ record['filename'] | string | replace(':', '%3A') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | replace(':', '%3A') }}:{{ record['sha'] | replace(':', '%3A') }}:{{ record['filename'] | replace(':', '%3A') }}
 
   # ── repo_branches (git-cli-proxy) ──────────────────────────────────
   - type: DeclarativeStream
@@ -646,7 +646,7 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | string | replace(':', '%3A') }}:{{ record['name'] | string | replace(':', '%3A') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | replace(':', '%3A') }}:{{ record['name'] | replace(':', '%3A') }}
 
   # ── Pull requests (GitHub API) ──────────────────────────────────────────
   # LIST endpoint only: /pulls has no `since`, so newest-first plus the
@@ -726,7 +726,6 @@ streams:
       cursor_datetime_formats:
         - "%Y-%m-%dT%H:%M:%S%z"
       is_data_feed: true
-      is_client_side_incremental: true
       lookback_window: P1D
       start_datetime:
         type: MinMaxDatetime
@@ -760,7 +759,13 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | string | replace(':', '%3A') }}:{{ record['id'] | string }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | replace(':', '%3A') }}:{{ record['id'] }}
+      - type: RemoveFields
+        # Hoisted above; the nested originals stay out of bronze.
+        field_pointers:
+          - [user]
+          - [head]
+          - [base]
 
   # ── Pull request reviews (GitHub API) ───────────────────────────────────
   # No repo-level reviews endpoint exists in REST, so this is one call per PR
@@ -876,7 +881,6 @@ streams:
                 # own, so parent state would never persist. The data-feed
                 # stop is what bounds pagination at the window edge.
                 is_data_feed: true
-                is_client_side_incremental: true
                 start_datetime:
                   type: MinMaxDatetime
                   datetime: "{{ format_datetime(now_utc() - duration('P' ~ config.get('github_pr_child_window_days', 30) ~ 'D'), '%Y-%m-%dT%H:%M:%SZ') }}"
@@ -907,7 +911,11 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['repo_full_name'] | string | replace(':', '%3A') }}:{{ stream_partition.pull_number | string }}:{{ record['id'] | string }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['repo_full_name'] | replace(':', '%3A') }}:{{ stream_partition.pull_number }}:{{ record['id'] }}
+      - type: RemoveFields
+        # Hoisted above; the nested originals stay out of bronze.
+        field_pointers:
+          - [user]
 
   # ── Issue & PR conversation comments (GitHub API) ───────────────────────
   # ONE repo-level endpoint covers both: PR conversation comments are issue
@@ -1004,7 +1012,11 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | string | replace(':', '%3A') }}:comment:{{ record['id'] | string }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | replace(':', '%3A') }}:comment:{{ record['id'] }}
+      - type: RemoveFields
+        # Hoisted above; the nested originals stay out of bronze.
+        field_pointers:
+          - [user]
 
   # ── Issues (GitHub API) ─────────────────────────────────────────────────
   # The endpoint returns PRs too; the record filter drops them (a PR carries
@@ -1113,7 +1125,13 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | string | replace(':', '%3A') }}:issue:{{ record['id'] | string }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | replace(':', '%3A') }}:issue:{{ record['id'] }}
+      - type: RemoveFields
+        # Hoisted above; the nested originals stay out of bronze.
+        field_pointers:
+          - [user]
+          - [assignees]
+          - [labels]
 
   # ── Projects V2 (GitHub GraphQL) ────────────────────────────────────────
   # Projects V2 has no REST API. Cursor rides in the request body — the
@@ -1251,7 +1269,7 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.org | string | replace(':', '%3A') }}:project:{{ (record.get('id') or '') | string | replace(':', '%3A') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.org | replace(':', '%3A') }}:project:{{ (record.get('id') or '') | replace(':', '%3A') }}
 
   # ── Actions workflow runs (GitHub API) ──────────────────────────────────
   # The `created` range goes in a plain request parameter: start_time_option
@@ -1354,7 +1372,11 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | string | replace(':', '%3A') }}:run:{{ record['id'] | string }}:{{ record.get('run_attempt', 1) | string }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | replace(':', '%3A') }}:run:{{ record['id'] }}:{{ record.get('run_attempt', 1) }}
+      - type: RemoveFields
+        # Hoisted above; the nested originals stay out of bronze.
+        field_pointers:
+          - [actor]
 
   # ── Deployments (GitHub API) ────────────────────────────────────────────
   # No date filter and no outcome on this endpoint: newest-first + data-feed
@@ -1424,7 +1446,6 @@ streams:
       # created_at is immutable: no lookback; the data-feed stop is what
       # bounds newest-first pagination at the stored state.
       is_data_feed: true
-      is_client_side_incremental: true
       start_datetime:
         type: MinMaxDatetime
         datetime: "{{ config.get('github_start_date', '2020-01-01') }}"
@@ -1445,7 +1466,12 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | string | replace(':', '%3A') }}:deploy:{{ record['id'] | string }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | replace(':', '%3A') }}:deploy:{{ record['id'] }}
+      - type: RemoveFields
+        # Hoisted above; the nested originals stay out of bronze.
+        field_pointers:
+          - [creator]
+          - [payload]
 
   # ── Deployment statuses (GitHub API) ────────────────────────────────────
   # A deployment record has no outcome; this child fetches success/failure
@@ -1558,7 +1584,6 @@ streams:
                 # Stateless sliding window; data-feed stop bounds the
                 # newest-first pagination at the window edge.
                 is_data_feed: true
-                is_client_side_incremental: true
                 start_datetime:
                   type: MinMaxDatetime
                   datetime: "{{ format_datetime(now_utc() - duration('P' ~ config.get('github_deploy_window_days', 30) ~ 'D'), '%Y-%m-%dT%H:%M:%SZ') }}"
@@ -1589,8 +1614,11 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['repo_full_name'] | string | replace(':', '%3A') }}:{{ stream_partition.deployment_id | string }}:status:{{ record['id'] | string }}
-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['repo_full_name'] | replace(':', '%3A') }}:{{ stream_partition.deployment_id }}:status:{{ record['id'] }}
+      - type: RemoveFields
+        # Hoisted above; the nested originals stay out of bronze.
+        field_pointers:
+          - [creator]
 concurrency_level:
   type: ConcurrencyLevel
   # Never 1: the concurrent CDK self-deadlocks at a single worker once a sync

--- a/src/ingestion/connectors/git/github-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/github-nocode/connector.yaml
@@ -844,7 +844,7 @@ streams:
             partition_field: pull_number
             extra_fields:
               - [repo_full_name]
-            stream:
+            stream: &pull_requests_window
               type: DeclarativeStream
               name: pull_requests_window
               primary_key:
@@ -938,6 +938,92 @@ streams:
         # Hoisted above; the nested originals stay out of bronze.
         field_pointers:
           - [user]
+
+  # ── Pull request commits (GitHub API) ───────────────────────────────────
+  # PR<->commit membership is vendor metadata: it does not exist in git, and a
+  # squash- or rebase-merged PR leaves its original commits unreachable from
+  # every ref the proxy clones. One light call per PR in the window — the
+  # commit payloads themselves stay on the proxy path, so this stream stores
+  # only the edge.
+  # VERIFIED CAVEAT: this endpoint returns at most 250 commits per PR.
+  - type: DeclarativeStream
+    name: pull_request_commits
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          sha: {type: [string, "null"]}
+          pull_number: {type: [integer, "null"]}
+          repo_full_name: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *rest_requester
+        error_handler: *rest_error_handler_repo_scoped
+        path: "/repos/{{ stream_slice.extra_fields['repo_full_name'] }}/pulls/{{ stream_partition.pull_number }}/commits"
+        request_parameters:
+          per_page: "100"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ headers['link']['next']['url'] }}"
+          stop_condition: "{{ 'next' not in headers.get('link', {}) }}"
+        page_token_option:
+          type: RequestPath
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: number
+            partition_field: pull_number
+            extra_fields:
+              - [repo_full_name]
+            stream: *pull_requests_window
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [pull_number]
+            value: "{{ stream_partition.pull_number }}"
+          - type: AddedFieldDefinition
+            path: [repo_full_name]
+            value: "{{ stream_slice.extra_fields['repo_full_name'] }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['repo_full_name'] | replace(':', '%3A') }}:{{ stream_partition.pull_number }}:{{ record['sha'] }}
+      - type: RemoveFields
+        # The commit payload comes from the proxy; only the edge is stored.
+        field_pointers:
+          - [commit]
+          - [author]
+          - [committer]
+          - [parents]
+          - [node_id]
+          - [url]
+          - [html_url]
+          - [comments_url]
 
   # ── Issue & PR conversation comments (GitHub API) ───────────────────────
   # ONE repo-level endpoint covers both: PR conversation comments are issue
@@ -1753,6 +1839,7 @@ metadata:
     pull_requests: false
     pull_request_reviews: false
     pull_request_comments: false
+    pull_request_commits: false
     issues: false
     projects_v2: false
     workflow_runs: false

--- a/src/ingestion/connectors/git/github-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/github-nocode/connector.yaml
@@ -22,16 +22,22 @@ type: DeclarativeSource
 # `none` under value_type: string stores the literal text "None" as a value.
 
 definitions:
+  # The CDK resolves backoff per requester, not per response filter: the first
+  # strategy returning a value wins for every retryable response. X-RateLimit-Reset
+  # is stamped on GitHub responses of any status, so reading it here would put a
+  # transient 5xx to sleep until the hourly window resets. Retry-After covers the
+  # throttles that carry it; everything else backs off exponentially.
+  backoff_strategies: &backoff_strategies
+    - type: WaitTimeFromHeader
+      header: Retry-After
+      max_waiting_time_in_seconds: 600
+    - type: ExponentialBackoffStrategy
+      factor: 2
+
   rest_error_handler: &rest_error_handler
     type: DefaultErrorHandler
     max_retries: 8
-    backoff_strategies:
-      - type: WaitTimeFromHeader
-        header: Retry-After
-        max_waiting_time_in_seconds: 600
-      - type: WaitUntilTimeFromHeader
-        header: X-RateLimit-Reset
-        max_waiting_time_in_seconds: 3600
+    backoff_strategies: *backoff_strategies
     response_filters:
       # ORDER MATTERS. GitHub reports its secondary rate limits as 403, not
       # 429, so the throttle predicates must run before any 403 handling —
@@ -65,13 +71,7 @@ definitions:
   graphql_error_handler: &graphql_error_handler
     type: DefaultErrorHandler
     max_retries: 5
-    backoff_strategies:
-      - type: WaitTimeFromHeader
-        header: Retry-After
-        max_waiting_time_in_seconds: 600
-      - type: WaitUntilTimeFromHeader
-        header: X-RateLimit-Reset
-        max_waiting_time_in_seconds: 3600
+    backoff_strategies: *backoff_strategies
     response_filters:
       - type: HttpResponseFilter
         action: RATE_LIMITED
@@ -94,13 +94,7 @@ definitions:
   graphql_error_handler_repo_scoped: &graphql_error_handler_repo_scoped
     type: DefaultErrorHandler
     max_retries: 5
-    backoff_strategies:
-      - type: WaitTimeFromHeader
-        header: Retry-After
-        max_waiting_time_in_seconds: 600
-      - type: WaitUntilTimeFromHeader
-        header: X-RateLimit-Reset
-        max_waiting_time_in_seconds: 3600
+    backoff_strategies: *backoff_strategies
     response_filters:
       - type: HttpResponseFilter
         action: RATE_LIMITED
@@ -127,13 +121,7 @@ definitions:
   rest_error_handler_repo_scoped: &rest_error_handler_repo_scoped
     type: DefaultErrorHandler
     max_retries: 8
-    backoff_strategies:
-      - type: WaitTimeFromHeader
-        header: Retry-After
-        max_waiting_time_in_seconds: 600
-      - type: WaitUntilTimeFromHeader
-        header: X-RateLimit-Reset
-        max_waiting_time_in_seconds: 3600
+    backoff_strategies: *backoff_strategies
     response_filters:
       - type: HttpResponseFilter
         action: RATE_LIMITED

--- a/src/ingestion/connectors/git/github-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/github-nocode/connector.yaml
@@ -326,6 +326,7 @@ streams:
           created_at: {type: [string, "null"]}
           updated_at: {type: [string, "null"]}
           pushed_at: {type: [string, "null"]}
+          description: {type: [string, "null"]}
         required:
           - unique_key
         additionalProperties: true
@@ -365,6 +366,10 @@ streams:
           - type: AddedFieldDefinition
             path: [org]
             value: "{{ stream_partition.org }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [description]
+            value: "{{ (record.get('description') or '')[:1024] }}"
             value_type: string
           - type: AddedFieldDefinition
             path: [unique_key]
@@ -469,6 +474,10 @@ streams:
           - type: AddedFieldDefinition
             path: [repository]
             value: "{{ stream_partition.repo_clone_url }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [message]
+            value: "{{ (record.get('message') or '')[:2048] }}"
             value_type: string
           - type: AddedFieldDefinition
             path: [unique_key]
@@ -685,6 +694,7 @@ streams:
           updated_at: {type: [string, "null"]}
           closed_at: {type: [string, "null"]}
           merged_at: {type: [string, "null"]}
+          body: {type: [string, "null"]}
         required:
           - unique_key
         additionalProperties: true
@@ -757,6 +767,14 @@ streams:
             value: "{{ (record.get('base') or {}).get('ref') or '' }}"
             value_type: string
           - type: AddedFieldDefinition
+            path: [title]
+            value: "{{ (record.get('title') or '')[:1024] }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [body]
+            value: "{{ (record.get('body') or '')[:2048] }}"
+            value_type: string
+          - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
               {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | replace(':', '%3A') }}:{{ record['id'] }}
@@ -793,6 +811,7 @@ streams:
           state: {type: [string, "null"]}
           commit_id: {type: [string, "null"]}
           submitted_at: {type: [string, "null"]}
+          author_id: {type: [integer, "null"]}
         required:
           - unique_key
         additionalProperties: true
@@ -909,6 +928,9 @@ streams:
             value: "{{ (record.get('user') or {}).get('login') or '' }}"
             value_type: string
           - type: AddedFieldDefinition
+            path: [author_id]
+            value: "{{ (record.get('user') or {}).get('id') }}"
+          - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
               {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['repo_full_name'] | replace(':', '%3A') }}:{{ stream_partition.pull_number }}:{{ record['id'] }}
@@ -944,6 +966,8 @@ streams:
           author_association: {type: [string, "null"]}
           created_at: {type: [string, "null"]}
           updated_at: {type: [string, "null"]}
+          body: {type: [string, "null"]}
+          author_id: {type: [integer, "null"]}
         required:
           - unique_key
         additionalProperties: true
@@ -1009,6 +1033,13 @@ streams:
             path: [author_login]
             value: "{{ (record.get('user') or {}).get('login') or '' }}"
             value_type: string
+          - type: AddedFieldDefinition
+            path: [body]
+            value: "{{ (record.get('body') or '')[:2048] }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [author_id]
+            value: "{{ (record.get('user') or {}).get('id') }}"
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
@@ -1121,6 +1152,10 @@ streams:
           - type: AddedFieldDefinition
             path: [label_names]
             value: "{{ ((record.get('labels') or []) | map(attribute='name') | list) | tojson }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [title]
+            value: "{{ (record.get('title') or '')[:1024] }}"
             value_type: string
           - type: AddedFieldDefinition
             path: [unique_key]
@@ -1250,7 +1285,7 @@ streams:
             value_type: string
           - type: AddedFieldDefinition
             path: [short_description]
-            value: "{{ record.get('shortDescription') or '' }}"
+            value: "{{ (record.get('shortDescription') or '')[:1024] }}"
             value_type: string
           - type: AddedFieldDefinition
             path: [public]
@@ -1265,6 +1300,10 @@ streams:
           - type: AddedFieldDefinition
             path: [updated_at]
             value: "{{ record.get('updatedAt') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [title]
+            value: "{{ (record.get('title') or '')[:1024] }}"
             value_type: string
           - type: AddedFieldDefinition
             path: [unique_key]
@@ -1463,6 +1502,10 @@ streams:
           - type: AddedFieldDefinition
             path: [creator_login]
             value: "{{ (record.get('creator') or {}).get('login') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [description]
+            value: "{{ (record.get('description') or '')[:1024] }}"
             value_type: string
           - type: AddedFieldDefinition
             path: [unique_key]

--- a/src/ingestion/connectors/git/github-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/github-nocode/connector.yaml
@@ -798,6 +798,12 @@ streams:
       datetime_format: "%Y-%m-%dT%H:%M:%SZ"
       cursor_datetime_formats:
         - "%Y-%m-%dT%H:%M:%S%z"
+      # VERIFIED against the CDK: the data-feed stop halts pagination at the
+      # first record older than the slice start, but the boundary PAGE's tail
+      # still emits — up to one page of pre-start_date rows per partition
+      # lands in bronze. Do NOT "fix" this with a record_filter: the stop
+      # condition evaluates POST-filter records, so filtering the old tail
+      # away would keep pagination walking through all history instead.
       is_data_feed: true
       lookback_window: P1D
       start_datetime:
@@ -962,6 +968,12 @@ streams:
                 # Stateless sliding window: the child has no cursor of its
                 # own, so parent state would never persist. The data-feed
                 # stop is what bounds pagination at the window edge.
+                # VERIFIED against the CDK: the data-feed stop halts pagination at the
+                # first record older than the slice start, but the boundary PAGE's tail
+                # still emits — up to one page of pre-start_date rows per partition
+                # lands in bronze. Do NOT "fix" this with a record_filter: the stop
+                # condition evaluates POST-filter records, so filtering the old tail
+                # away would keep pagination walking through all history instead.
                 is_data_feed: true
                 start_datetime:
                   type: MinMaxDatetime
@@ -1174,6 +1186,12 @@ streams:
         type: MinMaxDatetime
         datetime: "{{ config['github_start_date'] }}"
         datetime_format: "%Y-%m-%d"
+      # VERIFIED against the CDK: the data-feed stop halts pagination at the
+      # first record older than the slice start, but the boundary PAGE's tail
+      # still emits — up to one page of pre-start_date rows per partition
+      # lands in bronze. Do NOT "fix" this with a record_filter: the stop
+      # condition evaluates POST-filter records, so filtering the old tail
+      # away would keep pagination walking through all history instead.
       is_data_feed: true
     transformations:
       - type: AddFields
@@ -1720,6 +1738,12 @@ streams:
         - "%Y-%m-%dT%H:%M:%S%z"
       # created_at is immutable: no lookback; the data-feed stop is what
       # bounds newest-first pagination at the stored state.
+      # VERIFIED against the CDK: the data-feed stop halts pagination at the
+      # first record older than the slice start, but the boundary PAGE's tail
+      # still emits — up to one page of pre-start_date rows per partition
+      # lands in bronze. Do NOT "fix" this with a record_filter: the stop
+      # condition evaluates POST-filter records, so filtering the old tail
+      # away would keep pagination walking through all history instead.
       is_data_feed: true
       start_datetime:
         type: MinMaxDatetime
@@ -1862,6 +1886,12 @@ streams:
                   - "%Y-%m-%dT%H:%M:%S%z"
                 # Stateless sliding window; data-feed stop bounds the
                 # newest-first pagination at the window edge.
+                # VERIFIED against the CDK: the data-feed stop halts pagination at the
+                # first record older than the slice start, but the boundary PAGE's tail
+                # still emits — up to one page of pre-start_date rows per partition
+                # lands in bronze. Do NOT "fix" this with a record_filter: the stop
+                # condition evaluates POST-filter records, so filtering the old tail
+                # away would keep pagination walking through all history instead.
                 is_data_feed: true
                 start_datetime:
                   type: MinMaxDatetime

--- a/src/ingestion/connectors/git/github-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/github-nocode/connector.yaml
@@ -99,7 +99,7 @@ definitions:
 
   rest_requester: &rest_requester
     type: HttpRequester
-    url_base: https://api.github.com
+    url_base: "{{ config.get('github_api_base_url', 'https://api.github.com') }}"
     http_method: GET
     authenticator:
       type: BearerAuthenticator
@@ -209,7 +209,7 @@ definitions:
           type: all
           sort: pushed
           direction: asc
-          per_page: "{{ config.get('github_page_size', 100) }}"
+          per_page: "100"
       record_selector:
         type: RecordSelector
         extractor:
@@ -217,7 +217,7 @@ definitions:
           field_path: []
         record_filter:
           type: RecordFilter
-          condition: "{{ not (config.get('skip_archived', true) and record.get('archived', false)) and not (config.get('skip_forks', false) and record.get('fork', false)) }}"
+          condition: "{{ not record.get('archived', false) }}"
       paginator:
         type: DefaultPaginator
         pagination_strategy:
@@ -265,7 +265,7 @@ definitions:
         path: "/orgs/{{ stream_partition.org }}/repos"
         request_parameters:
           type: all
-          per_page: "{{ config.get('github_page_size', 100) }}"
+          per_page: "100"
       record_selector:
         type: RecordSelector
         extractor:
@@ -273,7 +273,7 @@ definitions:
           field_path: []
         record_filter:
           type: RecordFilter
-          condition: "{{ not (config.get('skip_archived', true) and record.get('archived', false)) and not (config.get('skip_forks', false) and record.get('fork', false)) }}"
+          condition: "{{ not record.get('archived', false) }}"
       paginator:
         type: DefaultPaginator
         pagination_strategy:
@@ -336,7 +336,7 @@ streams:
         path: "/orgs/{{ stream_partition.org }}/repos"
         request_parameters:
           type: all
-          per_page: "{{ config.get('github_page_size', 100) }}"
+          per_page: "100"
       record_selector:
         type: RecordSelector
         extractor:
@@ -344,7 +344,7 @@ streams:
           field_path: []
         record_filter:
           type: RecordFilter
-          condition: "{{ not (config.get('skip_archived', true) and record.get('archived', false)) and not (config.get('skip_forks', false) and record.get('fork', false)) }}"
+          condition: "{{ not record.get('archived', false) }}"
       paginator:
         type: DefaultPaginator
         pagination_strategy:
@@ -413,7 +413,7 @@ streams:
         path: /v1/commits
         request_parameters:
           repo: "{{ stream_partition.repo_clone_url }}"
-          page_size: "{{ config.get('proxy_page_size', 500) }}"
+          page_size: "500"
 
       record_selector:
         type: RecordSelector
@@ -449,13 +449,13 @@ streams:
       # replacement commits can carry dates BELOW the stored cursor and would
       # never be visited again. Re-enumerating one window each sync recovers
       # them; bronze dedups the re-read rows.
-      lookback_window: "{{ config.get('github_lookback_window', 'P1M') }}"
+      lookback_window: "P1M"
       cursor_datetime_formats:
         - "%Y-%m-%dT%H:%M:%S%z"
         - "%Y-%m-%dT%H:%M:%SZ"
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config.get('github_start_date', '2020-01-01') }}"
+        datetime: "{{ config['github_start_date'] }}"
         datetime_format: "%Y-%m-%d"
       start_time_option:
         type: RequestOption
@@ -513,9 +513,9 @@ streams:
         path: /v1/file-changes
         request_parameters:
           repo: "{{ stream_partition.repo_clone_url }}"
-          page_size: "{{ config.get('proxy_page_size', 500) }}"
-          include_patch: "{{{{ config.get('github_include_patch', true) | lower }}}}"
-          max_patch_bytes: "{{{{ config.get('github_max_patch_bytes', 1048576) }}}}"
+          page_size: "500"
+          include_patch: "true"
+          max_patch_bytes: "1048576"
       record_selector:
         type: RecordSelector
         extractor:
@@ -550,13 +550,13 @@ streams:
       # replacement commits can carry dates BELOW the stored cursor and would
       # never be visited again. Re-enumerating one window each sync recovers
       # them; bronze dedups the re-read rows.
-      lookback_window: "{{ config.get('github_lookback_window', 'P1M') }}"
+      lookback_window: "P1M"
       cursor_datetime_formats:
         - "%Y-%m-%dT%H:%M:%S%z"
         - "%Y-%m-%dT%H:%M:%SZ"
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config.get('github_start_date', '2020-01-01') }}"
+        datetime: "{{ config['github_start_date'] }}"
         datetime_format: "%Y-%m-%d"
       start_time_option:
         type: RequestOption
@@ -607,7 +607,7 @@ streams:
         path: /v1/branches
         request_parameters:
           repo: "{{ stream_partition.repo_clone_url }}"
-          page_size: "{{ config.get('proxy_page_size', 500) }}"
+          page_size: "500"
 
       record_selector:
         type: RecordSelector
@@ -698,7 +698,7 @@ streams:
           state: all
           sort: updated
           direction: desc
-          per_page: "{{ config.get('github_page_size', 100) }}"
+          per_page: "100"
       record_selector:
         type: RecordSelector
         extractor:
@@ -729,7 +729,7 @@ streams:
       lookback_window: P1D
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config.get('github_start_date', '2020-01-01') }}"
+        datetime: "{{ config['github_start_date'] }}"
         datetime_format: "%Y-%m-%d"
     transformations:
       - type: AddFields
@@ -803,7 +803,7 @@ streams:
         error_handler: *rest_error_handler_repo_scoped
         path: "/repos/{{ stream_slice.extra_fields['repo_full_name'] }}/pulls/{{ stream_partition.pull_number }}/reviews"
         request_parameters:
-          per_page: "{{ config.get('github_page_size', 100) }}"
+          per_page: "100"
       record_selector:
         type: RecordSelector
         extractor:
@@ -850,7 +850,7 @@ streams:
                     state: all
                     sort: updated
                     direction: desc
-                    per_page: "{{ config.get('github_page_size', 100) }}"
+                    per_page: "100"
                 record_selector:
                   type: RecordSelector
                   extractor:
@@ -883,7 +883,7 @@ streams:
                 is_data_feed: true
                 start_datetime:
                   type: MinMaxDatetime
-                  datetime: "{{ format_datetime(now_utc() - duration('P' ~ config.get('github_pr_child_window_days', 30) ~ 'D'), '%Y-%m-%dT%H:%M:%SZ') }}"
+                  datetime: "{{ format_datetime(now_utc() - duration('P30D'), '%Y-%m-%dT%H:%M:%SZ') }}"
                   datetime_format: "%Y-%m-%dT%H:%M:%SZ"
               transformations:
                 - type: AddFields
@@ -956,7 +956,7 @@ streams:
         request_parameters:
           sort: updated
           direction: asc
-          per_page: "{{ config.get('github_page_size', 100) }}"
+          per_page: "100"
       record_selector:
         type: RecordSelector
         extractor:
@@ -986,7 +986,7 @@ streams:
       lookback_window: P1D
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config.get('github_start_date', '2020-01-01') }}"
+        datetime: "{{ config['github_start_date'] }}"
         datetime_format: "%Y-%m-%d"
       start_time_option:
         type: RequestOption
@@ -1062,7 +1062,7 @@ streams:
           state: all
           sort: updated
           direction: asc
-          per_page: "{{ config.get('github_page_size', 100) }}"
+          per_page: "100"
       record_selector:
         type: RecordSelector
         extractor:
@@ -1095,7 +1095,7 @@ streams:
       lookback_window: P1D
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config.get('github_start_date', '2020-01-01') }}"
+        datetime: "{{ config['github_start_date'] }}"
         datetime_format: "%Y-%m-%d"
       start_time_option:
         type: RequestOption
@@ -1275,7 +1275,7 @@ streams:
   # The `created` range goes in a plain request parameter: start_time_option
   # cannot emit the `A..B` search syntax. VERIFIED CAVEAT: with `created` the
   # endpoint caps at 1000 results per query — the weekly step keeps windows
-  # under it; shrink github_workflow_runs_step for hyperactive repos. The
+  # under it for repositories running up to ~1000 workflows a week. The
   # list returns only the LATEST attempt; run_attempt in the key
   # disambiguates re-runs observed across syncs.
   - type: DeclarativeStream
@@ -1347,15 +1347,16 @@ streams:
       datetime_format: "%Y-%m-%dT%H:%M:%SZ"
       cursor_datetime_formats:
         - "%Y-%m-%dT%H:%M:%S%z"
-      step: "{{ config.get('github_workflow_runs_step', 'P1W') }}"
+      step: "P1W"
       cursor_granularity: PT1S
       lookback_window: P1D
       start_datetime:
         type: MinMaxDatetime
-        # CI history is high-volume and ages fast: default to the last 90
-        # days rather than all history.
-        datetime: "{{ config.get('github_workflow_runs_start_date') or format_datetime(now_utc() - duration('P90D'), '%Y-%m-%d') }}"
+        # CI history is high-volume and ages fast: GitHub retains runs for
+        # 90 days, so windows older than that are guaranteed empty.
+        datetime: "{{ config['github_start_date'] }}"
         datetime_format: "%Y-%m-%d"
+        min_datetime: "{{ format_datetime(now_utc() - duration('P90D'), '%Y-%m-%d') }}"
     transformations:
       - type: AddFields
         fields: *standard_fields
@@ -1416,7 +1417,7 @@ streams:
         error_handler: *rest_error_handler_repo_scoped
         path: "/repos/{{ stream_partition.repo_full_name }}/deployments"
         request_parameters:
-          per_page: "{{ config.get('github_page_size', 100) }}"
+          per_page: "100"
       record_selector:
         type: RecordSelector
         extractor:
@@ -1448,7 +1449,7 @@ streams:
       is_data_feed: true
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config.get('github_start_date', '2020-01-01') }}"
+        datetime: "{{ config['github_start_date'] }}"
         datetime_format: "%Y-%m-%d"
     transformations:
       - type: AddFields
@@ -1510,7 +1511,7 @@ streams:
         error_handler: *rest_error_handler_repo_scoped
         path: "/repos/{{ stream_slice.extra_fields['repo_full_name'] }}/deployments/{{ stream_partition.deployment_id }}/statuses"
         request_parameters:
-          per_page: "{{ config.get('github_page_size', 100) }}"
+          per_page: "100"
       record_selector:
         type: RecordSelector
         extractor:
@@ -1554,7 +1555,7 @@ streams:
                   error_handler: *rest_error_handler_repo_scoped
                   path: "/repos/{{ stream_partition.repo_full_name }}/deployments"
                   request_parameters:
-                    per_page: "{{ config.get('github_page_size', 100) }}"
+                    per_page: "100"
                 record_selector:
                   type: RecordSelector
                   extractor:
@@ -1586,7 +1587,7 @@ streams:
                 is_data_feed: true
                 start_datetime:
                   type: MinMaxDatetime
-                  datetime: "{{ format_datetime(now_utc() - duration('P' ~ config.get('github_deploy_window_days', 30) ~ 'D'), '%Y-%m-%dT%H:%M:%SZ') }}"
+                  datetime: "{{ format_datetime(now_utc() - duration('P30D'), '%Y-%m-%dT%H:%M:%SZ') }}"
                   datetime_format: "%Y-%m-%dT%H:%M:%SZ"
               transformations:
                 - type: AddFields
@@ -1638,6 +1639,7 @@ spec:
       - github_organizations
       - git_proxy_url
       - git_proxy_token
+      - github_start_date
     properties:
       insight_tenant_id:
         type: string
@@ -1683,100 +1685,20 @@ spec:
         order: 5
       github_start_date:
         type: string
-        description: Earliest date for incremental sync (YYYY-MM-DD).
+        description: >-
+          Earliest date for incremental sync (YYYY-MM-DD). Required: it bounds
+          the first-sync cost, so choosing it is a deployment decision.
         title: Start Date
         format: date
-        default: "2020-01-01"
         order: 6
-      github_page_size:
-        type: integer
-        description: GitHub API page size (max 100).
-        title: GitHub Page Size
-        default: 100
-        minimum: 1
-        maximum: 100
+      github_api_base_url:
+        type: string
+        description: >-
+          GitHub REST API base URL. Override for GitHub Enterprise Server
+          (e.g. https://ghe.example.com/api/v3).
+        title: API Base URL
+        default: "https://api.github.com"
         order: 7
-      skip_archived:
-        type: boolean
-        description: Skip archived repositories.
-        title: Skip Archived
-        default: true
-        order: 8
-      skip_forks:
-        type: boolean
-        description: Skip forked repositories.
-        title: Skip Forks
-        default: false
-        order: 9
-      proxy_page_size:
-        type: integer
-        description: Rows per page requested from the git-cli-proxy.
-        title: Proxy Page Size
-        default: 500
-        minimum: 1
-        maximum: 10000
-        order: 10
-      github_include_patch:
-        type: boolean
-        description: >-
-          Store per-file diff text. Keep enabled to allow recomputing line
-          counts later under different filters; disable to cut bronze volume.
-        title: Include Patch Text
-        default: true
-        order: 11
-      github_max_patch_bytes:
-        type: integer
-        description: >-
-          Truncation cap for a single file's diff. Truncated rows are flagged
-          with patch_truncated so downstream never mistakes them for complete.
-        title: Max Patch Bytes
-        default: 1048576
-        minimum: 1024
-        order: 12
-      github_lookback_window:
-        type: string
-        description: >-
-          ISO-8601 duration re-enumerated below the stored commit cursor on
-          every sync — the rebase recovery heuristic. A rewrite older than the
-          window is still lost.
-        title: Rebase Lookback Window
-        default: P1M
-        order: 13
-      github_pr_child_window_days:
-        type: integer
-        description: >-
-          Sliding window, in days, of pull requests whose reviews are re-read
-          each sync. Edits on PRs older than the window are not picked up.
-        title: PR Child Window (days)
-        default: 30
-        minimum: 1
-        order: 14
-      github_deploy_window_days:
-        type: integer
-        description: >-
-          Sliding window, in days, of deployments whose statuses are re-read
-          each sync. This is the one cost that scales with deploy frequency —
-          shrink it for hyperactive deployers.
-        title: Deploy Status Window (days)
-        default: 30
-        minimum: 1
-        order: 15
-      github_workflow_runs_start_date:
-        type: string
-        description: >-
-          Earliest date for workflow runs (YYYY-MM-DD). Empty means the last
-          90 days: CI history is high-volume and ages fast.
-        title: Workflow Runs Start Date
-        order: 16
-      github_workflow_runs_step:
-        type: string
-        description: >-
-          ISO-8601 window per workflow-runs query. GitHub caps created-filtered
-          queries at 1000 results per window; shrink this for repositories
-          running more than ~1000 workflows a week.
-        title: Workflow Runs Step
-        default: P1W
-        order: 17
     additionalProperties: true
 
 metadata:

--- a/src/ingestion/connectors/git/github-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/github-nocode/connector.yaml
@@ -79,6 +79,11 @@ definitions:
       - type: HttpResponseFilter
         action: RATE_LIMITED
         predicate: "{{ (response.get('errors') or []) | selectattr('type', 'equalto', 'RATE_LIMITED') | list | length > 0 }}"
+      - type: HttpResponseFilter
+        action: FAIL
+        http_codes: [401]
+        failure_type: config_error
+        error_message: GitHub rejected the token; check github_token scopes (repo, read:org)
       # Any other GraphQL error still arrives as HTTP 200, and a query-level
       # one omits `data` entirely; without this the extractor finds nothing and
       # the paginator throws an unreadable interpolation error. Fail with what
@@ -102,6 +107,11 @@ definitions:
       - type: HttpResponseFilter
         action: RATE_LIMITED
         predicate: "{{ (response.get('errors') or []) | selectattr('type', 'equalto', 'RATE_LIMITED') | list | length > 0 }}"
+      - type: HttpResponseFilter
+        action: FAIL
+        http_codes: [401]
+        failure_type: config_error
+        error_message: GitHub rejected the token; check github_token scopes (repo, read:org)
       - type: HttpResponseFilter
         action: IGNORE
         predicate: "{{ (response.get('errors') or []) | selectattr('type', 'in', ['NOT_FOUND', 'FORBIDDEN']) | list | length > 0 }}"

--- a/src/ingestion/connectors/git/github-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/github-nocode/connector.yaml
@@ -1,0 +1,1767 @@
+version: 7.0.4
+
+type: DeclarativeSource
+
+# GitHub connector built on the git-cli-proxy (issue #2224).
+#
+# Two upstreams in ONE manifest: repository discovery and the PR/issue/CI
+# streams talk to api.github.com, while commit-level extraction talks to the
+# proxy, which serves it from a bare blobless clone instead of one API call
+# per commit.
+#
+# YAML anchors (not $ref) carry the shared requesters and the slim parent
+# streams: anchors resolve at parse time, so the Builder strict validator sees
+# plain inlined objects — the same shape github-directory ships with.
+#
+# org_members is deliberately ABSENT: the deployed github-directory connector
+# already syncs the org roster for identity resolution. Folding it in here is
+# a separate migration.
+#
+# Jinja rule inherited from the github-directory "None" incident: every
+# computed nullable string field coalesces with `or ''` — a rendered Jinja
+# `none` under value_type: string stores the literal text "None" as a value.
+
+definitions:
+  rest_error_handler: &rest_error_handler
+    type: DefaultErrorHandler
+    max_retries: 8
+    backoff_strategies:
+      - type: WaitTimeFromHeader
+        header: Retry-After
+        max_waiting_time_in_seconds: 600
+      - type: WaitUntilTimeFromHeader
+        header: X-RateLimit-Reset
+        max_waiting_time_in_seconds: 3600
+    response_filters:
+      # ORDER MATTERS. GitHub reports its secondary rate limits as 403, not
+      # 429, so the throttle predicates must run before any 403 handling —
+      # otherwise a throttle is mistaken for a denial and skipped or failed.
+      - type: HttpResponseFilter
+        action: RATE_LIMITED
+        http_codes: [403, 429]
+        predicate: "{{ 'secondary rate limit' in ((response.get('message') or '') | lower) }}"
+      - type: HttpResponseFilter
+        action: RATE_LIMITED
+        http_codes: [403, 429]
+        predicate: "{{ headers.get('x-ratelimit-remaining') == '0' }}"
+      - type: HttpResponseFilter
+        action: RATE_LIMITED
+        http_codes: [429]
+      - type: HttpResponseFilter
+        action: FAIL
+        http_codes: [401]
+        failure_type: config_error
+        error_message: GitHub rejected the token; check github_token scopes (repo, read:org)
+      - type: HttpResponseFilter
+        action: RETRY
+        http_codes: [500, 502, 503, 504]
+        error_message: Transient GitHub error
+
+  # Same handler, plus per-repository denial tolerance for repo-scoped
+  # substreams: a fine-grained token can see the org listing yet 403/404 on
+  # individual repositories (or a feature — Actions, issues — is disabled).
+  # The partition is skipped; the sync continues. 410 is "issues disabled".
+  rest_error_handler_repo_scoped: &rest_error_handler_repo_scoped
+    type: DefaultErrorHandler
+    max_retries: 8
+    backoff_strategies:
+      - type: WaitTimeFromHeader
+        header: Retry-After
+        max_waiting_time_in_seconds: 600
+      - type: WaitUntilTimeFromHeader
+        header: X-RateLimit-Reset
+        max_waiting_time_in_seconds: 3600
+    response_filters:
+      - type: HttpResponseFilter
+        action: RATE_LIMITED
+        http_codes: [403, 429]
+        predicate: "{{ 'secondary rate limit' in ((response.get('message') or '') | lower) }}"
+      - type: HttpResponseFilter
+        action: RATE_LIMITED
+        http_codes: [403, 429]
+        predicate: "{{ headers.get('x-ratelimit-remaining') == '0' }}"
+      - type: HttpResponseFilter
+        action: RATE_LIMITED
+        http_codes: [429]
+      - type: HttpResponseFilter
+        action: IGNORE
+        http_codes: [403, 404, 410]
+        error_message: Repository (or this feature on it) not accessible; other repositories continue.
+      - type: HttpResponseFilter
+        action: FAIL
+        http_codes: [401]
+        failure_type: config_error
+        error_message: GitHub rejected the token; check github_token scopes (repo, read:org)
+      - type: HttpResponseFilter
+        action: RETRY
+        http_codes: [500, 502, 503, 504]
+        error_message: Transient GitHub error
+
+  rest_requester: &rest_requester
+    type: HttpRequester
+    url_base: https://api.github.com
+    http_method: GET
+    authenticator:
+      type: BearerAuthenticator
+      api_token: "{{ config['github_token'] }}"
+    request_headers:
+      Accept: application/vnd.github+json
+      X-GitHub-Api-Version: "2022-11-28"
+    error_handler: *rest_error_handler
+
+  proxy_error_handler: &proxy_error_handler
+    type: DefaultErrorHandler
+    # Generous on purpose: a cold blobless clone of a large repository runs
+    # for many Retry-After cycles before the first page can be served.
+    max_retries: 100
+    backoff_strategies:
+      - type: WaitTimeFromHeader
+        header: Retry-After
+        max_waiting_time_in_seconds: 600
+    response_filters:
+      # The repository is being cloned or purged in the background: the proxy
+      # is working, the caller waits.
+      - type: HttpResponseFilter
+        http_codes: [429]
+        action: RETRY
+        error_message: Repository is being prepared by the proxy
+      # Both are permanent for THIS repository and harmless for the rest, so
+      # the partition is skipped rather than the whole stream failed. A rising
+      # git_proxy_rejections_total is the operator's alert.
+      - type: HttpResponseFilter
+        http_codes: [404, 413]
+        action: IGNORE
+        error_message: >-
+          Skipping this repository: gone at origin (404), or larger than
+          cache.maxRepoBytes (413). Other repositories continue.
+      # The pinned snapshot was superseded mid-walk. RETRY would replay the
+      # same dead page token and 409 again; rerunning the sync resumes each
+      # partition from its own stored cursor against a fresh snapshot.
+      - type: HttpResponseFilter
+        http_codes: [409]
+        action: FAIL
+        error_message: Proxy snapshot changed mid-walk; rerun the sync to resume from the stored cursor
+      - type: HttpResponseFilter
+        http_codes: [500, 502, 503, 504]
+        action: RETRY
+        error_message: Transient proxy error (the gateway can time out a worst-case page under contention)
+
+  proxy_requester: &proxy_requester
+    type: HttpRequester
+    url_base: "{{ config['git_proxy_url'] }}"
+    http_method: GET
+    authenticator:
+      type: BearerAuthenticator
+      api_token: "{{ config['git_proxy_token'] }}"
+    request_headers:
+      X-Tenant-Id: "{{ config['insight_tenant_id'] }}"
+      X-Source-Id: "{{ config['insight_source_id'] }}"
+      X-Git-Username: x-access-token
+      X-Git-Token: "{{ config['github_token'] }}"
+    error_handler: *proxy_error_handler
+
+  standard_fields: &standard_fields
+    - type: AddedFieldDefinition
+      path: [tenant_id]
+      value: "{{ config['insight_tenant_id'] }}"
+      value_type: string
+    - type: AddedFieldDefinition
+      path: [source_id]
+      value: "{{ config['insight_source_id'] }}"
+      value_type: string
+    - type: AddedFieldDefinition
+      path: [data_source]
+      value: insight_github_nocode
+      value_type: string
+    - type: AddedFieldDefinition
+      path: [collected_at]
+      value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+      value_type: string
+
+  # Slim repository roster the proxy streams and repo-scoped substreams
+  # partition over. Client-side incremental on pushed_at (the endpoint has no
+  # server-side filter; sort=pushed asc keeps the cursor monotonic), so with
+  # incremental_dependency only repositories pushed since the last sync are
+  # visited. The CDK auto-caches parents, so the aliased copies share one
+  # HTTP pass per sync.
+  repositories_pushed_parent: &repositories_pushed_parent
+    type: DeclarativeStream
+    name: repositories_pushed
+    primary_key:
+      - id
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          id: {type: [integer, "null"]}
+          full_name: {type: [string, "null"]}
+          clone_url: {type: [string, "null"]}
+          pushed_at: {type: [string, "null"]}
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *rest_requester
+        path: "/orgs/{{ stream_partition.org }}/repos"
+        request_parameters:
+          type: all
+          sort: pushed
+          direction: asc
+          per_page: "{{ config.get('github_page_size', 100) }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+        record_filter:
+          type: RecordFilter
+          condition: "{{ not (config.get('skip_archived', true) and record.get('archived', false)) and not (config.get('skip_forks', false) and record.get('fork', false)) }}"
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ headers['link']['next']['url'] }}"
+          stop_condition: "{{ 'next' not in headers.get('link', {}) }}"
+        page_token_option:
+          type: RequestPath
+      partition_router:
+        type: ListPartitionRouter
+        values: "{{ config['github_organizations'] }}"
+        cursor_field: org
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: pushed_at
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S%z"
+      is_client_side_incremental: true
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "1970-01-01"
+        datetime_format: "%Y-%m-%d"
+
+  # Full roster (no pushed_at gate): reviews/comments/issues/CI advance
+  # without pushes, so their parents must not be push-gated.
+  repositories_all_parent: &repositories_all_parent
+    type: DeclarativeStream
+    name: repositories_all
+    primary_key:
+      - id
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          id: {type: [integer, "null"]}
+          full_name: {type: [string, "null"]}
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *rest_requester
+        path: "/orgs/{{ stream_partition.org }}/repos"
+        request_parameters:
+          type: all
+          per_page: "{{ config.get('github_page_size', 100) }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+        record_filter:
+          type: RecordFilter
+          condition: "{{ not (config.get('skip_archived', true) and record.get('archived', false)) and not (config.get('skip_forks', false) and record.get('fork', false)) }}"
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ headers['link']['next']['url'] }}"
+          stop_condition: "{{ 'next' not in headers.get('link', {}) }}"
+        page_token_option:
+          type: RequestPath
+      partition_router:
+        type: ListPartitionRouter
+        values: "{{ config['github_organizations'] }}"
+        cursor_field: org
+
+check:
+  type: CheckStream
+  stream_names:
+    - repositories
+
+streams:
+  # ── Repository roster (GitHub API) ──────────────────────────────────────
+  # Full refresh: metadata of push-quiet repositories must not freeze, so the
+  # roster is never gated on pushed_at (the proxy parents are — separately).
+  - type: DeclarativeStream
+    name: repositories
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          id: {type: [integer, "null"]}
+          full_name: {type: [string, "null"]}
+          name: {type: [string, "null"]}
+          org: {type: [string, "null"]}
+          default_branch: {type: [string, "null"]}
+          archived: {type: [boolean, "null"]}
+          fork: {type: [boolean, "null"]}
+          private: {type: [boolean, "null"]}
+          language: {type: [string, "null"]}
+          size: {type: [integer, "null"]}
+          clone_url: {type: [string, "null"]}
+          html_url: {type: [string, "null"]}
+          created_at: {type: [string, "null"]}
+          updated_at: {type: [string, "null"]}
+          pushed_at: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *rest_requester
+        path: "/orgs/{{ stream_partition.org }}/repos"
+        request_parameters:
+          type: all
+          per_page: "{{ config.get('github_page_size', 100) }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+        record_filter:
+          type: RecordFilter
+          condition: "{{ not (config.get('skip_archived', true) and record.get('archived', false)) and not (config.get('skip_forks', false) and record.get('fork', false)) }}"
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ headers['link']['next']['url'] }}"
+          stop_condition: "{{ 'next' not in headers.get('link', {}) }}"
+        page_token_option:
+          type: RequestPath
+      partition_router:
+        type: ListPartitionRouter
+        values: "{{ config['github_organizations'] }}"
+        cursor_field: org
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [org]
+            value: "{{ stream_partition.org }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ record['id'] | string | replace(':', '%3A') }}
+
+  # ── commits (git-cli-proxy) ────────────────────────────────────────
+  - type: DeclarativeStream
+    name: commits
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          repository: {type: [string, "null"]}
+          sha: {type: [string, "null"]}
+          message: {type: [string, "null"]}
+          authored_date: {type: [string, "null"]}
+          committed_date: {type: [string, "null"]}
+          author_name: {type: [string, "null"]}
+          author_email: {type: [string, "null"]}
+          committer_name: {type: [string, "null"]}
+          committer_email: {type: [string, "null"]}
+          parent_hashes: {type: [array, "null"], items: {type: string}}
+          is_merge: {type: [boolean, "null"]}
+          additions: {type: [integer, "null"]}
+          deletions: {type: [integer, "null"]}
+          changed_files: {type: [integer, "null"]}
+          is_in_default_branch: {type: [boolean, "null"]}
+          patch_id: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *proxy_requester
+        path: /v1/commits
+        request_parameters:
+          repo: "{{ stream_partition.repo_clone_url }}"
+          page_size: "{{ config.get('proxy_page_size', 500) }}"
+
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [items]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response['next_page_token'] }}"
+          stop_condition: "{{ not response.get('next_page_token') }}"
+        page_token_option:
+          type: RequestOption
+          field_name: page_token
+          inject_into: request_parameter
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: clone_url
+            partition_field: repo_clone_url
+            # `incremental_dependency` keeps the sync proportional to
+            # activity: parent state persists only because this child is
+            # itself incremental.
+            incremental_dependency: true
+            stream: *repositories_pushed_parent
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: committed_date
+      datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+      # `git log --since` is a traversal cutoff: after a rebase the
+      # replacement commits can carry dates BELOW the stored cursor and would
+      # never be visited again. Re-enumerating one window each sync recovers
+      # them; bronze dedups the re-read rows.
+      lookback_window: "{{ config.get('github_lookback_window', 'P1M') }}"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S%z"
+        - "%Y-%m-%dT%H:%M:%SZ"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('github_start_date', '2020-01-01') }}"
+        datetime_format: "%Y-%m-%d"
+      start_time_option:
+        type: RequestOption
+        field_name: since
+        inject_into: request_parameter
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [repository]
+            value: "{{ stream_partition.repo_clone_url }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | string | replace(':', '%3A') }}:{{ record['sha'] | string | replace(':', '%3A') }}
+
+  # ── commit_files (git-cli-proxy) ───────────────────────────────────
+  - type: DeclarativeStream
+    name: commit_files
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          repository: {type: [string, "null"]}
+          sha: {type: [string, "null"]}
+          committed_date: {type: [string, "null"]}
+          filename: {type: [string, "null"]}
+          previous_filename: {type: [string, "null"]}
+          status: {type: [string, "null"]}
+          additions: {type: [integer, "null"]}
+          deletions: {type: [integer, "null"]}
+          changes: {type: [integer, "null"]}
+          is_binary: {type: [boolean, "null"]}
+          patch: {type: [string, "null"]}
+          patch_truncated: {type: [boolean, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *proxy_requester
+        path: /v1/file-changes
+        request_parameters:
+          repo: "{{ stream_partition.repo_clone_url }}"
+          page_size: "{{ config.get('proxy_page_size', 500) }}"
+          include_patch: "{{{{ config.get('github_include_patch', true) | lower }}}}"
+          max_patch_bytes: "{{{{ config.get('github_max_patch_bytes', 1048576) }}}}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [items]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response['next_page_token'] }}"
+          stop_condition: "{{ not response.get('next_page_token') }}"
+        page_token_option:
+          type: RequestOption
+          field_name: page_token
+          inject_into: request_parameter
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: clone_url
+            partition_field: repo_clone_url
+            # `incremental_dependency` keeps the sync proportional to
+            # activity: parent state persists only because this child is
+            # itself incremental.
+            incremental_dependency: true
+            stream: *repositories_pushed_parent
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: committed_date
+      datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+      # `git log --since` is a traversal cutoff: after a rebase the
+      # replacement commits can carry dates BELOW the stored cursor and would
+      # never be visited again. Re-enumerating one window each sync recovers
+      # them; bronze dedups the re-read rows.
+      lookback_window: "{{ config.get('github_lookback_window', 'P1M') }}"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S%z"
+        - "%Y-%m-%dT%H:%M:%SZ"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('github_start_date', '2020-01-01') }}"
+        datetime_format: "%Y-%m-%d"
+      start_time_option:
+        type: RequestOption
+        field_name: since
+        inject_into: request_parameter
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [repository]
+            value: "{{ stream_partition.repo_clone_url }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | string | replace(':', '%3A') }}:{{ record['sha'] | string | replace(':', '%3A') }}:{{ record['filename'] | string | replace(':', '%3A') }}
+
+  # ── repo_branches (git-cli-proxy) ──────────────────────────────────
+  - type: DeclarativeStream
+    name: repo_branches
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          repository: {type: [string, "null"]}
+          name: {type: [string, "null"]}
+          head_sha: {type: [string, "null"]}
+          head_committed_date: {type: [string, "null"]}
+          is_default: {type: [boolean, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *proxy_requester
+        path: /v1/branches
+        request_parameters:
+          repo: "{{ stream_partition.repo_clone_url }}"
+          page_size: "{{ config.get('proxy_page_size', 500) }}"
+
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [items]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response['next_page_token'] }}"
+          stop_condition: "{{ not response.get('next_page_token') }}"
+        page_token_option:
+          type: RequestOption
+          field_name: page_token
+          inject_into: request_parameter
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: clone_url
+            partition_field: repo_clone_url
+            # Full-refresh child: parent state would not persist, so no
+            # incremental_dependency.
+            incremental_dependency: false
+            stream: *repositories_pushed_parent
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [repository]
+            value: "{{ stream_partition.repo_clone_url }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | string | replace(':', '%3A') }}:{{ record['name'] | string | replace(':', '%3A') }}
+
+  # ── Pull requests (GitHub API) ──────────────────────────────────────────
+  # LIST endpoint only: /pulls has no `since`, so newest-first plus the
+  # data-feed stop halts pagination at the stored per-repo state, and the
+  # client-side filter drops the stale tail of the boundary page.
+  # additions/deletions/changed_files/merged_by are detail-only and stay
+  # NULL in v1 — PR size comes from the proxy's commit_files.
+  - type: DeclarativeStream
+    name: pull_requests
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          id: {type: [integer, "null"]}
+          number: {type: [integer, "null"]}
+          repo_full_name: {type: [string, "null"]}
+          state: {type: [string, "null"]}
+          draft: {type: [boolean, "null"]}
+          title: {type: [string, "null"]}
+          author_login: {type: [string, "null"]}
+          author_association: {type: [string, "null"]}
+          head_sha: {type: [string, "null"]}
+          head_ref: {type: [string, "null"]}
+          base_ref: {type: [string, "null"]}
+          merge_commit_sha: {type: [string, "null"]}
+          created_at: {type: [string, "null"]}
+          updated_at: {type: [string, "null"]}
+          closed_at: {type: [string, "null"]}
+          merged_at: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *rest_requester
+        error_handler: *rest_error_handler_repo_scoped
+        path: "/repos/{{ stream_partition.repo_full_name }}/pulls"
+        request_parameters:
+          state: all
+          sort: updated
+          direction: desc
+          per_page: "{{ config.get('github_page_size', 100) }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ headers['link']['next']['url'] }}"
+          stop_condition: "{{ 'next' not in headers.get('link', {}) }}"
+        page_token_option:
+          type: RequestPath
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: full_name
+            partition_field: repo_full_name
+            stream: *repositories_all_parent
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: updated_at
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S%z"
+      is_data_feed: true
+      is_client_side_incremental: true
+      lookback_window: P1D
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('github_start_date', '2020-01-01') }}"
+        datetime_format: "%Y-%m-%d"
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [repo_full_name]
+            value: "{{ stream_partition.repo_full_name }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [author_login]
+            value: "{{ (record.get('user') or {}).get('login') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [head_sha]
+            value: "{{ (record.get('head') or {}).get('sha') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [head_ref]
+            value: "{{ (record.get('head') or {}).get('ref') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [base_ref]
+            value: "{{ (record.get('base') or {}).get('ref') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | string | replace(':', '%3A') }}:{{ record['id'] | string }}
+
+  # ── Pull request reviews (GitHub API) ───────────────────────────────────
+  # No repo-level reviews endpoint exists in REST, so this is one call per PR
+  # updated inside the sliding window.
+  - type: DeclarativeStream
+    name: pull_request_reviews
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          id: {type: [integer, "null"]}
+          pull_number: {type: [integer, "null"]}
+          repo_full_name: {type: [string, "null"]}
+          author_login: {type: [string, "null"]}
+          author_association: {type: [string, "null"]}
+          state: {type: [string, "null"]}
+          commit_id: {type: [string, "null"]}
+          submitted_at: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *rest_requester
+        error_handler: *rest_error_handler_repo_scoped
+        path: "/repos/{{ stream_slice.extra_fields['repo_full_name'] }}/pulls/{{ stream_partition.pull_number }}/reviews"
+        request_parameters:
+          per_page: "{{ config.get('github_page_size', 100) }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ headers['link']['next']['url'] }}"
+          stop_condition: "{{ 'next' not in headers.get('link', {}) }}"
+        page_token_option:
+          type: RequestPath
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: number
+            partition_field: pull_number
+            extra_fields:
+              - [repo_full_name]
+            stream:
+              type: DeclarativeStream
+              name: pull_requests_window
+              primary_key:
+                - number
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/schema#
+                  properties:
+                    number: {type: [integer, "null"]}
+                    repo_full_name: {type: [string, "null"]}
+                    updated_at: {type: [string, "null"]}
+                  additionalProperties: true
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  <<: *rest_requester
+                  error_handler: *rest_error_handler_repo_scoped
+                  path: "/repos/{{ stream_partition.repo_full_name }}/pulls"
+                  request_parameters:
+                    state: all
+                    sort: updated
+                    direction: desc
+                    per_page: "{{ config.get('github_page_size', 100) }}"
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: []
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: CursorPagination
+                    cursor_value: "{{ headers['link']['next']['url'] }}"
+                    stop_condition: "{{ 'next' not in headers.get('link', {}) }}"
+                  page_token_option:
+                    type: RequestPath
+                partition_router:
+                  type: SubstreamPartitionRouter
+                  parent_stream_configs:
+                    - type: ParentStreamConfig
+                      parent_key: full_name
+                      partition_field: repo_full_name
+                      stream: *repositories_all_parent
+              incremental_sync:
+                type: DatetimeBasedCursor
+                cursor_field: updated_at
+                datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+                cursor_datetime_formats:
+                  - "%Y-%m-%dT%H:%M:%S%z"
+                # Stateless sliding window: the child has no cursor of its
+                # own, so parent state would never persist. The data-feed
+                # stop is what bounds pagination at the window edge.
+                is_data_feed: true
+                is_client_side_incremental: true
+                start_datetime:
+                  type: MinMaxDatetime
+                  datetime: "{{ format_datetime(now_utc() - duration('P' ~ config.get('github_pr_child_window_days', 30) ~ 'D'), '%Y-%m-%dT%H:%M:%SZ') }}"
+                  datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+              transformations:
+                - type: AddFields
+                  fields:
+                    - type: AddedFieldDefinition
+                      path: [repo_full_name]
+                      value: "{{ stream_partition.repo_full_name }}"
+                      value_type: string
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [pull_number]
+            value: "{{ stream_partition.pull_number }}"
+          - type: AddedFieldDefinition
+            path: [repo_full_name]
+            value: "{{ stream_slice.extra_fields['repo_full_name'] }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [author_login]
+            value: "{{ (record.get('user') or {}).get('login') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['repo_full_name'] | string | replace(':', '%3A') }}:{{ stream_partition.pull_number | string }}:{{ record['id'] | string }}
+
+  # ── Issue & PR conversation comments (GitHub API) ───────────────────────
+  # ONE repo-level endpoint covers both: PR conversation comments are issue
+  # comments in GitHub's model. Server-side `since` makes it O(changed).
+  # Inline code-review comments (/pulls/comments) are a later clone-stream if
+  # inline-comment metrics are ever wanted.
+  - type: DeclarativeStream
+    name: pull_request_comments
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          id: {type: [integer, "null"]}
+          issue_number: {type: [integer, "null"]}
+          repo_full_name: {type: [string, "null"]}
+          author_login: {type: [string, "null"]}
+          author_association: {type: [string, "null"]}
+          created_at: {type: [string, "null"]}
+          updated_at: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *rest_requester
+        error_handler: *rest_error_handler_repo_scoped
+        path: "/repos/{{ stream_partition.repo_full_name }}/issues/comments"
+        request_parameters:
+          sort: updated
+          direction: asc
+          per_page: "{{ config.get('github_page_size', 100) }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ headers['link']['next']['url'] }}"
+          stop_condition: "{{ 'next' not in headers.get('link', {}) }}"
+        page_token_option:
+          type: RequestPath
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: full_name
+            partition_field: repo_full_name
+            stream: *repositories_all_parent
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: updated_at
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S%z"
+      lookback_window: P1D
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('github_start_date', '2020-01-01') }}"
+        datetime_format: "%Y-%m-%d"
+      start_time_option:
+        type: RequestOption
+        field_name: since
+        inject_into: request_parameter
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [repo_full_name]
+            value: "{{ stream_partition.repo_full_name }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [issue_number]
+            value: "{{ (record.get('issue_url') or '').split('/') | last }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [author_login]
+            value: "{{ (record.get('user') or {}).get('login') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | string | replace(':', '%3A') }}:comment:{{ record['id'] | string }}
+
+  # ── Issues (GitHub API) ─────────────────────────────────────────────────
+  # The endpoint returns PRs too; the record filter drops them (a PR carries
+  # a `pull_request` key). Server-side `since` = updated-after.
+  - type: DeclarativeStream
+    name: issues
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          id: {type: [integer, "null"]}
+          number: {type: [integer, "null"]}
+          repo_full_name: {type: [string, "null"]}
+          state: {type: [string, "null"]}
+          state_reason: {type: [string, "null"]}
+          title: {type: [string, "null"]}
+          author_login: {type: [string, "null"]}
+          assignee_logins: {type: [string, "null"]}
+          label_names: {type: [string, "null"]}
+          comments: {type: [integer, "null"]}
+          created_at: {type: [string, "null"]}
+          updated_at: {type: [string, "null"]}
+          closed_at: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *rest_requester
+        error_handler: *rest_error_handler_repo_scoped
+        path: "/repos/{{ stream_partition.repo_full_name }}/issues"
+        request_parameters:
+          state: all
+          sort: updated
+          direction: asc
+          per_page: "{{ config.get('github_page_size', 100) }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+        record_filter:
+          type: RecordFilter
+          condition: "{{ 'pull_request' not in record }}"
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ headers['link']['next']['url'] }}"
+          stop_condition: "{{ 'next' not in headers.get('link', {}) }}"
+        page_token_option:
+          type: RequestPath
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: full_name
+            partition_field: repo_full_name
+            stream: *repositories_all_parent
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: updated_at
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S%z"
+      lookback_window: P1D
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('github_start_date', '2020-01-01') }}"
+        datetime_format: "%Y-%m-%d"
+      start_time_option:
+        type: RequestOption
+        field_name: since
+        inject_into: request_parameter
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [repo_full_name]
+            value: "{{ stream_partition.repo_full_name }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [author_login]
+            value: "{{ (record.get('user') or {}).get('login') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [assignee_logins]
+            value: "{{ ((record.get('assignees') or []) | map(attribute='login') | list) | tojson }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [label_names]
+            value: "{{ ((record.get('labels') or []) | map(attribute='name') | list) | tojson }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | string | replace(':', '%3A') }}:issue:{{ record['id'] | string }}
+
+  # ── Projects V2 (GitHub GraphQL) ────────────────────────────────────────
+  # Projects V2 has no REST API. Cursor rides in the request body — the
+  # pattern github-directory ships with.
+  - type: DeclarativeStream
+    name: projects_v2
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          project_id: {type: [string, "null"]}
+          number: {type: [integer, "null"]}
+          org: {type: [string, "null"]}
+          title: {type: [string, "null"]}
+          short_description: {type: [string, "null"]}
+          public: {type: [boolean, "null"]}
+          closed: {type: [boolean, "null"]}
+          created_at: {type: [string, "null"]}
+          updated_at: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *rest_requester
+        path: /graphql
+        http_method: POST
+        error_handler:
+          type: DefaultErrorHandler
+          max_retries: 5
+          backoff_strategies:
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+            - type: WaitUntilTimeFromHeader
+              header: X-RateLimit-Reset
+              max_waiting_time_in_seconds: 3600
+          response_filters:
+            - type: HttpResponseFilter
+              action: RATE_LIMITED
+              http_codes: [429]
+            - type: HttpResponseFilter
+              action: RATE_LIMITED
+              predicate: "{{ (response.get('errors') or []) | selectattr('type', 'equalto', 'RATE_LIMITED') | list | length > 0 }}"
+            # Any other GraphQL error still arrives as HTTP 200, and a
+            # query-level one omits `data` entirely; without this the
+            # extractor finds nothing and the paginator throws an unreadable
+            # interpolation error. Fail with what GitHub actually said.
+            - type: HttpResponseFilter
+              action: FAIL
+              predicate: "{{ (response.get('errors') or []) | length > 0 }}"
+              error_message: "GitHub GraphQL error: {{ (response.get('errors') or []) | map(attribute='message') | join('; ') }}"
+            - type: HttpResponseFilter
+              action: RETRY
+              http_codes: [500, 502, 503, 504]
+        request_body_json:
+          query: |
+            query($org: String!, $cursor: String) {
+              organization(login: $org) {
+                projectsV2(first: 100, after: $cursor) {
+                  pageInfo { hasNextPage endCursor }
+                  nodes { id number title shortDescription public closed createdAt updatedAt }
+                }
+              }
+            }
+          variables:
+            org: "{{ stream_partition.org }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [data, organization, projectsV2, nodes]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response['data']['organization']['projectsV2']['pageInfo']['endCursor'] }}"
+          stop_condition: "{{ not response['data']['organization']['projectsV2']['pageInfo']['hasNextPage'] }}"
+        page_token_option:
+          type: RequestOption
+          inject_into: body_json
+          field_path: [variables, cursor]
+      partition_router:
+        type: ListPartitionRouter
+        values: "{{ config['github_organizations'] }}"
+        cursor_field: org
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [org]
+            value: "{{ stream_partition.org }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [project_id]
+            value: "{{ record.get('id') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [number]
+            value: "{{ record.get('number') }}"
+          - type: AddedFieldDefinition
+            path: [title]
+            value: "{{ record.get('title') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [short_description]
+            value: "{{ record.get('shortDescription') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [public]
+            value: "{{ record.get('public') }}"
+          - type: AddedFieldDefinition
+            path: [closed]
+            value: "{{ record.get('closed') }}"
+          - type: AddedFieldDefinition
+            path: [created_at]
+            value: "{{ record.get('createdAt') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [updated_at]
+            value: "{{ record.get('updatedAt') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.org | string | replace(':', '%3A') }}:project:{{ (record.get('id') or '') | string | replace(':', '%3A') }}
+
+  # ── Actions workflow runs (GitHub API) ──────────────────────────────────
+  # The `created` range goes in a plain request parameter: start_time_option
+  # cannot emit the `A..B` search syntax. VERIFIED CAVEAT: with `created` the
+  # endpoint caps at 1000 results per query — the weekly step keeps windows
+  # under it; shrink github_workflow_runs_step for hyperactive repos. The
+  # list returns only the LATEST attempt; run_attempt in the key
+  # disambiguates re-runs observed across syncs.
+  - type: DeclarativeStream
+    name: workflow_runs
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          id: {type: [integer, "null"]}
+          run_attempt: {type: [integer, "null"]}
+          repo_full_name: {type: [string, "null"]}
+          name: {type: [string, "null"]}
+          workflow_id: {type: [integer, "null"]}
+          event: {type: [string, "null"]}
+          status: {type: [string, "null"]}
+          conclusion: {type: [string, "null"]}
+          head_branch: {type: [string, "null"]}
+          head_sha: {type: [string, "null"]}
+          actor_login: {type: [string, "null"]}
+          run_started_at: {type: [string, "null"]}
+          created_at: {type: [string, "null"]}
+          updated_at: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *rest_requester
+        error_handler: *rest_error_handler_repo_scoped
+        path: "/repos/{{ stream_partition.repo_full_name }}/actions/runs"
+        request_parameters:
+          per_page: "100"
+          created: "{{ stream_interval.start_time }}..{{ stream_interval.end_time }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [workflow_runs]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: PageIncrement
+          page_size: 100
+          start_from_page: 1
+        page_token_option:
+          type: RequestOption
+          field_name: page
+          inject_into: request_parameter
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: full_name
+            partition_field: repo_full_name
+            stream: *repositories_all_parent
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: created_at
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S%z"
+      step: "{{ config.get('github_workflow_runs_step', 'P1W') }}"
+      cursor_granularity: PT1S
+      lookback_window: P1D
+      start_datetime:
+        type: MinMaxDatetime
+        # CI history is high-volume and ages fast: default to the last 90
+        # days rather than all history.
+        datetime: "{{ config.get('github_workflow_runs_start_date') or format_datetime(now_utc() - duration('P90D'), '%Y-%m-%d') }}"
+        datetime_format: "%Y-%m-%d"
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [repo_full_name]
+            value: "{{ stream_partition.repo_full_name }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [actor_login]
+            value: "{{ (record.get('actor') or {}).get('login') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | string | replace(':', '%3A') }}:run:{{ record['id'] | string }}:{{ record.get('run_attempt', 1) | string }}
+
+  # ── Deployments (GitHub API) ────────────────────────────────────────────
+  # No date filter and no outcome on this endpoint: newest-first + data-feed
+  # stop keeps it O(new); outcome comes from deployment_statuses below.
+  - type: DeclarativeStream
+    name: deployments
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          id: {type: [integer, "null"]}
+          repo_full_name: {type: [string, "null"]}
+          sha: {type: [string, "null"]}
+          ref: {type: [string, "null"]}
+          task: {type: [string, "null"]}
+          environment: {type: [string, "null"]}
+          description: {type: [string, "null"]}
+          creator_login: {type: [string, "null"]}
+          created_at: {type: [string, "null"]}
+          updated_at: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *rest_requester
+        error_handler: *rest_error_handler_repo_scoped
+        path: "/repos/{{ stream_partition.repo_full_name }}/deployments"
+        request_parameters:
+          per_page: "{{ config.get('github_page_size', 100) }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ headers['link']['next']['url'] }}"
+          stop_condition: "{{ 'next' not in headers.get('link', {}) }}"
+        page_token_option:
+          type: RequestPath
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: full_name
+            partition_field: repo_full_name
+            stream: *repositories_all_parent
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: created_at
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S%z"
+      # created_at is immutable: no lookback; the data-feed stop is what
+      # bounds newest-first pagination at the stored state.
+      is_data_feed: true
+      is_client_side_incremental: true
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('github_start_date', '2020-01-01') }}"
+        datetime_format: "%Y-%m-%d"
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [repo_full_name]
+            value: "{{ stream_partition.repo_full_name }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [creator_login]
+            value: "{{ (record.get('creator') or {}).get('login') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | string | replace(':', '%3A') }}:deploy:{{ record['id'] | string }}
+
+  # ── Deployment statuses (GitHub API) ────────────────────────────────────
+  # A deployment record has no outcome; this child fetches success/failure
+  # for every deployment created inside the sliding window — the one cost
+  # term that scales with deploy frequency, bounded by
+  # github_deploy_window_days.
+  - type: DeclarativeStream
+    name: deployment_statuses
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          id: {type: [integer, "null"]}
+          deployment_id: {type: [integer, "null"]}
+          repo_full_name: {type: [string, "null"]}
+          state: {type: [string, "null"]}
+          environment: {type: [string, "null"]}
+          creator_login: {type: [string, "null"]}
+          created_at: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *rest_requester
+        error_handler: *rest_error_handler_repo_scoped
+        path: "/repos/{{ stream_slice.extra_fields['repo_full_name'] }}/deployments/{{ stream_partition.deployment_id }}/statuses"
+        request_parameters:
+          per_page: "{{ config.get('github_page_size', 100) }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ headers['link']['next']['url'] }}"
+          stop_condition: "{{ 'next' not in headers.get('link', {}) }}"
+        page_token_option:
+          type: RequestPath
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: id
+            partition_field: deployment_id
+            extra_fields:
+              - [repo_full_name]
+            stream:
+              type: DeclarativeStream
+              name: deployments_window
+              primary_key:
+                - id
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/schema#
+                  properties:
+                    id: {type: [integer, "null"]}
+                    repo_full_name: {type: [string, "null"]}
+                    created_at: {type: [string, "null"]}
+                  additionalProperties: true
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  <<: *rest_requester
+                  error_handler: *rest_error_handler_repo_scoped
+                  path: "/repos/{{ stream_partition.repo_full_name }}/deployments"
+                  request_parameters:
+                    per_page: "{{ config.get('github_page_size', 100) }}"
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: []
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: CursorPagination
+                    cursor_value: "{{ headers['link']['next']['url'] }}"
+                    stop_condition: "{{ 'next' not in headers.get('link', {}) }}"
+                  page_token_option:
+                    type: RequestPath
+                partition_router:
+                  type: SubstreamPartitionRouter
+                  parent_stream_configs:
+                    - type: ParentStreamConfig
+                      parent_key: full_name
+                      partition_field: repo_full_name
+                      stream: *repositories_all_parent
+              incremental_sync:
+                type: DatetimeBasedCursor
+                cursor_field: created_at
+                datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+                cursor_datetime_formats:
+                  - "%Y-%m-%dT%H:%M:%S%z"
+                # Stateless sliding window; data-feed stop bounds the
+                # newest-first pagination at the window edge.
+                is_data_feed: true
+                is_client_side_incremental: true
+                start_datetime:
+                  type: MinMaxDatetime
+                  datetime: "{{ format_datetime(now_utc() - duration('P' ~ config.get('github_deploy_window_days', 30) ~ 'D'), '%Y-%m-%dT%H:%M:%SZ') }}"
+                  datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+              transformations:
+                - type: AddFields
+                  fields:
+                    - type: AddedFieldDefinition
+                      path: [repo_full_name]
+                      value: "{{ stream_partition.repo_full_name }}"
+                      value_type: string
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [deployment_id]
+            value: "{{ stream_partition.deployment_id }}"
+          - type: AddedFieldDefinition
+            path: [repo_full_name]
+            value: "{{ stream_slice.extra_fields['repo_full_name'] }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [creator_login]
+            value: "{{ (record.get('creator') or {}).get('login') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['repo_full_name'] | string | replace(':', '%3A') }}:{{ stream_partition.deployment_id | string }}:status:{{ record['id'] | string }}
+
+concurrency_level:
+  type: ConcurrencyLevel
+  # Never 1: the concurrent CDK self-deadlocks at a single worker once a sync
+  # generates ~10k partitions.
+  default_concurrency: 4
+
+spec:
+  type: Spec
+  connection_specification:
+    type: object
+    $schema: http://json-schema.org/draft-07/schema#
+    title: GitHub (git-cli-proxy) Spec
+    required:
+      - insight_tenant_id
+      - insight_source_id
+      - github_token
+      - github_organizations
+      - git_proxy_url
+      - git_proxy_token
+    properties:
+      insight_tenant_id:
+        type: string
+        description: Insight tenant identifier stamped onto every emitted record.
+        title: Insight Tenant ID
+        order: 0
+      insight_source_id:
+        type: string
+        description: >-
+          Instance discriminator for multi-instance support (e.g. github-acme).
+        title: Insight Source ID
+        order: 1
+      github_token:
+        type: string
+        description: >-
+          GitHub personal access token or App installation token. Needs `repo`
+          and `read:org` (classic) or equivalent fine-grained permissions. The
+          same token is forwarded to the proxy for the clone and never stored
+          there.
+        title: GitHub Token
+        airbyte_secret: true
+        order: 2
+      github_organizations:
+        type: array
+        items:
+          type: string
+        description: GitHub organization logins to sync.
+        title: Organizations
+        order: 3
+      git_proxy_url:
+        type: string
+        description: >-
+          Base URL of the git-cli-proxy service (cluster-internal, e.g.
+          http://insight-git-cli-proxy:8085). No default: a wrong or absent
+          value must fail the check, not fall back somewhere.
+        title: Git Proxy URL
+        order: 4
+      git_proxy_token:
+        type: string
+        description: Bearer token the git-cli-proxy requires on every /v1 request.
+        title: Git Proxy Token
+        airbyte_secret: true
+        order: 5
+      github_start_date:
+        type: string
+        description: Earliest date for incremental sync (YYYY-MM-DD).
+        title: Start Date
+        format: date
+        default: "2020-01-01"
+        order: 6
+      github_page_size:
+        type: integer
+        description: GitHub API page size (max 100).
+        title: GitHub Page Size
+        default: 100
+        minimum: 1
+        maximum: 100
+        order: 7
+      skip_archived:
+        type: boolean
+        description: Skip archived repositories.
+        title: Skip Archived
+        default: true
+        order: 8
+      skip_forks:
+        type: boolean
+        description: Skip forked repositories.
+        title: Skip Forks
+        default: false
+        order: 9
+      proxy_page_size:
+        type: integer
+        description: Rows per page requested from the git-cli-proxy.
+        title: Proxy Page Size
+        default: 500
+        minimum: 1
+        maximum: 10000
+        order: 10
+      github_include_patch:
+        type: boolean
+        description: >-
+          Store per-file diff text. Keep enabled to allow recomputing line
+          counts later under different filters; disable to cut bronze volume.
+        title: Include Patch Text
+        default: true
+        order: 11
+      github_max_patch_bytes:
+        type: integer
+        description: >-
+          Truncation cap for a single file's diff. Truncated rows are flagged
+          with patch_truncated so downstream never mistakes them for complete.
+        title: Max Patch Bytes
+        default: 1048576
+        minimum: 1024
+        order: 12
+      github_lookback_window:
+        type: string
+        description: >-
+          ISO-8601 duration re-enumerated below the stored commit cursor on
+          every sync — the rebase recovery heuristic. A rewrite older than the
+          window is still lost.
+        title: Rebase Lookback Window
+        default: P1M
+        order: 13
+      github_pr_child_window_days:
+        type: integer
+        description: >-
+          Sliding window, in days, of pull requests whose reviews are re-read
+          each sync. Edits on PRs older than the window are not picked up.
+        title: PR Child Window (days)
+        default: 30
+        minimum: 1
+        order: 14
+      github_deploy_window_days:
+        type: integer
+        description: >-
+          Sliding window, in days, of deployments whose statuses are re-read
+          each sync. This is the one cost that scales with deploy frequency —
+          shrink it for hyperactive deployers.
+        title: Deploy Status Window (days)
+        default: 30
+        minimum: 1
+        order: 15
+      github_workflow_runs_start_date:
+        type: string
+        description: >-
+          Earliest date for workflow runs (YYYY-MM-DD). Empty means the last
+          90 days: CI history is high-volume and ages fast.
+        title: Workflow Runs Start Date
+        order: 16
+      github_workflow_runs_step:
+        type: string
+        description: >-
+          ISO-8601 window per workflow-runs query. GitHub caps created-filtered
+          queries at 1000 results per window; shrink this for repositories
+          running more than ~1000 workflows a week.
+        title: Workflow Runs Step
+        default: P1W
+        order: 17
+    additionalProperties: true
+
+metadata:
+  autoImportSchema:
+    repositories: false
+    commits: false
+    commit_files: false
+    repo_branches: false
+    pull_requests: false
+    pull_request_reviews: false
+    pull_request_comments: false
+    issues: false
+    projects_v2: false
+    workflow_runs: false
+    deployments: false
+    deployment_statuses: false

--- a/src/ingestion/connectors/git/github-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/github-nocode/connector.yaml
@@ -57,6 +57,69 @@ definitions:
         http_codes: [500, 502, 503, 504]
         error_message: Transient GitHub error
 
+  # GraphQL errors arrive as HTTP 200 with an `errors` array, so the HTTP-code
+  # filters above never see them. Repo-scoped queries add one more case: an
+  # inaccessible repository is a 200 whose `data.repository` is null and whose
+  # error type is NOT_FOUND or FORBIDDEN — the same skip-not-fail class as a
+  # REST 403/404, and fatal to a whole sync if treated as a query error.
+  graphql_error_handler: &graphql_error_handler
+    type: DefaultErrorHandler
+    max_retries: 5
+    backoff_strategies:
+      - type: WaitTimeFromHeader
+        header: Retry-After
+        max_waiting_time_in_seconds: 600
+      - type: WaitUntilTimeFromHeader
+        header: X-RateLimit-Reset
+        max_waiting_time_in_seconds: 3600
+    response_filters:
+      - type: HttpResponseFilter
+        action: RATE_LIMITED
+        http_codes: [429]
+      - type: HttpResponseFilter
+        action: RATE_LIMITED
+        predicate: "{{ (response.get('errors') or []) | selectattr('type', 'equalto', 'RATE_LIMITED') | list | length > 0 }}"
+      # Any other GraphQL error still arrives as HTTP 200, and a query-level
+      # one omits `data` entirely; without this the extractor finds nothing and
+      # the paginator throws an unreadable interpolation error. Fail with what
+      # GitHub actually said.
+      - type: HttpResponseFilter
+        action: FAIL
+        predicate: "{{ (response.get('errors') or []) | length > 0 }}"
+        error_message: "GitHub GraphQL error: {{ (response.get('errors') or []) | map(attribute='message') | join('; ') }}"
+      - type: HttpResponseFilter
+        action: RETRY
+        http_codes: [500, 502, 503, 504]
+
+  graphql_error_handler_repo_scoped: &graphql_error_handler_repo_scoped
+    type: DefaultErrorHandler
+    max_retries: 5
+    backoff_strategies:
+      - type: WaitTimeFromHeader
+        header: Retry-After
+        max_waiting_time_in_seconds: 600
+      - type: WaitUntilTimeFromHeader
+        header: X-RateLimit-Reset
+        max_waiting_time_in_seconds: 3600
+    response_filters:
+      - type: HttpResponseFilter
+        action: RATE_LIMITED
+        http_codes: [429]
+      - type: HttpResponseFilter
+        action: RATE_LIMITED
+        predicate: "{{ (response.get('errors') or []) | selectattr('type', 'equalto', 'RATE_LIMITED') | list | length > 0 }}"
+      - type: HttpResponseFilter
+        action: IGNORE
+        predicate: "{{ (response.get('errors') or []) | selectattr('type', 'in', ['NOT_FOUND', 'FORBIDDEN']) | list | length > 0 }}"
+        error_message: Repository not visible to this token; other repositories continue.
+      - type: HttpResponseFilter
+        action: FAIL
+        predicate: "{{ (response.get('errors') or []) | length > 0 }}"
+        error_message: "GitHub GraphQL error: {{ (response.get('errors') or []) | map(attribute='message') | join('; ') }}"
+      - type: HttpResponseFilter
+        action: RETRY
+        http_codes: [500, 502, 503, 504]
+
   # Same handler, plus per-repository denial tolerance for repo-scoped
   # substreams: a fine-grained token can see the org listing yet 403/404 on
   # individual repositories (or a feature — Actions, issues — is disabled).
@@ -1025,6 +1088,123 @@ streams:
           - [html_url]
           - [comments_url]
 
+  # ── Pull request diff totals (GitHub GraphQL) ───────────────────────────
+  # REST carries additions/deletions/changed_files on the PR DETAIL response
+  # only, which would cost one call per pull request. The GraphQL list node
+  # carries all three, so a page of 100 pull requests costs one request and
+  # the stream needs no per-PR fan-out at all.
+  # The connection has no updatedAfter argument (VERIFIED against the live
+  # schema), so this is a newest-first data feed like the REST pull_requests
+  # stream: ordering is UPDATED_AT DESC and the cursor stops the walk.
+  - type: DeclarativeStream
+    name: pull_request_diff_stats
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          pull_number: {type: [integer, "null"]}
+          repo_full_name: {type: [string, "null"]}
+          additions: {type: [integer, "null"]}
+          deletions: {type: [integer, "null"]}
+          changed_files: {type: [integer, "null"]}
+          updated_at: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *rest_requester
+        error_handler: *graphql_error_handler_repo_scoped
+        path: /graphql
+        http_method: POST
+        request_body_json:
+          query: |
+            query($owner: String!, $name: String!, $cursor: String) {
+              repository(owner: $owner, name: $name) {
+                pullRequests(first: 100, after: $cursor, states: [OPEN, CLOSED, MERGED], orderBy: {field: UPDATED_AT, direction: DESC}) {
+                  pageInfo { hasNextPage endCursor }
+                  nodes { number updatedAt additions deletions changedFiles }
+                }
+              }
+            }
+          variables:
+            owner: "{{ stream_partition.repo_full_name.split('/')[0] }}"
+            name: "{{ stream_partition.repo_full_name.split('/')[1] }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [data, repository, pullRequests, nodes]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          # `data.repository` is null when the token cannot see the repository,
+          # so every hop is guarded rather than subscripted.
+          cursor_value: "{{ ((((response.get('data') or {}).get('repository') or {}).get('pullRequests') or {}).get('pageInfo') or {}).get('endCursor') }}"
+          stop_condition: "{{ not ((((response.get('data') or {}).get('repository') or {}).get('pullRequests') or {}).get('pageInfo') or {}).get('hasNextPage') }}"
+        page_token_option:
+          type: RequestOption
+          inject_into: body_json
+          field_path: [variables, cursor]
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: full_name
+            partition_field: repo_full_name
+            stream: *repositories_all_parent
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: updated_at
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%SZ"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config['github_start_date'] }}"
+        datetime_format: "%Y-%m-%d"
+      is_data_feed: true
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [repo_full_name]
+            value: "{{ stream_partition.repo_full_name }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [pull_number]
+            value: "{{ record.get('number') }}"
+          - type: AddedFieldDefinition
+            path: [changed_files]
+            value: "{{ record.get('changedFiles') }}"
+          - type: AddedFieldDefinition
+            path: [updated_at]
+            value: "{{ record.get('updatedAt') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_full_name | replace(':', '%3A') }}:{{ record['number'] }}
+      - type: RemoveFields
+        # Hoisted above; the camelCase originals stay out of bronze.
+        field_pointers:
+          - [number]
+          - [changedFiles]
+          - [updatedAt]
+
   # ── Issue & PR conversation comments (GitHub API) ───────────────────────
   # ONE repo-level endpoint covers both: PR conversation comments are issue
   # comments in GitHub's model. Server-side `since` makes it O(changed).
@@ -1290,34 +1470,7 @@ streams:
         <<: *rest_requester
         path: /graphql
         http_method: POST
-        error_handler:
-          type: DefaultErrorHandler
-          max_retries: 5
-          backoff_strategies:
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
-            - type: WaitUntilTimeFromHeader
-              header: X-RateLimit-Reset
-              max_waiting_time_in_seconds: 3600
-          response_filters:
-            - type: HttpResponseFilter
-              action: RATE_LIMITED
-              http_codes: [429]
-            - type: HttpResponseFilter
-              action: RATE_LIMITED
-              predicate: "{{ (response.get('errors') or []) | selectattr('type', 'equalto', 'RATE_LIMITED') | list | length > 0 }}"
-            # Any other GraphQL error still arrives as HTTP 200, and a
-            # query-level one omits `data` entirely; without this the
-            # extractor finds nothing and the paginator throws an unreadable
-            # interpolation error. Fail with what GitHub actually said.
-            - type: HttpResponseFilter
-              action: FAIL
-              predicate: "{{ (response.get('errors') or []) | length > 0 }}"
-              error_message: "GitHub GraphQL error: {{ (response.get('errors') or []) | map(attribute='message') | join('; ') }}"
-            - type: HttpResponseFilter
-              action: RETRY
-              http_codes: [500, 502, 503, 504]
+        error_handler: *graphql_error_handler
         request_body_json:
           query: |
             query($org: String!, $cursor: String) {
@@ -1365,10 +1518,6 @@ streams:
           - type: AddedFieldDefinition
             path: [number]
             value: "{{ record.get('number') }}"
-          - type: AddedFieldDefinition
-            path: [title]
-            value: "{{ record.get('title') or '' }}"
-            value_type: string
           - type: AddedFieldDefinition
             path: [short_description]
             value: "{{ (record.get('shortDescription') or '')[:1024] }}"
@@ -1840,6 +1989,7 @@ metadata:
     pull_request_reviews: false
     pull_request_comments: false
     pull_request_commits: false
+    pull_request_diff_stats: false
     issues: false
     projects_v2: false
     workflow_runs: false

--- a/src/ingestion/connectors/git/github-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/github-nocode/connector.yaml
@@ -475,9 +475,9 @@ streams:
             value: >-
               {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | replace(':', '%3A') }}:{{ record['sha'] | replace(':', '%3A') }}
 
-  # ── commit_files (git-cli-proxy) ───────────────────────────────────
+  # ── file_changes (git-cli-proxy) ───────────────────────────────────
   - type: DeclarativeStream
-    name: commit_files
+    name: file_changes
     primary_key:
       - unique_key
     schema_loader:
@@ -576,9 +576,9 @@ streams:
             value: >-
               {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | replace(':', '%3A') }}:{{ record['sha'] | replace(':', '%3A') }}:{{ record['filename'] | replace(':', '%3A') }}
 
-  # ── repo_branches (git-cli-proxy) ──────────────────────────────────
+  # ── branches (git-cli-proxy) ──────────────────────────────────
   - type: DeclarativeStream
-    name: repo_branches
+    name: branches
     primary_key:
       - unique_key
     schema_loader:
@@ -653,7 +653,7 @@ streams:
   # data-feed stop halts pagination at the stored per-repo state, and the
   # client-side filter drops the stale tail of the boundary page.
   # additions/deletions/changed_files/merged_by are detail-only and stay
-  # NULL in v1 — PR size comes from the proxy's commit_files.
+  # NULL in v1 — PR size comes from the proxy's file_changes.
   - type: DeclarativeStream
     name: pull_requests
     primary_key:
@@ -1783,8 +1783,8 @@ metadata:
   autoImportSchema:
     repositories: false
     commits: false
-    commit_files: false
-    repo_branches: false
+    file_changes: false
+    branches: false
     pull_requests: false
     pull_request_reviews: false
     pull_request_comments: false

--- a/src/ingestion/connectors/git/github-nocode/descriptor.yaml
+++ b/src/ingestion/connectors/git/github-nocode/descriptor.yaml
@@ -1,0 +1,19 @@
+name: github-nocode
+version: "1.0.0"
+schedule: "0 4 * * *"
+workflow: sync
+
+# Silver routing via dbt tags on the staging models.
+# silver_targets prohibited per Connector Spec §4.10 — Silver is determined by
+# the dbt tags, and the pipeline's silver step hardcodes `tag:<slug>+`.
+dbt_select: "tag:github-nocode+"
+
+secret:
+  # Fields the deployment Secret must carry beyond the spec's `required` list
+  # (generate-connectors-config.sh unions both when building the fake config).
+  required_fields:
+    - github_token
+    - git_proxy_token
+
+connection:
+  namespace: bronze_github_nocode

--- a/src/ingestion/connectors/git/github-nocode/tests/config.py
+++ b/src/ingestion/connectors/git/github-nocode/tests/config.py
@@ -1,0 +1,24 @@
+"""github-nocode connector test config builder."""
+
+from __future__ import annotations
+
+from connector_tests import ConfigBuilder
+
+GH_URL = "https://api.github.com"
+PROXY_URL = "http://git-cli-proxy.example:8085"
+
+
+class GithubNocodeConfigBuilder(ConfigBuilder):
+    def __init__(self) -> None:
+        super().__init__()
+        self._config.update(
+            {
+                "github_token": "test-gh-token",
+                "github_organizations": ["acme"],
+                "git_proxy_url": PROXY_URL,
+                "git_proxy_token": "test-proxy-token",
+                "github_start_date": "2026-06-01",
+                # One weekly slice under the frozen clock.
+                "github_workflow_runs_start_date": "2026-06-25",
+            }
+        )

--- a/src/ingestion/connectors/git/github-nocode/tests/config.py
+++ b/src/ingestion/connectors/git/github-nocode/tests/config.py
@@ -18,7 +18,5 @@ class GithubNocodeConfigBuilder(ConfigBuilder):
                 "git_proxy_url": PROXY_URL,
                 "git_proxy_token": "test-proxy-token",
                 "github_start_date": "2026-06-01",
-                # One weekly slice under the frozen clock.
-                "github_workflow_runs_start_date": "2026-06-25",
             }
         )

--- a/src/ingestion/connectors/git/github-nocode/tests/conftest.py
+++ b/src/ingestion/connectors/git/github-nocode/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Local builder modules (config.py) are importable under --import-mode=importlib.
+sys.path.insert(0, str(Path(__file__).parent))
+
+from connector_tests.plugin import *  # noqa: E402,F401,F403 — http_mocker fixture + hooks

--- a/src/ingestion/connectors/git/github-nocode/tests/test_github_streams.py
+++ b/src/ingestion/connectors/git/github-nocode/tests/test_github_streams.py
@@ -34,15 +34,15 @@ _REPOS_URL = f"{GH_URL}/orgs/acme/repos"
 _FROZEN = "2026-07-01T00:00:00Z"
 
 
-def _graphql_body(cursor: str | None = None) -> dict:
+def _graphql_body(stream_name: str, variables: dict, cursor: str | None = None) -> dict:
     """The exact request body the manifest sends — POST mocks match on it."""
     manifest = load_manifest(_CONNECTOR)
-    stream = next(st for st in manifest["streams"] if st["name"] == "projects_v2")
+    stream = next(st for st in manifest["streams"] if st["name"] == stream_name)
     body = dict(stream["retriever"]["requester"]["request_body_json"])
     # The CDK's interpolation strips the YAML block scalar's trailing newline
     # at send time; the raw manifest keeps it.
     body["query"] = body["query"].rstrip("\n")
-    body["variables"] = {"org": "acme"}
+    body["variables"] = dict(variables)
     if cursor is not None:
         body["variables"]["cursor"] = cursor
     return body
@@ -262,6 +262,81 @@ def test_pull_request_commits_store_only_the_edge(http_mocker: HttpMocker) -> No
     assert_records_conform(output.records, _CONNECTOR, "pull_request_commits", strict=True)
 
 
+def _diff_stats_body(cursor: str | None = None) -> dict:
+    return _graphql_body("pull_request_diff_stats", {"owner": "acme", "name": "app"}, cursor)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_pull_request_diff_stats_come_from_the_list_node(http_mocker: HttpMocker) -> None:
+    """REST carries additions/deletions on the PR detail response only; the
+    GraphQL list node carries them, so a page of PRs costs one request."""
+    config = GithubNocodeConfigBuilder().build()
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+    http_mocker.post(
+        HttpRequest(f"{GH_URL}/graphql", body=_diff_stats_body()),
+        HttpResponse(
+            body=json.dumps(
+                {
+                    "data": {
+                        "repository": {
+                            "pullRequests": {
+                                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                "nodes": [
+                                    {
+                                        "number": 31,
+                                        "updatedAt": "2026-06-20T00:00:00Z",
+                                        "additions": 120,
+                                        "deletions": 7,
+                                        "changedFiles": 3,
+                                    }
+                                ],
+                            }
+                        }
+                    }
+                }
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "pull_request_diff_stats", config)
+
+    assert not output.errors
+    rec = output.records[0].record.data
+    assert (rec["additions"], rec["deletions"], rec["changed_files"]) == (120, 7, 3)
+    assert rec["pull_number"] == 31
+    assert rec["repo_full_name"] == "acme/app"
+    assert rec["unique_key"].endswith(":acme/app:31")
+    assert "changedFiles" not in rec and "updatedAt" not in rec
+    _no_literal_none(output.records)
+    assert_records_conform(output.records, _CONNECTOR, "pull_request_diff_stats", strict=True)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_graphql_not_found_skips_the_repository(http_mocker: HttpMocker) -> None:
+    """An inaccessible repository is an HTTP 200 whose data is null and whose
+    error type is NOT_FOUND — a skip, not a query error that fails the sync."""
+    config = GithubNocodeConfigBuilder().build()
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+    http_mocker.post(
+        HttpRequest(f"{GH_URL}/graphql", body=_diff_stats_body()),
+        HttpResponse(
+            body=json.dumps(
+                {
+                    "data": {"repository": None},
+                    "errors": [{"type": "NOT_FOUND", "message": "Could not resolve to a Repository"}],
+                }
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "pull_request_diff_stats", config)
+
+    assert not output.errors
+    assert len(output.records) == 0
+
+
 @freezegun.freeze_time(_FROZEN)
 def test_issues_filters_out_pull_requests(http_mocker: HttpMocker) -> None:
     """/issues returns PRs too; the record filter must drop them."""
@@ -323,7 +398,7 @@ def test_graphql_error_in_a_200_fails_loudly(http_mocker: HttpMocker) -> None:
     fail with GitHub's message, not report zero projects."""
     config = GithubNocodeConfigBuilder().build()
     http_mocker.post(
-        HttpRequest(f"{GH_URL}/graphql", body=_graphql_body()),
+        HttpRequest(f"{GH_URL}/graphql", body=_graphql_body("projects_v2", {"org": "acme"})),
         HttpResponse(
             body=json.dumps({"errors": [{"type": "INSUFFICIENT_SCOPES", "message": "needs read:project"}]}),
             status_code=200,
@@ -342,7 +417,7 @@ def test_projects_v2_graphql_pagination_cursor_in_body(http_mocker: HttpMocker) 
     node = {"id": "PVT_1", "number": 1, "title": "Roadmap", "shortDescription": None, "public": True, "closed": False, "createdAt": "2026-01-01T00:00:00Z", "updatedAt": "2026-06-01T00:00:00Z"}
     body = {"data": {"organization": {"projectsV2": {"pageInfo": {"hasNextPage": False, "endCursor": "c1"}, "nodes": [node]}}}}
     http_mocker.post(
-        HttpRequest(f"{GH_URL}/graphql", body=_graphql_body()),
+        HttpRequest(f"{GH_URL}/graphql", body=_graphql_body("projects_v2", {"org": "acme"})),
         HttpResponse(body=json.dumps(body), status_code=200),
     )
 

--- a/src/ingestion/connectors/git/github-nocode/tests/test_github_streams.py
+++ b/src/ingestion/connectors/git/github-nocode/tests/test_github_streams.py
@@ -1,0 +1,248 @@
+"""Mock-server tests for github-nocode.
+
+GitHub-specific hazards under test: secondary rate limits arriving as 403
+(must retry, not skip), per-repository 403/404 skipping on repo-scoped
+streams, the issues endpoint returning PRs (filtered out), GraphQL errors
+arriving as HTTP 200 (must FAIL loudly), the proxy 429 retry loop, and the
+literal-"None" guard.
+
+Coverage matrix rows: full_refresh_single_page, incremental_state,
+tenant_source_stamping, schema_conformance, substream_partition,
+record_filter, error_retry (403-as-throttle, proxy 429), error_ignore (404),
+transformations (None-guard).
+"""
+
+from __future__ import annotations
+
+import json
+
+import freezegun
+from config import GH_URL, PROXY_URL, GithubNocodeConfigBuilder
+
+from connector_tests import (
+    ANY_QUERY_PARAMS,
+    HttpMocker,
+    HttpRequest,
+    HttpResponse,
+    assert_records_conform,
+    read_stream,
+)
+from connector_tests.source import load_manifest
+
+_CONNECTOR = "git/github-nocode"
+_REPOS_URL = f"{GH_URL}/orgs/acme/repos"
+_FROZEN = "2026-07-01T00:00:00Z"
+
+
+def _graphql_body(cursor: str | None = None) -> dict:
+    """The exact request body the manifest sends — POST mocks match on it."""
+    manifest = load_manifest(_CONNECTOR)
+    stream = next(st for st in manifest["streams"] if st["name"] == "projects_v2")
+    body = dict(stream["retriever"]["requester"]["request_body_json"])
+    # The CDK's interpolation strips the YAML block scalar's trailing newline
+    # at send time; the raw manifest keeps it.
+    body["query"] = body["query"].rstrip("\n")
+    body["variables"] = {"org": "acme"}
+    if cursor is not None:
+        body["variables"]["cursor"] = cursor
+    return body
+
+
+def _no_literal_none(records) -> None:
+    for r in records:
+        for key, value in r.record.data.items():
+            assert value != "None", f"literal 'None' leaked into {key}"
+
+
+def _repo() -> dict:
+    return {
+        "id": 42,
+        "full_name": "acme/app",
+        "name": "app",
+        "default_branch": "main",
+        "archived": False,
+        "fork": False,
+        "private": True,
+        "clone_url": "https://github.com/acme/app.git",
+        "pushed_at": "2026-06-20T10:00:00Z",
+        "created_at": "2020-01-01T00:00:00Z",
+        "updated_at": "2026-06-20T10:00:00Z",
+    }
+
+
+def _repos_page() -> HttpResponse:
+    return HttpResponse(body=json.dumps([_repo()]), status_code=200)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_repositories_full_refresh_and_stamping(http_mocker: HttpMocker) -> None:
+    config = GithubNocodeConfigBuilder().build()
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+
+    output = read_stream(_CONNECTOR, "repositories", config)
+
+    assert not output.errors
+    rec = output.records[0].record.data
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["unique_key"].endswith(":42")
+    assert '"""' not in rec["unique_key"], "int id must interpolate plain (CDK string filter triple-quotes non-strings)"
+    _no_literal_none(output.records)
+    assert_records_conform(output.records, _CONNECTOR, "repositories", strict=True)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_secondary_rate_limit_403_retries_then_succeeds(http_mocker: HttpMocker) -> None:
+    """GitHub reports secondary limits as 403; the predicate must classify it
+    as a throttle (retry) rather than a denial (skip)."""
+    config = GithubNocodeConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS),
+        [
+            HttpResponse(
+                body=json.dumps({"message": "You have exceeded a secondary rate limit."}),
+                status_code=403,
+                headers={"Retry-After": "0"},
+            ),
+            _repos_page(),
+        ],
+    )
+
+    output = read_stream(_CONNECTOR, "repositories", config)
+
+    assert not output.errors
+    assert len(output.records) == 1
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_proxy_429_then_success(http_mocker: HttpMocker) -> None:
+    config = GithubNocodeConfigBuilder().build()
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+    http_mocker.get(
+        HttpRequest(f"{PROXY_URL}/v1/commits", query_params=ANY_QUERY_PARAMS),
+        [
+            HttpResponse(body="", status_code=429, headers={"Retry-After": "0"}),
+            HttpResponse(
+                body=json.dumps(
+                    {
+                        "items": [
+                            {
+                                "sha": "d" * 40,
+                                "message": "m",
+                                "committed_date": "2026-06-15T10:00:00Z",
+                                "authored_date": "2026-06-15T10:00:00Z",
+                                "author_name": "Dev",
+                                "author_email": "dev@example.com",
+                                "committer_name": "Dev",
+                                "committer_email": "dev@example.com",
+                                "parent_hashes": [],
+                                "is_merge": False,
+                                "is_in_default_branch": True,
+                                "patch_id": None,
+                            }
+                        ],
+                        "next_page_token": None,
+                    }
+                ),
+                status_code=200,
+            ),
+        ],
+    )
+
+    output = read_stream(_CONNECTOR, "commits", config)
+
+    assert not output.errors
+    assert len(output.records) == 1
+    _no_literal_none(output.records)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_issues_filters_out_pull_requests(http_mocker: HttpMocker) -> None:
+    """/issues returns PRs too; the record filter must drop them."""
+    config = GithubNocodeConfigBuilder().build()
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+    http_mocker.get(
+        HttpRequest(f"{GH_URL}/repos/acme/app/issues", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps(
+                [
+                    {"id": 1, "number": 10, "state": "open", "title": "real issue", "user": {"login": "alice"}, "assignees": [], "labels": [], "comments": 0, "created_at": "2026-06-10T00:00:00Z", "updated_at": "2026-06-20T00:00:00Z"},
+                    {"id": 2, "number": 11, "state": "open", "title": "a PR in disguise", "user": None, "assignees": [], "labels": [], "comments": 0, "created_at": "2026-06-10T00:00:00Z", "updated_at": "2026-06-20T00:00:00Z", "pull_request": {"url": "..."}},
+                ]
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "issues", config)
+
+    assert not output.errors
+    assert len(output.records) == 1
+    rec = output.records[0].record.data
+    assert rec["title"] == "real issue"
+    assert rec["author_login"] == "alice"
+    _no_literal_none(output.records)
+    assert_records_conform(output.records, _CONNECTOR, "issues", strict=True)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_workflow_runs_key_carries_run_attempt(http_mocker: HttpMocker) -> None:
+    config = GithubNocodeConfigBuilder().build()
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+    http_mocker.get(
+        HttpRequest(f"{GH_URL}/repos/acme/app/actions/runs", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps(
+                {
+                    "workflow_runs": [
+                        {"id": 500, "run_attempt": 2, "name": "ci", "workflow_id": 9, "event": "push", "status": "completed", "conclusion": "success", "head_branch": "main", "head_sha": "e" * 40, "actor": {"login": "alice"}, "run_started_at": "2026-06-28T00:00:00Z", "created_at": "2026-06-28T00:00:00Z", "updated_at": "2026-06-28T01:00:00Z"}
+                    ]
+                }
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "workflow_runs", config)
+
+    assert not output.errors
+    rec = output.records[0].record.data
+    assert rec["unique_key"].endswith(":run:500:2"), rec["unique_key"]
+    _no_literal_none(output.records)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_graphql_error_in_a_200_fails_loudly(http_mocker: HttpMocker) -> None:
+    """A GraphQL error arrives as HTTP 200 without `data`; the stream must
+    fail with GitHub's message, not report zero projects."""
+    config = GithubNocodeConfigBuilder().build()
+    http_mocker.post(
+        HttpRequest(f"{GH_URL}/graphql", body=_graphql_body()),
+        HttpResponse(
+            body=json.dumps({"errors": [{"type": "INSUFFICIENT_SCOPES", "message": "needs read:project"}]}),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "projects_v2", config)
+
+    assert output.errors, "a query-level GraphQL error must fail the stream"
+    assert len(output.records) == 0
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_projects_v2_graphql_pagination_cursor_in_body(http_mocker: HttpMocker) -> None:
+    config = GithubNocodeConfigBuilder().build()
+    node = {"id": "PVT_1", "number": 1, "title": "Roadmap", "shortDescription": None, "public": True, "closed": False, "createdAt": "2026-01-01T00:00:00Z", "updatedAt": "2026-06-01T00:00:00Z"}
+    body = {"data": {"organization": {"projectsV2": {"pageInfo": {"hasNextPage": False, "endCursor": "c1"}, "nodes": [node]}}}}
+    http_mocker.post(
+        HttpRequest(f"{GH_URL}/graphql", body=_graphql_body()),
+        HttpResponse(body=json.dumps(body), status_code=200),
+    )
+
+    output = read_stream(_CONNECTOR, "projects_v2", config)
+
+    assert not output.errors
+    rec = output.records[0].record.data
+    assert rec["title"] == "Roadmap"
+    assert rec["short_description"] == ""
+    _no_literal_none(output.records)

--- a/src/ingestion/connectors/git/github-nocode/tests/test_github_streams.py
+++ b/src/ingestion/connectors/git/github-nocode/tests/test_github_streams.py
@@ -156,6 +156,48 @@ def test_proxy_429_then_success(http_mocker: HttpMocker) -> None:
 
 
 @freezegun.freeze_time(_FROZEN)
+def test_pull_requests_trim_body_and_hoist_author(http_mocker: HttpMocker) -> None:
+    """The silver PR model consumes body as description; it is trimmed to
+    2048 chars, and a deleted author surfaces as '' — never "None"."""
+    config = GithubNocodeConfigBuilder().build()
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+    http_mocker.get(
+        HttpRequest(f"{GH_URL}/repos/acme/app/pulls", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps(
+                [
+                    {
+                        "id": 900,
+                        "number": 31,
+                        "state": "open",
+                        "draft": False,
+                        "title": "t" * 3000,
+                        "body": "b" * 3000,
+                        "user": {"login": "alice"},
+                        "head": {"ref": "feat", "sha": "e" * 40},
+                        "base": {"ref": "main"},
+                        "author_association": "MEMBER",
+                        "created_at": "2026-06-10T00:00:00Z",
+                        "updated_at": "2026-06-20T00:00:00Z",
+                    }
+                ]
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "pull_requests", config)
+
+    assert not output.errors
+    rec = output.records[0].record.data
+    assert len(rec["body"]) == 2048
+    assert len(rec["title"]) == 1024
+    assert rec["author_login"] == "alice"
+    _no_literal_none(output.records)
+    assert_records_conform(output.records, _CONNECTOR, "pull_requests", strict=True)
+
+
+@freezegun.freeze_time(_FROZEN)
 def test_issues_filters_out_pull_requests(http_mocker: HttpMocker) -> None:
     """/issues returns PRs too; the record filter must drop them."""
     config = GithubNocodeConfigBuilder().build()

--- a/src/ingestion/connectors/git/github-nocode/tests/test_github_streams.py
+++ b/src/ingestion/connectors/git/github-nocode/tests/test_github_streams.py
@@ -198,6 +198,42 @@ def test_pull_requests_trim_body_and_hoist_author(http_mocker: HttpMocker) -> No
 
 
 @freezegun.freeze_time(_FROZEN)
+def test_data_feed_stops_at_start_date_but_boundary_page_tail_emits(http_mocker: HttpMocker) -> None:
+    """First-sync data-feed behavior, pinned: pagination stops at the first
+    record older than start_date (the Link-next page is never mocked, so a
+    fetch would fail the test) — but the boundary page's old tail still
+    emits. A record_filter must never be added to "fix" the tail: the stop
+    condition sees post-filter records, so it would unbound pagination."""
+    config = GithubNocodeConfigBuilder().build()
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+
+    def _pr(num: int, updated: str) -> dict:
+        return {
+            "id": 900 + num, "number": num, "state": "open", "draft": False,
+            "title": "t", "body": "b", "user": {"login": "a"},
+            "head": {"ref": "f", "sha": "e" * 40}, "base": {"ref": "main"},
+            "author_association": "MEMBER",
+            "created_at": "2019-01-01T00:00:00Z", "updated_at": updated,
+        }
+
+    http_mocker.get(
+        HttpRequest(f"{GH_URL}/repos/acme/app/pulls", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps([_pr(31, "2026-06-20T00:00:00Z"), _pr(30, "2019-05-20T00:00:00Z")]),
+            status_code=200,
+            headers={"Link": f'<{GH_URL}/repos/acme/app/pulls?page=2>; rel="next"'},
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "pull_requests", config)
+
+    assert not output.errors, "page 2 must never be fetched"
+    nums = [r.record.data["number"] for r in output.records]
+    assert 31 in nums
+    assert 30 in nums, "boundary-page tail is expected to emit (accepted, documented)"
+
+
+@freezegun.freeze_time(_FROZEN)
 def test_pull_request_commits_store_only_the_edge(http_mocker: HttpMocker) -> None:
     """PR<->commit membership is vendor-only; the commit payload belongs to
     the proxy streams, so bronze keeps the sha and the PR identity alone."""

--- a/src/ingestion/connectors/git/github-nocode/tests/test_github_streams.py
+++ b/src/ingestion/connectors/git/github-nocode/tests/test_github_streams.py
@@ -198,6 +198,71 @@ def test_pull_requests_trim_body_and_hoist_author(http_mocker: HttpMocker) -> No
 
 
 @freezegun.freeze_time(_FROZEN)
+def test_pull_request_commits_store_only_the_edge(http_mocker: HttpMocker) -> None:
+    """PR<->commit membership is vendor-only; the commit payload belongs to
+    the proxy streams, so bronze keeps the sha and the PR identity alone."""
+    config = GithubNocodeConfigBuilder().build()
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+    http_mocker.get(
+        HttpRequest(f"{GH_URL}/repos/acme/app/pulls", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps(
+                [
+                    {
+                        "id": 900,
+                        "number": 31,
+                        "state": "open",
+                        "draft": False,
+                        "title": "t",
+                        "body": "b",
+                        "user": {"login": "alice"},
+                        "head": {"ref": "feat", "sha": "e" * 40},
+                        "base": {"ref": "main"},
+                        "author_association": "MEMBER",
+                        "created_at": "2026-06-10T00:00:00Z",
+                        "updated_at": "2026-06-20T00:00:00Z",
+                    }
+                ]
+            ),
+            status_code=200,
+        ),
+    )
+    http_mocker.get(
+        HttpRequest(f"{GH_URL}/repos/acme/app/pulls/31/commits", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps(
+                [
+                    {
+                        "sha": "a" * 40,
+                        "node_id": "C_1",
+                        "commit": {"message": "feat: x", "author": {"name": "Alice"}},
+                        "url": "https://api.github.com/repos/acme/app/commits/" + "a" * 40,
+                        "html_url": "https://github.com/acme/app/commit/" + "a" * 40,
+                        "comments_url": "https://api.github.com/repos/acme/app/commits/x/comments",
+                        "author": {"login": "alice"},
+                        "committer": {"login": "alice"},
+                        "parents": [{"sha": "b" * 40}],
+                    }
+                ]
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "pull_request_commits", config)
+
+    assert not output.errors
+    rec = output.records[0].record.data
+    assert rec["sha"] == "a" * 40
+    assert rec["pull_number"] == 31
+    assert rec["repo_full_name"] == "acme/app"
+    assert rec["unique_key"].endswith(f":acme/app:31:{'a' * 40}")
+    assert "commit" not in rec and "parents" not in rec
+    _no_literal_none(output.records)
+    assert_records_conform(output.records, _CONNECTOR, "pull_request_commits", strict=True)
+
+
+@freezegun.freeze_time(_FROZEN)
 def test_issues_filters_out_pull_requests(http_mocker: HttpMocker) -> None:
     """/issues returns PRs too; the record filter must drop them."""
     config = GithubNocodeConfigBuilder().build()

--- a/src/ingestion/connectors/git/gitlab-nocode/README.md
+++ b/src/ingestion/connectors/git/gitlab-nocode/README.md
@@ -46,7 +46,7 @@ stringData:
 |-------|----------|-------------|
 | `gitlab_url` | Yes | Base URL, no trailing slash, no `/api` suffix |
 | `gitlab_token` | Yes | Access token; needs `read_api` + `read_repository` |
-| `gitlab_groups` | Yes | Group full paths, subgroups included. Required: a read-only service account is a member of no project, so membership-scoped discovery returns nothing, and a declarative manifest cannot express the CDK connector's instance-wide fallback. A project reachable from two configured groups is emitted twice under one key and collapses downstream |
+| `gitlab_groups` | No | Group full paths, subgroups included. Empty = full instance: discovery switches to keyset-paginated `/projects` (no offset ceiling), merge requests to `/merge_requests?scope=all`, members to `/users`. gitlab.com installs must set groups — full-instance there would enumerate every public project. A project reachable from two configured groups is emitted twice under one key and collapses downstream |
 | `git_proxy_url` | Yes | git-cli-proxy base URL. No default — a wrong value must fail `check`, not fall back |
 | `git_proxy_token` | Yes | Bearer token the proxy requires on every `/v1` request |
 | `gitlab_start_date` | Yes | Earliest date for incremental sync (YYYY-MM-DD); bounds the first-sync cost |

--- a/src/ingestion/connectors/git/gitlab-nocode/README.md
+++ b/src/ingestion/connectors/git/gitlab-nocode/README.md
@@ -49,12 +49,7 @@ stringData:
 | `gitlab_groups` | Yes | Group full paths, subgroups included. Required: a read-only service account is a member of no project, so membership-scoped discovery returns nothing, and a declarative manifest cannot express the CDK connector's instance-wide fallback. A project reachable from two configured groups is emitted twice under one key and collapses downstream |
 | `git_proxy_url` | Yes | git-cli-proxy base URL. No default — a wrong value must fail `check`, not fall back |
 | `git_proxy_token` | Yes | Bearer token the proxy requires on every `/v1` request |
-| `gitlab_start_date` | No | Earliest date for the initial sync (default `2020-01-01`) |
-| `gitlab_page_size` | No | GitLab API page size, max 100 |
-| `proxy_page_size` | No | Rows per proxy page (default 500) |
-| `gitlab_include_patch` | No | Store per-file diff text (default true) |
-| `gitlab_max_patch_bytes` | No | Truncation cap per file diff (default 1 MiB) |
-| `gitlab_lookback_window` | No | ISO-8601 duration re-enumerated below the cursor each sync, so a rebase does not strand commits dated below it (default `P1M`) |
+| `gitlab_start_date` | Yes | Earliest date for incremental sync (YYYY-MM-DD); bounds the first-sync cost |
 
 ### Automatically injected
 

--- a/src/ingestion/connectors/git/gitlab-nocode/README.md
+++ b/src/ingestion/connectors/git/gitlab-nocode/README.md
@@ -74,6 +74,13 @@ kubectl apply -f src/ingestion/secrets/connectors/gitlab-nocode.yaml
 | `commits` | proxy `/v1/commits` | incremental, per repository | `committed_date` |
 | `file_changes` | proxy `/v1/file-changes` | incremental, per repository | `committed_date` |
 | `branches` | proxy `/v1/branches` | full refresh, per repository | — |
+| `merge_requests` | GitLab `/groups/{g}/merge_requests` | incremental, monthly steps | `updated_at` |
+| `merge_request_notes` | `/merge_requests/{iid}/notes` | windowed MR parent, full refresh per MR | — |
+| `merge_request_commits` | `/merge_requests/{iid}/commits` | windowed MR parent, full refresh per MR | — |
+| `merge_request_approvals` | `/merge_requests/{iid}/approvals` | windowed MR parent, full refresh per MR | — |
+| `users` | `/groups/{g}/members/all` | full refresh | — |
+| `pipelines` | `/projects/{id}/pipelines` | incremental | `updated_at` |
+| `deployments` | `/projects/{id}/deployments` | incremental | `updated_at` |
 
 ### How the incremental streams fit together
 

--- a/src/ingestion/connectors/git/gitlab-nocode/README.md
+++ b/src/ingestion/connectors/git/gitlab-nocode/README.md
@@ -75,6 +75,7 @@ kubectl apply -f src/ingestion/secrets/connectors/gitlab-nocode.yaml
 | `file_changes` | proxy `/v1/file-changes` | incremental, per repository | `committed_date` |
 | `branches` | proxy `/v1/branches` | full refresh, per repository | — |
 | `merge_requests` | GitLab `/groups/{g}/merge_requests` | incremental, monthly steps | `updated_at` |
+| `merge_request_diff_stats` | GraphQL `group.mergeRequests.diffStatsSummary` | incremental, server-side `updatedAfter` | `updated_at` |
 | `merge_request_notes` | `/merge_requests/{iid}/notes` | windowed MR parent, full refresh per MR | — |
 | `merge_request_commits` | `/merge_requests/{iid}/commits` | windowed MR parent, full refresh per MR | — |
 | `merge_request_approvals` | `/merge_requests/{iid}/approvals` | windowed MR parent, full refresh per MR | — |
@@ -108,6 +109,17 @@ the proxy clones it in the background; every proxy stream retries on `429`.
 `409` (the pinned snapshot was superseded) and `413` (repository over the
 proxy's size cap) fail the stream instead — retrying the same page token would
 loop.
+
+### PR size
+
+`merge_request_diff_stats` is the only source of merge-request line counts.
+REST exposes no additions/deletions on a merge request — only `changes_count`,
+a capped string (`"1000+"`) on the detail response — so the stream queries
+GraphQL `diffStatsSummary`, which carries real integers. The group-level
+connection filters server-side by `updatedAfter`, so this costs one paged
+query per group with no per-MR fan-out. A merge request whose stats GitLab has
+not finished computing reports null rather than zero; the next window re-reads
+it.
 
 ## Silver Targets
 

--- a/src/ingestion/connectors/git/gitlab-nocode/README.md
+++ b/src/ingestion/connectors/git/gitlab-nocode/README.md
@@ -77,15 +77,15 @@ kubectl apply -f src/ingestion/secrets/connectors/gitlab-nocode.yaml
 |--------|----------|-----------|--------|
 | `repositories` | GitLab `/projects` | incremental | `last_activity_at` |
 | `commits` | proxy `/v1/commits` | incremental, per repository | `committed_date` |
-| `commit_files` | proxy `/v1/file-changes` | incremental, per repository | `committed_date` |
-| `repo_branches` | proxy `/v1/branches` | full refresh, per repository | — |
+| `file_changes` | proxy `/v1/file-changes` | incremental, per repository | `committed_date` |
+| `branches` | proxy `/v1/branches` | full refresh, per repository | — |
 
 ### How the incremental streams fit together
 
 `repositories` is the incremental **parent**: the commit streams route through
 `SubstreamPartitionRouter` with `incremental_dependency: true`, so a sync visits
 only repositories whose `last_activity_at` advanced. The CDK persists parent
-state only when the child stream is incremental — `commits` and `commit_files`
+state only when the child stream is incremental — `commits` and `file_changes`
 are, which is what makes the dependency hold.
 
 The streams are otherwise **independent**: each carries its own cursor and each
@@ -93,7 +93,7 @@ asks the proxy for its own window. Nothing is shared between them at runtime
 (unlike the CDK connector, where `file_changes` reads a temp file written by
 `commits` in the same process). They join downstream by `sha`.
 
-`repo_branches` is full refresh: bronze keeps the latest state per branch, and
+`branches` is full refresh: bronze keeps the latest state per branch, and
 head-movement history is derived by the `snapshot` / `fields_history` dbt macros
 — the same pattern user profiles use. Its `unique_key` therefore excludes
 `head_sha`, so the ReplacingMergeTree collapses to current state and a head move

--- a/src/ingestion/connectors/git/gitlab-nocode/README.md
+++ b/src/ingestion/connectors/git/gitlab-nocode/README.md
@@ -1,0 +1,123 @@
+# GitLab (git-cli-proxy) Connector
+
+Declarative GitLab connector that extracts commit-level data through the
+[git-cli-proxy](../../../../../docs/components/connectors/git/git-cli-proxy/specs/DESIGN.md)
+instead of the vendor API, removing the one-API-call-per-commit cost that drives
+the CDK git connectors into rate limits. Repository discovery still uses the
+GitLab API — that is one call per page of projects, not per commit.
+
+Auth: GitLab personal/project access token (`PRIVATE-TOKEN` header) for the API;
+the same token is forwarded to the proxy per request as HTTP basic credentials
+for the clone, and a separate bearer token authenticates the proxy itself.
+
+## Prerequisites
+
+1. A GitLab access token with `read_api` (project discovery) and
+   `read_repository` (the clone the proxy performs on its behalf). Personal,
+   project or group tokens all work.
+2. A reachable git-cli-proxy deployment and its bearer token. In-cluster the
+   umbrella composes both (`insight-git-cli-proxy-config`); the proxy accepts
+   traffic only from the namespaces its NetworkPolicy allows.
+
+## K8s Secret
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-gitlab-nocode-main
+  labels:
+    app.kubernetes.io/part-of: insight
+  annotations:
+    insight.cyberfabric.com/connector: gitlab-nocode
+    insight.cyberfabric.com/source-id: gitlab-nocode-main
+type: Opaque
+stringData:
+  gitlab_url: "https://gitlab.example.com"
+  gitlab_token: "CHANGE_ME"
+  git_proxy_url: "http://insight-git-cli-proxy:8085"
+  git_proxy_token: "CHANGE_ME"
+  gitlab_start_date: "2020-01-01"
+```
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `gitlab_url` | Yes | Base URL, no trailing slash, no `/api` suffix |
+| `gitlab_token` | Yes | Access token; needs `read_api` + `read_repository` |
+| `gitlab_groups` | Yes | Group full paths, subgroups included. Required: a read-only service account is a member of no project, so membership-scoped discovery returns nothing, and a declarative manifest cannot express the CDK connector's instance-wide fallback. A project reachable from two configured groups is emitted twice under one key and collapses downstream |
+| `git_proxy_url` | Yes | git-cli-proxy base URL. No default — a wrong value must fail `check`, not fall back |
+| `git_proxy_token` | Yes | Bearer token the proxy requires on every `/v1` request |
+| `gitlab_start_date` | No | Earliest date for the initial sync (default `2020-01-01`) |
+| `gitlab_page_size` | No | GitLab API page size, max 100 |
+| `proxy_page_size` | No | Rows per proxy page (default 500) |
+| `gitlab_include_patch` | No | Store per-file diff text (default true) |
+| `gitlab_max_patch_bytes` | No | Truncation cap per file diff (default 1 MiB) |
+| `gitlab_lookback_window` | No | ISO-8601 duration re-enumerated below the cursor each sync, so a rebase does not strand commits dated below it (default `P1M`) |
+
+### Automatically injected
+
+| Field | Source |
+|-------|--------|
+| `insight_tenant_id` | `tenant_id` from tenant YAML |
+| `insight_source_id` | `insight.cyberfabric.com/source-id` annotation |
+
+### Local development
+
+```bash
+cp src/ingestion/secrets/connectors/gitlab-nocode.yaml.example src/ingestion/secrets/connectors/gitlab-nocode.yaml
+# fill in real values, then:
+kubectl apply -f src/ingestion/secrets/connectors/gitlab-nocode.yaml
+```
+
+## Streams
+
+| Stream | Upstream | Sync Mode | Cursor |
+|--------|----------|-----------|--------|
+| `repositories` | GitLab `/projects` | incremental | `last_activity_at` |
+| `commits` | proxy `/v1/commits` | incremental, per repository | `committed_date` |
+| `commit_files` | proxy `/v1/file-changes` | incremental, per repository | `committed_date` |
+| `repo_branches` | proxy `/v1/branches` | full refresh, per repository | — |
+
+### How the incremental streams fit together
+
+`repositories` is the incremental **parent**: the commit streams route through
+`SubstreamPartitionRouter` with `incremental_dependency: true`, so a sync visits
+only repositories whose `last_activity_at` advanced. The CDK persists parent
+state only when the child stream is incremental — `commits` and `commit_files`
+are, which is what makes the dependency hold.
+
+The streams are otherwise **independent**: each carries its own cursor and each
+asks the proxy for its own window. Nothing is shared between them at runtime
+(unlike the CDK connector, where `file_changes` reads a temp file written by
+`commits` in the same process). They join downstream by `sha`.
+
+`repo_branches` is full refresh: bronze keeps the latest state per branch, and
+head-movement history is derived by the `snapshot` / `fields_history` dbt macros
+— the same pattern user profiles use. Its `unique_key` therefore excludes
+`head_sha`, so the ReplacingMergeTree collapses to current state and a head move
+is a tracked-column change.
+
+### Cold repositories
+
+The first request for an uncached repository gets `429` + `Retry-After` while
+the proxy clones it in the background; every proxy stream retries on `429`.
+`409` (the pinned snapshot was superseded) and `413` (repository over the
+proxy's size cap) fail the stream instead — retrying the same page token would
+loop.
+
+## Silver Targets
+
+Not wired yet. The silver models map to the same `class_*` tables the CDK
+`git/gitlab` connector feeds, and their column types must match its models
+exactly (`union_by_tag` UNION ALLs the branches; one mismatched type raises
+`Code: 386 NO_COMMON_TYPE` and breaks the shared class for every source). Until
+those models land this connector is bronze-only and contributes nothing to the
+dashboards.
+
+## Not ported
+
+Merge requests, notes and approvals stay on the vendor API — that data does not
+exist in git. Porting them is a mechanical translation of the CDK connector's
+streams and is tracked separately from the proxy work.

--- a/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
@@ -1,0 +1,886 @@
+version: 7.0.4
+
+type: DeclarativeSource
+
+# GitLab connector built on the git-cli-proxy (issue #2224).
+#
+# Two upstreams in ONE manifest, which is the whole point: repository discovery
+# talks to the GitLab API, while commit-level extraction talks to the proxy,
+# which serves it from a bare blobless clone instead of one API call per commit.
+# `url_base` is a per-requester property, so mixing them needs no special
+# machinery.
+#
+# The manifest is FULLY INLINED (no $ref, no definitions.linked): the Builder
+# strict validator resolves no $ref, so a shared authenticator or url_base is
+# rejected. Duplication here is the price of Builder compatibility.
+#
+#   repositories     -> GitLab /api/v4/projects        incremental (last_activity_at)
+#   commits          -> proxy /v1/commits              incremental (committed_date), per repo
+#   commit_files     -> proxy /v1/file-changes         incremental (committed_date), per repo
+#   repo_branches    -> proxy /v1/branches             full refresh, per repo
+#
+# The proxy answers 429 + Retry-After while a cold repository is being cloned
+# in the background, so every proxy stream retries on 429 and fails fast on the
+# permanent ones (409 superseded snapshot, 413 oversized repository).
+#
+# NOT ported here: merge requests, notes, approvals. That data does not exist in
+# git, so it stays on the vendor API — a mechanical port of the CDK connector's
+# streams, tracked separately.
+
+check:
+  type: CheckStream
+  stream_names:
+    - repositories
+
+streams:
+  # ── Repository discovery (GitLab API) ───────────────────────────────────
+  # The incremental parent: only repositories whose last_activity_at advanced
+  # are visited by the commit streams below.
+  - type: DeclarativeStream
+    name: repositories
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          project_id: {type: [integer, "null"]}
+          path_with_namespace: {type: [string, "null"]}
+          name: {type: [string, "null"]}
+          default_branch: {type: [string, "null"]}
+          visibility: {type: [string, "null"]}
+          archived: {type: [boolean, "null"]}
+          web_url: {type: [string, "null"]}
+          http_url_to_repo: {type: [string, "null"]}
+          created_at: {type: [string, "null"]}
+          last_activity_at: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['gitlab_url'] }}/api/v4"
+        authenticator:
+          type: ApiKeyAuthenticator
+          api_token: "{{ config['gitlab_token'] }}"
+          inject_into:
+            type: RequestOption
+            field_name: PRIVATE-TOKEN
+            inject_into: header
+        path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/projects"
+        http_method: GET
+        request_parameters:
+          include_subgroups: "true"
+          archived: "false"
+          order_by: last_activity_at
+          sort: asc
+          per_page: "{{ config.get('gitlab_page_size', 100) }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: PageIncrement
+          page_size: "{{ config.get('gitlab_page_size', 100) }}"
+          start_from_page: 1
+        page_token_option:
+          type: RequestOption
+          field_name: page
+          inject_into: request_parameter
+      partition_router:
+        # INSIDE `retriever`: at stream level the CDK silently ignores it.
+        # A read_api service account is a member of nothing, so /projects?membership
+        # returns zero rows; group scoping works by group visibility instead.
+        type: ListPartitionRouter
+        values: "{{ config['gitlab_groups'] }}"
+        cursor_field: group
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: last_activity_at
+      datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S.%f%z"
+        - "%Y-%m-%dT%H:%M:%S%z"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('gitlab_start_date', '2020-01-01') }}"
+        datetime_format: "%Y-%m-%d"
+      start_time_option:
+        type: RequestOption
+        field_name: last_activity_after
+        inject_into: request_parameter
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_gitlab_nocode
+          - type: AddedFieldDefinition
+            path: [project_id]
+            value: "{{ record['id'] }}"
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ record['id'] | string | replace(':', '%3A') }}
+  # ── Commits (git-cli-proxy) ─────────────────────────────────────────────
+  - type: DeclarativeStream
+    name: commits
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          project_id: {type: [string, "null"]}
+          sha: {type: [string, "null"]}
+          message: {type: [string, "null"]}
+          authored_date: {type: [string, "null"]}
+          committed_date: {type: [string, "null"]}
+          author_name: {type: [string, "null"]}
+          author_email: {type: [string, "null"]}
+          committer_name: {type: [string, "null"]}
+          committer_email: {type: [string, "null"]}
+          parent_hashes: {type: [array, "null"], items: {type: string}}
+          is_merge: {type: [boolean, "null"]}
+          additions: {type: [integer, "null"]}
+          deletions: {type: [integer, "null"]}
+          changed_files: {type: [integer, "null"]}
+          is_in_default_branch: {type: [boolean, "null"]}
+          patch_id: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['git_proxy_url'] }}"
+        authenticator:
+          type: BearerAuthenticator
+          api_token: "{{ config['git_proxy_token'] }}"
+        request_headers:
+          X-Tenant-Id: "{{ config['insight_tenant_id'] }}"
+          X-Source-Id: "{{ config['insight_source_id'] }}"
+          X-Git-Username: oauth2
+          X-Git-Token: "{{ config['gitlab_token'] }}"
+        path: /v1/commits
+        http_method: GET
+        request_parameters:
+          repo: "{{ stream_partition.repo_clone_url }}"
+          page_size: "{{ config.get('proxy_page_size', 500) }}"
+        error_handler:
+          type: DefaultErrorHandler
+          backoff_strategies:
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+          response_filters:
+            # The repository is being cloned in the background: the proxy is
+            # working, the caller waits.
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RETRY
+              error_message: Repository is being prepared by the proxy
+            # Both are permanent for THIS repository and harmless for the rest,
+            # so the partition is skipped rather than the whole stream failed.
+            # A rising git_proxy_admission_rejects_total is the alert: a 413
+            # means a repository is silently absent from bronze until an
+            # operator raises cache.maxRepoBytes.
+            - type: HttpResponseFilter
+              http_codes: [404, 413]
+              action: IGNORE
+              error_message: >-
+                Skipping this repository: gone at origin (404), or larger than
+                cache.maxRepoBytes (413). Other repositories continue.
+            # The pinned snapshot was superseded mid-walk. RETRY would replay
+            # the same dead page token and 409 again; a response filter cannot
+            # reset it. Rerunning the sync resumes each partition from its own
+            # stored cursor against a fresh snapshot.
+            - type: HttpResponseFilter
+              http_codes: [409]
+              action: FAIL
+              error_message: >-
+                Proxy snapshot changed mid-walk; rerun the sync to resume from the stored cursor
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [items]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response['next_page_token'] }}"
+          stop_condition: "{{ not response.get('next_page_token') }}"
+        page_token_option:
+          type: RequestOption
+          field_name: page_token
+          inject_into: request_parameter
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: http_url_to_repo
+            partition_field: repo_clone_url
+            # `incremental_dependency` is what keeps the sync proportional to
+            # activity: the parent is itself incremental, so only repositories
+            # touched since the last sync are visited. The CDK persists parent
+            # state ONLY when the child is incremental — which this stream is.
+            incremental_dependency: true
+            # Inlined: the Builder strict validator rejects a whole-object
+            # $ref for a substream parent.
+            stream:
+              type: DeclarativeStream
+              name: repositories_for_commits
+              primary_key:
+                - id
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/schema#
+                  properties:
+                    id: {type: [integer, "null"]}
+                    http_url_to_repo: {type: [string, "null"]}
+                    last_activity_at: {type: [string, "null"]}
+                  additionalProperties: true
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: "{{ config['gitlab_url'] }}/api/v4"
+                  authenticator:
+                    type: ApiKeyAuthenticator
+                    api_token: "{{ config['gitlab_token'] }}"
+                    inject_into:
+                      type: RequestOption
+                      field_name: PRIVATE-TOKEN
+                      inject_into: header
+                  path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/projects"
+                  http_method: GET
+                  request_parameters:
+                    include_subgroups: "true"
+                    archived: "false"
+                    order_by: last_activity_at
+                    sort: asc
+                    per_page: "{{ config.get('gitlab_page_size', 100) }}"
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: []
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: PageIncrement
+                    page_size: "{{ config.get('gitlab_page_size', 100) }}"
+                    start_from_page: 1
+                  page_token_option:
+                    type: RequestOption
+                    field_name: page
+                    inject_into: request_parameter
+                partition_router:
+                  # INSIDE `retriever`: at stream level the CDK silently ignores it.
+                  # A read_api service account is a member of nothing, so /projects?membership
+                  # returns zero rows; group scoping works by group visibility instead.
+                  type: ListPartitionRouter
+                  values: "{{ config['gitlab_groups'] }}"
+                  cursor_field: group
+              incremental_sync:
+                type: DatetimeBasedCursor
+                cursor_field: last_activity_at
+                datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
+                cursor_datetime_formats:
+                  - "%Y-%m-%dT%H:%M:%S.%f%z"
+                  - "%Y-%m-%dT%H:%M:%S%z"
+                start_datetime:
+                  type: MinMaxDatetime
+                  datetime: "{{ config.get('gitlab_start_date', '2020-01-01') }}"
+                  datetime_format: "%Y-%m-%d"
+                start_time_option:
+                  type: RequestOption
+                  field_name: last_activity_after
+                  inject_into: request_parameter
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: committed_date
+      datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+      # `git log --since` is a traversal cutoff: after a rebase the
+      # replacement commits can carry dates BELOW the stored cursor and
+      # would never be visited again. Re-enumerating one window each
+      # sync recovers them; bronze dedups the re-read rows. This is a
+      # heuristic, not a guarantee — a rewrite older than the window is
+      # still lost, and nothing detects it.
+      lookback_window: "{{ config.get('gitlab_lookback_window', 'P1M') }}"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S%z"
+        - "%Y-%m-%dT%H:%M:%SZ"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('gitlab_start_date', '2020-01-01') }}"
+        datetime_format: "%Y-%m-%d"
+      start_time_option:
+        type: RequestOption
+        field_name: since
+        inject_into: request_parameter
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_gitlab_nocode
+          - type: AddedFieldDefinition
+            path: [project_id]
+            value: "{{ stream_partition.repo_clone_url }}"
+          # Repository identity is REQUIRED in the key: forks share commit
+          # SHAs, so tenant+source+sha alone would let the ReplacingMergeTree
+          # collapse commits from different repositories into one row.
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | string | replace(':', '%3A') }}:{{ record['sha'] | string | replace(':', '%3A') }}
+
+  # ── Per-file changes (git-cli-proxy) ────────────────────────────────────
+  - type: DeclarativeStream
+    name: commit_files
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          project_id: {type: [string, "null"]}
+          sha: {type: [string, "null"]}
+          committed_date: {type: [string, "null"]}
+          filename: {type: [string, "null"]}
+          previous_filename: {type: [string, "null"]}
+          status: {type: [string, "null"]}
+          additions: {type: [integer, "null"]}
+          deletions: {type: [integer, "null"]}
+          changes: {type: [integer, "null"]}
+          is_binary: {type: [boolean, "null"]}
+          patch: {type: [string, "null"]}
+          patch_truncated: {type: [boolean, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['git_proxy_url'] }}"
+        authenticator:
+          type: BearerAuthenticator
+          api_token: "{{ config['git_proxy_token'] }}"
+        request_headers:
+          X-Tenant-Id: "{{ config['insight_tenant_id'] }}"
+          X-Source-Id: "{{ config['insight_source_id'] }}"
+          X-Git-Username: oauth2
+          X-Git-Token: "{{ config['gitlab_token'] }}"
+        path: /v1/file-changes
+        http_method: GET
+        request_parameters:
+          repo: "{{ stream_partition.repo_clone_url }}"
+          page_size: "{{ config.get('proxy_page_size', 500) }}"
+          include_patch: "{{ config.get('gitlab_include_patch', true) | lower }}"
+          max_patch_bytes: "{{ config.get('gitlab_max_patch_bytes', 1048576) }}"
+        error_handler:
+          type: DefaultErrorHandler
+          backoff_strategies:
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+          response_filters:
+            # The repository is being cloned in the background: the proxy is
+            # working, the caller waits.
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RETRY
+              error_message: Repository is being prepared by the proxy
+            # Both are permanent for THIS repository and harmless for the rest,
+            # so the partition is skipped rather than the whole stream failed.
+            # A rising git_proxy_admission_rejects_total is the alert: a 413
+            # means a repository is silently absent from bronze until an
+            # operator raises cache.maxRepoBytes.
+            - type: HttpResponseFilter
+              http_codes: [404, 413]
+              action: IGNORE
+              error_message: >-
+                Skipping this repository: gone at origin (404), or larger than
+                cache.maxRepoBytes (413). Other repositories continue.
+            # The pinned snapshot was superseded mid-walk. RETRY would replay
+            # the same dead page token and 409 again; a response filter cannot
+            # reset it. Rerunning the sync resumes each partition from its own
+            # stored cursor against a fresh snapshot.
+            - type: HttpResponseFilter
+              http_codes: [409]
+              action: FAIL
+              error_message: >-
+                Proxy snapshot changed mid-walk; rerun the sync to resume from the stored cursor
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [items]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response['next_page_token'] }}"
+          stop_condition: "{{ not response.get('next_page_token') }}"
+        page_token_option:
+          type: RequestOption
+          field_name: page_token
+          inject_into: request_parameter
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: http_url_to_repo
+            partition_field: repo_clone_url
+            incremental_dependency: true
+            stream:
+              type: DeclarativeStream
+              name: repositories_for_files
+              primary_key:
+                - id
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/schema#
+                  properties:
+                    id: {type: [integer, "null"]}
+                    http_url_to_repo: {type: [string, "null"]}
+                    last_activity_at: {type: [string, "null"]}
+                  additionalProperties: true
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: "{{ config['gitlab_url'] }}/api/v4"
+                  authenticator:
+                    type: ApiKeyAuthenticator
+                    api_token: "{{ config['gitlab_token'] }}"
+                    inject_into:
+                      type: RequestOption
+                      field_name: PRIVATE-TOKEN
+                      inject_into: header
+                  path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/projects"
+                  http_method: GET
+                  request_parameters:
+                    include_subgroups: "true"
+                    archived: "false"
+                    order_by: last_activity_at
+                    sort: asc
+                    per_page: "{{ config.get('gitlab_page_size', 100) }}"
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: []
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: PageIncrement
+                    page_size: "{{ config.get('gitlab_page_size', 100) }}"
+                    start_from_page: 1
+                  page_token_option:
+                    type: RequestOption
+                    field_name: page
+                    inject_into: request_parameter
+                partition_router:
+                  # INSIDE `retriever`: at stream level the CDK silently ignores it.
+                  # A read_api service account is a member of nothing, so /projects?membership
+                  # returns zero rows; group scoping works by group visibility instead.
+                  type: ListPartitionRouter
+                  values: "{{ config['gitlab_groups'] }}"
+                  cursor_field: group
+              incremental_sync:
+                type: DatetimeBasedCursor
+                cursor_field: last_activity_at
+                datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
+                cursor_datetime_formats:
+                  - "%Y-%m-%dT%H:%M:%S.%f%z"
+                  - "%Y-%m-%dT%H:%M:%S%z"
+                start_datetime:
+                  type: MinMaxDatetime
+                  datetime: "{{ config.get('gitlab_start_date', '2020-01-01') }}"
+                  datetime_format: "%Y-%m-%d"
+                start_time_option:
+                  type: RequestOption
+                  field_name: last_activity_after
+                  inject_into: request_parameter
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: committed_date
+      datetime_format: "%Y-%m-%dT%H:%M:%S%z"
+      # `git log --since` is a traversal cutoff: after a rebase the
+      # replacement commits can carry dates BELOW the stored cursor and
+      # would never be visited again. Re-enumerating one window each
+      # sync recovers them; bronze dedups the re-read rows. This is a
+      # heuristic, not a guarantee — a rewrite older than the window is
+      # still lost, and nothing detects it.
+      lookback_window: "{{ config.get('gitlab_lookback_window', 'P1M') }}"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S%z"
+        - "%Y-%m-%dT%H:%M:%SZ"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('gitlab_start_date', '2020-01-01') }}"
+        datetime_format: "%Y-%m-%d"
+      start_time_option:
+        type: RequestOption
+        field_name: since
+        inject_into: request_parameter
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_gitlab_nocode
+          - type: AddedFieldDefinition
+            path: [project_id]
+            value: "{{ stream_partition.repo_clone_url }}"
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | string | replace(':', '%3A') }}:{{ record['sha'] | string | replace(':', '%3A') }}:{{ record['filename'] | string | replace(':', '%3A') }}
+
+  # ── Branch heads (git-cli-proxy) ────────────────────────────────────────
+  # Full refresh: bronze keeps the LATEST state per branch, and head-movement
+  # history is derived downstream by the snapshot/fields_history dbt macros —
+  # the same pattern user profiles use.
+  - type: DeclarativeStream
+    name: repo_branches
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          project_id: {type: [string, "null"]}
+          name: {type: [string, "null"]}
+          head_sha: {type: [string, "null"]}
+          head_committed_date: {type: [string, "null"]}
+          is_default: {type: [boolean, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['git_proxy_url'] }}"
+        authenticator:
+          type: BearerAuthenticator
+          api_token: "{{ config['git_proxy_token'] }}"
+        request_headers:
+          X-Tenant-Id: "{{ config['insight_tenant_id'] }}"
+          X-Source-Id: "{{ config['insight_source_id'] }}"
+          X-Git-Username: oauth2
+          X-Git-Token: "{{ config['gitlab_token'] }}"
+        path: /v1/branches
+        http_method: GET
+        request_parameters:
+          repo: "{{ stream_partition.repo_clone_url }}"
+          page_size: "{{ config.get('proxy_page_size', 500) }}"
+        error_handler:
+          type: DefaultErrorHandler
+          backoff_strategies:
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+          response_filters:
+            # The repository is being cloned in the background: the proxy is
+            # working, the caller waits.
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RETRY
+              error_message: Repository is being prepared by the proxy
+            # Both are permanent for THIS repository and harmless for the rest,
+            # so the partition is skipped rather than the whole stream failed.
+            # A rising git_proxy_admission_rejects_total is the alert: a 413
+            # means a repository is silently absent from bronze until an
+            # operator raises cache.maxRepoBytes.
+            - type: HttpResponseFilter
+              http_codes: [404, 413]
+              action: IGNORE
+              error_message: >-
+                Skipping this repository: gone at origin (404), or larger than
+                cache.maxRepoBytes (413). Other repositories continue.
+            # The pinned snapshot was superseded mid-walk. RETRY would replay
+            # the same dead page token and 409 again; a response filter cannot
+            # reset it. Rerunning the sync resumes each partition from its own
+            # stored cursor against a fresh snapshot.
+            - type: HttpResponseFilter
+              http_codes: [409]
+              action: FAIL
+              error_message: >-
+                Proxy snapshot changed mid-walk; rerun the sync to resume from the stored cursor
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [items]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response['next_page_token'] }}"
+          stop_condition: "{{ not response.get('next_page_token') }}"
+        page_token_option:
+          type: RequestOption
+          field_name: page_token
+          inject_into: request_parameter
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: http_url_to_repo
+            partition_field: repo_clone_url
+            # No `incremental_dependency` here: this stream is full refresh, so
+            # the CDK would not persist parent state anyway. Branch heads are
+            # cheap and must be re-read for every repository each sync.
+            stream:
+              type: DeclarativeStream
+              name: repositories_for_branches
+              primary_key:
+                - id
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/schema#
+                  properties:
+                    id: {type: [integer, "null"]}
+                    http_url_to_repo: {type: [string, "null"]}
+                  additionalProperties: true
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: "{{ config['gitlab_url'] }}/api/v4"
+                  authenticator:
+                    type: ApiKeyAuthenticator
+                    api_token: "{{ config['gitlab_token'] }}"
+                    inject_into:
+                      type: RequestOption
+                      field_name: PRIVATE-TOKEN
+                      inject_into: header
+                  path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/projects"
+                  http_method: GET
+                  request_parameters:
+                    include_subgroups: "true"
+                    archived: "false"
+                    per_page: "{{ config.get('gitlab_page_size', 100) }}"
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: []
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: PageIncrement
+                    page_size: "{{ config.get('gitlab_page_size', 100) }}"
+                    start_from_page: 1
+                  page_token_option:
+                    type: RequestOption
+                    field_name: page
+                    inject_into: request_parameter
+                partition_router:
+                  # INSIDE `retriever`: at stream level the CDK silently ignores it.
+                  # A read_api service account is a member of nothing, so /projects?membership
+                  # returns zero rows; group scoping works by group visibility instead.
+                  type: ListPartitionRouter
+                  values: "{{ config['gitlab_groups'] }}"
+                  cursor_field: group
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_gitlab_nocode
+          - type: AddedFieldDefinition
+            path: [project_id]
+            value: "{{ stream_partition.repo_clone_url }}"
+          # No head_sha in the key: the key identifies the BRANCH, so the RMT
+          # collapses to its latest state and a head move is a change the
+          # downstream snapshot macro can see.
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | string | replace(':', '%3A') }}:{{ record['name'] | string | replace(':', '%3A') }}
+
+concurrency_level:
+  type: ConcurrencyLevel
+  # Never 1: the concurrent CDK self-deadlocks at a single worker once a sync
+  # generates ~10k partitions.
+  default_concurrency: 4
+
+spec:
+  type: Spec
+  connection_specification:
+    type: object
+    $schema: http://json-schema.org/draft-07/schema#
+    title: GitLab (git-cli-proxy) Spec
+    required:
+      - insight_tenant_id
+      - insight_source_id
+      - gitlab_url
+      - gitlab_token
+      - gitlab_groups
+      - git_proxy_url
+      - git_proxy_token
+    properties:
+      insight_tenant_id:
+        type: string
+        description: Insight tenant identifier stamped onto every emitted record.
+        title: Insight Tenant ID
+        order: 0
+      insight_source_id:
+        type: string
+        description: >-
+          Instance discriminator for multi-instance support (e.g. gitlab-acme).
+        title: Insight Source ID
+        order: 1
+      gitlab_url:
+        type: string
+        description: >-
+          GitLab base URL without a trailing slash or the /api suffix (e.g. https://gitlab.example.com).
+        title: GitLab URL
+        order: 2
+      gitlab_token:
+        type: string
+        description: >-
+          GitLab personal or project access token. Needs `read_api` for repository discovery and `read_repository` for the clone the proxy performs on its behalf — the same token is forwarded to the proxy and never stored there.
+        title: GitLab Access Token
+        airbyte_secret: true
+        order: 3
+      gitlab_groups:
+        type: array
+        items:
+          type: string
+        description: >-
+          Full paths of the GitLab groups to sync, including nested ones (e.g. acme, acme/platform). Subgroups are included. REQUIRED, and deliberately so: a read-only service account is a member of no project, so membership-scoped discovery returns nothing, and a declarative manifest cannot express the CDK connector's instance-wide fallback. A project reachable from two configured groups is emitted twice under one key and collapses downstream.
+        title: GitLab Groups
+        order: 4
+      git_proxy_url:
+        type: string
+        description: >-
+          Base URL of the git-cli-proxy service (cluster-internal, e.g. http://insight-git-cli-proxy:8085). No default: a wrong or absent value must fail the check, not fall back somewhere.
+        title: Git Proxy URL
+        order: 4
+      git_proxy_token:
+        type: string
+        description: Bearer token the git-cli-proxy requires on every /v1 request.
+        title: Git Proxy Token
+        airbyte_secret: true
+        order: 5
+      gitlab_start_date:
+        type: string
+        description: Earliest date for incremental sync (YYYY-MM-DD).
+        title: Start Date
+        format: date
+        default: "2020-01-01"
+        order: 6
+      gitlab_page_size:
+        type: integer
+        description: GitLab API page size (max 100).
+        title: GitLab Page Size
+        default: 100
+        minimum: 1
+        maximum: 100
+        order: 7
+      proxy_page_size:
+        type: integer
+        description: Rows per page requested from the git-cli-proxy.
+        title: Proxy Page Size
+        default: 500
+        minimum: 1
+        maximum: 10000
+        order: 8
+      gitlab_include_patch:
+        type: boolean
+        description: >-
+          Store per-file diff text. Keep enabled to allow recomputing line counts later under different filters (blank lines, comments); disable to cut bronze volume.
+        title: Include Patch Text
+        default: true
+        order: 9
+      gitlab_max_patch_bytes:
+        type: integer
+        description: >-
+          Truncation cap for a single file's diff. Truncated rows are flagged with patch_truncated so downstream never mistakes them for complete.
+        title: Max Patch Bytes
+        default: 1048576
+        minimum: 1024
+        order: 10
+      gitlab_lookback_window:
+        type: string
+        description: >-
+          ISO-8601 duration re-enumerated below the stored cursor on every sync. `git log --since` is a traversal cutoff, so after a rebase the replacement commits can carry dates below the cursor and would never be visited again. Bronze dedups the re-read rows, so the cost is one window per sync. A rewrite older than the window is still lost.
+        title: Rebase Lookback Window
+        default: P1M
+        order: 11
+    additionalProperties: true
+
+metadata:
+  autoImportSchema:
+    repositories: false
+    commits: false
+    commit_files: false
+    repo_branches: false

--- a/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
@@ -944,6 +944,180 @@ streams:
           - [author]
           - [merged_by]
 
+  # ── Merge request diff totals (GitLab GraphQL) ──────────────────────────
+  # REST exposes no line counts on a merge request — only `changes_count`, a
+  # capped STRING ("1000+") on the detail response (VERIFIED against the live
+  # API docs). GraphQL carries real integers in diffStatsSummary, and the
+  # group-level connection filters server-side by updatedAfter, so this stream
+  # costs one paged query per group with no per-MR fan-out.
+  - type: DeclarativeStream
+    name: merge_request_diff_stats
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          mr_iid: {type: [integer, "null"]}
+          project_id: {type: [integer, "null"]}
+          additions: {type: [integer, "null"]}
+          deletions: {type: [integer, "null"]}
+          files_changed: {type: [integer, "null"]}
+          updated_at: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['gitlab_url'] }}/api"
+        authenticator:
+          type: ApiKeyAuthenticator
+          api_token: "{{ config['gitlab_token'] }}"
+          inject_into:
+            type: RequestOption
+            field_name: PRIVATE-TOKEN
+            inject_into: header
+        path: /graphql
+        http_method: POST
+        error_handler:
+          type: DefaultErrorHandler
+          max_retries: 5
+          backoff_strategies:
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+          response_filters:
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RATE_LIMITED
+              error_message: GitLab is rate limiting this token
+            # GraphQL errors arrive as HTTP 200 with an `errors` array. A group
+            # the token cannot see comes back as data.group = null WITHOUT an
+            # error, which the guarded paginator below reads as an empty page.
+            - type: HttpResponseFilter
+              action: FAIL
+              predicate: "{{ (response.get('errors') or []) | length > 0 }}"
+              error_message: "GitLab GraphQL error: {{ (response.get('errors') or []) | map(attribute='message') | join('; ') }}"
+            - type: HttpResponseFilter
+              http_codes: [401]
+              action: FAIL
+              failure_type: config_error
+              error_message: GitLab rejected the token; check gitlab_token scopes (read_api)
+            - type: HttpResponseFilter
+              http_codes: [500, 502, 503, 504]
+              action: RETRY
+              error_message: Transient GitLab error
+        request_body_json:
+          query: |
+            query($group: ID!, $updatedAfter: Time, $cursor: String) {
+              group(fullPath: $group) {
+                mergeRequests(includeSubgroups: true, updatedAfter: $updatedAfter, sort: UPDATED_ASC, first: 100, after: $cursor) {
+                  pageInfo { hasNextPage endCursor }
+                  nodes {
+                    iid
+                    updatedAt
+                    project { id }
+                    diffStatsSummary { additions deletions fileCount }
+                  }
+                }
+              }
+            }
+          variables:
+            group: "{{ stream_partition.group }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [data, group, mergeRequests, nodes]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          # `data.group` is null when the token cannot see the group, so every
+          # hop is guarded rather than subscripted.
+          cursor_value: "{{ ((((response.get('data') or {}).get('group') or {}).get('mergeRequests') or {}).get('pageInfo') or {}).get('endCursor') }}"
+          stop_condition: "{{ not ((((response.get('data') or {}).get('group') or {}).get('mergeRequests') or {}).get('pageInfo') or {}).get('hasNextPage') }}"
+        page_token_option:
+          type: RequestOption
+          inject_into: body_json
+          field_path: [variables, cursor]
+      partition_router:
+        type: ListPartitionRouter
+        values: "{{ config['gitlab_groups'] }}"
+        cursor_field: group
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: updated_at
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%SZ"
+        - "%Y-%m-%dT%H:%M:%S%z"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config['gitlab_start_date'] }}"
+        datetime_format: "%Y-%m-%d"
+      start_time_option:
+        type: RequestOption
+        inject_into: body_json
+        field_path: [variables, updatedAfter]
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_gitlab_nocode
+          - type: AddedFieldDefinition
+            path: [collected_at]
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          - type: AddedFieldDefinition
+            path: [mr_iid]
+            value: "{{ record.get('iid') | int }}"
+          - type: AddedFieldDefinition
+            path: [project_id]
+            value: "{{ ((record.get('project') or {}).get('id') or '') | replace('gid://gitlab/Project/', '') | int }}"
+          # diffStatsSummary is nullable: GitLab computes the stats
+          # asynchronously, so a just-opened MR reports null rather than zero
+          # and the next window re-reads it.
+          - type: AddedFieldDefinition
+            path: [additions]
+            value: "{{ (record.get('diffStatsSummary') or {}).get('additions') }}"
+          - type: AddedFieldDefinition
+            path: [deletions]
+            value: "{{ (record.get('diffStatsSummary') or {}).get('deletions') }}"
+          - type: AddedFieldDefinition
+            path: [files_changed]
+            value: "{{ (record.get('diffStatsSummary') or {}).get('fileCount') }}"
+          - type: AddedFieldDefinition
+            path: [updated_at]
+            value: "{{ record.get('updatedAt') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ ((record.get('project') or {}).get('id') or '') | replace('gid://gitlab/Project/', '') }}:{{ record['iid'] }}
+      - type: RemoveFields
+        # Hoisted above; the GraphQL originals stay out of bronze.
+        field_pointers:
+          - [iid]
+          - [updatedAt]
+          - [project]
+          - [diffStatsSummary]
+
   # ── Merge request notes (GitLab API) ────────────────────────────────────
   # Child of a stateless sliding window of MRs (see the parent's
   # updated_after comment). Bodies are stored trimmed to 2048 chars — the
@@ -2121,6 +2295,7 @@ metadata:
     merge_requests: false
     merge_request_notes: false
     merge_request_commits: false
+    merge_request_diff_stats: false
     merge_request_approvals: false
     users: false
     pipelines: false

--- a/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
@@ -23,8 +23,10 @@ type: DeclarativeSource
 # in the background, so every proxy stream retries on 429 and fails fast on the
 # permanent ones (409 superseded snapshot, 413 oversized repository).
 #
-# Vendor-API streams (merge requests, notes, approvals, members, pipelines,
-# deployments) live in this same manifest: that data does not exist in git.
+# Vendor-API streams (merge requests, notes, commits, approvals, members,
+# pipelines, deployments) live in this same manifest: that data does not exist
+# in git — an MR's commit list included, since a squashed MR leaves its
+# original commits unreachable from every ref the proxy clones.
 # Issues and epics are deliberately not synced.
 
 check:
@@ -1150,6 +1152,204 @@ streams:
           - [author]
           - [position]
 
+  # ── Merge request commits (GitLab API) ──────────────────────────────────
+  # MR<->commit membership is vendor metadata: it does not exist in git, and a
+  # squashed or rebased MR leaves its original commits unreachable from every
+  # ref the proxy clones. One light call per MR in the window — the commit
+  # payloads themselves stay on the proxy path, so this stream stores only the
+  # edge.
+  - type: DeclarativeStream
+    name: merge_request_commits
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          sha: {type: [string, "null"]}
+          mr_iid: {type: [integer, "null"]}
+          project_id: {type: [integer, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['gitlab_url'] }}/api/v4"
+        authenticator:
+          type: ApiKeyAuthenticator
+          api_token: "{{ config['gitlab_token'] }}"
+          inject_into:
+            type: RequestOption
+            field_name: PRIVATE-TOKEN
+            inject_into: header
+        path: "/projects/{{ stream_slice.extra_fields['project_id'] }}/merge_requests/{{ stream_partition.mr_iid }}/commits"
+        http_method: GET
+        request_parameters:
+          per_page: "100"
+        error_handler:
+          type: DefaultErrorHandler
+          backoff_strategies:
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+          response_filters:
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RATE_LIMITED
+              error_message: GitLab is rate limiting this token
+            - type: HttpResponseFilter
+              http_codes: [403, 404]
+              action: IGNORE
+              error_message: >-
+                MR gone or not visible to this token; other merge requests continue.
+            - type: HttpResponseFilter
+              http_codes: [401]
+              action: FAIL
+              failure_type: config_error
+              error_message: GitLab rejected the token; check gitlab_token scopes (read_api)
+            - type: HttpResponseFilter
+              http_codes: [500, 502, 503, 504]
+              action: RETRY
+              error_message: Transient GitLab error
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: PageIncrement
+          page_size: "100"
+          start_from_page: 1
+        page_token_option:
+          type: RequestOption
+          field_name: page
+          inject_into: request_parameter
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: iid
+            partition_field: mr_iid
+            extra_fields:
+              - [project_id]
+            stream:
+              type: DeclarativeStream
+              name: merge_requests_for_commits
+              primary_key:
+                - id
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/schema#
+                  properties:
+                    id: {type: [integer, "null"]}
+                    iid: {type: [integer, "null"]}
+                    project_id: {type: [integer, "null"]}
+                    updated_at: {type: [string, "null"]}
+                  additionalProperties: true
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: "{{ config['gitlab_url'] }}/api/v4"
+                  authenticator:
+                    type: ApiKeyAuthenticator
+                    api_token: "{{ config['gitlab_token'] }}"
+                    inject_into:
+                      type: RequestOption
+                      field_name: PRIVATE-TOKEN
+                      inject_into: header
+                  path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/merge_requests"
+                  http_method: GET
+                  request_parameters:
+                    scope: all
+                    order_by: updated_at
+                    sort: asc
+                    per_page: "100"
+                    # Stateless sliding window, not a cursor: these children
+                    # have no cursor of their own, so parent state would never
+                    # persist (incremental_dependency requires an incremental
+                    # child). RMT dedups the re-read window.
+                    updated_after: "{{ format_datetime(now_utc() - duration('P30D'), '%Y-%m-%dT%H:%M:%SZ') }}"
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: []
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: PageIncrement
+                    page_size: "100"
+                    start_from_page: 1
+                  page_token_option:
+                    type: RequestOption
+                    field_name: page
+                    inject_into: request_parameter
+                partition_router:
+                  type: ListPartitionRouter
+                  values: "{{ config['gitlab_groups'] }}"
+                  cursor_field: group
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_gitlab_nocode
+          - type: AddedFieldDefinition
+            path: [collected_at]
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          - type: AddedFieldDefinition
+            path: [mr_iid]
+            value: "{{ stream_partition.mr_iid }}"
+          - type: AddedFieldDefinition
+            path: [project_id]
+            value: "{{ stream_slice.extra_fields['project_id'] }}"
+          - type: AddedFieldDefinition
+            path: [sha]
+            value: "{{ record.get('id') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['project_id'] }}:{{ stream_partition.mr_iid }}:{{ record['id'] }}
+      - type: RemoveFields
+        # The commit payload comes from the proxy; only the edge is stored.
+        field_pointers:
+          - [id]
+          - [short_id]
+          - [title]
+          - [message]
+          - [author_name]
+          - [author_email]
+          - [authored_date]
+          - [committer_name]
+          - [committer_email]
+          - [committed_date]
+          - [created_at]
+          - [parent_ids]
+          - [trailers]
+          - [extended_trailers]
+          - [web_url]
+
   # ── Merge request approvals (GitLab API) ────────────────────────────────
   # Single object per MR; snapshot semantics — the RMT keeps the latest row
   # per unique_key. 402 is "approvals are a paid feature", not an error.
@@ -1920,6 +2120,7 @@ metadata:
     branches: false
     merge_requests: false
     merge_request_notes: false
+    merge_request_commits: false
     merge_request_approvals: false
     users: false
     pipelines: false

--- a/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
@@ -82,7 +82,7 @@ streams:
           archived: "false"
           order_by: last_activity_at
           sort: asc
-          per_page: "{{ config.get('gitlab_page_size', 100) }}"
+          per_page: "100"
       record_selector:
         type: RecordSelector
         extractor:
@@ -92,7 +92,7 @@ streams:
         type: DefaultPaginator
         pagination_strategy:
           type: PageIncrement
-          page_size: "{{ config.get('gitlab_page_size', 100) }}"
+          page_size: "100"
           start_from_page: 1
         page_token_option:
           type: RequestOption
@@ -114,7 +114,7 @@ streams:
         - "%Y-%m-%dT%H:%M:%S%z"
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config.get('gitlab_start_date', '2020-01-01') }}"
+        datetime: "{{ config['gitlab_start_date'] }}"
         datetime_format: "%Y-%m-%d"
       # /groups/:id/projects has no last_activity_after filter (GitLab
       # silently ignores it; the CDK connector full-lists too), so the cursor
@@ -191,7 +191,7 @@ streams:
         http_method: GET
         request_parameters:
           repo: "{{ stream_partition.repo_clone_url }}"
-          page_size: "{{ config.get('proxy_page_size', 500) }}"
+          page_size: "500"
         error_handler:
           type: DefaultErrorHandler
           backoff_strategies:
@@ -287,7 +287,7 @@ streams:
                     archived: "false"
                     order_by: last_activity_at
                     sort: asc
-                    per_page: "{{ config.get('gitlab_page_size', 100) }}"
+                    per_page: "100"
                 record_selector:
                   type: RecordSelector
                   extractor:
@@ -297,7 +297,7 @@ streams:
                   type: DefaultPaginator
                   pagination_strategy:
                     type: PageIncrement
-                    page_size: "{{ config.get('gitlab_page_size', 100) }}"
+                    page_size: "100"
                     start_from_page: 1
                   page_token_option:
                     type: RequestOption
@@ -319,7 +319,7 @@ streams:
                   - "%Y-%m-%dT%H:%M:%S%z"
                 start_datetime:
                   type: MinMaxDatetime
-                  datetime: "{{ config.get('gitlab_start_date', '2020-01-01') }}"
+                  datetime: "{{ config['gitlab_start_date'] }}"
                   datetime_format: "%Y-%m-%d"
                 # No server-side activity filter on this endpoint; the
                 # cursor filters client-side (see repositories stream).
@@ -334,13 +334,13 @@ streams:
       # sync recovers them; bronze dedups the re-read rows. This is a
       # heuristic, not a guarantee — a rewrite older than the window is
       # still lost, and nothing detects it.
-      lookback_window: "{{ config.get('gitlab_lookback_window', 'P1M') }}"
+      lookback_window: "P1M"
       cursor_datetime_formats:
         - "%Y-%m-%dT%H:%M:%S%z"
         - "%Y-%m-%dT%H:%M:%SZ"
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config.get('gitlab_start_date', '2020-01-01') }}"
+        datetime: "{{ config['gitlab_start_date'] }}"
         datetime_format: "%Y-%m-%d"
       start_time_option:
         type: RequestOption
@@ -416,9 +416,9 @@ streams:
         http_method: GET
         request_parameters:
           repo: "{{ stream_partition.repo_clone_url }}"
-          page_size: "{{ config.get('proxy_page_size', 500) }}"
-          include_patch: "{{ config.get('gitlab_include_patch', true) | lower }}"
-          max_patch_bytes: "{{ config.get('gitlab_max_patch_bytes', 1048576) }}"
+          page_size: "500"
+          include_patch: "true"
+          max_patch_bytes: "1048576"
         error_handler:
           type: DefaultErrorHandler
           backoff_strategies:
@@ -508,7 +508,7 @@ streams:
                     archived: "false"
                     order_by: last_activity_at
                     sort: asc
-                    per_page: "{{ config.get('gitlab_page_size', 100) }}"
+                    per_page: "100"
                 record_selector:
                   type: RecordSelector
                   extractor:
@@ -518,7 +518,7 @@ streams:
                   type: DefaultPaginator
                   pagination_strategy:
                     type: PageIncrement
-                    page_size: "{{ config.get('gitlab_page_size', 100) }}"
+                    page_size: "100"
                     start_from_page: 1
                   page_token_option:
                     type: RequestOption
@@ -540,7 +540,7 @@ streams:
                   - "%Y-%m-%dT%H:%M:%S%z"
                 start_datetime:
                   type: MinMaxDatetime
-                  datetime: "{{ config.get('gitlab_start_date', '2020-01-01') }}"
+                  datetime: "{{ config['gitlab_start_date'] }}"
                   datetime_format: "%Y-%m-%d"
                 # No server-side activity filter on this endpoint; the
                 # cursor filters client-side (see repositories stream).
@@ -555,13 +555,13 @@ streams:
       # sync recovers them; bronze dedups the re-read rows. This is a
       # heuristic, not a guarantee — a rewrite older than the window is
       # still lost, and nothing detects it.
-      lookback_window: "{{ config.get('gitlab_lookback_window', 'P1M') }}"
+      lookback_window: "P1M"
       cursor_datetime_formats:
         - "%Y-%m-%dT%H:%M:%S%z"
         - "%Y-%m-%dT%H:%M:%SZ"
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config.get('gitlab_start_date', '2020-01-01') }}"
+        datetime: "{{ config['gitlab_start_date'] }}"
         datetime_format: "%Y-%m-%d"
       start_time_option:
         type: RequestOption
@@ -630,7 +630,7 @@ streams:
         http_method: GET
         request_parameters:
           repo: "{{ stream_partition.repo_clone_url }}"
-          page_size: "{{ config.get('proxy_page_size', 500) }}"
+          page_size: "500"
         error_handler:
           type: DefaultErrorHandler
           backoff_strategies:
@@ -719,7 +719,7 @@ streams:
                   request_parameters:
                     include_subgroups: "true"
                     archived: "false"
-                    per_page: "{{ config.get('gitlab_page_size', 100) }}"
+                    per_page: "100"
                 record_selector:
                   type: RecordSelector
                   extractor:
@@ -729,7 +729,7 @@ streams:
                   type: DefaultPaginator
                   pagination_strategy:
                     type: PageIncrement
-                    page_size: "{{ config.get('gitlab_page_size', 100) }}"
+                    page_size: "100"
                     start_from_page: 1
                   page_token_option:
                     type: RequestOption
@@ -824,7 +824,7 @@ streams:
           scope: all
           order_by: updated_at
           sort: asc
-          per_page: "{{ config.get('gitlab_page_size', 100) }}"
+          per_page: "100"
         error_handler:
           type: DefaultErrorHandler
           backoff_strategies:
@@ -854,7 +854,7 @@ streams:
         type: DefaultPaginator
         pagination_strategy:
           type: PageIncrement
-          page_size: "{{ config.get('gitlab_page_size', 100) }}"
+          page_size: "100"
           start_from_page: 1
         page_token_option:
           type: RequestOption
@@ -873,7 +873,7 @@ streams:
         - "%Y-%m-%dT%H:%M:%S%z"
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config.get('gitlab_start_date', '2020-01-01') }}"
+        datetime: "{{ config['gitlab_start_date'] }}"
         datetime_format: "%Y-%m-%d"
       step: P1M
       cursor_granularity: PT1S
@@ -966,7 +966,7 @@ streams:
         path: "/projects/{{ stream_slice.extra_fields['project_id'] }}/merge_requests/{{ stream_partition.mr_iid }}/notes"
         http_method: GET
         request_parameters:
-          per_page: "{{ config.get('gitlab_page_size', 100) }}"
+          per_page: "100"
         error_handler:
           type: DefaultErrorHandler
           backoff_strategies:
@@ -1001,7 +1001,7 @@ streams:
         type: DefaultPaginator
         pagination_strategy:
           type: PageIncrement
-          page_size: "{{ config.get('gitlab_page_size', 100) }}"
+          page_size: "100"
           start_from_page: 1
         page_token_option:
           type: RequestOption
@@ -1049,12 +1049,12 @@ streams:
                     scope: all
                     order_by: updated_at
                     sort: asc
-                    per_page: "{{ config.get('gitlab_page_size', 100) }}"
+                    per_page: "100"
                     # Stateless sliding window, not a cursor: these children
                     # have no cursor of their own, so parent state would never
                     # persist (incremental_dependency requires an incremental
                     # child). RMT dedups the re-read window.
-                    updated_after: "{{ format_datetime(now_utc() - duration('P' ~ config.get('gitlab_child_window_days', 30) ~ 'D'), '%Y-%m-%dT%H:%M:%SZ') }}"
+                    updated_after: "{{ format_datetime(now_utc() - duration('P30D'), '%Y-%m-%dT%H:%M:%SZ') }}"
                 record_selector:
                   type: RecordSelector
                   extractor:
@@ -1064,7 +1064,7 @@ streams:
                   type: DefaultPaginator
                   pagination_strategy:
                     type: PageIncrement
-                    page_size: "{{ config.get('gitlab_page_size', 100) }}"
+                    page_size: "100"
                     start_from_page: 1
                   page_token_option:
                     type: RequestOption
@@ -1224,12 +1224,12 @@ streams:
                     scope: all
                     order_by: updated_at
                     sort: asc
-                    per_page: "{{ config.get('gitlab_page_size', 100) }}"
+                    per_page: "100"
                     # Stateless sliding window, not a cursor: these children
                     # have no cursor of their own, so parent state would never
                     # persist (incremental_dependency requires an incremental
                     # child). RMT dedups the re-read window.
-                    updated_after: "{{ format_datetime(now_utc() - duration('P' ~ config.get('gitlab_child_window_days', 30) ~ 'D'), '%Y-%m-%dT%H:%M:%SZ') }}"
+                    updated_after: "{{ format_datetime(now_utc() - duration('P30D'), '%Y-%m-%dT%H:%M:%SZ') }}"
                 record_selector:
                   type: RecordSelector
                   extractor:
@@ -1239,7 +1239,7 @@ streams:
                   type: DefaultPaginator
                   pagination_strategy:
                     type: PageIncrement
-                    page_size: "{{ config.get('gitlab_page_size', 100) }}"
+                    page_size: "100"
                     start_from_page: 1
                   page_token_option:
                     type: RequestOption
@@ -1327,7 +1327,7 @@ streams:
         path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/members/all"
         http_method: GET
         request_parameters:
-          per_page: "{{ config.get('gitlab_page_size', 100) }}"
+          per_page: "100"
         error_handler:
           type: DefaultErrorHandler
           backoff_strategies:
@@ -1362,7 +1362,7 @@ streams:
         type: DefaultPaginator
         pagination_strategy:
           type: PageIncrement
-          page_size: "{{ config.get('gitlab_page_size', 100) }}"
+          page_size: "100"
           start_from_page: 1
         page_token_option:
           type: RequestOption
@@ -1446,7 +1446,7 @@ streams:
         request_parameters:
           order_by: updated_at
           sort: asc
-          per_page: "{{ config.get('gitlab_page_size', 100) }}"
+          per_page: "100"
         error_handler:
           type: DefaultErrorHandler
           backoff_strategies:
@@ -1481,7 +1481,7 @@ streams:
         type: DefaultPaginator
         pagination_strategy:
           type: PageIncrement
-          page_size: "{{ config.get('gitlab_page_size', 100) }}"
+          page_size: "100"
           start_from_page: 1
         page_token_option:
           type: RequestOption
@@ -1524,7 +1524,7 @@ streams:
                   request_parameters:
                     include_subgroups: "true"
                     archived: "false"
-                    per_page: "{{ config.get('gitlab_page_size', 100) }}"
+                    per_page: "100"
                 record_selector:
                   type: RecordSelector
                   extractor:
@@ -1534,7 +1534,7 @@ streams:
                   type: DefaultPaginator
                   pagination_strategy:
                     type: PageIncrement
-                    page_size: "{{ config.get('gitlab_page_size', 100) }}"
+                    page_size: "100"
                     start_from_page: 1
                   page_token_option:
                     type: RequestOption
@@ -1554,7 +1554,7 @@ streams:
       lookback_window: P1D
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config.get('gitlab_start_date', '2020-01-01') }}"
+        datetime: "{{ config['gitlab_start_date'] }}"
         datetime_format: "%Y-%m-%d"
       start_time_option:
         type: RequestOption
@@ -1630,7 +1630,7 @@ streams:
         request_parameters:
           order_by: updated_at
           sort: asc
-          per_page: "{{ config.get('gitlab_page_size', 100) }}"
+          per_page: "100"
         error_handler:
           type: DefaultErrorHandler
           backoff_strategies:
@@ -1665,7 +1665,7 @@ streams:
         type: DefaultPaginator
         pagination_strategy:
           type: PageIncrement
-          page_size: "{{ config.get('gitlab_page_size', 100) }}"
+          page_size: "100"
           start_from_page: 1
         page_token_option:
           type: RequestOption
@@ -1708,7 +1708,7 @@ streams:
                   request_parameters:
                     include_subgroups: "true"
                     archived: "false"
-                    per_page: "{{ config.get('gitlab_page_size', 100) }}"
+                    per_page: "100"
                 record_selector:
                   type: RecordSelector
                   extractor:
@@ -1718,7 +1718,7 @@ streams:
                   type: DefaultPaginator
                   pagination_strategy:
                     type: PageIncrement
-                    page_size: "{{ config.get('gitlab_page_size', 100) }}"
+                    page_size: "100"
                     start_from_page: 1
                   page_token_option:
                     type: RequestOption
@@ -1738,7 +1738,7 @@ streams:
       lookback_window: P1D
       start_datetime:
         type: MinMaxDatetime
-        datetime: "{{ config.get('gitlab_start_date', '2020-01-01') }}"
+        datetime: "{{ config['gitlab_start_date'] }}"
         datetime_format: "%Y-%m-%d"
       start_time_option:
         type: RequestOption
@@ -1799,6 +1799,7 @@ spec:
       - gitlab_groups
       - git_proxy_url
       - git_proxy_token
+      - gitlab_start_date
     properties:
       insight_tenant_id:
         type: string
@@ -1846,60 +1847,12 @@ spec:
         order: 6
       gitlab_start_date:
         type: string
-        description: Earliest date for incremental sync (YYYY-MM-DD).
+        description: >-
+          Earliest date for incremental sync (YYYY-MM-DD). Required: it bounds
+          the first-sync cost, so choosing it is a deployment decision.
         title: Start Date
         format: date
-        default: "2020-01-01"
         order: 7
-      gitlab_page_size:
-        type: integer
-        description: GitLab API page size (max 100).
-        title: GitLab Page Size
-        default: 100
-        minimum: 1
-        maximum: 100
-        order: 8
-      proxy_page_size:
-        type: integer
-        description: Rows per page requested from the git-cli-proxy.
-        title: Proxy Page Size
-        default: 500
-        minimum: 1
-        maximum: 10000
-        order: 9
-      gitlab_include_patch:
-        type: boolean
-        description: >-
-          Store per-file diff text. Keep enabled to allow recomputing line counts later under different filters (blank lines, comments); disable to cut bronze volume.
-        title: Include Patch Text
-        default: true
-        order: 10
-      gitlab_max_patch_bytes:
-        type: integer
-        description: >-
-          Truncation cap for a single file's diff. Truncated rows are flagged with patch_truncated so downstream never mistakes them for complete.
-        title: Max Patch Bytes
-        default: 1048576
-        minimum: 1024
-        order: 11
-      gitlab_lookback_window:
-        type: string
-        description: >-
-          ISO-8601 duration re-enumerated below the stored cursor on every sync. `git log --since` is a traversal cutoff, so after a rebase the replacement commits can carry dates below the cursor and would never be visited again. Bronze dedups the re-read rows, so the cost is one window per sync. A rewrite older than the window is still lost.
-        title: Rebase Lookback Window
-        default: P1M
-        order: 12
-      gitlab_child_window_days:
-        type: integer
-        description: >-
-          Sliding window, in days, of merge requests whose notes and approvals
-          are re-read each sync. The children have no cursor of their own, so
-          the window is what bounds their cost; edits on MRs older than the
-          window are not picked up.
-        title: MR Child Window (days)
-        default: 30
-        minimum: 1
-        order: 13
     additionalProperties: true
 
 metadata:

--- a/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
@@ -138,7 +138,7 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ record['id'] | string | replace(':', '%3A') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ record['id'] }}
   # ── Commits (git-cli-proxy) ─────────────────────────────────────────────
   - type: DeclarativeStream
     name: commits
@@ -367,7 +367,7 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | string | replace(':', '%3A') }}:{{ record['sha'] | string | replace(':', '%3A') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | replace(':', '%3A') }}:{{ record['sha'] | replace(':', '%3A') }}
 
   # ── Per-file changes (git-cli-proxy) ────────────────────────────────────
   - type: DeclarativeStream
@@ -586,7 +586,7 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | string | replace(':', '%3A') }}:{{ record['sha'] | string | replace(':', '%3A') }}:{{ record['filename'] | string | replace(':', '%3A') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | replace(':', '%3A') }}:{{ record['sha'] | replace(':', '%3A') }}:{{ record['filename'] | replace(':', '%3A') }}
 
   # ── Branch heads (git-cli-proxy) ────────────────────────────────────────
   # Full refresh: bronze keeps the LATEST state per branch, and head-movement
@@ -764,7 +764,7 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | string | replace(':', '%3A') }}:{{ record['name'] | string | replace(':', '%3A') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | replace(':', '%3A') }}:{{ record['name'] | replace(':', '%3A') }}
 
   # ── Merge requests (GitLab API) ─────────────────────────────────────────
   # Group-level endpoint: one listing covers the group and its subgroups,
@@ -913,7 +913,12 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ record['id'] | string | replace(':', '%3A') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ record['id'] }}
+      - type: RemoveFields
+        # Hoisted above; the nested originals stay out of bronze.
+        field_pointers:
+          - [author]
+          - [merged_by]
 
   # ── Merge request notes (GitLab API) ────────────────────────────────────
   # Child of a stateless sliding window of MRs (see the parent's
@@ -1098,7 +1103,11 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['project_id'] | string }}:{{ record['id'] | string | replace(':', '%3A') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['project_id'] }}:{{ record['id'] }}
+      - type: RemoveFields
+        # Hoisted above; the nested originals stay out of bronze.
+        field_pointers:
+          - [author]
 
   # ── Merge request approvals (GitLab API) ────────────────────────────────
   # Single object per MR; snapshot semantics — the RMT keeps the latest row
@@ -1269,7 +1278,11 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['project_id'] | string }}:{{ stream_partition.mr_iid | string }}:approvals
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['project_id'] }}:{{ stream_partition.mr_iid }}:approvals
+      - type: RemoveFields
+        # Hoisted above; the nested originals stay out of bronze.
+        field_pointers:
+          - [approved_by]
 
   # ── Group members (GitLab API) ──────────────────────────────────────────
   # /members/all = direct + inherited. Non-admin tokens see no email; identity
@@ -1382,7 +1395,7 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.group | string | replace(':', '%3A') }}:{{ record['id'] | string | replace(':', '%3A') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.group | replace(':', '%3A') }}:{{ record['id'] }}
 
   # ── CI pipelines (GitLab API) ───────────────────────────────────────────
   # Parent is a FULL-REFRESH slim projects copy on purpose: scheduled
@@ -1566,7 +1579,7 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ record['id'] | string | replace(':', '%3A') }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ record['id'] }}
 
   # ── Deployments (GitLab API) ────────────────────────────────────────────
   # Only populated where teams use GitLab environments; an empty stream is
@@ -1761,8 +1774,12 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ record['id'] | string | replace(':', '%3A') }}
-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ record['id'] }}
+      - type: RemoveFields
+        # Hoisted above; the nested originals stay out of bronze.
+        field_pointers:
+          - [environment]
+          - [deployable]
 concurrency_level:
   type: ConcurrencyLevel
   # Never 1: the concurrent CDK self-deadlocks at a single worker once a sync

--- a/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
@@ -16,8 +16,8 @@ type: DeclarativeSource
 #
 #   repositories     -> GitLab /api/v4/projects        incremental (last_activity_at)
 #   commits          -> proxy /v1/commits              incremental (committed_date), per repo
-#   commit_files     -> proxy /v1/file-changes         incremental (committed_date), per repo
-#   repo_branches    -> proxy /v1/branches             full refresh, per repo
+#   file_changes     -> proxy /v1/file-changes         incremental (committed_date), per repo
+#   branches         -> proxy /v1/branches             full refresh, per repo
 #
 # The proxy answers 429 + Retry-After while a cold repository is being cloned
 # in the background, so every proxy stream retries on 429 and fails fast on the
@@ -116,10 +116,11 @@ streams:
         type: MinMaxDatetime
         datetime: "{{ config.get('gitlab_start_date', '2020-01-01') }}"
         datetime_format: "%Y-%m-%d"
-      start_time_option:
-        type: RequestOption
-        field_name: last_activity_after
-        inject_into: request_parameter
+      # /groups/:id/projects has no last_activity_after filter (GitLab
+      # silently ignores it; the CDK connector full-lists too), so the cursor
+      # filters client-side and only repositories active since the last sync
+      # are emitted downstream.
+      is_client_side_incremental: true
     transformations:
       - type: AddFields
         fields:
@@ -320,10 +321,9 @@ streams:
                   type: MinMaxDatetime
                   datetime: "{{ config.get('gitlab_start_date', '2020-01-01') }}"
                   datetime_format: "%Y-%m-%d"
-                start_time_option:
-                  type: RequestOption
-                  field_name: last_activity_after
-                  inject_into: request_parameter
+                # No server-side activity filter on this endpoint; the
+                # cursor filters client-side (see repositories stream).
+                is_client_side_incremental: true
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: committed_date
@@ -371,7 +371,7 @@ streams:
 
   # ── Per-file changes (git-cli-proxy) ────────────────────────────────────
   - type: DeclarativeStream
-    name: commit_files
+    name: file_changes
     primary_key:
       - unique_key
     schema_loader:
@@ -542,10 +542,9 @@ streams:
                   type: MinMaxDatetime
                   datetime: "{{ config.get('gitlab_start_date', '2020-01-01') }}"
                   datetime_format: "%Y-%m-%d"
-                start_time_option:
-                  type: RequestOption
-                  field_name: last_activity_after
-                  inject_into: request_parameter
+                # No server-side activity filter on this endpoint; the
+                # cursor filters client-side (see repositories stream).
+                is_client_side_incremental: true
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: committed_date
@@ -593,7 +592,7 @@ streams:
   # history is derived downstream by the snapshot/fields_history dbt macros —
   # the same pattern user profiles use.
   - type: DeclarativeStream
-    name: repo_branches
+    name: branches
     primary_key:
       - unique_key
     schema_loader:
@@ -1907,8 +1906,8 @@ metadata:
   autoImportSchema:
     repositories: false
     commits: false
-    commit_files: false
-    repo_branches: false
+    file_changes: false
+    branches: false
     merge_requests: false
     merge_request_notes: false
     merge_request_approvals: false

--- a/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
@@ -29,6 +29,48 @@ type: DeclarativeSource
 # original commits unreachable from every ref the proxy clones.
 # Issues and epics are deliberately not synced.
 
+definitions:
+  proxy_error_handler: &proxy_error_handler
+    type: DefaultErrorHandler
+    # Generous on purpose: a cold blobless clone of a large repository runs
+    # for many Retry-After cycles before the first page can be served.
+    max_retries: 100
+    backoff_strategies:
+      - type: WaitTimeFromHeader
+        header: Retry-After
+        max_waiting_time_in_seconds: 600
+    response_filters:
+      # The repository is being cloned in the background: the proxy is
+      # working, the caller waits.
+      - type: HttpResponseFilter
+        http_codes: [429]
+        action: RETRY
+        error_message: Repository is being prepared by the proxy
+      # Both are permanent for THIS repository and harmless for the rest,
+      # so the partition is skipped rather than the whole stream failed.
+      # A rising git_proxy_admission_rejects_total is the alert: a 413
+      # means a repository is silently absent from bronze until an
+      # operator raises cache.maxRepoBytes.
+      - type: HttpResponseFilter
+        http_codes: [404, 413]
+        action: IGNORE
+        error_message: >-
+          Skipping this repository: gone at origin (404), or larger than
+          cache.maxRepoBytes (413). Other repositories continue.
+      # The pinned snapshot was superseded mid-walk. RETRY would replay
+      # the same dead page token and 409 again; a response filter cannot
+      # reset it. Rerunning the sync resumes each partition from its own
+      # stored cursor against a fresh snapshot.
+      - type: HttpResponseFilter
+        http_codes: [409]
+        action: FAIL
+        error_message: >-
+          Proxy snapshot changed mid-walk; rerun the sync to resume from the stored cursor
+      - type: HttpResponseFilter
+        http_codes: [500, 502, 503, 504]
+        action: RETRY
+        error_message: Transient proxy error (the origin can reset a clone mid-transfer)
+
 check:
   type: CheckStream
   stream_names:
@@ -209,39 +251,7 @@ streams:
         request_parameters:
           repo: "{{ stream_partition.repo_clone_url }}"
           page_size: "500"
-        error_handler:
-          type: DefaultErrorHandler
-          backoff_strategies:
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
-          response_filters:
-            # The repository is being cloned in the background: the proxy is
-            # working, the caller waits.
-            - type: HttpResponseFilter
-              http_codes: [429]
-              action: RETRY
-              error_message: Repository is being prepared by the proxy
-            # Both are permanent for THIS repository and harmless for the rest,
-            # so the partition is skipped rather than the whole stream failed.
-            # A rising git_proxy_admission_rejects_total is the alert: a 413
-            # means a repository is silently absent from bronze until an
-            # operator raises cache.maxRepoBytes.
-            - type: HttpResponseFilter
-              http_codes: [404, 413]
-              action: IGNORE
-              error_message: >-
-                Skipping this repository: gone at origin (404), or larger than
-                cache.maxRepoBytes (413). Other repositories continue.
-            # The pinned snapshot was superseded mid-walk. RETRY would replay
-            # the same dead page token and 409 again; a response filter cannot
-            # reset it. Rerunning the sync resumes each partition from its own
-            # stored cursor against a fresh snapshot.
-            - type: HttpResponseFilter
-              http_codes: [409]
-              action: FAIL
-              error_message: >-
-                Proxy snapshot changed mid-walk; rerun the sync to resume from the stored cursor
+        error_handler: *proxy_error_handler
       record_selector:
         type: RecordSelector
         extractor:
@@ -445,39 +455,7 @@ streams:
           page_size: "500"
           include_patch: "true"
           max_patch_bytes: "1048576"
-        error_handler:
-          type: DefaultErrorHandler
-          backoff_strategies:
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
-          response_filters:
-            # The repository is being cloned in the background: the proxy is
-            # working, the caller waits.
-            - type: HttpResponseFilter
-              http_codes: [429]
-              action: RETRY
-              error_message: Repository is being prepared by the proxy
-            # Both are permanent for THIS repository and harmless for the rest,
-            # so the partition is skipped rather than the whole stream failed.
-            # A rising git_proxy_admission_rejects_total is the alert: a 413
-            # means a repository is silently absent from bronze until an
-            # operator raises cache.maxRepoBytes.
-            - type: HttpResponseFilter
-              http_codes: [404, 413]
-              action: IGNORE
-              error_message: >-
-                Skipping this repository: gone at origin (404), or larger than
-                cache.maxRepoBytes (413). Other repositories continue.
-            # The pinned snapshot was superseded mid-walk. RETRY would replay
-            # the same dead page token and 409 again; a response filter cannot
-            # reset it. Rerunning the sync resumes each partition from its own
-            # stored cursor against a fresh snapshot.
-            - type: HttpResponseFilter
-              http_codes: [409]
-              action: FAIL
-              error_message: >-
-                Proxy snapshot changed mid-walk; rerun the sync to resume from the stored cursor
+        error_handler: *proxy_error_handler
       record_selector:
         type: RecordSelector
         extractor:
@@ -662,39 +640,7 @@ streams:
         request_parameters:
           repo: "{{ stream_partition.repo_clone_url }}"
           page_size: "500"
-        error_handler:
-          type: DefaultErrorHandler
-          backoff_strategies:
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
-          response_filters:
-            # The repository is being cloned in the background: the proxy is
-            # working, the caller waits.
-            - type: HttpResponseFilter
-              http_codes: [429]
-              action: RETRY
-              error_message: Repository is being prepared by the proxy
-            # Both are permanent for THIS repository and harmless for the rest,
-            # so the partition is skipped rather than the whole stream failed.
-            # A rising git_proxy_admission_rejects_total is the alert: a 413
-            # means a repository is silently absent from bronze until an
-            # operator raises cache.maxRepoBytes.
-            - type: HttpResponseFilter
-              http_codes: [404, 413]
-              action: IGNORE
-              error_message: >-
-                Skipping this repository: gone at origin (404), or larger than
-                cache.maxRepoBytes (413). Other repositories continue.
-            # The pinned snapshot was superseded mid-walk. RETRY would replay
-            # the same dead page token and 409 again; a response filter cannot
-            # reset it. Rerunning the sync resumes each partition from its own
-            # stored cursor against a fresh snapshot.
-            - type: HttpResponseFilter
-              http_codes: [409]
-              action: FAIL
-              error_message: >-
-                Proxy snapshot changed mid-walk; rerun the sync to resume from the stored cursor
+        error_handler: *proxy_error_handler
       record_selector:
         type: RecordSelector
         extractor:

--- a/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
@@ -23,9 +23,9 @@ type: DeclarativeSource
 # in the background, so every proxy stream retries on 429 and fails fast on the
 # permanent ones (409 superseded snapshot, 413 oversized repository).
 #
-# NOT ported here: merge requests, notes, approvals. That data does not exist in
-# git, so it stays on the vendor API — a mechanical port of the CDK connector's
-# streams, tracked separately.
+# Vendor-API streams (merge requests, notes, approvals, members, pipelines,
+# deployments) live in this same manifest: that data does not exist in git.
+# Issues and epics are deliberately not synced.
 
 check:
   type: CheckStream
@@ -766,6 +766,1003 @@ streams:
             value: >-
               {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.repo_clone_url | string | replace(':', '%3A') }}:{{ record['name'] | string | replace(':', '%3A') }}
 
+  # ── Merge requests (GitLab API) ─────────────────────────────────────────
+  # Group-level endpoint: one listing covers the group and its subgroups,
+  # server-filtered by updated_after. The P1M step bounds offset-pagination
+  # depth per window (this endpoint has no keyset mode), so deep-offset caps
+  # only ever threaten a single window, not the whole backfill.
+  - type: DeclarativeStream
+    name: merge_requests
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          id: {type: [integer, "null"]}
+          iid: {type: [integer, "null"]}
+          project_id: {type: [integer, "null"]}
+          state: {type: [string, "null"]}
+          draft: {type: [boolean, "null"]}
+          title: {type: [string, "null"]}
+          author_username: {type: [string, "null"]}
+          source_branch: {type: [string, "null"]}
+          target_branch: {type: [string, "null"]}
+          sha: {type: [string, "null"]}
+          merge_commit_sha: {type: [string, "null"]}
+          squash_commit_sha: {type: [string, "null"]}
+          created_at: {type: [string, "null"]}
+          updated_at: {type: [string, "null"]}
+          merged_at: {type: [string, "null"]}
+          closed_at: {type: [string, "null"]}
+          merged_by_username: {type: [string, "null"]}
+          user_notes_count: {type: [integer, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['gitlab_url'] }}/api/v4"
+        authenticator:
+          type: ApiKeyAuthenticator
+          api_token: "{{ config['gitlab_token'] }}"
+          inject_into:
+            type: RequestOption
+            field_name: PRIVATE-TOKEN
+            inject_into: header
+        path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/merge_requests"
+        http_method: GET
+        request_parameters:
+          scope: all
+          order_by: updated_at
+          sort: asc
+          per_page: "{{ config.get('gitlab_page_size', 100) }}"
+        error_handler:
+          type: DefaultErrorHandler
+          backoff_strategies:
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+          response_filters:
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RATE_LIMITED
+              error_message: GitLab is rate limiting this token
+            - type: HttpResponseFilter
+              http_codes: [401]
+              action: FAIL
+              failure_type: config_error
+              error_message: GitLab rejected the token; check gitlab_token scopes (read_api)
+            - type: HttpResponseFilter
+              http_codes: [500, 502, 503, 504]
+              action: RETRY
+              error_message: Transient GitLab error
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: PageIncrement
+          page_size: "{{ config.get('gitlab_page_size', 100) }}"
+          start_from_page: 1
+        page_token_option:
+          type: RequestOption
+          field_name: page
+          inject_into: request_parameter
+      partition_router:
+        type: ListPartitionRouter
+        values: "{{ config['gitlab_groups'] }}"
+        cursor_field: group
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: updated_at
+      datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S.%f%z"
+        - "%Y-%m-%dT%H:%M:%S%z"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('gitlab_start_date', '2020-01-01') }}"
+        datetime_format: "%Y-%m-%d"
+      step: P1M
+      cursor_granularity: PT1S
+      lookback_window: P1D
+      start_time_option:
+        type: RequestOption
+        field_name: updated_after
+        inject_into: request_parameter
+      end_time_option:
+        type: RequestOption
+        field_name: updated_before
+        inject_into: request_parameter
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_gitlab_nocode
+          - type: AddedFieldDefinition
+            path: [collected_at]
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          - type: AddedFieldDefinition
+            path: [author_username]
+            value: "{{ (record.get('author') or {}).get('username') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [merged_by_username]
+            value: "{{ (record.get('merged_by') or {}).get('username') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ record['id'] | string | replace(':', '%3A') }}
+
+  # ── Merge request notes (GitLab API) ────────────────────────────────────
+  # Child of a stateless sliding window of MRs (see the parent's
+  # updated_after comment). Note bodies are deliberately not stored: review
+  # metrics need who/when/what-kind, not prose.
+  - type: DeclarativeStream
+    name: merge_request_notes
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          id: {type: [integer, "null"]}
+          mr_iid: {type: [integer, "null"]}
+          project_id: {type: [integer, "null"]}
+          author_username: {type: [string, "null"]}
+          system: {type: [boolean, "null"]}
+          type: {type: [string, "null"]}
+          resolvable: {type: [boolean, "null"]}
+          resolved: {type: [boolean, "null"]}
+          created_at: {type: [string, "null"]}
+          updated_at: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['gitlab_url'] }}/api/v4"
+        authenticator:
+          type: ApiKeyAuthenticator
+          api_token: "{{ config['gitlab_token'] }}"
+          inject_into:
+            type: RequestOption
+            field_name: PRIVATE-TOKEN
+            inject_into: header
+        path: "/projects/{{ stream_slice.extra_fields['project_id'] }}/merge_requests/{{ stream_partition.mr_iid }}/notes"
+        http_method: GET
+        request_parameters:
+          per_page: "{{ config.get('gitlab_page_size', 100) }}"
+        error_handler:
+          type: DefaultErrorHandler
+          backoff_strategies:
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+          response_filters:
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RATE_LIMITED
+              error_message: GitLab is rate limiting this token
+            - type: HttpResponseFilter
+              http_codes: [403, 404]
+              action: IGNORE
+              error_message: >-
+                MR gone or not visible to this token; other merge requests continue.
+            - type: HttpResponseFilter
+              http_codes: [401]
+              action: FAIL
+              failure_type: config_error
+              error_message: GitLab rejected the token; check gitlab_token scopes (read_api)
+            - type: HttpResponseFilter
+              http_codes: [500, 502, 503, 504]
+              action: RETRY
+              error_message: Transient GitLab error
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: PageIncrement
+          page_size: "{{ config.get('gitlab_page_size', 100) }}"
+          start_from_page: 1
+        page_token_option:
+          type: RequestOption
+          field_name: page
+          inject_into: request_parameter
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: iid
+            partition_field: mr_iid
+            extra_fields:
+              - [project_id]
+            stream:
+              type: DeclarativeStream
+              name: merge_requests_for_notes
+              primary_key:
+                - id
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/schema#
+                  properties:
+                    id: {type: [integer, "null"]}
+                    iid: {type: [integer, "null"]}
+                    project_id: {type: [integer, "null"]}
+                    updated_at: {type: [string, "null"]}
+                  additionalProperties: true
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: "{{ config['gitlab_url'] }}/api/v4"
+                  authenticator:
+                    type: ApiKeyAuthenticator
+                    api_token: "{{ config['gitlab_token'] }}"
+                    inject_into:
+                      type: RequestOption
+                      field_name: PRIVATE-TOKEN
+                      inject_into: header
+                  path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/merge_requests"
+                  http_method: GET
+                  request_parameters:
+                    scope: all
+                    order_by: updated_at
+                    sort: asc
+                    per_page: "{{ config.get('gitlab_page_size', 100) }}"
+                    # Stateless sliding window, not a cursor: these children
+                    # have no cursor of their own, so parent state would never
+                    # persist (incremental_dependency requires an incremental
+                    # child). RMT dedups the re-read window.
+                    updated_after: "{{ format_datetime(now_utc() - duration('P' ~ config.get('gitlab_child_window_days', 30) ~ 'D'), '%Y-%m-%dT%H:%M:%SZ') }}"
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: []
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: PageIncrement
+                    page_size: "{{ config.get('gitlab_page_size', 100) }}"
+                    start_from_page: 1
+                  page_token_option:
+                    type: RequestOption
+                    field_name: page
+                    inject_into: request_parameter
+                partition_router:
+                  type: ListPartitionRouter
+                  values: "{{ config['gitlab_groups'] }}"
+                  cursor_field: group
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_gitlab_nocode
+          - type: AddedFieldDefinition
+            path: [collected_at]
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          - type: AddedFieldDefinition
+            path: [mr_iid]
+            value: "{{ stream_partition.mr_iid }}"
+          - type: AddedFieldDefinition
+            path: [project_id]
+            value: "{{ stream_slice.extra_fields['project_id'] }}"
+          - type: AddedFieldDefinition
+            path: [author_username]
+            value: "{{ (record.get('author') or {}).get('username') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['project_id'] | string }}:{{ record['id'] | string | replace(':', '%3A') }}
+
+  # ── Merge request approvals (GitLab API) ────────────────────────────────
+  # Single object per MR; snapshot semantics — the RMT keeps the latest row
+  # per unique_key. 402 is "approvals are a paid feature", not an error.
+  - type: DeclarativeStream
+    name: merge_request_approvals
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          mr_iid: {type: [integer, "null"]}
+          project_id: {type: [integer, "null"]}
+          approved: {type: [boolean, "null"]}
+          approvals_required: {type: [integer, "null"]}
+          approvals_left: {type: [integer, "null"]}
+          approved_by_usernames: {type: [string, "null"]}
+          updated_at: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['gitlab_url'] }}/api/v4"
+        authenticator:
+          type: ApiKeyAuthenticator
+          api_token: "{{ config['gitlab_token'] }}"
+          inject_into:
+            type: RequestOption
+            field_name: PRIVATE-TOKEN
+            inject_into: header
+        path: "/projects/{{ stream_slice.extra_fields['project_id'] }}/merge_requests/{{ stream_partition.mr_iid }}/approvals"
+        http_method: GET
+        error_handler:
+          type: DefaultErrorHandler
+          backoff_strategies:
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+          response_filters:
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RATE_LIMITED
+              error_message: GitLab is rate limiting this token
+            - type: HttpResponseFilter
+              http_codes: [402, 403, 404]
+              action: IGNORE
+              error_message: >-
+                Approvals unavailable for this MR (paid feature, gone, or not visible); other merge requests continue.
+            - type: HttpResponseFilter
+              http_codes: [401]
+              action: FAIL
+              failure_type: config_error
+              error_message: GitLab rejected the token; check gitlab_token scopes (read_api)
+            - type: HttpResponseFilter
+              http_codes: [500, 502, 503, 504]
+              action: RETRY
+              error_message: Transient GitLab error
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+      paginator:
+        type: NoPagination
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: iid
+            partition_field: mr_iid
+            extra_fields:
+              - [project_id]
+            stream:
+              type: DeclarativeStream
+              name: merge_requests_for_approvals
+              primary_key:
+                - id
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/schema#
+                  properties:
+                    id: {type: [integer, "null"]}
+                    iid: {type: [integer, "null"]}
+                    project_id: {type: [integer, "null"]}
+                    updated_at: {type: [string, "null"]}
+                  additionalProperties: true
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: "{{ config['gitlab_url'] }}/api/v4"
+                  authenticator:
+                    type: ApiKeyAuthenticator
+                    api_token: "{{ config['gitlab_token'] }}"
+                    inject_into:
+                      type: RequestOption
+                      field_name: PRIVATE-TOKEN
+                      inject_into: header
+                  path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/merge_requests"
+                  http_method: GET
+                  request_parameters:
+                    scope: all
+                    order_by: updated_at
+                    sort: asc
+                    per_page: "{{ config.get('gitlab_page_size', 100) }}"
+                    # Stateless sliding window, not a cursor: these children
+                    # have no cursor of their own, so parent state would never
+                    # persist (incremental_dependency requires an incremental
+                    # child). RMT dedups the re-read window.
+                    updated_after: "{{ format_datetime(now_utc() - duration('P' ~ config.get('gitlab_child_window_days', 30) ~ 'D'), '%Y-%m-%dT%H:%M:%SZ') }}"
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: []
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: PageIncrement
+                    page_size: "{{ config.get('gitlab_page_size', 100) }}"
+                    start_from_page: 1
+                  page_token_option:
+                    type: RequestOption
+                    field_name: page
+                    inject_into: request_parameter
+                partition_router:
+                  type: ListPartitionRouter
+                  values: "{{ config['gitlab_groups'] }}"
+                  cursor_field: group
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_gitlab_nocode
+          - type: AddedFieldDefinition
+            path: [collected_at]
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          - type: AddedFieldDefinition
+            path: [mr_iid]
+            value: "{{ stream_partition.mr_iid }}"
+          - type: AddedFieldDefinition
+            path: [project_id]
+            value: "{{ stream_slice.extra_fields['project_id'] }}"
+          - type: AddedFieldDefinition
+            path: [approved_by_usernames]
+            value: "{{ ((record.get('approved_by') or []) | map(attribute='user.username') | list) | tojson }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['project_id'] | string }}:{{ stream_partition.mr_iid | string }}:approvals
+
+  # ── Group members (GitLab API) ──────────────────────────────────────────
+  # /members/all = direct + inherited. Non-admin tokens see no email; identity
+  # joins on username. The same user in several groups keeps one row per
+  # group: access_level differs.
+  - type: DeclarativeStream
+    name: users
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          id: {type: [integer, "null"]}
+          username: {type: [string, "null"]}
+          name: {type: [string, "null"]}
+          state: {type: [string, "null"]}
+          access_level: {type: [integer, "null"]}
+          created_at: {type: [string, "null"]}
+          group: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['gitlab_url'] }}/api/v4"
+        authenticator:
+          type: ApiKeyAuthenticator
+          api_token: "{{ config['gitlab_token'] }}"
+          inject_into:
+            type: RequestOption
+            field_name: PRIVATE-TOKEN
+            inject_into: header
+        path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/members/all"
+        http_method: GET
+        request_parameters:
+          per_page: "{{ config.get('gitlab_page_size', 100) }}"
+        error_handler:
+          type: DefaultErrorHandler
+          backoff_strategies:
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+          response_filters:
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RATE_LIMITED
+              error_message: GitLab is rate limiting this token
+            - type: HttpResponseFilter
+              http_codes: [403]
+              action: IGNORE
+              error_message: >-
+                Token cannot list this group's members; other groups continue.
+            - type: HttpResponseFilter
+              http_codes: [401]
+              action: FAIL
+              failure_type: config_error
+              error_message: GitLab rejected the token; check gitlab_token scopes (read_api)
+            - type: HttpResponseFilter
+              http_codes: [500, 502, 503, 504]
+              action: RETRY
+              error_message: Transient GitLab error
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: PageIncrement
+          page_size: "{{ config.get('gitlab_page_size', 100) }}"
+          start_from_page: 1
+        page_token_option:
+          type: RequestOption
+          field_name: page
+          inject_into: request_parameter
+      partition_router:
+        type: ListPartitionRouter
+        values: "{{ config['gitlab_groups'] }}"
+        cursor_field: group
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_gitlab_nocode
+          - type: AddedFieldDefinition
+            path: [collected_at]
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          - type: AddedFieldDefinition
+            path: [group]
+            value: "{{ stream_partition.group }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.group | string | replace(':', '%3A') }}:{{ record['id'] | string | replace(':', '%3A') }}
+
+  # ── CI pipelines (GitLab API) ───────────────────────────────────────────
+  # Parent is a FULL-REFRESH slim projects copy on purpose: scheduled
+  # pipelines run without bumping the project's last_activity_at, so an
+  # incremental parent would silently skip them. The list object is slim —
+  # `duration` is detail-only and deliberately absent in v1.
+  - type: DeclarativeStream
+    name: pipelines
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          id: {type: [integer, "null"]}
+          iid: {type: [integer, "null"]}
+          project_id: {type: [integer, "null"]}
+          status: {type: [string, "null"]}
+          source: {type: [string, "null"]}
+          ref: {type: [string, "null"]}
+          sha: {type: [string, "null"]}
+          name: {type: [string, "null"]}
+          created_at: {type: [string, "null"]}
+          updated_at: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['gitlab_url'] }}/api/v4"
+        authenticator:
+          type: ApiKeyAuthenticator
+          api_token: "{{ config['gitlab_token'] }}"
+          inject_into:
+            type: RequestOption
+            field_name: PRIVATE-TOKEN
+            inject_into: header
+        path: "/projects/{{ stream_partition.project_id }}/pipelines"
+        http_method: GET
+        request_parameters:
+          order_by: updated_at
+          sort: asc
+          per_page: "{{ config.get('gitlab_page_size', 100) }}"
+        error_handler:
+          type: DefaultErrorHandler
+          backoff_strategies:
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+          response_filters:
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RATE_LIMITED
+              error_message: GitLab is rate limiting this token
+            - type: HttpResponseFilter
+              http_codes: [403, 404]
+              action: IGNORE
+              error_message: >-
+                Not visible or disabled for this project; other projects continue.
+            - type: HttpResponseFilter
+              http_codes: [401]
+              action: FAIL
+              failure_type: config_error
+              error_message: GitLab rejected the token; check gitlab_token scopes (read_api)
+            - type: HttpResponseFilter
+              http_codes: [500, 502, 503, 504]
+              action: RETRY
+              error_message: Transient GitLab error
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: PageIncrement
+          page_size: "{{ config.get('gitlab_page_size', 100) }}"
+          start_from_page: 1
+        page_token_option:
+          type: RequestOption
+          field_name: page
+          inject_into: request_parameter
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: id
+            partition_field: project_id
+            stream:
+              type: DeclarativeStream
+              name: projects_for_pipelines
+              primary_key:
+                - id
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/schema#
+                  properties:
+                    id: {type: [integer, "null"]}
+                    last_activity_at: {type: [string, "null"]}
+                  additionalProperties: true
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: "{{ config['gitlab_url'] }}/api/v4"
+                  authenticator:
+                    type: ApiKeyAuthenticator
+                    api_token: "{{ config['gitlab_token'] }}"
+                    inject_into:
+                      type: RequestOption
+                      field_name: PRIVATE-TOKEN
+                      inject_into: header
+                  path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/projects"
+                  http_method: GET
+                  request_parameters:
+                    include_subgroups: "true"
+                    archived: "false"
+                    per_page: "{{ config.get('gitlab_page_size', 100) }}"
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: []
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: PageIncrement
+                    page_size: "{{ config.get('gitlab_page_size', 100) }}"
+                    start_from_page: 1
+                  page_token_option:
+                    type: RequestOption
+                    field_name: page
+                    inject_into: request_parameter
+                partition_router:
+                  type: ListPartitionRouter
+                  values: "{{ config['gitlab_groups'] }}"
+                  cursor_field: group
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: updated_at
+      datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S.%f%z"
+        - "%Y-%m-%dT%H:%M:%S%z"
+      lookback_window: P1D
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('gitlab_start_date', '2020-01-01') }}"
+        datetime_format: "%Y-%m-%d"
+      start_time_option:
+        type: RequestOption
+        field_name: updated_after
+        inject_into: request_parameter
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_gitlab_nocode
+          - type: AddedFieldDefinition
+            path: [collected_at]
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ record['id'] | string | replace(':', '%3A') }}
+
+  # ── Deployments (GitLab API) ────────────────────────────────────────────
+  # Only populated where teams use GitLab environments; an empty stream is
+  # normal, not an error. Outcome (`status`) is in the list — the cheap DORA
+  # signal.
+  - type: DeclarativeStream
+    name: deployments
+    primary_key:
+      - unique_key
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          unique_key: {type: string}
+          tenant_id: {type: [string, "null"]}
+          source_id: {type: [string, "null"]}
+          data_source: {type: [string, "null"]}
+          collected_at: {type: [string, "null"]}
+          id: {type: [integer, "null"]}
+          iid: {type: [integer, "null"]}
+          project_id: {type: [integer, "null"]}
+          status: {type: [string, "null"]}
+          ref: {type: [string, "null"]}
+          sha: {type: [string, "null"]}
+          environment_name: {type: [string, "null"]}
+          deployable_status: {type: [string, "null"]}
+          pipeline_id: {type: [integer, "null"]}
+          created_at: {type: [string, "null"]}
+          updated_at: {type: [string, "null"]}
+        required:
+          - unique_key
+        additionalProperties: true
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['gitlab_url'] }}/api/v4"
+        authenticator:
+          type: ApiKeyAuthenticator
+          api_token: "{{ config['gitlab_token'] }}"
+          inject_into:
+            type: RequestOption
+            field_name: PRIVATE-TOKEN
+            inject_into: header
+        path: "/projects/{{ stream_partition.project_id }}/deployments"
+        http_method: GET
+        request_parameters:
+          order_by: updated_at
+          sort: asc
+          per_page: "{{ config.get('gitlab_page_size', 100) }}"
+        error_handler:
+          type: DefaultErrorHandler
+          backoff_strategies:
+            - type: WaitTimeFromHeader
+              header: Retry-After
+              max_waiting_time_in_seconds: 600
+          response_filters:
+            - type: HttpResponseFilter
+              http_codes: [429]
+              action: RATE_LIMITED
+              error_message: GitLab is rate limiting this token
+            - type: HttpResponseFilter
+              http_codes: [403, 404]
+              action: IGNORE
+              error_message: >-
+                Not visible or disabled for this project; other projects continue.
+            - type: HttpResponseFilter
+              http_codes: [401]
+              action: FAIL
+              failure_type: config_error
+              error_message: GitLab rejected the token; check gitlab_token scopes (read_api)
+            - type: HttpResponseFilter
+              http_codes: [500, 502, 503, 504]
+              action: RETRY
+              error_message: Transient GitLab error
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: PageIncrement
+          page_size: "{{ config.get('gitlab_page_size', 100) }}"
+          start_from_page: 1
+        page_token_option:
+          type: RequestOption
+          field_name: page
+          inject_into: request_parameter
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: id
+            partition_field: project_id
+            stream:
+              type: DeclarativeStream
+              name: projects_for_deployments
+              primary_key:
+                - id
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/schema#
+                  properties:
+                    id: {type: [integer, "null"]}
+                    last_activity_at: {type: [string, "null"]}
+                  additionalProperties: true
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: "{{ config['gitlab_url'] }}/api/v4"
+                  authenticator:
+                    type: ApiKeyAuthenticator
+                    api_token: "{{ config['gitlab_token'] }}"
+                    inject_into:
+                      type: RequestOption
+                      field_name: PRIVATE-TOKEN
+                      inject_into: header
+                  path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/projects"
+                  http_method: GET
+                  request_parameters:
+                    include_subgroups: "true"
+                    archived: "false"
+                    per_page: "{{ config.get('gitlab_page_size', 100) }}"
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: []
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: PageIncrement
+                    page_size: "{{ config.get('gitlab_page_size', 100) }}"
+                    start_from_page: 1
+                  page_token_option:
+                    type: RequestOption
+                    field_name: page
+                    inject_into: request_parameter
+                partition_router:
+                  type: ListPartitionRouter
+                  values: "{{ config['gitlab_groups'] }}"
+                  cursor_field: group
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: updated_at
+      datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S.%f%z"
+        - "%Y-%m-%dT%H:%M:%S%z"
+      lookback_window: P1D
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('gitlab_start_date', '2020-01-01') }}"
+        datetime_format: "%Y-%m-%d"
+      start_time_option:
+        type: RequestOption
+        field_name: updated_after
+        inject_into: request_parameter
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_gitlab_nocode
+          - type: AddedFieldDefinition
+            path: [collected_at]
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          - type: AddedFieldDefinition
+            path: [environment_name]
+            value: "{{ (record.get('environment') or {}).get('name') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [deployable_status]
+            value: "{{ (record.get('deployable') or {}).get('status') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [pipeline_id]
+            value: "{{ ((record.get('deployable') or {}).get('pipeline') or {}).get('id') }}"
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: >-
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ record['id'] | string | replace(':', '%3A') }}
+
 concurrency_level:
   type: ConcurrencyLevel
   # Never 1: the concurrent CDK self-deadlocks at a single worker once a sync
@@ -824,20 +1821,20 @@ spec:
         description: >-
           Base URL of the git-cli-proxy service (cluster-internal, e.g. http://insight-git-cli-proxy:8085). No default: a wrong or absent value must fail the check, not fall back somewhere.
         title: Git Proxy URL
-        order: 4
+        order: 5
       git_proxy_token:
         type: string
         description: Bearer token the git-cli-proxy requires on every /v1 request.
         title: Git Proxy Token
         airbyte_secret: true
-        order: 5
+        order: 6
       gitlab_start_date:
         type: string
         description: Earliest date for incremental sync (YYYY-MM-DD).
         title: Start Date
         format: date
         default: "2020-01-01"
-        order: 6
+        order: 7
       gitlab_page_size:
         type: integer
         description: GitLab API page size (max 100).
@@ -845,7 +1842,7 @@ spec:
         default: 100
         minimum: 1
         maximum: 100
-        order: 7
+        order: 8
       proxy_page_size:
         type: integer
         description: Rows per page requested from the git-cli-proxy.
@@ -853,14 +1850,14 @@ spec:
         default: 500
         minimum: 1
         maximum: 10000
-        order: 8
+        order: 9
       gitlab_include_patch:
         type: boolean
         description: >-
           Store per-file diff text. Keep enabled to allow recomputing line counts later under different filters (blank lines, comments); disable to cut bronze volume.
         title: Include Patch Text
         default: true
-        order: 9
+        order: 10
       gitlab_max_patch_bytes:
         type: integer
         description: >-
@@ -868,14 +1865,25 @@ spec:
         title: Max Patch Bytes
         default: 1048576
         minimum: 1024
-        order: 10
+        order: 11
       gitlab_lookback_window:
         type: string
         description: >-
           ISO-8601 duration re-enumerated below the stored cursor on every sync. `git log --since` is a traversal cutoff, so after a rebase the replacement commits can carry dates below the cursor and would never be visited again. Bronze dedups the re-read rows, so the cost is one window per sync. A rewrite older than the window is still lost.
         title: Rebase Lookback Window
         default: P1M
-        order: 11
+        order: 12
+      gitlab_child_window_days:
+        type: integer
+        description: >-
+          Sliding window, in days, of merge requests whose notes and approvals
+          are re-read each sync. The children have no cursor of their own, so
+          the window is what bounds their cost; edits on MRs older than the
+          window are not picked up.
+        title: MR Child Window (days)
+        default: 30
+        minimum: 1
+        order: 13
     additionalProperties: true
 
 metadata:
@@ -884,3 +1892,9 @@ metadata:
     commits: false
     commit_files: false
     repo_branches: false
+    merge_requests: false
+    merge_request_notes: false
+    merge_request_approvals: false
+    users: false
+    pipelines: false
+    deployments: false

--- a/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
@@ -79,12 +79,17 @@ streams:
             type: RequestOption
             field_name: PRIVATE-TOKEN
             inject_into: header
-        path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/projects"
+        path: "{{ '/projects' if stream_partition.group == '*' else '/groups/' ~ (stream_partition.group | string | replace('/', '%2F')) ~ '/projects' }}"
         http_method: GET
         request_parameters:
-          include_subgroups: "true"
+          # Instance mode ('*'): keyset pagination on /projects — the
+          # offset cap (default 50k) applies only there, and keyset needs
+          # order_by=id. A parameter whose value renders '' is dropped
+          # from the request entirely (None would send the text "None").
+          include_subgroups: "{{ '' if stream_partition.group == '*' else 'true' }}"
           archived: "false"
-          order_by: last_activity_at
+          pagination: "{{ 'keyset' if stream_partition.group == '*' else '' }}"
+          order_by: "{{ 'id' if stream_partition.group == '*' else 'last_activity_at' }}"
           sort: asc
           per_page: "100"
           statistics: "true"
@@ -96,19 +101,19 @@ streams:
       paginator:
         type: DefaultPaginator
         pagination_strategy:
-          type: PageIncrement
-          page_size: "100"
-          start_from_page: 1
+          type: CursorPagination
+          # GitLab sends Link rel=next for offset AND keyset pagination,
+          # so one cursor serves both modes; the server drives.
+          cursor_value: "{{ headers['link']['next']['url'] }}"
+          stop_condition: "{{ 'next' not in headers.get('link', {}) }}"
         page_token_option:
-          type: RequestOption
-          field_name: page
-          inject_into: request_parameter
+          type: RequestPath
       partition_router:
         # INSIDE `retriever`: at stream level the CDK silently ignores it.
-        # A read_api service account is a member of nothing, so /projects?membership
-        # returns zero rows; group scoping works by group visibility instead.
+        # Groups scope every stream's endpoint addressing; empty means one
+        # '*' partition = the whole instance the token can see.
         type: ListPartitionRouter
-        values: "{{ config['gitlab_groups'] }}"
+        values: "{{ config['gitlab_groups'] or ['*'] }}"
         cursor_field: group
     incremental_sync:
       type: DatetimeBasedCursor
@@ -292,12 +297,17 @@ streams:
                       type: RequestOption
                       field_name: PRIVATE-TOKEN
                       inject_into: header
-                  path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/projects"
+                  path: "{{ '/projects' if stream_partition.group == '*' else '/groups/' ~ (stream_partition.group | string | replace('/', '%2F')) ~ '/projects' }}"
                   http_method: GET
                   request_parameters:
-                    include_subgroups: "true"
+                    # Instance mode ('*'): keyset pagination on /projects — the
+                    # offset cap (default 50k) applies only there, and keyset needs
+                    # order_by=id. A parameter whose value renders '' is dropped
+                    # from the request entirely (None would send the text "None").
+                    include_subgroups: "{{ '' if stream_partition.group == '*' else 'true' }}"
                     archived: "false"
-                    order_by: last_activity_at
+                    pagination: "{{ 'keyset' if stream_partition.group == '*' else '' }}"
+                    order_by: "{{ 'id' if stream_partition.group == '*' else 'last_activity_at' }}"
                     sort: asc
                     per_page: "100"
                 record_selector:
@@ -308,19 +318,19 @@ streams:
                 paginator:
                   type: DefaultPaginator
                   pagination_strategy:
-                    type: PageIncrement
-                    page_size: "100"
-                    start_from_page: 1
+                    type: CursorPagination
+                    # GitLab sends Link rel=next for offset AND keyset pagination,
+                    # so one cursor serves both modes; the server drives.
+                    cursor_value: "{{ headers['link']['next']['url'] }}"
+                    stop_condition: "{{ 'next' not in headers.get('link', {}) }}"
                   page_token_option:
-                    type: RequestOption
-                    field_name: page
-                    inject_into: request_parameter
+                    type: RequestPath
                 partition_router:
                   # INSIDE `retriever`: at stream level the CDK silently ignores it.
                   # A read_api service account is a member of nothing, so /projects?membership
                   # returns zero rows; group scoping works by group visibility instead.
                   type: ListPartitionRouter
-                  values: "{{ config['gitlab_groups'] }}"
+                  values: "{{ config['gitlab_groups'] or ['*'] }}"
                   cursor_field: group
               incremental_sync:
                 type: DatetimeBasedCursor
@@ -517,12 +527,17 @@ streams:
                       type: RequestOption
                       field_name: PRIVATE-TOKEN
                       inject_into: header
-                  path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/projects"
+                  path: "{{ '/projects' if stream_partition.group == '*' else '/groups/' ~ (stream_partition.group | string | replace('/', '%2F')) ~ '/projects' }}"
                   http_method: GET
                   request_parameters:
-                    include_subgroups: "true"
+                    # Instance mode ('*'): keyset pagination on /projects — the
+                    # offset cap (default 50k) applies only there, and keyset needs
+                    # order_by=id. A parameter whose value renders '' is dropped
+                    # from the request entirely (None would send the text "None").
+                    include_subgroups: "{{ '' if stream_partition.group == '*' else 'true' }}"
                     archived: "false"
-                    order_by: last_activity_at
+                    pagination: "{{ 'keyset' if stream_partition.group == '*' else '' }}"
+                    order_by: "{{ 'id' if stream_partition.group == '*' else 'last_activity_at' }}"
                     sort: asc
                     per_page: "100"
                 record_selector:
@@ -533,19 +548,19 @@ streams:
                 paginator:
                   type: DefaultPaginator
                   pagination_strategy:
-                    type: PageIncrement
-                    page_size: "100"
-                    start_from_page: 1
+                    type: CursorPagination
+                    # GitLab sends Link rel=next for offset AND keyset pagination,
+                    # so one cursor serves both modes; the server drives.
+                    cursor_value: "{{ headers['link']['next']['url'] }}"
+                    stop_condition: "{{ 'next' not in headers.get('link', {}) }}"
                   page_token_option:
-                    type: RequestOption
-                    field_name: page
-                    inject_into: request_parameter
+                    type: RequestPath
                 partition_router:
                   # INSIDE `retriever`: at stream level the CDK silently ignores it.
                   # A read_api service account is a member of nothing, so /projects?membership
                   # returns zero rows; group scoping works by group visibility instead.
                   type: ListPartitionRouter
-                  values: "{{ config['gitlab_groups'] }}"
+                  values: "{{ config['gitlab_groups'] or ['*'] }}"
                   cursor_field: group
               incremental_sync:
                 type: DatetimeBasedCursor
@@ -730,11 +745,18 @@ streams:
                       type: RequestOption
                       field_name: PRIVATE-TOKEN
                       inject_into: header
-                  path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/projects"
+                  path: "{{ '/projects' if stream_partition.group == '*' else '/groups/' ~ (stream_partition.group | string | replace('/', '%2F')) ~ '/projects' }}"
                   http_method: GET
                   request_parameters:
-                    include_subgroups: "true"
+                    # Instance mode ('*'): keyset pagination on /projects — the
+                    # offset cap (default 50k) applies only there, and keyset needs
+                    # order_by=id. A parameter whose value renders '' is dropped
+                    # from the request entirely (None would send the text "None").
+                    include_subgroups: "{{ '' if stream_partition.group == '*' else 'true' }}"
                     archived: "false"
+                    pagination: "{{ 'keyset' if stream_partition.group == '*' else '' }}"
+                    order_by: "{{ 'id' if stream_partition.group == '*' else '' }}"
+                    sort: "{{ 'asc' if stream_partition.group == '*' else '' }}"
                     per_page: "100"
                 record_selector:
                   type: RecordSelector
@@ -744,19 +766,19 @@ streams:
                 paginator:
                   type: DefaultPaginator
                   pagination_strategy:
-                    type: PageIncrement
-                    page_size: "100"
-                    start_from_page: 1
+                    type: CursorPagination
+                    # GitLab sends Link rel=next for offset AND keyset pagination,
+                    # so one cursor serves both modes; the server drives.
+                    cursor_value: "{{ headers['link']['next']['url'] }}"
+                    stop_condition: "{{ 'next' not in headers.get('link', {}) }}"
                   page_token_option:
-                    type: RequestOption
-                    field_name: page
-                    inject_into: request_parameter
+                    type: RequestPath
                 partition_router:
                   # INSIDE `retriever`: at stream level the CDK silently ignores it.
                   # A read_api service account is a member of nothing, so /projects?membership
                   # returns zero rows; group scoping works by group visibility instead.
                   type: ListPartitionRouter
-                  values: "{{ config['gitlab_groups'] }}"
+                  values: "{{ config['gitlab_groups'] or ['*'] }}"
                   cursor_field: group
     transformations:
       - type: AddFields
@@ -835,7 +857,7 @@ streams:
             type: RequestOption
             field_name: PRIVATE-TOKEN
             inject_into: header
-        path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/merge_requests"
+        path: "{{ '/merge_requests' if stream_partition.group == '*' else '/groups/' ~ (stream_partition.group | string | replace('/', '%2F')) ~ '/merge_requests' }}"
         http_method: GET
         request_parameters:
           scope: all
@@ -879,7 +901,7 @@ streams:
           inject_into: request_parameter
       partition_router:
         type: ListPartitionRouter
-        values: "{{ config['gitlab_groups'] }}"
+        values: "{{ config['gitlab_groups'] or ['*'] }}"
         cursor_field: group
     incremental_sync:
       type: DatetimeBasedCursor
@@ -947,9 +969,11 @@ streams:
   # ── Merge request diff totals (GitLab GraphQL) ──────────────────────────
   # REST exposes no line counts on a merge request — only `changes_count`, a
   # capped STRING ("1000+") on the detail response (VERIFIED against the live
-  # API docs). GraphQL carries real integers in diffStatsSummary, and the
-  # group-level connection filters server-side by updatedAfter, so this stream
-  # costs one paged query per group with no per-MR fan-out.
+  # API docs). GraphQL carries real integers in diffStatsSummary. There is no
+  # instance-wide GraphQL mergeRequests query, so the stream fans out one
+  # paged query per project — the uniform shape for group-scoped and
+  # full-instance installs alike; incremental_dependency keeps the fan-out
+  # proportional to repository activity, and updatedAfter bounds each query.
   - type: DeclarativeStream
     name: merge_request_diff_stats
     primary_key:
@@ -1000,9 +1024,10 @@ streams:
               http_codes: [429]
               action: RATE_LIMITED
               error_message: GitLab is rate limiting this token
-            # GraphQL errors arrive as HTTP 200 with an `errors` array. A group
-            # the token cannot see comes back as data.group = null WITHOUT an
-            # error, which the guarded paginator below reads as an empty page.
+            # GraphQL errors arrive as HTTP 200 with an `errors` array. A
+            # project the token cannot see (or deleted mid-sync) comes back as
+            # data.project = null WITHOUT an error, which the guarded paginator
+            # below reads as an empty page.
             - type: HttpResponseFilter
               action: FAIL
               predicate: "{{ (response.get('errors') or []) | length > 0 }}"
@@ -1018,42 +1043,123 @@ streams:
               error_message: Transient GitLab error
         request_body_json:
           query: |
-            query($group: ID!, $updatedAfter: Time, $cursor: String) {
-              group(fullPath: $group) {
-                mergeRequests(includeSubgroups: true, updatedAfter: $updatedAfter, sort: UPDATED_ASC, first: 100, after: $cursor) {
+            query($project: ID!, $updatedAfter: Time, $cursor: String) {
+              project(fullPath: $project) {
+                mergeRequests(updatedAfter: $updatedAfter, sort: UPDATED_ASC, first: 100, after: $cursor) {
                   pageInfo { hasNextPage endCursor }
                   nodes {
                     iid
                     updatedAt
-                    project { id }
                     diffStatsSummary { additions deletions fileCount }
                   }
                 }
               }
             }
           variables:
-            group: "{{ stream_partition.group }}"
+            project: "{{ stream_partition.project_path }}"
       record_selector:
         type: RecordSelector
         extractor:
           type: DpathExtractor
-          field_path: [data, group, mergeRequests, nodes]
+          field_path: [data, project, mergeRequests, nodes]
       paginator:
         type: DefaultPaginator
         pagination_strategy:
           type: CursorPagination
-          # `data.group` is null when the token cannot see the group, so every
-          # hop is guarded rather than subscripted.
-          cursor_value: "{{ ((((response.get('data') or {}).get('group') or {}).get('mergeRequests') or {}).get('pageInfo') or {}).get('endCursor') }}"
-          stop_condition: "{{ not ((((response.get('data') or {}).get('group') or {}).get('mergeRequests') or {}).get('pageInfo') or {}).get('hasNextPage') }}"
+          # `data.project` is null when the token cannot see the project, so
+          # every hop is guarded rather than subscripted.
+          cursor_value: "{{ ((((response.get('data') or {}).get('project') or {}).get('mergeRequests') or {}).get('pageInfo') or {}).get('endCursor') }}"
+          stop_condition: "{{ not ((((response.get('data') or {}).get('project') or {}).get('mergeRequests') or {}).get('pageInfo') or {}).get('hasNextPage') }}"
         page_token_option:
           type: RequestOption
           inject_into: body_json
           field_path: [variables, cursor]
       partition_router:
-        type: ListPartitionRouter
-        values: "{{ config['gitlab_groups'] }}"
-        cursor_field: group
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: path_with_namespace
+            partition_field: project_path
+            extra_fields:
+              - [id]
+            # `incremental_dependency` is what keeps the fan-out proportional
+            # to activity: the parent is itself incremental, so only projects
+            # touched since the last sync are queried. The CDK persists parent
+            # state ONLY when the child is incremental — which this stream is.
+            incremental_dependency: true
+            stream:
+              type: DeclarativeStream
+              name: projects_for_diff_stats
+              primary_key:
+                - id
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  type: object
+                  $schema: http://json-schema.org/schema#
+                  properties:
+                    id: {type: [integer, "null"]}
+                    path_with_namespace: {type: [string, "null"]}
+                    last_activity_at: {type: [string, "null"]}
+                  additionalProperties: true
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  type: HttpRequester
+                  url_base: "{{ config['gitlab_url'] }}/api/v4"
+                  authenticator:
+                    type: ApiKeyAuthenticator
+                    api_token: "{{ config['gitlab_token'] }}"
+                    inject_into:
+                      type: RequestOption
+                      field_name: PRIVATE-TOKEN
+                      inject_into: header
+                  path: "{{ '/projects' if stream_partition.group == '*' else '/groups/' ~ (stream_partition.group | string | replace('/', '%2F')) ~ '/projects' }}"
+                  http_method: GET
+                  request_parameters:
+                    # Instance mode ('*'): keyset pagination on /projects — the
+                    # offset cap (default 50k) applies only there, and keyset needs
+                    # order_by=id. A parameter whose value renders '' is dropped
+                    # from the request entirely (None would send the text "None").
+                    include_subgroups: "{{ '' if stream_partition.group == '*' else 'true' }}"
+                    archived: "false"
+                    pagination: "{{ 'keyset' if stream_partition.group == '*' else '' }}"
+                    order_by: "{{ 'id' if stream_partition.group == '*' else 'last_activity_at' }}"
+                    sort: asc
+                    per_page: "100"
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: []
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: CursorPagination
+                    # GitLab sends Link rel=next for offset AND keyset pagination,
+                    # so one cursor serves both modes; the server drives.
+                    cursor_value: "{{ headers['link']['next']['url'] }}"
+                    stop_condition: "{{ 'next' not in headers.get('link', {}) }}"
+                  page_token_option:
+                    type: RequestPath
+                partition_router:
+                  type: ListPartitionRouter
+                  values: "{{ config['gitlab_groups'] or ['*'] }}"
+                  cursor_field: group
+              incremental_sync:
+                type: DatetimeBasedCursor
+                cursor_field: last_activity_at
+                datetime_format: "%Y-%m-%dT%H:%M:%S.%f%z"
+                cursor_datetime_formats:
+                  - "%Y-%m-%dT%H:%M:%S.%f%z"
+                  - "%Y-%m-%dT%H:%M:%S%z"
+                start_datetime:
+                  type: MinMaxDatetime
+                  datetime: "{{ config['gitlab_start_date'] }}"
+                  datetime_format: "%Y-%m-%d"
+                # No server-side activity filter on this endpoint; the
+                # cursor filters client-side (see repositories stream).
+                is_client_side_incremental: true
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: updated_at
@@ -1089,7 +1195,7 @@ streams:
             value: "{{ record.get('iid') | int }}"
           - type: AddedFieldDefinition
             path: [project_id]
-            value: "{{ ((record.get('project') or {}).get('id') or '') | replace('gid://gitlab/Project/', '') | int }}"
+            value: "{{ stream_slice.extra_fields['id'] }}"
           # diffStatsSummary is nullable: GitLab computes the stats
           # asynchronously, so a just-opened MR reports null rather than zero
           # and the next window re-reads it.
@@ -1109,13 +1215,12 @@ streams:
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
-              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ ((record.get('project') or {}).get('id') or '') | replace('gid://gitlab/Project/', '') }}:{{ record['iid'] }}
+              {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['id'] }}:{{ record['iid'] }}
       - type: RemoveFields
         # Hoisted above; the GraphQL originals stay out of bronze.
         field_pointers:
           - [iid]
           - [updatedAt]
-          - [project]
           - [diffStatsSummary]
 
   # ── Merge request notes (GitLab API) ────────────────────────────────────
@@ -1246,7 +1351,7 @@ streams:
                       type: RequestOption
                       field_name: PRIVATE-TOKEN
                       inject_into: header
-                  path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/merge_requests"
+                  path: "{{ '/merge_requests' if stream_partition.group == '*' else '/groups/' ~ (stream_partition.group | string | replace('/', '%2F')) ~ '/merge_requests' }}"
                   http_method: GET
                   request_parameters:
                     scope: all
@@ -1275,7 +1380,7 @@ streams:
                     inject_into: request_parameter
                 partition_router:
                   type: ListPartitionRouter
-                  values: "{{ config['gitlab_groups'] }}"
+                  values: "{{ config['gitlab_groups'] or ['*'] }}"
                   cursor_field: group
     transformations:
       - type: AddFields
@@ -1445,7 +1550,7 @@ streams:
                       type: RequestOption
                       field_name: PRIVATE-TOKEN
                       inject_into: header
-                  path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/merge_requests"
+                  path: "{{ '/merge_requests' if stream_partition.group == '*' else '/groups/' ~ (stream_partition.group | string | replace('/', '%2F')) ~ '/merge_requests' }}"
                   http_method: GET
                   request_parameters:
                     scope: all
@@ -1474,7 +1579,7 @@ streams:
                     inject_into: request_parameter
                 partition_router:
                   type: ListPartitionRouter
-                  values: "{{ config['gitlab_groups'] }}"
+                  values: "{{ config['gitlab_groups'] or ['*'] }}"
                   cursor_field: group
     transformations:
       - type: AddFields
@@ -1635,7 +1740,7 @@ streams:
                       type: RequestOption
                       field_name: PRIVATE-TOKEN
                       inject_into: header
-                  path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/merge_requests"
+                  path: "{{ '/merge_requests' if stream_partition.group == '*' else '/groups/' ~ (stream_partition.group | string | replace('/', '%2F')) ~ '/merge_requests' }}"
                   http_method: GET
                   request_parameters:
                     scope: all
@@ -1664,7 +1769,7 @@ streams:
                     inject_into: request_parameter
                 partition_router:
                   type: ListPartitionRouter
-                  values: "{{ config['gitlab_groups'] }}"
+                  values: "{{ config['gitlab_groups'] or ['*'] }}"
                   cursor_field: group
     transformations:
       - type: AddFields
@@ -1747,7 +1852,7 @@ streams:
             type: RequestOption
             field_name: PRIVATE-TOKEN
             inject_into: header
-        path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/members/all"
+        path: "{{ '/users' if stream_partition.group == '*' else '/groups/' ~ (stream_partition.group | string | replace('/', '%2F')) ~ '/members/all' }}"
         http_method: GET
         request_parameters:
           per_page: "100"
@@ -1793,7 +1898,7 @@ streams:
           inject_into: request_parameter
       partition_router:
         type: ListPartitionRouter
-        values: "{{ config['gitlab_groups'] }}"
+        values: "{{ config['gitlab_groups'] or ['*'] }}"
         cursor_field: group
     transformations:
       - type: AddFields
@@ -1950,11 +2055,18 @@ streams:
                       type: RequestOption
                       field_name: PRIVATE-TOKEN
                       inject_into: header
-                  path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/projects"
+                  path: "{{ '/projects' if stream_partition.group == '*' else '/groups/' ~ (stream_partition.group | string | replace('/', '%2F')) ~ '/projects' }}"
                   http_method: GET
                   request_parameters:
-                    include_subgroups: "true"
+                    # Instance mode ('*'): keyset pagination on /projects — the
+                    # offset cap (default 50k) applies only there, and keyset needs
+                    # order_by=id. A parameter whose value renders '' is dropped
+                    # from the request entirely (None would send the text "None").
+                    include_subgroups: "{{ '' if stream_partition.group == '*' else 'true' }}"
                     archived: "false"
+                    pagination: "{{ 'keyset' if stream_partition.group == '*' else '' }}"
+                    order_by: "{{ 'id' if stream_partition.group == '*' else '' }}"
+                    sort: "{{ 'asc' if stream_partition.group == '*' else '' }}"
                     per_page: "100"
                 record_selector:
                   type: RecordSelector
@@ -1964,16 +2076,16 @@ streams:
                 paginator:
                   type: DefaultPaginator
                   pagination_strategy:
-                    type: PageIncrement
-                    page_size: "100"
-                    start_from_page: 1
+                    type: CursorPagination
+                    # GitLab sends Link rel=next for offset AND keyset pagination,
+                    # so one cursor serves both modes; the server drives.
+                    cursor_value: "{{ headers['link']['next']['url'] }}"
+                    stop_condition: "{{ 'next' not in headers.get('link', {}) }}"
                   page_token_option:
-                    type: RequestOption
-                    field_name: page
-                    inject_into: request_parameter
+                    type: RequestPath
                 partition_router:
                   type: ListPartitionRouter
-                  values: "{{ config['gitlab_groups'] }}"
+                  values: "{{ config['gitlab_groups'] or ['*'] }}"
                   cursor_field: group
     incremental_sync:
       type: DatetimeBasedCursor
@@ -2134,11 +2246,18 @@ streams:
                       type: RequestOption
                       field_name: PRIVATE-TOKEN
                       inject_into: header
-                  path: "/groups/{{ stream_partition.group | string | replace('/', '%2F') }}/projects"
+                  path: "{{ '/projects' if stream_partition.group == '*' else '/groups/' ~ (stream_partition.group | string | replace('/', '%2F')) ~ '/projects' }}"
                   http_method: GET
                   request_parameters:
-                    include_subgroups: "true"
+                    # Instance mode ('*'): keyset pagination on /projects — the
+                    # offset cap (default 50k) applies only there, and keyset needs
+                    # order_by=id. A parameter whose value renders '' is dropped
+                    # from the request entirely (None would send the text "None").
+                    include_subgroups: "{{ '' if stream_partition.group == '*' else 'true' }}"
                     archived: "false"
+                    pagination: "{{ 'keyset' if stream_partition.group == '*' else '' }}"
+                    order_by: "{{ 'id' if stream_partition.group == '*' else '' }}"
+                    sort: "{{ 'asc' if stream_partition.group == '*' else '' }}"
                     per_page: "100"
                 record_selector:
                   type: RecordSelector
@@ -2148,16 +2267,16 @@ streams:
                 paginator:
                   type: DefaultPaginator
                   pagination_strategy:
-                    type: PageIncrement
-                    page_size: "100"
-                    start_from_page: 1
+                    type: CursorPagination
+                    # GitLab sends Link rel=next for offset AND keyset pagination,
+                    # so one cursor serves both modes; the server drives.
+                    cursor_value: "{{ headers['link']['next']['url'] }}"
+                    stop_condition: "{{ 'next' not in headers.get('link', {}) }}"
                   page_token_option:
-                    type: RequestOption
-                    field_name: page
-                    inject_into: request_parameter
+                    type: RequestPath
                 partition_router:
                   type: ListPartitionRouter
-                  values: "{{ config['gitlab_groups'] }}"
+                  values: "{{ config['gitlab_groups'] or ['*'] }}"
                   cursor_field: group
     incremental_sync:
       type: DatetimeBasedCursor
@@ -2227,7 +2346,6 @@ spec:
       - insight_source_id
       - gitlab_url
       - gitlab_token
-      - gitlab_groups
       - git_proxy_url
       - git_proxy_token
       - gitlab_start_date
@@ -2261,7 +2379,7 @@ spec:
         items:
           type: string
         description: >-
-          Full paths of the GitLab groups to sync, including nested ones (e.g. acme, acme/platform). Subgroups are included. REQUIRED, and deliberately so: a read-only service account is a member of no project, so membership-scoped discovery returns nothing, and a declarative manifest cannot express the CDK connector's instance-wide fallback. A project reachable from two configured groups is emitted twice under one key and collapses downstream.
+          Full paths of the GitLab groups to sync, including nested ones (e.g. acme, acme/platform). Subgroups are included. Leave EMPTY to sync the full instance — every project the token can see — which uses keyset pagination and so has no offset ceiling. Groups scope every stream's endpoint addressing (projects, merge requests, members), not just discovery. A project reachable from two configured groups is emitted twice under one key and collapses downstream.
         title: GitLab Groups
         order: 4
       git_proxy_url:
@@ -2285,6 +2403,21 @@ spec:
         format: date
         order: 7
     additionalProperties: true
+    allOf:
+      # Full-instance mode on gitlab.com would enumerate every public project
+      # in the world; SaaS installs must scope by group.
+      - if:
+          properties:
+            gitlab_url:
+              pattern: "^https://(www\\.)?gitlab\\.com/?$"
+          required:
+            - gitlab_url
+        then:
+          properties:
+            gitlab_groups:
+              minItems: 1
+          required:
+            - gitlab_groups
 
 metadata:
   autoImportSchema:

--- a/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
@@ -71,6 +71,50 @@ definitions:
         action: RETRY
         error_message: Transient proxy error (the origin can reset a clone mid-transfer)
 
+  # Retry-After covers the throttles that carry it; a 5xx does not, so the
+  # exponential fallback is what bounds those retries.
+  vendor_backoff: &vendor_backoff
+    - type: WaitTimeFromHeader
+      header: Retry-After
+      max_waiting_time_in_seconds: 600
+    - type: ExponentialBackoffStrategy
+      factor: 2
+
+  # Repository discovery is the parent every other stream partitions on, so a
+  # throttle or a bad token here must classify, not surface as a generic error.
+  discovery_error_handler: &discovery_error_handler
+    type: DefaultErrorHandler
+    max_retries: 5
+    backoff_strategies: *vendor_backoff
+    response_filters:
+      - type: HttpResponseFilter
+        http_codes: [429]
+        action: RATE_LIMITED
+        error_message: GitLab is rate limiting this token
+      - type: HttpResponseFilter
+        http_codes: [401]
+        action: FAIL
+        failure_type: config_error
+        error_message: GitLab rejected the token; check gitlab_token scopes (read_api)
+      - type: HttpResponseFilter
+        http_codes: [500, 502, 503, 504]
+        action: RETRY
+        error_message: Transient GitLab error
+
+  proxy_requester: &proxy_requester
+    type: HttpRequester
+    url_base: "{{ config['git_proxy_url'] }}"
+    http_method: GET
+    authenticator:
+      type: BearerAuthenticator
+      api_token: "{{ config['git_proxy_token'] }}"
+    request_headers:
+      X-Tenant-Id: "{{ config['insight_tenant_id'] }}"
+      X-Source-Id: "{{ config['insight_source_id'] }}"
+      X-Git-Username: oauth2
+      X-Git-Token: "{{ config['gitlab_token'] }}"
+    error_handler: *proxy_error_handler
+
 check:
   type: CheckStream
   stream_names:
@@ -135,6 +179,7 @@ streams:
           sort: asc
           per_page: "100"
           statistics: "true"
+        error_handler: *discovery_error_handler
       record_selector:
         type: RecordSelector
         extractor:
@@ -236,22 +281,11 @@ streams:
     retriever:
       type: SimpleRetriever
       requester:
-        type: HttpRequester
-        url_base: "{{ config['git_proxy_url'] }}"
-        authenticator:
-          type: BearerAuthenticator
-          api_token: "{{ config['git_proxy_token'] }}"
-        request_headers:
-          X-Tenant-Id: "{{ config['insight_tenant_id'] }}"
-          X-Source-Id: "{{ config['insight_source_id'] }}"
-          X-Git-Username: oauth2
-          X-Git-Token: "{{ config['gitlab_token'] }}"
+        <<: *proxy_requester
         path: /v1/commits
-        http_method: GET
         request_parameters:
           repo: "{{ stream_partition.repo_clone_url }}"
           page_size: "500"
-        error_handler: *proxy_error_handler
       record_selector:
         type: RecordSelector
         extractor:
@@ -438,24 +472,13 @@ streams:
     retriever:
       type: SimpleRetriever
       requester:
-        type: HttpRequester
-        url_base: "{{ config['git_proxy_url'] }}"
-        authenticator:
-          type: BearerAuthenticator
-          api_token: "{{ config['git_proxy_token'] }}"
-        request_headers:
-          X-Tenant-Id: "{{ config['insight_tenant_id'] }}"
-          X-Source-Id: "{{ config['insight_source_id'] }}"
-          X-Git-Username: oauth2
-          X-Git-Token: "{{ config['gitlab_token'] }}"
+        <<: *proxy_requester
         path: /v1/file-changes
-        http_method: GET
         request_parameters:
           repo: "{{ stream_partition.repo_clone_url }}"
           page_size: "500"
           include_patch: "true"
           max_patch_bytes: "1048576"
-        error_handler: *proxy_error_handler
       record_selector:
         type: RecordSelector
         extractor:
@@ -625,22 +648,11 @@ streams:
     retriever:
       type: SimpleRetriever
       requester:
-        type: HttpRequester
-        url_base: "{{ config['git_proxy_url'] }}"
-        authenticator:
-          type: BearerAuthenticator
-          api_token: "{{ config['git_proxy_token'] }}"
-        request_headers:
-          X-Tenant-Id: "{{ config['insight_tenant_id'] }}"
-          X-Source-Id: "{{ config['insight_source_id'] }}"
-          X-Git-Username: oauth2
-          X-Git-Token: "{{ config['gitlab_token'] }}"
+        <<: *proxy_requester
         path: /v1/branches
-        http_method: GET
         request_parameters:
           repo: "{{ stream_partition.repo_clone_url }}"
           page_size: "500"
-        error_handler: *proxy_error_handler
       record_selector:
         type: RecordSelector
         extractor:
@@ -812,10 +824,8 @@ streams:
           per_page: "100"
         error_handler:
           type: DefaultErrorHandler
-          backoff_strategies:
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
+          max_retries: 5
+          backoff_strategies: *vendor_backoff
           response_filters:
             - type: HttpResponseFilter
               http_codes: [429]
@@ -961,10 +971,7 @@ streams:
         error_handler:
           type: DefaultErrorHandler
           max_retries: 5
-          backoff_strategies:
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
+          backoff_strategies: *vendor_backoff
           response_filters:
             - type: HttpResponseFilter
               http_codes: [429]
@@ -1223,10 +1230,8 @@ streams:
           per_page: "100"
         error_handler:
           type: DefaultErrorHandler
-          backoff_strategies:
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
+          max_retries: 5
+          backoff_strategies: *vendor_backoff
           response_filters:
             - type: HttpResponseFilter
               http_codes: [429]
@@ -1422,10 +1427,8 @@ streams:
           per_page: "100"
         error_handler:
           type: DefaultErrorHandler
-          backoff_strategies:
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
+          max_retries: 5
+          backoff_strategies: *vendor_backoff
           response_filters:
             - type: HttpResponseFilter
               http_codes: [429]
@@ -1620,10 +1623,8 @@ streams:
         http_method: GET
         error_handler:
           type: DefaultErrorHandler
-          backoff_strategies:
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
+          max_retries: 5
+          backoff_strategies: *vendor_backoff
           response_filters:
             - type: HttpResponseFilter
               http_codes: [429]
@@ -1804,10 +1805,8 @@ streams:
           per_page: "100"
         error_handler:
           type: DefaultErrorHandler
-          backoff_strategies:
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
+          max_retries: 5
+          backoff_strategies: *vendor_backoff
           response_filters:
             - type: HttpResponseFilter
               http_codes: [429]
@@ -1931,10 +1930,8 @@ streams:
           per_page: "100"
         error_handler:
           type: DefaultErrorHandler
-          backoff_strategies:
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
+          max_retries: 5
+          backoff_strategies: *vendor_backoff
           response_filters:
             - type: HttpResponseFilter
               http_codes: [429]
@@ -2122,10 +2119,8 @@ streams:
           per_page: "100"
         error_handler:
           type: DefaultErrorHandler
-          backoff_strategies:
-            - type: WaitTimeFromHeader
-              header: Retry-After
-              max_waiting_time_in_seconds: 600
+          max_retries: 5
+          backoff_strategies: *vendor_backoff
           response_filters:
             - type: HttpResponseFilter
               http_codes: [429]

--- a/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
+++ b/src/ingestion/connectors/git/gitlab-nocode/connector.yaml
@@ -60,6 +60,8 @@ streams:
           http_url_to_repo: {type: [string, "null"]}
           created_at: {type: [string, "null"]}
           last_activity_at: {type: [string, "null"]}
+          description: {type: [string, "null"]}
+          statistics_repository_size: {type: [integer, "null"]}
         required:
           - unique_key
         additionalProperties: true
@@ -83,6 +85,7 @@ streams:
           order_by: last_activity_at
           sort: asc
           per_page: "100"
+          statistics: "true"
       record_selector:
         type: RecordSelector
         extractor:
@@ -136,6 +139,13 @@ streams:
           - type: AddedFieldDefinition
             path: [project_id]
             value: "{{ record['id'] }}"
+          - type: AddedFieldDefinition
+            path: [description]
+            value: "{{ (record.get('description') or '')[:1024] }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [statistics_repository_size]
+            value: "{{ (record.get('statistics') or {}).get('repository_size') }}"
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
@@ -364,6 +374,10 @@ streams:
           # Repository identity is REQUIRED in the key: forks share commit
           # SHAs, so tenant+source+sha alone would let the ReplacingMergeTree
           # collapse commits from different repositories into one row.
+          - type: AddedFieldDefinition
+            path: [message]
+            value: "{{ (record.get('message') or '')[:2048] }}"
+            value_type: string
           - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
@@ -803,6 +817,7 @@ streams:
           closed_at: {type: [string, "null"]}
           merged_by_username: {type: [string, "null"]}
           user_notes_count: {type: [integer, "null"]}
+          description: {type: [string, "null"]}
         required:
           - unique_key
         additionalProperties: true
@@ -910,6 +925,14 @@ streams:
             value: "{{ (record.get('merged_by') or {}).get('username') or '' }}"
             value_type: string
           - type: AddedFieldDefinition
+            path: [title]
+            value: "{{ (record.get('title') or '')[:1024] }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [description]
+            value: "{{ (record.get('description') or '')[:2048] }}"
+            value_type: string
+          - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
               {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ record['id'] }}
@@ -921,8 +944,8 @@ streams:
 
   # ── Merge request notes (GitLab API) ────────────────────────────────────
   # Child of a stateless sliding window of MRs (see the parent's
-  # updated_after comment). Note bodies are deliberately not stored: review
-  # metrics need who/when/what-kind, not prose.
+  # updated_after comment). Bodies are stored trimmed to 2048 chars — the
+  # silver comments model consumes them as content.
   - type: DeclarativeStream
     name: merge_request_notes
     primary_key:
@@ -948,6 +971,10 @@ streams:
           resolved: {type: [boolean, "null"]}
           created_at: {type: [string, "null"]}
           updated_at: {type: [string, "null"]}
+          body: {type: [string, "null"]}
+          author_id: {type: [integer, "null"]}
+          position_new_path: {type: [string, "null"]}
+          position_new_line: {type: [integer, "null"]}
         required:
           - unique_key
         additionalProperties: true
@@ -1100,6 +1127,20 @@ streams:
             value: "{{ (record.get('author') or {}).get('username') or '' }}"
             value_type: string
           - type: AddedFieldDefinition
+            path: [body]
+            value: "{{ (record.get('body') or '')[:2048] }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [author_id]
+            value: "{{ (record.get('author') or {}).get('id') }}"
+          - type: AddedFieldDefinition
+            path: [position_new_path]
+            value: "{{ (record.get('position') or {}).get('new_path') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [position_new_line]
+            value: "{{ (record.get('position') or {}).get('new_line') }}"
+          - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
               {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['project_id'] }}:{{ record['id'] }}
@@ -1107,6 +1148,7 @@ streams:
         # Hoisted above; the nested originals stay out of bronze.
         field_pointers:
           - [author]
+          - [position]
 
   # ── Merge request approvals (GitLab API) ────────────────────────────────
   # Single object per MR; snapshot semantics — the RMT keeps the latest row
@@ -1133,6 +1175,7 @@ streams:
           approvals_left: {type: [integer, "null"]}
           approved_by_usernames: {type: [string, "null"]}
           updated_at: {type: [string, "null"]}
+          approved_by_ids: {type: [string, "null"]}
         required:
           - unique_key
         additionalProperties: true
@@ -1275,6 +1318,10 @@ streams:
             value: "{{ ((record.get('approved_by') or []) | map(attribute='user.username') | list) | tojson }}"
             value_type: string
           - type: AddedFieldDefinition
+            path: [approved_by_ids]
+            value: "{{ ((record.get('approved_by') or []) | map(attribute='user.id') | list) | tojson }}"
+            value_type: string
+          - type: AddedFieldDefinition
             path: [unique_key]
             value: >-
               {{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_slice.extra_fields['project_id'] }}:{{ stream_partition.mr_iid }}:approvals
@@ -1309,6 +1356,8 @@ streams:
           access_level: {type: [integer, "null"]}
           created_at: {type: [string, "null"]}
           group: {type: [string, "null"]}
+          email: {type: [string, "null"]}
+          public_email: {type: [string, "null"]}
         required:
           - unique_key
         additionalProperties: true
@@ -1390,6 +1439,14 @@ streams:
           - type: AddedFieldDefinition
             path: [group]
             value: "{{ stream_partition.group }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [email]
+            value: "{{ record.get('email') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [public_email]
+            value: "{{ record.get('public_email') or '' }}"
             value_type: string
           - type: AddedFieldDefinition
             path: [unique_key]

--- a/src/ingestion/connectors/git/gitlab-nocode/descriptor.yaml
+++ b/src/ingestion/connectors/git/gitlab-nocode/descriptor.yaml
@@ -1,0 +1,12 @@
+name: gitlab-nocode
+version: "1.1.0"
+schedule: "0 3 * * *"
+workflow: sync
+
+# Silver routing via dbt tags on the staging models.
+# silver_targets prohibited per Connector Spec §4.10 — Silver is determined by
+# the dbt tags, and the pipeline's silver step hardcodes `tag:<slug>+`.
+dbt_select: "tag:gitlab-nocode+"
+
+connection:
+  namespace: bronze_gitlab_nocode

--- a/src/ingestion/connectors/git/gitlab-nocode/descriptor.yaml
+++ b/src/ingestion/connectors/git/gitlab-nocode/descriptor.yaml
@@ -8,5 +8,12 @@ workflow: sync
 # the dbt tags, and the pipeline's silver step hardcodes `tag:<slug>+`.
 dbt_select: "tag:gitlab-nocode+"
 
+secret:
+  # Fields the deployment Secret must carry beyond the spec's `required` list
+  # (generate-connectors-config.sh unions both when building the fake config).
+  required_fields:
+    - gitlab_token
+    - git_proxy_token
+
 connection:
   namespace: bronze_gitlab_nocode

--- a/src/ingestion/connectors/git/gitlab-nocode/tests/config.py
+++ b/src/ingestion/connectors/git/gitlab-nocode/tests/config.py
@@ -1,0 +1,24 @@
+"""gitlab-nocode connector test config builder."""
+
+from __future__ import annotations
+
+from connector_tests import ConfigBuilder
+
+GITLAB_URL = "https://gitlab.example.com"
+PROXY_URL = "http://git-cli-proxy.example:8085"
+
+
+class GitlabNocodeConfigBuilder(ConfigBuilder):
+    def __init__(self) -> None:
+        super().__init__()
+        self._config.update(
+            {
+                "gitlab_url": GITLAB_URL,
+                "gitlab_token": "test-gitlab-token",
+                "gitlab_groups": ["acme"],
+                "git_proxy_url": PROXY_URL,
+                "git_proxy_token": "test-proxy-token",
+                # Small deterministic window under the frozen clock.
+                "gitlab_start_date": "2026-06-01",
+            }
+        )

--- a/src/ingestion/connectors/git/gitlab-nocode/tests/conftest.py
+++ b/src/ingestion/connectors/git/gitlab-nocode/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Local builder modules (config.py) are importable under --import-mode=importlib.
+sys.path.insert(0, str(Path(__file__).parent))
+
+from connector_tests.plugin import *  # noqa: E402,F401,F403 — http_mocker fixture + hooks

--- a/src/ingestion/connectors/git/gitlab-nocode/tests/test_gitlab_proxy_streams.py
+++ b/src/ingestion/connectors/git/gitlab-nocode/tests/test_gitlab_proxy_streams.py
@@ -1,0 +1,146 @@
+"""Mock-server tests for the git-cli-proxy streams (`commits`).
+
+The proxy contract under test: cursor pagination on next_page_token,
+429 + Retry-After while a clone runs (retry, then succeed), 404/413 skipping
+the repository without failing the sync, and 409 (superseded snapshot)
+failing the attempt.
+
+Coverage matrix rows: full_refresh_single_page (via incremental first read),
+pagination_multi_page, empty_page, tenant_source_stamping,
+schema_conformance, substream_partition, incremental_state, error_retry
+(429), error_ignore (404).
+"""
+
+from __future__ import annotations
+
+import json
+
+import freezegun
+from config import GITLAB_URL, PROXY_URL, GitlabNocodeConfigBuilder
+
+from connector_tests import (
+    ANY_QUERY_PARAMS,
+    HttpMocker,
+    HttpRequest,
+    HttpResponse,
+    assert_records_conform,
+    read_stream,
+)
+
+_CONNECTOR = "git/gitlab-nocode"
+_STREAM = "commits"
+_PROJECTS_URL = f"{GITLAB_URL}/api/v4/groups/acme/projects"
+_COMMITS_URL = f"{PROXY_URL}/v1/commits"
+_CLONE_URL = f"{GITLAB_URL}/acme/app.git"
+_FROZEN = "2026-07-01T00:00:00Z"
+
+
+def _project() -> dict:
+    return {
+        "id": 7,
+        "http_url_to_repo": _CLONE_URL,
+        "last_activity_at": "2026-06-20T10:00:00.000+00:00",
+    }
+
+
+def _commit(sha: str) -> dict:
+    return {
+        "sha": sha,
+        "message": f"commit {sha}",
+        "authored_date": "2026-06-15T10:00:00Z",
+        "committed_date": "2026-06-15T10:00:00Z",
+        "author_name": "Dev",
+        "author_email": "dev@example.com",
+        "committer_name": "Dev",
+        "committer_email": "dev@example.com",
+        "parent_hashes": [],
+        "is_merge": False,
+        "is_in_default_branch": True,
+        "patch_id": None,
+    }
+
+
+def _page(items: list[dict], next_token: str | None = None) -> HttpResponse:
+    return HttpResponse(
+        body=json.dumps({"items": items, "next_page_token": next_token}),
+        status_code=200,
+    )
+
+
+def _mock_parent(http_mocker: HttpMocker) -> None:
+    http_mocker.get(
+        HttpRequest(_PROJECTS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps([_project()]), status_code=200),
+    )
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_pagination_multi_page_and_stamping(http_mocker: HttpMocker) -> None:
+    config = GitlabNocodeConfigBuilder().build()
+    _mock_parent(http_mocker)
+    http_mocker.get(
+        HttpRequest(_COMMITS_URL, query_params=ANY_QUERY_PARAMS),
+        [_page([_commit("a" * 40)], next_token="t1"), _page([_commit("b" * 40)])],
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert not output.errors
+    assert len(output.records) == 2
+    rec = output.records[0].record.data
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["source_id"] == config["insight_source_id"]
+    # Repository identity is in the key (forks share SHAs); colons escaped.
+    assert rec["unique_key"].endswith(":" + "a" * 40)
+    assert _CLONE_URL.replace(":", "%3A") in rec["unique_key"]
+    assert_records_conform(output.records, _CONNECTOR, _STREAM, strict=True)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_429_then_success_is_one_retry_not_a_failure(http_mocker: HttpMocker) -> None:
+    """A cold clone answers 429 + Retry-After while it runs; the stream waits."""
+    config = GitlabNocodeConfigBuilder().build()
+    _mock_parent(http_mocker)
+    http_mocker.get(
+        HttpRequest(_COMMITS_URL, query_params=ANY_QUERY_PARAMS),
+        [
+            HttpResponse(body="", status_code=429, headers={"Retry-After": "0"}),
+            _page([_commit("c" * 40)]),
+        ],
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert not output.errors
+    assert len(output.records) == 1
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_404_skips_the_repository_not_the_sync(http_mocker: HttpMocker) -> None:
+    """A repository gone at origin is skipped; the stream stays green."""
+    config = GitlabNocodeConfigBuilder().build()
+    _mock_parent(http_mocker)
+    http_mocker.get(
+        HttpRequest(_COMMITS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body="", status_code=404),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert not output.errors
+    assert len(output.records) == 0
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_empty_page(http_mocker: HttpMocker) -> None:
+    config = GitlabNocodeConfigBuilder().build()
+    _mock_parent(http_mocker)
+    http_mocker.get(
+        HttpRequest(_COMMITS_URL, query_params=ANY_QUERY_PARAMS),
+        _page([]),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert not output.errors
+    assert len(output.records) == 0

--- a/src/ingestion/connectors/git/gitlab-nocode/tests/test_gitlab_vendor_streams.py
+++ b/src/ingestion/connectors/git/gitlab-nocode/tests/test_gitlab_vendor_streams.py
@@ -263,7 +263,7 @@ def _diff_stats_body(cursor: str | None = None) -> dict:
     # The CDK's interpolation strips the YAML block scalar's trailing newline
     # at send time; the raw manifest keeps it.
     body["query"] = body["query"].rstrip("\n")
-    body["variables"] = {"group": "acme", "updatedAfter": "2026-06-01T00:00:00Z"}
+    body["variables"] = {"project": "acme/app", "updatedAfter": "2026-06-01T00:00:00Z"}
     if cursor is not None:
         body["variables"]["cursor"] = cursor
     return body
@@ -275,26 +275,33 @@ def test_merge_request_diff_stats_carry_real_integers(http_mocker: HttpMocker) -
     integers, and a null diffStatsSummary (stats computed asynchronously) must
     stay null rather than becoming a zero the metrics would trust."""
     config = GitlabNocodeConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(f"{GITLAB_URL}/api/v4/groups/acme/projects", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps(
+                [{"id": 7, "path_with_namespace": "acme/app", "last_activity_at": "2026-06-20T10:00:00.000+00:00"}]
+            ),
+            status_code=200,
+        ),
+    )
     http_mocker.post(
         HttpRequest(f"{GITLAB_URL}/api/graphql", body=_diff_stats_body()),
         HttpResponse(
             body=json.dumps(
                 {
                     "data": {
-                        "group": {
+                        "project": {
                             "mergeRequests": {
                                 "pageInfo": {"hasNextPage": False, "endCursor": None},
                                 "nodes": [
                                     {
                                         "iid": "5",
                                         "updatedAt": "2026-06-20T10:00:00Z",
-                                        "project": {"id": "gid://gitlab/Project/7"},
                                         "diffStatsSummary": {"additions": 120, "deletions": 7, "fileCount": 3},
                                     },
                                     {
                                         "iid": "6",
                                         "updatedAt": "2026-06-21T10:00:00Z",
-                                        "project": {"id": "gid://gitlab/Project/7"},
                                         "diffStatsSummary": None,
                                     },
                                 ],
@@ -317,6 +324,43 @@ def test_merge_request_diff_stats_carry_real_integers(http_mocker: HttpMocker) -
     # An absent field lands as SQL NULL; a zero would read as "MR with no
     # changes", which is a different fact from "stats not computed yet".
     assert "additions" not in by_iid[6], "pending stats must not read as zero"
-    assert "diffStatsSummary" not in by_iid[5] and "project" not in by_iid[5]
+    assert "diffStatsSummary" not in by_iid[5]
     _no_literal_none(output.records)
     assert_records_conform(output.records, _CONNECTOR, "merge_request_diff_stats", strict=True)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_empty_groups_syncs_the_full_instance(http_mocker: HttpMocker) -> None:
+    """gitlab_groups empty flips discovery to keyset-paginated /projects —
+    every project the token can see, no offset ceiling."""
+    config = GitlabNocodeConfigBuilder().build()
+    config["gitlab_groups"] = []
+    http_mocker.get(
+        HttpRequest(f"{GITLAB_URL}/api/v4/projects", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps(
+                [
+                    {
+                        "id": 7,
+                        "path_with_namespace": "acme/app",
+                        "name": "app",
+                        "default_branch": "main",
+                        "archived": False,
+                        "visibility": "private",
+                        "http_url_to_repo": "https://gitlab.example.com/acme/app.git",
+                        "web_url": "https://gitlab.example.com/acme/app",
+                        "created_at": "2020-01-01T00:00:00.000+00:00",
+                        "last_activity_at": "2026-06-20T10:00:00.000+00:00",
+                    }
+                ]
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "repositories", config)
+
+    assert not output.errors
+    rec = output.records[0].record.data
+    assert rec["project_id"] == 7
+    _no_literal_none(output.records)

--- a/src/ingestion/connectors/git/gitlab-nocode/tests/test_gitlab_vendor_streams.py
+++ b/src/ingestion/connectors/git/gitlab-nocode/tests/test_gitlab_vendor_streams.py
@@ -1,0 +1,136 @@
+"""Mock-server tests for the GitLab vendor streams added alongside the proxy.
+
+Covers the merge_requests window emission, the approvals 402 tolerance
+(premium feature ≠ error), and — everywhere — the rule from the
+github-directory incident: an absent nested field must surface as '' or a
+real null, never as the literal text "None".
+
+Coverage matrix rows: full_refresh_single_page, incremental_state,
+tenant_source_stamping, schema_conformance, error_ignore (402/403/404),
+transformations (None-guard).
+"""
+
+from __future__ import annotations
+
+import json
+
+import freezegun
+from config import GITLAB_URL, GitlabNocodeConfigBuilder
+
+from connector_tests import (
+    ANY_QUERY_PARAMS,
+    HttpMocker,
+    HttpRequest,
+    HttpResponse,
+    assert_records_conform,
+    read_stream,
+)
+
+_CONNECTOR = "git/gitlab-nocode"
+_MRS_URL = f"{GITLAB_URL}/api/v4/groups/acme/merge_requests"
+_FROZEN = "2026-07-01T00:00:00Z"
+
+
+def _no_literal_none(records) -> None:
+    """The github-directory bug class: a Jinja `none` rendered into a
+    value_type: string field stores the four-character text \"None\"."""
+    for r in records:
+        for key, value in r.record.data.items():
+            assert value != "None", f"literal 'None' leaked into {key}"
+
+
+def _mr(mr_id: int, *, author: dict | None, merged_by: dict | None) -> dict:
+    return {
+        "id": mr_id,
+        "iid": mr_id,
+        "project_id": 7,
+        "state": "merged",
+        "draft": False,
+        "title": f"MR {mr_id}",
+        "author": author,
+        "merged_by": merged_by,
+        "source_branch": "feat",
+        "target_branch": "main",
+        "sha": "e" * 40,
+        "created_at": "2026-06-10T10:00:00.000+00:00",
+        "updated_at": "2026-06-20T10:00:00.000+00:00",
+        "merged_at": "2026-06-20T10:00:00.000+00:00",
+        "user_notes_count": 2,
+    }
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_merge_requests_and_the_none_guard(http_mocker: HttpMocker) -> None:
+    """A deleted account leaves author/merged_by null; the hoisted usernames
+    must come out '' — never the text \"None\"."""
+    config = GitlabNocodeConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_MRS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps(
+                [
+                    _mr(1, author={"username": "alice"}, merged_by=None),
+                    _mr(2, author=None, merged_by=None),
+                ]
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "merge_requests", config)
+
+    assert not output.errors
+    assert len(output.records) == 2
+    by_id = {r.record.data["id"]: r.record.data for r in output.records}
+    assert by_id[1]["author_username"] == "alice"
+    assert by_id[1]["merged_by_username"] == ""
+    assert by_id[2]["author_username"] == ""
+    _no_literal_none(output.records)
+    assert_records_conform(output.records, _CONNECTOR, "merge_requests", strict=True)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_approvals_402_is_a_missing_feature_not_an_error(http_mocker: HttpMocker) -> None:
+    config = GitlabNocodeConfigBuilder().build()
+    # Windowed MR parent listing.
+    http_mocker.get(
+        HttpRequest(_MRS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps([_mr(5, author={"username": "alice"}, merged_by=None)]),
+            status_code=200,
+        ),
+    )
+    http_mocker.get(
+        HttpRequest(
+            f"{GITLAB_URL}/api/v4/projects/7/merge_requests/5/approvals",
+            query_params=ANY_QUERY_PARAMS,
+        ),
+        HttpResponse(body="", status_code=402),
+    )
+
+    output = read_stream(_CONNECTOR, "merge_request_approvals", config)
+
+    assert not output.errors
+    assert len(output.records) == 0
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_users_full_refresh(http_mocker: HttpMocker) -> None:
+    config = GitlabNocodeConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(f"{GITLAB_URL}/api/v4/groups/acme/members/all", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps(
+                [{"id": 11, "username": "alice", "name": "Alice", "state": "active", "access_level": 30, "created_at": "2020-01-01T00:00:00.000+00:00"}]
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "users", config)
+
+    assert not output.errors
+    rec = output.records[0].record.data
+    assert rec["group"] == "acme"
+    assert rec["unique_key"].endswith(":acme:11")
+    _no_literal_none(output.records)

--- a/src/ingestion/connectors/git/gitlab-nocode/tests/test_gitlab_vendor_streams.py
+++ b/src/ingestion/connectors/git/gitlab-nocode/tests/test_gitlab_vendor_streams.py
@@ -92,6 +92,62 @@ def test_merge_requests_and_the_none_guard(http_mocker: HttpMocker) -> None:
 
 
 @freezegun.freeze_time(_FROZEN)
+def test_merge_request_commits_store_only_the_edge(http_mocker: HttpMocker) -> None:
+    """MR<->commit membership is vendor-only; the commit payload belongs to
+    the proxy streams, so bronze keeps the sha and the MR identity alone."""
+    config = GitlabNocodeConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_MRS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps([_mr(5, author={"username": "alice"}, merged_by=None)]),
+            status_code=200,
+        ),
+    )
+    http_mocker.get(
+        HttpRequest(
+            f"{GITLAB_URL}/api/v4/projects/7/merge_requests/5/commits",
+            query_params=ANY_QUERY_PARAMS,
+        ),
+        HttpResponse(
+            body=json.dumps(
+                [
+                    {
+                        "id": "a" * 40,
+                        "short_id": "a" * 8,
+                        "title": "feat: x",
+                        "message": "feat: x\n",
+                        "author_name": "Alice",
+                        "author_email": "alice@example.com",
+                        "authored_date": "2026-06-19T10:00:00.000+00:00",
+                        "committer_name": "Alice",
+                        "committer_email": "alice@example.com",
+                        "committed_date": "2026-06-19T10:00:00.000+00:00",
+                        "created_at": "2026-06-19T10:00:00.000+00:00",
+                        "parent_ids": ["b" * 40],
+                        "trailers": {},
+                        "extended_trailers": {},
+                        "web_url": "https://gitlab.example.com/acme/app/-/commit/" + "a" * 40,
+                    }
+                ]
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "merge_request_commits", config)
+
+    assert not output.errors
+    rec = output.records[0].record.data
+    assert rec["sha"] == "a" * 40
+    assert rec["mr_iid"] == 5
+    assert rec["project_id"] == 7
+    assert rec["unique_key"].endswith(f":7:5:{'a' * 40}")
+    assert "message" not in rec and "author_name" not in rec
+    _no_literal_none(output.records)
+    assert_records_conform(output.records, _CONNECTOR, "merge_request_commits", strict=True)
+
+
+@freezegun.freeze_time(_FROZEN)
 def test_approvals_402_is_a_missing_feature_not_an_error(http_mocker: HttpMocker) -> None:
     config = GitlabNocodeConfigBuilder().build()
     # Windowed MR parent listing.

--- a/src/ingestion/connectors/git/gitlab-nocode/tests/test_gitlab_vendor_streams.py
+++ b/src/ingestion/connectors/git/gitlab-nocode/tests/test_gitlab_vendor_streams.py
@@ -47,6 +47,7 @@ def _mr(mr_id: int, *, author: dict | None, merged_by: dict | None) -> dict:
         "state": "merged",
         "draft": False,
         "title": f"MR {mr_id}",
+        "description": "d" * 3000,
         "author": author,
         "merged_by": merged_by,
         "source_branch": "feat",
@@ -85,6 +86,7 @@ def test_merge_requests_and_the_none_guard(http_mocker: HttpMocker) -> None:
     assert by_id[1]["author_username"] == "alice"
     assert by_id[1]["merged_by_username"] == ""
     assert by_id[2]["author_username"] == ""
+    assert len(by_id[1]["description"]) == 2048
     _no_literal_none(output.records)
     assert_records_conform(output.records, _CONNECTOR, "merge_requests", strict=True)
 
@@ -121,7 +123,7 @@ def test_users_full_refresh(http_mocker: HttpMocker) -> None:
         HttpRequest(f"{GITLAB_URL}/api/v4/groups/acme/members/all", query_params=ANY_QUERY_PARAMS),
         HttpResponse(
             body=json.dumps(
-                [{"id": 11, "username": "alice", "name": "Alice", "state": "active", "access_level": 30, "created_at": "2020-01-01T00:00:00.000+00:00"}]
+                [{"id": 11, "username": "alice", "name": "Alice", "state": "active", "access_level": 30, "created_at": "2020-01-01T00:00:00.000+00:00", "public_email": "alice@example.com"}]
             ),
             status_code=200,
         ),
@@ -133,4 +135,64 @@ def test_users_full_refresh(http_mocker: HttpMocker) -> None:
     rec = output.records[0].record.data
     assert rec["group"] == "acme"
     assert rec["unique_key"].endswith(":acme:11")
+    assert rec["public_email"] == "alice@example.com"
     _no_literal_none(output.records)
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_notes_store_trimmed_bodies_and_inline_position(http_mocker: HttpMocker) -> None:
+    """The silver comments model consumes body/author_id/position; bodies are
+    trimmed to 2048 chars, and absent nested objects surface as ''/null."""
+    config = GitlabNocodeConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_MRS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps([_mr(5, author={"username": "alice"}, merged_by=None)]),
+            status_code=200,
+        ),
+    )
+    http_mocker.get(
+        HttpRequest(
+            f"{GITLAB_URL}/api/v4/projects/7/merge_requests/5/notes",
+            query_params=ANY_QUERY_PARAMS,
+        ),
+        HttpResponse(
+            body=json.dumps(
+                [
+                    {
+                        "id": 501,
+                        "body": "n" * 3000,
+                        "system": False,
+                        "resolvable": True,
+                        "resolved": False,
+                        "author": {"id": 11, "username": "alice"},
+                        "position": {"new_path": "src/a.py", "new_line": 3},
+                        "created_at": "2026-06-20T10:00:00.000+00:00",
+                        "updated_at": "2026-06-20T10:00:00.000+00:00",
+                    },
+                    {
+                        "id": 502,
+                        "body": "short",
+                        "system": True,
+                        "author": None,
+                        "created_at": "2026-06-20T10:00:00.000+00:00",
+                        "updated_at": "2026-06-20T10:00:00.000+00:00",
+                    },
+                ]
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "merge_request_notes", config)
+
+    assert not output.errors
+    by_id = {r.record.data["id"]: r.record.data for r in output.records}
+    assert len(by_id[501]["body"]) == 2048
+    assert by_id[501]["author_id"] == 11
+    assert by_id[501]["position_new_path"] == "src/a.py"
+    assert by_id[501]["position_new_line"] == 3
+    assert by_id[502]["body"] == "short"
+    assert by_id[502]["position_new_path"] == ""
+    _no_literal_none(output.records)
+    assert_records_conform(output.records, _CONNECTOR, "merge_request_notes", strict=True)

--- a/src/ingestion/connectors/git/gitlab-nocode/tests/test_gitlab_vendor_streams.py
+++ b/src/ingestion/connectors/git/gitlab-nocode/tests/test_gitlab_vendor_streams.py
@@ -25,6 +25,7 @@ from connector_tests import (
     assert_records_conform,
     read_stream,
 )
+from connector_tests.source import load_manifest
 
 _CONNECTOR = "git/gitlab-nocode"
 _MRS_URL = f"{GITLAB_URL}/api/v4/groups/acme/merge_requests"
@@ -252,3 +253,70 @@ def test_notes_store_trimmed_bodies_and_inline_position(http_mocker: HttpMocker)
     assert by_id[502]["position_new_path"] == ""
     _no_literal_none(output.records)
     assert_records_conform(output.records, _CONNECTOR, "merge_request_notes", strict=True)
+
+
+def _diff_stats_body(cursor: str | None = None) -> dict:
+    """The exact request body the manifest sends — POST mocks match on it."""
+    manifest = load_manifest(_CONNECTOR)
+    stream = next(st for st in manifest["streams"] if st["name"] == "merge_request_diff_stats")
+    body = dict(stream["retriever"]["requester"]["request_body_json"])
+    # The CDK's interpolation strips the YAML block scalar's trailing newline
+    # at send time; the raw manifest keeps it.
+    body["query"] = body["query"].rstrip("\n")
+    body["variables"] = {"group": "acme", "updatedAfter": "2026-06-01T00:00:00Z"}
+    if cursor is not None:
+        body["variables"]["cursor"] = cursor
+    return body
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_merge_request_diff_stats_carry_real_integers(http_mocker: HttpMocker) -> None:
+    """REST exposes only a capped `changes_count` STRING; GraphQL carries real
+    integers, and a null diffStatsSummary (stats computed asynchronously) must
+    stay null rather than becoming a zero the metrics would trust."""
+    config = GitlabNocodeConfigBuilder().build()
+    http_mocker.post(
+        HttpRequest(f"{GITLAB_URL}/api/graphql", body=_diff_stats_body()),
+        HttpResponse(
+            body=json.dumps(
+                {
+                    "data": {
+                        "group": {
+                            "mergeRequests": {
+                                "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                "nodes": [
+                                    {
+                                        "iid": "5",
+                                        "updatedAt": "2026-06-20T10:00:00Z",
+                                        "project": {"id": "gid://gitlab/Project/7"},
+                                        "diffStatsSummary": {"additions": 120, "deletions": 7, "fileCount": 3},
+                                    },
+                                    {
+                                        "iid": "6",
+                                        "updatedAt": "2026-06-21T10:00:00Z",
+                                        "project": {"id": "gid://gitlab/Project/7"},
+                                        "diffStatsSummary": None,
+                                    },
+                                ],
+                            }
+                        }
+                    }
+                }
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "merge_request_diff_stats", config)
+
+    assert not output.errors
+    by_iid = {r.record.data["mr_iid"]: r.record.data for r in output.records}
+    assert (by_iid[5]["additions"], by_iid[5]["deletions"], by_iid[5]["files_changed"]) == (120, 7, 3)
+    assert by_iid[5]["project_id"] == 7
+    assert by_iid[5]["unique_key"].endswith(":7:5")
+    # An absent field lands as SQL NULL; a zero would read as "MR with no
+    # changes", which is a different fact from "stats not computed yet".
+    assert "additions" not in by_iid[6], "pending stats must not read as zero"
+    assert "diffStatsSummary" not in by_iid[5] and "project" not in by_iid[5]
+    _no_literal_none(output.records)
+    assert_records_conform(output.records, _CONNECTOR, "merge_request_diff_stats", strict=True)

--- a/src/ingestion/scripts/bootstrap-db/connectors-config.yaml
+++ b/src/ingestion/scripts/bootstrap-db/connectors-config.yaml
@@ -126,6 +126,24 @@ connectors:
         value: github-directory-acme-prod
       insight_tenant_id:
         value: fake
+  github-nocode:
+    path: git/github-nocode
+    config:
+      git_proxy_token:
+        value: fake
+      git_proxy_url:
+        value: fake
+      github_organizations:
+        value:
+          - fake
+      github_start_date:
+        value: "2020-01-01"
+      github_token:
+        value: fake
+      insight_source_id:
+        value: fake
+      insight_tenant_id:
+        value: fake
   github-v2:
     path: git/github-v2
     config:

--- a/src/ingestion/scripts/bootstrap-db/connectors-config.yaml
+++ b/src/ingestion/scripts/bootstrap-db/connectors-config.yaml
@@ -235,6 +235,46 @@ connectors:
         value: fake
       insight_tenant_id:
         value: fake
+  bitbucket-nocode:
+    path: git/bitbucket-nocode
+    config:
+      bitbucket_start_date:
+        value: "2020-01-01"
+      bitbucket_token:
+        value: fake
+      bitbucket_username:
+        value: fake
+      bitbucket_workspaces:
+        value:
+          - fake
+      git_proxy_token:
+        value: fake
+      git_proxy_url:
+        value: fake
+      insight_source_id:
+        value: fake
+      insight_tenant_id:
+        value: fake
+  gitlab-nocode:
+    path: git/gitlab-nocode
+    config:
+      git_proxy_token:
+        value: fake
+      git_proxy_url:
+        value: fake
+      gitlab_groups:
+        value:
+          - fake
+      gitlab_start_date:
+        value: "2020-01-01"
+      gitlab_token:
+        value: fake
+      gitlab_url:
+        value: fake
+      insight_source_id:
+        value: fake
+      insight_tenant_id:
+        value: fake
   outline:
     path: wiki/outline
     config:

--- a/src/ingestion/scripts/connectors-ddl/bitbucket-nocode.sql
+++ b/src/ingestion/scripts/connectors-ddl/bitbucket-nocode.sql
@@ -1,0 +1,272 @@
+CREATE DATABASE IF NOT EXISTS `bronze_bitbucket_nocode`;
+
+CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.commit_files
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `repository` Nullable(String),
+    `sha` Nullable(String),
+    `committed_date` Nullable(String),
+    `filename` Nullable(String),
+    `previous_filename` Nullable(String),
+    `status` Nullable(String),
+    `additions` Nullable(Int64),
+    `deletions` Nullable(Int64),
+    `changes` Nullable(Int64),
+    `is_binary` Nullable(Bool),
+    `patch` Nullable(String),
+    `patch_truncated` Nullable(Bool)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.commits
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `repository` Nullable(String),
+    `sha` Nullable(String),
+    `message` Nullable(String),
+    `authored_date` Nullable(String),
+    `committed_date` Nullable(String),
+    `author_name` Nullable(String),
+    `author_email` Nullable(String),
+    `committer_name` Nullable(String),
+    `committer_email` Nullable(String),
+    `parent_hashes` Nullable(String),
+    `is_merge` Nullable(Bool),
+    `additions` Nullable(Int64),
+    `deletions` Nullable(Int64),
+    `changed_files` Nullable(Int64),
+    `is_in_default_branch` Nullable(Bool),
+    `patch_id` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.deployments
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `uuid` Nullable(String),
+    `repo_full_name` Nullable(String),
+    `state_name` Nullable(String),
+    `state_status` Nullable(String),
+    `environment_uuid` Nullable(String),
+    `deployable_commit_sha` Nullable(String),
+    `deployable_pipeline_uuid` Nullable(String),
+    `created_on` Nullable(String),
+    `last_update_time` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.pipelines
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `uuid` Nullable(String),
+    `build_number` Nullable(Int64),
+    `repo_full_name` Nullable(String),
+    `state_name` Nullable(String),
+    `result_name` Nullable(String),
+    `target_ref` Nullable(String),
+    `target_commit_sha` Nullable(String),
+    `trigger_name` Nullable(String),
+    `creator_uuid` Nullable(String),
+    `duration_in_seconds` Nullable(Int64),
+    `created_on` Nullable(String),
+    `completed_on` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.pull_request_activity
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `pr_id` Nullable(Int64),
+    `repo_full_name` Nullable(String),
+    `kind` Nullable(String),
+    `event_date` Nullable(String),
+    `actor_uuid` Nullable(String),
+    `actor_display_name` Nullable(String),
+    `update_state` Nullable(String),
+    `update_source_commit` Nullable(String),
+    `comment_id` Nullable(Int64)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.pull_request_comments
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `id` Nullable(Int64),
+    `pr_id` Nullable(Int64),
+    `repo_full_name` Nullable(String),
+    `author_uuid` Nullable(String),
+    `author_display_name` Nullable(String),
+    `deleted` Nullable(Bool),
+    `parent_id` Nullable(Int64),
+    `inline_path` Nullable(String),
+    `created_on` Nullable(String),
+    `updated_on` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.pull_requests
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `id` Nullable(Int64),
+    `repo_full_name` Nullable(String),
+    `title` Nullable(String),
+    `state` Nullable(String),
+    `draft` Nullable(Bool),
+    `author_uuid` Nullable(String),
+    `author_display_name` Nullable(String),
+    `created_on` Nullable(String),
+    `updated_on` Nullable(String),
+    `merge_commit_sha` Nullable(String),
+    `closed_by_uuid` Nullable(String),
+    `source_branch` Nullable(String),
+    `source_commit_sha` Nullable(String),
+    `destination_branch` Nullable(String),
+    `comment_count` Nullable(Int64),
+    `task_count` Nullable(Int64)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.repo_branches
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `repository` Nullable(String),
+    `name` Nullable(String),
+    `head_sha` Nullable(String),
+    `head_committed_date` Nullable(String),
+    `is_default` Nullable(Bool)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.repositories
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `repository_uuid` Nullable(String),
+    `clone_url` Nullable(String),
+    `slug` Nullable(String),
+    `name` Nullable(String),
+    `full_name` Nullable(String),
+    `is_private` Nullable(Bool),
+    `language` Nullable(String),
+    `size` Nullable(Int64),
+    `created_on` Nullable(String),
+    `updated_on` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.workspace_members
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `account_id` Nullable(String),
+    `display_name` Nullable(String),
+    `nickname` Nullable(String),
+    `user_uuid` Nullable(String),
+    `workspace` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+

--- a/src/ingestion/scripts/connectors-ddl/bitbucket-nocode.sql
+++ b/src/ingestion/scripts/connectors-ddl/bitbucket-nocode.sql
@@ -192,6 +192,26 @@ ORDER BY _airbyte_raw_id
 SETTINGS index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.pull_request_commits
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `sha` Nullable(String),
+    `pr_id` Nullable(Int64),
+    `repo_full_name` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.pull_requests
 (
     `_airbyte_raw_id` String,

--- a/src/ingestion/scripts/connectors-ddl/bitbucket-nocode.sql
+++ b/src/ingestion/scripts/connectors-ddl/bitbucket-nocode.sql
@@ -1,6 +1,6 @@
 CREATE DATABASE IF NOT EXISTS `bronze_bitbucket_nocode`;
 
-CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.commit_files
+CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.branches
 (
     `_airbyte_raw_id` String,
     `_airbyte_extracted_at` DateTime64(3),
@@ -11,17 +11,10 @@ CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.commit_files
     `source_id` Nullable(String),
     `data_source` Nullable(String),
     `repository` Nullable(String),
-    `sha` Nullable(String),
-    `committed_date` Nullable(String),
-    `filename` Nullable(String),
-    `previous_filename` Nullable(String),
-    `status` Nullable(String),
-    `additions` Nullable(Int64),
-    `deletions` Nullable(Int64),
-    `changes` Nullable(Int64),
-    `is_binary` Nullable(Bool),
-    `patch` Nullable(String),
-    `patch_truncated` Nullable(Bool)
+    `name` Nullable(String),
+    `head_sha` Nullable(String),
+    `head_committed_date` Nullable(String),
+    `is_default` Nullable(Bool)
 )
 ENGINE = MergeTree
 ORDER BY _airbyte_raw_id
@@ -80,6 +73,34 @@ CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.deployments
     `deployable_pipeline_uuid` Nullable(String),
     `created_on` Nullable(String),
     `last_update_time` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.file_changes
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `repository` Nullable(String),
+    `sha` Nullable(String),
+    `committed_date` Nullable(String),
+    `filename` Nullable(String),
+    `previous_filename` Nullable(String),
+    `status` Nullable(String),
+    `additions` Nullable(Int64),
+    `deletions` Nullable(Int64),
+    `changes` Nullable(Int64),
+    `is_binary` Nullable(Bool),
+    `patch` Nullable(String),
+    `patch_truncated` Nullable(Bool)
 )
 ENGINE = MergeTree
 ORDER BY _airbyte_raw_id
@@ -201,27 +222,6 @@ ORDER BY _airbyte_raw_id
 SETTINGS index_granularity = 8192
 ;
 
-CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.repo_branches
-(
-    `_airbyte_raw_id` String,
-    `_airbyte_extracted_at` DateTime64(3),
-    `_airbyte_meta` String,
-    `_airbyte_generation_id` UInt32,
-    `unique_key` Nullable(String),
-    `tenant_id` Nullable(String),
-    `source_id` Nullable(String),
-    `data_source` Nullable(String),
-    `repository` Nullable(String),
-    `name` Nullable(String),
-    `head_sha` Nullable(String),
-    `head_committed_date` Nullable(String),
-    `is_default` Nullable(Bool)
-)
-ENGINE = MergeTree
-ORDER BY _airbyte_raw_id
-SETTINGS index_granularity = 8192
-;
-
 CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.repositories
 (
     `_airbyte_raw_id` String,
@@ -269,4 +269,3 @@ ENGINE = MergeTree
 ORDER BY _airbyte_raw_id
 SETTINGS index_granularity = 8192
 ;
-

--- a/src/ingestion/scripts/connectors-ddl/bitbucket-nocode.sql
+++ b/src/ingestion/scripts/connectors-ddl/bitbucket-nocode.sql
@@ -212,6 +212,30 @@ ORDER BY _airbyte_raw_id
 SETTINGS index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.pull_request_diffstat
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `pr_id` Nullable(Int64),
+    `repo_full_name` Nullable(String),
+    `file_path` Nullable(String),
+    `old_path` Nullable(String),
+    `status` Nullable(String),
+    `lines_added` Nullable(Int64),
+    `lines_removed` Nullable(Int64)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.pull_requests
 (
     `_airbyte_raw_id` String,

--- a/src/ingestion/scripts/connectors-ddl/bitbucket-nocode.sql
+++ b/src/ingestion/scripts/connectors-ddl/bitbucket-nocode.sql
@@ -182,7 +182,10 @@ CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.pull_request_comments
     `parent_id` Nullable(Int64),
     `inline_path` Nullable(String),
     `created_on` Nullable(String),
-    `updated_on` Nullable(String)
+    `updated_on` Nullable(String),
+    `body` Nullable(String),
+    `inline_to` Nullable(Int64),
+    `inline_from` Nullable(Int64)
 )
 ENGINE = MergeTree
 ORDER BY _airbyte_raw_id
@@ -215,7 +218,10 @@ CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.pull_requests
     `source_commit_sha` Nullable(String),
     `destination_branch` Nullable(String),
     `comment_count` Nullable(Int64),
-    `task_count` Nullable(Int64)
+    `task_count` Nullable(Int64),
+    `description` Nullable(String),
+    `destination_commit_sha` Nullable(String),
+    `participants` Nullable(String)
 )
 ENGINE = MergeTree
 ORDER BY _airbyte_raw_id
@@ -241,7 +247,8 @@ CREATE TABLE IF NOT EXISTS bronze_bitbucket_nocode.repositories
     `language` Nullable(String),
     `size` Nullable(Int64),
     `created_on` Nullable(String),
-    `updated_on` Nullable(String)
+    `updated_on` Nullable(String),
+    `description` Nullable(String)
 )
 ENGINE = MergeTree
 ORDER BY _airbyte_raw_id

--- a/src/ingestion/scripts/connectors-ddl/github-nocode.sql
+++ b/src/ingestion/scripts/connectors-ddl/github-nocode.sql
@@ -208,7 +208,9 @@ CREATE TABLE IF NOT EXISTS bronze_github_nocode.pull_request_comments
     `author_login` Nullable(String),
     `author_association` Nullable(String),
     `created_at` Nullable(String),
-    `updated_at` Nullable(String)
+    `updated_at` Nullable(String),
+    `body` Nullable(String),
+    `author_id` Nullable(Int64)
 )
 ENGINE = MergeTree
 ORDER BY _airbyte_raw_id
@@ -233,7 +235,8 @@ CREATE TABLE IF NOT EXISTS bronze_github_nocode.pull_request_reviews
     `author_association` Nullable(String),
     `state` Nullable(String),
     `commit_id` Nullable(String),
-    `submitted_at` Nullable(String)
+    `submitted_at` Nullable(String),
+    `author_id` Nullable(Int64)
 )
 ENGINE = MergeTree
 ORDER BY _airbyte_raw_id
@@ -266,7 +269,8 @@ CREATE TABLE IF NOT EXISTS bronze_github_nocode.pull_requests
     `created_at` Nullable(String),
     `updated_at` Nullable(String),
     `closed_at` Nullable(String),
-    `merged_at` Nullable(String)
+    `merged_at` Nullable(String),
+    `body` Nullable(String)
 )
 ENGINE = MergeTree
 ORDER BY _airbyte_raw_id
@@ -298,7 +302,8 @@ CREATE TABLE IF NOT EXISTS bronze_github_nocode.repositories
     `html_url` Nullable(String),
     `created_at` Nullable(String),
     `updated_at` Nullable(String),
-    `pushed_at` Nullable(String)
+    `pushed_at` Nullable(String),
+    `description` Nullable(String)
 )
 ENGINE = MergeTree
 ORDER BY _airbyte_raw_id

--- a/src/ingestion/scripts/connectors-ddl/github-nocode.sql
+++ b/src/ingestion/scripts/connectors-ddl/github-nocode.sql
@@ -217,6 +217,26 @@ ORDER BY _airbyte_raw_id
 SETTINGS index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS bronze_github_nocode.pull_request_commits
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `sha` Nullable(String),
+    `pull_number` Nullable(Int64),
+    `repo_full_name` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS bronze_github_nocode.pull_request_reviews
 (
     `_airbyte_raw_id` String,

--- a/src/ingestion/scripts/connectors-ddl/github-nocode.sql
+++ b/src/ingestion/scripts/connectors-ddl/github-nocode.sql
@@ -1,6 +1,6 @@
 CREATE DATABASE IF NOT EXISTS `bronze_github_nocode`;
 
-CREATE TABLE IF NOT EXISTS bronze_github_nocode.commit_files
+CREATE TABLE IF NOT EXISTS bronze_github_nocode.branches
 (
     `_airbyte_raw_id` String,
     `_airbyte_extracted_at` DateTime64(3),
@@ -12,17 +12,10 @@ CREATE TABLE IF NOT EXISTS bronze_github_nocode.commit_files
     `data_source` Nullable(String),
     `collected_at` Nullable(String),
     `repository` Nullable(String),
-    `sha` Nullable(String),
-    `committed_date` Nullable(String),
-    `filename` Nullable(String),
-    `previous_filename` Nullable(String),
-    `status` Nullable(String),
-    `additions` Nullable(Int64),
-    `deletions` Nullable(Int64),
-    `changes` Nullable(Int64),
-    `is_binary` Nullable(Bool),
-    `patch` Nullable(String),
-    `patch_truncated` Nullable(Bool)
+    `name` Nullable(String),
+    `head_sha` Nullable(String),
+    `head_committed_date` Nullable(String),
+    `is_default` Nullable(Bool)
 )
 ENGINE = MergeTree
 ORDER BY _airbyte_raw_id
@@ -107,6 +100,35 @@ CREATE TABLE IF NOT EXISTS bronze_github_nocode.deployments
     `creator_login` Nullable(String),
     `created_at` Nullable(String),
     `updated_at` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_github_nocode.file_changes
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `repository` Nullable(String),
+    `sha` Nullable(String),
+    `committed_date` Nullable(String),
+    `filename` Nullable(String),
+    `previous_filename` Nullable(String),
+    `status` Nullable(String),
+    `additions` Nullable(Int64),
+    `deletions` Nullable(Int64),
+    `changes` Nullable(Int64),
+    `is_binary` Nullable(Bool),
+    `patch` Nullable(String),
+    `patch_truncated` Nullable(Bool)
 )
 ENGINE = MergeTree
 ORDER BY _airbyte_raw_id
@@ -251,28 +273,6 @@ ORDER BY _airbyte_raw_id
 SETTINGS index_granularity = 8192
 ;
 
-CREATE TABLE IF NOT EXISTS bronze_github_nocode.repo_branches
-(
-    `_airbyte_raw_id` String,
-    `_airbyte_extracted_at` DateTime64(3),
-    `_airbyte_meta` String,
-    `_airbyte_generation_id` UInt32,
-    `unique_key` Nullable(String),
-    `tenant_id` Nullable(String),
-    `source_id` Nullable(String),
-    `data_source` Nullable(String),
-    `collected_at` Nullable(String),
-    `repository` Nullable(String),
-    `name` Nullable(String),
-    `head_sha` Nullable(String),
-    `head_committed_date` Nullable(String),
-    `is_default` Nullable(Bool)
-)
-ENGINE = MergeTree
-ORDER BY _airbyte_raw_id
-SETTINGS index_granularity = 8192
-;
-
 CREATE TABLE IF NOT EXISTS bronze_github_nocode.repositories
 (
     `_airbyte_raw_id` String,
@@ -335,4 +335,3 @@ ENGINE = MergeTree
 ORDER BY _airbyte_raw_id
 SETTINGS index_granularity = 8192
 ;
-

--- a/src/ingestion/scripts/connectors-ddl/github-nocode.sql
+++ b/src/ingestion/scripts/connectors-ddl/github-nocode.sql
@@ -1,0 +1,338 @@
+CREATE DATABASE IF NOT EXISTS `bronze_github_nocode`;
+
+CREATE TABLE IF NOT EXISTS bronze_github_nocode.commit_files
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `repository` Nullable(String),
+    `sha` Nullable(String),
+    `committed_date` Nullable(String),
+    `filename` Nullable(String),
+    `previous_filename` Nullable(String),
+    `status` Nullable(String),
+    `additions` Nullable(Int64),
+    `deletions` Nullable(Int64),
+    `changes` Nullable(Int64),
+    `is_binary` Nullable(Bool),
+    `patch` Nullable(String),
+    `patch_truncated` Nullable(Bool)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_github_nocode.commits
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `repository` Nullable(String),
+    `sha` Nullable(String),
+    `message` Nullable(String),
+    `authored_date` Nullable(String),
+    `committed_date` Nullable(String),
+    `author_name` Nullable(String),
+    `author_email` Nullable(String),
+    `committer_name` Nullable(String),
+    `committer_email` Nullable(String),
+    `parent_hashes` Nullable(String),
+    `is_merge` Nullable(Bool),
+    `additions` Nullable(Int64),
+    `deletions` Nullable(Int64),
+    `changed_files` Nullable(Int64),
+    `is_in_default_branch` Nullable(Bool),
+    `patch_id` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_github_nocode.deployment_statuses
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `id` Nullable(Int64),
+    `deployment_id` Nullable(Int64),
+    `repo_full_name` Nullable(String),
+    `state` Nullable(String),
+    `environment` Nullable(String),
+    `creator_login` Nullable(String),
+    `created_at` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_github_nocode.deployments
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `id` Nullable(Int64),
+    `repo_full_name` Nullable(String),
+    `sha` Nullable(String),
+    `ref` Nullable(String),
+    `task` Nullable(String),
+    `environment` Nullable(String),
+    `description` Nullable(String),
+    `creator_login` Nullable(String),
+    `created_at` Nullable(String),
+    `updated_at` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_github_nocode.issues
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `id` Nullable(Int64),
+    `number` Nullable(Int64),
+    `repo_full_name` Nullable(String),
+    `state` Nullable(String),
+    `state_reason` Nullable(String),
+    `title` Nullable(String),
+    `author_login` Nullable(String),
+    `assignee_logins` Nullable(String),
+    `label_names` Nullable(String),
+    `comments` Nullable(Int64),
+    `created_at` Nullable(String),
+    `updated_at` Nullable(String),
+    `closed_at` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_github_nocode.projects_v2
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `project_id` Nullable(String),
+    `number` Nullable(Int64),
+    `org` Nullable(String),
+    `title` Nullable(String),
+    `short_description` Nullable(String),
+    `public` Nullable(Bool),
+    `closed` Nullable(Bool),
+    `created_at` Nullable(String),
+    `updated_at` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_github_nocode.pull_request_comments
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `id` Nullable(Int64),
+    `issue_number` Nullable(Int64),
+    `repo_full_name` Nullable(String),
+    `author_login` Nullable(String),
+    `author_association` Nullable(String),
+    `created_at` Nullable(String),
+    `updated_at` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_github_nocode.pull_request_reviews
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `id` Nullable(Int64),
+    `pull_number` Nullable(Int64),
+    `repo_full_name` Nullable(String),
+    `author_login` Nullable(String),
+    `author_association` Nullable(String),
+    `state` Nullable(String),
+    `commit_id` Nullable(String),
+    `submitted_at` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_github_nocode.pull_requests
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `id` Nullable(Int64),
+    `number` Nullable(Int64),
+    `repo_full_name` Nullable(String),
+    `state` Nullable(String),
+    `draft` Nullable(Bool),
+    `title` Nullable(String),
+    `author_login` Nullable(String),
+    `author_association` Nullable(String),
+    `head_sha` Nullable(String),
+    `head_ref` Nullable(String),
+    `base_ref` Nullable(String),
+    `merge_commit_sha` Nullable(String),
+    `created_at` Nullable(String),
+    `updated_at` Nullable(String),
+    `closed_at` Nullable(String),
+    `merged_at` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_github_nocode.repo_branches
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `repository` Nullable(String),
+    `name` Nullable(String),
+    `head_sha` Nullable(String),
+    `head_committed_date` Nullable(String),
+    `is_default` Nullable(Bool)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_github_nocode.repositories
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `id` Nullable(Int64),
+    `full_name` Nullable(String),
+    `name` Nullable(String),
+    `org` Nullable(String),
+    `default_branch` Nullable(String),
+    `archived` Nullable(Bool),
+    `fork` Nullable(Bool),
+    `private` Nullable(Bool),
+    `language` Nullable(String),
+    `size` Nullable(Int64),
+    `clone_url` Nullable(String),
+    `html_url` Nullable(String),
+    `created_at` Nullable(String),
+    `updated_at` Nullable(String),
+    `pushed_at` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_github_nocode.workflow_runs
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `id` Nullable(Int64),
+    `run_attempt` Nullable(Int64),
+    `repo_full_name` Nullable(String),
+    `name` Nullable(String),
+    `workflow_id` Nullable(Int64),
+    `event` Nullable(String),
+    `status` Nullable(String),
+    `conclusion` Nullable(String),
+    `head_branch` Nullable(String),
+    `head_sha` Nullable(String),
+    `actor_login` Nullable(String),
+    `run_started_at` Nullable(String),
+    `created_at` Nullable(String),
+    `updated_at` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+

--- a/src/ingestion/scripts/connectors-ddl/github-nocode.sql
+++ b/src/ingestion/scripts/connectors-ddl/github-nocode.sql
@@ -237,6 +237,29 @@ ORDER BY _airbyte_raw_id
 SETTINGS index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS bronze_github_nocode.pull_request_diff_stats
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `pull_number` Nullable(Int64),
+    `repo_full_name` Nullable(String),
+    `additions` Nullable(Int64),
+    `deletions` Nullable(Int64),
+    `changed_files` Nullable(Int64),
+    `updated_at` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS bronze_github_nocode.pull_request_reviews
 (
     `_airbyte_raw_id` String,

--- a/src/ingestion/scripts/connectors-ddl/gitlab-nocode.sql
+++ b/src/ingestion/scripts/connectors-ddl/gitlab-nocode.sql
@@ -126,7 +126,8 @@ CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.merge_request_approvals
     `approvals_required` Nullable(Int64),
     `approvals_left` Nullable(Int64),
     `approved_by_usernames` Nullable(String),
-    `updated_at` Nullable(String)
+    `updated_at` Nullable(String),
+    `approved_by_ids` Nullable(String)
 )
 ENGINE = MergeTree
 ORDER BY _airbyte_raw_id
@@ -153,7 +154,11 @@ CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.merge_request_notes
     `resolvable` Nullable(Bool),
     `resolved` Nullable(Bool),
     `created_at` Nullable(String),
-    `updated_at` Nullable(String)
+    `updated_at` Nullable(String),
+    `body` Nullable(String),
+    `author_id` Nullable(Int64),
+    `position_new_path` Nullable(String),
+    `position_new_line` Nullable(Int64)
 )
 ENGINE = MergeTree
 ORDER BY _airbyte_raw_id
@@ -188,7 +193,8 @@ CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.merge_requests
     `merged_at` Nullable(String),
     `closed_at` Nullable(String),
     `merged_by_username` Nullable(String),
-    `user_notes_count` Nullable(Int64)
+    `user_notes_count` Nullable(Int64),
+    `description` Nullable(String)
 )
 ENGINE = MergeTree
 ORDER BY _airbyte_raw_id
@@ -241,7 +247,9 @@ CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.repositories
     `web_url` Nullable(String),
     `http_url_to_repo` Nullable(String),
     `created_at` Nullable(String),
-    `last_activity_at` Nullable(String)
+    `last_activity_at` Nullable(String),
+    `description` Nullable(String),
+    `statistics_repository_size` Nullable(Int64)
 )
 ENGINE = MergeTree
 ORDER BY _airbyte_raw_id
@@ -265,7 +273,9 @@ CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.users
     `state` Nullable(String),
     `access_level` Nullable(Int64),
     `created_at` Nullable(String),
-    `group` Nullable(String)
+    `group` Nullable(String),
+    `email` Nullable(String),
+    `public_email` Nullable(String)
 )
 ENGINE = MergeTree
 ORDER BY _airbyte_raw_id

--- a/src/ingestion/scripts/connectors-ddl/gitlab-nocode.sql
+++ b/src/ingestion/scripts/connectors-ddl/gitlab-nocode.sql
@@ -1,0 +1,274 @@
+CREATE DATABASE IF NOT EXISTS `bronze_gitlab_nocode`;
+
+CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.commit_files
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `project_id` Nullable(String),
+    `sha` Nullable(String),
+    `committed_date` Nullable(String),
+    `filename` Nullable(String),
+    `previous_filename` Nullable(String),
+    `status` Nullable(String),
+    `additions` Nullable(Int64),
+    `deletions` Nullable(Int64),
+    `changes` Nullable(Int64),
+    `is_binary` Nullable(Bool),
+    `patch` Nullable(String),
+    `patch_truncated` Nullable(Bool)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.commits
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `project_id` Nullable(String),
+    `sha` Nullable(String),
+    `message` Nullable(String),
+    `authored_date` Nullable(String),
+    `committed_date` Nullable(String),
+    `author_name` Nullable(String),
+    `author_email` Nullable(String),
+    `committer_name` Nullable(String),
+    `committer_email` Nullable(String),
+    `parent_hashes` Nullable(String),
+    `is_merge` Nullable(Bool),
+    `additions` Nullable(Int64),
+    `deletions` Nullable(Int64),
+    `changed_files` Nullable(Int64),
+    `is_in_default_branch` Nullable(Bool),
+    `patch_id` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.deployments
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `id` Nullable(Int64),
+    `iid` Nullable(Int64),
+    `project_id` Nullable(Int64),
+    `status` Nullable(String),
+    `ref` Nullable(String),
+    `sha` Nullable(String),
+    `environment_name` Nullable(String),
+    `deployable_status` Nullable(String),
+    `pipeline_id` Nullable(Int64),
+    `created_at` Nullable(String),
+    `updated_at` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.merge_request_approvals
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `mr_iid` Nullable(Int64),
+    `project_id` Nullable(Int64),
+    `approved` Nullable(Bool),
+    `approvals_required` Nullable(Int64),
+    `approvals_left` Nullable(Int64),
+    `approved_by_usernames` Nullable(String),
+    `updated_at` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.merge_request_notes
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `id` Nullable(Int64),
+    `mr_iid` Nullable(Int64),
+    `project_id` Nullable(Int64),
+    `author_username` Nullable(String),
+    `system` Nullable(Bool),
+    `type` Nullable(String),
+    `resolvable` Nullable(Bool),
+    `resolved` Nullable(Bool),
+    `created_at` Nullable(String),
+    `updated_at` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.merge_requests
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `id` Nullable(Int64),
+    `iid` Nullable(Int64),
+    `project_id` Nullable(Int64),
+    `state` Nullable(String),
+    `draft` Nullable(Bool),
+    `title` Nullable(String),
+    `author_username` Nullable(String),
+    `source_branch` Nullable(String),
+    `target_branch` Nullable(String),
+    `sha` Nullable(String),
+    `merge_commit_sha` Nullable(String),
+    `squash_commit_sha` Nullable(String),
+    `created_at` Nullable(String),
+    `updated_at` Nullable(String),
+    `merged_at` Nullable(String),
+    `closed_at` Nullable(String),
+    `merged_by_username` Nullable(String),
+    `user_notes_count` Nullable(Int64)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.pipelines
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `id` Nullable(Int64),
+    `iid` Nullable(Int64),
+    `project_id` Nullable(Int64),
+    `status` Nullable(String),
+    `source` Nullable(String),
+    `ref` Nullable(String),
+    `sha` Nullable(String),
+    `name` Nullable(String),
+    `created_at` Nullable(String),
+    `updated_at` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.repo_branches
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `project_id` Nullable(String),
+    `name` Nullable(String),
+    `head_sha` Nullable(String),
+    `head_committed_date` Nullable(String),
+    `is_default` Nullable(Bool)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.repositories
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `project_id` Nullable(Int64),
+    `path_with_namespace` Nullable(String),
+    `name` Nullable(String),
+    `default_branch` Nullable(String),
+    `visibility` Nullable(String),
+    `archived` Nullable(Bool),
+    `web_url` Nullable(String),
+    `http_url_to_repo` Nullable(String),
+    `created_at` Nullable(String),
+    `last_activity_at` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.users
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `id` Nullable(Int64),
+    `username` Nullable(String),
+    `name` Nullable(String),
+    `state` Nullable(String),
+    `access_level` Nullable(Int64),
+    `created_at` Nullable(String),
+    `group` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+

--- a/src/ingestion/scripts/connectors-ddl/gitlab-nocode.sql
+++ b/src/ingestion/scripts/connectors-ddl/gitlab-nocode.sql
@@ -134,6 +134,26 @@ ORDER BY _airbyte_raw_id
 SETTINGS index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.merge_request_commits
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `sha` Nullable(String),
+    `mr_iid` Nullable(Int64),
+    `project_id` Nullable(Int64)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.merge_request_notes
 (
     `_airbyte_raw_id` String,

--- a/src/ingestion/scripts/connectors-ddl/gitlab-nocode.sql
+++ b/src/ingestion/scripts/connectors-ddl/gitlab-nocode.sql
@@ -154,6 +154,29 @@ ORDER BY _airbyte_raw_id
 SETTINGS index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.merge_request_diff_stats
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `collected_at` Nullable(String),
+    `mr_iid` Nullable(Int64),
+    `project_id` Nullable(Int64),
+    `additions` Nullable(Int64),
+    `deletions` Nullable(Int64),
+    `files_changed` Nullable(Int64),
+    `updated_at` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.merge_request_notes
 (
     `_airbyte_raw_id` String,

--- a/src/ingestion/scripts/connectors-ddl/gitlab-nocode.sql
+++ b/src/ingestion/scripts/connectors-ddl/gitlab-nocode.sql
@@ -1,6 +1,6 @@
 CREATE DATABASE IF NOT EXISTS `bronze_gitlab_nocode`;
 
-CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.commit_files
+CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.branches
 (
     `_airbyte_raw_id` String,
     `_airbyte_extracted_at` DateTime64(3),
@@ -11,17 +11,10 @@ CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.commit_files
     `source_id` Nullable(String),
     `data_source` Nullable(String),
     `project_id` Nullable(String),
-    `sha` Nullable(String),
-    `committed_date` Nullable(String),
-    `filename` Nullable(String),
-    `previous_filename` Nullable(String),
-    `status` Nullable(String),
-    `additions` Nullable(Int64),
-    `deletions` Nullable(Int64),
-    `changes` Nullable(Int64),
-    `is_binary` Nullable(Bool),
-    `patch` Nullable(String),
-    `patch_truncated` Nullable(Bool)
+    `name` Nullable(String),
+    `head_sha` Nullable(String),
+    `head_committed_date` Nullable(String),
+    `is_default` Nullable(Bool)
 )
 ENGINE = MergeTree
 ORDER BY _airbyte_raw_id
@@ -82,6 +75,34 @@ CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.deployments
     `pipeline_id` Nullable(Int64),
     `created_at` Nullable(String),
     `updated_at` Nullable(String)
+)
+ENGINE = MergeTree
+ORDER BY _airbyte_raw_id
+SETTINGS index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.file_changes
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `unique_key` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `data_source` Nullable(String),
+    `project_id` Nullable(String),
+    `sha` Nullable(String),
+    `committed_date` Nullable(String),
+    `filename` Nullable(String),
+    `previous_filename` Nullable(String),
+    `status` Nullable(String),
+    `additions` Nullable(Int64),
+    `deletions` Nullable(Int64),
+    `changes` Nullable(Int64),
+    `is_binary` Nullable(Bool),
+    `patch` Nullable(String),
+    `patch_truncated` Nullable(Bool)
 )
 ENGINE = MergeTree
 ORDER BY _airbyte_raw_id
@@ -201,27 +222,6 @@ ORDER BY _airbyte_raw_id
 SETTINGS index_granularity = 8192
 ;
 
-CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.repo_branches
-(
-    `_airbyte_raw_id` String,
-    `_airbyte_extracted_at` DateTime64(3),
-    `_airbyte_meta` String,
-    `_airbyte_generation_id` UInt32,
-    `unique_key` Nullable(String),
-    `tenant_id` Nullable(String),
-    `source_id` Nullable(String),
-    `data_source` Nullable(String),
-    `project_id` Nullable(String),
-    `name` Nullable(String),
-    `head_sha` Nullable(String),
-    `head_committed_date` Nullable(String),
-    `is_default` Nullable(Bool)
-)
-ENGINE = MergeTree
-ORDER BY _airbyte_raw_id
-SETTINGS index_granularity = 8192
-;
-
 CREATE TABLE IF NOT EXISTS bronze_gitlab_nocode.repositories
 (
     `_airbyte_raw_id` String,
@@ -271,4 +271,3 @@ ENGINE = MergeTree
 ORDER BY _airbyte_raw_id
 SETTINGS index_granularity = 8192
 ;
-

--- a/src/ingestion/secrets/connectors/bitbucket-nocode.yaml.example
+++ b/src/ingestion/secrets/connectors/bitbucket-nocode.yaml.example
@@ -9,14 +9,11 @@ metadata:
     insight.cyberfabric.com/source-id: bitbucket-nocode-main
 type: Opaque
 stringData:
-  # Atlassian account username or email — personal API tokens authenticate as
-  # HTTP basic username:token, both for the API and for the clone.
+  # Atlassian account email/username. Set for personal API tokens (Basic
+  # username:token, API and clone alike); leave unset for workspace or
+  # repository access tokens, which authenticate as Bearer.
   bitbucket_username: "CHANGE_ME"
   bitbucket_token: "CHANGE_ME"
-  # The CLONE username, which is not the API credential. Leave unset for a
-  # personal API token; set the account's short username for a workspace or
-  # repository access token.
-  # bitbucket_git_username: "x-bitbucket-api-token-auth"
   # JSON array of workspace slugs.
   bitbucket_workspaces: '["acme"]'
   # Cluster-internal git-cli-proxy Service.

--- a/src/ingestion/secrets/connectors/bitbucket-nocode.yaml.example
+++ b/src/ingestion/secrets/connectors/bitbucket-nocode.yaml.example
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-bitbucket-nocode-main
+  labels:
+    app.kubernetes.io/part-of: insight
+  annotations:
+    insight.cyberfabric.com/connector: bitbucket-nocode
+    insight.cyberfabric.com/source-id: bitbucket-nocode-main
+type: Opaque
+stringData:
+  # Atlassian account username or email — personal API tokens authenticate as
+  # HTTP basic username:token, both for the API and for the clone.
+  bitbucket_username: "CHANGE_ME"
+  bitbucket_token: "CHANGE_ME"
+  # The CLONE username, which is not the API credential. Leave unset for a
+  # personal API token; set the account's short username for a workspace or
+  # repository access token.
+  # bitbucket_git_username: "x-bitbucket-api-token-auth"
+  # JSON array of workspace slugs.
+  bitbucket_workspaces: '["acme"]'
+  # Cluster-internal git-cli-proxy Service.
+  git_proxy_url: "http://insight-git-cli-proxy:8085"
+  # Same value as APP__gears__git_cli_proxy__config__proxy_token in the
+  # insight-git-cli-proxy-config Secret the umbrella composes.
+  git_proxy_token: "CHANGE_ME"
+  bitbucket_start_date: "2020-01-01"

--- a/src/ingestion/secrets/connectors/github-nocode.yaml.example
+++ b/src/ingestion/secrets/connectors/github-nocode.yaml.example
@@ -1,0 +1,19 @@
+# Secret for the github-nocode connector. Copy to github-nocode.yaml, fill the
+# values, and apply to the insight namespace. git_proxy_token must equal
+# APP__gears__git_cli_proxy__config__proxy_token in the umbrella-composed
+# insight-git-cli-proxy-config Secret.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: airbyte-source-github-nocode
+  labels:
+    app.kubernetes.io/part-of: insight
+  annotations:
+    insight.cyberfabric.com/connector: github-nocode
+    insight.cyberfabric.com/source-id: github-acme
+stringData:
+  github_token: CHANGE_ME            # PAT: repo, read:org (classic) or fine-grained equivalent
+  github_organizations: '["acme"]'   # JSON array of org logins
+  git_proxy_url: http://insight-git-cli-proxy:8085
+  git_proxy_token: CHANGE_ME
+  github_start_date: "2020-01-01"

--- a/src/ingestion/secrets/connectors/gitlab-nocode.yaml.example
+++ b/src/ingestion/secrets/connectors/gitlab-nocode.yaml.example
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-gitlab-nocode-main
+  labels:
+    app.kubernetes.io/part-of: insight
+  annotations:
+    insight.cyberfabric.com/connector: gitlab-nocode
+    insight.cyberfabric.com/source-id: gitlab-nocode-main
+type: Opaque
+stringData:
+  gitlab_url: "https://gitlab.example.com"
+  # Needs read_api (project discovery) AND read_repository (the clone the proxy
+  # performs on this token's behalf). The proxy never stores it.
+  gitlab_token: "CHANGE_ME"
+  # JSON array of group full paths, subgroups included. REQUIRED: a read-only
+  # service account is a member of no project, so membership-scoped discovery
+  # finds nothing.
+  gitlab_groups: '["acme", "acme/platform"]'
+  # Cluster-internal git-cli-proxy Service.
+  git_proxy_url: "http://insight-git-cli-proxy:8085"
+  # Same value as APP__gears__git_cli_proxy__config__proxy_token in the
+  # insight-git-cli-proxy-config Secret the umbrella composes.
+  git_proxy_token: "CHANGE_ME"
+  gitlab_start_date: "2020-01-01"

--- a/src/ingestion/secrets/connectors/gitlab-nocode.yaml.example
+++ b/src/ingestion/secrets/connectors/gitlab-nocode.yaml.example
@@ -13,10 +13,11 @@ stringData:
   # Needs read_api (project discovery) AND read_repository (the clone the proxy
   # performs on this token's behalf). The proxy never stores it.
   gitlab_token: "CHANGE_ME"
-  # JSON array of group full paths, subgroups included. REQUIRED: a read-only
-  # service account is a member of no project, so membership-scoped discovery
-  # finds nothing.
-  gitlab_groups: '["acme", "acme/platform"]'
+  # JSON array of group full paths, subgroups included. Leave [] to sync the
+  # FULL INSTANCE — every project the token can see (self-hosted only;
+  # gitlab.com requires groups, or discovery would enumerate every public
+  # project in the world).
+  gitlab_groups: '[]'
   # Cluster-internal git-cli-proxy Service.
   git_proxy_url: "http://insight-git-cli-proxy:8085"
   # Same value as APP__gears__git_cli_proxy__config__proxy_token in the


### PR DESCRIPTION
Three declarative (nocode) git connectors — **github-nocode**, **gitlab-nocode**, **bitbucket-nocode** — consuming the git-cli-proxy shipped in #2288: commit-level extraction (commits, per-file changes, branches) is served from a bare blobless clone by the proxy instead of one vendor API call per commit; everything git cannot carry stays on the vendor API in the same manifest. Refs #2224, design in `docs/components/connectors/git/git-cli-proxy/specs/DESIGN.md` §5.

The CDK connectors (`github-v2`, `gitlab`, `bitbucket-cloud`) coexist untouched; each nocode connector has its own `data_source`. `org_members` stays in the deployed `github-directory` connector — folding it in is a separate migration.

## Streams

Stream names match the CDK connectors, and the same concept carries the same name on every vendor (`repositories`, `commits`, `file_changes`, `branches`).

| | github-nocode (14) | gitlab-nocode (12) | bitbucket-nocode (12) |
|---|---|---|---|
| proxy | commits, file_changes, branches | same | same |
| roster | repositories | repositories | repositories |
| review | pull_requests, reviews, comments, commits, diff_stats | merge_requests, notes, commits, approvals, diff_stats | pull_requests, comments, commits, diffstat, activity |
| people | — (github-directory) | users | workspace_members |
| planning | issues, projects_v2 (GraphQL) | — | — |
| CI/deploy | workflow_runs, deployments, deployment_statuses | pipelines, deployments | pipelines, deployments |

Incremental design: server-side time filters where the vendor has them (GitHub `since`, Bitbucket BBQL, GitLab `updated_after` on merge requests); newest-first data-feeds where it doesn't (GitHub pulls/deployments, Bitbucket pipelines-module); client-side filtering where the vendor advertises a filter it silently ignores (GitLab `/groups/:id/projects`, which has no `last_activity_after` — the CDK connector full-lists it too). PR/MR children read a stateless 30-day sliding window of recently updated parents since they have no cursor of their own — the ReplacingMergeTree absorbs re-emission.

Pull-request size lands via a per-vendor diff-stats stream, each taking that vendor's cheapest route (verified against the live GraphQL schemas and REST references, not inherited from the CDK connectors): GitHub's GraphQL list node carries `additions`/`deletions`/`changedFiles` so a page of 100 costs one request; GitLab's `diffStatsSummary` carries real integers where REST offers only a capped `changes_count` string, filtered server-side by `updatedAfter` with no per-MR fan-out; Bitbucket has neither, so per-file `diffstat` rows are the only source and silver sums them. Stats GitLab has not finished computing stay null rather than becoming a zero that reads as an empty merge request.

The PR↔commit edge is a vendor call rather than a proxy derivation on purpose: a squash- or rebase-merged PR leaves its original commits unreachable from every ref the proxy clones, so no clone-side reconstruction can recover the membership. The commit payloads still come from the proxy; the child stores the edge alone.

## Configuration

Required per connector: tenant/source ids, the vendor credential and scope list, the proxy URL/token, and a start date. Nothing else — page sizes, patch caps, lookback and child windows are constants of the design rather than per-install variance, so they live in the manifests. API base URLs stay configurable on all three vendors (GitHub Enterprise Server, self-hosted GitLab, Bitbucket). GitLab's `gitlab_groups` is optional: empty means full-instance sync — discovery flips to keyset-paginated `/projects` (no offset ceiling; one Link-header paginator serves offset and keyset alike), merge requests to `/merge_requests?scope=all`, members to `/users`, and diff stats fan out one GraphQL query per active project (no instance-wide GraphQL MR query exists). The spec rejects full-instance mode on gitlab.com, where it would enumerate every public project. Bitbucket accepts either credential type: `bitbucket_username` set selects Basic (personal API token), empty selects Bearer (workspace access token), and the clone username the proxy presents follows the same choice.

## Bronze fields

The streams carry the columns the existing silver models consume, so the follow-up dbt work is a mapping exercise rather than a re-sync: PR/MR titles and descriptions, comment and note bodies, reviewer identity, inline comment positions. Long text is trimmed at the bitbucket-cloud CDK precedent — 2048 characters for bodies and commit messages, 1024 for titles. Diff text is not trimmed here: the proxy caps it per file and flags `patch_truncated`, so line counts stay exact and filtered recomputation (blank lines, comments) still works off stored patches.

## Robustness

- Per-repository 403/404 (valid token, inaccessible repo — the class that used to break whole syncs) skips the repository, never the stream; GitLab approvals tolerate 402 (paid tier); GitHub 410 (issues disabled) likewise.
- GitHub secondary rate limits arrive as 403: throttle predicates (body message, `x-ratelimit-remaining: 0`) run before any 403 handling.
- Proxy 429 + Retry-After (cold clone in progress) retries generously; 404/413 skip the repository; 409 (superseded snapshot) fails the attempt and the rerun resumes from stored cursors.
- GraphQL errors arrive as HTTP 200 — rate-limit-typed back off, anything else fails with the vendor's message.
- Jinja hygiene: every computed nullable string coalesces to `''` (a rendered `none` under `value_type: string` stores the literal text "None"); integer key parts interpolate plain (the CDK's `string` filter triple-quotes non-strings); hoisted nested objects are removed after flattening.

## Verification

- L0: all three manifests pass `validate-strict` (Builder) and the CDK loader.
- L1: mock suites (30 cases) through the harness's black-box read — proxy retry/skip/fail matrix, secondary-limit predicate, GraphQL error-in-200, four-state Bitbucket path, synthesized activity keys, body trimming, and a literal-"None" sweep on every stream. Registered in `connector-mock-tests`.
- Writing the suites caught three manifest defect classes before any live run: the `string`-filter triple-quoting, the `is_data_feed`/`is_client_side_incremental` exclusivity, and a brace-escaping leftover that sent malformed patch parameters to the proxy.
- DDL snapshots cover every stream (14/12/12 tables), generated through the real discover → destination pipeline.

## Not in this PR

- Silver dbt models (bronze-only until they land; `union_by_tag` type-locks them against the CDK models).
- L2 live smoke against vendor accounts + schema regeneration from real reads — the exit-from-draft gate; the `is_data_feed` pagination-stop behavior is the #1 checkpoint there.
- Per-branch commit attribution: the proxy deduplicates commits by sha and reports default-branch membership only — reachability was removed from its contract deliberately (DESIGN §`/v1/commits`) because it cost one `git branch --contains` per commit. Branch attribution for anything that went through a PR is derivable from the new PR-commit edge plus the PR's head ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
