### PR TITLE
ci(test-stand): build whichever tree the ref changes

### DIFF
--- a/.github/workflows/e2e-stand.yml
+++ b/.github/workflows/e2e-stand.yml
@@ -6,21 +6,13 @@ name: E2E — Compose stand
 # exercises the in-process ingestion rig and now carries one blocking gate
 # (metric coverage) — that workflow is untouched by this one.
 #
-# By default nothing here builds the product. `test-stand up` pulls the frontend
-# and the four backend services, each pinned to its own chart's appVersion;
-# compiling the backend cost ~26 min per job.
-#
-# Those appVersions name what MAIN released, so a lane that pins a tree the ref
-# changes reports green for code it never ran. `up` has a guard for exactly
-# that, but the guard needs origin/main and these lanes clone at depth 1, so it
-# is inert here and the decision is made in this file instead: `changes` answers
-# per tree, and each answer maps to its own flag —
-#
-#   src/backend/  changed -> up --build-backend   (~26 min, hence 75-min timeout)
-#   src/frontend/ changed -> up --build-frontend  (a pnpm build, timeout unchanged)
-#
-# Both flags together are what `up --build` means; the lanes pass them
-# separately so a SPA-only diff never pays for the compiler.
+# Nothing here builds by default: `test-stand up` pulls the frontend and the
+# four backend services at their charts' appVersions, which name main's build.
+# A ref that changes one of those trees has to build it or the lane reports on
+# code it never ran. `up` guards that, but the guard needs origin/main and these
+# lanes clone at depth 1 — so `changes` decides instead, per tree, and the lanes
+# pass --build-backend (~28 min, hence the wider timeout) and --build-frontend
+# (a pnpm build) independently.
 #
 # Two independently-reporting checks, split by what they need rather than by
 # what they cover:
@@ -98,9 +90,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
-      # One per buildable tree: whether the diff touches it, and so whether a
-      # pinned image would be main's build rather than the change under test.
-      # The lanes turn each into its own --build-* flag.
+      # One per buildable tree; the lanes turn each into its own --build-* flag.
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
@@ -123,10 +113,8 @@ jobs:
           # would attribute unrelated commits that landed on main after this
           # branch forked to the pull request and run the stand unnecessarily.
           #
-          # No base at all — a schedule or a dispatch. There is no pull request
-          # whose relevance could be in question, so those runs are relevant by
-          # definition and only the build answers come from a comparison, taken
-          # against origin/main.
+          # No base means a schedule or a dispatch: nothing to filter, so it
+          # runs either way and the comparison only decides what to build.
           forced=false
           if [ -n "${BASE:-}" ]; then
             base_point="$(git merge-base "$BASE" "$HEAD" 2>/dev/null || true)"
@@ -135,9 +123,8 @@ jobs:
             base_point="$(git rev-parse --verify --quiet origin/main || true)"
             echo "no base sha — running, and comparing against origin/main to decide what to build"
           fi
-          # Nothing to compare against. Run, and build BOTH trees: pinning on a
-          # comparison that could not be made is how a lane ends up reporting
-          # green for images this ref never built.
+          # No comparison point: build both rather than pin on a comparison that
+          # was never made.
           if [ -z "$base_point" ]; then
             echo "no comparison point — running the stand and building the product"
             emit true true true
@@ -195,10 +182,9 @@ jobs:
     needs: [changes, resolve-target]
     if: needs.resolve-target.outputs.target == 'compose'
     runs-on: ubuntu-latest
