### PR TITLE
gitops: compose experiments_enabled into the authenticator config

### DIFF
--- a/deploy/gitops/scripts/compose-app-secrets.sh
+++ b/deploy/gitops/scripts/compose-app-secrets.sh
@@ -150,6 +150,7 @@ AUTH_SOURCE_TYPE=$(yq -r '.authenticator.oidc.sourceType // ""' "$VALUES")
 AUTH_EXTERNAL_ID_CLAIM=$(yq -r '.authenticator.oidc.externalIdClaim // "sub"' "$VALUES")
 # `__override` view-as login (insight#1941/#1944) — dev/demo stands ONLY.
 AUTH_OVERRIDE_ENABLED=$(yq -r '.authenticator.overrideEnabled // false' "$VALUES")
+AUTH_EXPERIMENTS_ENABLED=$(yq -r '.authenticator.experimentsEnabled // false' "$VALUES")
 # The authn-tls discovery FQDN — the minted token `iss` and downstream issuer.
 GATEWAY_ISSUER="https://${RELEASE}-authenticator.${NS_APP}.svc.cluster.local:8443"
 GATEWAY_JWKS_URL="http://${RELEASE}-authenticator.${NS_APP}.svc.cluster.local:8083/.well-known/jwks.json"
@@ -283,6 +284,7 @@ stringData:
   APP__gears__authenticator__config__oidc_scopes: "${AUTH_SCOPES}"
   APP__gears__authenticator__config__service_tokens__audience: "${AUTH_TOKEN_AUD}"
   APP__gears__authenticator__config__override_enabled: "${AUTH_OVERRIDE_ENABLED}"
+  APP__gears__authenticator__config__experiments_enabled: "${AUTH_EXPERIMENTS_ENABLED}"
 EOF
 } | kubectl -n "$NS_APP" apply -f - >/dev/null
 echo "composed → $NS_APP/insight-authenticator-config"


### PR DESCRIPTION
## Summary
Follow-up to #2380: that knob only covers **helm-mode** installs, where `charts/insight/templates/secrets.yaml` composes `insight-authenticator-config`. On **gitops-mode** stands that Secret is built by `deploy/gitops/scripts/compose-app-secrets.sh`, which did not read the flag — so `authenticator.experimentsEnabled: true` in an env's values rendered into release values but never reached the pod (found on a live stand: values carried the flag, the composed Secret had no `experiments_enabled` key, and the umbrella's Secret template is not used in that mode).

One-line-each fix, mirroring `override_enabled`: read `.authenticator.experimentsEnabled // false` and emit `APP__gears__authenticator__config__experiments_enabled`.

Phase 0 of #1981.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring authenticator experiments through deployment settings.
  * The setting defaults to disabled when not explicitly configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->