### PR TITLE
Return the identity e2e suite to CI and fix the four tests that blocked it

### DIFF
--- a/.github/workflows/e2e-bronze-to-api.yml
+++ b/.github/workflows/e2e-bronze-to-api.yml
@@ -7,13 +7,15 @@ name: E2E — Bronze to API
 # defined at src/ingestion/tests/e2e/compose/Dockerfile.runner. The same
 # image is used for local development via src/ingestion/tests/e2e/e2e.sh.
 #
-# This is now the DATA-PATH rig, and only that. The `api` and `identity-rust`
-# lanes retired with the HTTP contract suites they ran: those contracts are
-# asserted against a deployed stand in `e2e-stand.yml` (tests/stand), which
-# crosses a real gateway with a real Keycloak session and can therefore prove
-# the 401/403 behaviour an in-process rig structurally cannot. What is left
-# here is what only this rig can do — bronze → dbt → ClickHouse → analytics
-# response, over fixtures it seeds itself.
+# This is the rig for what only a throwaway stack can assert. The `api` lane
+# and identity's HTTP CONTRACT suites retired: those contracts are asserted
+# against a deployed stand in `e2e-stand.yml` (tests/stand), which crosses a
+# real gateway with a real Keycloak session and can therefore prove the
+# 401/403 behaviour an in-process rig structurally cannot. What is left here
+# is bronze → dbt → ClickHouse → analytics response over fixtures it seeds
+# itself (the `metrics` lane), plus the identity writes the stand may not make
+# — the correction verbs append to a journal with no delete, so a suite that
+# must clean up after itself cannot run them (the `identity` lane).
 #
 # Topology: a cheap `changes` job decides whether the diff can reach the data
 # path at all and everything expensive hangs off it; a shared upstream `build`
@@ -21,14 +23,15 @@ name: E2E — Bronze to API
 # on PRs from the component images build-images.yml already built (or the
 # published :latest for path-skipped components), elsewhere by compiling
 # analytics + each connector's enrich binary via build-only services — and
-# hands it to `e2e-metrics` as a saved image
+# hands it to `e2e-metrics` and `e2e-identity` as a saved image
 # artifact, which also makes `build` the SOLE writer of the GHA BuildKit
 # cache scopes wired in compose/docker-compose.cache.yml (two concurrent
-# writers to the same scope key just thrash each other's cache). The lane is
-# a shard matrix: each leg loads the pre-built image, boots its own isolated
-# stack, runs its slice of the suite, and snapshots that session's
+# writers to the same scope key just thrash each other's cache). The metrics
+# lane is a shard matrix: each leg loads the pre-built image, boots its own
+# isolated stack, runs its slice of the suite, and snapshots that session's
 # `.artifacts/` for `metric-coverage-gate`, which analyses it
-# as a pure-Python check (no Docker, no app boot). See
+# as a pure-Python check (no Docker, no app boot). `e2e-identity` is one
+# unsharded session beside it, sharing nothing at run time. See
 # src/ingestion/tests/e2e/lib/{metric_coverage,collect_metric_definitions}.py.
 #
 # Specs: docs/domain/bronze-to-api-e2e/specs/
@@ -75,9 +78,9 @@ jobs:
   # including the ones `changes` decided are irrelevant.
   #
   # Skipping cascades by default `needs` semantics: `changes` says irrelevant →
-  # `build` skips → `e2e-metrics` skips → `metric-coverage-gate` skips. A red
-  # `build` produces the same cascade, so the umbrella distinguishes the two
-  # cases from `changes`'s own output rather than from the lane results.
+  # `build` skips → `e2e-metrics` and `e2e-identity` skip → `metric-coverage-gate`
+  # skips. A red `build` produces the same cascade, so the umbrella distinguishes
+  # the two cases from `changes`'s own output rather than from the lane results.
 
   # ─── changes ──────────────────────────────────────────────────────────────
   # What an `on: paths:` filter would have done, moved into a job so the
@@ -479,6 +482,77 @@ jobs:
         if: always()
         run: ./e2e.sh down || true
 
