### PR TITLE
test(stand): seed Claude Team seat overage so the ai_cost sweep reconciles

### DIFF
--- a/dev-compose.sh
+++ b/dev-compose.sh
@@ -1582,6 +1582,7 @@ test_stand_write_env() {
 #   git     <- class_git_{commits,file_changes,pull_requests,…}          (git.py)
 #   collab  <- class_collab_{chat,email,meeting}_activity, focus_metrics (collab.py)
 #   ai      <- class_ai_{assistant,dev}_usage                            (ai.py)
+#   ai_cost <- class_ai_overage                                          (ai.py)
 #
 # `wiki_metric_observations` is absent ON PURPOSE: its evidence model reads
 # class_wiki_* and there is no wiki generator, so requiring it would hang every
@@ -1592,6 +1593,7 @@ TEST_STAND_READY_TABLES=(
   git_metric_observations
   collab_metric_observations
   ai_metric_observations
+  ai_cost_metric_observations
 )
 
 test_stand_ch_query() {

--- a/src/ingestion/tools/seed/insight_seed/generators/ai.py
+++ b/src/ingestion/tools/seed/insight_seed/generators/ai.py
@@ -1,14 +1,18 @@
 """
-AI tooling silver-table generator: dev usage + assistant usage.
+AI tooling silver-table generator: dev usage + assistant usage + seat overage.
 
 dev-usage (`silver.class_ai_dev_usage`) covers Cursor + Claude Code.
 assistant-usage (`silver.class_ai_assistant_usage`) covers ChatGPT +
 Claude web. The gold-view filters discriminate by `tool` and `surface`
 so we honour those exact strings.
+seat-overage (`silver.class_ai_overage`) covers Claude Team seat spend
+against the ceiling an administrator set on it, at seat-month grain.
 """
 
 from __future__ import annotations
 
+import datetime as _dt
+import json
 from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
@@ -44,6 +48,13 @@ _ASSISTANT_TOOLS = (
     ("chatgpt", "chat", "chatgpt"),
     ("claude", "chat", "claude_team"),
 )
+# Which seats an administrator put on a tier. A seat left `unassigned` carries
+# no ceiling, so the utilisation metric emits no row for it — the honest-NULL
+# the gold pair relies on, which is only present in seeded data while some team
+# stays unassigned. A team absent here is unassigned too.
+_SEAT_TIER_BY_TEAM = {"development": "team_tier_1", "support": "unassigned"}
+# The ceiling a tiered seat carries, in the cents the vendor reports: $100.00.
+_SEAT_CEILING_CENTS = 10_000
 
 
 def seed_ai_dev_usage(
@@ -220,6 +231,109 @@ def seed_ai_assistant_usage(
     return bulk_insert(client, "silver", "class_ai_assistant_usage", cols, rows)
 
 
+def _seat_month_reads(days: int) -> list[tuple[_dt.date, _dt.date]]:
+    """One (billing month, day that month was last read) pair per month covered.
+
+    The vendor reports spend-to-date for the month in progress and carries no
+    period field, so a month's row freezes at its final read. That day is what
+    dates the evidence, which is why the current month reads on the anchor.
+    """
+    last_read: dict[_dt.date, _dt.date] = {}
+    for d in days_window(days):
+        last_read[d.replace(day=1)] = d
+    return sorted(last_read.items())
+
+
+def seed_ai_seat_overage(
+    client: clickhouse_connect.driver.client.Client,
+    roster: Sequence[Person],
+    tenant_uuid: str,
+    days: int,
+) -> int:
+    """Claude Team seat spend against its ceiling, one row per seat per month.
+
+    `used_amount_cents` is the money billed once a seat exhausted the usage its
+    fee included — not the excess over the ceiling. A fifth of tiered
+    seat-months land a few cents past the ceiling, which is what an enforced
+    limit looks like.
+    """
+    truncate(client, "silver", "class_ai_overage")
+    cols = [
+        "insight_tenant_id",
+        "source_id",
+        "unique_key",
+        "email",
+        "account_id",
+        "period_month",
+        "tool",
+        "seat_tier",
+        "currency",
+        "credit_limit_cents",
+        "used_amount_cents",
+        "overage_cents",
+        "is_over_limit",
+        "is_enabled",
+        "overage_metrics_json",
+        "source",
+        "data_source",
+        "collected_at",
+        "_version",
+    ]
+    rows: list[tuple[object, ...]] = []
+    version = 1
+    # One connector instance serves the whole stream, as a tenant's single
+    # claude-team source does.
+    source_id = deterministic_uuid("ai.overage.src", tenant_uuid)
+    for p in roster:
+        if not p.team:
+            continue
+        if TEAM_PROFILES[p.team].weights.get("claude_team", 0) <= 0:
+            continue
+        persona = persona_multiplier(p.uuid)
+        account_id = deterministic_uuid("ai.overage.seat", p.uuid)
+        tier = _SEAT_TIER_BY_TEAM.get(p.team, "unassigned")
+        ceiling = None if tier == "unassigned" else _SEAT_CEILING_CENTS
+        for period_month, read_day in _seat_month_reads(days):
+            rng = seeded_rng(p.uuid, read_day, "ai.overage")
+            if ceiling is None:
+                used = int(rng.uniform(50, 4000) * persona)
+            elif rng.random() < 0.2:
+                used = ceiling + rng.randint(2, 48)
+            else:
+                used = int(min(rng.uniform(300, 9000) * persona, ceiling - 100))
+            rows.append(
+                (
+                    tenant_uuid,
+                    source_id,
+                    f"{tenant_uuid}-{source_id}-{account_id}-{period_month:%Y-%m}",
+                    p.email,
+                    account_id,
+                    period_month,
+                    "claude",
+                    tier,
+                    "USD",
+                    ceiling,
+                    used,
+                    None if ceiling is None else max(0, used - ceiling),
+                    None if ceiling is None else int(used > ceiling),
+                    1,
+                    json.dumps(
+                        {
+                            "limit_type": "" if ceiling is None else "seat_tier",
+                            "used_credits_basis": "post_discount",
+                            "out_of_credits": "",
+                            "seat_tier": tier,
+                        }
+                    ),
+                    "claude_team",
+                    "insight_claude_team",
+                    _dt.datetime.combine(read_day, _dt.time(), tzinfo=_dt.UTC),
+                    version,
+                )
+            )
+    return bulk_insert(client, "silver", "class_ai_overage", cols, rows)
+
+
 def generate(
     client: clickhouse_connect.driver.client.Client,
     roster: Sequence[Person],
@@ -231,4 +345,5 @@ def generate(
         "silver.class_ai_assistant_usage": seed_ai_assistant_usage(
             client, roster, tenant_uuid, days
         ),
+        "silver.class_ai_overage": seed_ai_seat_overage(client, roster, tenant_uuid, days),
     }

--- a/src/ingestion/tools/seed/insight_seed/generators/base.py
+++ b/src/ingestion/tools/seed/insight_seed/generators/base.py
@@ -169,6 +169,7 @@ RESET_TARGETS: tuple[tuple[str, str], ...] = (
     ("bronze_bamboohr", "employees"),
     ("silver", "class_ai_assistant_usage"),
     ("silver", "class_ai_dev_usage"),
+    ("silver", "class_ai_overage"),
     ("silver", "class_collab_chat_activity"),
     ("silver", "class_collab_email_activity"),
     ("silver", "class_collab_meeting_activity"),


### PR DESCRIPTION
Part of #2428. Follows #2473, which named the two metrics in the sweep's matrix; this makes the sweep actually reconcile them.

## Do not merge into this base

The base is #2431's branch because the gold pair and the registry source only exist there: on `main` the readiness gate would wait for `ai_cost_metric_observations`, which no model builds yet, and hang. Merging here would also dismiss #2431's approval a second time. Leave this open until #2431 lands — GitHub retargets it to `main` when the base branch goes.

## Why

`test_drilldown_reconciles_with_the_metric_value` passed for `ai.extra_usage_cost` and `ai.extra_usage_utilisation` without proving anything: the stand's AI generator writes dev and assistant usage only, so `silver.class_ai_overage` was empty, the gold pair over it had no rows, and both cases took the empty-evidence branch — asserting a null metric rather than that evidence adds up to the value. DECOMPOSITION 2.3 declares drilldown capability for both metrics, and the sweep is what proves it.

## What lands

- **`generators/ai.py`** — `seed_ai_seat_overage`: one row per seat per billing month, dated at the day that month was last read, matching how the connector's staging model stamps `collected_at`. Field values follow the connector's own fixture (`tool='claude'`, `source='claude_team'`, `data_source='insight_claude_team'`, `seat_tier='team_tier_1'`, amounts already in cents). `unassigned` seats carry no ceiling, so the honest-NULL path the utilisation metric depends on exists in seeded data; a fifth of tiered seat-months land 2-48 cents past the ceiling, the signature #2428 measured.
- **`generators/base.py`** — `class_ai_overage` registered in `RESET_TARGETS`; `truncate` refuses an unregistered relation.
- **`dev-compose.sh`** — `ai_cost_metric_observations` added to the readiness gate, per the list's own rule that a populated family nothing waits for fails later as tests missing rows.

## Test plan

Run in WSL Ubuntu against a stand brought up with `test-stand up --build` from this branch:

- [x] Full `down` + `up --build` from wiped volumes: gate reports `waiting for 5 gold observation tables` and `all 5 rebuilt and populated`.
- [x] Seeded from empty: 36 rows, 12 seats, 3 billing months, 18 rows without a ceiling, 2 over limit. Gold pair: 36 `extra_usage_usd` rows and 18 `extra_usage_limit_usd` rows.
- [x] **The sweep is no longer vacuous**: `dev_lead` has 3 resolved evidence rows per measure inside the manifest window `2026-06-14..2026-08-12`, and both sides agree — $106.19 of money, 35.3967% utilisation from 106.19/300.
- [x] `test-stand test --ignore=tests/stand/ui` — 299 passed, 1 skipped, 2 xfailed, 3 xpassed, 0 failed. Same xfail/xpass set as CI (#2360, #2361).
- [x] `-k extra_usage -rw` — both cases pass with no warning, so neither returned early on the page budget.
- [x] Seed package unit tests: `uv run --extra dev python -m unittest discover -s tests -t .` — 38 tests OK, including the `RESET_TARGETS` contract.
- [x] `pre-commit run --files` on all three: `ruff check`, `ruff format` and the hygiene hooks pass; `pycln` 2.6.0 reports both Python files unchanged.

The UI lane was NOT run: the browser needs system libraries this environment cannot install. The seeded data reaches no UI surface — the frontend references neither metric key, and neither is a `KPI_ROW` candidate — so no browser assertion depends on it.