-    # Pull mode measured near 8m, so 45 leaves ~5x headroom for a cold runner
-    # and a slow registry while not letting a hung stand burn an hour and a
-    # half. A backend-building run was measured at 28m (26m of it the build),
-    # hence the wider ceiling on that path.
+    # Measured over 60 runs: pull-path jobs 3-6m, build-path jobs 25-34m. 45
+    # absorbs a cold runner and a slow registry; 75 keeps ~2x over the worst
+    # build, without letting a hung stand burn an hour and a half.
     timeout-minutes: ${{ needs.changes.outputs.backend == 'true' && 75 || 45 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -231,9 +217,8 @@ jobs:
           BUILD_FRONTEND: ${{ needs.changes.outputs.frontend }}
         run: |
           set -euo pipefail
-          # One output, one flag, per tree. `if` blocks rather than
-          # `[ … ] && flags+=(…)`: under set -e a false test as the last
-          # command of an && list ends the step.
+          # `if` blocks, not `[ … ] && flags+=(…)`: under set -e a false test as
+          # the last command of an && list ends the step.
           flags=()
           if [ "$BUILD_BACKEND" = "true" ]; then flags+=(--build-backend); fi
           if [ "$BUILD_FRONTEND" = "true" ]; then flags+=(--build-frontend); fi
@@ -377,9 +362,8 @@ jobs:
           BUILD_FRONTEND: ${{ needs.changes.outputs.frontend }}
         run: |
           set -euo pipefail
-          # One output, one flag, per tree. `if` blocks rather than
-          # `[ … ] && flags+=(…)`: under set -e a false test as the last
-          # command of an && list ends the step.
+          # `if` blocks, not `[ … ] && flags+=(…)`: under set -e a false test as
+          # the last command of an && list ends the step.
           flags=()
           if [ "$BUILD_BACKEND" = "true" ]; then flags+=(--build-backend); fi
           if [ "$BUILD_FRONTEND" = "true" ]; then flags+=(--build-frontend); fi

--- a/.github/workflows/e2e-stand.yml
+++ b/.github/workflows/e2e-stand.yml
@@ -6,12 +6,21 @@ name: E2E — Compose stand
 # exercises the in-process ingestion rig and now carries one blocking gate
 # (metric coverage) — that workflow is untouched by this one.
 #
-# By default nothing here compiles the backend. `test-stand up` pulls
-# analytics, authenticator, identity-resolution and gateway at their charts'
-# appVersions; building them cost ~26 min per job. `up` refuses a tree that
-# changes src/backend/ rather than silently testing it against main's images,
-# so when the diff touches the backend the `changes` job flags it and the
-# lanes pass --build (and take the longer timeout) instead.
+# By default nothing here builds the product. `test-stand up` pulls the frontend
+# and the four backend services, each pinned to its own chart's appVersion;
+# compiling the backend cost ~26 min per job.
+#
+# Those appVersions name what MAIN released, so a lane that pins a tree the ref
+# changes reports green for code it never ran. `up` has a guard for exactly
+# that, but the guard needs origin/main and these lanes clone at depth 1, so it
+# is inert here and the decision is made in this file instead: `changes` answers
+# per tree, and each answer maps to its own flag —
+#
+#   src/backend/  changed -> up --build-backend   (~26 min, hence 75-min timeout)
+#   src/frontend/ changed -> up --build-frontend  (a pnpm build, timeout unchanged)
+#
+# Both flags together are what `up --build` means; the lanes pass them
+# separately so a SPA-only diff never pays for the compiler.
 #
 # Two independently-reporting checks, split by what they need rather than by
 # what they cover:
@@ -89,10 +98,11 @@ jobs:
     timeout-minutes: 5
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
-      # Whether the diff touches src/backend/ — the lanes turn this into
-      # `up --build`, because `up` refuses a backend-changing tree
-      # rather than silently testing it against main's pulled images.
+      # One per buildable tree: whether the diff touches it, and so whether a
+      # pinned image would be main's build rather than the change under test.
+      # The lanes turn each into its own --build-* flag.
       backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -104,45 +114,50 @@ jobs:
           HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
-          # No base to diff against (merge_group without one, or a manual
-          # run): assume relevant rather than skipping a gate on a guess, and
-          # take the backend answer from the same comparison `up` itself
-          # makes, so the flag and the refusal cannot disagree.
-          if [ -z "${BASE:-}" ]; then
-            BASE="$(git rev-parse --verify --quiet origin/main || true)"
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-            echo "no base sha — running"
-            if [ -n "$BASE" ] && [ -n "$(git diff --name-only "$BASE" "$HEAD" -- src/backend | head -1)" ]; then
-              echo "backend=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "backend=false" >> "$GITHUB_OUTPUT"
-            fi
-            exit 0
-          fi
+          emit() { # emit <relevant> <backend> <frontend>
+            printf 'relevant=%s\nbackend=%s\nfrontend=%s\n' "$1" "$2" "$3" >> "$GITHUB_OUTPUT"
+            echo "relevant=$1 backend=$2 frontend=$3"
+          }
           # Match pull_request path-filter semantics: compare the branch from
           # its merge base, not from the current base-branch tip. A two-dot diff
           # would attribute unrelated commits that landed on main after this
           # branch forked to the pull request and run the stand unnecessarily.
-          base_point="$(git merge-base "$BASE" "$HEAD" 2>/dev/null || true)"
+          #
+          # No base at all — a schedule or a dispatch. There is no pull request
+          # whose relevance could be in question, so those runs are relevant by
+          # definition and only the build answers come from a comparison, taken
+          # against origin/main.
+          forced=false
+          if [ -n "${BASE:-}" ]; then
+            base_point="$(git merge-base "$BASE" "$HEAD" 2>/dev/null || true)"
+          else
+            forced=true
+            base_point="$(git rev-parse --verify --quiet origin/main || true)"
+            echo "no base sha — running, and comparing against origin/main to decide what to build"
+          fi
+          # Nothing to compare against. Run, and build BOTH trees: pinning on a
+          # comparison that could not be made is how a lane ends up reporting
+          # green for images this ref never built.
           if [ -z "$base_point" ]; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-            echo "backend=true" >> "$GITHUB_OUTPUT"
-            echo "no merge base between $BASE and $HEAD — running and building"
+            echo "no comparison point — running the stand and building the product"
+            emit true true true
             exit 0
           fi
           changed="$(git diff --name-only "$base_point" "$HEAD")"
           printf '  %s\n' "${changed//$'\n'/$'\n  '}"
+          relevant="$forced"
+          backend=false
+          frontend=false
           if echo "$changed" | grep -qE '^(tests/|deploy/compose/|src/ingestion/tools/seed/|docker-compose\.yml|dev-compose\.sh|src/backend/|src/frontend/|docs/components/backend/.*/openapi\.json|\.github/workflows/e2e-stand\.yml|\.github/workflows/scripts/redact-playwright-trace\.py)'; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            relevant=true
+          elif [ "$forced" = true ]; then
+            echo "nothing the stand covers changed — running anyway, this event has no pull request to filter"
           else
-            echo "relevant=false" >> "$GITHUB_OUTPUT"
             echo "nothing the stand covers changed"
           fi
-          if echo "$changed" | grep -q '^src/backend/'; then
-            echo "backend=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "backend=false" >> "$GITHUB_OUTPUT"
-          fi
+          if echo "$changed" | grep -q '^src/backend/'; then backend=true; fi
+          if echo "$changed" | grep -q '^src/frontend/'; then frontend=true; fi
+          emit "$relevant" "$backend" "$frontend"
 
   resolve-target:
     name: resolve-target
@@ -213,10 +228,15 @@ jobs:
       - name: Bring the stand up
         env:
           BUILD_BACKEND: ${{ needs.changes.outputs.backend }}
+          BUILD_FRONTEND: ${{ needs.changes.outputs.frontend }}
         run: |
           set -euo pipefail
+          # One output, one flag, per tree. `if` blocks rather than
+          # `[ … ] && flags+=(…)`: under set -e a false test as the last
+          # command of an && list ends the step.
           flags=()
-          if [ "$BUILD_BACKEND" = "true" ]; then flags+=(--build); fi
+          if [ "$BUILD_BACKEND" = "true" ]; then flags+=(--build-backend); fi
+          if [ "$BUILD_FRONTEND" = "true" ]; then flags+=(--build-frontend); fi
           ./dev-compose.sh test-stand up "${flags[@]}"
 
       - name: Run the API suite
@@ -354,10 +374,15 @@ jobs:
       - name: Bring the stand up
         env:
           BUILD_BACKEND: ${{ needs.changes.outputs.backend }}
+          BUILD_FRONTEND: ${{ needs.changes.outputs.frontend }}
         run: |
           set -euo pipefail
+          # One output, one flag, per tree. `if` blocks rather than
+          # `[ … ] && flags+=(…)`: under set -e a false test as the last
+          # command of an && list ends the step.
           flags=()
-          if [ "$BUILD_BACKEND" = "true" ]; then flags+=(--build); fi
+          if [ "$BUILD_BACKEND" = "true" ]; then flags+=(--build-backend); fi
+          if [ "$BUILD_FRONTEND" = "true" ]; then flags+=(--build-frontend); fi
           ./dev-compose.sh test-stand up "${flags[@]}"
 
       # The suite's own Chromium, resolved by the locked test environment so

--- a/dev-compose.sh
+++ b/dev-compose.sh
@@ -1432,16 +1432,23 @@ for dbt-built gold data rather than for containers to report healthy.
           The four backend services (analytics, authenticator,
           identity-resolution, gateway) and the frontend are PULLED, each
           pinned to its own chart's appVersion — never :latest, and never
-          compiled here. Building them took ~26 minutes for code the stand
-          does not change.
+          compiled here. Compiling the backend took ~26 minutes for code the
+          stand does not change.
 
-          --build  Build the whole product from this working tree instead:
-                   the backend compiled from source and the frontend built
-                   with pnpm (served by the front-built nginx). Needed to
-                   test a local change: `up` otherwise refuses when the tree
-                   differs from origin/main under src/backend/ or
-                   src/frontend/, since the pinned images would not be what
-                   ran.
+          Two trees, two independent flags. Pass the one whose source this
+          working tree changes — an appVersion names what main released, so a
+          pinned image would not carry the change under test:
+
+          --build-backend    Compile analytics, authenticator and
+                             identity-resolution from this tree (~26 min).
+          --build-frontend   Build the SPA from this tree with pnpm, served by
+                             the front-built nginx. The backend stays pinned.
+          --build            Both of the above.
+
+          `up` refuses to pin a tree that differs from origin/main under
+          src/backend/ or src/frontend/ and names the flag to pass. That check
+          needs origin/main in the checkout: a shallow clone (every CI runner)
+          says so on stderr and leaves the decision to its caller.
   seed    Re-seed the running stand (default target: all).
   test    Run the stand suite against an already-up stand. Passes extra
           arguments through to pytest — no `--` separator.
@@ -1524,7 +1531,14 @@ test_stand_tree_matches_charts() {
   local subtree="$1" flag="$2"
   git rev-parse --git-dir >/dev/null 2>&1 || return 0
   git remote get-url origin >/dev/null 2>&1 || return 0
-  git rev-parse --verify --quiet origin/main >/dev/null || return 0
+  # Say so rather than passing quietly. A CI checkout is depth-1 and has no
+  # origin/main, so this guard is INERT there — the caller (e2e-stand.yml's
+  # `changes` job) decides what to build, and a reader of the log who thinks
+  # this line vouched for the pinning would be wrong.
+  git rev-parse --verify --quiet origin/main >/dev/null || {
+    echo "NOTE: no origin/main in this checkout — cannot check ${subtree}/ against" >&2
+    echo "      the pinned images; trusting the caller's ${flag} decision." >&2
+    return 0; }
 
   local changed
   changed="$(git diff --name-only origin/main -- "$subtree" 2>/dev/null | head -5)"
@@ -1539,11 +1553,11 @@ test_stand_tree_matches_charts() {
 }
 
 test_stand_backend_matches_charts() {
-  test_stand_tree_matches_charts src/backend --build
+  test_stand_tree_matches_charts src/backend --build-backend
 }
 
 test_stand_frontend_matches_chart() {
-  test_stand_tree_matches_charts src/frontend --build
+  test_stand_tree_matches_charts src/frontend --build-frontend
 }
 
 # Derive the test env file from the committed example, overriding only the
@@ -1801,31 +1815,41 @@ cmd_test_stand() {
 
   case "$verb" in
     up)
-      local image build=false
+      # Two independent axes. Each tree is either PINNED to what its chart's
+      # appVersion names — main's build — or built from this working tree, and
+      # the two questions are asked separately because the two builds cost two
+      # different things: a ~26-minute Rust compile against a pnpm build.
+      # --build is the both-axes alias.
+      local image build_backend=false build_frontend=false
       while [[ $# -gt 0 ]]; do
         case "$1" in
-          --build) build=true; shift ;;
+          --build)          build_backend=true; build_frontend=true; shift ;;
+          --build-backend)  build_backend=true; shift ;;
+          --build-frontend) build_frontend=true; shift ;;
           -h|--help) cmd_test_stand_help; return 0 ;;
           *) echo "ERROR: unknown test-stand up option: $1" >&2; return 2 ;;
         esac
       done
 
