### PR TITLE
fix(github): make the start date bound every stream

### DIFF
--- a/src/ingestion/connectors/git/github/README.md
+++ b/src/ingestion/connectors/git/github/README.md
@@ -36,6 +36,28 @@ feeds the shared `class_git_*` silver models.
 connector already syncs the org roster for identity resolution. Folding it in
 here is a separate migration.
 
+## What `github_start_date` bounds
+
+One bound, one direction: every stream fetches everything from the start date to
+now, and nothing before it. It is a floor on age, not a window size — a stream
+that stops short of it discards data inside the range that was asked for, and
+one that reaches behind it spends requests on data nobody wants.
+
+Two consequences worth stating, because both are easy to get wrong:
+
+- **A repository whose last push predates the start date is not walked at all.**
+  It has no commit, file change or author inside the window, so the clone the
+  proxy streams would spend on it buys nothing.
+- **A pull request's reviews, commits and lifecycle events reach as far back as
+  the pull requests themselves do**, as do a deployment's statuses. Each of
+  those streams carries its own cursor and sets `incremental_dependency`, which
+  is what makes that affordable: the first sync walks the whole window once,
+  and later syncs resume from stored state instead of re-reading it.
+
+Sub-resources of an item inside the window are fetched whole — every review of
+an in-window pull request, including one submitted before the start date. The
+item is what the bound applies to.
+
 ## Commit attribution
 
 A commit carries a name and an e-mail; it never carries an account, because git

--- a/src/ingestion/connectors/git/github/connector.yaml
+++ b/src/ingestion/connectors/git/github/connector.yaml
@@ -300,9 +300,16 @@ definitions:
       cursor_datetime_formats:
         - "%Y-%m-%dT%H:%M:%S%z"
       is_client_side_incremental: true
+      # A repository whose last push predates the start date has no commit,
+      # file change or author inside the window, so it is never worth the
+      # clone the proxy streams would spend on it. `pushed_at` is never older
+      # than the newest commit's push, so nothing in the window is lost by
+      # dropping it here. The endpoint offers no date filter, hence the
+      # client-side drop — and the CDK refuses to pair that with a data-feed
+      # stop, so the listing itself is still walked whole.
       start_datetime:
         type: MinMaxDatetime
-        datetime: "1970-01-01"
+        datetime: "{{ config['github_start_date'] }}"
         datetime_format: "%Y-%m-%d"
 
   # Full roster (no pushed_at gate): reviews/comments/issues/CI advance
@@ -1230,6 +1237,10 @@ streams:
             partition_field: pull_number
             extra_fields:
               - [repo_full_name]
+            # Without this the parent cursor never persists, and every
+            # pull request since the start date is re-walked — one call each —
+            # on every sync.
+            incremental_dependency: true
             stream: &pull_requests_window
               type: DeclarativeStream
               name: pull_requests_window
@@ -1282,9 +1293,12 @@ streams:
                 datetime_format: "%Y-%m-%dT%H:%M:%SZ"
                 cursor_datetime_formats:
                   - "%Y-%m-%dT%H:%M:%S%z"
-                # Stateless sliding window: the child has no cursor of its
-                # own, so parent state would never persist. The data-feed
-                # stop is what bounds pagination at the window edge.
+                # The start date, so a pull request's reviews, commits and
+                # lifecycle events cover the same period the pull request
+                # itself does. Every child of this window carries a cursor and
+                # sets `incremental_dependency`, which is what makes the bound
+                # affordable: this walk is paid once, and later syncs resume
+                # from the stored state rather than re-reading the window.
                 # VERIFIED against the CDK: the data-feed stop halts pagination at the
                 # first record older than the slice start, but the boundary PAGE's tail
                 # still emits — up to one page of pre-start_date rows per partition
@@ -1294,8 +1308,8 @@ streams:
                 is_data_feed: true
                 start_datetime:
                   type: MinMaxDatetime
-                  datetime: "{{ format_datetime(now_utc() - duration('P30D'), '%Y-%m-%dT%H:%M:%SZ') }}"
-                  datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+                  datetime: "{{ config['github_start_date'] }}"
+                  datetime_format: "%Y-%m-%d"
               transformations:
                 - type: AddFields
                   fields:
@@ -1303,6 +1317,20 @@ streams:
                       path: [repo_full_name]
                       value: "{{ stream_partition.repo_full_name }}"
                       value_type: string
+    incremental_sync:
+      # A cursor of its own is what lets the parent's state persist
+      # (`incremental_dependency` above): the review's own timestamp, so a later sync
+      # resumes instead of re-reading everything since the start date.
+      type: DatetimeBasedCursor
+      cursor_field: submitted_at
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S%z"
+        - "%Y-%m-%dT%H:%M:%SZ"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config['github_start_date'] }}"
+        datetime_format: "%Y-%m-%d"
     transformations:
       - type: AddFields
         fields: *standard_fields
