### PR TITLE
fix(bamboohr): sync fields the API key can read instead of failing (release-2026.07.1)

### DIFF
--- a/src/ingestion/connectors/hr-directory/bamboohr/README.md
+++ b/src/ingestion/connectors/hr-directory/bamboohr/README.md
@@ -83,14 +83,14 @@ BambooHR caps a custom report at 400 fields and answers a larger request with a
 rows merged on employee id.
 
 Requested fields the API key cannot read are dropped from the report silently, with
-the call still succeeding. The connector compares the report's declared columns
-against what it asked for, but only holds the bronze columns to it: those are named
-by alias and come back under it, and publishing one empty would clear identity
-values downstream, so a missing one stops the sync. The rest cannot be checked that
-way — field metadata lists entries a custom report will not return, and a field
-asked for by numeric id comes back under an indexed `<id>.N` key — so an apparent
-gap there says more about BambooHR's naming than about access. A report that
-declares no columns at all is treated as unverifiable rather than as loss.
+the call still succeeding. An API key may hold access to only a subset of the
+declared bronze columns; the sync proceeds and publishes the missing ones as null.
+Bronze columns are named by alias and come back under it, so their absence is
+detectable — the connector logs a warning naming them. The rest cannot be checked
+that way — field metadata lists entries a custom report will not return, and a
+field asked for by numeric id comes back under an indexed `<id>.N` key — so an
+apparent gap there says more about BambooHR's naming than about access. A report
+that declares no columns at all is treated as unverifiable and not warned about.
 
 `SENSITIVE_FIELDS` in `source_bamboohr/streams/employees.py` is the exception:
 government identifiers, protected demographics, personal contact details, street

--- a/src/ingestion/connectors/hr-directory/bamboohr/source_bamboohr/streams/employees.py
+++ b/src/ingestion/connectors/hr-directory/bamboohr/source_bamboohr/streams/employees.py
@@ -151,23 +151,18 @@ def returned_fields(payload: Mapping[str, Any], rows: Sequence[Any]) -> set[str]
 
 def _report_omissions(requested: Sequence[str], answered: set[str]) -> None:
     """BambooHR silently drops requested fields the credential cannot read and
-    still answers 200, so a shrinking payload is indistinguishable from cleared
-    values downstream: the snapshot versions on the change and the field history
-    dates it as a clear.
-
-    Only the declared bronze columns are held to that standard. They are named by
-    alias and come back under it, so their absence is real and identity resolution
-    would carry the damage. The rest cannot be checked this way — field metadata
-    lists entries a custom report will not return, and a field asked for by
-    numeric id comes back under an indexed key — so an apparent gap there is far
-    more likely to be BambooHR's own naming than lost access.
+    still answers 200. The API key may legitimately hold access to only a subset
+    of the declared bronze columns, so an omission is not an error — the sync
+    proceeds and the columns are published as null. The warning names them so a
+    key that lost access it used to have is still diagnosable from the logs.
     """
     missing = [name for name in requested if name in BUSINESS_FIELDS and name not in answered]
     if missing:
-        raise RuntimeError(
-            f"BambooHR omitted {len(missing)} declared employee column(s) from the report: "
-            f"{', '.join(missing)}. The API key likely lost access to them; publishing them "
-            "as empty would clear the values downstream."
+        logger.warning(
+            "BambooHR omitted %d declared employee column(s) from the report: %s. "
+            "The API key has no access to them; they are published as null.",
+            len(missing),
+            ", ".join(missing),
         )
 
 

--- a/src/ingestion/connectors/hr-directory/bamboohr/tests/test_streams.py
+++ b/src/ingestion/connectors/hr-directory/bamboohr/tests/test_streams.py
@@ -167,11 +167,11 @@ class TestSilentlyOmittedFields:
         (record,) = read(stream)
         assert record["raw_data"]["4463.0"] == "checked"
 
-    def test_a_withheld_bronze_column_stops_the_sync(self):
+    def test_a_withheld_bronze_column_does_not_stop_the_sync(self):
         stream, _ = employees_stream([EMPLOYEE], omit={"workEmail"})
 
-        with pytest.raises(RuntimeError, match="workEmail"):
-            read(stream)
+        (record,) = read(stream)
+        assert record["workEmail"] is None
 
     def test_a_report_that_declares_no_columns_is_not_read_as_data_loss(self):
         meta = [meta_field(4001, alias="customTeam")]


### PR DESCRIPTION
Backport of #2516 to release-2026.07.1.

## Problem

A BambooHR API key scoped to a subset of employee fields failed the entire employee sync: when the custom report omitted a declared bronze column the key cannot read, the connector raised and stopped.

## Fix

Treat withheld bronze columns as null instead of an error. The sync proceeds; a warning names each missing column so a key that lost access it previously had is still diagnosable from the logs.

## Validation

Connector test suite: 143 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)