### PR TITLE
ci(e2e-stand): pass --build, the flag that replaced --build-backend

### DIFF
--- a/.github/workflows/e2e-stand.yml
+++ b/.github/workflows/e2e-stand.yml
@@ -11,7 +11,7 @@ name: E2E — Compose stand
 # appVersions; building them cost ~26 min per job. `up` refuses a tree that
 # changes src/backend/ rather than silently testing it against main's images,
 # so when the diff touches the backend the `changes` job flags it and the
-# lanes pass --build-backend (and take the longer timeout) instead.
+# lanes pass --build (and take the longer timeout) instead.
 #
 # Two independently-reporting checks, split by what they need rather than by
 # what they cover:
@@ -105,7 +105,7 @@ jobs:
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
       # Whether the diff touches src/backend/ — the lanes turn this into
-      # `up --build-backend`, because `up` refuses a backend-changing tree
+      # `up --build`, because `up` refuses a backend-changing tree
       # rather than silently testing it against main's pulled images.
       backend: ${{ steps.filter.outputs.backend }}
     steps:
@@ -220,7 +220,7 @@ jobs:
         run: |
           set -euo pipefail
           flags=()
-          if [ "$BUILD_BACKEND" = "true" ]; then flags+=(--build-backend); fi
+          if [ "$BUILD_BACKEND" = "true" ]; then flags+=(--build); fi
           ./dev-compose.sh test-stand up "${flags[@]}"
 
       - name: Run the API suite
@@ -361,7 +361,7 @@ jobs:
         run: |
           set -euo pipefail
           flags=()
-          if [ "$BUILD_BACKEND" = "true" ]; then flags+=(--build-backend); fi
+          if [ "$BUILD_BACKEND" = "true" ]; then flags+=(--build); fi
           ./dev-compose.sh test-stand up "${flags[@]}"
 
       # The suite's own Chromium, resolved by the locked test environment so


### PR DESCRIPTION
## Summary

#2455 replaced `test-stand up --build-backend` with `--build` in `dev-compose.sh` but left the workflow passing the old flag at both call sites, so `up` exits 2 (`unknown test-stand up option: --build-backend`) before the stand starts — both stand lanes fail for any PR whose diff touches `src/backend/`. First observed on #2463's PR run.

## Validation

- `grep -n 'build-backend' .github/workflows/e2e-stand.yml` → no remaining call sites (comments updated too)
- `git show origin/main:dev-compose.sh` accepts `--build` and no longer accepts `--build-backend`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the end-to-end testing workflow to use the current rebuild option.
  * Revised related workflow guidance to reflect the updated process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->