### PR TITLE
fix(frontend): stop rows showing through the pinned totals

### DIFF
--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-presentations.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-presentations.test.tsx
@@ -179,6 +179,9 @@ describe("metric timeseries presentations", () => {
     expect(foot.className).toContain("sticky");
     expect(foot.className).toContain("bottom-0");
     expect(foot.className).toContain("inset_0_1px_0_0");
+    // Opaque, not tinted: the row the footer covers showed through sliced
+    // along its middle, and the totals read as riding on it.
+    expect(foot.className).toMatch(/(^|\s)bg-muted(\s|$)/);
   });
 
   it("keeps the grand total beside its label when the table is scrolled", () => {

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-table.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-table.tsx
@@ -383,7 +383,12 @@ export function MetricTimeseriesTable({
       </TableBody>
       {/* The top edge is what says the rows continue underneath; without it
           the pinned block reads as the end of the table. */}
-      <TableFooter className="sticky bottom-0 z-20 shadow-[inset_0_1px_0_0_var(--border)]">
+      {/* Opaque, overriding the default half-transparent tint: the value cells
+          carry no background of their own, so rows travelled under the totals
+          and the row the footer covers showed through sliced along its middle.
+          A frosted variant keeps that sliver visible by design — the totals
+          need the row behind them gone, not softened. */}
+      <TableFooter className="sticky bottom-0 z-20 bg-muted shadow-[inset_0_1px_0_0_var(--border)]">
         <TableRow>
           <TableCell className="sticky left-0 z-10 w-28 max-w-28 min-w-28 bg-muted px-2 py-1 font-semibold after:absolute after:inset-y-0 after:right-0 after:w-px after:bg-border">
             Total


### PR DESCRIPTION
Follow-up to #2465, which pinned the totals to the foot of the box. The pinning worked; the surface under it did not.

## What was wrong
`TableFooter` defaults to a half-transparent tint, and the value cells in the Total row carry no background of their own. Rows travelled visibly under the totals, and the two read as one smeared line.

## Frosted was tried first and is not what this needs
The obvious treatment is a translucent panel with a backdrop blur, and it was built that way first. Looked at side by side at the same scroll offset, it is worse:

| Treatment | At a mid-scroll position |
|---|---|
| `bg-muted/85` + `backdrop-blur-md` | The row the footer covers shows through, sliced along its middle, directly under the totals |
| `bg-muted` | Whole rows, then a clean edge, then the totals |

A blurred panel keeps what is behind it visible — that is the whole idea of one — and what is behind this panel is the top sliver of a data row. The totals need the row behind them gone, not softened.

## Verification
Compared in a browser at the same scroll offset on a table with real vertical overflow. The existing footer test gains an assertion that the background carries no opacity modifier, so a later "let's frost it" cannot quietly reintroduce the sliver. Unit suite green, typecheck and lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the totals footer in metric time-series tables with an opaque muted background.
  * Prevented table rows from showing through the sticky totals area while scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->