+  # ─── identity ─────────────────────────────────────────────────────────────
+  # The operator-correction surface (`/v1/resolution/*`) and the persons-seed
+  # projection. Both are rig work rather than stand work for one reason: they
+  # MUTATE. A binding observation has no delete — the correction verbs only ever
+  # append — and the seed rewrites org_chart from connector evidence, so neither
+  # can run under the stand suite's create-then-remove policy
+  # (tests/stand/api/scratch.py). A rig that discards its whole stack can.
+  #
+  # The complementary half — the edge refusal and the role gate over a real
+  # gateway and a real Keycloak session — is NOT asserted anywhere yet. It needs
+  # `/v1/resolution/*` in the stand catalogue (tests/stand/api/operations.py)
+  # plus a module driving it, and that is deliberately not in this change: it is
+  # unverifiable until the stand can boot again (its seeder inserts an int into
+  # `silver.class_git_pull_requests.pr_id`, a String column). Stated here so the
+  # gap is a known absence rather than an assumed cover.
+  #
+  # No coverage artifact: this workflow's endpoint gate retired with the api
+  # lane, and the identity one lives in e2e-stand.yml now.
+  e2e-identity:
+    name: identity
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    defaults:
+      run:
+        working-directory: src/ingestion/tests/e2e
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Download runner image
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: e2e-runner-image
+          path: src/ingestion/tests/e2e
+
+      - name: Ensure zstd is available
+        run: command -v zstd >/dev/null || (sudo apt-get update && sudo apt-get install -y zstd)
+
+      - name: Load runner image
+        run: zstd -d < runner-image.tar.zst | docker load
+
+      # Serial, like the metrics lane and for the same reason: the session rig
+      # is not xdist-safe (see conftest.py).
+      #
+      # `identity/` as a DIRECTORY, with nothing deselected and no node-id list.
+      # An explicit include-list is exactly how this whole directory fell out of
+      # CI: the suite was pinned to `metrics/test_fixtures.py::...` ids, and
+      # three identity modules stopped running without anything going red. A
+      # bare directory keeps the default "a new test here runs in CI", and it is
+      # the only spelling under which that stays true by itself.
+      - name: E2E suite — identity
+        run: ./e2e.sh test identity/ --tb=short -q
+
+      - name: Dump compose logs on failure
+        if: failure()
+        run: |
+          echo "::group::clickhouse logs"
+          ./e2e.sh logs clickhouse || true
+          echo "::endgroup::"
+          echo "::group::mariadb logs"
+          ./e2e.sh logs mariadb || true
+          echo "::endgroup::"
+
+      - name: Tear down
+        if: always()
+        run: ./e2e.sh down || true
+
   # ─── Gate jobs — pure-Python analysis of the collected artifacts ──────────
   # Each runs after its own lane's suite job (needs), downloads that lane's
   # artifact, and reads plain files. No Docker, no analytics boot.
@@ -541,6 +615,7 @@ jobs:
       - changes
       - build
       - e2e-metrics
+      - e2e-identity
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     # 5 min sufficed for the needs-check alone; the image-build gate below may
@@ -554,16 +629,17 @@ jobs:
       # collapsed with `contains(needs.*.result, 'skipped')` — that expression
       # cannot tell the two apart, and it would also fold in `changes`'s own
       # result now that it is a `needs` entry.
-      - name: Require the build and the data-path lane to have succeeded
+      - name: Require the build and the data-path lanes to have succeeded
         env:
           CHANGES: ${{ needs.changes.result }}
           RELEVANT: ${{ needs.changes.outputs.relevant }}
           BUILD: ${{ needs.build.result }}
           # Matrix aggregate: 'success' only when EVERY shard passed.
           METRICS: ${{ needs.e2e-metrics.result }}
+          IDENTITY: ${{ needs.e2e-identity.result }}
         run: |
           set -euo pipefail
-          echo "changes=$CHANGES relevant=$RELEVANT build=$BUILD metrics=$METRICS"
+          echo "changes=$CHANGES relevant=$RELEVANT build=$BUILD metrics=$METRICS identity=$IDENTITY"
 
           # Fail closed. A `changes` job that did not succeed leaves `relevant`
           # empty, which would otherwise read as "irrelevant" and green a
@@ -576,13 +652,13 @@ jobs:
           if [ "$RELEVANT" != "true" ]; then
             echo "nothing on the bronze → dbt → ClickHouse → analytics path changed — nothing to prove."
           else
