### PR TITLE
docs(skills): file-bug-insight — attach screenshots via the asset upload endpoint

### DIFF
--- a/.claude/skills/file-bug-insight/SKILL.md
+++ b/.claude/skills/file-bug-insight/SKILL.md
@@ -222,12 +222,17 @@ Verify those IDs with `gh project field-list 40 --owner constructorfabric` if an
 **Images.** There is no *documented* API, but the web UI's upload endpoint accepts a plain `gh auth token` (verified 2026-08). Upload **before** creating the issue and embed the returned URL in the body, so the asset attaches with the initial render:
 
 ```sh
-# Upload one PNG; prints the asset URL to embed
-ASSET=$(curl -sf "https://uploads.github.com/user-attachments/assets?name=<shot>.png&content_type=image/png&repository_id=$(gh api repos/constructorfabric/insight --jq .id)" \
-  -X POST -H "Authorization: Bearer $(gh auth token)" -H "Accept: application/json" \
-  --data-binary "@<shot>.png" | jq -r .url)
-# → https://github.com/user-attachments/assets/<uuid>; embed as ![<what it shows>]($ASSET)
-# empty $ASSET = upload failed (curl -sf swallows the error body) → use the fallback below
+# Upload one PNG; prints the asset URL to embed. The token rides stdin (-H @-),
+# never curl's argv, so it can't show up in a process listing.
+REPO_ID=$(gh api repos/constructorfabric/insight --jq .id)
+ASSET=$(gh auth token | sed 's/^/Authorization: Bearer /' \
+  | curl -sf --connect-timeout 5 --max-time 120 -X POST -H @- -H "Accept: application/json" \
+      --data-binary "@<shot>.png" \
+      "https://uploads.github.com/user-attachments/assets?name=<shot>.png&content_type=image/png&repository_id=$REPO_ID" \
+  | jq -er '.url // empty')
+[ -n "$ASSET" ] || echo "upload failed — use the manual fallback" >&2
+# → https://github.com/user-attachments/assets/<uuid>; write ![<what it shows>]($ASSET)
+#   into $BODY where the evidence belongs — the embed doesn't happen by itself
 ```
 
 Three caveats. The endpoint is **undocumented** — if the POST fails (empty `$ASSET`), fall back to the old flow: create the issue, then tell the user to drag the PNGs into the description box (don't imply they attached automatically). Always pass this repo's `repository_id` — the POST 404s without it, and asset visibility is scoped to it. And the screenshot is public the moment the issue is: scrub it like the body (no internal hostnames in the URL bar, no tokens in a visible console). Unattached uploads 404 anonymously until the issue references them — that's normal, not a failure. For a data or pipeline bug the inline query proof is usually the evidence and no screenshot is needed.

--- a/.claude/skills/file-bug-insight/SKILL.md
+++ b/.claude/skills/file-bug-insight/SKILL.md
@@ -224,7 +224,8 @@ Verify those IDs with `gh project field-list 40 --owner constructorfabric` if an
 ```sh
 # Upload one PNG; prints the asset URL to embed. The token rides stdin (-H @-),
 # never curl's argv, so it can't show up in a process listing.
-REPO_ID=$(gh api repos/constructorfabric/insight --jq .id)
+REPO=constructorfabric/insight   # the repo the issue will live in — swap when reusing elsewhere
+REPO_ID=$(gh api "repos/$REPO" --jq .id)
 ASSET=$(gh auth token | sed 's/^/Authorization: Bearer /' \
   | curl -sf --connect-timeout 5 --max-time 120 -X POST -H @- -H "Accept: application/json" \
       --data-binary "@<shot>.png" \
@@ -235,7 +236,7 @@ ASSET=$(gh auth token | sed 's/^/Authorization: Bearer /' \
 #   into $BODY where the evidence belongs — the embed doesn't happen by itself
 ```
 
-Three caveats. The endpoint is **undocumented** — if the POST fails (empty `$ASSET`), fall back to the old flow: create the issue, then tell the user to drag the PNGs into the description box (don't imply they attached automatically). Always pass this repo's `repository_id` — the POST 404s without it, and asset visibility is scoped to it. And the screenshot is public the moment the issue is: scrub it like the body (no internal hostnames in the URL bar, no tokens in a visible console). Unattached uploads 404 anonymously until the issue references them — that's normal, not a failure. For a data or pipeline bug the inline query proof is usually the evidence and no screenshot is needed.
+Three caveats. The endpoint is **undocumented** — if the POST fails (empty `$ASSET`), fall back to the old flow: create the issue, then tell the user to drag the PNGs into the description box (don't imply they attached automatically). Always pass the target repo's `repository_id` — the POST 404s without it, and asset visibility is scoped to that repo. And the screenshot is public the moment the issue is: scrub it like the body (no internal hostnames in the URL bar, no tokens in a visible console). Unattached uploads 404 anonymously until the issue references them — that's normal, not a failure. For a data or pipeline bug the inline query proof is usually the evidence and no screenshot is needed.
 
 ## Verify what landed
 

--- a/.claude/skills/file-bug-insight/SKILL.md
+++ b/.claude/skills/file-bug-insight/SKILL.md
@@ -219,7 +219,18 @@ gh project item-edit --project-id PVT_kwDOERGOus4Ba9e9 --id "$ITEM" \
 
 Verify those IDs with `gh project field-list 40 --owner constructorfabric` if an edit fails.
 
-**Images — the honest constraint.** GitHub has **no API to upload an image to an issue**, and `gh` cannot do it either; the web UI uploads via drag-drop. Create the issue with the body, then tell the user to drag the PNGs into the description box. Don't imply they will be attached automatically. For a data or pipeline bug the inline query proof is usually the evidence and no screenshot is needed.
+**Images.** There is no *documented* API, but the web UI's upload endpoint accepts a plain `gh auth token` (verified 2026-08). Upload **before** creating the issue and embed the returned URL in the body, so the asset attaches with the initial render:
+
+```sh
+# Upload one PNG; prints the asset URL to embed
+ASSET=$(curl -sf "https://uploads.github.com/user-attachments/assets?name=<shot>.png&content_type=image/png&repository_id=$(gh api repos/constructorfabric/insight --jq .id)" \
+  -X POST -H "Authorization: Bearer $(gh auth token)" -H "Accept: application/json" \
+  --data-binary "@<shot>.png" | jq -r .url)
+# → https://github.com/user-attachments/assets/<uuid>; embed as ![<what it shows>]($ASSET)
+# empty $ASSET = upload failed (curl -sf swallows the error body) → use the fallback below
+```
+
+Three caveats. The endpoint is **undocumented** — if the POST fails (empty `$ASSET`), fall back to the old flow: create the issue, then tell the user to drag the PNGs into the description box (don't imply they attached automatically). Always pass this repo's `repository_id` — the POST 404s without it, and asset visibility is scoped to it. And the screenshot is public the moment the issue is: scrub it like the body (no internal hostnames in the URL bar, no tokens in a visible console). Unattached uploads 404 anonymously until the issue references them — that's normal, not a failure. For a data or pipeline bug the inline query proof is usually the evidence and no screenshot is needed.
 
 ## Verify what landed
 


### PR DESCRIPTION
## What

Replaces the "no API, drag the PNGs in manually" guidance in the file-bug-insight skill with a verified flow: upload the screenshot to GitHub's user-attachments asset endpoint (it accepts a plain `gh auth token`) **before** creating the issue, and embed the returned URL so the image lands with the initial render. Manual drag-and-drop stays as the fallback since the endpoint is undocumented.

## Why

Filing a UI bug previously required a manual follow-up step that was easy to skip, leaving issues without their screenshot evidence.

## Verification

Tested against the live endpoint:
- POST returns 201 with `{"url": "https://github.com/user-attachments/assets/<uuid>"}` — the `jq -r .url` extraction works as written.
- `repository_id` is required — the POST 404s without it.
- Unattached uploads 404 anonymously until an issue references them; after that they serve publicly.
- A failed POST yields an empty `$ASSET` (`curl -sf` swallows the error body) — called out in the snippet so the fallback triggers.
- Exercised end-to-end: #2406 was filed with its screenshot uploaded through this flow and the image renders in the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved screenshot attachment handling when creating issues.
  * Screenshots are uploaded automatically and included directly in the issue description.
  * Added fallback guidance when an upload cannot be completed.
  * Documented repository scoping and handling for unattached image assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->