### PR TITLE
fix(frontend): highlight the portal item the content is showing

### DIFF
--- a/src/frontend/src/components/portal/context-pane.test.tsx
+++ b/src/frontend/src/components/portal/context-pane.test.tsx
@@ -51,6 +51,8 @@ import { ContextPane } from "./context-pane";
 
 const pane = () => render(<SidebarProvider><ContextPane /></SidebarProvider>);
 
+const buttonFor = (label: string) => screen.getByText(label).closest("button");
+
 beforeEach(() => {
   window.matchMedia ??= ((query: string) => ({
     matches: false,
@@ -117,6 +119,36 @@ describe("ContextPane", () => {
     pane();
     expect(screen.getByText("Catalog, identity & governance")).toBeInTheDocument();
     expect(screen.getByText(/Metric catalog/i)).toBeInTheDocument();
+  });
+
+  it.each([
+    ["overview", "At a glance"],
+    ["aicost", "Overview"],
+    ["people", "People (roster)"],
+  ])("highlights the default item of %s when the URL names none", (zone, label) => {
+    mocks.zone = { activeZone: zone, activePerson: "boss@x" };
+    pane();
+    expect(buttonFor(label)).toHaveAttribute("data-active");
+  });
+
+  it("moves the highlight to the item the URL names", () => {
+    act(() => portalRouter.set({ item: "trend" }));
+    pane();
+    expect(buttonFor("Trend")).toHaveAttribute("data-active");
+    expect(buttonFor("At a glance")).not.toHaveAttribute("data-active");
+  });
+
+  it("ignores an item left behind by another zone", () => {
+    mocks.zone = { activeZone: "people", activePerson: "boss@x" };
+    act(() => portalRouter.set({ item: "trend" }));
+    pane();
+    expect(buttonFor("People (roster)")).toHaveAttribute("data-active");
+  });
+
+  it("highlights nothing in Manage, whose no-item view is no menu entry", () => {
+    mocks.zone = { activeZone: "manage", activePerson: "boss@x" };
+    pane();
+    expect(buttonFor("Metric catalog")).not.toHaveAttribute("data-active");
   });
 
   it("renders the person's sections nav in the Person zone", () => {

--- a/src/frontend/src/components/portal/context-pane.tsx
+++ b/src/frontend/src/components/portal/context-pane.tsx
@@ -36,6 +36,7 @@ import {
   PEOPLE_ITEMS,
   PLANNED_GROUP_LABEL,
   partitionByReadiness,
+  resolveZoneItem,
   ZONE_SECTIONS,
   zoneById,
   type Direction,
@@ -89,6 +90,7 @@ export function ContextPane() {
   const { activeZone } = useActiveZone();
   const zone = zoneById(activeZone);
   const title = zone?.label ?? "Insight";
+  const active = resolveZoneItem(activeZone, usePortalItem());
 
   return (
     <Sidebar collapsible={drawer ? "offcanvas" : "none"} className="border-e">
@@ -111,13 +113,13 @@ export function ContextPane() {
         {activeZone === "directions" ? (
           <DirectionsNav />
         ) : activeZone === "people" ? (
-          <PeopleNav />
+          <PeopleNav active={active} />
         ) : activeZone === "manage" ? (
-          <ItemsNav items={MANAGE_ITEMS} groupLabel="Manage" />
+          <ItemsNav items={MANAGE_ITEMS} groupLabel="Manage" active={active} />
         ) : activeZone === "person" ? (
           <PersonSectionsNav />
         ) : (
-          <ThemeNav zoneId={activeZone} />
+          <ThemeNav zoneId={activeZone} active={active} />
         )}
       </SidebarContent>
       {isPhone ? (
@@ -227,9 +229,8 @@ function MobileZoneNav() {
 
 /* ── Theme zones (Overview / AI & Cost / Scorecard / Reports) ────────── */
 
-function ThemeNav({ zoneId }: { zoneId: string }) {
+function ThemeNav({ zoneId, active }: { zoneId: string; active: string | null }) {
   const groups = ZONE_SECTIONS[zoneId] ?? [];
-  const active = usePortalItem();
   const showPlanned = usePortalShowPlanned();
   // Everything not yet real is pulled out of its original group and collected
   // under one demoted "Planned" group at the bottom, so the working menu reads
@@ -271,11 +272,12 @@ function ThemeNav({ zoneId }: { zoneId: string }) {
 function ItemsNav({
   items,
   groupLabel,
+  active,
 }: {
   items: readonly PaneItem[];
   groupLabel: string;
+  active: string | null;
 }) {
-  const active = usePortalItem();
   const showPlanned = usePortalShowPlanned();
   const { live, planned } = partitionByReadiness(items, showPlanned);
   return (
@@ -451,8 +453,7 @@ function DirectionItem({ direction }: { direction: Direction }) {
 
 /* ── People / Person zones ───────────────────────────────────────────── */
 
-function PeopleNav() {
-  const active = usePortalItem();
+function PeopleNav({ active }: { active: string | null }) {
   return (
     <>
       <SidebarGroup>

--- a/src/frontend/src/components/portal/zone-content.tsx
+++ b/src/frontend/src/components/portal/zone-content.tsx
@@ -5,7 +5,7 @@ import { OverviewView } from "@/components/portal/overview-view";
 import { ManageView } from "@/components/portal/manage-view";
 import { PeopleView } from "@/components/portal/people-view";
 import { PersonView } from "@/components/portal/person-view";
-import { zoneById } from "@/lib/portal/nav-model";
+import { resolveZoneItem, zoneById } from "@/lib/portal/nav-model";
 import {
   usePortalDir,
   usePortalItem,
@@ -26,7 +26,9 @@ export function ZoneContent() {
   const { activeZone, activePerson } = useActiveZone();
   const dir = usePortalDir();
   const lens = usePortalLens();
-  const item = usePortalItem();
+  // Resolved here, not per view: the pane highlights the same value, so the
+  // menu and the content can never name different things.
+  const item = resolveZoneItem(activeZone, usePortalItem());
 
   switch (activeZone) {
     case "person":

--- a/src/frontend/src/lib/portal/nav-model.test.ts
+++ b/src/frontend/src/lib/portal/nav-model.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  partitionByReadiness,
+  resolveZoneItem,
+  ZONE_DEFAULT_ITEM,
+  zoneById,
+  zoneItems,
+} from "./nav-model";
+
+const defaults = Object.entries(ZONE_DEFAULT_ITEM);
+
+describe("zone item defaults", () => {
+  it("name a zone the rail has", () => {
+    for (const [zone] of defaults) expect(zoneById(zone), zone).toBeDefined();
+  });
+
+  it("name an item the pane always renders", () => {
+    // A default the pane can filter out (planned / unbuilt) would highlight a
+    // row that isn't there.
+    for (const [zone, id] of defaults) {
+      const { live } = partitionByReadiness(zoneItems(zone), false);
+      expect(live.map((i) => i.id), zone).toContain(id);
+    }
+  });
+});
+
+describe("resolveZoneItem", () => {
+  it("keeps an item the zone lists", () => {
+    expect(resolveZoneItem("overview", "trend")).toBe("trend");
+  });
+
+  it("falls back for an item that belongs to another zone", () => {
+    expect(resolveZoneItem("people", "trend")).toBe("roster");
+  });
+
+  it("falls back when the URL names none", () => {
+    expect(resolveZoneItem("aicost", null)).toBe("overview");
+  });
+
+  it("stays null for a zone whose no-item view is no menu row", () => {
+    expect(resolveZoneItem("manage", null)).toBeNull();
+    expect(resolveZoneItem("manage", "trend")).toBeNull();
+    expect(resolveZoneItem("manage", "data-health")).toBe("data-health");
+  });
+});

--- a/src/frontend/src/lib/portal/nav-model.ts
+++ b/src/frontend/src/lib/portal/nav-model.ts
@@ -294,3 +294,35 @@ export const MANAGE_ITEMS: readonly PaneItem[] = [
   { id: "config", label: "Config & setup", icon: Settings2, readiness: "unbuilt" },
   { id: "whats-new", label: "What's new", icon: Megaphone, readiness: "unbuilt" },
 ];
+
+/* ── Zone item resolution ────────────────────────────────────────────── */
+
+/**
+ * The item a zone falls back to when the URL names none. Absent = the zone's
+ * no-item view is no menu row (Manage), or its default has no id at all
+ * (Person — see ContextPane.PersonSectionsNav).
+ */
+export const ZONE_DEFAULT_ITEM: Record<string, string> = {
+  overview: "at-a-glance",
+  aicost: "overview",
+  people: "roster",
+};
+
+/** Every pane item a zone lists, in display order, planned ones included. */
+export function zoneItems(zoneId: string): readonly PaneItem[] {
+  if (zoneId === "people") return PEOPLE_ITEMS;
+  if (zoneId === "manage") return MANAGE_ITEMS;
+  return (ZONE_SECTIONS[zoneId] ?? []).flatMap((g) => g.items);
+}
+
+/**
+ * The item a zone is showing: the one the URL names if this zone has it, else
+ * the zone's default. Pane and content resolve through here so the menu marks
+ * the view on screen — a bare `?zone=` used to highlight nothing while the
+ * content rendered a default, and an `item` left behind by another zone still
+ * matched nothing here while that zone's view fell back.
+ */
+export function resolveZoneItem(zoneId: string, item: string | null): string | null {
+  if (item && zoneItems(zoneId).some((i) => i.id === item)) return item;
+  return ZONE_DEFAULT_ITEM[zoneId] ?? null;
+}

--- a/src/frontend/src/lib/portal/overview-configs.ts
+++ b/src/frontend/src/lib/portal/overview-configs.ts
@@ -1,5 +1,6 @@
 import { headlineMetricKeys } from "@/lib/insight/groups";
 import { sectionMetricKeys, type LensConfig } from "@/lib/portal/lens-configs";
+import { ZONE_DEFAULT_ITEM } from "@/lib/portal/nav-model";
 
 /**
  * The Overview zone registry: each pane item (nav-model ZONE_SECTIONS.overview)
@@ -12,7 +13,7 @@ import { sectionMetricKeys, type LensConfig } from "@/lib/portal/lens-configs";
 const ATTENTION_KEYS: readonly string[] = headlineMetricKeys();
 
 /** The item the router renders when no pane item is selected. */
-export const DEFAULT_OVERVIEW_ITEM = "at-a-glance";
+export const DEFAULT_OVERVIEW_ITEM = ZONE_DEFAULT_ITEM.overview!;
 
 export const OVERVIEW_ITEMS: Record<string, LensConfig> = {
   [DEFAULT_OVERVIEW_ITEM]: {


### PR DESCRIPTION
## Problem

The context pane matched `?item=` against its own item ids, so the highlight and the content could disagree in two ways:

1. **No `item` in the URL** — `/portal?zone=overview` renders **At a glance**, but the menu marked nothing. The reader sees content with no idea which entry produced it.
2. **An `item` belonging to another zone** — e.g. a People route still carrying `item=trend`. The view falls back to the roster, the pane matches nothing, and again no row is marked.

Overview, AI & Cost and People were all affected; each of those views already falls back to a default item internally, so the disagreement was structural rather than a one-off.

## Fix

Resolve the effective item **once**, in the nav model:

```ts
resolveZoneItem(zoneId, item)  // the URL item if the zone lists it, else the zone's default
```

Both the context pane and the `ZoneContent` dispatcher read it, so the menu and the content can no longer name different things. `ZONE_DEFAULT_ITEM` is the single place a zone default is written; `DEFAULT_OVERVIEW_ITEM` now derives from it instead of restating the id.

Zones deliberately absent from the map:

- **Manage** — with no `item` it renders a generic scaffold that is no menu row, so nothing should be highlighted.
- **Person** — its default is a pseudo-item with no id, handled in `PersonSectionsNav`.

## Behaviour change

`?zone=overview&item=<unknown-id>` now renders the default view instead of “*x* isn't an Overview view yet.” — unavoidable if the menu and the content must agree on one value.

## Testing

- `nav-model.test.ts` — defaults name a zone the rail has and an item the pane always renders (never a `planned`/`unbuilt` row); `resolveZoneItem` keeps a listed item, falls back for a foreign one, falls back when none is named, stays null for Manage.
- `context-pane.test.tsx` — default highlighted for each of the three zones, highlight follows an explicit `item`, a foreign `item` is ignored, Manage still highlights nothing.
- Full frontend suite (1121 tests), `typecheck` and `lint` clean.
- Verified in a browser on a local compose stand: both cases before and after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved portal navigation so the correct item is highlighted based on the selected zone and URL.
  * Added sensible default selections when no valid item is selected.
  * Prevented stale selections from another zone from appearing active.
  * Improved handling for zones without menu items, including Manage.

* **Tests**
  * Added coverage for zone defaults, invalid selections, readiness filtering, and active-item highlighting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Closes #2494


## Screenshots

Local compose install, demo seed roster. Rail icon and pane row both mark the open view.

| Surface | Before | After |
|---|---|---|
| `?zone=overview` | [nothing marked](https://github.com/user-attachments/assets/18a682bc-df6d-4ad5-a5b9-f8e81dd92b93) | [At a glance](https://github.com/user-attachments/assets/cd203a79-64b3-4053-9bdd-c736a051b922) |
| `?zone=aicost` | [nothing marked](https://github.com/user-attachments/assets/eea0adcc-ee19-4962-b833-650cf9306794) | [Overview](https://github.com/user-attachments/assets/04eb72ba-97eb-4798-89da-04f10613ccf8) |
| `/ic/<person>/team?item=trend` | [nothing marked](https://github.com/user-attachments/assets/5dfd08f3-24a0-473b-b0b5-ee876bd7deae) | [People (roster)](https://github.com/user-attachments/assets/d10709f8-f4fd-4c96-9f09-e34e61db9db2) |

`?zone=overview` after the fix:

![Overview with At a glance marked](https://github.com/user-attachments/assets/cd203a79-64b3-4053-9bdd-c736a051b922)

`/ic/<person>/team` — roster marked:

![People zone with the roster marked](https://github.com/user-attachments/assets/5dfa9629-0d3d-4f87-a966-fdad8b62f247)

`?zone=overview&item=<unknown-id>` — the behaviour change above, rendering the default view:

![Overview falling back to At a glance for an unknown item](https://github.com/user-attachments/assets/2ea44704-cacc-4bc7-a4c6-4fc841e6762e)

`?zone=manage` with no item — nothing marked, deliberately:

![Manage zone with no entry marked](https://github.com/user-attachments/assets/4d0349c8-921b-40a0-8858-e26617aea88d)
