### PR TITLE
frontend: serve under any /exp/<name> prefix — relative base + runtime basepath

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -2,8 +2,21 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <!-- Runtime <base>: under /exp/<name>/ every relative URL (assets, favicon)
+         resolves inside the experiment; at "/" behavior is unchanged. Must be
+         the first resource-affecting element; hashed in the nginx CSP. -->
+    <script>
+      (function () {
+        var m = location.pathname.match(
+          /^\/exp\/[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?=\/|$)/
+        );
+        var b = document.createElement("base");
+        b.href = m ? m[0] + "/" : "/";
+        document.head.appendChild(b);
+      })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <title>Insight</title>
   </head>
   <body>

--- a/src/frontend/nginx/default.conf.template
+++ b/src/frontend/nginx/default.conf.template
@@ -1,5 +1,5 @@
 map $sent_http_content_type $csp_header {
-    default "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ${SENTRY_CONNECT_SRC}; frame-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; object-src 'none'";
+    default "default-src 'self'; script-src 'self' 'sha256-i9A/vbD6Kql89msQo2Bn8ybuTF8CVOlyNpNudpq3/I8='; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ${SENTRY_CONNECT_SRC}; frame-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'; object-src 'none'";
 }
 
 server {

--- a/src/frontend/src/base-href-csp.test.ts
+++ b/src/frontend/src/base-href-csp.test.ts
@@ -1,0 +1,45 @@
+// The index.html <base>-injecting inline script must stay byte-identical to
+// the sha256 the nginx CSP allows: a reformat breaks the hash, CSP blocks the
+// script, and prefix serving (/exp/<name>/) silently dies.
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const root = join(__dirname, "..");
+
+describe("base-href bootstrap script", () => {
+  const html = readFileSync(join(root, "index.html"), "utf8");
+  const script = /<script>([\s\S]*?)<\/script>/.exec(html)?.[1];
+
+  it("exists as the first head element", () => {
+    expect(script).toBeTruthy();
+    const head = html.indexOf("<head>");
+    expect(html.indexOf("<script>")).toBeGreaterThan(head);
+    expect(html.indexOf("<script>")).toBeLessThan(html.indexOf("<link"));
+  });
+
+  it("hash matches the nginx CSP allowance", () => {
+    const digest = createHash("sha256")
+      .update(script ?? "")
+      .digest("base64");
+    const nginx = readFileSync(
+      join(root, "nginx/default.conf.template"),
+      "utf8"
+    );
+    expect(nginx).toContain(`'sha256-${digest}'`);
+  });
+
+  it("prefix regex accepts experiment slugs and rejects lookalikes", () => {
+    const re = /^\/exp\/[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?=\/|$)/;
+    expect("/exp/demo/".match(re)?.[0]).toBe("/exp/demo");
+    expect("/exp/widget-alpha/deep/route".match(re)?.[0]).toBe(
+      "/exp/widget-alpha"
+    );
+    expect("/exp/a".match(re)?.[0]).toBe("/exp/a");
+    for (const miss of ["/", "/expunge/x", "/exp/", "/exp/-bad", "/EXP/demo"]) {
+      expect(miss.match(re), `should reject: ${miss}`).toBeNull();
+    }
+  });
+});

--- a/src/frontend/src/base-href-csp.test.ts
+++ b/src/frontend/src/base-href-csp.test.ts
@@ -8,21 +8,19 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const root = join(__dirname, "..");
+const html = readFileSync(join(root, "index.html"), "utf8");
+const scriptElement = /<script>([\s\S]*?)<\/script>/.exec(html);
 
 describe("base-href bootstrap script", () => {
-  const html = readFileSync(join(root, "index.html"), "utf8");
-  const script = /<script>([\s\S]*?)<\/script>/.exec(html)?.[1];
-
-  it("exists as the first head element", () => {
-    expect(script).toBeTruthy();
-    const head = html.indexOf("<head>");
-    expect(html.indexOf("<script>")).toBeGreaterThan(head);
-    expect(html.indexOf("<script>")).toBeLessThan(html.indexOf("<link"));
+  it("exists as the first resource-affecting head element", () => {
+    expect(scriptElement).toBeTruthy();
+    expect(scriptElement?.index).toBeGreaterThan(html.indexOf("<head>"));
+    expect(scriptElement?.index).toBeLessThan(html.indexOf("<link"));
   });
 
   it("hash matches the nginx CSP allowance", () => {
     const digest = createHash("sha256")
-      .update(script ?? "")
+      .update(scriptElement?.[1] ?? "")
       .digest("base64");
     const nginx = readFileSync(
       join(root, "nginx/default.conf.template"),
@@ -32,7 +30,12 @@ describe("base-href bootstrap script", () => {
   });
 
   it("prefix regex accepts experiment slugs and rejects lookalikes", () => {
-    const re = /^\/exp\/[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(?=\/|$)/;
+    // Test the regex the script actually ships, not a copy of it.
+    const source = /location\.pathname\.match\(\s*\/((?:\\.|[^/])*)\/\s*\)/.exec(
+      scriptElement?.[1] ?? ""
+    )?.[1];
+    expect(source).toBeTruthy();
+    const re = new RegExp(source ?? "(?!)");
     expect("/exp/demo/".match(re)?.[0]).toBe("/exp/demo");
     expect("/exp/widget-alpha/deep/route".match(re)?.[0]).toBe(
       "/exp/widget-alpha"

--- a/src/frontend/src/lib/base-path.test.ts
+++ b/src/frontend/src/lib/base-path.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { servingBasepath } from "./base-path";
+
+describe("servingBasepath", () => {
+  it("is / for the main deployment", () => {
+    expect(servingBasepath("http://stand.test/")).toBe("/");
+  });
+
+  it("is the experiment prefix inside a preview", () => {
+    expect(servingBasepath("http://stand.test/exp/demo/")).toBe("/exp/demo/");
+    expect(servingBasepath("http://stand.test/exp/widget-alpha/")).toBe(
+      "/exp/widget-alpha/"
+    );
+  });
+
+  it("defaults to the document base (jsdom root)", () => {
+    expect(servingBasepath()).toBe("/");
+  });
+});

--- a/src/frontend/src/lib/base-path.ts
+++ b/src/frontend/src/lib/base-path.ts
@@ -1,0 +1,6 @@
+// The runtime <base> tag (injected first-in-head by index.html) is the single
+// source of the serving prefix: "/" normally, "/exp/<name>/" inside a preview
+// experiment. Everything that needs the prefix derives it from here.
+export function servingBasepath(baseURI: string = document.baseURI): string {
+  return new URL(baseURI).pathname;
+}

--- a/src/frontend/src/router.test.ts
+++ b/src/frontend/src/router.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+import { router } from "./router";
+
+describe("router", () => {
+  it("basepath follows the document base", () => {
+    // jsdom serves at "/": the runtime <base> contract maps that to basepath "/".
+    expect(router.basepath).toBe("/");
+  });
+});

--- a/src/frontend/src/router.ts
+++ b/src/frontend/src/router.ts
@@ -1,15 +1,12 @@
 import { createRouter } from "@tanstack/react-router";
 
 import { AppBootSpinner } from "@/components/app-boot-spinner";
+import { servingBasepath } from "@/lib/base-path";
 import { routeTree } from "./routeTree.gen";
-
-// The runtime <base> tag (index.html) is the single source of the serving
-// prefix: "/" normally, "/exp/<name>/" inside a preview experiment.
-const basepath = new URL(document.baseURI).pathname;
 
 export const router = createRouter({
   routeTree,
-  basepath,
+  basepath: servingBasepath(),
   defaultPreload: "intent",
   defaultPendingComponent: AppBootSpinner,
   defaultPendingMs: 200,

--- a/src/frontend/src/router.ts
+++ b/src/frontend/src/router.ts
@@ -3,8 +3,13 @@ import { createRouter } from "@tanstack/react-router";
 import { AppBootSpinner } from "@/components/app-boot-spinner";
 import { routeTree } from "./routeTree.gen";
 
+// The runtime <base> tag (index.html) is the single source of the serving
+// prefix: "/" normally, "/exp/<name>/" inside a preview experiment.
+const basepath = new URL(document.baseURI).pathname;
+
 export const router = createRouter({
   routeTree,
+  basepath,
   defaultPreload: "intent",
   defaultPendingComponent: AppBootSpinner,
   defaultPendingMs: 200,

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -41,6 +41,10 @@ export default defineConfig(({ mode, command }) => {
   // Assigning undefined would store the literal string "undefined".
   if (release) process.env.VITE_APP_RELEASE = release;
   return {
+    // Relative asset base: one image serves at "/" AND under an /exp/<name>
+    // preview prefix. Correct resolution on nested routes comes from the
+    // runtime <base href> injected in index.html.
+    base: "./",
     plugins: [
       tanstackRouter({ target: "react", autoCodeSplitting: true }),
       react(),


### PR DESCRIPTION
## Summary
Implements the FE half of the preview contract that #1971's DESIGN claimed but never shipped (found closing Phase 0 of #1981): one frontend image now serves both at `/` and under an `/exp/<name>/` preview prefix. Closes #2402.

- **Vite `base: "./"`** — built asset URLs are relative.
- **Runtime `<base href>`** — a tiny inline script, first in `<head>`, computes the serving prefix from `location.pathname` (`/exp/<dns-label>` or `/`) and injects a `<base>` tag. This is what keeps relative URLs correct on *nested* routes (`/ic/<person>/personal`) in both deployments — plain relative base alone would break them.
- **Router basepath from `document.baseURI`** — TanStack Router navigation and history URLs stay inside the experiment; the base tag is the single source of truth.
- **CSP**: `script-src 'self'` gains exactly that script's `'sha256-…'` (`base-uri 'self'` already permitted the tag). A new unit test recomputes the hash from `index.html` against the nginx template, so a reformat cannot silently CSP-block the script — which would otherwise break prefix serving invisibly.
- `/api/*` and `/auth/*` stay absolute by design (shared backend); `signIn` already returns to the full current path, so the login round-trip stays inside an experiment.

## Verification
- `pnpm build`: dist/index.html emits `./assets/*`, the inline script survives byte-identical (hash test asserts source ↔ nginx CSP).
- `pnpm test`: 1030 passed (adds 3: script placement, CSP hash drift, prefix-regex accept/reject table).
- `typecheck` + `lint` clean.
- Live check after an image builds: `/exp/<name>/` serves assets and navigates; `/` unchanged.

Part of #1981 (Phase -1). Unblocks #2374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for running the application at the root URL and within nested experiment preview paths.
  * Updated asset, navigation, and favicon links to resolve correctly across deployment locations.
* **Bug Fixes**
  * Prevented incorrect routing and resource loading when accessing preview deployments.
  * Strengthened security policy coverage for the updated startup behavior.
* **Tests**
  * Added coverage for valid and invalid preview paths, startup ordering, and security policy compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->