### PR TITLE
fix(gitops): unblock the stands the proxy default broke

### DIFF
--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -524,6 +524,12 @@ analytics:
 # changes and commit authors through this service, so an instance without it can
 # sync no git source at all. The cost is one PVC (`persistence.size`) on an
 # instance that syncs none — set deploy=false there.
+# Two prerequisites an environment must meet before this renders for it:
+#   * under `credentials.deploymentMode: gitops`, set `proxyToken` (or
+#     pre-create insight-git-cli-proxy-config) — a template-time token would
+#     differ on every sync, so secrets.yaml refuses to generate one;
+#   * the deploy credential must hold a persistentvolumeclaims rule for the
+#     cache claim (test-stand: ci-deployer-rbac.yaml).
 gitCliProxy:
   deploy: true
   replicaCount: 1

--- a/deploy/gitops/Makefile
+++ b/deploy/gitops/Makefile
@@ -895,6 +895,10 @@ verify-ci-credential: vpn-up kube-ctx
 	check yes "create Roles in $(NS_APP) (chart renders its own RBAC)"      create roles.rbac.authorization.k8s.io -n $(NS_APP); \
 	check yes "create WorkflowTemplates in $(NS_APP)"                        create workflowtemplates.argoproj.io -n $(NS_APP); \
 	check yes "update HTTPRoutes in $(NS_APP) (chart renders the edge routes)" update httproutes.gateway.networking.k8s.io -n $(NS_APP); \
+	check yes "get PVCs in $(NS_APP) (helm reads the git-cli-proxy cache claim every upgrade)" get persistentvolumeclaims -n $(NS_APP); \
+	check yes "update PVCs in $(NS_APP) (its chart/version labels change every bump)" update persistentvolumeclaims -n $(NS_APP); \
+	check no  "delete PVCs in $(NS_APP) (the clone cache outlives the release)" delete persistentvolumeclaims -n $(NS_APP); \
+	check yes "update NetworkPolicies in $(NS_APP) (rendered when a stand restricts ingress)" update networkpolicies.networking.k8s.io -n $(NS_APP); \
 	check yes "get Roles in $(AIRBYTE_NAMESPACE) (helm reads airbyte-auth-reader every upgrade)" get roles.rbac.authorization.k8s.io -n $(AIRBYTE_NAMESPACE); \
 	check yes "update Roles in $(AIRBYTE_NAMESPACE) (its chart/version labels change every bump)" update roles.rbac.authorization.k8s.io -n $(AIRBYTE_NAMESPACE); \
 	check yes "create Roles in $(AIRBYTE_NAMESPACE)"                         create roles.rbac.authorization.k8s.io -n $(AIRBYTE_NAMESPACE); \

--- a/deploy/gitops/Makefile
+++ b/deploy/gitops/Makefile
@@ -898,7 +898,6 @@ verify-ci-credential: vpn-up kube-ctx
 	check yes "get PVCs in $(NS_APP) (helm reads the git-cli-proxy cache claim every upgrade)" get persistentvolumeclaims -n $(NS_APP); \
 	check yes "update PVCs in $(NS_APP) (its chart/version labels change every bump)" update persistentvolumeclaims -n $(NS_APP); \
 	check no  "delete PVCs in $(NS_APP) (the clone cache outlives the release)" delete persistentvolumeclaims -n $(NS_APP); \
-	check yes "update NetworkPolicies in $(NS_APP) (rendered when a stand restricts ingress)" update networkpolicies.networking.k8s.io -n $(NS_APP); \
 	check yes "get Roles in $(AIRBYTE_NAMESPACE) (helm reads airbyte-auth-reader every upgrade)" get roles.rbac.authorization.k8s.io -n $(AIRBYTE_NAMESPACE); \
 	check yes "update Roles in $(AIRBYTE_NAMESPACE) (its chart/version labels change every bump)" update roles.rbac.authorization.k8s.io -n $(AIRBYTE_NAMESPACE); \
 	check yes "create Roles in $(AIRBYTE_NAMESPACE)"                         create roles.rbac.authorization.k8s.io -n $(AIRBYTE_NAMESPACE); \

