### PR TITLE
feat(analytics): carry subject and tags through custom-metric CRUD

### DIFF
--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -203,6 +203,20 @@
           "source_key": {
             "type": "string"
           },
+          "subject": {
+            "description": "The single topic this metric groups under within its family; a\nlowercase snake-case slug. Optional for custom metrics.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "tags": {
+            "description": "Cross-cutting filter labels; lowercase snake-case slugs, unique per\nmetric. Optional — defaults to empty.",
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "transform": {
             "oneOf": [
               {
@@ -280,6 +294,13 @@
           },
           "metric_key": {
             "type": "string"
+          },
+          "subject": {
+            "description": "Grouping subject, so the management list can partition custom metrics\nby topic like the definitions listing; absent when none is declared.",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [

--- a/src/backend/services/analytics/src/domain/metric_crud.rs
+++ b/src/backend/services/analytics/src/domain/metric_crud.rs
@@ -31,6 +31,7 @@ mod live_tests;
 /// edge so one request cannot fan out into an unbounded write.
 const MAX_MEASURES: usize = 64;
 const MAX_DIMENSIONS: usize = 64;
+const MAX_TAGS: usize = 64;
 const MAX_INPUTS: usize = 2;
 const MAX_OBSERVATION_SQL_BYTES: usize = 64 * 1024;
 
@@ -54,6 +55,10 @@ pub struct CustomMetric {
     pub label: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub short_label: Option<String>,
+    /// The single topic this metric groups under within its family; a
+    /// lowercase snake-case slug. Optional for custom metrics.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -74,6 +79,10 @@ pub struct CustomMetric {
     pub observation_sql: String,
     pub measures: Vec<String>,
     pub dimensions: Vec<String>,
+    /// Cross-cutting filter labels; lowercase snake-case slugs, unique per
+    /// metric. Optional — defaults to empty.
+    #[serde(default)]
+    pub tags: Vec<String>,
     pub inputs: Vec<CustomMetricInput>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub origin: Option<String>,
@@ -91,6 +100,10 @@ pub struct CustomMetricInput {
 pub struct CustomMetricSummary {
     pub metric_key: String,
     pub label: String,
+    /// Grouping subject, so the management list can partition custom metrics
+    /// by topic like the definitions listing; absent when none is declared.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject: Option<String>,
     pub computation: MetricComputation,
     pub entity_type: String,
 }
@@ -184,12 +197,39 @@ pub fn validate_graph(graph: &CustomMetric) -> Result<(), GraphViolation> {
     {
         return Err(violation("peer_cohort_key", "must match ^[a-z][a-z0-9_]*$"));
     }
+    if graph
+        .subject
+        .as_deref()
+        .is_some_and(|subject| !is_simple_key(subject))
+    {
+        return Err(violation("subject", "must match ^[a-z][a-z0-9_]*$"));
+    }
 
     validate_measures(graph)?;
     validate_dimensions(graph)?;
+    validate_tags(graph)?;
     validate_observation_sql(graph)?;
     validate_inputs(graph)?;
 
+    Ok(())
+}
+
+fn validate_tags(graph: &CustomMetric) -> Result<(), GraphViolation> {
+    if graph.tags.len() > MAX_TAGS {
+        return Err(violation(
+            "tags",
+            format!("at most {MAX_TAGS} tags are allowed"),
+        ));
+    }
+    let mut seen = std::collections::BTreeSet::new();
+    for tag in &graph.tags {
+        if !is_simple_key(tag) {
+            return Err(violation("tags", "must match ^[a-z][a-z0-9_]*$"));
+        }
+        if !seen.insert(tag.as_str()) {
+            return Err(violation("tags", "tag keys must be unique"));
+        }
+    }
     Ok(())
 }
 
@@ -485,17 +525,18 @@ async fn insert_graph<C: ConnectionTrait>(
     conn.execute(Statement::from_sql_and_values(
         conn.get_database_backend(),
         "INSERT INTO metric_definitions \
-            (id, tenant_id, metric_key, label, short_label, description, explanation, unit, \
+            (id, tenant_id, metric_key, label, short_label, subject, description, explanation, unit, \
              format, direction, entity_type, computation_type, scale, transform_multiplier, \
              transform_offset, transform_clamp_min, transform_clamp_max, peer_cohort_key, \
              origin, is_enabled, schema_status) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'custom', TRUE, 'unchecked')",
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'custom', TRUE, 'unchecked')",
         [
             uuid_value(definition_id),
             uuid_value(tenant_id),
             Value::from(graph.metric_key.as_str()),
             Value::from(graph.label.as_str()),
             nullable_str(graph.short_label.as_deref()),
+            nullable_str(graph.subject.as_deref()),
             nullable_str(graph.description.as_deref()),
             nullable_str(graph.explanation.as_deref()),
             nullable_str(graph.unit.as_deref()),
@@ -556,6 +597,22 @@ async fn insert_graph<C: ConnectionTrait>(
         .await?;
     }
 
+    for (order, tag) in graph.tags.iter().enumerate() {
+        conn.execute(Statement::from_sql_and_values(
+            conn.get_database_backend(),
+            "INSERT INTO metric_definition_tags \
+                (id, metric_definition_id, tag, display_order) \
+             VALUES (?, ?, ?, ?)",
+            [
+                uuid_value(Uuid::now_v7()),
+                uuid_value(definition_id),
+                Value::from(tag.as_str()),
+                Value::from(order_value(order)),
+            ],
+        ))
+        .await?;
+    }
+
     Ok(())
 }
 
@@ -609,13 +666,14 @@ pub async fn list_custom_metrics(
     struct Row {
         metric_key: String,
         label: String,
+        subject: Option<String>,
         computation_type: String,
         entity_type: String,
     }
 
     let rows = Row::find_by_statement(Statement::from_sql_and_values(
         db.get_database_backend(),
-        "SELECT metric_key, label, computation_type, entity_type \
+        "SELECT metric_key, label, subject, computation_type, entity_type \
          FROM metric_definitions \
          WHERE origin = 'custom' AND tenant_id = ? \
          ORDER BY metric_key \
@@ -632,6 +690,7 @@ pub async fn list_custom_metrics(
         items.push(CustomMetricSummary {
             metric_key: row.metric_key,
             label: row.label,
+            subject: row.subject,
             computation,
             entity_type: row.entity_type,
         });
@@ -658,9 +717,12 @@ pub async fn fetch_custom_metric(
     };
     let measures = fetch_measure_keys(db, source.source_id).await?;
     let dimensions = fetch_dimension_keys(db, row.definition_id).await?;
+    let tags = fetch_tag_keys(db, row.definition_id).await?;
     let inputs = fetch_input_rows(db, row.definition_id).await?;
 
-    Ok(Some(row.into_graph(source, measures, dimensions, inputs)?))
+    Ok(Some(
+        row.into_graph(source, measures, dimensions, tags, inputs)?,
+    ))
 }
 
 /// The tenant's full custom metric graphs (for export).
@@ -692,6 +754,7 @@ struct DefinitionRow {
     metric_key: String,
     label: String,
     short_label: Option<String>,
+    subject: Option<String>,
     description: Option<String>,
     explanation: Option<String>,
     unit: Option<String>,
@@ -724,6 +787,7 @@ impl DefinitionRow {
         source: SourceRow,
         measures: Vec<String>,
         dimensions: Vec<String>,
+        tags: Vec<String>,
         inputs: Vec<CustomMetricInput>,
     ) -> Result<CustomMetric, DbErr> {
         let transform = ValueTransform {
@@ -747,6 +811,7 @@ impl DefinitionRow {
             metric_key: self.metric_key,
             label: self.label,
             short_label: self.short_label,
+            subject: self.subject,
             description: self.description,
             explanation: self.explanation,
             entity_type: self.entity_type,
@@ -761,6 +826,7 @@ impl DefinitionRow {
             observation_sql,
             measures,
             dimensions,
+            tags,
             inputs,
             origin: Some("custom".to_owned()),
         })
@@ -781,7 +847,7 @@ async fn fetch_definition_row<C: ConnectionTrait>(
     DefinitionRow::find_by_statement(Statement::from_sql_and_values(
         conn.get_database_backend(),
         "SELECT \
-            id AS definition_id, metric_key, label, short_label, description, explanation, unit, \
+            id AS definition_id, metric_key, label, short_label, subject, description, explanation, unit, \
             format, direction, entity_type, computation_type, \
             CAST(scale AS DOUBLE) AS scale, \
             CAST(transform_multiplier AS DOUBLE) AS transform_multiplier, \
@@ -853,6 +919,27 @@ async fn fetch_dimension_keys<C: ConnectionTrait>(
     .all(conn)
     .await
     .map(|rows| rows.into_iter().map(|row| row.dimension_key).collect())
+}
+
+async fn fetch_tag_keys<C: ConnectionTrait>(
+    conn: &C,
+    definition_id: Uuid,
+) -> Result<Vec<String>, DbErr> {
+    #[derive(FromQueryResult)]
+    struct Row {
+        tag: String,
+    }
+    Row::find_by_statement(Statement::from_sql_and_values(
+        conn.get_database_backend(),
+        "SELECT t.tag AS tag \
+         FROM metric_definition_tags t \
+         WHERE t.metric_definition_id = ? \
+         ORDER BY t.display_order, t.tag",
+        [uuid_value(definition_id)],
+    ))
+    .all(conn)
+    .await
+    .map(|rows| rows.into_iter().map(|row| row.tag).collect())
 }
 
 async fn fetch_input_rows<C: ConnectionTrait>(
@@ -961,6 +1048,7 @@ mod tests {
             metric_key: "custom.example".to_owned(),
             label: "Example".to_owned(),
             short_label: None,
+            subject: Some("activity".to_owned()),
             description: None,
             explanation: None,
             entity_type: "person".to_owned(),
@@ -977,6 +1065,7 @@ mod tests {
                 .to_owned(),
             measures: vec!["events".to_owned()],
             dimensions: vec!["tool".to_owned()],
+            tags: vec!["example".to_owned()],
             inputs: vec![CustomMetricInput {
                 role: MetricInputRole::Value,
                 measure_key: "events".to_owned(),
@@ -1038,6 +1127,29 @@ mod tests {
     }
 
     #[test]
+    fn rejects_malformed_subject_and_tags() {
+        let mut graph = sum_graph();
+        graph.subject = Some("Bad Subject".to_owned());
+        assert_eq!(rejected_field(&graph), "subject");
+
+        let mut graph = sum_graph();
+        graph.tags = vec!["Bad-Tag".to_owned()];
+        assert_eq!(rejected_field(&graph), "tags");
+
+        let mut graph = sum_graph();
+        graph.tags = vec!["dup".to_owned(), "dup".to_owned()];
+        assert_eq!(rejected_field(&graph), "tags");
+    }
+
+    #[test]
+    fn accepts_absent_subject_and_empty_tags() {
+        let mut graph = sum_graph();
+        graph.subject = None;
+        graph.tags = vec![];
+        assert!(validate_graph(&graph).is_ok());
+    }
+
+    #[test]
     fn rejects_non_single_select_observation_sql() {
         let mut graph = sum_graph();
         graph.observation_sql = "SELECT 1; DROP TABLE t".to_owned();
@@ -1088,6 +1200,7 @@ mod tests {
             metric_key: "custom.example".to_owned(),
             label: "Example".to_owned(),
             short_label: None,
+            subject: Some("activity".to_owned()),
             description: None,
             explanation: None,
             unit: None,
@@ -1115,11 +1228,19 @@ mod tests {
     #[test]
     fn into_graph_rebuilds_a_valid_row_and_stamps_origin() {
         let graph = definition_row()
-            .into_graph(source_row(), vec!["events".to_owned()], vec![], vec![])
+            .into_graph(
+                source_row(),
+                vec!["events".to_owned()],
+                vec![],
+                vec!["rate".to_owned()],
+                vec![],
+            )
             .unwrap_or_else(|error| panic!("valid row must rebuild: {error}"));
         assert_eq!(graph.origin.as_deref(), Some("custom"));
         assert_eq!(graph.observation_sql, "SELECT 1");
         assert_eq!(graph.measures, vec!["events".to_owned()]);
+        assert_eq!(graph.subject.as_deref(), Some("activity"));
+        assert_eq!(graph.tags, vec!["rate".to_owned()]);
     }
 
     #[test]
@@ -1132,7 +1253,7 @@ mod tests {
             let mut row = definition_row();
             mutate(&mut row);
             assert!(
-                row.into_graph(source_row(), vec![], vec![], vec![])
+                row.into_graph(source_row(), vec![], vec![], vec![], vec![])
                     .is_err(),
                 "a corrupt enum must not be silently reshaped"
             );
@@ -1142,7 +1263,7 @@ mod tests {
         source.observation_sql = None;
         assert!(
             definition_row()
-                .into_graph(source, vec![], vec![], vec![])
+                .into_graph(source, vec![], vec![], vec![], vec![])
                 .is_err(),
             "a NULL observation_sql on a custom source is corrupt"
         );

--- a/src/backend/services/analytics/src/domain/metric_crud_live_tests.rs
+++ b/src/backend/services/analytics/src/domain/metric_crud_live_tests.rs
@@ -53,6 +53,7 @@ fn sum_graph(suffix: &str) -> CustomMetric {
         metric_key: format!("custom.k{suffix}"),
         label: "Example".to_owned(),
         short_label: Some("Ex".to_owned()),
+        subject: Some("activity".to_owned()),
         description: Some("desc".to_owned()),
         explanation: None,
         entity_type: "person".to_owned(),
@@ -69,6 +70,7 @@ fn sum_graph(suffix: &str) -> CustomMetric {
             .to_owned(),
         measures: vec!["events".to_owned()],
         dimensions: vec!["tool".to_owned(), "repository".to_owned()],
+        tags: vec!["rate".to_owned(), "duration".to_owned()],
         inputs: vec![CustomMetricInput {
             role: MetricInputRole::Value,
             measure_key: "events".to_owned(),
@@ -119,12 +121,18 @@ async fn create_fetch_list_delete_roundtrip() -> R {
     assert_eq!(fetched.observation_sql, graph.observation_sql);
     assert_eq!(fetched.measures, graph.measures);
     assert_eq!(fetched.dimensions, graph.dimensions);
+    assert_eq!(fetched.tags, graph.tags);
     assert_eq!(fetched.inputs.len(), 1);
     assert_eq!(fetched.origin.as_deref(), Some("custom"));
     assert_eq!(fetched.short_label.as_deref(), Some("Ex"));
+    assert_eq!(fetched.subject.as_deref(), Some("activity"));
 
     let summaries = list_custom_metrics(&db, tenant).await?;
-    assert!(summaries.iter().any(|s| s.metric_key == graph.metric_key));
+    let summary = summaries
+        .iter()
+        .find(|s| s.metric_key == graph.metric_key)
+        .unwrap_or_else(|| panic!("created metric must be listed"));
+    assert_eq!(summary.subject.as_deref(), Some("activity"));
 
     assert!(delete_custom_metric(&db, tenant, &graph.metric_key).await?);
     assert!(

--- a/tests/stand/api/analytics/test_metrics.py
+++ b/tests/stand/api/analytics/test_metrics.py
@@ -93,6 +93,55 @@ def test_custom_metric_create_get_update_delete_round_trip(api: ApiClient) -> No
     assert metric_key not in _listed_keys(api), "a deleted custom metric is still listed"
 
 
+def test_custom_metric_round_trips_subject_and_tags(api: ApiClient) -> None:
+    """`subject` and `tags` persist through create → read → list → update.
+
+    A custom metric can declare a grouping `subject` and cross-cutting `tags` —
+    the same fields the builtin definitions listing exposes. The create echoes
+    them, the read returns them, the list summary carries the `subject` a
+    management screen groups by, and an update replaces both. `extra="forbid"`
+    on the models means a dropped field surfaces as a missing value here rather
+    than passing silently. (The export path is xfail on a fresh stand per
+    #2360, so its subject/tags round-trip is left to the Rust `into_graph`
+    test.) Deleted in a `finally` so the row cannot leak.
+    """
+    metric_key, source_key = scratch_metric_identity("subjtags")
+    body = custom_metric_body(
+        metric_key, source_key, subject="throughput", tags=["rate", "duration"]
+    )
+    created = api.post(METRICS, json_body=body)
+    assert created.status_code == 201, f"create: {created.status_code} {created.text[:300]}"
+    track(METRICS, "metric_key", metric_key)
+    try:
+        made = created.parse(CustomMetric)
+        assert made.subject == "throughput", f"create dropped subject: {made.subject!r}"
+        assert made.tags == ["rate", "duration"], f"create dropped tags: {made.tags!r}"
+
+        fetched = api.get(_metric_path(metric_key)).parse(CustomMetric)
+        assert fetched.subject == "throughput", f"read dropped subject: {fetched.subject!r}"
+        assert fetched.tags == ["rate", "duration"], f"read dropped tags: {fetched.tags!r}"
+
+        summary = next(
+            (
+                item
+                for item in api.get(METRICS).parse(CustomMetricListResponse).items
+                if item.metric_key == metric_key
+            ),
+            None,
+        )
+        assert summary is not None, "created metric is not listed"
+        assert summary.subject == "throughput", f"list dropped subject: {summary.subject!r}"
+
+        changed = custom_metric_body(metric_key, source_key, subject="quality", tags=["ratio"])
+        updated = api.put(_metric_path(metric_key), json_body=changed)
+        assert updated.status_code == 200, f"update: {updated.status_code} {updated.text[:300]}"
+        reloaded = updated.parse(CustomMetric)
+        assert reloaded.subject == "quality", f"update kept stale subject: {reloaded.subject!r}"
+        assert reloaded.tags == ["ratio"], f"update kept stale tags: {reloaded.tags!r}"
+    finally:
+        api.delete(_metric_path(metric_key))
+
+
 def test_get_metric_404_unknown(api: ApiClient) -> None:
     response = api.get(_metric_path(UNKNOWN_METRIC_KEY))
     assert response.status_code == 404, f"status={response.status_code} {response.text[:300]}"
@@ -145,8 +194,10 @@ def test_create_metric_409_on_a_duplicate_key(api: ApiClient) -> None:
         ("bad metric_key", {"metric_key": "NoDot"}),
         ("non-single-select observation_sql", {"observation_sql": "DROP TABLE t"}),
         ("observation_sql omitting a contract column", {"observation_sql": "SELECT 1 AS one"}),
+        ("malformed subject", {"subject": "Bad Subject"}),
+        ("malformed tag", {"tags": ["Bad-Tag"]}),
     ],
-    ids=["bad-key", "not-a-read", "missing-column"],
+    ids=["bad-key", "not-a-read", "missing-column", "bad-subject", "bad-tag"],
 )
 def test_create_metric_400_for_an_invalid_graph(
     api: ApiClient, label: str, mutation: dict[str, Any]

--- a/tests/stand/api/schemas/analytics.py
+++ b/tests/stand/api/schemas/analytics.py
@@ -617,6 +617,7 @@ class CustomMetricSummary(BaseModel):
     entity_type: str
     label: str
     metric_key: str
+    subject: str | None = Field(None, description='Grouping subject, so the management list can partition custom metrics\nby topic like the definitions listing; absent when none is declared.')
 
 
 class MetricDefinitionView(BaseModel):
@@ -779,6 +780,8 @@ class CustomMetric(BaseModel):
     scale: float | None = None
     short_label: str | None = None
     source_key: str
+    subject: str | None = Field(None, description='The single topic this metric groups under within its family; a\nlowercase snake-case slug. Optional for custom metrics.')
+    tags: list[str] | None = Field(None, description='Cross-cutting filter labels; lowercase snake-case slugs, unique per\nmetric. Optional — defaults to empty.')
     transform: ValueTransform | None = None
     unit: str | None = None
 

--- a/tests/stand/api/scratch.py
+++ b/tests/stand/api/scratch.py
@@ -155,14 +155,21 @@ def scratch_metric_identity(tag: str) -> tuple[str, str]:
     return f"example.{slug}", slug
 
 
-def custom_metric_body(metric_key: str, source_key: str) -> dict[str, object]:
+def custom_metric_body(
+    metric_key: str,
+    source_key: str,
+    *,
+    subject: str | None = None,
+    tags: list[str] | None = None,
+) -> dict[str, object]:
     """A minimal valid custom-metric graph: a sum over one measure.
 
     The create/import/update body. Callers mutate a copy for the rejection cases
     — a bad key, a non-single-select statement, or SQL that omits a contract
-    column.
+    column. `subject`/`tags` are omitted unless a caller asks for them, so the
+    default body stays the smallest valid graph.
     """
-    return {
+    body: dict[str, object] = {
         "metric_key": metric_key,
         "label": "Scratch probe metric",
         "entity_type": "person",
@@ -175,6 +182,11 @@ def custom_metric_body(metric_key: str, source_key: str) -> dict[str, object]:
         "dimensions": [],
         "inputs": [{"role": "value", "measure_key": "events"}],
     }
+    if subject is not None:
+        body["subject"] = subject
+    if tags is not None:
+        body["tags"] = tags
+    return body
 
 
 def create_custom_metric(client: ApiClient, tag: str) -> CustomMetric:


### PR DESCRIPTION
> **Stacked on #2397** — builds on `fix/2344-metric-subject-tags`. Review/merge after #2397; until it lands, the diff here also shows #2397's commit. Refs #2344.

## Summary

#2397 gave **builtin** metrics `subject` (grouping partition) and `tags` (cross-cutting filters) via the registry. This PR closes the matching gap for **custom** (tenant-authored) metrics: the CRUD could neither accept nor return them, so a custom metric was stuck with `subject = NULL` and no tags, unreachable from the API.

Both are now threaded through the full custom-metric path (`domain/metric_crud.rs`):

- **DTO:** `subject` (optional slug) and `tags` (slug list) on `CustomMetric`; `subject` on `CustomMetricSummary` so the management list can group by topic like the definitions listing.
- **Validation:** subject shape, tag shape + per-metric uniqueness, a `MAX_TAGS` bound — mirroring the existing measures/dimensions rules.
- **Create / import:** `subject` on the `metric_definitions` insert; a `metric_definition_tags` insert loop mirroring the dimensions loop.
- **Read / export:** `subject` on the definition read and summary; new `fetch_tag_keys`; `into_graph` carries subject + tags, so **export/import round-trips** them.

## Not included (follow-up)

- **Frontend display** of subject/tags (the `insight-front` side) — will be a separate change on this branch or its own PR.

## Testing

- `cargo test -p analytics` → 416 passed (incl. new `rejects_malformed_subject_and_tags`, `accepts_absent_subject_and_empty_tags`, and round-trip assertions in the ignored live tests), 0 failed.
- `cargo clippy -p analytics --tests` clean.
- Regenerated `openapi.json` (drift-checked) and the stand `analytics.py` schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom metrics can now include an optional subject and descriptive tags.
  * Tags support up to 64 unique values and require valid lowercase snake-case formatting.
  * Subject and tag metadata is preserved when metrics are saved, retrieved, listed, and exported.
  * Metric summaries now display the associated subject when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->