### PR TITLE
ci: probe the --build-backend lane (do not merge)

### DIFF
--- a/.github/workflows/e2e-stand.yml
+++ b/.github/workflows/e2e-stand.yml
@@ -6,21 +6,13 @@ name: E2E — Compose stand
 # exercises the in-process ingestion rig and now carries one blocking gate
 # (metric coverage) — that workflow is untouched by this one.
 #
-# By default nothing here builds the product. `test-stand up` pulls the frontend
-# and the four backend services, each pinned to its own chart's appVersion;
-# compiling the backend cost ~26 min per job.
-#
-# Those appVersions name what MAIN released, so a lane that pins a tree the ref
-# changes reports green for code it never ran. `up` has a guard for exactly
-# that, but the guard needs origin/main and these lanes clone at depth 1, so it
-# is inert here and the decision is made in this file instead: `changes` answers
-# per tree, and each answer maps to its own flag —
-#
-#   src/backend/  changed -> up --build-backend   (~26 min, hence 75-min timeout)
-#   src/frontend/ changed -> up --build-frontend  (a pnpm build, timeout unchanged)
-#
-# Both flags together are what `up --build` means; the lanes pass them
-# separately so a SPA-only diff never pays for the compiler.
+# Nothing here builds by default: `test-stand up` pulls the frontend and the
+# four backend services at their charts' appVersions, which name main's build.
+# A ref that changes one of those trees has to build it or the lane reports on
+# code it never ran. `up` guards that, but the guard needs origin/main and these
+# lanes clone at depth 1 — so `changes` decides instead, per tree, and the lanes
+# pass --build-backend (~28 min, hence the wider timeout) and --build-frontend
+# (a pnpm build) independently.
 #
 # Two independently-reporting checks, split by what they need rather than by
 # what they cover:
@@ -98,9 +90,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
-      # One per buildable tree: whether the diff touches it, and so whether a
-      # pinned image would be main's build rather than the change under test.
-      # The lanes turn each into its own --build-* flag.
+      # One per buildable tree; the lanes turn each into its own --build-* flag.
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
@@ -123,10 +113,8 @@ jobs:
           # would attribute unrelated commits that landed on main after this
           # branch forked to the pull request and run the stand unnecessarily.
           #
-          # No base at all — a schedule or a dispatch. There is no pull request
-          # whose relevance could be in question, so those runs are relevant by
-          # definition and only the build answers come from a comparison, taken
-          # against origin/main.
+          # No base means a schedule or a dispatch: nothing to filter, so it
+          # runs either way and the comparison only decides what to build.
           forced=false
           if [ -n "${BASE:-}" ]; then
             base_point="$(git merge-base "$BASE" "$HEAD" 2>/dev/null || true)"
@@ -135,9 +123,8 @@ jobs:
             base_point="$(git rev-parse --verify --quiet origin/main || true)"
             echo "no base sha — running, and comparing against origin/main to decide what to build"
           fi
-          # Nothing to compare against. Run, and build BOTH trees: pinning on a
-          # comparison that could not be made is how a lane ends up reporting
-          # green for images this ref never built.
+          # No comparison point: build both rather than pin on a comparison that
+          # was never made.
           if [ -z "$base_point" ]; then
             echo "no comparison point — running the stand and building the product"
             emit true true true
@@ -195,10 +182,9 @@ jobs:
     needs: [changes, resolve-target]
     if: needs.resolve-target.outputs.target == 'compose'
     runs-on: ubuntu-latest
