### PR TITLE
fix(test-stand): stop deploying a clone cache this stand never reads

### DIFF
--- a/deploy/gitops/environments/test-stand/credentials-runbook.md
+++ b/deploy/gitops/environments/test-stand/credentials-runbook.md
@@ -537,6 +537,25 @@ its own reconcile Role with `argoproj.io` and `onepassword.com` rules. Someone
 trimmed the supplemental `Role` in `ci-deployer-rbac.yaml` — diff it against
 git history and re-run `make provision-ci ENV=test-stand` to repair drift.
 
+**`could not get information about the resource <kind> … is forbidden`**
+The chart grew a kind the Role does not enumerate. This is the designed
+failure, not a broken credential: the grant is a list of kinds rather than a
+bind to `admin`, so a new one stops the deploy instead of installing under a
+grant nobody reviewed. Helm reads *every* rendered object before it plans the
+patch, so one unreadable kind fails the whole upgrade rather than one object —
+`get` is enough to trigger it.
+
+Two ways out, and which one is right depends on whether this stand needs the
+thing at all:
+
+- The stand needs it → add the kind to `ci-deployer-rbac.yaml` with the full
+  verb set and re-apply with `make -C deploy/gitops provision-ci ENV=test-stand`.
+  That does not rotate the token, so the GitHub environment secret stays valid.
+  Grant the kind the chart renders; a wildcard here would retire the guard.
+- The stand does not → turn the subchart off in this environment's
+  `values.yaml`. Nothing renders, nothing is claimed, and the credential stays
+  as narrow as it was. `gitCliProxy.deploy: false` is there for that reason.
+
 **`namespaces is forbidden` on a first install**
 `helm upgrade --install --create-namespace` POSTs a Namespace at cluster scope,
 but only when the release does not yet exist. This credential cannot create

--- a/deploy/gitops/environments/test-stand/values.yaml
+++ b/deploy/gitops/environments/test-stand/values.yaml
@@ -424,6 +424,20 @@ analytics:
     requests: {cpu: 100m, memory: 128Mi}
     limits: {cpu: 500m, memory: 512Mi}
 
+gitCliProxy:
+  # Off, against the chart default. The proxy exists to clone repositories for
+  # the nocode git connectors, and this stand runs none — every row it serves
+  # comes from the seeder, which writes bronze directly. What the chart's
+  # default buys here is a 50Gi volume nothing reads.
+  #
+  # Cost of the switch: reconcile logs a WARN and skips any connector whose
+  # descriptor sets `platform_config.git_proxy`, because GIT_PROXY_URL and
+  # GIT_PROXY_TOKEN reach that CronJob only when this is true. A stand that
+  # grows a real git source has to turn this back on — and grant the CI
+  # credential `persistentvolumeclaims`, which it does not hold, because
+  # ci-deployer-rbac.yaml enumerates the kinds the chart may render.
+  deploy: false
+
 frontend: # the web UI (dashboard)
   replicaCount: 1
   route:


### PR DESCRIPTION
Every post-publish deploy since `gitCliProxy.deploy` flipped to true has failed
before applying a single object, so the stand sits on an older chart and no
merge since has been seeded, smoked or suited.

## The defect

The git-cli-proxy subchart carries the repo's first `PersistentVolumeClaim`.
The CI deploy credential enumerates the kinds the chart may render rather than
binding the built-in `admin` ClusterRole, and it does not name claims:

```
UPGRADE FAILED: Unable to continue with update: could not get information about
the resource PersistentVolumeClaim "…-cache": persistentvolumeclaims is
forbidden: User "system:serviceaccount:insight:ci-deployer" cannot get resource
"persistentvolumeclaims"
```

`get`, not `create` — helm reads every rendered object before it plans the
patch, so one unreadable kind fails the entire upgrade rather than one object.
Nothing was applied and the release still reports the last chart that installed
cleanly.

## What changed

`gitCliProxy.deploy: false` for this environment.

The proxy clones repositories for the nocode git connectors. **This stand runs
none** — every row it serves comes from the seeder, which writes bronze
directly. What the chart's default buys here is a 50Gi volume nothing reads,
on a stand that has never had a claim at all, so whether the storage class
binds one is unproven besides.

The alternative was granting the credential `persistentvolumeclaims`. Not
rendering an object beats being allowed to render one nothing uses: the guard
keeps its shape, and the next kind the chart grows still stops a deploy that
would otherwise install under a grant nobody reviewed.

The runbook gets the general form of this failure, with both exits — add the
kind when the stand needs it, turn the subchart off when it does not.

## Result

| | before | after |
| --- | --- | --- |
| deploy after a merge | fails at the claim, nothing applied | proceeds |
| objects rendered here | + PVC, Deployment, Service, ConfigMap, Secret | none of them |
| CI credential | unchanged | unchanged |
| git connectors on this stand | none configured | skipped with a WARN if one appears |

## Verification

Rendering the umbrella at `0.5.171` against this environment's values, with and
without the switch, differs by exactly five objects: the subchart's PVC,
Deployment, Service and ConfigMap, plus the umbrella's proxy-config Secret.
Nothing else moves, and `GIT_PROXY_URL` leaves the reconcile CronJob. Every
kind that remains is one the Role already enumerates.

The failure itself reproduces directly: `kubectl auth can-i get
persistentvolumeclaims` against the live CI credential answers `no`.

## Notes for review

**The cost is the git connectors.** `reconcile.sh` logs a WARN and skips any
connector whose descriptor sets `platform_config.git_proxy`, because
`GIT_PROXY_URL` and `GIT_PROXY_TOKEN` reach that CronJob only while this is
true. No connector is configured on this stand today, so nothing is skipped —
but a stand that grows a real git source has to turn this back on, and grant
the credential the claim at the same time. The values comment says so at the
switch.

**This diverges the stand from the chart default**, which is a real cost: a
stand is worth most when it installs what everyone else installs. It buys back
the credential's narrowness, and the divergence is one line with its reason
next to it.

**Nothing else needs the claim.** The RBAC manifest is unchanged, so the
credential does not need re-provisioning and the GitHub environment secret
stays as it is. The next post-publish deploy is what proves this.

**Only this environment has a committed values file.** Any other install that
syncs no git source is paying the same 50Gi for the same nothing.
