### PR TITLE
fix(preview): FE image serves on 8080, not 80

### DIFF
--- a/deploy/preview/templates/deployment.yaml
+++ b/deploy/preview/templates/deployment.yaml
@@ -34,7 +34,9 @@ spec:
           # return path arrives with #1972; the FE only serves static assets here.
           ports:
             - name: http
-              containerPort: 80
+              # The FE image serves on the non-root port (same as the main
+              # frontend chart) — probes and the Service target it by name.
+              containerPort: 8080
               protocol: TCP
           livenessProbe:
             httpGet:


### PR DESCRIPTION
## Summary
Provisioning a preview experiment produced a pod that never went Ready: the frontend image serves on the non-root port **8080** (as the main frontend chart already reflects), while the preview chart still declared `containerPort: 80` and probed it — nginx starts, the probe hits a closed port, kubelet restart-loops the pod, and the edge answers with an upstream connection reset.

One-field fix: named port `http` → 8080. The Service targets the port **by name**, so `service.port: 80` and the HTTPRoute `backendRef` are unchanged.

Found running Phase 0 of #1981 (first experiment provisioned against a current FE build).

## Verification
- `helm lint` + render-contract tests (14) pass.
- Live: a re-provisioned experiment pod goes Ready and serves through the edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)