### PR TITLE
fix(frontend): keyboard focus in the zone rail, and the day readout's anchor

### DIFF
--- a/src/frontend/src/components/portal/lens-rail.test.tsx
+++ b/src/frontend/src/components/portal/lens-rail.test.tsx
@@ -53,6 +53,12 @@ const labelOf = (name: string) =>
   screen.getByRole("button", { name }).querySelector("span:not(.sr-only)");
 
 beforeEach(() => {
+  // `shouldAdvanceTime` is required, not incidental: `userEvent` awaits a real
+  // promise between events, and with a clock that only moves when a test moves
+  // it that await is never resolved — every pointer interaction here hangs
+  // until the runner's timeout. It does mean the opening wait can expire on
+  // its own mid-test, which is harmless: the next action either wanted it open
+  // anyway, or is a leave, and a leave cancels the pending timer as it closes.
   vi.useFakeTimers({ shouldAdvanceTime: true });
   mocks.layout = "wide";
   mocks.selected = [];
@@ -165,6 +171,28 @@ describe("LensRail state that only breaks in a particular order", () => {
     mocks.layout = "wide";
     rerender(<SidebarProvider><LensRail /></SidebarProvider>);
     expect(labelOf("Overview")).toHaveClass("opacity-0");
+  });
+
+  it("keeps the labels while the keyboard is still inside it", async () => {
+    // Two ways in, and only one of them is the pointer's to end. A pointer
+    // crossing the rail on its way somewhere else used to collapse it under a
+    // focused button, putting a keyboard user back on an unlabelled icon they
+    // had no way to re-reveal.
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    rail();
+    const el = screen.getByTestId("lens-rail");
+    await user.tab();
+    await user.tab();
+    expect(labelOf("People")).toHaveClass("opacity-100");
+
+    await user.hover(el);
+    await user.unhover(el);
+    settle();
+    expect(labelOf("People")).toHaveClass("opacity-100");
+
+    // Leaving with the keyboard is what ends a keyboard visit.
+    act(() => (document.activeElement as HTMLElement).blur());
+    expect(labelOf("People")).toHaveClass("opacity-0");
   });
 
   it("stays shut for a pointer that is only passing through", async () => {

--- a/src/frontend/src/components/portal/lens-rail.tsx
+++ b/src/frontend/src/components/portal/lens-rail.tsx
@@ -153,8 +153,13 @@ export function LensRail() {
         cancel();
         timer.current = setTimeout(() => setOpen(true), OPEN_AFTER_MS);
       }}
-      onPointerLeave={() => {
-        close();
+      // Keeps the labels while the keyboard is still in here. A pointer
+      // crossing the rail on its way elsewhere is not a reason to collapse
+      // under a focused button: the word on it would go to zero opacity and
+      // leave a keyboard user on an unlabelled icon they cannot re-reveal
+      // without a pointer. Blur is what ends a keyboard visit — see below.
+      onPointerLeave={(e) => {
+        if (!e.currentTarget.contains(document.activeElement)) close();
         setDismissed(false);
       }}
       // Keyboard gets the labels too, and immediately: a sighted keyboard user

--- a/src/frontend/src/components/widgets/metric-views/metric-activity.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-activity.test.tsx
@@ -8,7 +8,7 @@
  * out of, and a metric with no detail says so rather than leaving a hole that
  * reads as a failed load.
  */
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { MetricResult } from "@/api/metric-results-client";
@@ -190,6 +190,38 @@ describe("MetricActivity", () => {
     expect(label).toMatch(/Messages Sent by day/);
     expect(label).toMatch(/busiest/);
     expect(label).toMatch(/3 days have no reading/);
+  });
+
+  it("anchors the day readout to the edge of the day it describes", () => {
+    // The readout grows away from the nearer end so it cannot run off the
+    // strip, and which edge it hangs from has to follow: one growing leftwards
+    // ENDS at its day's right boundary. Anchoring both directions to the left
+    // boundary put every readout in the second half a full day to the left of
+    // the day under the pointer.
+    detail.state.data = {
+      columns: [
+        { key: "date", label: "Date", type: "date" },
+        { key: "value", label: "Value", type: "number" },
+      ],
+      rows: [
+        { values: { date: "2026-03-01", value: 4 } },
+        { values: { date: "2026-03-05", value: 9 } },
+      ],
+    };
+    const { container } = draw(metric("collab.messages_sent", ["source_summary"], 13));
+    const bars = container.querySelectorAll<HTMLElement>('[role="img"] > div');
+    expect(bars).toHaveLength(5);
+    const readout = () =>
+      container.querySelector<HTMLElement>('[role="img"] > [aria-hidden]')!;
+
+    fireEvent.pointerEnter(bars[0]!);
+    expect(readout().style.left).toBe("0%");
+    expect(readout().style.transform).toBe("");
+
+    // The last of five days: its right boundary is the strip's own end.
+    fireEvent.pointerEnter(bars[4]!);
+    expect(readout().style.left).toBe("100%");
+    expect(readout().style.transform).toBe("translateX(-100%)");
   });
 
   it("says nothing was recorded rather than drawing an empty chart", () => {

--- a/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
@@ -285,6 +285,9 @@ function DayStrip({
   if (days.length === 0) return null;
 
   const hoveredDay = hovered != null ? (days[hovered] ?? null) : null;
+  // Which way the hover readout grows: rightwards from the bar over the first
+  // half of the strip, leftwards over the second, so it never runs off an end.
+  const leftAnchored = hovered != null && hovered < days.length / 2;
   const silent = silentDays(days);
   // One denominator for the whole period is worth naming: it is the thing a
   // reader argues with when a share looks wrong, and it is invisible in the
@@ -330,9 +333,15 @@ function DayStrip({
               // "3 messages" to "3.5 hours of 8", so any constant guarding the
               // ends is a guess that the longer strings walk straight past.
               // Growing inwards cannot overflow whatever the text says.
-              left: `${(hovered / days.length) * 100}%`,
-              transform:
-                hovered < days.length / 2 ? undefined : "translateX(-100%)",
+              //
+              // Which edge is the bar's own edge depends on the direction it
+              // grows in: a readout on the left half starts at the bar's left
+              // boundary, one on the right half ENDS at its right boundary.
+              // Taking the left boundary for both put every right-half readout
+              // a full bar to the left of the bar it describes, and left the
+              // last bar with a strip of empty space beside it.
+              left: `${((hovered + (leftAnchored ? 0 : 1)) / days.length) * 100}%`,
+              transform: leftAnchored ? undefined : "translateX(-100%)",
             }}
           >
             {dayTitle(metric, hoveredDay)}


### PR DESCRIPTION
Follow-up to #2441. Its automated review landed after the merge, so two
real defects it caught are on main. Both are in code that PR introduced.

### The rail collapses under a focused button

The rail reveals its labels on focus as well as on hover — eight
identical icons are not navigable by a sighted keyboard user otherwise.
But `onPointerLeave` closed it unconditionally, so any pointer crossing
the rail on its way somewhere else collapsed the labels while focus was
still inside, leaving that user on an unlabelled icon with no way to
reveal it again without a pointer.

Leave now closes only when focus is not contained, matching what
`onBlurCapture` already did. Blur remains what ends a keyboard visit.

### The day readout hangs off the wrong edge

The hover readout grows away from the nearer end of the strip so it can
never run off it, but both directions were anchored to the hovered day's
*left* boundary. A readout growing leftwards therefore ended where its
own day begins — one full day to the left of the day under the pointer —
and the last day was left with an empty strip beside it. Which boundary
it hangs from now follows the direction it grows in.

### Not changed

The review also proposed dropping `shouldAdvanceTime` from the rail
suite's fake timers. That option turns out to be load-bearing: without
it, eight of the nine tests hang until the runner's timeout, because
`userEvent` awaits a real promise between events and the clock never
moves to resolve it. The mid-test expiry it allows is harmless — the
next action either wanted the rail open anyway, or is a leave, and a
leave cancels the pending timer as it closes. Kept, with that recorded
where the option is set.

A fourth comment asked for the denominator's own unit in the strip
caption rather than a bare `per day`. The caption is accurate as it
stands — the figure is a per-day denominator — but it does not say what
the denominator counts, and the API does not currently supply that. Left
alone.

### Verification

New regression tests for both fixes: the rail keeps its labels through a
pointer crossing while focus is inside and drops them on blur, and the
readout is pinned to each end of the strip. Both fail on main. Full unit
suite green (1083), typecheck and lint clean.
