### PR TITLE
fix(frontend): pre-bundle the one dependency a story imports at runtime

### DIFF
--- a/src/frontend/vitest.config.ts
+++ b/src/frontend/vitest.config.ts
@@ -104,6 +104,10 @@ export default defineConfig({
             "@base-ui/react/tooltip",
             "@sentry/react",
             "@tanstack/react-virtual",
+            // `await import("exceljs")` inside the export path: the scan cannot
+            // see it, so it is discovered while the export story is running and
+            // takes the page down with it as vite reloads.
+            "exceljs",
             "react-day-picker",
             "react-error-boundary",
             "sonner",


### PR DESCRIPTION
The xlsx export story fails on CI with

```
TypeError: Failed to fetch dynamically imported module: …/sb-vitest/deps/exceljs.js?v=…
```

and the failure is reported against whichever test happened to be running, not the one at fault — so it reads as an unrelated flake.

## Why it happens

`exceljs` is reached through `await import("exceljs")` inside the export path, so vite's pre-bundling scan never reaches it from a story entry. It is discovered *while the story runs*: vite re-optimizes, reloads the page, and the very import that triggered the discovery dies with the page it was loading into.

This is exactly the case `optimizeDeps.include` already exists for in this config, and the comment above the list names this symptom in as many words. `exceljs` is also the only third-party package the source imports dynamically — every other `await import(...)` resolves an internal `@/` alias, which vite treats as source and never pre-bundles. So this closes the class, not just one instance.

## What I could not do

**Reproduce it locally.** A cold run with both `node_modules/.vite` and the storybook cache removed passes here with and without the change, so the race is one this machine does not lose. CI is the only place it has been observed.

That makes the fix reasoned rather than demonstrated, and it is worth saying plainly. What would disprove it: the same import failing again after this lands.

## Why it is on its own

It blocks #2340 today and will catch anything else that touches those stories, so it should not wait behind a product change. Nothing else is in this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export test stability by preventing unnecessary reloads when using Excel-related functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->