### PR TITLE
chore(deps): bump sea-orm & sea-orm-migration to 2.0

### DIFF
--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -61,6 +61,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "serde",
@@ -138,8 +139,8 @@ dependencies = [
  "redis",
  "reqwest 0.12.28",
  "rust_xlsxwriter",
- "sea-orm",
- "sea-orm-migration",
+ "sea-orm 2.0.2",
+ "sea-orm-migration 2.0.2",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -266,6 +267,165 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "arrow"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cfdd0833e32a9874d2b55089333ad310c0be208aafa277385ce2461dec90be3"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a41203398f0eaa6f7ec8e62c0da742a21abf282c148fc157f6c35c90e29981a"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae33dad492b7df00a217563a7b0ef2874df68a0deea1b1a3acf628152f7f7a69"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9552f96391c005e6ab449fa941420935e7e062489b12b8b1b08879b2163f5b5"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint 0.4.6",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8a327c9649f30d8406995f27642b68df354713cca3baaaf100f076f18d5f34"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64 0.22.1",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b24852db04738907e06c04ea61e42fe7fda962a34513022dc0d0e754fb7976b"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63a083ec750f5c043f02946b4baf05fcdbb55f4560a3277055caca5cc99f3eb0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514ba0ef0d4c5896202dae736251ce415abb43a950bed570fb7981b8716c0e4c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ca356ad6425cecb6eb7b28e4f659f1ee7880fbb1a16127de7dd62901efee9e"
+
+[[package]]
+name = "arrow-select"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58da39eb3d8350ad4a549e5c2bc49284dac554016c69829310350f1731b0aad"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6789b388467525e3271326b6b4915666ecfdf5142aef09779445c954b67543c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
 
 [[package]]
 name = "async-compression"
@@ -1118,7 +1278,7 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "rustls",
- "sea-orm-migration",
+ "sea-orm-migration 1.1.20",
  "serde",
  "serde-saphyr 0.0.22",
  "serde_json",
@@ -1148,7 +1308,7 @@ dependencies = [
  "axum",
  "cf-gears-toolkit-canonical-errors-macro",
  "http",
- "sea-orm",
+ "sea-orm 1.1.20",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1187,8 +1347,8 @@ dependencies = [
  "figment",
  "rust_decimal",
  "ryu",
- "sea-orm",
- "sea-orm-migration",
+ "sea-orm 1.1.20",
+ "sea-orm-migration 1.1.20",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1636,6 +1796,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1743,6 +1923,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
@@ -1981,6 +2167,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2159,7 +2356,7 @@ dependencies = [
  "ff 0.13.1",
  "generic-array",
  "group 0.13.0",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468 0.7.0",
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
@@ -2250,7 +2447,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2262,6 +2459,16 @@ dependencies = [
  "cfg-if",
  "home",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2391,6 +2598,17 @@ name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2774,6 +2992,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2831,6 +3061,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2866,6 +3105,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
  "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -3193,8 +3441,8 @@ dependencies = [
  "clap",
  "clickhouse",
  "insight-clickhouse",
- "sea-orm",
- "sea-orm-migration",
+ "sea-orm 2.0.2",
+ "sea-orm-migration 2.0.2",
  "serde",
  "serde_json",
  "tokio",
@@ -3247,6 +3495,15 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -3471,6 +3728,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3620,6 +3934,16 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4420,6 +4744,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "pluralizer"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3eba432a00a1f6c16f39147847a870e94e2e9b992759b503e330efec778cbe"
+dependencies = [
+ "once_cell",
+ "regex",
+]
+
+[[package]]
 name = "polonius-the-crab"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4598,7 +4932,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -4754,7 +5088,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5329,7 +5663,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5388,7 +5722,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5535,18 +5869,66 @@ dependencies = [
  "ouroboros",
  "pgvector",
  "rust_decimal",
- "sea-orm-macros",
- "sea-query",
+ "sea-orm-macros 1.1.20",
+ "sea-query 0.32.7",
  "sea-query-binder",
  "serde",
  "serde_json",
- "sqlx",
- "strum",
+ "sqlx 0.8.6",
+ "strum 0.26.3",
  "thiserror 2.0.18",
  "time",
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "sea-orm"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a334e83ced3ae3ee44db0f84d1fcf8d2087a1ad9bb9036f00f9f6067156ea197"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "bigdecimal",
+ "chrono",
+ "derive-where",
+ "derive_more",
+ "futures-util",
+ "itertools 0.14.0",
+ "log",
+ "mac_address",
+ "ouroboros",
+ "pgvector",
+ "rust_decimal",
+ "sea-orm-arrow",
+ "sea-orm-macros 2.0.2",
+ "sea-query 1.0.2",
+ "sea-query-sqlx",
+ "sea-schema 0.18.1",
+ "serde",
+ "serde_json",
+ "sqlx 0.9.0",
+ "sqlx-core 0.9.0",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+ "web-time",
+]
+
+[[package]]
+name = "sea-orm-arrow"
+version = "2.0.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c800d9db902534d7d01728faf98e33d13c1d57bb8c57d8e4c518309172bddda"
+dependencies = [
+ "arrow",
+ "sea-query 1.0.2",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5556,12 +5938,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da80ebcdb44571e86f03a2bdcb5532136a87397f366f38bbce64673fc5e6a450"
 dependencies = [
  "chrono",
+ "glob",
+ "regex",
+ "sea-schema 0.16.2",
+ "sqlx 0.8.6",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
+name = "sea-orm-cli"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a53505884d7c907bcf4f7b4ddb1b29425e62fef8b98aea9c99e17781cceb798"
+dependencies = [
+ "chrono",
  "clap",
  "dotenvy",
  "glob",
+ "indoc",
  "regex",
- "sea-schema",
- "sqlx",
+ "sea-schema 0.18.1",
+ "sqlx 0.9.0",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -5583,17 +5983,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "sea-orm-macros"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4039a86f9acc4d3b52747508b347dddc6fd725bbc429902ebeb6d26225fc2528"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.14.0",
+ "pluralizer",
+ "proc-macro2",
+ "quote",
+ "sea-bae",
+ "syn 2.0.117",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sea-orm-migration"
 version = "1.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07c577f2959277e936c1d08109acd1e08fc36a95ef29ec028190ba82cad8f96e"
 dependencies = [
  "async-trait",
+ "sea-orm 1.1.20",
+ "sea-orm-cli 1.1.20",
+ "sea-schema 0.16.2",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sea-orm-migration"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd09adbef87100d07131a60a8c5508b53d0cf2136521f654aae47af5e6a097fe"
+dependencies = [
+ "async-trait",
  "clap",
  "dotenvy",
- "sea-orm",
- "sea-orm-cli",
- "sea-schema",
+ "sea-orm 2.0.2",
+ "sea-orm-cli 2.0.2",
+ "sea-schema 0.18.1",
  "tracing",
  "tracing-subscriber",
 ]
@@ -5604,12 +6034,26 @@ version = "0.32.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a5d1c518eaf5eda38e5773f902b26ab6d5e9e9e2bb2349ca6c64cf96f80448c"
 dependencies = [
- "bigdecimal",
  "chrono",
  "inherent",
  "ordered-float 4.6.0",
  "rust_decimal",
- "sea-query-derive",
+ "sea-query-derive 0.4.3",
+ "serde_json",
+ "time",
+ "uuid",
+]
+
+[[package]]
+name = "sea-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "546040c653a705e60ec65ecd3191a809603734bebbc225775916dea9ae409b31"
+dependencies = [
+ "chrono",
+ "ordered-float 4.6.0",
+ "rust_decimal",
+ "sea-query-derive 1.0.0",
  "serde_json",
  "time",
  "uuid",
@@ -5621,12 +6065,11 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0019f47430f7995af63deda77e238c17323359af241233ec768aba1faea7608"
 dependencies = [
- "bigdecimal",
  "chrono",
  "rust_decimal",
- "sea-query",
+ "sea-query 0.32.7",
  "serde_json",
- "sqlx",
+ "sqlx 0.8.6",
  "time",
  "uuid",
 ]
@@ -5646,16 +6089,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "sea-query-derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0b0f466921cdd3cf4b89d5c3ac2173dba89a873ab395b123a645de181ec7537"
+dependencies = [
+ "darling 0.20.11",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sea-query-sqlx"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eaa419cdb9157da1361186b1959983eb2ea0dcb9a3c69dc45c449ecb2af8fef"
+dependencies = [
+ "sea-query 1.0.2",
+ "sqlx 0.9.0",
+]
+
+[[package]]
 name = "sea-schema"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2239ff574c04858ca77485f112afea1a15e53135d3097d0c86509cef1def1338"
 dependencies = [
  "futures",
- "sea-query",
+ "sea-query 0.32.7",
  "sea-query-binder",
  "sea-schema-derive",
- "sqlx",
+ "sqlx 0.8.6",
+]
+
+[[package]]
+name = "sea-schema"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3553c77dceed56e95bece9ea876c4dd67ca879ef51055a0b97a7bb89a8ae4fed"
+dependencies = [
+ "async-trait",
+ "sea-query 1.0.2",
+ "sea-query-sqlx",
+ "sea-schema-derive",
+ "sqlx 0.9.0",
 ]
 
 [[package]]
@@ -5945,6 +6425,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6145,11 +6636,24 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
 dependencies = [
- "sqlx-core",
- "sqlx-macros",
- "sqlx-mysql",
- "sqlx-postgres",
- "sqlx-sqlite",
+ "sqlx-core 0.8.6",
+ "sqlx-macros 0.8.6",
+ "sqlx-mysql 0.8.6",
+ "sqlx-postgres 0.8.6",
+ "sqlx-sqlite 0.8.6",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
+dependencies = [
+ "sqlx-core 0.9.0",
+ "sqlx-macros 0.9.0",
+ "sqlx-mysql 0.9.0",
+ "sqlx-postgres 0.9.0",
+ "sqlx-sqlite 0.9.0",
 ]
 
 [[package]]
@@ -6159,7 +6663,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
  "base64 0.22.1",
- "bigdecimal",
  "bytes",
  "chrono",
  "crc",
@@ -6171,11 +6674,49 @@ dependencies = [
  "futures-io",
  "futures-util",
  "hashbrown 0.15.5",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap 2.14.0",
  "log",
  "memchr",
  "once_cell",
+ "percent-encoding",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "cfg-if",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.16.1",
+ "hashlink 0.11.1",
+ "indexmap 2.14.0",
+ "log",
+ "memchr",
  "percent-encoding",
  "rust_decimal",
  "serde",
@@ -6199,8 +6740,21 @@ checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
 dependencies = [
  "proc-macro2",
  "quote",
- "sqlx-core",
- "sqlx-macros-core",
+ "sqlx-core 0.8.6",
+ "sqlx-macros-core 0.8.6",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core 0.9.0",
+ "sqlx-macros-core 0.9.0",
  "syn 2.0.117",
 ]
 
@@ -6220,10 +6774,35 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "sqlx-core",
- "sqlx-mysql",
- "sqlx-postgres",
- "sqlx-sqlite",
+ "sqlx-core 0.8.6",
+ "sqlx-mysql 0.8.6",
+ "sqlx-postgres 0.8.6",
+ "sqlx-sqlite 0.8.6",
+ "syn 2.0.117",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
+dependencies = [
+ "cfg-if",
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core 0.9.0",
+ "sqlx-mysql 0.9.0",
+ "sqlx-postgres 0.9.0",
+ "sqlx-sqlite 0.9.0",
  "syn 2.0.117",
  "tokio",
  "url",
@@ -6237,7 +6816,6 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bigdecimal",
  "bitflags",
  "byteorder",
  "bytes",
@@ -6252,11 +6830,11 @@ dependencies = [
  "futures-util",
  "generic-array",
  "hex",
- "hkdf",
+ "hkdf 0.12.4",
  "hmac 0.12.1",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "percent-encoding",
@@ -6264,16 +6842,46 @@ dependencies = [
  "rsa",
  "rust_decimal",
  "serde",
- "sha1",
+ "sha1 0.10.6",
  "sha2 0.10.9",
  "smallvec",
- "sqlx-core",
+ "sqlx-core 0.8.6",
  "stringprep",
  "thiserror 2.0.18",
  "time",
  "tracing",
  "uuid",
- "whoami",
+ "whoami 1.6.1",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest 0.11.3",
+ "dotenvy",
+ "either",
+ "futures-core",
+ "futures-util",
+ "generic-array",
+ "log",
+ "percent-encoding",
+ "rust_decimal",
+ "serde",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "sqlx-core 0.9.0",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -6284,25 +6892,23 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bigdecimal",
  "bitflags",
  "byteorder",
  "chrono",
  "crc",
  "dotenvy",
- "etcetera",
+ "etcetera 0.8.0",
  "futures-channel",
  "futures-core",
  "futures-util",
  "hex",
- "hkdf",
+ "hkdf 0.12.4",
  "hmac 0.12.1",
  "home",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
- "num-bigint 0.4.6",
  "once_cell",
  "rand 0.8.7",
  "rust_decimal",
@@ -6310,13 +6916,52 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "smallvec",
- "sqlx-core",
+ "sqlx-core 0.8.6",
  "stringprep",
  "thiserror 2.0.18",
  "time",
  "tracing",
  "uuid",
- "whoami",
+ "whoami 1.6.1",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera 0.11.0",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
+ "itoa",
+ "log",
+ "md-5 0.11.0",
+ "memchr",
+ "rand 0.10.2",
+ "rust_decimal",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "smallvec",
+ "sqlx-core 0.9.0",
+ "stringprep",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "uuid",
+ "whoami 2.1.3",
 ]
 
 [[package]]
@@ -6327,7 +6972,7 @@ checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
 dependencies = [
  "atoi",
  "chrono",
- "flume",
+ "flume 0.11.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -6338,7 +6983,34 @@ dependencies = [
  "percent-encoding",
  "serde",
  "serde_urlencoded",
- "sqlx-core",
+ "sqlx-core 0.8.6",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume 0.12.0",
+ "form_urlencoded",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "sqlx-core 0.9.0",
  "thiserror 2.0.18",
  "time",
  "tracing",
@@ -6393,6 +7065,12 @@ name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 
 [[package]]
 name = "subtle"
@@ -6502,10 +7180,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6587,6 +7265,15 @@ checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -7411,6 +8098,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "whoami"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "626c4bac6755d76ffc12cb01b2eac751db1996b9e0041de9aa02c8c211ddc82c"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7432,7 +8125,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -57,8 +57,8 @@ futures-util = { version = "0.3", default-features = false, features = ["std"] }
 axum = "0.8"
 
 # Database (MariaDB via SeaORM)
-sea-orm = { version = "1.1", features = ["runtime-tokio", "sqlx-mysql", "with-uuid", "with-chrono", "with-json", "macros"] }
-sea-orm-migration = { version = "1.1", features = ["runtime-tokio", "sqlx-mysql"] }
+sea-orm = { version = "2.0", features = ["runtime-tokio", "sqlx-mysql", "with-uuid", "with-chrono", "with-json", "macros"] }
+sea-orm-migration = { version = "2.0", features = ["runtime-tokio", "sqlx-mysql"] }
 
 # IDs and time
 uuid = { version = "1.19", features = ["serde", "v7"] }

--- a/src/backend/services/analytics/src/domain/metric_crud.rs
+++ b/src/backend/services/analytics/src/domain/metric_crud.rs
@@ -469,7 +469,7 @@ async fn insert_graph<C: ConnectionTrait>(
     let source_id = Uuid::now_v7();
     let definition_id = Uuid::now_v7();
 
-    conn.execute(Statement::from_sql_and_values(
+    conn.execute_raw(Statement::from_sql_and_values(
         conn.get_database_backend(),
         "INSERT INTO metric_sources \
             (id, tenant_id, source_key, source_kind, source_ref, observation_sql, origin, is_enabled, schema_status) \
@@ -491,7 +491,7 @@ async fn insert_graph<C: ConnectionTrait>(
     for measure in &graph.measures {
         let measure_id = Uuid::now_v7();
         measure_ids.insert(measure.as_str(), measure_id);
-        conn.execute(Statement::from_sql_and_values(
+        conn.execute_raw(Statement::from_sql_and_values(
             conn.get_database_backend(),
             "INSERT INTO metric_source_measures (id, source_id, measure_key, is_enabled) \
              VALUES (?, ?, ?, TRUE)",
@@ -508,7 +508,7 @@ async fn insert_graph<C: ConnectionTrait>(
     for (order, dimension) in graph.dimensions.iter().enumerate() {
         let dimension_id = Uuid::now_v7();
         dimension_ids.insert(dimension.as_str(), dimension_id);
-        conn.execute(Statement::from_sql_and_values(
+        conn.execute_raw(Statement::from_sql_and_values(
             conn.get_database_backend(),
             "INSERT INTO metric_source_dimensions (id, source_id, dimension_key, display_order) \
              VALUES (?, ?, ?, ?)",
@@ -522,7 +522,7 @@ async fn insert_graph<C: ConnectionTrait>(
         .await?;
     }
 
-    conn.execute(Statement::from_sql_and_values(
+    conn.execute_raw(Statement::from_sql_and_values(
         conn.get_database_backend(),
         "INSERT INTO metric_definitions \
             (id, tenant_id, metric_key, label, short_label, subject, description, explanation, unit, \
@@ -561,7 +561,7 @@ async fn insert_graph<C: ConnectionTrait>(
                 input.measure_key
             ))
         })?;
-        conn.execute(Statement::from_sql_and_values(
+        conn.execute_raw(Statement::from_sql_and_values(
             conn.get_database_backend(),
             "INSERT INTO metric_definition_inputs \
                 (id, metric_definition_id, input_role, source_measure_id) \
@@ -582,7 +582,7 @@ async fn insert_graph<C: ConnectionTrait>(
                 "dimension {dimension} missing from source dimensions"
             ))
         })?;
-        conn.execute(Statement::from_sql_and_values(
+        conn.execute_raw(Statement::from_sql_and_values(
             conn.get_database_backend(),
             "INSERT INTO metric_definition_dimensions \
                 (id, metric_definition_id, source_dimension_id, display_order) \
@@ -598,7 +598,7 @@ async fn insert_graph<C: ConnectionTrait>(
     }
 
     for (order, tag) in graph.tags.iter().enumerate() {
-        conn.execute(Statement::from_sql_and_values(
+        conn.execute_raw(Statement::from_sql_and_values(
             conn.get_database_backend(),
             "INSERT INTO metric_definition_tags \
                 (id, metric_definition_id, tag, display_order) \
@@ -636,14 +636,14 @@ async fn delete_graph<C: ConnectionTrait>(
         .await?
         .map(|source| source.source_id);
 
-    conn.execute(Statement::from_sql_and_values(
+    conn.execute_raw(Statement::from_sql_and_values(
         conn.get_database_backend(),
         "DELETE FROM metric_definitions WHERE id = ?",
         [uuid_value(definition_id)],
     ))
     .await?;
     if let Some(source_id) = source_id {
-        conn.execute(Statement::from_sql_and_values(
+        conn.execute_raw(Statement::from_sql_and_values(
             conn.get_database_backend(),
             "DELETE FROM metric_sources WHERE id = ? AND origin = 'custom'",
             [uuid_value(source_id)],
@@ -1008,7 +1008,7 @@ async fn exists<C: ConnectionTrait>(
     values: Vec<Value>,
 ) -> Result<bool, DbErr> {
     Ok(conn
-        .query_one(Statement::from_sql_and_values(
+        .query_one_raw(Statement::from_sql_and_values(
             conn.get_database_backend(),
             sql,
             values,
@@ -1018,7 +1018,7 @@ async fn exists<C: ConnectionTrait>(
 }
 
 fn uuid_value(id: Uuid) -> Value {
-    Value::Bytes(Some(Box::new(id.as_bytes().to_vec())))
+    Value::Bytes(Some(id.as_bytes().to_vec()))
 }
 
 fn order_value(idx: usize) -> i32 {

--- a/src/backend/services/analytics/src/domain/metric_crud_live_tests.rs
+++ b/src/backend/services/analytics/src/domain/metric_crud_live_tests.rs
@@ -330,7 +330,7 @@ async fn definition_with_no_inputs_is_still_deletable() -> R {
     // the definition's input rows out of band. The definition is now
     // unreachable through the inputs join, but it must not become a listed,
     // unremovable ghost.
-    db.execute(Statement::from_sql_and_values(
+    db.execute_raw(Statement::from_sql_and_values(
         db.get_database_backend(),
         "DELETE i FROM metric_definition_inputs i \
          INNER JOIN metric_definitions d ON d.id = i.metric_definition_id \
@@ -351,7 +351,7 @@ async fn definition_with_no_inputs_is_still_deletable() -> R {
 /// least one is guaranteed to exist.
 async fn a_builtin_metric_key(db: &DatabaseConnection) -> Result<String, sea_orm::DbErr> {
     let row = db
-        .query_one(Statement::from_string(
+        .query_one_raw(Statement::from_string(
             db.get_database_backend(),
             "SELECT metric_key FROM metric_definitions \
              WHERE origin = 'builtin' AND tenant_id IS NULL LIMIT 1",

--- a/src/backend/services/analytics/src/domain/metric_definitions/listing.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/listing.rs
@@ -11,7 +11,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use sea_orm::{ConnectionTrait, DatabaseConnection, FromQueryResult, Statement, Value};
+use sea_orm::{DatabaseConnection, FromQueryResult, Statement, Value};
 use serde::Serialize;
 use toolkit_canonical_errors::CanonicalError;
 use uuid::Uuid;
@@ -270,7 +270,7 @@ async fn fetch_listing_rows(
          FROM metric_definitions d \
          WHERE d.tenant_id IS NULL OR d.tenant_id = ? \
          ORDER BY d.metric_key",
-        [Value::Bytes(Some(Box::new(tenant_id.as_bytes().to_vec())))],
+        [Value::Bytes(Some(tenant_id.as_bytes().to_vec()))],
     ))
     .all(db)
     .await

--- a/src/backend/services/analytics/src/domain/metric_definitions/live_tests.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/live_tests.rs
@@ -42,7 +42,7 @@ async fn connect_or_skip() -> Option<DatabaseConnection> {
 /// one is guaranteed to exist.
 async fn a_product_metric_key(db: &DatabaseConnection) -> Result<String, sea_orm::DbErr> {
     let row = db
-        .query_one(Statement::from_string(
+        .query_one_raw(Statement::from_string(
             db.get_database_backend(),
             "SELECT metric_key FROM metric_definitions WHERE tenant_id IS NULL LIMIT 1",
         ))
@@ -60,14 +60,14 @@ async fn insert_definition(
     label: &str,
 ) -> Result<Uuid, sea_orm::DbErr> {
     let id = Uuid::now_v7();
-    db.execute(Statement::from_sql_and_values(
+    db.execute_raw(Statement::from_sql_and_values(
         db.get_database_backend(),
         "INSERT INTO metric_definitions \
             (id, tenant_id, metric_key, label, format, direction, entity_type, computation_type, origin) \
          VALUES (?, ?, ?, ?, 'integer', 'higher_is_better', 'person', 'sum', 'custom')",
         [
-            Value::Bytes(Some(Box::new(id.as_bytes().to_vec()))),
-            Value::Bytes(Some(Box::new(tenant.as_bytes().to_vec()))),
+            Value::Bytes(Some(id.as_bytes().to_vec())),
+            Value::Bytes(Some(tenant.as_bytes().to_vec())),
             Value::from(metric_key),
             Value::from(label),
         ],
@@ -81,10 +81,10 @@ async fn stored_last_observed(
     id: Uuid,
 ) -> Result<Option<chrono::NaiveDate>, sea_orm::DbErr> {
     let row = db
-        .query_one(Statement::from_sql_and_values(
+        .query_one_raw(Statement::from_sql_and_values(
             db.get_database_backend(),
             "SELECT last_observed_date FROM metric_definitions WHERE id = ?",
-            [Value::Bytes(Some(Box::new(id.as_bytes().to_vec())))],
+            [Value::Bytes(Some(id.as_bytes().to_vec()))],
         ))
         .await?
         .ok_or_else(|| sea_orm::DbErr::Custom("definition disappeared".to_owned()))?;
@@ -284,12 +284,12 @@ async fn invalid_evidence_reference_is_an_error_not_unchecked() -> anyhow::Resul
     };
     let fixture = DrilldownFixture::insert(&db, &["git.commits"], &[]).await?;
     let result = async {
-        db.execute(Statement::from_sql_and_values(
+        db.execute_raw(Statement::from_sql_and_values(
             db.get_database_backend(),
             "UPDATE metric_sources SET evidence_ref = ? WHERE id = ?",
             [
                 Value::from("Not A Relation"),
-                Value::Bytes(Some(Box::new(fixture.source_id.as_bytes().to_vec()))),
+                Value::Bytes(Some(fixture.source_id.as_bytes().to_vec())),
             ],
         ))
         .await?;

--- a/src/backend/services/analytics/src/domain/metric_definitions/repository.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/repository.rs
@@ -238,7 +238,7 @@ async fn fetch_definition_rows(
     );
 
     let mut values = metric_keys.iter().map(Value::from).collect::<Vec<_>>();
-    values.push(Value::Bytes(Some(Box::new(tenant_id.as_bytes().to_vec()))));
+    values.push(Value::Bytes(Some(tenant_id.as_bytes().to_vec())));
 
     DefinitionRow::find_by_statement(Statement::from_sql_and_values(
         db.get_database_backend(),
@@ -279,7 +279,7 @@ async fn fetch_input_rows(
     );
     let values = definition_ids
         .iter()
-        .map(|id| Value::Bytes(Some(Box::new(id.as_bytes().to_vec()))))
+        .map(|id| Value::Bytes(Some(id.as_bytes().to_vec())))
         .collect::<Vec<_>>();
 
     InputRow::find_by_statement(Statement::from_sql_and_values(
@@ -434,7 +434,7 @@ pub(super) async fn fetch_dimensions(
     );
     let values = definition_ids
         .iter()
-        .map(|id| Value::Bytes(Some(Box::new(id.as_bytes().to_vec()))))
+        .map(|id| Value::Bytes(Some(id.as_bytes().to_vec())))
         .collect::<Vec<_>>();
 
     DimensionRow::find_by_statement(Statement::from_sql_and_values(
@@ -474,7 +474,7 @@ pub(super) async fn fetch_tags(
     );
     let values = definition_ids
         .iter()
-        .map(|id| Value::Bytes(Some(Box::new(id.as_bytes().to_vec()))))
+        .map(|id| Value::Bytes(Some(id.as_bytes().to_vec())))
         .collect::<Vec<_>>();
 
     TagRow::find_by_statement(Statement::from_sql_and_values(
@@ -672,7 +672,7 @@ pub async fn update_evidence_status(
     error_code: Option<MetricSchemaErrorCode>,
 ) -> Result<(), sea_orm::DbErr> {
     let result = db
-        .execute(Statement::from_sql_and_values(
+        .execute_raw(Statement::from_sql_and_values(
             db.get_database_backend(),
             "UPDATE metric_sources \
          SET evidence_schema_status = ?, \
@@ -709,7 +709,7 @@ pub async fn update_source_status(
     error_code: Option<MetricSchemaErrorCode>,
 ) -> Result<(), sea_orm::DbErr> {
     let result = db
-        .execute(Statement::from_sql_and_values(
+        .execute_raw(Statement::from_sql_and_values(
             db.get_database_backend(),
             "UPDATE metric_sources \
          SET schema_status = ?, \
@@ -744,7 +744,7 @@ pub async fn update_definitions_for_source_status(
     status: SchemaStatus,
     error_code: Option<MetricSchemaErrorCode>,
 ) -> Result<(), sea_orm::DbErr> {
-    db.execute(Statement::from_sql_and_values(
+    db.execute_raw(Statement::from_sql_and_values(
         db.get_database_backend(),
         "UPDATE metric_definitions \
          SET schema_status = ?, \
@@ -763,7 +763,7 @@ pub async fn update_definitions_for_source_status(
                 Some(code) => Value::from(code.as_db()),
                 None => Value::String(None),
             },
-            Value::Bytes(Some(Box::new(source_id.as_bytes().to_vec()))),
+            Value::Bytes(Some(source_id.as_bytes().to_vec())),
         ],
     ))
     .await?;
@@ -785,7 +785,7 @@ pub async fn update_definition_status(
         Some(date) => Value::from(date.to_string()),
         None => Value::String(None),
     };
-    db.execute(Statement::from_sql_and_values(
+    db.execute_raw(Statement::from_sql_and_values(
         db.get_database_backend(),
         "UPDATE metric_definitions \
          SET schema_status = ?, \
@@ -814,7 +814,7 @@ pub async fn update_definition_status(
 }
 
 fn uuid_value(value: Uuid) -> Value {
-    Value::Bytes(Some(Box::new(value.as_bytes().to_vec())))
+    Value::Bytes(Some(value.as_bytes().to_vec()))
 }
 
 fn unavailable(metric_key: &str) -> CanonicalError {

--- a/src/backend/services/analytics/src/domain/metric_definitions/seeds.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/seeds.rs
@@ -38,7 +38,7 @@ async fn reconcile_source(
     let source_id = fetch_source_id(db, &builtin_source.source.key).await?;
 
     for measure in &builtin_source.measures {
-        db.execute(Statement::from_sql_and_values(
+        db.execute_raw(Statement::from_sql_and_values(
             db.get_database_backend(),
             "INSERT INTO metric_source_measures \
                 (id, source_id, measure_key, evidence_granularity, is_enabled) \
@@ -57,7 +57,7 @@ async fn reconcile_source(
     }
 
     for (idx, dimension_key) in builtin_source.dimensions.iter().enumerate() {
-        db.execute(Statement::from_sql_and_values(
+        db.execute_raw(Statement::from_sql_and_values(
             db.get_database_backend(),
             "INSERT INTO metric_source_dimensions \
                 (id, source_id, dimension_key, display_order) \
@@ -81,7 +81,7 @@ async fn upsert_source(
     db: &DatabaseConnection,
     builtin_source: &BuiltinSource,
 ) -> Result<(), DbErr> {
-    db.execute(Statement::from_sql_and_values(
+    db.execute_raw(Statement::from_sql_and_values(
         db.get_database_backend(),
         "INSERT INTO metric_sources \
             (id, tenant_id, source_key, source_kind, source_ref, evidence_ref, origin, is_enabled) \
@@ -105,7 +105,7 @@ async fn upsert_source(
 }
 
 async fn upsert_metric(db: &impl ConnectionTrait, metric: &MetricSeed) -> Result<(), DbErr> {
-    db.execute(Statement::from_sql_and_values(
+    db.execute_raw(Statement::from_sql_and_values(
         db.get_database_backend(),
         "INSERT INTO metric_definitions \
             (id, tenant_id, metric_key, label, short_label, subject, description, explanation, unit, format, direction, entity_type, \
@@ -167,7 +167,7 @@ async fn replace_inputs(
     metric_id: Uuid,
     inputs: &[InputSeed],
 ) -> Result<(), DbErr> {
-    db.execute(Statement::from_sql_and_values(
+    db.execute_raw(Statement::from_sql_and_values(
         db.get_database_backend(),
         "DELETE FROM metric_definition_inputs WHERE metric_definition_id = ?",
         [uuid_value(metric_id)],
@@ -176,7 +176,7 @@ async fn replace_inputs(
 
     for input in inputs {
         let measure_id = fetch_measure_id(db, source_id, &input.measure_key).await?;
-        db.execute(Statement::from_sql_and_values(
+        db.execute_raw(Statement::from_sql_and_values(
             db.get_database_backend(),
             "INSERT INTO metric_definition_inputs \
                 (id, metric_definition_id, input_role, source_measure_id) \
@@ -199,7 +199,7 @@ async fn replace_dimensions(
     metric_id: Uuid,
     dimensions: &[String],
 ) -> Result<(), DbErr> {
-    db.execute(Statement::from_sql_and_values(
+    db.execute_raw(Statement::from_sql_and_values(
         db.get_database_backend(),
         "DELETE FROM metric_definition_dimensions WHERE metric_definition_id = ?",
         [uuid_value(metric_id)],
@@ -208,7 +208,7 @@ async fn replace_dimensions(
 
     for (idx, dimension) in dimensions.iter().enumerate() {
         let dimension_id = fetch_source_dimension_id(db, source_id, dimension).await?;
-        db.execute(Statement::from_sql_and_values(
+        db.execute_raw(Statement::from_sql_and_values(
             db.get_database_backend(),
             "INSERT INTO metric_definition_dimensions \
                 (id, metric_definition_id, source_dimension_id, display_order) \
@@ -230,7 +230,7 @@ async fn replace_tags(
     metric_id: Uuid,
     tags: &[String],
 ) -> Result<(), DbErr> {
-    db.execute(Statement::from_sql_and_values(
+    db.execute_raw(Statement::from_sql_and_values(
         db.get_database_backend(),
         "DELETE FROM metric_definition_tags WHERE metric_definition_id = ?",
         [uuid_value(metric_id)],
@@ -238,7 +238,7 @@ async fn replace_tags(
     .await?;
 
     for (idx, tag) in tags.iter().enumerate() {
-        db.execute(Statement::from_sql_and_values(
+        db.execute_raw(Statement::from_sql_and_values(
             db.get_database_backend(),
             "INSERT INTO metric_definition_tags \
                 (id, metric_definition_id, tag, display_order) \
@@ -301,7 +301,7 @@ async fn disable_missing_builtin_rows(db: &DatabaseConnection) -> Result<(), DbE
 
         let mut values = vec![uuid_value(source_id)];
         values.extend(measure_keys.iter().map(|key| Value::from(*key)));
-        db.execute(Statement::from_sql_and_values(
+        db.execute_raw(Statement::from_sql_and_values(
             db.get_database_backend(),
             sql,
             values,
@@ -325,7 +325,7 @@ async fn disable_missing(
         format!("{base_sql} AND {key_column} NOT IN ({placeholders})")
     };
     let values = keys.iter().map(|key| Value::from(*key)).collect::<Vec<_>>();
-    db.execute(Statement::from_sql_and_values(
+    db.execute_raw(Statement::from_sql_and_values(
         db.get_database_backend(),
         sql,
         values,
@@ -389,7 +389,7 @@ async fn fetch_uuid(
     key: &str,
 ) -> Result<Uuid, DbErr> {
     let row = db
-        .query_one(Statement::from_sql_and_values(
+        .query_one_raw(Statement::from_sql_and_values(
             db.get_database_backend(),
             sql,
             values.to_vec(),
@@ -404,7 +404,7 @@ fn order_value(idx: usize) -> i32 {
 }
 
 fn uuid_value(id: Uuid) -> Value {
-    Value::Bytes(Some(Box::new(id.as_bytes().to_vec())))
+    Value::Bytes(Some(id.as_bytes().to_vec()))
 }
 
 fn nullable_str(value: Option<&str>) -> Value {

--- a/src/backend/services/analytics/src/domain/metric_definitions/test_fixture.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/test_fixture.rs
@@ -20,7 +20,7 @@ impl DrilldownFixture {
         let source_ref = format!("test_{suffix}_metric_observations");
         let evidence_ref = format!("test_{suffix}_metric_evidence");
 
-        db.execute(Statement::from_sql_and_values(
+        db.execute_raw(Statement::from_sql_and_values(
             db.get_database_backend(),
             "INSERT INTO metric_sources \
                 (id, tenant_id, source_key, source_kind, source_ref, evidence_ref, origin, \
@@ -35,7 +35,7 @@ impl DrilldownFixture {
             ],
         ))
         .await?;
-        db.execute(Statement::from_sql_and_values(
+        db.execute_raw(Statement::from_sql_and_values(
             db.get_database_backend(),
             "INSERT INTO metric_source_measures \
                 (id, source_id, measure_key, evidence_granularity, schema_status) \
@@ -47,7 +47,7 @@ impl DrilldownFixture {
         let source_dimensions = insert_dimensions(db, source_id, dimensions).await?;
         insert_definitions(db, tenant_id, measure_id, metric_keys, &source_dimensions).await?;
 
-        db.execute(Statement::from_sql_and_values(
+        db.execute_raw(Statement::from_sql_and_values(
             db.get_database_backend(),
             "UPDATE metric_sources \
              SET schema_status = 'ok', schema_error_code = NULL, \
@@ -65,13 +65,13 @@ impl DrilldownFixture {
     }
 
     pub(crate) async fn delete(self, db: &DatabaseConnection) -> Result<(), sea_orm::DbErr> {
-        db.execute(Statement::from_sql_and_values(
+        db.execute_raw(Statement::from_sql_and_values(
             db.get_database_backend(),
             "DELETE FROM metric_definitions WHERE tenant_id = ?",
             [uuid_value(self.tenant_id)],
         ))
         .await?;
-        db.execute(Statement::from_sql_and_values(
+        db.execute_raw(Statement::from_sql_and_values(
             db.get_database_backend(),
             "DELETE FROM metric_sources WHERE id = ?",
             [uuid_value(self.source_id)],
@@ -85,7 +85,7 @@ impl DrilldownFixture {
         db: &DatabaseConnection,
     ) -> Result<String, sea_orm::DbErr> {
         let row = db
-            .query_one(Statement::from_sql_and_values(
+            .query_one_raw(Statement::from_sql_and_values(
                 db.get_database_backend(),
                 "SELECT DATE_FORMAT(updated_at, '%Y-%m-%d %H:%i:%s.%f') AS config_revision \
                  FROM metric_sources WHERE id = ?",
@@ -101,7 +101,7 @@ impl DrilldownFixture {
         db: &DatabaseConnection,
     ) -> Result<(String, String, Option<String>), sea_orm::DbErr> {
         let row = db
-            .query_one(Statement::from_sql_and_values(
+            .query_one_raw(Statement::from_sql_and_values(
                 db.get_database_backend(),
                 "SELECT schema_status, evidence_schema_status, evidence_schema_error_code \
                  FROM metric_sources WHERE id = ?",
@@ -126,7 +126,7 @@ async fn insert_dimensions(
     for (display_order, dimension) in dimensions.iter().enumerate() {
         let display_order = checked_display_order(display_order)?;
         let dimension_id = Uuid::now_v7();
-        db.execute(Statement::from_sql_and_values(
+        db.execute_raw(Statement::from_sql_and_values(
             db.get_database_backend(),
             "INSERT INTO metric_source_dimensions \
                 (id, source_id, dimension_key, display_order) \
@@ -153,7 +153,7 @@ async fn insert_definitions(
 ) -> Result<(), sea_orm::DbErr> {
     for metric_key in metric_keys {
         let definition_id = Uuid::now_v7();
-        db.execute(Statement::from_sql_and_values(
+        db.execute_raw(Statement::from_sql_and_values(
             db.get_database_backend(),
             "INSERT INTO metric_definitions \
                 (id, tenant_id, metric_key, label, format, direction, entity_type, \
@@ -168,7 +168,7 @@ async fn insert_definitions(
             ],
         ))
         .await?;
-        db.execute(Statement::from_sql_and_values(
+        db.execute_raw(Statement::from_sql_and_values(
             db.get_database_backend(),
             "INSERT INTO metric_definition_inputs \
                 (id, metric_definition_id, input_role, source_measure_id) \
@@ -192,7 +192,7 @@ async fn insert_definition_dimensions(
 ) -> Result<(), sea_orm::DbErr> {
     for (display_order, dimension_id) in source_dimensions.iter().enumerate() {
         let display_order = checked_display_order(display_order)?;
-        db.execute(Statement::from_sql_and_values(
+        db.execute_raw(Statement::from_sql_and_values(
             db.get_database_backend(),
             "INSERT INTO metric_definition_dimensions \
                 (id, metric_definition_id, source_dimension_id, display_order) \
@@ -214,5 +214,5 @@ fn checked_display_order(value: usize) -> Result<i32, sea_orm::DbErr> {
 }
 
 fn uuid_value(value: Uuid) -> Value {
-    Value::Bytes(Some(Box::new(value.as_bytes().to_vec())))
+    Value::Bytes(Some(value.as_bytes().to_vec()))
 }

--- a/src/backend/services/analytics/src/domain/metric_definitions/validator.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/validator.rs
@@ -1227,7 +1227,7 @@ mod tests {
     #[tokio::test]
     async fn custom_observation_sql_sources_are_never_probed() {
         let validator = MetricDefinitionValidator::new(
-            sea_orm::DatabaseConnection::Disconnected,
+            sea_orm::DatabaseConnection::default(),
             insight_clickhouse::Client::new(insight_clickhouse::Config::new(
                 "http://unused",
                 "silver",
@@ -1259,7 +1259,7 @@ mod tests {
         }]));
 
         let validator = MetricDefinitionValidator::new(
-            sea_orm::DatabaseConnection::Disconnected,
+            sea_orm::DatabaseConnection::default(),
             insight_clickhouse::Client::new(insight_clickhouse::Config::new(mock.url(), "silver")),
         );
         let evidence = EvidenceRelation::parse("git_metric_evidence")

--- a/src/backend/services/analytics/src/domain/metric_drilldown/capability.rs
+++ b/src/backend/services/analytics/src/domain/metric_drilldown/capability.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeMap, HashMap};
 
-use sea_orm::{ConnectionTrait, DatabaseConnection, FromQueryResult, Statement, Value};
+use sea_orm::{DatabaseConnection, FromQueryResult, Statement, Value};
 use toolkit_canonical_errors::CanonicalError;
 use uuid::Uuid;
 
@@ -56,7 +56,7 @@ pub async fn load_capabilities(
          ORDER BY d.metric_key, i.input_role, m.measure_key"
     );
     let mut values = metric_keys.iter().map(Value::from).collect::<Vec<_>>();
-    values.push(Value::Bytes(Some(Box::new(tenant_id.as_bytes().to_vec()))));
+    values.push(Value::Bytes(Some(tenant_id.as_bytes().to_vec())));
     let rows = CapabilityRow::find_by_statement(Statement::from_sql_and_values(
         db.get_database_backend(),
         sql,

--- a/src/backend/services/analytics/src/domain/metric_drilldown/validation.rs
+++ b/src/backend/services/analytics/src/domain/metric_drilldown/validation.rs
@@ -1,4 +1,4 @@
-use sea_orm::{ConnectionTrait, DatabaseConnection, FromQueryResult, Statement, Value};
+use sea_orm::{DatabaseConnection, FromQueryResult, Statement, Value};
 use toolkit_canonical_errors::CanonicalError;
 use uuid::Uuid;
 
@@ -259,9 +259,7 @@ async fn load_evidence_plan(
          INNER JOIN metric_sources s ON s.id = m.source_id \
          WHERE i.metric_definition_id = ? AND m.is_enabled = TRUE AND s.is_enabled = TRUE \
          ORDER BY i.input_role, m.measure_key",
-        [Value::Bytes(Some(Box::new(
-            definition_id.as_bytes().to_vec(),
-        )))],
+        [Value::Bytes(Some(definition_id.as_bytes().to_vec()))],
     ))
     .all(db)
     .await

--- a/src/backend/services/analytics/src/infra/db/check_probe.rs
+++ b/src/backend/services/analytics/src/infra/db/check_probe.rs
@@ -27,7 +27,7 @@
 //! single error so a single bad deploy doesn't require N restarts to surface
 //! all gaps.
 
-use sea_orm::{ConnectionTrait, DatabaseConnection, FromQueryResult, Statement, Value};
+use sea_orm::{DatabaseConnection, FromQueryResult, Statement, Value};
 
 use crate::migration::REQUIRED_CHECKS_BY_TABLE;
 

--- a/src/backend/services/analytics/src/migration/m20260527_000001_seed_metric_catalog.rs
+++ b/src/backend/services/analytics/src/migration/m20260527_000001_seed_metric_catalog.rs
@@ -1132,11 +1132,11 @@ impl MigrationTrait for Migration {
             let threshold_id = Uuid::now_v7();
             let source_tags_json_str = source_tags_json(row.source_tags);
 
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_CATALOG_SQL,
                 [
-                    Value::Bytes(Some(Box::new(catalog_id.as_bytes().to_vec()))),
+                    Value::Bytes(Some(catalog_id.as_bytes().to_vec())),
                     Value::from(row.metric_key),
                     Value::from(row.label),
                     nullable_str_value(row.sublabel),
@@ -1150,11 +1150,11 @@ impl MigrationTrait for Migration {
             ))
             .await?;
 
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_THRESHOLD_SQL,
                 [
-                    Value::Bytes(Some(Box::new(threshold_id.as_bytes().to_vec()))),
+                    Value::Bytes(Some(threshold_id.as_bytes().to_vec())),
                     Value::from(row.metric_key),
                     Value::from(row.good),
                     Value::from(row.warn),

--- a/src/backend/services/analytics/src/migration/m20260529_000001_metric_query_catalog_link.rs
+++ b/src/backend/services/analytics/src/migration/m20260529_000001_metric_query_catalog_link.rs
@@ -252,7 +252,7 @@ impl MigrationTrait for Migration {
         let backend = manager.get_database_backend();
 
         for (metrics_hex, table_prefix) in QUERY_TO_CATALOG_PREFIX {
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_LINKS_FOR_METRICS_SQL,
                 [Value::from(*metrics_hex), Value::from(*table_prefix)],

--- a/src/backend/services/analytics/src/migration/m20260601_000002_seed_claude_team_metrics_catalog.rs
+++ b/src/backend/services/analytics/src/migration/m20260601_000002_seed_claude_team_metrics_catalog.rs
@@ -168,11 +168,11 @@ impl MigrationTrait for Migration {
             let threshold_id = Uuid::now_v7();
             let source_tags_json_str = source_tags_json(row.source_tags);
 
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_CATALOG_SQL,
                 [
-                    Value::Bytes(Some(Box::new(catalog_id.as_bytes().to_vec()))),
+                    Value::Bytes(Some(catalog_id.as_bytes().to_vec())),
                     Value::from(row.metric_key),
                     Value::from(row.label),
                     nullable_str_value(row.sublabel),
@@ -186,11 +186,11 @@ impl MigrationTrait for Migration {
             ))
             .await?;
 
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_THRESHOLD_SQL,
                 [
-                    Value::Bytes(Some(Box::new(threshold_id.as_bytes().to_vec()))),
+                    Value::Bytes(Some(threshold_id.as_bytes().to_vec())),
                     Value::from(row.metric_key),
                     Value::from(row.good),
                     Value::from(row.warn),

--- a/src/backend/services/analytics/src/migration/m20260603_000001_seed_crm_metric_catalog.rs
+++ b/src/backend/services/analytics/src/migration/m20260603_000001_seed_crm_metric_catalog.rs
@@ -249,11 +249,11 @@ impl MigrationTrait for Migration {
             let threshold_id = Uuid::now_v7();
             let source_tags_json_str = source_tags_json(row.source_tags);
 
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_CATALOG_SQL,
                 [
-                    Value::Bytes(Some(Box::new(catalog_id.as_bytes().to_vec()))),
+                    Value::Bytes(Some(catalog_id.as_bytes().to_vec())),
                     Value::from(row.metric_key),
                     Value::from(row.label),
                     nullable_str_value(row.sublabel),
@@ -267,11 +267,11 @@ impl MigrationTrait for Migration {
             ))
             .await?;
 
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_THRESHOLD_SQL,
                 [
-                    Value::Bytes(Some(Box::new(threshold_id.as_bytes().to_vec()))),
+                    Value::Bytes(Some(threshold_id.as_bytes().to_vec())),
                     Value::from(row.metric_key),
                     Value::from(row.good),
                     Value::from(row.warn),

--- a/src/backend/services/analytics/src/migration/m20260603_000002_link_crm_query_catalog.rs
+++ b/src/backend/services/analytics/src/migration/m20260603_000002_link_crm_query_catalog.rs
@@ -84,7 +84,7 @@ impl MigrationTrait for Migration {
         for (metrics_hex, bare_keys) in CRM_QUERY_LINKS {
             for bare_key in *bare_keys {
                 let full_key = format!("{CRM_TABLE_PREFIX}.{bare_key}");
-                conn.execute(Statement::from_sql_and_values(
+                conn.execute_raw(Statement::from_sql_and_values(
                     backend,
                     INSERT_LINK_SQL,
                     [Value::from(*metrics_hex), Value::from(full_key)],

--- a/src/backend/services/analytics/src/migration/m20260609_000002_seed_chatgpt_team_metrics_catalog.rs
+++ b/src/backend/services/analytics/src/migration/m20260609_000002_seed_chatgpt_team_metrics_catalog.rs
@@ -186,11 +186,11 @@ impl MigrationTrait for Migration {
             let threshold_id = Uuid::now_v7();
             let source_tags_json_str = source_tags_json(row.source_tags);
 
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_CATALOG_SQL,
                 [
-                    Value::Bytes(Some(Box::new(catalog_id.as_bytes().to_vec()))),
+                    Value::Bytes(Some(catalog_id.as_bytes().to_vec())),
                     Value::from(row.metric_key),
                     Value::from(row.label),
                     nullable_str_value(row.sublabel),
@@ -204,11 +204,11 @@ impl MigrationTrait for Migration {
             ))
             .await?;
 
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_THRESHOLD_SQL,
                 [
-                    Value::Bytes(Some(Box::new(threshold_id.as_bytes().to_vec()))),
+                    Value::Bytes(Some(threshold_id.as_bytes().to_vec())),
                     Value::from(row.metric_key),
                     Value::from(row.good),
                     Value::from(row.warn),

--- a/src/backend/services/analytics/src/migration/m20260612_000002_seed_support_catalog.rs
+++ b/src/backend/services/analytics/src/migration/m20260612_000002_seed_support_catalog.rs
@@ -152,11 +152,11 @@ impl MigrationTrait for Migration {
         let conn = manager.get_connection();
         let backend = manager.get_database_backend();
         for row in SEEDS {
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_CATALOG_SQL,
                 [
-                    Value::Bytes(Some(Box::new(Uuid::now_v7().as_bytes().to_vec()))),
+                    Value::Bytes(Some(Uuid::now_v7().as_bytes().to_vec())),
                     Value::from(row.metric_key),
                     Value::from(row.label),
                     nullable_str(row.sublabel),
@@ -168,11 +168,11 @@ impl MigrationTrait for Migration {
                 ],
             ))
             .await?;
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_THRESHOLD_SQL,
                 [
-                    Value::Bytes(Some(Box::new(Uuid::now_v7().as_bytes().to_vec()))),
+                    Value::Bytes(Some(Uuid::now_v7().as_bytes().to_vec())),
                     Value::from(row.metric_key),
                     Value::from(row.good),
                     Value::from(row.warn),

--- a/src/backend/services/analytics/src/migration/m20260612_000003_link_support_query_catalog.rs
+++ b/src/backend/services/analytics/src/migration/m20260612_000003_link_support_query_catalog.rs
@@ -50,7 +50,7 @@ impl MigrationTrait for Migration {
         for (metrics_hex, bare_keys) in SUPPORT_QUERY_LINKS {
             for bare_key in *bare_keys {
                 let full_key = format!("{SUPPORT_TABLE_PREFIX}.{bare_key}");
-                conn.execute(Statement::from_sql_and_values(
+                conn.execute_raw(Statement::from_sql_and_values(
                     backend,
                     INSERT_LINK_SQL,
                     [Value::from(*metrics_hex), Value::from(full_key)],

--- a/src/backend/services/analytics/src/migration/m20260618_000002_seed_claude_team_overage_catalog.rs
+++ b/src/backend/services/analytics/src/migration/m20260618_000002_seed_claude_team_overage_catalog.rs
@@ -119,11 +119,11 @@ impl MigrationTrait for Migration {
             let threshold_id = Uuid::now_v7();
             let source_tags_json_str = source_tags_json(row.source_tags);
 
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_CATALOG_SQL,
                 [
-                    Value::Bytes(Some(Box::new(catalog_id.as_bytes().to_vec()))),
+                    Value::Bytes(Some(catalog_id.as_bytes().to_vec())),
                     Value::from(row.metric_key),
                     Value::from(row.label),
                     nullable_str_value(row.sublabel),
@@ -137,11 +137,11 @@ impl MigrationTrait for Migration {
             ))
             .await?;
 
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_THRESHOLD_SQL,
                 [
-                    Value::Bytes(Some(Box::new(threshold_id.as_bytes().to_vec()))),
+                    Value::Bytes(Some(threshold_id.as_bytes().to_vec())),
                     Value::from(row.metric_key),
                     Value::from(row.good),
                     Value::from(row.warn),

--- a/src/backend/services/analytics/src/migration/m20260620_000002_seed_wiki_catalog.rs
+++ b/src/backend/services/analytics/src/migration/m20260620_000002_seed_wiki_catalog.rs
@@ -151,11 +151,11 @@ impl MigrationTrait for Migration {
             let threshold_id = Uuid::now_v7();
             let source_tags_json_str = source_tags_json(row.source_tags);
 
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_CATALOG_SQL,
                 [
-                    Value::Bytes(Some(Box::new(catalog_id.as_bytes().to_vec()))),
+                    Value::Bytes(Some(catalog_id.as_bytes().to_vec())),
                     Value::from(row.metric_key),
                     Value::from(row.label),
                     nullable_str_value(row.sublabel),
@@ -169,11 +169,11 @@ impl MigrationTrait for Migration {
             ))
             .await?;
 
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_THRESHOLD_SQL,
                 [
-                    Value::Bytes(Some(Box::new(threshold_id.as_bytes().to_vec()))),
+                    Value::Bytes(Some(threshold_id.as_bytes().to_vec())),
                     Value::from(row.metric_key),
                     Value::from(row.good),
                     Value::from(row.warn),

--- a/src/backend/services/analytics/src/migration/m20260623_000002_seed_ai_personal_metric_catalog.rs
+++ b/src/backend/services/analytics/src/migration/m20260623_000002_seed_ai_personal_metric_catalog.rs
@@ -184,11 +184,11 @@ impl MigrationTrait for Migration {
 
         for row in SEEDS {
             let catalog_id = Uuid::now_v7();
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_CATALOG_SQL,
                 [
-                    Value::Bytes(Some(Box::new(catalog_id.as_bytes().to_vec()))),
+                    Value::Bytes(Some(catalog_id.as_bytes().to_vec())),
                     Value::from(row.metric_key),
                     Value::from(row.label),
                     nullable_str_value(row.sublabel),
@@ -202,11 +202,11 @@ impl MigrationTrait for Migration {
             .await?;
 
             let threshold_id = Uuid::now_v7();
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_THRESHOLD_SQL,
                 [
-                    Value::Bytes(Some(Box::new(threshold_id.as_bytes().to_vec()))),
+                    Value::Bytes(Some(threshold_id.as_bytes().to_vec())),
                     Value::from(row.metric_key),
                     Value::from(row.good),
                     Value::from(row.warn),
@@ -214,7 +214,7 @@ impl MigrationTrait for Migration {
             ))
             .await?;
 
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_LINK_SQL,
                 [

--- a/src/backend/services/analytics/src/migration/m20260624_000002_seed_zulip_collab_catalog.rs
+++ b/src/backend/services/analytics/src/migration/m20260624_000002_seed_zulip_collab_catalog.rs
@@ -105,11 +105,11 @@ impl MigrationTrait for Migration {
             let threshold_id = Uuid::now_v7();
             let source_tags_json_str = source_tags_json(row.source_tags);
 
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_CATALOG_SQL,
                 [
-                    Value::Bytes(Some(Box::new(catalog_id.as_bytes().to_vec()))),
+                    Value::Bytes(Some(catalog_id.as_bytes().to_vec())),
                     Value::from(row.metric_key),
                     Value::from(row.label),
                     nullable_str_value(row.sublabel),
@@ -123,11 +123,11 @@ impl MigrationTrait for Migration {
             ))
             .await?;
 
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_THRESHOLD_SQL,
                 [
-                    Value::Bytes(Some(Box::new(threshold_id.as_bytes().to_vec()))),
+                    Value::Bytes(Some(threshold_id.as_bytes().to_vec())),
                     Value::from(row.metric_key),
                     Value::from(row.good),
                     Value::from(row.warn),

--- a/src/backend/services/analytics/src/migration/m20260702_000002_seed_collab_messaging_catalog.rs
+++ b/src/backend/services/analytics/src/migration/m20260702_000002_seed_collab_messaging_catalog.rs
@@ -118,11 +118,11 @@ impl MigrationTrait for Migration {
 
         for row in SEEDS {
             let catalog_id = Uuid::now_v7();
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_CATALOG_SQL,
                 [
-                    Value::Bytes(Some(Box::new(catalog_id.as_bytes().to_vec()))),
+                    Value::Bytes(Some(catalog_id.as_bytes().to_vec())),
                     Value::from(row.metric_key),
                     Value::from(row.label),
                     nullable_str_value(row.sublabel),
@@ -136,11 +136,11 @@ impl MigrationTrait for Migration {
             .await?;
 
             let threshold_id = Uuid::now_v7();
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_THRESHOLD_SQL,
                 [
-                    Value::Bytes(Some(Box::new(threshold_id.as_bytes().to_vec()))),
+                    Value::Bytes(Some(threshold_id.as_bytes().to_vec())),
                     Value::from(row.metric_key),
                     Value::from(row.good),
                     Value::from(row.warn),
@@ -148,7 +148,7 @@ impl MigrationTrait for Migration {
             ))
             .await?;
 
-            conn.execute(Statement::from_sql_and_values(
+            conn.execute_raw(Statement::from_sql_and_values(
                 backend,
                 INSERT_LINK_SQL,
                 [

--- a/src/backend/services/identity-resolution/src/infra/db/bootstrap.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/bootstrap.rs
@@ -52,7 +52,7 @@ pub async fn bootstrap_admin(db: &DatabaseConnection, config: &GearConfig) -> an
 
     let person_role_id = Uuid::now_v7();
     let result = db
-        .execute(Statement::from_sql_and_values(
+        .execute_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             SQL,
             [

--- a/src/backend/services/identity-resolution/src/infra/db/mod.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/mod.rs
@@ -129,7 +129,7 @@ impl SeedLockGuard {
         use sea_orm::{ConnectionTrait, DbBackend, Statement};
         let conn = connect_single(database_url).await?;
         let acquired: Option<i8> = conn
-            .query_one(Statement::from_sql_and_values(
+            .query_one_raw(Statement::from_sql_and_values(
                 DbBackend::MySql,
                 "SELECT GET_LOCK(?, ?)",
                 [
@@ -156,7 +156,7 @@ impl SeedLockGuard {
         use sea_orm::{ConnectionTrait, DbBackend, Statement};
         let _ = self
             .conn
-            .execute(Statement::from_sql_and_values(
+            .execute_raw(Statement::from_sql_and_values(
                 DbBackend::MySql,
                 "SELECT RELEASE_LOCK(?)",
                 [format!("{SEED_LOCK_PREFIX}{}", self.tenant_id).into()],
@@ -194,7 +194,7 @@ impl SyncLockGuard {
         use sea_orm::{ConnectionTrait, DbBackend, Statement};
         let conn = connect_single(database_url).await?;
         let acquired: Option<i8> = conn
-            .query_one(Statement::from_sql_and_values(
+            .query_one_raw(Statement::from_sql_and_values(
                 DbBackend::MySql,
                 "SELECT GET_LOCK(?, ?)",
                 [SYNC_LOCK.into(), wait_secs.into()],
@@ -216,7 +216,7 @@ impl SyncLockGuard {
         use sea_orm::{ConnectionTrait, DbBackend, Statement};
         let _ = self
             .conn
-            .execute(Statement::from_sql_and_values(
+            .execute_raw(Statement::from_sql_and_values(
                 DbBackend::MySql,
                 "SELECT RELEASE_LOCK(?)",
                 [SYNC_LOCK.into()],
@@ -259,7 +259,7 @@ pub async fn run_migrations(
     use sea_orm_migration::MigratorTrait;
 
     let acquired: Option<i8> = db
-        .query_one(Statement::from_sql_and_values(
+        .query_one_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             "SELECT GET_LOCK(?, ?)",
             [MIGRATION_LOCK.into(), MIGRATION_LOCK_TIMEOUT_SECS.into()],
@@ -282,7 +282,7 @@ pub async fn run_migrations(
 
     // Best-effort release either way; the lock also dies with the session.
     let _ = db
-        .execute(Statement::from_sql_and_values(
+        .execute_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             "SELECT RELEASE_LOCK(?)",
             [MIGRATION_LOCK.into()],
@@ -312,7 +312,7 @@ mod tests {
         values: impl IntoIterator<Item = sea_orm::Value>,
     ) -> anyhow::Result<i64> {
         let row = db
-            .query_one(Statement::from_sql_and_values(
+            .query_one_raw(Statement::from_sql_and_values(
                 DbBackend::MySql,
                 sql,
                 values,
@@ -352,12 +352,12 @@ mod tests {
         // Crash-recovery regression (012): a migrator killed between the DROP
         // and ADD CONSTRAINT statements leaves the constraint absent — a
         // re-run must converge, not fail on the unconditional DROP.
-        db.execute(Statement::from_string(
+        db.execute_raw(Statement::from_string(
             DbBackend::MySql,
             "ALTER TABLE org_chart DROP CONSTRAINT IF EXISTS chk_no_self_loop",
         ))
         .await?;
-        db.execute(Statement::from_string(
+        db.execute_raw(Statement::from_string(
             DbBackend::MySql,
             "DELETE FROM seaql_migrations WHERE version = 'm20260724_000012_org_chart_nullable_parent'",
         ))

--- a/src/backend/services/identity-resolution/src/infra/db/ops_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/ops_repo.rs
@@ -92,7 +92,7 @@ pub async fn enqueue(
              insight_tenant_id, author_person_id, request_json)
         VALUES (?, ?, 'queued', ?, ?, ?)
     ";
-    db.execute(Statement::from_sql_and_values(
+    db.execute_raw(Statement::from_sql_and_values(
         DbBackend::MySql,
         SQL,
         [
@@ -117,7 +117,7 @@ pub async fn try_start(db: &DatabaseConnection, operation_id: Uuid) -> anyhow::R
     const SQL: &str =
         "UPDATE operations SET status = 'running' WHERE operation_id = ? AND status = 'queued'";
     let res = db
-        .execute(Statement::from_sql_and_values(
+        .execute_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             SQL,
             [operation_id.as_bytes().to_vec().into()],
@@ -141,7 +141,7 @@ pub async fn complete(
         SET status = 'completed', summary_json = ?, completed_at = UTC_TIMESTAMP(6)
         WHERE operation_id = ?
     ";
-    db.execute(Statement::from_sql_and_values(
+    db.execute_raw(Statement::from_sql_and_values(
         DbBackend::MySql,
         SQL,
         [summary_json.into(), operation_id.as_bytes().to_vec().into()],
@@ -165,7 +165,7 @@ pub async fn fail(
         SET status = 'failed', error_message = ?, completed_at = UTC_TIMESTAMP(6)
         WHERE operation_id = ?
     ";
-    db.execute(Statement::from_sql_and_values(
+    db.execute_raw(Statement::from_sql_and_values(
         DbBackend::MySql,
         SQL,
         [
@@ -191,7 +191,7 @@ pub async fn get_by_id(
         "SELECT {COLUMNS} FROM operations WHERE insight_tenant_id = ? AND operation_id = ? LIMIT 1"
     );
     let row = db
-        .query_one(Statement::from_sql_and_values(
+        .query_one_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             &sql,
             [
@@ -234,7 +234,7 @@ pub async fn list(
     params.push(limit.into());
 
     let rows = db
-        .query_all(Statement::from_sql_and_values(
+        .query_all_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             &sql,
             params,
@@ -303,7 +303,7 @@ pub async fn sweep_zombies(db: &DatabaseConnection, older_than: DateTime) -> any
           AND started_at < ?
     ";
     let res = db
-        .execute(Statement::from_sql_and_values(
+        .execute_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             SQL,
             [older_than.into()],

--- a/src/backend/services/identity-resolution/src/infra/db/ops_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/ops_repo.rs
@@ -267,7 +267,7 @@ pub async fn corrections_for_account(
     );
 
     let rows = db
-        .query_all(Statement::from_sql_and_values(
+        .query_all_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             &sql,
             [

--- a/src/backend/services/identity-resolution/src/infra/db/person_listing.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/person_listing.rs
@@ -261,7 +261,7 @@ async fn page(
 ) -> anyhow::Result<Vec<PersonListRow>> {
     let (sql, values) = build_query(tenant_id, terms, narrowed_to, restrict, after, limit);
     let stmt = Statement::from_sql_and_values(DbBackend::MySql, &sql, values);
-    rows_from(db.query_all(stmt).await?)
+    rows_from(db.query_all_raw(stmt).await?)
 }
 
 /// Decide what the ranking may read.
@@ -311,7 +311,7 @@ async fn candidate_persons(
     let (sql, values) = build_probe(tenant_id, first, rest);
     let stmt = Statement::from_sql_and_values(DbBackend::MySql, &sql, values);
 
-    let rows = db.query_all(stmt).await?;
+    let rows = db.query_all_raw(stmt).await?;
     let mut found = Vec::with_capacity(rows.len());
     for row in rows {
         let raw: Vec<u8> = row.try_get("", "person_id")?;

--- a/src/backend/services/identity-resolution/src/infra/db/person_roles_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/person_roles_repo.rs
@@ -72,7 +72,7 @@ pub async fn get_by_id(
             person_role_id.as_bytes().to_vec().into(),
         ],
     );
-    db.query_one(stmt)
+    db.query_one_raw(stmt)
         .await?
         .as_ref()
         .map(row_to_person_role)
@@ -111,7 +111,7 @@ pub async fn list(
     params.push(limit.into());
 
     let rows = db
-        .query_all(Statement::from_sql_and_values(
+        .query_all_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             &sql,
             params,
@@ -158,7 +158,7 @@ pub async fn insert(
             reason.into(),
         ],
     );
-    db.execute(stmt).await?;
+    db.execute_raw(stmt).await?;
     Ok(())
 }
 
@@ -196,7 +196,7 @@ pub async fn soft_delete(
             person_role_id.as_bytes().to_vec().into(),
         ],
     );
-    Ok(db.execute(stmt).await?.rows_affected())
+    Ok(db.execute_raw(stmt).await?.rows_affected())
 }
 
 /// Revoke (soft-delete) an assignment, but REFUSE to remove the tenant's last
@@ -273,7 +273,7 @@ pub async fn try_soft_delete_protecting_last_admin(
         .begin_with_config(Some(IsolationLevel::RepeatableRead), None)
         .await?;
 
-    txn.query_one(Statement::from_sql_and_values(
+    txn.query_one_raw(Statement::from_sql_and_values(
         DbBackend::MySql,
         LOCK_SQL,
         [pr.clone().into(), admin.clone().into()],
@@ -281,7 +281,7 @@ pub async fn try_soft_delete_protecting_last_admin(
     .await?;
 
     let rows = txn
-        .execute(Statement::from_sql_and_values(
+        .execute_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             SQL,
             [admin.clone().into(), pr.into(), reason.into(), admin.into()],

--- a/src/backend/services/identity-resolution/src/infra/db/persons_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/persons_repo.rs
@@ -365,7 +365,7 @@ pub async fn provisional_persons(
     }
 
     let rows = db
-        .query_all(Statement::from_sql_and_values(
+        .query_all_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             &sql,
             params,

--- a/src/backend/services/identity-resolution/src/infra/db/persons_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/persons_repo.rs
@@ -73,7 +73,7 @@ pub async fn resolve_person_ids_by_email(
         ],
     );
 
-    let rows = db.query_all(stmt).await?;
+    let rows = db.query_all_raw(stmt).await?;
     person_ids_from_rows(rows)
 }
 
@@ -126,7 +126,7 @@ pub async fn resolve_person_id_by_email_any_tenant(
         ],
     );
 
-    match db.query_one(stmt).await? {
+    match db.query_one_raw(stmt).await? {
         Some(row) => {
             let bytes: Vec<u8> = row.try_get("", "person_id")?;
             Ok(Some(Uuid::from_slice(&bytes)?))
@@ -201,7 +201,7 @@ pub async fn resolve_person_id_by_source_any_tenant(
         ],
     );
 
-    match db.query_one(stmt).await? {
+    match db.query_one_raw(stmt).await? {
         Some(row) => {
             let bytes: Vec<u8> = row.try_get("", "person_id")?;
             Ok(Some(Uuid::from_slice(&bytes)?))
@@ -260,7 +260,7 @@ pub async fn resolve_person_ids_by_source_id(
         ],
     );
 
-    let rows = db.query_all(stmt).await?;
+    let rows = db.query_all_raw(stmt).await?;
     person_ids_from_rows(rows)
 }
 
@@ -510,7 +510,7 @@ pub async fn current_source_ids_for_person(
         ],
     );
 
-    let rows = db.query_all(stmt).await?;
+    let rows = db.query_all_raw(stmt).await?;
     let mut ids = Vec::with_capacity(rows.len());
     for row in rows {
         let source_type: String = row.try_get("", "insight_source_type")?;
@@ -572,7 +572,7 @@ pub async fn current_parents_for_child(
         ],
     );
 
-    let rows = db.query_all(stmt).await?;
+    let rows = db.query_all_raw(stmt).await?;
     let mut edges = Vec::with_capacity(rows.len());
     for row in rows {
         let source_type: String = row.try_get("", "insight_source_type")?;
@@ -625,7 +625,7 @@ pub async fn current_children_for_parent(
         ],
     );
 
-    let rows = db.query_all(stmt).await?;
+    let rows = db.query_all_raw(stmt).await?;
     let mut edges = Vec::with_capacity(rows.len());
     for row in rows {
         let source_type: String = row.try_get("", "insight_source_type")?;

--- a/src/backend/services/identity-resolution/src/infra/db/resolution_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/resolution_repo.rs
@@ -141,7 +141,7 @@ pub async fn current_bindings(
         }
 
         let rows = db
-            .query_all(Statement::from_sql_and_values(
+            .query_all_raw(Statement::from_sql_and_values(
                 DbBackend::MySql,
                 &sql,
                 params,
@@ -271,7 +271,7 @@ pub async fn accounts_of_person(
     ";
 
     let rows = db
-        .query_all(Statement::from_sql_and_values(
+        .query_all_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             SQL,
             [
@@ -310,7 +310,7 @@ pub async fn person_exists(
         "SELECT 1 AS hit FROM persons WHERE insight_tenant_id = ? AND person_id = ? LIMIT 1";
 
     let row = db
-        .query_one(Statement::from_sql_and_values(
+        .query_one_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             SQL,
             [
@@ -492,7 +492,7 @@ pub async fn append_bindings(
         }
 
         let res = txn
-            .execute(Statement::from_sql_and_values(
+            .execute_raw(Statement::from_sql_and_values(
                 DbBackend::MySql,
                 &sql,
                 params,
@@ -539,7 +539,7 @@ pub async fn binding_history(
     ";
 
     let rows = db
-        .query_all(Statement::from_sql_and_values(
+        .query_all_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             SQL,
             [
@@ -608,7 +608,7 @@ pub async fn present_rows(
         }
 
         let hits = db
-            .query_all(Statement::from_sql_and_values(
+            .query_all_raw(Statement::from_sql_and_values(
                 DbBackend::MySql,
                 &sql,
                 params,

--- a/src/backend/services/identity-resolution/src/infra/db/resolution_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/resolution_repo.rs
@@ -186,7 +186,7 @@ pub async fn current_bindings_in_tenant(
     // truncation would then refuse a complete answer.
     let probe = ceiling.rows().saturating_add(1);
     let mut rows = db
-        .query_all(Statement::from_sql_and_values(
+        .query_all_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             current_bindings_sql(Scope::WholeTenant),
             [tenant_id.as_bytes().to_vec().into(), probe.into()],
@@ -421,7 +421,7 @@ pub async fn append_binding_if_unbound(
         ],
     );
 
-    let result = match txn.execute(statement).await {
+    let result = match txn.execute_raw(statement).await {
         Ok(result) => result,
         // A lock conflict here means another login is writing THIS account
         // right now. "We did not write" is the truthful answer, and the

--- a/src/backend/services/identity-resolution/src/infra/db/roles_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/roles_repo.rs
@@ -138,7 +138,7 @@ pub async fn active_roles_of_person(
         ],
     );
 
-    db.query_all(stmt).await?.iter().map(row_to_role).collect()
+    db.query_all_raw(stmt).await?.iter().map(row_to_role).collect()
 }
 
 /// All roles, ordered by name. Ported from `SqlRoles.ListAllRoles`.

--- a/src/backend/services/identity-resolution/src/infra/db/roles_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/roles_repo.rs
@@ -44,7 +44,7 @@ pub async fn has_active_role(
         ],
     );
 
-    Ok(db.query_one(stmt).await?.is_some())
+    Ok(db.query_one_raw(stmt).await?.is_some())
 }
 
 /// Convenience: does `person_id` hold the active `admin` role in the tenant?
@@ -84,7 +84,7 @@ fn row_to_role(r: &sea_orm::QueryResult) -> anyhow::Result<Role> {
 pub async fn get_by_name(db: &DatabaseConnection, name: &str) -> anyhow::Result<Option<Role>> {
     const SQL: &str = "SELECT role_id, name FROM roles WHERE name = ? LIMIT 1";
     let stmt = Statement::from_sql_and_values(DbBackend::MySql, SQL, [name.into()]);
-    db.query_one(stmt)
+    db.query_one_raw(stmt)
         .await?
         .as_ref()
         .map(row_to_role)
@@ -100,7 +100,7 @@ pub async fn get_by_id(db: &DatabaseConnection, role_id: Uuid) -> anyhow::Result
     const SQL: &str = "SELECT role_id, name FROM roles WHERE role_id = ? LIMIT 1";
     let stmt =
         Statement::from_sql_and_values(DbBackend::MySql, SQL, [role_id.as_bytes().to_vec().into()]);
-    db.query_one(stmt)
+    db.query_one_raw(stmt)
         .await?
         .as_ref()
         .map(row_to_role)
@@ -149,7 +149,11 @@ pub async fn active_roles_of_person(
 pub async fn list_all(db: &DatabaseConnection) -> anyhow::Result<Vec<Role>> {
     const SQL: &str = "SELECT role_id, name FROM roles ORDER BY name";
     let stmt = Statement::from_sql_and_values(DbBackend::MySql, SQL, []);
-    db.query_all(stmt).await?.iter().map(row_to_role).collect()
+    db.query_all_raw(stmt)
+        .await?
+        .iter()
+        .map(row_to_role)
+        .collect()
 }
 
 /// Insert a new role. Ported from `SqlRoles.InsertRole`.
@@ -164,7 +168,7 @@ pub async fn insert_role(db: &DatabaseConnection, role_id: Uuid, name: &str) -> 
         SQL,
         [role_id.as_bytes().to_vec().into(), name.into()],
     );
-    db.execute(stmt).await?;
+    db.execute_raw(stmt).await?;
     Ok(())
 }
 
@@ -188,7 +192,7 @@ pub async fn try_delete_if_unused(db: &DatabaseConnection, role_id: Uuid) -> any
     let bytes = role_id.as_bytes().to_vec();
     let stmt =
         Statement::from_sql_and_values(DbBackend::MySql, SQL, [bytes.clone().into(), bytes.into()]);
-    Ok(db.execute(stmt).await?.rows_affected())
+    Ok(db.execute_raw(stmt).await?.rows_affected())
 }
 
 /// Count active `person_roles` referencing a role across ALL tenants — feeds the
@@ -205,7 +209,7 @@ pub async fn count_active_assignments_any_tenant(
         "SELECT COUNT(*) AS c FROM person_roles WHERE role_id = ? AND valid_to IS NULL";
     let stmt =
         Statement::from_sql_and_values(DbBackend::MySql, SQL, [role_id.as_bytes().to_vec().into()]);
-    match db.query_one(stmt).await? {
+    match db.query_one_raw(stmt).await? {
         Some(row) => Ok(row.try_get::<i64>("", "c")?),
         None => Ok(0),
     }

--- a/src/backend/services/identity-resolution/src/infra/db/seed_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/seed_repo.rs
@@ -88,7 +88,7 @@ pub struct TenantPresence {
 pub async fn distinct_tenants(db: &DatabaseConnection, cap: u64) -> anyhow::Result<Vec<Uuid>> {
     const SQL: &str = "SELECT DISTINCT insight_tenant_id FROM persons LIMIT ?";
     let rows = db
-        .query_all(Statement::from_sql_and_values(
+        .query_all_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             SQL,
             [cap.into()],
@@ -120,7 +120,7 @@ pub async fn tenant_presence(
             EXISTS(SELECT 1 FROM persons WHERE insight_tenant_id <> ?) AS has_other
     ";
     let row = db
-        .query_one(Statement::from_sql_and_values(
+        .query_one_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             SQL,
             [
@@ -199,7 +199,7 @@ pub async fn latest_email_to_person(
         [tenant_id.as_bytes().to_vec().into()],
     );
 
-    let rows = db.query_all(stmt).await?;
+    let rows = db.query_all_raw(stmt).await?;
     let mut map = HashMap::with_capacity(rows.len());
     for row in rows {
         let email: String = row.try_get("", "email")?;
@@ -494,13 +494,13 @@ async fn rebuild_derived_caches(
     let author_bytes = author_person_id.as_bytes().to_vec();
 
     // Rebuild account_person_map for the tenant (delete + reinsert).
-    txn.execute(Statement::from_sql_and_values(
+    txn.execute_raw(Statement::from_sql_and_values(
         DbBackend::MySql,
         DELETE_APM,
         [tenant_bytes.clone().into()],
     ))
     .await?;
-    txn.execute(Statement::from_sql_and_values(
+    txn.execute_raw(Statement::from_sql_and_values(
         DbBackend::MySql,
         INSERT_APM,
         [tenant_bytes.clone().into()],
@@ -510,14 +510,14 @@ async fn rebuild_derived_caches(
 
     // Rebuild org_chart for the tenant. The CTE binds the tenant six times, then
     // the author once — same order as INSERT_ORG_CHART's `?` markers.
-    txn.execute(Statement::from_sql_and_values(
+    txn.execute_raw(Statement::from_sql_and_values(
         DbBackend::MySql,
         DELETE_ORG_CHART,
         [tenant_bytes.clone().into()],
     ))
     .await?;
     let org_chart = txn
-        .execute(Statement::from_sql_and_values(
+        .execute_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             INSERT_ORG_CHART,
             [
@@ -592,7 +592,7 @@ pub async fn apply(
             params.push(r.created_at.into());
         }
         let res = txn
-            .execute(Statement::from_sql_and_values(
+            .execute_raw(Statement::from_sql_and_values(
                 DbBackend::MySql,
                 &sql,
                 params,

--- a/src/backend/services/identity-resolution/src/infra/db/subchart_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/subchart_repo.rs
@@ -122,7 +122,7 @@ pub async fn is_target_in_visible_set(
     )?;
 
     let row = db
-        .query_one(Statement::from_sql_and_values(
+        .query_one_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             &sql,
             values,
@@ -162,7 +162,7 @@ pub async fn has_wildcard_grant(
         [bytes(tenant_id), bytes(viewer_person_id)],
     );
 
-    Ok(db.query_one(stmt).await?.is_some())
+    Ok(db.query_one_raw(stmt).await?.is_some())
 }
 
 /// Batch form of [`is_target_in_visible_set`]: the same union, computed once and
@@ -245,7 +245,7 @@ pub async fn visible_targets(
     let (sql, values) = bind_named(&SQL.replace("@candidates", &list), &params)?;
 
     let rows = db
-        .query_all(Statement::from_sql_and_values(
+        .query_all_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             &sql,
             values,
@@ -335,7 +335,7 @@ pub async fn get_subchart_flat(
     )?;
 
     let rows = db
-        .query_all(Statement::from_sql_and_values(
+        .query_all_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             &sql,
             values,
@@ -486,7 +486,7 @@ pub async fn get_forest_flat(
     )?;
 
     let rows = db
-        .query_all(Statement::from_sql_and_values(
+        .query_all_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             &sql,
             values,

--- a/src/backend/services/identity-resolution/src/infra/db/test_fixture.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/test_fixture.rs
@@ -366,7 +366,7 @@ impl Fixture {
 
     async fn exec(&self, sql: &str, values: impl IntoIterator<Item = Value>) -> anyhow::Result<()> {
         self.db
-            .execute(Statement::from_sql_and_values(
+            .execute_raw(Statement::from_sql_and_values(
                 DbBackend::MySql,
                 sql,
                 values,

--- a/src/backend/services/identity-resolution/src/infra/db/visibility_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/visibility_repo.rs
@@ -79,7 +79,7 @@ pub async fn get_by_id(
             visibility_id.as_bytes().to_vec().into(),
         ],
     );
-    db.query_one(stmt)
+    db.query_one_raw(stmt)
         .await?
         .as_ref()
         .map(row_to_visibility)
@@ -118,7 +118,7 @@ pub async fn list(
     params.push(limit.into());
 
     let rows = db
-        .query_all(Statement::from_sql_and_values(
+        .query_all_raw(Statement::from_sql_and_values(
             DbBackend::MySql,
             &sql,
             params,
@@ -165,7 +165,7 @@ pub async fn insert(
             reason.into(),
         ],
     );
-    db.execute(stmt).await?;
+    db.execute_raw(stmt).await?;
     Ok(())
 }
 
@@ -199,5 +199,5 @@ pub async fn soft_delete(
             visibility_id.as_bytes().to_vec().into(),
         ],
     );
-    Ok(db.execute(stmt).await?.rows_affected())
+    Ok(db.execute_raw(stmt).await?.rows_affected())
 }


### PR DESCRIPTION
Consolidates the two Dependabot bumps into a single PR and makes the backend compile against the new major:

- Supersedes #2412 (sea-orm 1.1.20 → 2.0.1)
- Supersedes #2411 (sea-orm-migration 1.1.20 → 2.0.1)

Both must move together — a split bump leaves two `sea_orm` versions in the graph and the `Statement` type stops matching across the boundary.

## SeaORM 2.0 API migration

- `ConnectionTrait::{execute,query_one,query_all}` now take an `&impl StatementBuilder`. Raw `sea_orm::Statement` values run through the new `{execute,query_one,query_all}_raw` methods (by value).
- `sea_query` `Value::Bytes` now holds `Option<Vec<u8>>` instead of `Option<Box<Vec<u8>>>`; the `Box` wrapper is dropped.
- `DatabaseConnection::Disconnected` moved onto `DatabaseConnectionType`; the disconnected sentinel is now `DatabaseConnection::default()`.
- Dropped `ConnectionTrait` imports that are no longer needed at call sites.

## Verification

- `cargo build --workspace` — clean
- `cargo clippy --workspace --all-targets` — clean (workspace denies pedantic)
- `cargo test --workspace --no-run` — all test binaries link
- pre-commit (`cargo fmt`, `cargo clippy`) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Maintenance**
  * Updated database connectivity components for compatibility with the latest database framework version.
  * Improved consistency of database queries, updates, migrations, and seed operations across analytics and identity-resolution services.
  * Preserved existing SQL behavior, data mappings, migration flows, and error handling.

* **Tests**
  * Updated integration tests and test fixtures to reflect the database compatibility changes.
  * Existing test assertions and expected behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->