### PR TITLE
feat(git-cli-proxy): deploy the proxy by default

### DIFF
--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -517,10 +517,12 @@ analytics:
 # Git CLI Proxy — clone-based commit extraction for the nocode git connectors.
 # Airbyte-only consumer: no gateway route, no platform-config entry (other
 # services must not discover it), ingress restricted by its own NetworkPolicy.
-# Deploy is OFF by default: it costs a PVC and is only useful once a git
-# connector is configured to use it.
+# Deployed by default: every nocode git connector reads its commits, file
+# changes and commit authors through this service, so an instance without it can
+# sync no git source at all. The cost is one PVC (`persistence.size`) on an
+# instance that syncs none — set deploy=false there.
 gitCliProxy:
-  deploy: false
+  deploy: true
   replicaCount: 1
   image:
     repository: ghcr.io/constructorfabric/insight-git-cli-proxy
@@ -549,10 +551,16 @@ gitCliProxy:
   # Composed by templates/secrets.yaml (carries the bearer token).
   existingSecret: "insight-git-cli-proxy-config"
   networkPolicy:
-    enabled: true
+    # Off by default, as on the authenticator: the /v1 bearer token is the
+    # control, and requiring every deployment to declare where Airbyte runs
+    # before the chart will install is friction the token already covers.
+    # Enable it per deployment — the clone cache serves private source, so
+    # hiding it from the rest of the cluster is worth the one value.
+    enabled: false
     # Namespaces whose pods may call the proxy: the one running Airbyte
-    # connector jobs. Required when deploy=true — the subchart refuses to
-    # render an allow-list that would deny every caller.
+    # connector jobs, which is `airbyte.namespace` above when that is set.
+    # Required whenever enabled=true — the subchart refuses to render an
+    # allow-list that would deny every caller.
     allowedNamespaceLabels:
       - key: kubernetes.io/metadata.name
         values: []

--- a/src/backend/services/git-cli-proxy/helm/tests/test_chart_contract.py
+++ b/src/backend/services/git-cli-proxy/helm/tests/test_chart_contract.py
@@ -23,9 +23,10 @@ CHART = Path(__file__).resolve().parents[1]
 RELEASE = "insight"
 
 
-# The chart refuses to render an allow-list that names no namespace, so every
-# render that is not about that refusal has to name one.
+# The policy is opt-in, and enabling it without naming a namespace refuses to
+# render — so every render that is about the policy turns it on AND names one.
 ALLOWED_NAMESPACE = {
+    "networkPolicy__enabled": "true",
     "networkPolicy__allowedNamespaceLabels[0]__key": "kubernetes.io/metadata.name",
     "networkPolicy__allowedNamespaceLabels[0]__values[0]": "airbyte",
 }
@@ -182,12 +183,24 @@ def test_token_never_reaches_the_configmap():
     )
 
 
-def test_an_allow_list_naming_no_namespace_refuses_to_render():
+def test_enabling_the_policy_without_a_namespace_refuses_to_render():
     """It would render a policy that denies every caller — an install that looks
     healthy and times out every sync."""
-    done = subprocess.run(helm_args(SECRET), capture_output=True, text=True, check=False)
+    overrides = {**SECRET, "networkPolicy__enabled": "true"}
+    done = subprocess.run(helm_args(overrides), capture_output=True, text=True, check=False)
     assert done.returncode != 0, f"render should have failed, got:\n{done.stdout}"
     assert "allowedNamespaceLabels names no namespace" in done.stderr
+
+
+def test_the_policy_is_opt_in_so_a_bare_install_renders():
+    """The /v1 bearer token is what authenticates a caller; requiring every
+    deployment to declare where Airbyte runs before the chart will install is
+    friction the token already covers. Same posture as the authenticator."""
+    out = subprocess.run(helm_args(SECRET), capture_output=True, text=True, check=True).stdout
+    docs = [doc for doc in yaml.safe_load_all(out) if doc]
+    assert not [doc for doc in docs if doc.get("kind") == "NetworkPolicy"], (
+        "no policy unless a deployment asks for one"
+    )
 
 
 def test_ingress_stays_closed_to_everything_unnamed():

--- a/src/backend/services/git-cli-proxy/helm/values.yaml
+++ b/src/backend/services/git-cli-proxy/helm/values.yaml
@@ -79,13 +79,16 @@ caCertSecret: ""
 existingSecret: ""
 
 networkPolicy:
-  # Ingress is restricted to the namespaces that run Airbyte connector pods.
-  # Disabling this exposes git credentials-bearing endpoints to the whole
-  # cluster — only do it on a cluster without NetworkPolicy support.
-  enabled: true
-  # Namespaces allowed to reach the service, matched by label. Naming none
-  # refuses to render: a policy with no rule denies every caller, which looks
-  # like a healthy install and fails every sync.
+  # Off by default, as on the authenticator: the bearer token authenticates
+  # every /v1 request, so the policy is defence-in-depth rather than the
+  # control, and a chart that cannot install without knowing where its caller
+  # runs is friction on every deployment. Enable it per deployment and name the
+  # namespace running Airbyte connector jobs — that hides the clone cache, which
+  # serves private source, from everything else in the cluster.
+  enabled: false
+  # Namespaces allowed to reach the service, matched by label. Naming none while
+  # enabled refuses to render: a policy with no rule denies every caller, which
+  # looks like a healthy install and fails every sync.
   allowedNamespaceLabels:
     - key: kubernetes.io/metadata.name
       values: []


### PR DESCRIPTION
## Problem

Every nocode git connector reads its commits, file changes and commit authors through the git-cli-proxy, so an instance without it can sync no git source at all. `gitCliProxy.deploy` defaulted to `false`, which meant the first git deploy on any instance had to discover that — from an install that looked healthy.

Turning it on then hit a second wall: `networkPolicy.enabled` defaulted to `true` with an empty allow-list, and the subchart refuses to render an allow-list that names no namespace. So enabling the proxy also required knowing which namespace runs Airbyte before the chart would install at all.

## Fix

- `gitCliProxy.deploy: true`.
- The ingress policy becomes opt-in (`networkPolicy.enabled: false`), matching the authenticator, which ships its policy off for the same reason: the `/v1` bearer token authenticates every caller, so the policy is defence-in-depth rather than the control.

A deployment that wants the clone cache — which serves private source — hidden from the rest of the cluster enables the policy and names the namespace running Airbyte connector jobs, which is `airbyte.namespace` where that is set. Enabling it without naming one still refuses to render, so the deny-everything install stays impossible.

The cost is one PVC (`persistence.size`) on an instance that syncs no git source; that instance can set `deploy=false`.

## Notes

- Deployments with Airbyte in its own namespace (`test-stand` uses `airbyte`) should enable the policy and name it in their environment values. Not done here — it changes a live stand's network posture and belongs with whoever owns that stand.
- `helm lint` in `git-cli-proxy-helm.yml` no longer exercises the policy path, since the default is now off. The rendered-contract tests do (their shared overrides enable it), including the refusal case. Adding `--set networkPolicy.enabled=true` to the lint step would restore it; excluded here because the push token cannot modify workflow files.

## Verification

`helm lint` passes both with the policy off and with it on and named. 27/27 rendered-contract tests pass, including two reworked ones: enabling the policy with no namespace still refuses to render, and a bare install renders no policy at all.