### PR TITLE
feat(analytics): cache metric-result views in Redis

### DIFF
--- a/src/backend/services/analytics/src/api/http_live_tests.rs
+++ b/src/backend/services/analytics/src/api/http_live_tests.rs
@@ -76,6 +76,7 @@ fn build_state(db: DatabaseConnection, identity: IdentityClient) -> AppState {
         ch: dead_ch(),
         identity,
         config: GearConfig::default(),
+        view_cache: crate::infra::cache::MetricViewCache::disabled(),
     }
 }
 

--- a/src/backend/services/analytics/src/api/metric_results.rs
+++ b/src/backend/services/analytics/src/api/metric_results.rs
@@ -184,9 +184,12 @@ async fn resolve_views(
         }
     }
 
-    if !writes.is_empty() {
+    if let Some(permit) = (!writes.is_empty())
+        .then(|| state.view_cache.try_admit_write())
+        .flatten()
+    {
         let cache = Arc::clone(&state.view_cache);
-        tokio::spawn(async move { cache.set_many(writes).await });
+        tokio::spawn(async move { cache.set_many(permit, writes).await });
     }
 
     Ok(views)

--- a/src/backend/services/analytics/src/api/metric_results.rs
+++ b/src/backend/services/analytics/src/api/metric_results.rs
@@ -13,12 +13,14 @@ use super::AppState;
 use super::error::MetricError;
 use crate::domain::metric_drilldown::load_capabilities;
 use crate::domain::metric_results::{
-    BatchItem, BreakdownQueryRow, CompiledQuery, HistogramQueryRow, MetricResultViewDto,
-    MetricResultsRequest, MetricResultsResponse, PeerWideRow, PeriodWideRow, PlannedQuery,
-    RankingQueryRow, TimeseriesQueryRow, UnbatchedView, ValidatedMetricResultsRequest,
-    build_breakdown_view, build_histogram_view, build_metric_result, build_peer_view,
-    build_period_view, build_ranked_groups, build_timeseries_view, demux_peer_rows,
-    demux_period_rows, enforce_view_row_limit, plan_queries, plan_rankings, validate_request,
+    BatchItem, BreakdownQueryRow, CacheOutcome, CachePlan, CompiledQuery, HistogramQueryRow,
+    MetricResultViewDto, MetricResultsRequest, MetricResultsResponse, PeerWideRow, PeriodWideRow,
+    PlannedQuery, RankedGroup, RankingPolicyKey, RankingQueryRow, TimeseriesQueryRow,
+    UnbatchedView, ValidatedMetricResultsRequest, ViewOutcome, build_breakdown_view,
+    build_histogram_view, build_metric_result, build_ranked_groups, build_timeseries_view,
+    demux_peer_rows, demux_period_rows, derive_view_keys, enforce_view_row_limit, flat_keys,
+    plan_queries, plan_rankings, relation_epochs, required_relations, uncacheable_keys,
+    validate_request,
 };
 use crate::domain::person_visibility::authorize_entity_ids;
 use toolkit_security::SecurityContext;
@@ -58,46 +60,13 @@ pub async fn query_metric_results(
         .map(|metric| metric.def.key().to_owned())
         .collect::<Vec<_>>();
     let capabilities = load_capabilities(&state.db, tenant_id, &metric_keys);
-    let rankings = async {
-        let mut ranking_results = BTreeMap::new();
-        let mut rankings = stream::iter(plan_rankings(&req))
-            .map(|ranking| {
-                let state = Arc::clone(&state);
-                async move {
-                    let comment = format!("metric-results:ranking:{}", ranking.key.rank_metric_key);
-                    let rows =
-                        fetch_rows::<RankingQueryRow>(&state, ranking.query, &comment).await?;
-                    let groups = build_ranked_groups(&ranking.dimensions, rows)?;
-                    Ok::<_, CanonicalError>((ranking.key, groups))
-                }
-            })
-            .buffer_unordered(QUERY_CONCURRENCY);
-        while let Some(result) = rankings.next().await {
-            let (key, groups) = result?;
-            ranking_results.insert(key, groups);
-        }
-        Ok::<_, CanonicalError>(ranking_results)
-    };
-    let (ranking_results, capabilities) = tokio::join!(rankings, capabilities);
-    let ranking_results = ranking_results?;
-    let planned = plan_queries(&req, &ranking_results)?;
+    let (plan, capabilities, rankings) = tokio::join!(
+        probe_cache(&state, &req),
+        capabilities,
+        fetch_rankings(&state, &req)
+    );
 
-    let mut views_by_metric: Vec<Vec<Option<MetricResultViewDto>>> = req
-        .metrics
-        .iter()
-        .map(|metric| (0..metric.views.len()).map(|_| None).collect())
-        .collect();
-
-    // Consuming results as they complete bails on the first error; dropping
-    // the stream cancels the in-flight and queued queries.
-    let mut results = stream::iter(planned)
-        .map(|query| execute_planned(&state, &req, query))
-        .buffer_unordered(QUERY_CONCURRENCY);
-    while let Some(result) = results.next().await {
-        for view in result? {
-            views_by_metric[view.metric_index][view.view_index] = Some(view.view);
-        }
-    }
+    let mut views_by_metric = resolve_views(&state, &req, plan, rankings?).await?;
 
     let capabilities = match capabilities {
         Ok(capabilities) => capabilities,
@@ -109,11 +78,10 @@ pub async fn query_metric_results(
     let mut metrics = Vec::with_capacity(req.metrics.len());
     for (idx, metric) in req.metrics.iter().enumerate() {
         let mut views = Vec::with_capacity(metric.views.len());
-        for (view_index, view) in views_by_metric[idx].drain(..).enumerate() {
+        for view in views_by_metric[idx].drain(..) {
             let Some(view) = view else {
                 return Err(CanonicalError::internal("missing metric view result").create());
             };
-            enforce_view_row_limit(&view, format!("metrics[{idx}].views[{view_index}]"))?;
             views.push(view);
         }
         let selection = crate::domain::metric_results::MetricResultSelectionDto {
@@ -147,10 +115,112 @@ pub async fn query_metric_results(
     Ok(Json(response))
 }
 
+/// Reads the cache for every requested view and reports what is left to run.
+/// Anything that goes wrong here — no Redis, no epoch, a slow read — resolves to
+/// "nothing was cached".
+async fn probe_cache(state: &Arc<AppState>, req: &ValidatedMetricResultsRequest) -> CachePlan {
+    if !state.view_cache.enabled() {
+        return CachePlan::build(req, uncacheable_keys(req), &[]);
+    }
+
+    let relations = required_relations(&req.metrics);
+    let Some(epochs) = relation_epochs(&state.ch, &relations).await else {
+        return CachePlan::build(req, uncacheable_keys(req), &[]);
+    };
+
+    let keys = derive_view_keys(req, &epochs);
+    let cached = state.view_cache.get_many(&flat_keys(&keys)).await;
+
+    CachePlan::build(req, keys, &cached)
+}
+
+async fn resolve_views(
+    state: &Arc<AppState>,
+    req: &ValidatedMetricResultsRequest,
+    mut plan: CachePlan,
+    rankings: BTreeMap<RankingPolicyKey, Vec<RankedGroup>>,
+) -> Result<Vec<Vec<Option<MetricResultViewDto>>>, CanonicalError> {
+    let cache_stats = plan.stats();
+    tracing::debug!(
+        hits = cache_stats.hits,
+        misses = cache_stats.misses,
+        uncacheable = cache_stats.uncacheable,
+        "metric-results view cache"
+    );
+
+    // Each narrowed request carries its own entity set, so its queries must be
+    // built AND rendered against that request, never the caller's.
+    let mut jobs = Vec::new();
+    for (origin, narrowed) in plan.narrowed() {
+        let scope = Arc::new(narrowed.req.clone());
+        for query in plan_queries(&narrowed.req, &rankings)? {
+            jobs.push((origin, Arc::clone(&scope), query));
+        }
+    }
+
+    // Consuming results as they complete bails on the first error; dropping
+    // the stream cancels the in-flight and queued queries.
+    let mut results = stream::iter(jobs)
+        .map(|(origin, scope, query)| async move {
+            let produced = execute_planned(state, &scope, query).await?;
+            Ok::<_, CanonicalError>((origin, produced))
+        })
+        .buffer_unordered(QUERY_CONCURRENCY);
+    while let Some(result) = results.next().await {
+        let (origin, produced) = result?;
+        for item in produced {
+            plan.record(origin, item.metric_index, item.view_index, item.outcome)?;
+        }
+    }
+
+    let CacheOutcome { views, writes } = plan.finish(req)?;
+
+    // The response gate runs before anything is stored, so a view the caller is
+    // about to be refused never reaches Redis.
+    for (metric_index, metric_views) in views.iter().enumerate() {
+        for (view_index, view) in metric_views.iter().enumerate() {
+            let Some(view) = view else { continue };
+            enforce_view_row_limit(view, format!("metrics[{metric_index}].views[{view_index}]"))?;
+        }
+    }
+
+    if !writes.is_empty() {
+        let cache = Arc::clone(&state.view_cache);
+        tokio::spawn(async move { cache.set_many(writes).await });
+    }
+
+    Ok(views)
+}
+
+async fn fetch_rankings(
+    state: &Arc<AppState>,
+    req: &ValidatedMetricResultsRequest,
+) -> Result<BTreeMap<RankingPolicyKey, Vec<RankedGroup>>, CanonicalError> {
+    let mut ranking_results = BTreeMap::new();
+    let mut rankings = stream::iter(plan_rankings(req))
+        .map(|ranking| {
+            let state = Arc::clone(state);
+            async move {
+                let comment = format!("metric-results:ranking:{}", ranking.key.rank_metric_key);
+                let rows = fetch_rows::<RankingQueryRow>(&state, ranking.query, &comment).await?;
+                let groups = build_ranked_groups(&ranking.dimensions, rows)?;
+                Ok::<_, CanonicalError>((ranking.key, groups))
+            }
+        })
+        .buffer_unordered(QUERY_CONCURRENCY);
+
+    while let Some(result) = rankings.next().await {
+        let (key, groups) = result?;
+        ranking_results.insert(key, groups);
+    }
+
+    Ok(ranking_results)
+}
+
 struct MetricViewResult {
     metric_index: usize,
     view_index: usize,
-    view: MetricResultViewDto,
+    outcome: ViewOutcome,
 }
 
 async fn execute_planned(
@@ -166,7 +236,7 @@ async fn execute_planned(
             Ok(items
                 .iter()
                 .zip(rows_by_item)
-                .map(|(item, rows)| view_result(item, build_period_view(&item.def, req, rows)))
+                .map(|(item, rows)| view_result(item, ViewOutcome::PeriodRows(rows)))
                 .collect())
         }
         PlannedQuery::PeerBatch { items, query } => {
@@ -176,7 +246,7 @@ async fn execute_planned(
             Ok(items
                 .iter()
                 .zip(rows_by_item)
-                .map(|(item, rows)| view_result(item, build_peer_view(rows)))
+                .map(|(item, rows)| view_result(item, ViewOutcome::PeerRows(rows)))
                 .collect())
         }
         PlannedQuery::Single {
@@ -208,7 +278,7 @@ async fn execute_planned(
             Ok(vec![MetricViewResult {
                 metric_index,
                 view_index,
-                view,
+                outcome: ViewOutcome::View(view),
             }])
         }
     }
@@ -225,11 +295,11 @@ fn batch_log_comment(kind: &str, items: &[BatchItem]) -> String {
     format!("metric-results:{kind}-batch:{keys}")
 }
 
-fn view_result(item: &BatchItem, view: MetricResultViewDto) -> MetricViewResult {
+fn view_result(item: &BatchItem, outcome: ViewOutcome) -> MetricViewResult {
     MetricViewResult {
         metric_index: item.metric_index,
         view_index: item.view_index,
-        view,
+        outcome,
     }
 }
 

--- a/src/backend/services/analytics/src/api/mod.rs
+++ b/src/backend/services/analytics/src/api/mod.rs
@@ -31,6 +31,7 @@ use crate::config::GearConfig;
 use crate::domain::metric_crud;
 use crate::domain::metric_definitions::listing as metric_definitions_listing;
 use crate::domain::saved_query;
+use crate::infra::cache::MetricViewCache;
 use crate::infra::identity::IdentityClient;
 
 /// Shared application state.
@@ -39,8 +40,8 @@ pub struct AppState {
     pub db: DatabaseConnection,
     pub ch: insight_clickhouse::Client,
     pub identity: IdentityClient,
-    #[allow(dead_code)] // will be used for runtime config access (rate limits, feature flags)
     pub config: GearConfig,
+    pub view_cache: Arc<MetricViewCache>,
 }
 
 pub(crate) fn forwarded_authorization(headers: &axum::http::HeaderMap) -> Option<&str> {

--- a/src/backend/services/analytics/src/api/mod.rs
+++ b/src/backend/services/analytics/src/api/mod.rs
@@ -41,7 +41,7 @@ pub struct AppState {
     pub ch: insight_clickhouse::Client,
     pub identity: IdentityClient,
     pub config: GearConfig,
-    pub view_cache: Arc<MetricViewCache>,
+    pub(crate) view_cache: Arc<MetricViewCache>,
 }
 
 pub(crate) fn forwarded_authorization(headers: &axum::http::HeaderMap) -> Option<&str> {

--- a/src/backend/services/analytics/src/config.rs
+++ b/src/backend/services/analytics/src/config.rs
@@ -9,6 +9,8 @@
 
 use serde::Deserialize;
 
+const DEFAULT_CACHE_TTL_SECS: u64 = 3600;
+
 /// Configuration consumed by the analytics gear. Deserialized from
 /// `gears.analytics.config`.
 #[derive(Debug, Clone, Deserialize)]
@@ -43,10 +45,19 @@ pub struct GearConfig {
     /// Redis URL (e.g., `redis://localhost:6379`). Empty disables every
     /// Redis-backed path; multi-replica deploys configure it so a cache added
     /// here is coordinated across replicas rather than per-process.
+    ///
+    /// This backs the metric-result view cache, whose key count grows with the
+    /// variety of requests served and shrinks only as entries expire. Point it
+    /// at an instance with an eviction policy, or at one dedicated to this
+    /// service — an instance shared with session state and left on `noeviction`
+    /// will start refusing writes once the cache fills it.
     pub redis_url: String,
 
     /// Metric read configuration.
     pub metric_catalog: MetricCatalogConfig,
+
+    /// Metric-result view cache configuration.
+    pub metric_results_cache: MetricResultsCacheConfig,
 }
 
 impl Default for GearConfig {
@@ -61,6 +72,27 @@ impl Default for GearConfig {
             identity_url: String::new(),
             redis_url: String::new(),
             metric_catalog: MetricCatalogConfig::default(),
+            metric_results_cache: MetricResultsCacheConfig::default(),
+        }
+    }
+}
+
+/// Per-environment knobs for the metric-result view cache. The cache is keyed
+/// by the warehouse relation UUID, so a rebuild invalidates exactly; the TTL
+/// only bounds how long superseded keys occupy Redis.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct MetricResultsCacheConfig {
+    /// Lifetime of a cached view fragment.
+    ///
+    /// Env: `APP__gears__analytics__config__metric_results_cache__ttl_secs`.
+    pub ttl_secs: u64,
+}
+
+impl Default for MetricResultsCacheConfig {
+    fn default() -> Self {
+        Self {
+            ttl_secs: DEFAULT_CACHE_TTL_SECS,
         }
     }
 }

--- a/src/backend/services/analytics/src/config.rs
+++ b/src/backend/services/analytics/src/config.rs
@@ -57,7 +57,7 @@ pub struct GearConfig {
     pub metric_catalog: MetricCatalogConfig,
 
     /// Metric-result view cache configuration.
-    pub metric_results_cache: MetricResultsCacheConfig,
+    pub(crate) metric_results_cache: MetricResultsCacheConfig,
 }
 
 impl Default for GearConfig {
@@ -82,11 +82,11 @@ impl Default for GearConfig {
 /// only bounds how long superseded keys occupy Redis.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default)]
-pub struct MetricResultsCacheConfig {
+pub(crate) struct MetricResultsCacheConfig {
     /// Lifetime of a cached view fragment.
     ///
     /// Env: `APP__gears__analytics__config__metric_results_cache__ttl_secs`.
-    pub ttl_secs: u64,
+    pub(crate) ttl_secs: u64,
 }
 
 impl Default for MetricResultsCacheConfig {

--- a/src/backend/services/analytics/src/domain/metric_definitions/definition.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/definition.rs
@@ -281,6 +281,21 @@ impl MetricDefinition {
             ComputationSpec::Ratio { numerator, .. } => &numerator.observation,
         }
     }
+
+    /// Every input the compiler reads, not just the one that names the batch
+    /// group — a ratio's denominator can carry its own observation source.
+    pub fn inputs(&self) -> Vec<&MetricInput> {
+        match &self.spec {
+            ComputationSpec::Sum { value }
+            | ComputationSpec::Median { value }
+            | ComputationSpec::DistinctCount { value } => vec![value],
+            ComputationSpec::Ratio {
+                numerator,
+                denominator,
+                ..
+            } => vec![numerator, denominator],
+        }
+    }
 }
 
 impl ObservationRelation {

--- a/src/backend/services/analytics/src/domain/metric_definitions/definition.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/definition.rs
@@ -282,8 +282,6 @@ impl MetricDefinition {
         }
     }
 
-    /// Every input the compiler reads, not just the one that names the batch
-    /// group — a ratio's denominator can carry its own observation source.
     pub fn inputs(&self) -> Vec<&MetricInput> {
         match &self.spec {
             ComputationSpec::Sum { value }

--- a/src/backend/services/analytics/src/domain/metric_results/builder.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/builder.rs
@@ -45,7 +45,6 @@ impl SeriesData {
 }
 
 pub fn build_period_view(
-    _def: &MetricDefinition,
     req: &ValidatedMetricResultsRequest,
     rows: Vec<PeriodQueryRow>,
 ) -> MetricResultViewDto {
@@ -161,12 +160,26 @@ pub fn build_ranked_groups(
         .collect()
 }
 
-pub fn build_peer_view(rows: Vec<PeerQueryRow>) -> MetricResultViewDto {
-    MetricResultViewDto::Peer {
-        values: rows
-            .into_iter()
-            .map(|row| PeerValueDto {
-                entity_id: row.entity_id,
+/// Peer values stay sparse — an entity outside the cohort relation has no
+/// pool to compare against and is omitted rather than zero-filled. Ordering
+/// follows the requested ids so the same pool always renders the same bytes.
+pub fn build_peer_view(
+    req: &ValidatedMetricResultsRequest,
+    rows: Vec<PeerQueryRow>,
+) -> MetricResultViewDto {
+    let mut rows_by_entity: HashMap<String, PeerQueryRow> = rows
+        .into_iter()
+        .map(|row| (row.entity_id.clone(), row))
+        .collect();
+
+    let values = req
+        .entity
+        .entity_ids()
+        .into_iter()
+        .filter_map(|entity_id| {
+            let row = rows_by_entity.remove(&entity_id)?;
+            Some(PeerValueDto {
+                entity_id,
                 target_value: row.target_value,
                 p25: row.p25,
                 median: row.median,
@@ -175,8 +188,10 @@ pub fn build_peer_view(rows: Vec<PeerQueryRow>) -> MetricResultViewDto {
                 max: row.max,
                 n: row.n.unwrap_or(0),
             })
-            .collect(),
-    }
+        })
+        .collect();
+
+    MetricResultViewDto::Peer { values }
 }
 
 pub fn build_breakdown_view(
@@ -358,7 +373,6 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use crate::domain::metric_definitions::definition::ValueTransform;
     use chrono::NaiveDate;
     use serde_json::json;
 
@@ -493,8 +507,7 @@ mod tests {
             entity_id: "00000000-0000-0000-0000-00000000000a".to_owned(),
             value: Some(5.0),
         }];
-        let MetricResultViewDto::Period { values } = build_period_view(&sum_metric(), &req, rows)
-        else {
+        let MetricResultViewDto::Period { values } = build_period_view(&req, rows) else {
             panic!("expected period view");
         };
         assert_eq!(values[0].entity_id, "00000000-0000-0000-0000-00000000000b");
@@ -510,9 +523,7 @@ mod tests {
             "2026-01-01",
             "2026-01-31",
         );
-        let MetricResultViewDto::Period { values } =
-            build_period_view(&ratio_metric(), &req, Vec::new())
-        else {
+        let MetricResultViewDto::Period { values } = build_period_view(&req, Vec::new()) else {
             panic!("expected period view");
         };
         assert_eq!(values[0].value, None);
@@ -526,9 +537,7 @@ mod tests {
             "2026-01-01",
             "2026-01-31",
         );
-        let MetricResultViewDto::Period { values } =
-            build_period_view(&median_metric(), &req, Vec::new())
-        else {
+        let MetricResultViewDto::Period { values } = build_period_view(&req, Vec::new()) else {
             panic!("expected period view");
         };
         assert_eq!(values[0].value, None);
@@ -541,9 +550,7 @@ mod tests {
             "2026-01-01",
             "2026-01-31",
         );
-        let MetricResultViewDto::Period { values } =
-            build_period_view(&distinct_count_metric(), &req, Vec::new())
-        else {
+        let MetricResultViewDto::Period { values } = build_period_view(&req, Vec::new()) else {
             panic!("expected period view");
         };
         assert_eq!(values[0].value, None);
@@ -973,22 +980,38 @@ mod tests {
     }
 
     #[test]
-    fn missing_value_ignores_the_transform() {
-        let mut def = sum_metric();
-        def.transform = Some(ValueTransform {
-            multiplier: Some(-1.0),
-            offset: Some(100.0),
-            clamp_min: Some(0.0),
-            clamp_max: Some(100.0),
-        });
+    fn peer_view_omits_entities_without_a_pool_and_follows_requested_order() {
         let req = request(
-            vec!["00000000-0000-0000-0000-00000000000c"],
+            vec![
+                "00000000-0000-0000-0000-00000000000b",
+                "00000000-0000-0000-0000-00000000000c",
+                "00000000-0000-0000-0000-00000000000a",
+            ],
             "2026-01-01",
             "2026-01-31",
         );
-        let MetricResultViewDto::Period { values } = build_period_view(&def, &req, vec![]) else {
-            panic!("expected period view");
+        let row = |entity_id: &str, target: f64| PeerQueryRow {
+            entity_id: entity_id.to_owned(),
+            target_value: Some(target),
+            p25: None,
+            median: None,
+            p75: None,
+            min: None,
+            max: None,
+            n: Some(5),
         };
-        assert_eq!(values[0].value, None);
+        // Row order out of the pool query is unspecified; person C has no cohort row.
+        let rows = vec![
+            row("00000000-0000-0000-0000-00000000000a", 1.0),
+            row("00000000-0000-0000-0000-00000000000b", 2.0),
+        ];
+
+        let MetricResultViewDto::Peer { values } = build_peer_view(&req, rows) else {
+            panic!("expected peer view");
+        };
+
+        assert_eq!(values.len(), 2);
+        assert_eq!(values[0].entity_id, "00000000-0000-0000-0000-00000000000b");
+        assert_eq!(values[1].entity_id, "00000000-0000-0000-0000-00000000000a");
     }
 }

--- a/src/backend/services/analytics/src/domain/metric_results/cache/epoch.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/cache/epoch.rs
@@ -10,6 +10,9 @@ use super::super::validation::{ValidatedMetricRequest, ValidatedMetricView};
 /// The cache may never be the reason a request stalls, so a slow epoch lookup
 /// degrades to "nothing was cached" like every other failure here.
 const EPOCH_TIMEOUT: Duration = Duration::from_millis(500);
+/// A database whose engine is not Atomic reports this for every table, so it
+/// would never change and could never invalidate a fragment.
+const UNSET_UUID: &str = "00000000-0000-0000-0000-000000000000";
 
 /// A warehouse relation a cached fragment was computed from.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -114,6 +117,13 @@ pub async fn relation_epochs(
     let by_relation = rows
         .into_iter()
         .filter_map(|row| {
+            if row.uuid == UNSET_UUID {
+                tracing::debug!(
+                    table = %row.name,
+                    "metric-results cache: relation reports no table UUID"
+                );
+                return None;
+            }
             let relation = relations
                 .iter()
                 .find(|r| r.database == row.database && r.table == row.name)?;

--- a/src/backend/services/analytics/src/domain/metric_results/cache/epoch.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/cache/epoch.rs
@@ -1,0 +1,208 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::Duration;
+
+use serde::Deserialize;
+
+use crate::domain::metric_definitions::{CohortSource, ObservationSource};
+
+use super::super::validation::{ValidatedMetricRequest, ValidatedMetricView};
+
+/// The cache may never be the reason a request stalls, so a slow epoch lookup
+/// degrades to "nothing was cached" like every other failure here.
+const EPOCH_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// A warehouse relation a cached fragment was computed from.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RelationRef {
+    pub database: &'static str,
+    pub table: String,
+}
+
+/// Current table UUID per relation. dbt rebuilds a gold model as a new table,
+/// so the UUID changing is exactly "the data behind this fragment was
+/// replaced" — cached keys carrying the old UUID become unreachable.
+#[derive(Debug, Default)]
+pub struct RelationEpochs(BTreeMap<RelationRef, String>);
+
+impl RelationEpochs {
+    pub fn get(&self, relation: &RelationRef) -> Option<&str> {
+        self.0.get(relation).map(String::as_str)
+    }
+}
+
+#[derive(Debug, Deserialize, clickhouse::Row)]
+struct RelationEpochRow {
+    database: String,
+    name: String,
+    uuid: String,
+}
+
+/// Relations every cacheable fragment of this request depends on: each managed
+/// observation relation, plus the cohort relation when a peer view is asked
+/// for. Custom observation SQL has no relation to pin, so it contributes
+/// nothing here and its views never cache.
+pub fn required_relations(metrics: &[ValidatedMetricRequest]) -> BTreeSet<RelationRef> {
+    let mut relations = BTreeSet::new();
+    for metric in metrics {
+        for input in metric.def.inputs() {
+            if let ObservationSource::Managed(relation) = &input.observation {
+                let (database, table) = relation.table_ref();
+                relations.insert(RelationRef {
+                    database,
+                    table: table.to_owned(),
+                });
+            }
+        }
+
+        let wants_cohort = metric
+            .views
+            .iter()
+            .any(|view| matches!(view, ValidatedMetricView::Peer { .. }));
+        if wants_cohort {
+            let (database, table) = CohortSource::MetricEntityCohortsCurrent.table_ref();
+            relations.insert(RelationRef {
+                database,
+                table: table.to_owned(),
+            });
+        }
+    }
+    relations
+}
+
+/// Reads every epoch in one query. A relation missing from the reply is left
+/// out, which makes its views uncacheable rather than wrong.
+pub async fn relation_epochs(
+    ch: &insight_clickhouse::Client,
+    relations: &BTreeSet<RelationRef>,
+) -> Option<RelationEpochs> {
+    if relations.is_empty() {
+        return Some(RelationEpochs::default());
+    }
+
+    let databases: BTreeSet<&str> = relations.iter().map(|r| r.database).collect();
+    let tables: BTreeSet<&str> = relations.iter().map(|r| r.table.as_str()).collect();
+    let sql = format!(
+        "SELECT database, name, toString(uuid) AS uuid \
+         FROM system.tables WHERE database IN ({}) AND name IN ({})",
+        placeholders(databases.len()),
+        placeholders(tables.len()),
+    );
+
+    let mut query = ch
+        .query(&sql)
+        .with_setting("log_comment", "metric-results:epochs");
+    for database in &databases {
+        query = query.bind(*database);
+    }
+    for table in &tables {
+        query = query.bind(*table);
+    }
+
+    let rows =
+        match tokio::time::timeout(EPOCH_TIMEOUT, query.fetch_all::<RelationEpochRow>()).await {
+            Ok(Ok(rows)) => rows,
+            Ok(Err(error)) => {
+                tracing::debug!(error = %error, "metric-results cache epoch lookup failed");
+                return None;
+            }
+            Err(_) => {
+                tracing::debug!("metric-results cache epoch lookup timed out");
+                return None;
+            }
+        };
+
+    let by_relation = rows
+        .into_iter()
+        .filter_map(|row| {
+            let relation = relations
+                .iter()
+                .find(|r| r.database == row.database && r.table == row.name)?;
+            Some((relation.clone(), row.uuid))
+        })
+        .collect();
+
+    Some(RelationEpochs(by_relation))
+}
+
+fn placeholders(count: usize) -> String {
+    std::iter::repeat_n("?", count)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+impl RelationEpochs {
+    pub fn from_pairs(pairs: Vec<(RelationRef, String)>) -> Self {
+        Self(pairs.into_iter().collect())
+    }
+}
+
+#[cfg(test)]
+pub fn relation_epochs_for_test(relations: &BTreeSet<RelationRef>, epoch: &str) -> RelationEpochs {
+    RelationEpochs(
+        relations
+            .iter()
+            .cloned()
+            .map(|relation| (relation, epoch.to_owned()))
+            .collect(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::metric_results::cache::test_support::{
+        custom_sql_metric, metric_request, sum_metric,
+    };
+    use crate::domain::metric_results::view::Bucket;
+
+    #[test]
+    fn managed_observation_and_cohort_relations_are_both_required() {
+        let metrics = vec![metric_request(
+            sum_metric(),
+            vec![
+                ValidatedMetricView::Period,
+                ValidatedMetricView::Peer {
+                    cohort_key: "org_unit".to_owned(),
+                },
+            ],
+        )];
+
+        let relations = required_relations(&metrics);
+
+        let tables: Vec<&str> = relations.iter().map(|r| r.table.as_str()).collect();
+        assert_eq!(
+            tables,
+            vec!["ai_metric_observations", "metric_entity_cohorts_current"]
+        );
+    }
+
+    #[test]
+    fn cohort_relation_is_required_only_for_peer_views() {
+        let metrics = vec![metric_request(
+            sum_metric(),
+            vec![
+                ValidatedMetricView::Period,
+                ValidatedMetricView::Timeseries {
+                    bucket: Bucket::Day,
+                    dimensions: Vec::new(),
+                    group_limit: None,
+                },
+            ],
+        )];
+
+        let relations = required_relations(&metrics);
+
+        assert_eq!(relations.len(), 1);
+    }
+
+    #[test]
+    fn custom_observation_sql_contributes_no_relation() {
+        let metrics = vec![metric_request(
+            custom_sql_metric(),
+            vec![ValidatedMetricView::Period],
+        )];
+
+        assert!(required_relations(&metrics).is_empty());
+    }
+}

--- a/src/backend/services/analytics/src/domain/metric_results/cache/fragment.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/cache/fragment.rs
@@ -1,0 +1,192 @@
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+
+use super::super::compiler::{PeerQueryRow, PeriodQueryRow};
+
+/// One entity's period value. The period builder emits a row for every
+/// requested entity, so this is always a value — unknown included.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PeriodFragment(Option<f64>);
+
+/// One entity's peer statistics, or `None` for "this entity has no peer pool".
+/// The builder renders that state by omitting the entity, so it has to survive
+/// a round trip distinctly from a cache miss.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PeerFragment(Option<PeerStats>);
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PeerStats {
+    target_value: Option<f64>,
+    p25: Option<f64>,
+    median: Option<f64>,
+    p75: Option<f64>,
+    min: Option<f64>,
+    max: Option<f64>,
+    n: Option<u64>,
+}
+
+impl PeriodFragment {
+    pub fn from_row(row: Option<&PeriodQueryRow>) -> Self {
+        Self(row.and_then(|row| row.value))
+    }
+
+    pub fn into_row(self, entity_id: String) -> PeriodQueryRow {
+        PeriodQueryRow {
+            entity_id,
+            value: self.0,
+        }
+    }
+}
+
+impl PeerFragment {
+    pub fn from_row(row: Option<&PeerQueryRow>) -> Self {
+        Self(row.map(|row| PeerStats {
+            target_value: row.target_value,
+            p25: row.p25,
+            median: row.median,
+            p75: row.p75,
+            min: row.min,
+            max: row.max,
+            n: row.n,
+        }))
+    }
+
+    pub fn into_row(self, entity_id: String) -> Option<PeerQueryRow> {
+        let stats = self.0?;
+        Some(PeerQueryRow {
+            entity_id,
+            target_value: stats.target_value,
+            p25: stats.p25,
+            median: stats.median,
+            p75: stats.p75,
+            min: stats.min,
+            max: stats.max,
+            n: stats.n,
+        })
+    }
+}
+
+pub fn encode<T: Serialize>(value: &T) -> Option<Vec<u8>> {
+    serde_json::to_vec(value).ok()
+}
+
+/// `serde_json` writes a non-finite float as `null`, which a required `f64` field
+/// then refuses on the way back in. Storing such an entry would burn a key that
+/// is rewritten on every request and never once readable, so it is not stored.
+pub fn encode_readable<T: Serialize + DeserializeOwned>(value: &T) -> Option<Vec<u8>> {
+    let bytes = encode(value)?;
+    serde_json::from_slice::<T>(&bytes).ok()?;
+    Some(bytes)
+}
+
+/// A fragment written by an older shape decodes to `None`, which the caller
+/// treats as a miss and overwrites.
+pub fn decode<T: DeserializeOwned>(bytes: &[u8]) -> Option<T> {
+    match serde_json::from_slice(bytes) {
+        Ok(value) => Some(value),
+        Err(error) => {
+            tracing::debug!(error = %error, "discarding undecodable metric-results cache entry");
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn period_fragment_round_trips_unknown_and_known_values() {
+        for value in [None, Some(0.0), Some(-1.5)] {
+            let row = PeriodQueryRow {
+                entity_id: "e".to_owned(),
+                value,
+            };
+
+            let bytes = encode(&PeriodFragment::from_row(Some(&row)))
+                .unwrap_or_else(|| panic!("fragment must encode"));
+            let decoded: PeriodFragment =
+                decode(&bytes).unwrap_or_else(|| panic!("fragment must decode"));
+
+            assert_eq!(
+                decoded.into_row("e".to_owned()).value,
+                value,
+                "should round trip: {value:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn absent_peer_pool_round_trips_as_absent_not_as_zeroed_stats() {
+        let bytes =
+            encode(&PeerFragment::from_row(None)).unwrap_or_else(|| panic!("fragment must encode"));
+        let decoded: PeerFragment =
+            decode(&bytes).unwrap_or_else(|| panic!("fragment must decode"));
+
+        assert!(decoded.into_row("e".to_owned()).is_none());
+    }
+
+    #[test]
+    fn peer_fragment_round_trips_every_statistic() {
+        let row = PeerQueryRow {
+            entity_id: "e".to_owned(),
+            target_value: Some(1.0),
+            p25: Some(2.0),
+            median: None,
+            p75: Some(4.0),
+            min: Some(0.5),
+            max: Some(9.0),
+            n: Some(7),
+        };
+
+        let bytes = encode(&PeerFragment::from_row(Some(&row)))
+            .unwrap_or_else(|| panic!("fragment must encode"));
+        let decoded: PeerFragment =
+            decode(&bytes).unwrap_or_else(|| panic!("fragment must decode"));
+        let restored = decoded
+            .into_row("e".to_owned())
+            .unwrap_or_else(|| panic!("stats must restore"));
+
+        assert_eq!(restored.target_value, row.target_value);
+        assert_eq!(restored.p25, row.p25);
+        assert_eq!(restored.median, row.median);
+        assert_eq!(restored.p75, row.p75);
+        assert_eq!(restored.min, row.min);
+        assert_eq!(restored.max, row.max);
+        assert_eq!(restored.n, row.n);
+    }
+
+    #[test]
+    fn corrupt_bytes_decode_to_none() {
+        assert!(decode::<PeriodFragment>(b"not json").is_none());
+    }
+
+    /// `serde_json` turns a non-finite float into `null`, which a required `f64`
+    /// will not decode — such a value must not be stored at all.
+    #[test]
+    fn a_value_that_could_not_be_read_back_is_not_encoded() {
+        use super::super::super::dto::{HistogramBinDto, HistogramValueDto, MetricResultViewDto};
+
+        let view = |lo: f64| MetricResultViewDto::Histogram {
+            values: vec![HistogramValueDto {
+                entity_id: "e".to_owned(),
+                bins: vec![HistogramBinDto {
+                    lo,
+                    hi: 1.0,
+                    count: 1,
+                }],
+            }],
+        };
+
+        assert!(
+            encode_readable(&view(0.0)).is_some(),
+            "a finite bound stores normally"
+        );
+        for bad in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert!(
+                encode_readable(&view(bad)).is_none(),
+                "should refuse to store an unreadable bound: {bad}"
+            );
+        }
+    }
+}

--- a/src/backend/services/analytics/src/domain/metric_results/cache/key.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/cache/key.rs
@@ -1,0 +1,722 @@
+use std::collections::BTreeSet;
+
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use uuid::Uuid;
+
+use crate::domain::metric_definitions::{CohortSource, MetricDefinition, ObservationSource};
+
+use super::super::compiler::{
+    CompiledQuery, compile_breakdown_query, compile_histogram_query, compile_peer_batch_query,
+    compile_period_batch_query, compile_timeseries_query,
+};
+use super::super::validation::{
+    ValidatedDimensionFilter, ValidatedEntitySelection, ValidatedMetricRequest,
+    ValidatedMetricResultsRequest, ValidatedMetricView,
+};
+use super::super::view::MetricResultViewKind;
+use super::epoch::{RelationEpochs, RelationRef};
+
+/// Namespaced apart from the session keys sharing this Redis. The hash tag is
+/// per tenant, not global: a request only ever spans one tenant, so this keeps
+/// its keys in one cluster slot for MGET while still spreading tenants across
+/// shards instead of pointing every metric read at a single one.
+const KEY_NAMESPACE: &str = "amrc";
+const KEY_VERSION: u32 = 1;
+/// Bump to strand every existing fragment after a shape or semantics change
+/// that the compiled probe does not already capture.
+const KEY_SCHEMA: u32 = 1;
+/// A request asking for more keys than this skips the cache rather than issue
+/// an unbounded MGET.
+const MAX_KEYS_PER_REQUEST: usize = 10_000;
+const PROBE_ENTITY: Uuid = Uuid::nil();
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CacheKey(String);
+
+impl CacheKey {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// The row shape a per-entity entry restores to. Carried on the plan so the
+/// assembler cannot re-derive it from the view and disagree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PerEntityKind {
+    Period,
+    Peer,
+}
+
+/// How one requested view can be served from cache.
+#[derive(Debug)]
+pub enum ViewKeyPlan {
+    /// Nothing to look up: custom observation SQL has no relation epoch to pin,
+    /// and a group-limited timeseries cannot be keyed before its ranking runs.
+    Uncacheable,
+    /// One entry for the whole view, keyed by the full requested entity set.
+    Whole(CacheKey),
+    /// One entry per requested entity, in requested order. Only for views whose
+    /// per-entity result does not depend on which other entities were asked
+    /// for.
+    PerEntity {
+        kind: PerEntityKind,
+        keys: Vec<CacheKey>,
+    },
+}
+
+/// The shape of a request no key could be derived for — a disabled cache or an
+/// epoch lookup that failed. Costs no probe compiles.
+pub fn uncacheable_keys(req: &ValidatedMetricResultsRequest) -> Vec<Vec<ViewKeyPlan>> {
+    req.metrics
+        .iter()
+        .map(|metric| {
+            metric
+                .views
+                .iter()
+                .map(|_| ViewKeyPlan::Uncacheable)
+                .collect()
+        })
+        .collect()
+}
+
+/// Cache keys for every requested view, indexed as `[metric][view]`.
+pub fn derive_view_keys(
+    req: &ValidatedMetricResultsRequest,
+    epochs: &RelationEpochs,
+) -> Vec<Vec<ViewKeyPlan>> {
+    let key_count = upper_bound_key_count(req);
+    if key_count > MAX_KEYS_PER_REQUEST {
+        tracing::debug!(key_count, "metric-results cache skipped: too many keys");
+        return uncacheable_keys(req);
+    }
+
+    // INVARIANT: whole-view keys carry the requested entity ORDER, because a
+    // whole-view hit replays a stored DTO verbatim and some builders render one
+    // row per entity in the order asked for. Sorting here would let a request
+    // inherit another request's ordering.
+    let full_set = probe_request(req, requested_entity_ids(&req.entity));
+    let single = probe_request(req, vec![PROBE_ENTITY]);
+
+    req.metrics
+        .iter()
+        .map(|metric| {
+            let filters = canonical_filters(&metric.filters);
+            let resolved = metric_epochs(&metric.def, epochs);
+            metric
+                .views
+                .iter()
+                .map(|view| match &resolved {
+                    None => ViewKeyPlan::Uncacheable,
+                    Some(metric_epochs) => view_key_plan(
+                        req,
+                        metric,
+                        view,
+                        &filters,
+                        metric_epochs,
+                        epochs,
+                        &full_set,
+                        &single,
+                    ),
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// Counted from the request shape alone, before any probe is compiled or
+/// hashed, so an oversized request is rejected without paying for the keys it
+/// will never use.
+fn upper_bound_key_count(req: &ValidatedMetricResultsRequest) -> usize {
+    let entity_count = req.entity.len();
+    req.metrics
+        .iter()
+        .flat_map(|metric| metric.views.iter())
+        .map(|view| match view {
+            ValidatedMetricView::Period | ValidatedMetricView::Peer { .. } => entity_count,
+            ValidatedMetricView::Timeseries { .. }
+            | ValidatedMetricView::Breakdown { .. }
+            | ValidatedMetricView::Histogram => 1,
+        })
+        .sum()
+}
+
+#[expect(
+    clippy::too_many_arguments,
+    reason = "one pure fan-out over request parts"
+)]
+fn view_key_plan(
+    req: &ValidatedMetricResultsRequest,
+    metric: &ValidatedMetricRequest,
+    view: &ValidatedMetricView,
+    filters: &[ValidatedDimensionFilter],
+    epochs: &[(String, String)],
+    all_epochs: &RelationEpochs,
+    full_set: &ValidatedMetricResultsRequest,
+    single: &ValidatedMetricResultsRequest,
+) -> ViewKeyPlan {
+    let def = &metric.def;
+    match view {
+        ValidatedMetricView::Period => {
+            let probe = compile_period_batch_query(&[def], single, filters);
+            per_entity_keys(req, PerEntityKind::Period, &probe, epochs)
+        }
+
+        ValidatedMetricView::Peer { cohort_key } => {
+            let Some(epochs) = with_cohort_epoch(all_epochs, epochs) else {
+                return ViewKeyPlan::Uncacheable;
+            };
+            let probe = compile_peer_batch_query(&[def], single, cohort_key, filters);
+            per_entity_keys(req, PerEntityKind::Peer, &probe, &epochs)
+        }
+
+        // The compiled SQL embeds the resolved top-N groups, which are only
+        // known after the ranking query has run over the whole entity set.
+        ValidatedMetricView::Timeseries {
+            group_limit: Some(_),
+            ..
+        } => ViewKeyPlan::Uncacheable,
+
+        ValidatedMetricView::Timeseries {
+            bucket,
+            dimensions,
+            group_limit: None,
+        } => {
+            let probe = compile_timeseries_query(def, full_set, *bucket, dimensions, filters, None);
+            whole_key(MetricResultViewKind::Timeseries, req, &probe, epochs)
+        }
+
+        ValidatedMetricView::Breakdown { dimensions } => {
+            let probe = compile_breakdown_query(def, full_set, dimensions, filters);
+            whole_key(MetricResultViewKind::Breakdown, req, &probe, epochs)
+        }
+
+        ValidatedMetricView::Histogram => {
+            let probe = compile_histogram_query(def, full_set, filters);
+            whole_key(MetricResultViewKind::Histogram, req, &probe, epochs)
+        }
+    }
+}
+
+fn whole_key(
+    kind: MetricResultViewKind,
+    req: &ValidatedMetricResultsRequest,
+    probe: &CompiledQuery,
+    epochs: &[(String, String)],
+) -> ViewKeyPlan {
+    let Some(digest) = view_digest(kind, req.tenant_id, probe, epochs) else {
+        return ViewKeyPlan::Uncacheable;
+    };
+    ViewKeyPlan::Whole(cache_key(req.tenant_id, &digest, None))
+}
+
+/// The probe digest is per (metric, view); only the entity id varies, so it is
+/// hashed once and mixed in per entity rather than re-serializing the SQL for
+/// every requested id.
+fn per_entity_keys(
+    req: &ValidatedMetricResultsRequest,
+    kind: PerEntityKind,
+    probe: &CompiledQuery,
+    epochs: &[(String, String)],
+) -> ViewKeyPlan {
+    let view_kind = match kind {
+        PerEntityKind::Period => MetricResultViewKind::Period,
+        PerEntityKind::Peer => MetricResultViewKind::Peer,
+    };
+    let Some(digest) = view_digest(view_kind, req.tenant_id, probe, epochs) else {
+        return ViewKeyPlan::Uncacheable;
+    };
+
+    let keys = req
+        .entity
+        .entity_ids()
+        .iter()
+        .map(|entity_id| cache_key(req.tenant_id, &digest, Some(entity_id.as_str())))
+        .collect();
+
+    ViewKeyPlan::PerEntity { kind, keys }
+}
+
+/// The compiled probe query IS the fingerprint of everything that shapes the
+/// result — measure keys, transform, dates, tenant predicate, filters,
+/// dimensions — so a definition edit or a compiler change lands on a new key
+/// without anything here enumerating what changed.
+#[derive(Serialize)]
+struct ViewKeyMaterial<'a> {
+    schema: u32,
+    tenant_id: Uuid,
+    view_kind: MetricResultViewKind,
+    sql: &'a str,
+    params: &'a [String],
+    epochs: &'a [(String, String)],
+}
+
+fn view_digest(
+    kind: MetricResultViewKind,
+    tenant_id: Uuid,
+    probe: &CompiledQuery,
+    epochs: &[(String, String)],
+) -> Option<[u8; 32]> {
+    let material = ViewKeyMaterial {
+        schema: KEY_SCHEMA,
+        tenant_id,
+        view_kind: kind,
+        sql: &probe.sql,
+        params: &probe.params,
+        epochs,
+    };
+    let bytes = serde_json::to_vec(&material).ok()?;
+
+    Some(Sha256::digest(bytes).into())
+}
+
+fn cache_key(tenant_id: Uuid, digest: &[u8; 32], entity_id: Option<&str>) -> CacheKey {
+    let mut hasher = Sha256::new();
+    hasher.update(digest);
+    if let Some(entity_id) = entity_id {
+        hasher.update(b"\0");
+        hasher.update(entity_id.as_bytes());
+    }
+
+    CacheKey(format!(
+        "{{{KEY_NAMESPACE}:{tenant_id}}}:v{KEY_VERSION}:{}",
+        hex::encode(hasher.finalize())
+    ))
+}
+
+/// `None` when any input reads custom SQL or its relation has no epoch — either
+/// way there is nothing to invalidate against.
+fn metric_epochs(def: &MetricDefinition, epochs: &RelationEpochs) -> Option<Vec<(String, String)>> {
+    let mut resolved = BTreeSet::new();
+    for input in def.inputs() {
+        let ObservationSource::Managed(relation) = &input.observation else {
+            return None;
+        };
+        let (database, table) = relation.table_ref();
+        let relation = RelationRef {
+            database,
+            table: table.to_owned(),
+        };
+        let epoch = epochs.get(&relation)?;
+        resolved.insert((format!("{database}.{table}"), epoch.to_owned()));
+    }
+    Some(resolved.into_iter().collect())
+}
+
+/// Peer keys additionally pin the cohort relation: a cohort rebuild changes
+/// every pool without touching an observation table.
+fn with_cohort_epoch(
+    epochs: &RelationEpochs,
+    metric_epochs: &[(String, String)],
+) -> Option<Vec<(String, String)>> {
+    let (database, table) = CohortSource::MetricEntityCohortsCurrent.table_ref();
+    let relation = RelationRef {
+        database,
+        table: table.to_owned(),
+    };
+    let epoch = epochs.get(&relation)?;
+
+    let mut resolved: BTreeSet<(String, String)> = metric_epochs.iter().cloned().collect();
+    resolved.insert((format!("{database}.{table}"), epoch.to_owned()));
+    Some(resolved.into_iter().collect())
+}
+
+fn probe_request(
+    req: &ValidatedMetricResultsRequest,
+    ids: Vec<Uuid>,
+) -> ValidatedMetricResultsRequest {
+    ValidatedMetricResultsRequest {
+        tenant_id: req.tenant_id,
+        entity: match &req.entity {
+            ValidatedEntitySelection::Person { .. } => ValidatedEntitySelection::Person { ids },
+        },
+        from: req.from,
+        to: req.to,
+        metrics: Vec::new(),
+        enforce_tenant_scope: req.enforce_tenant_scope,
+    }
+}
+
+fn requested_entity_ids(entity: &ValidatedEntitySelection) -> Vec<Uuid> {
+    match entity {
+        ValidatedEntitySelection::Person { ids } => ids.clone(),
+    }
+}
+
+fn canonical_filters(filters: &[ValidatedDimensionFilter]) -> Vec<ValidatedDimensionFilter> {
+    let mut filters: Vec<ValidatedDimensionFilter> = filters
+        .iter()
+        .map(|filter| {
+            let mut values = filter.values.clone();
+            values.sort_unstable();
+            values.dedup();
+            ValidatedDimensionFilter {
+                dimension: filter.dimension.clone(),
+                values,
+            }
+        })
+        .collect();
+    filters.sort();
+    filters
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::epoch::{RelationEpochs, relation_epochs_for_test, required_relations};
+    use super::super::test_support::{
+        TENANT, custom_sql_metric, entity, filtered_metric_request, metric_request, request,
+        split_source_ratio_metric, sum_metric,
+    };
+    use super::*;
+    use crate::domain::metric_definitions::definition::ValueTransform;
+    use crate::domain::metric_results::validation::ValidatedGroupLimit;
+    use crate::domain::metric_results::view::Bucket;
+
+    fn epochs_for(req: &ValidatedMetricResultsRequest) -> RelationEpochs {
+        relation_epochs_for_test(&required_relations(&req.metrics), "epoch-1")
+    }
+
+    fn keys_of(req: &ValidatedMetricResultsRequest) -> Vec<Vec<ViewKeyPlan>> {
+        derive_view_keys(req, &epochs_for(req))
+    }
+
+    fn whole(plan: &ViewKeyPlan) -> &str {
+        match plan {
+            ViewKeyPlan::Whole(key) => key.as_str(),
+            other => panic!("expected a whole-view key, got {other:?}"),
+        }
+    }
+
+    fn per_entity(plan: &ViewKeyPlan) -> Vec<&str> {
+        match plan {
+            ViewKeyPlan::PerEntity { keys, .. } => keys.iter().map(CacheKey::as_str).collect(),
+            other => panic!("expected per-entity keys, got {other:?}"),
+        }
+    }
+
+    fn timeseries(group_limit: Option<ValidatedGroupLimit>) -> ValidatedMetricView {
+        ValidatedMetricView::Timeseries {
+            bucket: Bucket::Day,
+            dimensions: Vec::new(),
+            group_limit,
+        }
+    }
+
+    #[test]
+    fn identical_requests_derive_identical_keys() {
+        let views = vec![ValidatedMetricView::Period, timeseries(None)];
+        let ids = vec![entity(1), entity(2)];
+
+        let left = keys_of(&request(
+            ids.clone(),
+            vec![metric_request(sum_metric(), views.clone())],
+        ));
+        let right = keys_of(&request(ids, vec![metric_request(sum_metric(), views)]));
+
+        assert_eq!(per_entity(&left[0][0]), per_entity(&right[0][0]));
+        assert_eq!(whole(&left[0][1]), whole(&right[0][1]));
+    }
+
+    /// A whole-view hit replays a stored DTO verbatim, and the histogram builder
+    /// emits one value per entity in the order asked for — so a permuted request
+    /// must not be able to collect the earlier request's ordering.
+    #[test]
+    fn entity_order_changes_whole_view_keys() {
+        let forward = keys_of(&request(
+            vec![entity(1), entity(2)],
+            vec![metric_request(
+                sum_metric(),
+                vec![ValidatedMetricView::Histogram],
+            )],
+        ));
+        let reversed = keys_of(&request(
+            vec![entity(2), entity(1)],
+            vec![metric_request(
+                sum_metric(),
+                vec![ValidatedMetricView::Histogram],
+            )],
+        ));
+
+        assert_ne!(whole(&forward[0][0]), whole(&reversed[0][0]));
+    }
+
+    #[test]
+    fn per_entity_keys_ignore_the_rest_of_the_entity_set() {
+        let alone = keys_of(&request(
+            vec![entity(1)],
+            vec![metric_request(
+                sum_metric(),
+                vec![ValidatedMetricView::Period],
+            )],
+        ));
+        let crowded = keys_of(&request(
+            vec![entity(9), entity(1), entity(4)],
+            vec![metric_request(
+                sum_metric(),
+                vec![ValidatedMetricView::Period],
+            )],
+        ));
+
+        assert_eq!(per_entity(&alone[0][0])[0], per_entity(&crowded[0][0])[1]);
+    }
+
+    #[test]
+    fn per_entity_keys_follow_requested_order_and_differ_per_entity() {
+        let keys = keys_of(&request(
+            vec![entity(1), entity(2)],
+            vec![metric_request(
+                sum_metric(),
+                vec![ValidatedMetricView::Period],
+            )],
+        ));
+
+        let keys = per_entity(&keys[0][0]);
+        assert_eq!(keys.len(), 2);
+        assert_ne!(keys[0], keys[1]);
+    }
+
+    #[test]
+    fn filter_value_order_does_not_change_keys() {
+        let filter = |values: Vec<&str>| {
+            vec![ValidatedDimensionFilter {
+                dimension: "tool".to_owned(),
+                values: values.into_iter().map(str::to_owned).collect(),
+            }]
+        };
+        let of = |values: Vec<&str>| {
+            let req = request(
+                vec![entity(1)],
+                vec![filtered_metric_request(
+                    sum_metric(),
+                    filter(values),
+                    vec![timeseries(None)],
+                )],
+            );
+            whole(&keys_of(&req)[0][0]).to_owned()
+        };
+
+        assert_eq!(of(vec!["a", "b"]), of(vec!["b", "a"]));
+    }
+
+    #[test]
+    fn a_different_filter_changes_the_key() {
+        let of = |values: Vec<&str>| {
+            let filters = vec![ValidatedDimensionFilter {
+                dimension: "tool".to_owned(),
+                values: values.into_iter().map(str::to_owned).collect(),
+            }];
+            let req = request(
+                vec![entity(1)],
+                vec![filtered_metric_request(
+                    sum_metric(),
+                    filters,
+                    vec![timeseries(None)],
+                )],
+            );
+            whole(&keys_of(&req)[0][0]).to_owned()
+        };
+
+        assert_ne!(of(vec!["a"]), of(vec!["a", "b"]));
+    }
+
+    #[test]
+    fn request_shape_changes_that_change_results_change_keys() {
+        let baseline = request(
+            vec![entity(1)],
+            vec![metric_request(sum_metric(), vec![timeseries(None)])],
+        );
+        let key = whole(&keys_of(&baseline)[0][0]).to_owned();
+
+        let mut other_tenant = baseline.clone();
+        other_tenant.tenant_id = Uuid::from_u128(0xdead);
+        assert_ne!(key, whole(&keys_of(&other_tenant)[0][0]), "tenant");
+
+        let mut other_period = baseline.clone();
+        other_period.to = super::super::test_support::date("2026-02-28");
+        assert_ne!(key, whole(&keys_of(&other_period)[0][0]), "period");
+
+        let mut unscoped = baseline.clone();
+        unscoped.enforce_tenant_scope = false;
+        assert_ne!(key, whole(&keys_of(&unscoped)[0][0]), "tenant scope");
+
+        let mut other_bucket = baseline.clone();
+        other_bucket.metrics[0].views[0] = ValidatedMetricView::Timeseries {
+            bucket: Bucket::Week,
+            dimensions: Vec::new(),
+            group_limit: None,
+        };
+        assert_ne!(key, whole(&keys_of(&other_bucket)[0][0]), "bucket");
+
+        let mut dimensioned = baseline.clone();
+        dimensioned.metrics[0].views[0] = ValidatedMetricView::Timeseries {
+            bucket: Bucket::Day,
+            dimensions: vec!["tool".to_owned()],
+            group_limit: None,
+        };
+        assert_ne!(key, whole(&keys_of(&dimensioned)[0][0]), "dimensions");
+
+        let mut transformed = baseline.clone();
+        transformed.metrics[0].def.transform = Some(ValueTransform {
+            multiplier: Some(2.0),
+            offset: None,
+            clamp_min: None,
+            clamp_max: None,
+        });
+        assert_ne!(key, whole(&keys_of(&transformed)[0][0]), "transform");
+    }
+
+    #[test]
+    fn a_rebuilt_relation_changes_the_key() {
+        let req = request(
+            vec![entity(1)],
+            vec![metric_request(sum_metric(), vec![timeseries(None)])],
+        );
+        let relations = required_relations(&req.metrics);
+
+        let before = derive_view_keys(&req, &relation_epochs_for_test(&relations, "epoch-1"));
+        let after = derive_view_keys(&req, &relation_epochs_for_test(&relations, "epoch-2"));
+
+        assert_ne!(whole(&before[0][0]), whole(&after[0][0]));
+    }
+
+    #[test]
+    fn a_rebuilt_cohort_relation_changes_peer_keys_only() {
+        let req = request(
+            vec![entity(1)],
+            vec![metric_request(
+                sum_metric(),
+                vec![
+                    ValidatedMetricView::Peer {
+                        cohort_key: "org_unit".to_owned(),
+                    },
+                    timeseries(None),
+                ],
+            )],
+        );
+        let observations = RelationRef {
+            database: "insight",
+            table: "ai_metric_observations".to_owned(),
+        };
+        let cohorts = RelationRef {
+            database: "insight",
+            table: "metric_entity_cohorts_current".to_owned(),
+        };
+
+        let before = derive_view_keys(
+            &req,
+            &RelationEpochs::from_pairs(vec![
+                (observations.clone(), "obs-1".to_owned()),
+                (cohorts.clone(), "cohort-1".to_owned()),
+            ]),
+        );
+        let after = derive_view_keys(
+            &req,
+            &RelationEpochs::from_pairs(vec![
+                (observations, "obs-1".to_owned()),
+                (cohorts, "cohort-2".to_owned()),
+            ]),
+        );
+
+        assert_ne!(per_entity(&before[0][0]), per_entity(&after[0][0]), "peer");
+        assert_eq!(whole(&before[0][1]), whole(&after[0][1]), "timeseries");
+    }
+
+    #[test]
+    fn peer_view_without_a_cohort_epoch_is_uncacheable() {
+        let req = request(
+            vec![entity(1)],
+            vec![metric_request(
+                sum_metric(),
+                vec![ValidatedMetricView::Peer {
+                    cohort_key: "org_unit".to_owned(),
+                }],
+            )],
+        );
+        let observations_only = RelationEpochs::from_pairs(vec![(
+            RelationRef {
+                database: "insight",
+                table: "ai_metric_observations".to_owned(),
+            },
+            "obs-1".to_owned(),
+        )]);
+
+        let keys = derive_view_keys(&req, &observations_only);
+
+        assert!(matches!(keys[0][0], ViewKeyPlan::Uncacheable));
+    }
+
+    #[test]
+    fn custom_observation_sql_is_never_cached() {
+        for def in [custom_sql_metric(), split_source_ratio_metric()] {
+            let req = request(
+                vec![entity(1)],
+                vec![metric_request(
+                    def,
+                    vec![ValidatedMetricView::Period, timeseries(None)],
+                )],
+            );
+
+            let keys = keys_of(&req);
+
+            assert!(matches!(keys[0][0], ViewKeyPlan::Uncacheable));
+            assert!(matches!(keys[0][1], ViewKeyPlan::Uncacheable));
+        }
+    }
+
+    #[test]
+    fn group_limited_timeseries_is_uncacheable() {
+        let req = request(
+            vec![entity(1)],
+            vec![metric_request(
+                sum_metric(),
+                vec![timeseries(Some(ValidatedGroupLimit {
+                    count: 5,
+                    rank_by: Box::new(sum_metric()),
+                    include_remainder: true,
+                }))],
+            )],
+        );
+
+        assert!(matches!(keys_of(&req)[0][0], ViewKeyPlan::Uncacheable));
+    }
+
+    #[test]
+    fn an_oversized_key_set_skips_the_cache_entirely() {
+        let ids: Vec<Uuid> = (0..=MAX_KEYS_PER_REQUEST).map(entity).collect();
+        let req = request(
+            ids,
+            vec![metric_request(
+                sum_metric(),
+                vec![ValidatedMetricView::Period],
+            )],
+        );
+
+        assert!(matches!(keys_of(&req)[0][0], ViewKeyPlan::Uncacheable));
+    }
+
+    /// One slot per tenant: a request stays MGET-able, but metric reads do not
+    /// all pile onto the shard a single global tag would select.
+    #[test]
+    fn keys_are_hash_tagged_per_tenant() {
+        let req = request(
+            vec![entity(1)],
+            vec![metric_request(
+                sum_metric(),
+                vec![ValidatedMetricView::Period, timeseries(None)],
+            )],
+        );
+        let expected = format!("{{{KEY_NAMESPACE}:{TENANT}}}:v{KEY_VERSION}:");
+
+        let keys = keys_of(&req);
+
+        assert!(per_entity(&keys[0][0])[0].starts_with(&expected));
+        assert!(whole(&keys[0][1]).starts_with(&expected));
+
+        let mut other_tenant = req.clone();
+        other_tenant.tenant_id = Uuid::from_u128(0xfeed);
+        assert!(
+            !whole(&keys_of(&other_tenant)[0][1]).starts_with(&expected),
+            "a different tenant must land in a different slot"
+        );
+    }
+}

--- a/src/backend/services/analytics/src/domain/metric_results/cache/key.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/cache/key.rs
@@ -170,8 +170,6 @@ fn view_key_plan(
             per_entity_keys(req, PerEntityKind::Peer, &probe, &epochs)
         }
 
-        // The compiled SQL embeds the resolved top-N groups, which are only
-        // known after the ranking query has run over the whole entity set.
         ValidatedMetricView::Timeseries {
             group_limit: Some(_),
             ..

--- a/src/backend/services/analytics/src/domain/metric_results/cache/mod.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/cache/mod.rs
@@ -1,0 +1,11 @@
+mod epoch;
+mod fragment;
+mod key;
+mod plan;
+
+#[cfg(test)]
+pub(crate) mod test_support;
+
+pub use epoch::{relation_epochs, required_relations};
+pub use key::{derive_view_keys, uncacheable_keys};
+pub use plan::{CacheOutcome, CachePlan, ViewOutcome, flat_keys};

--- a/src/backend/services/analytics/src/domain/metric_results/cache/plan.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/cache/plan.rs
@@ -1,0 +1,1291 @@
+use std::collections::{BTreeSet, HashMap};
+
+use toolkit_canonical_errors::CanonicalError;
+
+use super::super::builder::{build_peer_view, build_period_view};
+use super::super::compiler::{PeerQueryRow, PeriodQueryRow};
+use super::super::dto::MetricResultViewDto;
+use super::super::validation::{
+    ValidatedEntitySelection, ValidatedMetricRequest, ValidatedMetricResultsRequest,
+    ValidatedMetricView,
+};
+use super::fragment::{self, PeerFragment, PeriodFragment};
+use super::key::{CacheKey, PerEntityKind, ViewKeyPlan};
+
+/// Which narrowed request a result came back from. The two carry different
+/// entity sets, so a result cannot be remapped without knowing its origin.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Origin {
+    /// Views needing every requested entity: whole-view misses and everything
+    /// uncacheable.
+    FullSet,
+    /// Per-entity views, over the union of the entities they are missing.
+    Subset,
+}
+
+/// What the executor produced for one requested view. Period and peer arrive as
+/// rows because cached fragments contribute rows to the very same view.
+#[derive(Debug)]
+pub enum ViewOutcome {
+    View(MetricResultViewDto),
+    PeriodRows(Vec<PeriodQueryRow>),
+    PeerRows(Vec<PeerQueryRow>),
+}
+
+#[derive(Debug)]
+enum Slot {
+    Pending,
+    Done {
+        view: MetricResultViewDto,
+        fresh: bool,
+    },
+    Period {
+        cached: Vec<PeriodQueryRow>,
+        fresh: Vec<PeriodQueryRow>,
+        absent: BTreeSet<String>,
+    },
+    Peer {
+        cached: Vec<PeerQueryRow>,
+        fresh: Vec<PeerQueryRow>,
+        absent: BTreeSet<String>,
+    },
+}
+
+#[derive(Debug)]
+pub struct NarrowedRequest {
+    pub req: ValidatedMetricResultsRequest,
+    origins: Vec<Vec<(usize, usize)>>,
+}
+
+impl NarrowedRequest {
+    fn origin(&self, metric_index: usize, view_index: usize) -> Option<(usize, usize)> {
+        self.origins
+            .get(metric_index)
+            .and_then(|views| views.get(view_index))
+            .copied()
+    }
+}
+
+#[derive(Debug)]
+pub struct CacheOutcome {
+    pub views: Vec<Vec<Option<MetricResultViewDto>>>,
+    pub writes: Vec<(String, Vec<u8>)>,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CacheStats {
+    pub hits: usize,
+    pub misses: usize,
+    pub uncacheable: usize,
+}
+
+#[derive(Debug)]
+pub struct CachePlan {
+    slots: Vec<Vec<Slot>>,
+    keys: Vec<Vec<ViewKeyPlan>>,
+    entity_ids: Vec<String>,
+    full_set: Option<NarrowedRequest>,
+    subset: Option<NarrowedRequest>,
+    stats: CacheStats,
+}
+
+impl CachePlan {
+    /// Splits the request into what the cache already answered and what still
+    /// has to run. `cached` holds one entry per key in `keys`, in the order
+    /// [`flat_keys`] produces.
+    pub fn build(
+        req: &ValidatedMetricResultsRequest,
+        keys: Vec<Vec<ViewKeyPlan>>,
+        cached: &[Option<Vec<u8>>],
+    ) -> Self {
+        let entity_ids = req.entity.entity_ids();
+        let mut reader = CachedReader::new(cached);
+        let mut stats = CacheStats::default();
+
+        let mut slots: Vec<Vec<Slot>> = Vec::with_capacity(req.metrics.len());
+        let mut full_set_views: Vec<Vec<usize>> = Vec::with_capacity(req.metrics.len());
+        let mut subset_views: Vec<Vec<usize>> = Vec::with_capacity(req.metrics.len());
+        let mut subset_ids: BTreeSet<String> = BTreeSet::new();
+
+        for (metric_index, metric) in req.metrics.iter().enumerate() {
+            let mut metric_slots = Vec::with_capacity(metric.views.len());
+            let mut full_set = Vec::new();
+            let mut subset = Vec::new();
+
+            for (view_index, view) in metric.views.iter().enumerate() {
+                let plan = &keys[metric_index][view_index];
+                let read = read_slot(view, plan, &entity_ids, &mut reader, &mut stats);
+
+                match &read.slot {
+                    Slot::Done { .. } => {}
+                    Slot::Pending => full_set.push(view_index),
+                    Slot::Period { .. } | Slot::Peer { .. } => {
+                        if !read.absent.is_empty() {
+                            subset.push(view_index);
+                            subset_ids.extend(read.absent);
+                        }
+                    }
+                }
+
+                metric_slots.push(read.slot);
+            }
+
+            slots.push(metric_slots);
+            full_set_views.push(full_set);
+            subset_views.push(subset);
+        }
+
+        let full_set = narrow(req, &full_set_views, None);
+        let subset = narrow(req, &subset_views, Some(&subset_ids));
+
+        Self {
+            slots,
+            keys,
+            entity_ids,
+            full_set,
+            subset,
+            stats,
+        }
+    }
+
+    pub fn stats(&self) -> CacheStats {
+        self.stats
+    }
+
+    pub fn narrowed(&self) -> Vec<(Origin, &NarrowedRequest)> {
+        [
+            (Origin::FullSet, self.full_set.as_ref()),
+            (Origin::Subset, self.subset.as_ref()),
+        ]
+        .into_iter()
+        .filter_map(|(origin, narrowed)| narrowed.map(|narrowed| (origin, narrowed)))
+        .collect()
+    }
+
+    /// A result that cannot be routed is a broken internal invariant, not a
+    /// missing value: dropping it would cache an absence no query measured.
+    pub fn record(
+        &mut self,
+        origin: Origin,
+        metric_index: usize,
+        view_index: usize,
+        outcome: ViewOutcome,
+    ) -> Result<(), CanonicalError> {
+        let narrowed = match origin {
+            Origin::FullSet => self.full_set.as_ref(),
+            Origin::Subset => self.subset.as_ref(),
+        };
+        let Some((metric_index, view_index)) =
+            narrowed.and_then(|narrowed| narrowed.origin(metric_index, view_index))
+        else {
+            tracing::error!(?origin, "metric-results cache result has no requested view");
+            return Err(unroutable());
+        };
+        let Some(slot) = self
+            .slots
+            .get_mut(metric_index)
+            .and_then(|views| views.get_mut(view_index))
+        else {
+            tracing::error!(
+                metric_index,
+                view_index,
+                "metric-results cache slot missing"
+            );
+            return Err(unroutable());
+        };
+
+        match (&mut *slot, outcome) {
+            (Slot::Pending, ViewOutcome::View(view)) => {
+                *slot = Slot::Done { view, fresh: true };
+                Ok(())
+            }
+            (Slot::Period { fresh, .. }, ViewOutcome::PeriodRows(rows)) => {
+                *fresh = rows;
+                Ok(())
+            }
+            (Slot::Peer { fresh, .. }, ViewOutcome::PeerRows(rows)) => {
+                *fresh = rows;
+                Ok(())
+            }
+            (slot, outcome) => {
+                tracing::error!(
+                    ?slot,
+                    ?outcome,
+                    "metric-results cache slot does not match the executed view"
+                );
+                Err(unroutable())
+            }
+        }
+    }
+
+    /// Assembles every view through the builders the uncached path uses, so a
+    /// partially cached response is identical to a fully computed one.
+    pub fn finish(
+        self,
+        req: &ValidatedMetricResultsRequest,
+    ) -> Result<CacheOutcome, CanonicalError> {
+        let Self {
+            slots,
+            keys,
+            entity_ids,
+            ..
+        } = self;
+
+        let mut writes = Vec::new();
+        let mut views = Vec::with_capacity(slots.len());
+
+        for (metric_index, metric_slots) in slots.into_iter().enumerate() {
+            let mut metric_views = Vec::with_capacity(metric_slots.len());
+
+            for (view_index, slot) in metric_slots.into_iter().enumerate() {
+                let view_keys = &keys[metric_index][view_index];
+                let view = match slot {
+                    Slot::Pending => {
+                        return Err(CanonicalError::internal("missing metric view result").create());
+                    }
+
+                    Slot::Done { view, fresh } => {
+                        if let (true, ViewKeyPlan::Whole(key)) = (fresh, view_keys) {
+                            push_write(&mut writes, key, &view);
+                        }
+                        view
+                    }
+
+                    Slot::Period {
+                        cached,
+                        fresh,
+                        absent,
+                    } => {
+                        let rows = merge_rows(cached, fresh, &absent);
+                        push_entity_writes(
+                            &mut writes,
+                            view_keys,
+                            &entity_ids,
+                            &absent,
+                            &rows,
+                            PeriodFragment::from_row,
+                        );
+                        build_period_view(req, rows)
+                    }
+
+                    Slot::Peer {
+                        cached,
+                        fresh,
+                        absent,
+                    } => {
+                        let rows = merge_rows(cached, fresh, &absent);
+                        push_entity_writes(
+                            &mut writes,
+                            view_keys,
+                            &entity_ids,
+                            &absent,
+                            &rows,
+                            PeerFragment::from_row,
+                        );
+                        build_peer_view(req, rows)
+                    }
+                };
+
+                metric_views.push(Some(view));
+            }
+
+            views.push(metric_views);
+        }
+
+        Ok(CacheOutcome { views, writes })
+    }
+}
+
+/// Only entities this view actually recomputed are written back. The rest came
+/// out of the cache, so rewriting them would extend their TTL for free — and for
+/// an entity the view never queried it would store an absence nothing measured.
+fn push_entity_writes<Row: EntityRow, Frag: serde::Serialize>(
+    writes: &mut Vec<(String, Vec<u8>)>,
+    keys: &ViewKeyPlan,
+    entity_ids: &[String],
+    absent: &BTreeSet<String>,
+    rows: &[Row],
+    fragment_of: impl Fn(Option<&Row>) -> Frag,
+) {
+    let ViewKeyPlan::PerEntity { keys, .. } = keys else {
+        return;
+    };
+    if absent.is_empty() {
+        return;
+    }
+
+    let by_entity: HashMap<&str, &Row> = rows.iter().map(|row| (row.entity_id(), row)).collect();
+    for (entity_id, key) in entity_ids.iter().zip(keys) {
+        if !absent.contains(entity_id) {
+            continue;
+        }
+        let row = by_entity.get(entity_id.as_str()).copied();
+        if let Some(bytes) = fragment::encode(&fragment_of(row)) {
+            writes.push((key.as_str().to_owned(), bytes));
+        }
+    }
+}
+
+fn unroutable() -> CanonicalError {
+    CanonicalError::internal("metric view result could not be assembled").create()
+}
+
+/// Flattens the key grid in the order [`CachePlan::build`] consumes it.
+pub fn flat_keys(keys: &[Vec<ViewKeyPlan>]) -> Vec<String> {
+    keys.iter()
+        .flatten()
+        .flat_map(|plan| match plan {
+            ViewKeyPlan::Uncacheable => Vec::new(),
+            ViewKeyPlan::Whole(key) => vec![key.as_str().to_owned()],
+            ViewKeyPlan::PerEntity { keys, .. } => {
+                keys.iter().map(|key| key.as_str().to_owned()).collect()
+            }
+        })
+        .collect()
+}
+
+trait EntityRow {
+    fn entity_id(&self) -> &str;
+}
+
+impl EntityRow for PeriodQueryRow {
+    fn entity_id(&self) -> &str {
+        &self.entity_id
+    }
+}
+
+impl EntityRow for PeerQueryRow {
+    fn entity_id(&self) -> &str {
+        &self.entity_id
+    }
+}
+
+struct CachedReader<'a> {
+    cached: &'a [Option<Vec<u8>>],
+    next: usize,
+}
+
+impl<'a> CachedReader<'a> {
+    fn new(cached: &'a [Option<Vec<u8>>]) -> Self {
+        Self { cached, next: 0 }
+    }
+
+    fn take(&mut self) -> Option<&'a [u8]> {
+        let entry = self.cached.get(self.next)?;
+        self.next += 1;
+        entry.as_deref()
+    }
+}
+
+struct SlotRead {
+    slot: Slot,
+    absent: BTreeSet<String>,
+}
+
+/// INVARIANT: consumes exactly as many cached entries as `flat_keys` emitted for
+/// this plan — a short read here would hand the next view someone else's bytes.
+fn read_slot(
+    view: &ValidatedMetricView,
+    plan: &ViewKeyPlan,
+    entity_ids: &[String],
+    reader: &mut CachedReader<'_>,
+    stats: &mut CacheStats,
+) -> SlotRead {
+    match plan {
+        ViewKeyPlan::Uncacheable => {
+            stats.uncacheable += 1;
+            let absent: BTreeSet<String> = match view {
+                ValidatedMetricView::Period | ValidatedMetricView::Peer { .. } => {
+                    entity_ids.iter().cloned().collect()
+                }
+                ValidatedMetricView::Timeseries { .. }
+                | ValidatedMetricView::Breakdown { .. }
+                | ValidatedMetricView::Histogram => BTreeSet::new(),
+            };
+            SlotRead {
+                slot: empty_slot(view, absent.clone()),
+                absent,
+            }
+        }
+
+        ViewKeyPlan::Whole(_) => {
+            let cached = reader.take().and_then(fragment::decode);
+            let slot = if let Some(view) = cached {
+                stats.hits += 1;
+                Slot::Done { view, fresh: false }
+            } else {
+                stats.misses += 1;
+                Slot::Pending
+            };
+
+            SlotRead {
+                slot,
+                absent: BTreeSet::new(),
+            }
+        }
+
+        ViewKeyPlan::PerEntity { kind, keys } => {
+            let mut absent = BTreeSet::new();
+            let mut period = Vec::new();
+            let mut peer = Vec::new();
+
+            for index in 0..keys.len() {
+                let bytes = reader.take();
+                let Some(entity_id) = entity_ids.get(index) else {
+                    continue;
+                };
+
+                match kind {
+                    PerEntityKind::Period => {
+                        if let Some(found) = bytes.and_then(fragment::decode::<PeriodFragment>) {
+                            stats.hits += 1;
+                            period.push(found.into_row(entity_id.clone()));
+                        } else {
+                            stats.misses += 1;
+                            absent.insert(entity_id.clone());
+                        }
+                    }
+
+                    PerEntityKind::Peer => {
+                        if let Some(found) = bytes.and_then(fragment::decode::<PeerFragment>) {
+                            stats.hits += 1;
+                            peer.extend(found.into_row(entity_id.clone()));
+                        } else {
+                            stats.misses += 1;
+                            absent.insert(entity_id.clone());
+                        }
+                    }
+                }
+            }
+
+            let slot = match kind {
+                PerEntityKind::Period => Slot::Period {
+                    cached: period,
+                    fresh: Vec::new(),
+                    absent: absent.clone(),
+                },
+                PerEntityKind::Peer => Slot::Peer {
+                    cached: peer,
+                    fresh: Vec::new(),
+                    absent: absent.clone(),
+                },
+            };
+
+            SlotRead { slot, absent }
+        }
+    }
+}
+
+fn empty_slot(view: &ValidatedMetricView, absent: BTreeSet<String>) -> Slot {
+    match view {
+        ValidatedMetricView::Period => Slot::Period {
+            cached: Vec::new(),
+            fresh: Vec::new(),
+            absent,
+        },
+        ValidatedMetricView::Peer { .. } => Slot::Peer {
+            cached: Vec::new(),
+            fresh: Vec::new(),
+            absent,
+        },
+        ValidatedMetricView::Timeseries { .. }
+        | ValidatedMetricView::Breakdown { .. }
+        | ValidatedMetricView::Histogram => Slot::Pending,
+    }
+}
+
+/// Each side contributes exactly the entities it owns: cached rows for the
+/// entities this view had, fresh rows for the ones it was missing. The subset
+/// query covers the union across views, so a fresh row for an entity this view
+/// already had is another view's work and is dropped rather than churning a TTL.
+fn merge_rows<Row: EntityRow>(
+    cached: Vec<Row>,
+    fresh: Vec<Row>,
+    absent: &BTreeSet<String>,
+) -> Vec<Row> {
+    let mut rows: Vec<Row> = cached
+        .into_iter()
+        .filter(|row| !absent.contains(row.entity_id()))
+        .collect();
+    rows.extend(
+        fresh
+            .into_iter()
+            .filter(|row| absent.contains(row.entity_id())),
+    );
+    rows
+}
+
+fn narrow(
+    req: &ValidatedMetricResultsRequest,
+    wanted: &[Vec<usize>],
+    entity_ids: Option<&BTreeSet<String>>,
+) -> Option<NarrowedRequest> {
+    let entity = match entity_ids {
+        None => req.entity.clone(),
+        Some(wanted) => {
+            let entity = retain_entities(&req.entity, wanted);
+            if entity.len() == 0 {
+                return None;
+            }
+            entity
+        }
+    };
+
+    let mut metrics = Vec::new();
+    let mut origins = Vec::new();
+    for (metric_index, view_indexes) in wanted.iter().enumerate() {
+        if view_indexes.is_empty() {
+            continue;
+        }
+
+        let metric = &req.metrics[metric_index];
+        metrics.push(ValidatedMetricRequest {
+            def: metric.def.clone(),
+            filters: metric.filters.clone(),
+            views: view_indexes
+                .iter()
+                .map(|view_index| metric.views[*view_index].clone())
+                .collect(),
+        });
+        origins.push(
+            view_indexes
+                .iter()
+                .map(|view_index| (metric_index, *view_index))
+                .collect(),
+        );
+    }
+
+    if metrics.is_empty() {
+        return None;
+    }
+
+    Some(NarrowedRequest {
+        req: ValidatedMetricResultsRequest {
+            tenant_id: req.tenant_id,
+            entity,
+            from: req.from,
+            to: req.to,
+            metrics,
+            enforce_tenant_scope: req.enforce_tenant_scope,
+        },
+        origins,
+    })
+}
+
+fn retain_entities(
+    entity: &ValidatedEntitySelection,
+    wanted: &BTreeSet<String>,
+) -> ValidatedEntitySelection {
+    match entity {
+        ValidatedEntitySelection::Person { ids } => ValidatedEntitySelection::Person {
+            ids: ids
+                .iter()
+                .filter(|id| wanted.contains(&id.to_string()))
+                .copied()
+                .collect(),
+        },
+    }
+}
+
+fn push_write(writes: &mut Vec<(String, Vec<u8>)>, key: &CacheKey, view: &MetricResultViewDto) {
+    if let Some(bytes) = fragment::encode_readable(view) {
+        writes.push((key.as_str().to_owned(), bytes));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::super::epoch::{relation_epochs_for_test, required_relations};
+    use super::super::key::{derive_view_keys, uncacheable_keys};
+    use super::super::test_support::{
+        custom_sql_metric, entity, metric_request, request, sum_metric,
+    };
+    use super::*;
+    use crate::domain::metric_results::batch::{PlannedQuery, plan_queries};
+    use crate::domain::metric_results::builder::build_histogram_view;
+    use crate::domain::metric_results::dto::{PeerValueDto, PeriodValueDto};
+    use crate::domain::metric_results::view::Bucket;
+
+    fn keys(req: &ValidatedMetricResultsRequest) -> Vec<Vec<ViewKeyPlan>> {
+        let epochs = relation_epochs_for_test(&required_relations(&req.metrics), "epoch-1");
+        derive_view_keys(req, &epochs)
+    }
+
+    fn period_row(entity_id: &str, value: Option<f64>) -> PeriodQueryRow {
+        PeriodQueryRow {
+            entity_id: entity_id.to_owned(),
+            value,
+        }
+    }
+
+    fn peer_row(entity_id: &str, target: f64) -> PeerQueryRow {
+        PeerQueryRow {
+            entity_id: entity_id.to_owned(),
+            target_value: Some(target),
+            p25: None,
+            median: None,
+            p75: None,
+            min: None,
+            max: None,
+            n: Some(3),
+        }
+    }
+
+    fn record(
+        plan: &mut CachePlan,
+        origin: Origin,
+        metric_index: usize,
+        view_index: usize,
+        outcome: ViewOutcome,
+    ) {
+        plan.record(origin, metric_index, view_index, outcome)
+            .unwrap_or_else(|error| panic!("result must route: {error}"));
+    }
+
+    fn view_at(outcome: &CacheOutcome, metric: usize, view: usize) -> &MetricResultViewDto {
+        match outcome.views[metric][view].as_ref() {
+            Some(view) => view,
+            None => panic!("view [{metric}][{view}] was never filled"),
+        }
+    }
+
+    fn period_values(view: &MetricResultViewDto) -> &[PeriodValueDto] {
+        match view {
+            MetricResultViewDto::Period { values } => values,
+            other => panic!("expected a period view, got {other:?}"),
+        }
+    }
+
+    fn peer_values(view: &MetricResultViewDto) -> &[PeerValueDto] {
+        match view {
+            MetricResultViewDto::Peer { values } => values,
+            other => panic!("expected a peer view, got {other:?}"),
+        }
+    }
+
+    fn cached_period(value: Option<f64>) -> Option<Vec<u8>> {
+        fragment::encode(&PeriodFragment::from_row(Some(&period_row("x", value))))
+    }
+
+    /// Every requested entity is queried and nothing is written back when no key
+    /// could be derived — the shape the disabled cache produces.
+    #[test]
+    fn an_uncacheable_request_queries_everything_and_writes_nothing() {
+        let req = request(
+            vec![entity(1), entity(2)],
+            vec![metric_request(
+                sum_metric(),
+                vec![ValidatedMetricView::Period, ValidatedMetricView::Histogram],
+            )],
+        );
+        let mut plan = CachePlan::build(&req, uncacheable_keys(&req), &[]);
+
+        let entity_counts: Vec<(Origin, usize)> = plan
+            .narrowed()
+            .iter()
+            .map(|(origin, narrowed)| (*origin, narrowed.req.entity.len()))
+            .collect();
+        assert_eq!(
+            entity_counts,
+            vec![(Origin::FullSet, 2), (Origin::Subset, 2)],
+            "both narrowed requests keep every requested entity"
+        );
+
+        record(
+            &mut plan,
+            Origin::Subset,
+            0,
+            0,
+            ViewOutcome::PeriodRows(vec![period_row(&entity(1).to_string(), Some(4.0))]),
+        );
+        record(
+            &mut plan,
+            Origin::FullSet,
+            0,
+            0,
+            ViewOutcome::View(MetricResultViewDto::Histogram { values: Vec::new() }),
+        );
+
+        let outcome = plan
+            .finish(&req)
+            .unwrap_or_else(|error| panic!("plan must finish: {error}"));
+
+        assert!(outcome.writes.is_empty(), "nothing is cacheable");
+        assert_eq!(period_values(view_at(&outcome, 0, 0)).len(), 2);
+    }
+
+    #[test]
+    fn a_fully_cached_request_runs_no_query() {
+        let req = request(
+            vec![entity(1), entity(2)],
+            vec![metric_request(
+                sum_metric(),
+                vec![ValidatedMetricView::Period],
+            )],
+        );
+        let cached = vec![cached_period(Some(1.0)), cached_period(Some(2.0))];
+
+        let plan = CachePlan::build(&req, keys(&req), &cached);
+
+        assert!(plan.narrowed().is_empty());
+        assert_eq!(plan.stats().hits, 2);
+        assert_eq!(plan.stats().misses, 0);
+
+        let outcome = plan
+            .finish(&req)
+            .unwrap_or_else(|error| panic!("plan must finish: {error}"));
+
+        let values = period_values(view_at(&outcome, 0, 0));
+        assert_eq!(values[0].value, Some(1.0));
+        assert_eq!(values[1].value, Some(2.0));
+        assert!(outcome.writes.is_empty(), "a hit must not refresh its TTL");
+    }
+
+    #[test]
+    fn a_partial_hit_queries_only_the_missing_entities() {
+        let req = request(
+            vec![entity(1), entity(2), entity(3)],
+            vec![metric_request(
+                sum_metric(),
+                vec![ValidatedMetricView::Period],
+            )],
+        );
+        let cached = vec![cached_period(Some(1.0)), None, cached_period(Some(3.0))];
+
+        let mut plan = CachePlan::build(&req, keys(&req), &cached);
+
+        let narrowed = plan.narrowed();
+        assert_eq!(narrowed.len(), 1);
+        let (origin, subset) = narrowed[0];
+        assert_eq!(origin, Origin::Subset);
+        assert_eq!(subset.req.entity.entity_ids(), vec![entity(2).to_string()]);
+
+        record(
+            &mut plan,
+            Origin::Subset,
+            0,
+            0,
+            ViewOutcome::PeriodRows(vec![period_row(&entity(2).to_string(), Some(2.0))]),
+        );
+
+        let outcome = plan
+            .finish(&req)
+            .unwrap_or_else(|error| panic!("plan must finish: {error}"));
+
+        let values = period_values(view_at(&outcome, 0, 0));
+        assert_eq!(
+            values.iter().map(|value| value.value).collect::<Vec<_>>(),
+            vec![Some(1.0), Some(2.0), Some(3.0)],
+            "cached and fresh values merge in requested order"
+        );
+        assert_eq!(
+            outcome.writes.len(),
+            1,
+            "only the recomputed entity is stored"
+        );
+    }
+
+    /// An entity the subset query returned no row for is stored as a known-absent
+    /// value, so the next request does not re-query it.
+    #[test]
+    fn an_entity_with_no_observations_is_cached_as_unknown() {
+        let req = request(
+            vec![entity(1)],
+            vec![metric_request(
+                sum_metric(),
+                vec![ValidatedMetricView::Period],
+            )],
+        );
+        let mut plan = CachePlan::build(&req, keys(&req), &[None]);
+
+        record(
+            &mut plan,
+            Origin::Subset,
+            0,
+            0,
+            ViewOutcome::PeriodRows(Vec::new()),
+        );
+
+        let outcome = plan
+            .finish(&req)
+            .unwrap_or_else(|error| panic!("plan must finish: {error}"));
+
+        assert_eq!(period_values(view_at(&outcome, 0, 0))[0].value, None);
+        assert_eq!(outcome.writes.len(), 1);
+    }
+
+    #[test]
+    fn a_cached_peer_entity_without_a_pool_stays_omitted() {
+        let req = request(
+            vec![entity(1), entity(2)],
+            vec![metric_request(
+                sum_metric(),
+                vec![ValidatedMetricView::Peer {
+                    cohort_key: "org_unit".to_owned(),
+                }],
+            )],
+        );
+        let absent = fragment::encode(&PeerFragment::from_row(None));
+        let present = fragment::encode(&PeerFragment::from_row(Some(&peer_row("x", 9.0))));
+        let cached = vec![absent, present];
+
+        let plan = CachePlan::build(&req, keys(&req), &cached);
+
+        assert!(plan.narrowed().is_empty());
+
+        let outcome = plan
+            .finish(&req)
+            .unwrap_or_else(|error| panic!("plan must finish: {error}"));
+
+        let values = peer_values(view_at(&outcome, 0, 0));
+        assert_eq!(values.len(), 1, "the entity with no pool stays omitted");
+        assert_eq!(values[0].entity_id, entity(2).to_string());
+        assert_eq!(values[0].target_value, Some(9.0));
+    }
+
+    /// The subset query covers the union across views, so each view takes fresh
+    /// rows only for the entities it was itself missing and keeps the rest.
+    #[test]
+    fn each_view_takes_fresh_rows_only_for_the_entities_it_was_missing() {
+        let req = request(
+            vec![entity(1), entity(2)],
+            vec![metric_request(
+                sum_metric(),
+                vec![ValidatedMetricView::Period, ValidatedMetricView::Period],
+            )],
+        );
+        // View 0 misses entity 1, view 1 misses entity 2, so the subset covers
+        // both entities and each view sees fresh rows for both.
+        let cached = vec![
+            None,
+            cached_period(Some(20.0)),
+            cached_period(Some(1.0)),
+            None,
+        ];
+
+        let mut plan = CachePlan::build(&req, keys(&req), &cached);
+
+        let fresh = || {
+            vec![
+                period_row(&entity(1).to_string(), Some(99.0)),
+                period_row(&entity(2).to_string(), Some(88.0)),
+            ]
+        };
+        record(
+            &mut plan,
+            Origin::Subset,
+            0,
+            0,
+            ViewOutcome::PeriodRows(fresh()),
+        );
+        record(
+            &mut plan,
+            Origin::Subset,
+            0,
+            1,
+            ViewOutcome::PeriodRows(fresh()),
+        );
+
+        let outcome = plan
+            .finish(&req)
+            .unwrap_or_else(|error| panic!("plan must finish: {error}"));
+
+        assert_eq!(
+            period_values(view_at(&outcome, 0, 0))
+                .iter()
+                .map(|value| value.value)
+                .collect::<Vec<_>>(),
+            vec![Some(99.0), Some(20.0)],
+            "view 0 takes fresh entity 1 and keeps its cached entity 2"
+        );
+        assert_eq!(
+            period_values(view_at(&outcome, 0, 1))
+                .iter()
+                .map(|value| value.value)
+                .collect::<Vec<_>>(),
+            vec![Some(1.0), Some(88.0)],
+            "view 1 keeps its cached entity 1 and takes fresh entity 2"
+        );
+        assert_eq!(
+            outcome.writes.len(),
+            2,
+            "each view writes back only the entity it was missing"
+        );
+    }
+
+    /// The subset is a union across views, so a view that never ran must keep
+    /// the rows it had for entities another view happened to be missing.
+    #[test]
+    fn a_view_that_did_not_run_keeps_its_cached_rows() {
+        let req = request(
+            vec![entity(1), entity(2)],
+            vec![metric_request(
+                sum_metric(),
+                vec![ValidatedMetricView::Period, ValidatedMetricView::Period],
+            )],
+        );
+        // View 0 is fully cached; view 1 misses entity 1 and drives the subset.
+        let cached = vec![
+            cached_period(Some(1.0)),
+            cached_period(Some(2.0)),
+            None,
+            cached_period(Some(20.0)),
+        ];
+
+        let mut plan = CachePlan::build(&req, keys(&req), &cached);
+
+        record(
+            &mut plan,
+            Origin::Subset,
+            0,
+            0,
+            ViewOutcome::PeriodRows(vec![period_row(&entity(1).to_string(), Some(99.0))]),
+        );
+
+        let outcome = plan
+            .finish(&req)
+            .unwrap_or_else(|error| panic!("plan must finish: {error}"));
+
+        let untouched = period_values(view_at(&outcome, 0, 0));
+        assert_eq!(
+            untouched
+                .iter()
+                .map(|value| value.value)
+                .collect::<Vec<_>>(),
+            vec![Some(1.0), Some(2.0)],
+            "a view outside the subset keeps every cached row"
+        );
+        assert!(
+            outcome.writes.len() == 1,
+            "only the view that ran writes back"
+        );
+    }
+
+    /// The narrowed requests carry their own metric and view indexes; every
+    /// result has to land back on the coordinates the caller asked about.
+    #[test]
+    fn planned_queries_remap_onto_the_requested_coordinates() {
+        let req = request(
+            vec![entity(1)],
+            vec![
+                metric_request(
+                    sum_metric(),
+                    vec![ValidatedMetricView::Histogram, ValidatedMetricView::Period],
+                ),
+                metric_request(
+                    sum_metric(),
+                    vec![ValidatedMetricView::Timeseries {
+                        bucket: Bucket::Day,
+                        dimensions: Vec::new(),
+                        group_limit: None,
+                    }],
+                ),
+            ],
+        );
+        let mut plan = CachePlan::build(&req, uncacheable_keys(&req), &[]);
+
+        let mut recorded = Vec::new();
+        for (origin, narrowed) in plan.narrowed() {
+            let planned = plan_queries(&narrowed.req, &BTreeMap::new())
+                .unwrap_or_else(|error| panic!("planning must succeed: {error}"));
+            for query in planned {
+                match query {
+                    PlannedQuery::PeriodBatch { items, .. }
+                    | PlannedQuery::PeerBatch { items, .. } => {
+                        for item in items {
+                            recorded.push((origin, item.metric_index, item.view_index));
+                        }
+                    }
+                    PlannedQuery::Single {
+                        metric_index,
+                        view_index,
+                        ..
+                    } => recorded.push((origin, metric_index, view_index)),
+                }
+            }
+        }
+
+        for (origin, metric_index, view_index) in recorded {
+            let outcome = match origin {
+                Origin::Subset => ViewOutcome::PeriodRows(Vec::new()),
+                Origin::FullSet => {
+                    ViewOutcome::View(MetricResultViewDto::Histogram { values: Vec::new() })
+                }
+            };
+            record(&mut plan, origin, metric_index, view_index, outcome);
+        }
+
+        let outcome = plan
+            .finish(&req)
+            .unwrap_or_else(|error| panic!("every requested view must be filled: {error}"));
+
+        assert_eq!(outcome.views.len(), 2);
+        assert_eq!(outcome.views[0].len(), 2);
+        assert_eq!(outcome.views[1].len(), 1);
+        assert!(outcome.views.iter().flatten().all(Option::is_some));
+    }
+
+    /// The whole point of assembling through the builders: whether a value came
+    /// from ClickHouse or from Redis must not be visible on the wire.
+    #[test]
+    fn a_cached_response_is_byte_identical_to_a_computed_one() {
+        let req = request(
+            vec![entity(1), entity(2), entity(3)],
+            vec![metric_request(
+                sum_metric(),
+                vec![
+                    ValidatedMetricView::Period,
+                    ValidatedMetricView::Peer {
+                        cohort_key: "org_unit".to_owned(),
+                    },
+                ],
+            )],
+        );
+        // Entity 2 has no observations and no cohort row.
+        let period_rows = || {
+            vec![
+                period_row(&entity(1).to_string(), Some(1.0)),
+                period_row(&entity(3).to_string(), None),
+            ]
+        };
+        let peer_rows = || {
+            vec![
+                peer_row(&entity(3).to_string(), 30.0),
+                peer_row(&entity(1).to_string(), 10.0),
+            ]
+        };
+
+        let mut computed =
+            CachePlan::build(&req, keys(&req), &[None, None, None, None, None, None]);
+        record(
+            &mut computed,
+            Origin::Subset,
+            0,
+            0,
+            ViewOutcome::PeriodRows(period_rows()),
+        );
+        record(
+            &mut computed,
+            Origin::Subset,
+            0,
+            1,
+            ViewOutcome::PeerRows(peer_rows()),
+        );
+        let computed = computed
+            .finish(&req)
+            .unwrap_or_else(|error| panic!("plan must finish: {error}"));
+
+        // Replay the writes the computed pass produced as the next request's hits.
+        let by_key: BTreeMap<&str, &Vec<u8>> = computed
+            .writes
+            .iter()
+            .map(|(key, bytes)| (key.as_str(), bytes))
+            .collect();
+        let replayed: Vec<Option<Vec<u8>>> = flat_keys(&keys(&req))
+            .iter()
+            .map(|key| by_key.get(key.as_str()).map(|bytes| (*bytes).clone()))
+            .collect();
+        assert!(
+            replayed.iter().all(Option::is_some),
+            "every entity of a fully computed pass must be written back"
+        );
+
+        let cached = CachePlan::build(&req, keys(&req), &replayed);
+        assert!(cached.narrowed().is_empty(), "nothing left to query");
+        let cached = cached
+            .finish(&req)
+            .unwrap_or_else(|error| panic!("plan must finish: {error}"));
+
+        for (index, (left, right)) in computed.views[0].iter().zip(&cached.views[0]).enumerate() {
+            let left = serde_json::to_value(left).unwrap_or_else(|error| panic!("{error}"));
+            let right = serde_json::to_value(right).unwrap_or_else(|error| panic!("{error}"));
+            assert_eq!(left, right, "view {index} must render identically");
+        }
+    }
+
+    /// A whole-view hit replays a stored DTO verbatim, so a request that asks
+    /// for the same entities in another order must not collect the first
+    /// request's ordering.
+    #[test]
+    fn a_permuted_request_does_not_inherit_a_cached_entity_order() {
+        let histogram = || {
+            vec![metric_request(
+                sum_metric(),
+                vec![ValidatedMetricView::Histogram],
+            )]
+        };
+        let forward = request(vec![entity(1), entity(2)], histogram());
+        let reversed = request(vec![entity(2), entity(1)], histogram());
+
+        let mut computed = CachePlan::build(&forward, keys(&forward), &[None]);
+        record(
+            &mut computed,
+            Origin::FullSet,
+            0,
+            0,
+            ViewOutcome::View(build_histogram_view(&forward, Vec::new())),
+        );
+        let computed = computed
+            .finish(&forward)
+            .unwrap_or_else(|error| panic!("plan must finish: {error}"));
+        assert_eq!(computed.writes.len(), 1, "the computed view is stored");
+
+        // Offer that stored view to the permuted request under its own keys.
+        let stored: Vec<Option<Vec<u8>>> = flat_keys(&keys(&reversed))
+            .iter()
+            .map(|key| {
+                computed
+                    .writes
+                    .iter()
+                    .find(|(written, _)| written == key)
+                    .map(|(_, bytes)| bytes.clone())
+            })
+            .collect();
+
+        assert!(
+            stored.iter().all(Option::is_none),
+            "a permuted request must not match the stored key"
+        );
+
+        let mut permuted = CachePlan::build(&reversed, keys(&reversed), &stored);
+        record(
+            &mut permuted,
+            Origin::FullSet,
+            0,
+            0,
+            ViewOutcome::View(build_histogram_view(&reversed, Vec::new())),
+        );
+        let permuted = permuted
+            .finish(&reversed)
+            .unwrap_or_else(|error| panic!("plan must finish: {error}"));
+
+        let MetricResultViewDto::Histogram { values } = view_at(&permuted, 0, 0) else {
+            panic!("expected a histogram view");
+        };
+        assert_eq!(
+            values
+                .iter()
+                .map(|v| v.entity_id.clone())
+                .collect::<Vec<_>>(),
+            vec![entity(2).to_string(), entity(1).to_string()],
+            "the response follows the order this request asked for"
+        );
+    }
+
+    /// The whole-view path: a stored DTO is served back without querying, and a
+    /// hit is not rewritten.
+    #[test]
+    fn a_whole_view_hit_is_served_from_cache_and_not_rewritten() {
+        let req = request(
+            vec![entity(1), entity(2)],
+            vec![metric_request(
+                sum_metric(),
+                vec![ValidatedMetricView::Histogram],
+            )],
+        );
+
+        let mut computed = CachePlan::build(&req, keys(&req), &[None]);
+        record(
+            &mut computed,
+            Origin::FullSet,
+            0,
+            0,
+            ViewOutcome::View(build_histogram_view(&req, Vec::new())),
+        );
+        let computed = computed
+            .finish(&req)
+            .unwrap_or_else(|error| panic!("plan must finish: {error}"));
+        assert_eq!(computed.writes.len(), 1, "a computed whole view is stored");
+
+        let stored = vec![Some(computed.writes[0].1.clone())];
+        let cached = CachePlan::build(&req, keys(&req), &stored);
+
+        assert!(cached.narrowed().is_empty(), "nothing left to query");
+        assert_eq!(cached.stats().hits, 1);
+
+        let cached = cached
+            .finish(&req)
+            .unwrap_or_else(|error| panic!("plan must finish: {error}"));
+
+        assert!(
+            cached.writes.is_empty(),
+            "a whole-view hit must not rewrite its entry"
+        );
+        let MetricResultViewDto::Histogram { values } = view_at(&cached, 0, 0) else {
+            panic!("expected the histogram view back, not another variant");
+        };
+        assert_eq!(values.len(), 2, "every requested entity is still listed");
+    }
+
+    /// The subset is a union across views, so an uncacheable view must not drag
+    /// a partially-cached view into re-querying and rewriting everything.
+    #[test]
+    fn an_uncacheable_view_does_not_invalidate_another_views_cached_rows() {
+        let req = request(
+            vec![entity(1), entity(2)],
+            vec![
+                metric_request(custom_sql_metric(), vec![ValidatedMetricView::Period]),
+                metric_request(sum_metric(), vec![ValidatedMetricView::Period]),
+            ],
+        );
+        // The custom-SQL metric is uncacheable, so it contributes no keys; the
+        // managed metric has entity 1 cached and entity 2 missing.
+        let cached = vec![cached_period(Some(1.0)), None];
+
+        let mut plan = CachePlan::build(&req, keys(&req), &cached);
+
+        record(
+            &mut plan,
+            Origin::Subset,
+            0,
+            0,
+            ViewOutcome::PeriodRows(vec![
+                period_row(&entity(1).to_string(), Some(11.0)),
+                period_row(&entity(2).to_string(), Some(22.0)),
+            ]),
+        );
+        record(
+            &mut plan,
+            Origin::Subset,
+            1,
+            0,
+            ViewOutcome::PeriodRows(vec![
+                period_row(&entity(1).to_string(), Some(99.0)),
+                period_row(&entity(2).to_string(), Some(2.0)),
+            ]),
+        );
+
+        let outcome = plan
+            .finish(&req)
+            .unwrap_or_else(|error| panic!("plan must finish: {error}"));
+
+        let managed = period_values(view_at(&outcome, 1, 0));
+        assert_eq!(
+            managed.iter().map(|value| value.value).collect::<Vec<_>>(),
+            vec![Some(1.0), Some(2.0)],
+            "the cached row survives an unrelated view's re-query"
+        );
+        assert_eq!(
+            outcome.writes.len(),
+            1,
+            "only the entity this view was missing is written back"
+        );
+    }
+
+    #[test]
+    fn a_view_that_was_never_produced_is_an_internal_error() {
+        let req = request(
+            vec![entity(1)],
+            vec![metric_request(
+                sum_metric(),
+                vec![ValidatedMetricView::Histogram],
+            )],
+        );
+
+        let plan = CachePlan::build(&req, uncacheable_keys(&req), &[]);
+
+        assert!(plan.finish(&req).is_err());
+    }
+}

--- a/src/backend/services/analytics/src/domain/metric_results/cache/test_support.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/cache/test_support.rs
@@ -1,0 +1,138 @@
+use chrono::NaiveDate;
+use uuid::Uuid;
+
+use crate::domain::metric_definitions::definition::{
+    ComputationSpec, CustomObservationSql, MetricBase, MetricDefinition, MetricDirection,
+    MetricFormat, MetricInput, MetricInputRole, ObservationRelation, ObservationSource,
+};
+
+use super::super::validation::{
+    ValidatedDimensionFilter, ValidatedEntitySelection, ValidatedMetricRequest,
+    ValidatedMetricResultsRequest, ValidatedMetricView,
+};
+
+pub const TENANT: Uuid = Uuid::from_u128(0x7a11);
+
+pub fn entity(index: usize) -> Uuid {
+    Uuid::from_u128(index as u128)
+}
+
+fn base() -> MetricBase {
+    MetricBase {
+        key: "ai.accepted_lines".to_owned(),
+        label: "AI-added lines".to_owned(),
+        short_label: None,
+        description: None,
+        explanation: None,
+        entity_type: "person".to_owned(),
+        format: MetricFormat::Integer,
+        unit: None,
+        direction: MetricDirection::HigherIsBetter,
+        peer_cohort_key: None,
+        allowed_dimensions: vec!["tool".to_owned()],
+    }
+}
+
+fn managed_input() -> MetricInput {
+    MetricInput {
+        role: MetricInputRole::Value,
+        observation: ObservationSource::Managed(
+            ObservationRelation::parse("ai_metric_observations")
+                .unwrap_or_else(|| panic!("fixture relation must parse")),
+        ),
+        source_key: "ai_usage".to_owned(),
+        measure_key: "accepted_lines".to_owned(),
+    }
+}
+
+pub fn sum_metric() -> MetricDefinition {
+    MetricDefinition {
+        transform: None,
+        base: base(),
+        spec: ComputationSpec::Sum {
+            value: managed_input(),
+        },
+    }
+}
+
+/// A ratio whose denominator reads inline SQL: only the numerator names a
+/// managed relation, so nothing about this metric can be pinned to an epoch.
+pub fn split_source_ratio_metric() -> MetricDefinition {
+    MetricDefinition {
+        transform: None,
+        base: base(),
+        spec: ComputationSpec::Ratio {
+            numerator: managed_input(),
+            denominator: MetricInput {
+                role: MetricInputRole::Denominator,
+                observation: ObservationSource::Custom(CustomObservationSql::new(
+                    "SELECT * FROM insight.ai_metric_observations".to_owned(),
+                )),
+                source_key: "ai_usage".to_owned(),
+                measure_key: "tool_use_offered".to_owned(),
+            },
+            scale: 100.0,
+        },
+    }
+}
+
+pub fn custom_sql_metric() -> MetricDefinition {
+    MetricDefinition {
+        transform: None,
+        base: base(),
+        spec: ComputationSpec::Sum {
+            value: MetricInput {
+                role: MetricInputRole::Value,
+                observation: ObservationSource::Custom(CustomObservationSql::new(
+                    "SELECT * FROM insight.ai_metric_observations".to_owned(),
+                )),
+                source_key: "ai_usage".to_owned(),
+                measure_key: "accepted_lines".to_owned(),
+            },
+        },
+    }
+}
+
+pub fn metric_request(
+    def: MetricDefinition,
+    views: Vec<ValidatedMetricView>,
+) -> ValidatedMetricRequest {
+    ValidatedMetricRequest {
+        def,
+        filters: Vec::new(),
+        views,
+    }
+}
+
+pub fn filtered_metric_request(
+    def: MetricDefinition,
+    filters: Vec<ValidatedDimensionFilter>,
+    views: Vec<ValidatedMetricView>,
+) -> ValidatedMetricRequest {
+    ValidatedMetricRequest {
+        def,
+        filters,
+        views,
+    }
+}
+
+pub fn request(
+    ids: Vec<Uuid>,
+    metrics: Vec<ValidatedMetricRequest>,
+) -> ValidatedMetricResultsRequest {
+    ValidatedMetricResultsRequest {
+        tenant_id: TENANT,
+        entity: ValidatedEntitySelection::Person { ids },
+        from: date("2026-01-01"),
+        to: date("2026-01-31"),
+        metrics,
+        enforce_tenant_scope: true,
+    }
+}
+
+pub fn date(value: &str) -> NaiveDate {
+    match NaiveDate::parse_from_str(value, "%Y-%m-%d") {
+        Ok(date) => date,
+        Err(error) => panic!("bad fixture date {value}: {error}"),
+    }
+}

--- a/src/backend/services/analytics/src/domain/metric_results/dto.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/dto.rs
@@ -140,7 +140,7 @@ pub enum ComputationDto {
     DistinctCount,
 }
 
-#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(tag = "view", rename_all = "snake_case")]
 pub enum MetricResultViewDto {
     Period {
@@ -162,7 +162,7 @@ pub enum MetricResultViewDto {
     },
 }
 
-#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct HistogramValueDto {
     pub entity_id: String,
     /// Empty when the entity has no events in the period — the entity is
@@ -170,49 +170,49 @@ pub struct HistogramValueDto {
     pub bins: Vec<HistogramBinDto>,
 }
 
-#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct HistogramBinDto {
     pub lo: f64,
     pub hi: f64,
     pub count: u64,
 }
 
-#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct MetricDimensionDto {
     pub key: String,
     pub value: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
 }
 
-#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct PeriodValueDto {
     pub entity_id: String,
     pub value: Option<f64>,
 }
 
-#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct TimeseriesDto {
     pub entity_id: String,
     pub dimensions: Vec<MetricDimensionDto>,
     #[schema(required)]
     pub total: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub rank: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub remainder: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
     pub points: Vec<TimeseriesPointDto>,
 }
 
-#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct TimeseriesPointDto {
     pub bucket_start: String,
     pub value: Option<f64>,
 }
 
-#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct PeerValueDto {
     pub entity_id: String,
     pub target_value: Option<f64>,
@@ -224,7 +224,7 @@ pub struct PeerValueDto {
     pub n: u64,
 }
 
-#[derive(Debug, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct BreakdownValueDto {
     pub entity_id: String,
     pub dimensions: Vec<MetricDimensionDto>,
@@ -233,3 +233,106 @@ pub struct BreakdownValueDto {
 
 impl toolkit::api::api_dto::RequestApiDto for MetricResultsRequest {}
 impl toolkit::api::api_dto::ResponseApiDto for MetricResultsResponse {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Cached views are stored as their own wire shape, so anything the wire
+    /// omits has to come back as the same absence rather than a decode failure.
+    #[test]
+    fn every_view_survives_a_round_trip_through_its_wire_shape() {
+        let dimension = || MetricDimensionDto {
+            key: "tool".to_owned(),
+            value: "example".to_owned(),
+            label: None,
+        };
+        let views = vec![
+            MetricResultViewDto::Period {
+                values: vec![
+                    PeriodValueDto {
+                        entity_id: "a".to_owned(),
+                        value: Some(1.5),
+                    },
+                    PeriodValueDto {
+                        entity_id: "b".to_owned(),
+                        value: None,
+                    },
+                ],
+            },
+            MetricResultViewDto::Timeseries {
+                bucket: Bucket::Week,
+                series: vec![
+                    TimeseriesDto {
+                        entity_id: "a".to_owned(),
+                        dimensions: vec![dimension()],
+                        total: None,
+                        rank: None,
+                        remainder: None,
+                        label: None,
+                        points: vec![TimeseriesPointDto {
+                            bucket_start: "2026-01-01".to_owned(),
+                            value: None,
+                        }],
+                    },
+                    TimeseriesDto {
+                        entity_id: "b".to_owned(),
+                        dimensions: Vec::new(),
+                        total: Some(3.0),
+                        rank: Some(2),
+                        remainder: Some(true),
+                        label: Some("Other".to_owned()),
+                        points: Vec::new(),
+                    },
+                ],
+            },
+            MetricResultViewDto::Peer {
+                values: vec![PeerValueDto {
+                    entity_id: "a".to_owned(),
+                    target_value: Some(1.0),
+                    p25: None,
+                    median: None,
+                    p75: None,
+                    min: None,
+                    max: None,
+                    n: 7,
+                }],
+            },
+            MetricResultViewDto::Breakdown {
+                dimensions: vec!["tool".to_owned()],
+                values: vec![BreakdownValueDto {
+                    entity_id: "a".to_owned(),
+                    dimensions: vec![dimension()],
+                    value: None,
+                }],
+            },
+            MetricResultViewDto::Histogram {
+                values: vec![HistogramValueDto {
+                    entity_id: "a".to_owned(),
+                    bins: vec![HistogramBinDto {
+                        lo: 0.0,
+                        hi: 1.0,
+                        count: 4,
+                    }],
+                }],
+            },
+        ];
+
+        for view in views {
+            let encoded = match serde_json::to_value(&view) {
+                Ok(encoded) => encoded,
+                Err(error) => panic!("should serialize {view:?}: {error}"),
+            };
+            let decoded: MetricResultViewDto = match serde_json::from_value(encoded.clone()) {
+                Ok(decoded) => decoded,
+                Err(error) => panic!("should decode {encoded}: {error}"),
+            };
+            let reencoded = match serde_json::to_value(&decoded) {
+                Ok(reencoded) => reencoded,
+                Err(error) => panic!("should re-serialize {decoded:?}: {error}"),
+            };
+
+            assert_eq!(encoded, reencoded, "should round trip: {encoded}");
+        }
+    }
+}

--- a/src/backend/services/analytics/src/domain/metric_results/mod.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/mod.rs
@@ -1,6 +1,6 @@
 mod batch;
 mod builder;
-pub(crate) mod cache;
+mod cache;
 pub(crate) mod compiler;
 mod dto;
 mod validation;

--- a/src/backend/services/analytics/src/domain/metric_results/mod.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/mod.rs
@@ -1,17 +1,22 @@
 mod batch;
 mod builder;
+pub(crate) mod cache;
 pub(crate) mod compiler;
 mod dto;
 mod validation;
 mod view;
 
 pub use batch::{
-    BatchItem, PeerWideRow, PeriodWideRow, PlannedQuery, UnbatchedView, demux_peer_rows,
-    demux_period_rows, plan_queries, plan_rankings,
+    BatchItem, PeerWideRow, PeriodWideRow, PlannedQuery, RankedGroup, RankingPolicyKey,
+    UnbatchedView, demux_peer_rows, demux_period_rows, plan_queries, plan_rankings,
 };
 pub use builder::{
-    build_breakdown_view, build_histogram_view, build_metric_result, build_peer_view,
-    build_period_view, build_ranked_groups, build_timeseries_view, enforce_view_row_limit,
+    build_breakdown_view, build_histogram_view, build_metric_result, build_ranked_groups,
+    build_timeseries_view, enforce_view_row_limit,
+};
+pub use cache::{
+    CacheOutcome, CachePlan, ViewOutcome, derive_view_keys, flat_keys, relation_epochs,
+    required_relations, uncacheable_keys,
 };
 pub use compiler::{
     BreakdownQueryRow, CompiledQuery, HistogramQueryRow, RankingQueryRow, TimeseriesQueryRow,

--- a/src/backend/services/analytics/src/domain/metric_results/validation.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/validation.rs
@@ -71,7 +71,7 @@ impl ValidatedEntitySelection {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ValidatedMetricResultsRequest {
     pub tenant_id: Uuid,
     pub entity: ValidatedEntitySelection,
@@ -84,7 +84,7 @@ pub struct ValidatedMetricResultsRequest {
     pub enforce_tenant_scope: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ValidatedMetricRequest {
     pub def: MetricDefinition,
     pub filters: Vec<ValidatedDimensionFilter>,

--- a/src/backend/services/analytics/src/gear.rs
+++ b/src/backend/services/analytics/src/gear.rs
@@ -12,6 +12,7 @@
 //! own sea-orm pool in `AppState`.
 
 use std::sync::{Arc, OnceLock};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use toolkit::api::OpenApiRegistry;
@@ -92,11 +93,19 @@ impl Gear for AnalyticsApiGear {
 
         let contract_ch = ch.clone();
 
+        // Fails open by construction: an unreachable Redis leaves the cache
+        // disabled and retrying in the background instead of holding up boot.
+        let view_cache = infra::cache::MetricViewCache::connect(
+            &cfg.redis_url,
+            Duration::from_secs(cfg.metric_results_cache.ttl_secs),
+        );
+
         let state = api::AppState {
             db,
             ch,
             identity,
             config: cfg,
+            view_cache,
         };
 
         self.state

--- a/src/backend/services/analytics/src/gear.rs
+++ b/src/backend/services/analytics/src/gear.rs
@@ -93,8 +93,6 @@ impl Gear for AnalyticsApiGear {
 
         let contract_ch = ch.clone();
 
-        // Fails open by construction: an unreachable Redis leaves the cache
-        // disabled and retrying in the background instead of holding up boot.
         let view_cache = infra::cache::MetricViewCache::connect(
             &cfg.redis_url,
             Duration::from_secs(cfg.metric_results_cache.ttl_secs),

--- a/src/backend/services/analytics/src/infra/cache.rs
+++ b/src/backend/services/analytics/src/infra/cache.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use redis::AsyncCommands;
 use redis::aio::ConnectionManager;
-use tokio::sync::Semaphore;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 /// Values above this are served but not stored, so one pathological view
 /// cannot dominate a Redis shared with session state.
@@ -13,6 +13,9 @@ const MAX_ENTRY_BYTES: usize = 256 * 1024;
 /// few thousand fragments; sending them as one command would occupy the shared
 /// server for the whole reply, delaying session traffic behind it.
 const MAX_KEYS_PER_COMMAND: usize = 256;
+/// Bytes per command, alongside the key count: 256 maximum-sized entries would
+/// otherwise put ~64 MiB on the wire in one round trip.
+const MAX_COMMAND_BYTES: usize = 1024 * 1024;
 /// Budget for one Redis command. Applied per chunk so a large read degrades
 /// chunk by chunk instead of discarding everything it already fetched.
 const COMMAND_TIMEOUT: Duration = Duration::from_millis(150);
@@ -29,16 +32,16 @@ const MAX_CONCURRENT_WRITERS: usize = 8;
 /// carries authenticator sessions and a metric read must never be the reason a
 /// login fails.
 #[derive(Debug)]
-pub struct MetricViewCache {
+pub(crate) struct MetricViewCache {
     conn: OnceLock<ConnectionManager>,
     ttl: Duration,
-    writers: Semaphore,
+    writers: Arc<Semaphore>,
     connect_reported: AtomicBool,
     op_reported: AtomicBool,
 }
 
 impl MetricViewCache {
-    pub fn disabled() -> Arc<Self> {
+    pub(crate) fn disabled() -> Arc<Self> {
         Arc::new(Self::new(Duration::ZERO))
     }
 
@@ -46,7 +49,7 @@ impl MetricViewCache {
         Self {
             conn: OnceLock::new(),
             ttl,
-            writers: Semaphore::new(MAX_CONCURRENT_WRITERS),
+            writers: Arc::new(Semaphore::new(MAX_CONCURRENT_WRITERS)),
             connect_reported: AtomicBool::new(false),
             op_reported: AtomicBool::new(false),
         }
@@ -55,7 +58,7 @@ impl MetricViewCache {
     /// Never fails: an empty URL disables the cache, and an unreachable Redis
     /// leaves it disabled while a background task keeps trying, so a cold Redis
     /// cannot hold up boot.
-    pub fn connect(redis_url: &str, ttl: Duration) -> Arc<Self> {
+    pub(crate) fn connect(redis_url: &str, ttl: Duration) -> Arc<Self> {
         if redis_url.trim().is_empty() || ttl.is_zero() {
             return Self::disabled();
         }
@@ -74,13 +77,23 @@ impl MetricViewCache {
         cache
     }
 
-    pub fn enabled(&self) -> bool {
+    pub(crate) fn enabled(&self) -> bool {
         self.conn.get().is_some()
+    }
+
+    /// A write is admitted before its task is spawned, so a slow Redis cannot
+    /// accumulate queued writers each retaining an encoded batch.
+    pub(crate) fn try_admit_write(&self) -> Option<OwnedSemaphorePermit> {
+        let Ok(permit) = Arc::clone(&self.writers).try_acquire_owned() else {
+            tracing::debug!("metric-results cache write skipped; writer limit reached");
+            return None;
+        };
+        Some(permit)
     }
 
     /// A chunk that fails or times out yields misses for its own keys only;
     /// everything already fetched is still served.
-    pub async fn get_many(&self, keys: &[String]) -> Vec<Option<Vec<u8>>> {
+    pub(crate) async fn get_many(&self, keys: &[String]) -> Vec<Option<Vec<u8>>> {
         let mut found = Vec::with_capacity(keys.len());
         if keys.is_empty() {
             return found;
@@ -90,7 +103,7 @@ impl MetricViewCache {
         };
 
         let mut conn = conn.clone();
-        for chunk in keys.chunks(MAX_KEYS_PER_COMMAND) {
+        for chunk in budgeted(keys, String::len) {
             let read = conn.mget::<_, Vec<Option<Vec<u8>>>>(chunk);
             let batch = match tokio::time::timeout(COMMAND_TIMEOUT, read).await {
                 Ok(Ok(batch)) if batch.len() == chunk.len() => batch,
@@ -113,14 +126,14 @@ impl MetricViewCache {
         found
     }
 
-    pub async fn set_many(&self, entries: Vec<(String, Vec<u8>)>) {
+    // INVARIANT: the permit is held for the whole call — that hold is the
+    // concurrency cap, so it is taken by the caller and dropped only on return.
+    pub(crate) async fn set_many(
+        &self,
+        _permit: OwnedSemaphorePermit,
+        entries: Vec<(String, Vec<u8>)>,
+    ) {
         let Some(conn) = self.conn.get() else {
-            return;
-        };
-        // INVARIANT: the permit is held across the writes it bounds — that hold
-        // is the concurrency cap, not incidental.
-        let Ok(_permit) = self.writers.try_acquire() else {
-            tracing::debug!("metric-results cache write skipped; writer limit reached");
             return;
         };
 
@@ -134,7 +147,7 @@ impl MetricViewCache {
 
         let ttl_secs = self.ttl.as_secs();
         let mut conn = conn.clone();
-        for chunk in storable.chunks(MAX_KEYS_PER_COMMAND) {
+        for chunk in budgeted(&storable, |(key, value)| key.len() + value.len()) {
             let mut pipe = redis::pipe();
             for (key, value) in chunk {
                 pipe.set_ex::<_, _>(key, value, ttl_secs).ignore();
@@ -175,6 +188,28 @@ impl MetricViewCache {
     }
 }
 
+/// Splits into commands bounded by BOTH key count and serialized bytes, so one
+/// command's size cannot scale with the caller's payload.
+fn budgeted<T>(items: &[T], size_of: impl Fn(&T) -> usize) -> Vec<&[T]> {
+    let mut chunks = Vec::new();
+    let mut start = 0;
+    while start < items.len() {
+        let mut bytes = 0;
+        let mut end = start;
+        while end < items.len() && end - start < MAX_KEYS_PER_COMMAND {
+            let next = bytes + size_of(&items[end]);
+            if end > start && next > MAX_COMMAND_BYTES {
+                break;
+            }
+            bytes = next;
+            end += 1;
+        }
+        chunks.push(&items[start..end]);
+        start = end;
+    }
+    chunks
+}
+
 async fn connect_until_ready(cache: Arc<MetricViewCache>, client: redis::Client) {
     loop {
         match client.get_connection_manager().await {
@@ -210,14 +245,26 @@ mod tests {
             cache.get_many(&["a".to_owned(), "b".to_owned()]).await,
             vec![None, None]
         );
-        cache.set_many(vec![("a".to_owned(), vec![1, 2, 3])]).await;
+        assert!(
+            cache.try_admit_write().is_some(),
+            "a disabled cache still admits, and then stores nothing"
+        );
     }
 
     #[tokio::test]
-    async fn empty_url_and_zero_ttl_disable_the_cache() {
-        assert!(!MetricViewCache::connect("", Duration::from_mins(1)).enabled());
-        assert!(!MetricViewCache::connect("   ", Duration::from_mins(1)).enabled());
-        assert!(!MetricViewCache::connect("redis://127.0.0.1:6379", Duration::ZERO).enabled());
+    async fn an_absent_url_or_a_zero_ttl_disables_the_cache() {
+        let cases = [
+            ("", Duration::from_mins(1)),
+            ("   ", Duration::from_mins(1)),
+            ("redis://127.0.0.1:6379", Duration::ZERO),
+        ];
+
+        for (url, ttl) in cases {
+            assert!(
+                !MetricViewCache::connect(url, ttl).enabled(),
+                "should stay disabled: url={url:?} ttl={ttl:?}"
+            );
+        }
     }
 
     #[tokio::test]
@@ -227,7 +274,37 @@ mod tests {
 
         assert!(!cache.enabled());
         assert_eq!(cache.get_many(&["k".to_owned()]).await, vec![None]);
-        cache.set_many(vec![("k".to_owned(), vec![0])]).await;
+    }
+
+    #[test]
+    fn a_command_is_bounded_by_key_count_and_by_bytes() {
+        let small: Vec<usize> = (0..=(MAX_KEYS_PER_COMMAND * 2)).collect();
+        let by_count = budgeted(&small, |_| 1);
+
+        assert!(
+            by_count
+                .iter()
+                .all(|chunk| chunk.len() <= MAX_KEYS_PER_COMMAND),
+            "a chunk exceeded the key cap"
+        );
+        assert_eq!(
+            by_count.iter().map(|chunk| chunk.len()).sum::<usize>(),
+            small.len(),
+            "chunking dropped or duplicated items"
+        );
+
+        let heavy = vec![MAX_COMMAND_BYTES / 2; 8];
+        let by_bytes = budgeted(&heavy, |size| *size);
+
+        assert!(
+            by_bytes.iter().all(|chunk| chunk.len() <= 2),
+            "byte budget did not bound a chunk well under the key cap"
+        );
+
+        // An item larger than the whole budget still ships, alone.
+        let oversized = vec![MAX_COMMAND_BYTES * 4];
+        assert_eq!(budgeted(&oversized, |size| *size).len(), 1);
+        assert!(budgeted::<usize>(&[], |_| 1).is_empty());
     }
 
     #[tokio::test]

--- a/src/backend/services/analytics/src/infra/cache.rs
+++ b/src/backend/services/analytics/src/infra/cache.rs
@@ -1,0 +1,239 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use redis::AsyncCommands;
+use redis::aio::ConnectionManager;
+use tokio::sync::Semaphore;
+
+/// Values above this are served but not stored, so one pathological view
+/// cannot dominate a Redis shared with session state.
+const MAX_ENTRY_BYTES: usize = 256 * 1024;
+/// Keys per MGET and writes per pipeline. A dashboard request can reference a
+/// few thousand fragments; sending them as one command would occupy the shared
+/// server for the whole reply, delaying session traffic behind it.
+const MAX_KEYS_PER_COMMAND: usize = 256;
+/// Budget for one Redis command. Applied per chunk so a large read degrades
+/// chunk by chunk instead of discarding everything it already fetched.
+const COMMAND_TIMEOUT: Duration = Duration::from_millis(150);
+const CONNECT_RETRY: Duration = Duration::from_secs(30);
+/// Write-back is optional work, so it is capped rather than queued: past this
+/// many concurrent writers a request skips its write instead of adding load to
+/// a Redis that also carries session state.
+const MAX_CONCURRENT_WRITERS: usize = 8;
+
+/// Read-through storage for metric-result view fragments.
+///
+/// Every operation fails open: a missing connection, a timeout, or a Redis
+/// error degrades to "not cached" instead of an error, because the same Redis
+/// carries authenticator sessions and a metric read must never be the reason a
+/// login fails.
+#[derive(Debug)]
+pub struct MetricViewCache {
+    conn: OnceLock<ConnectionManager>,
+    ttl: Duration,
+    writers: Semaphore,
+    connect_reported: AtomicBool,
+    op_reported: AtomicBool,
+}
+
+impl MetricViewCache {
+    pub fn disabled() -> Arc<Self> {
+        Arc::new(Self::new(Duration::ZERO))
+    }
+
+    fn new(ttl: Duration) -> Self {
+        Self {
+            conn: OnceLock::new(),
+            ttl,
+            writers: Semaphore::new(MAX_CONCURRENT_WRITERS),
+            connect_reported: AtomicBool::new(false),
+            op_reported: AtomicBool::new(false),
+        }
+    }
+
+    /// Never fails: an empty URL disables the cache, and an unreachable Redis
+    /// leaves it disabled while a background task keeps trying, so a cold Redis
+    /// cannot hold up boot.
+    pub fn connect(redis_url: &str, ttl: Duration) -> Arc<Self> {
+        if redis_url.trim().is_empty() || ttl.is_zero() {
+            return Self::disabled();
+        }
+
+        let client = match redis::Client::open(redis_url) {
+            Ok(client) => client,
+            Err(error) => {
+                tracing::warn!(error = %error, "metric-results cache URL unusable; serving uncached");
+                return Self::disabled();
+            }
+        };
+
+        let cache = Arc::new(Self::new(ttl));
+        tokio::spawn(connect_until_ready(Arc::clone(&cache), client));
+
+        cache
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.conn.get().is_some()
+    }
+
+    /// A chunk that fails or times out yields misses for its own keys only;
+    /// everything already fetched is still served.
+    pub async fn get_many(&self, keys: &[String]) -> Vec<Option<Vec<u8>>> {
+        let mut found = Vec::with_capacity(keys.len());
+        if keys.is_empty() {
+            return found;
+        }
+        let Some(conn) = self.conn.get() else {
+            return keys.iter().map(|_| None).collect();
+        };
+
+        let mut conn = conn.clone();
+        for chunk in keys.chunks(MAX_KEYS_PER_COMMAND) {
+            let read = conn.mget::<_, Vec<Option<Vec<u8>>>>(chunk);
+            let batch = match tokio::time::timeout(COMMAND_TIMEOUT, read).await {
+                Ok(Ok(batch)) if batch.len() == chunk.len() => batch,
+                Ok(Ok(_)) => {
+                    self.report("read", "reply length did not match the requested keys");
+                    chunk.iter().map(|_| None).collect()
+                }
+                Ok(Err(error)) => {
+                    self.report("read", &error.to_string());
+                    chunk.iter().map(|_| None).collect()
+                }
+                Err(_) => {
+                    self.report("read", "timed out");
+                    chunk.iter().map(|_| None).collect()
+                }
+            };
+            found.extend(batch);
+        }
+
+        found
+    }
+
+    pub async fn set_many(&self, entries: Vec<(String, Vec<u8>)>) {
+        let Some(conn) = self.conn.get() else {
+            return;
+        };
+        // INVARIANT: the permit is held across the writes it bounds — that hold
+        // is the concurrency cap, not incidental.
+        let Ok(_permit) = self.writers.try_acquire() else {
+            tracing::debug!("metric-results cache write skipped; writer limit reached");
+            return;
+        };
+
+        let storable: Vec<(String, Vec<u8>)> = entries
+            .into_iter()
+            .filter(|(_, value)| value.len() <= MAX_ENTRY_BYTES)
+            .collect();
+        if storable.is_empty() {
+            return;
+        }
+
+        let ttl_secs = self.ttl.as_secs();
+        let mut conn = conn.clone();
+        for chunk in storable.chunks(MAX_KEYS_PER_COMMAND) {
+            let mut pipe = redis::pipe();
+            for (key, value) in chunk {
+                pipe.set_ex::<_, _>(key, value, ttl_secs).ignore();
+            }
+
+            let write = pipe.query_async::<()>(&mut conn);
+            match tokio::time::timeout(COMMAND_TIMEOUT, write).await {
+                Ok(Ok(())) => {}
+                Ok(Err(error)) => {
+                    self.report("write", &error.to_string());
+                    return;
+                }
+                Err(_) => {
+                    self.report("write", "timed out");
+                    return;
+                }
+            }
+        }
+    }
+
+    /// One warning per process, then debug: a Redis outage would otherwise emit
+    /// a warning per view per request. Read/write failures keep their own flag
+    /// so ordinary boot-order connect retries cannot consume it.
+    fn report(&self, op: &str, error: &str) {
+        Self::report_once(&self.op_reported, op, error);
+    }
+
+    fn report_once(reported: &AtomicBool, op: &str, error: &str) {
+        if reported.swap(true, Ordering::Relaxed) {
+            tracing::debug!(op, error, "metric-results cache unavailable");
+            return;
+        }
+        tracing::warn!(
+            op,
+            error,
+            "metric-results cache unavailable; serving uncached"
+        );
+    }
+}
+
+async fn connect_until_ready(cache: Arc<MetricViewCache>, client: redis::Client) {
+    loop {
+        match client.get_connection_manager().await {
+            Ok(conn) => {
+                if cache.conn.set(conn).is_err() {
+                    return;
+                }
+                tracing::info!("metric-results cache connected");
+                return;
+            }
+            Err(error) => {
+                MetricViewCache::report_once(
+                    &cache.connect_reported,
+                    "connect",
+                    &error.to_string(),
+                );
+                tokio::time::sleep(CONNECT_RETRY).await;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn disabled_cache_reads_empty_and_swallows_writes() {
+        let cache = MetricViewCache::disabled();
+
+        assert!(!cache.enabled());
+        assert_eq!(
+            cache.get_many(&["a".to_owned(), "b".to_owned()]).await,
+            vec![None, None]
+        );
+        cache.set_many(vec![("a".to_owned(), vec![1, 2, 3])]).await;
+    }
+
+    #[tokio::test]
+    async fn empty_url_and_zero_ttl_disable_the_cache() {
+        assert!(!MetricViewCache::connect("", Duration::from_mins(1)).enabled());
+        assert!(!MetricViewCache::connect("   ", Duration::from_mins(1)).enabled());
+        assert!(!MetricViewCache::connect("redis://127.0.0.1:6379", Duration::ZERO).enabled());
+    }
+
+    #[tokio::test]
+    async fn unreachable_redis_serves_uncached_without_erroring() {
+        // Port 1 is never a Redis; the handle must degrade, not fail.
+        let cache = MetricViewCache::connect("redis://127.0.0.1:1", Duration::from_mins(1));
+
+        assert!(!cache.enabled());
+        assert_eq!(cache.get_many(&["k".to_owned()]).await, vec![None]);
+        cache.set_many(vec![("k".to_owned(), vec![0])]).await;
+    }
+
+    #[tokio::test]
+    async fn malformed_url_disables_without_panicking() {
+        let cache = MetricViewCache::connect("not-a-redis-url", Duration::from_mins(1));
+
+        assert!(!cache.enabled());
+    }
+}

--- a/src/backend/services/analytics/src/infra/mod.rs
+++ b/src/backend/services/analytics/src/infra/mod.rs
@@ -1,3 +1,3 @@
-pub mod cache;
+pub(crate) mod cache;
 pub mod db;
 pub mod identity;

--- a/src/backend/services/analytics/src/infra/mod.rs
+++ b/src/backend/services/analytics/src/infra/mod.rs
@@ -1,2 +1,3 @@
+pub mod cache;
 pub mod db;
 pub mod identity;

--- a/tests/stand/api/analytics/test_results.py
+++ b/tests/stand/api/analytics/test_results.py
@@ -20,7 +20,7 @@ The 401 half is in `test_gateway.py`, swept over every operation at once.
 from __future__ import annotations
 
 import pytest
-from insight_stand import ApiClient, ApiResponse, Manifest, analytics_path
+from insight_stand import ApiClient, ApiResponse, Manifest, analytics_path, wait_until
 from insight_stand.api import JsonValue
 
 from ..schemas import (
@@ -314,23 +314,28 @@ def test_asking_the_same_question_twice_gives_the_same_answer(
 ) -> None:
     """A repeated request answers identically, however it was served.
 
-    The deployed service answers metric reads through a result cache, so the
-    second identical request is served from stored fragments rather than
-    recomputed from ClickHouse. That is invisible to the caller only if the two
-    responses agree exactly — this asserts the whole document, so a value, an
-    ordering or an omitted entity that survives one path but not the other
-    fails here rather than in a dashboard.
+    The deployed service answers metric reads through a result cache, so a
+    repeat may be assembled from stored fragments rather than recomputed. That
+    is invisible to the caller only if the documents agree exactly, which is
+    what this asserts — a value, an ordering or an omitted entity that survives
+    one path but not the other fails here rather than in a dashboard.
 
-    Nothing in the request says "cache": the point is that the caller cannot
-    tell, and neither can this test.
+    Whether any given response was a hit is deliberately NOT asserted: the API
+    exposes no such signal, and inventing one would test the test. The write
+    behind a first request is dispatched without blocking it, so the repeat is
+    polled rather than issued once — that both lets the store settle and makes a
+    disagreement loud instead of racy.
     """
     person = stand_manifest.fixture("dev_lead")
     metric_key = _a_metric_key(api)
 
-    cold = _ok(_ask_many(api, stand_manifest, [person.uuid], metric_key))
-    warm = _ok(_ask_many(api, stand_manifest, [person.uuid], metric_key))
+    first = _ok(_ask_many(api, stand_manifest, [person.uuid], metric_key))
 
-    assert cold == warm, "the same request answered differently the second time"
+    wait_until(
+        lambda: _ok(_ask_many(api, stand_manifest, [person.uuid], metric_key)) == first,
+        timeout_s=15,
+        description="a repeated metric-results request to answer identically",
+    )
 
 
 @pytest.mark.requires_seed("dev_lead", "development_ic")

--- a/tests/stand/api/analytics/test_results.py
+++ b/tests/stand/api/analytics/test_results.py
@@ -282,3 +282,133 @@ def test_one_hidden_person_refuses_the_whole_request(
         f"a request naming one hidden person answered {response.status_code} — if it "
         f"succeeded, the hidden entity was silently dropped: {response.text[:300]}"
     )
+
+
+def _ask_many(
+    api: ApiClient, manifest: Manifest, entity_ids: list[str], metric_key: str
+) -> ApiResponse:
+    start, end = query_window(manifest)
+    return api.post(
+        METRIC_RESULTS,
+        json_body={
+            "entity": {"type": "person", "ids": entity_ids},
+            "period": {"from": start, "to": end},
+            "metrics": [
+                {
+                    "metric_key": metric_key,
+                    "views": [{"view": "period"}, {"view": "peer"}],
+                }
+            ],
+        },
+    )
+
+
+def _ok(response: ApiResponse) -> JsonValue:
+    assert response.status_code == 200, f"status={response.status_code} {response.text[:300]}"
+    return response.json()
+
+
+@pytest.mark.reliability
+def test_asking_the_same_question_twice_gives_the_same_answer(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """A repeated request answers identically, however it was served.
+
+    The deployed service answers metric reads through a result cache, so the
+    second identical request is served from stored fragments rather than
+    recomputed from ClickHouse. That is invisible to the caller only if the two
+    responses agree exactly — this asserts the whole document, so a value, an
+    ordering or an omitted entity that survives one path but not the other
+    fails here rather than in a dashboard.
+
+    Nothing in the request says "cache": the point is that the caller cannot
+    tell, and neither can this test.
+    """
+    person = stand_manifest.fixture("dev_lead")
+    metric_key = _a_metric_key(api)
+
+    cold = _ok(_ask_many(api, stand_manifest, [person.uuid], metric_key))
+    warm = _ok(_ask_many(api, stand_manifest, [person.uuid], metric_key))
+
+    assert cold == warm, "the same request answered differently the second time"
+
+
+@pytest.mark.requires_seed("dev_lead", "development_ic")
+@pytest.mark.reliability
+def test_adding_a_person_leaves_the_others_answer_unchanged(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """One person's numbers do not depend on who else was asked about.
+
+    Period and peer are both per-entity results — a person's period total is
+    their own, and their peer pool is their cohort's, neither of which the
+    composition of the request may influence. Asking alone and then in company
+    is the observable form of that promise, and the one a roster-shaped
+    dashboard depends on when it pages through people in chunks.
+
+    `development_ic` is inside a development lead's subchart, so both people are
+    visible to this session and the request is answered rather than refused.
+    """
+    lead = stand_manifest.fixture("dev_lead")
+    report = stand_manifest.fixture("development_ic")
+    metric_key = _a_metric_key(api)
+
+    def entry(document: JsonValue, entity_id: str) -> list[JsonValue]:
+        metrics = document["metrics"]  # type: ignore[index,call-overload]
+        return [
+            value
+            for metric in metrics
+            for view in metric["views"]
+            for value in view["values"]
+            if value["entity_id"] == entity_id
+        ]
+
+    alone = _ok(_ask_many(api, stand_manifest, [lead.uuid], metric_key))
+    together = _ok(_ask_many(api, stand_manifest, [lead.uuid, report.uuid], metric_key))
+
+    assert entry(alone, lead.uuid) == entry(together, lead.uuid), (
+        f"{metric_key} answered differently for the same person once another "
+        f"person joined the request"
+    )
+
+
+@pytest.mark.requires_seed("dev_lead", "development_ic")
+@pytest.mark.reliability
+def test_the_answer_follows_the_order_the_request_asked_in(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """Reversing the entity list reverses the answer, and nothing else.
+
+    Period values are rendered in the order the caller listed their people, so
+    a permuted request must be answered in its own order — never in the order
+    of some earlier request that happened to name the same people. The values
+    themselves have to survive the permutation untouched.
+    """
+    lead = stand_manifest.fixture("dev_lead")
+    report = stand_manifest.fixture("development_ic")
+    metric_key = _a_metric_key(api)
+
+    def period_values(document: JsonValue) -> list[tuple[str, float | None]]:
+        metrics = document["metrics"]  # type: ignore[index,call-overload]
+        return [
+            (value["entity_id"], value["value"])
+            for metric in metrics
+            for view in metric["views"]
+            if view["view"] == "period"
+            for value in view["values"]
+        ]
+
+    forward = period_values(
+        _ok(_ask_many(api, stand_manifest, [lead.uuid, report.uuid], metric_key))
+    )
+    reversed_ = period_values(
+        _ok(_ask_many(api, stand_manifest, [report.uuid, lead.uuid], metric_key))
+    )
+
+    assert [entity for entity, _ in forward] == [lead.uuid, report.uuid]
+    assert [entity for entity, _ in reversed_] == [report.uuid, lead.uuid], (
+        "the permuted request was answered in the first request's order"
+    )
+    assert dict(forward) == dict(reversed_), (
+        "permuting the entity list changed the values themselves"
+    )


### PR DESCRIPTION
## Problem

Every dashboard load refans `POST /v1/metric-results` into ClickHouse. The
frontend issues many narrow requests per screen — per collection, per entity
chunk, per period — over a shared entity set and period, so the same
(metric, view) work is recomputed across users and sessions. The frontend's
own cache only covers same-session repeats.

## What this does

Caches per **(metric, view)**, at two grains:

- **Period and peer: per entity.** Neither result depends on which other
  entities were asked for — peer stats come from the entity's cohort, not the
  request. So a roster request overlapping an earlier one by 38 of 40 people
  re-queries 2.
- **Timeseries, breakdown, histogram: whole view**, keyed by the requested
  entity set and its order.

Cached period/peer fragments are restored as query rows and rebuilt through
the same view builders a fresh request uses, so a partially cached response is
identical to a computed one — asserted by a test that replays a computed pass's
write-backs as the next request's hits.

## Keying and invalidation

A key hashes the **compiled probe query** for that view. One fingerprint
therefore covers dates, tenant, filters, dimensions, measure keys, the value
transform, a custom-metric definition edit, and compiler changes across
deploys, without enumerating any of them.

Invalidation is the ClickHouse relation UUID in the key: dbt rebuilds a gold
model as a new table, so the UUID rotates and old keys become unreachable. Peer
keys additionally pin the cohort relation. TTL (default 1h, configurable) only
bounds how long superseded keys occupy memory.

Never cached: metrics reading custom observation SQL (no relation to pin), and
group-limited timeseries (the SQL embeds resolved top-N groups only known after
the ranking query runs).

## Sharing the Redis

`redis_url` may point at an instance that also holds authenticator sessions, so
every path fails open — no Redis, no epoch, a slow read, a timeout, an
undecodable entry all degrade to uncached rather than erroring, and an
unreachable Redis at boot leaves the cache disabled with a background retry
rather than failing startup.

Bounds: 256 KiB per entry, 256 keys per command, a per-command timeout, a cap on
concurrent writers, and a per-request key ceiling checked before any hashing.
Keys are hash-tagged per tenant, so a request stays MGET-able on cluster without
routing every tenant to one shard.

Operators can isolate the cache entirely by pointing
`APP__gears__analytics__config__metric_results_cache` at its own instance; the
`redis_url` doc comment now states the eviction-policy requirement when it is
shared.

## Default is off

`redis_url` defaults to empty, which disables the cache. The existing suites run
that path.

## Testing

- 459 unit tests pass; 32 new, covering key derivation and stability, fragment
  round-trips, the narrowing/remap, cold-vs-warm equivalence, and fail-open
  behaviour.
- Clippy clean under pedantic/deny; OpenAPI drift gate unchanged (the added
  `Deserialize` derives change no wire schema).
- Three stand tests added to `tests/stand/api/analytics/test_results.py`:
  repeated requests answer identically, adding a person leaves the others'
  values unchanged, and a permuted entity list is answered in its own order.

**Not yet run against a live Redis or ClickHouse.** The epoch query, the chunked
MGET/pipeline and the writer bound are exercised only by their disabled and
unreachable paths. The stand suite is the first place the cache actually
executes — hence draft.

## Behaviour change worth noting

`build_peer_view` now orders values by the requested entity ids. The peer query
has no `ORDER BY`, so the previous order was unspecified; a canonical order is
required for cached and uncached responses to agree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added caching for metric results to improve response times for repeated requests.
  * Added configurable cache expiration settings.
  * Cache usage now supports partial results and refreshes only missing data.
* **Bug Fixes**
  * Improved consistency when requesting results repeatedly or alongside additional entities.
  * Preserved the requested entity order in metric-result responses.
  * Improved handling of unavailable or invalid cached data without interrupting requests.
* **Tests**
  * Added coverage for cache behavior, response consistency, entity isolation, and ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->