@@ -1416,7 +1444,25 @@ streams:
             partition_field: pull_number
             extra_fields:
               - [repo_full_name]
+            # Without this the parent cursor never persists, and every
+            # pull request since the start date is re-walked — one call each —
+            # on every sync.
+            incremental_dependency: true
             stream: *pull_requests_window
+    incremental_sync:
+      # A cursor of its own is what lets the parent's state persist
+      # (`incremental_dependency` above): the commit's own timestamp, so a later sync
+      # resumes instead of re-reading everything since the start date.
+      type: DatetimeBasedCursor
+      cursor_field: committed_date
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S%z"
+        - "%Y-%m-%dT%H:%M:%SZ"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config['github_start_date'] }}"
+        datetime_format: "%Y-%m-%d"
     transformations:
       - type: AddFields
         fields: *standard_fields
@@ -2650,6 +2696,10 @@ streams:
             partition_field: deployment_id
             extra_fields:
               - [repo_full_name]
+            # Without this the parent cursor never persists, and every
+            # deployment since the start date is re-walked — one call each —
+            # on every sync.
+            incremental_dependency: true
             stream:
               type: DeclarativeStream
               name: deployments_window
@@ -2699,8 +2749,10 @@ streams:
                 datetime_format: "%Y-%m-%dT%H:%M:%SZ"
                 cursor_datetime_formats:
                   - "%Y-%m-%dT%H:%M:%S%z"
-                # Stateless sliding window; data-feed stop bounds the
-                # newest-first pagination at the window edge.
+                # The start date, so a deployment's outcome covers the same
+                # period the deployment does. The child carries a cursor and
+                # sets `incremental_dependency`, so this walk is paid once and
+                # later syncs resume from the stored state.
                 # VERIFIED against the CDK: the data-feed stop halts pagination at the
                 # first record older than the slice start, but the boundary PAGE's tail
                 # still emits — up to one page of pre-start_date rows per partition
@@ -2710,8 +2762,8 @@ streams:
                 is_data_feed: true
                 start_datetime:
                   type: MinMaxDatetime
-                  datetime: "{{ format_datetime(now_utc() - duration('P30D'), '%Y-%m-%dT%H:%M:%SZ') }}"
-                  datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+                  datetime: "{{ config['github_start_date'] }}"
+                  datetime_format: "%Y-%m-%d"
               transformations:
                 - type: AddFields
                   fields:
@@ -2719,6 +2771,20 @@ streams:
                       path: [repo_full_name]
                       value: "{{ stream_partition.repo_full_name }}"
                       value_type: string
+    incremental_sync:
+      # A cursor of its own is what lets the parent's state persist
+      # (`incremental_dependency` above): the status's own timestamp, so a later sync
+      # resumes instead of re-reading everything since the start date.
+      type: DatetimeBasedCursor
+      cursor_field: created_at
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S%z"
+        - "%Y-%m-%dT%H:%M:%SZ"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config['github_start_date'] }}"
+        datetime_format: "%Y-%m-%d"
     transformations:
       - type: AddFields
         fields: *standard_fields
@@ -2861,7 +2927,25 @@ streams:
             partition_field: pull_number
             extra_fields:
               - [repo_full_name]
+            # Without this the parent cursor never persists, and every
+            # pull request since the start date is re-walked — one call each —
+            # on every sync.
+            incremental_dependency: true
             stream: *pull_requests_window
+    incremental_sync:
+      # A cursor of its own is what lets the parent's state persist
+      # (`incremental_dependency` above): the event's own timestamp, so a later sync
+      # resumes instead of re-reading everything since the start date.
+      type: DatetimeBasedCursor
+      cursor_field: event_at
+      datetime_format: "%Y-%m-%dT%H:%M:%SZ"
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S%z"
+        - "%Y-%m-%dT%H:%M:%SZ"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config['github_start_date'] }}"
+        datetime_format: "%Y-%m-%d"
     transformations:
       - type: AddFields
         fields: *standard_fields

--- a/src/ingestion/connectors/git/github/descriptor.yaml
+++ b/src/ingestion/connectors/git/github/descriptor.yaml
@@ -1,5 +1,5 @@
 name: github
-version: "2.3.0"
+version: "2.4.0"
 schedule: "0 4 * * *"
 workflow: sync
 