--- a/deploy/gitops/environments/functional-ci/values.yaml
+++ b/deploy/gitops/environments/functional-ci/values.yaml
@@ -2,6 +2,13 @@ credentials:
   deploymentMode: gitops
   autoGenerate: false
 
+# No git connector runs here, and gitops mode cannot self-generate the proxy's
+# bearer token (secrets.yaml refuses: a template-time token would differ on
+# every sync). Enabling git syncing on this environment means setting
+# gitCliProxy.proxyToken as well.
+gitCliProxy:
+  deploy: false
+
 global:
   storageClass: local-path
   tenantDefaultId: "00000000-df51-5b42-9538-d2b56b7ee953"

--- a/deploy/gitops/environments/local/values.yaml.template
+++ b/deploy/gitops/environments/local/values.yaml.template
@@ -21,6 +21,13 @@ credentials:
   deploymentMode: gitops
   autoGenerate: false
 
+# No git connector runs here, and gitops mode cannot self-generate the proxy's
+# bearer token (secrets.yaml refuses: a template-time token would differ on
+# every sync). Enabling git syncing on this environment means setting
+# gitCliProxy.proxyToken as well.
+gitCliProxy:
+  deploy: false
+
 global:
   storageClass: local-path
   # Single-tenant fallback for the analytics metric-catalog resolver

--- a/deploy/gitops/environments/test-stand/ci-deployer-rbac.yaml
+++ b/deploy/gitops/environments/test-stand/ci-deployer-rbac.yaml
@@ -28,6 +28,18 @@ rules:
   - apiGroups: [""]
     resources: [configmaps, secrets, services, serviceaccounts]
     verbs: [get, list, watch, create, update, patch, delete]
+  # The git-cli-proxy's clone cache. No `delete`: the claim is annotated
+  # helm.sh/resource-policy=keep so a release never removes it, and a
+  # credential that could would discard the cache of every synced repository.
+  - apiGroups: [""]
+    resources: [persistentvolumeclaims]
+    verbs: [get, list, watch, create, update, patch]
+  # Ingress restrictions the authenticator and git-cli-proxy render when a
+  # deployment enables them. Both default off, so a stand that turns one on
+  # would otherwise fail its next upgrade the way the claim above did.
+  - apiGroups: ["networking.k8s.io"]
+    resources: [networkpolicies]
+    verbs: [get, list, watch, create, update, patch, delete]
   - apiGroups: ["apps"]
     resources: [deployments]
     verbs: [get, list, watch, create, update, patch, delete]

--- a/deploy/gitops/environments/test-stand/ci-deployer-rbac.yaml
+++ b/deploy/gitops/environments/test-stand/ci-deployer-rbac.yaml
@@ -34,12 +34,6 @@ rules:
   - apiGroups: [""]
     resources: [persistentvolumeclaims]
     verbs: [get, list, watch, create, update, patch]
-  # Ingress restrictions the authenticator and git-cli-proxy render when a
-  # deployment enables them. Both default off, so a stand that turns one on
-  # would otherwise fail its next upgrade the way the claim above did.
-  - apiGroups: ["networking.k8s.io"]
-    resources: [networkpolicies]
-    verbs: [get, list, watch, create, update, patch, delete]
   - apiGroups: ["apps"]
     resources: [deployments]
     verbs: [get, list, watch, create, update, patch, delete]

--- a/deploy/gitops/environments/test-stand/credentials-runbook.md
+++ b/deploy/gitops/environments/test-stand/credentials-runbook.md
@@ -149,6 +149,9 @@ make -C deploy/gitops verify-ci-credential ENV=test-stand
 | `create roles.rbac.authorization.k8s.io -n insight` | the chart renders its own reconcile RBAC |
 | `create workflowtemplates.argoproj.io -n insight` | the chart renders WorkflowTemplates and CronWorkflows |
 | `update httproutes.gateway.networking.k8s.io -n insight` | the umbrella renders both edge routes from `gateway.route` / `keycloak.route`, so `helm upgrade` writes them on every run |
+| `get persistentvolumeclaims -n insight` | the git-cli-proxy renders a claim for its clone cache, and `helm upgrade` reads it before patching |
+| `update persistentvolumeclaims -n insight` | its chart and version labels change on every bump |
+| `update networkpolicies.networking.k8s.io -n insight` | the authenticator and git-cli-proxy render one where a stand restricts ingress |
 | `create roles.rbac.authorization.k8s.io -n airbyte` | the chart renders `insight-airbyte-auth-reader` into the Airbyte namespace, not the release one |
 | `create rolebindings.rbac.authorization.k8s.io -n airbyte` | same object, the binding half |
 
