### PR TITLE
fix(frontend): no subject may crowd the attention list out

### DIFF
--- a/src/frontend/src/components/portal/attention-list.test.tsx
+++ b/src/frontend/src/components/portal/attention-list.test.tsx
@@ -40,6 +40,38 @@ const FLAGS = Array.from({ length: 5 }, (_, i) =>
 );
 
 describe("AttentionList", () => {
+  it("gives no subject more rows than the cap, however many they trip", () => {
+    // A row is one finding and the list is ranked by severity, so without a
+    // cap the subject in the most trouble takes the most of the visible slice
+    // and pushes everyone else behind "+N more" — the list hides people better
+    // the worse things are.
+    const many = [
+      flag({ personId: pid("p0"), name: "Busy", metricLabel: "Commits", severity: 9 }),
+      flag({ personId: pid("p0"), name: "Busy", metricLabel: "PRs merged", severity: 8 }),
+      flag({ personId: pid("p0"), name: "Busy", metricLabel: "Code lines", severity: 7 }),
+      flag({ personId: pid("p1"), name: "Other", metricLabel: "Active days", severity: 6 }),
+    ];
+    render(<AttentionList flags={many} summary="s" />);
+    expect(screen.getAllByText("Busy")).toHaveLength(2);
+    // The one dropped is the weakest, and the other subject still shows.
+    expect(screen.queryByText("Code lines")).not.toBeInTheDocument();
+    expect(screen.getByText("Other")).toBeInTheDocument();
+  });
+
+  it("counts the capped rows in \"+N more\", not the raw findings", () => {
+    // The toggle has to promise what expanding will actually reveal.
+    const many = Array.from({ length: 4 }, (_, i) =>
+      flag({
+        personId: pid("p0"),
+        name: "Busy",
+        metricLabel: `Metric ${i}`,
+        severity: 9 - i,
+      }),
+    );
+    render(<AttentionList flags={many} summary="s" max={1} />);
+    expect(screen.getByRole("button", { name: "+1 more" })).toBeInTheDocument();
+  });
+
   it("renders the summary, people label and flag rows with reasons", () => {
     render(
       <AttentionList

--- a/src/frontend/src/components/portal/attention-list.tsx
+++ b/src/frontend/src/components/portal/attention-list.tsx
@@ -15,6 +15,34 @@ const FLAG_ICON: Record<FlagKind, typeof AlertTriangle> = {
   collapse: AlertTriangle,
 };
 
+/** Rows one subject may occupy before the rest wait on their own page. */
+const MAX_ROWS_PER_SUBJECT = 2;
+
+/**
+ * Keep every subject's strongest findings and no more.
+ *
+ * A row is one finding, so a subject who trips five metrics takes five rows —
+ * and because the list is ranked by severity, the subject in the most trouble
+ * takes the most of it. The visible slice then fills with one person while
+ * others wait behind "+N more", which is precisely backwards: the list hides
+ * people better the worse things are.
+ *
+ * Capping keeps the shape — one row, one readable claim — and bounds what any
+ * one subject can crowd out. What is dropped is never lost: every row opens
+ * that subject's own page, where all of their findings are.
+ *
+ * Input order is preserved, so the strongest findings survive the cap.
+ */
+function capPerSubject(flags: AttentionFlag[]): AttentionFlag[] {
+  const taken = new Map<string, number>();
+  return flags.filter((f) => {
+    const n = taken.get(f.personId) ?? 0;
+    if (n >= MAX_ROWS_PER_SUBJECT) return false;
+    taken.set(f.personId, n + 1);
+    return true;
+  });
+}
+
 /**
  * Shared "needs attention" panel: a rule-based summary line (placeholder for a
  * future AI insight) plus the ranked flag rows, each linking into that person.
@@ -34,7 +62,8 @@ export function AttentionList({
 }) {
   const { setZone } = usePortalNavActions();
   const [expanded, setExpanded] = useState(false);
-  const shown = expanded ? flags : flags.slice(0, max);
+  const ranked = capPerSubject(flags);
+  const shown = expanded ? ranked : ranked.slice(0, max);
   return (
     <section className="flex flex-col gap-3">
       <div className="flex items-center justify-between">
@@ -92,13 +121,13 @@ export function AttentionList({
               </Link>
             );
           })}
-          {flags.length > max ? (
+          {ranked.length > max ? (
             <button
               type="button"
               onClick={() => setExpanded((v) => !v)}
               className="self-start px-3 pt-1 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
             >
-              {expanded ? "Show less" : `+${flags.length - max} more`}
+              {expanded ? "Show less" : `+${ranked.length - max} more`}
             </button>
           ) : null}
         </div>

--- a/src/frontend/src/lib/insight/attention-flags.test.ts
+++ b/src/frontend/src/lib/insight/attention-flags.test.ts
@@ -181,13 +181,87 @@ describe("attentionSummary", () => {
     );
   });
 
-  it("names the top metric themes with counts", () => {
+  it("names the top metric themes, counted in people", () => {
+    // The line already opens in people, so the theme has to be in people too:
+    // "most flags on Commits (5)" over "3 of 16 people" holds two units in one
+    // sentence, and leaves a reader to work out that five flags can belong to
+    // two people.
     const flags = computeAttentionFlags(
       params({ byKey: new Map([["t.metric", fixture([...BASE, ["x", 0]])]]) }),
     );
     expect(attentionSummary(flags, 1, 8)).toBe(
-      "1 of 8 people need a look — most flags on Commits (1).",
+      "1 of 8 people need a look — most often Commits (1 person).",
     );
+  });
+});
+
+describe("one fact is one flag", () => {
+  /** A metric with its own key and label, so containment can be exercised. */
+  function metric(
+    key: string,
+    label: string,
+    period: Array<[string, number | null]>,
+  ): NormalizedMetricResult {
+    return { ...fixture(period, { label }), metric_key: key };
+  }
+
+  it("keeps the more specific metric when a person trips both", () => {
+    // "All lines added" contains "lines added to code files"; a person whose
+    // output collapses trips both at once, and that is one fact. Reported
+    // twice it doubles their rows and doubles any count of what is wrong.
+    // The NARROWER one survives — it excludes documentation, tests and
+    // configuration, so it says something the wider metric cannot.
+    const flags = computeAttentionFlags(
+      params({
+        headlineKeys: ["git.lines_added", "git.code_lines"],
+        byKey: new Map([
+          ["git.lines_added", metric("git.lines_added", "Lines added", [...BASE, ["x", 0]])],
+          ["git.code_lines", metric("git.code_lines", "Code lines", [...BASE, ["x", 0]])],
+        ]),
+      }),
+    );
+    expect(flags.map((f) => f.metricKey)).toEqual(["git.code_lines"]);
+  });
+
+  it("keeps the same pair for two people as two findings", () => {
+    // Thinning is per person: two people tripping the same related metrics are
+    // two findings, not one.
+    const flags = computeAttentionFlags(
+      params({
+        headlineKeys: ["git.lines_added", "git.code_lines"],
+        memberIds: [...IDS, "y"],
+        byKey: new Map([
+          [
+            "git.lines_added",
+            metric("git.lines_added", "Lines added", [...BASE, ["x", 0], ["y", 0]]),
+          ],
+          [
+            "git.code_lines",
+            metric("git.code_lines", "Code lines", [...BASE, ["x", 0], ["y", 0]]),
+          ],
+        ]),
+      }),
+    );
+    expect(flags).toHaveLength(2);
+    expect(new Set(flags.map((f) => f.personId))).toEqual(
+      new Set(["person-x", "person-y"]),
+    );
+  });
+
+  it("leaves unrelated metrics alone", () => {
+    const flags = computeAttentionFlags(
+      params({
+        headlineKeys: ["git.lines_added", "collab.messages_sent"],
+        byKey: new Map([
+          ["git.lines_added", metric("git.lines_added", "Lines added", [...BASE, ["x", 0]])],
+          [
+            "collab.messages_sent",
+            metric("collab.messages_sent", "Messages sent", [...BASE, ["x", 0]]),
+          ],
+        ]),
+      }),
+    );
+    expect(flags).toHaveLength(2);
   });
 });
 

--- a/src/frontend/src/lib/insight/attention-flags.ts
+++ b/src/frontend/src/lib/insight/attention-flags.ts
@@ -1,4 +1,5 @@
 import { formatMetricValue } from "@/lib/format";
+import { dropRedundantMetrics } from "@/lib/insight/metric-containment";
 import { MIN_COHORT, quantile } from "@/lib/insight/within-team-peer";
 import {
   forEntity,
@@ -200,7 +201,46 @@ export function computeAttentionFlags({
     const cur = best.get(k);
     if (!cur || f.severity > cur.severity) best.set(k, f);
   }
-  return [...best.values()].sort((a, b) => b.severity - a.severity);
+  return thinPerPerson([...best.values()]).sort(
+    (a, b) => b.severity - a.severity,
+  );
+}
+
+/**
+ * Drop flags that restate another flag on the same person.
+ *
+ * Some metrics contain others — lines added contains code lines, files shared
+ * contains its internal and external splits — and one real change trips every
+ * metric of a containing set at once. Left alone, one fact arrives as several
+ * flags: the person appears several times over, and any count of "how many
+ * things are wrong" is really a count of how many ways we measured one thing.
+ *
+ * Thinned per person rather than globally: two people tripping the same pair of
+ * related metrics are two findings, not one.
+ *
+ * Of a contained pair the NARROWER metric survives — the containment helper's
+ * rule, and the right one: "lines added to code files" excludes documentation,
+ * tests and configuration, so it says something "all lines added" cannot.
+ *
+ * Strongest first before thinning, because of several RESTATING metrics the
+ * helper keeps the first it meets — so the flag that survives that case is the
+ * one worth surviving.
+ */
+function thinPerPerson(flags: AttentionFlag[]): AttentionFlag[] {
+  const byPerson = new Map<string, AttentionFlag[]>();
+  for (const f of flags) {
+    const list = byPerson.get(f.personId);
+    if (list) list.push(f);
+    else byPerson.set(f.personId, [f]);
+  }
+  return [...byPerson.values()].flatMap((list) =>
+    dropRedundantMetrics(
+      [...list]
+        .sort((a, b) => b.severity - a.severity)
+        // The containment map is keyed on `key`; flags carry `metricKey`.
+        .map((flag) => ({ key: flag.metricKey, flag })),
+    ).map((item) => item.flag),
+  );
 }
 
 /** "1 person" / "3 people" — a scope of one is a real case (a lead with one report). */
@@ -216,9 +256,18 @@ export function attentionSummary(
 ): string {
   if (flags.length === 0)
     return `All ${people(teamSize)} are within their usual range this period.`;
-  const byMetric = new Map<string, number>();
-  for (const f of flags) byMetric.set(f.metricLabel, (byMetric.get(f.metricLabel) ?? 0) + 1);
-  const top = [...byMetric.entries()].sort((a, b) => b[1] - a[1]).slice(0, 2);
-  const themes = top.map(([label, n]) => `${label} (${n})`).join(", ");
-  return `${flaggedPeople} of ${people(teamSize)} need a look — most flags on ${themes}.`;
+  // Counted in PEOPLE, like the rest of the line. Counting flags here made one
+  // sentence hold two units — "3 of 16 people … most flags on Commits (5)" —
+  // and left a reader to work out that five flags can belong to two people.
+  const byMetric = new Map<string, Set<string>>();
+  for (const f of flags) {
+    const seen = byMetric.get(f.metricLabel) ?? new Set<string>();
+    seen.add(f.personId);
+    byMetric.set(f.metricLabel, seen);
+  }
+  const top = [...byMetric.entries()]
+    .sort((a, b) => b[1].size - a[1].size)
+    .slice(0, 2);
+  const themes = top.map(([label, who]) => `${label} (${people(who.size)})`).join(", ");
+  return `${flaggedPeople} of ${people(teamSize)} need a look — most often ${themes}.`;
 }


### PR DESCRIPTION
Closes #2378 — as much of it as should be fixed before the engine lands.

## What the report found, and what it did not

The bug reports that the panel's header counts people while its rows count
findings, and asks for rows grouped into people. The header inconsistency is
real. The grouping is the part I have not done, and deliberately.

The strongest observation in the report is its last one: a subject who trips
several metrics occupies several rows, and because the list is ranked by
severity, the subject in the most trouble occupies the most of the visible
slice — pushing others behind "+N more". The list hid people better the worse
things were. That is the part that costs a reader something, and it is fixed
here.

## Why not group into people

#1610 owns the panel's shape and describes a row as subject + metric, with a
worked example in that form. Regrouping the list would fix this bug by
contradicting the epic that replaces this code. So the row stays one finding,
and the crowding it risks is bounded by a cap instead: **two rows per subject**.

Nothing is lost to the cap. Every row opens that subject's own page, where all
of their findings are.

That decision is now written into #1610 rather than left implicit, along with
the alternative and what each costs.

## The duplication underneath

Some metrics contain others. Lines added contains code lines; files shared
contains its internal and external splits. A subject whose output drops trips
every metric of a containing set at once, so one fact arrived as several flags —
which both multiplied their rows and inflated any count of what is wrong.

Flags are now thinned per subject before ranking, reusing the containment map
the person page already uses. Per subject, not globally: two people tripping the
same related pair are two findings, not one. Of a contained pair the **narrower**
metric survives — the helper's existing rule, and the right one, since "lines
added to code files" excludes documentation, tests and configuration and so says
something the wider metric cannot.

## The header

`attentionSummary` counted flags per metric while opening in people, so one
sentence carried two units — "3 of 16 people need a look — most flags on Commits
(5)" leaves a reader to work out that five flags can belong to two people. It
now counts people throughout.

## Scope

This is interim by design: #1610 and #1611 both retire
`src/frontend/src/lib/insight/attention-flags.ts`. Flag lifecycle, "not enough
evidence" and served thresholds are specified there and are not reimplemented
here.

## Verification

`tsc -b` clean and `vitest --project unit` green: 134 files, 939 tests. Five new
cases cover the cap, the "+N more" count following it, containment thinning,
thinning staying per subject, and unrelated metrics being left alone.

Not re-checked in a browser. The panel renders only in the Overview and Team
zones, and the account available here has no reports, so those zones are not
offered to it — the change was exercised through the component's own tests
instead. The row markup is untouched; what changed is which rows survive into
the list.
