### PR TITLE
Add authenticator.experimentsEnabled umbrella knob (#1973)

### DIFF
--- a/charts/insight/templates/secrets.yaml
+++ b/charts/insight/templates/secrets.yaml
@@ -236,6 +236,10 @@ stringData:
   # `__override` view-as login (#1941) — dev/demo environments ONLY.
   APP__gears__authenticator__config__override_enabled: "true"
   {{- end }}
+  {{- if .Values.authenticator.experimentsEnabled }}
+  # Preview experiments `/exp/<name>` return path (#1973) — dev/demo stands ONLY.
+  APP__gears__authenticator__config__experiments_enabled: "true"
+  {{- end }}
 
 {{- if .Values.identityResolution.deploy }}
 {{- if and ((.Values.identityResolution.seed).enabled) (not ((.Values.global | default dict).tenantDefaultId)) (not ((.Values.identityResolution.seed).tenantDefaultId)) }}

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -388,6 +388,11 @@ authenticator:
   # minted for that person instead of the authenticated one. Dev/demo
   # environments ONLY — MUST stay false anywhere real users log in.
   overrideEnabled: false
+  # Honor a post-login return into the `/exp/<name>` preview subtree (#1973):
+  # only when true is a login return under that prefix accepted. Dev/demo
+  # preview stands ONLY — a production stand leaves this false so it cannot
+  # host experimental frontends against its data.
+  experimentsEnabled: false
 # ─── keycloak ────────────────────────────────────────────────────────────────
 # The stack's Keycloak (identity broker, ADR-0003): start, MariaDB-backed,
 # admin from a Secret; realm content via keycloakConfig only.


### PR DESCRIPTION
## Summary
Surfaces the authenticator's existing `experiments_enabled` gate (config.rs) as a chart value, so a stand can opt into honoring post-login returns into the `/exp/<name>` preview subtree. Mirrors the existing `authenticator.overrideEnabled` knob exactly.

- `charts/insight/values.yaml`: new `authenticator.experimentsEnabled` (default **false**).
- `charts/insight/templates/secrets.yaml`: when true, composes `APP__gears__authenticator__config__experiments_enabled="true"` into `insight-authenticator-config`.

Default false keeps every existing stand unchanged; a production stand cannot host experimental frontends against its data. This is the prerequisite chart change for Phase 0 of the preview self-service epic (#1981) — a gitops overlay then flips it per dev/demo stand.

## Verification
`helm template` of the umbrella:
- flag **on** → `insight-authenticator-config` carries `...experiments_enabled: "true"`.
- flag **off** (default) → key absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional authenticator setting to enable experiment preview paths.
  - The setting is disabled by default and can be enabled through application configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->