### PR TITLE
Usage: separate events that shared a beacon, and name sections opened without a zone

### DIFF
--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -1635,6 +1635,14 @@
               "string",
               "null"
             ]
+          },
+          "time_triggered": {
+            "description": "Epoch milliseconds, stamped by the SDK when the event happened. Without\nit every record of a batch lands on its flush time.",
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
           }
         },
         "type": "object"

--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -1636,8 +1636,16 @@
               "null"
             ]
           },
+          "time_sent": {
+            "description": "Epoch milliseconds on the same clock: when the batch was flushed.",
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
           "time_triggered": {
-            "description": "Epoch milliseconds, stamped by the SDK when the event happened. Without\nit every record of a batch lands on its flush time.",
+            "description": "Epoch milliseconds on the browser's clock: when the event happened.",
             "format": "int64",
             "type": [
               "integer",

--- a/src/backend/services/analytics/src/api/usage.rs
+++ b/src/backend/services/analytics/src/api/usage.rs
@@ -66,10 +66,12 @@ pub struct TelemetryRecord {
     pub context_app_name: Option<String>,
     #[serde(default)]
     pub context_app_version: Option<String>,
-    /// Epoch milliseconds, stamped by the SDK when the event happened. Without
-    /// it every record of a batch lands on its flush time.
+    /// Epoch milliseconds on the browser's clock: when the event happened.
     #[serde(default)]
     pub time_triggered: Option<i64>,
+    /// Epoch milliseconds on the same clock: when the batch was flushed.
+    #[serde(default)]
+    pub time_sent: Option<i64>,
     #[serde(default)]
     pub data: Option<serde_json::Value>,
 }
@@ -85,12 +87,13 @@ pub async fn ingest_usage_events(
 
     let tenant_id = ctx.subject_tenant_id();
     let person_id = ctx.subject_id();
+    let arrival = Utc::now();
 
     let rows: Vec<UsageEventRow> = req
         .records
         .iter()
         .take(MAX_RECORDS)
-        .map(|record| to_row(record, &req.meta, tenant_id, person_id))
+        .map(|record| to_row(record, &req.meta, tenant_id, person_id, arrival))
         .filter(is_recordable)
         .collect();
 
@@ -121,10 +124,25 @@ struct UsageEventRow {
     app_version: String,
 }
 
-fn event_time(time_triggered: Option<i64>) -> DateTime<Utc> {
-    time_triggered
-        .and_then(DateTime::from_timestamp_millis)
-        .unwrap_or_else(Utc::now)
+/// How long a record may plausibly have waited in the browser's buffer. Past
+/// this the correction cannot place it in the right day, which is the only
+/// thing it exists to protect.
+const MAX_BUFFERED_MS: i64 = 24 * 60 * 60 * 1000;
+
+/// Both stamps come off the browser's clock, so their difference — how long the
+/// record waited to be flushed — survives a clock that is hours out. Anchoring
+/// that to the arrival instant keeps the timestamp ours while still separating
+/// records the SDK sent in one beacon.
+fn event_time(record: &TelemetryRecord, arrival: DateTime<Utc>) -> DateTime<Utc> {
+    let (Some(triggered), Some(sent)) = (record.time_triggered, record.time_sent) else {
+        return arrival;
+    };
+    match sent.checked_sub(triggered) {
+        Some(buffered) if (0..=MAX_BUFFERED_MS).contains(&buffered) => {
+            arrival - Duration::milliseconds(buffered)
+        }
+        _ => arrival,
+    }
 }
 
 /// A field the SDK hoists into `meta` is cloned into every record of the batch,
@@ -138,10 +156,11 @@ fn to_row(
     meta: &TelemetryRecord,
     tenant_id: Uuid,
     person_id: Uuid,
+    arrival: DateTime<Utc>,
 ) -> UsageEventRow {
     let data = record.data.as_ref().or(meta.data.as_ref());
     UsageEventRow {
-        ts: event_time(record.time_triggered),
+        ts: event_time(record, arrival),
         tenant_id,
         person_id,
         session_id: shared(

--- a/src/backend/services/analytics/src/api/usage.rs
+++ b/src/backend/services/analytics/src/api/usage.rs
@@ -4,7 +4,7 @@ use axum::Json;
 use axum::extract::{Extension, Query};
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
-use chrono::{Duration, NaiveDate, Utc};
+use chrono::{DateTime, Duration, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 use toolkit_canonical_errors::CanonicalError;
 use toolkit_security::SecurityContext;
@@ -66,6 +66,10 @@ pub struct TelemetryRecord {
     pub context_app_name: Option<String>,
     #[serde(default)]
     pub context_app_version: Option<String>,
+    /// Epoch milliseconds, stamped by the SDK when the event happened. Without
+    /// it every record of a batch lands on its flush time.
+    #[serde(default)]
+    pub time_triggered: Option<i64>,
     #[serde(default)]
     pub data: Option<serde_json::Value>,
 }
@@ -100,9 +104,11 @@ pub async fn ingest_usage_events(
     Ok(StatusCode::NO_CONTENT)
 }
 
-/// INVARIANT: `event_id` and `ts` are omitted so the table's DEFAULTs apply.
+/// INVARIANT: `event_id` is omitted so the table's DEFAULT applies.
 #[derive(Debug, Serialize, clickhouse::Row)]
 struct UsageEventRow {
+    #[serde(with = "clickhouse::serde::chrono::datetime64::millis")]
+    ts: DateTime<Utc>,
     #[serde(with = "clickhouse::serde::uuid")]
     tenant_id: Uuid,
     #[serde(with = "clickhouse::serde::uuid")]
@@ -113,6 +119,12 @@ struct UsageEventRow {
     target: String,
     app_name: String,
     app_version: String,
+}
+
+fn event_time(time_triggered: Option<i64>) -> DateTime<Utc> {
+    time_triggered
+        .and_then(DateTime::from_timestamp_millis)
+        .unwrap_or_else(Utc::now)
 }
 
 /// A field the SDK hoists into `meta` is cloned into every record of the batch,
@@ -129,6 +141,7 @@ fn to_row(
 ) -> UsageEventRow {
     let data = record.data.as_ref().or(meta.data.as_ref());
     UsageEventRow {
+        ts: event_time(record.time_triggered),
         tenant_id,
         person_id,
         session_id: shared(

--- a/src/backend/services/analytics/src/api/usage/tests.rs
+++ b/src/backend/services/analytics/src/api/usage/tests.rs
@@ -32,6 +32,7 @@ fn the_session_decides_identity_not_the_payload() {
         &TelemetryRecord::default(),
         tenant,
         person,
+        Utc::now(),
     );
     assert_eq!(row.tenant_id, tenant);
     assert_eq!(row.person_id, person);
@@ -50,7 +51,7 @@ fn a_field_the_batch_shares_is_read_from_the_hoisted_meta() {
         ..TelemetryRecord::default()
     };
 
-    let row = to_row(&sent, &hoisted, Uuid::now_v7(), Uuid::now_v7());
+    let row = to_row(&sent, &hoisted, Uuid::now_v7(), Uuid::now_v7(), Utc::now());
     assert_eq!(row.event_name, PAGE_VIEW);
     assert_eq!(row.session_id, "s-1");
     assert_eq!(row.path, "/portal/manage");
@@ -68,6 +69,7 @@ fn a_records_own_value_beats_the_hoisted_one() {
         &hoisted,
         Uuid::now_v7(),
         Uuid::now_v7(),
+        Utc::now(),
     );
     assert_eq!(row.event_name, "drill");
 }
@@ -89,6 +91,7 @@ fn every_field_the_caller_controls_is_bounded() {
         &TelemetryRecord::default(),
         Uuid::now_v7(),
         Uuid::now_v7(),
+        Utc::now(),
     );
     assert_eq!(row.event_name.chars().count(), MAX_NAME);
     assert_eq!(row.app_name.chars().count(), MAX_NAME);
@@ -111,6 +114,7 @@ fn a_hoisted_field_is_bounded_before_the_batch_multiplies_it() {
         &hoisted,
         Uuid::now_v7(),
         Uuid::now_v7(),
+        Utc::now(),
     );
     assert_eq!(row.app_name.chars().count(), MAX_NAME);
 }
@@ -142,6 +146,7 @@ fn the_sdks_own_page_view_is_dropped_as_a_duplicate() {
             &TelemetryRecord::default(),
             Uuid::now_v7(),
             Uuid::now_v7(),
+            Utc::now(),
         )
     };
     assert!(!is_recordable(&row(
@@ -210,52 +215,96 @@ fn a_malformed_day_is_refused_rather_than_queried() {
 }
 
 #[test]
-fn the_event_time_is_the_browsers_not_the_inserts() {
+fn a_clock_hours_out_still_places_the_event_correctly() {
+    let arrival = Utc::now();
+    let skew = 3 * 60 * 60 * 1000;
+    let buffered = 90_000;
+
     let mut event = record("page_view", serde_json::json!({ "path": "/portal" }));
-    event.time_triggered = Some(1_755_400_000_123);
+    event.time_triggered = Some(arrival.timestamp_millis() + skew - buffered);
+    event.time_sent = Some(arrival.timestamp_millis() + skew);
 
     let row = to_row(
         &event,
         &TelemetryRecord::default(),
         Uuid::now_v7(),
         Uuid::now_v7(),
+        arrival,
     );
 
-    assert_eq!(row.ts.timestamp_millis(), 1_755_400_000_123);
+    assert_eq!(row.ts, arrival - Duration::milliseconds(buffered));
 }
 
 #[test]
 fn two_events_flushed_together_keep_their_own_times() {
+    let arrival = Utc::now();
     let meta = TelemetryRecord::default();
-    let tenant = Uuid::now_v7();
-    let person = Uuid::now_v7();
+    let sent = arrival.timestamp_millis();
 
     let mut first = record("page_view", serde_json::json!({ "path": "/a" }));
-    first.time_triggered = Some(1_755_400_000_000);
+    first.time_triggered = Some(sent - 120_000);
+    first.time_sent = Some(sent);
     let mut second = record("page_view", serde_json::json!({ "path": "/b" }));
-    second.time_triggered = Some(1_755_400_060_000);
+    second.time_triggered = Some(sent - 1_000);
+    second.time_sent = Some(sent);
 
     let rows = [
-        to_row(&first, &meta, tenant, person),
-        to_row(&second, &meta, tenant, person),
+        to_row(&first, &meta, Uuid::now_v7(), Uuid::now_v7(), arrival),
+        to_row(&second, &meta, Uuid::now_v7(), Uuid::now_v7(), arrival),
     ];
 
-    assert_ne!(
-        rows[0].ts, rows[1].ts,
-        "one beacon carried both, but they happened a minute apart"
-    );
+    assert_eq!(rows[0].ts, arrival - Duration::milliseconds(120_000));
+    assert_eq!(rows[1].ts, arrival - Duration::milliseconds(1_000));
 }
 
 #[test]
 fn a_record_with_no_browser_time_falls_back_to_arrival() {
-    let before = chrono::Utc::now().timestamp_millis();
+    let arrival = Utc::now();
 
     let row = to_row(
         &record("page_view", serde_json::json!({ "path": "/portal" })),
         &TelemetryRecord::default(),
         Uuid::now_v7(),
         Uuid::now_v7(),
+        arrival,
     );
 
-    assert!(row.ts.timestamp_millis() >= before);
+    assert_eq!(row.ts, arrival);
+}
+
+#[test]
+fn a_clock_that_ran_backwards_is_not_trusted() {
+    let arrival = Utc::now();
+    let mut event = record("page_view", serde_json::json!({ "path": "/portal" }));
+    event.time_triggered = Some(arrival.timestamp_millis());
+    event.time_sent = Some(arrival.timestamp_millis() - 5_000);
+
+    let row = to_row(
+        &event,
+        &TelemetryRecord::default(),
+        Uuid::now_v7(),
+        Uuid::now_v7(),
+        arrival,
+    );
+
+    assert_eq!(row.ts, arrival);
+}
+
+#[test]
+fn an_event_held_longer_than_a_day_is_not_trusted() {
+    let arrival = Utc::now();
+    let sent = arrival.timestamp_millis();
+    let mut event = record("page_view", serde_json::json!({ "path": "/portal" }));
+    event.time_triggered = Some(sent - MAX_BUFFERED_MS - 1);
+    event.time_sent = Some(sent);
+
+    let row = to_row(
+        &event,
+        &TelemetryRecord::default(),
+        Uuid::now_v7(),
+        Uuid::now_v7(),
+        arrival,
+    );
+
+    assert_eq!(row.ts, arrival);
 }

--- a/src/backend/services/analytics/src/api/usage/tests.rs
+++ b/src/backend/services/analytics/src/api/usage/tests.rs
@@ -208,3 +208,54 @@ fn a_malformed_day_is_refused_rather_than_queried() {
         Some("2026-01-31".to_owned())
     );
 }
+
+#[test]
+fn the_event_time_is_the_browsers_not_the_inserts() {
+    let mut event = record("page_view", serde_json::json!({ "path": "/portal" }));
+    event.time_triggered = Some(1_755_400_000_123);
+
+    let row = to_row(
+        &event,
+        &TelemetryRecord::default(),
+        Uuid::now_v7(),
+        Uuid::now_v7(),
+    );
+
+    assert_eq!(row.ts.timestamp_millis(), 1_755_400_000_123);
+}
+
+#[test]
+fn two_events_flushed_together_keep_their_own_times() {
+    let meta = TelemetryRecord::default();
+    let tenant = Uuid::now_v7();
+    let person = Uuid::now_v7();
+
+    let mut first = record("page_view", serde_json::json!({ "path": "/a" }));
+    first.time_triggered = Some(1_755_400_000_000);
+    let mut second = record("page_view", serde_json::json!({ "path": "/b" }));
+    second.time_triggered = Some(1_755_400_060_000);
+
+    let rows = [
+        to_row(&first, &meta, tenant, person),
+        to_row(&second, &meta, tenant, person),
+    ];
+
+    assert_ne!(
+        rows[0].ts, rows[1].ts,
+        "one beacon carried both, but they happened a minute apart"
+    );
+}
+
+#[test]
+fn a_record_with_no_browser_time_falls_back_to_arrival() {
+    let before = chrono::Utc::now().timestamp_millis();
+
+    let row = to_row(
+        &record("page_view", serde_json::json!({ "path": "/portal" })),
+        &TelemetryRecord::default(),
+        Uuid::now_v7(),
+        Uuid::now_v7(),
+    );
+
+    assert!(row.ts.timestamp_millis() >= before);
+}

--- a/src/frontend/src/lib/portal/screen-label.test.ts
+++ b/src/frontend/src/lib/portal/screen-label.test.ts
@@ -26,6 +26,14 @@ describe("screenLabel", () => {
     expect(screenLabel("/ic/:id/team/git_output")).toBe("Person › Team › Git output");
   });
 
+  it("names a section reached without a zone in the url", () => {
+    expect(screenLabel("/portal/collaboration")).toBe("Collaboration");
+    expect(screenLabel("/portal/git_output")).toBe("Git output");
+    expect(screenLabel("/portal/ai_adoption")).toBe("AI adoption");
+    expect(screenLabel("/portal/wiki")).toBe("Wiki");
+    expect(screenLabel("/portal/task_delivery")).toBe("Task delivery");
+  });
+
   it("keeps a path it cannot name rather than inventing one", () => {
     expect(screenLabel("/some/new/route")).toBe("/some/new/route");
     expect(screenLabel("/portal/manage/not-a-real-item")).toBe(

--- a/src/frontend/src/lib/portal/screen-label.ts
+++ b/src/frontend/src/lib/portal/screen-label.ts
@@ -26,7 +26,7 @@ export function screenLabel(path: string): string {
   if (first === "portal") {
     if (!second) return "Portal";
     const zone = zoneById(second);
-    if (!zone) return path;
+    if (!zone) return GROUPS.find((group) => group.id === second)?.title ?? path;
     return third ? `${zone.label}${SEPARATOR}${itemLabel(second, third)}` : zone.label;
   }
 

--- a/src/frontend/src/telemetry-release.test.ts
+++ b/src/frontend/src/telemetry-release.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ createTelemetry: vi.fn() }));
+
+vi.mock("@gears-frontx/telemetry", () => {
+  const service = {
+    identify: () => service,
+    start: () => service,
+    logEvent: () => {},
+    destroy: () => {},
+  };
+  mocks.createTelemetry.mockImplementation(() => service);
+  return { createTelemetry: mocks.createTelemetry };
+});
+
+vi.mock("@/api/usage-client", () => ({
+  getUsageConfig: () => Promise.resolve({ enabled: true }),
+}));
+
+const SESSION = { personId: "p1", impersonatorEmail: null };
+
+beforeEach(() => {
+  vi.resetModules();
+  mocks.createTelemetry.mockClear();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("the release the collector reports", () => {
+  it("is the one the image was built with", async () => {
+    vi.stubEnv("VITE_APP_RELEASE", "2026.08.17.06.05-2d6d2b2");
+
+    const { startUsageTelemetry } = await import("./telemetry");
+    await startUsageTelemetry(SESSION as never);
+
+    expect(mocks.createTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({ appVersion: "2026.08.17.06.05-2d6d2b2" }),
+    );
+  });
+
+  it("falls back to a placeholder only when nothing stamped one", async () => {
+    vi.stubEnv("VITE_APP_RELEASE", "");
+
+    const { startUsageTelemetry } = await import("./telemetry");
+    await startUsageTelemetry(SESSION as never);
+
+    expect(mocks.createTelemetry).toHaveBeenCalledWith(
+      expect.objectContaining({ appVersion: "0.0.0" }),
+    );
+  });
+});

--- a/src/frontend/src/telemetry.ts
+++ b/src/frontend/src/telemetry.ts
@@ -9,7 +9,7 @@ const BASE =
 const APP_NAME = "insight-frontend";
 
 const APP_VERSION =
-  (import.meta.env.VITE_APP_VERSION as string | undefined) ?? "0.0.0";
+  (import.meta.env.VITE_APP_RELEASE as string | undefined) || "0.0.0";
 
 let service: TelemetryService | null = null;
 

--- a/tests/stand/api/schemas/analytics.py
+++ b/tests/stand/api/schemas/analytics.py
@@ -557,7 +557,8 @@ class TelemetryRecord(BaseModel):
     context_session_id: str | None = None
     data: Any | None = None
     name: str | None = None
-    time_triggered: int | None = Field(None, description='Epoch milliseconds, stamped by the SDK when the event happened. Without\nit every record of a batch lands on its flush time.')
+    time_sent: int | None = Field(None, description='Epoch milliseconds on the same clock: when the batch was flushed.')
+    time_triggered: int | None = Field(None, description="Epoch milliseconds on the browser's clock: when the event happened.")
 
 
 class TimeseriesPointDto(BaseModel):

--- a/tests/stand/api/schemas/analytics.py
+++ b/tests/stand/api/schemas/analytics.py
@@ -557,6 +557,7 @@ class TelemetryRecord(BaseModel):
     context_session_id: str | None = None
     data: Any | None = None
     name: str | None = None
+    time_triggered: int | None = Field(None, description='Epoch milliseconds, stamped by the SDK when the event happened. Without\nit every record of a batch lands on its flush time.')
 
 
 class TimeseriesPointDto(BaseModel):


### PR DESCRIPTION
Three defects found reading real rows on the dev stand after #2580.

**Every record in a beacon shared one timestamp** — 166 of 195 rows, worst batch 17 across 14 paths. A batch flushed after midnight files everything under the next day, which is what `by_day` buckets on.

`time_triggered` and `time_sent` come off the same clock, so their difference — how long a record waited to flush — holds even when that clock is hours out. Subtracting it from arrival keeps the timestamp server-issued (as #2580 intended) and still separates records. Backwards clock or a delay past a day falls back to arrival.

**Sections opened without a zone showed raw paths** — `/portal/collaboration`, `/portal/wiki`, and three more. `screenLabel` checked `ZONES` only, but a group is picked with `setItem`, which writes `?item=` and no `?zone=`. Now falls back to `GROUPS`; an unknown segment still returns the path.

**`app_version` was `0.0.0` on all 195 rows.** The collector read `VITE_APP_VERSION`, which nothing in the repo sets. CI already passes `VITE_APP_RELEASE` — the Dockerfile declares it, `sentry.ts` reports it, the README documents it. Only this reader invented its own spelling.

Regenerates the analytics OpenAPI document and the stand's generated models.
