### PR TITLE
Stop the GitHub directory connector storing absent profile fields as the text "None"

### DIFF
--- a/src/ingestion/connectors/git/github-directory/connector.yaml
+++ b/src/ingestion/connectors/git/github-directory/connector.yaml
@@ -178,21 +178,33 @@ streams:
           - type: AddedFieldDefinition
             path: [member_id]
             value: "{{ (record.get('node') or {}).get('databaseId') }}"
+          # `or ''`, never `or none`: these carry `value_type: string`, so a
+          # Jinja `none` renders as the four-character text "None" and is stored
+          # as a value rather than as absence — an "e-mail" every memberless-
+          # e-mail account shares, which identity then groups into one person.
+          #
+          # `''` rather than a real NULL on purpose. `fields_history` compares
+          # versions with `curr != prev`, which is NULL-unsafe in ClickHouse:
+          # across a NULL boundary the comparison yields NULL and NO history row
+          # is emitted, in EITHER direction. A field that later gains a value
+          # would never be observed. The empty string compares normally, and the
+          # downstream filters (`new_value != ''`, `WHERE {{ f }} != ''`) already
+          # treat it as absence. Same shape as `login_normalized` above.
           - type: AddedFieldDefinition
             path: [name]
-            value: "{{ (record.get('node') or {}).get('name') or none }}"
+            value: "{{ (record.get('node') or {}).get('name') or '' }}"
             value_type: string
           - type: AddedFieldDefinition
             path: [email]
-            value: "{{ (record.get('node') or {}).get('email') or none }}"
+            value: "{{ (record.get('node') or {}).get('email') or '' }}"
             value_type: string
           - type: AddedFieldDefinition
             path: [company]
-            value: "{{ (record.get('node') or {}).get('company') or none }}"
+            value: "{{ (record.get('node') or {}).get('company') or '' }}"
             value_type: string
           - type: AddedFieldDefinition
             path: [role]
-            value: "{{ record.get('role') or none }}"
+            value: "{{ record.get('role') or '' }}"
             value_type: string
           - type: AddedFieldDefinition
             path: [created_at]

--- a/src/ingestion/connectors/git/github-directory/tests/test_org_members.py
+++ b/src/ingestion/connectors/git/github-directory/tests/test_org_members.py
@@ -137,6 +137,38 @@ def test_login_normalized_is_lowercased(http_mocker: HttpMocker) -> None:
     assert record["unique_key"] == f"test-tenant:test-source:{ORG}:dev-one"
 
 
+def test_absent_profile_fields_are_empty_not_the_text_none(http_mocker: HttpMocker) -> None:
+    """A field GitHub does not expose must arrive as `''`, never as `"None"`.
+
+    GitHub returns `null` for a member's e-mail unless it is verified and
+    visible to the token's scopes, so this is the COMMON case, not an edge one.
+    These fields carry `value_type: string`, which renders a Jinja `none` as the
+    four-character text `None` — a value, not an absence. Identity anchors on
+    e-mail, so every such member would share one "address" and be grouped into a
+    single person: one member's sign-in would then load another's profile.
+
+    Asserted as `''` rather than as a real NULL deliberately.
+    `fields_history` detects changes with `curr != prev`, which yields NULL
+    across a NULL boundary in ClickHouse and emits NO history row in either
+    direction — so a field that later gained a value would never be observed at
+    all. `''` compares normally and the downstream filters already read it as
+    absence.
+    """
+    config = GitHubDirectoryConfigBuilder().build()
+    http_mocker.post(
+        HttpRequest(GRAPHQL_URL, body=_body()),
+        _page([_member("dev-one", 7001, email=None, name=None, company=None)]),
+    )
+
+    record = read_stream(CONNECTOR, _STREAM, config).records[0].record.data
+
+    for field in ("email", "name", "company"):
+        assert record[field] == "", (
+            f"{field} came through as {record[field]!r}; anything other than '' "
+            f"is stored as a value and groups unrelated members together"
+        )
+
+
 def test_pagination_injects_cursor(http_mocker: HttpMocker) -> None:
     config = GitHubDirectoryConfigBuilder().build()
     http_mocker.post(


### PR DESCRIPTION
Fixes #2393.

## Problem

The GitHub directory manifest builds four profile fields with a Jinja `or none` while declaring `value_type: string`:

```yaml
value: "{{ (record.get('node') or {}).get('email') or none }}"
value_type: string
```

A rendered `none` becomes the four-character text `None`. So a field the GitHub API does not expose is stored as a **value**, not as an absence.

For `email` that is not cosmetic. Identity resolution anchors on e-mail: the seed groups accounts that share an address into one person. GitHub returns `null` for a member's e-mail unless it is verified and visible to the token's scopes — the common case, not an edge case — so every such member carries the same `"None"` "address", they group into a single person, and a sign-in through that IdP can resolve to somebody else's profile. That is the failure #2393 describes.

The same `or none` shape was on `name`, `company` and `role`, so those fields could read as the literal `None` too.

## Why `''` and not a real NULL

Deliberate, and the more interesting half of the change.

`fields_history` detects a change with `curr != prev`. That comparison is NULL-unsafe in ClickHouse: across a NULL boundary it yields NULL, so **no history row is emitted in either direction**. Verified:

| expression | result |
|---|---|
| `NULL != 'None'` | NULL → no row |
| `'x' != NULL` | NULL → no row |
| `'' != 'None'` | true |
| `'x' != ''` | true |

With NULL, a field that later *gained* a value would never be observed at all — trading a wrong merge for a silent loss. The empty string compares normally, and the downstream filters (`new_value != ''` in `identity_inputs_from_history`, `WHERE <field> != ''` in `fields_history`) already read it as absence.

Two fields in this same manifest never had the defect and both show the intended shape: `login_normalized` puts `or ''` *before* its filter, and `member_id` declares no `value_type`, so its `none` stays a real null.

## Affected areas

- `connectors/git/github-directory/connector.yaml` — the four field definitions.
- `connectors/git/github-directory/tests/test_org_members.py` — one new case.

Nothing else. No dbt models, no other connector, no backend service. `bronze_github_directory.org_members` already declares all four columns `Nullable(String)`, so no DDL change is needed, and no relation outside this connector reads these fields.

## How to test

```bash
cd src/ingestion/tests/connectors
uv run --project . pytest ../../connectors/git/github-directory/tests -q
```

Expected: 9 passed. The new case (`test_absent_profile_fields_are_empty_not_the_text_none`) fails on the previous manifest and passes on this one.

The shared member fixture already set `email: None` but asserted nothing about it, so the case looked covered and was not — that is why this shipped.

## What this change does NOT do

Reviewers should know two limits, both structural rather than oversights:

1. **It does not repair rows already written.** The persons journal is append-only, so bindings a previous run derived from the `"None"` address stay in force and continue to read as resolved — they do not fall back into the operator review queue on their own. An environment that already ingested this connector needs a separate data repair.

2. **Correcting the connector does not by itself clear the stale observation.** `identity_inputs_from_history` filters empty values rather than emitting a tombstone, so a `"None"` → `""` transition produces a history row the macro then drops — nothing supersedes the earlier observation. Clearing it means removing those rows from the identity inputs, not just fixing the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub directory member profiles now show blank values for missing name, email, company, and role fields instead of displaying “None.”
  * Improved consistency for profile history comparisons and filtering of absent values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->