### PR TITLE
ci(security): accept the connector name in the gitlab-nocode DDL snapshot

### DIFF
--- a/.github/trufflehog-allowlist.txt
+++ b/.github/trufflehog-allowlist.txt
@@ -25,6 +25,7 @@ c71d7d6ef85cd006  Gitlab             src/ingestion/connectors/git/gitlab/dbt/git
 5804c17e4c07e9bb  Gitlab             src/ingestion/connectors/git/gitlab/source_gitlab/streams/merge_requests.py  # code identifier / constant name
 cd968567652ff20b  Gitlab             src/ingestion/connectors/git/gitlab/source_gitlab/streams/project_incremental.py  # code identifier / constant name
 d1c1dd2c5248b565  Gitlab             src/ingestion/connectors/git/gitlab/tests/test_source.py  # code identifier / constant name
+079c134aaca8eb24  Gitlab             src/ingestion/scripts/connectors-ddl/gitlab-nocode.sql  # connector name in a DDL snapshot, not a token
 5976017fb71ea0e2  HubSpotApiKey      docs/architecture/CONNECTOR_AUTOMATION.md  # synthetic UUID fixture
 fdd801f84b096f9b  HubSpotApiKey      src/ingestion/tests/e2e/lib/metric_coverage.py  # synthetic UUID fixture
 93192185cb9d3fc6  HubSpotApiKey      src/ingestion/tests/e2e/lib/metric_coverage.py  # synthetic UUID fixture


### PR DESCRIPTION
Refs #2301.

The nightly scan reports one finding outside the baseline: the GitLab detector reading the connector's own name in `src/ingestion/scripts/connectors-ddl/gitlab-nocode.sql` as a token. Same class as everything else in the file — a name whose shape matches a key's.

With this line the nightly report is empty again: 208 findings, all accounted for.

## Test plan

- [x] The corpus the nightly scan produces — every ref of the repository, 42 175 chunks, 208 findings — run through the gate with this allowlist: `No new secrets. 208 known finding(s) matched the allowlist`
- [x] The same corpus against the allowlist as it stands on `main`: one finding reported, the one this entry covers, so the entry is doing the work rather than covering an absence


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration to recognize a GitLab connector identifier as a non-sensitive value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->