### PR TITLE
feat(frontend): serve the Sentry DSN from the chart, not the image

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -841,7 +841,6 @@ jobs:
           context: src/frontend
           platforms: ${{ matrix.platform }}
           build-args: |
-            VITE_SENTRY_DSN=${{ secrets.FRONTEND_SENTRY_DSN }}
             VITE_APP_RELEASE=${{ needs.changes.outputs.build_tag }}
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}/insight-frontend,push-by-digest=true,name-canonical=true,push=${{ needs.changes.outputs.should_push == 'true' }}
           cache-from: type=gha,scope=frontend-${{ matrix.arch }}

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -564,3 +564,5 @@ frontend:
     # Sentry origin the SPA posts to, e.g. "https://sentry.example.com".
     # Empty leaves it out of the CSP, which blocks every event.
     connectSrc: ""
+    # DSN the SPA reads from /config.js at load. Empty disables reporting.
+    dsn: ""

--- a/src/frontend/.env.example
+++ b/src/frontend/.env.example
@@ -22,7 +22,6 @@ VITE_ENABLE_MOCKS=false
 # image. Mocks themselves keep running. No effect when mocks are off.
 # VITE_HIDE_MOCK_BANNER=true
 
-# Sentry DSN. Unset means no reporting — the normal state for local work. A
-# deployed stand also needs the same origin in the chart's `sentry.connectSrc`,
-# or its CSP blocks every event.
+# Sentry DSN, local only — a deployed stand gets it from the chart's
+# `sentry.dsn`. Unset means no reporting, the normal state for local work.
 # VITE_SENTRY_DSN=https://<key>@sentry.example.com/<project-id>

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -12,7 +12,6 @@ RUN pnpm install --frozen-lockfile --ignore-scripts
 
 COPY . .
 
-ARG VITE_SENTRY_DSN
 ARG VITE_APP_RELEASE
 
 RUN pnpm run build

--- a/src/frontend/README.md
+++ b/src/frontend/README.md
@@ -118,7 +118,7 @@ Build-time (Vite, `.env.local`):
 | `VITE_API_PROXY_TARGET` | Dev-only `/api` proxy target (e.g. `http://localhost:8080`). |
 | `VITE_API_BASE` | Override analytics API base URL (default `/api/analytics/v1`). |
 | `VITE_IDENTITY_BASE` | Override identity API base URL (default `/api/identity/v1`). |
-| `VITE_SENTRY_DSN` | Sentry DSN. Unset means Sentry never initializes. |
+| `VITE_SENTRY_DSN` | Sentry DSN for local runs only; a deployed stand uses `sentry.dsn`. Unset means Sentry never initializes. |
 | `VITE_APP_RELEASE` | Release attached to events. Defaults to `local-<git sha>`; CI passes the image tag. |
 
 ## Error Reporting and Tracing
@@ -139,13 +139,17 @@ What leaves the browser:
 Events carry the hostname as their `environment` (`local` on localhost) — one
 image serves every stand, so nothing else tells them apart.
 
-Two settings must agree:
+The image carries no DSN. A deployed stand takes two chart values, and they
+must agree:
 
-1. `VITE_SENTRY_DSN` at build time — a `--build-arg` for the image, or the
-   `FRONTEND_SENTRY_DSN` repository secret in CI.
-2. `sentry.connectSrc` in the deployed chart values, set to the same origin.
-   The container's CSP is rendered from it at start; without it the browser
-   blocks every event and nothing arrives.
+1. `sentry.dsn` — rendered into a ConfigMap that mounts over `/config.js`,
+   which the SPA reads before it boots.
+2. `sentry.connectSrc`, set to the same origin. The container's CSP is
+   rendered from it at start; without it the browser blocks every event and
+   nothing arrives.
+
+Locally there is no chart, so `VITE_SENTRY_DSN` stands in for the first and
+the CSP does not apply.
 
 The SDK attaches no cookies, IP or headers to events. Session Replay is not
 enabled.

--- a/src/frontend/helm/templates/configmap.yaml
+++ b/src/frontend/helm/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "insight-frontend.fullname" . }}-runtime
+  labels:
+    {{- include "insight-frontend.labels" . | nindent 4 }}
+data:
+  config.js: |
+    window.__INSIGHT_CONFIG__ = {{ toJson (dict "sentryDsn" .Values.sentry.dsn) }};

--- a/src/frontend/helm/templates/deployment.yaml
+++ b/src/frontend/helm/templates/deployment.yaml
@@ -13,10 +13,13 @@ spec:
     metadata:
       labels:
         {{- include "insight-frontend.selectorLabels" . | nindent 8 }}
-      {{- with .Values.podAnnotations }}
       annotations:
+        # `subPath` mounts never refresh in place, so the pod must roll when
+        # the rendered config changes.
+        checksum/runtime-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
     spec:
       {{- with .Values.global }}
       {{- with .imagePullSecrets }}
@@ -56,6 +59,10 @@ spec:
               mountPath: /tmp
             - name: nginx-conf
               mountPath: /etc/nginx/conf.d
