### PR TITLE
fix(test-stand): stop deploying a clone cache this stand never reads

### DIFF
--- a/deploy/gitops/environments/test-stand/credentials-runbook.md
+++ b/deploy/gitops/environments/test-stand/credentials-runbook.md
@@ -540,6 +540,15 @@ its own reconcile Role with `argoproj.io` and `onepassword.com` rules. Someone
 trimmed the supplemental `Role` in `ci-deployer-rbac.yaml` — diff it against
 git history and re-run `make provision-ci ENV=test-stand` to repair drift.
 
+**`could not get information about the resource <kind> … is forbidden`**
+The chart grew a kind the Role does not enumerate — the guard working, not a
+broken credential. Helm reads *every* rendered object before it plans the
+patch, so one unreadable kind fails the whole upgrade. Either add the kind to
+`ci-deployer-rbac.yaml` and re-apply (`make -C deploy/gitops provision-ci
+ENV=test-stand`, which does not rotate the token), or turn the subchart off in
+this environment's `values.yaml` when the stand does not need it —
+`gitCliProxy.deploy: false` is there for that reason.
+
 **`namespaces is forbidden` on a first install**
 `helm upgrade --install --create-namespace` POSTs a Namespace at cluster scope,
 but only when the release does not yet exist. This credential cannot create

--- a/deploy/gitops/environments/test-stand/values.yaml
+++ b/deploy/gitops/environments/test-stand/values.yaml
@@ -424,6 +424,12 @@ analytics:
     requests: {cpu: 100m, memory: 128Mi}
     limits: {cpu: 500m, memory: 512Mi}
 
+gitCliProxy:
+  # Off, against the chart default: the proxy clones repositories for the
+  # nocode git connectors and this stand runs none. While it is off reconcile
+  # skips any connector whose descriptor sets `platform_config.git_proxy`.
+  deploy: false
+
 frontend: # the web UI (dashboard)
   replicaCount: 1
   route:


### PR DESCRIPTION
Every deploy to the stand has failed since the umbrella began deploying
git-cli-proxy by default. That subchart renders a `PersistentVolumeClaim`, and
the stand's CI credential has no permission on claims:

```
could not get information about the resource PersistentVolumeClaim
"insight-git-cli-proxy-cache" … persistentvolumeclaims is forbidden
```

Helm reads every rendered object before it patches, so that one read fails the
whole upgrade. Six deploys in a row, nothing applied, stand still on `0.5.168`.

#2593 added the missing rule to `ci-deployer-rbac.yaml`, but that manifest is
applied by hand — the live Role is unchanged, and `0.5.173` failed the same way
after it merged. `kubectl auth can-i get persistentvolumeclaims -n insight`
still answers `no`.

This stand runs no git connectors; its rows come from the seeder. So
`gitCliProxy.deploy: false` here: nothing renders, nothing is claimed, and the
deploy works again on merge without touching the cluster.

**Cost** — reconcile skips any connector whose descriptor sets
`platform_config.git_proxy`. None is configured here.

**Verification** — rendering this environment at `0.5.173` with and without the
switch differs by exactly five objects: the subchart's PVC, Deployment, Service
and ConfigMap, plus the umbrella's proxy-config Secret. No `GIT_PROXY_*` env or
proxy Secret reference survives anywhere in the render.

**Still worth doing** — `make -C deploy/gitops provision-ci ENV=test-stand` from
an admin kubeconfig, so the live Role matches the manifest. It cannot be done
from CI: escalation prevention stops the credential granting itself a permission
it does not hold.
