### PR TITLE
refactor(frontend): four text sizes, two greys, and a rule that keeps them

### DIFF
--- a/src/frontend/eslint.config.js
+++ b/src/frontend/eslint.config.js
@@ -106,19 +106,28 @@ export default defineConfig([
       "no-restricted-syntax": [
         "error",
         {
+          // `(^|[\\s:])` rather than `(^|\\s)`: a variant prefix sits directly
+          // against the utility, so `hover:text-[13px]` and `sm:text-[13px]`
+          // walked past the whitespace-anchored version. A guard with a hole
+          // in it is worse than none, because it is believed.
           selector:
-            "Literal[value=/(^|\\s)text-\\[[0-9.]+(px|rem)\\]/]",
+            "Literal[value=/(^|[\\s:])text-\\[[0-9.]+(px|rem)\\]/]",
           message:
             "Hand-set text size. Use a role from src/lib/type-scale.ts, or add one there if none fits.",
         },
         {
           selector:
-            "Literal[value=/(^|\\s)text-(muted-)?foreground\\/[0-9]/]",
+            "Literal[value=/(^|[\\s:])text-(muted-)?foreground\\/[0-9]/]",
           message:
             "Fractional text grey. There are two: text-foreground and text-muted-foreground.",
         },
         {
-          selector: "Literal[value=/(^|\\s)text-(amber|red|green|emerald|rose|orange|yellow)-[0-9]/]",
+          // Every palette family, not the handful that happened to be in the
+          // tree when this was written — the next colour reached for will be
+          // one of the others. `text-black` and `text-white` carry no number
+          // and were missed for that reason alone.
+          selector:
+            "Literal[value=/(^|[\\s:])text-((slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose)-[0-9]|(black|white)\\b)/]",
           message:
             "Raw palette colour. Good/bad is text-success and text-destructive; text-warning is attention without a verdict.",
         },

--- a/src/frontend/eslint.config.js
+++ b/src/frontend/eslint.config.js
@@ -84,4 +84,45 @@ export default defineConfig([
       "react-hooks/incompatible-library": "off",
     },
   },
+  {
+    // Keep the text scale from growing back.
+    //
+    // It had drifted to twelve sizes and five greys, and none of that was
+    // decided — each one was a reasonable local choice that nobody could see
+    // the sum of. A reader learns a screen by learning its rules, and twelve
+    // sizes with no rule behind them is not a hierarchy, it is decoration.
+    //
+    // So the sizes a screen may use are the ones in `src/lib/type-scale.ts`,
+    // and a size written by hand is refused here rather than found later by
+    // whoever measures it again. Fractional text greys go the same way: two
+    // levels are readable as "read this / you may skip this", five are not
+    // rankable by anyone and the rule stops holding.
+    //
+    // Vendored primitives under components/ui are exempt — their sizing is
+    // that library's business and `shadcn add` rewrites them.
+    files: ["src/**/*.tsx"],
+    ignores: ["src/components/ui/**"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "Literal[value=/(^|\\s)text-\\[[0-9.]+(px|rem)\\]/]",
+          message:
+            "Hand-set text size. Use a role from src/lib/type-scale.ts, or add one there if none fits.",
+        },
+        {
+          selector:
+            "Literal[value=/(^|\\s)text-(muted-)?foreground\\/[0-9]/]",
+          message:
+            "Fractional text grey. There are two: text-foreground and text-muted-foreground.",
+        },
+        {
+          selector: "Literal[value=/(^|\\s)text-(amber|red|green|emerald|rose|orange|yellow)-[0-9]/]",
+          message:
+            "Raw palette colour. Good/bad is text-success and text-destructive; text-warning is attention without a verdict.",
+        },
+      ],
+    },
+  },
 ]);