--- a/src/ingestion/connectors/git/github/tests/test_github_streams.py
+++ b/src/ingestion/connectors/git/github/tests/test_github_streams.py
@@ -907,3 +907,80 @@ def test_commit_authors_drops_an_email_github_matches_to_nobody(
 
     assert not output.errors
     assert len(output.records) == 0, "an unmatched e-mail claims no account"
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_roster_skips_a_repository_untouched_since_the_start_date(
+    http_mocker: HttpMocker,
+) -> None:
+    """The proxy streams partition over this roster, so a repository whose last
+    push predates the start date would be cloned for nothing: it has no commit,
+    file change or author inside the window."""
+    config = GithubConfigBuilder().build()
+    stale = _repo() | {
+        "id": 45,
+        "full_name": "acme/dormant",
+        "name": "dormant",
+        "clone_url": "https://github.com/acme/dormant.git",
+        "pushed_at": "2024-01-01T00:00:00Z",
+    }
+    http_mocker.get(
+        HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps([_repo(), stale]), status_code=200),
+    )
+    # Every partition that IS walked yields a branch stamped with its clone URL.
+    http_mocker.get(
+        HttpRequest(f"{PROXY_URL}/v1/branches", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps(
+                {
+                    "items": [
+                        {
+                            "name": "main",
+                            "head_sha": "f" * 40,
+                            "head_committed_date": "2026-06-20T10:00:00Z",
+                            "is_default": True,
+                        }
+                    ],
+                    "next_page_token": None,
+                }
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "branches", config)
+
+    assert not output.errors
+    walked = {record.record.data["repository"] for record in output.records}
+    assert walked == {"https://github.com/acme/app.git"}, (
+        f"only repositories pushed since the start date may be walked: {walked}"
+    )
+
+
+def test_every_dated_stream_floors_on_the_start_date() -> None:
+    """The start date is one bound in one direction: fetch everything since it,
+    nothing before it. A stream that floors on anything else — a rolling window,
+    an epoch — either discards data inside the window or fetches outside it, and
+    both failures are silent."""
+    manifest = load_manifest(_CONNECTOR)
+    offenders: list[str] = []
+
+    def walk(node, name="?"):
+        if isinstance(node, dict):
+            if node.get("type") == "DeclarativeStream":
+                name = node.get("name", name)
+                start = ((node.get("incremental_sync") or {}).get("start_datetime") or {})
+                declared = start.get("datetime") if isinstance(start, dict) else start
+                if declared and "github_start_date" not in str(declared):
+                    offenders.append(f"{name}: {declared}")
+            for value in node.values():
+                walk(value, name)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item, name)
+
+    walk(manifest)
+    assert not offenders, "streams flooring on something other than the start date: " + "; ".join(
+        offenders
+    )


### PR DESCRIPTION
## Problem

`github_start_date` means one thing: fetch everything since it, nothing before it. It is a floor on age, not a window size. Three places did not honour it — and the CI wiring guard added for the bitbucket audit passes this connector, because it checks that *a* filter exists, never *what date* it filters on.

**Over-fetch.** The repository roster the proxy streams partition over floored on `1970-01-01`. `is_client_side_incremental` only skips repositories on later syncs, so a first sync admitted every repository the organisation had ever owned and the proxy cloned each one — including repositories nobody had pushed to in years, which hold nothing inside the window.

**Under-fetch, silently.** The pull-request and deployment windows floored on `now − 30d`, unrelated to the start date. A two-year backfill therefore collected two years of pull requests and **one month** of their reviews, commits and lifecycle events, and one month of deployment statuses. Nothing errors; the rows are simply absent.

## Fix

- The roster floors on `github_start_date`. `pushed_at` is never older than the newest commit's push, so nothing inside the window is lost by skipping a dormant repository. The endpoint offers no date filter, so the drop stays client-side — and the CDK refuses to pair that with a data-feed stop, so the listing itself is still walked whole.
- Both windows floor on `github_start_date`.
- `pull_request_reviews`, `pull_request_commits`, `pull_request_timeline_events` and `deployment_statuses` each gain a cursor of their own — `submitted_at`, `committed_date`, `event_at`, `created_at` — and their parent configs set `incremental_dependency: true`.

That last part is what makes the bound affordable rather than theoretical. These children kept no state, so the parent restarted from its floor on every sync: with the floor at the start date and no state, each sync would re-walk the whole window at one request per pull request — at a two-year window and this organisation's volume, roughly 78k requests, or over a day per sync. With state the walk is paid once and later syncs resume. The mechanism is the one `commits` already uses against the same roster, and `issue_timeline_events` already used against its own parent.

No new config: the start date is the only date input, and adding a second dial for an age bound that already has one is surface we do not want.

## Verification

- 20/20 connector tests. Two are new and both hold the rule: a repository dormant since before the start date is not walked, and no stream floors on anything other than the start date.
- The dormant-repository test was confirmed to fail against the old epoch floor (it walked `acme/dormant`), so it discriminates rather than merely passing.
- Every chain re-audited from the manifest: 18 streams and their nested parents, all floors now resolve to `github_start_date`.
- Deliberately unchanged: the full `repositories_all` roster stays unfiltered, because reviews, comments and issues advance without pushes and gating it would lose data; its children are all floored. `repositories` and `projects_v2` stay full-refresh.

## Deployment note

Making a child incremental changes its sync mode, so an existing Airbyte connection needs those four streams re-selected. Fresh deploys are unaffected. Descriptor bumped to 2.4.0 so reconcile rolls the manifest out.

The first sync after this lands is the expensive one, by design — it collects the pull-request detail the 30-day window was skipping.