### PR TITLE
Bump the github-directory descriptor so the "None" fix can reach Airbyte

### DIFF
--- a/src/ingestion/connectors/git/github-directory/descriptor.yaml
+++ b/src/ingestion/connectors/git/github-directory/descriptor.yaml
@@ -11,7 +11,13 @@
 
 name: github-directory
 # Strict semver per ADR-0015.
-version: "1.0.0"
+#
+# 1.0.1 — the manifest stopped storing absent profile fields as the text
+# "None" (#2393). The bump is what makes that reach Airbyte at all: reconcile
+# republishes a nocode manifest only on descriptor-version drift, so the
+# previous manifest-only change was live in the repo and inert on every
+# cluster.
+version: "1.0.1"
 # `nocode` = declarative-manifest connector (connector.yaml published to the
 # Airbyte builder), as opposed to `cdk`. MUST be `nocode`/absent for
 # declarative connectors: reconcile only branches on `nocode` vs `cdk` — any


### PR DESCRIPTION
Follow-up to #2415. Same issue: #2393.

## Problem

#2415 changed `connectors/git/github-directory/connector.yaml` and did not touch `descriptor.yaml`. That leaves the fix **inert**.

Reconcile republishes a nocode manifest only when the descriptor `version` differs from the version stored on the Airbyte definition (ADR-0015). Equal versions are a no-op, so a manifest-only change stays in the repository and reaches no cluster — while the deploy reports success with the previous manifest still active. That combination is what makes the omission easy to miss: nothing fails, and the connector keeps serving the pre-fix manifest indefinitely.

The connector's own deploy prerequisites already state this:

> `descriptor.yaml` `version` bumped whenever `connector.yaml` changed. […] A manifest-only PR without a version bump silently never reaches Airbyte — the deploy "succeeds" with the old manifest still active. CI auto-bumps descriptors only for image ref changes, NOT for manifest edits.

I missed it in #2415.

## Change

One line: `version: "1.0.0"` → `"1.0.1"`, plus a comment recording why the bump exists, so the next manifest edit has the precedent in front of it.

Strict semver per ADR-0015; a manifest behaviour fix with no schema or stream change is a patch.

## Affected areas

`connectors/git/github-directory/descriptor.yaml` only. No manifest change, no schema change, no stream change — #2415 already carries those.

## How to test

Nothing to run locally; the descriptor is read at reconcile time, not by any test suite. What it enables is verifiable after deployment, in the bronze table the connector writes:

```sql
SELECT
    countIf(email = 'None') AS as_text_none,   -- expected 0 with the fixed manifest
    countIf(email = '')     AS as_empty        -- expected > 0
FROM bronze_github_directory.org_members;
```

`as_empty > 0` is expected because GitHub returns no e-mail for a member whose address is unverified or outside the token's scopes — the common case. `as_text_none > 0` after a sync means the definition serving it is still the pre-fix one.

## Note for whoever redeploys

Order matters on an environment that already ingested this connector. The manifest fix stops *new* `"None"` values; it does not remove observations already recorded, and it does not release bindings already derived from them — the persons journal is append-only, and those accounts read as resolved rather than returning to the operator review queue. Recreating the database without redeploying the connector first reproduces the original defect from the first sync, because a fresh database has no incremental watermark to accidentally suppress the stale value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub directory connector to its latest descriptor version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->