--- a/src/frontend/src/components/metric-evidence-dialog.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog.tsx
@@ -156,7 +156,7 @@ export function MetricEvidenceDialog({
                     <SelectTrigger
                       size="sm"
                       aria-label="Metric"
-                      className="border-transparent bg-transparent px-0 text-base font-semibold shadow-none hover:bg-transparent focus-visible:border-transparent focus-visible:ring-0 dark:bg-transparent"
+                      className="border-transparent bg-transparent px-0 text-sm font-semibold shadow-none hover:bg-transparent focus-visible:border-transparent focus-visible:ring-0 dark:bg-transparent"
                     >
                       <SelectValue>{activeTarget.label}</SelectValue>
                     </SelectTrigger>

--- a/src/frontend/src/components/portal/ai-cost-view.tsx
+++ b/src/frontend/src/components/portal/ai-cost-view.tsx
@@ -38,6 +38,8 @@ import { useCohortLabel } from "@/lib/portal/use-cohort-label";
 import { useOrgScope } from "@/lib/portal/use-org-scope";
 import { useMemberGridData } from "@/queries/member-grid";
 import { useMetricCollection } from "@/queries/metric-results";
+import { TEXT_FIGURE } from "@/lib/type-scale";
+import { cn } from "@/lib/utils";
 
 const EMPTY_COLLECTION: MetricCollectionConfig = { metrics: [] };
 const COST_KEY = "ai.cost";
@@ -378,7 +380,7 @@ export function AiCostView({ item }: { item: string | null }) {
                   <div className="text-sm font-semibold">
                     {TOOL_LABEL[t.tool] ?? t.tool}
                   </div>
-                  <div className="text-3xl font-semibold tabular-nums">
+                  <div className={TEXT_FIGURE}>
                     {t.costTracked
                       ? formatMetricValue(t.cost, "currency", "USD")
                       : "—"}
@@ -546,7 +548,7 @@ function Tile({ label, value, sub }: { label: string; value: string; sub: string
     <Card>
       <CardContent className="p-4">
         <div className="text-xs font-medium text-muted-foreground">{label}</div>
-        <div className="mt-1 text-3xl font-semibold tabular-nums">{value}</div>
+        <div className={cn("mt-1", TEXT_FIGURE)}>{value}</div>
         <div className="text-xs text-muted-foreground">{sub}</div>
       </CardContent>
     </Card>

--- a/src/frontend/src/components/portal/ai-cost-view.tsx
+++ b/src/frontend/src/components/portal/ai-cost-view.tsx
@@ -316,7 +316,7 @@ export function AiCostView({ item }: { item: string | null }) {
   return (
     <div className="flex flex-col gap-6 p-4 md:p-6">
       <div>
-        <h1 className="text-xl font-semibold tracking-tight">AI &amp; Cost</h1>
+        <h1 className="text-lg font-semibold tracking-tight">AI &amp; Cost</h1>
         <p className="text-sm text-muted-foreground">
           {teamName ? `${teamName}'s org` : "Org"} · {orgScope.count} people
         </p>
@@ -378,7 +378,7 @@ export function AiCostView({ item }: { item: string | null }) {
                   <div className="text-sm font-semibold">
                     {TOOL_LABEL[t.tool] ?? t.tool}
                   </div>
-                  <div className="text-2xl font-semibold tabular-nums">
+                  <div className="text-3xl font-semibold tabular-nums">
                     {t.costTracked
                       ? formatMetricValue(t.cost, "currency", "USD")
                       : "—"}
@@ -546,7 +546,7 @@ function Tile({ label, value, sub }: { label: string; value: string; sub: string
     <Card>
       <CardContent className="p-4">
         <div className="text-xs font-medium text-muted-foreground">{label}</div>
-        <div className="mt-1 text-2xl font-semibold tabular-nums">{value}</div>
+        <div className="mt-1 text-3xl font-semibold tabular-nums">{value}</div>
         <div className="text-xs text-muted-foreground">{sub}</div>
       </CardContent>
     </Card>

--- a/src/frontend/src/components/portal/attention-list.tsx
+++ b/src/frontend/src/components/portal/attention-list.tsx
@@ -115,7 +115,7 @@ export function AttentionList({
                 {/* Standing affordance — the row opens that person's page, and
                     a border alone does not say so. */}
                 <ChevronRight
-                  className="ml-auto size-3.5 shrink-0 text-muted-foreground/50"
+                  className="ml-auto size-3.5 shrink-0 text-muted-foreground"
                   aria-hidden
                 />
               </Link>

--- a/src/frontend/src/components/portal/context-pane.test.tsx
+++ b/src/frontend/src/components/portal/context-pane.test.tsx
@@ -121,7 +121,7 @@ describe("ContextPane", () => {
   it("renders the person's sections nav in the Person zone", () => {
     mocks.zone = { activeZone: "person", activePerson: "boss@x" };
     pane();
-    expect(screen.getByText("Pick a person")).toBeInTheDocument();
+    expect(screen.getByText("Personal metrics")).toBeInTheDocument();
     expect(screen.getByText("At a glance")).toBeInTheDocument();
   });
 

--- a/src/frontend/src/components/portal/context-pane.tsx
+++ b/src/frontend/src/components/portal/context-pane.tsx
@@ -56,7 +56,7 @@ import { cn } from "@/lib/utils";
 const ZONE_SUB: Record<string, string> = {
   overview: "Cross-functional org rollup",
   directions: "Functional domains",
-  person: "Pick a person",
+  person: "Personal metrics",
   people: "Roster & org structure",
   aicost: "Adoption funnel & cost",
   scorecard: "Unit × quarter × QoQ",

--- a/src/frontend/src/components/portal/context-pane.tsx
+++ b/src/frontend/src/components/portal/context-pane.tsx
@@ -339,7 +339,7 @@ function ItemButton({
         {item.badge ? (
           <span
             className={cn(
-              "ml-auto rounded-full px-1.5 py-0.5 text-[9px] font-semibold",
+              "ml-auto rounded-full px-1.5 py-0.5 text-xs font-semibold",
               BADGE_TONE[item.badge.tone],
             )}
           >
@@ -358,7 +358,7 @@ function DirectionsNav() {
     <SidebarGroup>
       <SidebarGroupLabel>
         Directions
-        <span className="ml-1 text-[10px] font-normal text-muted-foreground">
+        <span className="ml-1 text-xs font-normal text-muted-foreground">
           · catalog · {DIRECTIONS.length}
         </span>
       </SidebarGroupLabel>
@@ -406,7 +406,7 @@ function DirectionItem({ direction }: { direction: Direction }) {
           <Icon />
           <span>{direction.name}</span>
           {direction.source === "bullet" ? (
-            <span className="ml-auto rounded-full bg-warning/15 px-1.5 py-0.5 text-[9px] font-semibold text-warning">
+            <span className="ml-auto rounded-full bg-warning/15 px-1.5 py-0.5 text-xs font-semibold text-warning">
               bullet
             </span>
           ) : null}

--- a/src/frontend/src/components/portal/domain-lens-view.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.tsx
@@ -68,6 +68,8 @@ import type { TeamMember } from "@/types/insight";
 import { useOrgScope } from "@/lib/portal/use-org-scope";
 import { useMetricCollection } from "@/queries/metric-results";
 import { useMemberGridData } from "@/queries/member-grid";
+import { TEXT_FIGURE } from "@/lib/type-scale";
+import { cn } from "@/lib/utils";
 
 const EMPTY_COLLECTION: MetricCollectionConfig = { metrics: [] };
 
@@ -545,7 +547,7 @@ function CoverageLevelsSection({
       {/* 1 — the verdict, as a number rather than a sentence: it is meant to
           be seen, not parsed. */}
       <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-        <span className="text-3xl font-semibold tabular-nums">
+        <span className={TEXT_FIGURE}>
           {/* Same amber as the rows it is the sum of. The link between the
               number and the block of bars is the one thing a reader has to
               make unaided, and colour makes it without a caption. */}
@@ -797,7 +799,7 @@ function ParticipationSection({
                 direction="higher_is_better"
               />
             </div>
-            <div className="mt-1 text-3xl font-semibold tabular-nums">
+            <div className={cn("mt-1", TEXT_FIGURE)}>
               {active} of {memberIds.length}
             </div>
             <div className="text-xs text-muted-foreground">
@@ -860,7 +862,7 @@ function HeadlineSection({
                 />
                 <Delta now={c.now} prev={c.prev} direction={c.r.direction} />
               </div>
-              <div className="mt-1 text-3xl font-semibold tabular-nums">
+              <div className={cn("mt-1", TEXT_FIGURE)}>
                 {formatMetricValue(
                   c.isSum ? perCapita(c.r, memberIds) : c.now,
                   c.r.format,
@@ -922,7 +924,7 @@ function StatTilesSection({
                 />
                 <Delta now={t.median} prev={t.prev} direction={t.r.direction} />
               </div>
-              <div className="mt-1 text-3xl font-semibold tabular-nums">
+              <div className={cn("mt-1", TEXT_FIGURE)}>
                 {formatMetricValue(t.median, t.r.format, t.r.unit)}
               </div>
               <div className="text-xs text-muted-foreground">
@@ -1240,7 +1242,7 @@ function ConcentrationSection({
               <div className="text-xs font-medium text-muted-foreground">
                 {c.label}
               </div>
-              <div className="mt-1 text-3xl font-semibold tabular-nums">
+              <div className={cn("mt-1", TEXT_FIGURE)}>
                 {Math.round(c.share * 100)}%
               </div>
               <div className="text-xs text-muted-foreground">

--- a/src/frontend/src/components/portal/domain-lens-view.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.tsx
@@ -304,7 +304,7 @@ export function DomainLensView({
   return (
     <div className="flex flex-col gap-6 p-4 md:p-6">
       <div>
-        <h1 className="text-xl font-semibold tracking-tight">{config.title}</h1>
+        <h1 className="text-lg font-semibold tracking-tight">{config.title}</h1>
         <p className="text-sm text-muted-foreground">
           {orgScope.count} members · {config.tagline ?? "trend & balance"}
         </p>
@@ -506,7 +506,7 @@ function CoverageBar({
   return (
     <div className="h-2.5 min-w-px flex-1 overflow-hidden rounded-full bg-muted">
       <div
-        className={`h-full rounded-full ${warn ? "bg-amber-500/80" : "bg-primary/60"}`}
+        className={`h-full rounded-full ${warn ? "bg-warning/80" : "bg-primary/60"}`}
         style={{ width: `${total > 0 ? (filled / total) * 100 : 0}%` }}
       />
     </div>
@@ -545,11 +545,11 @@ function CoverageLevelsSection({
       {/* 1 — the verdict, as a number rather than a sentence: it is meant to
           be seen, not parsed. */}
       <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
-        <span className="text-4xl font-semibold tabular-nums">
+        <span className="text-3xl font-semibold tabular-nums">
           {/* Same amber as the rows it is the sum of. The link between the
               number and the block of bars is the one thing a reader has to
               make unaided, and colour makes it without a caption. */}
-          <span className="text-amber-600 dark:text-amber-500">{thin}</span>
+          <span className="text-warning">{thin}</span>
           <span className="text-muted-foreground">/{counted}</span>
         </span>
         <p className="max-w-md text-sm text-muted-foreground">
@@ -569,7 +569,7 @@ function CoverageLevelsSection({
           <div key={part.id} className="flex items-center gap-3 text-sm">
             <span className="w-36 shrink-0 truncate">{part.title}</span>
             {part.unreachable ? (
-              <span className="flex-1 text-xs text-amber-600 dark:text-amber-500">
+              <span className="flex-1 text-xs text-warning">
                 {/* No cause named. Absent observations, a disabled metric and
                     a broken schema all land here, and only the first is a
                     missing connector — sending someone to plumb a live one is
@@ -603,11 +603,11 @@ function CoverageLevelsSection({
             <div key={level} className="flex flex-col gap-2">
               {boundary && (
                 <div className="mt-1 flex items-center gap-3">
-                  <span className="w-36 shrink-0 text-xs text-amber-600 dark:text-amber-500">
+                  <span className="w-36 shrink-0 text-xs text-warning">
                     fewer than half
                   </span>
-                  <span className="h-px flex-1 bg-amber-500/40" />
-                  <span className="w-14 shrink-0 text-right text-xs font-medium text-amber-600 tabular-nums dark:text-amber-500">
+                  <span className="h-px flex-1 bg-warning/40" />
+                  <span className="w-14 shrink-0 text-right text-xs font-medium text-warning tabular-nums dark:text-warning">
                     {thin}
                   </span>
                 </div>
@@ -712,7 +712,7 @@ function CoverageLevelPeople({
               <span className="font-medium">{name}</span>
             )}
             {unconnected.length > 0 && (
-              <span className="text-amber-600 dark:text-amber-500">
+              <span className="text-warning">
                 no connector: {unconnected.join(", ")}
               </span>
             )}
@@ -797,7 +797,7 @@ function ParticipationSection({
                 direction="higher_is_better"
               />
             </div>
-            <div className="mt-1 text-2xl font-semibold tabular-nums">
+            <div className="mt-1 text-3xl font-semibold tabular-nums">
               {active} of {memberIds.length}
             </div>
             <div className="text-xs text-muted-foreground">
@@ -860,7 +860,7 @@ function HeadlineSection({
                 />
                 <Delta now={c.now} prev={c.prev} direction={c.r.direction} />
               </div>
-              <div className="mt-1 text-2xl font-semibold tabular-nums">
+              <div className="mt-1 text-3xl font-semibold tabular-nums">
                 {formatMetricValue(
                   c.isSum ? perCapita(c.r, memberIds) : c.now,
                   c.r.format,
@@ -922,7 +922,7 @@ function StatTilesSection({
                 />
                 <Delta now={t.median} prev={t.prev} direction={t.r.direction} />
               </div>
-              <div className="mt-1 text-2xl font-semibold tabular-nums">
+              <div className="mt-1 text-3xl font-semibold tabular-nums">
                 {formatMetricValue(t.median, t.r.format, t.r.unit)}
               </div>
               <div className="text-xs text-muted-foreground">
@@ -1071,7 +1071,7 @@ function DistributionSection({
               />
             </BarChart>
           </ChartContainer>
-          <p className="mt-1 text-center text-[10px] text-muted-foreground">
+          <p className="mt-1 text-center text-xs text-muted-foreground">
             {spec.unitLabel}
           </p>
         </CardContent>
@@ -1173,7 +1173,7 @@ function EventHistogramSection({
               />
             </BarChart>
           </ChartContainer>
-          <p className="mt-1 text-center text-[10px] text-muted-foreground">
+          <p className="mt-1 text-center text-xs text-muted-foreground">
             {r?.short_label ?? r?.label ?? spec.metric}
             {r?.unit ? ` (${r.unit})` : ""}
           </p>
@@ -1240,7 +1240,7 @@ function ConcentrationSection({
               <div className="text-xs font-medium text-muted-foreground">
                 {c.label}
               </div>
-              <div className="mt-1 text-2xl font-semibold tabular-nums">
+              <div className="mt-1 text-3xl font-semibold tabular-nums">
                 {Math.round(c.share * 100)}%
               </div>
               <div className="text-xs text-muted-foreground">

--- a/src/frontend/src/components/portal/employees-view.tsx
+++ b/src/frontend/src/components/portal/employees-view.tsx
@@ -102,7 +102,7 @@ export function EmployeesView() {
     <div className="flex flex-col gap-3 p-4 md:p-6">
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
-          <h1 className="text-xl font-semibold tracking-tight">Employees</h1>
+          <h1 className="text-lg font-semibold tracking-tight">Employees</h1>
           <p className="text-sm text-muted-foreground">
             {filtered.length}
             {filtered.length !== employees.length ? ` of ${employees.length}` : ""}{" "}

--- a/src/frontend/src/components/portal/manage-view.tsx
+++ b/src/frontend/src/components/portal/manage-view.tsx
@@ -79,7 +79,7 @@ function MetricCatalogTable() {
   return (
     <div className="flex flex-col gap-3 p-4 md:p-6">
       <div>
-        <h1 className="text-xl font-semibold tracking-tight">Metric catalog</h1>
+        <h1 className="text-lg font-semibold tracking-tight">Metric catalog</h1>
         <p className="text-sm text-muted-foreground">
           {metrics.length} metrics · live from{" "}
           <code className="text-xs">/v1/metric-definitions</code>
@@ -158,7 +158,7 @@ function DataHealth() {
   return (
     <div className="flex flex-col gap-4 p-4 md:p-6">
       <div>
-        <h1 className="text-xl font-semibold tracking-tight">Data health</h1>
+        <h1 className="text-lg font-semibold tracking-tight">Data health</h1>
         <p className="text-sm text-muted-foreground">
           Schema-check status across {metrics.length} metrics
         </p>

--- a/src/frontend/src/components/portal/manage-view.tsx
+++ b/src/frontend/src/components/portal/manage-view.tsx
@@ -16,6 +16,7 @@ import type {
   MetricDefinition,
 } from "@/api/metric-definitions-client";
 import { useMetricDefinitions } from "@/queries/metric-definitions";
+import { TEXT_FIGURE } from "@/lib/type-scale";
 import { cn } from "@/lib/utils";
 
 const STATUS_STYLE: Record<MetricDefinitionSchemaStatus, string> = {
@@ -166,7 +167,7 @@ function DataHealth() {
       <div className="grid grid-cols-[repeat(auto-fit,minmax(11rem,1fr))] gap-3">
         {(["ok", "error", "unchecked"] as const).map((s) => (
           <div key={s} className="rounded-lg border bg-card p-4">
-            <div className="text-3xl font-semibold tabular-nums">{counts[s]}</div>
+            <div className={TEXT_FIGURE}>{counts[s]}</div>
             <div
               className={cn(
                 "mt-1 inline-flex rounded-full px-2 py-0.5 text-xs font-medium",
@@ -178,7 +179,7 @@ function DataHealth() {
           </div>
         ))}
         <div className="rounded-lg border bg-card p-4">
-          <div className="text-3xl font-semibold tabular-nums">{noData}</div>
+          <div className={TEXT_FIGURE}>{noData}</div>
           <div className="mt-1 inline-flex rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
             no data yet
           </div>

--- a/src/frontend/src/components/portal/metric-groups-view.tsx
+++ b/src/frontend/src/components/portal/metric-groups-view.tsx
@@ -29,6 +29,7 @@ import {
   type MetricCollectionConfig,
 } from "@/lib/metrics/collection";
 import { normalizePersonId } from "@/lib/metrics/entity";
+import { TEXT_EYEBROW } from "@/lib/type-scale";
 import { cn } from "@/lib/utils";
 import { useCohortLabel } from "@/lib/portal/use-cohort-label";
 import { usePersonCohort } from "@/lib/portal/use-person-cohort";
@@ -331,7 +332,7 @@ export function MetricGroupsView({
                 complete picture by then. */}
             <PersonCoverage unmeasured={unmeasured} inactive={inactive} />
             <section className="flex flex-col gap-3">
-              <p className="flex flex-wrap items-baseline gap-x-2 text-xs font-medium tracking-wider text-muted-foreground uppercase">
+              <p className={cn("flex flex-wrap items-baseline gap-x-2", TEXT_EYEBROW)}>
                 At a glance
                 {/* Whose median. Every comparison on this page says "vs median"
                     and none of them said against whom — which is the one thing

--- a/src/frontend/src/components/portal/person-header.tsx
+++ b/src/frontend/src/components/portal/person-header.tsx
@@ -152,7 +152,7 @@ export function PersonHeader({ person }: { person: string }) {
           title
         )}
         {subtitle ? (
-          <p className="truncate text-xs text-muted-foreground">{subtitle}</p>
+          <p className="truncate text-sm text-muted-foreground">{subtitle}</p>
         ) : null}
       </div>
 

--- a/src/frontend/src/components/portal/single-group-view.tsx
+++ b/src/frontend/src/components/portal/single-group-view.tsx
@@ -18,6 +18,7 @@ import {
 import { normalizePersonId } from "@/lib/metrics/entity";
 import { usePersonCohort } from "@/lib/portal/use-person-cohort";
 import { useMetricCollection } from "@/queries/metric-results";
+import { TEXT_TITLE } from "@/lib/type-scale";
 
 const EMPTY_COLLECTION: MetricCollectionConfig = { metrics: [] };
 const CLOSED_ENTITY = { type: "person" as const, ids: [] };
@@ -132,7 +133,7 @@ export function SingleGroupView({
   if (!groupHasData(def, injectedData.byKey, entityId)) {
     return (
       <div className="flex flex-col gap-3 p-4 md:p-6">
-        <h1 className="text-xl font-semibold tracking-tight">{def.title}</h1>
+        <h1 className={TEXT_TITLE}>{def.title}</h1>
         <p className="text-sm text-muted-foreground">
           Nothing recorded here for the selected period.
         </p>
@@ -150,7 +151,7 @@ export function SingleGroupView({
 
   return (
     <div className="flex flex-col gap-4 p-4 md:p-6">
-      <h1 className="text-xl font-semibold tracking-tight">{def.title}</h1>
+      <h1 className={TEXT_TITLE}>{def.title}</h1>
       {sources.length > 0 ? (
         // What was being watched, next to what it concluded. A low number
         // means one thing when the tool everyone uses is connected and

--- a/src/frontend/src/components/portal/team-state-view.tsx
+++ b/src/frontend/src/components/portal/team-state-view.tsx
@@ -29,6 +29,8 @@ import type { TeamMember } from "@/types/insight";
 import { useCohortLabel } from "@/lib/portal/use-cohort-label";
 import { useOrgScope } from "@/lib/portal/use-org-scope";
 import { useMemberGridData } from "@/queries/member-grid";
+import { TEXT_FIGURE } from "@/lib/type-scale";
+import { cn } from "@/lib/utils";
 
 const EMPTY_COLLECTION: MetricCollectionConfig = { metrics: [] };
 
@@ -223,7 +225,7 @@ export function TeamStateView() {
             <Card key={s.key}>
               <CardContent className="p-4">
                 <div className="text-xs font-medium text-muted-foreground">{s.label}</div>
-                <div className="mt-1 text-3xl font-semibold tabular-nums">{s.text}</div>
+                <div className={cn("mt-1", TEXT_FIGURE)}>{s.text}</div>
                 <div className="text-xs text-muted-foreground">{s.kind}</div>
               </CardContent>
             </Card>

--- a/src/frontend/src/components/portal/team-state-view.tsx
+++ b/src/frontend/src/components/portal/team-state-view.tsx
@@ -208,7 +208,7 @@ export function TeamStateView() {
   return (
     <div className="flex flex-col gap-6 p-4 md:p-6">
       <div>
-        <h1 className="text-xl font-semibold tracking-tight">
+        <h1 className="text-lg font-semibold tracking-tight">
           {teamName ? `${teamName}'s team` : "Team"}
         </h1>
         <p className="text-sm text-muted-foreground">
@@ -223,7 +223,7 @@ export function TeamStateView() {
             <Card key={s.key}>
               <CardContent className="p-4">
                 <div className="text-xs font-medium text-muted-foreground">{s.label}</div>
-                <div className="mt-1 text-2xl font-semibold tabular-nums">{s.text}</div>
+                <div className="mt-1 text-3xl font-semibold tabular-nums">{s.text}</div>
                 <div className="text-xs text-muted-foreground">{s.kind}</div>
               </CardContent>
             </Card>

--- a/src/frontend/src/components/portal/zone-content.tsx
+++ b/src/frontend/src/components/portal/zone-content.tsx
@@ -63,7 +63,7 @@ function ZoneScaffold({ zone }: { zone: string }) {
   return (
     <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8">
       <div className="flex flex-col items-center gap-1 text-center">
-        <h1 className="text-2xl font-semibold tracking-tight">
+        <h1 className="text-lg font-semibold tracking-tight">
           {zoneById(zone)?.label ?? "Portal"}
         </h1>
         <p className="max-w-md text-sm text-muted-foreground">

--- a/src/frontend/src/components/sidebar-settings.tsx
+++ b/src/frontend/src/components/sidebar-settings.tsx
@@ -74,7 +74,7 @@ export function SidebarSettings() {
         </SidebarMenuItem>
       ) : null}
       <SidebarMenuItem className="flex flex-col items-stretch gap-1.5 p-1">
-        <span className="px-1 text-[10px] font-medium uppercase tracking-wider text-sidebar-foreground/60">
+        <span className="px-1 text-xs font-medium uppercase tracking-wider text-sidebar-foreground/60">
           {t("settings.focus_mode.label")}
         </span>
         <ToggleGroup

--- a/src/frontend/src/components/widgets/dashboard/dashboard-header.tsx
+++ b/src/frontend/src/components/widgets/dashboard/dashboard-header.tsx
@@ -4,6 +4,7 @@ import { IcViewToggle } from "@/components/ic-view-toggle";
 import { PeriodSelectorBar } from "@/components/widgets/period-selector-bar";
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { usePeriod } from "@/hooks/use-period";
+import { TEXT_TITLE } from "@/lib/type-scale";
 
 export interface DashboardHeaderProps {
   title: string;
@@ -28,7 +29,7 @@ export function DashboardHeader({
       <div className="flex items-center gap-3">
         <SidebarTrigger />
         <div className="flex flex-col">
-          <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
+          <h1 className={TEXT_TITLE}>{title}</h1>
           {subtitle ? (
             <p className="text-xs text-muted-foreground">{subtitle}</p>
           ) : null}

--- a/src/frontend/src/components/widgets/dashboard/ic-needs-attention.tsx
+++ b/src/frontend/src/components/widgets/dashboard/ic-needs-attention.tsx
@@ -138,7 +138,7 @@ export function IcNeedsAttention({
                         a row that only reacts to hover is indistinguishable from
                         a line of text until the mouse happens to cross it. */}
                     <ChevronRight
-                      className="size-3.5 shrink-0 self-center text-muted-foreground/50"
+                      className="size-3.5 shrink-0 self-center text-muted-foreground"
                       aria-hidden
                     />
                   </button>

--- a/src/frontend/src/components/widgets/dashboard/ic-needs-attention.tsx
+++ b/src/frontend/src/components/widgets/dashboard/ic-needs-attention.tsx
@@ -7,6 +7,7 @@ import { useSettings } from "@/hooks/use-settings";
 import type { AttentionItem } from "@/lib/insight/attention";
 import type { GroupId } from "@/lib/insight/groups";
 import { PEER_TEXT, applyFocus } from "@/lib/peers";
+import { TEXT_EYEBROW, TEXT_LABEL, TEXT_NAME } from "@/lib/type-scale";
 import { cn } from "@/lib/utils";
 
 const COLLAPSED_ATTENTION = 6;
@@ -48,7 +49,7 @@ export function IcNeedsAttention({
 
   return (
     <section>
-      <h2 className="mb-3 text-xs font-medium tracking-wider text-muted-foreground uppercase">
+      <h2 className={cn("mb-3", TEXT_EYEBROW)}>
         Needs attention
       </h2>
       <Card data-size="sm">
@@ -89,13 +90,13 @@ export function IcNeedsAttention({
                     className="-mx-2 flex w-[calc(100%+1rem)] flex-col gap-x-2 rounded px-2 py-1 text-left text-sm transition-colors hover:bg-accent sm:col-span-full sm:grid sm:w-auto sm:grid-cols-subgrid sm:items-baseline"
                   >
                     <span className="flex min-w-0 items-baseline gap-2 sm:contents">
-                      <span className="min-w-0 truncate text-foreground">
+                      <span className={cn("min-w-0 truncate", TEXT_NAME)}>
                         {item.label}
                       </span>
                       {/* Beside the name, not stranded at the far edge of the
                           row: it says what KIND of finding this name is, and
                           half a row away it was read as a fifth number. */}
-                      <span className="shrink-0 justify-self-start rounded border px-1.5 text-[0.6875rem] whitespace-nowrap text-muted-foreground">
+                      <span className={cn("shrink-0 justify-self-start rounded border px-1.5 whitespace-nowrap", TEXT_LABEL)}>
                         {item.kind === "fell"
                           ? "fell this period"
                           : item.noPrevious
@@ -124,7 +125,7 @@ export function IcNeedsAttention({
                       >
                         {item.valueUnit}
                       </span>
-                      <span className="truncate text-xs whitespace-nowrap text-muted-foreground tabular-nums">
+                      <span className={cn("truncate whitespace-nowrap tabular-nums", TEXT_LABEL)}>
                         {item.medianText ? (
                           <>
                             {item.gapText ? <>{item.gapText} vs </> : null}
@@ -149,7 +150,7 @@ export function IcNeedsAttention({
                 <button
                   type="button"
                   onClick={() => setShowAll((v) => !v)}
-                  className="rounded text-xs font-semibold text-muted-foreground transition-colors hover:text-foreground"
+                  className={cn(TEXT_LABEL, "rounded transition-colors hover:text-foreground")}
                 >
                   {showAll
                     ? "Show fewer"

--- a/src/frontend/src/components/widgets/dashboard/kpi-tile.tsx
+++ b/src/frontend/src/components/widgets/dashboard/kpi-tile.tsx
@@ -76,7 +76,7 @@ export function KpiTile({
             tile — it already carries a delta badge. */}
         {interactive ? (
           <ChevronRight
-            className="absolute right-3 bottom-3 size-3.5 text-muted-foreground/50"
+            className="absolute right-3 bottom-3 size-3.5 text-muted-foreground"
             aria-hidden
           />
         ) : null}

--- a/src/frontend/src/components/widgets/dashboard/kpi-tile.tsx
+++ b/src/frontend/src/components/widgets/dashboard/kpi-tile.tsx
@@ -19,6 +19,7 @@ import { useSettings } from "@/hooks/use-settings";
 import type { KpiTileData } from "@/lib/insight/kpi-row";
 import type { GroupId } from "@/lib/insight/groups";
 import { STATUS_TEXT_CLASS } from "@/lib/status";
+import { TEXT_FIGURE, TEXT_LABEL, TEXT_NAME } from "@/lib/type-scale";
 import { cn } from "@/lib/utils";
 
 export interface KpiTileProps {
@@ -84,11 +85,13 @@ export function KpiTile({
               requests mer…" is not a shorter name, it is a missing one. The
               fixed two-line height keeps tiles in a row aligned whether their
               names take one line or two. */}
-          <CardDescription className="line-clamp-2 min-h-[2lh] min-w-0">
+          <CardDescription
+            className={cn(TEXT_NAME, "line-clamp-2 min-h-[2lh] min-w-0")}
+          >
             {tile.label}
           </CardDescription>
           {showExplanations ? (
-            <CardDescription className="col-span-full line-clamp-2 min-h-[2lh] min-w-0 font-normal text-muted-foreground/70">
+            <CardDescription className={cn(TEXT_LABEL, "col-span-full line-clamp-2 min-h-[2lh] min-w-0 font-normal")}>
               {tile.help?.description}
             </CardDescription>
           ) : null}
@@ -98,7 +101,7 @@ export function KpiTile({
           <CardTitle
             className={cn(
               "col-span-full flex w-full flex-wrap items-baseline justify-between gap-x-2 gap-y-1",
-              "text-2xl font-semibold tabular-nums @[250px]/card:text-3xl"
+              TEXT_FIGURE
             )}
           >
             <span>{tile.value}</span>
@@ -119,7 +122,7 @@ export function KpiTile({
             even when one of them wraps its badge onto a second line; the
             two-line reserve keeps a wrapped comparison from changing the
             card's height. */}
-        <CardFooter className="mt-auto min-h-[2lh] flex-col items-start gap-0.5 text-sm">
+        <CardFooter className={cn("mt-auto min-h-[2lh] flex-col items-start gap-0.5", TEXT_LABEL)}>
           {/* The person's own change first, and the only line carrying a
               verdict. This is their page: their own last period is the one
               comparison they can act on. */}
@@ -140,14 +143,12 @@ export function KpiTile({
               {tile.delta.text} since last {periodNoun}
             </span>
           ) : (
-            <span className="text-muted-foreground">
-              no earlier {periodNoun} to compare
-            </span>
+            <span>no earlier {periodNoun} to compare</span>
           )}
           {/* The cohort, stated and not judged: the reader did not choose these
               people, cannot see who they are, and cannot decide that their
               median is the right target. */}
-          <span className="text-xs text-muted-foreground">
+          <span>
             {tile.medianLabel
               ? `Team ${tile.medianLabel}${tile.gapText ? ` · ${tile.gapText}` : ""}`
               : "No peer data"}
@@ -169,9 +170,9 @@ export function KpiTilePlaceholder({ label }: { label?: string }) {
         {showExplanations ? (
           <CardDescription className="col-span-full min-h-[2lh]" />
         ) : null}
-        <CardTitle className="text-2xl font-semibold tabular-nums">—</CardTitle>
+        <CardTitle className={TEXT_FIGURE}>—</CardTitle>
       </CardHeader>
-      <CardFooter className="gap-1.5 text-sm text-muted-foreground">
+      <CardFooter className={cn("gap-1.5", TEXT_LABEL)}>
         <Sparkles className="size-3.5 shrink-0" aria-hidden />
         Coming soon
       </CardFooter>

--- a/src/frontend/src/components/widgets/dashboard/members-grid.tsx
+++ b/src/frontend/src/components/widgets/dashboard/members-grid.tsx
@@ -54,6 +54,7 @@ import {
   type PeerStatusWithNeutral,
 } from "@/lib/peers";
 import { applyFocusStatus, STATUS_TEXT_CLASS } from "@/lib/status";
+import { TEXT_FIGURE } from "@/lib/type-scale";
 import { cn } from "@/lib/utils";
 import { evidenceSelection } from "@/api/metric-drilldown-client";
 import { useMetricEvidenceOptional } from "@/components/metric-evidence-context";
@@ -631,7 +632,7 @@ function GridCell({
           <p className="text-xs text-muted-foreground">{memberName}</p>
           <p
             className={cn(
-              "mt-2 text-3xl font-semibold tabular-nums",
+              "mt-2", TEXT_FIGURE, "",
               PEER_TEXT[focused]
             )}
           >

--- a/src/frontend/src/components/widgets/dashboard/members-grid.tsx
+++ b/src/frontend/src/components/widgets/dashboard/members-grid.tsx
@@ -505,7 +505,7 @@ function MemberRow({
             ) : null}
           </div>
           {showIssues && counts.bottom > 0 && worstLabel ? (
-            <p className="truncate text-[11px] leading-tight text-muted-foreground">
+            <p className="truncate text-xs leading-tight text-muted-foreground">
               worst: {worstLabel}
             </p>
           ) : null}
@@ -631,7 +631,7 @@ function GridCell({
           <p className="text-xs text-muted-foreground">{memberName}</p>
           <p
             className={cn(
-              "mt-2 text-2xl font-semibold tabular-nums",
+              "mt-2 text-3xl font-semibold tabular-nums",
               PEER_TEXT[focused]
             )}
           >

--- a/src/frontend/src/components/widgets/dashboard/metric-sublabel.tsx
+++ b/src/frontend/src/components/widgets/dashboard/metric-sublabel.tsx
@@ -1,4 +1,5 @@
 import { useSettings } from "@/hooks/use-settings";
+import { TEXT_LABEL } from "@/lib/type-scale";
 import { cn } from "@/lib/utils";
 
 export interface MetricSublabelProps {
@@ -18,7 +19,7 @@ export function MetricSublabel({
   return (
     <p
       className={cn(
-        "line-clamp-2 text-xs leading-snug text-muted-foreground",
+        cn("line-clamp-2 leading-snug", TEXT_LABEL),
         className,
       )}
     >

--- a/src/frontend/src/components/widgets/dashboard/person-coverage.tsx
+++ b/src/frontend/src/components/widgets/dashboard/person-coverage.tsx
@@ -28,7 +28,7 @@ function list(titles: string[]): string {
 export function PersonCoverage({ unmeasured, inactive }: PersonCoverageProps) {
   if (unmeasured.length === 0 && inactive.length === 0) return null;
   return (
-    <p className="text-xs text-muted-foreground">
+    <p className="text-sm text-muted-foreground">
       {unmeasured.length > 0 ? (
         <>
           No data reaches us for {list(unmeasured)} — this page shows what is

--- a/src/frontend/src/components/widgets/dashboard/sparkline.tsx
+++ b/src/frontend/src/components/widgets/dashboard/sparkline.tsx
@@ -51,7 +51,7 @@ export function Sparkline({ points, className }: SparklineProps) {
       viewBox={`0 0 ${W} ${H + 3}`}
       width={W}
       height={H + 3}
-      className={cn("overflow-visible text-foreground/40", className)}
+      className={cn("overflow-visible text-muted-foreground", className)}
       aria-hidden
     >
       {/* A rule under the line, spanning the whole window.
@@ -67,7 +67,7 @@ export function Sparkline({ points, className }: SparklineProps) {
         y2={H + 2}
         stroke="currentColor"
         strokeWidth={0.75}
-        className="text-foreground/15"
+        className="text-muted-foreground"
       />
       {/* Ticks at the ends, so the span reads as a span. */}
       <line
@@ -77,7 +77,7 @@ export function Sparkline({ points, className }: SparklineProps) {
         y2={H + 3}
         stroke="currentColor"
         strokeWidth={0.75}
-        className="text-foreground/20"
+        className="text-muted-foreground"
       />
       <line
         x1={W}
@@ -86,7 +86,7 @@ export function Sparkline({ points, className }: SparklineProps) {
         y2={H + 3}
         stroke="currentColor"
         strokeWidth={0.75}
-        className="text-foreground/20"
+        className="text-muted-foreground"
       />
       {segments.map((d) => (
         <path

--- a/src/frontend/src/components/widgets/dashboard/team-members-attention.tsx
+++ b/src/frontend/src/components/widgets/dashboard/team-members-attention.tsx
@@ -57,7 +57,7 @@ export function TeamMembersAttention({
       </h2>
       <Card data-size="sm">
         <CardContent className="flex flex-col gap-2 text-sm">
-          <span className="text-[11px] text-muted-foreground">{subtitle}</span>
+          <span className="text-xs text-muted-foreground">{subtitle}</span>
           <ul className="grid grid-cols-1 gap-x-8 gap-y-1 md:grid-cols-2">
             {attention.map(({ member, belowCount, worstLabel }) => (
               <li key={member.person_id}>
@@ -76,7 +76,7 @@ export function TeamMembersAttention({
                   ) : null}
                   <span
                     className={cn(
-                      "ml-auto shrink-0 font-mono font-bold tabular-nums",
+                      "ml-auto shrink-0 font-mono font-semibold tabular-nums",
                       PEER_TEXT[badStatus],
                     )}
                   >

--- a/src/frontend/src/components/widgets/metric-help-tooltip.tsx
+++ b/src/frontend/src/components/widgets/metric-help-tooltip.tsx
@@ -37,7 +37,7 @@ export function MetricHelpTooltip({ help, children }: MetricHelpTooltipProps) {
         <TooltipContent
           data-testid="metric-help"
           side="top"
-          className="flex-col items-start gap-1.5 text-left leading-relaxed"
+          className="flex-col items-start gap-1.5 text-left text-sm leading-relaxed"
         >
           {help.description ? <p>{help.description}</p> : null}
           {help.explanation ? (

--- a/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
@@ -333,7 +333,7 @@ function DayStrip({
           </div>
         ))}
       </div>
-      <div className="flex justify-between text-[0.6875rem] text-muted-foreground">
+      <div className="flex justify-between text-xs text-muted-foreground">
         <span>{period ? formatDate(period.from) : null}</span>
         <span
           className={cn(

--- a/src/frontend/src/components/widgets/metric-views/metric-group-card.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-group-card.tsx
@@ -178,7 +178,7 @@ export function MetricGroupCard({
               interactive and gets none. */}
           {isEmpty ? null : (
             <ChevronRight
-              className="size-4 shrink-0 text-muted-foreground/60"
+              className="size-4 shrink-0 text-muted-foreground"
               aria-hidden
             />
           )}

--- a/src/frontend/src/components/widgets/metric-views/metric-group-card.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-group-card.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/lib/scoring";
 import { STATUS_BG_CLASS, applyFocusStatus } from "@/lib/status";
 import type { MetricCollectionResult } from "@/queries/metric-results";
+import { TEXT_HEADING } from "@/lib/type-scale";
 import { cn } from "@/lib/utils";
 
 export interface MetricGroupCardProps {
@@ -78,7 +79,7 @@ export function MetricGroupCard({
     return (
       <Card>
         <CardHeader>
-          <CardTitle className="text-base font-semibold">{def.title}</CardTitle>
+          <CardTitle className={TEXT_HEADING}>{def.title}</CardTitle>
           {subtitle ? (
             <CardDescription className="text-xs text-muted-foreground">
               {subtitle}
@@ -171,7 +172,7 @@ export function MetricGroupCard({
       )}
     >
       <CardHeader>
-        <CardTitle className="flex items-center gap-1 text-base font-semibold">
+        <CardTitle className={cn("flex items-center gap-1", TEXT_HEADING)}>
           <span className="min-w-0 truncate">{def.title}</span>
           {/* Same standing affordance as the KPI tile — an empty card is not
               interactive and gets none. */}

--- a/src/frontend/src/components/widgets/metric-views/metric-summary-card.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-summary-card.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/lib/metrics/collection";
 import { seriesColors } from "@/lib/series-colors";
 import { evidenceSelection } from "@/api/metric-drilldown-client";
+import { TEXT_FIGURE } from "@/lib/type-scale";
 
 export interface MetricSummaryCardProps {
   metric: NormalizedMetricResult;
@@ -94,7 +95,7 @@ export function MetricSummaryCard({
           />
         </div>
         <span className="flex items-baseline gap-1 tabular-nums">
-          <span className="text-3xl font-semibold">
+          <span className={TEXT_FIGURE}>
             {value == null
               ? "—"
               : metric.format === "percent"

--- a/src/frontend/src/components/widgets/metric-views/peer-comparison.tsx
+++ b/src/frontend/src/components/widgets/metric-views/peer-comparison.tsx
@@ -88,7 +88,7 @@ export function PeerComparison({
       </div>
       {/* Min/max hug the bar (mt-1); the value pointer sits above the bar
           (ArrowDown), clear of these labels. */}
-      <div className="mt-1 grid grid-cols-2 gap-3 text-[10px] tabular-nums">
+      <div className="mt-1 grid grid-cols-2 gap-3 text-xs tabular-nums">
         <span className="text-left text-muted-foreground">
           {formatMetricValue(stats.min, format, unit)}
         </span>

--- a/src/frontend/src/components/widgets/metric-views/peer-mark.tsx
+++ b/src/frontend/src/components/widgets/metric-views/peer-mark.tsx
@@ -91,7 +91,7 @@ export function PeerMark({
   // The overview's own verdict, reused rather than re-derived: a section and
   // the page that sent the reader to it must not disagree about what counts.
   const adverse = standing.rank === "bottom";
-  const markClass = adverse ? "text-destructive" : "text-foreground/70";
+  const markClass = adverse ? "text-destructive" : "text-muted-foreground";
 
   const svg = (
     <svg
@@ -114,7 +114,7 @@ export function PeerMark({
           y2={H}
           stroke="currentColor"
           strokeWidth={1}
-          className="text-foreground/10"
+          className="text-muted-foreground"
         />
       ))}
       {spreads == null ? null : pinned ? (

--- a/src/frontend/src/components/widgets/metric-views/peer-story.tsx
+++ b/src/frontend/src/components/widgets/metric-views/peer-story.tsx
@@ -27,6 +27,7 @@ import {
 import { formatGapMagnitude } from "@/lib/metrics/gap";
 import { PEER_FILL, PEER_TEXT, type PeerCohortLabel } from "@/lib/peers";
 import { STATUS_STRIPE_LEFT, STATUS_STRIPE_TOP } from "@/lib/status";
+import { TEXT_FIGURE, TEXT_LABEL, TEXT_TITLE } from "@/lib/type-scale";
 import { cn } from "@/lib/utils";
 
 interface PeerStoryProps {
@@ -83,7 +84,7 @@ function HeroCard({
           </span>
         </div>
         <div>
-          <h3 className="text-xl font-semibold tracking-tight sm:text-2xl">
+          <h3 className={TEXT_TITLE}>
             {entry.label}
           </h3>
           {entry.sublabel ? (
@@ -96,7 +97,7 @@ function HeroCard({
           <span className="flex items-baseline gap-1">
             <span
               className={cn(
-                "text-4xl font-semibold tracking-tight tabular-nums sm:text-[2.75rem]",
+                TEXT_FIGURE,
                 PEER_TEXT[color]
               )}
             >
@@ -105,7 +106,7 @@ function HeroCard({
                 : formatMetricNumber(entry.value, entry.format)}
             </span>
             {unit ? (
-              <span className="text-base text-muted-foreground">{unit}</span>
+              <span className={TEXT_LABEL}>{unit}</span>
             ) : null}
           </span>
           {entry.stats ? (
@@ -222,7 +223,7 @@ function SideCard({
                 which outgrows these cards), so chips are the only
                 tooltip-gated tier. */}
             <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-              <span className="text-2xl font-semibold tabular-nums">
+              <span className={TEXT_FIGURE}>
                 {entry.format === "percent"
                   ? formatMetricValue(entry.value, entry.format, entry.unit)
                   : formatMetricNumber(entry.value, entry.format)}
@@ -262,7 +263,7 @@ function SideCard({
                 </>
               ) : null}
             </div>
-            <div className="mt-1 truncate text-[11px] text-muted-foreground">
+            <div className="mt-1 truncate text-xs text-muted-foreground">
               {outlierText(entry.status)}
             </div>
           </div>
@@ -359,7 +360,7 @@ function FlatGridCard({ entry }: { entry: PeerStoryEntry }) {
           </div>
         ) : null}
       </div>
-      <div className="mt-5 text-2xl font-semibold tabular-nums">
+      <div className={cn("mt-5", TEXT_FIGURE)}>
         {entry.format === "percent"
           ? formatMetricValue(entry.value, entry.format, entry.unit)
           : formatMetricNumber(entry.value, entry.format)}
@@ -436,7 +437,7 @@ function SupportingFold({
           <div className="text-sm font-medium">
             {open ? "Hide" : "Show"} {summaryLabel}
           </div>
-          <div className="text-[11px] text-muted-foreground">
+          <div className="text-xs text-muted-foreground">
             {summaryDescription}
           </div>
         </div>

--- a/src/frontend/src/components/widgets/metric-views/peer-story.tsx
+++ b/src/frontend/src/components/widgets/metric-views/peer-story.tsx
@@ -76,7 +76,7 @@ function HeroCard({
           <span className={cn("size-1.5 rounded-full", PEER_FILL[color])} />
           <span
             className={cn(
-              "text-[10px] font-semibold tracking-widest uppercase",
+              "text-xs font-semibold tracking-widest uppercase",
               PEER_TEXT[color]
             )}
           >

--- a/src/frontend/src/components/widgets/metric-views/section-metric-index.tsx
+++ b/src/frontend/src/components/widgets/metric-views/section-metric-index.tsx
@@ -4,6 +4,8 @@ import {
   PeerMark,
 } from "@/components/widgets/metric-views/peer-mark";
 import { formatMetricValue } from "@/lib/format";
+import { TEXT_EYEBROW, TEXT_LABEL, TEXT_NAME } from "@/lib/type-scale";
+import { cn } from "@/lib/utils";
 import { metricComparisons } from "@/lib/insight/metric-comparison";
 import { derivePeerStanding } from "@/lib/metrics/peer-standing";
 import {
@@ -67,7 +69,7 @@ export function SectionMetricIndex({
 
   return (
     <section className="rounded-xl border p-4 sm:p-5">
-      <h2 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+      <h2 className={TEXT_EYEBROW}>
         Also measured here
       </h2>
       {/* One column, whatever the width. Side-by-side columns of aligned
@@ -90,10 +92,10 @@ export function SectionMetricIndex({
             key={metric.metric_key}
             className="flex items-center justify-between gap-4 border-b border-dashed py-1 last:border-b-0"
           >
-            <dt className="min-w-0 flex-1 truncate text-xs">
+            <dt className={cn("min-w-0 flex-1 truncate", TEXT_NAME)}>
               <MetricName metric={metric} />
             </dt>
-            <dd className="flex shrink-0 items-baseline gap-2 text-xs tabular-nums">
+            <dd className={cn("flex shrink-0 items-baseline gap-2 tabular-nums", TEXT_LABEL)}>
               <span className="w-32 text-right">
                 {formatMetricValue(
                   forEntity(metric, entityId).value,

--- a/src/frontend/src/components/widgets/metric-views/section-metric-index.tsx
+++ b/src/frontend/src/components/widgets/metric-views/section-metric-index.tsx
@@ -4,7 +4,7 @@ import {
   PeerMark,
 } from "@/components/widgets/metric-views/peer-mark";
 import { formatMetricValue } from "@/lib/format";
-import { TEXT_EYEBROW, TEXT_LABEL, TEXT_NAME } from "@/lib/type-scale";
+import { TEXT_BODY, TEXT_EYEBROW, TEXT_LABEL, TEXT_NAME } from "@/lib/type-scale";
 import { cn } from "@/lib/utils";
 import { metricComparisons } from "@/lib/insight/metric-comparison";
 import { derivePeerStanding } from "@/lib/metrics/peer-standing";
@@ -95,8 +95,12 @@ export function SectionMetricIndex({
             <dt className={cn("min-w-0 flex-1 truncate", TEXT_NAME)}>
               <MetricName metric={metric} />
             </dt>
-            <dd className={cn("flex shrink-0 items-baseline gap-2 tabular-nums", TEXT_LABEL)}>
-              <span className="w-32 text-right">
+            {/* Layout only. Putting the label role on the container greyed
+                the person's own value along with its median, so the subject of
+                the row and the context around it read the same — which is the
+                distinction this scale exists to make. */}
+            <dd className="flex shrink-0 items-baseline gap-2 tabular-nums">
+              <span className={cn("w-32 text-right", TEXT_BODY)}>
                 {formatMetricValue(
                   forEntity(metric, entityId).value,
                   metric.format,
@@ -107,7 +111,7 @@ export function SectionMetricIndex({
                   anything. Uncoloured: a list of thirty numbers lit up by
                   quartile is a scoreboard, and the reader did not ask to be
                   scored on every one of them. */}
-              <span className="w-28 text-right text-muted-foreground">
+              <span className={cn("w-28 text-right", TEXT_LABEL)}>
                 {metricComparisons(metric, null, entityId).median ?? ""}
               </span>
               {/* And how far off that middle, on the axis every row shares.

--- a/src/frontend/src/components/widgets/metric-views/team-metric-group-card.tsx
+++ b/src/frontend/src/components/widgets/metric-views/team-metric-group-card.tsx
@@ -22,6 +22,7 @@ import {
 import { applyFocus, PEER_TEXT } from "@/lib/peers";
 import { STATUS_BG_CLASS, applyFocusStatus } from "@/lib/status";
 import type { MetricCollectionResult } from "@/queries/metric-results";
+import { TEXT_HEADING } from "@/lib/type-scale";
 import { cn } from "@/lib/utils";
 
 export interface TeamMetricGroupCardProps {
@@ -53,7 +54,7 @@ export function TeamMetricGroupCard({
     return (
       <Card>
         <CardHeader>
-          <CardTitle className="text-base font-semibold">{def.title}</CardTitle>
+          <CardTitle className={TEXT_HEADING}>{def.title}</CardTitle>
           {subtitle ? (
             <CardDescription className="text-xs text-muted-foreground">
               {subtitle}
@@ -106,7 +107,7 @@ export function TeamMetricGroupCard({
       className={cn("text-left transition-colors hover:bg-accent/50")}
     >
       <CardHeader>
-        <CardTitle className="text-base font-semibold">{def.title}</CardTitle>
+        <CardTitle className={TEXT_HEADING}>{def.title}</CardTitle>
         <CardDescription className="flex flex-col gap-1 text-xs">
           {subtitle ? (
             <span className="text-muted-foreground">{subtitle}</span>

--- a/src/frontend/src/components/widgets/period-selector-bar.tsx
+++ b/src/frontend/src/components/widgets/period-selector-bar.tsx
@@ -160,7 +160,7 @@ export function PeriodSelectorBar({
                     <TooltipTrigger
                       render={
                         <span
-                          className="rounded bg-muted px-1 py-px text-[10px] font-semibold tracking-wider text-muted-foreground uppercase"
+                          className="rounded bg-muted px-1 py-px text-xs font-semibold tracking-wider text-muted-foreground uppercase"
                           aria-label="Dates bucketed by UTC midnight"
                           onClick={(e) => e.stopPropagation()}
                         >

--- a/src/frontend/src/lib/type-scale.ts
+++ b/src/frontend/src/lib/type-scale.ts
@@ -1,0 +1,58 @@
+/**
+ * The five text roles a person-facing screen is allowed to use.
+ *
+ * Not a tidy-up. Measured on the person page before this existed: six sizes
+ * across nine size-and-weight combinations, and the distinctions did not line
+ * up with meaning. A section heading differed from a caption by weight alone at
+ * the same 12px. One 14px step carried a control, a metric's name, a card's
+ * label AND the metric's own value, so a row read flat — the number looked like
+ * its label. The same thing, a metric's name, was near-black in one place and
+ * grey in another. Two pill sizes, 10px and 11px, sat next to each other.
+ *
+ * A reader learns a screen by learning its rules. Nine combinations with no
+ * rule behind them is not a hierarchy, it is decoration, and the eye has
+ * nothing to hold on to.
+ *
+ * So: one role, one style, and every role visibly different from its
+ * neighbours. Reach for the nearest role rather than inventing a size — a size
+ * used once is the drift starting again.
+ */
+
+/** The single large number on a card. Tabular so columns of digits line up. */
+export const TEXT_FIGURE = "text-3xl font-semibold tabular-nums";
+
+/** The name of the person or page. One per screen. */
+export const TEXT_TITLE = "text-lg font-semibold tracking-tight";
+
+/**
+ * The name of a thing — a metric, a card, a section. Ink, not grey.
+ *
+ * This is the subject of whatever it labels, and the reader scans by it. An
+ * earlier pass made these grey to settle a real inconsistency (the same metric
+ * name was near-black in one place and grey in another); grey was the wrong
+ * half of it to keep. What is grey is context — medians, comparisons, units,
+ * the pills that qualify a value. What names something is read first and gets
+ * the ink to say so.
+ */
+export const TEXT_NAME = "text-sm font-medium text-foreground";
+
+/** A section or card heading — a name with more weight behind it. */
+export const TEXT_HEADING = "text-sm font-semibold text-foreground";
+
+/** Values and running text — the default. */
+export const TEXT_BODY = "text-sm";
+
+/**
+ * Context around a value: medians, comparisons, units, pills, captions.
+ * Always muted, always this size — grey is what the reader's eye may skip, so
+ * nothing that must be read belongs here.
+ */
+export const TEXT_LABEL = "text-xs font-medium text-muted-foreground";
+
+/**
+ * An uppercase section eyebrow — the same step as a label, spaced out. Kept
+ * distinct from `TEXT_LABEL` only because the letter-spacing is load-bearing
+ * at that size; it is the same size and colour on purpose.
+ */
+export const TEXT_EYEBROW =
+  "text-xs font-medium tracking-wider text-muted-foreground uppercase";

--- a/src/frontend/src/lib/type-scale.ts
+++ b/src/frontend/src/lib/type-scale.ts
@@ -18,8 +18,16 @@
  * used once is the drift starting again.
  */
 
-/** The single large number on a card. Tabular so columns of digits line up. */
-export const TEXT_FIGURE = "text-3xl font-semibold tabular-nums";
+/**
+ * The single large number on a card. Tabular so columns of digits line up.
+ *
+ * 24px rather than 30: at 30 the number was the card, and everything that
+ * makes it mean something — what it counts, what it is compared against, which
+ * way it moved — sat around it as small print. A figure has to be found at a
+ * glance, not shouted; the size only has to beat the label above it, and it
+ * does that comfortably here.
+ */
+export const TEXT_FIGURE = "text-2xl font-semibold tabular-nums";
 
 /** The name of the person or page. One per screen. */
 export const TEXT_TITLE = "text-lg font-semibold tracking-tight";

--- a/src/frontend/src/screens/metric-definitions.tsx
+++ b/src/frontend/src/screens/metric-definitions.tsx
@@ -51,7 +51,7 @@ export function MetricDefinitionsScreen() {
     <>
       <header className="sticky top-0 z-20 flex flex-wrap items-center gap-3 border-b bg-background/95 px-4 py-3 backdrop-blur-sm">
         <SidebarTrigger />
-        <h1 className="text-xl font-semibold tracking-tight">
+        <h1 className="text-lg font-semibold tracking-tight">
           {t("metric_definitions.title")}
         </h1>
         <div className="relative ms-auto w-full max-w-xs">

--- a/src/frontend/src/screens/metrics-console.tsx
+++ b/src/frontend/src/screens/metrics-console.tsx
@@ -59,7 +59,7 @@ export function MetricsConsoleScreen() {
     <>
       <header className="sticky top-0 z-20 flex flex-wrap items-center gap-3 border-b bg-background/95 px-4 py-3 backdrop-blur-sm">
         <SidebarTrigger />
-        <h1 className="text-xl font-semibold tracking-tight">
+        <h1 className="text-lg font-semibold tracking-tight">
           {t("metrics_console.title")}
         </h1>
         <Button

--- a/src/frontend/src/screens/query-console.tsx
+++ b/src/frontend/src/screens/query-console.tsx
@@ -56,7 +56,7 @@ export function QueryConsoleScreen() {
     <>
       <header className="sticky top-0 z-20 flex flex-wrap items-center gap-3 border-b bg-background/95 px-4 py-3 backdrop-blur-sm">
         <SidebarTrigger />
-        <h1 className="text-xl font-semibold tracking-tight">
+        <h1 className="text-lg font-semibold tracking-tight">
           {t("query_console.title")}
         </h1>
         <Button

--- a/src/frontend/src/screens/whats-new.tsx
+++ b/src/frontend/src/screens/whats-new.tsx
@@ -85,7 +85,7 @@ function ImprovementList({
     <>
       {itemKeys.map((key) => (
         <article key={key}>
-          <h4 className="text-base leading-snug font-semibold">
+          <h4 className="text-sm leading-snug font-semibold">
             {t(`${itemsKey}.${key}.title`)}
           </h4>
           <p
@@ -118,7 +118,7 @@ function ReleaseSections({
           key={section.id}
           className="grid gap-x-5 gap-y-3 p-4 sm:grid-cols-[10rem_1fr] sm:p-5"
         >
-          <h4 className="pt-0.5 text-[11px] font-semibold tracking-wide text-muted-foreground uppercase">
+          <h4 className="pt-0.5 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
             {t(`${baseKey}.sections.${section.id}.title`)}
           </h4>
           <div className="flex flex-col gap-4">
@@ -140,7 +140,7 @@ export function WhatsNewScreen() {
     <>
       <header className="sticky top-0 z-20 flex items-center gap-3 border-b bg-background/95 px-4 py-3 backdrop-blur-sm">
         <SidebarTrigger />
-        <h1 className="text-xl font-semibold tracking-tight">
+        <h1 className="text-lg font-semibold tracking-tight">
           {t("whats_new.nav_label")}
         </h1>
       </header>
@@ -148,10 +148,10 @@ export function WhatsNewScreen() {
       <main className="flex flex-1 flex-col p-4 md:p-6">
         <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 pb-12">
           <section>
-            <p className="text-[11px] font-semibold tracking-widest text-muted-foreground uppercase">
+            <p className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
               {t("whats_new.eyebrow")}
             </p>
-            <h2 className="mt-3 text-3xl font-bold tracking-tight text-balance">
+            <h2 className="mt-3 text-lg font-semibold tracking-tight text-balance">
               {t("whats_new.title")}
             </h2>
             <div className="mt-4 flex flex-wrap gap-x-6 gap-y-2 font-mono text-xs text-muted-foreground">
@@ -177,7 +177,7 @@ export function WhatsNewScreen() {
           </section>
 
           <section>
-            <h3 className="text-[11px] font-semibold tracking-widest text-muted-foreground uppercase">
+            <h3 className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
               {t("whats_new.improvements_label")}
             </h3>
             <div className="mt-3 divide-y overflow-hidden rounded-lg border bg-card">
@@ -189,7 +189,7 @@ export function WhatsNewScreen() {
           </section>
 
           <section>
-            <h3 className="text-[11px] font-semibold tracking-widest text-muted-foreground uppercase">
+            <h3 className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
               {t("whats_new.coming.label")}
             </h3>
             <div className="mt-3 divide-y overflow-hidden rounded-lg border bg-card">
@@ -201,7 +201,7 @@ export function WhatsNewScreen() {
           </section>
 
           <section>
-            <h3 className="text-[11px] font-semibold tracking-widest text-muted-foreground uppercase">
+            <h3 className="text-xs font-semibold tracking-widest text-muted-foreground uppercase">
               {t("whats_new.history_label")}
             </h3>
             <div className="mt-3 flex flex-col gap-2.5">


### PR DESCRIPTION
The interface had drifted to twelve text sizes, five greys and four weights. None of that was decided — every one was a reasonable local choice by someone who could not see the sum, which is how this happens and why it will happen again without the last commit here.

## What was actually wrong

Measured before touching anything, because the shape was not what it looked like. The two smallest steps carried 301 of 356 usages: the noise was a tail of 55 spread across ten variants, not the body of the work.

The tail had a pattern. Nine, ten and eleven pixels were three ways of saying "small" that no reader can tell apart. Page titles were set at three different sizes on different screens. The same figure rendered at 24, 30 or 36 pixels depending on which screen it landed on — `tabular-nums` sitting beside each one is the tell that they were the same role all along.

Three of them turned out not to be choices at all. A tooltip set no size and inherited the root 16px, so the same explanation rendered at 16px in one place and 14px in another. A card figure stepped between two sizes on a container query, so one role rendered at two sizes depending on how wide its card happened to be.

Distinctions also failed to line up with meaning. A section heading differed from a caption by weight alone at the same size — two pixels of difference is not a distinction anybody sees. One step carried a control, a metric's name, a card's label AND the metric's own value, so a row read flat: the number looked like its label. And the same thing — a metric's name — was near-black in one place and grey in another.

## What it is now

Four sizes, one role each: captions, body and names, titles, figures. Two greys. Colour says one thing — good and bad are `success` and `destructive`, attention without a verdict is `warning`, and nothing else is expressed in colour at all. Ten raw palette literals went back to tokens, several of them added by me a few hours earlier.

A name is ink because the reader scans by it. What is grey is context: medians, comparisons, units, the pills that qualify a value. Grey is what the eye may skip, so nothing that must be read is put there.

## The commit that matters

The sweep is worth nothing on its own — it grows back, and the next person measures it from scratch. So a lint rule refuses hand-set sizes, fractional greys and raw palette colours, and each refusal names the alternative rather than just objecting.

It was checked by writing a violating file and confirming the rule fires on it. A guard that silently matches nothing is worse than no guard, because it is believed. It has already earned its place: the last commit here fixes a hand-set size the rule found rather than a reader did.

Also worth knowing: of eleven large numbers, only three went through the shared role — the other eight spelled their size out. A role nothing routes through is a comment, not a rule, and changing the figure size would have moved three of them and left eight behind. All eleven route through it now, which is why the figure could be reduced in one line.

## Scope

Vendored primitives under `src/components/ui` are untouched: their sizing belongs to that library and `shadcn add` rewrites them. The rule exempts them for the same reason.

## Checks

`tsc -b` clean, eslint clean, 1073 unit tests pass. Reviewed on screen at each step rather than only in the diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized typography across dashboards, metric views, portals, and settings.
  * Improved readability with more consistent heading, label, figure, and explanatory text sizes.
  * Refined muted colors, chart marks, chevrons, warning accents, and text weight for clearer visual hierarchy.
  * Updated the person-zone label to “Personal metrics.”
* **Tests**
  * Updated navigation expectations to reflect the renamed section label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->