### PR TITLE
Reach evidence from distribution cards, and make the evidence table navigable

### DIFF
--- a/src/frontend/src/components/metric-evidence-dialog.test.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog.test.tsx
@@ -405,6 +405,60 @@ describe("MetricEvidenceDialog", () => {
       act(() => onSortChange(key));
     }
 
+    it("does not call a search empty while pages are still coming", async () => {
+      const user = userEvent.setup();
+      renderDialog({ fetchNextPage: vi.fn(), hasNextPage: true });
+
+      await user.type(
+        screen.getByRole("searchbox", { name: "Search records" }),
+        "nothing"
+      );
+      expect(
+        screen.getByText("Nothing matched yet — still loading the rest")
+      ).toBeInTheDocument();
+      expect(screen.getByText("0 of 3 records so far")).toBeInTheDocument();
+      expect(
+        screen.queryByText("No records match this search")
+      ).not.toBeInTheDocument();
+    });
+
+    it("says the rest could not be loaded rather than claiming no match", async () => {
+      const user = userEvent.setup();
+      const fetchNextPage = vi.fn();
+      renderDialog({
+        fetchNextPage,
+        hasNextPage: true,
+        isFetchNextPageError: true,
+      });
+
+      await user.type(
+        screen.getByRole("searchbox", { name: "Search records" }),
+        "nothing"
+      );
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "the rest could not be loaded"
+      );
+      expect(screen.getByText("0 of 3 records so far")).toBeInTheDocument();
+
+      fetchNextPage.mockClear();
+      await user.click(screen.getByRole("button", { name: "Retry" }));
+      expect(fetchNextPage).toHaveBeenCalled();
+    });
+
+    it("calls a search empty once every page is in", async () => {
+      const user = userEvent.setup();
+      renderDialog();
+
+      await user.type(
+        screen.getByRole("searchbox", { name: "Search records" }),
+        "nothing"
+      );
+      expect(
+        screen.getByText("No records match this search")
+      ).toBeInTheDocument();
+      expect(screen.getByText("0 of 3 records")).toBeInTheDocument();
+    });
+
     it("cycles a column through ascending, descending and back", () => {
       renderDialog();
 

--- a/src/frontend/src/components/metric-evidence-dialog.test.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -331,5 +331,163 @@ describe("MetricEvidenceDialog", () => {
     await waitFor(() =>
       expect(screen.getByRole("alert")).toHaveTextContent("Export failed")
     );
+  });
+
+  describe("searching and sorting", () => {
+    const threeRows = readyQuery({
+      data: {
+        pages: [
+          {
+            columns: [
+              { key: "ref", label: "Ref", type: "string" },
+              { key: "value", label: "Value", type: "number" },
+            ],
+            rows: [
+              { values: { ref: "add-parser", value: 12 } },
+              { values: { ref: "fix-logging", value: 3 } },
+              { values: { ref: "add-cache", value: 40 } },
+            ],
+            next_cursor: null,
+          },
+        ],
+      },
+    });
+
+    function renderDialog(overrides: Record<string, unknown> = {}) {
+      mocks.query = { ...threeRows, ...overrides };
+      return render(
+        <MetricEvidenceDialog
+          state={state}
+          onMetricChange={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+    }
+
+    function tableRefs(): unknown[] {
+      const rows = mocks.tableProps?.rows as Array<{
+        values: Record<string, unknown>;
+      }>;
+      return rows.map((row) => row.values.ref);
+    }
+
+    it("counts the records it is showing", () => {
+      renderDialog();
+      expect(screen.getByText("3 records")).toBeInTheDocument();
+    });
+
+    it("narrows the rows to the search and says how many of how many", async () => {
+      const user = userEvent.setup();
+      renderDialog();
+
+      await user.type(screen.getByRole("searchbox", { name: "Search records" }), "add");
+      expect(tableRefs()).toEqual(["add-parser", "add-cache"]);
+      expect(screen.getByText("2 of 3 records")).toBeInTheDocument();
+    });
+
+    it("offers a way back when the search matches nothing", async () => {
+      const user = userEvent.setup();
+      renderDialog();
+      const box = screen.getByRole("searchbox", { name: "Search records" });
+
+      await user.type(box, "nothing here");
+      expect(screen.queryByText("evidence table")).not.toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Clear search" }));
+      expect(screen.getByText("evidence table")).toBeInTheDocument();
+      expect(box).toHaveValue("");
+    });
+
+    function sortBy(key: string): void {
+      const onSortChange = mocks.tableProps?.onSortChange as (
+        column: string
+      ) => void;
+      act(() => onSortChange(key));
+    }
+
+    it("cycles a column through ascending, descending and back", () => {
+      renderDialog();
+
+      sortBy("value");
+      expect(mocks.tableProps?.sort).toEqual({
+        key: "value",
+        direction: "asc",
+      });
+      expect(tableRefs()).toEqual(["fix-logging", "add-parser", "add-cache"]);
+
+      sortBy("value");
+      expect(mocks.tableProps?.sort).toEqual({
+        key: "value",
+        direction: "desc",
+      });
+      expect(tableRefs()).toEqual(["add-cache", "add-parser", "fix-logging"]);
+
+      sortBy("value");
+      expect(mocks.tableProps?.sort).toBeNull();
+    });
+
+    it("pulls in the remaining pages once a search is on, so it answers for all of them", async () => {
+      const user = userEvent.setup();
+      const fetchNextPage = vi.fn();
+      renderDialog({ fetchNextPage, hasNextPage: true });
+      fetchNextPage.mockClear();
+
+      await user.type(screen.getByRole("searchbox", { name: "Search records" }), "add");
+      await waitFor(() => expect(fetchNextPage).toHaveBeenCalled());
+    });
+
+    it("stops pulling pages after one fails rather than retrying forever", async () => {
+      const user = userEvent.setup();
+      const fetchNextPage = vi.fn();
+      renderDialog({
+        fetchNextPage,
+        hasNextPage: true,
+        isFetchNextPageError: true,
+      });
+      fetchNextPage.mockClear();
+
+      await user.type(screen.getByRole("searchbox", { name: "Search records" }), "add");
+      expect(fetchNextPage).not.toHaveBeenCalled();
+    });
+
+    it("drops the search and sort when the dialog moves to another metric", async () => {
+      const user = userEvent.setup();
+      const multiState: EvidenceDialogState = {
+        targets: [
+          { selection, label: "Commits" },
+          {
+            selection: { ...selection, metric_key: "wiki.pages" },
+            label: "Wiki pages",
+          },
+        ],
+        activeMetricKey: "git.commits",
+      };
+      mocks.query = threeRows;
+      const view = render(
+        <MetricEvidenceDialog
+          state={multiState}
+          onMetricChange={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+
+      await user.type(screen.getByRole("searchbox", { name: "Search records" }), "add");
+      sortBy("value");
+      expect(mocks.tableProps?.sort).not.toBeNull();
+
+      view.rerender(
+        <MetricEvidenceDialog
+          state={{ ...multiState, activeMetricKey: "wiki.pages" }}
+          onMetricChange={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+
+      expect(mocks.tableProps?.sort).toBeNull();
+      expect(
+        screen.getByRole("searchbox", { name: "Search records" })
+      ).toHaveValue("");
+      expect(tableRefs()).toHaveLength(3);
+    });
   });
 });

--- a/src/frontend/src/components/metric-evidence-dialog.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog.tsx
@@ -1,6 +1,6 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Download, FileSpreadsheet, FileText } from "lucide-react";
+import { Download, FileSpreadsheet, FileText, Search } from "lucide-react";
 
 import {
   downloadMetricDrilldown,
@@ -24,6 +24,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { formatMetricNumber } from "@/lib/format";
 import {
   Select,
   SelectContent,
@@ -32,6 +34,11 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
+import {
+  nextSort,
+  visibleEvidenceRows,
+  type EvidenceSort,
+} from "@/lib/metrics/evidence-rows";
 
 export function MetricEvidenceDialog({
   state,
@@ -70,7 +77,11 @@ export function MetricEvidenceDialog({
       failureCount < 1 &&
       (!(error instanceof AnalyticsApiError) || error.status >= 500),
   });
-  const rows = query.data?.pages.flatMap((page) => page.rows) ?? [];
+  const pages = query.data?.pages;
+  const rows = useMemo(
+    () => pages?.flatMap((page) => page.rows) ?? [],
+    [pages]
+  );
   const columns = useMemo(() => {
     const columns = query.data?.pages[0]?.columns ?? [];
     const order = new Map([
@@ -91,6 +102,44 @@ export function MetricEvidenceDialog({
   }, [query.data?.pages]);
   const { fetchNextPage, hasNextPage, isFetchingNextPage } = query;
   const pageLimitReached = (query.data?.pages.length ?? 0) >= 50 && hasNextPage;
+  const canLoadMore = hasNextPage && !pageLimitReached;
+
+  const [search, setSearch] = useState("");
+  const [sort, setSort] = useState<EvidenceSort | null>(null);
+  const activeMetricKey = selection?.metric_key ?? null;
+  const [scopedTo, setScopedTo] = useState(activeMetricKey);
+  if (scopedTo !== activeMetricKey) {
+    setScopedTo(activeMetricKey);
+    setSearch("");
+    setSort(null);
+  }
+
+  const narrowed = search.trim() !== "" || sort != null;
+  const visibleRows = useMemo(
+    () => visibleEvidenceRows({ rows, columns, search, sort }),
+    [rows, columns, search, sort]
+  );
+
+  // Searching and sorting must answer for the whole result, not for whichever
+  // pages happened to be scrolled into view, so narrowing pulls the rest in.
+  // The table's own scroll-triggered paging cannot do it: a search that hides
+  // most rows also stops the scroll that would load more.
+  useEffect(() => {
+    if (
+      narrowed &&
+      canLoadMore &&
+      !isFetchingNextPage &&
+      !query.isFetchNextPageError
+    ) {
+      void fetchNextPage();
+    }
+  }, [
+    narrowed,
+    canLoadMore,
+    isFetchingNextPage,
+    query.isFetchNextPageError,
+    fetchNextPage,
+  ]);
 
   useEffect(
     () => () => {
@@ -206,6 +255,32 @@ export function MetricEvidenceDialog({
                 {exportFailure}
               </p>
             ) : null}
+            {query.isPending || (query.isError && !query.data) ? null : (
+              <div className="flex flex-wrap items-center gap-3">
+                <div className="relative min-w-0 flex-1 sm:max-w-xs">
+                  <Search className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    type="search"
+                    value={search}
+                    onChange={(event) => setSearch(event.target.value)}
+                    placeholder="Search records"
+                    aria-label="Search records"
+                    className="h-8 ps-8"
+                  />
+                </div>
+                <p
+                  aria-live="polite"
+                  className="text-sm text-muted-foreground tabular-nums"
+                >
+                  {recordCount({
+                    visible: visibleRows.length,
+                    loaded: rows.length,
+                    filtered: search.trim() !== "",
+                    loadingMore: narrowed && isFetchingNextPage,
+                  })}
+                </p>
+              </div>
+            )}
           </DialogHeader>
           {query.isPending ? (
             <div className="flex flex-1 items-center justify-center">
@@ -224,10 +299,21 @@ export function MetricEvidenceDialog({
             <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
               No supporting data for this selection
             </div>
+          ) : visibleRows.length === 0 ? (
+            <div className="flex flex-1 flex-col items-center justify-center gap-3">
+              <p className="text-sm text-muted-foreground">
+                No records match this search
+              </p>
+              <Button variant="outline" onClick={() => setSearch("")}>
+                Clear search
+              </Button>
+            </div>
           ) : (
             <MetricEvidenceTable
-              rows={rows}
+              rows={visibleRows}
               columns={columns}
+              sort={sort}
+              onSortChange={(key) => setSort((current) => nextSort(current, key))}
               fetchNextPage={fetchNextPage}
               hasNextPage={hasNextPage && !pageLimitReached}
               isFetchingNextPage={isFetchingNextPage}
@@ -239,6 +325,28 @@ export function MetricEvidenceDialog({
       ) : null}
     </Dialog>
   );
+}
+
+/**
+ * Both counts are of what has been paged in so far, so a run still loading
+ * says as much rather than letting a partial total read as the answer.
+ */
+function recordCount({
+  visible,
+  loaded,
+  filtered,
+  loadingMore,
+}: {
+  visible: number;
+  loaded: number;
+  filtered: boolean;
+  loadingMore: boolean;
+}): string {
+  const noun = visible === 1 && !filtered ? "record" : "records";
+  const count = filtered
+    ? `${formatMetricNumber(visible, "integer")} of ${formatMetricNumber(loaded, "integer")}`
+    : formatMetricNumber(visible, "integer");
+  return `${count} ${noun}${loadingMore ? " so far" : ""}`;
 }
 
 function errorMessage(error: unknown, fallback: string): string {

--- a/src/frontend/src/components/metric-evidence-dialog.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog.tsx
@@ -276,7 +276,8 @@ export function MetricEvidenceDialog({
                     visible: visibleRows.length,
                     loaded: rows.length,
                     filtered: search.trim() !== "",
-                    loadingMore: narrowed && isFetchingNextPage,
+                    partial:
+                      narrowed && (canLoadMore || query.isFetchNextPageError),
                   })}
                 </p>
               </div>
@@ -301,12 +302,40 @@ export function MetricEvidenceDialog({
             </div>
           ) : visibleRows.length === 0 ? (
             <div className="flex flex-1 flex-col items-center justify-center gap-3">
-              <p className="text-sm text-muted-foreground">
-                No records match this search
-              </p>
-              <Button variant="outline" onClick={() => setSearch("")}>
-                Clear search
-              </Button>
+              {query.isFetchNextPageError ? (
+                // Only the pages that loaded were searched, so "no match"
+                // would be a claim about records nobody has seen.
+                <>
+                  <p role="alert" className="text-sm text-muted-foreground">
+                    Nothing matched the records loaded so far, and the rest
+                    could not be loaded
+                  </p>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      onClick={() => void fetchNextPage()}
+                    >
+                      Retry
+                    </Button>
+                    <Button variant="ghost" onClick={() => setSearch("")}>
+                      Clear search
+                    </Button>
+                  </div>
+                </>
+              ) : canLoadMore ? (
+                <p className="text-sm text-muted-foreground">
+                  Nothing matched yet — still loading the rest
+                </p>
+              ) : (
+                <>
+                  <p className="text-sm text-muted-foreground">
+                    No records match this search
+                  </p>
+                  <Button variant="outline" onClick={() => setSearch("")}>
+                    Clear search
+                  </Button>
+                </>
+              )}
             </div>
           ) : (
             <MetricEvidenceTable
@@ -328,25 +357,26 @@ export function MetricEvidenceDialog({
 }
 
 /**
- * Both counts are of what has been paged in so far, so a run still loading
- * says as much rather than letting a partial total read as the answer.
+ * Both counts are of what has been paged in, so whenever pages are still
+ * outstanding — loading, or left behind by a failure — the total says as much
+ * rather than reading as the answer.
  */
 function recordCount({
   visible,
   loaded,
   filtered,
-  loadingMore,
+  partial,
 }: {
   visible: number;
   loaded: number;
   filtered: boolean;
-  loadingMore: boolean;
+  partial: boolean;
 }): string {
   const noun = visible === 1 && !filtered ? "record" : "records";
   const count = filtered
     ? `${formatMetricNumber(visible, "integer")} of ${formatMetricNumber(loaded, "integer")}`
     : formatMetricNumber(visible, "integer");
-  return `${count} ${noun}${loadingMore ? " so far" : ""}`;
+  return `${count} ${noun}${partial ? " so far" : ""}`;
 }
 
 function errorMessage(error: unknown, fallback: string): string {

--- a/src/frontend/src/components/metric-evidence-table.test.tsx
+++ b/src/frontend/src/components/metric-evidence-table.test.tsx
@@ -40,6 +40,8 @@ function renderTable(
   const props = {
     rows,
     columns,
+    sort: null,
+    onSortChange: vi.fn(),
     fetchNextPage: vi.fn().mockResolvedValue(undefined),
     hasNextPage: false,
     isFetchingNextPage: false,
@@ -72,6 +74,23 @@ describe("MetricEvidenceTable", () => {
     expect(screen.getByText("Yes")).toBeInTheDocument();
     expect(screen.getByText("No")).toBeInTheDocument();
     expect(screen.getAllByText("—")).toHaveLength(2);
+  });
+
+  it("announces which column is sorted and which way", () => {
+    renderTable({ sort: { key: "value", direction: "desc" } });
+
+    const [ref, value] = screen.getAllByRole("columnheader");
+    expect(value).toHaveAttribute("aria-sort", "descending");
+    expect(ref).toHaveAttribute("aria-sort", "none");
+  });
+
+  it("asks for a sort when a header is clicked", async () => {
+    const user = userEvent.setup();
+    const onSortChange = vi.fn();
+    renderTable({ onSortChange });
+
+    await user.click(screen.getByRole("button", { name: "Value" }));
+    expect(onSortChange).toHaveBeenCalledWith("value");
   });
 
   it("copies references and reports clipboard failures", async () => {

--- a/src/frontend/src/components/metric-evidence-table.tsx
+++ b/src/frontend/src/components/metric-evidence-table.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { Check, Copy } from "lucide-react";
+import { ArrowDown, ArrowUp, Check, ChevronsUpDown, Copy } from "lucide-react";
 import { toast } from "sonner";
 
 import type {
@@ -17,18 +17,8 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { formatMetricNumber } from "@/lib/format";
+import { cellText, type EvidenceSort } from "@/lib/metrics/evidence-rows";
 import { cn } from "@/lib/utils";
-
-function cellText(value: unknown, type: MetricEvidenceColumn["type"]): string {
-  if (value == null) return "—";
-  if (type === "number" && typeof value === "number") {
-    return formatMetricNumber(value, "decimal");
-  }
-  if (typeof value === "boolean") return value ? "Yes" : "No";
-  if (typeof value === "object") return JSON.stringify(value);
-  return String(value);
-}
 
 function columnLayout(column: MetricEvidenceColumn) {
   if (column.key === "ref") return { basisRem: 9, grow: 0 };
@@ -77,9 +67,19 @@ function CopyValueButton({ value }: { value: string }) {
   );
 }
 
+function SortIcon({ state }: { state: "asc" | "desc" | null }) {
+  if (state === "asc") return <ArrowUp className="size-3.5 shrink-0" />;
+  if (state === "desc") return <ArrowDown className="size-3.5 shrink-0" />;
+  return (
+    <ChevronsUpDown className="size-3.5 shrink-0 text-muted-foreground opacity-0 transition-opacity group-hover/sort:opacity-100" />
+  );
+}
+
 export function MetricEvidenceTable({
   rows,
   columns,
+  sort,
+  onSortChange,
   fetchNextPage,
   hasNextPage,
   isFetchingNextPage,
@@ -88,6 +88,8 @@ export function MetricEvidenceTable({
 }: {
   rows: MetricEvidenceRow[];
   columns: MetricEvidenceColumn[];
+  sort: EvidenceSort | null;
+  onSortChange: (key: string) => void;
   fetchNextPage: () => Promise<unknown>;
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
@@ -150,21 +152,39 @@ export function MetricEvidenceTable({
           >
             {columns.map((column) => {
               const layout = columnLayout(column);
+              const state = sort?.key === column.key ? sort.direction : null;
+              const numeric = column.type === "number";
               return (
                 <TableHead
                   role="columnheader"
                   key={column.key}
+                  aria-sort={
+                    state === "asc"
+                      ? "ascending"
+                      : state === "desc"
+                        ? "descending"
+                        : "none"
+                  }
                   className={cn(
                     "flex h-10 min-w-0 items-center px-3 py-0",
-                    column.type === "number"
-                      ? "justify-end text-right"
-                      : "justify-start text-left"
+                    numeric ? "justify-end text-right" : "justify-start text-left"
                   )}
                   style={{
                     flex: `${layout.grow} 0 ${layout.basisRem}rem`,
                   }}
                 >
-                  {column.label}
+                  <button
+                    type="button"
+                    onClick={() => onSortChange(column.key)}
+                    className={cn(
+                      "group/sort flex min-w-0 items-center gap-1 rounded-sm hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
+                      numeric && "flex-row-reverse",
+                      state && "text-foreground"
+                    )}
+                  >
+                    <span className="min-w-0 truncate">{column.label}</span>
+                    <SortIcon state={state} />
+                  </button>
                 </TableHead>
               );
             })}

--- a/src/frontend/src/components/widgets/metric-views/metric-histogram.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-histogram.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
 
+import { EvidenceDialogContext } from "@/components/metric-evidence-context";
 import { MetricHistogram } from "@/components/widgets/metric-views/metric-histogram";
 import {
   normalizeMetricResults,
@@ -84,5 +86,64 @@ describe("MetricHistogram", () => {
   it("shows the empty state for an entity absent from the view", () => {
     render(<MetricHistogram metric={medianMetric(BINS)} entityId="nobody@x.com" />);
     expect(screen.getByText("No values in this period")).toBeInTheDocument();
+  });
+
+  describe("supporting data", () => {
+    function drillable(
+      metric: NormalizedMetricResult
+    ): NormalizedMetricResult {
+      return {
+        ...metric,
+        drilldown: { granularity: ["event"] },
+        selection: {
+          metric_key: "git.pr_cycle_time_h",
+          entity: { type: "person", ids: ["me@x.com"] },
+          period: { from: "2026-07-01", to: "2026-07-31" },
+          filters: [],
+        },
+      };
+    }
+
+    function renderWithEvidence(metric: NormalizedMetricResult) {
+      const openEvidence = vi.fn();
+      render(
+        <EvidenceDialogContext.Provider
+          value={{ openEvidence, openEvidenceTargets: vi.fn() }}
+        >
+          <MetricHistogram metric={metric} entityId="me@x.com" />
+        </EvidenceDialogContext.Provider>
+      );
+      return openEvidence;
+    }
+
+    it("opens the records behind the distribution", async () => {
+      const user = userEvent.setup();
+      const openEvidence = renderWithEvidence(drillable(medianMetric(BINS)));
+
+      await user.click(
+        screen.getByRole("button", { name: "More actions for PR cycle time" })
+      );
+      await user.click(
+        await screen.findByRole("menuitem", { name: "View supporting data" })
+      );
+      expect(openEvidence).toHaveBeenCalledWith(
+        expect.objectContaining({ metric_key: "git.pr_cycle_time_h" }),
+        "PR cycle time"
+      );
+    });
+
+    it("offers them on an empty period too, since the metric is still drillable", () => {
+      renderWithEvidence(drillable(medianMetric([])));
+      expect(
+        screen.getByRole("button", { name: "More actions for PR cycle time" })
+      ).toBeInTheDocument();
+    });
+
+    it("offers nothing for a metric that declares no drilldown", () => {
+      renderWithEvidence(medianMetric(BINS));
+      expect(
+        screen.queryByRole("button", { name: /More actions/ })
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/frontend/src/components/widgets/metric-views/metric-histogram.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-histogram.tsx
@@ -11,11 +11,14 @@ import {
   YAxis,
   type ChartConfig,
 } from "@/components/ui/chart";
+import { evidenceSelection } from "@/api/metric-drilldown-client";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { ChartEmpty } from "@/components/widgets/metric-views/chart-empty";
+import { MetricCardActions } from "@/components/widgets/metric-views/metric-card-actions";
 import { formatMetricNumber } from "@/lib/format";
 import { forEntity, type NormalizedMetricResult } from "@/lib/metrics/collection";
 import { STATUS_COLOR_VAR, statusVsMedian, type Status } from "@/lib/status";
+import { cn } from "@/lib/utils";
 
 export interface MetricHistogramProps {
   metric: NormalizedMetricResult;
@@ -104,11 +107,15 @@ export function MetricHistogram({ metric, entityId }: MetricHistogramProps) {
   const ownMedian = data.value;
   const peerMedian = data.peer?.median ?? null;
   const direction = directionText(metric);
+  const evidence = metric.drilldown
+    ? evidenceSelection(metric.selection, entityId)
+    : null;
+  const actions = <MetricCardActions evidence={evidence} label={metric.label} />;
 
   // Shared header so an empty tile reads as the same chart, laid out to match
   // its populated neighbours in the grid rather than collapsing to a corner.
   const header = (
-    <CardHeader className="pb-2">
+    <CardHeader className={cn("pb-2", evidence && "pr-10")}>
       <div className="flex items-start justify-between gap-2">
         <div className="flex min-w-0 flex-col">
           <span className="truncate text-sm font-semibold">{metric.label}</span>
@@ -138,7 +145,8 @@ export function MetricHistogram({ metric, entityId }: MetricHistogramProps) {
 
   if (bins.length === 0) {
     return (
-      <Card className="shrink-0">
+      <Card className="relative shrink-0">
+        {actions}
         {header}
         <CardContent>
           <ChartEmpty message="No values in this period" />
@@ -150,7 +158,8 @@ export function MetricHistogram({ metric, entityId }: MetricHistogramProps) {
   const { rows, pivotLabel } = buildRows(bins, peerMedian, metric);
 
   return (
-    <Card className="shrink-0">
+    <Card className="relative shrink-0">
+      {actions}
       {header}
       <CardContent>
         <ChartContainer config={CONFIG} className="h-48 min-h-48 w-full">

--- a/src/frontend/src/lib/metrics/evidence-rows.test.ts
+++ b/src/frontend/src/lib/metrics/evidence-rows.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+
+import type { MetricEvidenceColumn } from "@/api/metric-drilldown-client";
+import {
+  cellText,
+  nextSort,
+  visibleEvidenceRows,
+} from "@/lib/metrics/evidence-rows";
+
+const COLUMNS: MetricEvidenceColumn[] = [
+  { key: "ref", label: "Ref", type: "string" },
+  { key: "title", label: "Title", type: "string" },
+  { key: "value", label: "Value", type: "number" },
+];
+
+const ROWS = [
+  { values: { ref: "a1", title: "Add parser", value: 12 } },
+  { values: { ref: "b2", title: "Fix logging", value: 3 } },
+  { values: { ref: "c3", title: "Add cache", value: 40 } },
+];
+
+describe("cellText", () => {
+  it("renders a missing value as a dash rather than an empty cell", () => {
+    expect(cellText(null, "string")).toBe("—");
+    expect(cellText(undefined, "number")).toBe("—");
+  });
+
+  it("formats numbers and leaves strings alone", () => {
+    expect(cellText(1500, "number")).toBe("1,500");
+    expect(cellText("a1", "string")).toBe("a1");
+  });
+
+  it("spells out booleans and serialises objects", () => {
+    expect(cellText(true, "string")).toBe("Yes");
+    expect(cellText({ a: 1 }, "string")).toBe('{"a":1}');
+  });
+});
+
+describe("visibleEvidenceRows", () => {
+  it("returns every row when nothing is asked of it", () => {
+    const out = visibleEvidenceRows({
+      rows: ROWS,
+      columns: COLUMNS,
+      search: "",
+      sort: null,
+    });
+    expect(out).toHaveLength(3);
+  });
+
+  it("matches the search against any column, case-insensitively", () => {
+    const out = visibleEvidenceRows({
+      rows: ROWS,
+      columns: COLUMNS,
+      search: "ADD",
+      sort: null,
+    });
+    expect(out.map((row) => row.values.ref)).toEqual(["a1", "c3"]);
+  });
+
+  it("searches formatted text, so a number reads as it is displayed", () => {
+    const rows = [{ values: { ref: "a1", title: "t", value: 1500 } }];
+    const out = visibleEvidenceRows({
+      rows,
+      columns: COLUMNS,
+      search: "1,500",
+      sort: null,
+    });
+    expect(out).toHaveLength(1);
+  });
+
+  it("sorts numbers numerically, not as text", () => {
+    const out = visibleEvidenceRows({
+      rows: ROWS,
+      columns: COLUMNS,
+      search: "",
+      sort: { key: "value", direction: "asc" },
+    });
+    expect(out.map((row) => row.values.value)).toEqual([3, 12, 40]);
+  });
+
+  it("reverses on a descending sort", () => {
+    const out = visibleEvidenceRows({
+      rows: ROWS,
+      columns: COLUMNS,
+      search: "",
+      sort: { key: "value", direction: "desc" },
+    });
+    expect(out.map((row) => row.values.value)).toEqual([40, 12, 3]);
+  });
+
+  it("keeps rows with no value last in both directions", () => {
+    const rows = [
+      { values: { ref: "a", value: 5 } },
+      { values: { ref: "b", value: null } },
+      { values: { ref: "c", value: 1 } },
+    ];
+    for (const direction of ["asc", "desc"] as const) {
+      const out = visibleEvidenceRows({
+        rows,
+        columns: COLUMNS,
+        search: "",
+        sort: { key: "value", direction },
+      });
+      expect(out.at(-1)?.values.ref).toBe("b");
+    }
+  });
+
+  it("does not reorder the array it was given", () => {
+    const rows = [...ROWS];
+    visibleEvidenceRows({
+      rows,
+      columns: COLUMNS,
+      search: "",
+      sort: { key: "value", direction: "asc" },
+    });
+    expect(rows.map((row) => row.values.ref)).toEqual(["a1", "b2", "c3"]);
+  });
+
+  it("applies the search before the sort", () => {
+    const out = visibleEvidenceRows({
+      rows: ROWS,
+      columns: COLUMNS,
+      search: "add",
+      sort: { key: "value", direction: "desc" },
+    });
+    expect(out.map((row) => row.values.ref)).toEqual(["c3", "a1"]);
+  });
+});
+
+describe("nextSort", () => {
+  it("starts a new column ascending", () => {
+    expect(nextSort(null, "value")).toEqual({ key: "value", direction: "asc" });
+    expect(nextSort({ key: "ref", direction: "desc" }, "value")).toEqual({
+      key: "value",
+      direction: "asc",
+    });
+  });
+
+  it("cycles the same column through descending and back to unsorted", () => {
+    const ascending = nextSort(null, "value");
+    const descending = nextSort(ascending, "value");
+    expect(descending).toEqual({ key: "value", direction: "desc" });
+    expect(nextSort(descending, "value")).toBeNull();
+  });
+});

--- a/src/frontend/src/lib/metrics/evidence-rows.ts
+++ b/src/frontend/src/lib/metrics/evidence-rows.ts
@@ -1,0 +1,90 @@
+import type {
+  MetricEvidenceColumn,
+  MetricEvidenceRow,
+} from "@/api/metric-drilldown-client";
+import { formatMetricNumber } from "@/lib/format";
+
+export type EvidenceSortDirection = "asc" | "desc";
+
+export interface EvidenceSort {
+  key: string;
+  direction: EvidenceSortDirection;
+}
+
+export function cellText(
+  value: unknown,
+  type: MetricEvidenceColumn["type"]
+): string {
+  if (value == null) return "—";
+  if (type === "number" && typeof value === "number") {
+    return formatMetricNumber(value, "decimal");
+  }
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+  if (typeof value === "object") return JSON.stringify(value);
+  return String(value);
+}
+
+function matchesSearch(
+  row: MetricEvidenceRow,
+  columns: readonly MetricEvidenceColumn[],
+  needle: string
+): boolean {
+  return columns.some((column) =>
+    cellText(row.values[column.key], column.type)
+      .toLowerCase()
+      .includes(needle)
+  );
+}
+
+function compare(left: unknown, right: unknown): number {
+  if (typeof left === "number" && typeof right === "number") {
+    return left - right;
+  }
+  return String(left).localeCompare(String(right), undefined, {
+    numeric: true,
+  });
+}
+
+/**
+ * Filter and sort loaded evidence rows.
+ *
+ * Rows with no value for the sorted column sort last in both directions —
+ * a missing field is not a small one, and floating them to the top of an
+ * ascending sort would bury the smallest real values.
+ */
+export function visibleEvidenceRows({
+  rows,
+  columns,
+  search,
+  sort,
+}: {
+  rows: readonly MetricEvidenceRow[];
+  columns: readonly MetricEvidenceColumn[];
+  search: string;
+  sort: EvidenceSort | null;
+}): MetricEvidenceRow[] {
+  const needle = search.trim().toLowerCase();
+  const filtered = needle
+    ? rows.filter((row) => matchesSearch(row, columns, needle))
+    : [...rows];
+  if (!sort) return filtered;
+
+  const factor = sort.direction === "asc" ? 1 : -1;
+  return filtered.sort((left, right) => {
+    const leftValue = left.values[sort.key];
+    const rightValue = right.values[sort.key];
+    if (leftValue == null && rightValue == null) return 0;
+    if (leftValue == null) return 1;
+    if (rightValue == null) return -1;
+    return compare(leftValue, rightValue) * factor;
+  });
+}
+
+export function nextSort(
+  current: EvidenceSort | null,
+  key: string
+): EvidenceSort | null {
+  if (current?.key !== key) return { key, direction: "asc" };
+  if (current.direction === "asc") return { key, direction: "desc" };
+  return null;
+}


### PR DESCRIPTION
## What

Two changes to the supporting-data (evidence) surface.

**Distributions can be drilled.** A distribution card sat in the same grid as
the summary card and the breakdown, took the same props, and was the only one
of the three with no way into the records behind it. It now carries the same
actions menu. The menu gates itself on the metric declaring a drilldown, so
cards for metrics without one look exactly as they did.

**The evidence table can be navigated.** It was a plain paginated list:
sorting and finding a record were both impossible once a result ran past a
screenful. Now:

- column headers sort, cycling ascending -> descending -> unsorted, with
  `aria-sort` on each header
- a search box filters across every column, matching the text as displayed
- the header states how many records are in view (`12 of 340 records`)

Searching or sorting over a partly-loaded result would answer for whichever
pages had been scrolled past, which is worse than not offering it — so
narrowing pulls the remaining pages in. The table's own scroll-triggered
paging cannot do this: a search that hides most rows also stops the scroll
that would load more. While that runs the counts read "so far", and a failed
page stops the pulling rather than retrying in a loop.

## Not included

No per-column totals. Whether a column may be summed depends on the metric's
computation, which rides on metric *results* and is not available where the
dialog is opened from; a sum over a column of medians or ratios would be a
number nobody should read. Worth doing once that is threaded through.

## Verification

- `pnpm typecheck`, `eslint`, `vitest run --project unit` (1197 passing)
- Exercised in a browser against a running instance: the menu appears on
  distribution cards for drillable metrics and is absent for the rest;
  sorting, search, the record count and the no-match state all behave as
  described.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added search and match counts to metric evidence tables.
  * Added sortable evidence columns with ascending, descending, and reset states.
  * Evidence searches can automatically load additional records as needed.
  * Added clear-search messaging when no records match.
  * Added supporting-data actions to histogram metrics, including empty states.
* **Accessibility**
  * Added sort-state announcements and improved numeric-column alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->