-    # Pull mode measured near 8m, so 45 leaves ~5x headroom for a cold runner
-    # and a slow registry while not letting a hung stand burn an hour and a
-    # half. A backend-building run was measured at 28m (26m of it the build),
-    # hence the wider ceiling on that path.
+    # Measured over 60 runs: pull-path jobs 3-6m, build-path jobs 25-34m. 45
+    # absorbs a cold runner and a slow registry; 75 keeps ~2x over the worst
+    # build, without letting a hung stand burn an hour and a half.
     timeout-minutes: ${{ needs.changes.outputs.backend == 'true' && 75 || 45 }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -231,9 +217,8 @@ jobs:
           BUILD_FRONTEND: ${{ needs.changes.outputs.frontend }}
         run: |
           set -euo pipefail
-          # One output, one flag, per tree. `if` blocks rather than
-          # `[ … ] && flags+=(…)`: under set -e a false test as the last
-          # command of an && list ends the step.
+          # `if` blocks, not `[ … ] && flags+=(…)`: under set -e a false test as
+          # the last command of an && list ends the step.
           flags=()
           if [ "$BUILD_BACKEND" = "true" ]; then flags+=(--build-backend); fi
           if [ "$BUILD_FRONTEND" = "true" ]; then flags+=(--build-frontend); fi
@@ -377,9 +362,8 @@ jobs:
           BUILD_FRONTEND: ${{ needs.changes.outputs.frontend }}
         run: |
           set -euo pipefail
-          # One output, one flag, per tree. `if` blocks rather than
-          # `[ … ] && flags+=(…)`: under set -e a false test as the last
-          # command of an && list ends the step.
+          # `if` blocks, not `[ … ] && flags+=(…)`: under set -e a false test as
+          # the last command of an && list ends the step.
           flags=()
           if [ "$BUILD_BACKEND" = "true" ]; then flags+=(--build-backend); fi
           if [ "$BUILD_FRONTEND" = "true" ]; then flags+=(--build-frontend); fi

--- a/.github/workflows/e2e-stand.yml
+++ b/.github/workflows/e2e-stand.yml
@@ -6,12 +6,21 @@ name: E2E — Compose stand
 # exercises the in-process ingestion rig and now carries one blocking gate
 # (metric coverage) — that workflow is untouched by this one.
 #
-# By default nothing here compiles the backend. `test-stand up` pulls
-# analytics, authenticator, identity-resolution and gateway at their charts'
-# appVersions; building them cost ~26 min per job. `up` refuses a tree that
-# changes src/backend/ rather than silently testing it against main's images,
-# so when the diff touches the backend the `changes` job flags it and the
-# lanes pass --build (and take the longer timeout) instead.
+# By default nothing here builds the product. `test-stand up` pulls the frontend
+# and the four backend services, each pinned to its own chart's appVersion;
+# compiling the backend cost ~26 min per job.
+#
+# Those appVersions name what MAIN released, so a lane that pins a tree the ref
+# changes reports green for code it never ran. `up` has a guard for exactly
+# that, but the guard needs origin/main and these lanes clone at depth 1, so it
+# is inert here and the decision is made in this file instead: `changes` answers
+# per tree, and each answer maps to its own flag —
+#
+#   src/backend/  changed -> up --build-backend   (~26 min, hence 75-min timeout)
+#   src/frontend/ changed -> up --build-frontend  (a pnpm build, timeout unchanged)
+#
+# Both flags together are what `up --build` means; the lanes pass them
+# separately so a SPA-only diff never pays for the compiler.
 #
 # Two independently-reporting checks, split by what they need rather than by
 # what they cover:
@@ -89,10 +98,11 @@ jobs:
     timeout-minutes: 5
     outputs:
       relevant: ${{ steps.filter.outputs.relevant }}
-      # Whether the diff touches src/backend/ — the lanes turn this into
-      # `up --build`, because `up` refuses a backend-changing tree
-      # rather than silently testing it against main's pulled images.
+      # One per buildable tree: whether the diff touches it, and so whether a
+      # pinned image would be main's build rather than the change under test.
+      # The lanes turn each into its own --build-* flag.
       backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -104,45 +114,50 @@ jobs:
           HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
-          # No base to diff against (merge_group without one, or a manual
-          # run): assume relevant rather than skipping a gate on a guess, and
-          # take the backend answer from the same comparison `up` itself
-          # makes, so the flag and the refusal cannot disagree.
-          if [ -z "${BASE:-}" ]; then
-            BASE="$(git rev-parse --verify --quiet origin/main || true)"
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-            echo "no base sha — running"
-            if [ -n "$BASE" ] && [ -n "$(git diff --name-only "$BASE" "$HEAD" -- src/backend | head -1)" ]; then
-              echo "backend=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "backend=false" >> "$GITHUB_OUTPUT"
-            fi
-            exit 0
-          fi
+          emit() { # emit <relevant> <backend> <frontend>
+            printf 'relevant=%s\nbackend=%s\nfrontend=%s\n' "$1" "$2" "$3" >> "$GITHUB_OUTPUT"
+            echo "relevant=$1 backend=$2 frontend=$3"
+          }
           # Match pull_request path-filter semantics: compare the branch from
           # its merge base, not from the current base-branch tip. A two-dot diff
           # would attribute unrelated commits that landed on main after this
           # branch forked to the pull request and run the stand unnecessarily.
-          base_point="$(git merge-base "$BASE" "$HEAD" 2>/dev/null || true)"
+          #
+          # No base at all — a schedule or a dispatch. There is no pull request
+          # whose relevance could be in question, so those runs are relevant by
+          # definition and only the build answers come from a comparison, taken
+          # against origin/main.
+          forced=false
+          if [ -n "${BASE:-}" ]; then
+            base_point="$(git merge-base "$BASE" "$HEAD" 2>/dev/null || true)"
+          else
+            forced=true
+            base_point="$(git rev-parse --verify --quiet origin/main || true)"
+            echo "no base sha — running, and comparing against origin/main to decide what to build"
+          fi
+          # Nothing to compare against. Run, and build BOTH trees: pinning on a
+          # comparison that could not be made is how a lane ends up reporting
+          # green for images this ref never built.
           if [ -z "$base_point" ]; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
-            echo "backend=true" >> "$GITHUB_OUTPUT"
-            echo "no merge base between $BASE and $HEAD — running and building"
+            echo "no comparison point — running the stand and building the product"
+            emit true true true
             exit 0
           fi
           changed="$(git diff --name-only "$base_point" "$HEAD")"
           printf '  %s\n' "${changed//$'\n'/$'\n  '}"
+          relevant="$forced"
+          backend=false
+          frontend=false
           if echo "$changed" | grep -qE '^(tests/|deploy/compose/|src/ingestion/tools/seed/|docker-compose\.yml|dev-compose\.sh|src/backend/|src/frontend/|docs/components/backend/.*/openapi\.json|\.github/workflows/e2e-stand\.yml|\.github/workflows/scripts/redact-playwright-trace\.py)'; then
-            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            relevant=true
+          elif [ "$forced" = true ]; then
+            echo "nothing the stand covers changed — running anyway, this event has no pull request to filter"
           else
-            echo "relevant=false" >> "$GITHUB_OUTPUT"
             echo "nothing the stand covers changed"
           fi
-          if echo "$changed" | grep -q '^src/backend/'; then
-            echo "backend=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "backend=false" >> "$GITHUB_OUTPUT"
-          fi
+          if echo "$changed" | grep -q '^src/backend/'; then backend=true; fi
+          if echo "$changed" | grep -q '^src/frontend/'; then frontend=true; fi
+          emit "$relevant" "$backend" "$frontend"
 
   resolve-target:
     name: resolve-target
@@ -213,10 +228,15 @@ jobs:
       - name: Bring the stand up
         env:
           BUILD_BACKEND: ${{ needs.changes.outputs.backend }}
+          BUILD_FRONTEND: ${{ needs.changes.outputs.frontend }}
         run: |
           set -euo pipefail
+          # One output, one flag, per tree. `if` blocks rather than
+          # `[ … ] && flags+=(…)`: under set -e a false test as the last
+          # command of an && list ends the step.
           flags=()
-          if [ "$BUILD_BACKEND" = "true" ]; then flags+=(--build); fi
+          if [ "$BUILD_BACKEND" = "true" ]; then flags+=(--build-backend); fi
+          if [ "$BUILD_FRONTEND" = "true" ]; then flags+=(--build-frontend); fi
           ./dev-compose.sh test-stand up "${flags[@]}"
 
       - name: Run the API suite
@@ -354,10 +374,15 @@ jobs:
       - name: Bring the stand up
         env:
           BUILD_BACKEND: ${{ needs.changes.outputs.backend }}
+          BUILD_FRONTEND: ${{ needs.changes.outputs.frontend }}
         run: |
           set -euo pipefail
+          # One output, one flag, per tree. `if` blocks rather than
+          # `[ … ] && flags+=(…)`: under set -e a false test as the last
+          # command of an && list ends the step.
           flags=()
-          if [ "$BUILD_BACKEND" = "true" ]; then flags+=(--build); fi
+          if [ "$BUILD_BACKEND" = "true" ]; then flags+=(--build-backend); fi
+          if [ "$BUILD_FRONTEND" = "true" ]; then flags+=(--build-frontend); fi
           ./dev-compose.sh test-stand up "${flags[@]}"
 
       # The suite's own Chromium, resolved by the locked test environment so

--- a/dev-compose.sh
+++ b/dev-compose.sh
@@ -1432,16 +1432,23 @@ for dbt-built gold data rather than for containers to report healthy.
           The four backend services (analytics, authenticator,
           identity-resolution, gateway) and the frontend are PULLED, each
           pinned to its own chart's appVersion — never :latest, and never
-          compiled here. Building them took ~26 minutes for code the stand
-          does not change.
+          compiled here. Compiling the backend took ~26 minutes for code the
+          stand does not change.
 
-          --build  Build the whole product from this working tree instead:
-                   the backend compiled from source and the frontend built
-                   with pnpm (served by the front-built nginx). Needed to
-                   test a local change: `up` otherwise refuses when the tree
-                   differs from origin/main under src/backend/ or
-                   src/frontend/, since the pinned images would not be what
-                   ran.
+          Two trees, two independent flags. Pass the one whose source this
+          working tree changes — an appVersion names what main released, so a
+          pinned image would not carry the change under test:
+
+          --build-backend    Compile analytics, authenticator and
+                             identity-resolution from this tree (~26 min).
+          --build-frontend   Build the SPA from this tree with pnpm, served by
+                             the front-built nginx. The backend stays pinned.
+          --build            Both of the above.
+
+          `up` refuses to pin a tree that differs from origin/main under
+          src/backend/ or src/frontend/ and names the flag to pass. That check
+          needs origin/main in the checkout: a shallow clone (every CI runner)
+          says so on stderr and leaves the decision to its caller.
   seed    Re-seed the running stand (default target: all).
   test    Run the stand suite against an already-up stand. Passes extra
           arguments through to pytest — no `--` separator.
@@ -1524,7 +1531,14 @@ test_stand_tree_matches_charts() {
   local subtree="$1" flag="$2"
   git rev-parse --git-dir >/dev/null 2>&1 || return 0
   git remote get-url origin >/dev/null 2>&1 || return 0
-  git rev-parse --verify --quiet origin/main >/dev/null || return 0
+  # Say so rather than passing quietly. A CI checkout is depth-1 and has no
+  # origin/main, so this guard is INERT there — the caller (e2e-stand.yml's
+  # `changes` job) decides what to build, and a reader of the log who thinks
+  # this line vouched for the pinning would be wrong.
+  git rev-parse --verify --quiet origin/main >/dev/null || {
+    echo "NOTE: no origin/main in this checkout — cannot check ${subtree}/ against" >&2
+    echo "      the pinned images; trusting the caller's ${flag} decision." >&2
+    return 0; }
 
   local changed
   changed="$(git diff --name-only origin/main -- "$subtree" 2>/dev/null | head -5)"
@@ -1539,11 +1553,11 @@ test_stand_tree_matches_charts() {
 }
 
 test_stand_backend_matches_charts() {
-  test_stand_tree_matches_charts src/backend --build
+  test_stand_tree_matches_charts src/backend --build-backend
 }
 
 test_stand_frontend_matches_chart() {
-  test_stand_tree_matches_charts src/frontend --build
+  test_stand_tree_matches_charts src/frontend --build-frontend
 }
 
 # Derive the test env file from the committed example, overriding only the
@@ -1801,31 +1815,41 @@ cmd_test_stand() {
 
   case "$verb" in
     up)
-      local image build=false
+      # Two independent axes. Each tree is either PINNED to what its chart's
+      # appVersion names — main's build — or built from this working tree, and
+      # the two questions are asked separately because the two builds cost two
+      # different things: a ~26-minute Rust compile against a pnpm build.
+      # --build is the both-axes alias.
+      local image build_backend=false build_frontend=false
       while [[ $# -gt 0 ]]; do
         case "$1" in
-          --build) build=true; shift ;;
+          --build)          build_backend=true; build_frontend=true; shift ;;
+          --build-backend)  build_backend=true; shift ;;
+          --build-frontend) build_frontend=true; shift ;;
           -h|--help) cmd_test_stand_help; return 0 ;;
           *) echo "ERROR: unknown test-stand up option: $1" >&2; return 2 ;;
         esac
       done
 
