### PR TITLE
fix(hr): backport the one-row-per-person class_people fix to release-2026.07.1

### DIFF
--- a/docs/components/connectors/hr-directory/README.md
+++ b/docs/components/connectors/hr-directory/README.md
@@ -64,7 +64,19 @@ prd: pending
 
 ### 1.1 Architectural Vision
 
-The HR Silver Layer transforms raw HR directory data from Bronze source tables (BambooHR, Workday, LDAP/Active Directory) into two canonical, workspace-isolated Silver tables: `class_people` and `class_org_units`. Both tables follow the SCD Type 2 pattern: each row captures a point-in-time snapshot of a person or organisational unit, with `valid_from`/`valid_to` interval semantics. The current state of any entity is always the row where `valid_to IS NULL`.
+> **Implementation status.** This document is the original HR Silver design. Parts of it describe components that were never built, and they must not be read as the current contract:
+>
+> - There is **no "SCD2 Merge" component**. Bronze → Silver is plain dbt (`<source>__to_class_people` staging views unioned by `union_by_tag` into `silver.class_people`). Every section describing row-closing writes (`UPDATE ... SET valid_to = ...`) is unimplemented design.
+> - **`class_people` has no `valid_to`** and holds no version history — see below.
+> - **`class_org_units` does not exist** as a table or a dbt model. `class_people.org_unit_id` is consequently unpopulated; department attribution currently flows through `department_name`.
+>
+> For the shipped data-flow contract see [ADR-0001](../../../domain/ingestion-data-flow/specs/ADR/0001-rmt-with-version-and-unique-key.md) and [ADR-0004](../../../domain/ingestion-data-flow/specs/ADR/0004-unique-key-formula.md).
+
+The HR Silver Layer transforms raw HR directory data from Bronze source tables (BambooHR, MS Entra, Workday, LDAP/Active Directory) into two canonical, workspace-isolated Silver tables: `class_people` and `class_org_units`.
+
+`class_people` is a **current-state snapshot**: exactly one row per person per source, keyed on an entity-level `unique_key`. `valid_from` records when the source last changed the record; there is no `valid_to`. It is `materialized='table'` and rebuilt in full on every run, so it cannot accumulate history by construction.
+
+HR attribute history lives in the per-source SCD2 chain — `<source>__<entity>_snapshot` and `<source>__<entity>_fields_history` — which are `incremental`/`append` and therefore genuinely accumulate versions across syncs, tracking strictly more fields than `class_people` exposes. Do not add version rows to `class_people`: see ADR-0004 and ADR-0001 for the headcount-inflation bug this caused.
 
 The design makes the HR domain the authoritative source for person identity and organisational structure within the Insight platform. `class_people` serves as the canonical person registry consumed by all other Silver streams that carry `person_id`. `class_org_units` provides the org hierarchy needed for hierarchical scoping of metrics — the depth, path, and head of each organisational unit — data that cannot be reliably derived from `class_people` alone.
 
@@ -89,7 +101,7 @@ Extensibility for company-specific HR attributes is handled natively via two typ
 | NFR ID | NFR Summary | Allocated To | Design Response | Verification Approach |
 |---|---|---|---|---|
 | `cpt-insightspec-nfr-tenant-isolation` | Zero cross-workspace data leakage | `workspace_id` column on both Silver tables | `workspace_id` is a partition key component on `class_people` and `class_org_units`; DataScopeFilter injects `workspace_id = ?` predicate on every query | Integration tests asserting no cross-workspace rows returned under adversarial queries |
-| `cpt-insightspec-nfr-query-performance` | Sub-second queries for org-scoped metrics | ClickHouse partition pruning | `(workspace_id, valid_to)` partition key enables pruning for current-state queries (`WHERE valid_to IS NULL`); `path LIKE '/company/eng/%'` enables subtree scoping | Query benchmarks on representative dataset sizes |
+| `cpt-insightspec-nfr-query-performance` | Sub-second queries for org-scoped metrics | ClickHouse sparse primary index | `class_people` is one row per person (current headcount, not turnover-scaled), so current-state reads need no interval predicate and scan a table bounded by headcount; `ORDER BY unique_key` indexes the tenant-prefixed key | Query benchmarks on representative dataset sizes |
 
 ### 1.3 Architecture Layers
 
@@ -165,7 +177,9 @@ Every row in `class_people` and `class_org_units` must carry `workspace_id`. The
 
 - [ ] `p2` - **ID**: `cpt-insightspec-constraint-no-overlapping-intervals`
 
-For a given (`person_id`, `workspace_id`) pair, no two rows in `class_people` may have overlapping `[valid_from, valid_to)` intervals. Exactly one row per person may have `valid_to IS NULL` (the current state). The SCD2 Merge component enforces this invariant before writing to ClickHouse.
+`class_people` MUST contain exactly one row per (`workspace_id`, `source`, `source_person_id`). Because it is a current-state snapshot there are no intervals to overlap: `unique_key` is the entity key, so the versionless ReplacingMergeTree collapses to one row per person, and the `union_by_tag` read-time dedup guarantees it within a single build.
+
+Two things enforce this. Each staging `__to_class_people` view MUST keep `unique_key` entity-level (never append a version axis such as `lastChanged`), and MUST dedup its own bronze read with `FINAL` — bronze is append-only and RMT only collapses on background merge, so a bare read leaks unmerged snapshot rows. The `assert_class_people_one_row_per_person` data-quality check asserts the invariant.
 
 #### Source Priority
 
@@ -329,7 +343,7 @@ Not applicable. `class_people` and `class_org_units` are internal ClickHouse tab
 |---|---|---|
 | ClickHouse cluster | Native ClickHouse client | Stores both Bronze (read) and Silver (write) hr-directory tables |
 
-ClickHouse partition pruning on `(workspace_id, valid_to)` is the primary performance mechanism for current-state queries. All `class_people` and `class_org_units` queries from the Gold layer are expected to include `WHERE workspace_id = ? AND valid_to IS NULL` to leverage pruning.
+`class_people` is a current-state snapshot with one row per person, so Gold-layer queries need no `valid_to IS NULL` predicate — there is no `valid_to` column. Gold queries are expected to include `WHERE workspace_id = ?` for tenant isolation.
 
 #### Identity Resolution V3 (PostgreSQL / MariaDB)
 
@@ -414,9 +428,8 @@ sequenceDiagram
 |---|---|---|
 | `person_id` | String | Canonical person ID (from Identity Resolution V3) |
 | `workspace_id` | String | Tenant identifier — partition key component |
-| `valid_from` | DateTime | Start of this state snapshot (UTC) |
-| `valid_to` | DateTime | End of this state snapshot (UTC); NULL = current row |
-| `source` | String | Origin system: `bamboohr` / `workday` / `ldap` |
+| `valid_from` | DateTime | When the source last changed this record (UTC) |
+| `source` | String | Origin system: `bamboohr` / `ms-entra` / `workday` / `ldap` |
 | `source_person_id` | String | Native ID in the source system (for lineage) |
 | `employee_number` | String | Company-assigned HR employee number |
 | `display_name` | String | Full display name |
