### PR TITLE
ci(frontend): hold the Sentry upload credentials one secret per line

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -823,6 +823,10 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      # Both arches emit identical maps under one release, and a pull_request
+      # image is discarded.
+      UPLOAD_SOURCEMAPS: ${{ needs.changes.outputs.should_push == 'true' && matrix.arch == 'amd64' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -834,13 +838,23 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      # One secret per setting: a masked CI variable holds a single line, so the
+      # dotenv the build wants is assembled here rather than stored whole.
+      - name: Write the Sentry upload credentials
+        if: env.UPLOAD_SOURCEMAPS == 'true'
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_URL: ${{ secrets.SENTRY_URL }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+        run: |
+          umask 077
+          printf 'SENTRY_AUTH_TOKEN=%s\nSENTRY_URL=%s\nSENTRY_ORG=%s\nSENTRY_PROJECT=%s\n' \
+            "$SENTRY_AUTH_TOKEN" "$SENTRY_URL" "$SENTRY_ORG" "$SENTRY_PROJECT" \
+            > "$RUNNER_TEMP/sentry.env"
       # No `file:` — the Dockerfile is at the context root.
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         id: build
-        env:
-          # Both arches emit identical maps under one release, and a
-          # pull_request image is discarded.
-          UPLOAD_SOURCEMAPS: ${{ needs.changes.outputs.should_push == 'true' && matrix.arch == 'amd64' }}
         with:
           context: src/frontend
           platforms: ${{ matrix.platform }}
@@ -848,10 +862,8 @@ jobs:
             VITE_SENTRY_DSN=${{ secrets.FRONTEND_SENTRY_DSN }}
             VITE_APP_RELEASE=${{ needs.changes.outputs.build_tag }}
             SENTRY_UPLOAD=${{ env.UPLOAD_SOURCEMAPS }}
-          # Quoted: the value is a multiline dotenv, and the action reads
-          # unquoted newlines as further entries.
-          secrets: |
-            "sentry_env=${{ env.UPLOAD_SOURCEMAPS == 'true' && secrets.SENTRY_BUILD_ENV || '' }}"
+          secret-files: |
+            ${{ env.UPLOAD_SOURCEMAPS == 'true' && format('sentry_env={0}/sentry.env', runner.temp) || '' }}
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}/insight-frontend,push-by-digest=true,name-canonical=true,push=${{ needs.changes.outputs.should_push == 'true' }}
           cache-from: type=gha,scope=frontend-${{ matrix.arch }}
           cache-to: ${{ needs.changes.outputs.should_push == 'true' && format('type=gha,mode=max,scope=frontend-{0},ignore-error=true', matrix.arch) || '' }}

--- a/src/frontend/README.md
+++ b/src/frontend/README.md
@@ -166,15 +166,21 @@ SENTRY_ORG=example-org
 SENTRY_PROJECT=example-project
 ```
 
-The token needs the `project:releases` and `org:read` scopes.
+The token needs the `project:releases` and `org:read` scopes, or `org:ci` on an
+organization auth token.
 
-Store it as the `SENTRY_BUILD_ENV` repository secret. A secret rather than build
-args because this job builds PR-authored source and `ARG` values persist in
-builder history.
+CI holds one secret per line — `SENTRY_AUTH_TOKEN`, `SENTRY_URL`, `SENTRY_ORG`,
+`SENTRY_PROJECT` — and the workflow assembles the file before the build. A
+masked CI variable holds a single line with no whitespace, so the dotenv cannot
+be stored whole. Secrets rather than build args because this job builds
+PR-authored source and `ARG` values persist in builder history.
 
-Without the secret the file is absent and the build skips the upload. A failed
-upload — expired token, Sentry unreachable — logs and continues, so image builds
-do not depend on Sentry being up.
+`SENTRY_URL` may be empty for Sentry's hosted service; the plugin then uses its
+own default.
+
+Without the credentials the file is absent or its values empty, and the build
+skips the upload. A failed upload — expired token, Sentry unreachable — logs and
+continues, so image builds do not depend on Sentry being up.
 
 `@sentry/cli` fetches its binary in a postinstall, so `package.json` allowlists
 it under `pnpm.onlyBuiltDependencies`. Everything else stays blocked: pnpm 10


### PR DESCRIPTION
## Why

The sourcemap upload credentials were stored as one multiline dotenv secret. A masked CI variable holds a single line with no whitespace, so that shape cannot be stored as a masked variable at all — it only worked because GitHub Actions places no such limit on secrets. One secret per setting rotates independently and stays maskable anywhere.

## What

- `SENTRY_BUILD_ENV` splits into `SENTRY_AUTH_TOKEN`, `SENTRY_URL`, `SENTRY_ORG`, `SENTRY_PROJECT`
- The frontend job writes the dotenv itself before the build and passes it through `secret-files`; the Dockerfile still mounts `/run/secrets/sentry_env` and is unchanged
- `UPLOAD_SOURCEMAPS` moves to the job so both the writing step and the build read one value
- README documents the four secrets, and records `org:ci` as an alternative to `project:releases` + `org:read`

An empty `SENTRY_URL` is allowed — the plugin then falls back to its own default. Missing credentials still mean the build skips the upload rather than failing.

Part of #2354.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Sentry sourcemap configuration requirements with separate credential values and token permissions.
  * Clarified that sourcemap uploads are skipped when credentials are missing or empty.
  * Documented support for hosted Sentry instances without a Sentry URL.
* **Security**
  * Improved protection of Sentry credentials during frontend builds by using restricted temporary secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->