### PR TITLE
fix(github): let the platform supply the proxy address and token

### DIFF
--- a/deploy/CONNECTORS.md
+++ b/deploy/CONNECTORS.md
@@ -188,8 +188,8 @@ stringData:
 ```yaml
 # Declarative GitHub connector on the git-cli-proxy: commit-level data comes
 # from a bare clone served by the proxy instead of one vendor API call per
-# commit. Needs a reachable git-cli-proxy deployment, with git_proxy_token
-# equal to the proxy's own configured token.
+# commit. Needs a deployed git-cli-proxy (gitCliProxy.deploy); its address and
+# token are injected by reconcile, so this Secret carries neither.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -202,8 +202,6 @@ stringData:
   github_token:         "ghp_CHANGE_ME"   # repo, read:org, read:project
   github_organizations: '["myorg"]'       # JSON array
   github_start_date:    "2026-01-01"
-  git_proxy_url:        "http://insight-git-cli-proxy:8085"
-  git_proxy_token:      "CHANGE_ME"       # must match the proxy's own Secret
 ```
 
 ### Issue tracking & docs

--- a/src/ingestion/connectors/git/github/descriptor.yaml
+++ b/src/ingestion/connectors/git/github/descriptor.yaml
@@ -8,15 +8,21 @@ workflow: sync
 # the dbt tags, and the pipeline's silver step hardcodes `tag:<slug>+`.
 dbt_select: "tag:github+"
 
+# The proxy's address and bearer token belong to the platform, not to the
+# operator: the chart owns both and publishes them into the reconcile CronJob,
+# which injects them into this connector's source config. A Secret carrying them
+# would be a second copy of a port and a token that the chart can change.
+platform_config:
+  git_proxy: true
+
 secret:
   # The pre-flight Secret validator reads this list and nothing else, so it
-  # carries every field the spec requires, not only the ones beyond it.
+  # carries every field the operator must supply — the proxy address and token
+  # are not among them, because platform_config.git_proxy injects those.
   required_fields:
     - github_token
     - github_organizations
     - github_start_date
-    - git_proxy_url
-    - git_proxy_token
 
 connection:
   namespace: bronze_github

--- a/src/ingestion/secrets/connectors/github.yaml.example
+++ b/src/ingestion/secrets/connectors/github.yaml.example
@@ -1,7 +1,9 @@
 # Secret for the github connector. Copy to github.yaml, fill the values, and
-# apply to the insight namespace. git_proxy_token must equal
-# APP__gears__git_cli_proxy__config__proxy_token in the umbrella-composed
-# insight-git-cli-proxy-config Secret.
+# apply to the insight namespace.
+#
+# The git-cli-proxy address and bearer token are deliberately absent: the chart
+# owns both and reconcile injects them into the source config, so nothing here
+# has to track the proxy's port or rotate with its token.
 apiVersion: v1
 kind: Secret
 metadata:
@@ -15,6 +17,4 @@ type: Opaque
 stringData:
   github_token: CHANGE_ME            # PAT: repo, read:org, read:project (classic) or fine-grained equivalent
   github_organizations: '["acme"]'   # JSON array of org logins
-  git_proxy_url: http://insight-git-cli-proxy:8085
-  git_proxy_token: CHANGE_ME
   github_start_date: "2026-01-01"


### PR DESCRIPTION
## Problem

The chart owns the git-cli-proxy address and bearer token: it publishes `GIT_PROXY_URL` and `GIT_PROXY_TOKEN` into the reconcile CronJob, and reconcile injects them into the source config of any connector whose descriptor sets `platform_config.git_proxy` — so, in the chart's own words, "no connector Secret carries either and a port change cannot desync them".

No descriptor set that flag. The one connector that uses the proxy instead listed `git_proxy_url` and `git_proxy_token` in `secret.required_fields`, so the pre-flight validator demanded both from the operator, and the injection path was dead code.

Worse, the values an operator was told to copy were wrong: `github.yaml.example` and the deploy walkthrough both named port **8085**, while the chart's service port is **8084** and reconcile builds the URL from that value. A Secret filled in from either document points at nothing.

## Fix

- `platform_config: {git_proxy: true}` on the github descriptor, so reconcile injects both values.
- Drop `git_proxy_url` and `git_proxy_token` from `secret.required_fields` — the validator reads that list to decide what the operator must supply, and these are no longer operator-supplied.
- Remove both from `github.yaml.example` and from `deploy/CONNECTORS.md`, which kills the port mismatch rather than correcting it.

The connector manifest still declares both required in its own `spec`: the connector needs them at run time. Only their source changes.

## Verification

- The descriptor parser reads the new flag on both paths — `True` via PyYAML, `true` via the no-PyYAML fallback (reconcile lowercases either).
- `secret.required_fields` and the example's `stringData` keys now agree exactly: `github_token`, `github_organizations`, `github_start_date`.
- `generate-connectors-config.sh github` still emits all seven config keys, including the two proxy fields, because it unions the manifest's `spec.required` with the descriptor list — so `bootstrap-db` and the committed `connectors-config.yaml` are unaffected.