### PR TITLE
identity: operator console for manual resolution (Manage → Identities) + backend prerequisites

### DIFF
--- a/docs/components/backend/identity-resolution/openapi.json
+++ b/docs/components/backend/identity-resolution/openapi.json
@@ -295,6 +295,48 @@
         ],
         "type": "object"
       },
+      "MeResponse": {
+        "description": "The caller as the gateway JWT identifies them, with their active roles.",
+        "properties": {
+          "insight_tenant_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "person_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "roles": {
+            "items": {
+              "$ref": "#/components/schemas/MeRoleResponse"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "person_id",
+          "insight_tenant_id",
+          "roles"
+        ],
+        "type": "object"
+      },
+      "MeRoleResponse": {
+        "description": "One active role assignment of the caller.",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "role_id": {
+            "format": "uuid",
+            "type": "string"
+          }
+        },
+        "required": [
+          "role_id",
+          "name"
+        ],
+        "type": "object"
+      },
       "MergeRequest": {
         "properties": {
           "comment": {
@@ -1230,6 +1272,99 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/v1/me": {
+      "get": {
+        "operationId": "identity_resolution.me.get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeResponse"
+                }
+              }
+            },
+            "description": "Who the gateway JWT identifies, with their active identity roles"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "The caller's identity and active roles"
+      }
+    },
     "/v1/person-roles": {
       "get": {
         "operationId": "identity_resolution.person_roles.list",

--- a/docs/components/backend/identity-resolution/openapi.json
+++ b/docs/components/backend/identity-resolution/openapi.json
@@ -415,6 +415,32 @@
         ],
         "type": "object"
       },
+      "PersonListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/PersonSummaryResponse"
+            },
+            "type": "array"
+          },
+          "next_cursor": {
+            "description": "Wire parity with the other listings: declared, always `null`.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "truncated": {
+            "description": "More persons matched than `limit` allowed — the page is a cut, not the\nanswer, and the UI should ask for narrower terms. Without this flag a\ntruncated page reads as \"the person does not exist\".",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "items",
+          "truncated"
+        ],
+        "type": "object"
+      },
       "PersonResponse": {
         "description": "A person node in the org tree (subordinate of a profile), matching the .NET\n`PersonResponse`. Unlike `ProfileResponse`, the attribute fields are plain\nstrings (empty when absent, not omitted) and the `supervisor_*`/`parent_*`\nfields serialize as `null` rather than being dropped.",
         "properties": {
@@ -1739,6 +1765,119 @@
           }
         ],
         "summary": "Revoke a role assignment (admin)"
+      }
+    },
+    "/v1/persons": {
+      "get": {
+        "operationId": "identity_resolution.persons.search",
+        "parameters": [
+          {
+            "description": "Search terms, at most 8; every whitespace-separated term must match one of the person's current observed values (case-insensitive substring)",
+            "in": "query",
+            "name": "q",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Cap on returned persons (1..=100, default 20)",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PersonListResponse"
+                }
+              }
+            },
+            "description": "Matching persons, named-first"
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Problem"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "summary": "Search persons by their current observed values (admin)"
       }
     },
     "/v1/persons-seed": {

--- a/docs/components/backend/identity-resolution/openapi.json
+++ b/docs/components/backend/identity-resolution/openapi.json
@@ -82,6 +82,10 @@
             },
             "type": "array"
           },
+          "items_truncated": {
+            "description": "`limit` cut the item list — more accounts await a decision than are\nlisted here. Distinct from `truncated`: the rates stay whole-tenant,\nonly this page is short.",
+            "type": "boolean"
+          },
           "rates": {
             "$ref": "#/components/schemas/ResolutionRatesResponse"
           },
@@ -93,7 +97,8 @@
         "required": [
           "items",
           "rates",
-          "truncated"
+          "truncated",
+          "items_truncated"
         ],
         "type": "object"
       },
@@ -2557,7 +2562,7 @@
         "operationId": "identity_resolution.resolution.attention",
         "parameters": [
           {
-            "description": "Cap on returned items (1..=1000, default 100). The rates always cover every observed account, whatever the cap.",
+            "description": "Cap on returned items (1..=1000, default 100); `items_truncated` says whether it cut the list. The rates cover every observed account whatever the cap — unless `truncated` is set, which means the evidence read itself hit its safety ceiling and both the rates and the queue describe only the accounts read before it.",
             "in": "query",
             "name": "limit",
             "required": false,

--- a/docs/components/backend/identity-resolution/openapi.json
+++ b/docs/components/backend/identity-resolution/openapi.json
@@ -573,6 +573,43 @@
         ],
         "type": "object"
       },
+      "PersonSummaryResponse": {
+        "description": "A person as operator surfaces display them: enough to recognise and pick,\nnothing more. Every field but the id may be null — a person the journal\nknows only through bindings still appears, as the id alone.",
+        "properties": {
+          "display_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "email": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "job_title": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "person_id": {
+            "format": "uuid",
+            "type": "string"
+          },
+          "status": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "person_id"
+        ],
+        "type": "object"
+      },
       "PersonsSeedListResponse": {
         "description": "List response wrapper (typed for OpenAPI).",
         "properties": {
@@ -922,10 +959,9 @@
             "type": "string"
           },
           "candidates": {
-            "description": "Persons this account could belong to, if any are known.",
+            "description": "Persons this account could belong to, if any are known — hydrated into\ncards so the operator UI never has to resolve bare ids itself.",
             "items": {
-              "format": "uuid",
-              "type": "string"
+              "$ref": "#/components/schemas/PersonSummaryResponse"
             },
             "type": "array"
           },

--- a/docs/components/backend/identity-resolution/openapi.json
+++ b/docs/components/backend/identity-resolution/openapi.json
@@ -629,6 +629,13 @@
               "string",
               "null"
             ]
+          },
+          "username": {
+            "description": "Source-native handle (e.g. a git login) — often the only recognisable\nfield of an identity no HR system has observed yet.",
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [
@@ -1772,7 +1779,7 @@
         "operationId": "identity_resolution.persons.search",
         "parameters": [
           {
-            "description": "Search terms, at most 8; every whitespace-separated term must match one of the person's current observed values (case-insensitive substring)",
+            "description": "Search terms, at most 8 (200 characters total); every whitespace-separated term must match one of the person's current identity values — email, username, display/first/last name or employee id (case-insensitive substring). Titles and statuses are displayed on the card but not searched.",
             "in": "query",
             "name": "q",
             "required": true,

--- a/docs/components/backend/identity-resolution/openapi.json
+++ b/docs/components/backend/identity-resolution/openapi.json
@@ -84,11 +84,16 @@
           },
           "rates": {
             "$ref": "#/components/schemas/ResolutionRatesResponse"
+          },
+          "truncated": {
+            "description": "The evidence read hit its safety cap: the queue and the rates describe\nonly the first accounts of the tenant, not all of them. Consumers must\nnot present these numbers as tenant-wide.",
+            "type": "boolean"
           }
         },
         "required": [
           "items",
-          "rates"
+          "rates",
+          "truncated"
         ],
         "type": "object"
       },

--- a/src/backend/services/identity-resolution/src/api/error.rs
+++ b/src/backend/services/identity-resolution/src/api/error.rs
@@ -35,3 +35,7 @@ pub struct SubchartError;
 /// Operator identity corrections (bind / merge / detach / exclude).
 #[resource_error("gts.cf.insight.identity_resolution.correction.v1~")]
 pub struct CorrectionError;
+
+/// Person search (`GET /v1/persons`) — the operator picker.
+#[resource_error("gts.cf.insight.identity_resolution.person_search.v1~")]
+pub struct PersonSearchError;

--- a/src/backend/services/identity-resolution/src/api/http_live_tests.rs
+++ b/src/backend/services/identity-resolution/src/api/http_live_tests.rs
@@ -29,6 +29,7 @@ use toolkit_security::SecurityContext;
 use super::AppState;
 use crate::config::GearConfig;
 use crate::infra::db::test_fixture::{Fixture, fixture_or_skip};
+use crate::infra::db::{person_roles_repo, roles_repo};
 
 type TestResult = anyhow::Result<()>;
 
@@ -89,6 +90,15 @@ fn json_req(uri: &str, body: &Value) -> anyhow::Result<Request<Body>> {
 
 async fn post(app: Router, uri: &str, body: &Value) -> anyhow::Result<(StatusCode, Value)> {
     let resp = app.oneshot(json_req(uri, body)?).await?;
+    let status = resp.status();
+    let bytes = to_bytes(resp.into_body(), usize::MAX).await?;
+    let payload = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+    Ok((status, payload))
+}
+
+async fn get(app: Router, uri: &str) -> anyhow::Result<(StatusCode, Value)> {
+    let req = Request::builder().method("GET").uri(uri).body(Body::empty())?;
+    let resp = app.oneshot(req).await?;
     let status = resp.status();
     let bytes = to_bytes(resp.into_body(), usize::MAX).await?;
     let payload = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
@@ -395,5 +405,113 @@ async fn an_unknown_value_type_is_a_client_error() -> TestResult {
     .await?;
 
     assert_eq!(status, StatusCode::BAD_REQUEST);
+    Ok(())
+}
+
+// ── GET /v1/me ──────────────────────────────────────────────
+
+async fn grant_admin(f: &Fixture, person: Uuid) -> anyhow::Result<Uuid> {
+    let grant = Uuid::now_v7();
+    person_roles_repo::insert(
+        &f.db,
+        grant,
+        f.tenant,
+        person,
+        roles_repo::ADMIN_ROLE_ID,
+        None,
+        person,
+        Some("http-live fixture"),
+    )
+    .await?;
+    Ok(grant)
+}
+
+fn role_names(payload: &Value) -> Vec<String> {
+    payload["roles"]
+        .as_array()
+        .map(|roles| {
+            roles
+                .iter()
+                .filter_map(|r| r["name"].as_str().map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[tokio::test]
+async fn me_names_the_caller_and_their_active_admin_role() -> TestResult {
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let caller = f.person("me-admin@http-live.test").await?;
+    grant_admin(&f, caller).await?;
+
+    let (status, body) = get(app(&f, caller), "/v1/me").await?;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["person_id"], caller.to_string());
+    assert_eq!(body["insight_tenant_id"], f.tenant.to_string());
+    assert_eq!(role_names(&body), vec!["admin".to_owned()]);
+    assert_eq!(
+        body["roles"][0]["role_id"],
+        roles_repo::ADMIN_ROLE_ID.to_string()
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn me_with_no_grants_is_an_empty_list_not_an_error() -> TestResult {
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let caller = f.person("me-plain@http-live.test").await?;
+
+    let (status, body) = get(app(&f, caller), "/v1/me").await?;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(role_names(&body), Vec::<String>::new());
+    Ok(())
+}
+
+#[tokio::test]
+async fn me_omits_a_revoked_grant() -> TestResult {
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let caller = f.person("me-revoked@http-live.test").await?;
+    let grant = grant_admin(&f, caller).await?;
+    person_roles_repo::soft_delete(&f.db, f.tenant, grant, None).await?;
+
+    let (status, body) = get(app(&f, caller), "/v1/me").await?;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(role_names(&body), Vec::<String>::new());
+    Ok(())
+}
+
+#[tokio::test]
+async fn me_omits_a_grant_from_another_tenant() -> TestResult {
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let caller = f.person("me-crosstenant@http-live.test").await?;
+    grant_admin(&f.in_another_tenant(), caller).await?;
+
+    let (status, body) = get(app(&f, caller), "/v1/me").await?;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(role_names(&body), Vec::<String>::new());
+    Ok(())
+}
+
+#[tokio::test]
+async fn me_without_a_caller_is_unauthenticated() -> TestResult {
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+
+    let (status, _) = get(app(&f, Uuid::nil()), "/v1/me").await?;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
     Ok(())
 }

--- a/src/backend/services/identity-resolution/src/api/http_live_tests.rs
+++ b/src/backend/services/identity-resolution/src/api/http_live_tests.rs
@@ -97,7 +97,10 @@ async fn post(app: Router, uri: &str, body: &Value) -> anyhow::Result<(StatusCod
 }
 
 async fn get(app: Router, uri: &str) -> anyhow::Result<(StatusCode, Value)> {
-    let req = Request::builder().method("GET").uri(uri).body(Body::empty())?;
+    let req = Request::builder()
+        .method("GET")
+        .uri(uri)
+        .body(Body::empty())?;
     let resp = app.oneshot(req).await?;
     let status = resp.status();
     let bytes = to_bytes(resp.into_body(), usize::MAX).await?;

--- a/src/backend/services/identity-resolution/src/api/http_live_tests.rs
+++ b/src/backend/services/identity-resolution/src/api/http_live_tests.rs
@@ -518,3 +518,214 @@ async fn me_without_a_caller_is_unauthenticated() -> TestResult {
     assert_eq!(status, StatusCode::UNAUTHORIZED);
     Ok(())
 }
+
+// ── GET /v1/persons ─────────────────────────────────────────
+
+fn found_ids(payload: &Value) -> Vec<String> {
+    payload["items"]
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|i| i["person_id"].as_str().map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+async fn admin_operator(f: &Fixture) -> anyhow::Result<Uuid> {
+    let operator = f.person("operator@http-live.test").await?;
+    grant_admin(f, operator).await?;
+    Ok(operator)
+}
+
+#[tokio::test]
+async fn persons_search_requires_the_admin_row() -> TestResult {
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let plain = f.person("plain-searcher@http-live.test").await?;
+
+    let (status, _) = get(app(&f, plain), "/v1/persons?q=anything").await?;
+
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    Ok(())
+}
+
+#[tokio::test]
+async fn persons_search_without_terms_is_a_client_error() -> TestResult {
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let operator = admin_operator(&f).await?;
+
+    for uri in ["/v1/persons", "/v1/persons?q=%20%20"] {
+        let (status, _) = get(app(&f, operator), uri).await?;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "should reject: {uri}");
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_person_is_found_by_a_current_email_fragment() -> TestResult {
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let operator = admin_operator(&f).await?;
+    let marker = Uuid::now_v7().simple().to_string();
+    let person = f.person(&format!("find-{marker}@http-live.test")).await?;
+
+    let (status, body) = get(app(&f, operator), &format!("/v1/persons?q=find-{marker}")).await?;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(found_ids(&body), vec![person.to_string()]);
+    assert_eq!(
+        body["items"][0]["email"],
+        format!("find-{marker}@http-live.test")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_superseded_email_no_longer_finds_its_old_owner() -> TestResult {
+    // The moved-mailbox case: the old owner observed a NEWER email from the
+    // same source, so the old address is theirs no more — only the person the
+    // address currently belongs to comes back.
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let operator = admin_operator(&f).await?;
+    let marker = Uuid::now_v7().simple().to_string();
+    let moved = format!("moved-{marker}@http-live.test");
+
+    let old_owner = f.person(&moved).await?;
+    f.observed(
+        old_owner,
+        "email",
+        &format!("fresh-{marker}@http-live.test"),
+    )
+    .await?;
+    let new_owner = f.person(&moved).await?;
+
+    let (status, body) = get(app(&f, operator), &format!("/v1/persons?q=moved-{marker}")).await?;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        found_ids(&body),
+        vec![new_owner.to_string()],
+        "the old owner's claim is superseded by their own fresher email"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_still_current_email_two_persons_claim_returns_both() -> TestResult {
+    // The handed-over mailbox with no fresher data for the old owner: the
+    // journal honestly says two persons currently claim it, and the operator
+    // is the one who gets to disambiguate.
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let operator = admin_operator(&f).await?;
+    let marker = Uuid::now_v7().simple().to_string();
+    let shared = format!("shared-{marker}@http-live.test");
+
+    let first = f.person(&shared).await?;
+    let second = f.person(&shared).await?;
+
+    let (status, body) = get(app(&f, operator), &format!("/v1/persons?q=shared-{marker}")).await?;
+
+    assert_eq!(status, StatusCode::OK);
+    let mut ids = found_ids(&body);
+    ids.sort();
+    let mut expected = vec![first.to_string(), second.to_string()];
+    expected.sort();
+    assert_eq!(ids, expected);
+    Ok(())
+}
+
+#[tokio::test]
+async fn every_term_must_match_though_not_the_same_value() -> TestResult {
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let operator = admin_operator(&f).await?;
+    let marker = Uuid::now_v7().simple().to_string();
+    let person = f.person(&format!("multi-{marker}@http-live.test")).await?;
+    f.observed(person, "display_name", &format!("Terman Findable {marker}"))
+        .await?;
+
+    let by_both = format!("/v1/persons?q=multi-{marker}%20findable");
+    let (status, body) = get(app(&f, operator), &by_both).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(found_ids(&body), vec![person.to_string()]);
+    assert_eq!(
+        body["items"][0]["display_name"],
+        format!("Terman Findable {marker}")
+    );
+
+    let with_a_miss = format!("/v1/persons?q=multi-{marker}%20nosuchterm");
+    let (status, body) = get(app(&f, operator), &with_a_miss).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(found_ids(&body), Vec::<String>::new());
+    Ok(())
+}
+
+#[tokio::test]
+async fn named_persons_sort_before_email_only_ones() -> TestResult {
+    // The named-first display contract: a person with a display_name lists
+    // before one the journal only knows by email, whatever their ids or
+    // email spellings say.
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let operator = admin_operator(&f).await?;
+    let marker = Uuid::now_v7().simple().to_string();
+
+    let email_only = f
+        .person(&format!("aaa-order-{marker}@http-live.test"))
+        .await?;
+    let named = f
+        .person(&format!("zzz-order-{marker}@http-live.test"))
+        .await?;
+    f.observed(named, "display_name", &format!("Orderly Named {marker}"))
+        .await?;
+
+    let (status, body) = get(app(&f, operator), &format!("/v1/persons?q=order-{marker}")).await?;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        found_ids(&body),
+        vec![named.to_string(), email_only.to_string()],
+        "named first, even though the email-only person's email sorts earlier"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_cut_page_says_so_instead_of_posing_as_the_answer() -> TestResult {
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let operator = admin_operator(&f).await?;
+    let marker = Uuid::now_v7().simple().to_string();
+    for i in 0..3 {
+        f.person(&format!("cut-{marker}-{i}@http-live.test"))
+            .await?;
+    }
+
+    let (status, body) = get(
+        app(&f, operator),
+        &format!("/v1/persons?q=cut-{marker}&limit=2"),
+    )
+    .await?;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(found_ids(&body).len(), 2, "the page honours the limit");
+    assert_eq!(body["truncated"], true, "the cut is announced");
+
+    let (_, full) = get(app(&f, operator), &format!("/v1/persons?q=cut-{marker}")).await?;
+    assert_eq!(found_ids(&full).len(), 3);
+    assert_eq!(full["truncated"], false);
+    Ok(())
+}

--- a/src/backend/services/identity-resolution/src/api/http_live_tests.rs
+++ b/src/backend/services/identity-resolution/src/api/http_live_tests.rs
@@ -429,16 +429,16 @@ async fn grant_admin(f: &Fixture, person: Uuid) -> anyhow::Result<Uuid> {
     Ok(grant)
 }
 
-fn role_names(payload: &Value) -> Vec<String> {
-    payload["roles"]
+fn role_names(payload: &Value) -> anyhow::Result<Vec<String>> {
+    // Fails on a missing/renamed field instead of defaulting to empty, so an
+    // "expects no roles" assertion cannot pass vacuously on shape drift.
+    let roles = payload["roles"]
         .as_array()
-        .map(|roles| {
-            roles
-                .iter()
-                .filter_map(|r| r["name"].as_str().map(str::to_owned))
-                .collect()
-        })
-        .unwrap_or_default()
+        .ok_or_else(|| anyhow::anyhow!("no `roles` array in {payload}"))?;
+    Ok(roles
+        .iter()
+        .filter_map(|r| r["name"].as_str().map(str::to_owned))
+        .collect())
 }
 
 #[tokio::test]
@@ -454,7 +454,7 @@ async fn me_names_the_caller_and_their_active_admin_role() -> TestResult {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["person_id"], caller.to_string());
     assert_eq!(body["insight_tenant_id"], f.tenant.to_string());
-    assert_eq!(role_names(&body), vec!["admin".to_owned()]);
+    assert_eq!(role_names(&body)?, vec!["admin".to_owned()]);
     assert_eq!(
         body["roles"][0]["role_id"],
         roles_repo::ADMIN_ROLE_ID.to_string()
@@ -472,7 +472,7 @@ async fn me_with_no_grants_is_an_empty_list_not_an_error() -> TestResult {
     let (status, body) = get(app(&f, caller), "/v1/me").await?;
 
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(role_names(&body), Vec::<String>::new());
+    assert_eq!(role_names(&body)?, Vec::<String>::new());
     Ok(())
 }
 
@@ -488,7 +488,7 @@ async fn me_omits_a_revoked_grant() -> TestResult {
     let (status, body) = get(app(&f, caller), "/v1/me").await?;
 
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(role_names(&body), Vec::<String>::new());
+    assert_eq!(role_names(&body)?, Vec::<String>::new());
     Ok(())
 }
 
@@ -503,7 +503,7 @@ async fn me_omits_a_grant_from_another_tenant() -> TestResult {
     let (status, body) = get(app(&f, caller), "/v1/me").await?;
 
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(role_names(&body), Vec::<String>::new());
+    assert_eq!(role_names(&body)?, Vec::<String>::new());
     Ok(())
 }
 
@@ -521,16 +521,15 @@ async fn me_without_a_caller_is_unauthenticated() -> TestResult {
 
 // ── GET /v1/persons ─────────────────────────────────────────
 
-fn found_ids(payload: &Value) -> Vec<String> {
-    payload["items"]
+fn found_ids(payload: &Value) -> anyhow::Result<Vec<String>> {
+    // Same shape-drift guard as `role_names`.
+    let items = payload["items"]
         .as_array()
-        .map(|items| {
-            items
-                .iter()
-                .filter_map(|i| i["person_id"].as_str().map(str::to_owned))
-                .collect()
-        })
-        .unwrap_or_default()
+        .ok_or_else(|| anyhow::anyhow!("no `items` array in {payload}"))?;
+    Ok(items
+        .iter()
+        .filter_map(|i| i["person_id"].as_str().map(str::to_owned))
+        .collect())
 }
 
 async fn admin_operator(f: &Fixture) -> anyhow::Result<Uuid> {
@@ -578,7 +577,7 @@ async fn a_person_is_found_by_a_current_email_fragment() -> TestResult {
     let (status, body) = get(app(&f, operator), &format!("/v1/persons?q=find-{marker}")).await?;
 
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(found_ids(&body), vec![person.to_string()]);
+    assert_eq!(found_ids(&body)?, vec![person.to_string()]);
     assert_eq!(
         body["items"][0]["email"],
         format!("find-{marker}@http-live.test")
@@ -611,7 +610,7 @@ async fn a_superseded_email_no_longer_finds_its_old_owner() -> TestResult {
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(
-        found_ids(&body),
+        found_ids(&body)?,
         vec![new_owner.to_string()],
         "the old owner's claim is superseded by their own fresher email"
     );
@@ -636,7 +635,7 @@ async fn a_still_current_email_two_persons_claim_returns_both() -> TestResult {
     let (status, body) = get(app(&f, operator), &format!("/v1/persons?q=shared-{marker}")).await?;
 
     assert_eq!(status, StatusCode::OK);
-    let mut ids = found_ids(&body);
+    let mut ids = found_ids(&body)?;
     ids.sort();
     let mut expected = vec![first.to_string(), second.to_string()];
     expected.sort();
@@ -658,7 +657,7 @@ async fn every_term_must_match_though_not_the_same_value() -> TestResult {
     let by_both = format!("/v1/persons?q=multi-{marker}%20findable");
     let (status, body) = get(app(&f, operator), &by_both).await?;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(found_ids(&body), vec![person.to_string()]);
+    assert_eq!(found_ids(&body)?, vec![person.to_string()]);
     assert_eq!(
         body["items"][0]["display_name"],
         format!("Terman Findable {marker}")
@@ -667,7 +666,7 @@ async fn every_term_must_match_though_not_the_same_value() -> TestResult {
     let with_a_miss = format!("/v1/persons?q=multi-{marker}%20nosuchterm");
     let (status, body) = get(app(&f, operator), &with_a_miss).await?;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(found_ids(&body), Vec::<String>::new());
+    assert_eq!(found_ids(&body)?, Vec::<String>::new());
     Ok(())
 }
 
@@ -695,7 +694,7 @@ async fn named_persons_sort_before_email_only_ones() -> TestResult {
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(
-        found_ids(&body),
+        found_ids(&body)?,
         vec![named.to_string(), email_only.to_string()],
         "named first, even though the email-only person's email sorts earlier"
     );
@@ -721,11 +720,11 @@ async fn a_cut_page_says_so_instead_of_posing_as_the_answer() -> TestResult {
     .await?;
 
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(found_ids(&body).len(), 2, "the page honours the limit");
+    assert_eq!(found_ids(&body)?.len(), 2, "the page honours the limit");
     assert_eq!(body["truncated"], true, "the cut is announced");
 
     let (_, full) = get(app(&f, operator), &format!("/v1/persons?q=cut-{marker}")).await?;
-    assert_eq!(found_ids(&full).len(), 3);
+    assert_eq!(found_ids(&full)?.len(), 3);
     assert_eq!(full["truncated"], false);
     Ok(())
 }

--- a/src/backend/services/identity-resolution/src/api/listing.rs
+++ b/src/backend/services/identity-resolution/src/api/listing.rs
@@ -1,0 +1,25 @@
+//! Shared `?limit=` handling for the list endpoints.
+
+/// Clamp `?limit=` to `[1, max]`; negatives → 1, absent → `default` (parity
+/// with the .NET `int?` clamp — a nonsense value never 400s the request).
+pub(crate) fn clamp_limit(limit: Option<i64>, default: u64, max: u64) -> u64 {
+    limit.map_or(default, |l| u64::try_from(l).unwrap_or(1).clamp(1, max))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn absent_negative_and_oversized_limits_all_land_in_range() {
+        for (limit, expected) in [
+            (None, 50),
+            (Some(-3), 1),
+            (Some(0), 1),
+            (Some(7), 7),
+            (Some(9_000), 500),
+        ] {
+            assert_eq!(clamp_limit(limit, 50, 500), expected, "limit: {limit:?}");
+        }
+    }
+}

--- a/src/backend/services/identity-resolution/src/api/me.rs
+++ b/src/backend/services/identity-resolution/src/api/me.rs
@@ -1,0 +1,71 @@
+//! Caller self-description — `GET /v1/me`.
+//!
+//! Answers "who does the gateway say I am, and which identity roles do I
+//! hold right now?" from the same `person_roles` rows the admin gate reads.
+//! Deliberately NOT admin-gated: an empty `roles` list IS the "not an admin"
+//! answer, so the SPA can gate its admin surfaces without probing for a 403.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::Extension;
+use axum::response::IntoResponse;
+use serde::Serialize;
+use toolkit_canonical_errors::CanonicalError;
+use toolkit_security::SecurityContext;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use super::AppState;
+use super::gate::require_caller;
+use crate::infra::db::roles_repo::{self, Role};
+
+/// One active role assignment of the caller.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct MeRoleResponse {
+    pub role_id: Uuid,
+    pub name: String,
+}
+
+impl From<Role> for MeRoleResponse {
+    fn from(r: Role) -> Self {
+        Self {
+            role_id: r.role_id,
+            name: r.name,
+        }
+    }
+}
+
+/// The caller as the gateway JWT identifies them, with their active roles.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct MeResponse {
+    pub person_id: Uuid,
+    pub insight_tenant_id: Uuid,
+    pub roles: Vec<MeRoleResponse>,
+}
+impl toolkit::api::api_dto::ResponseApiDto for MeResponse {}
+
+/// `GET /v1/me` — the caller's identity and active roles (any signed-in user).
+pub async fn get_me(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(ctx): Extension<SecurityContext>,
+) -> Result<impl IntoResponse, CanonicalError> {
+    let caller = require_caller(&ctx)?;
+    let tenant = ctx.subject_tenant_id();
+
+    let roles = roles_repo::active_roles_of_person(&state.db, tenant, caller)
+        .await
+        .map_err(read_err)?;
+
+    Ok(Json(MeResponse {
+        person_id: caller,
+        insight_tenant_id: tenant,
+        roles: roles.into_iter().map(MeRoleResponse::from).collect(),
+    }))
+}
+
+#[expect(clippy::needless_pass_by_value, reason = "used directly as map_err")]
+fn read_err(e: anyhow::Error) -> CanonicalError {
+    tracing::error!(error = %e, "caller roles query failed");
+    CanonicalError::internal("failed to read caller roles").create()
+}

--- a/src/backend/services/identity-resolution/src/api/mod.rs
+++ b/src/backend/services/identity-resolution/src/api/mod.rs
@@ -7,8 +7,10 @@ mod gate;
 mod handlers;
 #[cfg(test)]
 mod http_live_tests;
+mod listing;
 pub mod me;
 pub mod person_roles;
+pub mod persons;
 pub mod resolution;
 pub mod roles;
 pub mod seed;
@@ -140,6 +142,33 @@ fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) -> Router {
         )
         .standard_errors(openapi)
         .handler(me::get_me)
+        .register(router, openapi);
+
+    let router = OperationBuilder::get("/v1/persons")
+        .operation_id("identity_resolution.persons.search")
+        .summary("Search persons by their current observed values (admin)")
+        .authenticated()
+        .query_param(
+            "q",
+            true,
+            "Search terms, at most 8; every whitespace-separated term must match \
+             one of the person's current observed values (case-insensitive \
+             substring)",
+        )
+        .query_param_typed(
+            "limit",
+            false,
+            "Cap on returned persons (1..=100, default 20)",
+            "integer",
+        )
+        .no_license_required()
+        .json_response_with_schema::<persons::PersonListResponse>(
+            openapi,
+            StatusCode::OK,
+            "Matching persons, named-first",
+        )
+        .standard_errors(openapi)
+        .handler(persons::search_persons)
         .register(router, openapi);
 
     // Operator identity corrections (ADR-0003): each verb appends binding

--- a/src/backend/services/identity-resolution/src/api/mod.rs
+++ b/src/backend/services/identity-resolution/src/api/mod.rs
@@ -244,8 +244,11 @@ fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) -> Router {
         .query_param_typed(
             "limit",
             false,
-            "Cap on returned items (1..=1000, default 100). The rates always \
-             cover every observed account, whatever the cap.",
+            "Cap on returned items (1..=1000, default 100); `items_truncated` \
+             says whether it cut the list. The rates cover every observed \
+             account whatever the cap — unless `truncated` is set, which means \
+             the evidence read itself hit its safety ceiling and both the \
+             rates and the queue describe only the accounts read before it.",
             "integer",
         )
         .json_response_with_schema::<resolution::AttentionResponse>(

--- a/src/backend/services/identity-resolution/src/api/mod.rs
+++ b/src/backend/services/identity-resolution/src/api/mod.rs
@@ -151,9 +151,11 @@ fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) -> Router {
         .query_param(
             "q",
             true,
-            "Search terms, at most 8; every whitespace-separated term must match \
-             one of the person's current observed values (case-insensitive \
-             substring)",
+            "Search terms, at most 8 (200 characters total); every \
+             whitespace-separated term must match one of the person's current \
+             identity values — email, username, display/first/last name or \
+             employee id (case-insensitive substring). Titles and statuses are \
+             displayed on the card but not searched.",
         )
         .query_param_typed(
             "limit",

--- a/src/backend/services/identity-resolution/src/api/mod.rs
+++ b/src/backend/services/identity-resolution/src/api/mod.rs
@@ -7,6 +7,7 @@ mod gate;
 mod handlers;
 #[cfg(test)]
 mod http_live_tests;
+pub mod me;
 pub mod person_roles;
 pub mod resolution;
 pub mod roles;
@@ -125,6 +126,20 @@ fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) -> Router {
         )
         .standard_errors(openapi)
         .handler(handlers::resolve_profile)
+        .register(router, openapi);
+
+    let router = OperationBuilder::get("/v1/me")
+        .operation_id("identity_resolution.me.get")
+        .summary("The caller's identity and active roles")
+        .authenticated()
+        .no_license_required()
+        .json_response_with_schema::<me::MeResponse>(
+            openapi,
+            StatusCode::OK,
+            "Who the gateway JWT identifies, with their active identity roles",
+        )
+        .standard_errors(openapi)
+        .handler(me::get_me)
         .register(router, openapi);
 
     // Operator identity corrections (ADR-0003): each verb appends binding

--- a/src/backend/services/identity-resolution/src/api/person_roles.rs
+++ b/src/backend/services/identity-resolution/src/api/person_roles.rs
@@ -296,12 +296,8 @@ fn reason_too_long() -> CanonicalError {
     )
 }
 
-/// Clamp `?limit=` to `[1, 500]`; negatives → 1, absent → 50 (parity with the
-/// .NET `int?` clamp — a nonsense value never 400s the request).
 fn clamp_limit(limit: Option<i64>) -> u64 {
-    limit.map_or(LIST_DEFAULT_LIMIT, |l| {
-        u64::try_from(l).unwrap_or(1).clamp(1, LIST_MAX_LIMIT)
-    })
+    super::listing::clamp_limit(limit, LIST_DEFAULT_LIMIT, LIST_MAX_LIMIT)
 }
 
 #[cfg(test)]

--- a/src/backend/services/identity-resolution/src/api/persons.rs
+++ b/src/backend/services/identity-resolution/src/api/persons.rs
@@ -22,16 +22,19 @@ use toolkit_security::SecurityContext;
 use utoipa::ToSchema;
 
 use super::AppState;
-use super::error::CorrectionError;
+use super::error::PersonSearchError;
 use super::gate::require_admin;
 use super::resolution::PersonSummaryResponse;
-use crate::domain::person_card::PersonCard;
+use crate::domain::person_card;
 use crate::infra::db::persons_repo;
 
 const DEFAULT_LIMIT: u64 = 20;
 const MAX_LIMIT: u64 = 100;
 /// A picker query is a human typing, not a batch filter.
 const MAX_TERMS: usize = 8;
+/// Generous for anything a human pastes into a picker, and a hard ceiling on
+/// what each LIKE probe of the journal scan has to compare against.
+const MAX_QUERY_CHARS: usize = 200;
 
 #[derive(Debug, Deserialize)]
 pub struct SearchParams {
@@ -78,14 +81,8 @@ pub async fn search_persons(
     let cards = persons_repo::person_cards(&state.db, tenant, &ids)
         .await
         .map_err(|e| read_err(&e))?;
-    let mut items: Vec<PersonSummaryResponse> = ids
-        .iter()
-        .map(|id| {
-            cards
-                .get(id)
-                .cloned()
-                .unwrap_or_else(|| PersonCard::empty(*id))
-        })
+    let mut items: Vec<PersonSummaryResponse> = person_card::in_requested_order(&ids, &cards)
+        .into_iter()
         .map(PersonSummaryResponse::from)
         .collect();
     sort_for_display(&mut items);
@@ -97,13 +94,18 @@ pub async fn search_persons(
     }))
 }
 
-/// Split `q` into terms: non-empty, whitespace-separated, capped.
+/// Split `q` into terms: non-empty, whitespace-separated, capped in count and
+/// total length.
 fn search_terms(q: Option<&str>) -> Result<Vec<String>, CanonicalError> {
-    let terms: Vec<String> = q
-        .unwrap_or_default()
-        .split_whitespace()
-        .map(str::to_owned)
-        .collect();
+    let q = q.unwrap_or_default();
+    if q.chars().count() > MAX_QUERY_CHARS {
+        return Err(invalid(
+            "q",
+            &format!("at most {MAX_QUERY_CHARS} characters are accepted"),
+        ));
+    }
+
+    let terms: Vec<String> = q.split_whitespace().map(str::to_owned).collect();
 
     if terms.is_empty() {
         return Err(invalid("q", "search terms are required"));
@@ -117,20 +119,25 @@ fn search_terms(q: Option<&str>) -> Result<Vec<String>, CanonicalError> {
     Ok(terms)
 }
 
-/// Named first, alphabetically; card-less ids (bindings-only persons) last.
+/// Named first, then email-only, then username-only; persons the journal
+/// knows by nothing but an id come last. Alphabetical (case-folded) within
+/// each band.
 fn sort_for_display(items: &mut [PersonSummaryResponse]) {
     items.sort_by_cached_key(|i| {
         (
             i.display_name.is_none(),
             i.display_name.as_deref().map(str::to_lowercase),
-            i.email.clone(),
+            i.email.is_none(),
+            i.email.as_deref().map(str::to_lowercase),
+            i.username.is_none(),
+            i.username.as_deref().map(str::to_lowercase),
             i.person_id,
         )
     });
 }
 
 fn invalid(field: &str, message: &str) -> CanonicalError {
-    CorrectionError::invalid_argument()
+    PersonSearchError::invalid_argument()
         .with_field_violation(field, message, "INVALID")
         .create()
 }
@@ -155,6 +162,10 @@ mod tests {
         assert!(
             search_terms(Some("a b c d e f g h i")).is_err(),
             "over the term cap refused"
+        );
+        assert!(
+            search_terms(Some(&"x".repeat(201))).is_err(),
+            "over the length cap refused"
         );
         Ok(())
     }

--- a/src/backend/services/identity-resolution/src/api/persons.rs
+++ b/src/backend/services/identity-resolution/src/api/persons.rs
@@ -1,0 +1,161 @@
+//! Person search — the operator picker over the observation journal.
+//!
+//! `GET /v1/persons?q=` matches every whitespace-separated term against the
+//! caller-tenant persons' CURRENT observed values (the latest observation per
+//! person × source × value type — the same window rule `/v1/profiles` resolves
+//! by, so search and resolution cannot disagree). Superseded values stop
+//! matching their old owner; a value two persons both currently claim returns
+//! both — the operator is the disambiguator, and hiding one of them by
+//! recency would decide a contested case silently.
+//!
+//! Admin-gated and deliberately NOT visibility-filtered: this is the operator
+//! surface, and the seeded operator sits outside the org chart on purpose.
+
+use std::sync::Arc;
+
+use axum::Json;
+use axum::extract::{Extension, Query};
+use axum::response::IntoResponse;
+use serde::{Deserialize, Serialize};
+use toolkit_canonical_errors::CanonicalError;
+use toolkit_security::SecurityContext;
+use utoipa::ToSchema;
+
+use super::AppState;
+use super::error::CorrectionError;
+use super::gate::require_admin;
+use super::resolution::PersonSummaryResponse;
+use crate::domain::person_card::PersonCard;
+use crate::infra::db::persons_repo;
+
+const DEFAULT_LIMIT: u64 = 20;
+const MAX_LIMIT: u64 = 100;
+/// A picker query is a human typing, not a batch filter.
+const MAX_TERMS: usize = 8;
+
+#[derive(Debug, Deserialize)]
+pub struct SearchParams {
+    pub q: Option<String>,
+    // Signed so a negative `?limit=` clamps to 1 (parity with the other
+    // listings) rather than failing query deserialization.
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PersonListResponse {
+    pub items: Vec<PersonSummaryResponse>,
+    /// More persons matched than `limit` allowed — the page is a cut, not the
+    /// answer, and the UI should ask for narrower terms. Without this flag a
+    /// truncated page reads as "the person does not exist".
+    pub truncated: bool,
+    /// Wire parity with the other listings: declared, always `null`.
+    pub next_cursor: Option<String>,
+}
+impl toolkit::api::api_dto::ResponseApiDto for PersonListResponse {}
+
+/// `GET /v1/persons` — search persons by their current observed values (admin).
+pub async fn search_persons(
+    Extension(state): Extension<Arc<AppState>>,
+    Extension(ctx): Extension<SecurityContext>,
+    Query(params): Query<SearchParams>,
+) -> Result<impl IntoResponse, CanonicalError> {
+    require_admin(&state.db, &ctx).await?;
+    let tenant = ctx.subject_tenant_id();
+
+    let terms = search_terms(params.q.as_deref())?;
+    let limit = super::listing::clamp_limit(params.limit, DEFAULT_LIMIT, MAX_LIMIT);
+
+    // Over-fetch by one: the extra row is the truncation probe, never served.
+    let mut ids =
+        persons_repo::search_persons_by_current_values(&state.db, tenant, &terms, limit + 1)
+            .await
+            .map_err(|e| read_err(&e))?;
+    let truncated = ids.len() > usize::try_from(limit).unwrap_or(usize::MAX);
+    if truncated {
+        ids.pop();
+    }
+
+    let cards = persons_repo::person_cards(&state.db, tenant, &ids)
+        .await
+        .map_err(|e| read_err(&e))?;
+    let mut items: Vec<PersonSummaryResponse> = ids
+        .iter()
+        .map(|id| {
+            cards
+                .get(id)
+                .cloned()
+                .unwrap_or_else(|| PersonCard::empty(*id))
+        })
+        .map(PersonSummaryResponse::from)
+        .collect();
+    sort_for_display(&mut items);
+
+    Ok(Json(PersonListResponse {
+        items,
+        truncated,
+        next_cursor: None,
+    }))
+}
+
+/// Split `q` into terms: non-empty, whitespace-separated, capped.
+fn search_terms(q: Option<&str>) -> Result<Vec<String>, CanonicalError> {
+    let terms: Vec<String> = q
+        .unwrap_or_default()
+        .split_whitespace()
+        .map(str::to_owned)
+        .collect();
+
+    if terms.is_empty() {
+        return Err(invalid("q", "search terms are required"));
+    }
+    if terms.len() > MAX_TERMS {
+        return Err(invalid(
+            "q",
+            &format!("at most {MAX_TERMS} search terms are accepted"),
+        ));
+    }
+    Ok(terms)
+}
+
+/// Named first, alphabetically; card-less ids (bindings-only persons) last.
+fn sort_for_display(items: &mut [PersonSummaryResponse]) {
+    items.sort_by_cached_key(|i| {
+        (
+            i.display_name.is_none(),
+            i.display_name.as_deref().map(str::to_lowercase),
+            i.email.clone(),
+            i.person_id,
+        )
+    });
+}
+
+fn invalid(field: &str, message: &str) -> CanonicalError {
+    CorrectionError::invalid_argument()
+        .with_field_violation(field, message, "INVALID")
+        .create()
+}
+
+fn read_err(e: &anyhow::Error) -> CanonicalError {
+    tracing::error!(error = %e, "person search failed");
+    CanonicalError::internal("failed to search persons").create()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terms_split_on_any_whitespace_and_cap() -> anyhow::Result<()> {
+        let terms =
+            search_terms(Some("  alice   example.com ")).map_err(|e| anyhow::anyhow!("{e:?}"))?;
+        assert_eq!(terms, vec!["alice".to_owned(), "example.com".to_owned()]);
+
+        assert!(search_terms(None).is_err(), "absent q refused");
+        assert!(search_terms(Some("   ")).is_err(), "blank q refused");
+        assert!(
+            search_terms(Some("a b c d e f g h i")).is_err(),
+            "over the term cap refused"
+        );
+        Ok(())
+    }
+}

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 use super::AppState;
 use super::error::CorrectionError;
 use super::gate::require_admin;
-use crate::domain::person_card::PersonCard;
+use crate::domain::person_card::{self, PersonCard};
 use crate::domain::resolution::{self, EXCLUDED_PERSON, Target, Verb};
 use crate::domain::review_queue::{self, EvidenceAccount, ItemKind, Review};
 use crate::domain::seed::SourceAccountKey;
@@ -626,6 +626,9 @@ pub struct QueueItemResponse {
 pub struct PersonSummaryResponse {
     pub person_id: Uuid,
     pub email: Option<String>,
+    /// Source-native handle (e.g. a git login) — often the only recognisable
+    /// field of an identity no HR system has observed yet.
+    pub username: Option<String>,
     pub display_name: Option<String>,
     pub job_title: Option<String>,
     pub status: Option<String>,
@@ -636,6 +639,7 @@ impl From<PersonCard> for PersonSummaryResponse {
         Self {
             person_id: card.person_id,
             email: card.email,
+            username: card.username,
             display_name: card.display_name,
             job_title: card.job_title,
             status: card.status,
@@ -688,16 +692,9 @@ pub async fn attention(
             account_id: i.account.account_id,
             email: i.email,
             username: i.username,
-            candidates: i
-                .candidates
-                .iter()
-                .map(|id| {
-                    cards
-                        .get(id)
-                        .cloned()
-                        .unwrap_or_else(|| PersonCard::empty(*id))
-                        .into()
-                })
+            candidates: person_card::in_requested_order(&i.candidates, &cards)
+                .into_iter()
+                .map(PersonSummaryResponse::from)
                 .collect(),
         })
         .collect();

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -25,7 +25,9 @@ use crate::domain::resolution::{self, EXCLUDED_PERSON, Target, Verb};
 use crate::domain::review_queue::{self, EvidenceAccount, ItemKind, Review};
 use crate::domain::seed::SourceAccountKey;
 use crate::infra::db::{ops_repo, persons_repo, resolution_repo};
-use crate::infra::identity_evidence::{AccountEvidence, ClickHouseEvidenceReader};
+use crate::infra::identity_evidence::{
+    AccountEvidence, ClickHouseEvidenceReader, EvidenceSnapshot,
+};
 
 /// How many accounts one bulk call may carry — a prepared matching table is
 /// pasted by a human, not streamed.
@@ -151,6 +153,7 @@ pub async fn bind(
             ));
         }
 
+        reject_excluded_person(item.person_id, "person_id")?;
         require_known_person(&state.db, tenant, item.person_id).await?;
         targets.push(Target {
             account,
@@ -191,6 +194,8 @@ pub async fn merge(
             "source and target are the same person",
         ));
     }
+    reject_excluded_person(req.source_person_id, "source_person_id")?;
+    reject_excluded_person(req.target_person_id, "target_person_id")?;
     require_known_person(&state.db, tenant, req.source_person_id).await?;
     require_known_person(&state.db, tenant, req.target_person_id).await?;
 
@@ -570,6 +575,21 @@ async fn require_known_person(
         .create())
 }
 
+/// The excluded person is a sentinel, not a person: its first exclusion writes
+/// it into the journal, after which `person_exists` would vouch for it. As a
+/// bind target it becomes an exclude that skips `require_known_account`; as a
+/// merge side it moves every excluded account of the tenant in one call. Only
+/// the exclude verb may name it.
+fn reject_excluded_person(person_id: Uuid, field: &str) -> Result<(), CanonicalError> {
+    if person_id == EXCLUDED_PERSON {
+        return Err(invalid(
+            field,
+            "the reserved excluded person cannot take part in a correction; use the exclude verb",
+        ));
+    }
+    Ok(())
+}
+
 fn reject_empty(is_empty: bool, field: &str) -> Result<(), CanonicalError> {
     if is_empty {
         return Err(invalid(field, "must not be empty"));
@@ -662,6 +682,10 @@ pub struct ResolutionRatesResponse {
 pub struct AttentionResponse {
     pub items: Vec<QueueItemResponse>,
     pub rates: ResolutionRatesResponse,
+    /// The evidence read hit its safety cap: the queue and the rates describe
+    /// only the first accounts of the tenant, not all of them. Consumers must
+    /// not present these numbers as tenant-wide.
+    pub truncated: bool,
 }
 impl toolkit::api::api_dto::ResponseApiDto for AttentionResponse {}
 
@@ -675,7 +699,7 @@ pub async fn attention(
     require_admin(&state.db, &ctx).await?;
     let tenant = ctx.subject_tenant_id();
 
-    let review = build_review(&state, tenant).await?;
+    let (review, truncated) = build_review(&state, tenant).await?;
 
     let limit = params.limit.map_or(DEFAULT_QUEUE_LIMIT, |l| {
         usize::try_from(l).unwrap_or(1).clamp(1, MAX_QUEUE_LIMIT)
@@ -708,6 +732,7 @@ pub async fn attention(
             no_evidence: review.rates.no_evidence,
             excluded: review.rates.excluded,
         },
+        truncated,
     }))
 }
 
@@ -813,7 +838,7 @@ pub async fn person_accounts(
         .map_err(|e| internal(&e, "failed to read current bindings"))?;
     let evidence = read_evidence(&state).await?;
     let by_account: HashMap<&SourceAccountKey, &AccountEvidence> =
-        evidence.iter().map(|e| (&e.account, e)).collect();
+        evidence.accounts.iter().map(|e| (&e.account, e)).collect();
 
     let entries = accounts
         .iter()
@@ -849,15 +874,23 @@ fn kind_label(kind: ItemKind) -> &'static str {
     }
 }
 
-/// Join folded evidence with current bindings into the review.
-async fn build_review(state: &AppState, tenant: Uuid) -> Result<Review, CanonicalError> {
+/// Join folded evidence with current bindings into the review, keeping the
+/// read's own honesty flag: `truncated` means the rates cover a prefix of the
+/// tenant, not all of it.
+async fn build_review(state: &AppState, tenant: Uuid) -> Result<(Review, bool), CanonicalError> {
     let evidence = read_evidence(state).await?;
-    let accounts: Vec<SourceAccountKey> = evidence.iter().map(|e| e.account.clone()).collect();
+    let truncated = evidence.truncated;
+    let accounts: Vec<SourceAccountKey> = evidence
+        .accounts
+        .iter()
+        .map(|e| e.account.clone())
+        .collect();
     let bindings = resolution_repo::current_bindings(&state.db, tenant, &accounts)
         .await
         .map_err(|e| internal(&e, "failed to read current bindings"))?;
 
     let observed = evidence
+        .accounts
         .into_iter()
         .map(|e| EvidenceAccount {
             account: e.account,
@@ -867,7 +900,7 @@ async fn build_review(state: &AppState, tenant: Uuid) -> Result<Review, Canonica
         })
         .collect();
 
-    Ok(review_queue::build(observed, &bindings))
+    Ok((review_queue::build(observed, &bindings), truncated))
 }
 
 /// One hydration read for a queue page: every distinct candidate id, fetched
@@ -898,7 +931,7 @@ fn evidence_reader(state: &AppState) -> ClickHouseEvidenceReader {
     )
 }
 
-async fn read_evidence(state: &AppState) -> Result<Vec<AccountEvidence>, CanonicalError> {
+async fn read_evidence(state: &AppState) -> Result<EvidenceSnapshot, CanonicalError> {
     evidence_reader(state)
         .accounts()
         .await

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -20,7 +20,7 @@ use uuid::Uuid;
 use super::AppState;
 use super::error::CorrectionError;
 use super::gate::require_admin;
-use crate::domain::person_card::{self, PersonCard};
+use crate::domain::person_card::PersonCard;
 use crate::domain::resolution::{self, EXCLUDED_PERSON, Target, Verb};
 use crate::domain::review_queue::{self, EvidenceAccount, ItemKind, Review};
 use crate::domain::seed::SourceAccountKey;
@@ -887,16 +887,9 @@ async fn candidate_cards(
         .into_iter()
         .collect();
 
-    let rows = persons_repo::fetch_card_observations(
-        &state.db,
-        tenant,
-        &ids,
-        &person_card::CARD_VALUE_TYPES,
-    )
-    .await
-    .map_err(|e| internal(&e, "failed to read candidate cards"))?;
-
-    Ok(person_card::assemble_cards(rows))
+    persons_repo::person_cards(&state.db, tenant, &ids)
+        .await
+        .map_err(|e| internal(&e, "failed to read candidate cards"))
 }
 
 fn evidence_reader(state: &AppState) -> ClickHouseEvidenceReader {

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -20,10 +20,11 @@ use uuid::Uuid;
 use super::AppState;
 use super::error::CorrectionError;
 use super::gate::require_admin;
+use crate::domain::person_card::{self, PersonCard};
 use crate::domain::resolution::{self, EXCLUDED_PERSON, Target, Verb};
 use crate::domain::review_queue::{self, EvidenceAccount, ItemKind, Review};
 use crate::domain::seed::SourceAccountKey;
-use crate::infra::db::{ops_repo, resolution_repo};
+use crate::infra::db::{ops_repo, persons_repo, resolution_repo};
 use crate::infra::identity_evidence::{AccountEvidence, ClickHouseEvidenceReader};
 
 /// How many accounts one bulk call may carry — a prepared matching table is
@@ -613,8 +614,33 @@ pub struct QueueItemResponse {
     pub account_id: String,
     pub email: Option<String>,
     pub username: Option<String>,
-    /// Persons this account could belong to, if any are known.
-    pub candidates: Vec<Uuid>,
+    /// Persons this account could belong to, if any are known — hydrated into
+    /// cards so the operator UI never has to resolve bare ids itself.
+    pub candidates: Vec<PersonSummaryResponse>,
+}
+
+/// A person as operator surfaces display them: enough to recognise and pick,
+/// nothing more. Every field but the id may be null — a person the journal
+/// knows only through bindings still appears, as the id alone.
+#[derive(Debug, Serialize, ToSchema)]
+pub struct PersonSummaryResponse {
+    pub person_id: Uuid,
+    pub email: Option<String>,
+    pub display_name: Option<String>,
+    pub job_title: Option<String>,
+    pub status: Option<String>,
+}
+
+impl From<PersonCard> for PersonSummaryResponse {
+    fn from(card: PersonCard) -> Self {
+        Self {
+            person_id: card.person_id,
+            email: card.email,
+            display_name: card.display_name,
+            job_title: card.job_title,
+            status: card.status,
+        }
+    }
 }
 
 /// Share of observed accounts per resolution state — the operator-visible match
@@ -650,11 +676,11 @@ pub async fn attention(
     let limit = params.limit.map_or(DEFAULT_QUEUE_LIMIT, |l| {
         usize::try_from(l).unwrap_or(1).clamp(1, MAX_QUEUE_LIMIT)
     });
+    let page: Vec<_> = review.items.into_iter().take(limit).collect();
 
-    let items = review
-        .items
+    let cards = candidate_cards(state.as_ref(), tenant, &page).await?;
+    let items = page
         .into_iter()
-        .take(limit)
         .map(|i| QueueItemResponse {
             kind: kind_label(i.kind).to_owned(),
             source: i.account.source_type,
@@ -662,7 +688,17 @@ pub async fn attention(
             account_id: i.account.account_id,
             email: i.email,
             username: i.username,
-            candidates: i.candidates,
+            candidates: i
+                .candidates
+                .iter()
+                .map(|id| {
+                    cards
+                        .get(id)
+                        .cloned()
+                        .unwrap_or_else(|| PersonCard::empty(*id))
+                        .into()
+                })
+                .collect(),
         })
         .collect();
 
@@ -835,6 +871,32 @@ async fn build_review(state: &AppState, tenant: Uuid) -> Result<Review, Canonica
         .collect();
 
     Ok(review_queue::build(observed, &bindings))
+}
+
+/// One hydration read for a queue page: every distinct candidate id, fetched
+/// and collapsed into cards.
+async fn candidate_cards(
+    state: &AppState,
+    tenant: Uuid,
+    page: &[review_queue::QueueItem],
+) -> Result<HashMap<Uuid, PersonCard>, CanonicalError> {
+    let ids: Vec<Uuid> = page
+        .iter()
+        .flat_map(|i| i.candidates.iter().copied())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    let rows = persons_repo::fetch_card_observations(
+        &state.db,
+        tenant,
+        &ids,
+        &person_card::CARD_VALUE_TYPES,
+    )
+    .await
+    .map_err(|e| internal(&e, "failed to read candidate cards"))?;
+
+    Ok(person_card::assemble_cards(rows))
 }
 
 fn evidence_reader(state: &AppState) -> ClickHouseEvidenceReader {

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -686,6 +686,10 @@ pub struct AttentionResponse {
     /// only the first accounts of the tenant, not all of them. Consumers must
     /// not present these numbers as tenant-wide.
     pub truncated: bool,
+    /// `limit` cut the item list — more accounts await a decision than are
+    /// listed here. Distinct from `truncated`: the rates stay whole-tenant,
+    /// only this page is short.
+    pub items_truncated: bool,
 }
 impl toolkit::api::api_dto::ResponseApiDto for AttentionResponse {}
 
@@ -704,6 +708,7 @@ pub async fn attention(
     let limit = params.limit.map_or(DEFAULT_QUEUE_LIMIT, |l| {
         usize::try_from(l).unwrap_or(1).clamp(1, MAX_QUEUE_LIMIT)
     });
+    let items_truncated = review.items.len() > limit;
     let page: Vec<_> = review.items.into_iter().take(limit).collect();
 
     let cards = candidate_cards(state.as_ref(), tenant, &page).await?;
@@ -733,6 +738,7 @@ pub async fn attention(
             excluded: review.rates.excluded,
         },
         truncated,
+        items_truncated,
     }))
 }
 

--- a/src/backend/services/identity-resolution/src/domain/mod.rs
+++ b/src/backend/services/identity-resolution/src/domain/mod.rs
@@ -1,6 +1,7 @@
 //! Domain layer — DTOs and business logic (profile resolution/assembly).
 
 pub mod observation_slot;
+pub mod person_card;
 pub mod profile;
 pub mod resolution;
 pub mod review_queue;

--- a/src/backend/services/identity-resolution/src/domain/person_card.rs
+++ b/src/backend/services/identity-resolution/src/domain/person_card.rs
@@ -1,0 +1,176 @@
+//! Compact person card — the id→display projection operator surfaces embed
+//! where a bare `person_id` would push the lookup onto every consumer (queue
+//! candidates today, person search later). Deliberately flat: no supervisor,
+//! no subordinates, no source ids — those belong to the full profile.
+
+use std::collections::HashMap;
+
+use uuid::Uuid;
+
+use crate::domain::profile::latest_values;
+use crate::infra::db::entities::persons;
+
+/// The observation attributes a card is assembled from. The repo fetch filters
+/// on this list so hydrating a page of candidates reads card rows only, not
+/// every binding observation the journal holds for those persons.
+pub const CARD_VALUE_TYPES: [&str; 6] = [
+    "email",
+    "display_name",
+    "first_name",
+    "last_name",
+    "job_title",
+    "status",
+];
+
+#[derive(Debug, Clone)]
+pub struct PersonCard {
+    pub person_id: Uuid,
+    pub email: Option<String>,
+    pub display_name: Option<String>,
+    pub job_title: Option<String>,
+    pub status: Option<String>,
+}
+
+impl PersonCard {
+    /// The card for a person the journal holds no card attributes for — a
+    /// candidate observed only through bindings still gets an entry, so a
+    /// consumer can render the id rather than dropping the person.
+    #[must_use]
+    pub fn empty(person_id: Uuid) -> Self {
+        Self {
+            person_id,
+            email: None,
+            display_name: None,
+            job_title: None,
+            status: None,
+        }
+    }
+}
+
+/// Collapse card observations for MANY persons — rows as the repo returns
+/// them, grouped here — to one card per person, current value per attribute
+/// (same latest-wins rule the profile uses).
+#[must_use]
+pub fn assemble_cards(rows: Vec<persons::Model>) -> HashMap<Uuid, PersonCard> {
+    let mut by_person: HashMap<Uuid, Vec<persons::Model>> = HashMap::new();
+    for row in rows {
+        let Ok(person_id) = Uuid::from_slice(&row.person_id) else {
+            continue;
+        };
+        by_person.entry(person_id).or_default().push(row);
+    }
+
+    by_person
+        .into_iter()
+        .map(|(person_id, observations)| (person_id, card(person_id, observations)))
+        .collect()
+}
+
+fn card(person_id: Uuid, observations: Vec<persons::Model>) -> PersonCard {
+    let latest = latest_values(observations);
+    let get = |value_type: &str| latest.get(value_type).cloned();
+
+    // The profile splits display_name into first/last when those are missing;
+    // a card wants the opposite fallback — compose a display name from the
+    // parts when no display_name was ever observed.
+    let display_name =
+        get("display_name").or_else(|| compose_name(get("first_name"), get("last_name")));
+
+    PersonCard {
+        person_id,
+        email: get("email"),
+        display_name,
+        job_title: get("job_title"),
+        status: get("status"),
+    }
+}
+
+fn compose_name(first: Option<String>, last: Option<String>) -> Option<String> {
+    let joined = [first, last]
+        .into_iter()
+        .flatten()
+        .collect::<Vec<_>>()
+        .join(" ");
+    (!joined.trim().is_empty()).then_some(joined)
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::prelude::DateTime;
+
+    use super::*;
+
+    fn obs(
+        person: Uuid,
+        value_type: &str,
+        value: &str,
+        created_at: &str,
+    ) -> anyhow::Result<persons::Model> {
+        Ok(persons::Model {
+            id: 0,
+            value_type: value_type.to_owned(),
+            insight_source_type: "test".to_owned(),
+            insight_source_id: vec![0u8; 16],
+            insight_tenant_id: vec![0u8; 16],
+            value_id: None,
+            value_full_text: None,
+            value: None,
+            value_effective: Some(value.to_owned()),
+            value_hash: None,
+            person_id: person.as_bytes().to_vec(),
+            author_person_id: vec![0u8; 16],
+            reason: None,
+            created_at: created_at.parse::<DateTime>()?,
+        })
+    }
+
+    #[test]
+    fn rows_group_per_person_and_latest_value_wins() -> anyhow::Result<()> {
+        let a = Uuid::from_u128(1);
+        let b = Uuid::from_u128(2);
+        let cards = assemble_cards(vec![
+            obs(a, "email", "old@example.com", "2026-01-01T00:00:00")?,
+            obs(a, "email", "new@example.com", "2026-02-01T00:00:00")?,
+            obs(b, "display_name", "Bee Person", "2026-01-01T00:00:00")?,
+        ]);
+
+        assert_eq!(cards.len(), 2, "one card per person");
+        assert_eq!(cards[&a].email.as_deref(), Some("new@example.com"));
+        assert_eq!(cards[&b].display_name.as_deref(), Some("Bee Person"));
+        assert_eq!(cards[&b].email, None);
+        Ok(())
+    }
+
+    #[test]
+    fn display_name_composes_from_parts_only_when_unobserved() -> anyhow::Result<()> {
+        let named = Uuid::from_u128(1);
+        let parts_only = Uuid::from_u128(2);
+        let cards = assemble_cards(vec![
+            obs(named, "display_name", "Full Name", "2026-01-01T00:00:00")?,
+            obs(named, "first_name", "Other", "2026-01-01T00:00:00")?,
+            obs(parts_only, "first_name", "First", "2026-01-01T00:00:00")?,
+            obs(parts_only, "last_name", "Last", "2026-01-01T00:00:00")?,
+        ]);
+
+        assert_eq!(cards[&named].display_name.as_deref(), Some("Full Name"));
+        assert_eq!(
+            cards[&parts_only].display_name.as_deref(),
+            Some("First Last")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn a_lone_name_part_still_makes_a_display_name() -> anyhow::Result<()> {
+        let person = Uuid::from_u128(1);
+        let cards = assemble_cards(vec![obs(
+            person,
+            "last_name",
+            "Mononym",
+            "2026-01-01T00:00:00",
+        )?]);
+
+        assert_eq!(cards[&person].display_name.as_deref(), Some("Mononym"));
+        Ok(())
+    }
+}

--- a/src/backend/services/identity-resolution/src/domain/person_card.rs
+++ b/src/backend/services/identity-resolution/src/domain/person_card.rs
@@ -13,8 +13,9 @@ use crate::infra::db::entities::persons;
 /// The observation attributes a card is assembled from. The repo fetch filters
 /// on this list so hydrating a page of candidates reads card rows only, not
 /// every binding observation the journal holds for those persons.
-pub const CARD_VALUE_TYPES: [&str; 6] = [
+pub const CARD_VALUE_TYPES: [&str; 7] = [
     "email",
+    "username",
     "display_name",
     "first_name",
     "last_name",
@@ -26,6 +27,9 @@ pub const CARD_VALUE_TYPES: [&str; 6] = [
 pub struct PersonCard {
     pub person_id: Uuid,
     pub email: Option<String>,
+    /// Source-native handle (e.g. a git login) — often the only recognisable
+    /// field of an identity no HR system has observed yet.
+    pub username: Option<String>,
     pub display_name: Option<String>,
     pub job_title: Option<String>,
     pub status: Option<String>,
@@ -40,6 +44,7 @@ impl PersonCard {
         Self {
             person_id,
             email: None,
+            username: None,
             display_name: None,
             job_title: None,
             status: None,
@@ -79,10 +84,26 @@ fn card(person_id: Uuid, observations: Vec<persons::Model>) -> PersonCard {
     PersonCard {
         person_id,
         email: get("email"),
+        username: get("username"),
         display_name,
         job_title: get("job_title"),
         status: get("status"),
     }
+}
+
+/// Cards for `ids` in the callers' order — a person the map has no card for
+/// still appears, as the id alone. The one place the "absent card is not a
+/// dropped person" rule lives; both the queue and the search render through it.
+#[must_use]
+pub fn in_requested_order(ids: &[Uuid], cards: &HashMap<Uuid, PersonCard>) -> Vec<PersonCard> {
+    ids.iter()
+        .map(|id| {
+            cards
+                .get(id)
+                .cloned()
+                .unwrap_or_else(|| PersonCard::empty(*id))
+        })
+        .collect()
 }
 
 fn compose_name(first: Option<String>, last: Option<String>) -> Option<String> {

--- a/src/backend/services/identity-resolution/src/infra/db/persons_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/persons_repo.rs
@@ -321,6 +321,33 @@ pub async fn person_exists(
     Ok(found.is_some())
 }
 
+/// Fetch the card-attribute observations (see
+/// [`crate::domain::person_card::CARD_VALUE_TYPES`]) for MANY persons in one
+/// query — the hydration read behind embedding person cards into operator
+/// responses. The caller groups per person and collapses per attribute.
+///
+/// # Errors
+///
+/// Returns an error if the query fails.
+pub async fn fetch_card_observations(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    person_ids: &[Uuid],
+    value_types: &[&str],
+) -> anyhow::Result<Vec<persons::Model>> {
+    if person_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let rows = persons::Entity::find()
+        .filter(persons::Column::InsightTenantId.eq(tenant_id.as_bytes().to_vec()))
+        .filter(persons::Column::PersonId.is_in(person_ids.iter().map(|id| id.as_bytes().to_vec())))
+        .filter(persons::Column::ValueType.is_in(value_types.iter().copied()))
+        .all(db)
+        .await?;
+    Ok(rows)
+}
+
 /// Fetch every observation row for a person within the tenant (all value types,
 /// all sources). The caller collapses them to the current value per attribute.
 ///

--- a/src/backend/services/identity-resolution/src/infra/db/persons_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/persons_repo.rs
@@ -12,6 +12,8 @@
 //! so an excluded account resolves as no person rather than as the shared
 //! sentinel, and an older binding is never resurrected past an exclusion.
 
+use std::collections::HashMap;
+
 use sea_orm::{
     ColumnTrait, ConnectionTrait, DatabaseConnection, DbBackend, EntityTrait, QueryFilter,
     QueryResult, QuerySelect, Statement,
@@ -19,6 +21,7 @@ use sea_orm::{
 use uuid::Uuid;
 
 use super::entities::persons;
+use crate::domain::person_card::{self, CARD_VALUE_TYPES, PersonCard};
 use crate::domain::resolution::EXCLUDED_PERSON;
 
 /// Resolve the set of `person_id`s whose CURRENT email (latest observation per
@@ -321,31 +324,118 @@ pub async fn person_exists(
     Ok(found.is_some())
 }
 
-/// Fetch the card-attribute observations (see
-/// [`crate::domain::person_card::CARD_VALUE_TYPES`]) for MANY persons in one
-/// query — the hydration read behind embedding person cards into operator
-/// responses. The caller groups per person and collapses per attribute.
+/// Find persons whose CURRENT observed values match every search term
+/// (case-insensitive substring). "Current" is the same window rule
+/// [`resolve_person_ids_by_email`] applies — the latest observation per
+/// person × source × value type — so a value superseded by that person's own
+/// newer data stops matching, while a value two persons both currently claim
+/// returns both. Ordered by `person_id` for a stable page; the API layer
+/// re-sorts for display.
+///
+/// INVARIANT: this is a deliberate tenant-bounded scan, not a missing index.
+/// A substring match over the journal cannot use a B-tree, and a derived
+/// current-values table would be one more cache to keep in sync with every
+/// write path. The consumer is the admin picker — one debounced human — and
+/// the scan is bounded by the tenant filter and the six searchable value
+/// types. Revisit as a derived table only if measured slow at real scale.
+///
+/// # Errors
+///
+/// Returns an error if the query fails or a stored `person_id` is not 16 bytes.
+pub async fn search_persons_by_current_values(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    terms: &[String],
+    limit: u64,
+) -> anyhow::Result<Vec<Uuid>> {
+    if terms.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // One EXISTS per term: every term must match SOME current value of the
+    // person, not necessarily the same one ("iva example.com" finds a person
+    // via name + email together).
+    let mut sql = String::from(
+        r"
+        WITH ranked AS (
+            SELECT
+                person_id,
+                value_effective,
+                ROW_NUMBER() OVER (
+                    PARTITION BY person_id, insight_source_type, insight_source_id, value_type
+                    ORDER BY created_at DESC, id DESC
+                ) AS rn
+            FROM persons
+            WHERE insight_tenant_id = ?
+              AND value_type IN ('email', 'username', 'display_name',
+                                 'first_name', 'last_name', 'employee_id')
+        ),
+        current_vals AS (
+            SELECT person_id, value_effective
+            FROM ranked
+            WHERE rn = 1 AND value_effective IS NOT NULL
+        )
+        SELECT DISTINCT cv.person_id
+        FROM current_vals cv
+        WHERE cv.person_id != ?
+    ",
+    );
+    for _ in terms {
+        sql.push_str(
+            " AND EXISTS (SELECT 1 FROM current_vals t \
+              WHERE t.person_id = cv.person_id AND t.value_effective LIKE ? ESCAPE '!')",
+        );
+    }
+    sql.push_str(" ORDER BY cv.person_id LIMIT ?");
+
+    let mut values: Vec<sea_orm::Value> = vec![
+        tenant_id.as_bytes().to_vec().into(),
+        EXCLUDED_PERSON.as_bytes().to_vec().into(),
+    ];
+    values.extend(terms.iter().map(|t| like_pattern(t).into()));
+    values.push(limit.into());
+
+    let stmt = Statement::from_sql_and_values(DbBackend::MySql, &sql, values);
+    person_ids_from_rows(db.query_all(stmt).await?)
+}
+
+/// `%…%` LIKE pattern for a term, with the wildcard characters neutralised via
+/// the `!` escape (declared in the query) — `50%` searches for a literal
+/// percent sign instead of everything.
+fn like_pattern(term: &str) -> String {
+    let escaped = term
+        .replace('!', "!!")
+        .replace('%', "!%")
+        .replace('_', "!_");
+    format!("%{escaped}%")
+}
+
+/// Hydrate person cards for MANY persons in one query — the shared id→display
+/// read behind every operator response that embeds cards (queue candidates,
+/// person search). Fetches the card-attribute observations and collapses them
+/// per person; an id the journal holds no card attributes for is simply absent
+/// from the map, and the caller renders it via [`PersonCard::empty`].
 ///
 /// # Errors
 ///
 /// Returns an error if the query fails.
-pub async fn fetch_card_observations(
+pub async fn person_cards(
     db: &DatabaseConnection,
     tenant_id: Uuid,
     person_ids: &[Uuid],
-    value_types: &[&str],
-) -> anyhow::Result<Vec<persons::Model>> {
+) -> anyhow::Result<HashMap<Uuid, PersonCard>> {
     if person_ids.is_empty() {
-        return Ok(Vec::new());
+        return Ok(HashMap::new());
     }
 
     let rows = persons::Entity::find()
         .filter(persons::Column::InsightTenantId.eq(tenant_id.as_bytes().to_vec()))
         .filter(persons::Column::PersonId.is_in(person_ids.iter().map(|id| id.as_bytes().to_vec())))
-        .filter(persons::Column::ValueType.is_in(value_types.iter().copied()))
+        .filter(persons::Column::ValueType.is_in(CARD_VALUE_TYPES))
         .all(db)
         .await?;
-    Ok(rows)
+
+    Ok(person_card::assemble_cards(rows))
 }
 
 /// Fetch every observation row for a person within the tenant (all value types,
@@ -562,6 +652,18 @@ fn person_ids_from_rows(rows: Vec<QueryResult>) -> anyhow::Result<Vec<Uuid>> {
 mod tests {
     use super::*;
     use crate::infra::db;
+
+    #[test]
+    fn like_pattern_neutralises_wildcards() {
+        for (term, expected) in [
+            ("alice", "%alice%"),
+            ("50%", "%50!%%"),
+            ("a_b", "%a!_b%"),
+            ("bang!", "%bang!!%"),
+        ] {
+            assert_eq!(like_pattern(term), expected, "term: {term:?}");
+        }
+    }
 
     /// Integration test against a live MariaDB. Data-dependent (dev cluster).
     /// Set `IDENTITY_TEST_DB_URL` + `IDENTITY_TEST_TENANT_ID` + `IDENTITY_TEST_EMAIL`

--- a/src/backend/services/identity-resolution/src/infra/db/persons_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/persons_repo.rs
@@ -412,9 +412,13 @@ fn like_pattern(term: &str) -> String {
 
 /// Hydrate person cards for MANY persons in one query — the shared id→display
 /// read behind every operator response that embeds cards (queue candidates,
-/// person search). Fetches the card-attribute observations and collapses them
-/// per person; an id the journal holds no card attributes for is simply absent
-/// from the map, and the caller renders it via [`PersonCard::empty`].
+/// person search). Only the CURRENT observation per person × source × value
+/// type leaves the database (the same `rn = 1` window the resolvers use): the
+/// journal is append-only, and shipping a person's full re-observation history
+/// to collapse it in Rust would grow every response with tenant age. The Rust
+/// collapse then picks the latest across sources. An id the journal holds no
+/// card attributes for is simply absent from the map, and the caller renders
+/// it via [`PersonCard::empty`].
 ///
 /// # Errors
 ///
@@ -428,12 +432,38 @@ pub async fn person_cards(
         return Ok(HashMap::new());
     }
 
-    let rows = persons::Entity::find()
-        .filter(persons::Column::InsightTenantId.eq(tenant_id.as_bytes().to_vec()))
-        .filter(persons::Column::PersonId.is_in(person_ids.iter().map(|id| id.as_bytes().to_vec())))
-        .filter(persons::Column::ValueType.is_in(CARD_VALUE_TYPES))
-        .all(db)
-        .await?;
+    let id_placeholders = vec!["?"; person_ids.len()].join(", ");
+    let type_list = CARD_VALUE_TYPES
+        .iter()
+        .map(|t| format!("'{t}'"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let sql = format!(
+        r"
+        SELECT id, value_type, insight_source_type, insight_source_id,
+               insight_tenant_id, value_id, value_full_text, value,
+               value_effective, value_hash, person_id, author_person_id,
+               reason, created_at
+        FROM (
+            SELECT p.*,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY person_id, insight_source_type, insight_source_id, value_type
+                       ORDER BY created_at DESC, id DESC
+                   ) AS rn
+            FROM persons p
+            WHERE insight_tenant_id = ?
+              AND person_id IN ({id_placeholders})
+              AND value_type IN ({type_list})
+        ) current_rows
+        WHERE rn = 1
+    "
+    );
+
+    let mut values: Vec<sea_orm::Value> = vec![tenant_id.as_bytes().to_vec().into()];
+    values.extend(person_ids.iter().map(|id| id.as_bytes().to_vec().into()));
+
+    let stmt = Statement::from_sql_and_values(DbBackend::MySql, &sql, values);
+    let rows = persons::Entity::find().from_raw_sql(stmt).all(db).await?;
 
     Ok(person_card::assemble_cards(rows))
 }

--- a/src/backend/services/identity-resolution/src/infra/db/roles_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/roles_repo.rs
@@ -107,6 +107,40 @@ pub async fn get_by_id(db: &DatabaseConnection, role_id: Uuid) -> anyhow::Result
         .transpose()
 }
 
+/// Active (`valid_to IS NULL`) roles `person_id` holds in the tenant, with
+/// names, ordered by name. Backs `GET /v1/me`. DISTINCT because nothing in the
+/// schema forbids two active grants of the same role to one person.
+///
+/// # Errors
+///
+/// Returns an error if the query fails or a stored id is not 16 bytes.
+pub async fn active_roles_of_person(
+    db: &DatabaseConnection,
+    tenant_id: Uuid,
+    person_id: Uuid,
+) -> anyhow::Result<Vec<Role>> {
+    const SQL: &str = r"
+        SELECT DISTINCT r.role_id, r.name
+        FROM person_roles pr
+        JOIN roles r ON r.role_id = pr.role_id
+        WHERE pr.insight_tenant_id = ?
+          AND pr.person_id         = ?
+          AND pr.valid_to IS NULL
+        ORDER BY r.name
+    ";
+
+    let stmt = Statement::from_sql_and_values(
+        DbBackend::MySql,
+        SQL,
+        [
+            tenant_id.as_bytes().to_vec().into(),
+            person_id.as_bytes().to_vec().into(),
+        ],
+    );
+
+    db.query_all(stmt).await?.iter().map(row_to_role).collect()
+}
+
 /// All roles, ordered by name. Ported from `SqlRoles.ListAllRoles`.
 ///
 /// # Errors

--- a/src/backend/services/identity-resolution/src/infra/db/test_fixture.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/test_fixture.rs
@@ -65,6 +65,32 @@ impl Fixture {
         Ok(person_id)
     }
 
+    /// Append one observation of `value_type` for an existing person — the
+    /// building block for "this person's value changed later" scenarios.
+    pub(crate) async fn observed(
+        &self,
+        person: Uuid,
+        value_type: &str,
+        value: &str,
+    ) -> anyhow::Result<()> {
+        self.exec(
+            "INSERT INTO persons (value_type, insight_source_type, insight_source_id,
+                 insight_tenant_id, value_id, person_id, author_person_id, reason)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            [
+                value_type.into(),
+                SOURCE_TYPE.into(),
+                bytes(self.source_id),
+                bytes(self.tenant),
+                value.into(),
+                bytes(person),
+                bytes(person),
+                FIXTURE_REASON.into(),
+            ],
+        )
+        .await
+    }
+
     /// A person the log knows without an email observation — the shape the
     /// `person_id` key exists to serve and the email key structurally cannot.
     pub(crate) async fn emailless_person(&self) -> anyhow::Result<Uuid> {

--- a/src/backend/services/identity-resolution/src/infra/identity_evidence.rs
+++ b/src/backend/services/identity-resolution/src/infra/identity_evidence.rs
@@ -28,6 +28,16 @@ pub struct AccountEvidence {
     pub is_closed: bool,
 }
 
+/// The whole evidence read, with the one fact about the read itself a consumer
+/// must not lose: whether the cap cut it short. Rates derived from a truncated
+/// read describe a prefix of the tenant, and only the caller can say so to the
+/// operator.
+#[derive(Debug)]
+pub struct EvidenceSnapshot {
+    pub accounts: Vec<AccountEvidence>,
+    pub truncated: bool,
+}
+
 /// One row per observed account: latest operation and latest non-empty values.
 /// DELETE rows carry an empty value by contract, so the value aggregates filter
 /// on UPSERT — while the operation aggregate keeps every event, which is what
@@ -101,15 +111,21 @@ impl ClickHouseEvidenceReader {
     /// # Errors
     ///
     /// Returns an error if the query fails or a stored source id is not a UUID.
-    pub async fn accounts(&self) -> anyhow::Result<Vec<AccountEvidence>> {
+    pub async fn accounts(&self) -> anyhow::Result<EvidenceSnapshot> {
         let sql = format!("{FOLD_SQL} LIMIT {MAX_EVIDENCE_ACCOUNTS}");
         let rows: Vec<FoldedRow> = match self.client.query(&sql).fetch_all().await {
             Ok(rows) => rows,
-            Err(e) if is_missing_relation(&e) => return Ok(Vec::new()),
+            Err(e) if is_missing_relation(&e) => {
+                return Ok(EvidenceSnapshot {
+                    accounts: Vec::new(),
+                    truncated: false,
+                });
+            }
             Err(e) => return Err(e.into()),
         };
 
-        if rows.len() == MAX_EVIDENCE_ACCOUNTS {
+        let truncated = rows.len() == MAX_EVIDENCE_ACCOUNTS;
+        if truncated {
             tracing::warn!(
                 cap = MAX_EVIDENCE_ACCOUNTS,
                 "review evidence: read cap reached; the queue and its rates \
@@ -133,7 +149,10 @@ impl ClickHouseEvidenceReader {
                 "review evidence: rows with an unreadable source id"
             );
         }
-        Ok(accounts)
+        Ok(EvidenceSnapshot {
+            accounts,
+            truncated,
+        })
     }
 }
 

--- a/src/frontend/src/api/identity-client.test.ts
+++ b/src/frontend/src/api/identity-client.test.ts
@@ -4,7 +4,7 @@ vi.mock("@/api/fetch-with-auth", () => ({ fetchWithAuth: vi.fn() }));
 
 import { fetchWithAuth } from "@/api/fetch-with-auth";
 
-import { getAttention, getMe, getPerson, IdentityApiError } from "./identity-client";
+import { getAccountBinding, getAttention, getMe, getPerson, IdentityApiError } from "./identity-client";
 
 const mockFetch = fetchWithAuth as unknown as ReturnType<typeof vi.fn>;
 
@@ -228,5 +228,27 @@ describe("getAttention", () => {
     );
 
     await expect(getAttention()).rejects.toMatchObject({ status: 403 });
+  });
+});
+
+describe("getAccountBinding", () => {
+  it("URI-encodes every path segment — an account_id with slashes cannot escape", async () => {
+    mockFetch.mockResolvedValueOnce(
+      response({ source: "github", source_id: "s", account_id: "a/b c", history: [] }),
+    );
+
+    await getAccountBinding({ source: "github", source_id: "s", account_id: "a/b c" });
+
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      "/api/identity/v1/resolution/accounts/github/s/a%2Fb%20c",
+    );
+  });
+
+  it("rejects a body without a history array", async () => {
+    mockFetch.mockResolvedValueOnce(response({ source: "github" } as never));
+
+    await expect(
+      getAccountBinding({ source: "github", source_id: "s", account_id: "a" }),
+    ).rejects.toMatchObject({ body: { error: "malformed_binding" } });
   });
 });

--- a/src/frontend/src/api/identity-client.test.ts
+++ b/src/frontend/src/api/identity-client.test.ts
@@ -4,7 +4,17 @@ vi.mock("@/api/fetch-with-auth", () => ({ fetchWithAuth: vi.fn() }));
 
 import { fetchWithAuth } from "@/api/fetch-with-auth";
 
-import { getAccountBinding, getAttention, getMe, getPerson, IdentityApiError } from "./identity-client";
+import {
+  bindAccount,
+  detachAccount,
+  getAccountBinding,
+  getAttention,
+  getMe,
+  getPerson,
+  IdentityApiError,
+  mergePersons,
+  searchPersons,
+} from "./identity-client";
 
 const mockFetch = fetchWithAuth as unknown as ReturnType<typeof vi.fn>;
 
@@ -250,5 +260,82 @@ describe("getAccountBinding", () => {
     await expect(
       getAccountBinding({ source: "github", source_id: "s", account_id: "a" }),
     ).rejects.toMatchObject({ body: { error: "malformed_binding" } });
+  });
+});
+
+describe("correction verbs", () => {
+  const ACCOUNT = {
+    source: "github",
+    source_id: "01900000-0000-7000-8000-00000000aa01",
+    id: "dev-42",
+  };
+  const OK = {
+    applied: 1,
+    already_decided: 0,
+    items: [{ ...ACCOUNT, account_id: "dev-42", outcome: "applied" }],
+  };
+
+  it("bind wraps the single account into the bulk wire shape", async () => {
+    mockFetch.mockResolvedValueOnce(response(OK));
+
+    await bindAccount({ account: ACCOUNT, person_id: "p-1" });
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe("/api/identity/v1/resolution/bind");
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      bindings: [{ account: ACCOUNT, person_id: "p-1" }],
+      comment: "",
+    });
+  });
+
+  it("merge names source and target explicitly", async () => {
+    mockFetch.mockResolvedValueOnce(response(OK));
+
+    await mergePersons({ source_person_id: "p-1", target_person_id: "p-2" });
+
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toBe("/api/identity/v1/resolution/merge");
+    expect(JSON.parse((init as RequestInit).body as string)).toMatchObject({
+      source_person_id: "p-1",
+      target_person_id: "p-2",
+    });
+  });
+
+  it("detach returns the freshly minted person", async () => {
+    mockFetch.mockResolvedValueOnce(
+      response({ ...OK, new_person_id: "p-new" }),
+    );
+
+    const outcome = await detachAccount({ account: ACCOUNT });
+
+    expect(outcome.new_person_id).toBe("p-new");
+  });
+
+  it("a refusal body without items is malformed, not silently empty", async () => {
+    mockFetch.mockResolvedValueOnce(response({ applied: 0 } as never));
+
+    await expect(bindAccount({ account: ACCOUNT, person_id: "p-1" })).rejects.toMatchObject({
+      body: { error: "malformed_correction" },
+    });
+  });
+});
+
+describe("searchPersons", () => {
+  it("URI-encodes the terms", async () => {
+    mockFetch.mockResolvedValueOnce(response({ items: [], truncated: false }));
+
+    await searchPersons("iva example.com");
+
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      "/api/identity/v1/persons?q=iva%20example.com",
+    );
+  });
+
+  it("rejects a malformed body rather than reading it as no matches", async () => {
+    mockFetch.mockResolvedValueOnce(response({ truncated: false } as never));
+
+    await expect(searchPersons("x y")).rejects.toMatchObject({
+      body: { error: "malformed_search" },
+    });
   });
 });

--- a/src/frontend/src/api/identity-client.test.ts
+++ b/src/frontend/src/api/identity-client.test.ts
@@ -4,7 +4,7 @@ vi.mock("@/api/fetch-with-auth", () => ({ fetchWithAuth: vi.fn() }));
 
 import { fetchWithAuth } from "@/api/fetch-with-auth";
 
-import { getPerson, IdentityApiError } from "./identity-client";
+import { getMe, getPerson, IdentityApiError } from "./identity-client";
 
 const mockFetch = fetchWithAuth as unknown as ReturnType<typeof vi.fn>;
 
@@ -137,4 +137,51 @@ describe("getPerson", () => {
     });
   });
 
+});
+
+describe("getMe", () => {
+  it("GETs /me and returns the caller with their roles verbatim", async () => {
+    mockFetch.mockResolvedValueOnce(
+      response({
+        person_id: "019e27bc-dec0-7626-81a9-c5524662a6a9",
+        insight_tenant_id: "t-1",
+        roles: [
+          { role_id: "a4d11000-0000-4000-8000-000000000001", name: "admin" },
+        ],
+      }),
+    );
+
+    const me = await getMe();
+
+    expect(mockFetch.mock.calls[0][0]).toBe("/api/identity/v1/me");
+    expect(me.roles).toEqual([
+      { role_id: "a4d11000-0000-4000-8000-000000000001", name: "admin" },
+    ]);
+  });
+
+  it("keeps an empty roles list as a valid 'not an admin' answer", async () => {
+    mockFetch.mockResolvedValueOnce(
+      response({ person_id: "p-1", insight_tenant_id: "t-1", roles: [] }),
+    );
+
+    await expect(getMe()).resolves.toMatchObject({ roles: [] });
+  });
+
+  it("throws on an HTTP failure instead of pretending to an empty grant", async () => {
+    mockFetch.mockResolvedValueOnce(
+      response({ title: "unauthenticated" }, { ok: false, status: 401 }),
+    );
+
+    await expect(getMe()).rejects.toMatchObject({ status: 401 });
+  });
+
+  it("rejects a malformed body rather than reading it as 'no roles'", async () => {
+    mockFetch.mockResolvedValueOnce(
+      response({ person_id: "p-1", insight_tenant_id: "t-1" } as never),
+    );
+
+    await expect(getMe()).rejects.toMatchObject({
+      body: { error: "malformed_me" },
+    });
+  });
 });

--- a/src/frontend/src/api/identity-client.test.ts
+++ b/src/frontend/src/api/identity-client.test.ts
@@ -4,7 +4,7 @@ vi.mock("@/api/fetch-with-auth", () => ({ fetchWithAuth: vi.fn() }));
 
 import { fetchWithAuth } from "@/api/fetch-with-auth";
 
-import { getMe, getPerson, IdentityApiError } from "./identity-client";
+import { getAttention, getMe, getPerson, IdentityApiError } from "./identity-client";
 
 const mockFetch = fetchWithAuth as unknown as ReturnType<typeof vi.fn>;
 
@@ -183,5 +183,50 @@ describe("getMe", () => {
     await expect(getMe()).rejects.toMatchObject({
       body: { error: "malformed_me" },
     });
+  });
+});
+
+describe("getAttention", () => {
+  it("GETs the review queue with its limit and returns items + rates", async () => {
+    mockFetch.mockResolvedValueOnce(
+      response({
+        items: [
+          {
+            kind: "contested",
+            source: "github",
+            source_id: "01900000-0000-7000-8000-00000000aa01",
+            account_id: "dev-42",
+            email: "dev42@example.com",
+            username: null,
+            candidates: [],
+          },
+        ],
+        rates: { observed: 1, bound: 0, pending: 1, no_evidence: 0, excluded: 0 },
+      }),
+    );
+
+    const queue = await getAttention(50);
+
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      "/api/identity/v1/resolution/attention?limit=50",
+    );
+    expect(queue.items).toHaveLength(1);
+    expect(queue.rates.pending).toBe(1);
+  });
+
+  it("rejects a malformed body rather than reading it as an empty queue", async () => {
+    mockFetch.mockResolvedValueOnce(response({ rates: null } as never));
+
+    await expect(getAttention()).rejects.toMatchObject({
+      body: { error: "malformed_attention" },
+    });
+  });
+
+  it("throws on an HTTP failure (a revoked role must not look like zero work)", async () => {
+    mockFetch.mockResolvedValueOnce(
+      response({ title: "forbidden" }, { ok: false, status: 403 }),
+    );
+
+    await expect(getAttention()).rejects.toMatchObject({ status: 403 });
   });
 });

--- a/src/frontend/src/api/identity-client.test.ts
+++ b/src/frontend/src/api/identity-client.test.ts
@@ -11,6 +11,7 @@ import {
   getAttention,
   getMe,
   getPerson,
+  getPersonAccounts,
   IdentityApiError,
   mergePersons,
   searchPersons,
@@ -194,6 +195,24 @@ describe("getMe", () => {
       body: { error: "malformed_me" },
     });
   });
+
+  // The gate reads `role_id` off every entry, so a well-shaped list of badly
+  // shaped members has to fail here — downstream it would throw during render
+  // instead of failing closed.
+  it.each([
+    ["a null member", [null]],
+    ["a non-object member", ["admin"]],
+    ["a member with no role_id", [{ name: "admin" }]],
+    ["a member whose role_id is blank", [{ role_id: "  ", name: "admin" }]],
+  ])("rejects a roles array with %s", async (_name, roles) => {
+    mockFetch.mockResolvedValueOnce(
+      response({ person_id: "p-1", insight_tenant_id: "t-1", roles } as never),
+    );
+
+    await expect(getMe()).rejects.toMatchObject({
+      body: { error: "malformed_me" },
+    });
+  });
 });
 
 describe("getAttention", () => {
@@ -336,6 +355,55 @@ describe("searchPersons", () => {
 
     await expect(searchPersons("x y")).rejects.toMatchObject({
       body: { error: "malformed_search" },
+    });
+  });
+});
+
+describe("getPersonAccounts", () => {
+  const OWNED = {
+    person_id: "01900000-0000-7000-8000-0000000000b0",
+    accounts: [
+      {
+        source: "github",
+        source_id: "01900000-0000-7000-8000-00000000aa01",
+        account_id: "gh-1",
+        email: "gh-1@example.com",
+        username: null,
+        bound_by_operator: true,
+      },
+    ],
+  };
+
+  it("URI-encodes the person id and returns the accounts", async () => {
+    mockFetch.mockResolvedValueOnce(response(OWNED));
+
+    await expect(getPersonAccounts(OWNED.person_id)).resolves.toEqual(OWNED);
+    expect(mockFetch.mock.calls[0][0]).toBe(
+      `/api/identity/v1/resolution/persons/${OWNED.person_id}/accounts`,
+    );
+  });
+
+  it("keeps an empty account list a valid answer", async () => {
+    mockFetch.mockResolvedValueOnce(response({ person_id: "p-1", accounts: [] }));
+
+    await expect(getPersonAccounts("p-1")).resolves.toMatchObject({ accounts: [] });
+  });
+
+  it("throws on an HTTP failure instead of reporting nothing to move", async () => {
+    mockFetch.mockResolvedValueOnce(
+      response({ title: "forbidden" }, { ok: false, status: 403 }),
+    );
+
+    await expect(getPersonAccounts("p-1")).rejects.toMatchObject({ status: 403 });
+  });
+
+  // The merge preview counts this list, so a malformed body must not read as
+  // "no accounts move" — that would understate what the merge is about to do.
+  it("rejects a malformed body rather than reading it as nothing to move", async () => {
+    mockFetch.mockResolvedValueOnce(response({ person_id: "p-1" } as never));
+
+    await expect(getPersonAccounts("p-1")).rejects.toMatchObject({
+      body: { error: "malformed_accounts" },
     });
   });
 });

--- a/src/frontend/src/api/identity-client.ts
+++ b/src/frontend/src/api/identity-client.ts
@@ -79,11 +79,22 @@ export async function getMe(): Promise<MeResponse> {
   }
   // A malformed answer must read as "roles unknown", never as "no roles" —
   // the admin gate downstream fails closed either way, but an error is
-  // diagnosable where a silent [] is not.
-  if (!me.person_id?.trim() || !Array.isArray(me.roles)) {
+  // diagnosable where a silent [] is not. The entries are checked too: the
+  // gate reads `role_id` off each one, so a `[null]` would throw during
+  // render rather than fail closed.
+  if (!me.person_id?.trim() || !Array.isArray(me.roles) || !me.roles.every(isMeRole)) {
     throw new IdentityApiError(res.status, { error: "malformed_me" });
   }
   return me;
+}
+
+function isMeRole(role: unknown): role is MeRole {
+  return (
+    typeof role === "object" &&
+    role !== null &&
+    typeof (role as MeRole).role_id === "string" &&
+    (role as MeRole).role_id.trim() !== ""
+  );
 }
 
 /** A person as operator surfaces display them — the wire `PersonSummaryResponse`. */
@@ -125,6 +136,9 @@ export interface AttentionResponse {
    *  describe only a prefix of the tenant's accounts. Optional so a client
    *  deployed ahead of the backend keeps working; absent reads as complete. */
   truncated?: boolean;
+  /** `limit` cut the item list — the rates are still whole-tenant, only this
+   *  page is short. Optional for the same reason as {@link truncated}. */
+  items_truncated?: boolean;
 }
 
 /**

--- a/src/frontend/src/api/identity-client.ts
+++ b/src/frontend/src/api/identity-client.ts
@@ -42,6 +42,50 @@ interface ProfileResponse {
   ids?: unknown[];
 }
 
+/** One active role assignment of the caller, as `GET /me` reports it. */
+export interface MeRole {
+  role_id: string;
+  name: string;
+}
+
+/**
+ * Wire shape of `GET /me` — who the gateway JWT identifies, with their active
+ * identity roles. `roles` comes from the identity service's `person_roles`
+ * table (the same rows every admin endpoint's gate checks) — NOT from the
+ * login token's realm roles, which no identity endpoint reads. An empty list
+ * IS the "not an admin" answer; the endpoint never 403s.
+ */
+export interface MeResponse {
+  person_id: string;
+  insight_tenant_id: string;
+  roles: MeRole[];
+}
+
+/**
+ * The caller's identity and active roles. Live on every call: granting or
+ * revoking a role is visible on the next fetch, no re-login needed.
+ */
+export async function getMe(): Promise<MeResponse> {
+  const res = await fetchWithAuth(`${BASE}/me`);
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new IdentityApiError(res.status, body);
+  }
+  let me: MeResponse;
+  try {
+    me = (await res.json()) as MeResponse;
+  } catch {
+    throw new IdentityApiError(res.status, { error: "invalid_json" });
+  }
+  // A malformed answer must read as "roles unknown", never as "no roles" —
+  // the admin gate downstream fails closed either way, but an error is
+  // diagnosable where a silent [] is not.
+  if (!me.person_id?.trim() || !Array.isArray(me.roles)) {
+    throw new IdentityApiError(res.status, { error: "malformed_me" });
+  }
+  return me;
+}
+
 export class IdentityApiError extends Error {
   status: number;
   body: unknown;

--- a/src/frontend/src/api/identity-client.ts
+++ b/src/frontend/src/api/identity-client.ts
@@ -197,6 +197,163 @@ export async function getAccountBinding(ref: {
   return binding;
 }
 
+/** A source-native account, as the correction verbs address it on the wire. */
+export interface WireAccountRef {
+  source: string;
+  source_id: string;
+  /** The wire calls the account id `id` (unlike the read shapes). */
+  id: string;
+}
+
+/** What happened to one requested account. Open vocabulary. */
+export interface CorrectionItemResult {
+  source: string;
+  source_id: string;
+  account_id: string;
+  /** `applied` | `already_decided` | `refused` | future skip reasons. */
+  outcome: string;
+}
+
+export interface CorrectionResponse {
+  applied: number;
+  already_decided: number;
+  items: CorrectionItemResult[];
+  /** Set by `detach`: the freshly minted person the account moved to. */
+  new_person_id?: string | null;
+}
+
+async function postCorrection(
+  path: string,
+  body: unknown,
+): Promise<CorrectionResponse> {
+  const res = await fetchWithAuth(`${BASE}/resolution/${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const errBody = await res.json().catch(() => null);
+    throw new IdentityApiError(res.status, errBody);
+  }
+  let outcome: CorrectionResponse;
+  try {
+    outcome = (await res.json()) as CorrectionResponse;
+  } catch {
+    throw new IdentityApiError(res.status, { error: "invalid_json" });
+  }
+  if (!Array.isArray(outcome.items)) {
+    throw new IdentityApiError(res.status, { error: "malformed_correction" });
+  }
+  return outcome;
+}
+
+/** Attach an account to a person — also the "confirm the current binding" act. */
+export async function bindAccount(args: {
+  account: WireAccountRef;
+  person_id: string;
+  comment?: string;
+}): Promise<CorrectionResponse> {
+  return postCorrection("bind", {
+    bindings: [{ account: args.account, person_id: args.person_id }],
+    comment: args.comment ?? "",
+  });
+}
+
+/** Declare two persons one human: every account of `source` moves to `target`. */
+export async function mergePersons(args: {
+  source_person_id: string;
+  target_person_id: string;
+  comment?: string;
+}): Promise<CorrectionResponse> {
+  return postCorrection("merge", {
+    source_person_id: args.source_person_id,
+    target_person_id: args.target_person_id,
+    comment: args.comment ?? "",
+  });
+}
+
+/** Detach an account into a freshly minted person. */
+export async function detachAccount(args: {
+  account: WireAccountRef;
+  comment?: string;
+}): Promise<CorrectionResponse> {
+  return postCorrection("detach", {
+    account: args.account,
+    comment: args.comment ?? "",
+  });
+}
+
+/** Exclude an account as not a person (bot / CI / service account). */
+export async function excludeAccount(args: {
+  account: WireAccountRef;
+  comment?: string;
+}): Promise<CorrectionResponse> {
+  return postCorrection("exclude", {
+    account: args.account,
+    comment: args.comment ?? "",
+  });
+}
+
+export interface PersonSearchResponse {
+  items: PersonSummary[];
+  /** More persons matched than the limit allowed — ask for narrower terms. */
+  truncated: boolean;
+}
+
+/**
+ * The operator person picker (`GET /persons?q=`) — tenant-wide, admin-gated,
+ * matching every whitespace-separated term against current identity values.
+ */
+export async function searchPersons(q: string): Promise<PersonSearchResponse> {
+  const res = await fetchWithAuth(`${BASE}/persons?q=${encodeURIComponent(q)}`);
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new IdentityApiError(res.status, body);
+  }
+  let found: PersonSearchResponse;
+  try {
+    found = (await res.json()) as PersonSearchResponse;
+  } catch {
+    throw new IdentityApiError(res.status, { error: "invalid_json" });
+  }
+  if (!Array.isArray(found.items)) {
+    throw new IdentityApiError(res.status, { error: "malformed_search" });
+  }
+  return found;
+}
+
+export interface PersonAccountEntry {
+  source: string;
+  source_id: string;
+  account_id: string;
+  email?: string | null;
+  username?: string | null;
+  bound_by_operator: boolean;
+}
+
+/** Every account currently bound to a person — the merge preview's substance. */
+export async function getPersonAccounts(
+  personId: string,
+): Promise<{ person_id: string; accounts: PersonAccountEntry[] }> {
+  const res = await fetchWithAuth(
+    `${BASE}/resolution/persons/${encodeURIComponent(personId)}/accounts`,
+  );
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new IdentityApiError(res.status, body);
+  }
+  let owned: { person_id: string; accounts: PersonAccountEntry[] };
+  try {
+    owned = (await res.json()) as typeof owned;
+  } catch {
+    throw new IdentityApiError(res.status, { error: "invalid_json" });
+  }
+  if (!Array.isArray(owned.accounts)) {
+    throw new IdentityApiError(res.status, { error: "malformed_accounts" });
+  }
+  return owned;
+}
+
 export class IdentityApiError extends Error {
   status: number;
   body: unknown;

--- a/src/frontend/src/api/identity-client.ts
+++ b/src/frontend/src/api/identity-client.ts
@@ -146,6 +146,57 @@ export async function getAttention(limit = 200): Promise<AttentionResponse> {
   return attention;
 }
 
+/** One decision recorded for an account, newest first on the wire. */
+export interface BindingHistoryEntry {
+  person_id: string;
+  author_person_id: string;
+  /** True when a human recorded it; false = automation (seed/resolver). */
+  by_operator: boolean;
+  /** Verb code (`operator-bind`, …) or an automation reason. Open vocabulary. */
+  reason?: string | null;
+  recorded_at: string;
+}
+
+export interface AccountBinding {
+  source: string;
+  source_id: string;
+  account_id: string;
+  /** Absent = the account is currently bound to nobody. */
+  person_id?: string | null;
+  history: BindingHistoryEntry[];
+}
+
+/**
+ * One account's current binding and its full decision trail
+ * (`GET /resolution/accounts/{source}/{source_id}/{account_id}`). 404 means
+ * the account was never observed AND never decided — the state a stale shared
+ * link lands on.
+ */
+export async function getAccountBinding(ref: {
+  source: string;
+  source_id: string;
+  account_id: string;
+}): Promise<AccountBinding> {
+  const path = [ref.source, ref.source_id, ref.account_id]
+    .map(encodeURIComponent)
+    .join("/");
+  const res = await fetchWithAuth(`${BASE}/resolution/accounts/${path}`);
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new IdentityApiError(res.status, body);
+  }
+  let binding: AccountBinding;
+  try {
+    binding = (await res.json()) as AccountBinding;
+  } catch {
+    throw new IdentityApiError(res.status, { error: "invalid_json" });
+  }
+  if (!Array.isArray(binding.history)) {
+    throw new IdentityApiError(res.status, { error: "malformed_binding" });
+  }
+  return binding;
+}
+
 export class IdentityApiError extends Error {
   status: number;
   body: unknown;

--- a/src/frontend/src/api/identity-client.ts
+++ b/src/frontend/src/api/identity-client.ts
@@ -121,6 +121,10 @@ export interface ResolutionRates {
 export interface AttentionResponse {
   items: AttentionItem[];
   rates: ResolutionRates;
+  /** The server's evidence read hit its safety cap: the queue and the rates
+   *  describe only a prefix of the tenant's accounts. Optional so a client
+   *  deployed ahead of the backend keeps working; absent reads as complete. */
+  truncated?: boolean;
 }
 
 /**
@@ -168,9 +172,10 @@ export interface AccountBinding {
 
 /**
  * One account's current binding and its full decision trail
- * (`GET /resolution/accounts/{source}/{source_id}/{account_id}`). 404 means
- * the account was never observed AND never decided — the state a stale shared
- * link lands on.
+ * (`GET /resolution/accounts/{source}/{source_id}/{account_id}`). The read
+ * never 404s: an account nobody ever observed or decided answers 200 with
+ * `person_id: null` and an empty history — the state a stale shared link
+ * lands on.
  */
 export async function getAccountBinding(ref: {
   source: string;

--- a/src/frontend/src/api/identity-client.ts
+++ b/src/frontend/src/api/identity-client.ts
@@ -86,6 +86,66 @@ export async function getMe(): Promise<MeResponse> {
   return me;
 }
 
+/** A person as operator surfaces display them — the wire `PersonSummaryResponse`. */
+export interface PersonSummary {
+  person_id: string;
+  email?: string | null;
+  username?: string | null;
+  display_name?: string | null;
+  job_title?: string | null;
+  status?: string | null;
+}
+
+/** One account awaiting an operator decision. */
+export interface AttentionItem {
+  /** `contested` | `binding_conflict` | `no_evidence` — open vocabulary. */
+  kind: string;
+  source: string;
+  source_id: string;
+  account_id: string;
+  email?: string | null;
+  username?: string | null;
+  /** Hydrated person cards, not bare ids. */
+  candidates: PersonSummary[];
+}
+
+/** Counts over EVERY observed account, regardless of the item cap. */
+export interface ResolutionRates {
+  observed: number;
+  bound: number;
+  pending: number;
+  no_evidence: number;
+  excluded: number;
+}
+
+export interface AttentionResponse {
+  items: AttentionItem[];
+  rates: ResolutionRates;
+}
+
+/**
+ * The operator review queue (`GET /resolution/attention`) — accounts the
+ * resolver could not decide, with the tenant-wide match rate. Admin-gated
+ * server-side; the caller is expected to sit behind `useIsAdmin`.
+ */
+export async function getAttention(limit = 200): Promise<AttentionResponse> {
+  const res = await fetchWithAuth(`${BASE}/resolution/attention?limit=${limit}`);
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new IdentityApiError(res.status, body);
+  }
+  let attention: AttentionResponse;
+  try {
+    attention = (await res.json()) as AttentionResponse;
+  } catch {
+    throw new IdentityApiError(res.status, { error: "invalid_json" });
+  }
+  if (!Array.isArray(attention.items) || attention.rates == null) {
+    throw new IdentityApiError(res.status, { error: "malformed_attention" });
+  }
+  return attention;
+}
+
 export class IdentityApiError extends Error {
   status: number;
   body: unknown;

--- a/src/frontend/src/components/confirm-dialog.tsx
+++ b/src/frontend/src/components/confirm-dialog.tsx
@@ -31,6 +31,7 @@ export function ConfirmDialog({
   confirmLabel,
   destructive = false,
   isPending,
+  confirmDisabled = false,
   error,
   onConfirm,
 }: {
@@ -42,6 +43,9 @@ export function ConfirmDialog({
   confirmLabel: string;
   destructive?: boolean;
   isPending: boolean;
+  /** The caller's body is not ready to be confirmed — a preview still
+   *  loading or failed. Cancel stays available; only confirm locks. */
+  confirmDisabled?: boolean;
   error?: string | null;
   onConfirm: () => void;
 }) {
@@ -75,7 +79,7 @@ export function ConfirmDialog({
             type="button"
             variant={destructive ? "destructive" : "default"}
             onClick={onConfirm}
-            disabled={isPending}
+            disabled={isPending || confirmDisabled}
           >
             {confirmLabel}
           </Button>

--- a/src/frontend/src/components/confirm-dialog.tsx
+++ b/src/frontend/src/components/confirm-dialog.tsx
@@ -1,0 +1,86 @@
+/**
+ * A confirmation step for actions that change shared state — the first one in
+ * this codebase (existing delete flows fire immediately; identity corrections
+ * must not). Composed from `ui/dialog` in the console `StatusDialog` idiom
+ * rather than vendoring a new primitive.
+ *
+ * The body is the caller's: a merge renders its preview there, a bind names
+ * its target. The error slot keeps the dialog open on failure — closing over
+ * an unshown error would read as success.
+ */
+import { TriangleAlert } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  children,
+  confirmLabel,
+  destructive = false,
+  isPending,
+  error,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  title: string;
+  description?: string;
+  children?: React.ReactNode;
+  confirmLabel: string;
+  destructive?: boolean;
+  isPending: boolean;
+  error?: string | null;
+  onConfirm: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          {description ? (
+            <DialogDescription>{description}</DialogDescription>
+          ) : null}
+        </DialogHeader>
+        {children}
+        {error ? (
+          <Alert variant="destructive">
+            <TriangleAlert />
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        ) : null}
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => onOpenChange(false)}
+            disabled={isPending}
+          >
+            {t("common.actions.cancel")}
+          </Button>
+          <Button
+            type="button"
+            variant={destructive ? "destructive" : "default"}
+            onClick={onConfirm}
+            disabled={isPending}
+          >
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/frontend/src/components/confirm-dialog.tsx
+++ b/src/frontend/src/components/confirm-dialog.tsx
@@ -50,9 +50,17 @@ export function ConfirmDialog({
   onConfirm: () => void;
 }) {
   const { t } = useTranslation();
+  // A verb in flight is not dismissable. Disabling Cancel is not enough:
+  // Escape, an overlay click and the built-in close button all bypass it, and
+  // closing resets the mutation — so the operator would lose the outcome of a
+  // write the server goes on to apply.
+  const requestClose = (next: boolean) => {
+    if (isPending && !next) return;
+    onOpenChange(next);
+  };
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-md">
+    <Dialog open={open} onOpenChange={requestClose}>
+      <DialogContent className="sm:max-w-md" showCloseButton={!isPending}>
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           {description ? (
@@ -70,7 +78,7 @@ export function ConfirmDialog({
           <Button
             type="button"
             variant="ghost"
-            onClick={() => onOpenChange(false)}
+            onClick={() => requestClose(false)}
             disabled={isPending}
           >
             {t("common.actions.cancel")}

--- a/src/frontend/src/components/portal/account-actions.test.tsx
+++ b/src/frontend/src/components/portal/account-actions.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+/**
+ * The decision surface. What matters: the button on the currently bound
+ * candidate reads "Confirm" (re-asserting IS the decision) while others read
+ * "Bind"; Merge exists only when there is someone to absorb; every verb goes
+ * through a confirmation and sends the account in the WIRE shape (`id`, not
+ * `account_id`); the merge dialog previews what moves BEFORE anything
+ * happens; and the server's outcome renders verbatim — a refusal is never
+ * dressed up as success.
+ */
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import "@/i18n";
+import type { AccountBinding, CorrectionResponse } from "@/api/identity-client";
+
+const hooks = vi.hoisted(() => {
+  const verb = () => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null as unknown,
+  });
+  return {
+    bind: verb(),
+    merge: verb(),
+    detach: verb(),
+    exclude: verb(),
+    personAccounts: {
+      data: undefined as
+        | { person_id: string; accounts: unknown[] }
+        | undefined,
+      isLoading: false,
+    },
+    search: { data: undefined, isFetching: false, isError: false },
+  };
+});
+vi.mock("@/queries/identity-resolution", () => ({
+  useBindAccount: () => hooks.bind,
+  useMergePersons: () => hooks.merge,
+  useDetachAccount: () => hooks.detach,
+  useExcludeAccount: () => hooks.exclude,
+  usePersonAccounts: () => hooks.personAccounts,
+  usePersonSearch: () => hooks.search,
+}));
+
+import { AccountActions } from "./account-actions";
+
+const REF = {
+  source: "github",
+  source_id: "01900000-0000-7000-8000-00000000aa01",
+  account_id: "dev-42",
+};
+const BOB = {
+  person_id: "01900000-0000-7000-8000-0000000000b0",
+  display_name: "Bob Park",
+  email: "bob.park@example.com",
+};
+const CAROL = {
+  person_id: "01900000-0000-7000-8000-0000000000c0",
+  display_name: "Carol Chen",
+  email: "carol.chen@example.com",
+};
+
+function binding(over: Partial<AccountBinding> = {}): AccountBinding {
+  return { ...REF, person_id: BOB.person_id, history: [], ...over };
+}
+
+beforeEach(() => {
+  for (const verb of [hooks.bind, hooks.merge, hooks.detach, hooks.exclude]) {
+    verb.mutate.mockClear();
+    verb.isError = false;
+    verb.error = null;
+  }
+  hooks.personAccounts.data = undefined;
+  hooks.personAccounts.isLoading = false;
+});
+
+describe("AccountActions", () => {
+  it("labels the bound candidate Confirm and the rival Bind; Merge only on the rival", () => {
+    render(
+      <AccountActions accountRef={REF} binding={binding()} candidates={[BOB, CAROL]} />,
+    );
+
+    expect(screen.getByRole("button", { name: "Confirm" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Bind" })).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "Merge…" })).toHaveLength(1);
+  });
+
+  it("offers no Merge when the account is bound to nobody", () => {
+    render(
+      <AccountActions
+        accountRef={REF}
+        binding={binding({ person_id: null })}
+        candidates={[BOB]}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Merge…" })).not.toBeInTheDocument();
+  });
+
+  it("bind goes through a confirmation and sends the WIRE account shape", async () => {
+    render(
+      <AccountActions accountRef={REF} binding={binding()} candidates={[BOB, CAROL]} />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Bind" }));
+    const dialog = screen.getByRole("dialog");
+    expect(hooks.bind.mutate).not.toHaveBeenCalled();
+
+    await userEvent.click(within(dialog).getByRole("button", { name: "Bind" }));
+    expect(hooks.bind.mutate).toHaveBeenCalledWith(
+      {
+        account: { source: REF.source, source_id: REF.source_id, id: REF.account_id },
+        person_id: CAROL.person_id,
+      },
+      expect.anything(),
+    );
+  });
+
+  it("the merge dialog previews what moves before anything happens", async () => {
+    hooks.personAccounts.data = {
+      person_id: BOB.person_id,
+      accounts: [
+        { source: "github", source_id: "s", account_id: "gh-1", email: "a@example.com" },
+        { source: "gitlab", source_id: "s", account_id: "gl-2", username: "gl-2" },
+      ],
+    };
+    render(
+      <AccountActions accountRef={REF} binding={binding()} candidates={[BOB, CAROL]} />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Merge…" }));
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText(/2 accounts move/i)).toBeInTheDocument();
+    expect(hooks.merge.mutate).not.toHaveBeenCalled();
+
+    await userEvent.click(
+      within(dialog).getByRole("button", { name: "Merge persons" }),
+    );
+    expect(hooks.merge.mutate).toHaveBeenCalledWith(
+      { source_person_id: BOB.person_id, target_person_id: CAROL.person_id },
+      expect.anything(),
+    );
+  });
+
+  it("renders the server's outcome verbatim, refusals included", async () => {
+    const refusal: CorrectionResponse = {
+      applied: 0,
+      already_decided: 0,
+      items: [{ ...REF, account_id: REF.account_id, outcome: "refused" }],
+    };
+    hooks.detach.mutate.mockImplementation(
+      (_args: unknown, opts?: { onSuccess?: (r: CorrectionResponse) => void }) =>
+        opts?.onSuccess?.(refusal),
+    );
+    render(<AccountActions accountRef={REF} binding={binding()} candidates={[]} />);
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /detach into a new person/i }),
+    );
+    await userEvent.click(
+      within(screen.getByRole("dialog")).getByRole("button", { name: "Detach" }),
+    );
+
+    expect(screen.getByText(/1 refused/i)).toBeInTheDocument();
+    expect(screen.getByText(/0 applied/i)).toBeInTheDocument();
+  });
+
+  it("a failed verb keeps the dialog open with the server's reason", async () => {
+    hooks.exclude.isError = true;
+    const { IdentityApiError } = await import("@/api/identity-client");
+    hooks.exclude.error = new IdentityApiError(400, {
+      context: { field_violations: [{ field: "account", description: "account not found" }] },
+    });
+    render(<AccountActions accountRef={REF} binding={binding()} candidates={[]} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /exclude \(bot/i }));
+    const dialog = screen.getByRole("dialog");
+
+    expect(within(dialog).getByText("account not found")).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/portal/account-actions.test.tsx
+++ b/src/frontend/src/components/portal/account-actions.test.tsx
@@ -18,6 +18,7 @@ import type { AccountBinding, CorrectionResponse } from "@/api/identity-client";
 const hooks = vi.hoisted(() => {
   const verb = () => ({
     mutate: vi.fn(),
+    reset: vi.fn(),
     isPending: false,
     isError: false,
     error: null as unknown,
@@ -32,6 +33,8 @@ const hooks = vi.hoisted(() => {
         | { person_id: string; accounts: unknown[] }
         | undefined,
       isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
     },
     search: { data: undefined, isFetching: false, isError: false },
   };
@@ -70,11 +73,14 @@ function binding(over: Partial<AccountBinding> = {}): AccountBinding {
 beforeEach(() => {
   for (const verb of [hooks.bind, hooks.merge, hooks.detach, hooks.exclude]) {
     verb.mutate.mockClear();
+    verb.reset.mockClear();
     verb.isError = false;
     verb.error = null;
   }
   hooks.personAccounts.data = undefined;
   hooks.personAccounts.isLoading = false;
+  hooks.personAccounts.isError = false;
+  hooks.personAccounts.refetch.mockClear();
 });
 
 describe("AccountActions", () => {
@@ -145,6 +151,42 @@ describe("AccountActions", () => {
     );
   });
 
+  it("locks merge confirm until the preview names what moves", async () => {
+    hooks.personAccounts.isLoading = true;
+    render(
+      <AccountActions accountRef={REF} binding={binding()} candidates={[BOB, CAROL]} />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Merge…" }));
+    const dialog = screen.getByRole("dialog");
+
+    // The preview IS the consent — confirming a list the operator never saw
+    // would move accounts sight-unseen.
+    expect(
+      within(dialog).getByRole("button", { name: "Merge persons" }),
+    ).toBeDisabled();
+    expect(hooks.merge.mutate).not.toHaveBeenCalled();
+  });
+
+  it("a failed preview blocks merge and offers a retry, not a zero-account lie", async () => {
+    hooks.personAccounts.isError = true;
+    render(
+      <AccountActions accountRef={REF} binding={binding()} candidates={[BOB, CAROL]} />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Merge…" }));
+    const dialog = screen.getByRole("dialog");
+
+    expect(within(dialog).queryByText(/0 accounts move/i)).not.toBeInTheDocument();
+    expect(within(dialog).getByText(/could not count/i)).toBeInTheDocument();
+    expect(
+      within(dialog).getByRole("button", { name: "Merge persons" }),
+    ).toBeDisabled();
+
+    await userEvent.click(within(dialog).getByRole("button", { name: "Retry" }));
+    expect(hooks.personAccounts.refetch).toHaveBeenCalledOnce();
+  });
+
   it("renders the server's outcome verbatim, refusals included", async () => {
     const refusal: CorrectionResponse = {
       applied: 0,
@@ -166,6 +208,20 @@ describe("AccountActions", () => {
 
     expect(screen.getByText(/1 refused/i)).toBeInTheDocument();
     expect(screen.getByText(/0 applied/i)).toBeInTheDocument();
+  });
+
+  it("cancelling a dialog resets the verbs, so the next one opens clean", async () => {
+    render(<AccountActions accountRef={REF} binding={binding()} candidates={[]} />);
+
+    await userEvent.click(screen.getByRole("button", { name: /exclude \(bot/i }));
+    await userEvent.click(
+      within(screen.getByRole("dialog")).getByRole("button", { name: "Cancel" }),
+    );
+
+    // A dialog's error belongs to the attempt made in that dialog; without
+    // the reset the next dialog would open already wearing the old failure.
+    expect(hooks.exclude.reset).toHaveBeenCalled();
+    expect(hooks.bind.reset).toHaveBeenCalled();
   });
 
   it("a failed verb keeps the dialog open with the server's reason", async () => {

--- a/src/frontend/src/components/portal/account-actions.tsx
+++ b/src/frontend/src/components/portal/account-actions.tsx
@@ -73,7 +73,15 @@ export function AccountActions({
   };
   const boundId = binding.person_id ?? null;
 
-  const close = () => setAction({ kind: "closed" });
+  const close = () => {
+    setAction({ kind: "closed" });
+    // A dialog's error belongs to the attempt made in THAT dialog; without a
+    // reset the next dialog opens already wearing the previous failure.
+    bind.reset();
+    merge.reset();
+    detach.reset();
+    exclude.reset();
+  };
   const done = (result: CorrectionResponse) => {
     setOutcome(result);
     close();
@@ -275,10 +283,26 @@ function MergeDialog({
       confirmLabel={t("identities.actions.merge_confirm")}
       destructive
       isPending={isPending}
+      // The preview IS the consent: a merge confirmed before the list loads
+      // (or over a failed load rendering as "0 accounts move") would move
+      // accounts the operator never saw named.
+      confirmDisabled={owned.data == null}
       error={error}
       onConfirm={onConfirm}
     >
-      {owned.isLoading ? (
+      {owned.isError ? (
+        <div className="flex items-center gap-2 text-sm text-destructive">
+          <span>{t("identities.dialogs.merge_preview_failed")}</span>
+          <Button
+            type="button"
+            size="xs"
+            variant="outline"
+            onClick={() => void owned.refetch()}
+          >
+            {t("common.actions.retry")}
+          </Button>
+        </div>
+      ) : owned.data == null ? (
         <p className="text-sm text-muted-foreground">
           {t("identities.dialogs.merge_preview_loading")}
         </p>

--- a/src/frontend/src/components/portal/account-actions.tsx
+++ b/src/frontend/src/components/portal/account-actions.tsx
@@ -1,0 +1,341 @@
+/**
+ * The decision surface for one account: every correction verb, each behind a
+ * confirmation, with the server's per-item outcomes shown verbatim.
+ *
+ * Grammar (mirrors the API):
+ * - Bind — attach THIS account to a person. On the current person it is the
+ *   "confirm" act: re-asserting an automatic binding records the operator's
+ *   decision and clears the queue item.
+ * - Merge — declare the currently bound person and a candidate one human;
+ *   EVERY account of the absorbed person moves, so the dialog previews the
+ *   list before anything happens.
+ * - Detach — mint a fresh person for this account.
+ * - Exclude — not a person at all (bot / CI).
+ *
+ * Outcomes are never collapsed into a success toast: `already_decided` and
+ * `refused` are real states the operator must see (#2424).
+ */
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type {
+  AccountBinding,
+  CorrectionResponse,
+  PersonSummary,
+  WireAccountRef,
+} from "@/api/identity-client";
+import { ConfirmDialog } from "@/components/confirm-dialog";
+import { PersonCell } from "@/components/portal/person-cell";
+import { PersonPicker } from "@/components/portal/person-picker";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { AccountRef } from "@/lib/identities/account-key";
+import { personDisplayName } from "@/lib/identities/person-display";
+import { apiErrorReason } from "@/lib/query-console/api-error";
+import {
+  useBindAccount,
+  useDetachAccount,
+  useExcludeAccount,
+  useMergePersons,
+  usePersonAccounts,
+} from "@/queries/identity-resolution";
+
+type PendingAction =
+  | { kind: "closed" }
+  | { kind: "bind"; person: PersonSummary }
+  | { kind: "merge"; target: PersonSummary }
+  | { kind: "detach" }
+  | { kind: "exclude" };
+
+export function AccountActions({
+  accountRef,
+  binding,
+  candidates,
+}: {
+  accountRef: AccountRef;
+  binding: AccountBinding;
+  candidates: PersonSummary[];
+}) {
+  const { t } = useTranslation();
+  const [action, setAction] = useState<PendingAction>({ kind: "closed" });
+  const [outcome, setOutcome] = useState<CorrectionResponse | null>(null);
+
+  const bind = useBindAccount();
+  const merge = useMergePersons();
+  const detach = useDetachAccount();
+  const exclude = useExcludeAccount();
+
+  const wireRef: WireAccountRef = {
+    source: accountRef.source,
+    source_id: accountRef.source_id,
+    id: accountRef.account_id,
+  };
+  const boundId = binding.person_id ?? null;
+
+  const close = () => setAction({ kind: "closed" });
+  const done = (result: CorrectionResponse) => {
+    setOutcome(result);
+    close();
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      {outcome ? <OutcomeAlert outcome={outcome} /> : null}
+
+      {candidates.length > 0 ? (
+        <section>
+          <div className="mb-1.5 text-xs font-medium tracking-wide text-muted-foreground uppercase">
+            {t("identities.detail.candidates")}
+          </div>
+          <div className="flex flex-col gap-2">
+            {candidates.map((candidate) => {
+              const isBound = candidate.person_id === boundId;
+              return (
+                <div key={candidate.person_id} className="flex items-center gap-2">
+                  <PersonCell person={candidate} className="min-w-0 flex-1" />
+                  <Button
+                    type="button"
+                    size="xs"
+                    variant={isBound ? "default" : "outline"}
+                    onClick={() => setAction({ kind: "bind", person: candidate })}
+                  >
+                    {isBound
+                      ? t("identities.actions.confirm")
+                      : t("identities.actions.bind")}
+                  </Button>
+                  {boundId && !isBound ? (
+                    <Button
+                      type="button"
+                      size="xs"
+                      variant="outline"
+                      onClick={() => setAction({ kind: "merge", target: candidate })}
+                    >
+                      {t("identities.actions.merge")}
+                    </Button>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      ) : null}
+
+      <section>
+        <div className="mb-1.5 text-xs font-medium tracking-wide text-muted-foreground uppercase">
+          {t("identities.actions.assign_other")}
+        </div>
+        <PersonPicker
+          excludeIds={candidates.map((c) => c.person_id)}
+          onPick={(person) => setAction({ kind: "bind", person })}
+        />
+      </section>
+
+      <section className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          onClick={() => setAction({ kind: "detach" })}
+        >
+          {t("identities.actions.detach")}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="destructive"
+          onClick={() => setAction({ kind: "exclude" })}
+        >
+          {t("identities.actions.exclude")}
+        </Button>
+      </section>
+
+      {action.kind === "bind" ? (
+        <ConfirmDialog
+          open
+          onOpenChange={(open) => !open && close()}
+          title={
+            action.person.person_id === boundId
+              ? t("identities.dialogs.confirm_title")
+              : t("identities.dialogs.bind_title")
+          }
+          description={t("identities.dialogs.bind_description", {
+            name: personDisplayName(action.person),
+          })}
+          confirmLabel={
+            action.person.person_id === boundId
+              ? t("identities.actions.confirm")
+              : t("identities.actions.bind")
+          }
+          isPending={bind.isPending}
+          error={
+            bind.isError
+              ? apiErrorReason(bind.error, t("identities.dialogs.failed"))
+              : null
+          }
+          onConfirm={() =>
+            bind.mutate(
+              { account: wireRef, person_id: action.person.person_id },
+              { onSuccess: done },
+            )
+          }
+        >
+          <PersonCell person={action.person} />
+        </ConfirmDialog>
+      ) : null}
+
+      {action.kind === "merge" ? (
+        <MergeDialog
+          sourceId={boundId ?? ""}
+          target={action.target}
+          isPending={merge.isPending}
+          error={
+            merge.isError
+              ? apiErrorReason(merge.error, t("identities.dialogs.failed"))
+              : null
+          }
+          onClose={close}
+          onConfirm={() =>
+            merge.mutate(
+              {
+                source_person_id: boundId ?? "",
+                target_person_id: action.target.person_id,
+              },
+              { onSuccess: done },
+            )
+          }
+        />
+      ) : null}
+
+      {action.kind === "detach" ? (
+        <ConfirmDialog
+          open
+          onOpenChange={(open) => !open && close()}
+          title={t("identities.dialogs.detach_title")}
+          description={t("identities.dialogs.detach_description")}
+          confirmLabel={t("identities.actions.detach_confirm")}
+          isPending={detach.isPending}
+          error={
+            detach.isError
+              ? apiErrorReason(detach.error, t("identities.dialogs.failed"))
+              : null
+          }
+          onConfirm={() => detach.mutate({ account: wireRef }, { onSuccess: done })}
+        />
+      ) : null}
+
+      {action.kind === "exclude" ? (
+        <ConfirmDialog
+          open
+          onOpenChange={(open) => !open && close()}
+          title={t("identities.dialogs.exclude_title")}
+          description={t("identities.dialogs.exclude_description")}
+          confirmLabel={t("identities.actions.exclude_confirm")}
+          destructive
+          isPending={exclude.isPending}
+          error={
+            exclude.isError
+              ? apiErrorReason(exclude.error, t("identities.dialogs.failed"))
+              : null
+          }
+          onConfirm={() => exclude.mutate({ account: wireRef }, { onSuccess: done })}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+/** The merge preview: name what moves BEFORE anything happens. */
+function MergeDialog({
+  sourceId,
+  target,
+  isPending,
+  error,
+  onClose,
+  onConfirm,
+}: {
+  sourceId: string;
+  target: PersonSummary;
+  isPending: boolean;
+  error: string | null;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  const { t } = useTranslation();
+  const owned = usePersonAccounts(sourceId || null);
+  const accounts = owned.data?.accounts ?? [];
+  return (
+    <ConfirmDialog
+      open
+      onOpenChange={(open) => !open && onClose()}
+      title={t("identities.dialogs.merge_title")}
+      description={t("identities.dialogs.merge_description", {
+        name: personDisplayName(target),
+      })}
+      confirmLabel={t("identities.actions.merge_confirm")}
+      destructive
+      isPending={isPending}
+      error={error}
+      onConfirm={onConfirm}
+    >
+      {owned.isLoading ? (
+        <p className="text-sm text-muted-foreground">
+          {t("identities.dialogs.merge_preview_loading")}
+        </p>
+      ) : (
+        <div className="text-sm">
+          <p>{t("identities.dialogs.merge_preview", { count: accounts.length })}</p>
+          <ul className="mt-1.5 flex flex-col gap-1">
+            {accounts.slice(0, 5).map((account) => (
+              <li
+                key={`${account.source}:${account.source_id}:${account.account_id}`}
+                className="font-mono text-xs text-muted-foreground"
+              >
+                {account.source} · {account.email ?? account.username ?? account.account_id}
+              </li>
+            ))}
+          </ul>
+          {accounts.length > 5 ? (
+            <p className="mt-1 text-xs text-muted-foreground">
+              {t("identities.dialogs.merge_preview_more", {
+                count: accounts.length - 5,
+              })}
+            </p>
+          ) : null}
+        </div>
+      )}
+    </ConfirmDialog>
+  );
+}
+
+/** The server's answer, verbatim — three counters, never a bare "done". */
+function OutcomeAlert({ outcome }: { outcome: CorrectionResponse }) {
+  const { t } = useTranslation();
+  const refused = outcome.items.filter((i) => i.outcome === "refused").length;
+  return (
+    <Alert variant={refused > 0 ? "destructive" : "default"} role="status">
+      <AlertTitle className="flex flex-wrap items-center gap-1.5">
+        <Badge variant="secondary">
+          {t("identities.outcomes.applied", { count: outcome.applied })}
+        </Badge>
+        {outcome.already_decided > 0 ? (
+          <Badge variant="outline">
+            {t("identities.outcomes.already_decided", {
+              count: outcome.already_decided,
+            })}
+          </Badge>
+        ) : null}
+        {refused > 0 ? (
+          <Badge variant="secondary" className="bg-destructive/15 text-destructive">
+            {t("identities.outcomes.refused", { count: refused })}
+          </Badge>
+        ) : null}
+      </AlertTitle>
+      {outcome.new_person_id ? (
+        <AlertDescription className="font-mono text-xs">
+          {t("identities.outcomes.new_person")} {outcome.new_person_id}
+        </AlertDescription>
+      ) : null}
+    </Alert>
+  );
+}

--- a/src/frontend/src/components/portal/account-detail.test.tsx
+++ b/src/frontend/src/components/portal/account-detail.test.tsx
@@ -3,15 +3,15 @@
  * The detail panel. What matters: a bound person known to the queue renders
  * as a recognisable card while an unknown one stays an honest bare id; the
  * history names the verb (and unknown reasons pass through — the vocabulary
- * is open); a stale shared link (404) says so instead of erroring; and an
- * unbound account is a stated fact, not an empty gap.
+ * is open); a stale shared link (200 with an empty journal, off the queue —
+ * the read never 404s) says so and offers no verbs; and an unbound account
+ * is a stated fact, not an empty gap.
  */
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import "@/i18n";
 import type { AccountBinding, AttentionItem } from "@/api/identity-client";
-import { IdentityApiError } from "@/api/identity-client";
 
 const binding = vi.hoisted(() => ({
   q: {
@@ -105,14 +105,15 @@ describe("AccountDetail", () => {
           author_person_id: "x",
           by_operator: true,
           reason: "operator-merge",
-          recorded_at: "2026-08-01T10:15:00Z",
+          // Zone-less on purpose — the real wire never carries a `Z`.
+          recorded_at: "2026-08-01T10:15:00.000000",
         },
         {
           person_id: BOB.person_id,
           author_person_id: "y",
           by_operator: false,
           reason: "seed-backfill",
-          recorded_at: "2026-07-01T10:15:00Z",
+          recorded_at: "2026-07-01T10:15:00.000000",
         },
       ],
     });
@@ -124,18 +125,36 @@ describe("AccountDetail", () => {
     expect(screen.getByText(/1 Aug 2026/)).toBeInTheDocument();
   });
 
-  it("reads a 404 as a stale link, with no retry offered", () => {
-    binding.q.isError = true;
-    binding.q.error = new IdentityApiError(404, { title: "account not found" });
+  it("reads an off-queue empty journal as a stale link, offering no verbs", () => {
+    binding.q.data = bound({ person_id: null, history: [] });
     render(<AccountDetail accountRef={REF} queueItem={undefined} />);
 
     expect(screen.getByText(/link may be stale/i)).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument();
+    expect(screen.queryByTestId("account-actions")).not.toBeInTheDocument();
   });
 
-  it("offers a retry on any other failure", () => {
+  it("keeps an off-queue account with history actionable — decided is not stale", () => {
+    binding.q.data = bound({
+      person_id: null,
+      history: [
+        {
+          person_id: BOB.person_id,
+          author_person_id: "x",
+          by_operator: true,
+          reason: "operator-exclude",
+          recorded_at: "2026-08-01T10:15:00.000000",
+        },
+      ],
+    });
+    render(<AccountDetail accountRef={REF} queueItem={undefined} />);
+
+    expect(screen.queryByText(/link may be stale/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId("account-actions")).toBeInTheDocument();
+  });
+
+  it("offers a retry on a failed read", () => {
     binding.q.isError = true;
-    binding.q.error = new IdentityApiError(500, {});
+    binding.q.error = new Error("identity is down");
     render(<AccountDetail accountRef={REF} queueItem={undefined} />);
 
     expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();

--- a/src/frontend/src/components/portal/account-detail.test.tsx
+++ b/src/frontend/src/components/portal/account-detail.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+/**
+ * The detail panel. What matters: a bound person known to the queue renders
+ * as a recognisable card while an unknown one stays an honest bare id; the
+ * history names the verb (and unknown reasons pass through — the vocabulary
+ * is open); a stale shared link (404) says so instead of erroring; and an
+ * unbound account is a stated fact, not an empty gap.
+ */
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import "@/i18n";
+import type { AccountBinding, AttentionItem } from "@/api/identity-client";
+import { IdentityApiError } from "@/api/identity-client";
+
+const binding = vi.hoisted(() => ({
+  q: {
+    data: undefined as AccountBinding | undefined,
+    isLoading: false,
+    isError: false,
+    error: null as unknown,
+    refetch: vi.fn(),
+  },
+}));
+vi.mock("@/queries/identity-resolution", () => ({
+  useAccountBinding: () => binding.q,
+}));
+
+import { AccountDetail } from "./account-detail";
+
+const REF = {
+  source: "github",
+  source_id: "01900000-0000-7000-8000-00000000aa01",
+  account_id: "dev-42",
+};
+const BOB = {
+  person_id: "01900000-0000-7000-8000-0000000000b0",
+  display_name: "Bob Park",
+  email: "bob.park@example.com",
+};
+
+function queueItem(over: Partial<AttentionItem> = {}): AttentionItem {
+  return {
+    kind: "contested",
+    ...REF,
+    email: "dev42@example.com",
+    username: null,
+    candidates: [BOB],
+    ...over,
+  };
+}
+
+function bound(over: Partial<AccountBinding> = {}): AccountBinding {
+  return { ...REF, person_id: BOB.person_id, history: [], ...over };
+}
+
+beforeEach(() => {
+  binding.q.data = undefined;
+  binding.q.isLoading = false;
+  binding.q.isError = false;
+  binding.q.error = null;
+});
+
+describe("AccountDetail", () => {
+  it("shows the bound person as a card when the queue knows them", () => {
+    binding.q.data = bound();
+    render(<AccountDetail accountRef={REF} queueItem={queueItem()} />);
+
+    expect(screen.getByText(/currently bound to/i)).toBeInTheDocument();
+    expect(screen.getAllByText("Bob Park").length).toBeGreaterThan(0);
+  });
+
+  it("keeps an unknown bound person an honest bare id", () => {
+    binding.q.data = bound({ person_id: "01900000-0000-7000-8000-00000000ffff" });
+    render(<AccountDetail accountRef={REF} queueItem={queueItem({ candidates: [] })} />);
+
+    expect(
+      screen.getByText("01900000-0000-7000-8000-00000000ffff"),
+    ).toBeInTheDocument();
+  });
+
+  it("states an unbound account as a fact", () => {
+    binding.q.data = bound({ person_id: null });
+    render(<AccountDetail accountRef={REF} queueItem={queueItem()} />);
+
+    expect(screen.getByText(/account is unresolved/i)).toBeInTheDocument();
+  });
+
+  it("names known verbs and passes unknown reasons through verbatim", () => {
+    binding.q.data = bound({
+      history: [
+        {
+          person_id: BOB.person_id,
+          author_person_id: "x",
+          by_operator: true,
+          reason: "operator-merge",
+          recorded_at: "2026-08-01T10:15:00Z",
+        },
+        {
+          person_id: BOB.person_id,
+          author_person_id: "y",
+          by_operator: false,
+          reason: "seed-backfill",
+          recorded_at: "2026-07-01T10:15:00Z",
+        },
+      ],
+    });
+    render(<AccountDetail accountRef={REF} queueItem={queueItem()} />);
+
+    expect(screen.getByText("Merged")).toBeInTheDocument();
+    expect(screen.getByText("seed-backfill")).toBeInTheDocument();
+    expect(screen.getByText(/by an operator/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 Aug 2026/)).toBeInTheDocument();
+  });
+
+  it("reads a 404 as a stale link, with no retry offered", () => {
+    binding.q.isError = true;
+    binding.q.error = new IdentityApiError(404, { title: "account not found" });
+    render(<AccountDetail accountRef={REF} queueItem={undefined} />);
+
+    expect(screen.getByText(/link may be stale/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument();
+  });
+
+  it("offers a retry on any other failure", () => {
+    binding.q.isError = true;
+    binding.q.error = new IdentityApiError(500, {});
+    render(<AccountDetail accountRef={REF} queueItem={undefined} />);
+
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/portal/account-detail.test.tsx
+++ b/src/frontend/src/components/portal/account-detail.test.tsx
@@ -26,6 +26,13 @@ vi.mock("@/queries/identity-resolution", () => ({
   useAccountBinding: () => binding.q,
 }));
 
+// The verbs have their own test file; here the panel's reads are under test.
+vi.mock("@/components/portal/account-actions", () => ({
+  AccountActions: ({ candidates }: { candidates: unknown[] }) => (
+    <div data-testid="account-actions" data-candidates={candidates.length} />
+  ),
+}));
+
 import { AccountDetail } from "./account-detail";
 
 const REF = {
@@ -67,7 +74,11 @@ describe("AccountDetail", () => {
     render(<AccountDetail accountRef={REF} queueItem={queueItem()} />);
 
     expect(screen.getByText(/currently bound to/i)).toBeInTheDocument();
-    expect(screen.getAllByText("Bob Park").length).toBeGreaterThan(0);
+    expect(screen.getByText("Bob Park")).toBeInTheDocument();
+    expect(screen.getByTestId("account-actions")).toHaveAttribute(
+      "data-candidates",
+      "1",
+    );
   });
 
   it("keeps an unknown bound person an honest bare id", () => {

--- a/src/frontend/src/components/portal/account-detail.tsx
+++ b/src/frontend/src/components/portal/account-detail.tsx
@@ -17,6 +17,7 @@ import type {
   BindingHistoryEntry,
   PersonSummary,
 } from "@/api/identity-client";
+import { AccountActions } from "@/components/portal/account-actions";
 import { PersonCell } from "@/components/portal/person-cell";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -101,16 +102,11 @@ export function AccountDetail({
               </p>
             )}
           </section>
-          {candidates.length > 0 ? (
-            <section>
-              <SectionLabel>{t("identities.detail.candidates")}</SectionLabel>
-              <div className="flex flex-col gap-2">
-                {candidates.map((candidate) => (
-                  <PersonCell key={candidate.person_id} person={candidate} />
-                ))}
-              </div>
-            </section>
-          ) : null}
+          <AccountActions
+            accountRef={accountRef}
+            binding={binding.data}
+            candidates={candidates}
+          />
           <section>
             <SectionLabel>{t("identities.detail.history")}</SectionLabel>
             {binding.data.history.length === 0 ? (

--- a/src/frontend/src/components/portal/account-detail.tsx
+++ b/src/frontend/src/components/portal/account-detail.tsx
@@ -27,6 +27,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CenteredSpinner } from "@/components/widgets/centered-spinner";
 import { ComingSoon } from "@/components/widgets/coming-soon";
 import type { AccountRef } from "@/lib/identities/account-key";
+import { personDisplayName } from "@/lib/identities/person-display";
 import { formatUtcInstant } from "@/lib/format";
 import { useAccountBinding } from "@/queries/identity-resolution";
 
@@ -167,7 +168,7 @@ function HistoryRow({
         <span>{t("identities.history.to")}</span>
         {target ? (
           <span className="font-medium text-foreground">
-            {target.display_name?.trim() || target.email?.trim() || entry.person_id}
+            {personDisplayName(target)}
           </span>
         ) : (
           <PersonId id={entry.person_id} />

--- a/src/frontend/src/components/portal/account-detail.tsx
+++ b/src/frontend/src/components/portal/account-detail.tsx
@@ -5,7 +5,10 @@
  * append-only, so this trail is complete by construction).
  *
  * The panel answers a shared `?acct=` link even when the account is no longer
- * in the queue; a 404 is the stale-link state and says so instead of erroring.
+ * in the queue. The binding read never 404s: an account nobody ever observed
+ * or decided answers 200 with an empty journal, so "not in the queue, no
+ * binding, no history" is the stale-link state — it says so instead of
+ * offering verbs whose bind would pre-register a typo as a real account.
  * Person ids in the history arrive bare (there is no id→name read for
  * arbitrary persons yet); when an id matches a hydrated candidate we show the
  * card, otherwise the id itself — honest over pretty.
@@ -24,9 +27,8 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { CenteredSpinner } from "@/components/widgets/centered-spinner";
 import { ComingSoon } from "@/components/widgets/coming-soon";
 import type { AccountRef } from "@/lib/identities/account-key";
-import { formatDate } from "@/lib/format";
+import { formatUtcInstant } from "@/lib/format";
 import { useAccountBinding } from "@/queries/identity-resolution";
-import { IdentityApiError } from "@/api/identity-client";
 
 /** Known verb codes → i18n keys; anything else renders as-is (open vocabulary). */
 const VERB_KEYS: Record<string, string> = {
@@ -50,24 +52,34 @@ export function AccountDetail({
 
   if (binding.isLoading) return <PanelShell><CenteredSpinner className="min-h-40" /></PanelShell>;
   if (binding.isError) {
-    const notFound =
-      binding.error instanceof IdentityApiError && binding.error.status === 404;
     return (
       <PanelShell>
         <ComingSoon
           variant="card"
-          state={notFound ? "empty" : "error"}
-          label={
-            notFound
-              ? t("identities.detail.not_found")
-              : t("identities.detail.load_failed")
-          }
-          onRetry={notFound ? undefined : () => void binding.refetch()}
+          state="error"
+          label={t("identities.detail.load_failed")}
+          onRetry={() => void binding.refetch()}
         />
       </PanelShell>
     );
   }
   if (!binding.data) return null;
+
+  const neverSeen =
+    queueItem == null &&
+    binding.data.person_id == null &&
+    binding.data.history.length === 0;
+  if (neverSeen) {
+    return (
+      <PanelShell>
+        <ComingSoon
+          variant="card"
+          state="empty"
+          label={t("identities.detail.not_found")}
+        />
+      </PanelShell>
+    );
+  }
 
   const candidates = queueItem?.candidates ?? [];
   const boundCard = candidates.find(
@@ -148,7 +160,7 @@ function HistoryRow({
           {verbKey ? t(verbKey) : (entry.reason ?? t("identities.history.automatic"))}
         </Badge>
         <span className="ms-auto text-xs text-muted-foreground">
-          {formatDate(entry.recorded_at, "d MMM yyyy, HH:mm")}
+          {formatUtcInstant(entry.recorded_at, "d MMM yyyy, HH:mm")}
         </span>
       </div>
       <div className="mt-1.5 flex items-center gap-1.5 text-xs text-muted-foreground">

--- a/src/frontend/src/components/portal/account-detail.tsx
+++ b/src/frontend/src/components/portal/account-detail.tsx
@@ -1,0 +1,190 @@
+/**
+ * The detail panel for one selected account: what the resolver currently
+ * thinks (the binding), who it could belong to (the queue's hydrated
+ * candidates), and every decision ever recorded (the history — the journal is
+ * append-only, so this trail is complete by construction).
+ *
+ * The panel answers a shared `?acct=` link even when the account is no longer
+ * in the queue; a 404 is the stale-link state and says so instead of erroring.
+ * Person ids in the history arrive bare (there is no id→name read for
+ * arbitrary persons yet); when an id matches a hydrated candidate we show the
+ * card, otherwise the id itself — honest over pretty.
+ */
+import { useTranslation } from "react-i18next";
+
+import type {
+  AttentionItem,
+  BindingHistoryEntry,
+  PersonSummary,
+} from "@/api/identity-client";
+import { PersonCell } from "@/components/portal/person-cell";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { CenteredSpinner } from "@/components/widgets/centered-spinner";
+import { ComingSoon } from "@/components/widgets/coming-soon";
+import type { AccountRef } from "@/lib/identities/account-key";
+import { formatDate } from "@/lib/format";
+import { useAccountBinding } from "@/queries/identity-resolution";
+import { IdentityApiError } from "@/api/identity-client";
+
+/** Known verb codes → i18n keys; anything else renders as-is (open vocabulary). */
+const VERB_KEYS: Record<string, string> = {
+  "operator-bind": "identities.history.bind",
+  "operator-merge": "identities.history.merge",
+  "operator-detach": "identities.history.detach",
+  "operator-exclude": "identities.history.exclude",
+};
+
+export function AccountDetail({
+  accountRef,
+  queueItem,
+}: {
+  accountRef: AccountRef;
+  /** The queue row for this account, when it is still in the queue — the
+   *  source of hydrated candidate cards and observed evidence. */
+  queueItem: AttentionItem | undefined;
+}) {
+  const { t } = useTranslation();
+  const binding = useAccountBinding(accountRef);
+
+  if (binding.isLoading) return <PanelShell><CenteredSpinner className="min-h-40" /></PanelShell>;
+  if (binding.isError) {
+    const notFound =
+      binding.error instanceof IdentityApiError && binding.error.status === 404;
+    return (
+      <PanelShell>
+        <ComingSoon
+          variant="card"
+          state={notFound ? "empty" : "error"}
+          label={
+            notFound
+              ? t("identities.detail.not_found")
+              : t("identities.detail.load_failed")
+          }
+          onRetry={notFound ? undefined : () => void binding.refetch()}
+        />
+      </PanelShell>
+    );
+  }
+  if (!binding.data) return null;
+
+  const candidates = queueItem?.candidates ?? [];
+  const boundCard = candidates.find(
+    (c) => c.person_id === binding.data.person_id,
+  );
+
+  return (
+    <PanelShell>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">
+            {queueItem?.email?.trim() ||
+              queueItem?.username?.trim() ||
+              accountRef.account_id}
+          </CardTitle>
+          <div className="font-mono text-xs text-muted-foreground">
+            {accountRef.source} · {accountRef.account_id}
+          </div>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <section>
+            <SectionLabel>{t("identities.detail.current_binding")}</SectionLabel>
+            {binding.data.person_id ? (
+              boundCard ? (
+                <PersonCell person={boundCard} />
+              ) : (
+                <PersonId id={binding.data.person_id} />
+              )
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                {t("identities.detail.unbound")}
+              </p>
+            )}
+          </section>
+          {candidates.length > 0 ? (
+            <section>
+              <SectionLabel>{t("identities.detail.candidates")}</SectionLabel>
+              <div className="flex flex-col gap-2">
+                {candidates.map((candidate) => (
+                  <PersonCell key={candidate.person_id} person={candidate} />
+                ))}
+              </div>
+            </section>
+          ) : null}
+          <section>
+            <SectionLabel>{t("identities.detail.history")}</SectionLabel>
+            {binding.data.history.length === 0 ? (
+              <p className="text-sm text-muted-foreground">
+                {t("identities.detail.no_history")}
+              </p>
+            ) : (
+              <ol className="flex flex-col gap-2">
+                {binding.data.history.map((entry, index) => (
+                  <HistoryRow
+                    key={`${entry.recorded_at}-${index}`}
+                    entry={entry}
+                    candidates={candidates}
+                  />
+                ))}
+              </ol>
+            )}
+          </section>
+        </CardContent>
+      </Card>
+    </PanelShell>
+  );
+}
+
+function HistoryRow({
+  entry,
+  candidates,
+}: {
+  entry: BindingHistoryEntry;
+  candidates: PersonSummary[];
+}) {
+  const { t } = useTranslation();
+  const verbKey = entry.reason ? VERB_KEYS[entry.reason] : undefined;
+  const target = candidates.find((c) => c.person_id === entry.person_id);
+  return (
+    <li className="rounded-md border p-2">
+      <div className="flex items-center gap-2">
+        <Badge variant={entry.by_operator ? "secondary" : "outline"}>
+          {verbKey ? t(verbKey) : (entry.reason ?? t("identities.history.automatic"))}
+        </Badge>
+        <span className="ms-auto text-xs text-muted-foreground">
+          {formatDate(entry.recorded_at, "d MMM yyyy, HH:mm")}
+        </span>
+      </div>
+      <div className="mt-1.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+        <span>{t("identities.history.to")}</span>
+        {target ? (
+          <span className="font-medium text-foreground">
+            {target.display_name?.trim() || target.email?.trim() || entry.person_id}
+          </span>
+        ) : (
+          <PersonId id={entry.person_id} />
+        )}
+        {entry.by_operator ? (
+          <span className="ms-auto">{t("identities.history.by_operator")}</span>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+/** A bare person id, honest and copyable, when no card is known for it. */
+function PersonId({ id }: { id: string }) {
+  return <span className="font-mono text-xs">{id}</span>;
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mb-1.5 text-xs font-medium tracking-wide text-muted-foreground uppercase">
+      {children}
+    </div>
+  );
+}
+
+function PanelShell({ children }: { children: React.ReactNode }) {
+  return <div className="h-fit lg:sticky lg:top-4">{children}</div>;
+}

--- a/src/frontend/src/components/portal/context-pane.test.tsx
+++ b/src/frontend/src/components/portal/context-pane.test.tsx
@@ -5,6 +5,9 @@
  * items for People, catalog items for Manage), and clicking writes the
  * portal-store selection the content area renders from.
  */
+vi.mock("@/queries/identity-me", () => ({
+  useIsAdmin: () => ({ isAdmin: false, isPending: false }),
+}));
 vi.mock("@tanstack/react-router", async () => {
   const { portalRouterMock } = await import("@/test/portal-router");
   return portalRouterMock();

--- a/src/frontend/src/components/portal/context-pane.tsx
+++ b/src/frontend/src/components/portal/context-pane.tsx
@@ -32,7 +32,7 @@ import {
 } from "@/components/ui/sidebar";
 import {
   DIRECTIONS,
-  MANAGE_ITEMS,
+  manageItemsFor,
   PEOPLE_ITEMS,
   PLANNED_GROUP_LABEL,
   partitionByReadiness,
@@ -53,6 +53,7 @@ import {
 } from "@/lib/portal/portal-nav";
 import { useActiveZone } from "@/lib/portal/use-active-zone";
 import { cn } from "@/lib/utils";
+import { useIsAdmin } from "@/queries/identity-me";
 
 const ZONE_SUB: Record<string, string> = {
   overview: "Cross-functional org rollup",
@@ -115,7 +116,7 @@ export function ContextPane() {
         ) : activeZone === "people" ? (
           <PeopleNav active={active} />
         ) : activeZone === "manage" ? (
-          <ItemsNav items={MANAGE_ITEMS} groupLabel="Manage" active={active} />
+          <ManageNav active={active} />
         ) : activeZone === "person" ? (
           <PersonSectionsNav />
         ) : (
@@ -266,6 +267,19 @@ function ThemeNav({ zoneId, active }: { zoneId: string; active: string | null })
         </SidebarGroup>
       ) : null}
     </>
+  );
+}
+
+function ManageNav({ active }: { active: string | null }) {
+  // Admin-only surfaces (Identities) drop from the pane for everyone else;
+  // the view behind them refuses direct URLs on its own.
+  const { isAdmin } = useIsAdmin();
+  return (
+    <ItemsNav
+      items={manageItemsFor(isAdmin)}
+      groupLabel="Manage"
+      active={active}
+    />
   );
 }
 

--- a/src/frontend/src/components/portal/identities-view.test.tsx
+++ b/src/frontend/src/components/portal/identities-view.test.tsx
@@ -28,6 +28,14 @@ const attention = vi.hoisted(() => ({
 }));
 vi.mock("@/queries/identity-resolution", () => ({
   useAttention: () => attention.q,
+  // The panel under a selection; its own behaviour is account-detail.test's.
+  useAccountBinding: () => ({
+    data: undefined,
+    isLoading: true,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
 }));
 
 import { portalRouter } from "@/test/portal-router";

--- a/src/frontend/src/components/portal/identities-view.test.tsx
+++ b/src/frontend/src/components/portal/identities-view.test.tsx
@@ -76,6 +76,32 @@ describe("IdentitiesView", () => {
     expect(screen.getByText("60")).toBeInTheDocument();
   });
 
+  // An emptied backlog is exactly when a colleague opens the link they were
+  // sent, so the celebration must not take the detail panel down with it.
+  // `role="status"` is the panel's own loading state (the binding query is
+  // mocked pending here) — its presence means AccountDetail mounted.
+  it("answers a shared ?acct= link even after the backlog is worked to zero", () => {
+    attention.q.data = { items: [], rates: RATES };
+    portalRouter.set({
+      zone: "manage",
+      item: "identities",
+      acct: "github:01900000-0000-7000-8000-00000000aa01:dev-42",
+    });
+    render(<IdentitiesView />);
+
+    expect(screen.getByText(/everything is resolved/i)).toBeInTheDocument();
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+
+  it("keeps a bare empty queue a plain celebration — no panel, no placeholder", () => {
+    attention.q.data = { items: [], rates: RATES };
+    render(<IdentitiesView />);
+
+    expect(screen.getByText(/everything is resolved/i)).toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.queryByText(/pick an account from the queue/i)).not.toBeInTheDocument();
+  });
+
   it("says so when the server truncated the evidence — partial counts must not read as tenant-wide", () => {
     attention.q.data = { items: [], rates: RATES, truncated: true };
     render(<IdentitiesView />);

--- a/src/frontend/src/components/portal/identities-view.test.tsx
+++ b/src/frontend/src/components/portal/identities-view.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+/**
+ * The review queue, phase 1. What matters: the empty queue is a celebrated
+ * goal state, not a blank table; groups come in working order with honest
+ * counts and an unknown kind still shows up (the vocabulary is open by
+ * contract); selection lives in the URL so an operator can share a link; and
+ * the rates strip shows the tenant-wide counts, not the page's.
+ */
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import "@/i18n";
+import type { AttentionItem, AttentionResponse } from "@/api/identity-client";
+
+vi.mock("@tanstack/react-router", async () => {
+  const { portalRouterMock } = await import("@/test/portal-router");
+  return portalRouterMock();
+});
+
+const attention = vi.hoisted(() => ({
+  q: {
+    data: undefined as AttentionResponse | undefined,
+    isLoading: false,
+    isError: false,
+    refetch: vi.fn(),
+  },
+}));
+vi.mock("@/queries/identity-resolution", () => ({
+  useAttention: () => attention.q,
+}));
+
+import { portalRouter } from "@/test/portal-router";
+
+import { IdentitiesView } from "./identities-view";
+
+const RATES = { observed: 60, bound: 55, pending: 3, no_evidence: 1, excluded: 1 };
+
+function item(over: Partial<AttentionItem>): AttentionItem {
+  return {
+    kind: "contested",
+    source: "github",
+    source_id: "01900000-0000-7000-8000-00000000aa01",
+    account_id: "dev-42",
+    email: "dev42@example.com",
+    username: null,
+    candidates: [],
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  attention.q.data = undefined;
+  attention.q.isLoading = false;
+  attention.q.isError = false;
+  attention.q.refetch.mockClear();
+  portalRouter.reset();
+  portalRouter.set({ zone: "manage", item: "identities" });
+});
+
+describe("IdentitiesView", () => {
+  it("celebrates the empty queue instead of rendering a blank table", () => {
+    attention.q.data = { items: [], rates: RATES };
+    render(<IdentitiesView />);
+
+    expect(screen.getByText(/everything is resolved/i)).toBeInTheDocument();
+    // The rates strip still shows the tenant-wide picture.
+    expect(screen.getByText("60")).toBeInTheDocument();
+  });
+
+  it("groups by kind with honest counts, and an unknown kind still shows", () => {
+    attention.q.data = {
+      items: [
+        item({ account_id: "a1" }),
+        item({ account_id: "a2" }),
+        item({ kind: "no_evidence", account_id: "bot-1", email: null, username: "bot-1" }),
+        item({ kind: "quarantined", account_id: "q-1", email: null, username: null }),
+      ],
+      rates: RATES,
+    };
+    render(<IdentitiesView />);
+
+    const contested = screen.getByText(/contested/i).closest("[data-slot=card]");
+    expect(within(contested as HTMLElement).getByText("2")).toBeInTheDocument();
+    expect(screen.getByText(/nothing links the account/i)).toBeInTheDocument();
+    // Unknown kind lands in the catch-all group rather than vanishing.
+    expect(screen.getByText("q-1")).toBeInTheDocument();
+  });
+
+  it("renders candidates as person cells", () => {
+    attention.q.data = {
+      items: [
+        item({
+          candidates: [
+            {
+              person_id: "01900000-0000-7000-8000-000000000001",
+              display_name: "Bob Park",
+              email: "bob.park@example.com",
+            },
+          ],
+        }),
+      ],
+      rates: RATES,
+    };
+    render(<IdentitiesView />);
+
+    expect(screen.getByText("Bob Park")).toBeInTheDocument();
+  });
+
+  it("writes the selection into the URL and toggles it off on a second click", async () => {
+    attention.q.data = { items: [item({})], rates: RATES };
+    render(<IdentitiesView />);
+
+    const row = screen.getByRole("button", { name: /dev42@example\.com/i });
+    await userEvent.click(row);
+    expect(portalRouter.search.acct).toContain("dev-42");
+    expect(row).toHaveAttribute("aria-pressed", "true");
+
+    await userEvent.click(row);
+    expect(portalRouter.search.acct).toBeUndefined();
+  });
+
+  it("offers a retry on a failed load", async () => {
+    attention.q.isError = true;
+    render(<IdentitiesView />);
+
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(attention.q.refetch).toHaveBeenCalled();
+  });
+});

--- a/src/frontend/src/components/portal/identities-view.test.tsx
+++ b/src/frontend/src/components/portal/identities-view.test.tsx
@@ -109,6 +109,33 @@ describe("IdentitiesView", () => {
     expect(screen.getByText(/cover only part of the observed accounts/i)).toBeInTheDocument();
   });
 
+  // Two different facts: the evidence read hit its ceiling (rates are a
+  // prefix) versus the item cap cut the list (rates still whole-tenant).
+  it("says the list was cut when only the item cap was hit", () => {
+    attention.q.data = { items: [], rates: RATES, items_truncated: true };
+    render(<IdentitiesView />);
+
+    expect(screen.getByText(/only the first accounts needing review/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/cover only part of the observed accounts/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not repeat the item-cap notice when the evidence read was truncated too", () => {
+    attention.q.data = {
+      items: [],
+      rates: RATES,
+      truncated: true,
+      items_truncated: true,
+    };
+    render(<IdentitiesView />);
+
+    expect(screen.getByText(/cover only part of the observed accounts/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/only the first accounts needing review/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("shows no truncation warning on a complete read, including from an older backend", () => {
     attention.q.data = { items: [], rates: RATES };
     render(<IdentitiesView />);

--- a/src/frontend/src/components/portal/identities-view.test.tsx
+++ b/src/frontend/src/components/portal/identities-view.test.tsx
@@ -76,6 +76,22 @@ describe("IdentitiesView", () => {
     expect(screen.getByText("60")).toBeInTheDocument();
   });
 
+  it("says so when the server truncated the evidence — partial counts must not read as tenant-wide", () => {
+    attention.q.data = { items: [], rates: RATES, truncated: true };
+    render(<IdentitiesView />);
+
+    expect(screen.getByText(/cover only part of the observed accounts/i)).toBeInTheDocument();
+  });
+
+  it("shows no truncation warning on a complete read, including from an older backend", () => {
+    attention.q.data = { items: [], rates: RATES };
+    render(<IdentitiesView />);
+
+    expect(
+      screen.queryByText(/cover only part of the observed accounts/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("groups by kind with honest counts, and an unknown kind still shows", () => {
     attention.q.data = {
       items: [

--- a/src/frontend/src/components/portal/identities-view.tsx
+++ b/src/frontend/src/components/portal/identities-view.tsx
@@ -9,7 +9,8 @@
  * never just the visible page.
  *
  * Selection lives in `?acct=` so an operator can hand a colleague a link to
- * the exact account under discussion.
+ * the exact account under discussion — and that link answers whatever the
+ * queue looks like by then, an emptied backlog included.
  */
 import { useTranslation } from "react-i18next";
 
@@ -84,7 +85,7 @@ export function IdentitiesView() {
         </Alert>
       ) : null}
       <RatesStrip rates={rates} />
-      {items.length === 0 ? <AllResolved /> : <Queue items={items} />}
+      <Queue items={items} />
     </div>
   );
 }
@@ -141,18 +142,28 @@ function Queue({ items }: { items: AttentionItem[] }) {
   const other = items.filter((i) => !known.has(i.kind));
   if (other.length > 0) groups.push({ kind: "other", items: other });
 
+  // The worked-to-zero queue is the goal state — but a shared `?acct=` link
+  // has to answer even then, and the backlog reaching zero is exactly when a
+  // colleague opens the link they were sent. So the celebration replaces the
+  // GROUP LIST, never the grid the detail panel lives in.
+  if (items.length === 0 && !acct) return <AllResolved />;
+
   return (
     <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
       <div className="flex min-w-0 flex-col gap-4">
-        {groups.map((group) => (
-          <QueueGroup
-            key={group.kind}
-            kind={group.kind}
-            items={group.items}
-            selectedKey={acct}
-            onSelect={(key) => setAcct(key === acct ? null : key)}
-          />
-        ))}
+        {items.length === 0 ? (
+          <AllResolved />
+        ) : (
+          groups.map((group) => (
+            <QueueGroup
+              key={group.kind}
+              kind={group.kind}
+              items={group.items}
+              selectedKey={acct}
+              onSelect={(key) => setAcct(key === acct ? null : key)}
+            />
+          ))
+        )}
       </div>
       <DetailPane acct={acct} items={items} />
     </div>

--- a/src/frontend/src/components/portal/identities-view.tsx
+++ b/src/frontend/src/components/portal/identities-view.tsx
@@ -67,7 +67,8 @@ export function IdentitiesView() {
     );
   }
 
-  const { items, rates, truncated } = attention.data;
+  const { items, rates, truncated, items_truncated: itemsTruncated } =
+    attention.data;
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-6">
       <header>
@@ -82,6 +83,17 @@ export function IdentitiesView() {
         <Alert variant="destructive" role="status">
           <TriangleAlert />
           <AlertDescription>{t("identities.queue.truncated")}</AlertDescription>
+        </Alert>
+      ) : null}
+      {/* The list was cut by the server's item cap while the rates stay
+          whole-tenant — a different fact from `truncated`, and one an
+          operator working to zero has to know. */}
+      {itemsTruncated && !truncated ? (
+        <Alert role="status">
+          <TriangleAlert />
+          <AlertDescription>
+            {t("identities.queue.items_truncated")}
+          </AlertDescription>
         </Alert>
       ) : null}
       <RatesStrip rates={rates} />

--- a/src/frontend/src/components/portal/identities-view.tsx
+++ b/src/frontend/src/components/portal/identities-view.tsx
@@ -14,6 +14,7 @@
 import { useTranslation } from "react-i18next";
 
 import type { AttentionItem, ResolutionRates } from "@/api/identity-client";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { CenteredSpinner } from "@/components/widgets/centered-spinner";
 import { PersonCell } from "@/components/portal/person-cell";
 import { Badge } from "@/components/ui/badge";
@@ -34,7 +35,7 @@ import { useAttention } from "@/queries/identity-resolution";
 import { TEXT_FIGURE, TEXT_LABEL } from "@/lib/type-scale";
 import { STATUS_SURFACE_CLASS, type Status } from "@/lib/status";
 import { cn } from "@/lib/utils";
-import { PartyPopper, UserSearch } from "lucide-react";
+import { PartyPopper, TriangleAlert, UserSearch } from "lucide-react";
 
 /** Queue groups in working order: conflicts first, then the unknowns. */
 const KIND_ORDER = ["contested", "binding_conflict", "no_evidence"] as const;
@@ -65,7 +66,7 @@ export function IdentitiesView() {
     );
   }
 
-  const { items, rates } = attention.data;
+  const { items, rates, truncated } = attention.data;
   return (
     <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-6">
       <header>
@@ -76,6 +77,12 @@ export function IdentitiesView() {
           {t("identities.subtitle")}
         </p>
       </header>
+      {truncated ? (
+        <Alert variant="destructive" role="status">
+          <TriangleAlert />
+          <AlertDescription>{t("identities.queue.truncated")}</AlertDescription>
+        </Alert>
+      ) : null}
       <RatesStrip rates={rates} />
       {items.length === 0 ? <AllResolved /> : <Queue items={items} />}
     </div>
@@ -162,7 +169,10 @@ function DetailPane({
   const ref = parseAccountKey(acct);
   if (!ref) return <DetailPlaceholder />;
   const queueItem = items.find((i) => itemKey(i) === acct);
-  return <AccountDetail accountRef={ref} queueItem={queueItem} />;
+  // Keyed by the account: the panel holds per-account state (a verb's outcome
+  // alert, an open dialog), and a cached binding renders the next selection
+  // synchronously — an unkeyed panel would carry that state across accounts.
+  return <AccountDetail key={acct} accountRef={ref} queueItem={queueItem} />;
 }
 
 function QueueGroup({

--- a/src/frontend/src/components/portal/identities-view.tsx
+++ b/src/frontend/src/components/portal/identities-view.tsx
@@ -1,0 +1,234 @@
+/**
+ * The identity-resolution operator console (Manage → Identities), phase 1:
+ * the review queue, read-only.
+ *
+ * A triage surface, not a roster: the operator lands in what NEEDS a
+ * decision, grouped by why it does, and works the backlog to zero — the
+ * empty queue is the goal state and renders as one. The tenant-wide rates
+ * strip on top is honest about scale: it counts every observed account,
+ * never just the visible page.
+ *
+ * Selection lives in `?acct=` so an operator can hand a colleague a link to
+ * the exact account under discussion.
+ */
+import { useTranslation } from "react-i18next";
+
+import type { AttentionItem, ResolutionRates } from "@/api/identity-client";
+import { CenteredSpinner } from "@/components/widgets/centered-spinner";
+import { PersonCell } from "@/components/portal/person-cell";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { ComingSoon } from "@/components/widgets/coming-soon";
+import { usePortalSearch } from "@/lib/portal/portal-search";
+import { usePortalNavActions } from "@/lib/portal/portal-nav";
+import { itemKey } from "@/lib/identities/account-key";
+import { useAttention } from "@/queries/identity-resolution";
+import { TEXT_FIGURE, TEXT_LABEL } from "@/lib/type-scale";
+import { STATUS_SURFACE_CLASS, type Status } from "@/lib/status";
+import { cn } from "@/lib/utils";
+import { PartyPopper, UserSearch } from "lucide-react";
+
+/** Queue groups in working order: conflicts first, then the unknowns. */
+const KIND_ORDER = ["contested", "binding_conflict", "no_evidence"] as const;
+
+const RATE_TILES: ReadonlyArray<{ key: keyof ResolutionRates; status: Status }> = [
+  { key: "observed", status: "neutral" },
+  { key: "bound", status: "good" },
+  { key: "pending", status: "warn" },
+  { key: "no_evidence", status: "bad" },
+  { key: "excluded", status: "neutral" },
+];
+
+export function IdentitiesView() {
+  const { t } = useTranslation();
+  const attention = useAttention();
+
+  if (attention.isLoading) return <CenteredSpinner className="min-h-[60vh]" />;
+  if (attention.isError || !attention.data) {
+    return (
+      <div className="mx-auto w-full max-w-md p-8">
+        <ComingSoon
+          variant="card"
+          state="error"
+          label={t("identities.queue.load_failed")}
+          onRetry={() => void attention.refetch()}
+        />
+      </div>
+    );
+  }
+
+  const { items, rates } = attention.data;
+  return (
+    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 p-6">
+      <header>
+        <h1 className="text-lg font-semibold tracking-tight">
+          {t("identities.title")}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          {t("identities.subtitle")}
+        </p>
+      </header>
+      <RatesStrip rates={rates} />
+      {items.length === 0 ? <AllResolved /> : <Queue items={items} />}
+    </div>
+  );
+}
+
+function RatesStrip({ rates }: { rates: ResolutionRates }) {
+  const { t } = useTranslation();
+  return (
+    <div className="grid grid-cols-[repeat(auto-fit,minmax(9rem,1fr))] gap-3">
+      {RATE_TILES.map(({ key, status }) => (
+        <div key={key} className="rounded-lg border bg-card p-4">
+          <div className={TEXT_FIGURE}>{rates[key]}</div>
+          <span
+            className={cn(
+              TEXT_LABEL,
+              "mt-1 inline-block rounded px-1.5 py-0.5",
+              STATUS_SURFACE_CLASS[status],
+            )}
+          >
+            {t(`identities.rates.${key}`)}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** The goal state, celebrated rather than rendered as a blank table. */
+function AllResolved() {
+  const { t } = useTranslation();
+  return (
+    <Empty>
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <PartyPopper />
+        </EmptyMedia>
+        <EmptyTitle>{t("identities.queue.empty_title")}</EmptyTitle>
+        <EmptyDescription>
+          {t("identities.queue.empty_description")}
+        </EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  );
+}
+
+function Queue({ items }: { items: AttentionItem[] }) {
+  const { acct } = usePortalSearch();
+  const { setAcct } = usePortalNavActions();
+  const groups: Array<{ kind: string; items: AttentionItem[] }> = KIND_ORDER.map(
+    (kind) => ({ kind, items: items.filter((i) => i.kind === kind) }),
+  ).filter((g) => g.items.length > 0);
+  // An unknown kind from a newer backend still shows up rather than
+  // vanishing — the vocabulary is open by contract.
+  const known = new Set<string>(KIND_ORDER);
+  const other = items.filter((i) => !known.has(i.kind));
+  if (other.length > 0) groups.push({ kind: "other", items: other });
+
+  return (
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[minmax(0,1fr)_20rem]">
+      <div className="flex min-w-0 flex-col gap-4">
+        {groups.map((group) => (
+          <QueueGroup
+            key={group.kind}
+            kind={group.kind}
+            items={group.items}
+            selectedKey={acct}
+            onSelect={(key) => setAcct(key === acct ? null : key)}
+          />
+        ))}
+      </div>
+      <DetailPlaceholder hasSelection={Boolean(acct)} />
+    </div>
+  );
+}
+
+function QueueGroup({
+  kind,
+  items,
+  selectedKey,
+  onSelect,
+}: {
+  kind: string;
+  items: AttentionItem[];
+  selectedKey: string | undefined;
+  onSelect: (key: string) => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-sm">
+          {t(`identities.kind.${kind}`, { defaultValue: kind })}
+          <Badge variant="secondary">{items.length}</Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-1 p-2 pt-0">
+        {items.map((item) => {
+          const key = itemKey(item);
+          const selected = key === selectedKey;
+          return (
+            <button
+              key={key}
+              type="button"
+              onClick={() => onSelect(key)}
+              aria-pressed={selected}
+              className={cn(
+                "rounded-md border p-3 text-start",
+                selected
+                  ? "border-ring bg-muted"
+                  : "border-transparent hover:bg-muted/60",
+              )}
+            >
+              <div className="flex items-baseline gap-2">
+                <span className="truncate text-sm font-medium">
+                  {item.email?.trim() || item.username?.trim() || item.account_id}
+                </span>
+                <span className="ms-auto shrink-0 font-mono text-xs text-muted-foreground">
+                  {item.source}
+                </span>
+              </div>
+              {item.candidates.length > 0 ? (
+                <div className="mt-2 flex flex-wrap gap-x-6 gap-y-2">
+                  {item.candidates.map((candidate) => (
+                    <PersonCell key={candidate.person_id} person={candidate} />
+                  ))}
+                </div>
+              ) : null}
+            </button>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}
+
+/** Phase 1 stops at selection; the detail panel arrives with the next phase. */
+function DetailPlaceholder({ hasSelection }: { hasSelection: boolean }) {
+  const { t } = useTranslation();
+  return (
+    <Empty className="h-fit rounded-lg border lg:sticky lg:top-4">
+      <EmptyHeader>
+        <EmptyMedia variant="icon">
+          <UserSearch />
+        </EmptyMedia>
+        <EmptyTitle>
+          {hasSelection
+            ? t("identities.detail.coming_soon")
+            : t("identities.detail.no_selection")}
+        </EmptyTitle>
+        <EmptyDescription>
+          {t("identities.detail.no_selection_description")}
+        </EmptyDescription>
+      </EmptyHeader>
+    </Empty>
+  );
+}

--- a/src/frontend/src/components/portal/identities-view.tsx
+++ b/src/frontend/src/components/portal/identities-view.tsx
@@ -28,7 +28,8 @@ import {
 import { ComingSoon } from "@/components/widgets/coming-soon";
 import { usePortalSearch } from "@/lib/portal/portal-search";
 import { usePortalNavActions } from "@/lib/portal/portal-nav";
-import { itemKey } from "@/lib/identities/account-key";
+import { itemKey, parseAccountKey } from "@/lib/identities/account-key";
+import { AccountDetail } from "@/components/portal/account-detail";
 import { useAttention } from "@/queries/identity-resolution";
 import { TEXT_FIGURE, TEXT_LABEL } from "@/lib/type-scale";
 import { STATUS_SURFACE_CLASS, type Status } from "@/lib/status";
@@ -146,9 +147,22 @@ function Queue({ items }: { items: AttentionItem[] }) {
           />
         ))}
       </div>
-      <DetailPlaceholder hasSelection={Boolean(acct)} />
+      <DetailPane acct={acct} items={items} />
     </div>
   );
+}
+
+function DetailPane({
+  acct,
+  items,
+}: {
+  acct: string | undefined;
+  items: AttentionItem[];
+}) {
+  const ref = parseAccountKey(acct);
+  if (!ref) return <DetailPlaceholder />;
+  const queueItem = items.find((i) => itemKey(i) === acct);
+  return <AccountDetail accountRef={ref} queueItem={queueItem} />;
 }
 
 function QueueGroup({
@@ -211,8 +225,7 @@ function QueueGroup({
   );
 }
 
-/** Phase 1 stops at selection; the detail panel arrives with the next phase. */
-function DetailPlaceholder({ hasSelection }: { hasSelection: boolean }) {
+function DetailPlaceholder() {
   const { t } = useTranslation();
   return (
     <Empty className="h-fit rounded-lg border lg:sticky lg:top-4">
@@ -220,11 +233,7 @@ function DetailPlaceholder({ hasSelection }: { hasSelection: boolean }) {
         <EmptyMedia variant="icon">
           <UserSearch />
         </EmptyMedia>
-        <EmptyTitle>
-          {hasSelection
-            ? t("identities.detail.coming_soon")
-            : t("identities.detail.no_selection")}
-        </EmptyTitle>
+        <EmptyTitle>{t("identities.detail.no_selection")}</EmptyTitle>
         <EmptyDescription>
           {t("identities.detail.no_selection_description")}
         </EmptyDescription>

--- a/src/frontend/src/components/portal/manage-view.test.tsx
+++ b/src/frontend/src/components/portal/manage-view.test.tsx
@@ -9,6 +9,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import "@/i18n";
 import type { MetricDefinition } from "@/api/metric-definitions-client";
 import type { MetricDefinitionGroup } from "@/queries/metric-definitions";
 

--- a/src/frontend/src/components/portal/manage-view.test.tsx
+++ b/src/frontend/src/components/portal/manage-view.test.tsx
@@ -25,6 +25,13 @@ vi.mock("@/queries/metric-definitions", () => ({
   useMetricDefinitions: () => mocks.q,
 }));
 
+const adminGate = vi.hoisted(() => ({
+  value: { isAdmin: false, isPending: false },
+}));
+vi.mock("@/queries/identity-me", () => ({
+  useIsAdmin: () => adminGate.value,
+}));
+
 import { ManageView } from "./manage-view";
 
 function def(over: Partial<MetricDefinition>): MetricDefinition {
@@ -134,7 +141,37 @@ describe("Manage · Data health", () => {
 
 describe("Manage · unwired items", () => {
   it("renders an honest placeholder instead of a fake admin screen", () => {
-    render(<ManageView item="identities" />);
+    render(<ManageView item="taxonomy" />);
     expect(screen.getByText(/not wired yet/i)).toBeInTheDocument();
+  });
+});
+
+describe("identities gate", () => {
+  it("refuses a non-admin explicitly — a pasted URL must not look broken", () => {
+    adminGate.value = { isAdmin: false, isPending: false };
+    render(<ManageView item="identities" />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent(/admin surface/i);
+    expect(
+      screen.queryByText(/under construction/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("never flashes the console while the role check is in flight", () => {
+    adminGate.value = { isAdmin: false, isPending: true };
+    render(<ManageView item="identities" />);
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/under construction/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("opens for an admin", () => {
+    adminGate.value = { isAdmin: true, isPending: false };
+    render(<ManageView item="identities" />);
+
+    expect(screen.getByText(/under construction/i)).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 });

--- a/src/frontend/src/components/portal/manage-view.test.tsx
+++ b/src/frontend/src/components/portal/manage-view.test.tsx
@@ -26,7 +26,12 @@ vi.mock("@/queries/metric-definitions", () => ({
 }));
 
 const adminGate = vi.hoisted(() => ({
-  value: { isAdmin: false, isPending: false },
+  value: {
+    isAdmin: false,
+    isPending: false,
+    isError: false,
+    retry: () => undefined,
+  },
 }));
 vi.mock("@/queries/identity-me", () => ({
   useIsAdmin: () => adminGate.value,
@@ -152,8 +157,18 @@ describe("Manage · unwired items", () => {
 });
 
 describe("identities gate", () => {
+  const gate = (over: Partial<typeof adminGate.value>) => {
+    adminGate.value = {
+      isAdmin: false,
+      isPending: false,
+      isError: false,
+      retry: () => undefined,
+      ...over,
+    };
+  };
+
   it("refuses a non-admin explicitly — a pasted URL must not look broken", () => {
-    adminGate.value = { isAdmin: false, isPending: false };
+    gate({});
     render(<ManageView item="identities" />);
 
     expect(screen.getByRole("alert")).toHaveTextContent(/admin surface/i);
@@ -163,7 +178,7 @@ describe("identities gate", () => {
   });
 
   it("never flashes the console while the role check is in flight", () => {
-    adminGate.value = { isAdmin: false, isPending: true };
+    gate({ isPending: true });
     render(<ManageView item="identities" />);
 
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
@@ -173,10 +188,24 @@ describe("identities gate", () => {
   });
 
   it("opens for an admin", () => {
-    adminGate.value = { isAdmin: true, isPending: false };
+    gate({ isAdmin: true });
     render(<ManageView item="identities" />);
 
     expect(screen.getByTestId("identities-view")).toBeInTheDocument();
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("says 'could not verify' with a retry when the check itself failed", async () => {
+    const retry = vi.fn();
+    gate({ isError: true, retry });
+    render(<ManageView item="identities" />);
+
+    // Still no console (fail closed) — but the copy must not send a real
+    // admin to ask for a role they already hold.
+    expect(screen.queryByTestId("identities-view")).not.toBeInTheDocument();
+    expect(screen.queryByText(/admin surface/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/could not verify/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(retry).toHaveBeenCalledOnce();
   });
 });

--- a/src/frontend/src/components/portal/manage-view.test.tsx
+++ b/src/frontend/src/components/portal/manage-view.test.tsx
@@ -32,6 +32,11 @@ vi.mock("@/queries/identity-me", () => ({
   useIsAdmin: () => adminGate.value,
 }));
 
+// The console itself has its own test file; here only the gate is under test.
+vi.mock("@/components/portal/identities-view", () => ({
+  IdentitiesView: () => <div data-testid="identities-view" />,
+}));
+
 import { ManageView } from "./manage-view";
 
 function def(over: Partial<MetricDefinition>): MetricDefinition {
@@ -171,7 +176,7 @@ describe("identities gate", () => {
     adminGate.value = { isAdmin: true, isPending: false };
     render(<ManageView item="identities" />);
 
-    expect(screen.getByText(/under construction/i)).toBeInTheDocument();
+    expect(screen.getByTestId("identities-view")).toBeInTheDocument();
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 });

--- a/src/frontend/src/components/portal/manage-view.tsx
+++ b/src/frontend/src/components/portal/manage-view.tsx
@@ -56,10 +56,26 @@ export function ManageView({ item }: { item: string | null }) {
  * pasted URLs land here directly (the nav hides the item, the URL does not),
  * so a non-admin gets an explicit refusal rather than a broken or empty
  * screen — and never a flash of the console while the check is in flight.
+ * A FAILED check is a third state: still no console (fail closed), but the
+ * copy says "could not verify" with a retry — telling a real admin to go ask
+ * for a role they already hold would send them chasing a grant that fixes
+ * nothing.
  */
 function IdentitiesGate() {
-  const { isAdmin, isPending } = useIsAdmin();
+  const { isAdmin, isPending, isError, retry } = useIsAdmin();
   if (isPending) return <CenteredSpinner />;
+  if (isError) {
+    return (
+      <div className="mx-auto w-full max-w-md p-8">
+        <ComingSoon
+          variant="card"
+          state="error"
+          label="Could not verify the administrator role"
+          onRetry={retry}
+        />
+      </div>
+    );
+  }
   if (!isAdmin) {
     return (
       <div className="mx-auto w-full max-w-md p-8" role="alert">

--- a/src/frontend/src/components/portal/manage-view.tsx
+++ b/src/frontend/src/components/portal/manage-view.tsx
@@ -15,6 +15,7 @@ import type {
   MetricDefinitionSchemaStatus,
   MetricDefinition,
 } from "@/api/metric-definitions-client";
+import { IdentitiesView } from "@/components/portal/identities-view";
 import { useIsAdmin } from "@/queries/identity-me";
 import { useMetricDefinitions } from "@/queries/metric-definitions";
 import { TEXT_FIGURE } from "@/lib/type-scale";
@@ -72,15 +73,7 @@ function IdentitiesGate() {
       </div>
     );
   }
-  return (
-    <div className="mx-auto w-full max-w-md p-8">
-      <ComingSoon
-        variant="card"
-        state="empty"
-        label="Identity resolution console — under construction"
-      />
-    </div>
-  );
+  return <IdentitiesView />;
 }
 
 /** Flatten the prefix-grouped query result into one key-sorted list. */

--- a/src/frontend/src/components/portal/manage-view.tsx
+++ b/src/frontend/src/components/portal/manage-view.tsx
@@ -15,6 +15,7 @@ import type {
   MetricDefinitionSchemaStatus,
   MetricDefinition,
 } from "@/api/metric-definitions-client";
+import { useIsAdmin } from "@/queries/identity-me";
 import { useMetricDefinitions } from "@/queries/metric-definitions";
 import { TEXT_FIGURE } from "@/lib/type-scale";
 import { cn } from "@/lib/utils";
@@ -37,12 +38,46 @@ const STATUS_STYLE: Record<MetricDefinitionSchemaStatus, string> = {
 export function ManageView({ item }: { item: string | null }) {
   if (item === "metric-catalog") return <MetricCatalogTable />;
   if (item === "data-health") return <DataHealth />;
+  if (item === "identities") return <IdentitiesGate />;
   return (
     <div className="mx-auto w-full max-w-md p-8">
       <ComingSoon
         variant="card"
         state="empty"
         label="Admin surface — not wired yet"
+      />
+    </div>
+  );
+}
+
+/**
+ * The role gate in front of the identity-resolution console. Bookmarks and
+ * pasted URLs land here directly (the nav hides the item, the URL does not),
+ * so a non-admin gets an explicit refusal rather than a broken or empty
+ * screen — and never a flash of the console while the check is in flight.
+ */
+function IdentitiesGate() {
+  const { isAdmin, isPending } = useIsAdmin();
+  if (isPending) return <CenteredSpinner />;
+  if (!isAdmin) {
+    return (
+      <div className="mx-auto w-full max-w-md p-8" role="alert">
+        <div className="rounded-lg border p-6 text-center">
+          <p className="text-sm font-semibold">Identities is an admin surface</p>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Managing identity resolution needs the administrator role. Ask an
+            existing administrator to grant it if this is part of your job.
+          </p>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="mx-auto w-full max-w-md p-8">
+      <ComingSoon
+        variant="card"
+        state="empty"
+        label="Identity resolution console — under construction"
       />
     </div>
   );

--- a/src/frontend/src/components/portal/manage-view.tsx
+++ b/src/frontend/src/components/portal/manage-view.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
 
 import { CenteredSpinner } from "@/components/widgets/centered-spinner";
 import { ComingSoon } from "@/components/widgets/coming-soon";
@@ -62,6 +63,7 @@ export function ManageView({ item }: { item: string | null }) {
  * nothing.
  */
 function IdentitiesGate() {
+  const { t } = useTranslation();
   const { isAdmin, isPending, isError, retry } = useIsAdmin();
   if (isPending) return <CenteredSpinner />;
   if (isError) {
@@ -70,7 +72,7 @@ function IdentitiesGate() {
         <ComingSoon
           variant="card"
           state="error"
-          label="Could not verify the administrator role"
+          label={t("identities.gate.unverified")}
           onRetry={retry}
         />
       </div>
@@ -80,10 +82,9 @@ function IdentitiesGate() {
     return (
       <div className="mx-auto w-full max-w-md p-8" role="alert">
         <div className="rounded-lg border p-6 text-center">
-          <p className="text-sm font-semibold">Identities is an admin surface</p>
+          <p className="text-sm font-semibold">{t("identities.gate.title")}</p>
           <p className="mt-2 text-sm text-muted-foreground">
-            Managing identity resolution needs the administrator role. Ask an
-            existing administrator to grant it if this is part of your job.
+            {t("identities.gate.description")}
           </p>
         </div>
       </div>

--- a/src/frontend/src/components/portal/person-cell.test.tsx
+++ b/src/frontend/src/components/portal/person-cell.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+/**
+ * One person must read the same everywhere: name by the card's precedence
+ * (display name → email → username → id), an identifying second line that
+ * never repeats the name, and a leaver marked so nobody merges into them.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import "@/i18n";
+import type { PersonSummary } from "@/api/identity-client";
+
+import { personDisplayName } from "@/lib/identities/person-display";
+
+import { PersonCell } from "./person-cell";
+
+function person(over: Partial<PersonSummary>): PersonSummary {
+  return { person_id: "01900000-0000-7000-8000-000000000001", ...over };
+}
+
+describe("personDisplayName", () => {
+  it.each<[string, Partial<PersonSummary>, string]>([
+    ["display name first", { display_name: "Ann Lee", email: "a@example.com" }, "Ann Lee"],
+    ["email when unnamed", { email: "a@example.com", username: "alee" }, "a@example.com"],
+    ["username for a git-only identity", { username: "alee" }, "alee"],
+    ["the id when nothing else exists", {}, "01900000-0000-7000-8000-000000000001"],
+  ])("picks %s", (_name, fields, expected) => {
+    expect(personDisplayName(person(fields))).toBe(expected);
+  });
+});
+
+describe("PersonCell", () => {
+  it("identifies without repeating: the name field is skipped in the detail line", () => {
+    render(
+      <PersonCell
+        person={person({ email: "a@example.com", job_title: "Engineer" })}
+      />,
+    );
+
+    // email became the name — the detail line must not repeat it.
+    expect(screen.getByText("a@example.com")).toBeInTheDocument();
+    expect(screen.getByText("Engineer")).toBeInTheDocument();
+    expect(screen.queryAllByText(/a@example\.com/)).toHaveLength(1);
+  });
+
+  it("marks a terminated person", () => {
+    render(
+      <PersonCell
+        person={person({ display_name: "Gone Person", status: "terminated" })}
+      />,
+    );
+
+    expect(screen.getByText(/terminated/i)).toBeInTheDocument();
+  });
+
+  it("does not mark an active person", () => {
+    render(
+      <PersonCell person={person({ display_name: "Here Person", status: "active" })} />,
+    );
+
+    expect(screen.queryByText(/terminated/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/portal/person-cell.tsx
+++ b/src/frontend/src/components/portal/person-cell.tsx
@@ -1,0 +1,62 @@
+/**
+ * A person as a compact, recognisable cell: avatar initials, the best name
+ * the journal knows, and the identifying line under it. Shared by every
+ * identity-console surface (queue candidates, detail panel, picker) so the
+ * same person always reads the same way.
+ *
+ * Field precedence mirrors the backend card: `display_name`, else email, else
+ * a source-native username — a git-only identity is recognisable by its
+ * handle. A `terminated` status is marked so nobody merges INTO a leaver by
+ * accident.
+ */
+import { useTranslation } from "react-i18next";
+
+import type { PersonSummary } from "@/api/identity-client";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { personDisplayName } from "@/lib/identities/person-display";
+import { getInitials } from "@/lib/insight/get-initials";
+import { cn } from "@/lib/utils";
+
+const TERMINATED = "terminated";
+
+export function PersonCell({
+  person,
+  className,
+}: {
+  person: PersonSummary;
+  className?: string;
+}) {
+  const { t } = useTranslation();
+  const name = personDisplayName(person);
+  // The second line identifies, never repeats: whichever field became the
+  // name is skipped here.
+  const detail = [person.email, person.username, person.job_title]
+    .map((s) => s?.trim())
+    .filter((s): s is string => Boolean(s) && s !== name)
+    .join(" · ");
+
+  return (
+    <div className={cn("flex min-w-0 items-center gap-2", className)}>
+      <Avatar className="size-8">
+        <AvatarFallback>{getInitials(name)}</AvatarFallback>
+      </Avatar>
+      <div className="min-w-0">
+        <div className="flex items-center gap-1.5">
+          <span className="truncate text-sm font-medium">{name}</span>
+          {person.status?.trim().toLowerCase() === TERMINATED ? (
+            <Badge
+              variant="secondary"
+              className="bg-destructive/15 text-destructive"
+            >
+              {t("identities.person.terminated")}
+            </Badge>
+          ) : null}
+        </div>
+        {detail ? (
+          <div className="truncate text-xs text-muted-foreground">{detail}</div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/frontend/src/components/portal/person-picker.test.tsx
+++ b/src/frontend/src/components/portal/person-picker.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+/**
+ * The picker finds, it never decides: picking hands the person to the caller
+ * and fires nothing. Short input asks nobody; already-shown persons are not
+ * repeated; a truncated answer says "narrow the terms" instead of posing as
+ * complete.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import "@/i18n";
+import type { PersonSearchResponse } from "@/api/identity-client";
+
+const search = vi.hoisted(() => ({
+  q: "",
+  state: {
+    data: undefined as PersonSearchResponse | undefined,
+    isFetching: false,
+    isError: false,
+  },
+}));
+vi.mock("@/queries/identity-resolution", () => ({
+  usePersonSearch: (q: string) => {
+    search.q = q;
+    return search.state;
+  },
+}));
+// The debounce is a pure timing concern with its own unit test; identity here
+// keeps the picker test about behaviour, not timers.
+vi.mock("@/hooks/use-debounced-value", () => ({
+  useDebouncedValue: <T,>(value: T) => value,
+}));
+
+import { PersonPicker } from "./person-picker";
+
+const BOB = {
+  person_id: "01900000-0000-7000-8000-0000000000b0",
+  display_name: "Bob Park",
+  email: "bob.park@example.com",
+};
+const CAROL = {
+  person_id: "01900000-0000-7000-8000-0000000000c0",
+  display_name: "Carol Chen",
+  email: "carol.chen@example.com",
+};
+
+beforeEach(() => {
+  search.q = "";
+  search.state = { data: undefined, isFetching: false, isError: false };
+});
+
+describe("PersonPicker", () => {
+  it("hands the picked person to the caller and fires nothing else", async () => {
+    search.state.data = { items: [BOB], truncated: false };
+    const onPick = vi.fn();
+    render(<PersonPicker onPick={onPick} />);
+
+    await userEvent.type(screen.getByRole("searchbox"), "bob");
+    await userEvent.click(screen.getByRole("button", { name: /bob park/i }));
+
+    expect(onPick).toHaveBeenCalledWith(BOB);
+  });
+
+  it("does not repeat persons the panel already shows", async () => {
+    search.state.data = { items: [BOB, CAROL], truncated: false };
+    render(<PersonPicker onPick={vi.fn()} excludeIds={[BOB.person_id]} />);
+
+    await userEvent.type(screen.getByRole("searchbox"), "park");
+
+    expect(screen.getByText("Carol Chen")).toBeInTheDocument();
+    expect(screen.queryByText("Bob Park")).not.toBeInTheDocument();
+  });
+
+  it("a truncated answer asks for narrower terms", async () => {
+    search.state.data = { items: [BOB], truncated: true };
+    render(<PersonPicker onPick={vi.fn()} />);
+
+    await userEvent.type(screen.getByRole("searchbox"), "pa");
+
+    expect(screen.getByText(/narrow the terms/i)).toBeInTheDocument();
+  });
+
+  it("passes the typed query through to the search hook", async () => {
+    render(<PersonPicker onPick={vi.fn()} />);
+
+    await userEvent.type(screen.getByRole("searchbox"), "iva example");
+
+    expect(search.q).toBe("iva example");
+  });
+});

--- a/src/frontend/src/components/portal/person-picker.tsx
+++ b/src/frontend/src/components/portal/person-picker.tsx
@@ -1,0 +1,94 @@
+/**
+ * The person picker: find someone by any current identity value (name, any
+ * email ever current, git handle) and hand the choice back to the caller.
+ *
+ * A finding tool, not a deciding one (#2424): it never fires a verb itself.
+ * Composed from the house search idiom (Search icon inside an Input) over a
+ * debounced live query; a truncated answer says "narrow the terms" instead of
+ * posing as complete, and terminated people stay visible but marked — finding
+ * a leaver is often the point.
+ */
+import { Search } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { PersonSummary } from "@/api/identity-client";
+import { PersonCell } from "@/components/portal/person-cell";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { usePersonSearch } from "@/queries/identity-resolution";
+
+const DEBOUNCE_MS = 250;
+const MIN_QUERY_CHARS = 2;
+
+export function PersonPicker({
+  onPick,
+  /** Persons already shown elsewhere in the panel — filtered out, not repeated. */
+  excludeIds = [],
+}: {
+  onPick: (person: PersonSummary) => void;
+  excludeIds?: string[];
+}) {
+  const { t } = useTranslation();
+  const [query, setQuery] = useState("");
+  const debounced = useDebouncedValue(query, DEBOUNCE_MS);
+  const search = usePersonSearch(debounced);
+
+  const excluded = new Set(excludeIds);
+  const results = (search.data?.items ?? []).filter(
+    (p) => !excluded.has(p.person_id),
+  );
+  const active = debounced.trim().length >= MIN_QUERY_CHARS;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="relative w-full">
+        <Search className="absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          type="search"
+          className="ps-8"
+          placeholder={t("identities.picker.placeholder")}
+          aria-label={t("identities.picker.placeholder")}
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+      </div>
+      {search.isFetching ? (
+        <div className="flex justify-center py-2">
+          <Spinner className="size-4" />
+        </div>
+      ) : null}
+      {active && search.isError ? (
+        <p className="text-sm text-destructive">
+          {t("identities.picker.failed")}
+        </p>
+      ) : null}
+      {active && search.data && results.length === 0 && !search.isFetching ? (
+        <p className="text-sm text-muted-foreground">
+          {t("identities.picker.no_matches")}
+        </p>
+      ) : null}
+      {results.length > 0 ? (
+        <ul className="flex max-h-64 flex-col gap-1 overflow-y-auto">
+          {results.map((person) => (
+            <li key={person.person_id}>
+              <button
+                type="button"
+                onClick={() => onPick(person)}
+                className="w-full rounded-md border border-transparent p-2 text-start hover:bg-muted/60"
+              >
+                <PersonCell person={person} />
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+      {search.data?.truncated ? (
+        <p className="text-xs text-muted-foreground">
+          {t("identities.picker.truncated")}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/frontend/src/components/portal/portal-layout.tsx
+++ b/src/frontend/src/components/portal/portal-layout.tsx
@@ -31,7 +31,7 @@ export function PortalLayout() {
   // the admin role opens regardless of reports. The rules live in
   // `landingDecision` (pure, table-tested); this effect only applies them.
   const { isManager, isPending } = useViewerIsManager();
-  const { isAdmin, isPending: adminPending } = useIsAdmin();
+  const { isAdmin, isPending: adminPending, isError: adminError } = useIsAdmin();
   const zone = usePortalZone();
   const landed = useRef(false);
   useEffect(() => {
@@ -40,14 +40,18 @@ export function PortalLayout() {
       zone,
       mgrPending: isPending,
       isManager,
-      adminPending,
+      // An errored check is "unknown", not "no": the landing decision is
+      // one-shot, so resetting on it would permanently rewrite a URL an
+      // admin deliberately opened. Waiting costs nothing — the me query
+      // retries itself until an answer lands.
+      adminPending: adminPending || adminError,
       isAdmin,
     });
     if (decision.kind === "wait") return;
     landed.current = true;
     if (decision.kind === "pin-overview") replaceZone("overview");
     if (decision.kind === "reset") replaceZone(null);
-  }, [isPending, isManager, adminPending, isAdmin, zone, replaceZone]);
+  }, [isPending, isManager, adminPending, adminError, isAdmin, zone, replaceZone]);
 
   return (
     <SidebarProvider className="h-svh overflow-hidden">

--- a/src/frontend/src/components/portal/portal-layout.tsx
+++ b/src/frontend/src/components/portal/portal-layout.tsx
@@ -11,8 +11,10 @@ import {
   usePortalNavActions,
   usePortalZone,
 } from "@/lib/portal/portal-nav";
+import { landingDecision } from "@/lib/portal/landing-zone";
 import { useShellLayout, type ShellLayout } from "@/lib/portal/use-shell-layout";
 import { useViewerIsManager } from "@/lib/portal/use-viewer-is-manager";
+import { useIsAdmin } from "@/queries/identity-me";
 
 /**
  * Portal shell (Phase 1 buildout), rendered unless the reader opts out via
@@ -23,24 +25,29 @@ import { useViewerIsManager } from "@/lib/portal/use-viewer-is-manager";
  */
 export function PortalLayout() {
   const { replaceZone } = usePortalNavActions();
-  // Pin the landing zone exactly once, when the viewer's manager status first
-  // resolves: a manager lands on the Overview org rollup; an IC has no subtree,
-  // so we leave the zone route-driven (null) → their own Person page. The rail
-  // stays interactive while the status resolves, so honour a zone the user
-  // already picked: a manager's choice is never overridden, and an IC who
-  // landed on an org zone (now hidden for them) is reset to route-driven.
+  // Pin the landing zone exactly once, when the viewer's shape resolves: a
+  // manager lands on the Overview org rollup; an IC has no subtree, so their
+  // zone stays route-driven (their own Person page) — EXCEPT Manage, which
+  // the admin role opens regardless of reports. The rules live in
+  // `landingDecision` (pure, table-tested); this effect only applies them.
   const { isManager, isPending } = useViewerIsManager();
+  const { isAdmin, isPending: adminPending } = useIsAdmin();
   const zone = usePortalZone();
   const landed = useRef(false);
   useEffect(() => {
-    if (isPending || landed.current) return;
+    if (landed.current) return;
+    const decision = landingDecision({
+      zone,
+      mgrPending: isPending,
+      isManager,
+      adminPending,
+      isAdmin,
+    });
+    if (decision.kind === "wait") return;
     landed.current = true;
-    if (isManager) {
-      if (zone == null) replaceZone("overview");
-    } else if (zone != null && zone !== "person") {
-      replaceZone(null);
-    }
-  }, [isPending, isManager, zone, replaceZone]);
+    if (decision.kind === "pin-overview") replaceZone("overview");
+    if (decision.kind === "reset") replaceZone(null);
+  }, [isPending, isManager, adminPending, isAdmin, zone, replaceZone]);
 
   return (
     <SidebarProvider className="h-svh overflow-hidden">

--- a/src/frontend/src/components/portal/portal-shell.test.tsx
+++ b/src/frontend/src/components/portal/portal-shell.test.tsx
@@ -28,6 +28,9 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@/auth", () => ({
   useViewer: () => ({ email: "boss@x", personId: mocks.personId }),
 }));
+vi.mock("@/queries/identity-me", () => ({
+  useIsAdmin: () => ({ isAdmin: false, isPending: false }),
+}));
 vi.mock("@/lib/portal/use-viewer-is-manager", () => ({
   useViewerIsManager: () => ({ isManager: mocks.isManager, isPending: mocks.isPending }),
 }));

--- a/src/frontend/src/components/portal/shell-layout.test.tsx
+++ b/src/frontend/src/components/portal/shell-layout.test.tsx
@@ -28,6 +28,9 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@/hooks/use-mobile", () => ({ useIsMobile: () => mocks.layout === "phone" }));
 vi.mock("@/lib/portal/use-shell-layout", () => ({ useShellLayout: () => mocks.layout }));
 vi.mock("@/lib/portal/use-active-zone", () => ({ useActiveZone: () => mocks.zone }));
+vi.mock("@/queries/identity-me", () => ({
+  useIsAdmin: () => ({ isAdmin: false, isPending: false }),
+}));
 vi.mock("@/lib/portal/use-viewer-is-manager", () => ({
   useViewerIsManager: () => ({ isManager: mocks.isManager, isPending: false }),
 }));

--- a/src/frontend/src/hooks/use-debounced-value.test.ts
+++ b/src/frontend/src/hooks/use-debounced-value.test.ts
@@ -1,0 +1,27 @@
+/**
+ * The debounce contract: the value holds until the pause, then snaps to the
+ * latest — intermediate keystrokes never surface.
+ */
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useDebouncedValue } from "./use-debounced-value";
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+describe("useDebouncedValue", () => {
+  it("holds the old value until the delay passes, then takes the latest", () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebouncedValue(value, 250),
+      { initialProps: { value: "a" } },
+    );
+
+    rerender({ value: "ab" });
+    rerender({ value: "abc" });
+    expect(result.current).toBe("a");
+
+    act(() => vi.advanceTimersByTime(250));
+    expect(result.current).toBe("abc");
+  });
+});

--- a/src/frontend/src/hooks/use-debounced-value.ts
+++ b/src/frontend/src/hooks/use-debounced-value.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from "react";
+
+/**
+ * The value as of `delayMs` ago — the standard picker debounce, so a query
+ * fires per pause in typing rather than per keystroke.
+ */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+  return debounced;
+}

--- a/src/frontend/src/lib/format.test.ts
+++ b/src/frontend/src/lib/format.test.ts
@@ -5,6 +5,7 @@ import {
   formatMetricNumber,
   formatMetricValue,
   formatPp,
+  formatUtcInstant,
   metricDisplayUnit,
 } from "@/lib/format";
 
@@ -53,5 +54,15 @@ describe("small formatters", () => {
     expect(formatPp(0)).toBe("0.0 pp");
   });
 
+  // TZ-independent on purpose: a zone-less identity timestamp must name the
+  // same instant as its explicit-UTC spelling in EVERY runner timezone.
+  it("formatUtcInstant reads a zone-less timestamp as UTC, not local", () => {
+    expect(formatUtcInstant("2026-08-01T10:15:00.000000", "d MMM yyyy, HH:mm")).toBe(
+      formatUtcInstant("2026-08-01T10:15:00Z", "d MMM yyyy, HH:mm"),
+    );
+    expect(
+      formatUtcInstant("2026-08-01T10:15:00+02:00", "HH:mm"),
+    ).toBe(formatUtcInstant("2026-08-01T08:15:00Z", "HH:mm"));
+  });
 });
 

--- a/src/frontend/src/lib/format.ts
+++ b/src/frontend/src/lib/format.ts
@@ -101,6 +101,18 @@ export function formatDate(iso: string, pattern = "d MMM"): string {
   return format(parseISO(iso), pattern, { locale: enUS });
 }
 
+/**
+ * Format an instant the identity service journals. Its timestamps are UTC
+ * clock readings serialized WITHOUT a zone designator (`.NET` wire parity:
+ * `2026-08-01T10:15:00.000000`); `parseISO` would read that as local time and
+ * shift every audit entry by the viewer's UTC offset. Zone-suffixed input is
+ * passed through untouched, so the helper is safe for either shape.
+ */
+export function formatUtcInstant(iso: string, pattern = "d MMM"): string {
+  const hasZone = /(?:Z|[+-]\d{2}:?\d{2})$/i.test(iso);
+  return formatDate(hasZone ? iso : `${iso}Z`, pattern);
+}
+
 /** "1.0k" reads worse than "1k" on an axis. */
 function trimTrailingZero(s: string): string {
   return s.endsWith(".0") ? s.slice(0, -2) : s;

--- a/src/frontend/src/lib/identities/account-key.test.ts
+++ b/src/frontend/src/lib/identities/account-key.test.ts
@@ -27,6 +27,7 @@ describe("account key", () => {
     ["two parts", "github:x"],
     ["four parts", "github:x:y:z"],
     ["an empty part", "github::y"],
+    ["a truncated percent-escape", "github:x:dev%2"],
   ])("reads a key that is %s as no selection", (_name, key) => {
     expect(parseAccountKey(key)).toBeNull();
   });

--- a/src/frontend/src/lib/identities/account-key.test.ts
+++ b/src/frontend/src/lib/identities/account-key.test.ts
@@ -1,0 +1,33 @@
+/**
+ * The `?acct=` key must survive a round trip for ANY account_id — including
+ * one containing the separator itself — and a malformed or hand-mangled key
+ * must read as "nothing selected", never as a different account.
+ */
+import { describe, expect, it } from "vitest";
+
+import { accountKey, parseAccountKey } from "./account-key";
+
+describe("account key", () => {
+  it.each([
+    ["plain", "dev-42"],
+    ["contains the separator", "team:lead:42"],
+    ["contains url metacharacters", "a b?&=#/%"],
+  ])("round-trips an account_id that is %s", (_name, accountId) => {
+    const ref = {
+      source: "github",
+      source_id: "01900000-0000-7000-8000-00000000aa01",
+      account_id: accountId,
+    };
+    expect(parseAccountKey(accountKey(ref))).toEqual(ref);
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["empty", ""],
+    ["two parts", "github:x"],
+    ["four parts", "github:x:y:z"],
+    ["an empty part", "github::y"],
+  ])("reads a key that is %s as no selection", (_name, key) => {
+    expect(parseAccountKey(key)).toBeNull();
+  });
+});

--- a/src/frontend/src/lib/identities/account-key.ts
+++ b/src/frontend/src/lib/identities/account-key.ts
@@ -26,8 +26,14 @@ export function parseAccountKey(key: string | undefined): AccountRef | null {
   if (!key) return null;
   const parts = key.split(SEPARATOR);
   if (parts.length !== 3 || parts.some((p) => p === "")) return null;
-  const [source, source_id, account_id] = parts.map(decodeURIComponent);
-  return { source, source_id, account_id };
+  try {
+    const [source, source_id, account_id] = parts.map(decodeURIComponent);
+    return { source, source_id, account_id };
+  } catch {
+    // A truncated %-escape (a link cut mid-character) throws URIError; that is
+    // still a malformed key, not a render crash.
+    return null;
+  }
 }
 
 export function itemKey(item: AttentionItem): string {

--- a/src/frontend/src/lib/identities/account-key.ts
+++ b/src/frontend/src/lib/identities/account-key.ts
@@ -1,0 +1,35 @@
+/**
+ * The `?acct=` URL key for one source-native account. An account is a triple
+ * (source, source_id, account_id); the key packs it into one URL-safe string
+ * so an operator can share a link to the exact account they are looking at.
+ * Each part is URI-encoded before joining, so an `account_id` containing the
+ * separator cannot forge a different triple.
+ */
+import type { AttentionItem } from "@/api/identity-client";
+
+const SEPARATOR = ":";
+
+export interface AccountRef {
+  source: string;
+  source_id: string;
+  account_id: string;
+}
+
+export function accountKey(ref: AccountRef): string {
+  return [ref.source, ref.source_id, ref.account_id]
+    .map(encodeURIComponent)
+    .join(SEPARATOR);
+}
+
+/** Inverse of {@link accountKey}; a malformed key reads as "nothing selected". */
+export function parseAccountKey(key: string | undefined): AccountRef | null {
+  if (!key) return null;
+  const parts = key.split(SEPARATOR);
+  if (parts.length !== 3 || parts.some((p) => p === "")) return null;
+  const [source, source_id, account_id] = parts.map(decodeURIComponent);
+  return { source, source_id, account_id };
+}
+
+export function itemKey(item: AttentionItem): string {
+  return accountKey(item);
+}

--- a/src/frontend/src/lib/identities/person-display.ts
+++ b/src/frontend/src/lib/identities/person-display.ts
@@ -1,0 +1,15 @@
+/**
+ * The one name a person goes by across every identity-console surface —
+ * the card's precedence: display name, else email, else the source-native
+ * username (a git-only identity is recognisable by its handle), else the id.
+ */
+import type { PersonSummary } from "@/api/identity-client";
+
+export function personDisplayName(person: PersonSummary): string {
+  return (
+    person.display_name?.trim() ||
+    person.email?.trim() ||
+    person.username?.trim() ||
+    person.person_id
+  );
+}

--- a/src/frontend/src/lib/portal/landing-zone.test.ts
+++ b/src/frontend/src/lib/portal/landing-zone.test.ts
@@ -1,0 +1,57 @@
+/**
+ * The landing rules, as a table. The case that motivated the module: an
+ * admin who manages nobody must keep `?zone=manage`, and must not be reset
+ * while the role check is still in flight.
+ */
+import { describe, expect, it } from "vitest";
+
+import { landingDecision, type LandingDecision } from "./landing-zone";
+
+const resolved = { mgrPending: false, adminPending: false };
+
+describe("landingDecision", () => {
+  it.each<[string, Parameters<typeof landingDecision>[0], LandingDecision["kind"]]>([
+    [
+      "waits while manager status resolves",
+      { zone: "manage", mgrPending: true, isManager: false, adminPending: false, isAdmin: false },
+      "wait",
+    ],
+    [
+      "manager on bare /portal lands on the org rollup",
+      { zone: null, ...resolved, isManager: true, isAdmin: false },
+      "pin-overview",
+    ],
+    [
+      "manager keeps whatever zone they picked",
+      { zone: "directions", ...resolved, isManager: true, isAdmin: false },
+      "keep",
+    ],
+    [
+      "an IC keeps the route-driven person view",
+      { zone: null, ...resolved, isManager: false, isAdmin: false },
+      "keep",
+    ],
+    [
+      "an IC on an org zone is reset",
+      { zone: "overview", ...resolved, isManager: false, isAdmin: false },
+      "reset",
+    ],
+    [
+      "a non-manager on manage WAITS for the admin answer instead of resetting",
+      { zone: "manage", mgrPending: false, isManager: false, adminPending: true, isAdmin: false },
+      "wait",
+    ],
+    [
+      "an admin who manages nobody keeps manage",
+      { zone: "manage", ...resolved, isManager: false, isAdmin: true },
+      "keep",
+    ],
+    [
+      "a non-admin non-manager on manage is reset once the answer is in",
+      { zone: "manage", ...resolved, isManager: false, isAdmin: false },
+      "reset",
+    ],
+  ])("%s", (_name, args, expected) => {
+    expect(landingDecision(args).kind).toBe(expected);
+  });
+});

--- a/src/frontend/src/lib/portal/landing-zone.ts
+++ b/src/frontend/src/lib/portal/landing-zone.ts
@@ -1,0 +1,43 @@
+/**
+ * The landing-zone decision: what the portal shell does with the zone in the
+ * URL once the viewer's shape (manager? admin?) resolves.
+ *
+ * Pulled out of the layout effect because the rules braid three async facts
+ * together and the mistakes are silent: the original effect reset EVERY
+ * non-person zone for a non-manager, which kicked an admin operator (an IC by
+ * design — the seeded operator sits outside the org chart) off
+ * `?zone=manage` before the admin check could even answer.
+ */
+export type LandingDecision =
+  /** An input is still resolving — decide on a later render. */
+  | { kind: "wait" }
+  /** The zone in the URL stands. */
+  | { kind: "keep" }
+  /** A manager landing on bare /portal starts at the org rollup. */
+  | { kind: "pin-overview" }
+  /** The zone is not this viewer's to see — back to route-driven (Person). */
+  | { kind: "reset" };
+
+export function landingDecision(args: {
+  zone: string | null;
+  mgrPending: boolean;
+  isManager: boolean;
+  adminPending: boolean;
+  isAdmin: boolean;
+}): LandingDecision {
+  const { zone, mgrPending, isManager, adminPending, isAdmin } = args;
+
+  if (mgrPending) return { kind: "wait" };
+  if (isManager) return zone == null ? { kind: "pin-overview" } : { kind: "keep" };
+
+  // A non-manager's portal collapses to Person — except Manage, which is
+  // gated by the admin role, not by having reports. Hold the decision until
+  // the role answer is in: resetting first would discard the URL the admin
+  // deliberately opened.
+  if (zone == null || zone === "person") return { kind: "keep" };
+  if (zone === "manage") {
+    if (adminPending) return { kind: "wait" };
+    return isAdmin ? { kind: "keep" } : { kind: "reset" };
+  }
+  return { kind: "reset" };
+}

--- a/src/frontend/src/lib/portal/nav-model.test.ts
+++ b/src/frontend/src/lib/portal/nav-model.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  MANAGE_ITEMS,
+  manageItemsFor,
   partitionByReadiness,
   resolveZoneItem,
   ZONE_DEFAULT_ITEM,
@@ -42,5 +44,23 @@ describe("resolveZoneItem", () => {
     expect(resolveZoneItem("manage", null)).toBeNull();
     expect(resolveZoneItem("manage", "trend")).toBeNull();
     expect(resolveZoneItem("manage", "data-health")).toBe("data-health");
+  });
+});
+
+/**
+ * The Manage pane per viewer: admin-only surfaces exist for admins alone.
+ * The non-admin list must stay a strict subset — dropping a shared item or
+ * reordering would silently reshape the pane every operator already knows.
+ */
+describe("manageItemsFor", () => {
+  it("gives an admin the full pane", () => {
+    expect(manageItemsFor(true)).toEqual(MANAGE_ITEMS);
+  });
+
+  it("drops exactly the admin-only surfaces for everyone else", () => {
+    const visible = manageItemsFor(false);
+
+    expect(visible.map((i) => i.id)).not.toContain("identities");
+    expect(visible).toEqual(MANAGE_ITEMS.filter((i) => !i.adminOnly));
   });
 });

--- a/src/frontend/src/lib/portal/nav-model.ts
+++ b/src/frontend/src/lib/portal/nav-model.ts
@@ -293,7 +293,7 @@ export function manageItemsFor(isAdmin: boolean): readonly PaneItem[] {
 
 export const MANAGE_ITEMS: readonly PaneItem[] = [
   { id: "metric-catalog", label: "Metric catalog", icon: LayoutGrid },
-  { id: "identities", label: "Identities", icon: Fingerprint, readiness: "unbuilt", adminOnly: true },
+  { id: "identities", label: "Identities", icon: Fingerprint, adminOnly: true },
   { id: "taxonomy", label: "Roles & taxonomy", icon: Boxes, readiness: "unbuilt" },
   { id: "exclusions", label: "Data exclusions", icon: Filter, readiness: "unbuilt" },
   { id: "snapshots", label: "Org snapshots", icon: Clock, readiness: "unbuilt" },

--- a/src/frontend/src/lib/portal/nav-model.ts
+++ b/src/frontend/src/lib/portal/nav-model.ts
@@ -157,6 +157,12 @@ export interface PaneItem {
   badge?: { text: string; tone: "warn" | "new" | "error" };
   /** See {@link Readiness}. Absent = built and data-backed. */
   readiness?: Readiness;
+  /**
+   * Rendered only for viewers holding the active `admin` identity role
+   * (`useIsAdmin`) — a UI courtesy over the server-side gate, which refuses
+   * regardless of what the frontend draws.
+   */
+  adminOnly?: boolean;
 }
 
 export interface PaneGroup {
@@ -280,9 +286,14 @@ export const PEOPLE_ITEMS: readonly PaneItem[] = [
 
 /* ── Manage zone ─────────────────────────────────────────────────────── */
 
+/** The Manage pane for one viewer: admin-only surfaces drop for everyone else. */
+export function manageItemsFor(isAdmin: boolean): readonly PaneItem[] {
+  return MANAGE_ITEMS.filter((item) => !item.adminOnly || isAdmin);
+}
+
 export const MANAGE_ITEMS: readonly PaneItem[] = [
   { id: "metric-catalog", label: "Metric catalog", icon: LayoutGrid },
-  { id: "identities", label: "Identities", icon: Fingerprint, readiness: "unbuilt" },
+  { id: "identities", label: "Identities", icon: Fingerprint, readiness: "unbuilt", adminOnly: true },
   { id: "taxonomy", label: "Roles & taxonomy", icon: Boxes, readiness: "unbuilt" },
   { id: "exclusions", label: "Data exclusions", icon: Filter, readiness: "unbuilt" },
   { id: "snapshots", label: "Org snapshots", icon: Clock, readiness: "unbuilt" },

--- a/src/frontend/src/lib/portal/portal-nav.ts
+++ b/src/frontend/src/lib/portal/portal-nav.ts
@@ -67,6 +67,7 @@ export interface PortalNavActions {
   replaceScope: (patch: Partial<OrgScope>) => void;
   setZone: (zone: string | null) => void;
   setItem: (item: string | null) => void;
+  setAcct: (acct: string | null) => void;
   setDir: (dir: string) => void;
   setLens: (lens: string) => void;
   setSlice: (slice: string) => void;
@@ -82,15 +83,22 @@ export function usePortalNavActions(): PortalNavActions {
     () => ({
       // A zone change drops the item with it: `item` is per-zone, and carrying
       // it across renders a fallback view while the pane highlights nothing.
-      setZone: (zone) => setSearch({ zone: zone ?? undefined, item: undefined }),
+      // `acct` is per-item the same way `item` is per-zone, so both changes
+      // drop it: a selection has no meaning on another surface.
+      setZone: (zone) =>
+        setSearch({ zone: zone ?? undefined, item: undefined, acct: undefined }),
       replaceZone: (zone) =>
-        setSearch({ zone: zone ?? undefined, item: undefined }, { replace: true }),
+        setSearch(
+          { zone: zone ?? undefined, item: undefined, acct: undefined },
+          { replace: true },
+        ),
       replaceScope: (patch) =>
         setSearch(
           { ...("root" in patch ? { scope: patch.root ?? undefined } : {}) },
           { replace: true },
         ),
-      setItem: (item) => setSearch({ item: item ?? undefined }),
+      setItem: (item) => setSearch({ item: item ?? undefined, acct: undefined }),
+      setAcct: (acct) => setSearch({ acct: acct ?? undefined }),
       setDir: (dir) => setSearch({ dir: dir || undefined }),
       setLens: (lens) => setSearch({ lens: lens || undefined }),
       setSlice: (slice) => setSearch({ slice: slice || undefined }),

--- a/src/frontend/src/lib/portal/portal-search.ts
+++ b/src/frontend/src/lib/portal/portal-search.ts
@@ -24,6 +24,8 @@ export interface PortalSearch {
   zone?: string;
   /** Selected item within a zone (an Overview view, a Manage surface). */
   item?: string;
+  /** Selected account inside the Identities surface (an opaque account key). */
+  acct?: string;
   /** Expanded direction + its active lens, within the Directions zone. */
   dir?: string;
   lens?: string;
@@ -70,6 +72,7 @@ export function validatePortalSearch(raw: Record<string, unknown>): PortalSearch
   return {
     zone: str(raw.zone),
     item: str(raw.item),
+    acct: str(raw.acct),
     dir: str(raw.dir),
     lens: str(raw.lens),
     // Lower-cased to match `normalizePersonId`: the same id reaches us from a
@@ -92,6 +95,7 @@ export function validatePortalSearch(raw: Record<string, unknown>): PortalSearch
 export const PORTAL_SEARCH_KEYS = [
   "zone",
   "item",
+  "acct",
   "dir",
   "lens",
   "scope",

--- a/src/frontend/src/lib/portal/readiness.test.ts
+++ b/src/frontend/src/lib/portal/readiness.test.ts
@@ -59,9 +59,13 @@ describe("nav classification invariants", () => {
     ]);
   });
 
-  it("Manage keeps exactly the two surfaces that read live data", () => {
+  it("Manage keeps exactly the three surfaces that read live data", () => {
     const { live } = partitionByReadiness(MANAGE_ITEMS, false);
-    expect(live.map((i) => i.id)).toEqual(["metric-catalog", "data-health"]);
+    expect(live.map((i) => i.id)).toEqual([
+      "metric-catalog",
+      "identities",
+      "data-health",
+    ]);
   });
 
   it("every Overview item is live — that zone has no placeholders", () => {

--- a/src/frontend/src/lib/portal/use-zone-nav.ts
+++ b/src/frontend/src/lib/portal/use-zone-nav.ts
@@ -6,6 +6,7 @@ import {
 } from "@/lib/portal/portal-store";
 import { useActiveZone } from "@/lib/portal/use-active-zone";
 import { useViewerIsManager } from "@/lib/portal/use-viewer-is-manager";
+import { useIsAdmin } from "@/queries/identity-me";
 
 /**
  * Zones that still make sense when the viewer manages no one — everything else
@@ -35,10 +36,14 @@ export function useZoneNav(): {
   // shell collapses to Person. While the viewer's identity is still resolving,
   // assume manager so the nav doesn't flash a collapsed state.
   const orgZonesVisible = isManager || mgrPending;
+  // Manage is opened by the admin role, not by having reports: the operator
+  // persona is an IC by design. Fail closed while the role check is pending —
+  // a rail entry that vanishes is worse than one that appears a beat late.
+  const { isAdmin } = useIsAdmin();
 
   const zones = ZONES.filter(
     (z) =>
-      (orgZonesVisible || IC_ZONES.has(z.id)) &&
+      (orgZonesVisible || IC_ZONES.has(z.id) || (z.id === "manage" && isAdmin)) &&
       (z.readiness !== "unbuilt" || showPlanned),
   );
 

--- a/src/frontend/src/lib/portal/use-zone-nav.ts
+++ b/src/frontend/src/lib/portal/use-zone-nav.ts
@@ -65,7 +65,7 @@ export function useZoneNav(): {
       // a lingering `?zone=` there would only contradict it.
       search: (prev: Record<string, unknown>) => ({
         ...prev,
-        ...(activeZone !== zone.id ? { item: undefined } : {}),
+        ...(activeZone !== zone.id ? { item: undefined, acct: undefined } : {}),
         zone: entity ? undefined : zone.id,
       }),
     });

--- a/src/frontend/src/lib/query-console/api-error.test.ts
+++ b/src/frontend/src/lib/query-console/api-error.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { AnalyticsApiError } from "@/api/analytics-client";
+import { IdentityApiError } from "@/api/identity-client";
 
 import { apiErrorReason } from "./api-error";
 
@@ -16,6 +17,15 @@ describe("apiErrorReason", () => {
       },
     });
     expect(apiErrorReason(err, FALLBACK)).toBe("not a single SELECT");
+  });
+
+  it("unwraps an IdentityApiError the same way — both services speak problem+json", () => {
+    const err = new IdentityApiError(400, {
+      context: {
+        field_violations: [{ field: "q", description: "search terms are required" }],
+      },
+    });
+    expect(apiErrorReason(err, FALLBACK)).toBe("search terms are required");
   });
 
   it("falls back when the error is not an AnalyticsApiError", () => {

--- a/src/frontend/src/lib/query-console/api-error.test.ts
+++ b/src/frontend/src/lib/query-console/api-error.test.ts
@@ -28,6 +28,25 @@ describe("apiErrorReason", () => {
     expect(apiErrorReason(err, FALLBACK)).toBe("search terms are required");
   });
 
+  it("surfaces context.reason when there are no field violations — the 403 shape", () => {
+    const err = new IdentityApiError(403, {
+      context: { reason: "admin role required for this operation" },
+    });
+    expect(apiErrorReason(err, FALLBACK)).toBe(
+      "admin role required for this operation",
+    );
+  });
+
+  it("prefers the field violation when a body carries both", () => {
+    const err = new IdentityApiError(400, {
+      context: {
+        reason: "less specific",
+        field_violations: [{ field: "q", description: "more specific" }],
+      },
+    });
+    expect(apiErrorReason(err, FALLBACK)).toBe("more specific");
+  });
+
   it("falls back when the error is not an AnalyticsApiError", () => {
     expect(apiErrorReason(new Error("unexpected failure"), FALLBACK)).toBe(
       FALLBACK
@@ -45,6 +64,8 @@ describe("apiErrorReason", () => {
       { context: { field_violations: [] } },
       { context: { field_violations: [{ field: "x" }] } },
       { context: { field_violations: [{ description: 42 }] } },
+      { context: { reason: 42 } },
+      { context: { reason: "  " } },
     ]) {
       expect(apiErrorReason(new AnalyticsApiError(400, body), FALLBACK)).toBe(
         FALLBACK

--- a/src/frontend/src/lib/query-console/api-error.ts
+++ b/src/frontend/src/lib/query-console/api-error.ts
@@ -2,28 +2,42 @@ import { AnalyticsApiError } from "@/api/analytics-client";
 import { IdentityApiError } from "@/api/identity-client";
 
 /**
- * Pull the first field-violation description out of a canonical-error body so
- * the console can show the server's own reason — the single-SELECT gate's
- * rejection or a missing-named-parameter `400` — instead of a generic message.
- * Returns the fallback when the body carries no such reason. Both backend
- * services speak the same problem+json envelope, so one extractor serves both
- * error classes.
+ * Pull the server's own reason out of a canonical-error body so the console
+ * can show it — the single-SELECT gate's rejection, a missing-named-parameter
+ * `400`, or a `permission_denied` explanation — instead of a generic message.
+ * A `400` carries it in `context.field_violations`; a `403` (and other
+ * non-field refusals) in `context.reason`. Returns the fallback when the body
+ * carries neither. Both backend services speak the same problem+json
+ * envelope, so one extractor serves both error classes.
  */
 export function apiErrorReason(error: unknown, fallback: string): string {
   if (error instanceof AnalyticsApiError || error instanceof IdentityApiError) {
-    const reason = firstFieldViolation(error.body);
+    const reason =
+      firstFieldViolation(error.body) ?? contextReason(error.body);
     if (reason) return reason;
   }
   return fallback;
 }
 
 function firstFieldViolation(body: unknown): string | null {
-  if (typeof body !== "object" || body === null) return null;
-  const context = (body as { context?: unknown }).context;
-  if (typeof context !== "object" || context === null) return null;
+  const context = errorContext(body);
+  if (!context) return null;
   const violations = (context as { field_violations?: unknown })
     .field_violations;
   if (!Array.isArray(violations) || violations.length === 0) return null;
   const description = (violations[0] as { description?: unknown }).description;
   return typeof description === "string" ? description : null;
+}
+
+function contextReason(body: unknown): string | null {
+  const context = errorContext(body);
+  if (!context) return null;
+  const reason = (context as { reason?: unknown }).reason;
+  return typeof reason === "string" && reason.trim() !== "" ? reason : null;
+}
+
+function errorContext(body: unknown): object | null {
+  if (typeof body !== "object" || body === null) return null;
+  const context = (body as { context?: unknown }).context;
+  return typeof context === "object" && context !== null ? context : null;
 }

--- a/src/frontend/src/lib/query-console/api-error.ts
+++ b/src/frontend/src/lib/query-console/api-error.ts
@@ -1,13 +1,16 @@
 import { AnalyticsApiError } from "@/api/analytics-client";
+import { IdentityApiError } from "@/api/identity-client";
 
 /**
  * Pull the first field-violation description out of a canonical-error body so
  * the console can show the server's own reason — the single-SELECT gate's
  * rejection or a missing-named-parameter `400` — instead of a generic message.
- * Returns the fallback when the body carries no such reason.
+ * Returns the fallback when the body carries no such reason. Both backend
+ * services speak the same problem+json envelope, so one extractor serves both
+ * error classes.
  */
 export function apiErrorReason(error: unknown, fallback: string): string {
-  if (error instanceof AnalyticsApiError) {
+  if (error instanceof AnalyticsApiError || error instanceof IdentityApiError) {
     const reason = firstFieldViolation(error.body);
     if (reason) return reason;
   }

--- a/src/frontend/src/locales/en/translation.json
+++ b/src/frontend/src/locales/en/translation.json
@@ -58,7 +58,8 @@
       "expand": "Expand",
       "try_again": "Try again",
       "reload": "Reload",
-      "retry": "Retry"
+      "retry": "Retry",
+      "cancel": "Cancel"
     },
     "ui_components": {
       "sidebar": {
@@ -440,6 +441,48 @@
       "automatic": "Automatic",
       "to": "to",
       "by_operator": "by an operator"
+    },
+    "actions": {
+      "bind": "Bind",
+      "confirm": "Confirm",
+      "merge": "Merge…",
+      "merge_confirm": "Merge persons",
+      "detach": "Detach into a new person",
+      "detach_confirm": "Detach",
+      "exclude": "Exclude (bot / CI)",
+      "exclude_confirm": "Exclude",
+      "assign_other": "Assign to someone else"
+    },
+    "dialogs": {
+      "bind_title": "Bind this account?",
+      "confirm_title": "Confirm the current binding?",
+      "bind_description": "The account will belong to {{name}} from here on.",
+      "merge_title": "Merge two persons?",
+      "merge_description": "Every account of the currently bound person moves to {{name}}. Merging back is another merge — nothing is lost, but metrics re-attribute.",
+      "merge_preview_loading": "Counting the accounts that would move…",
+      "merge_preview_one": "{{count}} account moves:",
+      "merge_preview_other": "{{count}} accounts move:",
+      "merge_preview_more": "…and {{count}} more.",
+      "detach_title": "Detach into a new person?",
+      "detach_description": "The account gets a freshly minted person of its own.",
+      "exclude_title": "Exclude this account?",
+      "exclude_description": "Bots, CI and service accounts are excluded from every person metric. Reversible by binding the account to a person later.",
+      "failed": "The correction was not applied. Try again."
+    },
+    "outcomes": {
+      "applied_one": "{{count}} applied",
+      "applied_other": "{{count}} applied",
+      "already_decided_one": "{{count}} already decided",
+      "already_decided_other": "{{count}} already decided",
+      "refused_one": "{{count}} refused",
+      "refused_other": "{{count}} refused",
+      "new_person": "New person:"
+    },
+    "picker": {
+      "placeholder": "Search people by name, email or handle…",
+      "no_matches": "Nobody matches those terms.",
+      "truncated": "More people matched than shown — narrow the terms.",
+      "failed": "Search failed. Try again."
     }
   }
 }

--- a/src/frontend/src/locales/en/translation.json
+++ b/src/frontend/src/locales/en/translation.json
@@ -416,6 +416,7 @@
     },
     "queue": {
       "load_failed": "Unable to load the review queue",
+      "items_truncated": "Only the first accounts needing review are listed — resolve these and reload to see the rest.",
       "truncated": "The evidence read hit its cap — these counts and this queue cover only part of the observed accounts, not the whole tenant.",
       "empty_title": "Everything is resolved",
       "empty_description": "Every observed account is bound to a person. New conflicts will appear here."
@@ -485,6 +486,11 @@
       "no_matches": "Nobody matches those terms.",
       "truncated": "More people matched than shown — narrow the terms.",
       "failed": "Search failed. Try again."
+    },
+    "gate": {
+      "title": "Identities is an admin surface",
+      "description": "Managing identity resolution needs the administrator role. Ask an existing administrator to grant it if this is part of your job.",
+      "unverified": "Could not verify the administrator role"
     }
   }
 }

--- a/src/frontend/src/locales/en/translation.json
+++ b/src/frontend/src/locales/en/translation.json
@@ -396,5 +396,35 @@
       "entity_column": "entity_id",
       "value_column": "value"
     }
+  },
+  "identities": {
+    "title": "Identities",
+    "subtitle": "Accounts the resolver could not decide — review and resolve them.",
+    "rates": {
+      "observed": "Observed",
+      "bound": "Resolved",
+      "pending": "Pending review",
+      "no_evidence": "No evidence",
+      "excluded": "Excluded"
+    },
+    "kind": {
+      "contested": "Contested — more than one person claims the account",
+      "binding_conflict": "Binding conflicts — evidence disagrees with the current binding",
+      "no_evidence": "No evidence — nothing links the account to anyone",
+      "other": "Needs review"
+    },
+    "queue": {
+      "load_failed": "Unable to load the review queue",
+      "empty_title": "Everything is resolved",
+      "empty_description": "Every observed account is bound to a person. New conflicts will appear here."
+    },
+    "detail": {
+      "no_selection": "No account selected",
+      "no_selection_description": "Pick an account from the queue to see its evidence and history.",
+      "coming_soon": "Account detail is on its way"
+    },
+    "person": {
+      "terminated": "terminated"
+    }
   }
 }

--- a/src/frontend/src/locales/en/translation.json
+++ b/src/frontend/src/locales/en/translation.json
@@ -421,10 +421,25 @@
     "detail": {
       "no_selection": "No account selected",
       "no_selection_description": "Pick an account from the queue to see its evidence and history.",
-      "coming_soon": "Account detail is on its way"
+      "not_found": "This account is unknown — the link may be stale.",
+      "load_failed": "Unable to load the account",
+      "current_binding": "Currently bound to",
+      "unbound": "Nobody — the account is unresolved.",
+      "candidates": "Candidates",
+      "history": "Decision history",
+      "no_history": "No decisions recorded yet."
     },
     "person": {
       "terminated": "terminated"
+    },
+    "history": {
+      "bind": "Bound",
+      "merge": "Merged",
+      "detach": "Detached",
+      "exclude": "Excluded",
+      "automatic": "Automatic",
+      "to": "to",
+      "by_operator": "by an operator"
     }
   }
 }

--- a/src/frontend/src/locales/en/translation.json
+++ b/src/frontend/src/locales/en/translation.json
@@ -416,6 +416,7 @@
     },
     "queue": {
       "load_failed": "Unable to load the review queue",
+      "truncated": "The evidence read hit its cap — these counts and this queue cover only part of the observed accounts, not the whole tenant.",
       "empty_title": "Everything is resolved",
       "empty_description": "Every observed account is bound to a person. New conflicts will appear here."
     },
@@ -460,6 +461,7 @@
       "merge_title": "Merge two persons?",
       "merge_description": "Every account of the currently bound person moves to {{name}}. Merging back is another merge — nothing is lost, but metrics re-attribute.",
       "merge_preview_loading": "Counting the accounts that would move…",
+      "merge_preview_failed": "Could not count the accounts that would move.",
       "merge_preview_one": "{{count}} account moves:",
       "merge_preview_other": "{{count}} accounts move:",
       "merge_preview_more": "…and {{count}} more.",

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -385,16 +385,23 @@ export const handlers = [
     HttpResponse.json({ metrics: [] }),
   ),
   // One account's binding + decision trail. dev-42 carries a small history so
-  // the panel has something to show; any other account answers 404, which is
-  // exactly what a stale shared link should land on.
+  // the panel has something to show; any other account answers 200 with no
+  // binding and no history — the real endpoint has no 404: an account nobody
+  // ever observed or decided reads as an empty journal, and THAT is what a
+  // stale shared link lands on. Timestamps are zone-less UTC on the wire
+  // (.NET parity) — a `Z` here would train the panel on a shape production
+  // never sends.
   http.get(
     "/api/identity/v1/resolution/accounts/:source/:sourceId/:accountId",
     ({ params }) => {
       if (params.accountId !== "dev-42") {
-        return HttpResponse.json(
-          { title: "account not found" },
-          { status: 404 },
-        );
+        return HttpResponse.json({
+          source: params.source,
+          source_id: params.sourceId,
+          account_id: params.accountId,
+          person_id: null,
+          history: [],
+        });
       }
       const [bob, carol] = PEOPLE;
       return HttpResponse.json({
@@ -408,14 +415,14 @@ export const handlers = [
             author_person_id: carol?.person_id,
             by_operator: true,
             reason: "operator-bind",
-            recorded_at: "2026-08-01T10:15:00Z",
+            recorded_at: "2026-08-01T10:15:00.000000",
           },
           {
             person_id: carol?.person_id,
             author_person_id: "00000000-0000-0000-0000-000000000000",
             by_operator: false,
             reason: null,
-            recorded_at: "2026-07-15T08:00:00Z",
+            recorded_at: "2026-07-15T08:00:00.000000",
           },
         ],
       });
@@ -538,6 +545,7 @@ export const handlers = [
         },
       ],
       rates: { observed: 60, bound: 55, pending: 3, no_evidence: 1, excluded: 1 },
+      truncated: false,
     });
   }),
   http.post(

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -33,81 +33,6 @@ function mockSessionTiming(): { expires_at: number; refresh_at: number } {
   return { expires_at: now + 600, refresh_at: now + 510 };
 }
 
-export const handlers = [
-  http.get("/auth/me", () =>
-    HttpResponse.json({ ...MOCK_SESSION, ...mockSessionTiming() }),
-  ),
-  http.post("/auth/refresh", () => HttpResponse.json(mockSessionTiming())),
-  http.post("/auth/logout", () => HttpResponse.json({ rp_logout_url: null })),
-  http.post("/api/analytics/v1/metric-results", async ({ request }) => {
-    const body = (await request
-      .json()
-      .catch(() => null)) as MetricResultsRequest | null;
-    if (
-      !body ||
-      !Array.isArray(body.entity?.ids) ||
-      !Array.isArray(body.metrics)
-    ) {
-      return HttpResponse.json({ error: "invalid_argument" }, { status: 400 });
-    }
-    // Mirror the real endpoint since the identity cutover: entity ids are
-    // person UUIDs and an email is a 400. Without this the mock would happily
-    // answer a stale email fixture and hide the very regression it exists to
-    // catch.
-    if (!body.entity.ids.every((id) => typeof id === "string" && isPersonId(id))) {
-      return HttpResponse.json(
-        { error: "invalid_argument", field: "entity.ids" },
-        { status: 400 },
-      );
-    }
-    return HttpResponse.json(buildMetricResultsResponse(body));
-  }),
-  http.post(
-    "/api/identity/v1/profiles",
-    async ({ request }) => {
-      const body = (await request.json().catch(() => null)) as
-        | { value_type?: string; value?: string }
-        | null;
-      const value = (body?.value ?? "").trim();
-      // The service resolves `person_id` (the SPA's key) and `email` (legacy
-      // URL migration only); anything else is a client error.
-      if (body?.value_type !== "email" && body?.value_type !== "person_id") {
-        return HttpResponse.json(
-          { type: "urn:insight:error:invalid_argument" },
-          { status: 400 },
-        );
-      }
-      // A malformed person_id is a 400, not a 404 — matching the service, where
-      // "does not parse" and "resolves to nobody" are different answers.
-      if (body.value_type === "person_id" && !isPersonId(value)) {
-        return HttpResponse.json(
-          { type: "urn:insight:error:invalid_argument" },
-          { status: 400 },
-        );
-      }
-      const personId =
-        body.value_type === "email"
-          ? PEOPLE_BY_EMAIL[value.toLowerCase()]?.person_id
-          : value.toLowerCase();
-      if (!personId) {
-        return HttpResponse.json(
-          { type: "urn:insight:error:person_not_found" },
-          { status: 404 },
-        );
-      }
-      const tree = buildIdentityTree(personId);
-      if (!tree) {
-        return HttpResponse.json(
-          { type: "urn:insight:error:person_not_found" },
-          { status: 404 },
-        );
-      }
-      return HttpResponse.json(tree);
-    },
-  ),
-  ...savedQueryHandlers(),
-  ...customMetricHandlers(),
-];
 
 // ── Saved queries (`/v1/queries`) ────────────────────────────
 // A tiny in-memory store so the console's CRUD + run round-trip in mock,
@@ -403,3 +328,99 @@ function customMetricHandlers() {
     }),
   ];
 }
+
+
+// Assembled last: the sections above declare module-level stores/consts the
+// handler factories close over, and the factories are CALLED right here —
+// an earlier array literal hits the temporal dead zone (seen live as
+// `Cannot access 'QUERIES_BASE' before initialization`).
+export const handlers = [
+  http.get("/auth/me", () =>
+    HttpResponse.json({ ...MOCK_SESSION, ...mockSessionTiming() }),
+  ),
+  http.post("/auth/refresh", () => HttpResponse.json(mockSessionTiming())),
+  http.post("/auth/logout", () => HttpResponse.json({ rp_logout_url: null })),
+  http.post("/api/analytics/v1/metric-results", async ({ request }) => {
+    const body = (await request
+      .json()
+      .catch(() => null)) as MetricResultsRequest | null;
+    if (
+      !body ||
+      !Array.isArray(body.entity?.ids) ||
+      !Array.isArray(body.metrics)
+    ) {
+      return HttpResponse.json({ error: "invalid_argument" }, { status: 400 });
+    }
+    // Mirror the real endpoint since the identity cutover: entity ids are
+    // person UUIDs and an email is a 400. Without this the mock would happily
+    // answer a stale email fixture and hide the very regression it exists to
+    // catch.
+    if (!body.entity.ids.every((id) => typeof id === "string" && isPersonId(id))) {
+      return HttpResponse.json(
+        { error: "invalid_argument", field: "entity.ids" },
+        { status: 400 },
+      );
+    }
+    return HttpResponse.json(buildMetricResultsResponse(body));
+  }),
+  // The demo viewer is an identity admin, so mock mode exercises the admin
+  // surfaces (Manage → Identities). The role id is the backend's seeded
+  // `roles_repo::ADMIN_ROLE_ID` migration constant.
+  http.get("/api/identity/v1/me", () =>
+    HttpResponse.json({
+      person_id: defaultPerson?.person_id ?? "00000000-0000-0000-0000-0000000000bb",
+      insight_tenant_id: "00000000-0000-4000-8000-00000000c0de",
+      roles: [
+        {
+          role_id: "a4d11000-0000-4000-8000-000000000001",
+          name: "admin",
+        },
+      ],
+    }),
+  ),
+  http.post(
+    "/api/identity/v1/profiles",
+    async ({ request }) => {
+      const body = (await request.json().catch(() => null)) as
+        | { value_type?: string; value?: string }
+        | null;
+      const value = (body?.value ?? "").trim();
+      // The service resolves `person_id` (the SPA's key) and `email` (legacy
+      // URL migration only); anything else is a client error.
+      if (body?.value_type !== "email" && body?.value_type !== "person_id") {
+        return HttpResponse.json(
+          { type: "urn:insight:error:invalid_argument" },
+          { status: 400 },
+        );
+      }
+      // A malformed person_id is a 400, not a 404 — matching the service, where
+      // "does not parse" and "resolves to nobody" are different answers.
+      if (body.value_type === "person_id" && !isPersonId(value)) {
+        return HttpResponse.json(
+          { type: "urn:insight:error:invalid_argument" },
+          { status: 400 },
+        );
+      }
+      const personId =
+        body.value_type === "email"
+          ? PEOPLE_BY_EMAIL[value.toLowerCase()]?.person_id
+          : value.toLowerCase();
+      if (!personId) {
+        return HttpResponse.json(
+          { type: "urn:insight:error:person_not_found" },
+          { status: 404 },
+        );
+      }
+      const tree = buildIdentityTree(personId);
+      if (!tree) {
+        return HttpResponse.json(
+          { type: "urn:insight:error:person_not_found" },
+          { status: 404 },
+        );
+      }
+      return HttpResponse.json(tree);
+    },
+  ),
+  ...savedQueryHandlers(),
+  ...customMetricHandlers(),
+];

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -546,6 +546,7 @@ export const handlers = [
       ],
       rates: { observed: 60, bound: 55, pending: 3, no_evidence: 1, excluded: 1 },
       truncated: false,
+      items_truncated: false,
     });
   }),
   http.post(

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -421,6 +421,79 @@ export const handlers = [
       });
     },
   ),
+  // Person search for the picker: multi-term AND over the seeded roster.
+  http.get("/api/identity/v1/persons", ({ request }) => {
+    const q = new URL(request.url).searchParams.get("q")?.trim() ?? "";
+    if (!q) {
+      return HttpResponse.json(
+        { type: "urn:insight:error:invalid_argument" },
+        { status: 400 },
+      );
+    }
+    const terms = q.toLowerCase().split(/\s+/);
+    const items = PEOPLE.filter((p) =>
+      terms.every((term) =>
+        [p.name, p.email, p.role].some((v) => v.toLowerCase().includes(term)),
+      ),
+    )
+      .slice(0, 20)
+      .map((p) => ({
+        person_id: p.person_id,
+        email: p.email,
+        username: null,
+        display_name: p.name,
+        job_title: p.role,
+        status: "active",
+      }));
+    return HttpResponse.json({ items, truncated: false, next_cursor: null });
+  }),
+  // A merge preview's substance: two synthetic accounts for anyone.
+  http.get(
+    "/api/identity/v1/resolution/persons/:personId/accounts",
+    ({ params }) =>
+      HttpResponse.json({
+        person_id: params.personId,
+        accounts: [
+          {
+            source: "github",
+            source_id: "01900000-0000-7000-8000-00000000aa01",
+            account_id: "gh-main",
+            email: "main@example.com",
+            username: "gh-main",
+            bound_by_operator: false,
+          },
+          {
+            source: "gitlab",
+            source_id: "01900000-0000-7000-8000-00000000aa02",
+            account_id: "gl-alt",
+            email: null,
+            username: "gl-alt",
+            bound_by_operator: true,
+          },
+        ],
+      }),
+  ),
+  // The four correction verbs: happy-path outcomes, no state kept — the queue
+  // mock is static, so the demo shows the flow rather than a simulation.
+  ...["bind", "merge", "detach", "exclude"].map((verb) =>
+    http.post(`/api/identity/v1/resolution/${verb}`, () =>
+      HttpResponse.json({
+        applied: 1,
+        already_decided: 0,
+        items: [
+          {
+            source: "github",
+            source_id: "01900000-0000-7000-8000-00000000aa01",
+            account_id: "dev-42",
+            outcome: "applied",
+          },
+        ],
+        ...(verb === "detach"
+          ? { new_person_id: "01900000-0000-7000-8000-00000000dead" }
+          : {}),
+      }),
+    ),
+  ),
   // The review queue, exercising all three kinds. Candidates reuse the seeded
   // roster so names/emails stay consistent with every other mock surface.
   http.get("/api/identity/v1/resolution/attention", () => {

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -384,6 +384,43 @@ export const handlers = [
   http.get("/api/analytics/v1/metric-definitions", () =>
     HttpResponse.json({ metrics: [] }),
   ),
+  // One account's binding + decision trail. dev-42 carries a small history so
+  // the panel has something to show; any other account answers 404, which is
+  // exactly what a stale shared link should land on.
+  http.get(
+    "/api/identity/v1/resolution/accounts/:source/:sourceId/:accountId",
+    ({ params }) => {
+      if (params.accountId !== "dev-42") {
+        return HttpResponse.json(
+          { title: "account not found" },
+          { status: 404 },
+        );
+      }
+      const [bob, carol] = PEOPLE;
+      return HttpResponse.json({
+        source: params.source,
+        source_id: params.sourceId,
+        account_id: params.accountId,
+        person_id: bob?.person_id,
+        history: [
+          {
+            person_id: bob?.person_id,
+            author_person_id: carol?.person_id,
+            by_operator: true,
+            reason: "operator-bind",
+            recorded_at: "2026-08-01T10:15:00Z",
+          },
+          {
+            person_id: carol?.person_id,
+            author_person_id: "00000000-0000-0000-0000-000000000000",
+            by_operator: false,
+            reason: null,
+            recorded_at: "2026-07-15T08:00:00Z",
+          },
+        ],
+      });
+    },
+  ),
   // The review queue, exercising all three kinds. Candidates reuse the seeded
   // roster so names/emails stay consistent with every other mock surface.
   http.get("/api/identity/v1/resolution/attention", () => {

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -378,6 +378,58 @@ export const handlers = [
       ],
     }),
   ),
+  // Minimal, honest empty catalog: without this handler the request falls
+  // through to the network, and in a proxy-configured dev run the resulting
+  // 401 bounces the whole mock session to the real IdP.
+  http.get("/api/analytics/v1/metric-definitions", () =>
+    HttpResponse.json({ metrics: [] }),
+  ),
+  // The review queue, exercising all three kinds. Candidates reuse the seeded
+  // roster so names/emails stay consistent with every other mock surface.
+  http.get("/api/identity/v1/resolution/attention", () => {
+    const [bob, carol, alice] = PEOPLE;
+    const card = (p: (typeof PEOPLE)[number], extra?: object) => ({
+      person_id: p.person_id,
+      email: p.email,
+      username: null,
+      display_name: p.name,
+      job_title: p.role ?? null,
+      status: "active",
+      ...extra,
+    });
+    return HttpResponse.json({
+      items: [
+        {
+          kind: "contested",
+          source: "github",
+          source_id: "01900000-0000-7000-8000-00000000aa01",
+          account_id: "dev-42",
+          email: "dev42@example.com",
+          username: "dev42",
+          candidates: [card(bob), card(carol)],
+        },
+        {
+          kind: "binding_conflict",
+          source: "gitlab",
+          source_id: "01900000-0000-7000-8000-00000000aa02",
+          account_id: "a.kim",
+          email: alice?.email ?? "alice.kim@example.com",
+          username: null,
+          candidates: [card(alice)],
+        },
+        {
+          kind: "no_evidence",
+          source: "github",
+          source_id: "01900000-0000-7000-8000-00000000aa01",
+          account_id: "ci-bot-7",
+          email: null,
+          username: "ci-bot-7",
+          candidates: [],
+        },
+      ],
+      rates: { observed: 60, bound: 55, pending: 3, no_evidence: 1, excluded: 1 },
+    });
+  }),
   http.post(
     "/api/identity/v1/profiles",
     async ({ request }) => {

--- a/src/frontend/src/queries/identity-me.test.tsx
+++ b/src/frontend/src/queries/identity-me.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * The admin gate. What matters: it fails CLOSED — no session, a pending
+ * fetch, an error, or an empty grant list must all render as "not an admin";
+ * only the seeded role id opens it (the realm role name never appears here);
+ * and a session change keys a fresh cache entry so a sign-out/sign-in never
+ * inherits the previous caller's answer.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as identityClient from "@/api/identity-client";
+
+vi.mock("@/api/identity-client");
+
+const session = vi.hoisted(() => ({ value: { scope: "tenant-a" } as unknown }));
+vi.mock("@/auth/use-auth", () => ({
+  useAuth: () => ({ session: session.value }),
+}));
+vi.mock("@/auth/session-scope", () => ({
+  sessionAuthorizationScope: (s: unknown) =>
+    s == null ? null : (s as { scope: string }).scope,
+}));
+
+import { ADMIN_ROLE_ID, useIsAdmin } from "./identity-me";
+
+const getMe = vi.mocked(identityClient.getMe);
+
+function harness() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { wrapper };
+}
+
+function me(roles: identityClient.MeRole[]): identityClient.MeResponse {
+  return { person_id: "p-1", insight_tenant_id: "t-1", roles };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  session.value = { scope: "tenant-a" };
+});
+
+describe("useIsAdmin", () => {
+  it("opens only for the seeded admin role id", async () => {
+    getMe.mockResolvedValueOnce(
+      me([{ role_id: ADMIN_ROLE_ID, name: "renamed-later" }]),
+    );
+
+    const { result } = renderHook(() => useIsAdmin(), harness());
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(result.current.isAdmin).toBe(true);
+  });
+
+  it("stays closed for other roles, whatever they are named", async () => {
+    getMe.mockResolvedValueOnce(
+      me([{ role_id: "01900000-0000-7000-8000-00000000aaaa", name: "admin" }]),
+    );
+
+    const { result } = renderHook(() => useIsAdmin(), harness());
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(result.current.isAdmin).toBe(false);
+  });
+
+  it("reads an empty grant list as not-an-admin, not as an error", async () => {
+    getMe.mockResolvedValueOnce(me([]));
+
+    const { result } = renderHook(() => useIsAdmin(), harness());
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(result.current.isAdmin).toBe(false);
+  });
+
+  it("fails closed while pending and on a fetch error", async () => {
+    getMe.mockRejectedValueOnce(new Error("identity is down"));
+
+    const { result } = renderHook(() => useIsAdmin(), harness());
+
+    expect(result.current.isAdmin).toBe(false);
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(result.current.isAdmin).toBe(false);
+  });
+
+  it("never asks without a session, and stays closed", async () => {
+    session.value = null;
+
+    const { result } = renderHook(() => useIsAdmin(), harness());
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(getMe).not.toHaveBeenCalled();
+    expect(result.current.isAdmin).toBe(false);
+  });
+});

--- a/src/frontend/src/queries/identity-me.test.tsx
+++ b/src/frontend/src/queries/identity-me.test.tsx
@@ -87,6 +87,31 @@ describe("useIsAdmin", () => {
     expect(result.current.isAdmin).toBe(false);
   });
 
+  it("names a failed check as an error, distinct from a confirmed non-admin", async () => {
+    getMe.mockRejectedValueOnce(new Error("identity is down"));
+    getMe.mockResolvedValueOnce(me([{ role_id: ADMIN_ROLE_ID, name: "admin" }]));
+
+    const { result } = renderHook(() => useIsAdmin(), harness());
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.isAdmin).toBe(false);
+
+    // retry() re-asks and the gate opens once the answer lands — an errored
+    // check must never be terminal for the session.
+    result.current.retry();
+    await waitFor(() => expect(result.current.isAdmin).toBe(true));
+    expect(result.current.isError).toBe(false);
+  });
+
+  it("reports no error for a confirmed non-admin", async () => {
+    getMe.mockResolvedValueOnce(me([]));
+
+    const { result } = renderHook(() => useIsAdmin(), harness());
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(result.current.isError).toBe(false);
+  });
+
   it("never asks without a session, and stays closed", async () => {
     session.value = null;
 

--- a/src/frontend/src/queries/identity-me.ts
+++ b/src/frontend/src/queries/identity-me.ts
@@ -28,6 +28,9 @@ export const ADMIN_ROLE_ID = "a4d11000-0000-4000-8000-000000000001";
 /** Grants change rarely; a minute keeps a granted operator from waiting long. */
 const ME_STALE_TIME = 60 * 1000;
 
+/** How often an ERRORED role check re-asks on its own — see `useMe`. */
+const ME_ERROR_RETRY_MS = 30 * 1000;
+
 export function useMe(): UseQueryResult<MeResponse> {
   const { session } = useAuth();
   const sessionScope = sessionAuthorizationScope(session);
@@ -38,6 +41,17 @@ export function useMe(): UseQueryResult<MeResponse> {
     queryFn: getMe,
     staleTime: ME_STALE_TIME,
     enabled: sessionScope != null,
+    // The app-wide client never refetches on focus/reconnect (an analytics
+    // cadence), and the portal shell's observers of this query never remount
+    // — an errored check (the app opened during an identity blip) would
+    // otherwise read "not an admin" for the rest of the SPA session, with no
+    // affordance anywhere to recover. An authorization gate earns its own
+    // recovery: refetch on focus and reconnect, and poll slowly while
+    // errored until an answer lands.
+    refetchOnWindowFocus: true,
+    refetchOnReconnect: true,
+    refetchInterval: (query) =>
+      query.state.status === "error" ? ME_ERROR_RETRY_MS : false,
   });
 }
 
@@ -46,6 +60,13 @@ export interface AdminGate {
   isAdmin: boolean;
   /** True while the answer is not in yet; nav can avoid flashing either way. */
   isPending: boolean;
+  /** The check itself FAILED — "could not verify", which is not the same
+   *  answer as "not an admin". Gates still fail closed on it; surfaces that
+   *  refuse should say so and offer {@link AdminGate.retry} instead of
+   *  telling a real admin to go ask for a role they hold. */
+  isError: boolean;
+  /** Re-ask now — the retry affordance for the error state. */
+  retry: () => void;
 }
 
 /** Whether the viewer holds the active `admin` identity role. Fails closed. */
@@ -55,5 +76,7 @@ export function useIsAdmin(): AdminGate {
     isAdmin:
       me.data?.roles.some((role) => role.role_id === ADMIN_ROLE_ID) ?? false,
     isPending: me.isPending,
+    isError: me.isError,
+    retry: () => void me.refetch(),
   };
 }

--- a/src/frontend/src/queries/identity-me.ts
+++ b/src/frontend/src/queries/identity-me.ts
@@ -1,0 +1,59 @@
+/**
+ * The viewer's identity roles (`GET /api/identity/v1/me`) and the admin gate
+ * derived from them.
+ *
+ * Admin-ness is an active row in the identity service's `person_roles` table,
+ * checked server-side on every admin request — it is NOT the `insight-admin`
+ * realm role the session's `roles` array carries, and no identity endpoint
+ * reads that array. This hook is therefore the only honest source for "show
+ * the admin surfaces?": gating on the session roles would draw an admin
+ * console the backend then refuses with 403.
+ *
+ * The UI check is a courtesy, not a boundary — every admin endpoint re-runs
+ * its own gate regardless of what the frontend renders.
+ */
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { getMe, type MeResponse } from "@/api/identity-client";
+import { useAuth } from "@/auth/use-auth";
+import { sessionAuthorizationScope } from "@/auth/session-scope";
+
+/**
+ * The seeded `admin` role id — a stable migration constant, mirrored by the
+ * backend's `roles_repo::ADMIN_ROLE_ID`. Gating on the id rather than the
+ * name survives a rename of the display label.
+ */
+export const ADMIN_ROLE_ID = "a4d11000-0000-4000-8000-000000000001";
+
+/** Grants change rarely; a minute keeps a granted operator from waiting long. */
+const ME_STALE_TIME = 60 * 1000;
+
+export function useMe(): UseQueryResult<MeResponse> {
+  const { session } = useAuth();
+  const sessionScope = sessionAuthorizationScope(session);
+  return useQuery({
+    // Keyed by the session scope so a sign-out/sign-in (or view-as) never
+    // serves the previous caller's roles from cache.
+    queryKey: ["identity", "me", sessionScope],
+    queryFn: getMe,
+    staleTime: ME_STALE_TIME,
+    enabled: sessionScope != null,
+  });
+}
+
+export interface AdminGate {
+  /** False until proven admin — the pending state renders as "not admin". */
+  isAdmin: boolean;
+  /** True while the answer is not in yet; nav can avoid flashing either way. */
+  isPending: boolean;
+}
+
+/** Whether the viewer holds the active `admin` identity role. Fails closed. */
+export function useIsAdmin(): AdminGate {
+  const me = useMe();
+  return {
+    isAdmin:
+      me.data?.roles.some((role) => role.role_id === ADMIN_ROLE_ID) ?? false,
+    isPending: me.isPending,
+  };
+}

--- a/src/frontend/src/queries/identity-resolution.ts
+++ b/src/frontend/src/queries/identity-resolution.ts
@@ -5,13 +5,28 @@
  * render them only inside `IdentitiesGate`, so a 403 here means the role was
  * revoked mid-session — surfaced as an error state, not silently retried.
  */
-import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from "@tanstack/react-query";
 
 import {
+  bindAccount,
+  detachAccount,
+  excludeAccount,
   getAccountBinding,
   getAttention,
+  getPersonAccounts,
+  mergePersons,
+  searchPersons,
   type AccountBinding,
   type AttentionResponse,
+  type CorrectionResponse,
+  type PersonAccountEntry,
+  type PersonSearchResponse,
 } from "@/api/identity-client";
 import type { AccountRef } from "@/lib/identities/account-key";
 import { useAuth } from "@/auth/use-auth";
@@ -52,5 +67,59 @@ export function useAccountBinding(
     },
     staleTime: ATTENTION_STALE_TIME,
     enabled: sessionScope != null && ref != null,
+  });
+}
+
+/** Everything the console reads lives under this prefix — one invalidation
+ *  after any verb refreshes the queue, the rates and the open account. */
+const RESOLUTION_KEY = ["identity", "resolution"] as const;
+
+type Verb<TArgs> = UseMutationResult<CorrectionResponse, unknown, TArgs>;
+
+function useCorrection<TArgs>(
+  run: (args: TArgs) => Promise<CorrectionResponse>,
+): Verb<TArgs> {
+  const client = useQueryClient();
+  return useMutation({
+    mutationFn: run,
+    // Invalidate-only, the house style: the journal is the truth and a verb
+    // may land as `already_decided`/`refused`, so guessing the new state
+    // client-side would lie exactly when it matters.
+    onSuccess: () => void client.invalidateQueries({ queryKey: RESOLUTION_KEY }),
+  });
+}
+
+export const useBindAccount = () => useCorrection(bindAccount);
+export const useMergePersons = () => useCorrection(mergePersons);
+export const useDetachAccount = () => useCorrection(detachAccount);
+export const useExcludeAccount = () => useCorrection(excludeAccount);
+
+/** Live person search for the picker; the component debounces the input. */
+export function usePersonSearch(q: string): UseQueryResult<PersonSearchResponse> {
+  const { session } = useAuth();
+  const sessionScope = sessionAuthorizationScope(session);
+  const trimmed = q.trim();
+  return useQuery({
+    queryKey: ["identity", "persons", "search", sessionScope, trimmed],
+    queryFn: () => searchPersons(trimmed),
+    staleTime: ATTENTION_STALE_TIME,
+    enabled: sessionScope != null && trimmed.length >= 2,
+  });
+}
+
+/** The accounts a merge would move — fetched only while the preview is open. */
+export function usePersonAccounts(
+  personId: string | null,
+): UseQueryResult<{ person_id: string; accounts: PersonAccountEntry[] }> {
+  const { session } = useAuth();
+  const sessionScope = sessionAuthorizationScope(session);
+  return useQuery({
+    queryKey: [...RESOLUTION_KEY, "person-accounts", sessionScope, personId],
+    queryFn: () => {
+      if (!personId) throw new Error("person id is missing");
+      return getPersonAccounts(personId);
+    },
+    staleTime: ATTENTION_STALE_TIME,
+    enabled: sessionScope != null && personId != null,
   });
 }

--- a/src/frontend/src/queries/identity-resolution.ts
+++ b/src/frontend/src/queries/identity-resolution.ts
@@ -74,6 +74,11 @@ export function useAccountBinding(
  *  after any verb refreshes the queue, the rates and the open account. */
 const RESOLUTION_KEY = ["identity", "resolution"] as const;
 
+/** The picker's search cache lives outside {@link RESOLUTION_KEY} but a verb
+ *  changes its answers too: a merge absorbs a person the cache would keep
+ *  offering, and binding to them recreates the split the operator just fixed. */
+const PERSON_SEARCH_KEY = ["identity", "persons", "search"] as const;
+
 type Verb<TArgs> = UseMutationResult<CorrectionResponse, unknown, TArgs>;
 
 function useCorrection<TArgs>(
@@ -85,7 +90,10 @@ function useCorrection<TArgs>(
     // Invalidate-only, the house style: the journal is the truth and a verb
     // may land as `already_decided`/`refused`, so guessing the new state
     // client-side would lie exactly when it matters.
-    onSuccess: () => void client.invalidateQueries({ queryKey: RESOLUTION_KEY }),
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: RESOLUTION_KEY });
+      void client.invalidateQueries({ queryKey: PERSON_SEARCH_KEY });
+    },
   });
 }
 

--- a/src/frontend/src/queries/identity-resolution.ts
+++ b/src/frontend/src/queries/identity-resolution.ts
@@ -7,7 +7,13 @@
  */
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 
-import { getAttention, type AttentionResponse } from "@/api/identity-client";
+import {
+  getAccountBinding,
+  getAttention,
+  type AccountBinding,
+  type AttentionResponse,
+} from "@/api/identity-client";
+import type { AccountRef } from "@/lib/identities/account-key";
 import { useAuth } from "@/auth/use-auth";
 import { sessionAuthorizationScope } from "@/auth/session-scope";
 
@@ -22,5 +28,29 @@ export function useAttention(): UseQueryResult<AttentionResponse> {
     queryFn: () => getAttention(),
     staleTime: ATTENTION_STALE_TIME,
     enabled: sessionScope != null,
+  });
+}
+
+export function useAccountBinding(
+  ref: AccountRef | null,
+): UseQueryResult<AccountBinding> {
+  const { session } = useAuth();
+  const sessionScope = sessionAuthorizationScope(session);
+  return useQuery({
+    queryKey: [
+      "identity",
+      "resolution",
+      "account",
+      sessionScope,
+      ref?.source,
+      ref?.source_id,
+      ref?.account_id,
+    ],
+    queryFn: () => {
+      if (!ref) throw new Error("account ref is missing");
+      return getAccountBinding(ref);
+    },
+    staleTime: ATTENTION_STALE_TIME,
+    enabled: sessionScope != null && ref != null,
   });
 }

--- a/src/frontend/src/queries/identity-resolution.ts
+++ b/src/frontend/src/queries/identity-resolution.ts
@@ -1,0 +1,26 @@
+/**
+ * Data hooks for the identity-resolution operator console.
+ *
+ * All of these sit behind the admin gate server-side; components additionally
+ * render them only inside `IdentitiesGate`, so a 403 here means the role was
+ * revoked mid-session — surfaced as an error state, not silently retried.
+ */
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
+
+import { getAttention, type AttentionResponse } from "@/api/identity-client";
+import { useAuth } from "@/auth/use-auth";
+import { sessionAuthorizationScope } from "@/auth/session-scope";
+
+/** An operator works a queue; a minute of staleness is fine, losing edits is not. */
+const ATTENTION_STALE_TIME = 60 * 1000;
+
+export function useAttention(): UseQueryResult<AttentionResponse> {
+  const { session } = useAuth();
+  const sessionScope = sessionAuthorizationScope(session);
+  return useQuery({
+    queryKey: ["identity", "resolution", "attention", sessionScope],
+    queryFn: () => getAttention(),
+    staleTime: ATTENTION_STALE_TIME,
+    enabled: sessionScope != null,
+  });
+}

--- a/tests/stand/api/identity/test_me.py
+++ b/tests/stand/api/identity/test_me.py
@@ -1,0 +1,100 @@
+"""`GET /v1/me` — the caller's identity and active roles, as the admin gate sees them.
+
+    GET /v1/me   200 admin operator · 200 empty for a lead · 200 empty for the realm admin
+
+The SPA gates its admin surfaces on this answer, so what is worth proving on the
+deployed path is exactly the two confusions the endpoint exists to prevent:
+
+* the answer comes from `identity.person_roles`, not from the login token — the
+  CEO's `insight-admin` REALM role must NOT appear here, or the frontend would
+  show an admin console to someone every admin endpoint refuses with 403;
+* an empty list is the well-formed "not an admin" answer — a caller without the
+  row gets 200 and `roles: []`, never a refusal, so the SPA needs no 403 probe.
+
+The admin-operator case is the same person `test_admin.py` proves CAN open the
+gated routes; here the endpoint must SAY so, with the seeded `admin` role under
+its fixed id. The 401 half is in `test_gateway.py`, swept over every operation.
+"""
+
+from __future__ import annotations
+
+import pytest
+from insight_stand import ADMIN_ROLE, ApiClient, PersonaSession, identity_path
+
+from ..schemas import MeResponse
+
+ME = identity_path("/v1/me")
+
+#: The seeded `admin` role id — a stable constant mirrored by
+#: `roles_repo::ADMIN_ROLE_ID` and the `007_roles.sql` seed row.
+ADMIN_ROLE_ID = "a4d11000-0000-4000-8000-000000000001"
+
+
+def _me(client: ApiClient) -> MeResponse:
+    response = client.get(ME)
+    assert response.status_code == 200, f"me: {response.status_code} {response.text[:300]}"
+    return response.parse(MeResponse)
+
+
+def test_an_unauthenticated_caller_never_reaches_any_of_this(api_client: ApiClient) -> None:
+    """Proven per operation by `test_gateway.py`; spot-checked here so this
+    module carries its own reason for using a session at all."""
+    response = api_client.get(ME)
+    assert response.status_code == 401, f"{response.status_code} {response.text[:300]}"
+
+
+@pytest.mark.requires_seed("admin_operator")
+def test_the_admin_operator_sees_their_admin_role_under_its_fixed_id(
+    admin_operator_session: PersonaSession,
+) -> None:
+    """The one seeded holder of the `person_roles` row gets it named back.
+
+    Both halves of the item matter: the SPA gates on `role_id` (the stable
+    constant), while `name` is what an operator reads in any debugging output —
+    a row with the right id and the wrong name means the join broke.
+    """
+    me = _me(admin_operator_session.client)
+
+    assert str(me.person_id) == admin_operator_session.person.uuid, (
+        f"/v1/me answered about {me.person_id}, but the session belongs to "
+        f"{admin_operator_session.person.uuid} — the caller must come from the JWT"
+    )
+    roles = {(str(role.role_id), role.name) for role in me.roles}
+    assert (ADMIN_ROLE_ID, "admin") in roles, f"admin grant missing from {roles}"
+
+
+def test_a_lead_without_the_grant_gets_an_empty_list_not_a_refusal(
+    lead_session: PersonaSession,
+) -> None:
+    """200 with `roles: []` IS the "not an admin" answer.
+
+    If this ever becomes a 403, the SPA's boot call starts failing for every
+    ordinary user; if it ever lists a role the seed never granted, the admin
+    console opens for the whole org.
+    """
+    me = _me(lead_session.client)
+
+    assert str(me.person_id) == lead_session.person.uuid
+    assert me.roles == [], f"seed grants no roles to {lead_session.name}: {me.roles}"
+
+
+@pytest.mark.requires_seed("ceo")
+def test_the_realm_admin_role_does_not_leak_into_the_answer(
+    realm_admin_session: PersonaSession,
+) -> None:
+    """The CEO holds `insight-admin` in the REALM and no `person_roles` row.
+
+    `require_admin` refuses that persona on every gated route
+    (`test_admin.py`), so `/v1/me` must answer them an empty list — one field
+    copied from the login token here and the frontend would draw an admin
+    console the backend then 403s, which is precisely the confusion this
+    endpoint exists to prevent.
+    """
+    assert realm_admin_session.has_realm_role(ADMIN_ROLE)
+
+    me = _me(realm_admin_session.client)
+
+    assert me.roles == [], (
+        f"{realm_admin_session.name} holds {ADMIN_ROLE} in the realm only, yet "
+        f"/v1/me lists {me.roles}"
+    )

--- a/tests/stand/api/identity/test_me.py
+++ b/tests/stand/api/identity/test_me.py
@@ -36,6 +36,7 @@ def _me(client: ApiClient) -> MeResponse:
     return response.parse(MeResponse)
 
 
+@pytest.mark.security
 def test_an_unauthenticated_caller_never_reaches_any_of_this(api_client: ApiClient) -> None:
     """Proven per operation by `test_gateway.py`; spot-checked here so this
     module carries its own reason for using a session at all."""
@@ -44,6 +45,7 @@ def test_an_unauthenticated_caller_never_reaches_any_of_this(api_client: ApiClie
 
 
 @pytest.mark.requires_seed("admin_operator")
+@pytest.mark.reliability
 def test_the_admin_operator_sees_their_admin_role_under_its_fixed_id(
     admin_operator_session: PersonaSession,
 ) -> None:
@@ -63,6 +65,7 @@ def test_the_admin_operator_sees_their_admin_role_under_its_fixed_id(
     assert (ADMIN_ROLE_ID, "admin") in roles, f"admin grant missing from {roles}"
 
 
+@pytest.mark.reliability
 def test_a_lead_without_the_grant_gets_an_empty_list_not_a_refusal(
     lead_session: PersonaSession,
 ) -> None:
@@ -79,6 +82,7 @@ def test_a_lead_without_the_grant_gets_an_empty_list_not_a_refusal(
 
 
 @pytest.mark.requires_seed("ceo")
+@pytest.mark.security
 def test_the_realm_admin_role_does_not_leak_into_the_answer(
     realm_admin_session: PersonaSession,
 ) -> None:

--- a/tests/stand/api/identity/test_me.py
+++ b/tests/stand/api/identity/test_me.py
@@ -22,12 +22,9 @@ import pytest
 from insight_stand import ADMIN_ROLE, ApiClient, PersonaSession, identity_path
 
 from ..schemas import MeResponse
+from .test_admin import _admin_role_id
 
 ME = identity_path("/v1/me")
-
-#: The seeded `admin` role id — a stable constant mirrored by
-#: `roles_repo::ADMIN_ROLE_ID` and the `007_roles.sql` seed row.
-ADMIN_ROLE_ID = "a4d11000-0000-4000-8000-000000000001"
 
 
 def _me(client: ApiClient) -> MeResponse:
@@ -61,8 +58,9 @@ def test_the_admin_operator_sees_their_admin_role_under_its_fixed_id(
         f"/v1/me answered about {me.person_id}, but the session belongs to "
         f"{admin_operator_session.person.uuid} — the caller must come from the JWT"
     )
+    admin_role_id = _admin_role_id(admin_operator_session.client)
     roles = {(str(role.role_id), role.name) for role in me.roles}
-    assert (ADMIN_ROLE_ID, "admin") in roles, f"admin grant missing from {roles}"
+    assert (admin_role_id, "admin") in roles, f"admin grant missing from {roles}"
 
 
 @pytest.mark.reliability

--- a/tests/stand/api/identity/test_persons.py
+++ b/tests/stand/api/identity/test_persons.py
@@ -1,0 +1,90 @@
+"""`GET /v1/persons` — the operator's person search over current observed values.
+
+    GET /v1/persons   200 by email fragment · 400 no terms · 403 without the grant
+
+Display ordering and truncation are proven in the service's own live tests,
+where the journal can be staged to force them.
+
+The picker behind bind/merge: an operator holding an account's email fragment
+must find the person it currently belongs to, tenant-wide and WITHOUT the
+visibility filter — the seeded operator is deliberately outside the org chart,
+so a visibility-filtered search would answer them nobody, ever. What is worth
+proving on the deployed path is exactly that pairing: the admin row opens a
+tenant-wide view (`test_the_operator_finds_a_person_...`), and without the row
+the surface refuses rather than shrinking to an empty result
+(`test_without_the_admin_row_search_refuses`) — an empty 200 would read as
+"person does not exist" to the UI, which then offers a wrong detach.
+
+Match semantics (superseded values stop matching; a value two persons claim
+returns both) are proven per-row in the service's own live tests, where the
+journal can be staged; the stand's seeded journal is single-claim throughout.
+
+The 401 half is in `test_gateway.py`, swept over every operation.
+"""
+
+from __future__ import annotations
+
+import pytest
+from insight_stand import ApiClient, Manifest, PersonaSession, identity_path
+
+from ..schemas import PersonListResponse
+
+PERSONS = identity_path("/v1/persons")
+
+
+@pytest.mark.security
+def test_an_unauthenticated_caller_never_reaches_any_of_this(api_client: ApiClient) -> None:
+    """Proven per operation by `test_gateway.py`; spot-checked here so this
+    module carries its own reason for using a session at all."""
+    response = api_client.get(PERSONS, params={"q": "anything"})
+    assert response.status_code == 401, f"{response.status_code} {response.text[:300]}"
+
+
+@pytest.mark.requires_seed("admin_operator", "dev_lead")
+@pytest.mark.reliability
+def test_the_operator_finds_a_person_by_an_email_fragment(
+    admin_operator_session: PersonaSession, stand_manifest: Manifest
+) -> None:
+    """Tenant-wide search, not visibility-scoped: the operator sees nobody in
+    `/v1/subchart` (`test_admin.py` keeps that true) yet must find any person
+    here, or the picker is useless to the one persona allowed to use it.
+    """
+    lead = stand_manifest.fixture("dev_lead")
+    fragment = lead.email.split("@")[0]
+
+    response = admin_operator_session.client.get(PERSONS, params={"q": fragment})
+
+    assert response.status_code == 200, f"{response.status_code} {response.text[:300]}"
+    listing = response.parse(PersonListResponse)
+    matches = [str(item.person_id) for item in listing.items]
+    assert lead.uuid in matches, f"{fragment!r} did not find {lead.email}: {matches}"
+    assert listing.next_cursor is None
+
+    found = next(item for item in listing.items if str(item.person_id) == lead.uuid)
+    assert found.email == lead.email, "the card carries the current email"
+
+
+@pytest.mark.requires_seed("admin_operator")
+@pytest.mark.reliability
+def test_search_without_terms_is_a_client_error(
+    admin_operator_session: PersonaSession,
+) -> None:
+    """`q` is required: an admin surface must never dump the whole tenant
+    because a UI raced its debounce and sent an empty query."""
+    for params in (None, {"q": " "}):
+        response = admin_operator_session.client.get(PERSONS, params=params)
+        assert response.status_code == 400, (
+            f"q={params!r} answered {response.status_code}: {response.text[:300]}"
+        )
+
+
+@pytest.mark.requires_seed("ceo")
+@pytest.mark.security
+def test_without_the_admin_row_search_refuses(
+    realm_admin_session: PersonaSession,
+) -> None:
+    """403, not an empty 200 — the CEO holds the realm role and no
+    `person_roles` row, and a silent empty listing would read to the UI as
+    "no such person" rather than "you may not search"."""
+    response = realm_admin_session.client.get(PERSONS, params={"q": "anything"})
+    assert response.status_code == 403, f"{response.status_code} {response.text[:300]}"

--- a/tests/stand/api/identity/test_resolution.py
+++ b/tests/stand/api/identity/test_resolution.py
@@ -104,6 +104,12 @@ def test_the_queue_answers_with_coherent_tenant_wide_rates(
         "the seeded roster is far below the evidence cap — a truncated answer "
         "means the read is broken, not that the stand is big"
     )
+    # Two distinct caps, and the seeded roster clears both: a set flag here
+    # would mean the queue is a prefix, which makes the assertion above about
+    # its length meaningless.
+    assert queue.items_truncated is False, (
+        "the queue reports its item cap was hit on a roster far below it"
+    )
 
 
 @pytest.mark.requires_seed("admin_operator", "dev_lead")

--- a/tests/stand/api/identity/test_resolution.py
+++ b/tests/stand/api/identity/test_resolution.py
@@ -1,0 +1,197 @@
+"""The operator correction surface — the manual-resolution routes on the deployed path.
+
+    GET  /v1/resolution/attention                         200 rates arithmetic · 403 realm admin
+    GET  /v1/resolution/accounts/{source}/{sid}/{aid}     200 binding + history (round trip)
+    GET  /v1/resolution/persons/{id}/accounts             200 for a seeded person
+    POST /v1/resolution/bind                              200 applied → already_decided (round trip)
+    POST /v1/resolution/merge                             400 source == target (validation, no write)
+    POST /v1/resolution/detach                            404 unseen account (no write)
+    POST /v1/resolution/exclude                           200 applied (the round trip's cleanup)
+
+The verbs append to an append-only journal, so the scratch policy cannot be
+"create and delete". The round trip instead ends in `exclude`, whose end state
+is invisible to every read surface by contract: the account leaves the
+person's account list, never enters the review queue (it carries no connector
+evidence), and resolves as no person. What persists is journal rows — the same
+thing every operator decision leaves behind by design. The account id carries
+`scratch_name`'s run tag so a human reading the journal can attribute it.
+
+Merge and detach are exercised through pure-validation refusals: proving the
+route answers with a session without moving a single seeded binding — the
+stand must read the same before and after this module.
+
+The 401 half is in `test_gateway.py`, swept over every operation.
+"""
+
+from __future__ import annotations
+
+import pytest
+from insight_stand import ApiClient, Manifest, PersonaSession, identity_path
+
+from .. import scratch
+from ..schemas import (
+    AccountBindingResponse,
+    AttentionResponse,
+    CorrectionResponse,
+    PersonAccountsResponse,
+)
+
+ATTENTION = identity_path("/v1/resolution/attention")
+
+#: A connector-instance id for accounts that exist only in this module. Fixed,
+#: not random: the coverage template folds `{id}` per path segment either way,
+#: and a stable value keeps journal rows attributable to this suite.
+SCRATCH_SOURCE_ID = "01900000-0000-7000-8000-00000000feed"
+
+
+def _account_path(account_id: str) -> str:
+    return identity_path(
+        f"/v1/resolution/accounts/github/{SCRATCH_SOURCE_ID}/{account_id}"
+    )
+
+
+@pytest.mark.security
+def test_an_unauthenticated_caller_never_reaches_any_of_this(api_client: ApiClient) -> None:
+    """Proven per operation by `test_gateway.py`; spot-checked here so this
+    module carries its own reason for using a session at all."""
+    response = api_client.get(ATTENTION)
+    assert response.status_code == 401, f"{response.status_code} {response.text[:300]}"
+
+
+@pytest.mark.requires_seed("ceo")
+@pytest.mark.security
+def test_the_realm_admin_is_refused_the_queue(realm_admin_session: PersonaSession) -> None:
+    """The correction surface reads `person_roles`, never the realm role —
+    the same boundary `test_admin.py` pins for the CRUD listings."""
+    response = realm_admin_session.client.get(ATTENTION)
+    assert response.status_code == 403, f"{response.status_code} {response.text[:300]}"
+
+
+@pytest.mark.requires_seed("admin_operator")
+@pytest.mark.reliability
+def test_the_queue_answers_with_coherent_tenant_wide_rates(
+    admin_operator_session: PersonaSession,
+) -> None:
+    """`rates` counts every observed account, and the states partition it:
+    an account is bound, pending, evidence-less or excluded — never two at
+    once and never none. A sum mismatch means the fold dropped or
+    double-counted accounts, which the UI would show as a lying match rate.
+    """
+    response = admin_operator_session.client.get(ATTENTION)
+    assert response.status_code == 200, f"{response.status_code} {response.text[:300]}"
+
+    queue = response.parse(AttentionResponse)
+    rates = queue.rates
+    assert rates.observed == rates.bound + rates.pending + rates.no_evidence + rates.excluded, (
+        f"resolution states do not partition the observed set: {rates}"
+    )
+    assert len(queue.items) <= rates.pending + rates.no_evidence, (
+        "more queue items than undecided accounts"
+    )
+
+
+@pytest.mark.requires_seed("admin_operator", "dev_lead")
+@pytest.mark.reliability
+def test_a_seeded_person_lists_their_accounts(
+    admin_operator_session: PersonaSession, stand_manifest: Manifest
+) -> None:
+    lead = stand_manifest.fixture("dev_lead")
+    response = admin_operator_session.client.get(
+        identity_path(f"/v1/resolution/persons/{lead.uuid}/accounts")
+    )
+    assert response.status_code == 200, f"{response.status_code} {response.text[:300]}"
+
+    owned = response.parse(PersonAccountsResponse)
+    assert str(owned.person_id) == lead.uuid
+
+
+@pytest.mark.requires_seed("admin_operator", "dev_lead")
+@pytest.mark.reliability
+def test_bind_confirm_and_exclude_round_trip(
+    admin_operator_session: PersonaSession, stand_manifest: Manifest
+) -> None:
+    """One synthetic account through the operator's grammar.
+
+    bind → `applied`; the same bind again → `already_decided` (an operator
+    re-asserting their own decision is idempotent, not an error); the account
+    read shows the person and an operator-authored history entry; exclude →
+    `applied`, after which the account is off the person's list — the
+    invisible end state that stands in for deletion on an append-only journal.
+    """
+    client = admin_operator_session.client
+    lead = stand_manifest.fixture("dev_lead")
+    account_id = scratch.scratch_name("resolution")
+    account = {"source": "github", "source_id": SCRATCH_SOURCE_ID, "id": account_id}
+
+    bind = client.post(
+        identity_path("/v1/resolution/bind"),
+        json_body={"bindings": [{"account": account, "person_id": lead.uuid}]},
+    )
+    assert bind.status_code == 200, f"bind: {bind.status_code} {bind.text[:300]}"
+    first = bind.parse(CorrectionResponse)
+    assert first.applied == 1 and first.items[0].outcome == "applied", first
+
+    again = client.post(
+        identity_path("/v1/resolution/bind"),
+        json_body={"bindings": [{"account": account, "person_id": lead.uuid}]},
+    )
+    assert again.status_code == 200, f"rebind: {again.status_code} {again.text[:300]}"
+    second = again.parse(CorrectionResponse)
+    assert second.already_decided == 1 and second.items[0].outcome == "already_decided", second
+
+    read = client.get(_account_path(account_id))
+    assert read.status_code == 200, f"read: {read.status_code} {read.text[:300]}"
+    binding = read.parse(AccountBindingResponse)
+    assert str(binding.person_id) == lead.uuid
+    assert any(entry.by_operator for entry in binding.history), (
+        f"no operator-authored entry in {binding.history}"
+    )
+
+    exclude = client.post(
+        identity_path("/v1/resolution/exclude"),
+        json_body={"account": account, "comment": "stand scratch cleanup"},
+    )
+    assert exclude.status_code == 200, f"exclude: {exclude.status_code} {exclude.text[:300]}"
+    assert exclude.parse(CorrectionResponse).applied == 1
+
+    owned = client.get(
+        identity_path(f"/v1/resolution/persons/{lead.uuid}/accounts")
+    ).parse(PersonAccountsResponse)
+    assert account_id not in [a.account_id for a in owned.accounts], (
+        "the excluded scratch account still lists under the person — the stand is dirty"
+    )
+
+
+@pytest.mark.requires_seed("admin_operator", "dev_lead")
+@pytest.mark.reliability
+def test_merge_refuses_a_person_merged_into_themselves(
+    admin_operator_session: PersonaSession, stand_manifest: Manifest
+) -> None:
+    """Pure validation — proves the route answers a session without moving a
+    single seeded binding."""
+    lead = stand_manifest.fixture("dev_lead")
+    response = admin_operator_session.client.post(
+        identity_path("/v1/resolution/merge"),
+        json_body={"source_person_id": lead.uuid, "target_person_id": lead.uuid},
+    )
+    assert response.status_code == 400, f"{response.status_code} {response.text[:300]}"
+
+
+@pytest.mark.requires_seed("admin_operator")
+@pytest.mark.reliability
+def test_detach_refuses_an_account_nobody_ever_saw(
+    admin_operator_session: PersonaSession,
+) -> None:
+    """Binding an unseen account is allowed (pre-registration); detaching one
+    is not — there is nothing to detach. 404, and no write happens."""
+    response = admin_operator_session.client.post(
+        identity_path("/v1/resolution/detach"),
+        json_body={
+            "account": {
+                "source": "github",
+                "source_id": SCRATCH_SOURCE_ID,
+                "id": "never-observed-account",
+            }
+        },
+    )
+    assert response.status_code == 404, f"{response.status_code} {response.text[:300]}"

--- a/tests/stand/api/identity/test_resolution.py
+++ b/tests/stand/api/identity/test_resolution.py
@@ -3,8 +3,8 @@
     GET  /v1/resolution/attention                         200 rates arithmetic · 403 realm admin
     GET  /v1/resolution/accounts/{source}/{sid}/{aid}     200 binding + history (round trip)
     GET  /v1/resolution/persons/{id}/accounts             200 for a seeded person
-    POST /v1/resolution/bind                              200 applied → already_decided (round trip)
-    POST /v1/resolution/merge                             400 source == target (validation, no write)
+    POST /v1/resolution/bind                              200 applied → already_decided (round trip) · 400 excluded sentinel
+    POST /v1/resolution/merge                             400 source == target · excluded sentinel (validation, no write)
     POST /v1/resolution/detach                            404 unseen account (no write)
     POST /v1/resolution/exclude                           200 applied (the round trip's cleanup)
 
@@ -37,6 +37,12 @@ from ..schemas import (
 )
 
 ATTENTION = identity_path("/v1/resolution/attention")
+
+#: The reserved excluded-person sentinel (`Uuid::from_u128(u128::MAX)` in the
+#: service). Once any account was ever excluded it exists in the journal, so
+#: only an explicit guard keeps it out of bind/merge — these tests pin that
+#: guard.
+EXCLUDED_PERSON = "ffffffff-ffff-ffff-ffff-ffffffffffff"
 
 #: A connector-instance id for accounts that exist only in this module. Fixed,
 #: not random: the coverage template folds `{id}` per path segment either way,
@@ -82,11 +88,21 @@ def test_the_queue_answers_with_coherent_tenant_wide_rates(
 
     queue = response.parse(AttentionResponse)
     rates = queue.rates
+    # The floor first: 0 == 0+0+0+0 partitions perfectly, so without it a
+    # fold that silently reads zero rows (a broken join, a missing relation
+    # mapped to an empty answer) would pass the arithmetic below. The seed
+    # this test requires materializes identity evidence for the roster, so a
+    # seeded stand always has observed accounts.
+    assert rates.observed > 0, f"a seeded stand reports zero observed accounts: {rates}"
     assert rates.observed == rates.bound + rates.pending + rates.no_evidence + rates.excluded, (
         f"resolution states do not partition the observed set: {rates}"
     )
     assert len(queue.items) <= rates.pending + rates.no_evidence, (
         "more queue items than undecided accounts"
+    )
+    assert queue.truncated is False, (
+        "the seeded roster is far below the evidence cap — a truncated answer "
+        "means the read is broken, not that the stand is big"
     )
 
 
@@ -95,6 +111,10 @@ def test_the_queue_answers_with_coherent_tenant_wide_rates(
 def test_a_seeded_person_lists_their_accounts(
     admin_operator_session: PersonaSession, stand_manifest: Manifest
 ) -> None:
+    """The route echoes the requested id, so the id check alone proves
+    nothing; the list itself must be non-empty. Every roster persona gets a
+    login-bootstrap identity row from the seed, so a seeded person with zero
+    accounts means the query read the wrong place, not an empty stand."""
     lead = stand_manifest.fixture("dev_lead")
     response = admin_operator_session.client.get(
         identity_path(f"/v1/resolution/persons/{lead.uuid}/accounts")
@@ -103,6 +123,10 @@ def test_a_seeded_person_lists_their_accounts(
 
     owned = response.parse(PersonAccountsResponse)
     assert str(owned.person_id) == lead.uuid
+    assert owned.accounts, (
+        f"a seeded person lists no accounts — the seed guarantees {lead.email} "
+        "at least their login-bootstrap identity row"
+    )
 
 
 @pytest.mark.requires_seed("admin_operator", "dev_lead")
@@ -131,28 +155,32 @@ def test_bind_confirm_and_exclude_round_trip(
     first = bind.parse(CorrectionResponse)
     assert first.applied == 1 and first.items[0].outcome == "applied", first
 
-    again = client.post(
-        identity_path("/v1/resolution/bind"),
-        json_body={"bindings": [{"account": account, "person_id": lead.uuid}]},
-    )
-    assert again.status_code == 200, f"rebind: {again.status_code} {again.text[:300]}"
-    second = again.parse(CorrectionResponse)
-    assert second.already_decided == 1 and second.items[0].outcome == "already_decided", second
+    # From here the scratch account is bound to a REAL seeded persona, and no
+    # sweep can see a leaked binding (the journal has no scratch listing) —
+    # so the exclude must run even when an assertion in between fails.
+    try:
+        again = client.post(
+            identity_path("/v1/resolution/bind"),
+            json_body={"bindings": [{"account": account, "person_id": lead.uuid}]},
+        )
+        assert again.status_code == 200, f"rebind: {again.status_code} {again.text[:300]}"
+        second = again.parse(CorrectionResponse)
+        assert second.already_decided == 1 and second.items[0].outcome == "already_decided", second
 
-    read = client.get(_account_path(account_id))
-    assert read.status_code == 200, f"read: {read.status_code} {read.text[:300]}"
-    binding = read.parse(AccountBindingResponse)
-    assert str(binding.person_id) == lead.uuid
-    assert any(entry.by_operator for entry in binding.history), (
-        f"no operator-authored entry in {binding.history}"
-    )
-
-    exclude = client.post(
-        identity_path("/v1/resolution/exclude"),
-        json_body={"account": account, "comment": "stand scratch cleanup"},
-    )
-    assert exclude.status_code == 200, f"exclude: {exclude.status_code} {exclude.text[:300]}"
-    assert exclude.parse(CorrectionResponse).applied == 1
+        read = client.get(_account_path(account_id))
+        assert read.status_code == 200, f"read: {read.status_code} {read.text[:300]}"
+        binding = read.parse(AccountBindingResponse)
+        assert str(binding.person_id) == lead.uuid
+        assert any(entry.by_operator for entry in binding.history), (
+            f"no operator-authored entry in {binding.history}"
+        )
+    finally:
+        exclude = client.post(
+            identity_path("/v1/resolution/exclude"),
+            json_body={"account": account, "comment": "stand scratch cleanup"},
+        )
+        assert exclude.status_code == 200, f"exclude: {exclude.status_code} {exclude.text[:300]}"
+        assert exclude.parse(CorrectionResponse).applied == 1
 
     owned = client.get(
         identity_path(f"/v1/resolution/persons/{lead.uuid}/accounts")
@@ -173,6 +201,50 @@ def test_merge_refuses_a_person_merged_into_themselves(
     response = admin_operator_session.client.post(
         identity_path("/v1/resolution/merge"),
         json_body={"source_person_id": lead.uuid, "target_person_id": lead.uuid},
+    )
+    assert response.status_code == 400, f"{response.status_code} {response.text[:300]}"
+
+
+@pytest.mark.requires_seed("admin_operator")
+@pytest.mark.security
+def test_the_excluded_sentinel_is_not_a_bind_target(
+    admin_operator_session: PersonaSession,
+) -> None:
+    """Binding to the sentinel would be an exclude that skips the
+    known-account check (bind deliberately pre-registers unseen accounts).
+    Pure validation: refused before any existence lookup, so no write."""
+    response = admin_operator_session.client.post(
+        identity_path("/v1/resolution/bind"),
+        json_body={
+            "bindings": [
+                {
+                    "account": {
+                        "source": "github",
+                        "source_id": SCRATCH_SOURCE_ID,
+                        "id": "never-observed-account",
+                    },
+                    "person_id": EXCLUDED_PERSON,
+                }
+            ]
+        },
+    )
+    assert response.status_code == 400, f"{response.status_code} {response.text[:300]}"
+
+
+@pytest.mark.requires_seed("admin_operator", "dev_lead")
+@pytest.mark.security
+@pytest.mark.parametrize("side", ["source_person_id", "target_person_id"])
+def test_the_excluded_sentinel_is_not_a_merge_side(
+    admin_operator_session: PersonaSession, stand_manifest: Manifest, side: str
+) -> None:
+    """A merge naming the sentinel moves EVERY excluded account of the tenant
+    at once (as source), or mass-excludes a person's accounts while the
+    journal records a merge (as target). Refused as validation, no write."""
+    lead = stand_manifest.fixture("dev_lead")
+    body = {"source_person_id": lead.uuid, "target_person_id": lead.uuid}
+    body[side] = EXCLUDED_PERSON
+    response = admin_operator_session.client.post(
+        identity_path("/v1/resolution/merge"), json_body=body
     )
     assert response.status_code == 400, f"{response.status_code} {response.text[:300]}"
 

--- a/tests/stand/api/operations.py
+++ b/tests/stand/api/operations.py
@@ -138,8 +138,8 @@ IDENTITY_OPERATIONS: Final[tuple[Operation, ...]] = (
     _i("GET", "/v1/visibility"),
     _i("POST", "/v1/visibility"),
     _i("DELETE", f"/v1/visibility/{SOME_ID}"),
-    # `.authenticated()`, not admin-gated — and the substring test below does not
-    # catch it, which is correct: `/visible-persons` is not `/visibility`.
+    # `.authenticated()`, not admin-gated — deliberately absent from
+    # `_ADMIN_GATED_SUFFIXES` below.
     _i("POST", "/v1/visible-persons"),
 )
 

--- a/tests/stand/api/operations.py
+++ b/tests/stand/api/operations.py
@@ -116,12 +116,13 @@ ANALYTICS_OPERATIONS: Final[tuple[Operation, ...]] = (
     _a("DELETE", f"/v1/metrics/{SOME_METRIC_KEY}"),
 )
 
-#: identity-resolution — 18 operations. `/health` and `/healthz` are the host
+#: identity-resolution — 19 operations. `/health` and `/healthz` are the host
 #: router's, not the product API, and are deliberately absent: the real probes
 #: address the pod directly rather than passing the gateway.
 IDENTITY_OPERATIONS: Final[tuple[Operation, ...]] = (
     _i("POST", "/v1/profiles"),
     _i("GET", "/v1/me"),
+    _i("GET", "/v1/persons"),
     _i("GET", "/v1/subchart"),
     _i("GET", f"/v1/subchart/{SOME_ID}"),
     _i("GET", "/v1/persons-seed"),
@@ -144,15 +145,30 @@ IDENTITY_OPERATIONS: Final[tuple[Operation, ...]] = (
 
 ALL_OPERATIONS: Final[tuple[Operation, ...]] = ANALYTICS_OPERATIONS + IDENTITY_OPERATIONS
 
-#: The 13 identity operations behind `require_admin`, which resolves the caller
+#: Suffixes of the identity operations behind `require_admin`, enumerated
+#: exactly — a substring rule would silently classify future routes (and
+#: `/visible-persons` is one hyphen away from a false match today).
+_ADMIN_GATED_SUFFIXES: Final[tuple[str, ...]] = (
+    "/v1/persons",
+    "/v1/persons-seed",
+    f"/v1/persons-seed/{SOME_ID}",
+    "/v1/persons-sync",
+    f"/v1/persons-sync/{SOME_ID}",
+    "/v1/roles",
+    f"/v1/roles/{SOME_ID}",
+    "/v1/person-roles",
+    f"/v1/person-roles/{SOME_ID}",
+    "/v1/visibility",
+    f"/v1/visibility/{SOME_ID}",
+)
+
+#: The 14 identity operations behind `require_admin`, which resolves the caller
 #: from the gateway JWT and requires an active `admin` row in `person_roles` —
-#: it never reads the `insight-admin` REALM role. The seed grants nobody that
-#: row, so every persona is refused; see out/endpoint-coverage-preconditions.md.
+#: it never reads the `insight-admin` REALM role. The seed grants that row to
+#: exactly one persona, the admin operator; every other persona is refused.
+#: See out/endpoint-coverage-preconditions.md.
 ADMIN_GATED: Final[frozenset[str]] = frozenset(
     op.label
     for op in IDENTITY_OPERATIONS
-    if any(
-        seg in op.path
-        for seg in ("/persons-seed", "/persons-sync", "/roles", "/person-roles", "/visibility")
-    )
+    if op.path in {identity_path(suffix) for suffix in _ADMIN_GATED_SUFFIXES}
 )

--- a/tests/stand/api/operations.py
+++ b/tests/stand/api/operations.py
@@ -32,6 +32,10 @@ from insight_stand import analytics_path, identity_path
 # resolved — they only have to be well-formed enough to route.
 SOME_ID: Final[str] = "01900000-0000-7000-8000-000000000000"
 
+#: Stand-in for a source-native `{account_id}` path segment — an arbitrary
+#: string, not a UUID, so it needs its own recognisable value.
+SOME_ACCOUNT_ID: Final[str] = "stand-in-account"
+
 #: Stand-in for `{metric_key}`, which is a dotted `family.name` string rather
 #: than a UUID. Kept a DOTTED key on purpose: the literal `export`/`import`
 #: segments of the sibling routes must not collide with it, so the template
@@ -45,6 +49,7 @@ SOME_METRIC_KEY: Final[str] = "scratch.probe"
 _PARAMETERS: Final[dict[str, str]] = {
     SOME_ID: "{id}",
     SOME_METRIC_KEY: "{metric_key}",
+    SOME_ACCOUNT_ID: "{account_id}",
 }
 
 
@@ -116,13 +121,23 @@ ANALYTICS_OPERATIONS: Final[tuple[Operation, ...]] = (
     _a("DELETE", f"/v1/metrics/{SOME_METRIC_KEY}"),
 )
 
-#: identity-resolution — 19 operations. `/health` and `/healthz` are the host
+#: identity-resolution — 26 operations. `/health` and `/healthz` are the host
 #: router's, not the product API, and are deliberately absent: the real probes
 #: address the pod directly rather than passing the gateway.
 IDENTITY_OPERATIONS: Final[tuple[Operation, ...]] = (
     _i("POST", "/v1/profiles"),
     _i("GET", "/v1/me"),
     _i("GET", "/v1/persons"),
+    # The operator correction surface. `source` stays the literal `github` in
+    # the accounts read: it is a connector type, not an id, and the tests
+    # address the same literal — a stand-in would fold a segment nothing varies.
+    _i("GET", "/v1/resolution/attention"),
+    _i("GET", f"/v1/resolution/accounts/github/{SOME_ID}/{SOME_ACCOUNT_ID}"),
+    _i("GET", f"/v1/resolution/persons/{SOME_ID}/accounts"),
+    _i("POST", "/v1/resolution/bind"),
+    _i("POST", "/v1/resolution/merge"),
+    _i("POST", "/v1/resolution/detach"),
+    _i("POST", "/v1/resolution/exclude"),
     _i("GET", "/v1/subchart"),
     _i("GET", f"/v1/subchart/{SOME_ID}"),
     _i("GET", "/v1/persons-seed"),
@@ -150,6 +165,13 @@ ALL_OPERATIONS: Final[tuple[Operation, ...]] = ANALYTICS_OPERATIONS + IDENTITY_O
 #: `/visible-persons` is one hyphen away from a false match today).
 _ADMIN_GATED_SUFFIXES: Final[tuple[str, ...]] = (
     "/v1/persons",
+    "/v1/resolution/attention",
+    f"/v1/resolution/accounts/github/{SOME_ID}/{SOME_ACCOUNT_ID}",
+    f"/v1/resolution/persons/{SOME_ID}/accounts",
+    "/v1/resolution/bind",
+    "/v1/resolution/merge",
+    "/v1/resolution/detach",
+    "/v1/resolution/exclude",
     "/v1/persons-seed",
     f"/v1/persons-seed/{SOME_ID}",
     "/v1/persons-sync",
@@ -162,7 +184,7 @@ _ADMIN_GATED_SUFFIXES: Final[tuple[str, ...]] = (
     f"/v1/visibility/{SOME_ID}",
 )
 
-#: The 14 identity operations behind `require_admin`, which resolves the caller
+#: The 21 identity operations behind `require_admin`, which resolves the caller
 #: from the gateway JWT and requires an active `admin` row in `person_roles` —
 #: it never reads the `insight-admin` REALM role. The seed grants that row to
 #: exactly one persona, the admin operator; every other persona is refused.

--- a/tests/stand/api/operations.py
+++ b/tests/stand/api/operations.py
@@ -116,11 +116,12 @@ ANALYTICS_OPERATIONS: Final[tuple[Operation, ...]] = (
     _a("DELETE", f"/v1/metrics/{SOME_METRIC_KEY}"),
 )
 
-#: identity-resolution — 17 operations. `/health` and `/healthz` are the host
+#: identity-resolution — 18 operations. `/health` and `/healthz` are the host
 #: router's, not the product API, and are deliberately absent: the real probes
 #: address the pod directly rather than passing the gateway.
 IDENTITY_OPERATIONS: Final[tuple[Operation, ...]] = (
     _i("POST", "/v1/profiles"),
+    _i("GET", "/v1/me"),
     _i("GET", "/v1/subchart"),
     _i("GET", f"/v1/subchart/{SOME_ID}"),
     _i("GET", "/v1/persons-seed"),

--- a/tests/stand/api/schemas/__init__.py
+++ b/tests/stand/api/schemas/__init__.py
@@ -69,6 +69,7 @@ from .identity import (
     CorrectionResponse,
     MeResponse,
     PersonAccountsResponse,
+    PersonListResponse,
     SubchartNode,
 )
 from .identity import (
@@ -133,6 +134,7 @@ __all__: Sequence[str] = (
     "Operation",
     "PeriodView",
     "PersonAccountsResponse",
+    "PersonListResponse",
     "PersonRole",
     "PersonRoleList",
     "ProblemDocument",

--- a/tests/stand/api/schemas/__init__.py
+++ b/tests/stand/api/schemas/__init__.py
@@ -67,6 +67,7 @@ from .identity import (
     AccountBindingResponse,
     AttentionResponse,
     CorrectionResponse,
+    MeResponse,
     PersonAccountsResponse,
     SubchartNode,
 )
@@ -126,6 +127,7 @@ __all__: Sequence[str] = (
     "ImportCustomMetricsRequest",
     "ImportCustomMetricsResponse",
     "ListResponse",
+    "MeResponse",
     "MetricDefinitionListResponse",
     "MetricResultsResponse",
     "Operation",

--- a/tests/stand/api/schemas/identity.py
+++ b/tests/stand/api/schemas/identity.py
@@ -233,6 +233,7 @@ class PersonSummaryResponse(BaseModel):
     job_title: str | None = None
     person_id: UUID
     status: str | None = None
+    username: str | None = Field(None, description='Source-native handle (e.g. a git login) — often the only recognisable\nfield of an identity no HR system has observed yet.')
 
 
 class PersonsSeedOperationResponse(BaseModel):

--- a/tests/stand/api/schemas/identity.py
+++ b/tests/stand/api/schemas/identity.py
@@ -488,6 +488,7 @@ class AttentionResponse(BaseModel):
     )
     items: list[QueueItemResponse]
     rates: ResolutionRatesResponse
+    truncated: bool = Field(..., description='The evidence read hit its safety cap: the queue and the rates describe\nonly the first accounts of the tenant, not all of them. Consumers must\nnot present these numbers as tenant-wide.')
 
 
 class CorrectionResponse(BaseModel):

--- a/tests/stand/api/schemas/identity.py
+++ b/tests/stand/api/schemas/identity.py
@@ -219,6 +219,22 @@ class PersonRoleResponse(BaseModel):
     valid_to: str | None = None
 
 
+class PersonSummaryResponse(BaseModel):
+    """
+    A person as operator surfaces display them: enough to recognise and pick,
+    nothing more. Every field but the id may be null — a person the journal
+    knows only through bindings still appears, as the id alone.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    display_name: str | None = None
+    email: str | None = None
+    job_title: str | None = None
+    person_id: UUID
+    status: str | None = None
+
+
 class PersonsSeedOperationResponse(BaseModel):
     """
     One operation's status. Wire shape mirrors the .NET
@@ -330,7 +346,7 @@ class QueueItemResponse(BaseModel):
         extra='forbid',
     )
     account_id: str
-    candidates: list[UUID] = Field(..., description='Persons this account could belong to, if any are known.')
+    candidates: list[PersonSummaryResponse] = Field(..., description='Persons this account could belong to, if any are known — hydrated into\ncards so the operator UI never has to resolve bare ids itself.')
     email: str | None = None
     kind: str = Field(..., description='`contested` | `binding_conflict` | `no_evidence`.')
     source: str

--- a/tests/stand/api/schemas/identity.py
+++ b/tests/stand/api/schemas/identity.py
@@ -134,6 +134,17 @@ class ItemResult(BaseModel):
     source_id: UUID
 
 
+class MeRoleResponse(BaseModel):
+    """
+    One active role assignment of the caller.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    name: str
+    role_id: UUID
+
+
 class MergeRequest(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
@@ -470,6 +481,18 @@ class CorrectionResponse(BaseModel):
     applied: int = Field(..., ge=0)
     items: list[ItemResult]
     new_person_id: UUID | None = Field(None, description='Set by `detach` when the account reached the new person; absent when\nthe write was refused, since no binding points at that id.')
+
+
+class MeResponse(BaseModel):
+    """
+    The caller as the gateway JWT identifies them, with their active roles.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    insight_tenant_id: UUID
+    person_id: UUID
+    roles: list[MeRoleResponse]
 
 
 class PersonRoleListResponse(BaseModel):

--- a/tests/stand/api/schemas/identity.py
+++ b/tests/stand/api/schemas/identity.py
@@ -487,6 +487,7 @@ class AttentionResponse(BaseModel):
         extra='forbid',
     )
     items: list[QueueItemResponse]
+    items_truncated: bool = Field(..., description='`limit` cut the item list — more accounts await a decision than are\nlisted here. Distinct from `truncated`: the rates stay whole-tenant,\nonly this page is short.')
     rates: ResolutionRatesResponse
     truncated: bool = Field(..., description='The evidence read hit its safety cap: the queue and the rates describe\nonly the first accounts of the tenant, not all of them. Consumers must\nnot present these numbers as tenant-wide.')
 

--- a/tests/stand/api/schemas/identity.py
+++ b/tests/stand/api/schemas/identity.py
@@ -511,6 +511,15 @@ class MeResponse(BaseModel):
     roles: list[MeRoleResponse]
 
 
+class PersonListResponse(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    items: list[PersonSummaryResponse]
+    next_cursor: str | None = Field(None, description='Wire parity with the other listings: declared, always `null`.')
+    truncated: bool = Field(..., description='More persons matched than `limit` allowed — the page is a cut, not the\nanswer, and the UI should ask for narrower terms. Without this flag a\ntruncated page reads as "the person does not exist".')
+
+
 class PersonRoleListResponse(BaseModel):
     """
     List wrapper.


### PR DESCRIPTION
Closes #2424.

## Problem / summary

Manual identity resolution had an API but no operator surface: correcting an
account-to-person binding meant hand-crafting HTTP calls. This adds the
operator console (**Manage → Identities**) and the backend reads it needs.

**Backend (identity-resolution)**

- `GET /v1/me` — the caller's active identity roles. Admin-ness is a row in
  `person_roles`, not the realm role, and no identity endpoint reads the realm
  role; without this read the SPA could only guess, and would draw an admin
  console the backend then refuses with 403.
- `GET /v1/persons?q=` — operator person search over current observed values,
  so a binding can target someone who is not already a queue candidate.
- Attention-queue candidates are hydrated into person cards, so the UI never
  has to render bare ids.

**Frontend**

- The Manage zone opens to identity admins; the Identities surface is gated
  fail-closed on `GET /v1/me` (a pasted URL gets an explicit refusal, never a
  flash of the console).
- Review queue grouped by why an account needs a decision, with tenant-wide
  rates that count every observed account rather than the visible page.
- Account detail panel: the binding in force, hydrated candidates, and the
  full decision history.
- The four correction verbs (bind/confirm, merge, detach, exclude), each behind
  a confirmation, with the server's per-item outcomes shown verbatim —
  `already_decided` and `refused` are real states an operator must see.

**Tests** — stand contract cases for the new routes and the correction grammar.

## Defects found and fixed while reviewing this branch

Called out because several are cross-layer and would not show up in a diff read
of any single file:

- **History timestamps rendered in the wrong time.** The service serializes
  `recorded_at` as a zone-less UTC clock reading (wire parity with the retired
  implementation); the frontend parsed it with `parseISO`, which reads a
  zone-less string as local time. Every viewer outside UTC saw audit entries
  off by their offset. The MSW fixtures carried a `Z` the backend never sends,
  so no test could catch it — they now mirror the real shape.
- **A failed admin check was indistinguishable from "not an admin", and stuck.**
  The shared query client does not refetch on focus or reconnect and the portal
  shell's observers never remount, so an errored `GET /v1/me` (identity briefly
  unavailable at app start) read as "no role" for the rest of the SPA session:
  the Manage entry stayed hidden, a deep-linked `?zone=manage` URL was rewritten
  away, and the refusal card told a real admin to go ask for a role they hold.
  The check now recovers on its own, and the gate distinguishes "could not
  verify" from "not an admin".
- **The reserved excluded-person sentinel was accepted as an ordinary person.**
  Its first exclusion writes it into the journal, after which the existence
  check vouches for it — so it could be named as a bind target (an exclude that
  skips the known-account check) or as either side of a merge (moving every
  excluded account of the tenant in one call). Corrections now refuse it; only
  the exclude verb may name it.
- **The evidence read's cap was invisible to callers.** On reaching it the
  service logged a warning while the response still presented its counts as
  tenant-wide. The attention response now carries `truncated`, and the console
  says so rather than passing a prefix off as the whole tenant.
- **A stale-link state that production never produces.** The binding read never
  404s — an account nobody observed or decided answers 200 with an empty
  journal — yet the mock, the client docstring and the panel all encoded a 404.
  Against a real backend a mistyped `?acct=` link rendered a fully actionable
  panel where one click would pre-register the typo as an account. The stale
  state is now derived from what the backend actually returns, and offers no
  verbs.
- **Merge could be confirmed before its preview loaded**, and a failed preview
  rendered as "0 accounts move" while still allowing the merge. The preview is
  the operator's consent, so confirmation now waits for it and a failed load
  says so with a retry.
- Smaller ones: a verb's outcome alert survived switching to another account
  (making an untouched account read as already decided); a failed verb's error
  reappeared when a dialog was reopened for a different candidate; a truncated
  percent-escape in `?acct=` threw during render instead of reading as "nothing
  selected"; the person-search cache was not invalidated after a verb, so the
  picker kept offering a person who had just been merged away; a `403` carries
  its explanation in `context.reason`, which the console dropped in favour of
  "Try again"; and a shared `?acct=` link stopped answering once the queue was
  worked to zero — exactly when a colleague opens it.

## Affected areas

- `src/backend/services/identity-resolution/` — `api/` (me, persons,
  resolution, listing, error), `domain/person_card`, `infra/db/`
  (persons_repo, roles_repo), `infra/identity_evidence`
- `docs/components/backend/identity-resolution/openapi.json` — regenerated
- `src/frontend/src/` — portal components (identities view, account detail and
  actions, person picker, manage view, context pane, portal layout), identity
  client and queries, `lib/portal` nav/landing, `lib/format`, i18n strings,
  MSW handlers
- `tests/stand/api/identity/` and the generated response schemas

## How to test

Backend:

```bash
cd src/backend
cargo test -p identity-resolution
cargo clippy -p identity-resolution --all-targets -- -D warnings
```

Frontend:

```bash
cd src/frontend
pnpm typecheck && pnpm lint && pnpm test
```

OpenAPI drift (the committed document must match the emitted one):

```bash
(cd src/backend && cargo run --quiet -p identity-resolution --bin identity-resolution -- openapi) > /tmp/identity.live.json
python3 scripts/ci/openapi_spec.py check \
  --file docs/components/backend/identity-resolution/openapi.json \
  --live-file /tmp/identity.live.json
```

Deployed stand — needs `--build`, since the pinned images predate these routes:

```bash
./dev-compose.sh test-stand up --build
./dev-compose.sh test-stand test -k "resolution or identity_me or persons"
```

By hand, no backend required (the mocks now mirror the real wire shapes,
zone-less timestamps included):

```bash
cd src/frontend
VITE_ENABLE_MOCKS=true pnpm dev   # → Manage → Identities
```

Worth exercising there: switch between accounts after applying a verb (the
outcome must not follow you), open `?acct=` with an unknown account id (stale
state, no verbs), and open a merge dialog (confirmation waits for the preview).

## Known follow-up, not in this PR

A merged-away person keeps its own observations, so it still appears in search
and can be bound again — recreating the split the merge just fixed. The fix is
a persisted merge marker (or redirect to the surviving person) honoured by
search and the other reads; that is a write-path change with its own contract
and belongs in a separate PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an administrator-only Identities console for reviewing account-resolution queues.
  - Added person search with profile matching and truncated-result indicators.
  - Added account details, binding history, and actions to bind, merge, detach, or exclude accounts.
  - Added current-user identity and role information.
  - Added clearer person summaries, candidate details, resolution rates, and queue warnings.
- **Bug Fixes**
  - Restricted administrator-only navigation and management access.
  - Improved portal routing and account selection state handling.
- **UI/UX**
  - Added confirmations, loading states, retryable errors, localized labels, and status badges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->