-      if [[ "$build" == true ]]; then
+      if [[ "$build_frontend" == true ]]; then
         test_stand_write_env built || return 1
+        echo "=== the frontend is built from this tree (pnpm), not pulled ==="
       else
         test_stand_frontend_matches_chart || return 1
         image="$(test_stand_frontend_image)" || return 1
         test_stand_write_env ghcr "$image" || return 1
       fi
 
-      # Pinning writes the four *_IMAGE vars into the env file, which is what
-      # makes cmd_up put those services in its ghcr list — so this has to happen
-      # before cmd_up reads it.
-      if [[ "$build" != true ]]; then
+      # INVARIANT: pinning writes the four *_IMAGE vars into the env file, and
+      # that is the ONLY thing separating the two axes downstream — cmd_up puts
+      # a service in its ghcr list iff its image var is set, and compiles only
+      # the binaries that list leaves out. Pull before cmd_up reads the file, or
+      # a pinned backend gets compiled anyway.
+      if [[ "$build_backend" == true ]]; then
+        echo "=== the backend is compiled from this tree, not pulled ==="
+      else
         test_stand_backend_matches_charts || return 1
         test_stand_pull_backends || return 1
-      else
-        echo "=== --build: compiling the backend and building the frontend from this tree ==="
       fi
 
       local up_args=(--env-file "$TEST_STAND_ENV_FILE"

--- a/dev-compose.sh
+++ b/dev-compose.sh
@@ -1431,24 +1431,20 @@ for dbt-built gold data rather than for containers to report healthy.
 
           The four backend services (analytics, authenticator,
           identity-resolution, gateway) and the frontend are PULLED, each
-          pinned to its own chart's appVersion — never :latest, and never
-          compiled here. Compiling the backend took ~26 minutes for code the
-          stand does not change.
+          pinned to its own chart's appVersion — never :latest.
 
-          Two trees, two independent flags. Pass the one whose source this
-          working tree changes — an appVersion names what main released, so a
-          pinned image would not carry the change under test:
+          An appVersion names what main released, so pass the flag for whatever
+          tree this checkout changes, or the stand will not run it:
 
-          --build-backend    Compile analytics, authenticator and
-                             identity-resolution from this tree (~26 min).
+          --build-backend    Compile the Rust services from this tree. Adds
+                             ~28 min (measured across CI's build-path runs).
           --build-frontend   Build the SPA from this tree with pnpm, served by
-                             the front-built nginx. The backend stays pinned.
-          --build            Both of the above.
+                             the front-built nginx. Backend stays pinned.
+          --build            Both.
 
-          `up` refuses to pin a tree that differs from origin/main under
-          src/backend/ or src/frontend/ and names the flag to pass. That check
-          needs origin/main in the checkout: a shallow clone (every CI runner)
-          says so on stderr and leaves the decision to its caller.
+          `up` refuses to pin a tree that differs from origin/main and names
+          the flag to pass — but only when origin/main is in the checkout. A
+          shallow clone says so on stderr and defers to its caller.
   seed    Re-seed the running stand (default target: all).
   test    Run the stand suite against an already-up stand. Passes extra
           arguments through to pytest — no `--` separator.
@@ -1531,13 +1527,10 @@ test_stand_tree_matches_charts() {
   local subtree="$1" flag="$2"
   git rev-parse --git-dir >/dev/null 2>&1 || return 0
   git remote get-url origin >/dev/null 2>&1 || return 0
-  # Say so rather than passing quietly. A CI checkout is depth-1 and has no
-  # origin/main, so this guard is INERT there — the caller (e2e-stand.yml's
-  # `changes` job) decides what to build, and a reader of the log who thinks
-  # this line vouched for the pinning would be wrong.
+  # Inert on a depth-1 checkout (every CI runner). Say so, so a log reader does
+  # not read the silence as a passed check.
   git rev-parse --verify --quiet origin/main >/dev/null || {
-    echo "NOTE: no origin/main in this checkout — cannot check ${subtree}/ against" >&2
-    echo "      the pinned images; trusting the caller's ${flag} decision." >&2
+    echo "NOTE: no origin/main here — ${subtree}/ unchecked, ${flag} is the caller's call." >&2
     return 0; }
 
   local changed
@@ -1815,11 +1808,8 @@ cmd_test_stand() {
 
   case "$verb" in
     up)
-      # Two independent axes. Each tree is either PINNED to what its chart's
-      # appVersion names — main's build — or built from this working tree, and
-      # the two questions are asked separately because the two builds cost two
-      # different things: a ~26-minute Rust compile against a pnpm build.
-      # --build is the both-axes alias.
+      # Each tree is pinned to its chart's appVersion or built from this one,
+      # asked separately: --build is the both-axes alias.
       local image build_backend=false build_frontend=false
       while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -1840,11 +1830,9 @@ cmd_test_stand() {
         test_stand_write_env ghcr "$image" || return 1
       fi
 
-      # INVARIANT: pinning writes the four *_IMAGE vars into the env file, and
-      # that is the ONLY thing separating the two axes downstream — cmd_up puts
-      # a service in its ghcr list iff its image var is set, and compiles only
-      # the binaries that list leaves out. Pull before cmd_up reads the file, or
-      # a pinned backend gets compiled anyway.
+      # INVARIANT: pinning writes the *_IMAGE vars, and that is the only thing
+      # keeping cmd_up off the compiler — so it has to run before cmd_up reads
+      # the env file.
       if [[ "$build_backend" == true ]]; then
         echo "=== the backend is compiled from this tree, not pulled ==="
       else

--- a/src/frontend/src/components/metric-evidence-dialog.test.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog.test.tsx
@@ -298,6 +298,52 @@ describe("MetricEvidenceDialog", () => {
     });
   });
 
+  describe("what the dialog is named", () => {
+    const twoTargets = [
+      { selection, label: "Commits" },
+      {
+        selection: { ...selection, metric_key: "wiki.pages" },
+        label: "Wiki pages",
+      },
+    ] as const;
+
+    it("takes the caller's name for the whole set when it gives one", () => {
+      render(
+        <MetricEvidenceDialog
+          state={{
+            targets: [...twoTargets] as EvidenceDialogState["targets"],
+            activeMetricKey: "git.commits",
+            title: "Commits & Wiki pages",
+          }}
+          onMetricChange={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+      expect(
+        screen.getByRole("heading", { name: "Commits & Wiki pages" })
+      ).toBeInTheDocument();
+    });
+
+    it("otherwise names the metric on screen, never a placeholder", () => {
+      render(
+        <MetricEvidenceDialog
+          state={{
+            targets: [...twoTargets] as EvidenceDialogState["targets"],
+            activeMetricKey: "wiki.pages",
+          }}
+          onMetricChange={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+      expect(
+        screen.getByRole("heading", { name: "Wiki pages" })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("heading", { name: "Metric evidence" })
+      ).not.toBeInTheDocument();
+    });
+  });
+
   it("switches targets and reports export failures", async () => {
     const user = userEvent.setup();
     const onMetricChange = vi.fn();

--- a/src/frontend/src/components/metric-evidence-dialog.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog.tsx
@@ -190,8 +190,11 @@ export function MetricEvidenceDialog({
             <div className="flex items-center justify-between gap-4">
               {state.targets.length > 1 ? (
                 <>
+                  {/* INVARIANT: the dialog is named for what it shows — a
+                      caller that names the whole set wins, otherwise the
+                      metric on screen. */}
                   <DialogTitle className="sr-only">
-                    {state.title ?? "Metric evidence"}
+                    {state.title ?? activeTarget.label}
                   </DialogTitle>
                   <Select
                     value={activeTarget.selection.metric_key}

--- a/tests/stand/ui/test_team_grid_cell_evidence.py
+++ b/tests/stand/ui/test_team_grid_cell_evidence.py
@@ -24,6 +24,7 @@ from playwright.sync_api import Page, expect
 
 from .evidence_requests import evidence_selection
 from .flows import sign_in
+from .pages.group_dialog import MetricEvidenceDialog
 from .pages.person_view import PersonView
 from .pages.team_view import TeamView
 
@@ -63,6 +64,7 @@ def test_team_heatmap_cell_opens_that_members_supporting_data(
 
     cell = team.any_recorded_metric_cell(member.display_name)
     expect(cell).to_be_visible()
+    clicked = team.cell_metric_label(cell, member.display_name)
     with evidence_selection(page) as selection:
         evidence = team.open_cell_evidence(cell, member.display_name)
     expect(evidence.dialog).to_be_visible()
@@ -76,6 +78,32 @@ def test_team_heatmap_cell_opens_that_members_supporting_data(
     expect(table).to_be_visible()
     expect(evidence.column_header("Date")).to_be_visible()
     expect(table).to_have_attribute("aria-rowcount", re.compile(r"^[1-9]\d*$"))
-    assert evidence.metric_selector().count() == 0, (
-        "a cell names one metric, so its dialog must not offer a metric to choose"
+
+    # The row offers its own columns to switch between, opened on the one the
+    # reader clicked. The picker renders only for more than one metric, so its
+    # presence is also what makes the switch below reachable.
+    selector = evidence.metric_selector()
+    expect(selector).to_be_visible()
+    expect(selector).to_contain_text(clicked)
+
+    # Switching metric must not switch person: the scope is that member's row,
+    # and a scope rebuilt from the wrong axis would answer 200 with the lead's
+    # own rows under the member's name.
+    selector.click()
+    other = next(
+        label
+        for label in (text.strip() for text in page.get_by_role("option").all_inner_texts())
+        if label != clicked
+    )
+    with evidence_selection(page) as switched:
+        page.get_by_role("option", name=other, exact=True).click()
+
+    # A cell dialog takes its accessible name from the metric on show, so the
+    # switch renames it — the handle opened as `clicked` no longer resolves.
+    # What the switch has to hold is the PERSON, not rows: a neighbouring column
+    # this member has nothing recorded for answers honestly with no records.
+    expect(MetricEvidenceDialog(page, other).dialog).to_be_visible()
+    assert switched["entity"]["id"] == member.uuid, (
+        f"switching to {other} left the dialog asking about {switched['entity']} rather than "
+        f"{member.display_name}"
     )


### PR DESCRIPTION
## Why

The stand pins the frontend and the four backend services to their charts' `appVersion`s, which name what **main** released. `changes` asked "does this ref change that source?" for `src/backend/` only — so a diff touching just the SPA ran against main's frontend image, and the lane reported on code the run never executed.

`dev-compose.sh` carries a guard for exactly this case (`test_stand_frontend_matches_chart`), but it needs `origin/main` and both stand jobs clone at depth 1, so it returned early and said nothing.

That is not hypothetical: the three evidence-dialog journeys fail on every PR that reaches the lane, whichever tree the PR touches, because the pinned SPA carries a regression the ref cannot replace.

## What

The two trees get the same treatment on both sides of the interface.

`dev-compose.sh test-stand up` — two independent axes:

| flag | backend | frontend |
| --- | --- | --- |
| *(none)* | pinned + pulled | pinned image |
| `--build-backend` | compiled from tree | pinned image |
| `--build-frontend` | pinned + pulled | `pnpm build` from tree |
| `--build` | compiled from tree | `pnpm build` from tree |

`e2e-stand.yml` — `changes` emits one output per tree, and each lane maps each output onto its own flag. A SPA-only diff now costs a pnpm build instead of the 26-minute Rust compile that `--build` would have pulled in, so the short timeout still holds.

The guard now prints a NOTE when it cannot resolve `origin/main`, so a shallow CI log no longer reads as if it had vouched for the pinning.

Two behaviours the filter rewrite preserves deliberately: a schedule or dispatch run stays relevant even though its diff against `origin/main` is empty, and a run with no resolvable comparison point builds **both** trees rather than pinning on a comparison that was never made.

## The second commit

`fix(frontend): name the evidence dialog for the metric it shows` is cherry-picked from #2539 (authored by @dzarlax, authorship preserved). It is what makes this PR self-validating: without a frontend diff the new path never fires and `ui-journeys` would stay red on the pinned image. #2539 is superseded by this PR.

## Verification

- `actionlint` clean; `shellcheck` on `dev-compose.sh` unchanged against HEAD (7 pre-existing notes, same set).
- Flag parsing exercised for *none* / `--build-backend` / `--build-frontend` / both / `--build` / an unknown flag, asserting the resulting `FRONTEND_MODE`, whether `FRONTEND_IMAGE` is pinned or empty, and whether the backends were pulled.
- The real filter body run against ten synthetic diffs — frontend only, backend only, both, docs only, stand tests only, merge_group, schedule on the main tip, no base, no `origin/main`, no merge base — asserting all three outputs and a zero exit.
- This PR's own run is the end-to-end check: `changes` should report `relevant=true backend=false frontend=true`, both lanes should log that the frontend is built from this tree and the backend pinned, and `ui-journeys` should pass all three evidence-dialog journeys.