### PR TITLE
ci(deps): hold three majors Dependabot keeps re-offering (#2532)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -114,6 +114,12 @@ updates:
       tests-minor-patch:
         patterns: ["*"]
         update-types: [minor, patch]
+    ignore:
+      # CDK 7 changes the parent request the declarative engine emits, so the zoom
+      # substream suites go to zero records — 42 passed on 6.60.16 against 6 failed
+      # and 1 error on 7.23.8 (#2061). Moving belongs with the zoom manifest.
+      - dependency-name: airbyte-cdk
+        versions: [">=7"]
 
   # Frontend package tree. Grouped so a week's worth of bumps arrives as one
   # reviewable change rather than one pull request per package.
@@ -132,3 +138,12 @@ updates:
       # 8.66.0, and refuses to load past it, so TS 7 breaks the ESLint job (#2371).
       - dependency-name: typescript
         versions: [">=6.1"]
+      # v3 drops `initialize` and stops applying `parameters.msw.handlers`; stories
+      # have to call `context.msw.use` themselves, so the storybook setup file
+      # fails to load until that is rewritten (#2430).
+      - dependency-name: msw-storybook-addon
+        versions: [">=3"]
+      # The lint job runs inside mcr.microsoft.com/playwright, pinned in ci.yml
+      # where this ecosystem cannot see it; both move together, by hand (#2503).
+      - dependency-name: playwright
+        versions: [">1.62.1"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -143,6 +143,9 @@ updates:
       # fails to load until that is rewritten (#2430).
       - dependency-name: msw-storybook-addon
         versions: [">=3"]
+      # That addon declares `peer msw ^2.0.0`, so the two come off the hold together.
+      - dependency-name: msw
+        versions: [">=3"]
       # The lint job runs inside mcr.microsoft.com/playwright, pinned in ci.yml
       # where this ecosystem cannot see it; both move together, by hand (#2503).
       - dependency-name: playwright


### PR DESCRIPTION
Closes #2532. Adds three `ignore` entries; nothing else changes.

```
pip  /src/ingestion/tests/connectors, /src/ingestion/tests/e2e
       airbyte-cdk  >=7
npm  /src/frontend
       msw-storybook-addon  >=3
       msw                  >=3
       playwright           >1.62.1
```

## Why each

**airbyte-cdk 7** — measured in #2061: 42 passed on 6.60.16 against **6 failed + 1 error** on 7.23.8. The zoom parent–child substream suites go to zero records because CDK 7 emits a different parent request. #2450 proposes this bump today and shows green only because it edits `pyproject.toml` without re-locking — the lock still holds 6.60.x, so the trap is armed rather than sprung. Three comments in that file already explain why the 6.60 line is load-bearing: the `jsonschema` window, the exact `nltk`/`langchain-core` pins, and the `cryptography 44.0.3` resolution.

**msw-storybook-addon 3** — `initialize` is gone from the public surface and `parameters.msw.handlers` is no longer applied; `createPreviewAnnotations` only starts the worker and exposes it as `context.msw`, so each story must call `context.msw.use(...)`. `.storybook/preview.tsx` imports `initialize` at module scope, which makes the setup file fail to load and story files import as zero tests. Eight handler sites need rewriting first (#2430).

**msw 3** — the addon we hold at 2.0.7 declares `peer msw ^2.0.0`. Holding one without the other leaves the door open on the other side: an msw major lands, the peer breaks, and the storybook setup goes down exactly as it would have under the addon major. Found while auditing the holds for the gap that #2529 exposed — checking not only where a package is used, but what is coupled to it.

**playwright > 1.62.1** — the lint job runs inside `mcr.microsoft.com/playwright`, pinned in `ci.yml`, a path this ecosystem's `directories` do not cover. Browsers are baked into the image and there is no `playwright install` step, so package and tag move together by hand, as #2505 did (#2503).

## Not in scope

Grouping. Every ecosystem still uses one `patterns: ["*"]` bucket, which is why one broken member holds the rest — 40 updates stalled on typescript in #2371, 38 on msw in #2430. Splitting that is a change to all eight ecosystems and deserves its own review.

## Test plan

- [x] `.github/dependabot.yml` parses; 8 update entries, unchanged count.
- [x] Ignores resolve to docker→[python, node], cargo→[reqwest], pip→[airbyte-cdk], npm→[typescript, msw-storybook-addon, msw, playwright].
- [x] Scope checked: `airbyte-cdk` is declared only in `tests/connectors`, so covering `tests/e2e` too costs nothing; `@vitest/browser-playwright` declares `peer playwright: "*"` and needs no hold of its own.
- [ ] Next scheduled run regroups without the three held majors.
- [ ] #2450 can be closed and does not return.
