### PR TITLE
fix(dbt): backport the name-based snapshot append to release-2026.07.1

### DIFF
--- a/src/ingestion/dbt/macros/snapshot.sql
+++ b/src/ingestion/dbt/macros/snapshot.sql
@@ -48,6 +48,27 @@ WITH source_data AS (
 
 {% if is_incremental() %}
 
+{#- The adapter's INSERT maps SELECT output to the persisted table's columns
+    POSITIONALLY. A `s.*` projection follows the source's physical column
+    order, so a source rebuilt with a different layout (e.g. an Airbyte
+    connector migration) silently lands values in unrelated columns. Project
+    explicitly in the persisted target's own order, and refuse to write when
+    the column sets have drifted apart. -#}
+{%- set target_columns = adapter.get_columns_in_relation(this) -%}
+{%- set source_names = adapter.get_columns_in_relation(source_ref) | map(attribute='name') | list -%}
+{%- set generated_names = ['_row_hash', '_tracked_at'] -%}
+{%- set target_names = target_columns | map(attribute='name') | list -%}
+{%- set missing_in_source = target_names | reject('in', source_names) | reject('in', generated_names) | list -%}
+{%- set missing_in_target = source_names | reject('in', target_names) | list -%}
+{%- if missing_in_source or missing_in_target -%}
+    {{ exceptions.raise_compiler_error(
+        'snapshot(): column drift between ' ~ source_ref ~ ' and persisted ' ~ this ~ '. ' ~
+        'Missing in source: [' ~ missing_in_source | join(', ') ~ ']. ' ~
+        'New in source: [' ~ missing_in_target | join(', ') ~ ']. ' ~
+        'Migrate or rebuild the snapshot table before appending — a blind append would corrupt it.'
+    ) }}
+{%- endif %}
+
 , latest AS (
     SELECT
         {{ unique_key_col }},
@@ -57,8 +78,15 @@ WITH source_data AS (
 )
 
 SELECT
-    s.*,
-    now() AS _tracked_at
+    {%- for col in target_columns %}
+    {% if col.name == '_tracked_at' -%}
+        now() AS _tracked_at
+    {%- elif col.name == '_row_hash' -%}
+        s._row_hash
+    {%- else -%}
+        s.{{ adapter.quote(col.name) }}
+    {%- endif %}{{ ',' if not loop.last }}
+    {%- endfor %}
 FROM source_data s
 LEFT JOIN latest l ON s.{{ unique_key_col }} = l.{{ unique_key_col }}
 WHERE l.{{ unique_key_col }} IS NULL


### PR DESCRIPTION
Backport of #2512 (clean cherry-pick, zero diff against the main branch version; `dbt parse` clean).

## Why the release needs it

This branch carries the BambooHR connector migration, whose reconcile recreates the Airbyte source and can rebuild bronze with a different physical column order. The incremental snapshot appends `s.*` positionally, so the first sync after such a rebuild silently lands values in unrelated snapshot columns while the run reports success. An environment running this branch has reproduced exactly that.

Deploying this release to any environment with an existing employee snapshot, without this fix, corrupts that snapshot on the first BambooHR sync.

## What it changes

Incremental snapshot appends project columns explicitly, by name, in the persisted table's own order; a source whose column set has drifted from the snapshot fails at compile time with both column lists named, before anything is written.

## Deploy notes

- An environment whose snapshot is still healthy upgrades clean: appends keep mapping correctly and no rebuild is needed.
- An environment that already ran the corrupting sync is not repaired by this change; the drift guard may intentionally block its next append until the snapshot table is rebuilt.

Refs #2512, #2491