### PR TITLE
ci(frontend): move the Playwright container and package together (#2503)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -365,7 +365,7 @@ jobs:
     # at CI time stalls the runner. The tag MUST track `playwright` in the
     # component's package.json so the pre-installed build matches.
     container:
-      image: mcr.microsoft.com/playwright:v1.61.1-noble@sha256:5b8f294aff9041b7191c34a4bab3ac270157a28774d4b0660e9743297b697e48
+      image: mcr.microsoft.com/playwright:v1.62.1-noble@sha256:dcc5531e97840b9b5e794f2814476b21571c5124a3fca2267d73041f56e7580e
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -78,7 +78,7 @@
     "jsdom": "29.1.1",
     "msw": "2.14.6",
     "msw-storybook-addon": "2.0.7",
-    "playwright": "1.61.1",
+    "playwright": "1.62.1",
     "prettier": "3.8.3",
     "prettier-plugin-tailwindcss": "0.8.0",
     "storybook": "10.4.6",

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -141,7 +141,7 @@ importers:
         version: 6.0.1(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0))
       '@vitest/browser-playwright':
         specifier: 4.1.10
-        version: 4.1.10(msw@2.14.6(@types/node@25.6.2)(typescript@6.0.3))(playwright@1.61.1)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0))(vitest@4.1.10)
+        version: 4.1.10(msw@2.14.6(@types/node@25.6.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0))(vitest@4.1.10)
       '@vitest/coverage-v8':
         specifier: 4.1.10
         version: 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
@@ -173,8 +173,8 @@ importers:
         specifier: 2.0.7
         version: 2.0.7(msw@2.14.6(@types/node@25.6.2)(typescript@6.0.3))
       playwright:
-        specifier: 1.61.1
-        version: 1.61.1
+        specifier: 1.62.1
+        version: 1.62.1
       prettier:
         specifier: 3.8.3
         version: 3.8.3
@@ -3395,14 +3395,14 @@ packages:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
 
-  playwright-core@1.61.1:
-    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
-    engines: {node: '>=18'}
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
     hasBin: true
 
-  playwright@1.61.1:
-    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
-    engines: {node: '>=18'}
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
     hasBin: true
 
   pngjs@7.0.0:
@@ -5232,7 +5232,7 @@ snapshots:
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
     optionalDependencies:
       '@vitest/browser': 4.1.10(msw@2.14.6(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0))(vitest@4.1.10)
-      '@vitest/browser-playwright': 4.1.10(msw@2.14.6(@types/node@25.6.2)(typescript@6.0.3))(playwright@1.61.1)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(msw@2.14.6(@types/node@25.6.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0))(vitest@4.1.10)
       '@vitest/runner': 4.1.10
       vitest: 4.1.10(@types/node@25.6.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0))
     transitivePeerDependencies:
@@ -5713,11 +5713,11 @@ snapshots:
       '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.3)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0))
       babel-plugin-react-compiler: 1.0.0
 
-  '@vitest/browser-playwright@4.1.10(msw@2.14.6(@types/node@25.6.2)(typescript@6.0.3))(playwright@1.61.1)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0))(vitest@4.1.10)':
+  '@vitest/browser-playwright@4.1.10(msw@2.14.6(@types/node@25.6.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0))(vitest@4.1.10)':
     dependencies:
       '@vitest/browser': 4.1.10(msw@2.14.6(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0))(vitest@4.1.10)
       '@vitest/mocker': 4.1.10(msw@2.14.6(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0))
-      playwright: 1.61.1
+      playwright: 1.62.1
       tinyrainbow: 3.1.0
       vitest: 4.1.10(@types/node@25.6.2)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@25.6.2)(typescript@6.0.3))(vite@8.0.16(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0))
     transitivePeerDependencies:
@@ -7387,11 +7387,11 @@ snapshots:
 
   pkce-challenge@5.0.1: {}
 
-  playwright-core@1.61.1: {}
+  playwright-core@1.62.1: {}
 
-  playwright@1.61.1:
+  playwright@1.62.1:
     dependencies:
-      playwright-core: 1.61.1
+      playwright-core: 1.62.1
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -8119,7 +8119,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.2
-      '@vitest/browser-playwright': 4.1.10(msw@2.14.6(@types/node@25.6.2)(typescript@6.0.3))(playwright@1.61.1)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(msw@2.14.6(@types/node@25.6.2)(typescript@6.0.3))(playwright@1.62.1)(vite@8.0.16(@types/node@25.6.2)(esbuild@0.27.7)(jiti@2.7.0))(vitest@4.1.10)
       '@vitest/coverage-v8': 4.1.10(@vitest/browser@4.1.10)(vitest@4.1.10)
       '@vitest/ui': 4.1.10(vitest@4.1.10)
       jsdom: 29.1.1(@noble/hashes@1.8.0)


### PR DESCRIPTION
Closes #2503, and unblocks #2430.

## Why both halves are in one commit

The `js` job runs the `playwright` package **inside** `mcr.microsoft.com/playwright`. The browsers are baked into that image and there is no `playwright install` step, so the two versions have to agree — `ci.yml` states the rule right above the pin:

> The tag MUST track `playwright` in the component's package.json so the pre-installed build matches.

They agree today at 1.61.1. Either half moving alone is broken, in opposite directions:

- package ahead of the image → what #2430 shows now: `browserType.launch: Executable doesn't exist at /ms-playwright/chromium_headless_shell-1234/…`
- image ahead of the package → what #2442 hit on the stand side a day earlier, with the same launch error and the versions swapped

So a two-PR sequence has no safe order. Both move here.

```
.github/workflows/ci.yml     v1.61.1-noble → v1.62.1-noble (digest re-pinned)
src/frontend/package.json    playwright 1.61.1 → 1.62.1
src/frontend/pnpm-lock.yaml  re-locked
```

## Test plan

- [x] The digest pinned in `ci.yml` is the one the `v1.62.1-noble` tag currently resolves to — checked against the registry.
- [x] The image carries `chromium_headless_shell-1234` — exactly the build 1.62.1 asked for in the failure on #2430 — alongside `chromium-1234`, `firefox-1538`, `webkit-2336`, `ffmpeg-1011`. Its Node is 24.18.1, matching `engines.node: 24.x`.
- [x] Lockfile regenerated with pnpm 10.33.0 on Node 24, the version `packageManager` pins. The delta is 32 lines and touches only `playwright`, `playwright-core` and the `@vitest/browser-playwright` peer-resolution string; nothing else moves.
- [x] `pnpm install --frozen-lockfile` then `vitest run --project=storybook` inside the new container: the browser launches and the suite runs. The launch error is gone.
- [x] `actionlint`: 8 findings on `main`, 8 on the branch, identical set.

## On the flaky story

While running the browser project repeatedly I saw `metric-timeseries-view.stories.tsx` fail intermittently at `findByLabelText("Metric")` — once in three runs on this branch. It reproduces at the same rate on **unmodified `main`** with 1.61.1 in the old image, so it is pre-existing and not introduced here. Worth its own issue if it ever shows up on CI; it did not surface in these runs beyond the local flake.

## Order

Merge this first, then #2430 — that PR also raises `playwright` to 1.62.1, so once this lands Dependabot will regroup without it.

## Left open in #2503

Whether Dependabot should stop offering the npm half on its own, given it cannot see the container: an `ignore` on `playwright`, or bringing `.github/` into the docker ecosystem's `directories`. Not decided here.