### PR TITLE
feat(frontend): Reports — build and export a custom metric report

### DIFF
--- a/src/frontend/src/api/metric-results-client.ts
+++ b/src/frontend/src/api/metric-results-client.ts
@@ -181,7 +181,8 @@ export interface MetricResultsResponse {
 }
 
 export async function queryMetricResults(
-  body: MetricResultsRequest
+  body: MetricResultsRequest,
+  signal?: AbortSignal
 ): Promise<MetricResultsResponse> {
   // Refuse a request the backend is guaranteed to reject (400 invalid_argument,
   // "entity.ids must not be empty"). Callers are expected to keep the query
@@ -196,6 +197,7 @@ export async function queryMetricResults(
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
+    signal,
   });
   if (!res.ok) {
     const errorBody = await res.json().catch(() => null);

--- a/src/frontend/src/components/portal/report-builder-view.test.tsx
+++ b/src/frontend/src/components/portal/report-builder-view.test.tsx
@@ -165,6 +165,28 @@ describe("ReportBuilderView", () => {
     );
   });
 
+  it("withdraws the file when the scope becomes a different roster of the same size", async () => {
+    // Counting people would call these the same report. They are not, and the
+    // file carries the names of whoever was in scope when it was built.
+    const user = userEvent.setup();
+    const { rerender } = render(<ReportBuilderView />);
+    await user.click(box("Commits"));
+    await user.click(screen.getByRole("button", { name: "Build report" }));
+    await screen.findByRole("dialog");
+    await closeDialog(user);
+    await screen.findByRole("button", { name: /rows ·/ });
+
+    mocks.scope = {
+      ...mocks.scope,
+      pivot: { ...person, person_id: "P2", display_name: "Sam Smith" },
+      roster: [{ person_id: "P2" }],
+    };
+    rerender(<ReportBuilderView />);
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: /rows ·/ })).toBeNull(),
+    );
+  });
+
   it("downloads nothing when the run fails, and says so", async () => {
     mocks.run.mockRejectedValueOnce(new Error("network"));
     const user = userEvent.setup();

--- a/src/frontend/src/components/portal/report-builder-view.test.tsx
+++ b/src/frontend/src/components/portal/report-builder-view.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+/**
+ * The report builder's promises to the reader: never offer a metric the file
+ * cannot honestly contain, never offer a file built from something other than
+ * what is on screen, and never hand back a partial one.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  definitions: [] as unknown[],
+  computations: new Map<string, string>(),
+  scope: {} as Record<string, unknown>,
+  run: vi.fn(),
+  csv: vi.fn(),
+  xlsx: vi.fn(),
+}));
+
+vi.mock("@/queries/metric-definitions", () => ({
+  useMetricDefinitionsResponse: () => ({
+    data: { metrics: mocks.definitions },
+    isPending: false,
+    isError: false,
+  }),
+}));
+vi.mock("@/queries/report-catalogue", () => ({
+  useMetricComputations: () => ({
+    data: mocks.computations,
+    isPending: false,
+    isError: false,
+  }),
+}));
+vi.mock("@/lib/portal/use-org-scope", () => ({ useOrgScope: () => mocks.scope }));
+vi.mock("@/hooks/use-portal-period", () => ({
+  usePortalPeriod: () => ({
+    period: "quarter",
+    dateRange: { from: "2026-05-13", to: "2026-08-12" },
+  }),
+}));
+vi.mock("@/lib/reports/run-report", () => ({ runReport: mocks.run }));
+vi.mock("@/lib/export/matrix", () => ({
+  downloadMatrixCsv: mocks.csv,
+  downloadMatrixXlsx: mocks.xlsx,
+}));
+
+import { ReportBuilderView } from "@/components/portal/report-builder-view";
+
+const definition = (over: Record<string, unknown>) => ({
+  metric_key: "git.commits",
+  label: "Commits",
+  description: "Authored commits",
+  is_enabled: true,
+  schema_status: "ok",
+  last_observed_date: "2026-05-01",
+  origin: "builtin",
+  ...over,
+});
+
+const person = {
+  person_id: "P1",
+  email: "jane.doe@example.com",
+  display_name: "Jane Doe",
+  subordinates: [],
+};
+
+beforeEach(() => {
+  mocks.definitions = [
+    definition({}),
+    definition({ metric_key: "git.merge_rate", label: "Merge rate" }),
+    definition({
+      metric_key: "tasks.closed",
+      label: "Issues closed",
+      last_observed_date: null,
+    }),
+  ];
+  mocks.computations = new Map([
+    ["git.commits", "sum"],
+    ["git.merge_rate", "ratio"],
+  ]);
+  mocks.scope = {
+    pivot: person,
+    roster: [{ person_id: "P1" }],
+    label: "Jane Doe",
+    isLoading: false,
+    isError: false,
+  };
+  mocks.run.mockReset().mockResolvedValue(new Map());
+  mocks.csv.mockReset();
+  mocks.xlsx.mockReset();
+});
+
+const box = (name: string) => screen.getByRole("checkbox", { name });
+/** The checkbox is a span with a role, so disabled shows as an attribute. */
+const isDisabled = (name: string) =>
+  box(name).getAttribute("aria-disabled") === "true";
+/** The dialog opens over the page and takes the background out of the a11y
+ *  tree, so the offer behind it is only reachable once it is closed. */
+const closeDialog = (user: ReturnType<typeof userEvent.setup>) =>
+  user.keyboard("{Escape}");
+
+describe("ReportBuilderView", () => {
+  it("lists a metric nothing has reached, disabled, rather than hiding it", () => {
+    // A family that simply vanishes leaves the reader unable to tell "not
+    // measured here" from "I misremembered the name".
+    render(<ReportBuilderView />);
+    expect(isDisabled("Issues closed")).toBe(true);
+    expect(screen.getByText("Issues closed").closest("label")).toHaveAttribute(
+      "title",
+      expect.stringMatching(/No data reaches us/),
+    );
+  });
+
+  it("disables a non-additive metric only where buckets are added up", async () => {
+    const user = userEvent.setup();
+    render(<ReportBuilderView />);
+    expect(isDisabled("Merge rate")).toBe(false);
+
+    await user.click(screen.getByRole("button", { name: "Yearly" }));
+    expect(isDisabled("Merge rate")).toBe(true);
+    expect(isDisabled("Commits")).toBe(false);
+  });
+
+  it("cannot build until something is picked", async () => {
+    const user = userEvent.setup();
+    render(<ReportBuilderView />);
+    const build = screen.getByRole("button", { name: "Build report" });
+    expect(build).toBeDisabled();
+
+    await user.click(box("Commits"));
+    expect(build).not.toBeDisabled();
+  });
+
+  it("offers the file once the run has finished, stamped with what made it", async () => {
+    const user = userEvent.setup();
+    render(<ReportBuilderView />);
+    await user.click(box("Commits"));
+    await user.click(screen.getByRole("button", { name: "Build report" }));
+
+    // The preview opens on its own — the reader asked for it by building.
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveTextContent("Monthly");
+    expect(dialog).toHaveTextContent("2026-05-13 to 2026-08-12");
+    expect(mocks.run).toHaveBeenCalledTimes(1);
+
+    await closeDialog(user);
+    const offer = await screen.findByRole("button", { name: /rows ·/ });
+    expect(offer).toHaveTextContent("Monthly");
+  });
+
+  it("withdraws the file when the granularity it was built for changes", async () => {
+    // It is held in the screen, not saved. A table built monthly must not
+    // still be downloadable under a yearly heading.
+    const user = userEvent.setup();
+    render(<ReportBuilderView />);
+    await user.click(box("Commits"));
+    await user.click(screen.getByRole("button", { name: "Build report" }));
+    await screen.findByRole("dialog");
+    await closeDialog(user);
+    await screen.findByRole("button", { name: /rows ·/ });
+
+    await user.click(screen.getByRole("button", { name: "Quarterly" }));
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: /rows ·/ })).toBeNull(),
+    );
+  });
+
+  it("downloads nothing when the run fails, and says so", async () => {
+    mocks.run.mockRejectedValueOnce(new Error("network"));
+    const user = userEvent.setup();
+    render(<ReportBuilderView />);
+    await user.click(box("Commits"));
+    await user.click(screen.getByRole("button", { name: "Build report" }));
+
+    expect(await screen.findByText(/Could not build the report/)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /rows ·/ })).toBeNull();
+    expect(mocks.csv).not.toHaveBeenCalled();
+    expect(mocks.xlsx).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/src/components/portal/report-builder-view.tsx
+++ b/src/frontend/src/components/portal/report-builder-view.tsx
@@ -1,0 +1,480 @@
+import { useMemo, useRef, useState } from "react";
+import { Download, FileSpreadsheet, FileText, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { ComingSoon } from "@/components/widgets/coming-soon";
+import { usePortalPeriod } from "@/hooks/use-portal-period";
+import { downloadMatrixCsv, downloadMatrixXlsx } from "@/lib/export/matrix";
+import { normalizePersonId } from "@/lib/metrics/entity";
+import { useOrgScope } from "@/lib/portal/use-org-scope";
+import { unavailableReason } from "@/lib/reports/availability";
+import { byFamily } from "@/lib/reports/families";
+import { buildReportTable, type ReportTable } from "@/lib/reports/report-table";
+import { collectReportPeople } from "@/lib/reports/roster-columns";
+import {
+  bucketsInRange,
+  needsRollup,
+  requestBucket,
+  type ReportGranularity,
+} from "@/lib/reports/rollup";
+import { runReport } from "@/lib/reports/run-report";
+import { cn } from "@/lib/utils";
+import { TEXT_EYEBROW, TEXT_LABEL, TEXT_TITLE } from "@/lib/type-scale";
+import { useMetricComputations } from "@/queries/report-catalogue";
+import { useMetricDefinitionsResponse } from "@/queries/metric-definitions";
+
+const GRANULARITIES: ReadonlyArray<{ value: ReportGranularity; label: string }> = [
+  { value: "day", label: "Daily" },
+  { value: "week", label: "Weekly" },
+  { value: "month", label: "Monthly" },
+  { value: "quarter", label: "Quarterly" },
+  { value: "year", label: "Yearly" },
+];
+
+/** Enough to see the shape of the file without rendering the whole of it. */
+const PREVIEW_ROWS = 20;
+
+export function ReportBuilderView() {
+  const { dateRange } = usePortalPeriod();
+  const scope = useOrgScope();
+  const definitions = useMetricDefinitionsResponse();
+  const computations = useMetricComputations();
+
+  const [selected, setSelected] = useState<string[]>([]);
+  const [granularity, setGranularity] = useState<ReportGranularity>("month");
+  const [progress, setProgress] = useState<{ done: number; total: number } | null>(
+    null,
+  );
+  const [table, setTable] = useState<ReportTable | null>(null);
+  const [builtFor, setBuiltFor] = useState<string | null>(null);
+  const [builtAt, setBuiltAt] = useState<string | null>(null);
+  const [failure, setFailure] = useState<string | null>(null);
+  const [previewOpen, setPreviewOpen] = useState(false);
+  const abort = useRef<AbortController | null>(null);
+
+  // Everything enabled is listed; what this installation cannot serve is shown
+  // unavailable rather than omitted. The results endpoint rejects an
+  // unreachable key outright, so it must not be selectable — but dropping it
+  // silently takes whole families off the screen and leaves the reader hunting
+  // for a section that is simply not measured here.
+  const catalogue = useMemo(
+    () => (definitions.data?.metrics ?? []).filter((metric) => metric.is_enabled),
+    [definitions.data],
+  );
+  // The additivity restriction belongs to the rollup, not to the report. At a
+  // bucket the server has, it computed each value itself — a ratio is that
+  // bucket's own ratio — so the whole catalogue is fair game. Only a quarter
+  // and a year are months added together, and only there does the question
+  // "may this be added" arise.
+  // Nothing is dropped from the list. A metric that cannot go in this report
+  // is shown with the reason, because a metric that simply vanishes leaves the
+  // reader unable to tell "not measured here" from "I misremembered the name".
+  const offered = useMemo(
+    () =>
+      catalogue.map((metric) => ({
+        ...metric,
+        reason: unavailableReason(
+          metric,
+          granularity,
+          computations.data ?? new Map(),
+        ),
+      })),
+    [catalogue, computations.data, granularity],
+  );
+
+  const people = useMemo(() => {
+    const attrs = collectReportPeople(scope.pivot);
+    return (scope.roster ?? []).flatMap((entry) => {
+      const person = attrs.get(normalizePersonId(entry.person_id));
+      return person ? [person] : [];
+    });
+  }, [scope.pivot, scope.roster]);
+
+  const selectedMetrics = useMemo(
+    () =>
+      selected.flatMap((key) => {
+        const metric = offered.find((m) => m.metric_key === key && !m.reason);
+        return metric ? [{ metric_key: key, label: metric.label }] : [];
+      }),
+    [selected, offered],
+  );
+
+  // What the table on hand was built from. A report is not stored anywhere —
+  // it lives here until something it depends on changes, and then it is wrong
+  // rather than merely old: build it monthly, switch to yearly, and the button
+  // would still offer the monthly file under the new heading.
+  const recipe = [
+    granularity,
+    dateRange.from,
+    dateRange.to,
+    people.length,
+    ...selectedMetrics.map((metric) => metric.metric_key),
+  ].join(" ");
+  if (table && builtFor !== recipe) {
+    setTable(null);
+    setBuiltFor(null);
+    setBuiltAt(null);
+    setPreviewOpen(false);
+  }
+
+  const running = progress != null;
+  const canBuild = selectedMetrics.length > 0 && people.length > 0 && !running;
+
+  async function build(): Promise<void> {
+    const controller = new AbortController();
+    abort.current = controller;
+    setFailure(null);
+    setTable(null);
+    try {
+      const results = await runReport({
+        metricKeys: selectedMetrics.map((m) => m.metric_key),
+        entityIds: people.map((person) => person.entityId),
+        range: dateRange,
+        granularity,
+        bucketCount: bucketsInRange(
+          dateRange.from,
+          dateRange.to,
+          requestBucket(granularity),
+        ).length,
+        onProgress: (done, total) => setProgress({ done, total }),
+        signal: controller.signal,
+      });
+      setBuiltFor(recipe);
+      setBuiltAt(
+        new Date().toLocaleString(undefined, {
+          dateStyle: "medium",
+          timeStyle: "short",
+        }),
+      );
+      setPreviewOpen(true);
+      setTable(
+        buildReportTable({
+          people,
+          metrics: selectedMetrics,
+          results,
+          range: dateRange,
+          granularity,
+        }),
+      );
+    } catch (error) {
+      // A run that stopped early produces nothing: a file missing a few
+      // batches reads as a complete one once it is open.
+      setTable(null);
+      setFailure(
+        controller.signal.aborted
+          ? "Cancelled — nothing was downloaded."
+          : `Could not build the report: ${(error as Error).message}`,
+      );
+    } finally {
+      setProgress(null);
+      abort.current = null;
+    }
+  }
+
+  // The granularity is in the name too: two files for the same period that
+  // differ only in their buckets would otherwise overwrite each other in a
+  // downloads folder.
+  const filename = `insight-report_${granularity}_${dateRange.from}_${dateRange.to}`;
+
+  if (computations.isError || definitions.isError) {
+    return (
+      <div className="mx-auto w-full max-w-md p-8">
+        <ComingSoon variant="card" state="error" label="Unable to load the metric catalogue" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-4 md:p-6">
+      <div className="flex flex-col gap-1">
+        <h1 className={TEXT_TITLE}>Report builder</h1>
+        <p className="text-sm text-muted-foreground">
+          {scope.label ? `${scope.label} · ` : ""}
+          {people.length} {people.length === 1 ? "person" : "people"} · one row
+          per person per period
+        </p>
+      </div>
+
+      <Card>
+        <CardContent className="flex flex-col gap-4 p-4">
+          <div className="flex flex-wrap items-center gap-3">
+            <span className={TEXT_LABEL}>Granularity</span>
+            <ToggleGroup
+              value={[granularity]}
+              onValueChange={(value) => {
+                const next = Array.isArray(value) ? value[0] : value;
+                if (next) setGranularity(next as ReportGranularity);
+              }}
+              variant="outline"
+              size="sm"
+            >
+              {GRANULARITIES.map((option) => (
+                <ToggleGroupItem key={option.value} value={option.value}>
+                  {option.label}
+                </ToggleGroupItem>
+              ))}
+            </ToggleGroup>
+            <span className="text-xs text-muted-foreground">
+              The period comes from the bar above.
+            </span>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <span className={TEXT_LABEL}>
+              {needsRollup(granularity)
+                ? "Metrics that can be totalled — a quarter is its months added up"
+                : "Metrics"}
+            </span>
+            {needsRollup(granularity) && computations.isPending ? (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Spinner className="size-4" /> Reading the catalogue…
+              </div>
+            ) : (
+              <TooltipProvider delay={300}>
+              <div className="flex flex-col gap-4">
+                {byFamily(offered).map((group) => {
+                  const keys = group.metrics
+                    .filter((m) => !m.reason)
+                    .map((m) => m.metric_key);
+                  const allPicked =
+                    keys.length > 0 &&
+                    keys.every((key) => selected.includes(key));
+                  return (
+                    <div key={group.family} className="flex flex-col gap-1">
+                      <div className="flex items-center gap-2">
+                        <span className={TEXT_EYEBROW}>{group.name}</span>
+                        {keys.length > 0 ? (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="xs"
+                            onClick={() =>
+                              setSelected((current) =>
+                                allPicked
+                                  ? current.filter((key) => !keys.includes(key))
+                                  : [...new Set([...current, ...keys])],
+                              )
+                            }
+                          >
+                            {allPicked ? "None" : "All"}
+                          </Button>
+                        ) : (
+                          <span className="text-xs text-muted-foreground">
+                            nothing measured here yet
+                          </span>
+                        )}
+                      </div>
+                      <div className="grid grid-cols-1 gap-1 sm:grid-cols-2 lg:grid-cols-3">
+                        {group.metrics.map((metric) => {
+                          const checked = selected.includes(metric.metric_key);
+                          return (
+                            <Tooltip key={metric.metric_key}>
+                              <TooltipTrigger
+                                render={
+                            <label
+                              htmlFor={`report-${metric.metric_key}`}
+                              // A native title as well as the tooltip: the
+                              // reason a metric cannot be picked is the one
+                              // thing here that must reach the reader, and a
+                              // tooltip trigger on a label wrapping a disabled
+                              // control is not something to bet it on.
+                              title={metric.reason ?? undefined}
+                              className={cn(
+                                "flex items-center gap-2 rounded-sm px-1 py-1 text-start text-sm",
+                                metric.reason
+                                  ? "text-muted-foreground"
+                                  : "cursor-pointer hover:bg-muted",
+                              )}
+                            >
+                              <Checkbox
+                                id={`report-${metric.metric_key}`}
+                                checked={checked}
+                                disabled={Boolean(metric.reason)}
+                                onCheckedChange={() =>
+                                  setSelected((current) =>
+                                    checked
+                                      ? current.filter(
+                                          (key) => key !== metric.metric_key,
+                                        )
+                                      : [...current, metric.metric_key],
+                                  )
+                                }
+                              />
+                              {metric.label}
+                            </label>
+                                }
+                              />
+                              <TooltipContent
+                                side="top"
+                                className="max-w-xs text-xs leading-relaxed"
+                              >
+                                {metric.reason ? (
+                                  <>
+                                    <span className="font-medium">
+                                      Not available here.
+                                    </span>{" "}
+                                    {metric.reason}
+                                  </>
+                                ) : (
+                                  metric.description ??
+                                  metric.explanation ??
+                                  metric.label
+                                )}
+                              </TooltipContent>
+                            </Tooltip>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+              </TooltipProvider>
+            )}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Button type="button" disabled={!canBuild} onClick={() => void build()}>
+              Build report
+            </Button>
+            {running ? (
+              <>
+                <span className="text-sm text-muted-foreground">
+                  {progress.done} of {progress.total} batches
+                </span>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => abort.current?.abort()}
+                >
+                  <X className="size-4" />
+                  Cancel
+                </Button>
+              </>
+            ) : null}
+            {selected.length > 0 && !running ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setSelected([])}
+              >
+                Clear selection
+              </Button>
+            ) : null}
+          </div>
+
+          {failure ? (
+            <p className="text-sm text-destructive">{failure}</p>
+          ) : null}
+        </CardContent>
+      </Card>
+
+      {table ? (
+        <Button
+          type="button"
+          variant="outline"
+          className="self-start"
+          onClick={() => setPreviewOpen(true)}
+        >
+          <Download className="size-4" />
+          {table.rows.length} rows ·{" "}
+          {GRANULARITIES.find((g) => g.value === granularity)?.label} ·{" "}
+          {dateRange.from} to {dateRange.to}
+          {builtAt ? ` · built ${builtAt}` : ""}
+        </Button>
+            ) : null}
+
+      <Dialog open={previewOpen && table != null} onOpenChange={setPreviewOpen}>
+        <DialogContent className="flex max-h-[85vh] flex-col gap-3 sm:max-w-[min(96vw,1200px)]">
+          <DialogHeader>
+            <DialogTitle>
+              {table?.rows.length ?? 0} rows · showing the first{" "}
+              {Math.min(PREVIEW_ROWS, table?.rows.length ?? 0)}
+            </DialogTitle>
+            <p className="text-xs text-muted-foreground">
+              {GRANULARITIES.find((g) => g.value === granularity)?.label} ·{" "}
+              {dateRange.from} to {dateRange.to} · {people.length} people
+              {builtAt ? ` · built ${builtAt}` : ""}
+            </p>
+          </DialogHeader>
+          {table ? (
+            <>
+              <Table className="text-xs" containerClassName="overflow-auto">
+                <TableHeader>
+                  <TableRow>
+                    {table.columns.map((column) => (
+                      <TableHead key={column} className="whitespace-nowrap">
+                        {column}
+                      </TableHead>
+                    ))}
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {table.rows.slice(0, PREVIEW_ROWS).map((row, index) => (
+                    <TableRow key={index}>
+                      {row.map((cell, cellIndex) => (
+                        <TableCell
+                          key={cellIndex}
+                          className="whitespace-nowrap tabular-nums"
+                        >
+                          {cell ?? "—"}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+              <div className="flex items-center justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => downloadMatrixCsv(`${filename}.csv`, table)}
+                >
+                  <FileText className="size-4" />
+                  CSV
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={() =>
+                    void downloadMatrixXlsx(`${filename}.xlsx`, "Report", table)
+                  }
+                >
+                  <FileSpreadsheet className="size-4" />
+                  Excel
+                </Button>
+              </div>
+            </>
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/frontend/src/components/portal/report-builder-view.tsx
+++ b/src/frontend/src/components/portal/report-builder-view.tsx
@@ -131,7 +131,11 @@ export function ReportBuilderView() {
     granularity,
     dateRange.from,
     dateRange.to,
-    people.length,
+    // The people themselves, not how many: two different rosters of equal size
+    // would otherwise look like the same report, and a table built for one
+    // scope would stay downloadable under another.
+    ...people.map((person) => person.entityId),
+    "|",
     ...selectedMetrics.map((metric) => metric.metric_key),
   ].join(" ");
   if (table && builtFor !== recipe) {

--- a/src/frontend/src/components/portal/zone-content.tsx
+++ b/src/frontend/src/components/portal/zone-content.tsx
@@ -12,6 +12,7 @@ import {
   usePortalLens,
 } from "@/lib/portal/portal-nav";
 import { useActiveZone } from "@/lib/portal/use-active-zone";
+import { ReportBuilderView } from "@/components/portal/report-builder-view";
 
 /**
  * Content for the non-entity portal zones. Overview rolls the org up; Directions
@@ -43,8 +44,13 @@ export function ZoneContent() {
       return <PeopleView person={activePerson} item={item} />;
     case "manage":
       return <ManageView item={item} />;
-    case "scorecard":
     case "reports":
+      return item === "report-builder" ? (
+        <ReportBuilderView />
+      ) : (
+        <ZoneScaffold zone={activeZone} />
+      );
+    case "scorecard":
       return <ZoneScaffold zone={activeZone} />;
     default:
       return <ZoneScaffold zone={activeZone} />;

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-csv.ts
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-csv.ts
@@ -4,29 +4,13 @@ import {
   metricTimeseriesFilename,
 } from "@/components/widgets/metric-views/metric-timeseries-export";
 import type { MetricTimeseriesModel } from "@/components/widgets/metric-views/metric-timeseries-model";
-
-type CsvValue = string | number | null | undefined;
+import { csvCell } from "@/lib/export/matrix";
 
 const BUCKET_HEADER = {
   day: "Day",
   week: "Week",
   month: "Month",
 } as const;
-
-function stringValue(value: string): string {
-  return /^[\t\r ]*[=+\-@]/.test(value) ? `'${value}` : value;
-}
-
-function csvCell(value: CsvValue): string {
-  if (value == null) return "";
-  const raw =
-    typeof value === "number"
-      ? Number.isFinite(value)
-        ? String(value)
-        : ""
-      : stringValue(value);
-  return /[",\r\n]/.test(raw) ? `"${raw.replaceAll('"', '""')}"` : raw;
-}
 
 function columnHeader(
   model: MetricTimeseriesModel,

--- a/src/frontend/src/lib/export/matrix-download.test.ts
+++ b/src/frontend/src/lib/export/matrix-download.test.ts
@@ -60,6 +60,22 @@ describe("downloadMatrixXlsx", () => {
     expect(sheet?.getRow(1).font?.bold).toBe(true);
   });
 
+  it("drops a non-finite number rather than writing it into a cell", async () => {
+    // ExcelJS writes a number straight through, and Infinity in a cell can
+    // make the workbook unreadable. The CSV writer already refuses it.
+    await downloadMatrixXlsx("report.xlsx", "Report", {
+      columns: ["Person", "Ratio"],
+      rows: [["Jane Doe", Number.POSITIVE_INFINITY], ["Sam Smith", Number.NaN]],
+    });
+    const workbook = new Workbook();
+    await workbook.xlsx.load(
+      await (mocked.mock.calls[0]?.[0] as Blob).arrayBuffer(),
+    );
+    const sheet = workbook.getWorksheet("Report");
+    expect(sheet?.getRow(2).getCell(2).value).toBeNull();
+    expect(sheet?.getRow(3).getCell(2).value).toBeNull();
+  });
+
   it("keeps the sheet name inside the length a workbook allows", async () => {
     await downloadMatrixXlsx("r.xlsx", "x".repeat(60), matrix);
     const workbook = new Workbook();

--- a/src/frontend/src/lib/export/matrix-download.test.ts
+++ b/src/frontend/src/lib/export/matrix-download.test.ts
@@ -1,0 +1,71 @@
+import { Workbook } from "exceljs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/download", () => ({ downloadBlob: vi.fn() }));
+
+import { downloadBlob } from "@/lib/download";
+import { downloadMatrixCsv, downloadMatrixXlsx } from "@/lib/export/matrix";
+
+const mocked = vi.mocked(downloadBlob);
+
+const matrix = {
+  columns: ["Person", "Period", "Commits"],
+  rows: [
+    ["Jane Doe", "2026-Q1", 4],
+    ["=Sam", "2026-Q1", null],
+  ],
+};
+
+beforeEach(() => mocked.mockReset());
+
+describe("downloadMatrixCsv", () => {
+  it("writes the file under the name it was given", async () => {
+    downloadMatrixCsv("report.csv", matrix);
+    expect(mocked).toHaveBeenCalledTimes(1);
+    expect(mocked.mock.calls[0]?.[1]).toBe("report.csv");
+  });
+
+  it("leads with a BOM, so a spreadsheet reads it as UTF-8", async () => {
+    downloadMatrixCsv("report.csv", matrix);
+    const blob = mocked.mock.calls[0]?.[0] as Blob;
+    // Checked as bytes: a text decoder strips the mark, which is the whole
+    // reason it is there — Excel reads the bytes, not a decoded string.
+    const head = new Uint8Array((await blob.arrayBuffer()).slice(0, 3));
+    expect([...head]).toEqual([0xef, 0xbb, 0xbf]);
+
+    const text = await blob.text();
+    expect(text).toContain("Person,Period,Commits");
+    // The escaping rule travels with the writer.
+    expect(text).toContain("'=Sam");
+  });
+});
+
+describe("downloadMatrixXlsx", () => {
+  it("writes a sheet with a header row and every value row", async () => {
+    await downloadMatrixXlsx("report.xlsx", "Report", matrix);
+    expect(mocked.mock.calls[0]?.[1]).toBe("report.xlsx");
+
+    const workbook = new Workbook();
+    const blob = mocked.mock.calls[0]?.[0] as Blob;
+    await workbook.xlsx.load(await blob.arrayBuffer());
+    const sheet = workbook.getWorksheet("Report");
+    expect(sheet).toBeDefined();
+    expect(sheet?.getRow(1).values).toEqual([
+      undefined,
+      "Person",
+      "Period",
+      "Commits",
+    ]);
+    expect(sheet?.getRow(2).getCell(3).value).toBe(4);
+    expect(sheet?.getRow(1).font?.bold).toBe(true);
+  });
+
+  it("keeps the sheet name inside the length a workbook allows", async () => {
+    await downloadMatrixXlsx("r.xlsx", "x".repeat(60), matrix);
+    const workbook = new Workbook();
+    await workbook.xlsx.load(
+      await (mocked.mock.calls[0]?.[0] as Blob).arrayBuffer(),
+    );
+    expect(workbook.worksheets[0]?.name.length).toBeLessThanOrEqual(31);
+  });
+});

--- a/src/frontend/src/lib/export/matrix.test.ts
+++ b/src/frontend/src/lib/export/matrix.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { csvCell, matrixToCsv } from "@/lib/export/matrix";
+
+describe("csvCell", () => {
+  it("defuses a value a spreadsheet would run as a formula", () => {
+    // A name or a metric label starting with one of these is data, not a
+    // command, and the file is opened by a person who did not write it.
+    expect(csvCell("=1+1")).toBe("'=1+1");
+    expect(csvCell("+7")).toBe("'+7");
+    expect(csvCell("-lead")).toBe("'-lead");
+    expect(csvCell("@handle")).toBe("'@handle");
+  });
+
+  it("quotes what would otherwise break the row apart", () => {
+    expect(csvCell('say "hi"')).toBe('"say ""hi"""');
+    expect(csvCell("a,b")).toBe('"a,b"');
+    expect(csvCell("two\nlines")).toBe('"two\nlines"');
+  });
+
+  it("writes an absent value as empty and keeps a measured zero", () => {
+    expect(csvCell(null)).toBe("");
+    expect(csvCell(undefined)).toBe("");
+    expect(csvCell(0)).toBe("0");
+  });
+
+  it("drops a non-finite number rather than writing Infinity into a cell", () => {
+    expect(csvCell(Number.POSITIVE_INFINITY)).toBe("");
+    expect(csvCell(Number.NaN)).toBe("");
+  });
+});
+
+describe("matrixToCsv", () => {
+  it("writes the header first and separates rows with CRLF", () => {
+    expect(
+      matrixToCsv({
+        columns: ["Person", "Period", "Commits"],
+        rows: [
+          ["Jane Doe", "2026-Q1", 4],
+          ["Sam Smith", "2026-Q1", null],
+        ],
+      }),
+    ).toBe("Person,Period,Commits\r\nJane Doe,2026-Q1,4\r\nSam Smith,2026-Q1,");
+  });
+});

--- a/src/frontend/src/lib/export/matrix.ts
+++ b/src/frontend/src/lib/export/matrix.ts
@@ -55,7 +55,14 @@ export async function downloadMatrixXlsx(
 
   sheet.addRow(matrix.columns);
   for (const row of matrix.rows) {
-    sheet.addRow(row.map((cell) => cell ?? null));
+    // A non-finite number reaches the sheet as a raw value and can make the
+    // workbook unreadable, so it is dropped — the same answer the CSV writer
+    // already gives it.
+    sheet.addRow(
+      row.map((cell) =>
+        typeof cell === "number" && !Number.isFinite(cell) ? null : cell ?? null,
+      ),
+    );
   }
 
   const header = sheet.getRow(1);

--- a/src/frontend/src/lib/export/matrix.ts
+++ b/src/frontend/src/lib/export/matrix.ts
@@ -1,0 +1,83 @@
+import { downloadBlob } from "@/lib/download";
+
+export type MatrixCell = string | number | null | undefined;
+
+export interface Matrix {
+  columns: string[];
+  rows: MatrixCell[][];
+}
+
+/**
+ * Escape one cell for CSV.
+ *
+ * The leading-symbol guard is the load-bearing part: a spreadsheet treats a
+ * cell opening with `=`, `+`, `-` or `@` as a formula, so a value that looks
+ * like one is prefixed with an apostrophe. Shared so there is a single
+ * escaping rule across every export this app writes.
+ */
+export function csvCell(value: MatrixCell): string {
+  if (value == null) return "";
+  const raw =
+    typeof value === "number"
+      ? Number.isFinite(value)
+        ? String(value)
+        : ""
+      : /^[\t\r ]*[=+\-@]/.test(value)
+        ? `'${value}`
+        : value;
+  return /[",\r\n]/.test(raw) ? `"${raw.replaceAll('"', '""')}"` : raw;
+}
+
+export function matrixToCsv(matrix: Matrix): string {
+  return [matrix.columns, ...matrix.rows]
+    .map((row) => row.map(csvCell).join(","))
+    .join("\r\n");
+}
+
+export function downloadMatrixCsv(filename: string, matrix: Matrix): void {
+  // The BOM is what makes Excel read it as UTF-8 rather than the local
+  // codepage, which otherwise mangles every non-ASCII name in the file.
+  const blob = new Blob(["﻿", matrixToCsv(matrix), "\r\n"], {
+    type: "text/csv;charset=utf-8",
+  });
+  downloadBlob(blob, filename);
+}
+
+export async function downloadMatrixXlsx(
+  filename: string,
+  sheetName: string,
+  matrix: Matrix,
+): Promise<void> {
+  const { Workbook } = await import("exceljs");
+  const workbook = new Workbook();
+  workbook.creator = "Insight";
+  const sheet = workbook.addWorksheet(sheetName.slice(0, 31) || "Report");
+
+  sheet.addRow(matrix.columns);
+  for (const row of matrix.rows) {
+    sheet.addRow(row.map((cell) => cell ?? null));
+  }
+
+  const header = sheet.getRow(1);
+  header.font = { bold: true };
+  sheet.views = [{ state: "frozen", ySplit: 1 }];
+  sheet.autoFilter = {
+    from: { row: 1, column: 1 },
+    to: { row: 1, column: Math.max(1, matrix.columns.length) },
+  };
+  matrix.columns.forEach((column, index) => {
+    const widest = matrix.rows.reduce(
+      (max, row) => Math.max(max, String(row[index] ?? "").length),
+      column.length,
+    );
+    sheet.getColumn(index + 1).width = Math.min(40, Math.max(10, widest + 2));
+  });
+
+  const buffer = await workbook.xlsx.writeBuffer();
+  downloadBlob(
+    new Blob([buffer], {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    }),
+    filename,
+  );
+}

--- a/src/frontend/src/lib/portal/nav-model.ts
+++ b/src/frontend/src/lib/portal/nav-model.ts
@@ -78,7 +78,7 @@ export const ZONES: readonly Zone[] = [
   { id: "aicost", label: "AI & Cost", icon: DollarSign, kind: "theme" },
   // Pure scaffolds: no view, no data path. Our backlog, not a tenant gap.
   { id: "scorecard", label: "Scorecard", icon: BarChart3, kind: "theme", readiness: "unbuilt" },
-  { id: "reports", label: "Reports", icon: FileText, kind: "theme", readiness: "unbuilt" },
+  { id: "reports", label: "Reports", icon: FileText, kind: "theme" },
   { id: "manage", label: "Manage", icon: Settings2, kind: "manage" },
 ];
 
@@ -260,7 +260,7 @@ export const ZONE_SECTIONS: Record<string, readonly PaneGroup[]> = {
     {
       label: "Custom",
       items: [
-        { id: "report-builder", label: "Report builder", icon: LayoutGrid, readiness: "unbuilt" },
+        { id: "report-builder", label: "Report builder", icon: LayoutGrid },
         { id: "dashboards", label: "Saved dashboards", icon: Layers, readiness: "unbuilt" },
         { id: "new-report", label: "New report", icon: Plus, readiness: "unbuilt" },
       ],

--- a/src/frontend/src/lib/portal/readiness.test.ts
+++ b/src/frontend/src/lib/portal/readiness.test.ts
@@ -47,13 +47,14 @@ describe("partitionByReadiness", () => {
 describe("nav classification invariants", () => {
   it("hiding planned work still leaves every zone the portal can render", () => {
     const { live } = partitionByReadiness(ZONES, false);
-    // The five zones with real views must survive the strictest filter.
+    // Every zone with a real view must survive the strictest filter.
     expect(live.map((z) => z.id)).toEqual([
       "overview",
       "directions",
       "person",
       "people",
       "aicost",
+      "reports",
       "manage",
     ]);
   });

--- a/src/frontend/src/lib/reports/additive.ts
+++ b/src/frontend/src/lib/reports/additive.ts
@@ -1,0 +1,38 @@
+import type { MetricComputation } from "@/api/metric-results-client";
+
+/**
+ * Whether a metric's values may be added across periods.
+ *
+ * `distinct_count` is the one that has to be named: it is formatted as an
+ * integer and reads as a counter, but the same person is distinct in every
+ * month they were active, so summing months overstates a quarter.
+ */
+export function isAdditive(computation: MetricComputation): boolean {
+  return computation === "sum";
+}
+
+export const NOT_ADDITIVE_REASON: Record<MetricComputation, string | null> = {
+  sum: null,
+  ratio: "A ratio over a period is its own numerator over its own denominator",
+  median: "A median cannot be rebuilt from the medians of shorter periods",
+  distinct_count: "Someone active in two months is distinct in each of them",
+};
+
+/**
+ * The catalogue's additive metrics, in catalogue order.
+ *
+ * `computation` rides on metric RESULTS rather than on the definition
+ * listing, so the caller supplies the map a probe collected; a metric the
+ * probe did not answer for is left out rather than guessed at.
+ */
+export function additiveKeys(
+  catalogue: ReadonlyArray<{ metric_key: string }>,
+  computationByKey: ReadonlyMap<string, MetricComputation>,
+): string[] {
+  return catalogue
+    .filter((metric) => {
+      const computation = computationByKey.get(metric.metric_key);
+      return computation != null && isAdditive(computation);
+    })
+    .map((metric) => metric.metric_key);
+}

--- a/src/frontend/src/lib/reports/availability.ts
+++ b/src/frontend/src/lib/reports/availability.ts
@@ -1,0 +1,32 @@
+import type { MetricComputation } from "@/api/metric-results-client";
+import type { MetricDefinition } from "@/api/metric-definitions-client";
+import { NOT_ADDITIVE_REASON } from "@/lib/reports/additive";
+import { needsRollup, type ReportGranularity } from "@/lib/reports/rollup";
+
+/**
+ * Why a metric cannot be put in this report, or null when it can.
+ *
+ * Every reason is stated rather than acted on silently: a metric that vanishes
+ * from the picker sends the reader hunting for a section they remember, and
+ * they cannot tell "not measured here" from "I misremembered the name".
+ */
+export function unavailableReason(
+  metric: Pick<MetricDefinition, "metric_key" | "schema_status" | "last_observed_date" | "origin">,
+  granularity: ReportGranularity,
+  computationByKey: ReadonlyMap<string, MetricComputation>,
+): string | null {
+  if (metric.schema_status === "error") {
+    return "This metric is not computing on this installation";
+  }
+  if (metric.origin !== "custom" && metric.last_observed_date == null) {
+    return "No data reaches us for this metric yet";
+  }
+  if (!needsRollup(granularity)) return null;
+
+  const computation = computationByKey.get(metric.metric_key);
+  if (computation == null) return null;
+  const reason = NOT_ADDITIVE_REASON[computation];
+  return reason == null
+    ? null
+    : `${reason} — pick monthly or finer to include it`;
+}

--- a/src/frontend/src/lib/reports/availability.ts
+++ b/src/frontend/src/lib/reports/availability.ts
@@ -24,7 +24,12 @@ export function unavailableReason(
   if (!needsRollup(granularity)) return null;
 
   const computation = computationByKey.get(metric.metric_key);
-  if (computation == null) return null;
+  // Unknown is not the same as additive. The probe may still be in flight, and
+  // treating silence as permission is how a ratio ends up summed into a
+  // quarter — the one thing this whole path exists to prevent.
+  if (computation == null) {
+    return "Still checking whether this can be totalled over a period";
+  }
   const reason = NOT_ADDITIVE_REASON[computation];
   return reason == null
     ? null

--- a/src/frontend/src/lib/reports/batching.ts
+++ b/src/frontend/src/lib/reports/batching.ts
@@ -1,0 +1,50 @@
+/** The server rejects a request carrying more than this many metrics. */
+export const MAX_METRICS_PER_REQUEST = 50;
+
+/**
+ * How many values one request may carry back.
+ *
+ * NOT the server's row limit, which is checked per view and therefore never
+ * sees the metric count: fifty metrics for several hundred people across a
+ * year of months satisfies every check it makes and still returns a response
+ * of a size nothing bounded. Budgeting the product is what keeps each request
+ * comparable in weight — which is also what makes a progress indicator honest.
+ */
+export const MAX_VALUES_PER_REQUEST = 4500;
+
+export interface RequestBatch {
+  metricKeys: string[];
+  entityIds: string[];
+}
+
+function chunk<T>(items: readonly T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+/**
+ * Split a selection into requests that each stay within both caps.
+ *
+ * Metrics are capped first because their limit is hard; the people per
+ * request then follow from what is left of the value budget.
+ */
+export function planRequests(
+  metricKeys: readonly string[],
+  entityIds: readonly string[],
+  bucketCount: number,
+): RequestBatch[] {
+  if (metricKeys.length === 0 || entityIds.length === 0) return [];
+  const metricBatches = chunk([...metricKeys], MAX_METRICS_PER_REQUEST);
+  return metricBatches.flatMap((keys) => {
+    const perEntity = Math.max(1, keys.length * (bucketCount + 1));
+    const entitiesPerRequest = Math.max(
+      1,
+      Math.floor(MAX_VALUES_PER_REQUEST / perEntity),
+    );
+    return chunk([...entityIds], entitiesPerRequest).map((ids) => ({
+      metricKeys: keys,
+      entityIds: ids,
+    }));
+  });
+}

--- a/src/frontend/src/lib/reports/families.ts
+++ b/src/frontend/src/lib/reports/families.ts
@@ -1,0 +1,58 @@
+/**
+ * The family a metric key belongs to, and what to call it.
+ *
+ * The names are the ones the Directions zone already uses, so a metric sits
+ * under the same word wherever the reader meets it. `git` and `tasks` are both
+ * Development there; keeping them apart here is the finer split the picker
+ * needs, since a report is chosen metric by metric rather than lens by lens.
+ */
+const FAMILY_NAMES: Record<string, string> = {
+  git: "Development · Git",
+  tasks: "Development · Delivery",
+  collab: "Collaboration",
+  wiki: "Knowledge / Wiki",
+  ai: "AI",
+};
+
+export function familyOf(metricKey: string): string {
+  return metricKey.split(".")[0] ?? "";
+}
+
+export function familyName(family: string): string {
+  return FAMILY_NAMES[family] ?? family;
+}
+
+export interface MetricFamily<T> {
+  family: string;
+  name: string;
+  metrics: T[];
+}
+
+/**
+ * Group metrics by family, families in the order above and anything unnamed
+ * after them, so a newly-added family appears rather than disappearing.
+ */
+export function byFamily<T extends { metric_key: string }>(
+  metrics: readonly T[],
+): MetricFamily<T>[] {
+  const known = Object.keys(FAMILY_NAMES);
+  const grouped = new Map<string, T[]>();
+  for (const metric of metrics) {
+    const family = familyOf(metric.metric_key);
+    grouped.set(family, [...(grouped.get(family) ?? []), metric]);
+  }
+  return [...grouped.entries()]
+    .sort(([a], [b]) => {
+      const ai = known.indexOf(a);
+      const bi = known.indexOf(b);
+      if (ai === bi) return a.localeCompare(b);
+      if (ai === -1) return 1;
+      if (bi === -1) return -1;
+      return ai - bi;
+    })
+    .map(([family, group]) => ({
+      family,
+      name: familyName(family),
+      metrics: group,
+    }));
+}

--- a/src/frontend/src/lib/reports/report-table.ts
+++ b/src/frontend/src/lib/reports/report-table.ts
@@ -1,0 +1,90 @@
+import type { MetricResult, TimeseriesView } from "@/api/metric-results-client";
+import {
+  bucketSpan,
+  bucketsInRange,
+  rollUp,
+  type ReportGranularity,
+} from "@/lib/reports/rollup";
+import { PERSON_COLUMNS, type ReportPerson } from "@/lib/reports/roster-columns";
+
+export type ReportCell = string | number | null;
+
+export interface ReportTable {
+  columns: string[];
+  rows: ReportCell[][];
+}
+
+export interface ReportInput {
+  people: ReadonlyArray<ReportPerson>;
+  /** Selected metrics, in the order their columns should appear. */
+  metrics: ReadonlyArray<{ metric_key: string; label: string }>;
+  results: ReadonlyMap<string, MetricResult>;
+  range: { from: string; to: string };
+  granularity: ReportGranularity;
+}
+
+function timeseriesOf(result: MetricResult | undefined): TimeseriesView | null {
+  const view = result?.views.find((v) => v.view === "timeseries");
+  return view?.view === "timeseries" ? view : null;
+}
+
+const cellKey = (metricKey: string, entityId: string, bucket: string): string =>
+  `${metricKey} ${entityId} ${bucket}`;
+
+/**
+ * One row per person per bucket, the person's attributes repeated on each.
+ *
+ * Repeating them is the point: a file normalised into a person table and a
+ * measurement table cannot be pivoted, which is the one thing it is opened
+ * for.
+ */
+export function buildReportTable(input: ReportInput): ReportTable {
+  const buckets = bucketsInRange(
+    input.range.from,
+    input.range.to,
+    input.granularity,
+  );
+
+  const cells = new Map<string, number | null>();
+  for (const metric of input.metrics) {
+    const series = timeseriesOf(input.results.get(metric.metric_key))?.series;
+    for (const entry of series ?? []) {
+      // A grouped series carries a person once per group; the report asks for
+      // no grouping, so anything dimensioned is not ours to add.
+      if (entry.dimensions.length > 0) continue;
+      for (const [bucket, value] of rollUp(entry.points, input.granularity)) {
+        cells.set(cellKey(metric.metric_key, entry.entity_id, bucket), value);
+      }
+    }
+  }
+
+  const spans = new Map(
+    buckets.map((bucket) => [
+      bucket,
+      bucketSpan(bucket, input.granularity, input.range),
+    ]),
+  );
+
+  return {
+    columns: [
+      ...PERSON_COLUMNS.map((column) => column.header),
+      "Period",
+      "From",
+      "To",
+      ...input.metrics.map((metric) => metric.label),
+    ],
+    rows: input.people.flatMap((person) =>
+      buckets.map((bucket) => [
+        ...PERSON_COLUMNS.map((column) => column.of(person)),
+        bucket,
+        spans.get(bucket)?.from ?? "",
+        spans.get(bucket)?.to ?? "",
+        ...input.metrics.map(
+          (metric) =>
+            cells.get(cellKey(metric.metric_key, person.entityId, bucket)) ??
+            null,
+        ),
+      ]),
+    ),
+  };
+}

--- a/src/frontend/src/lib/reports/reports.test.ts
+++ b/src/frontend/src/lib/reports/reports.test.ts
@@ -1,0 +1,332 @@
+import { describe, expect, it } from "vitest";
+
+import { additiveKeys, isAdditive } from "@/lib/reports/additive";
+import {
+  MAX_METRICS_PER_REQUEST,
+  MAX_VALUES_PER_REQUEST,
+  planRequests,
+} from "@/lib/reports/batching";
+import { byFamily } from "@/lib/reports/families";
+import { buildReportTable } from "@/lib/reports/report-table";
+import {
+  bucketSpan,
+  bucketsInRange,
+  bucketLabel,
+  needsRollup,
+  rollUp,
+} from "@/lib/reports/rollup";
+import type { ReportPerson } from "@/lib/reports/roster-columns";
+import type { MetricResult } from "@/api/metric-results-client";
+
+const months = (...pairs: Array<[string, number | null]>) =>
+  pairs.map(([bucket_start, value]) => ({ bucket_start, value }));
+
+describe("rollUp", () => {
+  it("adds months into a quarter", () => {
+    const rolled = rollUp(
+      months(["2026-01-01", 10], ["2026-02-01", 5], ["2026-03-01", 1]),
+      "quarter",
+    );
+    expect(rolled.get("2026-Q1")).toBe(16);
+  });
+
+  it("keeps a bucket with no reading empty rather than zero", () => {
+    // A zero is a measurement. In a file someone will total, the two mean
+    // opposite things.
+    const rolled = rollUp(months(["2026-01-01", null]), "quarter");
+    expect(rolled.get("2026-Q1")).toBeNull();
+  });
+
+  it("treats a measured zero as a reading", () => {
+    const rolled = rollUp(months(["2026-01-01", null], ["2026-02-01", 0]), "quarter");
+    expect(rolled.get("2026-Q1")).toBe(0);
+  });
+
+  it("adds nothing at a bucket the server computed itself", () => {
+    // A ratio for one month is that month's ratio. Adding two of them would be
+    // meaningless, and at these granularities nothing is added: the value is
+    // relabelled and passed through, so the whole catalogue can be reported.
+    expect(needsRollup("day")).toBe(false);
+    expect(needsRollup("week")).toBe(false);
+    expect(needsRollup("month")).toBe(false);
+    expect(needsRollup("quarter")).toBe(true);
+    expect(needsRollup("year")).toBe(true);
+
+    const rolled = rollUp(
+      months(["2026-01-01", 40], ["2026-02-01", 60]),
+      "month",
+    );
+    expect([...rolled.values()]).toEqual([40, 60]);
+  });
+
+  it("labels each granularity the way a spreadsheet sorts it", () => {
+    expect(bucketLabel("2026-05-01", "month")).toBe("2026-05");
+    expect(bucketLabel("2026-05-01", "quarter")).toBe("2026-Q2");
+    expect(bucketLabel("2026-05-01", "year")).toBe("2026");
+    // A day and a week keep the date the server bucketed them by.
+    expect(bucketLabel("2026-05-04", "day")).toBe("2026-05-04");
+    expect(bucketLabel("2026-05-04", "week")).toBe("2026-05-04");
+  });
+
+  it("enumerates every bucket the period covers, once", () => {
+    expect(bucketsInRange("2026-01-15", "2026-08-02", "quarter")).toEqual([
+      "2026-Q1",
+      "2026-Q2",
+      "2026-Q3",
+    ]);
+  });
+});
+
+describe("additive", () => {
+  it("admits sums and refuses the rest", () => {
+    expect(isAdditive("sum")).toBe(true);
+    expect(isAdditive("ratio")).toBe(false);
+    expect(isAdditive("median")).toBe(false);
+    // The trap: formatted as an integer, reads as a counter, and someone
+    // active in two months is distinct in each of them.
+    expect(isAdditive("distinct_count")).toBe(false);
+  });
+
+  it("leaves out a metric the probe did not answer for", () => {
+    const catalogue = [{ metric_key: "a" }, { metric_key: "b" }];
+    expect(additiveKeys(catalogue, new Map([["a", "sum" as const]]))).toEqual([
+      "a",
+    ]);
+  });
+});
+
+describe("planRequests", () => {
+  it("never exceeds the metric cap", () => {
+    const metrics = Array.from({ length: 120 }, (_, i) => `m${i}`);
+    const batches = planRequests(metrics, ["p1"], 12);
+    expect(batches.every((b) => b.metricKeys.length <= MAX_METRICS_PER_REQUEST)).toBe(
+      true,
+    );
+    expect(new Set(batches.flatMap((b) => b.metricKeys)).size).toBe(120);
+  });
+
+  it("keeps the values one request carries inside the budget", () => {
+    // The server's row check never sees the metric count, so satisfying it
+    // alone would let a fifty-metric response through unbounded.
+    const metrics = Array.from({ length: 50 }, (_, i) => `m${i}`);
+    const people = Array.from({ length: 400 }, (_, i) => `p${i}`);
+    const buckets = 12;
+    for (const batch of planRequests(metrics, people, buckets)) {
+      const values = batch.metricKeys.length * batch.entityIds.length * (buckets + 1);
+      expect(values).toBeLessThanOrEqual(MAX_VALUES_PER_REQUEST);
+    }
+  });
+
+  it("covers every person exactly once per metric batch", () => {
+    const people = Array.from({ length: 90 }, (_, i) => `p${i}`);
+    const batches = planRequests(["a", "b"], people, 12);
+    expect(batches.flatMap((b) => b.entityIds).sort()).toEqual([...people].sort());
+  });
+
+  it("asks for nothing when nothing is selected", () => {
+    expect(planRequests([], ["p1"], 12)).toEqual([]);
+    expect(planRequests(["a"], [], 12)).toEqual([]);
+  });
+});
+
+const person = (over: Partial<ReportPerson> = {}): ReportPerson => ({
+  entityId: "p1",
+  name: "Jane Doe",
+  email: "jane.doe@example.com",
+  division: "Platform",
+  department: "Core",
+  jobTitle: "Engineer",
+  managerName: "Sam Smith",
+  managerEmail: "sam.smith@example.com",
+  status: "active",
+  ...over,
+});
+
+function seriesResult(
+  metricKey: string,
+  entityId: string,
+  points: Array<[string, number | null]>,
+): MetricResult {
+  return {
+    metric_key: metricKey,
+    label: metricKey,
+    computation: "sum",
+    views: [
+      {
+        view: "timeseries",
+        bucket: "month",
+        series: [{ entity_id: entityId, dimensions: [], points: months(...points) }],
+      },
+    ],
+  } as unknown as MetricResult;
+}
+
+describe("buildReportTable", () => {
+  it("repeats the person's attributes on every bucket row", () => {
+    const table = buildReportTable({
+      people: [person()],
+      metrics: [{ metric_key: "git.commits", label: "Commits" }],
+      results: new Map([
+        [
+          "git.commits",
+          seriesResult("git.commits", "p1", [
+            ["2026-01-01", 4],
+            ["2026-02-01", 6],
+            ["2026-04-01", 1],
+          ]),
+        ],
+      ]),
+      range: { from: "2026-01-01", to: "2026-06-30" },
+      granularity: "quarter",
+    });
+
+    expect(table.columns).toEqual([
+      "Person",
+      "Email",
+      "Division",
+      "Department",
+      "Job title",
+      "Manager",
+      "Manager email",
+      "Status",
+      "Period",
+      "From",
+      "To",
+      "Commits",
+    ]);
+    expect(table.rows).toEqual([
+      [
+        "Jane Doe",
+        "jane.doe@example.com",
+        "Platform",
+        "Core",
+        "Engineer",
+        "Sam Smith",
+        "sam.smith@example.com",
+        "active",
+        "2026-Q1",
+        // Clipped to the requested period, not the whole quarter: the report
+        // starts in January but ends in June.
+        "2026-01-01",
+        "2026-03-31",
+        10,
+      ],
+      [
+        "Jane Doe",
+        "jane.doe@example.com",
+        "Platform",
+        "Core",
+        "Engineer",
+        "Sam Smith",
+        "sam.smith@example.com",
+        "active",
+        "2026-Q2",
+        "2026-04-01",
+        "2026-06-30",
+        1,
+      ],
+    ]);
+  });
+
+  it("leaves a cell empty where the metric said nothing", () => {
+    const table = buildReportTable({
+      people: [person()],
+      metrics: [
+        { metric_key: "a", label: "A" },
+        { metric_key: "b", label: "B" },
+      ],
+      results: new Map([["a", seriesResult("a", "p1", [["2026-01-01", 3]])]]),
+      range: { from: "2026-01-01", to: "2026-01-31" },
+      granularity: "month",
+    });
+    expect(table.rows[0]?.at(-2)).toBe(3);
+    expect(table.rows[0]?.at(-1)).toBeNull();
+  });
+
+  it("holds a row for a person the metrics never mention", () => {
+    // Otherwise a reader cannot tell "no activity" from "left out of the file".
+    const table = buildReportTable({
+      people: [person(), person({ entityId: "p2", name: "Sam Smith" })],
+      metrics: [{ metric_key: "a", label: "A" }],
+      results: new Map([["a", seriesResult("a", "p1", [["2026-01-01", 3]])]]),
+      range: { from: "2026-01-01", to: "2026-01-31" },
+      granularity: "month",
+    });
+    expect(table.rows).toHaveLength(2);
+    expect(table.rows[1]?.at(-1)).toBeNull();
+  });
+});
+
+describe("byFamily", () => {
+  it("groups by the key's family, in the order a reader meets them", () => {
+    const grouped = byFamily([
+      { metric_key: "wiki.pages" },
+      { metric_key: "git.commits" },
+      { metric_key: "collab.messages" },
+      { metric_key: "tasks.closed" },
+      { metric_key: "git.prs_merged" },
+    ]);
+    expect(grouped.map((g) => g.family)).toEqual([
+      "git",
+      "tasks",
+      "collab",
+      "wiki",
+    ]);
+    expect(grouped[0]?.metrics).toHaveLength(2);
+  });
+
+  it("names families with the words the Directions zone uses", () => {
+    expect(byFamily([{ metric_key: "wiki.pages" }])[0]?.name).toBe(
+      "Knowledge / Wiki",
+    );
+  });
+
+  it("shows a family it has no name for rather than dropping it", () => {
+    // A metric added under a new prefix must appear in the picker, not vanish.
+    const grouped = byFamily([
+      { metric_key: "git.commits" },
+      { metric_key: "support.tickets" },
+    ]);
+    expect(grouped.map((g) => g.family)).toEqual(["git", "support"]);
+    expect(grouped[1]?.name).toBe("support");
+  });
+});
+
+describe("bucketSpan", () => {
+  const range = { from: "2026-05-13", to: "2026-08-12" };
+
+  it("clips a bucket to the period the reader asked for", () => {
+    // Q2 is April to June, but this report starts in mid-May. Printing the
+    // whole quarter's dates would invite comparison with a full quarter.
+    expect(bucketSpan("2026-Q2", "quarter", range)).toEqual({
+      from: "2026-05-13",
+      to: "2026-06-30",
+    });
+    expect(bucketSpan("2026-Q3", "quarter", range)).toEqual({
+      from: "2026-07-01",
+      to: "2026-08-12",
+    });
+  });
+
+  it("gives a month its own days, and the last one its real length", () => {
+    expect(bucketSpan("2026-06", "month", range)).toEqual({
+      from: "2026-06-01",
+      to: "2026-06-30",
+    });
+    expect(bucketSpan("2026-02", "month", { from: "2026-01-01", to: "2026-12-31" })).toEqual({
+      from: "2026-02-01",
+      to: "2026-02-28",
+    });
+  });
+
+  it("gives a week seven days and a day one", () => {
+    expect(bucketSpan("2026-06-01", "week", range)).toEqual({
+      from: "2026-06-01",
+      to: "2026-06-07",
+    });
+    expect(bucketSpan("2026-06-01", "day", range)).toEqual({
+      from: "2026-06-01",
+      to: "2026-06-01",
+    });
+  });
+});

--- a/src/frontend/src/lib/reports/reports.test.ts
+++ b/src/frontend/src/lib/reports/reports.test.ts
@@ -384,8 +384,15 @@ describe("unavailableReason", () => {
     expect(unavailableReason(enabled, "year", ratio)).toMatch(/monthly or finer/);
   });
 
-  it("says nothing about a metric the probe has not answered for yet", () => {
-    expect(unavailableReason(enabled, "quarter", new Map())).toBeNull();
+  it("refuses a metric the probe has not answered for, where it would be added", () => {
+    // Silence is not permission: the probe may still be in flight, and an
+    // unknown computation summed into a quarter is exactly the wrong number
+    // this path exists to prevent. Finer buckets are unaffected — nothing is
+    // added there.
+    expect(unavailableReason(enabled, "quarter", new Map())).toMatch(
+      /Still checking/,
+    );
+    expect(unavailableReason(enabled, "month", new Map())).toBeNull();
   });
 });
 

--- a/src/frontend/src/lib/reports/reports.test.ts
+++ b/src/frontend/src/lib/reports/reports.test.ts
@@ -6,6 +6,7 @@ import {
   MAX_VALUES_PER_REQUEST,
   planRequests,
 } from "@/lib/reports/batching";
+import { unavailableReason } from "@/lib/reports/availability";
 import { byFamily } from "@/lib/reports/families";
 import { buildReportTable } from "@/lib/reports/report-table";
 import {
@@ -15,7 +16,10 @@ import {
   needsRollup,
   rollUp,
 } from "@/lib/reports/rollup";
-import type { ReportPerson } from "@/lib/reports/roster-columns";
+import {
+  collectReportPeople,
+  type ReportPerson,
+} from "@/lib/reports/roster-columns";
 import type { MetricResult } from "@/api/metric-results-client";
 
 const months = (...pairs: Array<[string, number | null]>) =>
@@ -328,5 +332,130 @@ describe("bucketSpan", () => {
       from: "2026-06-01",
       to: "2026-06-01",
     });
+  });
+});
+
+describe("unavailableReason", () => {
+  const enabled = {
+    metric_key: "git.commits",
+    schema_status: "ok" as const,
+    last_observed_date: "2026-05-01",
+    origin: "builtin" as const,
+  };
+  const sums = new Map([["git.commits", "sum" as const]]);
+
+  it("lets a working, observed metric through at any granularity", () => {
+    for (const g of ["day", "week", "month", "quarter", "year"] as const) {
+      expect(unavailableReason(enabled, g, sums)).toBeNull();
+    }
+  });
+
+  it("names a broken metric before anything else", () => {
+    expect(
+      unavailableReason({ ...enabled, schema_status: "error" }, "month", sums),
+    ).toMatch(/not computing/);
+  });
+
+  it("names a metric nothing has ever reached", () => {
+    expect(
+      unavailableReason({ ...enabled, last_observed_date: null }, "month", sums),
+    ).toMatch(/No data reaches us/);
+  });
+
+  it("takes a custom metric at its word about freshness", () => {
+    // The validator stamps freshness from materialised relations only, so a
+    // custom metric's absent date says nothing about whether it serves data.
+    expect(
+      unavailableReason(
+        { ...enabled, last_observed_date: null, origin: "custom" },
+        "month",
+        sums,
+      ),
+    ).toBeNull();
+  });
+
+  it("refuses a non-additive metric only where buckets are added up", () => {
+    const ratio = new Map([["git.commits", "ratio" as const]]);
+    expect(unavailableReason(enabled, "month", ratio)).toBeNull();
+    expect(unavailableReason(enabled, "quarter", ratio)).toMatch(
+      /numerator over its own denominator/,
+    );
+    // The refusal says how to include it rather than only saying no.
+    expect(unavailableReason(enabled, "year", ratio)).toMatch(/monthly or finer/);
+  });
+
+  it("says nothing about a metric the probe has not answered for yet", () => {
+    expect(unavailableReason(enabled, "quarter", new Map())).toBeNull();
+  });
+});
+
+describe("collectReportPeople", () => {
+  const node = (over: Record<string, unknown> = {}) =>
+    ({
+      person_id: "P1",
+      email: "jane.doe@example.com",
+      display_name: "Jane Doe",
+      division: "Platform",
+      department: "Core",
+      job_title: "Engineer",
+      status: "Active",
+      supervisor_name: "Sam Smith",
+      supervisor_email: "sam.smith@example.com",
+      subordinates: [],
+      ...over,
+    }) as never;
+
+  it("keys people by the normalised id the metrics use", () => {
+    const people = collectReportPeople(node());
+    expect([...people.keys()]).toEqual(["p1"]);
+    expect(people.get("p1")?.managerEmail).toBe("sam.smith@example.com");
+  });
+
+  it("walks the whole subtree, not just the root", () => {
+    const people = collectReportPeople(
+      node({ subordinates: [node({ person_id: "P2", display_name: "Sam" })] }),
+    );
+    expect([...people.keys()].sort()).toEqual(["p1", "p2"]);
+  });
+
+  it("leaves a missing attribute empty rather than undefined in a cell", () => {
+    const people = collectReportPeople(
+      node({ division: undefined, supervisor_name: null }),
+    );
+    expect(people.get("p1")?.division).toBe("");
+    expect(people.get("p1")?.managerName).toBe("");
+  });
+
+  it("holds nothing when the viewer has no tree", () => {
+    expect(collectReportPeople(null).size).toBe(0);
+  });
+});
+
+describe("bucketsInRange", () => {
+  it("steps a day at a time", () => {
+    expect(bucketsInRange("2026-05-01", "2026-05-04", "day")).toEqual([
+      "2026-05-01",
+      "2026-05-02",
+      "2026-05-03",
+      "2026-05-04",
+    ]);
+  });
+
+  it("steps a week at a time", () => {
+    expect(bucketsInRange("2026-05-04", "2026-05-25", "week")).toEqual([
+      "2026-05-04",
+      "2026-05-11",
+      "2026-05-18",
+      "2026-05-25",
+    ]);
+  });
+
+  it("gives every month of a year its own bucket", () => {
+    expect(bucketsInRange("2026-01-01", "2026-12-31", "year")).toEqual(["2026"]);
+    expect(bucketsInRange("2026-01-01", "2026-03-31", "month")).toEqual([
+      "2026-01",
+      "2026-02",
+      "2026-03",
+    ]);
   });
 });

--- a/src/frontend/src/lib/reports/rollup.ts
+++ b/src/frontend/src/lib/reports/rollup.ts
@@ -1,0 +1,141 @@
+import type { MetricBucket } from "@/api/metric-results-client";
+
+export type ReportGranularity = MetricBucket | "quarter" | "year";
+
+/**
+ * Whether the client has to add buckets together to answer this.
+ *
+ * Day, week and month exist server-side, so the server computes each bucket
+ * itself — a ratio is that bucket's own ratio, a median that bucket's own
+ * median, and every metric in the catalogue can be reported. Quarter and year
+ * do not exist there, so they are months added up, and only a metric whose
+ * values may be added can be offered at all.
+ */
+export function needsRollup(granularity: ReportGranularity): boolean {
+  return granularity === "quarter" || granularity === "year";
+}
+
+/** The bucket to ask the server for, which is not always the one displayed. */
+export function requestBucket(granularity: ReportGranularity): MetricBucket {
+  return granularity === "quarter" || granularity === "year"
+    ? "month"
+    : granularity;
+}
+
+/** Sorts as text in the order it reads: 2026-03, 2026-Q1, 2026. */
+export function bucketLabel(
+  bucketStart: string,
+  granularity: ReportGranularity,
+): string {
+  const [year, month] = bucketStart.split("-");
+  if (!year || !month) return bucketStart;
+  if (granularity === "year") return year;
+  if (granularity === "quarter") {
+    return `${year}-Q${Math.floor((Number(month) - 1) / 3) + 1}`;
+  }
+  if (granularity === "month") return `${year}-${month}`;
+  return bucketStart;
+}
+
+/**
+ * Points folded into the requested bucket.
+ *
+ * A bucket with no reading at all stays absent rather than becoming zero: a
+ * zero is a measurement, and the two mean opposite things in a file someone
+ * will total. Where no rollup is needed each point stands alone, so this is
+ * simply a relabelling.
+ */
+export function rollUp(
+  points: ReadonlyArray<{ bucket_start: string; value: number | null }>,
+  granularity: ReportGranularity,
+): Map<string, number | null> {
+  const out = new Map<string, number | null>();
+  const adding = needsRollup(granularity);
+  for (const point of points) {
+    const key = bucketLabel(point.bucket_start, granularity);
+    if (point.value == null) {
+      if (!out.has(key)) out.set(key, null);
+      continue;
+    }
+    out.set(key, adding ? (out.get(key) ?? 0) + point.value : point.value);
+  }
+  return out;
+}
+
+const STEP_DAYS: Partial<Record<ReportGranularity, number>> = { day: 1, week: 7 };
+
+/** Every bucket the period covers, so a gap renders as an empty cell in place. */
+export function bucketsInRange(
+  from: string,
+  to: string,
+  granularity: ReportGranularity,
+): string[] {
+  const labels: string[] = [];
+  const step = STEP_DAYS[granularity];
+  if (step) {
+    for (
+      let d = new Date(`${from}T00:00:00Z`);
+      d <= new Date(`${to}T00:00:00Z`);
+      d.setUTCDate(d.getUTCDate() + step)
+    ) {
+      labels.push(d.toISOString().slice(0, 10));
+    }
+    return labels;
+  }
+  const end = new Date(`${to.slice(0, 7)}-01T00:00:00Z`);
+  for (
+    let d = new Date(`${from.slice(0, 7)}-01T00:00:00Z`);
+    d <= end;
+    d.setUTCMonth(d.getUTCMonth() + 1)
+  ) {
+    const label = bucketLabel(d.toISOString().slice(0, 10), granularity);
+    if (labels.at(-1) !== label) labels.push(label);
+  }
+  return labels;
+}
+
+const iso = (d: Date): string => d.toISOString().slice(0, 10);
+
+/**
+ * The days a bucket actually covers in this report, clipped to the requested
+ * period.
+ *
+ * Clipping is the honest part: a report from mid-May to mid-August touches
+ * three months of Q2 and Q3 without covering either, and a row labelled
+ * "2026-Q2" beside a full quarter's worth of dates would invite the reader to
+ * compare it with one.
+ */
+export function bucketSpan(
+  label: string,
+  granularity: ReportGranularity,
+  range: { from: string; to: string },
+): { from: string; to: string } {
+  const clip = (from: Date, to: Date) => ({
+    from: iso(from) < range.from ? range.from : iso(from),
+    to: iso(to) > range.to ? range.to : iso(to),
+  });
+  if (granularity === "day") return clip(new Date(`${label}T00:00:00Z`), new Date(`${label}T00:00:00Z`));
+  if (granularity === "week") {
+    const start = new Date(`${label}T00:00:00Z`);
+    const end = new Date(start);
+    end.setUTCDate(end.getUTCDate() + 6);
+    return clip(start, end);
+  }
+  if (granularity === "year") {
+    return clip(
+      new Date(`${label}-01-01T00:00:00Z`),
+      new Date(`${label}-12-31T00:00:00Z`),
+    );
+  }
+  if (granularity === "quarter") {
+    const [year, quarter] = label.split("-Q");
+    const firstMonth = (Number(quarter) - 1) * 3;
+    const start = new Date(Date.UTC(Number(year), firstMonth, 1));
+    const end = new Date(Date.UTC(Number(year), firstMonth + 3, 0));
+    return clip(start, end);
+  }
+  const [year, month] = label.split("-");
+  const start = new Date(Date.UTC(Number(year), Number(month) - 1, 1));
+  const end = new Date(Date.UTC(Number(year), Number(month), 0));
+  return clip(start, end);
+}

--- a/src/frontend/src/lib/reports/roster-columns.ts
+++ b/src/frontend/src/lib/reports/roster-columns.ts
@@ -1,0 +1,59 @@
+import { normalizePersonId } from "@/lib/metrics/entity";
+import type { IdentityPerson } from "@/types/insight";
+
+export interface ReportPerson {
+  entityId: string;
+  name: string;
+  email: string;
+  division: string;
+  department: string;
+  jobTitle: string;
+  managerName: string;
+  managerEmail: string;
+  status: string;
+}
+
+/**
+ * A person and their manager each get a name AND a key.
+ *
+ * Display names collide, and a pivot grouped on one silently merges two
+ * people who share it — the same reason cohorts key `manager` on the
+ * supervisor's email rather than their display name.
+ */
+export const PERSON_COLUMNS: ReadonlyArray<{
+  header: string;
+  of: (person: ReportPerson) => string;
+}> = [
+  { header: "Person", of: (p) => p.name },
+  { header: "Email", of: (p) => p.email },
+  { header: "Division", of: (p) => p.division },
+  { header: "Department", of: (p) => p.department },
+  { header: "Job title", of: (p) => p.jobTitle },
+  { header: "Manager", of: (p) => p.managerName },
+  { header: "Manager email", of: (p) => p.managerEmail },
+  { header: "Status", of: (p) => p.status },
+];
+
+export function collectReportPeople(
+  root: IdentityPerson | null,
+): Map<string, ReportPerson> {
+  const out = new Map<string, ReportPerson>();
+  const walk = (node: IdentityPerson): void => {
+    if (node.person_id) {
+      out.set(normalizePersonId(node.person_id), {
+        entityId: normalizePersonId(node.person_id),
+        name: node.display_name ?? "",
+        email: node.email ?? "",
+        division: node.division ?? "",
+        department: node.department ?? "",
+        jobTitle: node.job_title ?? "",
+        managerName: node.supervisor_name ?? "",
+        managerEmail: node.supervisor_email ?? "",
+        status: node.status ?? "",
+      });
+    }
+    node.subordinates.forEach(walk);
+  };
+  if (root) walk(root);
+  return out;
+}

--- a/src/frontend/src/lib/reports/run-report.test.ts
+++ b/src/frontend/src/lib/reports/run-report.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ query: vi.fn() }));
+vi.mock("@/api/metric-results-client", () => ({
+  queryMetricResults: mocks.query,
+}));
+
+import { runReport } from "@/lib/reports/run-report";
+
+const seriesFor = (metricKey: string, entityIds: string[]) => ({
+  metric_key: metricKey,
+  label: metricKey,
+  computation: "sum",
+  views: [
+    {
+      view: "timeseries",
+      bucket: "month",
+      series: entityIds.map((entity_id) => ({
+        entity_id,
+        dimensions: [],
+        points: [{ bucket_start: "2026-01-01", value: 1 }],
+      })),
+    },
+  ],
+});
+
+const people = (count: number) =>
+  Array.from({ length: count }, (_, i) => `p${i}`);
+
+beforeEach(() => {
+  mocks.query.mockReset();
+  mocks.query.mockImplementation((body: { entity: { ids: string[] }; metrics: Array<{ metric_key: string }> }) =>
+    Promise.resolve({
+      metrics: body.metrics.map((m) => seriesFor(m.metric_key, body.entity.ids)),
+    }),
+  );
+});
+
+describe("runReport", () => {
+  it("keeps every person when a metric spans several batches", () => {
+    // The second batch for a metric carries different people, not a fresher
+    // answer about the same ones — replacing would silently drop a chunk of
+    // the roster from the file.
+    return runReport({
+      metricKeys: ["a"],
+      entityIds: people(900),
+      range: { from: "2026-01-01", to: "2026-12-31" },
+      granularity: "month" as const,
+      bucketCount: 12,
+    }).then((merged) => {
+      const view = merged.get("a")?.views[0];
+      expect(view?.view).toBe("timeseries");
+      if (view?.view !== "timeseries") throw new Error("expected a series");
+      expect(new Set(view.series.map((s) => s.entity_id)).size).toBe(900);
+      expect(mocks.query.mock.calls.length).toBeGreaterThan(1);
+    });
+  });
+
+  it("reports progress once per batch, ending at the total", async () => {
+    const seen: Array<[number, number]> = [];
+    await runReport({
+      metricKeys: ["a", "b"],
+      entityIds: people(900),
+      range: { from: "2026-01-01", to: "2026-12-31" },
+      granularity: "month" as const,
+      bucketCount: 12,
+      onProgress: (done, total) => seen.push([done, total]),
+    });
+    expect(seen[0]?.[0]).toBe(0);
+    const [lastDone, lastTotal] = seen.at(-1) ?? [];
+    expect(lastDone).toBe(lastTotal);
+    expect(seen).toHaveLength((lastTotal ?? 0) + 1);
+  });
+
+  it("yields nothing when a batch fails", async () => {
+    mocks.query.mockRejectedValueOnce(new Error("network"));
+    await expect(
+      runReport({
+        metricKeys: ["a"],
+        entityIds: people(10),
+        range: { from: "2026-01-01", to: "2026-12-31" },
+        granularity: "month" as const,
+      bucketCount: 12,
+      }),
+    ).rejects.toThrow("network");
+  });
+
+  it.each([
+    ["day", "day"],
+    ["week", "week"],
+    ["month", "month"],
+    // No such bucket server-side, so months are asked for and added up.
+    ["quarter", "month"],
+    ["year", "month"],
+  ] as const)("asks for %s as bucket %s", async (granularity, bucket) => {
+    await runReport({
+      metricKeys: ["a"],
+      entityIds: people(1),
+      range: { from: "2026-01-01", to: "2026-12-31" },
+      granularity,
+      bucketCount: 4,
+    });
+    expect(mocks.query.mock.calls[0]?.[0].metrics[0].views).toEqual([
+      { view: "timeseries", bucket },
+    ]);
+  });
+});

--- a/src/frontend/src/lib/reports/run-report.ts
+++ b/src/frontend/src/lib/reports/run-report.ts
@@ -1,0 +1,75 @@
+import {
+  queryMetricResults,
+  type MetricResult,
+} from "@/api/metric-results-client";
+import { planRequests } from "@/lib/reports/batching";
+import { requestBucket, type ReportGranularity } from "@/lib/reports/rollup";
+
+export interface ReportRun {
+  metricKeys: readonly string[];
+  entityIds: readonly string[];
+  range: { from: string; to: string };
+  granularity: ReportGranularity;
+  bucketCount: number;
+  onProgress?: (done: number, total: number) => void;
+  signal?: AbortSignal;
+}
+
+/**
+ * Every selected metric, over every person in scope.
+ *
+ * Asked at the bucket the reader chose where the server has one, and at months
+ * for a quarter or a year, which it does not.
+ *
+ * Resolves only when every batch has arrived. A run that throws — including
+ * one that was cancelled — yields nothing at all, because a file missing a few
+ * batches is indistinguishable from a complete one once it is open.
+ */
+export async function runReport(
+  run: ReportRun,
+): Promise<Map<string, MetricResult>> {
+  const batches = planRequests(run.metricKeys, run.entityIds, run.bucketCount);
+  const merged = new Map<string, MetricResult>();
+  let done = 0;
+  run.onProgress?.(0, batches.length);
+
+  for (const batch of batches) {
+    const response = await queryMetricResults(
+      {
+        entity: { type: "person", ids: [...batch.entityIds] },
+        period: run.range,
+        metrics: batch.metricKeys.map((metric_key) => ({
+          metric_key,
+          views: [{ view: "timeseries", bucket: requestBucket(run.granularity) }],
+        })),
+      },
+      run.signal,
+    );
+    for (const result of response.metrics) {
+      mergeSeries(merged, result);
+    }
+    run.onProgress?.((done += 1), batches.length);
+  }
+  return merged;
+}
+
+/**
+ * People arrive across batches, so a metric's series accumulate rather than
+ * replace: the second batch for a metric carries different people, not a
+ * newer answer about the same ones.
+ */
+function mergeSeries(
+  into: Map<string, MetricResult>,
+  result: MetricResult,
+): void {
+  const held = into.get(result.metric_key);
+  if (!held) {
+    into.set(result.metric_key, result);
+    return;
+  }
+  const heldView = held.views.find((view) => view.view === "timeseries");
+  const incoming = result.views.find((view) => view.view === "timeseries");
+  if (heldView?.view === "timeseries" && incoming?.view === "timeseries") {
+    heldView.series = [...heldView.series, ...incoming.series];
+  }
+}

--- a/src/frontend/src/queries/report-catalogue.test.ts
+++ b/src/frontend/src/queries/report-catalogue.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ query: vi.fn() }));
+vi.mock("@/api/metric-results-client", () => ({ queryMetricResults: mocks.query }));
+
+import { probeComputations } from "@/queries/report-catalogue";
+
+beforeEach(() => {
+  mocks.query.mockReset();
+  mocks.query.mockImplementation(
+    (body: { metrics: Array<{ metric_key: string }> }) =>
+      Promise.resolve({
+        metrics: body.metrics.map((m) => ({
+          metric_key: m.metric_key,
+          computation: m.metric_key.startsWith("ratio") ? "ratio" : "sum",
+        })),
+      }),
+  );
+});
+
+describe("probeComputations", () => {
+  it("splits the catalogue to respect the per-request metric cap", async () => {
+    const keys = Array.from({ length: 130 }, (_, i) => `m${i}`);
+    const map = await probeComputations(keys, "p1", "2026-05-01");
+
+    expect(map.size).toBe(130);
+    expect(mocks.query.mock.calls.length).toBe(3);
+    for (const [body] of mocks.query.mock.calls) {
+      expect(body.metrics.length).toBeLessThanOrEqual(50);
+    }
+  });
+
+  it("asks about one person over one day — it wants the shape, not the data", () => {
+    return probeComputations(["a"], "p1", "2026-05-01").then(() => {
+      const [body] = mocks.query.mock.calls[0] ?? [];
+      expect(body.entity).toEqual({ type: "person", ids: ["p1"] });
+      expect(body.period).toEqual({ from: "2026-05-01", to: "2026-05-01" });
+      expect(body.metrics[0].views).toEqual([{ view: "period" }]);
+    });
+  });
+
+  it("reports each metric's computation as the server gave it", async () => {
+    const map = await probeComputations(["sum_a", "ratio_b"], "p1", "2026-05-01");
+    expect(map.get("sum_a")).toBe("sum");
+    expect(map.get("ratio_b")).toBe("ratio");
+  });
+
+  it("asks nothing when the catalogue is empty", async () => {
+    expect((await probeComputations([], "p1", "2026-05-01")).size).toBe(0);
+    expect(mocks.query).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/src/queries/report-catalogue.ts
+++ b/src/frontend/src/queries/report-catalogue.ts
@@ -57,11 +57,14 @@ export function useMetricComputations(): {
   // unavailable", and that rejection is all-or-nothing: one such key fails the
   // whole batch and empties the picker. `reachableMetricKeys` is the existing
   // answer to what this installation actually serves.
-  const keys = [...reachableMetricKeys(definitions.data?.metrics ?? [])];
+  const keys = [...reachableMetricKeys(definitions.data?.metrics ?? [])].sort();
   const day = new Date().toISOString().slice(0, 10);
 
   const query = useQuery({
-    queryKey: ["metric-computations", keys.length, personId],
+    // Keyed by the metrics themselves: one swapped for another leaves the
+    // count unchanged, and the cached answer would then describe a set that no
+    // longer exists.
+    queryKey: ["metric-computations", keys.join(" "), personId],
     queryFn: () => probeComputations(keys, personId ?? "", day),
     enabled: keys.length > 0 && Boolean(personId),
     staleTime: 30 * 60 * 1000,

--- a/src/frontend/src/queries/report-catalogue.ts
+++ b/src/frontend/src/queries/report-catalogue.ts
@@ -22,7 +22,7 @@ import { useMetricDefinitionsResponse } from "@/queries/metric-definitions";
  * A list of metric keys held in the client would drift the first time a metric
  * is added, and would do so silently.
  */
-async function probeComputations(
+export async function probeComputations(
   metricKeys: string[],
   personId: string,
   day: string,

--- a/src/frontend/src/queries/report-catalogue.ts
+++ b/src/frontend/src/queries/report-catalogue.ts
@@ -1,0 +1,75 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  queryMetricResults,
+  type MetricComputation,
+} from "@/api/metric-results-client";
+import { useViewer } from "@/auth";
+import { reachableMetricKeys } from "@/lib/insight/coverage";
+import { MAX_METRICS_PER_REQUEST } from "@/lib/reports/batching";
+import { useMetricDefinitionsResponse } from "@/queries/metric-definitions";
+
+/**
+ * Which metrics may be totalled, asked of the server rather than assumed.
+ *
+ * `computation` rides on metric RESULTS, not on the definition listing the
+ * picker reads, so it is collected by asking for every catalogue metric over a
+ * single day for a single person. The value comes from the definition rather
+ * than from the rows, so it arrives whether or not that metric has anything to
+ * report in the probed window, and the answer describes THIS installation
+ * rather than an assumption about it.
+ *
+ * A list of metric keys held in the client would drift the first time a metric
+ * is added, and would do so silently.
+ */
+async function probeComputations(
+  metricKeys: string[],
+  personId: string,
+  day: string,
+): Promise<Map<string, MetricComputation>> {
+  const out = new Map<string, MetricComputation>();
+  for (let i = 0; i < metricKeys.length; i += MAX_METRICS_PER_REQUEST) {
+    const batch = metricKeys.slice(i, i + MAX_METRICS_PER_REQUEST);
+    const response = await queryMetricResults({
+      entity: { type: "person", ids: [personId] },
+      period: { from: day, to: day },
+      metrics: batch.map((metric_key) => ({
+        metric_key,
+        views: [{ view: "period" }],
+      })),
+    });
+    for (const result of response.metrics) {
+      out.set(result.metric_key, result.computation);
+    }
+  }
+  return out;
+}
+
+export function useMetricComputations(): {
+  data: Map<string, MetricComputation> | undefined;
+  isPending: boolean;
+  isError: boolean;
+} {
+  const { personId } = useViewer();
+  const definitions = useMetricDefinitionsResponse();
+  // `is_enabled` is not the same question. A metric can be enabled in the
+  // catalogue and still be rejected by the results endpoint as "unknown or
+  // unavailable", and that rejection is all-or-nothing: one such key fails the
+  // whole batch and empties the picker. `reachableMetricKeys` is the existing
+  // answer to what this installation actually serves.
+  const keys = [...reachableMetricKeys(definitions.data?.metrics ?? [])];
+  const day = new Date().toISOString().slice(0, 10);
+
+  const query = useQuery({
+    queryKey: ["metric-computations", keys.length, personId],
+    queryFn: () => probeComputations(keys, personId ?? "", day),
+    enabled: keys.length > 0 && Boolean(personId),
+    staleTime: 30 * 60 * 1000,
+  });
+
+  return {
+    data: query.data,
+    isPending: definitions.isPending || query.isPending,
+    isError: definitions.isError || query.isError,
+  };
+}


### PR DESCRIPTION
Closes #1570.

Reports → Report builder: pick any set of metrics and a granularity, preview the table, download it as CSV or Excel. Design discussed on #1570; this is the frontend-only build it concluded with, and **nothing here is blocked on the backend**.

## What a reader does

Picks metrics, picks daily / weekly / monthly / quarterly / yearly, presses **Build report**, sees the table it is about to export, downloads it. People come from the topbar's scope and the period from the topbar's period, so the report is about whatever the rest of the portal is already about.

One row per person per bucket, org attributes repeated on every row so the file can be pivoted without editing first:

| Person | Email | Division | Department | Job title | Manager | Manager email | Status | Period | From | To | Commits |
|---|---|---|---|---|---|---|---|---|---|---|---|
| Jane Doe | jane.doe@example.com | Platform | Core | Engineer | Sam Smith | sam.smith@example.com | Active | 2026-05 | 2026-05-13 | 2026-05-31 | 128 |

`From`/`To` are the bucket's real span **clipped to the requested period** — a report starting mid-May shows its first month starting on the 13th, so nobody compares a part-month with a whole one.

## Decisions worth reviewing

**Granularity is asked of the server where it has one.** Day, week and month exist there, so the server computes each bucket and every metric can be reported — a ratio is that bucket's own ratio. Quarter and year do not exist, so they are months added together, and only there does "may this be added" arise. The trap that makes the question necessary is `distinct_count`: formatted as an integer, reads as a counter, and someone active in two months is distinct in each.

**Which metrics may be added is asked, not assumed.** `computation` rides on results rather than on the definition listing, so a one-day probe over the catalogue collects it. That keeps the answer true for the installation being looked at; a list of metric keys in the client would drift the first time a metric is added, silently. Publishing `computation` on the listing would remove the probe — worth doing, not required.

**Nothing is hidden from the picker.** A metric that cannot go in the report is listed with the reason: not computing here, never observed, or not something a quarter can add up. On an install that does not ingest a source this removes whole families, and a family that simply vanishes leaves the reader unable to tell "not measured here" from "I misremembered the name".

**Requests split along two axes.** Metrics because the endpoint refuses more than fifty; people because of the projected-row limit. That limit is checked per view and never sees the metric count, so satisfying it alone would let one response carry an unbounded amount — the split is sized on the product of metrics, people and buckets instead, which also makes each request comparable in weight and the progress honest.

**Failure yields nothing.** A run resolves only when every batch has arrived; one that fails or is cancelled produces no file, because a file missing a few batches reads as a complete one once it is open. Same reason a built report is stamped with what produced it and dropped when any of it changes: a table built monthly must not still be downloadable after the reader switches to yearly.

## Not in scope

- **Rows about teams or org units.** The results API knows one entity type, `person`. Aggregating people into a unit is a backend capability, not an export option.
- **Ratios and medians at quarter or year.** They need `Bucket::Quarter` and `Bucket::Year` computed where the data is. Nothing here blocks adding them later.

## Verification

Driven end to end in a browser against a populated instance: the picker's families and disabled reasons, building, the progress count, the preview dialog, both downloads, the clipping of `From`/`To` at both ends of the period, and that switching granularity withdraws a stale report.

Unit tests cover the parts where a wrong answer would be quiet: rollup arithmetic and the empty-versus-zero distinction, the additivity rule per computation, the request split against both caps, the clipped spans, batch merging across chunks, and the CSV formula guard. Full suite green (1143), typecheck and lint clean.

**One gap stated plainly:** the tooltip carrying a disabled metric's reason did not open on hover in testing — the label wraps a disabled control, which the tooltip primitive appears not to treat as a trigger. A native `title` carries the same text as a fallback, so the reason is always reachable, but it renders as a system tooltip rather than in the app's style. Worth a follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a report builder for selecting metrics, people, date ranges, and daily, weekly, monthly, quarterly, or yearly views.
  * Added report previews with progress tracking and cancellation.
  * Added CSV and Excel downloads with formatted headers and spreadsheet-safe values.
  * Added explanations when metrics are unavailable or incompatible with selected settings.
  * Reports are now available in the navigation.
* **Bug Fixes**
  * Improved handling of missing data and report results across time periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->