### PR TITLE
fix(tests): align the Playwright pins so browser journeys can start

### DIFF
--- a/deploy/compose/ui-tests.Dockerfile
+++ b/deploy/compose/ui-tests.Dockerfile
@@ -31,10 +31,13 @@
 # fetches a managed 3.13 and builds the venv on it.
 
 # Version policy: pinned by tag AND digest, so a rebuild can never silently
-# pick up a different image. Resolved 2026-07-31 as the newest stable tag in
-# the registry list (v1.61.0, cross-checked against the
-# microsoft/playwright-python v1.61.0 release and PyPI). -noble is the Ubuntu
+# pick up a different image. Resolved 2026-08-11 as the newest stable tag in
+# the registry list (v1.62.0, cross-checked against the
+# microsoft/playwright-python v1.62.0 release and PyPI). -noble is the Ubuntu
 # 24.04 LTS base; a -resolute variant of the same version also exists.
+# This tag, ui_tests.base_image in tests/versions.yaml and the playwright pin
+# in tests/pyproject.toml state one version between them; if they differ, the
+# package looks for a browser build the image does not contain.
 FROM mcr.microsoft.com/playwright/python:v1.62.0-noble@sha256:aa81288e738725378becba5b3e06cb0f3a7f012a610e87e8d767a090ea3f740d
 
 # uv, pinned the same way (0.12.0).
@@ -56,17 +59,22 @@ RUN uv sync --frozen --no-dev
 
 # Fail the BUILD, not a journey, if any of this is wrong: the interpreter must
 # satisfy the suite's floor, the library must import on it, and the pip
-# Playwright must match the browsers baked into the image — a mismatch there
-# means the package looks for a browser build the image does not contain.
+# Playwright must be able to start the browsers baked into the image — if the
+# two versions differ, the package looks for a browser build that is not here.
+#
+# The browser is LAUNCHED rather than version-compared against a literal. A
+# literal states the expected version twice, so it agrees with whichever pin
+# was not the one edited; starting chromium asserts the thing that matters.
 RUN uv run --frozen --no-dev python -c "\
 import sys, insight_stand; \
 assert sys.version_info >= (3, 13), f'interpreter {sys.version.split()[0]} is below the >=3.13 floor'; \
 print('insight_stand imports on', sys.version.split()[0])" \
  && uv run --frozen --no-dev python -c "\
-import subprocess; \
-out = subprocess.run(['playwright', '--version'], capture_output=True, text=True).stdout.strip(); \
-assert '1.61.0' in out, f'playwright pip pin != image: {out!r}'; \
-print('playwright matches the image:', out)"
+from playwright.sync_api import sync_playwright; \
+p = sync_playwright().start(); \
+b = p.chromium.launch(); \
+print('chromium starts:', b.version); \
+b.close(); p.stop()"
 
 # Drop root before anything runs. A browser rendering pages from the stand is
 # the least privileged thing in this repo and had the most privilege — and the

--- a/tests/pyproject.toml
+++ b/tests/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     # Pinned to the Playwright version baked into the ui-tests base image
     # (deploy/compose/ui-tests.Dockerfile). If these drift, the pip package
     # looks for a browser build the image does not contain.
-    "playwright==1.61.0",
+    "playwright==1.62.0",
     "pytest-playwright==0.8.0",
     # Response-schema validation. Already a proven version in this repo — the
     # integration rig resolves the same 2.13 line transitively.