@@ -424,10 +437,10 @@ sequenceDiagram
 | `last_name` | String | Family name |
 | `email` | String | Primary work email address |
 | `job_title` | String | Freeform job title as provided by source |
-| `department_name` | String | Department name at time of this snapshot |
-| `org_unit_id` | String | FK → `class_org_units.org_unit_id` (resolved at valid_from) |
+| `department_name` | String | Current department name |
+| `org_unit_id` | String | FK → `class_org_units.org_unit_id` (table not yet built — see status note in §1.1) |
 | `manager_person_id` | String | `person_id` of direct manager; empty string if none |
-| `status` | String | `active` / `on_leave` / `terminated` |
+| `status` | String | `active` / `on_leave` / `terminated` / `unknown` (source value outside the known vocabulary — never silently mapped to `active`) |
 | `employment_type` | String | `full_time` / `part_time` / `contractor` |
 | `hire_date` | DateTime | Employment start date |
 | `termination_date` | DateTime | Employment end date; NULL if not terminated |
@@ -438,16 +451,14 @@ sequenceDiagram
 | `custom_num_attrs` | Map(String, Float64) | Workspace-specific numeric attributes (e.g. scores, targets) |
 | `ingested_at` | DateTime | Timestamp when this row was written by the ETL Job |
 
-**PK**: (`workspace_id`, `person_id`, `valid_from`)
-
-**Partition key**: (`workspace_id`, `valid_to`) — supports pruning for current-state queries
+**Engine / ORDER BY** (as shipped): versionless `ReplacingMergeTree` `ORDER BY unique_key`, where `unique_key` is the entity-level `{tenant}-{source}-{source_person_id}`. No partition key.
 
 **Constraints**:
 
-- No two rows for the same (`person_id`, `workspace_id`) may have overlapping `[valid_from, valid_to)` intervals
-- Exactly one row per (`person_id`, `workspace_id`) may have `valid_to IS NULL`
+- Exactly one row per (`workspace_id`, `source`, `source_person_id`) — asserted by the `assert_class_people_one_row_per_person` data-quality check
+- `unique_key` MUST NOT carry a version axis; a per-version key defeats the RMT collapse and inflates headcount
 
-**Additional info**: Current-state query pattern: `WHERE workspace_id = ? AND valid_to IS NULL`. Point-in-time query: `WHERE workspace_id = ? AND valid_from <= ? AND (valid_to > ? OR valid_to IS NULL)`.
+**Additional info**: Current-state query pattern: `WHERE workspace_id = ?` — every row is current, so no interval predicate is needed. Point-in-time queries are not served by this table; read the per-source `*_snapshot` / `*_fields_history` chain instead.
 
 ---
 
@@ -490,7 +501,9 @@ sequenceDiagram
 
 ### Table Sizing and Retention
 
-`class_people` grows linearly with workspace count and employee turnover rate. For a workspace with 1,000 active employees and 20% annual turnover, approximately 1,200 rows accumulate per year per workspace (1,000 current + 200 historical snapshots). At 100 workspaces this is 120,000 rows per year — well within ClickHouse operational range. No automated retention policy is required at the Silver layer; historical rows are the source of truth for tenure and org-change analytics. Gold layer views must filter to `valid_to IS NULL` for current-state metrics to minimise scan cost.
+`class_people` holds one row per person currently present in the HR source, so its size tracks current headcount, not turnover: a workspace with 1,000 employees is 1,000 rows, and it does not grow year over year. At 100 workspaces this is ~100,000 rows — well within ClickHouse operational range. Leavers disappear from the table once the source stops returning them (the model is rebuilt in full each run), so no retention policy is needed at this layer.
+
+Tenure and org-change analytics must read the per-source `*_snapshot` / `*_fields_history` chain, which is where historical versions accumulate — not `class_people`. Those tables do grow with turnover and change rate.
 
 ### Sections Not Applicable
 

--- a/docs/domain/ingestion-data-flow/specs/ADR/0001-rmt-with-version-and-unique-key.md
+++ b/docs/domain/ingestion-data-flow/specs/ADR/0001-rmt-with-version-and-unique-key.md
@@ -107,8 +107,18 @@ never see duplicates. This is the property option A could not guarantee.
 - The `snapshot()` macro now reads its bronze source with `FINAL`, so transient
   duplicates do not create spurious SCD2 history versions.
 - `materialized='table'` silver models (`class_people`, `mtr_git_person_*`,
-  `class_hr_working_hours`) are rebuilt in full each run and already collapse to
-  one row per key via the `union_by_tag` dedup — left unchanged.
+  `class_hr_working_hours`) are rebuilt in full each run and collapse to one row
+  per `unique_key` via the `union_by_tag` dedup.
+
+  **Caveat — this is only equivalent to "one row per entity" while `unique_key`
+  IS the entity key.** `class_people` was originally exempted from the read-dedup
+  cleanup on this basis, but ADR-0004 had it carry a version axis (`lastChanged`),
+  so the dedup was per (entity, version): every changed record became a second
+  permanently-current row, and `FINAL` could not collapse it because the keys
+  genuinely differed. The staging read of bronze also lacked `FINAL`, so unmerged
+  bronze snapshots were the source of those versions. Both are fixed; the
+  exemption does not generalise — a `table` model still needs read-time dedup of
+  its own upstreams, and its `unique_key` must be the entity key.
 
 **Enforcement.** `src/ingestion/dbt/audit_rmt_read_dedup.py` checks every RMT read
 across staging, silver, and the gold-view migrations and fails (exit≠0) on an

--- a/docs/domain/ingestion-data-flow/specs/ADR/0004-unique-key-formula.md
+++ b/docs/domain/ingestion-data-flow/specs/ADR/0004-unique-key-formula.md
@@ -55,7 +55,9 @@ The formula:
 {insight_tenant_id}-{insight_source_id}-{natural_key_part_1}-{natural_key_part_2}-...
 ```
 
-Tenant first, source second, natural-key last. For SCD2 grains (`class_people`, `cursor__members_snapshot`), the natural-key parts MUST include the version axis (e.g. `valid_from`, `_tracked_at`, `event_id`) so per-version rows get distinct `unique_key`s.
+Tenant first, source second, natural-key last. For genuine SCD2 / history grains (`cursor__members_snapshot`, the per-source `*_snapshot` and `*_fields_history` models), the natural-key parts MUST include the version axis (e.g. `_tracked_at`, `event_id`) so per-version rows get distinct `unique_key`s.
+
+**A version axis belongs only in a table that is meant to accumulate versions** — in practice an `incremental`/`append` model. It MUST NOT be added to a current-state snapshot such as `class_people`, which is `materialized='table'` and rebuilt in full each run. Combining the two is what produced the `class_people` headcount-inflation bug: the version axis made each changed record a *second* row that the versionless silver RMT could never collapse (and that `FINAL` could not collapse either, because the keys genuinely differ), while `valid_to` stayed NULL so nothing marked which row was current. Snapshot models keep an entity-level `unique_key`; their history lives in the sibling `*_snapshot` / `*_fields_history` chain.
 
 For records produced by dbt explode models (one bronze row → many output rows), the producer MUST compute its own `unique_key` using the same formula — bronze's `unique_key` is at the wrong grain.
 
@@ -159,9 +161,14 @@ SELECT
 FROM {{ source('bronze_<connector>', '<table>') }} u
 ```
 
