### PR TITLE
test(stand): pin the two ai_cost metrics in the drilldown matrix

### DIFF
--- a/tests/stand/api/analytics/drilldown_matrix.py
+++ b/tests/stand/api/analytics/drilldown_matrix.py
@@ -119,6 +119,8 @@ MATRIX: Sequence[Expectation] = (
     Expectation("ai.chat_assistant_conversations", "ai", Tier.EXACT_SUM),
     Expectation("ai.cost", "ai", Tier.EXACT_SUM),
     Expectation("ai.dev_conversations", "ai", Tier.EXACT_SUM),
+    Expectation("ai.extra_usage_cost", "ai_cost", Tier.EXACT_SUM),
+    Expectation("ai.extra_usage_utilisation", "ai_cost", Tier.EXACT_RATIO, scale=100.0),
     Expectation("ai.removed_lines", "ai", Tier.EXACT_SUM),
     Expectation("ai.tool_acceptance_rate", "ai", Tier.EXACT_RATIO, scale=100.0),
     Expectation("collab.active_days", "collab", Tier.EXACT_DISTINCT_DATES),


### PR DESCRIPTION
Closes #2472. Targets #2431's branch, which serves the two metrics.

`MATRIX` in `tests/stand/api/analytics/drilldown_matrix.py` is the drilldown sweep's denominator, and it named neither `ai.extra_usage_cost` nor `ai.extra_usage_utilisation`, so `test_every_metric_definition_is_in_the_drilldown_matrix` failed on every stand that serves them.

Each tier follows the definition's computation in `registry.yaml`: `extra_usage_usd` is summed, so `EXACT_SUM`; `extra_usage_utilisation` is a ratio of `extra_usage_usd` over `extra_usage_limit_usd` at `scale: 100.0`, so `EXACT_RATIO`. `EXPORT_SHAPES` is unchanged — it is one metric per evidence presentation by design, and no test asserts it covers the catalogue.

## Test plan

Run on a stand brought up with `test-stand up --build` from this branch, so the backend serving the catalogue is the code under test:

- [x] `test-stand test --ignore=tests/stand/ui` — 299 passed, 1 skipped, 2 xfailed, 3 xpassed, 0 failed. Same xfail/xpass set as CI (#2360, #2361).
- [x] `-k "extra_usage or matrix"` — `test_every_metric_definition_is_in_the_drilldown_matrix` PASSED, and both new `test_drilldown_reconciles_with_the_metric_value` cases PASSED.
- [x] `pre-commit run --files tests/stand/api/analytics/drilldown_matrix.py` — `ruff check`, `ruff format` and the file-hygiene hooks pass; `pycln` 2.6.0 reports the file unchanged.

The numeric half of the two new reconciliation cases is NOT exercised: the stand seed leaves `silver.class_ai_overage` empty, so `insight.ai_cost_metric_evidence` has no rows (against 12,605 in `insight.ai_metric_evidence`) and both cases take the empty-evidence branch. What the run does prove for them is the column contract each tier implies — `_assert_shape` runs before that branch and reads the response's column metadata, so it requires a `value` column for the sum, and `numerator` plus `denominator` and no `value` for the ratio. A wrong tier fails there.