-      if [[ "$build" == true ]]; then
+      if [[ "$build_frontend" == true ]]; then
         test_stand_write_env built || return 1
+        echo "=== the frontend is built from this tree (pnpm), not pulled ==="
       else
         test_stand_frontend_matches_chart || return 1
         image="$(test_stand_frontend_image)" || return 1
         test_stand_write_env ghcr "$image" || return 1
       fi
 
-      # Pinning writes the four *_IMAGE vars into the env file, which is what
-      # makes cmd_up put those services in its ghcr list — so this has to happen
-      # before cmd_up reads it.
-      if [[ "$build" != true ]]; then
+      # INVARIANT: pinning writes the four *_IMAGE vars into the env file, and
+      # that is the ONLY thing separating the two axes downstream — cmd_up puts
+      # a service in its ghcr list iff its image var is set, and compiles only
+      # the binaries that list leaves out. Pull before cmd_up reads the file, or
+      # a pinned backend gets compiled anyway.
+      if [[ "$build_backend" == true ]]; then
+        echo "=== the backend is compiled from this tree, not pulled ==="
+      else
         test_stand_backend_matches_charts || return 1
         test_stand_pull_backends || return 1
-      else
-        echo "=== --build: compiling the backend and building the frontend from this tree ==="
       fi
 
       local up_args=(--env-file "$TEST_STAND_ENV_FILE"

--- a/dev-compose.sh
+++ b/dev-compose.sh
@@ -1431,24 +1431,20 @@ for dbt-built gold data rather than for containers to report healthy.
 
           The four backend services (analytics, authenticator,
           identity-resolution, gateway) and the frontend are PULLED, each
-          pinned to its own chart's appVersion — never :latest, and never
-          compiled here. Compiling the backend took ~26 minutes for code the
-          stand does not change.
+          pinned to its own chart's appVersion — never :latest.
 
-          Two trees, two independent flags. Pass the one whose source this
-          working tree changes — an appVersion names what main released, so a
-          pinned image would not carry the change under test:
+          An appVersion names what main released, so pass the flag for whatever
+          tree this checkout changes, or the stand will not run it:
 
-          --build-backend    Compile analytics, authenticator and
-                             identity-resolution from this tree (~26 min).
+          --build-backend    Compile the Rust services from this tree. Adds
+                             ~28 min (measured across CI's build-path runs).
           --build-frontend   Build the SPA from this tree with pnpm, served by
-                             the front-built nginx. The backend stays pinned.
-          --build            Both of the above.
+                             the front-built nginx. Backend stays pinned.
+          --build            Both.
 
-          `up` refuses to pin a tree that differs from origin/main under
-          src/backend/ or src/frontend/ and names the flag to pass. That check
-          needs origin/main in the checkout: a shallow clone (every CI runner)
-          says so on stderr and leaves the decision to its caller.
+          `up` refuses to pin a tree that differs from origin/main and names
+          the flag to pass — but only when origin/main is in the checkout. A
+          shallow clone says so on stderr and defers to its caller.
   seed    Re-seed the running stand (default target: all).
   test    Run the stand suite against an already-up stand. Passes extra
           arguments through to pytest — no `--` separator.
@@ -1531,13 +1527,10 @@ test_stand_tree_matches_charts() {
   local subtree="$1" flag="$2"
   git rev-parse --git-dir >/dev/null 2>&1 || return 0
   git remote get-url origin >/dev/null 2>&1 || return 0
-  # Say so rather than passing quietly. A CI checkout is depth-1 and has no
-  # origin/main, so this guard is INERT there — the caller (e2e-stand.yml's
-  # `changes` job) decides what to build, and a reader of the log who thinks
-  # this line vouched for the pinning would be wrong.
+  # Inert on a depth-1 checkout (every CI runner). Say so, so a log reader does
+  # not read the silence as a passed check.
   git rev-parse --verify --quiet origin/main >/dev/null || {
-    echo "NOTE: no origin/main in this checkout — cannot check ${subtree}/ against" >&2
-    echo "      the pinned images; trusting the caller's ${flag} decision." >&2
+    echo "NOTE: no origin/main here — ${subtree}/ unchecked, ${flag} is the caller's call." >&2
     return 0; }
 
   local changed
@@ -1815,11 +1808,8 @@ cmd_test_stand() {
 
   case "$verb" in
     up)
-      # Two independent axes. Each tree is either PINNED to what its chart's
-      # appVersion names — main's build — or built from this working tree, and
-      # the two questions are asked separately because the two builds cost two
-      # different things: a ~26-minute Rust compile against a pnpm build.
-      # --build is the both-axes alias.
+      # Each tree is pinned to its chart's appVersion or built from this one,
+      # asked separately: --build is the both-axes alias.
       local image build_backend=false build_frontend=false
       while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -1840,11 +1830,9 @@ cmd_test_stand() {
         test_stand_write_env ghcr "$image" || return 1
       fi
 
-      # INVARIANT: pinning writes the four *_IMAGE vars into the env file, and
-      # that is the ONLY thing separating the two axes downstream — cmd_up puts
-      # a service in its ghcr list iff its image var is set, and compiles only
-      # the binaries that list leaves out. Pull before cmd_up reads the file, or
-      # a pinned backend gets compiled anyway.
+      # INVARIANT: pinning writes the *_IMAGE vars, and that is the only thing
+      # keeping cmd_up off the compiler — so it has to run before cmd_up reads
+      # the env file.
       if [[ "$build_backend" == true ]]; then
         echo "=== the backend is compiled from this tree, not pulled ==="
       else

--- a/src/backend/CLAUDE.md
+++ b/src/backend/CLAUDE.md
@@ -111,3 +111,5 @@ deny). These rules cover only what tooling cannot enforce.
 - Tests read as spec: table-driven loops with per-case assert messages
   (`"should reject: {input:?}"`); alias `type R = Result<(), Box<dyn Error>>`
   to cut ceremony.
+
+<!-- CI probe: exercises the --build-backend lane. Not for merge. -->


### PR DESCRIPTION
Throwaway verification branch for #2540, not for merge.

It carries #2540's two CI commits plus a comment-only touch under `src/backend/`, so `changes` answers `backend=true frontend=false` and both lanes take `--build-backend` with the frontend still pinned — the one flag combination the symmetric wiring introduces that no run has taken yet.

What to read in the run:

- `changes` logs `relevant=true backend=true frontend=false`
- both lanes log `the backend is compiled from this tree, not pulled` and pin `insight-frontend:<appVersion>`, with no `Pinning the backend to published images` line
- `api-smoke` passes against the compiled backend

`ui-journeys` is expected to FAIL here on the three evidence-dialog journeys: this branch has no frontend fix, so it runs main's published SPA, which is the very regression #2540 exists to make testable. That failure is the control, not a defect in the lane.

Closed once read.