-            for lane in "build=$BUILD" "metrics=$METRICS"; do
+            for lane in "build=$BUILD" "metrics=$METRICS" "identity=$IDENTITY"; do
               if [ "${lane#*=}" != "success" ]; then
                 echo "::error::${lane%%=*} did not pass (${lane#*=}) — the E2E suite did not fully run for this change."
                 exit 1
               fi
             done
-            echo "E2E suite passed: build + the metrics lane succeeded."
+            echo "E2E suite passed: build + the metrics and identity lanes succeeded."
           fi
 
       # Unconditional, including on a PR `changes` found irrelevant: this gate

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -82,9 +82,10 @@ cargo fmt --check && cargo clippy --all-targets              # lint
 Components against a real store, and the API contract:
 
 - **Testcontainers** — identity-resolution (Rust) against a real MariaDB.
-- **Identity contract suite** — the e2e identity contract tests run against the Rust identity-resolution service
-  (`E2E_IDENTITY_IMPLEMENTATION=rust` is the default and only value; the CI dotnet lane and the .NET openapi-drift job
-  were removed with the retired .NET identity service).
+- **Identity rig suite** — the `identity/` lane of the `bronze-to-api` rig, against the Rust identity-resolution
+  service (`E2E_IDENTITY_IMPLEMENTATION=rust` is the default and only value). Scoped to what a deployed stand
+  cannot run: the operator-correction WRITES, which append to a journal with no delete, and their durability
+  across a seed/sync CLI re-run. The HTTP contracts themselves moved to the stand suite.
 - **dbt data tests** — bronze → silver → gold model assertions.
 - **Contract** — OpenAPI-drift + metric-coverage gates (every served `metric_key` is value-asserted or skip-listed).
 - **API & metric tests** — the `bronze-to-api` rig: seed bronze → dbt → CH gold-view → analytics-api HTTP == expected value.
@@ -98,8 +99,8 @@ cd src/ingestion/tests/e2e
 ./e2e.sh gates     # metric-coverage + openapi-drift
 ```
 
-**CI:** `e2e-bronze-to-api.yml` — blocking metric-coverage + openapi-drift gates. Its `api` and
-`identity-rust` HTTP contract lanes retired once those contracts moved to the compose stand
+**CI:** `e2e-bronze-to-api.yml` — two lanes (`metrics`, `identity`) plus blocking metric-coverage +
+openapi-drift gates. Its HTTP CONTRACT lanes retired once those contracts moved to the compose stand
 (`e2e-stand.yml`); the endpoint gate moved with them.
 
 ---

--- a/src/ingestion/dbt/macros/identity_inputs_from_history.sql
+++ b/src/ingestion/dbt/macros/identity_inputs_from_history.sql
@@ -154,8 +154,15 @@ id_upserts AS (
         'UPSERT' AS operation_type,
         toDateTime64(updated_at, 3) AS _synced_at,
         toUnixTimestamp64Milli(toDateTime64(updated_at, 3)) AS _version
-    FROM history
-    WHERE entity_id IS NOT NULL AND entity_id != ''
+    -- INVARIANT: one id row per activity instant, not per changed field. Every
+    -- column here derives from these four, and `history` carries one row PER
+    -- FIELD — so reading it directly emits N identical rows sharing a
+    -- unique_key whenever N identity fields change together.
+    FROM (
+        SELECT DISTINCT tenant_id, source_id, entity_id, updated_at
+        FROM history
+        WHERE entity_id IS NOT NULL AND entity_id != ''
+    )
 ),
 
 -- DELETE: mirror id-binding row at deactivation.
@@ -179,7 +186,9 @@ id_deletes AS (
         'DELETE' AS operation_type,
         toDateTime64(d.updated_at, 3) AS _synced_at,
         toUnixTimestamp64Milli(toDateTime64(d.updated_at, 3)) AS _version
-    FROM deactivation_events d
+    -- Same invariant as id_upserts: a deactivation condition satisfied by more
+    -- than one field must still retire the binding once.
+    FROM (SELECT DISTINCT tenant_id, source_id, entity_id, updated_at FROM deactivation_events) d
 )
 
 SELECT * FROM upserts

--- a/src/ingestion/tests/e2e/README.md
+++ b/src/ingestion/tests/e2e/README.md
@@ -47,9 +47,14 @@ cd src/ingestion/tests/e2e
 ./e2e.sh down               # tear down compose stack + volumes
 ```
 