--- a/tests/uv.lock
+++ b/tests/uv.lock
@@ -482,7 +482,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
-    { name = "playwright", specifier = "==1.61.0" },
+    { name = "playwright", specifier = "==1.62.0" },
     { name = "pydantic", specifier = ">=2.13" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.9" },
     { name = "pytest", specifier = ">=8" },
@@ -702,21 +702,21 @@ wheels = [
 
 [[package]]
 name = "playwright"
-version = "1.61.0"
+version = "1.62.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "greenlet" },
     { name = "pyee" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/ee/31e4e0db36588b817a10b299a0285082545fde7d36543c2abe498bb3d61a/playwright-1.61.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:ff138c3a604f69911e9d42fd036e55c2a171e5616edf04c1e7f60a2a285540b0", size = 43421877, upload-time = "2026-06-29T10:32:48.428Z" },
-    { url = "https://files.pythonhosted.org/packages/42/35/71395dd3ecc798965be4a3ef8c443217d4abca168e7cb34536304f9489e6/playwright-1.61.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:009588c2a7e499bc5a8b425b61fa65490968bbda9cd69e0cf2cff10f8304659a", size = 42205016, upload-time = "2026-06-29T10:32:52.104Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/44/323164cf5cd1647bdefce76ffce27651aadb959d089b48f53ea40918276e/playwright-1.61.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:9f7de4536088d12037c13a52b7ea34b59270b78926bb56935070597ffac6b1af", size = 43421884, upload-time = "2026-06-29T10:32:55.773Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/f8/a35bf179e4ba2522c1893635094a64e407572547bd61528820fc0abc87fe/playwright-1.61.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:54f3b39f6eab832e33458c1dd7da0b5682aedab3b09ae731b5c59fa12fd2024e", size = 47421381, upload-time = "2026-06-29T10:32:59.903Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/eb/e3f922348ec17c315f98c463f72faa1181a1c3de0bfe31a8d2edf6561723/playwright-1.61.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93454322ade8c11d5d6c211bfd91bdfb9ffb4810e3e026371bcbc4bec1b7ee4c", size = 47120545, upload-time = "2026-06-29T10:33:03.574Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/a6/5be4e52b40a9c0c8a073e7c5b0785c05cf5a9ea8f8a7b5b260e32d970342/playwright-1.61.0-py3-none-win32.whl", hash = "sha256:372d55a6f1248fa1dd47599686980cb8fb5bbe6fcda59eab793eb657c11d8a9b", size = 37844841, upload-time = "2026-06-29T10:33:07.361Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/fd/2b78036e5fbe9d5f5645bbe08a1eac7160c51243c0093963edbcf67c35d9/playwright-1.61.0-py3-none-win_amd64.whl", hash = "sha256:35c6cc4589a5d00964a59d7b3e59641e0aac0c02f15479a7af77d20f6bc79597", size = 37844846, upload-time = "2026-06-29T10:33:10.637Z" },
-    { url = "https://files.pythonhosted.org/packages/27/0d/1b0f3c4ee4eb0514bc805b5c2f9a223e5b6de4f11a926f5235d51d0fc81b/playwright-1.61.0-py3-none-win_arm64.whl", hash = "sha256:e9fcbffcf557a8620fdedd92491eb59a32d18e23d6f3b4f6214b952be324fe51", size = 33955127, upload-time = "2026-06-29T10:33:14.008Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/5b/ca2abcf3aa69f9fb510215e3064f30b57fe57657c8d04ede45bb966d5606/playwright-1.62.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:d8da938f3748841a8754f2e1f0216902c1c8f8ae3720de8b32ccf8e6913a7c4f", size = 43732091, upload-time = "2026-07-31T17:00:44.178Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/0bfbe9904350961f4dbb713f04342e40d548c5fc26c8157bd13617c81492/playwright-1.62.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:db755ab27db21a04186f1fe8169888e42356086e439b1059b923ef417f0b6034", size = 42510842, upload-time = "2026-07-31T17:00:48.596Z" },
+    { url = "https://files.pythonhosted.org/packages/66/dc/c0486b407ad0699a250f6bbe3066fca95344009a99ca66e88ca175c69dc1/playwright-1.62.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:5108bd5b3e87169ddf269feee097da5893af7f8aea4634dfc840518d64c1f1da", size = 43732093, upload-time = "2026-07-31T17:00:52.218Z" },
+    { url = "https://files.pythonhosted.org/packages/43/6b/b24aebc2b04bffcb342bccf96e287c78b363e1615bed5cea97500cc0393a/playwright-1.62.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:ba33bae6a13b3d9d354c751cb618af357d20fe1d57767cbcce52079bbef17ad3", size = 47748926, upload-time = "2026-07-31T17:00:56.438Z" },
+    { url = "https://files.pythonhosted.org/packages/36/43/b4b18bdc87e1949568fffdcde3ff9a0456266b2d0c6d4432cc34d89ea6eb/playwright-1.62.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db2d76613a57ad844362ce42f7d0c2fa26b19a4f7a46d4f76b891c631e6e5aff", size = 47441423, upload-time = "2026-07-31T17:01:00.404Z" },
+    { url = "https://files.pythonhosted.org/packages/81/22/af5d926fc2c32a339eec00a443644bc40ab9db1dd2dd9017873c59773c0c/playwright-1.62.0-py3-none-win32.whl", hash = "sha256:e5614fa89355d7081457680324bb219f79f69c423c5cb6fa250e30b0d8aebf1c", size = 38164450, upload-time = "2026-07-31T17:01:04.187Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a9/4160c1033c07af98bf841ad079457dd78408a5ee0dd56cbfe50b8b6a1c22/playwright-1.62.0-py3-none-win_amd64.whl", hash = "sha256:92c0d98ed04eb35af557b709875edba415b1f548bdb22ddb5bb3e1e6c835c2f1", size = 38164458, upload-time = "2026-07-31T17:01:08.459Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ec/06b55d619a7082a766aa04f2c6bb31435c87f02930087d8a0517119408fa/playwright-1.62.0-py3-none-win_arm64.whl", hash = "sha256:ea8d3055aa9d5a9f1832ac82517bd8b42c78fac7ebcbebb0107116735c8cb6a1", size = 34208868, upload-time = "2026-07-31T17:01:11.818Z" },
 ]
 
 [[package]]

--- a/tests/versions.yaml
+++ b/tests/versions.yaml
@@ -20,7 +20,7 @@
 # are the ones another component has to agree with.
 tests_stand:
   python: ">=3.13"
-  playwright: "1.61.0"
+  playwright: "1.62.0"
   pytest_playwright: "0.8.0"
   dependency_manager: "uv"
   lockfile: "tests/uv.lock"
@@ -28,15 +28,15 @@ tests_stand:
     This suite owns its Python floor: it reads the seeder's manifest as data and imports none of its modules, so the seeder's lower 3.12 floor (it ships inside the 3.12 toolbox image) does not bind here. uv provisions that interpreter in every runner, including inside the ui-tests image whose own system Python is older, so the floor holds everywhere rather than being a host-only aspiration. Still outstanding: every GitHub Actions workflow pins python-version "3.12", below this floor — reconciling that is CI enablement's job, not a reason to lower the suite. #magic___^_^___line
 # Browser runner image for tests/stand — deploy/compose/ui-tests.Dockerfile.
 # Both images pinned by tag AND digest so a rebuild cannot drift. Resolved
-# 2026-07-31 from the registry tag lists, cross-checked against the
-# microsoft/playwright-python v1.61.0 release and PyPI.
+# 2026-08-11 from the registry tag lists, cross-checked against the
+# microsoft/playwright-python v1.62.0 release and PyPI.
 ui_tests:
-  base_image: "mcr.microsoft.com/playwright/python:v1.61.0-noble"
-  base_image_digest: "sha256:a9731514f24121d1dcd25d58d0a38146646d290a5998fd80d3e533e7b5e21c69"
+  base_image: "mcr.microsoft.com/playwright/python:v1.62.0-noble"
+  base_image_digest: "sha256:aa81288e738725378becba5b3e06cb0f3a7f012a610e87e8d767a090ea3f740d"
   uv_image: "ghcr.io/astral-sh/uv:0.12.0"
   uv_image_digest: "sha256:606e70c71c852d03f611b1e56a195d08648507018a7057fab82c4974c4eae105"
   # The base image's own system Python. NOT what the suite runs on — recorded
   # because it is the reason uv provisions an interpreter instead of using it.
   base_image_python: "3.12.3"
   notes: >-
-    Browsers (chromium 1228) are baked into the base image and used as-is; there is no `playwright install` step. The pip playwright pin must equal the image's Playwright version or the package looks for a browser build the image does not contain — the build asserts that, along with the interpreter satisfying the >=3.13 floor and tests/lib importing on it, so a mismatch fails the image rather than a journey.
+    Browsers (chromium 1234) are baked into the base image and used as-is; there is no `playwright install` step. The pip playwright pin must equal the image's Playwright version or the package looks for a browser build the image does not contain — the build launches chromium, along with checking the interpreter against the >=3.13 floor and importing tests/lib on it, so a mismatch fails the image rather than a journey.


### PR DESCRIPTION
Every stand browser journey currently errors at browser launch, on `main` and in the merge queue. This aligns the three Playwright pins that must agree, and closes the two gaps that let them drift apart unnoticed.

## What is broken

`E2E — Compose stand` → `ui-journeys`: 17 errors at fixture setup in under three seconds. No journey runs. `api-smoke` passes.

```
playwright._impl._errors.Error: BrowserType.launch: Executable doesn't exist at
  /ms-playwright/chromium_headless_shell-1228/…
║ -  current: mcr.microsoft.com/playwright/python:v1.62.0-noble ║
║ - required: mcr.microsoft.com/playwright/python:v1.61.0-noble ║
```

The base image moved to `v1.62.0-noble`; the pip pin stayed at `playwright==1.61.0`. Browsers are baked into the base image and there is deliberately no `playwright install` step, so the library hunts for chromium build `1228` while the image ships `1234`.

This is not specific to one branch — the same failure appears in the merge-queue runs for #2331 and #2426.

## The fix

All three pins move to 1.62.0, keeping the newer base rather than reverting it:

| File | Change |
|---|---|
| `tests/versions.yaml` | `base_image` + digest → `v1.62.0-noble` / `sha256:aa81288e…` |
| `tests/pyproject.toml` | `playwright==1.61.0` → `==1.62.0` |
| `tests/uv.lock` | re-locked; only playwright moves (the image installs `--frozen`) |
| `deploy/compose/ui-tests.Dockerfile` | stale comment corrected — it still read "Resolved 2026-07-31 … v1.61.0" above a 1.62 `FROM` |

`playwright==1.62.0` and `pytest-playwright==0.8.0` resolve together with no conflict.

The `chromium 1228` note in `versions.yaml` was also wrong for this image; corrected to `1234`, confirmed by listing `/ms-playwright` inside it rather than from release notes.

## Why the existing build assert did not catch it

The Dockerfile already had a check meant for exactly this failure:

```python
assert '1.61.0' in out, f'playwright pip pin != image: {out!r}'
```

It compares the pip pin against a **hardcoded literal**, not against the image. When only the `FROM` moved, the pin still read 1.61.0 and so did the literal — the assert passed, and the broken image was published. The guard failed in the one case it existed for.

It now launches chromium instead. A browser that starts cannot be stale in the way a version string can.

## New cross-file guard

`scripts/ci/check_ui_tests_pins.py`, added to the existing **Connector wiring invariants** job. It checks:

1. the Dockerfile `FROM` tag equals `ui_tests.base_image`
2. the Dockerfile `FROM` digest equals `ui_tests.base_image_digest`
3. the pip `playwright==` pin equals the version in that tag

This is the divergence no in-image assert can see: building *inside* the bumped image moves both sides of any in-image comparison together. Only a file-to-file check catches a bot that rewrites one line.

## Verification

Built the image locally and ran the browser in it, in both directions:

| Library against the 1.62 image | Result |
|---|---|
| `playwright==1.61.0` (current state) | `Executable doesn't exist at /ms-playwright/chromium_headless_shell-1228/…` — reproduces the CI error exactly |
| `playwright==1.62.0` (this PR) | `CHROMIUM LAUNCHED: 151.0.7922.34` |

The new guard was also confirmed to **fail** before being trusted, against both real scenarios — a library mismatch and the tag drift — each exiting 1 with an actionable message. `ruff check` and `ruff format` are clean.

## After merge

`insight-ui-tests:latest` needs republishing before the stand lanes go green: the workflow pulls a floating tag, so the fix only takes effect once that image is rebuilt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated validation to ensure UI test image, browser, and package versions remain synchronized.
  - Added a runtime check confirming Chromium launches successfully in the UI test environment.

- **Maintenance**
  - Updated the UI testing environment and Playwright dependency to version 1.62.0.
  - Added coordinated version and digest metadata for reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->