### PR TITLE
fix(bamboohr): stop the field-history build running out of memory

### DIFF
--- a/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__employees_fields_history.sql
+++ b/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__employees_fields_history.sql
@@ -2,8 +2,21 @@
 {{ config(
     materialized='table',
     schema='staging',
+    query_settings={
+        'max_bytes_before_external_group_by': 268435456,
+        'max_bytes_ratio_before_external_group_by': 0,
+        'max_block_size': 8192,
+        'max_threads': 4,
+    },
     tags=['bamboohr', 'silver']
 ) }}
+
+{#-
+  fields_history_raw is shaped so its state is GROUP BY state, which spills to
+  disk past external_group_by; small blocks and few threads bound the residual
+  the pipeline holds in flight. No max_memory_usage: a self-imposed cap here
+  turns a build the server could still afford into a hard failure.
+-#}
 
 {{ fields_history_raw(
     snapshot_ref=ref('bamboohr__employees_snapshot'),

--- a/src/ingestion/dbt/macros/fields_history.sql
+++ b/src/ingestion/dbt/macros/fields_history.sql
@@ -99,46 +99,48 @@ WHERE version_num = 1
   field only carries a correct change timestamp if the snapshot versions on it.
 #}
 
-WITH versioned AS (
+{#-
+  Shaped as spillable GROUP BY aggregation, not window functions: aggregation
+  state spills to disk under max_bytes_before_external_group_by, window sort
+  state cannot spill and holds the whole exploded relation in memory.
+-#}
+WITH entity_versions AS (
     SELECT
         unique_key,
-        {{ entity_id_col }} AS entity_id,
-        tenant_id,
-        source_id,
-        _tracked_at AS updated_at,
-        {{ raw_data_fields(exclude_keys) }} AS fields,
-        ROW_NUMBER() OVER (
-            PARTITION BY unique_key ORDER BY _tracked_at
-        ) AS version_num
+        arraySort(groupArray(_tracked_at)) AS version_times
     FROM {{ snapshot_ref }}
+    GROUP BY unique_key
 ),
 
-transitions AS (
+-- One (entity, field) group with the value at every version carrying the key.
+-- Exploding pairs before grouping keeps the wide `raw_data` payload out of the
+-- ARRAY JOIN output: replicating it once per key is what costs gigabytes.
+field_values AS (
     SELECT
-        curr.entity_id AS entity_id,
-        curr.tenant_id AS tenant_id,
-        curr.source_id AS source_id,
-        curr.updated_at AS updated_at,
-        curr.fields AS curr_fields,
-        prev.fields AS prev_fields
-    FROM versioned curr
-    INNER JOIN versioned prev
-        ON curr.unique_key = prev.unique_key
-        AND curr.version_num = prev.version_num + 1
+        unique_key,
+        any({{ entity_id_col }}) AS entity_id,
+        any(tenant_id) AS tenant_id,
+        any(source_id) AS source_id,
+        pair.1 AS field_name,
+        CAST(groupArray((_tracked_at, pair.2)), 'Map(DateTime, String)') AS value_at
+    FROM {{ snapshot_ref }}
+    ARRAY JOIN CAST({{ raw_data_fields(exclude_keys) }}, 'Array(Tuple(String, String))') AS pair
+    GROUP BY unique_key, field_name
+),
 
-    UNION ALL
-
-    -- The first version has nothing to diff against; an empty map makes every
-    -- non-empty field read as a change from '', matching fields_history.
+-- INVARIANT: an absent key reads as '' — the timeline spans every version of
+-- the entity, so a version that stops carrying the key diffs as a change to ''
+-- and the first version diffs against '', both matching fields_history.
+timelines AS (
     SELECT
-        entity_id,
-        tenant_id,
-        source_id,
-        updated_at,
-        fields AS curr_fields,
-        CAST(map(), 'Map(String, String)') AS prev_fields
-    FROM versioned
-    WHERE version_num = 1
+        f.entity_id AS entity_id,
+        f.tenant_id AS tenant_id,
+        f.source_id AS source_id,
+        f.field_name AS field_name,
+        e.version_times AS times,
+        arrayMap(t -> f.value_at[t], e.version_times) AS vals
+    FROM field_values f
+    INNER JOIN entity_versions e ON f.unique_key = e.unique_key
 )
 
 SELECT
@@ -146,11 +148,11 @@ SELECT
     tenant_id,
     source_id,
     field_name,
-    prev_fields[field_name] AS old_value,
-    curr_fields[field_name] AS new_value,
-    updated_at
-FROM transitions
-ARRAY JOIN arrayDistinct(arrayConcat(mapKeys(curr_fields), mapKeys(prev_fields))) AS field_name
-WHERE curr_fields[field_name] != prev_fields[field_name]
+    change.1 AS old_value,
+    change.2 AS new_value,
+    change.3 AS updated_at
+FROM timelines
+ARRAY JOIN arrayFilter(c -> c.1 != c.2,
+    arrayMap(i -> (if(i = 1, '', vals[i - 1]), vals[i], times[i]), arrayEnumerate(vals))) AS change
 
 {% endmacro %}


### PR DESCRIPTION
## Problem

`bamboohr__employees_fields_history` diffs two per-version `Map(String, String)` payloads and reads both back *after* an `ARRAY JOIN` over the union of their keys. ClickHouse must therefore keep both maps alive across every replicated row, so one block costs (rows x keys x payload). The build is stopped by the server memory tracker with `Code: 241 ... While executing ArrayJoinTransform`, failing the sync after extraction has already committed its records and leaving the target table stale.

The BambooHR employee stream is the worst case for this by design: it collects every non-sensitive field the account defines, so the key count per row is large on purpose.

## Fix

Reshape `fields_history_raw` as GROUP BY aggregation over a per-field timeline: explode `raw_data` to `(key, value)` rows before any wide payload exists, group each (entity, field) into its value-per-version timeline, and derive the transitions with array functions.

The point is not just fewer bytes — it is *which operator* holds the state. Aggregation state spills to disk past `max_bytes_before_external_group_by`; `ARRAY JOIN` and window-sort state do not spill at all, which is why the spill knobs were inert on the previous shape (and, per #1921, on the one before that).

`max_memory_usage` is deliberately **not** set on the model. Testing it showed a self-imposed cap converting a build the server could still afford into a hard failure — the same trap as #1921.

## Verification

Local ClickHouse 25.7.5, synthetic fixtures only. Output byte-identical to the previous implementation on:

- an edge fixture covering field removed mid-history, removed at the last version, gap-then-reappears, multi-version gap, first appearance after v1, empty-string value, value-to-empty, single-version entity, and excluded-key churn
- a 301-row fixture
- a 217,000-row set: same row count, same byte total, same `cityHash64` checksum

| snapshot rows | before | after |
|---|---|---|
| 10,000 | 1.94 GiB / 48 s | 294 MiB / 1.0 s |
| 40,000 | fails at 3.60 GiB | 328 MiB / 3.5 s |

Peak memory no longer tracks snapshot size: 4x the data costs ~12% more memory. Spill to disk was confirmed active via `ExternalAggregationWritePart`.

`dbt parse` and `dbt compile` clean.

## Known limit

This raises the ceiling but does not remove it. The model is `materialized='table'` over an append-only snapshot, so every sync recomputes the entire history — millions of exploded rows to emit a few hundred thousand. At a snapshot roughly an order of magnitude larger than the sizes above, the build becomes impractically slow even though it no longer exhausts memory.

Computed transitions are immutable, so the durable answer is incremental materialization behind a watermark. That needs a design decision about the watermark and is left as follow-up rather than bundled here.

## Scope

`fields_history_raw` has one caller. The named-field `fields_history` used by the other nine connectors has no `ARRAY JOIN` and carries only scalar columns; it is untouched and unaffected.

Closes #2491
Refs #1804, #1921

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved field history tracking across entity versions.
  * Correctly records initial values, updated values, and fields that become absent.
  * Groups field changes more consistently for accurate historical results.

* **Performance**
  * Improved processing of large history datasets by limiting resource usage and allowing intermediate aggregation results to spill to disk when needed.

* **Documentation**
  * Added guidance describing memory usage and spill behavior during history processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->