### PR TITLE
fix(analytics): expose metric origin in the definitions listing

### DIFF
--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -458,7 +458,7 @@
             "type": "string"
           },
           "last_observed_date": {
-            "description": "Newest `metric_date` ever observed across the definition's input\nmeasures; absent when no observation has ever been seen. Freshness\nsignal, orthogonal to `schema_status`.",
+            "description": "Newest `metric_date` ever observed across the definition's input\nmeasures; absent when no observation has ever been seen. Freshness\nsignal, orthogonal to `schema_status`. Not maintained for `custom`\nmetrics (see `origin`).",
             "format": "date",
             "type": [
               "string",
@@ -467,6 +467,10 @@
           },
           "metric_key": {
             "type": "string"
+          },
+          "origin": {
+            "$ref": "#/components/schemas/MetricOrigin",
+            "description": "`builtin` metrics read managed observation relations; `custom` metrics\nexecute inline SQL at query time. The validator stamps `schema_status`\nand `last_observed_date` from materialized relations only, so for\n`custom` those fields stay `unchecked` / absent regardless of data —\nreaders must not interpret them as \"never measured\" for custom metrics."
           },
           "schema_error_code": {
             "oneOf": [
@@ -503,6 +507,7 @@
           "direction",
           "dimensions",
           "is_enabled",
+          "origin",
           "schema_status"
         ],
         "type": "object"
@@ -862,6 +867,13 @@
           "value",
           "numerator",
           "denominator"
+        ],
+        "type": "string"
+      },
+      "MetricOrigin": {
+        "enum": [
+          "builtin",
+          "custom"
         ],
         "type": "string"
       },

