### PR TITLE
fix(frontend): open each portal zone on its first built entry

### DIFF
--- a/src/frontend/src/components/portal/context-pane.test.tsx
+++ b/src/frontend/src/components/portal/context-pane.test.tsx
@@ -128,6 +128,8 @@ describe("ContextPane", () => {
     ["overview", "At a glance"],
     ["aicost", "Overview"],
     ["people", "People (roster)"],
+    ["reports", "Report builder"],
+    ["manage", "Metric catalog"],
   ])("highlights the default item of %s when the URL names none", (zone, label) => {
     mocks.zone = { activeZone: zone, activePerson: "boss@x" };
     pane();
@@ -148,10 +150,10 @@ describe("ContextPane", () => {
     expect(buttonFor("People (roster)")).toHaveAttribute("data-active");
   });
 
-  it("highlights nothing in Manage, whose no-item view is no menu entry", () => {
-    mocks.zone = { activeZone: "manage", activePerson: "boss@x" };
+  it("highlights nothing in a zone with nothing built to open on", () => {
+    mocks.zone = { activeZone: "scorecard", activePerson: "boss@x" };
     pane();
-    expect(buttonFor("Metric catalog")).not.toHaveAttribute("data-active");
+    expect(document.querySelectorAll("[data-active]")).toHaveLength(0);
   });
 
   it("renders the person's sections nav in the Person zone", () => {

--- a/src/frontend/src/lib/portal/nav-model.test.ts
+++ b/src/frontend/src/lib/portal/nav-model.test.ts
@@ -1,28 +1,49 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  defaultZoneItem,
   MANAGE_ITEMS,
   manageItemsFor,
   partitionByReadiness,
   resolveZoneItem,
-  ZONE_DEFAULT_ITEM,
-  zoneById,
+  ZONES,
   zoneItems,
 } from "./nav-model";
 
-const defaults = Object.entries(ZONE_DEFAULT_ITEM);
+const defaults = ZONES.map((z) => [z.id, defaultZoneItem(z.id)] as const);
 
 describe("zone item defaults", () => {
-  it("name a zone the rail has", () => {
-    for (const [zone] of defaults) expect(zoneById(zone), zone).toBeDefined();
+  it("open each zone on its first built entry", () => {
+    expect(Object.fromEntries(defaults)).toEqual({
+      overview: "at-a-glance",
+      directions: null,
+      person: null,
+      people: "roster",
+      aicost: "overview",
+      scorecard: null,
+      reports: "report-builder",
+      manage: "metric-catalog",
+    });
   });
 
   it("name an item the pane always renders", () => {
-    // A default the pane can filter out (planned / unbuilt) would highlight a
-    // row that isn't there.
     for (const [zone, id] of defaults) {
+      if (id == null) continue;
       const { live } = partitionByReadiness(zoneItems(zone), false);
       expect(live.map((i) => i.id), zone).toContain(id);
+    }
+  });
+
+  it("are null only where the zone lists nothing built", () => {
+    for (const [zone, id] of defaults) {
+      const { live } = partitionByReadiness(zoneItems(zone), false);
+      expect(id === null, zone).toBe(live.length === 0);
+    }
+  });
+
+  it("name an item every viewer can see, not an admin-only one", () => {
+    for (const [zone, id] of defaults) {
+      expect(zoneItems(zone).find((i) => i.id === id)?.adminOnly, zone).toBeFalsy();
     }
   });
 });
@@ -40,10 +61,14 @@ describe("resolveZoneItem", () => {
     expect(resolveZoneItem("aicost", null)).toBe("overview");
   });
 
-  it("stays null for a zone whose no-item view is no menu row", () => {
-    expect(resolveZoneItem("manage", null)).toBeNull();
-    expect(resolveZoneItem("manage", "trend")).toBeNull();
+  it("keeps a Manage item the URL names, and falls back for one it does not", () => {
     expect(resolveZoneItem("manage", "data-health")).toBe("data-health");
+    expect(resolveZoneItem("manage", "trend")).toBe("metric-catalog");
+  });
+
+  it("stays null for a zone with nothing built to open on", () => {
+    expect(resolveZoneItem("scorecard", null)).toBeNull();
+    expect(resolveZoneItem("person", null)).toBeNull();
   });
 });
 

--- a/src/frontend/src/lib/portal/nav-model.ts
+++ b/src/frontend/src/lib/portal/nav-model.ts
@@ -308,22 +308,21 @@ export const MANAGE_ITEMS: readonly PaneItem[] = [
 
 /* ── Zone item resolution ────────────────────────────────────────────── */
 
-/**
- * The item a zone falls back to when the URL names none. Absent = the zone's
- * no-item view is no menu row (Manage), or its default has no id at all
- * (Person — see ContextPane.PersonSectionsNav).
- */
-export const ZONE_DEFAULT_ITEM: Record<string, string> = {
-  overview: "at-a-glance",
-  aicost: "overview",
-  people: "roster",
-};
-
 /** Every pane item a zone lists, in display order, planned ones included. */
 export function zoneItems(zoneId: string): readonly PaneItem[] {
   if (zoneId === "people") return PEOPLE_ITEMS;
   if (zoneId === "manage") return MANAGE_ITEMS;
   return (ZONE_SECTIONS[zoneId] ?? []).flatMap((g) => g.items);
+}
+
+/**
+ * The item a zone falls back to when the URL names none: its first BUILT entry.
+ * Planned and unbuilt ones are skipped because the pane filters them out (see
+ * {@link partitionByReadiness}), and a default it filters out marks a row that
+ * is not on screen.
+ */
+export function defaultZoneItem(zoneId: string): string | null {
+  return zoneItems(zoneId).find((i) => i.readiness == null)?.id ?? null;
 }
 
 /**
@@ -335,5 +334,5 @@ export function zoneItems(zoneId: string): readonly PaneItem[] {
  */
 export function resolveZoneItem(zoneId: string, item: string | null): string | null {
   if (item && zoneItems(zoneId).some((i) => i.id === item)) return item;
-  return ZONE_DEFAULT_ITEM[zoneId] ?? null;
+  return defaultZoneItem(zoneId);
 }

--- a/src/frontend/src/lib/portal/overview-configs.ts
+++ b/src/frontend/src/lib/portal/overview-configs.ts
@@ -1,6 +1,6 @@
 import { headlineMetricKeys } from "@/lib/insight/groups";
 import { sectionMetricKeys, type LensConfig } from "@/lib/portal/lens-configs";
-import { ZONE_DEFAULT_ITEM } from "@/lib/portal/nav-model";
+import { defaultZoneItem } from "@/lib/portal/nav-model";
 
 /**
  * The Overview zone registry: each pane item (nav-model ZONE_SECTIONS.overview)
@@ -13,7 +13,7 @@ import { ZONE_DEFAULT_ITEM } from "@/lib/portal/nav-model";
 const ATTENTION_KEYS: readonly string[] = headlineMetricKeys();
 
 /** The item the router renders when no pane item is selected. */
-export const DEFAULT_OVERVIEW_ITEM = ZONE_DEFAULT_ITEM.overview!;
+export const DEFAULT_OVERVIEW_ITEM = defaultZoneItem("overview")!;
 
 export const OVERVIEW_ITEMS: Record<string, LensConfig> = {
   [DEFAULT_OVERVIEW_ITEM]: {


### PR DESCRIPTION
Closes #2567

## What changed

`ZONE_DEFAULT_ITEM` was a hand-kept map of zone → landing item. A zone missing from it resolved to `null`, so the pane marked nothing and the content fell through to a placeholder — indistinguishable from a zone that genuinely has nothing built. Reports had been in that state since the report builder landed.

`defaultZoneItem(zoneId)` derives it instead: the zone's first entry with no `readiness`. Not simply the first entry — the pane filters planned and unbuilt rows out, and Reports lists two unbuilt ones ahead of the builder, so the naive first row would mark something that is not on screen.

## Landing item per zone

| Zone | Opens on | Changed |
| --- | --- | --- |
| Overview | At a glance | — |
| Directions | (none — no rows here) | — |
| Person | its own sections nav | — |
| People | People (roster) | — |
| AI & Cost | Overview | — |
| Scorecard | (none — every row unbuilt) | — |
| Reports | **Report builder** | **yes** |
| Manage | **Metric catalog** | **yes** |

**Manage is a deliberate behaviour change worth a look.** It previously opened on no entry by design, showing a generic "not wired yet" card while Metric catalog sat one click away, built and live. Same shape as the Reports defect, so it follows the same rule now. Easy to carve back out if that card was load-bearing.

Also pinned in tests: no zone's default may be an `adminOnly` entry. True today, but reordering `MANAGE_ITEMS` would otherwise hand non-admins a default they cannot see — the same nothing-is-marked state, silently.

## Verification

All eight zones opened in a browser with no `item` in the URL, against the frontend's synthetic-data mode. Each marks the expected entry and renders its view; no console errors. Unit suite, typecheck and lint all clean.

Reports before — nothing marked, placeholder content:

![Reports zone before, no entry marked](https://github.com/user-attachments/assets/2325a61a-442f-412e-9d06-059334cab2ab)

Reports after — Report builder marked, builder rendered:

![Reports zone after, Report builder marked](https://github.com/user-attachments/assets/d3990ebc-630b-4496-bd0c-6c4dc0746a27)

Manage after — Metric catalog marked and rendered:

![Manage zone, Metric catalog marked](https://github.com/user-attachments/assets/5e07c9ec-6ba3-4e6b-83a0-7edce6dbcc3b)
