### PR TITLE
fix(frontend): pre-bundle every base-ui entry point, not the bystander

### DIFF
--- a/src/frontend/vitest.config.ts
+++ b/src/frontend/vitest.config.ts
@@ -92,16 +92,37 @@ export default defineConfig({
         // A component newly reached from a story can add to this list. The
         // symptom to match it to: "new dependencies optimized: …" followed by
         // "optimized dependencies changed. reloading" in the run output.
+        //
+        // Read the FIRST of those two lines, not the test that failed. The
+        // reload kills whichever import was in flight, so the failure is
+        // reported against a bystander — usually the slowest thing to load.
+        // Listing the bystander changes nothing; the dependency named by
+        // "new dependencies optimized" is the one to add.
+        //
+        // Every `@base-ui/react/*` entry point the source imports is listed,
+        // whether or not it has misbehaved yet, because none of them is
+        // reached until a story mounts. To check the set still matches:
+        //   grep -rhoE '"@base-ui/react/[a-z-]+"' src | sort -u
         optimizeDeps: {
           include: [
             "@base-ui/react/avatar",
+            "@base-ui/react/button",
+            "@base-ui/react/checkbox",
             "@base-ui/react/collapsible",
             "@base-ui/react/dialog",
             "@base-ui/react/input",
+            "@base-ui/react/menu",
+            "@base-ui/react/merge-props",
+            "@base-ui/react/popover",
             "@base-ui/react/preview-card",
+            "@base-ui/react/select",
             "@base-ui/react/separator",
             "@base-ui/react/switch",
+            "@base-ui/react/tabs",
+            "@base-ui/react/toggle",
+            "@base-ui/react/toggle-group",
             "@base-ui/react/tooltip",
+            "@base-ui/react/use-render",
             "@sentry/react",
             "@tanstack/react-virtual",
             // `await import("exceljs")` inside the export path: the scan cannot


### PR DESCRIPTION
`main` currently carries a storybook test that fails on some runs and not others. #2398 was meant to stop it and did not — the dependency it added was a bystander.

## What is actually happening

The failure reads:

```
TypeError: Failed to fetch dynamically imported module: …/sb-vitest/deps/exceljs.js?v=…
```

The line above it in the same run names the cause:

```
✨ new dependencies optimized: @base-ui/react/merge-props
✨ optimized dependencies changed. reloading
```

A dependency reached only after a story mounts is discovered mid-run. Vite re-optimizes and reloads the page, and the reload kills whichever import is in flight. That import is reported as the failure — so the slowest thing to load takes the blame for something it did not do. `exceljs` is simply the slowest thing in that suite.

## The change

Nine of the eighteen `@base-ui/react/*` entry points the source imports were missing from `optimizeDeps.include`. Any one of them can be the late discovery, so all eighteen are listed rather than the one that surfaced this week.

The comment now carries the rule that would have saved a round: **read the dependency named by "new dependencies optimized", never the test that failed** — and a one-liner to check the set still matches the source.

`exceljs` stays. It is genuinely imported dynamically and belongs on the list; it was just not the cause.

## Verification

Cold cache, both `node_modules/.vite` and the storybook cache removed, and verified by the **absence of the mechanism** rather than by a run that happened to pass: no "new dependencies optimized" line appears at all, where CI logged one for `merge-props`. 1041 tests pass across both projects, `tsc -b` clean.

That distinction matters here. #2398 was also "verified" by a passing queue run, and the same failure appeared two runs later — a green run proves nothing about a race, only the missing trigger does.
