### PR TITLE
fix(chart): let the proxy token follow the credentials contract

### DIFF
--- a/charts/insight/templates/secrets.yaml
+++ b/charts/insight/templates/secrets.yaml
@@ -310,13 +310,23 @@ stringData:
 
 {{- end }}
 
-{{- if .Values.gitCliProxy.deploy }}
+{{- if and .Values.gitCliProxy.deploy .Values.credentials.autoGenerate }}
 # 4. `insight-git-cli-proxy-config` — the service-to-service bearer token the
 # proxy requires on every /v1 request.
 #
-# Generated like the database passwords above: reconcile reads this Secret and
-# injects the token into each opted-in connector's Airbyte source config, so the
-# value never has to be re-derived anywhere an operator can see it.
+# Generated like the database passwords above, and on the same terms: reconcile
+# reads this Secret and injects the token into each opted-in connector's Airbyte
+# source config, so the value never has to be re-derived anywhere an operator
+# can see it.
+#
+# `autoGenerate: false` hands it to the operator, exactly as for
+# `insight-db-creds`: the deployment and the reconcile CronJob both read the
+# token from `gitCliProxy.existingSecret`, so a pre-created Secret carrying
+# APP__gears__git_cli_proxy__config__proxy_token is the whole contract. That is
+# also the only arrangement that works under `deploymentMode: gitops` — which
+# the validator already pairs with `autoGenerate: false` — because `helm
+# template` sees nothing from `lookup`, so a token generated here would differ
+# on every sync while the deployed Airbyte sources kept the previous one.
 {{- $existingProxy := (lookup "v1" "Secret" .Release.Namespace "insight-git-cli-proxy-config") }}
 {{- $proxyToken := "" }}
 {{- $proxyByo := false }}
@@ -337,11 +347,10 @@ stringData:
     {{- fail "insight-git-cli-proxy-config.APP__gears__git_cli_proxy__config__proxy_token is empty — refusing to install with a blank bearer token. Populate the key, or delete the Secret to have one generated." }}
   {{- end }}
 {{- else }}
+  {{- /* Reached only under autoGenerate, so `lookup` is live and a generated
+         token persists via the resource-policy below rather than rotating. */ -}}
   {{- $proxyToken = default "" .Values.gitCliProxy.proxyToken }}
   {{- if not $proxyToken }}
-    {{- if eq (default "helm" (default dict .Values.credentials).deploymentMode) "gitops" }}
-      {{- fail "gitCliProxy.proxyToken is empty and credentials.deploymentMode=gitops. `helm template` returns nil from `lookup`, so a generated token would differ on every sync and the deployed Airbyte sources would authenticate with a stale one. Set gitCliProxy.proxyToken, or pre-create insight-git-cli-proxy-config outside the chart." }}
-    {{- end }}
     {{- $proxyToken = randAlphaNum 32 }}
   {{- end }}
 {{- end }}

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -550,6 +550,12 @@ gitCliProxy:
   # first install and reused on every upgrade; reconcile hands it to the
   # connectors, so an operator never needs to see or copy it. Set it only to
   # pin a specific value.
+  #
+  # Under `credentials.autoGenerate: false` — which every gitops overlay runs —
+  # the chart emits no Secret at all and this value is unused: pre-create
+  # `existingSecret` below with the key
+  # APP__gears__git_cli_proxy__config__proxy_token, the same contract as
+  # `insight-db-creds`. Never inline the token here in a committed overlay.
   proxyToken: ""
   # Composed by templates/secrets.yaml (carries the bearer token).
   existingSecret: "insight-git-cli-proxy-config"


### PR DESCRIPTION
## Problem

`secrets.yaml` keeps every generated credential inside `{{- if .Values.credentials.autoGenerate }}`, so an overlay that sets it false pre-creates those Secrets itself. That is the arrangement every gitops overlay runs on — `insight.validate` already refuses `deploymentMode: gitops` together with `autoGenerate: true`, because `helm template` gets nil from `lookup` and would rotate each password per sync.

The git-cli-proxy's token block sat **outside** that gate. It ignored `autoGenerate` and instead demanded `gitCliProxy.proxyToken`, failing the render when it was empty under gitops. A gitops overlay therefore had no satisfiable option: pre-creating `insight-git-cli-proxy-config` does not help, because the same `lookup` cannot see it, and the only remaining input is a token committed in plain text — which those overlays explicitly forbid.

That is why every gitops environment broke when `gitCliProxy.deploy` became true by default: not a missing value, but a block that did not honour the contract the rest of the file follows.

## Fix

Gate the block on `autoGenerate` like the others. With it off the chart emits no proxy Secret and asks for nothing; the deployment and the reconcile CronJob already read the token from `gitCliProxy.existingSecret`, so a pre-created Secret carrying `APP__gears__git_cli_proxy__config__proxy_token` is the whole contract — the same one `insight-db-creds` uses.

The gitops-mode `fail` is removed rather than rewritten: the gate makes it unreachable, since gitops always implies `autoGenerate: false`.

## Verification

Rendering the umbrella with the proxy deployed:

- `autoGenerate: true` (helm default) — `insight-git-cli-proxy-config` renders exactly as before, generated or pinned via `proxyToken`.
- `deploymentMode: gitops` + `autoGenerate: false` — renders clean, no proxy Secret, no failure, and the proxy Deployment still references the operator-supplied one.

## Follow-up for the overlays

A gitops environment that wants git syncing now seals `insight-git-cli-proxy-config` alongside its other pre-created Secrets and sets `gitCliProxy.deploy: true`. Until it does, `deploy: false` is the correct setting there — which is what dev and the two committed gitops environments in this repo currently have.