### PR TITLE
fix(test-stand): stop deploying a clone cache this stand never reads

### DIFF
--- a/deploy/gitops/environments/test-stand/credentials-runbook.md
+++ b/deploy/gitops/environments/test-stand/credentials-runbook.md
@@ -540,6 +540,15 @@ its own reconcile Role with `argoproj.io` and `onepassword.com` rules. Someone
 trimmed the supplemental `Role` in `ci-deployer-rbac.yaml` — diff it against
 git history and re-run `make provision-ci ENV=test-stand` to repair drift.
 
+**`could not get information about the resource <kind> … is forbidden`**
+The chart grew a kind the Role does not enumerate — the guard working, not a
+broken credential. Helm reads *every* rendered object before it plans the
+patch, so one unreadable kind fails the whole upgrade. Either add the kind to
+`ci-deployer-rbac.yaml` and re-apply (`make -C deploy/gitops provision-ci
+ENV=test-stand`, which does not rotate the token), or turn the subchart off in
+this environment's `values.yaml` when the stand does not need it —
+`gitCliProxy.deploy: false` is there for that reason.
+
 **`namespaces is forbidden` on a first install**
 `helm upgrade --install --create-namespace` POSTs a Namespace at cluster scope,
 but only when the release does not yet exist. This credential cannot create

--- a/deploy/gitops/environments/test-stand/values.yaml
+++ b/deploy/gitops/environments/test-stand/values.yaml
@@ -424,6 +424,12 @@ analytics:
     requests: {cpu: 100m, memory: 128Mi}
     limits: {cpu: 500m, memory: 512Mi}
 
+gitCliProxy:
+  # Off, against the chart default: the proxy clones repositories for the
+  # nocode git connectors and this stand runs none. While it is off reconcile
+  # skips any connector whose descriptor sets `platform_config.git_proxy`.
+  deploy: false
+
 frontend: # the web UI (dashboard)
   replicaCount: 1
   route:


### PR DESCRIPTION
Reopens the change from #2596 (closed as covered by #2593 — it is not; see below).

Every post-publish deploy since `gitCliProxy.deploy` flipped to true has failed
before applying anything, and the stand has been stuck on `0.5.168` since.
That subchart carries the repo's first `PersistentVolumeClaim`, the stand's
`ci-deployer-core` Role does not name claims, and helm reads every rendered
object before it plans the patch — so the unreadable claim fails the whole
upgrade, on `get`, not `create`.

**#2593 does not unblock the stand, and 0.5.173 failed the same way after it
merged.** It adds the rule to `ci-deployer-rbac.yaml`, which is a committed
manifest — the live Role only changes when an operator with a human credential
re-applies it, and the CI credential cannot do that itself (escalation
prevention stops a subject granting what it does not hold). Read straight off
the stand: `kubectl auth can-i get persistentvolumeclaims -n insight` answers
`no`, and the live `ci-deployer-core` carries seven rules, none of them claims.

The proxy clones repositories for the nocode git connectors and this stand runs
none: every row it serves comes from the seeder. Turning the subchart off here
renders no claim at all, so the stand deploys again on merge with no cluster
access needed and no wait on someone's laptop. It also sidesteps a second
unknown — the claim asks for 50Gi at `ReadWriteOncePod` with no
`storageClassName`, on a stand that has never had a claim, so whether it would
even bind is unverified; an unbound claim fails `helm --wait` instead.

This composes with #2593 rather than reverting it: the grant stays, and a stand
that grows a real git source turns the switch back on once the manifest has
been applied. The cost meanwhile is that reconcile skips any connector whose
descriptor sets `platform_config.git_proxy` — `GIT_PROXY_URL` reaches that
CronJob only while this is true — and none is configured here.

Rendering the umbrella at `0.5.173` against this environment's values, with and
without the switch, differs by exactly five objects: the subchart's PVC,
Deployment, Service and ConfigMap, plus the umbrella's proxy-config Secret.
Every kind that remains is one the live Role already allows.

## The two ways out

1. **Apply the manifest** — `make -C deploy/gitops provision-ci ENV=test-stand` from an admin kubeconfig for the stand. No repo change: main already carries the rule. This keeps the stand on the chart default and is the right end state. Unverified risk: an unbound 50Gi `ReadWriteOncePod` claim would fail `helm --wait` next.
2. **This PR** — the stand deploys again on merge, with no cluster access and nothing waiting on anyone's laptop.

Not exclusive: merge this to unblock, apply the manifest when someone with admin is free, then flip the switch back if this stand ever needs the proxy. Auto-merge is deliberately **not** armed.
