### PR TITLE
fix(dbt): snapshot appends map by column name, not position

### DIFF
--- a/src/ingestion/dbt/macros/snapshot.sql
+++ b/src/ingestion/dbt/macros/snapshot.sql
@@ -48,6 +48,27 @@ WITH source_data AS (
 
 {% if is_incremental() %}
 
+{#- The adapter's INSERT maps SELECT output to the persisted table's columns
+    POSITIONALLY. A `s.*` projection follows the source's physical column
+    order, so a source rebuilt with a different layout (e.g. an Airbyte
+    connector migration) silently lands values in unrelated columns. Project
+    explicitly in the persisted target's own order, and refuse to write when
+    the column sets have drifted apart. -#}
+{%- set target_columns = adapter.get_columns_in_relation(this) -%}
+{%- set source_names = adapter.get_columns_in_relation(source_ref) | map(attribute='name') | list -%}
+{%- set generated_names = ['_row_hash', '_tracked_at'] -%}
+{%- set target_names = target_columns | map(attribute='name') | list -%}
+{%- set missing_in_source = target_names | reject('in', source_names) | reject('in', generated_names) | list -%}
+{%- set missing_in_target = source_names | reject('in', target_names) | list -%}
+{%- if missing_in_source or missing_in_target -%}
+    {{ exceptions.raise_compiler_error(
+        'snapshot(): column drift between ' ~ source_ref ~ ' and persisted ' ~ this ~ '. ' ~
+        'Missing in source: [' ~ missing_in_source | join(', ') ~ ']. ' ~
+        'New in source: [' ~ missing_in_target | join(', ') ~ ']. ' ~
+        'Migrate or rebuild the snapshot table before appending — a blind append would corrupt it.'
+    ) }}
+{%- endif %}
+
 , latest AS (
     SELECT
         {{ unique_key_col }},
@@ -57,8 +78,15 @@ WITH source_data AS (
 )
 
 SELECT
-    s.*,
-    now() AS _tracked_at
+    {%- for col in target_columns %}
+    {% if col.name == '_tracked_at' -%}
+        now() AS _tracked_at
+    {%- elif col.name == '_row_hash' -%}
+        s._row_hash
+    {%- else -%}
+        s.{{ adapter.quote(col.name) }}
+    {%- endif %}{{ ',' if not loop.last }}
+    {%- endfor %}
 FROM source_data s
 LEFT JOIN latest l ON s.{{ unique_key_col }} = l.{{ unique_key_col }}
 WHERE l.{{ unique_key_col }} IS NULL


### PR DESCRIPTION
## Problem

The incremental `snapshot()` macro projects `s.*` into the persisted snapshot table. The adapter's INSERT maps the SELECT output to the target's columns positionally, so the projection depends on the source table's physical column order staying identical to the layout the snapshot was created from.

An Airbyte connector migration recreates the source, which can rebuild the bronze table with a different column order. The next incremental append then lands values in unrelated snapshot columns — an extraction timestamp under `status`, a city under `workEmail` — and ClickHouse coerces enough of the mismatched values for dbt to report success. Field history and identity inputs are then built from semantically invalid rows.

This affects every connector using `snapshot()` with incremental append, not one source.

## Fix

Two changes in the incremental branch of the macro:

1. The projection is generated explicitly, by name, in the persisted target's own column order — the positional INSERT and the SELECT can no longer disagree.
2. When the source and target column sets have drifted (a column missing from the source, or a new one present), the append fails at compile time with both column lists named, before anything is written.

First-run (non-incremental) behavior is unchanged: the table is created from the query, so there is no persisted layout to disagree with.

## Verification

Against a live ClickHouse, using the BambooHR snapshot model:

| scenario | before | after |
|---|---|---|
| source reordered, coercible types | values silently land in wrong columns, run reports OK | correct mapping by name |
| source reordered, incompatible types | runtime insert error | correct mapping by name |
| source column added and removed | corrupt or fail mid-write | compile error naming the drift, zero rows written |

A repeated run with an unchanged source appends zero rows, as before. `dbt parse` clean.

## Notes

- A snapshot table that already contains positionally corrupted rows is not repaired by this change; it needs a rebuild. On such an instance the new drift guard may intentionally block the next append until that rebuild happens.
- Needs a backport to `release-2026.07.1` once merged: the release carries the connector migration that triggers the reorder, so deploying it without this fix corrupts the snapshot on the first sync.

Refs #2491