-**SCD2 extension** (`to_class_people.sql`):
+**SCD2 / history extension** (`*_snapshot`, `*_fields_history` — models that accumulate versions):
 ```sql
-CAST(concat(coalesce(unique_key, ''), '-', toString(lastChanged)) AS String) AS unique_key
+CAST(concat(coalesce(unique_key, ''), '-', toString(_tracked_at)) AS String) AS unique_key
+```
+
+**Snapshot models pass bronze's entity-level key straight through** (`to_class_people.sql`) — no version axis:
+```sql
+CAST(coalesce(unique_key, '') AS String) AS unique_key
 ```
 
 ## Traceability

--- a/docs/shared/glossary/README.md
+++ b/docs/shared/glossary/README.md
@@ -518,9 +518,8 @@ Existing code and specs that conflict with the adopted conventions. To be update
 
 | File | Violation | Convention |
 |------|-----------|------------|
-| `src/ingestion/connectors/hr-directory/bamboohr/dbt/to_class_people.sql:16` | `CAST(NULL AS Nullable(DateTime))` for `valid_to` | ClickHouse Nullable avoidance (section 6); use sentinel value (e.g., `'1970-01-01'`) instead of `Nullable` |
-| `src/ingestion/connectors/hr-directory/bamboohr/dbt/to_class_people.sql:12` | bare `tenant_id` | `insight_tenant_id` (section 3.1) |
-| `src/ingestion/connectors/hr-directory/bamboohr/dbt/to_class_people.sql:15` | `valid_from` / `valid_to` | `effective_from` / `effective_to` (section 4.2) |
+| `src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__to_class_people.sql` | bare `tenant_id` | `insight_tenant_id` (section 3.1) |
+| `src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__to_class_people.sql` | `valid_from` | `effective_from` (section 4.2) |
 | `src/ingestion/connectors/ai/claude-admin/dbt/claude_admin__ai_api_usage.sql` | `insight_source_id` without `insight_source_type` | Source tracking fields must co-occur (section 3.2) |
 | `src/ingestion/connectors/ai/claude-admin/dbt/claude_admin__ai_api_usage.sql` | bare `tenant_id` | `insight_tenant_id` (section 3.1) |
 

--- a/src/ingestion/connectors/hr-directory/active-directory/dbt/active_directory__to_class_people.sql
+++ b/src/ingestion/connectors/hr-directory/active-directory/dbt/active_directory__to_class_people.sql
@@ -1,8 +1,10 @@
 -- depends_on: {{ ref('active_directory__bronze_promoted') }}
 -- Bronze → Silver step 1: Active Directory users → class_people
 -- Full-refresh source. Maps directory records to the unified person registry.
