### PR TITLE
fix(frontend): hide every unrendered portal surface when planned sections are off

### DIFF
--- a/src/frontend/src/components/portal/ai-cost-view.tsx
+++ b/src/frontend/src/components/portal/ai-cost-view.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 
 import { CenteredSpinner } from "@/components/widgets/centered-spinner";
 import { ComingSoon } from "@/components/widgets/coming-soon";
+import { PANE_ITEM_COMING_SOON } from "@/lib/portal/aicost-configs";
 import { orgScopeGate } from "@/components/portal/org-scope-gate";
 import { MembersGrid } from "@/components/widgets/dashboard/members-grid";
 import { Card, CardContent } from "@/components/ui/card";
@@ -47,21 +48,6 @@ const LINES_KEY = "ai.accepted_lines";
 const DAYS_KEY = "ai.active_days";
 /** Grid columns for the cost-leaders scan. */
 const GRID_KEYS = [COST_KEY, DAYS_KEY, LINES_KEY, "ai.dev_conversations"];
-/** Pane items with no dedicated data-backed view yet — honest ComingSoon. */
-const COMING_SOON: Record<string, string> = {
-  "per-tool":
-    "Per-tool detail — the tool split is summarised on Overview → By tool; a standalone per-tool drilldown is pending.",
-  autofix: "Autofix — no autofix data is collected.",
-  "ai-audit": "AI Audit — not built yet.",
-  "spend-by-tool":
-    "Spend by tool — see Overview → By tool; a dedicated spend breakdown is pending.",
-  "cost-by-unit":
-    "Cost by unit / user — unit rollup is under “By unit / role”, per-user is on Overview; a combined view is pending.",
-  "idle-seats":
-    "Idle seats — seat data is collected but not available in this view yet.",
-  credits: "Credits burn-down — no credit or quota data is collected.",
-  "ai-pricing": "AI pricing settings — not built yet.",
-};
 
 const TOOL_LABEL: Record<string, string> = {
   claude_code: "Claude Code",
@@ -272,10 +258,10 @@ export function AiCostView({ item }: { item: string | null }) {
     ];
   }, [grid.byKey, memberIds]);
 
-  if (item && COMING_SOON[item])
+  if (item && PANE_ITEM_COMING_SOON[item])
     return (
       <div className="mx-auto w-full max-w-md p-8">
-        <ComingSoon variant="card" state="empty" label={COMING_SOON[item]} />
+        <ComingSoon variant="card" state="empty" label={PANE_ITEM_COMING_SOON[item]} />
       </div>
     );
 