--- a/docs/domain/metrics/specs/DESIGN.md
+++ b/docs/domain/metrics/specs/DESIGN.md
@@ -23,8 +23,10 @@
 - [Custom Metrics](#custom-metrics)
   - [Execution wire](#execution-wire)
   - [Observation contract the custom SQL must emit](#observation-contract-the-custom-sql-must-emit)
+  - [Catalog visibility](#catalog-visibility)
   - [Reconcile-safety of custom rows](#reconcile-safety-of-custom-rows)
   - [Validation and execution role](#validation-and-execution-role)
+  - [Tenant safety of custom SQL](#tenant-safety-of-custom-sql)
 - [Frontend Contract](#frontend-contract)
 - [Non-Goals](#non-goals)
 
@@ -609,6 +611,12 @@ Schema validation checks:
   `unchecked`, never `error`: filtered measures legitimately go quiet, and
   absence of data is indistinguishable from an unemitted measure.
 - probe failures never overwrite a previously established status.
+- custom observation SQL sources are not probed: the validator reads
+  materialized relations only, and executing tenant-authored SQL would leave
+  the `presentation_ro` execution role custom SQL is confined to. Custom
+  definitions therefore keep `schema_status = 'unchecked'` and never receive
+  `last_observed_date`; the listing exposes `origin` so readers can tell
+  these fields do not apply, instead of reading them as "never measured".
 - the validator sweeps periodically, not once at startup: managed relations
   are dbt-created and may appear after the service boots (fresh deploys) or
   regress later (a bad model change); both converge within one sweep with no
@@ -773,6 +781,15 @@ measure_key, observed_at, value, subject_key, dimensions
 ```
 
 Column semantics match the Source Measure Observation Contract above.
+
+### Catalog visibility
+
+`GET /v1/metric-definitions` exposes each definition's `origin` (`builtin` /
+`custom`). `schema_status` and `last_observed_date` are stamped by the
+managed-relation validator only, so for `origin = 'custom'` they stay
+`unchecked` / absent regardless of the data the metric serves; a consumer
+that treats a missing `last_observed_date` as "this metric has never
+measured anything" must scope that reading to `origin = 'builtin'`.
 
 ### Reconcile-safety of custom rows
 

--- a/src/backend/services/analytics/src/domain/metric_definitions/definition.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/definition.rs
@@ -66,6 +66,23 @@ impl EvidenceGranularity {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MetricOrigin {
+    Builtin,
+    Custom,
+}
+
+impl MetricOrigin {
+    pub fn from_db(value: &str) -> Option<Self> {
+        match value {
+            "builtin" => Some(Self::Builtin),
+            "custom" => Some(Self::Custom),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SourceKind {
@@ -514,6 +531,13 @@ mod tests {
             );
         }
         assert_eq!(EvidenceGranularity::from_db("unknown"), None);
+        for (value, origin) in [
+            ("builtin", MetricOrigin::Builtin),
+            ("custom", MetricOrigin::Custom),
+        ] {
+            assert_eq!(MetricOrigin::from_db(value), Some(origin));
+        }
+        assert_eq!(MetricOrigin::from_db("unknown"), None);
         let relation = ObservationRelation::parse("ai_metric_observations")
             .unwrap_or_else(|| panic!("builtin relation name must parse"));
         let (_, table) = relation.table_ref();

--- a/src/backend/services/analytics/src/domain/metric_definitions/listing.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/listing.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 use toolkit_canonical_errors::CanonicalError;
 use uuid::Uuid;
 
-use crate::domain::metric_definitions::definition::{MetricDirection, MetricFormat};
+use crate::domain::metric_definitions::definition::{MetricDirection, MetricFormat, MetricOrigin};
 use crate::domain::metric_definitions::error_code::{MetricSchemaErrorCode, SchemaStatus};
 use crate::domain::metric_definitions::repository::fetch_dimensions;
 use crate::domain::metric_drilldown::{MetricDrilldownCapability, load_capabilities};
@@ -44,13 +44,20 @@ pub struct MetricDefinitionView {
     pub direction: MetricDirection,
     pub dimensions: Vec<String>,
     pub is_enabled: bool,
+    /// `builtin` metrics read managed observation relations; `custom` metrics
+    /// execute inline SQL at query time. The validator stamps `schema_status`
+    /// and `last_observed_date` from materialized relations only, so for
+    /// `custom` those fields stay `unchecked` / absent regardless of data —
+    /// readers must not interpret them as "never measured" for custom metrics.
+    pub origin: MetricOrigin,
     pub schema_status: SchemaStatus,
     /// Why `schema_status` is `error`; absent otherwise (the DB enforces the
     /// biconditional).
     pub schema_error_code: Option<MetricSchemaErrorCode>,
     /// Newest `metric_date` ever observed across the definition's input
     /// measures; absent when no observation has ever been seen. Freshness
-    /// signal, orthogonal to `schema_status`.
+    /// signal, orthogonal to `schema_status`. Not maintained for `custom`
+    /// metrics (see `origin`).
     pub last_observed_date: Option<chrono::NaiveDate>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub drilldown: Option<MetricDrilldownCapability>,
@@ -71,6 +78,7 @@ struct ListingRow {
     format: String,
     direction: String,
     is_enabled: bool,
+    origin: String,
     schema_status: String,
     schema_error_code: Option<String>,
     last_observed_date: Option<chrono::NaiveDate>,
@@ -141,6 +149,8 @@ fn build_views(
             .ok_or_else(|| config_error(&row.metric_key, "format", &row.format))?;
         let direction = MetricDirection::from_db(&row.direction)
             .ok_or_else(|| config_error(&row.metric_key, "direction", &row.direction))?;
+        let origin = MetricOrigin::from_db(&row.origin)
+            .ok_or_else(|| config_error(&row.metric_key, "origin", &row.origin))?;
         let schema_status = SchemaStatus::from_db(&row.schema_status)
             .ok_or_else(|| config_error(&row.metric_key, "schema_status", &row.schema_status))?;
         let schema_error_code = row
@@ -162,6 +172,7 @@ fn build_views(
             direction,
             dimensions: dimensions.remove(&row.definition_id).unwrap_or_default(),
             is_enabled: row.is_enabled,
+            origin,
             schema_status,
             schema_error_code,
             last_observed_date: row.last_observed_date,
@@ -189,6 +200,7 @@ async fn fetch_listing_rows(
             d.format AS format, \
             d.direction AS direction, \
             d.is_enabled AS is_enabled, \
+            d.origin AS origin, \
             d.schema_status AS schema_status, \
             d.schema_error_code AS schema_error_code, \
             d.last_observed_date AS last_observed_date \
@@ -233,6 +245,7 @@ mod tests {
             format: "integer".to_owned(),
             direction: "higher_is_better".to_owned(),
             is_enabled: true,
+            origin: "builtin".to_owned(),
             schema_status: "unchecked".to_owned(),
             schema_error_code: None,
             last_observed_date: None,
@@ -264,6 +277,7 @@ mod tests {
     #[test]
     fn build_views_decodes_columns_and_attaches_dimensions() {
         let mut r = row("git.commits", None, "Commits");
+        r.origin = "custom".to_owned();
         r.schema_status = "error".to_owned();
         r.schema_error_code = Some("table_not_found".to_owned());
         let id = r.definition_id;
@@ -278,6 +292,7 @@ mod tests {
         };
         assert_eq!(view.format, MetricFormat::Integer);
         assert_eq!(view.direction, MetricDirection::HigherIsBetter);
+        assert_eq!(view.origin, MetricOrigin::Custom);
         assert_eq!(view.schema_status, SchemaStatus::Error);
         assert_eq!(
             view.schema_error_code,
@@ -290,6 +305,10 @@ mod tests {
     fn build_views_rejects_a_noncanonical_enum_value() {
         let mut r = row("git.commits", None, "Commits");
         r.format = "not-a-format".to_owned();
+        assert!(build_views(vec![r], HashMap::new()).is_err());
+
+        let mut r = row("git.commits", None, "Commits");
+        r.origin = "not-an-origin".to_owned();
         assert!(build_views(vec![r], HashMap::new()).is_err());
     }
 }

--- a/src/backend/services/analytics/src/domain/metric_definitions/listing.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/listing.rs
@@ -277,7 +277,6 @@ mod tests {
     #[test]
     fn build_views_decodes_columns_and_attaches_dimensions() {
         let mut r = row("git.commits", None, "Commits");
-        r.origin = "custom".to_owned();
         r.schema_status = "error".to_owned();
         r.schema_error_code = Some("table_not_found".to_owned());
         let id = r.definition_id;
@@ -292,13 +291,30 @@ mod tests {
         };
         assert_eq!(view.format, MetricFormat::Integer);
         assert_eq!(view.direction, MetricDirection::HigherIsBetter);
-        assert_eq!(view.origin, MetricOrigin::Custom);
+        assert_eq!(view.origin, MetricOrigin::Builtin);
         assert_eq!(view.schema_status, SchemaStatus::Error);
         assert_eq!(
             view.schema_error_code,
             Some(MetricSchemaErrorCode::TableNotFound)
         );
         assert_eq!(view.dimensions, vec!["repo".to_owned()]);
+    }
+
+    #[test]
+    fn build_views_decodes_custom_origin() {
+        let mut r = row("team.velocity", None, "Velocity");
+        r.origin = "custom".to_owned();
+
+        let Ok(views) = build_views(vec![r], HashMap::new()) else {
+            panic!("canonical rows must map");
+        };
+        let Some(view) = views.first() else {
+            panic!("one view");
+        };
+        assert_eq!(view.origin, MetricOrigin::Custom);
+        assert_eq!(view.schema_status, SchemaStatus::Unchecked);
+        assert_eq!(view.schema_error_code, None);
+        assert_eq!(view.last_observed_date, None);
     }
 
     #[test]

--- a/src/backend/services/analytics/src/domain/metric_definitions/validator.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/validator.rs
@@ -1219,6 +1219,28 @@ mod tests {
         assert!(!all_measures_covered(&windows, missing));
     }
 
+    // A custom_observation_sql source is executed at query time and
+    // materialises nothing, and the validator must not run tenant-authored SQL
+    // to probe it. It is therefore left inconclusive, which keeps the previous
+    // status: custom definitions stay `unchecked` and never get a
+    // last_observed_date. Returns without touching the (disconnected) backends.
+    #[tokio::test]
+    async fn custom_observation_sql_sources_are_never_probed() {
+        let validator = MetricDefinitionValidator::new(
+            sea_orm::DatabaseConnection::Disconnected,
+            insight_clickhouse::Client::new(insight_clickhouse::Config::new(
+                "http://unused",
+                "silver",
+            )),
+        );
+
+        let outcome = validator
+            .validate_source(SourceKind::CustomObservationSql.as_db(), "unused")
+            .await;
+
+        assert!(matches!(outcome, ProbeOutcome::Inconclusive));
+    }
+
     // Drives the two-probe granularity check (observation dates, then
     // granularities) against an in-process mock server, so the bounded query
     // paths run end-to-end.

--- a/tests/stand/api/schemas/analytics.py
+++ b/tests/stand/api/schemas/analytics.py
@@ -267,6 +267,11 @@ class MetricInputRole(StrEnum):
     denominator = 'denominator'
 
 
+class MetricOrigin(StrEnum):
+    builtin = 'builtin'
+    custom = 'custom'
+
+
 class Computation4(StrEnum):
     sum = 'sum'
 
@@ -629,8 +634,9 @@ class MetricDefinitionView(BaseModel):
     format: MetricFormat
     is_enabled: bool
     label: str
-    last_observed_date: date_aliased | None = Field(None, description="Newest `metric_date` ever observed across the definition's input\nmeasures; absent when no observation has ever been seen. Freshness\nsignal, orthogonal to `schema_status`.")
+    last_observed_date: date_aliased | None = Field(None, description="Newest `metric_date` ever observed across the definition's input\nmeasures; absent when no observation has ever been seen. Freshness\nsignal, orthogonal to `schema_status`. Not maintained for `custom`\nmetrics (see `origin`).")
     metric_key: str
+    origin: MetricOrigin = Field(..., description='`builtin` metrics read managed observation relations; `custom` metrics\nexecute inline SQL at query time. The validator stamps `schema_status`\nand `last_observed_date` from materialized relations only, so for\n`custom` those fields stay `unchecked` / absent regardless of data —\nreaders must not interpret them as "never measured" for custom metrics.')
     schema_error_code: MetricSchemaErrorCode | None = None
     schema_status: SchemaStatus
     short_label: str | None = Field(None, description='Compact label for dense surfaces; absent when the full label is\nalready compact enough.')


### PR DESCRIPTION
## Summary

Fixes #2343.

`GET /v1/metric-definitions` now returns each definition's `origin` (`builtin` / `custom`), so a reader can tell a custom metric — whose `schema_status` stays `unchecked` and `last_observed_date` stays absent by design — from a builtin metric that has genuinely never observed anything.

The issue offered two acceptable resolutions: stamp freshness/schema status for custom metrics too, or expose enough for a reader to tell the fields do not apply. This takes the second, because the first would require the validator (which runs with a service-level ClickHouse client) to execute tenant-authored SQL every sweep — breaking the DESIGN.md invariant that custom SQL only ever executes as `presentation_ro`.

## Changes

- `MetricOrigin` enum (`builtin` / `custom`) in `definition.rs`, decoded strictly from the DB like the sibling enums (a non-canonical stored value is a corrupt-config error).
- `origin` added to `MetricDefinitionView`, the listing projection, and the SELECT; field docs state that `schema_status` / `last_observed_date` are stamped from materialized relations only and must not be read as "never measured" for custom metrics.
- `docs/components/backend/analytics/openapi.json` regenerated via the drift-gate script (`origin` is required; new `MetricOrigin` component schema).
- `tests/stand/api/schemas/analytics.py` regenerated (`extra='forbid'` models must carry the new field).
- DESIGN.md: new "Catalog visibility" section under Custom Metrics plus a schema-validation bullet documenting why custom sources are not probed.

## Testing

- `cargo test -p analytics`: 410 passed, including new round-trip / decode / reject tests for `origin`.
- `cargo clippy -p analytics --all-targets` clean; pre-commit hooks passed.
- OpenAPI regenerated with `scripts/ci/openapi_spec.py update`, so the drift gate diff is minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metric listings now identify whether each metric is built-in or custom.
  * API schemas document the new metric origin values: `builtin` and `custom`.
* **Documentation**
  * Clarified that custom metrics do not provide observation freshness dates.
  * Documented catalog visibility, tenant filtering, and execution behavior for custom metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->