+            - name: runtime-config
+              mountPath: /usr/share/nginx/html/config.js
+              subPath: config.js
+              readOnly: true
           livenessProbe:
             httpGet:
               path: /healthz
@@ -75,3 +82,6 @@ spec:
           emptyDir: {}
         - name: nginx-conf
           emptyDir: {}
+        - name: runtime-config
+          configMap:
+            name: {{ include "insight-frontend.fullname" . }}-runtime

--- a/src/frontend/helm/templates/deployment.yaml
+++ b/src/frontend/helm/templates/deployment.yaml
@@ -13,13 +13,12 @@ spec:
     metadata:
       labels:
         {{- include "insight-frontend.selectorLabels" . | nindent 8 }}
+      # `subPath` mounts never refresh in place, so the pod must roll when the
+      # rendered config changes. Merged rather than listed alongside
+      # podAnnotations, which would emit the key twice if an operator set it.
+      {{- $checksum := dict "checksum/runtime-config" (include (print $.Template.BasePath "/configmap.yaml") . | sha256sum) }}
       annotations:
-        # `subPath` mounts never refresh in place, so the pod must roll when
-        # the rendered config changes.
-        checksum/runtime-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- with .Values.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
+        {{- toYaml (merge $checksum (default dict .Values.podAnnotations)) | nindent 8 }}
     spec:
       {{- with .Values.global }}
       {{- with .imagePullSecrets }}

--- a/src/frontend/helm/values.yaml
+++ b/src/frontend/helm/values.yaml
@@ -28,6 +28,8 @@ sentry:
   # Sentry origin the SPA posts to, e.g. "https://sentry.example.com".
   # Empty leaves it out of the CSP, which blocks every event.
   connectSrc: ""
+  # DSN the SPA reads from /config.js at load. Empty disables reporting.
+  dsn: ""
 
 resources:
   requests:

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -5,6 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Insight</title>
+    <!-- Deferred, like the module script, so both run in document order: this
+         one defines the config that one reads. -->
+    <script defer src="/config.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/frontend/nginx/default.conf.template
+++ b/src/frontend/nginx/default.conf.template
@@ -35,6 +35,14 @@ server {
         include /etc/nginx/snippets/security-headers.conf;
     }
 
+    # Exact match so it wins over the immutable-asset regex below — a cached
+    # copy would pin the browser to the DSN of an earlier deploy.
+    location = /config.js {
+        add_header Cache-Control "no-cache" always;
+        # Re-include security headers — see comment above for why.
+        include /etc/nginx/snippets/security-headers.conf;
+    }
+
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
         add_header Cache-Control "public, max-age=31536000, immutable" always;
         # Re-include security headers — see comment above for why.

--- a/src/frontend/public/config.js
+++ b/src/frontend/public/config.js
@@ -1,0 +1,1 @@
+window.__INSIGHT_CONFIG__ = {};

