### PR TITLE
feat(seed): generate wiki silver rows so the wiki metrics answer with data

### DIFF
--- a/.claude/skills/stand-scenarios/invariants.md
+++ b/.claude/skills/stand-scenarios/invariants.md
@@ -28,14 +28,17 @@ Enforced at: the API returns `null` rather than `0` for an unmeasured value
 renders `—` / "not recorded" / an explicit empty card.
 
 Partially covered: `test_the_personal_dashboard_renders_every_metric_domain`
-asserts the unseeded Wiki domain shows "No data" and
-"No metrics with data for this period.", and that populated KPI tiles are
-`not_to_have_text("—")`. `test_the_team_view_lists_every_report_the_roster_declares`
-asserts an unrecorded cell renders as unrecorded rather than as a number.
+asserts that populated KPI tiles are `not_to_have_text("—")`, and
+`test_the_team_view_lists_every_report_the_roster_declares` asserts that every
+member's cell renders for every column — recorded or an honest "not recorded" —
+without demanding a value.
 
-Gap worth a claim: the **API** half — that an unmeasured metric answers `null`
-and never `0`. The UI cannot prove it; a backend that returned `0` and a
-frontend that rendered `—` for falsy would look identical on screen.
+Gaps worth a claim: every metric domain is seeded now, so no view on this stand
+asserts the empty state itself — that a domain with no data renders its explicit
+empty card, and that an unmeasured cell reads "not recorded" rather than `0`.
+And the **API** half: that an unmeasured metric answers `null` and never `0`.
+The UI cannot prove that one at all; a backend that returned `0` and a frontend
+that rendered `—` for falsy would look identical on screen.
 
 ## R2 · Confidence and limitations travel with every conclusion
 