@@ -164,6 +167,7 @@ make -C deploy/gitops verify-ci-credential ENV=test-stand
 | `list nodes --all-namespaces` | no cluster-scoped reads |
 | `create clusterrolebindings… --all-namespaces` | cannot widen its own grant |
 | `get pods -n kube-system` | no unrelated namespace, control plane included |
+| `delete persistentvolumeclaims -n insight` | the clone cache is annotated `helm.sh/resource-policy: keep` and outlives the release; a credential that could delete it could discard every synced repository |
 
 ### 3.2 One RBAC subtlety worth knowing
 

--- a/deploy/gitops/environments/test-stand/credentials-runbook.md
+++ b/deploy/gitops/environments/test-stand/credentials-runbook.md
@@ -151,7 +151,6 @@ make -C deploy/gitops verify-ci-credential ENV=test-stand
 | `update httproutes.gateway.networking.k8s.io -n insight` | the umbrella renders both edge routes from `gateway.route` / `keycloak.route`, so `helm upgrade` writes them on every run |
 | `get persistentvolumeclaims -n insight` | the git-cli-proxy renders a claim for its clone cache, and `helm upgrade` reads it before patching |
 | `update persistentvolumeclaims -n insight` | its chart and version labels change on every bump |
-| `update networkpolicies.networking.k8s.io -n insight` | the authenticator and git-cli-proxy render one where a stand restricts ingress |
 | `create roles.rbac.authorization.k8s.io -n airbyte` | the chart renders `insight-airbyte-auth-reader` into the Airbyte namespace, not the release one |
 | `create rolebindings.rbac.authorization.k8s.io -n airbyte` | same object, the binding half |
 


### PR DESCRIPTION
## Problem

`gitCliProxy.deploy` became `true` by default (#2586) and every environment started rendering the proxy — hitting two latent gaps:

- **test-stand** (helm mode): `ci-deployer` enumerates the chart's kinds and had no `persistentvolumeclaims` rule, so `helm upgrade` cannot read the cache claim it is about to patch. Every deploy since fails at stage 1.
- **dev, and next in line functional-ci / local** (gitops mode): `helm template` returns nil from `lookup`, so the chart refuses to generate a `proxyToken` (it would differ on every sync while the deployed Airbyte sources keep the old one) and fails the render until the environment supplies one.

Fix-forward rather than revert: the default stays `true` — the proxy is what every nocode git connector reads through — and each environment either meets the prerequisites or opts out.

## Fix

- **RBAC**: `persistentvolumeclaims` for `ci-deployer-core` — `get, list, watch, create, update, patch`, no `delete` (the claim is `helm.sh/resource-policy: keep`; a credential able to delete it could discard the cached clone of every synced repository). Also `networkpolicies`, the one other chart kind with no rule — the authenticator and the proxy render one where a stand restricts ingress, which would be the next stuck deploy.
- **functional-ci / local**: explicit `gitCliProxy.deploy: false` — no git connector runs there, and gitops mode cannot self-generate the token.
- The umbrella values document the two prerequisites next to the flag.
- `verify-ci-credential` gains the matching assertions (including that deleting the claim stays denied), and the runbook's scope tables list them.

## What this PR does not fix

**dev** is in insight-gitops: set `gitCliProxy.proxyToken` there (or pre-create `insight-git-cli-proxy-config`), per the render error. Keeping `deploy: true` on dev is right — it is the stand that runs the github connector.

## Applying it

The RBAC manifest is applied by make, not CI, so after merge test-stand still needs:

```bash
make -C deploy/gitops provision-ci ENV=test-stand
```

which re-applies the Role and re-runs the scope assertions.

## Verification

Rendering the umbrella with the proxy enabled produces 14 kinds; PersistentVolumeClaim was the only one uncovered by the ci-deployer Roles, NetworkPolicy the only one appearing under a non-default value. RBAC YAML parses; both environment values files parse; the Makefile target parses.