-The same image is used in CI, which builds it ONCE in a shared upstream `build` job and hands it to the `e2e-metrics` lane as a saved image artifact — the lane loads the image, boots its stack, runs the suite (meta/ is local-only: it tests the harness, not the product), and uploads `coverage-inputs-metrics` for the metric gate — see `.github/workflows/e2e-bronze-to-api.yml`.
+The same image is used in CI, which builds it ONCE in a shared upstream `build` job and hands it to the `e2e-metrics` and `e2e-identity` lanes as a saved image artifact — each lane loads the image, boots its own stack and runs its slice (meta/ is local-only: it tests the harness, not the product); the metrics lane also uploads `coverage-inputs-metrics` for the metric gate — see `.github/workflows/e2e-bronze-to-api.yml`.
 
-**The `api/` and `identity/` HTTP contract suites have retired from this rig.** Those contracts are asserted against a deployed stand in [`tests/stand/`](../../../../tests/stand/), which crosses a real gateway with a real Keycloak session and can therefore prove the 401/403 behaviour an in-process rig structurally cannot. Their endpoint gate moved with them, to `tests/lib/insight_stand/coverage.py`. What remains here is what only this rig does: bronze → dbt → ClickHouse → analytics response, over fixtures it seeds itself.
+**The HTTP CONTRACT suites have retired from this rig — the `api/` one entirely, and identity's along with it.** Those contracts are asserted against a deployed stand in [`tests/stand/`](../../../../tests/stand/), which crosses a real gateway with a real Keycloak session and can therefore prove the 401/403 behaviour an in-process rig structurally cannot. Their endpoint gate moved with them, to `tests/lib/insight_stand/coverage.py`.
+
+What remains is what only this rig does, and it is two things rather than one:
+
+- **`metrics/`** — bronze → dbt → ClickHouse → analytics response, over fixtures it seeds itself.
+- **`identity/`** — the identity behaviour a stand may not exercise, because it MUTATES: the operator-correction verbs append to a journal with no delete, and the persons-seed projection rewrites org_chart from connector evidence. Neither fits a suite bound to remove what it creates.
 
 First session bootstraps `cargo build --release -p analytics` (~3-5 min). Subsequent sessions reuse the named volume so cargo is incremental (~10s).
 
@@ -90,6 +95,7 @@ e2e/
 ├── seed/
 │   └── metrics.yaml            # optional test-specific metric overrides (default: empty)
 ├── metrics/                      # <name>.test.yaml + schemas/ + templates/