--- SCD Type 2: valid_from = whenCreated, valid_to = NULL (current-state snapshot).
--- Full SCD history is handled downstream via active_directory__users_fields_history.
+-- Current-state snapshot: exactly one row per user. `valid_from` records when the
+-- directory object was created; there is no version history here. Attribute
+-- history lives in active_directory__users_snapshot /
+-- active_directory__users_fields_history, which accumulate across syncs.
 -- Sibling of ms_entra__to_class_people — same column contract, LDAP attributes.
 -- @cpt-constraint:cpt-dataflow-constraint-staging-class-column-types-match:p1
 {{ config(
@@ -14,15 +16,16 @@
 SELECT
     u.tenant_id,
     u.source_id,
-    -- SCD2 grain: per (entity, valid_from). Bronze `unique_key` is at entity
-    -- level (`{tenant}-{source}-{objectGUID}`); extend it with valid_from so
-    -- silver `class_people` can dedup by a single ORDER BY column.
-    CAST(concat(coalesce(u.unique_key, ''), '-', toString(coalesce(u.whenCreated, ''))) AS String) AS unique_key,
+    -- Entity-level grain: bronze `unique_key` is already
+    -- `{tenant}-{source}-{objectGUID}`, so silver `class_people` (versionless RMT
+    -- ORDER BY unique_key) collapses to one row per user. Do NOT add a version
+    -- axis here — that would make every changed record a second
+    -- permanently-"current" row (see ADR-0004).
+    CAST(coalesce(u.unique_key, '') AS String)      AS unique_key,
     coalesce(u.tenant_id, '')                       AS workspace_id,
     -- person_id resolved in Silver Step 2 via Identity Manager
     CAST(NULL AS Nullable(UUID))                    AS person_id,
     parseDateTimeBestEffortOrNull(u.whenCreated)    AS valid_from,
-    CAST(NULL AS Nullable(DateTime))                AS valid_to,
     'active-directory'                              AS source,
     u.id                                            AS source_person_id,
     u.employeeId                                    AS employee_number,
@@ -44,10 +47,12 @@ SELECT
     -- into silver.class_people — a UUID branch raises Code: 386 NO_COMMON_TYPE
     -- (cpt-dataflow-constraint-staging-class-column-types-match).
     CAST(NULL AS Nullable(String))                  AS manager_person_id,
+    -- NULL accountEnabled is genuinely unknown (never 'active' by default —
+    -- defaulting to active silently inflates headcount).
     CASE
         WHEN u.accountEnabled IS NOT NULL AND u.accountEnabled THEN 'active'
         WHEN u.accountEnabled IS NOT NULL AND NOT u.accountEnabled THEN 'terminated'
-        ELSE 'active'
+        ELSE 'unknown'
     END                                             AS status,
     -- AD has no employment-type field; default until the BambooHR join in
     -- Silver Step 2 (Identity Manager) supplies the real value.
@@ -63,4 +68,9 @@ SELECT
     ) AS Map(String, String))                       AS custom_str_attrs,
     CAST(map() AS Map(String, Float64))             AS custom_num_attrs,
     u._airbyte_extracted_at                         AS ingested_at
-FROM {{ source('bronze_active_directory', 'users') }} u
+-- FINAL is mandatory, not defensive: bronze is append-only (a full snapshot per
+-- sync) and RMT(_airbyte_extracted_at) only collapses on background merge. A
+-- bare read emits every unmerged snapshot row, and the downstream
+-- `LIMIT 1 BY unique_key` has no ORDER BY, so the winner is undefined.
+-- FINAL makes "latest sync wins" deterministic. See ADR-0001.
+FROM {{ source('bronze_active_directory', 'users') }} u FINAL

--- a/src/ingestion/connectors/hr-directory/active-directory/dbt/schema.yml
+++ b/src/ingestion/connectors/hr-directory/active-directory/dbt/schema.yml
@@ -15,16 +15,10 @@ sources:
 models:
   - name: active_directory__bronze_promoted
     description: >
-      Bootstrap model that promotes raw `bronze_active_directory.users` to a
-      ReplacingMergeTree table (idempotent). Run before downstream models that
-      depend on RMT semantics.
-
+      Bootstrap model that promotes raw `bronze_active_directory.users` to a ReplacingMergeTree table (idempotent). Run before downstream models that depend on RMT semantics. #magic___^_^___line
   - name: active_directory__users_snapshot
     description: >
-      SCD2 append-only snapshot of Active Directory users. Captures changes in
-      tracked fields (UPN, mail, displayName, employeeId, accountEnabled,
-      sAMAccountName, etc.) so the Identity Manager can observe identity changes
-      over time.
+      SCD2 append-only snapshot of Active Directory users. Captures changes in tracked fields (UPN, mail, displayName, employeeId, accountEnabled, sAMAccountName, etc.) so the Identity Manager can observe identity changes over time.
     columns:
       - name: unique_key
         description: Composite (tenant, source, objectGUID, _row_hash) snapshot key.
@@ -33,8 +27,7 @@ models:
 
   - name: active_directory__users_fields_history
     description: >
-      Field-level change log for Active Directory users. One row per (entity,
-      field, change). Drives `active_directory__identity_inputs`.
+      Field-level change log for Active Directory users. One row per (entity, field, change). Drives `active_directory__identity_inputs`.
     columns:
       - name: entity_id
         description: AD objectGUID.
@@ -55,9 +48,7 @@ models:
 
   - name: active_directory__identity_inputs
     description: >
-      Identity signals emitted to Identity Manager. Each row is one observation
-      (UPSERT or DELETE) of an identity field for a user. Identity Manager
-      consumes these to resolve `objectGUID → person_id`.
+      Identity signals emitted to Identity Manager. Each row is one observation (UPSERT or DELETE) of an identity field for a user. Identity Manager consumes these to resolve `objectGUID → person_id`.
     columns:
       - name: unique_key
         tests:
@@ -94,9 +85,7 @@ models:
 
   - name: active_directory__to_class_people
     description: >
-      Active Directory users → class_people (Silver Step 1).
-      Identity key: `email` (mail with UPN fallback). `source_person_id` is the
-      AD objectGUID — stable across renames and reusable as the directory join key.
+      Active Directory users → class_people (Silver Step 1). Identity key: `email` (mail with UPN fallback). `source_person_id` is the AD objectGUID — stable across renames and reusable as the directory join key.
     columns:
       - name: tenant_id
         tests:
@@ -121,7 +110,9 @@ models:
         tests:
           - not_null
       - name: status
+        description: >
+          Normalised from accountEnabled: active / terminated, or unknown when accountEnabled is NULL. Never defaults to active — that silently inflates headcount.
         tests:
           - accepted_values:
               arguments:
-                values: ['active', 'on_leave', 'terminated']
+                values: ['active', 'on_leave', 'terminated', 'unknown']

--- a/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__to_class_people.sql
+++ b/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__to_class_people.sql
@@ -1,8 +1,11 @@
 -- depends_on: {{ ref('bamboohr__bronze_promoted') }}
 -- Bronze → Silver step 1: BambooHR Employees → class_people
 -- Full-refresh source. Maps employee records to unified person registry.
--- SCD Type 2: valid_from = lastChanged, valid_to = NULL (current-state snapshot).
--- Full SCD history tracking is handled downstream.
+-- Current-state snapshot: exactly one row per employee. `valid_from` records
+-- when the source last changed the record; there is no version history here.
+-- HR attribute history lives in `bamboohr__employees_snapshot` /
+-- `bamboohr__employees_fields_history`, which accumulate across syncs
+-- (this model is rebuilt in full every run and cannot retain history).
 -- @cpt-constraint:cpt-dataflow-constraint-staging-class-column-types-match:p1
 {{ config(
     materialized='view',
@@ -13,15 +16,16 @@
 SELECT
     tenant_id,
     source_id,
-    -- SCD2 grain: per (entity, valid_from). Bronze `unique_key` is at entity
-    -- level (`{tenant}-{source}-{employee_id}`); we extend it with valid_from
-    -- so silver `class_people` can dedup by a single ORDER BY column.
-    CAST(concat(coalesce(unique_key, ''), '-', toString(lastChanged)) AS String) AS unique_key,
+    -- Entity-level grain: bronze `unique_key` is already
+    -- `{tenant}-{source}-{employee_id}`, so silver `class_people` (versionless
+    -- RMT ORDER BY unique_key) collapses to one row per employee. Do NOT add a
+    -- version axis here — that would make every changed record a second
+    -- permanently-"current" row (see ADR-0004).
+    CAST(coalesce(unique_key, '') AS String)        AS unique_key,
     coalesce(tenant_id, '')                         AS workspace_id,
     -- person_id resolved in Silver Step 2 via Identity Manager
     CAST(NULL AS Nullable(UUID))                    AS person_id,
     parseDateTimeBestEffortOrNull(lastChanged)      AS valid_from,
-    CAST(NULL AS Nullable(DateTime))                AS valid_to,
     'bamboohr'                                      AS source,
     id                                              AS source_person_id,
     employeeNumber                                  AS employee_number,
@@ -33,10 +37,13 @@ SELECT
     department                                      AS department_name,
     CAST(NULL AS Nullable(UUID))                    AS org_unit_id,
     supervisorEId                                   AS manager_person_id,
+    -- Never default to 'active': a record that is neither explicitly Active nor
+    -- explicitly Terminated (e.g. status='' with employmentHistoryStatus
+    -- 'Third party') would silently inflate headcount.
     CASE
         WHEN status = 'Active' THEN 'active'
         WHEN employmentHistoryStatus = 'Terminated' THEN 'terminated'
-        ELSE 'active'
+        ELSE 'unknown'
     END                                             AS status,
     'full_time'                                     AS employment_type,
     parseDateTimeBestEffortOrNull(hireDate)          AS hire_date,
@@ -48,4 +55,9 @@ SELECT
                                                     AS custom_str_attrs,
     CAST(map() AS Map(String, Float64))             AS custom_num_attrs,
     _airbyte_extracted_at                           AS ingested_at
-FROM {{ source('bamboohr', 'employees') }}
+-- FINAL is mandatory, not defensive: bronze is append-only (a full snapshot per
+-- sync) and RMT(_airbyte_extracted_at) only collapses on background merge. A
+-- bare read emits every unmerged snapshot row, and the downstream
+-- `LIMIT 1 BY unique_key` has no ORDER BY — with max_threads=1 it demonstrably
+-- picks the STALE row. FINAL makes "latest sync wins" deterministic. See ADR-0001.
+FROM {{ source('bamboohr', 'employees') }} FINAL

--- a/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__working_hours.sql
+++ b/src/ingestion/connectors/hr-directory/bamboohr/dbt/bamboohr__working_hours.sql
@@ -18,7 +18,13 @@ SELECT
     toFloat64(8.0)            AS working_hours_per_day,
     toFloat64(40.0)           AS working_hours_per_week,
     _airbyte_extracted_at     AS ingested_at
-FROM {{ source('bamboohr', 'employees') }}
+-- FINAL is mandatory: bronze is append-only RMT(_airbyte_extracted_at) and only
+-- collapses on background merge. Without it the `status = 'Active'` filter below
+-- is evaluated against EVERY unmerged snapshot, so an employee who has since gone
+-- inactive still qualifies via a stale row — and the downstream versionless
+-- `LIMIT 1 BY unique_key` has no ORDER BY, so which snapshot's hours win is
+-- undefined. See ADR-0001.
+FROM {{ source('bamboohr', 'employees') }} FINAL
 WHERE status = 'Active'
   AND id IS NOT NULL
   AND workEmail IS NOT NULL

--- a/src/ingestion/connectors/hr-directory/bamboohr/dbt/schema.yml
+++ b/src/ingestion/connectors/hr-directory/bamboohr/dbt/schema.yml
@@ -11,11 +11,7 @@ sources:
 models:
   - name: bamboohr__to_class_people
     description: >
-      BambooHR Employees -> class_people (Silver Step 1).
-      Full-refresh source. Identity key: email (workEmail).
-      Maps BambooHR status to normalised status (active/on_leave/terminated).
-      SCD Type 2 fields (valid_from/valid_to) are set as current-state snapshot
-      (valid_from = lastChanged, valid_to = NULL).
+      BambooHR Employees -> class_people (Silver Step 1). Full-refresh source. Identity key: email (workEmail). Maps BambooHR status to normalised status (active/terminated/unknown) — a record that is neither explicitly Active nor Terminated is `unknown`, never `active`, so it cannot silently inflate headcount. Current-state snapshot: entity-level `unique_key` (one row per employee) and `valid_from` = lastChanged. No `valid_to` — this model holds no version history; that lives in bamboohr__employees_snapshot / bamboohr__employees_fields_history. Reads bronze with FINAL because bronze is append-only RMT (see ADR-0001).
     columns:
       - name: tenant_id
         description: "Tenant isolation identifier"
@@ -42,11 +38,12 @@ models:
       - name: last_name
         description: "Last name"
       - name: status
-        description: "Normalised: active, on_leave, terminated"
+        description: >
+          Normalised: active, on_leave, terminated, or unknown when the source record is neither explicitly Active nor explicitly Terminated. Never defaults to active — that silently inflates headcount.
         tests:
           - accepted_values:
               arguments:
-                values: ['active', 'on_leave', 'terminated']
+                values: ['active', 'on_leave', 'terminated', 'unknown']
       - name: source
         description: "Always 'bamboohr'"
         tests:
@@ -61,9 +58,7 @@ models:
 
   - name: bamboohr__hr_events
     description: >
-      BambooHR leave_requests → class_hr_events (Silver Step 2 staging).
-      One row per leave request. Joins to employees to resolve email.
-      type/amount/status are JSON objects in Bronze — extracted with JSONExtractString.
+      BambooHR leave_requests → class_hr_events (Silver Step 2 staging). One row per leave request. Joins to employees to resolve email. type/amount/status are JSON objects in Bronze — extracted with JSONExtractString.
     columns:
       - name: insight_tenant_id
         tests:
@@ -118,9 +113,7 @@ models:
 
   - name: bamboohr__working_hours
     description: >
-      BambooHR active employees → class_hr_working_hours (Silver Step 2 staging).
-      One row per active employee with their scheduled working hours.
-      standardHoursPerWeek is not provided by this tenant; defaults to 8h/day / 40h/week.
+      BambooHR active employees → class_hr_working_hours (Silver Step 2 staging). One row per active employee with their scheduled working hours. standardHoursPerWeek is not provided by this tenant; defaults to 8h/day / 40h/week.
     columns:
       - name: insight_tenant_id
         tests:

--- a/src/ingestion/connectors/hr-directory/ms-entra/dbt/ms_entra__to_class_people.sql
+++ b/src/ingestion/connectors/hr-directory/ms-entra/dbt/ms_entra__to_class_people.sql
@@ -1,8 +1,10 @@
 -- depends_on: {{ ref('ms_entra__bronze_promoted') }}
 -- Bronze → Silver step 1: MS Entra users → class_people
 -- Full-refresh source. Maps directory records to the unified person registry.
--- SCD Type 2: valid_from = createdDateTime, valid_to = NULL (current-state snapshot).
--- Full SCD history is handled downstream via ms_entra__users_fields_history.
+-- Current-state snapshot: exactly one row per user. `valid_from` records when
+-- the directory object was created; there is no version history here.
+-- Attribute history lives in ms_entra__users_snapshot /
+-- ms_entra__users_fields_history, which accumulate across syncs.
 -- Canonical reference implementation for cpt-dataflow-constraint-staging-class-column-types-match.
 -- @cpt-constraint:cpt-dataflow-constraint-staging-class-column-types-match:p1
 {{ config(
@@ -14,15 +16,16 @@
 SELECT
     tenant_id,
     source_id,
-    -- SCD2 grain: per (entity, valid_from). Bronze `unique_key` is at entity
-    -- level (`{tenant}-{source}-{oid}`); we extend it with valid_from so
-    -- silver `class_people` can dedup by a single ORDER BY column.
-    CAST(concat(coalesce(unique_key, ''), '-', toString(coalesce(createdDateTime, ''))) AS String) AS unique_key,
+    -- Entity-level grain: bronze `unique_key` is already
+    -- `{tenant}-{source}-{oid}`, so silver `class_people` (versionless RMT
+    -- ORDER BY unique_key) collapses to one row per user. Do NOT add a version
+    -- axis here — that would make every changed record a second
+    -- permanently-"current" row (see ADR-0004).
+    CAST(coalesce(unique_key, '') AS String)        AS unique_key,
     coalesce(tenant_id, '')                         AS workspace_id,
     -- person_id resolved in Silver Step 2 via Identity Manager
     CAST(NULL AS Nullable(UUID))                    AS person_id,
     parseDateTimeBestEffortOrNull(createdDateTime)   AS valid_from,
-    CAST(NULL AS Nullable(DateTime))                AS valid_to,
     'ms-entra'                                      AS source,
     id                                              AS source_person_id,
     employeeId                                      AS employee_number,
@@ -38,10 +41,12 @@ SELECT
     -- Manager relationships are not collected in v1 of the connector;
     -- a future iteration will add `$expand=manager` to populate this.
     CAST(NULL AS Nullable(String))                  AS manager_person_id,
+    -- NULL accountEnabled is genuinely unknown (never 'active' by default —
+    -- defaulting to active silently inflates headcount).
     CASE
         WHEN accountEnabled IS NOT NULL AND accountEnabled THEN 'active'
         WHEN accountEnabled IS NOT NULL AND NOT accountEnabled THEN 'terminated'
-        ELSE 'active'
+        ELSE 'unknown'
     END                                             AS status,
     -- Entra has no employment-type field; default until the BambooHR join
     -- in Silver Step 2 (Identity Manager) supplies the real value.
@@ -57,4 +62,9 @@ SELECT
     ) AS Map(String, String))                       AS custom_str_attrs,
     CAST(map() AS Map(String, Float64))             AS custom_num_attrs,
     _airbyte_extracted_at                           AS ingested_at
-FROM {{ source('bronze_ms_entra', 'users') }}
+-- FINAL is mandatory, not defensive: bronze is append-only (a full snapshot per
+-- sync) and RMT(_airbyte_extracted_at) only collapses on background merge. A
+-- bare read emits every unmerged snapshot row, and the downstream
+-- `LIMIT 1 BY unique_key` has no ORDER BY, so the winner is undefined.
+-- FINAL makes "latest sync wins" deterministic. See ADR-0001.
+FROM {{ source('bronze_ms_entra', 'users') }} FINAL

--- a/src/ingestion/connectors/hr-directory/ms-entra/dbt/schema.yml
+++ b/src/ingestion/connectors/hr-directory/ms-entra/dbt/schema.yml
@@ -15,16 +15,10 @@ sources:
 models:
   - name: ms_entra__bronze_promoted
     description: >
-      Bootstrap model that promotes raw `bronze_ms_entra.users` to a
-      ReplacingMergeTree table (idempotent). Run before downstream models
-      that depend on RMT semantics.
-
+      Bootstrap model that promotes raw `bronze_ms_entra.users` to a ReplacingMergeTree table (idempotent). Run before downstream models that depend on RMT semantics. #magic___^_^___line
   - name: ms_entra__users_snapshot
     description: >
-      SCD2 append-only snapshot of MS Entra users. Captures changes in
-      tracked fields (UPN, mail, displayName, employeeId, accountEnabled,
-      onPremisesSamAccountName, etc.) so the Identity Manager can observe
-      identity changes over time.
+      SCD2 append-only snapshot of MS Entra users. Captures changes in tracked fields (UPN, mail, displayName, employeeId, accountEnabled, onPremisesSamAccountName, etc.) so the Identity Manager can observe identity changes over time.
     columns:
       - name: unique_key
         description: Composite (tenant, source, oid, _row_hash) snapshot key.
@@ -33,8 +27,7 @@ models:
 
   - name: ms_entra__users_fields_history
     description: >
-      Field-level change log for MS Entra users. One row per (entity,
-      field, change). Drives `ms_entra__identity_inputs`.
+      Field-level change log for MS Entra users. One row per (entity, field, change). Drives `ms_entra__identity_inputs`.
     columns:
       - name: entity_id
         description: Entra Object ID (oid). Equals JWT `oid` claim.
@@ -55,9 +48,7 @@ models:
 
   - name: ms_entra__identity_inputs
     description: >
-      Identity signals emitted to Identity Manager. Each row is one
-      observation (UPSERT or DELETE) of an identity field for a user.
-      Identity Manager consumes these to resolve `oid → person_id`.
+      Identity signals emitted to Identity Manager. Each row is one observation (UPSERT or DELETE) of an identity field for a user. Identity Manager consumes these to resolve `oid → person_id`.
     columns:
       - name: unique_key
         tests:
@@ -94,10 +85,7 @@ models:
 
   - name: ms_entra__to_class_people
     description: >
-      MS Entra users → class_people (Silver Step 1).
-      Identity key: `email` (mail with UPN fallback). `source_person_id`
-      is the Entra Object ID (oid) — stable, reusable across services
-      via JWT `oid` claim.
+      MS Entra users → class_people (Silver Step 1). Identity key: `email` (mail with UPN fallback). `source_person_id` is the Entra Object ID (oid) — stable, reusable across services via JWT `oid` claim. Maps accountEnabled to status (active/terminated); a NULL accountEnabled is `unknown`, never `active`, so it cannot silently inflate headcount. Current-state snapshot: entity-level `unique_key` (one row per user) and `valid_from` = createdDateTime. No `valid_to` — this model holds no version history; that lives in ms_entra__users_snapshot / ms_entra__users_fields_history. Reads bronze with FINAL because bronze is append-only RMT (see ADR-0001).
     columns:
       - name: tenant_id
         tests:
@@ -122,7 +110,9 @@ models:
         tests:
           - not_null
       - name: status
+        description: >
+          Normalised from accountEnabled: active / terminated, or unknown when accountEnabled is NULL. Never defaults to active — that silently inflates headcount.
         tests:
           - accepted_values:
               arguments:
-                values: ['active', 'on_leave', 'terminated']
+                values: ['active', 'on_leave', 'terminated', 'unknown']

--- a/src/ingestion/connectors/hr-directory/workday/dbt/schema.yml
+++ b/src/ingestion/connectors/hr-directory/workday/dbt/schema.yml
@@ -10,12 +10,7 @@ sources:
 models:
   - name: workday__to_class_people
     description: >
-      Workday Workers -> class_people (Silver Step 1).
-      Full-refresh RaaS source. Identity key: email (Work_Email).
-      Maps Workday Worker_Status to normalised status (active/on_leave/terminated)
-      and Worker_Type to employment_type (full_time/contractor).
-      SCD Type 2 fields (valid_from/valid_to) are set as current-state snapshot
-      (valid_from = Last_Functionally_Updated, valid_to = NULL).
+      Workday Workers -> class_people (Silver Step 1). Full-refresh RaaS source. Identity key: email (Work_Email). Maps Workday Worker_Status to normalised status (active/on_leave/terminated, else unknown — the vocabulary is contract-normative, so an unrecognised value is never `active`) and Worker_Type to employment_type (full_time/contractor). Current-state snapshot: entity-level `unique_key` (one row per worker) and `valid_from` = Last_Functionally_Updated. No `valid_to` — this model holds no version history; that lives in workday__workers_snapshot / workday__workers_fields_history. Reads bronze with FINAL because bronze is append-only RMT (see ADR-0001).
     columns:
       - name: tenant_id
         description: "Tenant isolation identifier"
@@ -42,11 +37,12 @@ models:
       - name: last_name
         description: "Last name"
       - name: status
-        description: "Normalised: active, on_leave, terminated"
+        description: >
+          Normalised from Worker_Status: active, on_leave, terminated, or unknown when the source value is outside the contract vocabulary. Never defaults to active — that silently inflates headcount.
         tests:
           - accepted_values:
               arguments:
-                values: ['active', 'on_leave', 'terminated']
+                values: ['active', 'on_leave', 'terminated', 'unknown']
       - name: employment_type
         description: "Normalised: full_time (Employee), contractor (Contingent Worker)"
         tests:
@@ -67,9 +63,7 @@ models:
 
   - name: workday__hr_events
     description: >
-      Workday leave_requests → class_hr_events (Silver Step 2 staging).
-      One row per time-off request. Joins to workers to resolve email.
-      Unlike BambooHR, RaaS report columns are flat — no JSON extraction needed.
+      Workday leave_requests → class_hr_events (Silver Step 2 staging). One row per time-off request. Joins to workers to resolve email. Unlike BambooHR, RaaS report columns are flat — no JSON extraction needed.
     columns:
       - name: insight_tenant_id
         tests:
@@ -124,9 +118,7 @@ models:
 
   - name: workday__working_hours
     description: >
-      Workday active workers → class_hr_working_hours (Silver Step 2 staging).
-      One row per active worker with their scheduled working hours.
-      Scheduled_Weekly_Hours is Workday-delivered; defaults to 40h/week when empty.
+      Workday active workers → class_hr_working_hours (Silver Step 2 staging). One row per active worker with their scheduled working hours. Scheduled_Weekly_Hours is Workday-delivered; defaults to 40h/week when empty.
     columns:
       - name: insight_tenant_id
         tests:
@@ -171,10 +163,7 @@ models:
 
   - name: workday__workers_snapshot
     description: >
-      SCD2 append-only snapshot of Workday workers.
-      Tracks changes in standard report columns and custom report columns
-      from raw_data. Custom columns list is passed via dbt var
-      workday_custom_fields.
+      SCD2 append-only snapshot of Workday workers. Tracks changes in standard report columns and custom report columns from raw_data. Custom columns list is passed via dbt var workday_custom_fields.
     columns:
       - name: unique_key
         tests:
@@ -186,9 +175,7 @@ models:
 
   - name: workday__workers_fields_history
     description: >
-      Field-level change log for Workday workers.
-      One row per changed field per version transition.
-      Includes both standard and custom report columns (from raw_data).
+      Field-level change log for Workday workers. One row per changed field per version transition. Includes both standard and custom report columns (from raw_data).
     columns:
       - name: entity_id
         description: "Workday Employee ID"

--- a/src/ingestion/connectors/hr-directory/workday/dbt/workday__to_class_people.sql
+++ b/src/ingestion/connectors/hr-directory/workday/dbt/workday__to_class_people.sql
@@ -1,8 +1,10 @@
 -- depends_on: {{ ref('workday__bronze_promoted') }}
 -- Bronze → Silver step 1: Workday Workers → class_people
 -- Full-refresh source (RaaS report returns current state only).
--- SCD Type 2: valid_from = Last_Functionally_Updated, valid_to = NULL
--- (current-state snapshot). Full SCD history tracking is handled downstream.
+-- Current-state snapshot: exactly one row per worker. `valid_from` records when
+-- the source last changed the record; there is no version history here.
+-- Attribute history lives in workday__workers_snapshot /
+-- workday__workers_fields_history, which accumulate across syncs.
 -- @cpt-constraint:cpt-dataflow-constraint-staging-class-column-types-match:p1
 {{ config(
     materialized='view',
@@ -13,15 +15,16 @@
 SELECT
     tenant_id,
     source_id,
-    -- SCD2 grain: per (entity, valid_from). Bronze `unique_key` is at entity
-    -- level (`{tenant}-{source}-{employee_id}`); we extend it with valid_from
-    -- so silver `class_people` can dedup by a single ORDER BY column.
-    CAST(concat(coalesce(unique_key, ''), '-', toString(Last_Functionally_Updated)) AS String) AS unique_key,
+    -- Entity-level grain: bronze `unique_key` is already
+    -- `{tenant}-{source}-{employee_id}`, so silver `class_people` (versionless
+    -- RMT ORDER BY unique_key) collapses to one row per worker. Do NOT add a
+    -- version axis here — that would make every changed record a second
+    -- permanently-"current" row (see ADR-0004).
+    CAST(coalesce(unique_key, '') AS String)                  AS unique_key,
     coalesce(tenant_id, '')                                  AS workspace_id,
     -- person_id resolved in Silver Step 2 via Identity Manager
     CAST(NULL AS Nullable(UUID))                             AS person_id,
     parseDateTimeBestEffortOrNull(Last_Functionally_Updated) AS valid_from,
-    CAST(NULL AS Nullable(DateTime))                         AS valid_to,
     'workday'                                                AS source,
     Employee_ID                                              AS source_person_id,
     Employee_ID                                              AS employee_number,
@@ -35,10 +38,15 @@ SELECT
     Supervisory_Organization                                 AS department_name,
     CAST(NULL AS Nullable(UUID))                             AS org_unit_id,
     Manager_Employee_ID                                      AS manager_person_id,
+    -- Worker_Status ∈ {Active, On Leave, Terminated} is contract-normative (a
+    -- tenant emitting other vocabulary must normalise it in the RaaS report).
+    -- Anything outside it is 'unknown', never 'active' by default — defaulting
+    -- to active silently inflates headcount.
     multiIf(
+        Worker_Status = 'Active',     'active',
         Worker_Status = 'Terminated', 'terminated',
         Worker_Status = 'On Leave',   'on_leave',
-        'active'
+        'unknown'
     )                                                        AS status,
     multiIf(
         Worker_Type = 'Contingent Worker', 'contractor',
@@ -55,4 +63,9 @@ SELECT
     ) AS Map(String, String))                                AS custom_str_attrs,
     CAST(map() AS Map(String, Float64))                      AS custom_num_attrs,
     _airbyte_extracted_at                                    AS ingested_at
-FROM {{ source('workday', 'workers') }}
+-- FINAL is mandatory, not defensive: bronze is append-only (a full snapshot per
+-- sync) and RMT(_airbyte_extracted_at) only collapses on background merge. A
+-- bare read emits every unmerged snapshot row, and the downstream
+-- `LIMIT 1 BY unique_key` has no ORDER BY, so the winner is undefined.
+-- FINAL makes "latest sync wins" deterministic. See ADR-0001.
+FROM {{ source('workday', 'workers') }} FINAL

--- a/src/ingestion/connectors/hr-directory/workday/dbt/workday__working_hours.sql
+++ b/src/ingestion/connectors/hr-directory/workday/dbt/workday__working_hours.sql
@@ -21,7 +21,13 @@ SELECT
     coalesce(toFloat64OrNull(toString(Scheduled_Weekly_Hours)), 40.0)
                               AS working_hours_per_week,
     _airbyte_extracted_at     AS ingested_at
-FROM {{ source('workday', 'workers') }}
+-- FINAL is mandatory: bronze is append-only RMT(_airbyte_extracted_at) and only
+-- collapses on background merge. Without it the `Worker_Status = 'Active'` filter
+-- below is evaluated against EVERY unmerged snapshot, so a worker who has since
+-- been terminated still qualifies via a stale row — and the downstream versionless
+-- `LIMIT 1 BY unique_key` has no ORDER BY, so which snapshot's hours win is
+-- undefined. See ADR-0001.
+FROM {{ source('workday', 'workers') }} FINAL
 WHERE Worker_Status = 'Active'
   AND Employee_ID IS NOT NULL
   AND Work_Email IS NOT NULL

--- a/src/ingestion/dbt/macros/union_by_tag.sql
+++ b/src/ingestion/dbt/macros/union_by_tag.sql
@@ -18,6 +18,17 @@
     dedup_version_col: version column for "latest wins" dedup (default
       `_version`). Pass `none` for versionless RMT sources (full-refresh
       `class_people`, `class_hr_working_hours`) where any row per key is fine.
+
+  IMPORTANT — "any row per key is fine" holds only when `unique_key` is the
+  ENTITY key and the staging views emit one row per entity. The versionless
+  branch is a bare `LIMIT 1 BY unique_key` with no `ORDER BY`, so which row wins
+  is undefined (empirically it picks the STALE row at `max_threads=1`). If
+  staging can emit several rows per entity — e.g. an un-deduped read of an
+  append-only bronze table holding multiple unmerged snapshots — the staging
+  model MUST dedup its own source (`FINAL` on RMT bronze), or attributes will
+  vary between runs. Never encode the version into `unique_key` to work around
+  this: that keeps every version as a separate permanently-current row. See
+  ADR-0001 and ADR-0004.
 -#}
 {% macro union_by_tag(tag_name, dedup_version_col='_version') %}
   {%- if execute -%}

--- a/src/ingestion/dbt/tests/hr/assert_class_people_one_row_per_person.sql
+++ b/src/ingestion/dbt/tests/hr/assert_class_people_one_row_per_person.sql
@@ -1,0 +1,34 @@
+{{ config(
+    tags=['data_quality'],
+    severity='warn',
+    store_failures=true,
+    meta={
+        'title': 'One class_people row per person',
+        'domain': 'hr',
+        'category': 'grain',
+        'tier': 'error',
+        'remediation': 'class_people is a current-state snapshot: exactly one row per (workspace, source, source_person_id). More than one means a staging `__to_class_people` view reintroduced a version axis into `unique_key` (e.g. appending lastChanged), so silver RMT can no longer collapse the versions and every changed record becomes a second permanently-current row — inflating headcount. Check the `unique_key` expression in the hr-directory staging views; it must stay entity-level. See ADR-0004 and silver/_shared/class_people.sql.'
+    }
+) }}
+-- class_people is a snapshot, not an SCD2 history table: HR attribute history
+-- lives in the per-source `*_snapshot` / `*_fields_history` chain. So the grain
+-- here is one row per person per source, and any surplus row is a duplicate
+-- that inflates every row-counting consumer (headcount, join fan-out).
+--
+-- FINAL still catches the regression this guards against: if a version axis
+-- comes back into `unique_key`, the version rows have *different* keys, so FINAL
+-- cannot collapse them and they surface here. A genuine transient RMT duplicate
+-- (same key, pre-merge) is correctly collapsed and is not a violation.
+SELECT
+    workspace_id,
+    source,
+    source_person_id,
+    count()                                AS row_count,
+    uniqExact(unique_key)                  AS distinct_unique_keys,
+    groupArray(toString(valid_from))        AS valid_from_values
+FROM silver.class_people FINAL
+GROUP BY
+    workspace_id,
+    source,
+    source_person_id
+HAVING count() > 1

--- a/src/ingestion/scripts/connectors-ddl/silver.sql
+++ b/src/ingestion/scripts/connectors-ddl/silver.sql
@@ -632,7 +632,6 @@ CREATE TABLE IF NOT EXISTS silver.class_people
     `workspace_id` String,
     `person_id` Nullable(UUID),
     `valid_from` Nullable(DateTime),
-    `valid_to` Nullable(DateTime),
     `source` String,
     `source_person_id` Nullable(String),
     `employee_number` Nullable(String),

--- a/src/ingestion/silver/_shared/schema.yml
+++ b/src/ingestion/silver/_shared/schema.yml
@@ -2,8 +2,15 @@ version: 2
 
 models:
   - name: class_people
-    description: "Unified person registry from all HR sources (BambooHR, Workday)"
+    description: >
+      Unified person registry from all HR sources (BambooHR, MS Entra, Workday). Current-state snapshot: exactly one row per person per source. NOT an SCD2 history table — HR attribute history lives in the per-source `*_snapshot` / `*_fields_history` chain, which accumulates across syncs (this model is `materialized='table'` and is rebuilt in full every run, so it cannot retain history). `valid_from` records when the source last changed the record; there is no `valid_to` — see ADR-0004.
     columns:
+      - name: unique_key
+        description: >
+          Entity-level key (`{tenant}-{source}-{source_person_id}`) and the RMT ORDER BY column. MUST NOT carry a version axis: a per-version key stops silver RMT from collapsing versions, so every changed record becomes a second permanently-current row.
+        tests:
+          - not_null
+          - unique
       - name: source_person_id
         description: "Source-specific employee ID"
         tests:


### PR DESCRIPTION
Backport of #2125 (`3062d4f2` + `83db3abf`, merged to main 2026-08-03; the release branch predates it).

## Why

The release branch still has both defects #2125 fixed, and together they create duplicate current rows in `silver.class_people`:

1. `__to_class_people` staging views read append-only bronze without `FINAL`, so unmerged Airbyte snapshot rows leak through as extra rows.
2. `unique_key` embeds a per-version axis (`lastChanged` for BambooHR), turning each transient duplicate into a permanently distinct silver key that neither RMT nor `FINAL` can collapse.

On an environment running this branch, `class_people FINAL` can hold more rows than there are accounts, which overstates headcount and duplicates people downstream of the person registry.

## What

Clean cherry-pick of the two PR #2125 commits, covering all four HR connectors (bamboohr, active-directory, ms-entra, workday): entity-level `unique_key`, deterministic `FINAL` reads, the `assert_class_people_one_row_per_person` dbt test, and the matching DDL/docs updates. One conflict in the BambooHR `schema.yml` model descriptions resolved in favor of this branch's wording (it already carries the full-field-sync descriptions).

`dbt parse` clean.

## Validation

After deploy, `SELECT count() FROM silver.class_people FINAL` grouped by source should return exactly one row per account; the new dbt test enforces this in CI.