### PR TITLE
security(keycloak): scope the public HTTPRoute to named realms

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -160,6 +160,10 @@ jobs:
               - 'deploy/compose/ui-tests.Dockerfile'
             umbrella:
               - 'charts/insight/**'
+              # The keycloak subchart is a file:// dependency packed into the
+              # published umbrella, so a leaf-chart-only change must also make
+              # publish-chart eligible.
+              - 'src/backend/services/keycloak/helm/**'
 
       # Compute the canonical build tag once per workflow run so every
       # downstream job (backend builds + matrix connector builds + toolbox +

--- a/.github/workflows/keycloak-helm.yml
+++ b/.github/workflows/keycloak-helm.yml
@@ -1,0 +1,50 @@
+name: Keycloak — Helm contract
+
+# Render-contract gate for the keycloak subchart's HTTPRoute realm allowlist:
+# the original finding was a bare /kc/realms PathPrefix publishing the master
+# realm's admin-cli token endpoint, so the exact set of published path values
+# is contract, not plumbing. Pure `helm template` + assertions — no cluster,
+# no images.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/backend/services/keycloak/helm/**"
+      - "charts/insight/**"
+      - "deploy/gitops/environments/local/values.yaml.template"
+      - ".github/workflows/keycloak-helm.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  helm-contract:
+    name: render contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Pinned to full SHAs (mutable tags are repointable — supply-chain
+      # hardening, same as identity-resolution-helm.yml).
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install test deps
+        run: pip install --quiet pytest pyyaml
+
+      - name: helm lint
+        run: |
+          helm lint src/backend/services/keycloak/helm
+          helm dependency update charts/insight
+          helm lint charts/insight
+
+      - name: Render-contract tests (HTTPRoute realm allowlist)
+        run: python -m pytest src/backend/services/keycloak/helm/tests/ -q

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -419,6 +419,11 @@ keycloak:
     passwordSecret: {name: "", key: ""}
   route:
     enabled: false
+    # Realms whose /kc/realms/<realm> OIDC surface is published. REQUIRED
+    # when route.enabled — an empty list fails the render rather than
+    # exposing a bare /kc/realms prefix (which would publish the master
+    # realm). List every realm the browser must reach.
+    realms: []
 # ─── keycloakConfig (broker realms as code — ADR-0003, EPIC #2193) ──────────
 # Hook Job applying the env's versioned realm YAML (pre-created ConfigMap from
 # the gitops `keycloak-broker-realms` target) with keycloak-config-cli on every

--- a/deploy/gitops/environments/local/values.yaml.template
+++ b/deploy/gitops/environments/local/values.yaml.template
@@ -169,6 +169,9 @@ keycloak:
     passwordSecret: {name: insight-db-creds, key: mariadb-password}
   route:
     enabled: true
+    # Only the listed realms' OIDC surface is published; master stays
+    # cluster-internal. Required when the route is enabled.
+    realms: [insight]
     parentRef:
       name: insight
       namespace: insight-infra

--- a/src/backend/services/keycloak/helm/templates/httproute.yaml
+++ b/src/backend/services/keycloak/helm/templates/httproute.yaml
@@ -3,10 +3,14 @@
 # under /kc natively (--http-relative-path) and discovery emits absolute URLs
 # off KC_HOSTNAME (= .Values.hostname), so no rewrite.
 #
-# Only the browser/OIDC surface is exposed: /kc/realms (discovery, auth,
-# tokens, broker callbacks, account console) and /kc/resources (theme
-# assets). The admin console and admin REST API (/kc/admin, plus the /kc
-# welcome redirect to it) stay cluster-internal — reach them with
+# Only the browser/OIDC surface of the EXPOSED realms is published: for each
+# `route.realms` entry, /kc/realms/<realm> (discovery, auth, tokens, broker
+# callbacks, account console) — plus /kc/resources (theme assets). A bare
+# /kc/realms prefix would also publish /kc/realms/master, whose admin-cli
+# password-grant token endpoint is a brute-force target; scoping to the app
+# realm(s) keeps master and every other realm off the internet. The admin
+# console and admin REST API (/kc/admin, plus the /kc welcome redirect to it)
+# stay cluster-internal — reach them with
 #   kubectl port-forward svc/<release>-keycloak {{ .Values.service.port }}
 # (adminHostname in values.yaml advertises that URL to the console).
 apiVersion: gateway.networking.k8s.io/v1
@@ -32,13 +36,18 @@ spec:
   {{- end }}
   rules:
     - matches:
+        {{- range .Values.route.realms }}
         - path:
             type: PathPrefix
-            value: /kc/realms
+            value: /kc/realms/{{ . }}
+        {{- end }}
         - path:
             type: PathPrefix
             value: /kc/resources
       backendRefs:
         - name: {{ include "insight-keycloak.fullname" . }}
           port: {{ .Values.service.port }}
+{{- end }}
+{{- if and .Values.route.enabled (not .Values.route.realms) }}
+{{- fail "keycloak.route.realms must list the realm(s) to expose (e.g. [insight]); a bare /kc/realms would publish the master realm to the internet" }}
 {{- end }}

--- a/src/backend/services/keycloak/helm/templates/httproute.yaml
+++ b/src/backend/services/keycloak/helm/templates/httproute.yaml
@@ -37,9 +37,13 @@ spec:
   rules:
     - matches:
         {{- range .Values.route.realms }}
+        {{- $realm := required "keycloak.route.realms entries must be non-empty (an empty entry would render the bare /kc/realms/ prefix)" . }}
+        {{- if eq $realm "master" }}
+        {{- fail "keycloak.route.realms must not include master — its admin surface stays cluster-internal" }}
+        {{- end }}
         - path:
             type: PathPrefix
-            value: /kc/realms/{{ . }}
+            value: {{ printf "/kc/realms/%s" $realm | quote }}
         {{- end }}
         - path:
             type: PathPrefix

--- a/src/backend/services/keycloak/helm/tests/test_httproute_contract.py
+++ b/src/backend/services/keycloak/helm/tests/test_httproute_contract.py
@@ -1,0 +1,147 @@
+"""Helm render-contract for the Keycloak HTTPRoute realm allowlist.
+
+The route publishes /kc on the shared Gateway, and the allowlist is the
+security boundary: a bare /kc/realms PathPrefix would also publish the master
+realm, whose admin-cli password-grant token endpoint is a brute-force target.
+The exact set of published path values is therefore contract, not plumbing:
+these tests render the chart(s) with `helm template` and assert the manifests
+the cluster would actually get. No cluster involved; runs anywhere helm +
+PyYAML exist (CI: .github/workflows/keycloak-helm.yml).
+
+Covered:
+  * one realm publishes exactly its own /kc/realms/<realm> prefix plus
+    /kc/resources — nothing else;
+  * several realms publish one exact prefix each;
+  * an empty list, an empty-string entry, a null entry, and `master` each
+    FAIL the render (fail-closed — never degrade to the bare prefix);
+  * no successful render contains /kc/realms or /kc/realms/ as a complete
+    path value;
+  * the committed local gitops overlay renders the umbrella successfully
+    (it enables the route, so it would fail atomically if the allowlist
+    requirement and the overlay ever drift apart).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+HERE = Path(__file__).resolve()
+SUBCHART = HERE.parents[1]  # .../keycloak/helm
+REPO_ROOT = HERE.parents[6]
+UMBRELLA = REPO_ROOT / "charts" / "insight"
+LOCAL_OVERLAY = REPO_ROOT / "deploy" / "gitops" / "environments" / "local" / "values.yaml.template"
+
+# Minimum viable subchart install: every `required` value outside the route.
+SUBCHART_BASE = [
+    "--set",
+    "hostname=https://host.test/kc",
+    "--set",
+    "admin.existingSecret=kc-admin",
+    "--set",
+    "database.host=db",
+    "--set",
+    "database.username=kc",
+    "--set",
+    "database.passwordSecret.name=db-creds",
+    "--set",
+    "database.passwordSecret.key=pw",
+    "--set",
+    "route.enabled=true",
+    "--set",
+    "route.host=host.test",
+]
+
+BARE_PREFIXES = {"/kc/realms", "/kc/realms/"}
+
+
+def _render(chart: Path, *extra: str) -> tuple[int, str, str]:
+    proc = subprocess.run(  # noqa: S603 — test-controlled argv
+        ["helm", "template", "contract-test", str(chart), *extra],  # noqa: S607
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _docs(manifests: str) -> list[dict]:
+    return [d for d in yaml.safe_load_all(manifests) if isinstance(d, dict)]
+
+
+def _realms_flag(realms: list) -> list[str]:
+    # --set-json survives entries --set cannot express: "", null.
+    return ["--set-json", f"route.realms={json.dumps(realms)}"]
+
+
+def _route_paths(docs: list[dict]) -> list[str]:
+    routes = [d for d in docs if d.get("kind") == "HTTPRoute" and "keycloak" in d["metadata"]["name"]]
+    assert len(routes) == 1, f"expected exactly one Keycloak HTTPRoute, got {len(routes)}"
+
+    (rule,) = routes[0]["spec"]["rules"]
+    paths = [m["path"] for m in rule["matches"]]
+    assert all(p["type"] == "PathPrefix" for p in paths)
+    return [p["value"] for p in paths]
+
+
+def _published(realms: list) -> list[str]:
+    rc, out, err = _render(SUBCHART, *SUBCHART_BASE, *_realms_flag(realms))
+    assert rc == 0, err
+
+    paths = _route_paths(_docs(out))
+    assert not BARE_PREFIXES & set(paths), f"bare realm prefix published: {paths}"
+    return paths
+
+
+def test_one_realm_publishes_exactly_that_realm() -> None:
+    assert _published(["insight"]) == ["/kc/realms/insight", "/kc/resources"]
+
+
+def test_several_realms_publish_one_exact_prefix_each() -> None:
+    assert _published(["insight", "partner"]) == ["/kc/realms/insight", "/kc/realms/partner", "/kc/resources"]
+
+
+@pytest.mark.parametrize(
+    ("realms", "expected_error"),
+    [
+        ([], "must list the realm"),
+        ([""], "must be non-empty"),
+        ([None], "must be non-empty"),
+        (["master"], "must not include master"),
+        (["insight", ""], "must be non-empty"),
+    ],
+    ids=["empty-list", "empty-string", "null", "master", "trailing-empty"],
+)
+def test_bad_allowlists_fail_the_render(realms: list, expected_error: str) -> None:
+    rc, _, err = _render(SUBCHART, *SUBCHART_BASE, *_realms_flag(realms))
+    assert rc != 0, f"render must fail for realms={realms!r}"
+    assert expected_error in err, err
+
+
+def test_route_disabled_renders_no_httproute() -> None:
+    rc, out, err = _render(SUBCHART, *SUBCHART_BASE, "--set", "route.enabled=false")
+    assert rc == 0, err
+    assert not [d for d in _docs(out) if d.get("kind") == "HTTPRoute"]
+
+
+def test_local_gitops_overlay_renders() -> None:
+    """The committed local overlay enables the route, so it must carry a
+    valid allowlist — this fails atomically if the two ever drift apart.
+
+    Requires `helm dependency update charts/insight` (the CI workflow runs
+    it; locally, run it once).
+    """
+    if not (UMBRELLA / "charts").is_dir():
+        pytest.skip("umbrella dependencies not built — run `helm dependency update charts/insight`")
+
+    rc, out, err = _render(UMBRELLA, "-f", str(LOCAL_OVERLAY))
+    assert rc == 0, err
+
+    paths = _route_paths(_docs(out))
+    assert "/kc/realms/insight" in paths
+    assert not BARE_PREFIXES & set(paths), f"bare realm prefix published: {paths}"

--- a/src/backend/services/keycloak/helm/values.yaml
+++ b/src/backend/services/keycloak/helm/values.yaml
@@ -36,11 +36,17 @@ database:
   username: ""
   passwordSecret: {name: "", key: ""}
 
-# Optional HTTPRoute on the shared Gateway exposing only /kc/realms and
-# /kc/resources (Keycloak serves under /kc natively — no rewrite). /kc/admin
-# stays cluster-internal; see adminHostname.
+# Optional HTTPRoute on the shared Gateway exposing only /kc/realms/<realm>
+# (per route.realms) and /kc/resources (Keycloak serves under /kc natively —
+# no rewrite). /kc/admin and unlisted realms (incl. master) stay
+# cluster-internal; see adminHostname.
 route:
   enabled: false
+  # Realms whose /kc/realms/<realm> OIDC surface is published. REQUIRED when
+  # route.enabled — an empty list fails the render rather than exposing a bare
+  # /kc/realms prefix (which would publish the master realm). List every realm
+  # the browser must reach: the app realm, plus any broker realms.
+  realms: []
   parentRef:
     name: insight
     namespace: insight-infra


### PR DESCRIPTION
## What

The Keycloak subchart's HTTPRoute matched a bare `/kc/realms` PathPrefix, which publishes **every** realm on the shared Gateway — including `master`. Keycloak's `master` realm exposes the `admin-cli` client with the direct password grant, so a bare-prefix route puts the IdP admin account's token endpoint on the public internet with no browser flow, PKCE, or challenge in front of it — a brute-force / password-spray target whose compromise is full auth-plane takeover (every realm, every user, the signing keys).

The route template already took care to keep `/kc/admin` and the admin REST API cluster-internal; this closes the sibling gap on the `/kc/realms` side.

## Change

- `route.realms` (new, **required** when `route.enabled`): the list of realms whose `/kc/realms/<realm>` OIDC surface is published. The route now emits one PathPrefix per named realm plus `/kc/resources` (theme assets).
- An empty `route.realms` **fails the render** rather than falling back to the wide prefix — fail-closed, so a future route can't silently re-widen.
- `master` and every unlisted realm stay cluster-internal.

## Verified

`helm template` renders: `realms: [insight]` → only `/kc/realms/insight` + `/kc/resources`; `realms: []` with the route enabled → render error naming the missing value. Multi-realm (broker) lists render one prefix each.

## Consumers

Any environment that sets `keycloak.route.enabled: true` must now also set `keycloak.route.realms` (e.g. `[insight]`). The one such environment in-tree arrives with a separate change; there is no route enabled on `main` today, so nothing here breaks on merge.