+├── identity/                   # the correction writes a deployed stand may not make
 └── meta/                       # the rig's own framework tests (dbt runner, expect engine, ref resolver)
 ```
 

--- a/src/ingestion/tests/e2e/identity/test_github_directory_login_binding.py
+++ b/src/ingestion/tests/e2e/identity/test_github_directory_login_binding.py
@@ -17,12 +17,14 @@ from __future__ import annotations
 
 import uuid
 
+import pymysql
 import pytest
 from lib import clickhouse
 from lib import identity_seed as seed
 from lib.ch_seeder import CHSeeder
 from lib.config import SessionConfig
 from lib.dbt_runner import DbtRunner
+from lib.identity import IDENTITY_DATABASE
 from lib.worker import WorkerContext
 
 pytestmark = [pytest.mark.identity, pytest.mark.mutating]
@@ -106,6 +108,43 @@ def _run_connector_dbt_path(
     dbt_runner.run("identity_inputs", worker_ctx=worker_ctx)
 
 
+def _stored_id_binding(cfg: SessionConfig, login: str) -> str | None:
+    """The `value_id` the connector actually wrote, byte for byte.
+
+    Read from the journal rather than probed through the API because no lookup
+    can answer this: `persons.value_id` is `utf8mb4_unicode_ci` since migration
+    004, so a stored `Foo` and a stored `foo` are indistinguishable to every
+    query — including the one in the WHERE clause here, which is what lets it
+    find the row whatever case the connector chose. Only the returned bytes say
+    which case that was.
+    """
+    with (
+        pymysql.connect(
+            host=cfg.mariadb_host,
+            port=cfg.mariadb_port,
+            user=cfg.mariadb_user,
+            password=cfg.mariadb_password,
+            database=IDENTITY_DATABASE,
+        ) as conn,
+        conn.cursor() as cur,
+    ):
+        cur.execute(
+            """
+            SELECT value_id
+            FROM persons
+            WHERE insight_source_type = 'github'
+              AND value_type = 'id'
+              AND value_id = %s
+            ORDER BY created_at DESC, id DESC
+            LIMIT 1
+            """,
+            (login,),
+        )
+        row = cur.fetchone()
+
+    return row[0] if row else None
+
+
 def _resolve_by_external_id(identity_svc, external_id: str) -> str | None:
     """Resolve exactly as the authenticator's login-bootstrap does."""
     with identity_svc.client(
@@ -177,14 +216,24 @@ def test_login_binding_is_lowercased_so_a_brokered_username_matches(
     ch_seeder: CHSeeder,
     dbt_runner: DbtRunner,
     worker_ctx: WorkerContext,
+    compose_stack: SessionConfig,
 ) -> None:
     """GitHub preserves the login's letter-case; Keycloak lowercases the
-    username it brokers from it. `persons.value_id` is `COLLATE utf8mb4_bin`,
-    so the comparison is byte-exact — storing GitHub's casing against a
-    lowercased claim yields a 403 indistinguishable from missing data.
+    username it brokers from it. The connector therefore binds on the
+    LOWERCASED login (ADR-0002), so the form the authenticator arrives with is
+    the form the journal holds.
 
-    The connector therefore binds on the lowercased login, and this pins it:
-    the lowercased form resolves, the mixed-case one does not.
+    Pinned in two steps, because one alone cannot see it. That the brokered form
+    resolves is necessary but not sufficient: `persons.value_id` is
+    `utf8mb4_unicode_ci` — migration 004 moved it off `utf8mb4_bin` deliberately
+    so a value that differs only in case still matches — which means the
+    lowercased lookup would succeed against a binding stored in GitHub's own
+    casing too. Asserting the mixed-case spelling does NOT resolve cannot
+    substitute for it either: under a case-insensitive collation that is
+    unobservable by construction, so the assertion would fail on a connector
+    doing exactly the right thing.
+
+    So the normalization itself is read from the journal, where the bytes are.
     """
     if not identity_svc.supports_seed_cli:
         pytest.skip("the seed CLI exists only on the Rust implementation (#1690)")
@@ -212,7 +261,10 @@ def test_login_binding_is_lowercased_so_a_brokered_username_matches(
     assert _resolve_by_external_id(identity_svc, mixed_case_login.lower()) is not None, (
         "a lowercased GitHub login must resolve — this is the form Keycloak brokers"
     )
-    assert _resolve_by_external_id(identity_svc, mixed_case_login) is None, (
-        "the mixed-case login resolved too, so the binding is not the normalized one this "
-        "connector promises — re-check login_normalized and the fields_history entity_id"
+
+    stored = _stored_id_binding(compose_stack, mixed_case_login)
+    assert stored == mixed_case_login.lower(), (
+        f"the id binding holds {stored!r}, not the lowercased login "
+        f"{mixed_case_login.lower()!r} — re-check login_normalized and the "
+        f"fields_history entity_id"
     )

--- a/src/ingestion/tests/e2e/identity/test_persons_seed_org_chart_gaps.py
+++ b/src/ingestion/tests/e2e/identity/test_persons_seed_org_chart_gaps.py
@@ -8,6 +8,7 @@ test at all. This module closes those gaps one at a time.
 
 from __future__ import annotations
 
+import json
 import uuid
 from pathlib import Path
 
@@ -58,15 +59,14 @@ def _ms_entra_user(*, run_tag: str, entity_id: str, email: str) -> dict:
     """A minimal `bronze_ms_entra.users` row — deliberately has no manager
     field of any kind, since the real DDL has none to give one.
 
-    Only `mail` is populated — of ALL eleven columns `ms_entra__users_snapshot`
-    tracks (not just the five `ms_entra__identity_inputs.sql` reads), since
-    the shared `identity_inputs_from_history` macro's ADR-0002 `id_upserts`
-    CTE emits one canonical `id` row per TRACKED-FIELD history row for the
-    entity (unfiltered by which fields identity_inputs actually reads), not
-    one per entity. Seeding a second non-null field in the same snapshot
-    batch collides on `unique_key` (every field's version-1 row shares the
-    same `updated_at`) — a separate latent issue in the shared macro, not
-    what this test is about.
+    Only `mail` is populated, which is now a simplification rather than a
+    workaround. It used to be forced: `identity_inputs_from_history`'s
+    `id_upserts` CTE emitted one canonical `id` row per TRACKED-FIELD history
+    row instead of one per activity, so a second non-null field in the same
+    snapshot batch collided on `unique_key` (every field's version-1 row shares
+    one `updated_at`). The macro now dedups, so populating more fields would be
+    safe — this row stays minimal only because the test is about the ABSENCE of
+    a manager field.
     """
     return {
         "_airbyte_raw_id": str(uuid.uuid4()),
@@ -85,19 +85,19 @@ def _bamboohr_employee(
     *, run_tag: str, entity_id: str, email: str, display_name: str, supervisor_email: str | None
 ) -> dict:
     """A minimal `bronze_bamboohr.employees` row — the real shape the bamboohr
-    connector would append, not a hand-crafted identity_inputs row."""
-    return {
-        # Non-nullable Airbyte CDK columns — real connector rows always carry
-        # these; some staging transformations (e.g. latest-row selection)
-        # rely on `_airbyte_extracted_at`.
-        "_airbyte_raw_id": str(uuid.uuid4()),
-        "_airbyte_extracted_at": "2026-01-05T00:00:00",
-        "_airbyte_meta": "{}",
-        "_airbyte_generation_id": 0,
+    connector would append, not a hand-crafted identity_inputs row.
+
+    `raw_data` is the part that makes this row reach the identity path at all,
+    and it is easy to leave out: bamboohr's history model is
+    `fields_history_raw`, which reads every tracked field out of THIS payload's
+    keys rather than off the typed columns. A row with the columns but no
+    `raw_data` yields an empty field map, so the history is empty, so
+    `bamboohr__identity_inputs` never emits — the seed then sees no evidence and
+    the failure surfaces far downstream as a 404 on a person that was never
+    created.
+    """
+    payload = {
         "id": entity_id,
-        "unique_key": f"pipeline-{run_tag}-bamboohr-{entity_id}",
-        "tenant_id": f"pipeline-tenant-{run_tag}",
-        "source_id": f"pipeline-source-{run_tag}",
         "workEmail": email,
         "displayName": display_name,
         "firstName": display_name.split(" ")[0],
@@ -107,6 +107,26 @@ def _bamboohr_employee(
         "department": "Engineering",
         "division": "Engineering",
         "status": "Active",
+    }
+    # Omitted rather than null when there is no supervisor: an empty
+    # parent_email observation is a different statement from "no statement",
+    # and the root of a chain makes the second one.
+    if supervisor_email is not None:
+        payload["supervisorEmail"] = supervisor_email
+
+    return {
+        # Non-nullable Airbyte CDK columns — real connector rows always carry
+        # these; some staging transformations (e.g. latest-row selection)
+        # rely on `_airbyte_extracted_at`.
+        "_airbyte_raw_id": str(uuid.uuid4()),
+        "_airbyte_extracted_at": "2026-01-05T00:00:00",
+        "_airbyte_meta": "{}",
+        "_airbyte_generation_id": 0,
+        "unique_key": f"pipeline-{run_tag}-bamboohr-{entity_id}",
+        "tenant_id": f"pipeline-tenant-{run_tag}",
+        "source_id": f"pipeline-source-{run_tag}",
+        "raw_data": json.dumps(payload),
+        **payload,
         "supervisorEmail": supervisor_email,
         "supervisorEId": None,
     }

--- a/src/ingestion/tests/e2e/pytest.ini
+++ b/src/ingestion/tests/e2e/pytest.ini
@@ -12,7 +12,7 @@ markers =
     slow: tests that take > 5s
     smoke: the rig's own framework tests (under meta/; local-only, CI skips them)
     api: endpoint contract tests covering every OpenAPI operation (under api/)
-    identity: identity service contract tests (under identity/, #1753) — implementation-agnostic (.NET today, Rust after the cutover)
+    identity: identity tests the deployed-stand suite cannot run (under identity/) — the correction writes and the persons-seed data path
     mutating: tests that write through the API under test; deselect with `-m "identity and not mutating"` against a shared environment
     fixture: tests generated from metrics/*.test.yaml
 log_cli = true


### PR DESCRIPTION
## Problem

The rig's `identity/` directory has not run in CI since the HTTP-contract lanes were retired. That change pinned the remaining suite to explicit `metrics/test_fixtures.py::...` node ids, and three identity modules stopped running — without anything going red, because nothing was left asserting they should. The operator-correction surface (`POST /v1/resolution/bind|merge|detach|exclude`, `GET /v1/resolution/attention|accounts/…|persons/…/accounts`) has had no PR-blocking coverage since.

This restores that coverage as an `e2e-identity` lane and fixes the four tests that turned out to be failing against `main` once they ran again.

The lane runs `identity/` as a bare **directory** — no node-id list, nothing deselected. An include-list is what lost these tests once already; a directory is the only spelling under which "a new test here runs in CI" stays true on its own.

### The four failures, three causes

**`identity_inputs_from_history` emitted duplicate id bindings** (product fix). The `id_upserts` branch read `FROM history` with no field filter, so a row changing N identity fields produced N identical `value_type='id'` rows sharing one `unique_key` — the id binding is keyed by (tenant, source, entity, updated_at), not by field. Deduped on those four; `id_deletes` had the same shape when a deactivation condition matches more than one field.

This was already known and worked around rather than fixed: `_ms_entra_user` was deliberately kept to a single populated field to avoid the collision, and only `github-directory` declares the uniqueness test that catches it — the other ten connectors on this macro produced the duplicates silently. Downstream readers were unaffected either way, which is why it stayed latent: `resolve_person_id` filters to `value_type='email'` and collapses through `HAVING uniqExact(person_id) = 1`, and `identity.identity_inputs` is a ReplacingMergeTree keyed on `unique_key`.

**The login-casing test asserted something unobservable** (test fix). It required a mixed-case login to *not* resolve, citing `COLLATE utf8mb4_bin` on `persons.value_id`. Migration `004_persons_relax_constraints.sql` moved that column to `utf8mb4_unicode_ci` on purpose — so the assertion fails on a connector doing exactly the right thing, and cannot distinguish a correctly normalized binding from a broken one. The stored value was verified to be correctly lowercased. Replaced with a read of the stored bytes, which is the only place normalization is visible under a case-insensitive collation.

**The bamboohr fixture omitted `raw_data`** (test fix, two failures). bamboohr's history model is `fields_history_raw`, which derives every tracked field from that JSON payload rather than from the typed columns — so the fixture produced an empty field map, an empty history, and no `bamboohr__identity_inputs` rows at all. The seed then saw no evidence, and it surfaced two modules later as a 404 on a person that was never created. The payload is now built from the same values the typed columns carry.

## Affected areas

- `.github/workflows/e2e-bronze-to-api.yml` — new `e2e-identity` lane, wired into the required `Run E2E suite` umbrella.
- `src/ingestion/dbt/macros/identity_inputs_from_history.sql` — id-binding dedup. **Shared by 11 connectors**; the reviewer-relevant blast radius is analysed above.
- `src/ingestion/tests/e2e/identity/` — the two test fixes.
- `src/ingestion/tests/e2e/{README.md,pytest.ini}`, `docs/TESTING.md` — the rig's composition, which described identity as retired.

## How to test

```bash
cd src/ingestion/tests/e2e
./e2e.sh build                      # the baked binaries must match this tree
./e2e.sh test identity/ --tb=short -q
```

Expected: `39 passed`, nothing deselected or skipped. Verified locally against a freshly torn-down stack.

To see the macro fix specifically, the dbt data test that was failing is `unique_github_directory__identity_inputs_unique_key`; it runs as part of `identity/test_github_directory_login_binding.py`.

**Open question — the metrics lane was not run locally.** The macro is shared, so a reviewer may reasonably want `./e2e.sh test metrics/` (or CI's sharded lane) before merging. The reasoning for why it should be unaffected is in the Affected areas section, but reasoning is not a run.

## Not in this PR

The complementary half — the edge refusal and the role gate over a real gateway and a real Keycloak session — still has **no** test, and the lane comment says so at the point somebody would look. It needs `/v1/resolution/*` in `tests/stand/api/operations.py` plus a module driving it. That is unverifiable right now: the compose stand cannot boot, because its seeder inserts an int into `silver.class_git_pull_requests.pr_id`, a `String` column. Adding catalogue entries without a verified module would also make the stand coverage gate demand operations nothing exercises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
