### PR TITLE
Find someone in the org tree

### DIFF
--- a/src/frontend/src/components/org-tree.test.tsx
+++ b/src/frontend/src/components/org-tree.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { OrgTree } from "@/components/org-tree";
+import type { IdentityPerson } from "@/types/insight";
+
+const mocks = vi.hoisted(() => ({ viewer: null as IdentityPerson | null }));
+
+vi.mock("@/auth", () => ({ useViewer: () => ({ personId: "root" }) }));
+vi.mock("@/queries/ic-dashboard", () => ({
+  useIcPerson: () => ({ data: mocks.viewer }),
+}));
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children }: { children?: React.ReactNode }) => <a>{children}</a>,
+  useRouterState: () => "/portal",
+}));
+vi.mock("@/lib/portal/portal-nav", () => ({
+  usePortalNavActions: () => ({ setScope: vi.fn() }),
+}));
+vi.mock("@/lib/metrics/entity", () => ({ personIdFromPath: () => null }));
+// The sidebar primitives need their provider; the tree's own markup is what
+// this file is about, so they stand in as plain elements.
+vi.mock("@/components/ui/sidebar", () => ({
+  SidebarMenu: ({ children }: { children?: React.ReactNode }) => (
+    <ul>{children}</ul>
+  ),
+  SidebarMenuItem: ({ children }: { children?: React.ReactNode }) => (
+    <li>{children}</li>
+  ),
+  SidebarMenuButton: ({ children }: { children?: React.ReactNode }) => (
+    <span>{children}</span>
+  ),
+}));
+
+function person(
+  id: string,
+  name: string,
+  subordinates: IdentityPerson[] = []
+): IdentityPerson {
+  return {
+    person_id: id,
+    email: `${id}@example.com`,
+    display_name: name,
+    subordinates,
+  };
+}
+
+mocks.viewer = person("root", "Root Person", [
+  person("lead", "Lead Person", [
+    person("deep", "Deep Person"),
+    person("other", "Other Person"),
+  ]),
+]);
+
+describe("OrgTree", () => {
+  it("shows only the root's own level until something opens it", () => {
+    render(<OrgTree />);
+    expect(screen.getByText("Root Person")).toBeInTheDocument();
+    expect(screen.getByText("Lead Person")).toBeInTheDocument();
+    // Nothing is active, so the lead's reports stay folded away.
+    expect(screen.queryByText("Deep Person")).not.toBeInTheDocument();
+  });
+
+  it("reveals a deep match and the managers above it, and nothing else", () => {
+    render(<OrgTree query="Deep" />);
+    expect(screen.getByText("Root Person")).toBeInTheDocument();
+    expect(screen.getByText("Lead Person")).toBeInTheDocument();
+    expect(screen.getByText("Deep Person")).toBeInTheDocument();
+    expect(screen.queryByText("Other Person")).not.toBeInTheDocument();
+  });
+
+  it("says so when the query names no one, rather than showing an empty tree", () => {
+    render(<OrgTree query="nobody" />);
+    expect(screen.getByText(/No one here matches/)).toBeInTheDocument();
+    expect(screen.queryByText("Root Person")).not.toBeInTheDocument();
+  });
+
+  it("goes back to the unfiltered tree when the query is cleared", () => {
+    const { rerender } = render(<OrgTree query="Deep" />);
+    rerender(<OrgTree query="" />);
+    expect(screen.queryByText("Deep Person")).not.toBeInTheDocument();
+    expect(screen.getByText("Lead Person")).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/org-tree.tsx
+++ b/src/frontend/src/components/org-tree.tsx
@@ -8,10 +8,12 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
-import {
-  usePortalNavActions,
-} from "@/lib/portal/portal-nav";
+import { usePortalNavActions } from "@/lib/portal/portal-nav";
 import { personIdFromPath } from "@/lib/metrics/entity";
+import {
+  filterOrgTree,
+  type OrgTreeFilter,
+} from "@/lib/portal/org-tree-filter";
 import { useIcPerson } from "@/queries/ic-dashboard";
 import type { IdentityPerson } from "@/types/insight";
 
@@ -31,14 +33,17 @@ function PersonNode({
   depth,
   activePersonId,
   leadsToTeam,
+  filter,
 }: {
   node: IdentityPerson;
   depth: number;
   activePersonId: string | null;
   /** Lead (has reports) links to their team roster instead of their own page. */
   leadsToTeam: boolean;
+  filter: OrgTreeFilter | null;
 }) {
   const { setScope } = usePortalNavActions();
+  if (filter && !filter.visible.has(node.person_id)) return null;
   const hasReports = node.subordinates.length > 0;
   const isActive = activePersonId
     ? personIdEq(activePersonId, node.person_id)
@@ -47,7 +52,9 @@ function PersonNode({
     hasReports && activePersonId
       ? node.subordinates.some((s) => containsPerson(s, activePersonId))
       : false;
-  const open = depth === 0 || isActive || hasActiveDescendant;
+  // While filtering, the chain to a match is what the reader asked to see, so
+  // it opens regardless of where they happen to be standing.
+  const open = filter ? true : depth === 0 || isActive || hasActiveDescendant;
   // A lead's name lands on their team; an IC's on their own page. (The two
   // literal `to`s keep the typed router happy vs. a computed path.) Drilling
   // into a lead also *sets the org scope* (design §6) so the topbar badge and
@@ -91,6 +98,7 @@ function PersonNode({
               depth={depth + 1}
               activePersonId={activePersonId}
               leadsToTeam={leadsToTeam}
+              filter={filter}
             />
           ))
         : null}
@@ -103,7 +111,10 @@ function PersonNode({
  * AppSidebar so the portal shell's context pane can reuse the same tree
  * without duplicating the traversal / active-node logic.
  */
-export function OrgTree({ leadsToTeam = false }: { leadsToTeam?: boolean } = {}) {
+export function OrgTree({
+  leadsToTeam = false,
+  query = "",
+}: { leadsToTeam?: boolean; query?: string } = {}) {
   const { personId: viewerPersonId } = useViewer();
   const viewerQ = useIcPerson(viewerPersonId ?? "");
   const viewer = viewerQ.data ?? null;
@@ -114,8 +125,16 @@ export function OrgTree({ leadsToTeam = false }: { leadsToTeam?: boolean } = {})
     if (pathname === "/" && viewerPersonId) return viewerPersonId;
     return null;
   }, [pathname, viewerPersonId]);
+  const filter = useMemo(() => filterOrgTree(viewer, query), [viewer, query]);
 
   if (!viewer) return null;
+  if (filter && filter.visible.size === 0) {
+    return (
+      <p className="px-4 py-2 text-sm text-muted-foreground">
+        No one here matches “{query.trim()}”
+      </p>
+    );
+  }
 
   return (
     <SidebarMenu>
@@ -124,6 +143,7 @@ export function OrgTree({ leadsToTeam = false }: { leadsToTeam?: boolean } = {})
         depth={0}
         activePersonId={activePersonId}
         leadsToTeam={leadsToTeam}
+        filter={filter}
       />
     </SidebarMenu>
   );

--- a/src/frontend/src/components/portal/context-pane.tsx
+++ b/src/frontend/src/components/portal/context-pane.tsx
@@ -1,8 +1,15 @@
-import { ChevronRight, Layers, LayoutGrid, Settings2 } from "lucide-react";
+import {
+  ChevronRight,
+  Layers,
+  LayoutGrid,
+  Search,
+  Settings2,
+} from "lucide-react";
 import { useState } from "react";
 
 import { AppSidebarFooter } from "@/components/app-sidebar-footer";
 import { OrgTree } from "@/components/org-tree";
+import { Input } from "@/components/ui/input";
 import {
   Popover,
   PopoverContent,
@@ -42,9 +49,7 @@ import {
   type Direction,
   type PaneItem,
 } from "@/lib/portal/nav-model";
-import {
-  usePortalShowPlanned,
-} from "@/lib/portal/portal-store";
+import { usePortalShowPlanned } from "@/lib/portal/portal-store";
 import {
   usePortalDir,
   usePortalItem,
@@ -140,7 +145,11 @@ export function ContextPane() {
                     </SidebarMenuButton>
                   }
                 />
-                <PopoverContent side="top" align="start" className="w-60 gap-0 p-1">
+                <PopoverContent
+                  side="top"
+                  align="start"
+                  className="w-60 gap-0 p-1"
+                >
                   <AppSidebarFooter />
                 </PopoverContent>
               </Popover>
@@ -199,7 +208,7 @@ function MobileZoneNav() {
               <ChevronRight
                 className={cn(
                   "ms-auto transition-transform",
-                  expanded && "rotate-90",
+                  expanded && "rotate-90"
                 )}
                 aria-hidden
               />
@@ -230,7 +239,13 @@ function MobileZoneNav() {
 
 /* ── Theme zones (Overview / AI & Cost / Scorecard / Reports) ────────── */
 
-function ThemeNav({ zoneId, active }: { zoneId: string; active: string | null }) {
+function ThemeNav({
+  zoneId,
+  active,
+}: {
+  zoneId: string;
+  active: string | null;
+}) {
   const groups = ZONE_SECTIONS[zoneId] ?? [];
   const showPlanned = usePortalShowPlanned();
   // Everything not yet real is pulled out of its original group and collected
@@ -252,7 +267,7 @@ function ThemeNav({ zoneId, active }: { zoneId: string; active: string | null })
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>
-        ) : null,
+        ) : null
       )}
       {planned.length ? (
         <SidebarGroup>
@@ -260,7 +275,12 @@ function ThemeNav({ zoneId, active }: { zoneId: string; active: string | null })
           <SidebarGroupContent>
             <SidebarMenu>
               {planned.map((it) => (
-                <ItemButton key={it.id} item={it} active={active === it.id} planned />
+                <ItemButton
+                  key={it.id}
+                  item={it}
+                  active={active === it.id}
+                  planned
+                />
               ))}
             </SidebarMenu>
           </SidebarGroupContent>
@@ -317,7 +337,12 @@ function ItemsNav({
           <SidebarGroupContent>
             <SidebarMenu>
               {planned.map((it) => (
-                <ItemButton key={it.id} item={it} active={active === it.id} planned />
+                <ItemButton
+                  key={it.id}
+                  item={it}
+                  active={active === it.id}
+                  planned
+                />
               ))}
             </SidebarMenu>
           </SidebarGroupContent>
@@ -356,7 +381,7 @@ function ItemButton({
           <span
             className={cn(
               "ml-auto rounded-full px-1.5 py-0.5 text-xs font-semibold",
-              BADGE_TONE[item.badge.tone],
+              BADGE_TONE[item.badge.tone]
             )}
           >
             {item.badge.text}
@@ -418,7 +443,11 @@ function DirectionItem({ direction }: { direction: Direction }) {
   return (
     <>
       <SidebarMenuItem>
-        <SidebarMenuButton isActive={expanded} onClick={toggle} aria-expanded={expanded}>
+        <SidebarMenuButton
+          isActive={expanded}
+          onClick={toggle}
+          aria-expanded={expanded}
+        >
           <Icon />
           <span>{direction.name}</span>
           {direction.source === "bullet" ? (
@@ -430,7 +459,7 @@ function DirectionItem({ direction }: { direction: Direction }) {
             className={cn(
               "size-4 text-muted-foreground transition-transform",
               direction.source === "bullet" ? "ml-1" : "ml-auto",
-              expanded && "rotate-90",
+              expanded && "rotate-90"
             )}
           />
         </SidebarMenuButton>
@@ -486,11 +515,24 @@ function PeopleNav({ active }: { active: string | null }) {
 }
 
 function WorkChart() {
+  const [query, setQuery] = useState("");
+
   return (
     <SidebarGroup>
       <SidebarGroupLabel>WorkChart</SidebarGroupLabel>
-      <SidebarGroupContent>
-        <OrgTree leadsToTeam />
+      <SidebarGroupContent className="flex flex-col gap-2">
+        <div className="relative px-2">
+          <Search className="pointer-events-none absolute top-1/2 left-4 size-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Find someone"
+            aria-label="Find someone in the org"
+            className="h-8 ps-7 text-sm"
+          />
+        </div>
+        <OrgTree leadsToTeam query={query} />
       </SidebarGroupContent>
     </SidebarGroup>
   );
@@ -574,7 +616,7 @@ function PersonSectionsNav() {
                           ? STATUS_BG_CLASS[standing.status]
                           : standing.peersHaveData
                             ? "bg-muted-foreground/30"
-                            : "border border-muted-foreground/40",
+                            : "border border-muted-foreground/40"
                       )}
                       aria-hidden
                     />

--- a/src/frontend/src/lib/portal/org-tree-filter.test.ts
+++ b/src/frontend/src/lib/portal/org-tree-filter.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { filterOrgTree } from "@/lib/portal/org-tree-filter";
+import type { IdentityPerson } from "@/types/insight";
+
+function person(
+  id: string,
+  fields: Partial<IdentityPerson> = {},
+  subordinates: IdentityPerson[] = []
+): IdentityPerson {
+  return {
+    person_id: id,
+    email: `${id}@example.com`,
+    display_name: id,
+    subordinates,
+    ...fields,
+  };
+}
+
+//  root
+//  ├── lead        (Engineering)
+//  │   ├── deep    (job title: Parser wrangler)
+//  │   └── other
+//  └── peer
+const tree = person("root", { display_name: "Root Person" }, [
+  person("lead", { display_name: "Lead Person", department: "Engineering" }, [
+    person("deep", { display_name: "Deep Person", job_title: "Parser wrangler" }),
+    person("other", { display_name: "Other Person" }),
+  ]),
+  person("peer", { display_name: "Peer Person" }),
+]);
+
+describe("filterOrgTree", () => {
+  it("does not filter a blank query", () => {
+    expect(filterOrgTree(tree, "")).toBeNull();
+    expect(filterOrgTree(tree, "   ")).toBeNull();
+    expect(filterOrgTree(null, "deep")).toBeNull();
+  });
+
+  it("keeps the managers that reach a match", () => {
+    const result = filterOrgTree(tree, "Deep");
+    expect([...result!.visible].sort()).toEqual(["deep", "lead", "root"]);
+    expect([...result!.matched]).toEqual(["deep"]);
+  });
+
+  it("leaves a matched manager's reports out unless they match too", () => {
+    const result = filterOrgTree(tree, "Lead");
+    expect(result!.visible.has("lead")).toBe(true);
+    expect(result!.visible.has("deep")).toBe(false);
+    expect(result!.visible.has("other")).toBe(false);
+  });
+
+  it("matches the fields the roster searches, not just the name", () => {
+    expect(filterOrgTree(tree, "engineering")!.matched.has("lead")).toBe(true);
+    expect(filterOrgTree(tree, "parser wrangler")!.matched.has("deep")).toBe(
+      true
+    );
+  });
+
+  it("ignores case and surrounding space", () => {
+    expect(filterOrgTree(tree, "  dEeP  ")!.matched.has("deep")).toBe(true);
+  });
+
+  it("reports nothing visible when no one matches", () => {
+    const result = filterOrgTree(tree, "nobody here");
+    expect(result!.visible.size).toBe(0);
+    expect(result!.matched.size).toBe(0);
+  });
+
+  it("keeps two separate branches when both hold a match", () => {
+    const result = filterOrgTree(tree, "Person");
+    expect([...result!.visible].sort()).toEqual([
+      "deep",
+      "lead",
+      "other",
+      "peer",
+      "root",
+    ]);
+  });
+});

--- a/src/frontend/src/lib/portal/org-tree-filter.ts
+++ b/src/frontend/src/lib/portal/org-tree-filter.ts
@@ -1,0 +1,53 @@
+import type { IdentityPerson } from "@/types/insight";
+
+export interface OrgTreeFilter {
+  /** Ids to render: every match, and the managers above it. */
+  visible: ReadonlySet<string>;
+  /** Ids that matched the query themselves. */
+  matched: ReadonlySet<string>;
+}
+
+function haystack(person: IdentityPerson): string {
+  return [
+    person.display_name,
+    person.job_title,
+    person.department,
+    person.division,
+    person.supervisor_name,
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+}
+
+/**
+ * Narrow the org tree to the people a query names and the chain of managers
+ * that reaches them.
+ *
+ * A matched manager does not drag their reports along: a query answered with a
+ * whole department buries the person who was asked for. Returns null for a
+ * blank query, which leaves the tree unfiltered.
+ */
+export function filterOrgTree(
+  root: IdentityPerson | null,
+  query: string
+): OrgTreeFilter | null {
+  const needle = query.trim().toLowerCase();
+  if (!root || needle === "") return null;
+
+  const visible = new Set<string>();
+  const matched = new Set<string>();
+
+  const walk = (person: IdentityPerson, ancestors: string[]): void => {
+    if (haystack(person).includes(needle)) {
+      matched.add(person.person_id);
+      visible.add(person.person_id);
+      for (const ancestor of ancestors) visible.add(ancestor);
+    }
+    const deeper = [...ancestors, person.person_id];
+    for (const report of person.subordinates) walk(report, deeper);
+  };
+  walk(root, []);
+
+  return { visible, matched };
+}


### PR DESCRIPTION
## Why

The WorkChart tree in the People pane opens only along the person you are
already looking at — a node unfolds when it is active or holds the active
descendant, and nothing else does. So reaching a report several levels down
required already knowing where they sat, which is the opposite of what someone
looking for them needs.

The roster beside it has had a search all along; the tree had none.

## What

A search box above the tree narrows it to the people a query names, together
with the managers that reach them, so a match keeps the context of where it
sits in the org.

A matched manager does **not** bring their reports along. A query answered
with a whole department buries the person who was asked for, and the reader
can still open that manager to see the team.

The fields are the ones the roster already searches — name, job title,
department, division, manager — so the two search alike on one screen.

While a query is active every remaining node is open: the chain to a match is
what the reader asked to see, not wherever they happen to be standing. An
empty result says so and repeats the query rather than rendering an empty
tree.

The filtering is a pure function over the identity tree; the component keeps
its single fetch, and the pane owns only the input.

## Verification

- `pnpm typecheck`, `eslint`, `vitest run --project unit` (1345 passing)
- 11 new tests: 7 on the filter, 4 on the tree. Mutation-checked — ignoring the
  filter fails the test that pins "the chain, and nothing else".
- Exercised against a running instance: a name three levels down collapses the
  tree to that chain; a job-title query returns the people who hold it, each
  under its own manager chain; a query that names no one shows the empty line;
  clearing the box restores the tree.