--- a/dev-compose.sh
+++ b/dev-compose.sh
@@ -1582,16 +1582,16 @@ test_stand_write_env() {
 #   git     <- class_git_{commits,file_changes,pull_requests,…}          (git.py)
 #   collab  <- class_collab_{chat,email,meeting}_activity, focus_metrics (collab.py)
 #   ai      <- class_ai_{assistant,dev}_usage                            (ai.py)
+#   wiki    <- class_wiki_{pages,activity,engagement}                    (wiki.py)
 #
-# `wiki_metric_observations` is absent ON PURPOSE: its evidence model reads
-# class_wiki_* and there is no wiki generator, so requiring it would hang every
-# run. The crm, support, hr and people generators have no observation table of
-# their own — they feed other surfaces — so they cannot be gated on here.
+# The crm, support, hr and people generators have no observation table of their
+# own — they feed other surfaces — so they cannot be gated on here.
 TEST_STAND_READY_TABLES=(
   task_metric_observations
   git_metric_observations
   collab_metric_observations
   ai_metric_observations
+  wiki_metric_observations
 )
 
 test_stand_ch_query() {

--- a/src/ingestion/tools/seed/insight_seed/generators/base.py
+++ b/src/ingestion/tools/seed/insight_seed/generators/base.py
@@ -187,6 +187,9 @@ RESET_TARGETS: tuple[tuple[str, str], ...] = (
     ("silver", "class_task_statuses"),
     ("silver", "class_task_users"),
     ("silver", "class_task_worklogs"),
+    ("silver", "class_wiki_activity"),
+    ("silver", "class_wiki_engagement"),
+    ("silver", "class_wiki_pages"),
 )
 
 

--- a/src/ingestion/tools/seed/insight_seed/generators/wiki.py
+++ b/src/ingestion/tools/seed/insight_seed/generators/wiki.py
@@ -1,0 +1,291 @@
+"""
+wiki silver-table generator: pages + per-author edits + page comments.
+
+All teams keep documentation, scaled by their profile.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from collections import Counter
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from ..profiles import TEAM_PROFILES, Person
+from .base import (
+    anchor_datetime,
+    bulk_insert,
+    days_window,
+    deterministic_uuid,
+    persona_multiplier,
+    poisson,
+    seeded_rng,
+    truncate,
+    weekday_multiplier,
+)
+
+if TYPE_CHECKING:
+    import clickhouse_connect.driver.client
+
+
+# The TEAM_PROFILES key stays short (outline) for readability; the emitted
+# `data_source` carries the `insight_` prefix every connector writes.
+SOURCE = "outline"
+DATA_SOURCE = "insight_" + SOURCE
+
+PAGES_CAP = 3
+EDITS_CAP = 12
+COMMENTS_CAP = 6
+
+# How long after a page is published it still attracts comments.
+COMMENT_WINDOW_DAYS = 8
+
+_PAGE_KINDS = ("runbook", "design note", "retro", "onboarding guide", "spec")
+
+
+@dataclass(frozen=True)
+class _Page:
+    author: Person
+    source_id: str
+    page_id: str
+    space_id: str
+    space_name: str
+    title: str
+    created_at: _dt.datetime
+    version_count: int
+
+
+def _wiki_authors(roster: Sequence[Person]) -> list[Person]:
+    """Everyone on a team with a non-zero outline weight."""
+    return [p for p in roster if p.team and TEAM_PROFILES[p.team].weights.get(SOURCE, 0) > 0]
+
+
+def _source_id(team: str) -> str:
+    return deterministic_uuid("wiki.source", team)
+
+
+def _plan_pages(roster: Sequence[Person], days: int) -> list[_Page]:
+    """Every page this run will write, decided before any row is emitted.
+
+    The engagement rows join back onto (tenant_id, source_id, page_id) INNER
+    and gold credits the PAGE's author with the comments, so both the comments
+    and the activity row's `pages_created` are derived from this list rather
+    than drawn independently.
+    """
+    pages: list[_Page] = []
+    for p in _wiki_authors(roster):
+        persona = persona_multiplier(p.uuid)
+        team = p.team or ""
+        weight = TEAM_PROFILES[team].weights[SOURCE]
+        source_id = _source_id(team)
+        space_id = deterministic_uuid("wiki.space", team)
+        for d in days_window(days):
+            rng = seeded_rng(p.uuid, d, "wiki.pages")
+            mean = 0.25 * persona * weight * weekday_multiplier(d)
+            for i in range(min(poisson(rng, mean), PAGES_CAP)):
+                kind = _PAGE_KINDS[rng.randrange(len(_PAGE_KINDS))]
+                created_at = _dt.datetime.combine(
+                    d,
+                    _dt.time(9 + rng.randint(0, 8), rng.randint(0, 59), tzinfo=_dt.UTC),
+                )
+                pages.append(
+                    _Page(
+                        author=p,
+                        source_id=source_id,
+                        page_id=deterministic_uuid("wiki.page", p.uuid, d.isoformat(), str(i)),
+                        space_id=space_id,
+                        space_name=f"{team} wiki",
+                        title=f"{team} {kind} {d.isoformat()}-{i + 1}",
+                        created_at=created_at,
+                        version_count=rng.randint(1, 12),
+                    )
+                )
+    return pages
+
+
+def seed_wiki_pages(
+    client: clickhouse_connect.driver.client.Client,
+    pages: Sequence[_Page],
+    tenant_uuid: str,
+) -> int:
+    truncate(client, "silver", "class_wiki_pages")
+    cols = [
+        "tenant_id",
+        "source_id",
+        "unique_key",
+        "page_id",
+        "space_id",
+        "space_name",
+        "title",
+        "status",
+        "author_id",
+        "author_email",
+        "version_count",
+        "created_at",
+        "updated_at",
+        "source",
+        "data_source",
+        "collected_at",
+        "_version",
+    ]
+    rows: list[tuple[object, ...]] = []
+    version = 1
+    now = anchor_datetime()
+    for page in pages:
+        rows.append(
+            (
+                tenant_uuid,
+                page.source_id,
+                deterministic_uuid("wiki.pages.row", page.page_id),
+                page.page_id,
+                page.space_id,
+                page.space_name,
+                page.title,
+                "published",
+                page.author.uuid,
+                page.author.email,
+                page.version_count,
+                page.created_at,
+                page.created_at + _dt.timedelta(minutes=15 * page.version_count),
+                SOURCE,
+                DATA_SOURCE,
+                now,
+                version,
+            )
+        )
+    return bulk_insert(client, "silver", "class_wiki_pages", cols, rows)
+
+
+def seed_wiki_activity(
+    client: clickhouse_connect.driver.client.Client,
+    roster: Sequence[Person],
+    pages: Sequence[_Page],
+    tenant_uuid: str,
+    days: int,
+) -> int:
+    truncate(client, "silver", "class_wiki_activity")
+    cols = [
+        "tenant_id",
+        "source_id",
+        "unique_key",
+        "author_id",
+        "author_email",
+        "day",
+        "pages_edited",
+        "total_edits",
+        "pages_created",
+        "source",
+        "data_source",
+        "collected_at",
+        "_version",
+    ]
+    authored = Counter((page.author.uuid, page.created_at.date()) for page in pages)
+    rows: list[tuple[object, ...]] = []
+    version = 1
+    now = anchor_datetime()
+    for p in _wiki_authors(roster):
+        persona = persona_multiplier(p.uuid)
+        team = p.team or ""
+        weight = TEAM_PROFILES[team].weights[SOURCE]
+        for d in days_window(days):
+            rng = seeded_rng(p.uuid, d, "wiki.activity")
+            mean = 1.2 * persona * weight * weekday_multiplier(d)
+            created = authored[(p.uuid, d)]
+            # Publishing a page is itself an edit, so the day's edits can
+            # never be fewer than the pages the planner dated to it.
+            edits = max(min(poisson(rng, mean), EDITS_CAP), created)
+            if edits == 0:
+                continue
+            edited = max(created, 1, int(edits * rng.uniform(0.4, 0.9)))
+            rows.append(
+                (
+                    tenant_uuid,
+                    _source_id(team),
+                    deterministic_uuid("wiki.activity.row", p.uuid, d.isoformat()),
+                    p.uuid,
+                    p.email,
+                    d,
+                    edited,
+                    edits,
+                    created,
+                    SOURCE,
+                    DATA_SOURCE,
+                    now,
+                    version,
+                )
+            )
+    return bulk_insert(client, "silver", "class_wiki_activity", cols, rows)
+
+
+def seed_wiki_engagement(
+    client: clickhouse_connect.driver.client.Client,
+    pages: Sequence[_Page],
+    tenant_uuid: str,
+    days: int,
+) -> int:
+    truncate(client, "silver", "class_wiki_engagement")
+    cols = [
+        "tenant_id",
+        "source_id",
+        "unique_key",
+        "page_id",
+        "day",
+        "total_comments",
+        "footer_comments",
+        "inline_comments",
+        "replies",
+        "unique_commenters",
+        "source",
+        "data_source",
+        "collected_at",
+        "_version",
+    ]
+    last_day = days_window(days)[-1]
+    rows: list[tuple[object, ...]] = []
+    version = 1
+    now = anchor_datetime()
+    for page in pages:
+        published_on = page.created_at.date()
+        rng = seeded_rng(page.author.uuid, published_on, f"wiki.comments.{page.page_id}")
+        for offset in range(COMMENT_WINDOW_DAYS):
+            d = published_on + _dt.timedelta(days=offset)
+            if d > last_day:
+                break
+            total = min(poisson(rng, 0.25 * weekday_multiplier(d)), COMMENTS_CAP)
+            if total == 0:
+                continue
+            footer = rng.randint(0, total)
+            rows.append(
+                (
+                    tenant_uuid,
+                    page.source_id,
+                    deterministic_uuid("wiki.engagement.row", page.page_id, d.isoformat()),
+                    page.page_id,
+                    d,
+                    total,
+                    footer,
+                    total - footer,
+                    int(total * rng.uniform(0.0, 0.5)),
+                    max(1, int(total * rng.uniform(0.5, 1.0))),
+                    SOURCE,
+                    DATA_SOURCE,
+                    now,
+                    version,
+                )
+            )
+    return bulk_insert(client, "silver", "class_wiki_engagement", cols, rows)
+
+
+def generate(
+    client: clickhouse_connect.driver.client.Client,
+    roster: Sequence[Person],
+    tenant_uuid: str,
+    days: int,
+) -> dict[str, int]:
+    pages = _plan_pages(roster, days)
+    return {
+        "silver.class_wiki_pages": seed_wiki_pages(client, pages, tenant_uuid),
+        "silver.class_wiki_activity": seed_wiki_activity(client, roster, pages, tenant_uuid, days),
+        "silver.class_wiki_engagement": seed_wiki_engagement(client, pages, tenant_uuid, days),
+    }

--- a/src/ingestion/tools/seed/insight_seed/profiles.py
+++ b/src/ingestion/tools/seed/insight_seed/profiles.py
@@ -200,6 +200,7 @@ TEAM_PROFILES: dict[str, TeamProfile] = {
             "zoom": 0.6,
             "gmail": 0.4,
             "bamboohr": 0.6,
+            "outline": 1.2,
             "cursor": 1.2,
             "claude_team": 1.0,
             "chatgpt": 0.6,
@@ -214,6 +215,7 @@ TEAM_PROFILES: dict[str, TeamProfile] = {
             "zoom": 1.2,
             "gmail": 1.2,
             "bamboohr": 0.4,
+            "outline": 0.6,
             "chatgpt": 0.6,
             "jira": 0.3,
         },
@@ -226,6 +228,7 @@ TEAM_PROFILES: dict[str, TeamProfile] = {
             "zoom": 0.6,
             "gmail": 0.8,
             "bamboohr": 1.5,
+            "outline": 1.0,
             "jira": 0.5,
             "chatgpt": 0.4,
         },
@@ -238,6 +241,7 @@ TEAM_PROFILES: dict[str, TeamProfile] = {
             "zoom": 0.5,
             "gmail": 0.8,
             "bamboohr": 0.4,
+            "outline": 0.8,
             "jira": 1.3,
             # No Zendesk connector in the repo — support rows use this
             # placeholder data_source so the per-team distinction is visible.

--- a/src/ingestion/tools/seed/insight_seed/silver.py
+++ b/src/ingestion/tools/seed/insight_seed/silver.py
@@ -40,7 +40,7 @@ from pathlib import Path
 import clickhouse_connect
 
 from . import config
-from .generators import ai, collab, crm, git, hr, people, support, task
+from .generators import ai, collab, crm, git, hr, people, support, task, wiki
 from .generators.base import seed_days
 from .profiles import build_roster, get_dev_user_email
 
@@ -171,6 +171,7 @@ def generate_rows(
     totals.update(ai.generate(client, roster, tenant_uuid, days))
     totals.update(task.generate(client, roster, tenant_uuid, days))
     totals.update(support.generate(client, roster, tenant_uuid, days))
+    totals.update(wiki.generate(client, roster, tenant_uuid, days))
 
     for table, n in sorted(totals.items()):
         LOG.info("  %-46s %6d rows", table, n)

--- a/src/ingestion/tools/seed/tests/test_preflight.py
+++ b/src/ingestion/tools/seed/tests/test_preflight.py
@@ -150,7 +150,7 @@ class SilverResetGuardTests(unittest.TestCase):
         for schema, table in RESET_TARGETS:
             with self.subTest(target=f"{schema}.{table}"):
                 self.assertIn(f"`{schema}`.`{table}`", scan)
-        self.assertNotIn("class_wiki_activity", scan)
+        self.assertNotIn("class_collab_document_activity", scan)
 
     def test_every_registered_target_is_actually_truncated_by_a_generator(self) -> None:
         """The registry is what preflight scans, so a target that no generator

--- a/tests/stand/api/analytics/drilldown_matrix.py
+++ b/tests/stand/api/analytics/drilldown_matrix.py
@@ -186,6 +186,12 @@ MATRIX: Sequence[Expectation] = (
     Expectation("wiki.pages_edited", "wiki", Tier.EXACT_SUM),
 )
 
+#: A metric the stand serves but has no evidence for: its measure reads
+#: `class_collab_document_activity`, which no generator writes, so the drilldown
+#: answers 200 with no rows. Named once because two tests need the same
+#: property, and it holds only as long as that relation stays unseeded.
+EMPTY_EVIDENCE_METRIC = "collab.files_engaged"
+
 #: One metric per distinct evidence presentation, plus the capable-but-empty
 #: case. A presentation is all an export can differ by — the column set and the
 #: header labels are everything it serializes — and every other metric in the
@@ -199,4 +205,5 @@ EXPORT_SHAPES: Sequence[str] = (
     "git.merge_rate",
     "collab.messages_sent",
     "wiki.pages_created",
+    EMPTY_EVIDENCE_METRIC,
 )

--- a/tests/stand/api/analytics/test_drilldown.py
+++ b/tests/stand/api/analytics/test_drilldown.py
@@ -66,7 +66,7 @@ from ..schemas.analytics import (
     MetricDrilldownColumnType,
     MetricDrilldownResponse,
 )
-from .drilldown_matrix import EXPORT_SHAPES, MATRIX, Expectation, Tier
+from .drilldown_matrix import EMPTY_EVIDENCE_METRIC, EXPORT_SHAPES, MATRIX, Expectation, Tier
 
 DRILLDOWN = analytics_path("/v1/metric-drilldown")
 DRILLDOWN_EXPORT = analytics_path("/v1/metric-drilldown/export")
@@ -975,14 +975,14 @@ def test_supported_metric_with_no_evidence_returns_an_empty_page(
     api: ApiClient, stand_manifest: Manifest
 ) -> None:
     request = _seeded_request(stand_manifest)
-    request["metric_key"] = "wiki.pages_created"
+    request["metric_key"] = EMPTY_EVIDENCE_METRIC
     request["filters"] = []
     request["display_dimensions"] = []
 
     response = api.post(DRILLDOWN, json_body=request)
     assert response.status_code == 200, f"status={response.status_code} {response.text[:300]}"
     result = response.parse(MetricDrilldownResponse)
-    assert result.selection.metric_key == "wiki.pages_created"
+    assert result.selection.metric_key == EMPTY_EVIDENCE_METRIC
     assert result.rows == []
     assert result.next_cursor is None
 

--- a/tests/stand/ui/test_seeded_data_visible.py
+++ b/tests/stand/ui/test_seeded_data_visible.py
@@ -16,8 +16,7 @@ asserted here is an IDENTITY fact read from the manifest at runtime — who the
 person is, and who the roster places under them.
 
 The dashboard coverage checks every KPI and domain card by its visible product
-label. It verifies that seeded domains are populated and that the unseeded Wiki
-domain renders its explicit empty state.
+label, verifying that every seeded domain renders as populated.
 """
 
 from __future__ import annotations
@@ -94,13 +93,8 @@ def test_the_personal_dashboard_renders_every_metric_domain(
         expect(view.kpi_tile(label)).to_be_visible()
         expect(view.kpi_value(label)).not_to_have_text("—")
 
-    for label in ("Task delivery", "Git output", "Collaboration", "AI adoption"):
+    for label in ("Task delivery", "Git output", "Collaboration", "AI adoption", "Wiki"):
         expect(view.populated_domain_card(label)).to_be_visible()
-
-    wiki = view.empty_domain_card("Wiki")
-    expect(wiki).to_be_visible()
-    expect(wiki.get_by_text("No data", exact=True)).to_be_visible()
-    expect(wiki.get_by_text("No metrics with data for this period.", exact=True)).to_be_visible()
 
 
 @pytest.mark.requires_seed("dev_lead")
@@ -171,16 +165,12 @@ def test_the_team_view_lists_every_report_the_roster_declares(
             "Focus Time",
             "Meeting Hours",
             "AI active days",
+            "Page edits",
         ):
             expect(team.metric_cell(name, metric_label)).to_be_visible()
         expect(team.any_recorded_metric_cell(name)).to_be_visible()
-        expect(team.unrecorded_metric_cell(name, "Page edits")).to_be_visible()
 
-    for label in ("Task delivery", "Git output", "Collaboration", "AI adoption"):
+    for label in ("Task delivery", "Git output", "Collaboration", "AI adoption", "Wiki"):
         card = team.domain_card(label)
         expect(card).to_be_visible()
         expect(card).not_to_contain_text("No metrics with peer data for this period.")
-
-    wiki = team.domain_card("Wiki")
-    expect(wiki).to_be_visible()
-    expect(wiki).to_contain_text("No metrics with peer data for this period.")


### PR DESCRIPTION
## What

The stand seeder has a generator per activity domain except wiki. So `silver.class_wiki_*` was always empty, `wiki_metric_evidence` built over nothing, and all four registered `wiki.*` metrics answered 200 with no rows — on every stand, compose and deployed alike, because both run the same seeder package.

Worth being precise about what was missing: the metrics themselves were never absent. They are compiled into the analytics registry and reconciled into MariaDB at service start, and their observation tables come from the committed DDL snapshot, so the schema probe reports them healthy and the catalogue advertises them. "Defined but has no data", not "does not exist". This adds the data.

## The generator

`generators/wiki.py`, modelled on `collab.py`, writing `class_wiki_pages`, `class_wiki_activity` and `class_wiki_engagement` for everyone with a team, scaled by a new per-team `outline` weight, the persona multiplier and the weekday multiplier. Volumes are sized against `docs/testing/REFERENCE-ORGS.md` §4.

One structural departure from `collab.py`: pages are planned before any row is emitted. The evidence model joins engagement onto `(tenant_id, source_id, page_id)` INNER and credits the **page's** author with the comments, so drawing comments independently would produce rows that silently vanish in the join. Comments and the activity row's `pages_created` both derive from that one planned list.

Registers the three relations in `RESET_TARGETS` (without which `truncate()` raises), adds the generator to the silver run, and adds `wiki_metric_observations` to the stand readiness gate — `dev-compose.sh` had it excluded with a note saying it was absent on purpose because no generator existed.

## The suite had built on the absence

Four places asserted the empty state, and each is now a positive assertion in the file's existing idiom:

- The person view asserted the Wiki card shows "No data"; it now asserts a populated card alongside the other four domains.
- The team view asserted "No metrics with peer data for this period"; same treatment.
- Every roster member was asserted to have an **unrecorded** "Page edits" cell; that label now joins the recorded-metric tuple.
- `test_supported_metric_with_no_evidence_returns_an_empty_page` hardcoded `wiki.pages_created` precisely *because* it had no evidence. It moves to `collab.files_engaged`, whose measure reads `class_collab_document_activity` — still unseeded. I verified against the deployed stand that it behaves identically to what it replaces: present, enabled, and 200 with zero rows. The same metric is added to `EXPORT_SHAPES`, whose docstring promises a capable-but-empty export case that `wiki.pages_created` no longer provides.

Four wiki entries in the drilldown reconciliation matrix have been short-circuiting on the empty branch; they start doing real sum/count reconciliation for the first time. Several gold dbt tests (unique grain, entity-id shape, non-negativity) have been vacuous zero-row passes and become live — the unique-grain one polices exactly the engagement join fan-out that is the riskiest part of this change.

## Coverage this gives up

`unrecorded_metric_cell(…, "Page edits")` was the only assertion that an unmeasured cell renders as "not recorded" rather than `0`, and no team-grid column is guaranteed unrecorded any more. Dropped rather than papered over, and recorded as a gap in the scenarios invariants.

## What is unverified

The seeder cannot run without a live ClickHouse, so this was checked offline against a fake client built from the real DDL column lists: 277 page / 840 activity / 377 engagement rows over the 60-day default for 24 people, no engagement row whose `(tenant_id, source_id, page_id)` is missing from pages, no date outside the window, distinct `unique_key` on all three tables, and every author carrying activity inside the SPA's default month. Column names were separately diffed against the DDL snapshot — every column written exists, so nothing is silently dropped.

Still unproven until this runs on a stand: that dbt builds the wiki gold relations non-empty from these rows, that identity resolves the seeded author emails for the wiki family, and that the domain card and the Page-edits column actually render populated. The `Stand E2E` gate on this PR brings up compose, seeds it and runs both lanes, so it proves all three before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added seeded Wiki activity, page, and engagement data for supported team views.
  * Wiki data is now included in readiness checks and dashboard coverage.
  * Team views now display Wiki page-edit metrics and peer data.

* **Bug Fixes**
  * Improved analytics coverage for metrics with no available evidence, including exports and empty results.

* **Tests**
  * Updated dashboard and drilldown validation to reflect populated Wiki data and empty-evidence scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->