### PR TITLE
fix(gitops): scope the test-stand /kc route to the insight realm

### DIFF
--- a/deploy/gitops/environments/test-stand/values.yaml
+++ b/deploy/gitops/environments/test-stand/values.yaml
@@ -157,6 +157,12 @@ keycloak:
     # and the prefix is part of the advertised issuer above — strip it and
     # discovery breaks in a way that looks like a TLS problem.
     enabled: true
+    # Publish only this realm's OIDC surface; unlisted realms — master and
+    # its admin-cli token endpoint included — stay cluster-internal. Inert
+    # until the stand picks up a chart with the realm-scoped route (#2457),
+    # which fails the render when this list is empty.
+    realms:
+      - insight
     host: insight-test.cfabric.org
     parentRef:
       name: insight


### PR DESCRIPTION
Adds `keycloak.route.realms: [insight]` to the test-stand environment values.

Pairs with #2457, which replaces the bare `/kc/realms` path prefix with a per-realm allowlist and fails the render when the list is empty. The key is inert under the currently published chart and becomes required the moment the stand deploys a chart containing #2457 — adding it first means the two changes can land in either order without breaking the test-stand deploy.

Follow-up to #2404: this line was intended for that PR but was pushed to a same-named branch on the wrong remote while the PR was merging, so it never entered the merge.

Refs #2457, #2404.