### PR TITLE
Bring the evidence comments under the comment rule

### DIFF
--- a/src/frontend/src/components/metric-evidence-dialog.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog.tsx
@@ -120,10 +120,8 @@ export function MetricEvidenceDialog({
     [rows, columns, search, sort]
   );
 
-  // Searching and sorting must answer for the whole result, not for whichever
-  // pages happened to be scrolled into view, so narrowing pulls the rest in.
-  // The table's own scroll-triggered paging cannot do it: a search that hides
-  // most rows also stops the scroll that would load more.
+  // INVARIANT: narrowing must see every page — the table's scroll-triggered
+  // paging stalls once a search hides most rows.
   useEffect(() => {
     if (
       narrowed &&
@@ -306,8 +304,8 @@ export function MetricEvidenceDialog({
           ) : visibleRows.length === 0 ? (
             <div className="flex flex-1 flex-col items-center justify-center gap-3">
               {query.isFetchNextPageError ? (
-                // Only the pages that loaded were searched, so "no match"
-                // would be a claim about records nobody has seen.
+                // SAFETY: only loaded pages were searched — "no match" would
+                // claim something about records nobody has seen.
                 <>
                   <p role="alert" className="text-sm text-muted-foreground">
                     Nothing matched the records loaded so far, and the rest
@@ -342,8 +340,8 @@ export function MetricEvidenceDialog({
             </div>
           ) : (
             <MetricEvidenceTable
-              // Expansion state is the table's; another metric's records must
-              // not inherit it.
+              // INVARIANT: remounts per metric — expansion state is the
+              // table's and must not carry across.
               key={activeMetricKey}
               rows={visibleRows}
               columns={columns}
@@ -362,11 +360,6 @@ export function MetricEvidenceDialog({
   );
 }
 
-/**
- * Both counts are of what has been paged in, so whenever pages are still
- * outstanding — loading, or left behind by a failure — the total says as much
- * rather than reading as the answer.
- */
 function recordCount({
   visible,
   loaded,

--- a/src/frontend/src/components/metric-evidence-table.test.tsx
+++ b/src/frontend/src/components/metric-evidence-table.test.tsx
@@ -80,9 +80,8 @@ describe("MetricEvidenceTable", () => {
   });
 
   it("hands every row to the virtualizer to measure", () => {
-    // An expanded row is as tall as its message, so without measurement the
-    // rows below it overlap. jsdom lays nothing out; the call is the only
-    // observable half of that contract.
+    // WORKAROUND: jsdom lays nothing out, so the call is all that is
+    // observable of the measurement contract.
     renderTable();
 
     const measured = mocks.measureElement.mock.calls
@@ -138,8 +137,8 @@ describe("MetricEvidenceTable", () => {
       await user.click(toggle!);
       expect(toggle).toHaveAttribute("aria-expanded", "true");
       const detail = screen.getByText(/It handles nested groups/);
-      // textContent keeps the newlines that toHaveTextContent would normalize
-      // away; the class is the only observable half of "they survive layout".
+      // INVARIANT: textContent, not toHaveTextContent — the latter normalizes
+      // away the newlines under test.
       expect(detail.textContent).toBe(message);
       expect(detail).toHaveClass("whitespace-pre-wrap");
     });
@@ -184,7 +183,8 @@ describe("MetricEvidenceTable", () => {
       await user.click(
         screen.getAllByRole("button", { name: "Show full record" })[0]!
       );
-      // jsdom lays nothing out, so the cap is only observable as the class.
+      // WORKAROUND: jsdom lays nothing out — the class is all that is
+      // observable of the cap.
       const panel = screen.getByText(/It handles nested groups/).closest("dl");
       expect(panel).toHaveClass("max-h-96", "overflow-y-auto");
     });

--- a/src/frontend/src/components/metric-evidence-table.tsx
+++ b/src/frontend/src/components/metric-evidence-table.tsx
@@ -123,9 +123,8 @@ export function MetricEvidenceTable({
     getScrollElement: () => viewport,
     estimateSize: () => 44,
     overscan: 8,
-    // The measured height of an expanded row is cached under this key. Left to
-    // default it is the index, and a re-sort then leaves a tall measurement on
-    // whichever row inherits the position.
+    // INVARIANT: must match the row's React key — the measured height of an
+    // expanded row is cached under it.
     getItemKey: useCallback((index: number) => rowKeys[index] ?? index, [rowKeys]),
   });
   const virtualRows = virtualizer.getVirtualItems();
@@ -316,14 +315,13 @@ export function MetricEvidenceTable({
                   <TableCell
                     role="cell"
                     aria-colspan={columns.length + 1}
-                    // Selecting the text fires a click on the row, which would
-                    // close the panel the reader is trying to read.
+                    // INVARIANT: selecting text here must not reach the row's
+                    // expand toggle.
                     onClick={(event) => event.stopPropagation()}
                     className="w-full basis-full cursor-auto border-t bg-muted/40 px-3 py-3"
                   >
-                    {/* Capped so a long message scrolls here rather than
-                        filling the table with one record. Not a vh: that is
-                        the window, which can exceed the table's own height. */}
+                    {/* INVARIANT: a fixed cap, not a vh — the window can
+                        exceed the table's own height. */}
                     <dl className="grid max-h-96 gap-x-6 gap-y-2 overflow-y-auto overscroll-contain sm:grid-cols-[10rem_1fr]">
                       {columns.map((column) => {
                         const text = cellText(row.values[column.key], column.type);

--- a/src/frontend/src/lib/metrics/evidence-rows.ts
+++ b/src/frontend/src/lib/metrics/evidence-rows.ts
@@ -24,19 +24,12 @@ export function cellText(
   return String(value);
 }
 
-/** The first non-blank line, so a leading newline is not read as a blank cell. */
 export function summaryLine(text: string): string {
   return text.split("\n").find((line) => line.trim() !== "") ?? text;
 }
 
-/**
- * A key per row that survives re-sorting.
- *
- * Not `ref`: it is a PR or issue number, unique only within a repository, so
- * two rows can share one. Evidence exposes no id of its own, leaving the whole
- * value set as the identity — and rows whose values match to the last field get
- * an occurrence suffix, since a duplicate key would join their expansion.
- */
+// INVARIANT: `ref` is a PR or issue number, unique only within a repository —
+// keying on it alone would join two rows' expansion.
 export function evidenceRowKeys(rows: readonly MetricEvidenceRow[]): string[] {
   const seen = new Map<string, number>();
   return rows.map((row) => {
@@ -72,13 +65,6 @@ function compare(left: unknown, right: unknown): number {
   });
 }
 
-/**
- * Filter and sort loaded evidence rows.
- *
- * Rows with no value for the sorted column sort last in both directions —
- * a missing field is not a small one, and floating them to the top of an
- * ascending sort would bury the smallest real values.
- */
 export function visibleEvidenceRows({
   rows,
   columns,


### PR DESCRIPTION
The comment rule in AGENTS.md now admits only brief tagged comments —
`SAFETY:`, `INVARIANT:`, `WORKAROUND:` — and rules out rationale, alternatives
considered, and anything a paragraph long. The evidence code merged in #2514
and #2518 was written before that and carries several comments that no longer
qualify. This brings them into line.

**Kept, retagged, cut to two lines.** Each names a constraint a later edit
could silently undo:

- the virtualizer's item key must match the row's React key, because the
  measured height of an expanded row is cached under it
- a click inside the expanded panel must not reach the row's expand toggle
- the panel's height cap is deliberately a fixed value rather than a viewport
  fraction, since the window can exceed the table's own height
- searching and sorting must see every page
- "no records match" must not speak for pages that failed to load
- the table remounts per metric so expansion state cannot carry across

Three in the tests explain why an assertion takes an odd shape — `textContent`
rather than `toHaveTextContent`, and asserting a class where jsdom computes no
layout. Without them a reader would simplify the assertion and quietly lose
what it checks.

**Deleted.** The doc paragraphs on `summaryLine`, `visibleEvidenceRows` and
`recordCount`. Each was the argument for the behaviour rather than a
constraint, and the tests already pin the behaviour itself.

No production code paths change.

## Verification

`pnpm typecheck`, `eslint`, `vitest run --project unit` (1317 passing).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for metric evidence display, row measurement, expanded details, and row identity handling.
  * Documented testing limitations related to layout measurement and observable behavior validation.

* **Tests**
  * Improved test documentation covering text content, CSS classes, measurement calls, newline preservation, and height limits in the test environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->