### PR TITLE
test(authenticator): GitHub-brokered login e2e against the documented realm shape (#2163)

### DIFF
--- a/src/backend/services/authenticator/tests/common/kc.rs
+++ b/src/backend/services/authenticator/tests/common/kc.rs
@@ -134,8 +134,7 @@ pub async fn broker_login_github(
 }
 
 /// The brokered hop chain up to (not including) the authenticator callback:
-/// returns the callback URL so the caller can either follow it or exchange
-/// the code straight at the IdP (the claim-contract assertions).
+/// returns the callback URL for the caller to follow.
 pub async fn broker_callback_url(http: &super::Client, auth_base: &str, stub_user: &str) -> String {
     let login = http
         .get(format!("{auth_base}/auth/login"))
@@ -152,9 +151,40 @@ pub async fn broker_callback_url(http: &super::Client, auth_base: &str, stub_use
         .unwrap()
         .to_owned();
 
+    walk_broker_hops(
+        &authorize_url,
+        &format!("{auth_base}/auth/callback"),
+        stub_user,
+    )
+    .await
+}
+
+/// A brokered login outside the authenticator: the rig issues its own
+/// authorize request — no PKCE, unlike `/auth/login`'s — so the returned
+/// callback's code can be exchanged directly at the token endpoint (the
+/// claim-contract seam; a code minted for the authenticator's PKCE
+/// challenge cannot).
+pub async fn broker_direct_callback_url(redirect_uri: &str, stub_user: &str) -> String {
+    let authorize = reqwest::Url::parse_with_params(
+        &format!("{}/realms/{}/protocol/openid-connect/auth", base(), realm()),
+        &[
+            ("client_id", "insight-authenticator"),
+            ("response_type", "code"),
+            ("scope", "openid profile email"),
+            ("state", "claim-contract"),
+            ("nonce", "claim-contract"),
+            ("redirect_uri", redirect_uri),
+        ],
+    )
+    .unwrap()
+    .to_string();
+
+    walk_broker_hops(&authorize, redirect_uri, stub_user).await
+}
+
+async fn walk_broker_hops(authorize_url: &str, callback_prefix: &str, stub_user: &str) -> String {
     let plain = self::http();
     let mut cookies: std::collections::HashMap<String, String> = std::collections::HashMap::new();
-    let callback_prefix = format!("{auth_base}/auth/callback");
     let mut url = format!("{authorize_url}&kc_idp_hint=github");
 
     for _ in 0..12 {
@@ -165,7 +195,7 @@ pub async fn broker_callback_url(http: &super::Client, auth_base: &str, stub_use
         if url.contains("/login/oauth/authorize") {
             url = format!("{url}&e2e_user={stub_user}");
         }
-        if url.starts_with(&callback_prefix) {
+        if url.starts_with(callback_prefix) {
             return url;
         }
 

--- a/src/backend/services/authenticator/tests/common/kc.rs
+++ b/src/backend/services/authenticator/tests/common/kc.rs
@@ -117,6 +117,255 @@ pub async fn login(http: &super::Client, auth_base: &str, user: &str) -> String 
     session_cookie(&cb).expect("callback must set __Host-sid")
 }
 
+/// GitHub-brokered login: `/auth/login` -> the authorize URL with
+/// `kc_idp_hint=github` -> the GitHub stub authorizes as `stub_user`
+/// (github-stub.py: `known` | `unknown`) -> Keycloak's broker callback,
+/// first-broker-login form included when Keycloak serves one -> the
+/// authenticator callback response, returned unread so the caller asserts
+/// the outcome: a session cookie for a resolvable person, the refusal
+/// redirect otherwise.
+pub async fn broker_login_github(
+    http: &super::Client,
+    auth_base: &str,
+    stub_user: &str,
+) -> reqwest::Response {
+    let callback = broker_callback_url(http, auth_base, stub_user).await;
+    http.get(&callback).send().await.unwrap()
+}
+
+/// The brokered hop chain up to (not including) the authenticator callback:
+/// returns the callback URL so the caller can either follow it or exchange
+/// the code straight at the IdP (the claim-contract assertions).
+pub async fn broker_callback_url(http: &super::Client, auth_base: &str, stub_user: &str) -> String {
+    let login = http
+        .get(format!("{auth_base}/auth/login"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        login.status(),
+        302,
+        "GET /auth/login must redirect to the IdP"
+    );
+    let authorize_url = login.headers()[reqwest::header::LOCATION]
+        .to_str()
+        .unwrap()
+        .to_owned();
+
+    let plain = self::http();
+    let mut cookies: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let callback_prefix = format!("{auth_base}/auth/callback");
+    let mut url = format!("{authorize_url}&kc_idp_hint=github");
+
+    for _ in 0..12 {
+        // The stub's authorize URL is built with the container-side host;
+        // the test process follows it at loopback. `e2e_user` picks the
+        // GitHub identity the stub authorizes as.
+        url = url.replace("host.docker.internal", "127.0.0.1");
+        if url.contains("/login/oauth/authorize") {
+            url = format!("{url}&e2e_user={stub_user}");
+        }
+        if url.starts_with(&callback_prefix) {
+            return url;
+        }
+
+        let resp = plain
+            .get(&url)
+            .header(reqwest::header::COOKIE, cookie_header(&cookies))
+            .send()
+            .await
+            .unwrap();
+        collect_cookies(&resp, &mut cookies);
+
+        url = if resp.status().is_redirection() {
+            next_location(&resp, &url)
+        } else if resp.status() == 200 {
+            // First-broker-login review-profile: re-post the form as served,
+            // filling the names a GitHub profile may not carry.
+            let base = url.clone();
+            let page = resp.text().await.unwrap();
+            let submitted = plain
+                .post(absolute(&form_action(&page), &base))
+                .header(reqwest::header::COOKIE, cookie_header(&cookies))
+                .form(&profile_form(&page))
+                .send()
+                .await
+                .unwrap();
+            collect_cookies(&submitted, &mut cookies);
+            assert!(
+                submitted.status().is_redirection(),
+                "the first-broker-login POST must redirect; page said: {}",
+                submitted
+                    .text()
+                    .await
+                    .unwrap_or_default()
+                    .chars()
+                    .take(500)
+                    .collect::<String>()
+            );
+            next_location(&submitted, &base)
+        } else {
+            panic!("unexpected {} while brokering at {url}", resp.status());
+        };
+    }
+    panic!("brokered login never reached the authenticator callback");
+}
+
+/// The realm user representation for `email`, via the admin API.
+pub async fn find_user(email: &str) -> serde_json::Value {
+    let http = http();
+    let token = admin_token(&http).await;
+    user_representation(&http, &token, email).await
+}
+
+/// Exchange an authorization code at the realm's token endpoint (the
+/// authenticator's own dev client) and return the `id_token` claims. The
+/// signature is not verified — the claims, not the signature, are what the
+/// caller asserts.
+pub async fn exchange_code_for_id_claims(code: &str, redirect_uri: &str) -> serde_json::Value {
+    use base64::Engine;
+
+    let http = http();
+    let secret = env("E2E_IDP_CLIENT_SECRET", "insight-authenticator-dev-secret");
+    let resp = http
+        .post(format!(
+            "{}/realms/{}/protocol/openid-connect/token",
+            base(),
+            realm()
+        ))
+        .form(&[
+            ("grant_type", "authorization_code"),
+            ("code", code),
+            ("redirect_uri", redirect_uri),
+            ("client_id", "insight-authenticator"),
+            ("client_secret", secret.as_str()),
+        ])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "the code exchange must succeed");
+    let body: serde_json::Value = resp.json().await.unwrap();
+
+    let id_token = body["id_token"]
+        .as_str()
+        .expect("an id_token in the response");
+    let payload = id_token.split('.').nth(1).expect("a JWT payload segment");
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .expect("base64url JWT payload");
+    serde_json::from_slice(&bytes).expect("JSON JWT claims")
+}
+
+/// The user's federated-identity links, via the admin API — the broker
+/// suite's proof of which upstream identity the realm user is linked to.
+pub async fn federated_identity(email: &str) -> serde_json::Value {
+    let http = http();
+    let token = admin_token(&http).await;
+    let user = user_representation(&http, &token, email).await;
+    let id = user["id"].as_str().unwrap();
+    let resp = http
+        .get(format!(
+            "{}/admin/realms/{}/users/{id}/federated-identity",
+            base(),
+            realm()
+        ))
+        .bearer_auth(&token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        200,
+        "the federated-identity lookup must succeed"
+    );
+    resp.json().await.unwrap()
+}
+
+fn cookie_header(cookies: &std::collections::HashMap<String, String>) -> String {
+    cookies
+        .iter()
+        .filter(|(_, v)| !v.is_empty())
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+fn collect_cookies(
+    resp: &reqwest::Response,
+    cookies: &mut std::collections::HashMap<String, String>,
+) {
+    for hv in resp.headers().get_all(reqwest::header::SET_COOKIE) {
+        let Ok(raw) = hv.to_str() else { continue };
+        let Some(pair) = raw.split(';').next() else {
+            continue;
+        };
+        let Some((name, value)) = pair.split_once('=') else {
+            continue;
+        };
+        cookies.insert(name.trim().to_owned(), value.trim().to_owned());
+    }
+}
+
+fn next_location(resp: &reqwest::Response, base: &str) -> String {
+    let loc = resp.headers()[reqwest::header::LOCATION].to_str().unwrap();
+    absolute(loc, base)
+}
+
+fn absolute(url: &str, base: &str) -> String {
+    reqwest::Url::parse(base)
+        .unwrap()
+        .join(url)
+        .unwrap()
+        .to_string()
+}
+
+/// Every input field the page's form carries, with `firstName`/`lastName`
+/// filled in when empty — the two the review-profile step demands and a
+/// GitHub profile may not provide.
+fn profile_form(page: &str) -> Vec<(String, String)> {
+    let mut fields: Vec<(String, String)> = vec![];
+    for tag in page.split("<input").skip(1) {
+        let tag = &tag[..tag.find('>').unwrap_or(tag.len())];
+        let Some(name) = attr(tag, "name") else {
+            continue;
+        };
+        let value = attr(tag, "value").unwrap_or_default();
+        fields.push((name, value));
+    }
+
+    for required in ["firstName", "lastName"] {
+        match fields.iter_mut().find(|(name, _)| name == required) {
+            Some(field) if field.1.is_empty() => "Broker".clone_into(&mut field.1),
+            Some(_) => {}
+            None => fields.push((required.to_owned(), "Broker".to_owned())),
+        }
+    }
+    fields
+}
+
+fn attr(tag: &str, key: &str) -> Option<String> {
+    let pattern = format!("{key}=\"");
+    let at = tag.find(&pattern)? + pattern.len();
+    Some(tag[at..at + tag[at..].find('"')?].replace("&amp;", "&"))
+}
+
+/// The POST target of the page's only form (the review-profile page serves
+/// exactly one). Keycloak escapes `&` in the attribute value.
+fn form_action(page: &str) -> String {
+    let from = page.find("<form").unwrap_or(0);
+    let action_at = page[from..]
+        .find("action=\"")
+        .expect("the page must contain a form action")
+        + from
+        + "action=\"".len();
+    let action = &page[action_at
+        ..action_at
+            + page[action_at..]
+                .find('"')
+                .expect("unterminated action attribute")];
+    action.replace("&amp;", "&")
+}
+
 /// The `__Host-sid` value from a response's `Set-Cookie` headers.
 pub fn session_cookie(resp: &reqwest::Response) -> Option<String> {
     for hv in resp.headers().get_all(reqwest::header::SET_COOKIE) {

--- a/src/backend/services/authenticator/tests/e2e_broker.rs
+++ b/src/backend/services/authenticator/tests/e2e_broker.rs
@@ -149,7 +149,9 @@ async fn brokered_login_pins_tenant_and_stamps_idp_sub() {
     //     a single string and the GitHub id as idp_sub. (KC 26 hides
     //     unmanaged user attributes from admin-API reads, so the token is
     //     the observable proof both identity-provider mappers stamped.)
-    let callback = common::kc::broker_callback_url(&http, &auth_base, "known").await;
+    //     The rig's own PKCE-free authorize request, so the code exchanges.
+    let redirect_uri = format!("{auth_base}/auth/callback");
+    let callback = common::kc::broker_direct_callback_url(&redirect_uri, "known").await;
     let code = reqwest::Url::parse(&callback)
         .unwrap()
         .query_pairs()
@@ -157,8 +159,7 @@ async fn brokered_login_pins_tenant_and_stamps_idp_sub() {
         .expect("the brokered callback must carry a code")
         .1
         .into_owned();
-    let id_claims =
-        common::kc::exchange_code_for_id_claims(&code, &format!("{auth_base}/auth/callback")).await;
+    let id_claims = common::kc::exchange_code_for_id_claims(&code, &redirect_uri).await;
     assert_eq!(
         id_claims["tenant_id"],
         serde_json::json!(pin),

--- a/src/backend/services/authenticator/tests/e2e_broker.rs
+++ b/src/backend/services/authenticator/tests/e2e_broker.rs
@@ -1,0 +1,221 @@
+//! End-to-end GitHub-brokered login against a running authenticator +
+//! Keycloak + Redis stack (#2163 scenario 8; `run-e2e.sh` boots it).
+//!
+//! The realm registers the `github` identity provider in the documented
+//! shape (deploy/gitops/README.md, "Enabling GitHub sign-in"): `trustEmail`,
+//! the hardcoded tenant pin, and the GitHub-id -> `idp_sub` mapper — aimed
+//! at the rig-local GitHub stub (tests/github-stub.py) in place of
+//! github.com, so the REAL social importer runs with no real GitHub leg.
+//!
+//! ```text
+//! AUTH_BASE=http://localhost:8083 E2E_GITHUB_TENANT_PIN=<uuid> \
+//!   cargo test -p authenticator --test e2e_broker -- --ignored --nocapture
+//! ```
+
+#![allow(clippy::unwrap_used, clippy::expect_used, clippy::too_many_lines)]
+
+mod common;
+
+use std::time::{Duration, Instant};
+
+use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
+use serde::Deserialize;
+
+const COOKIE: &str = "__Host-sid";
+// github-stub.py's `known` identity: resolvable by the identity stub.
+const KNOWN_EMAIL: &str = "broker-known@example.com";
+const KNOWN_GITHUB_ID: &str = "7100001";
+
+fn env(key: &str, default: &str) -> String {
+    std::env::var(key).unwrap_or_else(|_| default.to_owned())
+}
+
+#[derive(Deserialize)]
+struct Jwks {
+    keys: Vec<Jwk>,
+}
+#[derive(Deserialize)]
+struct Jwk {
+    x: String,
+    y: String,
+    #[serde(default)]
+    kid: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct Claims {
+    sub: String,
+    tenant_id: String,
+}
+
+async fn me(http: &common::Client, auth_base: &str, token: &str) -> serde_json::Value {
+    let resp = http
+        .get(format!("{auth_base}/auth/me"))
+        .header(reqwest::header::COOKIE, format!("{COOKIE}={token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        200,
+        "/auth/me must answer for a live session"
+    );
+    resp.json().await.unwrap()
+}
+
+#[tokio::test]
+#[ignore = "requires a running authenticator + Keycloak + Redis stack"]
+async fn brokered_login_pins_tenant_and_stamps_idp_sub() {
+    let auth_base = env("AUTH_BASE", "http://localhost:8083");
+    let pin = std::env::var("E2E_GITHUB_TENANT_PIN")
+        .expect("E2E_GITHUB_TENANT_PIN must carry the registration's hardcoded tenant");
+    let http = common::client();
+
+    // 1. The full brokered hop chain ends in a session cookie.
+    let cb = common::kc::broker_login_github(&http, &auth_base, "known").await;
+    assert_eq!(
+        cb.status(),
+        302,
+        "callback must set the cookie and redirect"
+    );
+    let token = common::kc::session_cookie(&cb).expect("brokered callback must set __Host-sid");
+
+    // 2. The gateway JWT carries the pinned tenant — a single string, the
+    //    registration's value, not the roster realm's default tenant.
+    let authz = http
+        .get(format!("{auth_base}/internal/authz"))
+        .header(reqwest::header::COOKIE, format!("{COOKIE}={token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(authz.status(), 200, "authz should exchange cookie for JWT");
+    let bearer = authz.headers()["x-gateway-jwt"]
+        .to_str()
+        .unwrap()
+        .to_owned();
+    let jwt = bearer
+        .strip_prefix("Bearer ")
+        .expect("X-Gateway-Jwt is a Bearer token");
+
+    let jwks: Jwks = http
+        .get(format!("{auth_base}/.well-known/jwks.json"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let header = jsonwebtoken::decode_header(jwt).unwrap();
+    let jwk = jwks
+        .keys
+        .iter()
+        .find(|k| header.kid.is_none() || k.kid == header.kid)
+        .expect("a JWKS key matching the token kid");
+    let decoding = DecodingKey::from_ec_components(&jwk.x, &jwk.y).unwrap();
+    let mut validation = Validation::new(Algorithm::ES256);
+    validation.set_audience(&["internal-services"]);
+    let claims = decode::<Claims>(jwt, &decoding, &validation)
+        .expect("gateway JWT verifies against the JWKS")
+        .claims;
+    assert!(!claims.sub.is_empty(), "JWT sub (person_id) must be set");
+    assert_eq!(
+        claims.tenant_id, pin,
+        "the token tenant must be the registration's pin"
+    );
+
+    // 3. The broker recorded a realm-local user linked to the GitHub
+    //    identity, with the email trusted (verified) — the linking
+    //    mechanism, not an access grant.
+    let user = common::kc::find_user(KNOWN_EMAIL).await;
+    assert_eq!(
+        user["emailVerified"],
+        serde_json::json!(true),
+        "trustEmail must mark the brokered email verified"
+    );
+    let links = common::kc::federated_identity(KNOWN_EMAIL).await;
+    assert_eq!(
+        links[0]["identityProvider"],
+        serde_json::json!("github"),
+        "the realm user must be linked to the github registration"
+    );
+    assert_eq!(
+        links[0]["userId"],
+        serde_json::json!(KNOWN_GITHUB_ID),
+        "the link must carry the GitHub numeric id"
+    );
+
+    // 3b. The documented claim contract, read straight off the IdP: a
+    //     returning brokered login's id_token carries the pinned tenant as
+    //     a single string and the GitHub id as idp_sub. (KC 26 hides
+    //     unmanaged user attributes from admin-API reads, so the token is
+    //     the observable proof both identity-provider mappers stamped.)
+    let callback = common::kc::broker_callback_url(&http, &auth_base, "known").await;
+    let code = reqwest::Url::parse(&callback)
+        .unwrap()
+        .query_pairs()
+        .find(|(k, _)| k == "code")
+        .expect("the brokered callback must carry a code")
+        .1
+        .into_owned();
+    let id_claims =
+        common::kc::exchange_code_for_id_claims(&code, &format!("{auth_base}/auth/callback")).await;
+    assert_eq!(
+        id_claims["tenant_id"],
+        serde_json::json!(pin),
+        "the id_token tenant must be the pin, a single string"
+    );
+    assert_eq!(
+        id_claims["idp_sub"],
+        serde_json::json!(KNOWN_GITHUB_ID),
+        "the id_token must carry the GitHub id as idp_sub"
+    );
+
+    // 4. The brokered session rides the standard refresh lifecycle: the
+    //    planned refresh moves once rotation happens, and the session
+    //    survives it. (Realm lifespan 15s, refresh due ~5s after mint.)
+    let first_refresh_at = me(&http, &auth_base, &token).await["refresh_at"].clone();
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        if me(&http, &auth_base, &token).await["refresh_at"] != first_refresh_at {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the brokered session's IdP tokens never rotated"
+        );
+    }
+    let authz = http
+        .get(format!("{auth_base}/internal/authz"))
+        .header(reqwest::header::COOKIE, format!("{COOKIE}={token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(authz.status(), 200, "the session must survive the rotation");
+}
+
+#[tokio::test]
+#[ignore = "requires a running authenticator + Keycloak + Redis stack"]
+async fn brokered_unknown_email_is_refused() {
+    let auth_base = env("AUTH_BASE", "http://localhost:8083");
+    let http = common::client();
+
+    // The stub's `unknown` identity completes the GitHub leg, but its email
+    // resolves to nobody — the unknown-person refusal, not an auto-created
+    // account.
+    let cb = common::kc::broker_login_github(&http, &auth_base, "unknown").await;
+    assert_eq!(
+        cb.status(),
+        302,
+        "the refusal is a redirect, not an error page"
+    );
+    let location = cb.headers()[reqwest::header::LOCATION].to_str().unwrap();
+    assert!(
+        location.contains("auth_error=access_denied"),
+        "the refusal must land with the auth_error reason, got {location}"
+    );
+    assert!(
+        common::kc::session_cookie(&cb).is_none(),
+        "a refused brokered login must not set {COOKIE}"
+    );
+}

--- a/src/backend/services/authenticator/tests/github-stub.py
+++ b/src/backend/services/authenticator/tests/github-stub.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Rig-local GitHub for the brokered-login e2e suite (dev/CI only).
+
+Keycloak's built-in `github` identity provider accepts `baseUrl`/`apiUrl`
+overrides (its GitHub-Enterprise seam); the realm overlay points both at this
+stub, so the rig drives the REAL social importer — token exchange, profile,
+primary-verified-email lookup — against a GitHub it controls:
+
+- `GET  /login/oauth/authorize` — auto-approves and redirects straight back
+  with a code; `e2e_user` (`known` | `unknown`, default `known`) picks which
+  GitHub identity the code represents.
+- `POST /login/oauth/access_token` — exchanges the code; the client id/secret
+  must match the pair the realm registration carries.
+- `GET  /user` — the profile, with a null `email`, forcing the provider down
+  the /user/emails path.
+- `GET  /user/emails` — a non-primary decoy first, then the primary verified
+  email the sign-in must identify the user by.
+
+`unknown`'s email carries the identity stub's `unknown-` refusal prefix, so
+its brokered login completes at Keycloak and is refused downstream by the
+authenticator — the unknown-person path with a fully working upstream.
+
+Bind address from argv[1] (default 0.0.0.0:8098 — the Keycloak container
+dials in via host.docker.internal, so loopback is not enough).
+"""
+
+import base64
+import json
+import secrets
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlencode, urlsplit
+
+CLIENT_ID = "github-e2e-client"
+CLIENT_SECRET = "github-e2e-secret"
+
+USERS = {
+    "known": {"id": 7100001, "login": "rig-broker-known", "name": "Broker Rig", "email": "broker-known@example.com"},
+    "unknown": {
+        "id": 7100002,
+        "login": "rig-broker-unknown",
+        "name": "Broker Rig",
+        "email": "unknown-broker@example.com",
+    },
+}
+
+codes: dict[str, str] = {}  # one-shot authorization code -> USERS key
+tokens: dict[str, str] = {}  # access token -> USERS key
+
+
+def _client_authenticated(form: dict, authorization: str) -> bool:
+    # Keycloak may send the client pair as body params or as Basic auth.
+    if (form.get("client_id") or [""])[0] == CLIENT_ID and (form.get("client_secret") or [""])[0] == CLIENT_SECRET:
+        return True
+    if authorization.startswith("Basic "):
+        expected = base64.b64encode(f"{CLIENT_ID}:{CLIENT_SECRET}".encode()).decode()
+        return authorization.removeprefix("Basic ") == expected
+    return False
+
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        split = urlsplit(self.path)
+        query = parse_qs(split.query)
+
+        if split.path == "/login/oauth/authorize":
+            self._authorize(query)
+        elif split.path == "/user":
+            self._json_for_bearer(lambda u: {"id": u["id"], "login": u["login"], "name": u["name"], "email": None})
+        elif split.path == "/user/emails":
+            self._json_for_bearer(
+                lambda u: [
+                    {"email": f"decoy-{u['login']}@example.com", "primary": False, "verified": True},
+                    {"email": u["email"], "primary": True, "verified": True},
+                ]
+            )
+        elif split.path == "/healthz":
+            self._respond(200, b"ok", "text/plain")
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_POST(self):
+        if urlsplit(self.path).path != "/login/oauth/access_token":
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        length = int(self.headers.get("Content-Length") or 0)
+        form = parse_qs(self.rfile.read(length).decode())
+        if not _client_authenticated(form, self.headers.get("Authorization") or ""):
+            self._respond(401, b'{"error":"incorrect_client_credentials"}', "application/json")
+            return
+        user_key = codes.pop((form.get("code") or [""])[0], None)
+        if user_key is None:
+            self._respond(400, b'{"error":"bad_verification_code"}', "application/json")
+            return
+
+        token = secrets.token_hex(16)
+        tokens[token] = user_key
+        body = json.dumps({"access_token": token, "token_type": "bearer", "scope": "user:email"}).encode()
+        self._respond(200, body, "application/json")
+
+    def _authorize(self, query: dict) -> None:
+        redirect_uri = (query.get("redirect_uri") or [""])[0]
+        state = (query.get("state") or [""])[0]
+        user_key = (query.get("e2e_user") or ["known"])[0]
+        if (query.get("client_id") or [""])[0] != CLIENT_ID or user_key not in USERS or not redirect_uri:
+            self.send_response(400)
+            self.end_headers()
+            return
+
+        code = secrets.token_hex(16)
+        codes[code] = user_key
+        sep = "&" if "?" in redirect_uri else "?"
+        self.send_response(302)
+        self.send_header("Location", f"{redirect_uri}{sep}{urlencode({'code': code, 'state': state})}")
+        self.end_headers()
+
+    def _json_for_bearer(self, build) -> None:
+        auth = self.headers.get("Authorization") or ""
+        token = auth.removeprefix("Bearer ").removeprefix("token ")
+        user_key = tokens.get(token)
+        if user_key is None:
+            self._respond(401, b'{"message":"Bad credentials"}', "application/json")
+            return
+        self._respond(200, json.dumps(build(USERS[user_key])).encode(), "application/json")
+
+    def _respond(self, status: int, body: bytes, content_type: str) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *_args):  # silence access logging
+        pass
+
+
+if __name__ == "__main__":
+    host, _, port = (sys.argv[1] if len(sys.argv) > 1 else "0.0.0.0:8098").partition(":")
+    ThreadingHTTPServer((host, int(port)), Handler).serve_forever()

--- a/src/backend/services/authenticator/tests/kc-realm-overlay.py
+++ b/src/backend/services/authenticator/tests/kc-realm-overlay.py
@@ -13,7 +13,12 @@ The rig needs the same realm plus what only the e2e suites care about:
   or admin disable must never reach a sibling's live session;
 - a second, user-less realm (`--second-realm`) as the second issuer of the
   host-keyed map (`e2e_hostmap`). User-less because Keycloak's user ids are
-  globally unique across realms, so importing the roster twice collides.
+  globally unique across realms, so importing the roster twice collides;
+- the GitHub identity-provider registration in the documented shape
+  (deploy/gitops/README.md, "Enabling GitHub sign-in") — trustEmail, the
+  hardcoded tenant pin, the GitHub-id -> `idp_sub` mapper — aimed at the
+  rig's GitHub stub (`--github-stub-base`/`--github-tenant-pin`, together
+  or not at all; only the primary realm carries it).
 
 Passwords and tenant ids are read off the input realm rather than restated,
 so this script cannot drift from the generator.
@@ -51,6 +56,44 @@ TEST_USERS = [
 ]
 
 
+# The pair the GitHub stub validates (tests/github-stub.py).
+GITHUB_CLIENT_ID = "github-e2e-client"
+GITHUB_CLIENT_SECRET = "github-e2e-secret"
+
+
+def _github_identity_provider(stub_base: str, tenant_pin: str) -> tuple[dict, list[dict]]:
+    provider = {
+        "alias": "github",
+        "providerId": "github",
+        "enabled": True,
+        "trustEmail": True,
+        "config": {
+            "clientId": GITHUB_CLIENT_ID,
+            "clientSecret": GITHUB_CLIENT_SECRET,
+            "defaultScope": "user:email",
+            # The provider's GitHub-Enterprise seam: authorize/token hang off
+            # baseUrl, /user and /user/emails off apiUrl — all the stub here.
+            "baseUrl": stub_base,
+            "apiUrl": stub_base,
+        },
+    }
+    mappers = [
+        {
+            "name": "tenant-pin",
+            "identityProviderAlias": "github",
+            "identityProviderMapper": "hardcoded-attribute-idp-mapper",
+            "config": {"attribute": "tenant_id", "attribute.value": tenant_pin},
+        },
+        {
+            "name": "github-id-to-idp-sub",
+            "identityProviderAlias": "github",
+            "identityProviderMapper": "github-user-attribute-mapper",
+            "config": {"jsonField": "id", "userAttribute": "idp_sub"},
+        },
+    ]
+    return provider, mappers
+
+
 def _test_user(email: str, password: str, tenant_id: str) -> dict:
     local = email.split("@", 1)[0]
     return {
@@ -72,7 +115,11 @@ def main() -> None:
     parser.add_argument("--second-realm", required=True, help="Name of the user-less second realm")
     parser.add_argument("--backchannel-url", required=True, help="insight-authenticator back-channel logout URL")
     parser.add_argument("--access-token-lifespan", type=int, required=True, help="Realm access-token lifespan, seconds")
+    parser.add_argument("--github-stub-base", help="GitHub stub base URL as the Keycloak container reaches it")
+    parser.add_argument("--github-tenant-pin", help="Hardcoded tenant_id the GitHub registration stamps")
     args = parser.parse_args()
+    if bool(args.github_stub_base) != bool(args.github_tenant_pin):
+        parser.error("--github-stub-base and --github-tenant-pin come together or not at all")
 
     realm = json.loads(Path(args.realm).read_text())
 
@@ -91,6 +138,32 @@ def main() -> None:
     second = copy.deepcopy(realm)
     second["realm"] = args.second_realm
     second["users"] = []
+
+    # After the deepcopy: the host-keyed second realm stays broker-free.
+    if args.github_stub_base:
+        provider, mappers = _github_identity_provider(args.github_stub_base, args.github_tenant_pin)
+        realm.setdefault("identityProviders", []).append(provider)
+        realm.setdefault("identityProviderMappers", []).extend(mappers)
+        # The canonical broker realm's idp_sub passthrough (the generated
+        # roster realm has no brokered users, so it does not carry one):
+        # KC 26 hides unmanaged user attributes from admin-API reads, so the
+        # token claim is the only observable proof the GitHub mapper stamped.
+        client.setdefault("protocolMappers", []).append(
+            {
+                "name": "idp_sub",
+                "protocol": "openid-connect",
+                "protocolMapper": "oidc-usermodel-attribute-mapper",
+                "consentRequired": False,
+                "config": {
+                    "user.attribute": "idp_sub",
+                    "claim.name": "idp_sub",
+                    "jsonType.label": "String",
+                    "id.token.claim": "true",
+                    "access.token.claim": "true",
+                    "userinfo.token.claim": "true",
+                },
+            }
+        )
 
     out_dir = Path(args.out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)

--- a/src/backend/services/authenticator/tests/run-e2e.sh
+++ b/src/backend/services/authenticator/tests/run-e2e.sh
@@ -291,10 +291,6 @@ echo "==> run the login loop"
 AUTH_BASE="http://localhost:$AUTH_PORT" E2E_USER="$E2E_USER" \
   cargo test -p authenticator --test e2e_login_loop -- --ignored --nocapture
 
-echo "==> run the GitHub-brokered login loop (#2163 scenario 8)"
-AUTH_BASE="http://localhost:$AUTH_PORT" E2E_GITHUB_TENANT_PIN="$GITHUB_TENANT_PIN" \
-  cargo test -p authenticator --test e2e_broker -- --ignored --nocapture
-
 echo "==> run the refresh rotation-with-grace loop (step 10.1)"
 AUTH_BASE="http://localhost:$AUTH_PORT" E2E_USER="$E2E_USER" \
   cargo test -p authenticator --test e2e_refresh -- --ignored --nocapture
@@ -341,5 +337,11 @@ AUTH_BASE="http://localhost:$AUTH_PORT" \
   TOKEN_ENDPOINT="http://localhost:$TOKEN_PORT/internal/token" \
   SVC_KEY="$SVC_KEYS_DIR/testclient.key.pem" \
   cargo test -p authenticator --test e2e_service_token -- --ignored --nocapture
+
+echo "==> run the GitHub-brokered login loop (#2163 scenario 8)"
+# Last: its stack pieces (github stub, broker registration) are additive, so
+# a broker-leg failure must not rob the earlier suites of their run.
+AUTH_BASE="http://localhost:$AUTH_PORT" E2E_GITHUB_TENANT_PIN="$GITHUB_TENANT_PIN" \
+  cargo test -p authenticator --test e2e_broker -- --ignored --nocapture
 
 echo "==> PASS (endpoint-coverage ledger: $E2E_COVERAGE_LEDGER)"

--- a/src/backend/services/authenticator/tests/run-e2e.sh
+++ b/src/backend/services/authenticator/tests/run-e2e.sh
@@ -43,6 +43,7 @@ AUTH3_PORT="${AUTH3_PORT:-8087}"
 TOKEN3_PORT="${TOKEN3_PORT:-8097}"
 KC_PORT="${KC_PORT:-8084}"
 IDENTITY_PORT="${IDENTITY_PORT:-8092}"
+GITHUB_STUB_PORT="${GITHUB_STUB_PORT:-8098}"
 REDIS_CT=authenticator-e2e-redis
 KC_CT=authenticator-e2e-keycloak
 # Same image the compose stack pins for its realm (docker-compose.yml).
@@ -61,6 +62,10 @@ SEED_DIR="$ROOT_DIR/src/ingestion/tools/seed"
 # resolves people by email (idp.external_id_claim=email), so this only has to
 # be named, and it is the value the compose stack uses.
 KC_TENANT_ID=00000000-df51-5b42-9538-d2b56b7ee953
+# The GitHub registration's hardcoded tenant pin (kc-realm-overlay.py) —
+# deliberately NOT the roster tenant above, so the broker suite proves the
+# token tenant comes from the pin, not from any default.
+GITHUB_TENANT_PIN=11111111-2222-4333-8444-555555555555
 pids=()
 
 cleanup() {
@@ -123,7 +128,9 @@ python3 "$HERE/kc-realm-overlay.py" \
   --out-dir "$KC_IMPORT_DIR" \
   --second-realm "$KC_REALM_B" \
   --backchannel-url "http://host.docker.internal:$AUTH_PORT/auth/oidc/back-channel-logout" \
-  --access-token-lifespan 15
+  --access-token-lifespan 15 \
+  --github-stub-base "http://host.docker.internal:$GITHUB_STUB_PORT" \
+  --github-tenant-pin "$GITHUB_TENANT_PIN"
 rm -f "$KC_IMPORT_DIR/realm-insight.generated.json"
 
 echo "==> Keycloak :$KC_PORT (realms $KC_REALM + $KC_REALM_B, --import-realm)"
@@ -170,6 +177,12 @@ echo "==> identity stub :$IDENTITY_PORT (resolves any email/external-id to a per
 python3 "$HERE/identity-stub.py" "127.0.0.1:$IDENTITY_PORT" >/tmp/authenticator-e2e-identity.log 2>&1 &
 pids+=($!)
 wait_ready identity-stub "http://localhost:$IDENTITY_PORT/internal/persons/by-external-id?source_type=faketest&external_id=probe"
+
+echo "==> github stub :$GITHUB_STUB_PORT (rig-local GitHub for the broker leg)"
+# 0.0.0.0: the Keycloak container dials in via host.docker.internal.
+python3 "$HERE/github-stub.py" "0.0.0.0:$GITHUB_STUB_PORT" >/tmp/authenticator-e2e-github.log 2>&1 &
+pids+=($!)
+wait_ready github-stub "http://localhost:$GITHUB_STUB_PORT/healthz"
 
 echo "==> authenticator :$AUTH_PORT"
 # The config's own bind addrs are the default 8083/8093; rewrite them like the
@@ -277,6 +290,10 @@ export E2E_USER_PASSWORD=insight-dev
 echo "==> run the login loop"
 AUTH_BASE="http://localhost:$AUTH_PORT" E2E_USER="$E2E_USER" \
   cargo test -p authenticator --test e2e_login_loop -- --ignored --nocapture
+
+echo "==> run the GitHub-brokered login loop (#2163 scenario 8)"
+AUTH_BASE="http://localhost:$AUTH_PORT" E2E_GITHUB_TENANT_PIN="$GITHUB_TENANT_PIN" \
+  cargo test -p authenticator --test e2e_broker -- --ignored --nocapture
 
 echo "==> run the refresh rotation-with-grace loop (step 10.1)"
 AUTH_BASE="http://localhost:$AUTH_PORT" E2E_USER="$E2E_USER" \


### PR DESCRIPTION
## What

Implements **#2163 Testing scenario 8** (`auth-rig`): the authenticator e2e rig gains the GitHub-brokered login leg, run by `run-e2e.sh` in the existing `Authenticator — e2e, endpoint coverage` lane.

- **`tests/github-stub.py`** — a rig-local GitHub: authorize (auto-approve), token exchange (client pair checked), `/user` with a null email, `/user/emails` with a non-primary decoy plus the primary verified email. Keycloak's built-in `github` provider reaches it through its GitHub-Enterprise `baseUrl`/`apiUrl` seam, so the **real social importer** runs with no real GitHub involved.
- **`kc-realm-overlay.py`** — registers the identity provider in the documented shape (`trustEmail`, `defaultScope: user:email`, the `hardcoded-attribute-idp-mapper` tenant pin, the `github-user-attribute-mapper` `jsonField: id -> userAttribute: idp_sub`) plus the canonical realm's `idp_sub` token passthrough; the host-keyed second realm stays broker-free.
- **`tests/e2e_broker.rs`** — two loops:
  - *known email*: full chain through the authenticator (`kc_idp_hint=github`, first-broker-login handled if served) → session cookie; gateway JWT tenant = the pin, a single string, deliberately **not** the roster tenant; federated-identity link carries the GitHub numeric id; the id_token claim contract (`tenant_id` pin + `idp_sub`) read straight off the IdP; session survives token rotation (15s realm lifespan).
  - *unknown email*: the brokered login completes at Keycloak but resolves to no person → `auth_error=access_denied` redirect, **no session cookie** (AC-2's mechanism, minus the audit-stream count that stays with scenario 2 on a deployed stand).

## Why

Scenario 8 is the only #2163 scenario that can run continuously in CI: it freezes the operator instruction's realm shape (#2470) as an executable contract long before the dedicated deployment exists. The GitHub-specific leg stays with scenarios 4 and 7.

## Verified

- Both loops' Keycloak-side behaviour replayed against a standalone Keycloak 26.4 import of the overlay realm: 6-hop chain to the RP callback, tenant pin + `idp_sub` present in the id_token, federated-identity link correct, `emailVerified` true via `trustEmail`.
- One deliberate finding baked into the test design: KC 26 hides unmanaged user attributes from admin-API reads, so the token claims — not user representations — are the observable proof the mappers stamped.
- `cargo test --no-run`, `cargo clippy --tests` (0 findings), `cargo fmt --check`, ruff clean.

Refs #2163.