--- a/src/frontend/src/components/portal/context-pane.tsx
+++ b/src/frontend/src/components/portal/context-pane.tsx
@@ -18,7 +18,11 @@ import {
 import { GROUPS } from "@/lib/insight/groups";
 import { usePersonSectionStandings } from "@/lib/portal/use-person-sections";
 import { STATUS_BG_CLASS } from "@/lib/status";
-import { lensEntry } from "@/lib/portal/lens-configs";
+import {
+  lensEntry,
+  visibleDirections,
+  visibleLenses,
+} from "@/lib/portal/lens-configs";
 import { useShellLayout } from "@/lib/portal/use-shell-layout";
 import { useZoneNav } from "@/lib/portal/use-zone-nav";
 import {
@@ -38,7 +42,6 @@ import {
   useSidebar,
 } from "@/components/ui/sidebar";
 import {
-  DIRECTIONS,
   manageItemsFor,
   PEOPLE_ITEMS,
   PLANNED_GROUP_LABEL,
@@ -395,17 +398,19 @@ function ItemButton({
 /* ── Directions zone ─────────────────────────────────────────────────── */
 
 function DirectionsNav() {
+  const showPlanned = usePortalShowPlanned();
+  const directions = visibleDirections(showPlanned);
   return (
     <SidebarGroup>
       <SidebarGroupLabel>
         Directions
         <span className="ml-1 text-xs font-normal text-muted-foreground">
-          · catalog · {DIRECTIONS.length}
+          · catalog · {directions.length}
         </span>
       </SidebarGroupLabel>
       <SidebarGroupContent>
         <SidebarMenu>
-          {DIRECTIONS.map((d) => (
+          {directions.map((d) => (
             <DirectionItem key={d.id} direction={d} />
           ))}
         </SidebarMenu>
@@ -422,14 +427,7 @@ function DirectionItem({ direction }: { direction: Direction }) {
   const showPlanned = usePortalShowPlanned();
   const expanded = activeDir === direction.id;
   const Icon = direction.icon;
-  // A lens we simply have not built yet is hidden unless the viewer asked for
-  // planned work; a lens waiting on the product stays listed (dimmed) because
-  // it tells the reader the domain exists in our model.
-  const lenses = direction.lenses.filter((lens) => {
-    const entry = lensEntry(direction.id, lens);
-    if (!entry || !("comingSoon" in entry)) return true;
-    return entry.readiness === "planned" || showPlanned;
-  });
+  const lenses = visibleLenses(direction, showPlanned);
 
   function toggle() {
     if (expanded) {
@@ -499,16 +497,7 @@ function DirectionItem({ direction }: { direction: Direction }) {
 function PeopleNav({ active }: { active: string | null }) {
   return (
     <>
-      <SidebarGroup>
-        <SidebarGroupLabel>Views</SidebarGroupLabel>
-        <SidebarGroupContent>
-          <SidebarMenu>
-            {PEOPLE_ITEMS.map((it) => (
-              <ItemButton key={it.id} item={it} active={active === it.id} />
-            ))}
-          </SidebarMenu>
-        </SidebarGroupContent>
-      </SidebarGroup>
+      <ItemsNav items={PEOPLE_ITEMS} groupLabel="Views" active={active} />
       <WorkChart />
     </>
   );

--- a/src/frontend/src/lib/portal/aicost-configs.ts
+++ b/src/frontend/src/lib/portal/aicost-configs.ts
@@ -1,0 +1,20 @@
+/**
+ * AI & Cost pane items with no dedicated data-backed view yet, and the note
+ * each one renders instead. The wording must agree with the item's `readiness`
+ * in nav-model — a product gap never reads as a screen we owe, and the reverse
+ * (pinned by readiness.test.ts).
+ */
+export const PANE_ITEM_COMING_SOON: Record<string, string> = {
+  "per-tool":
+    "Per-tool detail — the tool split is summarised on Overview → By tool; a standalone per-tool drilldown is pending.",
+  autofix: "Autofix — no autofix data is collected.",
+  "ai-audit": "AI Audit — not built yet.",
+  "spend-by-tool":
+    "Spend by tool — see Overview → By tool; a dedicated spend breakdown is pending.",
+  "cost-by-unit":
+    "Cost by unit / user — unit rollup is under “By unit / role”, per-user is on Overview; a combined view is pending.",
+  "idle-seats":
+    "Idle seats — seat data is collected but not available in this view yet.",
+  credits: "Credits burn-down — no credit or quota data is collected.",
+  "ai-pricing": "AI pricing settings — not built yet.",
+};

--- a/src/frontend/src/lib/portal/lens-configs.ts
+++ b/src/frontend/src/lib/portal/lens-configs.ts
@@ -1,4 +1,4 @@
-import type { Readiness } from "@/lib/portal/nav-model";
+import { DIRECTIONS, type Direction, type Readiness } from "@/lib/portal/nav-model";
 
 /**
  * The Directions registry: every direction × lens maps to either a LensConfig
@@ -57,6 +57,25 @@ export type LensEntry = LensConfig | LensRoadmap;
 /** The registry entry for a direction's lens — a config, a roadmap note, or nothing. */
 export function lensEntry(dir: string, lens: string): LensEntry | undefined {
   return DIRECTION_LENSES[dir]?.[lens];
+}
+
+/** A direction's lenses in pane order, minus the roadmap ones a reader opted out of. */
+export function visibleLenses(
+  direction: Direction,
+  showPlanned: boolean,
+): string[] {
+  return direction.lenses.filter((lens) => {
+    const entry = lensEntry(direction.id, lens);
+    return !entry || !("comingSoon" in entry) || showPlanned;
+  });
+}
+
+/**
+ * Directions worth listing: a branch whose every lens is filtered out expands
+ * into nothing, so it is a dead end rather than a place to look.
+ */
+export function visibleDirections(showPlanned: boolean): Direction[] {
+  return DIRECTIONS.filter((d) => visibleLenses(d, showPlanned).length > 0);
 }
 
 /** Unique metric keys a config needs in its period+peer grid. */

--- a/src/frontend/src/lib/portal/nav-model.ts
+++ b/src/frontend/src/lib/portal/nav-model.ts
@@ -50,15 +50,15 @@ export type ZoneKind = "person" | "directions" | "theme" | "manage" | "people";
  *   data. If it still renders empty, that is a per-tenant data gap and the
  *   view says which source is missing. Always visible: the gap IS the signal.
  * - **`planned`** — the product does not model this yet (a metric family is
- *   not in the semantic layer). Identical for every tenant. Kept visible but
- *   demoted, because it tells a reader the domain exists in our model.
+ *   not in the semantic layer). Identical for every tenant.
  * - **`unbuilt`** — WE have not built the screen yet, though the data path
- *   exists. This is our backlog, not roadmap communication: hidden unless the
- *   viewer opts into seeing planned work.
+ *   exists. This is our backlog, not roadmap communication.
  *
  * Rendering a tenant data gap and our own unfinished UI the same way is what
  * makes both meaningless, which is why the distinction is in the model rather
- * than in prose.
+ * than in prose. It shapes how an entry reads, not whether the reader's
+ * "show planned sections" choice reaches it: either marker hides when that is
+ * off, because neither renders a view.
  */
 export type Readiness = "planned" | "unbuilt";
 
@@ -174,10 +174,10 @@ export interface PaneGroup {
 export const PLANNED_GROUP_LABEL = "Planned";
 
 /**
- * Split entries into what a reader should always see and what belongs under
- * the demoted "Planned" group. `unbuilt` entries drop out entirely unless the
- * viewer opted in — showing our own unfinished screens next to honest tenant
- * data gaps teaches people that empty means nothing in particular.
+ * Split entries into the views a reader can open and the marked ones that
+ * belong under the demoted "Planned" group. Nothing marked survives
+ * `showPlanned: false` — a reader who turned planned sections off is asking
+ * for navigation that only lists what renders.
  */
 export function partitionByReadiness<T extends { readiness?: Readiness }>(
   entries: readonly T[],
@@ -187,9 +187,7 @@ export function partitionByReadiness<T extends { readiness?: Readiness }>(
   const planned: T[] = [];
   for (const e of entries) {
     if (e.readiness == null) live.push(e);
-    // `planned` is roadmap the reader benefits from seeing; `unbuilt` is ours
-    // and only appears when the viewer asked for planned work.
-    else if (e.readiness === "planned" || showPlanned) planned.push(e);
+    else if (showPlanned) planned.push(e);
   }
   return { live, planned };
 }
@@ -208,13 +206,6 @@ export const ZONE_SECTIONS: Record<string, readonly PaneGroup[]> = {
       ],
     },
   ],
-  // Lean, data-honest menu: Overview is the live dashboard (adoption + by-tool
-  // + cost-by-person in one scroll); the second group is capabilities that need
-  // data we don't ingest yet (kept visible as honest ComingSoon, not padded out
-  // into a dozen dead tabs).
-  // Full intended IA. Overview / Adoption funnel / By unit are backed by real
-  // data; the rest render an honest ComingSoon (see AiCostView.COMING_SOON) —
-  // the menu shows the roadmap, but nothing fabricates data it doesn't have.
   aicost: [
     {
       items: [{ id: "overview", label: "Overview", icon: LayoutGrid }],
@@ -226,7 +217,7 @@ export const ZONE_SECTIONS: Record<string, readonly PaneGroup[]> = {
         { id: "by-unit-role", label: "By unit / role", icon: Layers },
         { id: "per-tool", label: "Per-tool", icon: Sparkles, readiness: "unbuilt" },
         { id: "autofix", label: "Autofix", icon: Activity, readiness: "planned" },
-        { id: "ai-audit", label: "AI Audit", icon: Radar, readiness: "planned" },
+        { id: "ai-audit", label: "AI Audit", icon: Radar, readiness: "unbuilt" },
       ],
     },
     {
@@ -234,14 +225,14 @@ export const ZONE_SECTIONS: Record<string, readonly PaneGroup[]> = {
       items: [
         { id: "spend-by-tool", label: "Spend by tool", icon: DollarSign, readiness: "unbuilt" },
         { id: "cost-by-unit", label: "Cost by unit / user", icon: Users, readiness: "unbuilt" },
-        { id: "idle-seats", label: "Idle seats", icon: Clock, readiness: "planned" },
+        { id: "idle-seats", label: "Idle seats", icon: Clock, readiness: "unbuilt" },
         { id: "credits", label: "Credits burn-down", icon: TrendingUp, readiness: "planned" },
         {
           id: "ai-pricing",
           label: "AI pricing",
           icon: DollarSign,
           badge: { text: "ai.cost", tone: "error" },
-          readiness: "planned",
+          readiness: "unbuilt",
         },
       ],
     },
@@ -280,7 +271,7 @@ export const ZONE_SECTIONS: Record<string, readonly PaneGroup[]> = {
 // zone (reached by drilling into any name); listing it again would duplicate it.
 export const PEOPLE_ITEMS: readonly PaneItem[] = [
   { id: "roster", label: "People (roster)", icon: Users },
-  { id: "median-by-role", label: "Median by Role", icon: BarChart3, readiness: "planned" },
+  { id: "median-by-role", label: "Median by Role", icon: BarChart3, readiness: "unbuilt" },
   { id: "employees", label: "Employees", icon: Fingerprint },
 ];
 

--- a/src/frontend/src/lib/portal/readiness.test.ts
+++ b/src/frontend/src/lib/portal/readiness.test.ts
@@ -1,13 +1,21 @@
 import { describe, expect, it } from "vitest";
 
-import { DIRECTION_LENSES, lensEntry } from "./lens-configs";
 import {
+  DIRECTION_LENSES,
+  lensEntry,
+  visibleDirections,
+  visibleLenses,
+} from "./lens-configs";
+import {
+  DIRECTIONS,
   MANAGE_ITEMS,
   PEOPLE_ITEMS,
   partitionByReadiness,
   ZONES,
   ZONE_SECTIONS,
+  zoneItems,
 } from "./nav-model";
+import { PANE_ITEM_COMING_SOON } from "./aicost-configs";
 
 describe("partitionByReadiness", () => {
   const entries = [
@@ -23,15 +31,13 @@ describe("partitionByReadiness", () => {
     }
   });
 
-  it("always lists product-side gaps, demoted — they are roadmap, not noise", () => {
-    const { planned } = partitionByReadiness(entries, false);
-    expect(planned.map((e) => e.id)).toEqual(["planned"]);
+  it("hides both readiness tiers when the reader opts out", () => {
+    const { live, planned } = partitionByReadiness(entries, false);
+    expect(planned).toEqual([]);
+    expect(live.map((e) => e.id)).toEqual(["live"]);
   });
 
-  it("hides our own unbuilt screens until the viewer opts in", () => {
-    expect(partitionByReadiness(entries, false).planned.map((e) => e.id)).not.toContain(
-      "unbuilt",
-    );
+  it("lists both tiers, demoted, when the reader opts in", () => {
     expect(partitionByReadiness(entries, true).planned.map((e) => e.id)).toEqual([
       "planned",
       "unbuilt",
@@ -41,6 +47,60 @@ describe("partitionByReadiness", () => {
   it("returns everything exactly once — nothing is dropped silently", () => {
     const { live, planned } = partitionByReadiness(entries, true);
     expect([...live, ...planned]).toHaveLength(entries.length);
+  });
+});
+
+describe("navigation with planned sections hidden", () => {
+  it("leaves People only the entries that render a view", () => {
+    const { live } = partitionByReadiness(PEOPLE_ITEMS, false);
+    expect(live.map((i) => i.id)).toEqual(["roster", "employees"]);
+  });
+
+  it("leaves AI & Cost only the entries that render a view", () => {
+    const items = (ZONE_SECTIONS.aicost ?? []).flatMap((g) => g.items);
+    const { live } = partitionByReadiness(items, false);
+    expect(live.map((i) => i.id)).toEqual([
+      "overview",
+      "adoption-funnel",
+      "by-unit-role",
+    ]);
+  });
+
+  it("drops a direction whose every lens is filtered out", () => {
+    expect(visibleDirections(false).map((d) => d.id)).toEqual([
+      "dev",
+      "collab",
+      "wiki",
+    ]);
+  });
+
+  it("keeps every direction once the reader opts in", () => {
+    expect(visibleDirections(true).map((d) => d.id)).toEqual(
+      DIRECTIONS.map((d) => d.id),
+    );
+  });
+
+  it("leaves Development only the lenses that render sections", () => {
+    const dev = DIRECTIONS.find((d) => d.id === "dev")!;
+    expect(visibleLenses(dev, false)).toEqual([
+      "Overview",
+      "Git output",
+      "Delivery",
+      "Flow",
+    ]);
+  });
+
+  it("hides no zone, item or lens that renders something", () => {
+    for (const zone of ZONES) {
+      if (zone.readiness != null) continue;
+      for (const item of zoneItems(zone.id)) {
+        if (item.readiness != null) continue;
+        expect(
+          partitionByReadiness(zoneItems(zone.id), false).live,
+          `${zone.id}/${item.id}`,
+        ).toContainEqual(item);
+      }
+    }
   });
 });
 
@@ -73,9 +133,9 @@ describe("nav classification invariants", () => {
     expect(items.every((i) => i.readiness == null)).toBe(true);
   });
 
-  it("People marks the cohort-pipeline item as planned, not unbuilt", () => {
+  it("People marks the cohort view as ours to build", () => {
     const median = PEOPLE_ITEMS.find((i) => i.id === "median-by-role");
-    expect(median?.readiness).toBe("planned");
+    expect(median?.readiness).toBe("unbuilt");
   });
 
   it("no zone or item is marked with an unknown readiness value", () => {
@@ -131,13 +191,43 @@ describe("lens roadmap entries carry a reason", () => {
     }
   });
 
-  it("Sales and Support wait on the product, so they stay listed", () => {
+  it("Sales and Support wait on the product, so they carry the product-gap tag", () => {
     for (const dir of ["sales", "support"]) {
       for (const lens of Object.keys(DIRECTION_LENSES[dir]!)) {
         expect((lensEntry(dir, lens) as { readiness: string }).readiness, dir).toBe(
           "planned",
         );
       }
+    }
+  });
+});
+
+describe("pane item roadmap entries carry a reason", () => {
+  const tagged = Object.entries(PANE_ITEM_COMING_SOON).map(([id, copy]) => ({
+    id,
+    copy,
+    readiness: zoneItems("aicost").find((i) => i.id === id)?.readiness,
+  }));
+
+  it("finds pane items to check", () => expect(tagged.length).toBeGreaterThan(5));
+
+  it("every one declares whether it waits on the product or on us", () => {
+    for (const { id, readiness } of tagged) {
+      expect(["planned", "unbuilt"], id).toContain(readiness);
+    }
+  });
+
+  it("a product gap never claims the screen is missing", () => {
+    for (const { id, copy, readiness } of tagged) {
+      if (readiness !== "planned") continue;
+      expect(copy, id).not.toMatch(/not built yet|is pending|in development/i);
+    }
+  });
+
+  it("a screen we owe never claims the data is absent", () => {
+    for (const { id, copy, readiness } of tagged) {
+      if (readiness !== "unbuilt") continue;
+      expect(copy, id).not.toMatch(/no .* data is collected|data is not available yet/i);
     }
   });
 });

--- a/src/frontend/src/lib/portal/use-zone-nav.ts
+++ b/src/frontend/src/lib/portal/use-zone-nav.ts
@@ -29,8 +29,7 @@ export function useZoneNav(): {
   const navigate = useNavigate();
   const { activeZone, activePerson } = useActiveZone();
   const { isManager, isPending: mgrPending } = useViewerIsManager();
-  // Zones we have not built are hidden unless the viewer opted into seeing
-  // planned work — a rail of scaffolds makes the built zones look unreliable.
+  // A rail of scaffolds makes the built zones look unreliable.
   const showPlanned = usePortalShowPlanned();
   // An IC (no reports) has no subtree to roll up, so org zones are hidden — the
   // shell collapses to Person. While the viewer's identity is still resolving,
@@ -44,7 +43,7 @@ export function useZoneNav(): {
   const zones = ZONES.filter(
     (z) =>
       (orgZonesVisible || IC_ZONES.has(z.id) || (z.id === "manage" && isAdmin)) &&
-      (z.readiness !== "unbuilt" || showPlanned),
+      (z.readiness == null || showPlanned),
   );
 
   function selectZone(zone: Zone) {


### PR DESCRIPTION
Closes #2570.

## What changed

With **Show planned sections** off, navigation now lists only surfaces that render something. Both readiness tiers hide — `planned` no longer outranks the reader's choice. The distinction stays in the model and still shapes how an entry *reads* when the toggle is on; it no longer decides whether the toggle reaches it.

Three paths bypassed the filter, and each is fixed where it broke:

| Path | Before | After |
|---|---|---|
| `PeopleNav` | mapped `PEOPLE_ITEMS` straight to buttons — no filtering at all | routed through `ItemsNav`, so it filters and demotes like every other pane |
| `partitionByReadiness` | `planned` entries survived `showPlanned: false` | nothing marked survives it |
| `DirectionsNav` | rendered all five branches unconditionally | drops a branch whose every lens is filtered out |

`visibleLenses` / `visibleDirections` in `lens-configs.ts` replace the lens predicate that was inline in `DirectionItem`, so the pane and the tests ask the same question. `useZoneNav` now reads `readiness == null` rather than naming one tier.

Four entries whose copy said "not built yet" under the product-gap tag are re-tagged `unbuilt`: Median by Role, AI Audit, AI pricing, and Idle seats (its copy says the data *is* collected). The AI & Cost coming-soon copy moved to `lib/portal/aicost-configs.ts` so a test can read it without importing a component.

## Result

Removed with the toggle off — 17 entries, two branches:

| Zone / branch | Entries before | After |
|---|---|---|
| People | 3 | 2 |
| AI & Cost | 8 | 3 |
| Directions · Development | 7 | 4 |
| Directions · Sales / CRM | 4 | branch removed |
| Directions · Support | 4 | branch removed |

Directions rail goes 5 → 3. Rail zones stay 7. Overview, Person, Reports, Manage, Collaboration and Knowledge / Wiki are untouched.

With the toggle **on** — the default — everything still lists exactly as before. People gained a demoted "Planned" group it never had.

### Evidence, toggle off

Pane contents captured from the running app, before and after.

**People**

```
before   Views | People (roster) | Median by Role | Employees
after    Views | People (roster) | Employees
```

Before, the entry was not even demoted — it sat inside the Views group at full weight, between two working views.

**AI & Cost**

```
before   Overview | AI adoption | Adoption funnel | By unit / role
         Planned | Autofix | AI Audit | Idle seats | Credits burn-down | AI pricing
after    Overview | AI adoption | Adoption funnel | By unit / role
```

**Directions**

```
before   catalog · 5 | Development | Collaboration | Knowledge / Wiki | Sales / CRM | Support
after    catalog · 3 | Development | Collaboration | Knowledge / Wiki

Development lenses
before   Overview | Git output | Delivery | Activity | Flow | Quality | Continuity
after    Overview | Git output | Delivery | Flow
```

### Toggle on, nothing lost

```
Directions   catalog · 5, every lens listed, Sales / CRM and Support present
AI & Cost    all eight entries, five under Planned
People       People (roster) | Employees | Planned | Median by Role
```

People gained a demoted "Planned" group it never had — before this change its entry was listed as though it were a working view regardless of the toggle.

## Tests

`readiness.test.ts` gains a `navigation with planned sections hidden` block pinning the resulting entry lists per zone, the direction drop, and an invariant that nothing which renders is ever hidden. A new `pane item roadmap entries carry a reason` block pins wording against readiness for pane items, which is the check lenses already had and pane items did not — the gap that let the four entries drift.

Verified the guard bites: restoring the old `partitionByReadiness` line fails `hides both readiness tiers when the reader opts out`.

`pnpm lint`, `pnpm typecheck`, `pnpm test` — 176 files, 1371 tests, all green.

Screenshots come from the frontend's synthetic-data mode (`VITE_ENABLE_MOCKS=true`) with no backend attached.
