### PR TITLE
feat(compose): test-stand up --build runs the whole product from this tree

### DIFF
--- a/.claude/skills/insight-stand/SKILL.md
+++ b/.claude/skills/insight-stand/SKILL.md
@@ -43,8 +43,7 @@ Two consequences you will meet immediately:
 pass `--build` (the backend compiled from source AND the frontend pnpm-built,
 served by the front-built nginx); `up` otherwise refuses when the tree differs
 from `origin/main` under `src/backend/` or `src/frontend/`, since the pinned
-images would not be what ran. `--build-backend` survives as an alias of
-`--build`.
+images would not be what ran.
 
 **A path argument does not narrow the run.** The verb appends it to a hardcoded
 `tests/stand` and pytest unions path arguments, so `test-stand test

--- a/.claude/skills/insight-stand/SKILL.md
+++ b/.claude/skills/insight-stand/SKILL.md
@@ -38,11 +38,13 @@ Two consequences you will meet immediately:
 ./dev-compose.sh test-stand down    # stop AND remove volumes
 ```
 
-`up` pulls each backend service pinned to its own chart's `appVersion` — never
-`:latest`, never compiled here. To test a *backend* change pass
-`--build-backend`; `up` otherwise refuses when the tree differs from
-`origin/main` under `src/backend/`, since the pinned images would not be what
-ran.
+`up` pulls the frontend and each backend service pinned to its own chart's
+`appVersion` — never `:latest`, never compiled here. To test a local change
+pass `--build` (the backend compiled from source AND the frontend pnpm-built,
+served by the front-built nginx); `up` otherwise refuses when the tree differs
+from `origin/main` under `src/backend/` or `src/frontend/`, since the pinned
+images would not be what ran. `--build-backend` survives as an alias of
+`--build`.
 
 **A path argument does not narrow the run.** The verb appends it to a hardcoded
 `tests/stand` and pytest unions path arguments, so `test-stand test

--- a/dev-compose.sh
+++ b/dev-compose.sh
@@ -685,7 +685,7 @@ YML
     if [[ -z "${FRONTEND_INTERNAL_PORT:-}" ]]; then
       case "$FRONTEND_MODE" in
         dev)   FRONTEND_INTERNAL_PORT=5173 ;;  # vite
-        built) FRONTEND_INTERNAL_PORT=80   ;;  # stock nginx image, runs as root
+        built) FRONTEND_INTERNAL_PORT=8080 ;;  # the mounted template declares `listen 8080`
         ghcr)  FRONTEND_INTERNAL_PORT=8080 ;;  # published image, runs as uid 101
       esac
       export FRONTEND_INTERNAL_PORT
@@ -760,6 +760,21 @@ YML
   # retirement: the service no longer exists in docker-compose.yml, so an
   # in-place `up` would otherwise leave both IdPs running.
   docker rm -f "${COMPOSE_PROJECT_NAME:-insight}-fakeidp" >/dev/null 2>&1 || true
+
+  # The three frontend variants share one container_name but are different
+  # compose services, and a container owned by a profile-INACTIVE sibling is
+  # not an orphan — so an in-place `up` after a frontend mode switch dies on
+  # a name conflict instead of replacing it. Remove the old variant's
+  # container first; same-variant restarts are left to compose.
+  if [[ "$no_frontend" != "true" ]]; then
+    local front_ctr front_svc
+    front_ctr="${COMPOSE_PROJECT_NAME:-insight}-front"
+    front_svc="$(docker inspect --format '{{ index .Config.Labels "com.docker.compose.service" }}' "$front_ctr" 2>/dev/null || true)"
+    if [[ -n "$front_svc" && "$front_svc" != "insight-front-$FRONTEND_MODE" ]]; then
+      echo "=== frontend mode switch: removing $front_ctr (was $front_svc) ==="
+      docker rm -f "$front_ctr" >/dev/null 2>&1 || true
+    fi
+  fi
 
   echo "=== docker compose up ==="
   if ! "${compose_cmd[@]}" ${profiles[@]+"${profiles[@]}"} up -d --remove-orphans; then
@@ -1420,11 +1435,13 @@ for dbt-built gold data rather than for containers to report healthy.
           compiled here. Building them took ~26 minutes for code the stand
           does not change.
 
-          --build-backend  Compile the backend from this working tree instead.
-                           Needed to test a backend change: `up` otherwise
-                           refuses when the tree differs from origin/main
-                           under src/backend/, since the pinned images would
-                           not be what ran.
+          --build  Build the whole product from this working tree instead:
+                   the backend compiled from source and the frontend built
+                   with pnpm (served by the front-built nginx). Needed to
+                   test a local change: `up` otherwise refuses when the tree
+                   differs from origin/main under src/backend/ or
+                   src/frontend/, since the pinned images would not be what
+                   ran. (--build-backend remains as an alias.)
   seed    Re-seed the running stand (default target: all).
   test    Run the stand suite against an already-up stand. Passes extra
           arguments through to pytest — no `--` separator.
@@ -1481,7 +1498,7 @@ TEST_STAND_PINNED_BACKENDS=(
 # a 26-minute compile comes back invisibly.
 test_stand_pull_backends() {
   local entry var chart name image
-  echo "=== Pinning the backend to published images (skip with --build-backend) ==="
+  echo "=== Pinning the backend to published images (skip with --build) ==="
   for entry in "${TEST_STAND_PINNED_BACKENDS[@]}"; do
     IFS='|' read -r var chart name <<<"$entry"
     image="$(test_stand_pinned_image "$chart" "$name")" || return 1
@@ -1490,43 +1507,53 @@ test_stand_pull_backends() {
       echo "ERROR: cannot pull $image (pinned by $chart's appVersion)." >&2
       echo "       Not falling back to a source build — that would report a pass" >&2
       echo "       for an image this run never ran. Check ghcr access, or pass" >&2
-      echo "       --build-backend to build from source deliberately." >&2
+      echo "       --build to build from source deliberately." >&2
       return 1; }
     update_env_var "$TEST_STAND_ENV_FILE" "$var" "$image"
   done
 }
 
-# Refuse to pin when the working tree's backend differs from what the charts
-# describe.
+# Refuse to pin when the working tree differs from what a chart describes.
 #
-# The appVersions track main. A branch that edits src/backend/** and then runs
-# against published images would report green for code it never executed. The PR
-# path filter makes this unreachable in the normal lane; this covers
-# workflow_dispatch and local runs, which bypass it.
-test_stand_backend_matches_charts() {
+# The appVersions track main. A branch that edits the given source tree and
+# then runs against published images would report green for code it never
+# executed. The PR path filter makes this unreachable in the normal lane; this
+# covers workflow_dispatch and local runs, which bypass it.
+test_stand_tree_matches_charts() {
+  local subtree="$1" flag="$2"
   git rev-parse --git-dir >/dev/null 2>&1 || return 0
   git remote get-url origin >/dev/null 2>&1 || return 0
   git rev-parse --verify --quiet origin/main >/dev/null || return 0
 
   local changed
-  changed="$(git diff --name-only origin/main -- src/backend 2>/dev/null | head -5)"
+  changed="$(git diff --name-only origin/main -- "$subtree" 2>/dev/null | head -5)"
   [[ -z "$changed" ]] && return 0
 
-  echo "ERROR: this tree changes src/backend/ relative to origin/main:" >&2
+  echo "ERROR: this tree changes ${subtree}/ relative to origin/main:" >&2
   printf '         %s\n' $changed >&2
-  echo "       The stand pins each backend image to its chart's appVersion, which" >&2
+  echo "       The stand pins each published image to its chart's appVersion, which" >&2
   echo "       tracks main — so those changes would NOT be what runs. Pass" >&2
-  echo "       --build-backend to build this tree instead." >&2
+  echo "       ${flag} to build this tree instead." >&2
   return 1
+}
+
+test_stand_backend_matches_charts() {
+  test_stand_tree_matches_charts src/backend --build
+}
+
+test_stand_frontend_matches_chart() {
+  test_stand_tree_matches_charts src/frontend --build
 }
 
 # Derive the test env file from the committed example, overriding only the
 # knobs the test path forces. SEEDED_LOCAL_* are blanked so every `up` seeds.
+# `mode` is ghcr (image required) or built (image empty — the front-built
+# profile serves the pnpm build from src/frontend/dist).
 test_stand_write_env() {
-  local image="$1"
+  local mode="$1" image="${2:-}"
   [[ -f .env.compose.example ]] || { echo "ERROR: .env.compose.example not found." >&2; return 1; }
   cp .env.compose.example "$TEST_STAND_ENV_FILE"
-  update_env_var "$TEST_STAND_ENV_FILE" FRONTEND_MODE   "ghcr"
+  update_env_var "$TEST_STAND_ENV_FILE" FRONTEND_MODE   "$mode"
   update_env_var "$TEST_STAND_ENV_FILE" FRONTEND_IMAGE  "$image"
   update_env_var "$TEST_STAND_ENV_FILE" SEEDED_LOCAL_MARIA ""
   update_env_var "$TEST_STAND_ENV_FILE" SEEDED_LOCAL_CH    ""
@@ -1537,7 +1564,7 @@ test_stand_write_env() {
   # browser to its OWN loopback, and a host client to an origin that serves
   # the SPA rather than the authenticator.
   update_env_var "$TEST_STAND_ENV_FILE" AUTHENTICATOR_REDIRECT_URI "$(test_stand_origin)/auth/callback"
-  echo "=== test-stand env → $TEST_STAND_ENV_FILE (frontend: $image) ==="
+  echo "=== test-stand env → $TEST_STAND_ENV_FILE (frontend: ${image:-built from src/frontend}) ==="
   echo "    app origin: $(test_stand_origin)  callback: $(test_stand_origin)/auth/callback"
 }
 
@@ -1770,26 +1797,34 @@ cmd_test_stand() {
 
   case "$verb" in
     up)
-      local image build_backend=false
+      local image build=false
       while [[ $# -gt 0 ]]; do
         case "$1" in
-          --build-backend) build_backend=true; shift ;;
+          --build) build=true; shift ;;
+          # The old spelling, kept so muscle memory and scripts stay valid.
+          # It builds the frontend too now — the flag means "this tree runs".
+          --build-backend) build=true; shift ;;
           -h|--help) cmd_test_stand_help; return 0 ;;
           *) echo "ERROR: unknown test-stand up option: $1" >&2; return 2 ;;
         esac
       done
 
-      image="$(test_stand_frontend_image)" || return 1
-      test_stand_write_env "$image" || return 1
+      if [[ "$build" == true ]]; then
+        test_stand_write_env built || return 1
+      else
+        test_stand_frontend_matches_chart || return 1
+        image="$(test_stand_frontend_image)" || return 1
+        test_stand_write_env ghcr "$image" || return 1
+      fi
 
       # Pinning writes the four *_IMAGE vars into the env file, which is what
       # makes cmd_up put those services in its ghcr list — so this has to happen
       # before cmd_up reads it.
-      if [[ "$build_backend" != true ]]; then
+      if [[ "$build" != true ]]; then
         test_stand_backend_matches_charts || return 1
         test_stand_pull_backends || return 1
       else
-        echo "=== --build-backend: compiling the backend from this tree ==="
+        echo "=== --build: compiling the backend and building the frontend from this tree ==="
       fi
 
       local up_args=(--env-file "$TEST_STAND_ENV_FILE"

--- a/dev-compose.sh
+++ b/dev-compose.sh
@@ -1441,7 +1441,7 @@ for dbt-built gold data rather than for containers to report healthy.
                    test a local change: `up` otherwise refuses when the tree
                    differs from origin/main under src/backend/ or
                    src/frontend/, since the pinned images would not be what
-                   ran. (--build-backend remains as an alias.)
+                   ran.
   seed    Re-seed the running stand (default target: all).
   test    Run the stand suite against an already-up stand. Passes extra
           arguments through to pytest — no `--` separator.
@@ -1801,9 +1801,6 @@ cmd_test_stand() {
       while [[ $# -gt 0 ]]; do
         case "$1" in
           --build) build=true; shift ;;
-          # The old spelling, kept so muscle memory and scripts stay valid.
-          # It builds the frontend too now — the flag means "this tree runs".
-          --build-backend) build=true; shift ;;
           -h|--help) cmd_test_stand_help; return 0 ;;
           *) echo "ERROR: unknown test-stand up option: $1" >&2; return 2 ;;
         esac

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -549,7 +549,11 @@ services:
       insight:
         aliases: [insight-front]
     environment:
-      CSP_REMOTE: ${CSP_REMOTE:-}
+      # Must be DEFINED even when empty: the stock nginx entrypoint's envsubst
+      # only substitutes environment variables that exist, and an unsubstituted
+      # ${SENTRY_CONNECT_SRC} in the CSP template is an nginx [emerg]. The
+      # published image's own entrypoint substitutes it unconditionally.
+      SENTRY_CONNECT_SRC: ${SENTRY_CONNECT_SRC:-}
     volumes:
       # Host-built dist/ — produced by dev-compose.sh build (build-frontend)
       # or by running `pnpm build` in src/frontend.
@@ -557,7 +561,9 @@ services:
       - ./src/frontend/nginx/default.conf.template:/etc/nginx/templates/default.conf.template:ro
       - ./src/frontend/nginx/security-headers.conf:/etc/nginx/snippets/security-headers.conf:ro
     ports:
-      - "${FRONTEND_PORT:-3000}:80"
+      # 8080, not the stock image's 80: the mounted default.conf.template is
+      # the published image's and declares `listen 8080`.
+      - "${FRONTEND_PORT:-3000}:8080"
 
   insight-front-ghcr:
     !!merge <<: *restart-policy


### PR DESCRIPTION
## What

`./dev-compose.sh test-stand up --build` now runs the stand entirely from the working tree: the backend compiled from source (the old `--build-backend` path — that spelling is removed; `--build` is the only flag) **and** the frontend pnpm-built, served by the existing `front-built` nginx profile. With the frontend now living in this repo, a local change anywhere in the product can be exercised under the stand's real Keycloak login and dbt readiness gate.

The refusal guard is extended symmetrically: without `--build`, `up` refuses when the tree differs from `origin/main` under `src/frontend/` as well as `src/backend/` — the same protection against reporting green for code that never ran, now via one shared `test_stand_tree_matches_charts` helper.

## Drift fixed along the way

Reviving `FRONTEND_MODE=built` surfaced three integration gaps between the compose dev stack and the in-repo frontend, each fixed where it lives (they affect the dev stack's built mode generally, not just the test stand):

1. **Mode switch died on a name conflict** — the three frontend variants share one `container_name` but are separate compose services, and a profile-inactive sibling's container is not an orphan, so an in-place `up` after a mode switch could not replace it. `cmd_up` now removes the old variant's container first, matched by its compose-service label (same pattern as the existing fakeidp cleanup).
2. **CSP template variable** — the stock nginx entrypoint substitutes only *defined* env vars, so the template's `${SENTRY_CONNECT_SRC}` reached nginx verbatim: `[emerg] unknown "sentry_connect_src" variable`. The `front-built` service now defines it (empty by default), matching the published image's unconditional substitution, and drops `CSP_REMOTE`, which the template no longer reads.
3. **Listen port** — the in-repo template declares `listen 8080` (the published image's non-root layout) while `front-built` still assumed stock nginx's 80; the gateway proxied to a refused port and answered 502. Port map and `FRONTEND_INTERNAL_PORT` now say 8080.

## Verification

On a live bring-up of `test-stand up --build`: the stand reaches the readiness gate, the SPA the gateway serves is **byte-identical** to the freshly built `src/frontend/dist`, and the real-login UI journeys (login, seeded-data) plus the analytics custom-metric API tests pass against the all-local stack — 19 passed, 1 xfailed (the known #2360 export entry). The mode-switch cleanup was exercised live (ghcr → built on a running stack).