--- a/src/frontend/src/sentry.test.ts
+++ b/src/frontend/src/sentry.test.ts
@@ -25,6 +25,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllEnvs();
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("initSentry", () => {
@@ -44,5 +45,33 @@ describe("initSentry", () => {
 
   it("labels localhost as local", () => {
     expect(initWith().environment).toBe("local");
+  });
+
+  it("prefers the runtime config over the build-time env", () => {
+    vi.stubEnv("VITE_SENTRY_DSN", "https://public@sentry.example.com/2");
+    vi.stubGlobal("__INSIGHT_CONFIG__", { sentryDsn: DSN });
+
+    initSentry(ROUTER);
+
+    expect(vi.mocked(Sentry.init).mock.calls[0][0]!.dsn).toBe(DSN);
+  });
+
+  it("survives an init that throws", () => {
+    vi.mocked(Sentry.init).mockImplementationOnce(() => {
+      throw new Error("bad dsn");
+    });
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => initWith()).not.toThrow();
+  });
+
+  // What the chart renders when the operator leaves `sentry.dsn` unset.
+  it("does nothing when the runtime config carries an empty DSN", () => {
+    vi.stubEnv("VITE_SENTRY_DSN", "");
+    vi.stubGlobal("__INSIGHT_CONFIG__", { sentryDsn: "" });
+
+    initSentry(ROUTER);
+
+    expect(Sentry.init).not.toHaveBeenCalled();
   });
 });

--- a/src/frontend/src/sentry.test.ts
+++ b/src/frontend/src/sentry.test.ts
@@ -65,9 +65,10 @@ describe("initSentry", () => {
     expect(() => initWith()).not.toThrow();
   });
 
-  // What the chart renders when the operator leaves `sentry.dsn` unset.
+  // What the chart renders when the operator leaves `sentry.dsn` unset. The
+  // env var is set here so the case fails if the read ever falls through it.
   it("does nothing when the runtime config carries an empty DSN", () => {
-    vi.stubEnv("VITE_SENTRY_DSN", "");
+    vi.stubEnv("VITE_SENTRY_DSN", DSN);
     vi.stubGlobal("__INSIGHT_CONFIG__", { sentryDsn: "" });
 
     initSentry(ROUTER);

--- a/src/frontend/src/sentry.ts
+++ b/src/frontend/src/sentry.ts
@@ -9,8 +9,10 @@ declare global {
 }
 
 export function initSentry(router: unknown): void {
-  // /config.js comes from the chart in a pod, from the built stub anywhere else.
-  const dsn = window.__INSIGHT_CONFIG__?.sentryDsn || import.meta.env.VITE_SENTRY_DSN;
+  // /config.js comes from the chart in a pod, from the built stub anywhere
+  // else. Nullish, not `||`: the chart renders "" to mean reporting off, and
+  // that has to outrank a build-time DSN rather than fall through to it.
+  const dsn = window.__INSIGHT_CONFIG__?.sentryDsn ?? import.meta.env.VITE_SENTRY_DSN;
   if (!dsn) return;
 
   // The DSN arrives from the deploy, so a malformed one is a config mistake,

--- a/src/frontend/src/sentry.ts
+++ b/src/frontend/src/sentry.ts
@@ -2,18 +2,31 @@ import * as Sentry from "@sentry/react";
 
 const LOCAL_HOSTNAMES = new Set(["localhost", "127.0.0.1", "[::1]"]);
 
+declare global {
+  interface Window {
+    __INSIGHT_CONFIG__?: { sentryDsn?: string };
+  }
+}
+
 export function initSentry(router: unknown): void {
-  const dsn = import.meta.env.VITE_SENTRY_DSN;
+  // /config.js comes from the chart in a pod, from the built stub anywhere else.
+  const dsn = window.__INSIGHT_CONFIG__?.sentryDsn || import.meta.env.VITE_SENTRY_DSN;
   if (!dsn) return;
 
-  Sentry.init({
-    dsn,
-    environment: resolveEnvironment(),
-    release: import.meta.env.VITE_APP_RELEASE || undefined,
-    // Route pattern rather than resolved URL, so ids stay out of event names.
-    integrations: [Sentry.tanstackRouterBrowserTracingIntegration(router)],
-    tracesSampleRate: 0.1,
-  });
+  // The DSN arrives from the deploy, so a malformed one is a config mistake,
+  // not a code path — it must not take the app down on boot.
+  try {
+    Sentry.init({
+      dsn,
+      environment: resolveEnvironment(),
+      release: import.meta.env.VITE_APP_RELEASE || undefined,
+      // Route pattern rather than resolved URL, so ids stay out of event names.
+      integrations: [Sentry.tanstackRouterBrowserTracingIntegration(router)],
+      tracesSampleRate: 0.1,
+    });
+  } catch (error) {
+    console.error("Sentry init failed", error);
+  }
 }
 
 /** One image serves every stand, so the hostname is the only label it has. */


### PR DESCRIPTION
## What

The Sentry DSN moves from a Docker build argument to a deploy-time chart value.

- `sentry.dsn` renders into a ConfigMap holding a single `config.js`.
- It mounts with `subPath` over `/usr/share/nginx/html/config.js`, replacing the empty stub the image ships.
- `index.html` loads it with a deferred script, so `window.__INSIGHT_CONFIG__` is set before the bundle runs and `initSentry` stays synchronous.
- `src/sentry.ts` reads that global and falls back to `VITE_SENTRY_DSN`, which is now local-only.

## Why

As a build argument the DSN was compiled into a publicly pullable image, was identical on every stand, and could not be rotated without a rebuild and a chart repin. As a chart value it is set per environment and changes with a `helm upgrade`.

The chart default is empty, so anyone installing it gets no error reporting and no outbound calls unless they set a DSN deliberately.

## Notes

- An exact-match nginx location keeps `/config.js` out of the immutable asset cache; without it the browser would pin a stale DSN for a year.
- `subPath` mounts never refresh in place, so a `checksum/runtime-config` annotation rolls the pod when the value changes.
- `Sentry.init` is wrapped: a malformed DSN is now a deploy mistake rather than a code path, and must not take the app down at boot.
- The DSN is a write-only public key by design and is served to every browser, so a ConfigMap is the right classification. The CI secret was over-classification and is removed.

## Operator note

Reporting needs two values that name the same origin: `sentry.dsn` and `sentry.connectSrc`. If they disagree the CSP blocks every event silently. Deriving one from the other is a sensible follow-up.

Example values:

```yaml
frontend:
  sentry:
    connectSrc: "https://sentry.example.com"
    dsn: "https://<key>@sentry.example.com/<project-id>"
```

## Verification

`tsc -b`, `eslint --max-warnings 0`, unit tests, `helm lint`, `helm template` with and without a DSN, `nginx -t` on the rendered config inside the runtime base image, and a production build confirming the emitted `index.html` and `config.js`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added runtime configuration for Sentry, allowing deployed environments to set or disable error reporting without rebuilding the frontend.
  - Local development continues to support configuration through environment settings.

- **Bug Fixes**
  - Improved startup resilience: invalid Sentry configuration no longer prevents the application from loading.
  - Configuration updates are automatically applied when the frontend deployment restarts.

- **Documentation**
  - Updated setup and deployment guidance for configuring Sentry in local and deployed environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->