### PR TITLE
fix(ai-cost): stop the Claude Team path losing data it already has

### DIFF
--- a/.claude/skills/check-dbt-conventions/SKILL.md
+++ b/.claude/skills/check-dbt-conventions/SKILL.md
@@ -104,7 +104,7 @@ Every silver model and every dbt-owned staging model with append/event semantics
 For each `.sql` file under `src/ingestion/silver/` and `src/ingestion/connectors/*/dbt/`:
 
 - If `materialized='table'` AND model name is in the allow-list above → PASS
-- If `materialized='table'` AND model name is NOT in the allow-list → FAIL with suggestion: "Convert to `materialized='incremental'`. For **silver** use `incremental_strategy='delete+insert'` + `unique_key='unique_key'`; for **staging** use `incremental_strategy='append'`. Add `WHERE _version > (SELECT max(_version) FROM {{ this }})`. If upstream lacks `_version`, amend the SELECT to project `toUnixTimestamp64Milli(_airbyte_extracted_at) AS _version`."
+- If `materialized='table'` AND model name is NOT in the allow-list → FAIL with suggestion: "Convert to `materialized='incremental'`. For **silver** use `incremental_strategy='delete+insert'` + `unique_key='unique_key'`; for **staging** use `incremental_strategy='append'`. Scope the incremental boundary to one source instance with `{{ silver_incremental_watermark([...]) }}` — never a table-wide `max(_version)`, which lets one producer's boundary permanently exclude a slower producer's rows. If upstream lacks `_version`, amend the SELECT to project `toUnixTimestamp64Milli(_airbyte_extracted_at) AS _version`."
 - If `materialized='view'` for a silver `class_*` / `fct_*` / `mtr_*` → FAIL (views forbidden in silver per check 1)
 - If `materialized='ephemeral'` → cross-checked by Check 6
 

--- a/docs/components/backend/analytics/specs/ai-cost/DECOMPOSITION.md
+++ b/docs/components/backend/analytics/specs/ai-cost/DECOMPOSITION.md
@@ -65,11 +65,18 @@ against its eight. The real gaps are elsewhere:
 3. **Two facts stall inside our own pipeline**: `last_active` never leaves bronze, and rows
    with a non-active `status` are dropped without anyone knowing what is lost.
 
-**Deferred out of this issue.** `prs_with_cc_count` and `prs_total_count` also reach silver
-unread, but they answer whether a pull request involved Claude Code — the subject of `#1660`,
-not of cost. No requirement here calls for them, and FR-9 forbids the per-PR cost figure they
-would invite. Recorded as a candidate for `#1660`; the vendor populates them only where
-Anthropic's GitHub app is connected.
+**Resolved since.** The `status` half of gap 3 is closed: the value is carried into
+class-contract `seat_status` and reaches gold as a dimension, because filtering on it was
+retroactive — the vendor restates the status for every day it re-reads, so dropping non-active
+rows deleted the whole history of whoever left. See `audit-claude-team.md` D1. `last_active`
+still stops at bronze (D4).
+
+**Deferred out of this issue, then revised.** `prs_with_cc_count` and `prs_total_count` answer
+whether a pull request involved Claude Code — the subject of `#1660`, not of cost — and FR-9
+forbids the per-PR cost figure they would invite. That still holds for anything per-PR. The two
+counts themselves no longer stop in silver: they are served as `ai.prs_with_assistant` and
+`ai.prs_total`, emitted only where the vendor supplies a value, since the alternative was data
+nobody could reach. The vendor populates them only where Anthropic's GitHub app is connected.
 
 **Decomposition strategy**:
 
@@ -381,8 +388,8 @@ branch is picked up.
     paid seat nobody used is visible as money. Room left under the extra-usage ceiling is
     **not** underuse and is never counted as such: it was never purchased.
   - The seat-state filter lives inside the overage branch rather than being inherited from
-    the activity stream. A deactivated person keeps an overage row but loses activity rows,
-    and would otherwise read as an idle seat. The gate is `credit_limit_cents IS NOT NULL`;
+    the activity stream: a seat with no usage has no activity row to inherit a state from.
+    The gate is `credit_limit_cents IS NOT NULL`;
     `is_enabled` is carried as a dimension and never filtered on (2.1).
   - e2e for both.
 

--- a/docs/components/backend/analytics/specs/ai-cost/PRD.md
+++ b/docs/components/backend/analytics/specs/ai-cost/PRD.md
@@ -559,8 +559,9 @@ rest classified but unattributed. *Confirming the real value distribution on pro
 would make the rule exhaustive rather than defensive.*
 
 **OD-5 — Seat state filter.** *(resolved — recorded for traceability)* A deactivated person
-keeps an overage row but loses activity rows, so they would read as an unused seat. The
-filter must live inside the overage branch. `is_enabled` was the candidate; its semantics
+keeps an overage row and, since the seat status became a carried column rather than a filter,
+keeps their activity rows too. The filter must still live inside the overage branch, because a
+seat with no usage has no activity row to inherit a state from. `is_enabled` was the candidate; its semantics
 remain undocumented and one observation cannot separate "extra usage is disabled" from "the
 seat is not assigned", so it is carried as a dimension and never used as a filter. Seat state
 gates on `credit_limit_cents IS NOT NULL` instead.

--- a/docs/components/backend/analytics/specs/ai-cost/audit-claude-team.md
+++ b/docs/components/backend/analytics/specs/ai-cost/audit-claude-team.md
@@ -40,9 +40,19 @@ FROM bronze_claude_team.claude_team_code_metrics FINAL
 GROUP BY status
 ```
 
-**Decision: keep the filter.** The vendor documents no value set for this field, so a value
-other than `active` may appear at any time and would be dropped without a trace. Add a
-build-time check that counts non-active rows rather than removing the filter.
+**Decision: carry the field, do not filter on it.** The first reading — keep the filter, add
+a check that counts non-active rows — missed that the filter is retroactive. The endpoint
+restates the status for every day it re-reads, so the value describes the seat as of the read
+and not as of the metric date: the day a person's seat is deactivated, the filter deletes
+their entire history, and a full refresh removes it from silver altogether. Nothing about a
+seat's present state licenses deleting the work it recorded.
+
+So staging carries the value into the class-contract column `seat_status`, gold exposes it as
+the `seat_status` dimension, and emission is gated on the activity counters instead — the same
+gate every other contributor to the class already uses, and the one the class contract asks
+for. Rows written before the column existed carry no value and read as `unknown`, which is
+what they are: re-materialising them from bronze would mean a full refresh, and that is the
+operation that costs months of overage history.
 
 ## 3. `is_enabled` — resolves PRD OD-5
 
@@ -124,6 +134,15 @@ Anthropic populates both counters only for organisations that have connected its
    whether a pull request involved Claude Code, which is `#1660`'s subject, not cost — the
    entry was removed from the decomposition and recorded as a candidate for `#1660`.
 
+**Revised on the counters.** Leaving them in silver unread meant nobody could see them at all,
+which is a worse position than serving them with the vendor's own caveat attached. Both now
+reach gold as `ai.prs_with_assistant` and `ai.prs_total`, emitted only where the vendor
+supplies a value, so an organisation without the app returns no value rather than a zero —
+consequence 1 above, honoured by construction. Consequence 2 stands: a live demonstration
+still needs a tenant with the app connected. `ai.prs_total` is served as context for the other
+measure and not as a goal of its own, because the vendor's window may not be the day the row
+is dated.
+
 ## 7. Seat economics — what to show for 2.3
 
 ```sql
@@ -155,11 +174,11 @@ The properties the demonstration rests on, each visible in that query:
 
 | # | Decision | Affects |
 |---|---|---|
-| D1 | Keep the `status = 'active'` filter; add a build-time count of non-active rows | 2.1 → build |
+| D1 | Carry `status` into class-contract `seat_status` and gate emission on the activity counters instead; the filter was retroactive and deleted a deactivated person's whole history | 2.1 → build |
 | D2 | Seat-state gate is `credit_limit_cents IS NOT NULL` alone; `is_enabled` is carried as a dimension, never as a filter | 2.6; closes PRD OD-5 |
 | D3 | Do not carry `api_key_name`, `avg_cost_per_day`, `avg_lines_accepted_per_day`, `prs_with_cc_percentage` | 2.1 → closed |
 | D4 | Do not carry `last_active` yet; record as a candidate for an "idle seat" signal | 2.6 |
-| D5 | PR attribution leaves this decomposition; recorded as a candidate for `#1660` | — |
+| D5 | PR attribution leaves this decomposition. Superseded on the counters themselves: the two counts already in silver now reach gold as `ai.prs_with_assistant` / `ai.prs_total`, honest-NULL where the vendor does not report. The per-PR cost figure FR-9 forbids stays out, and the "did this PR involve the assistant" question remains `#1660`'s | — |
 | D6 | Guard `used_credits_basis` — the used-vs-limit comparison is only valid while every row shares one basis | 2.3 |
 | D7 | `members` and `invites` stop at bronze in both implementations; no parity gap, no action | — |
 | D8 | Invoices are the only genuine extraction gap against the reference | 2.5 |

--- a/docs/components/backend/analytics/specs/ai-cost/research-notes.md
+++ b/docs/components/backend/analytics/specs/ai-cost/research-notes.md
@@ -348,16 +348,19 @@ by `cost_type`, not by which connector produced it.** A `billing_model` column o
 | Stream (`connector.yaml`) | `claude_team_overage_spend` (line 168) | `claude_team_code_metrics` (line 288) |
 | Bronze table | `bronze_claude_team.claude_team_overage_spend` | `bronze_claude_team.claude_team_code_metrics` |
 | Grain | one row per seat, monthly snapshot | one row per (`metric_date`, `email`) |
-| Used in | `claude_team__ai_overage.sql` → column `is_enabled` | `claude_team__ai_dev_usage.sql:93` → `WHERE status = 'active'` |
+| Used in | `claude_team__ai_overage.sql` → column `is_enabled` | `claude_team__ai_dev_usage.sql` → class-contract column `seat_status` (was a `WHERE status = 'active'` filter; audit D1) |
 | Meaning | undocumented | undocumented beyond `'active'` |
 
 Consequence for seat-utilisation metrics: the denominator comes from `class_ai_overage`
-while activity comes from `class_ai_dev_usage` filtered to `status='active'`. A deactivated
-person keeps their overage row but loses their activity rows, and would register as an
-under-utilised seat. The state filter has to live inside the overage branch. `is_enabled`
-looked like the candidate when this section was written; §16 and audit decision D2 settle it
-the other way — the gate is `credit_limit_cents IS NOT NULL` alone, and `is_enabled` is
-carried as a dimension. This paragraph is kept for the reasoning, not for its conclusion.
+while activity comes from `class_ai_dev_usage`, which at the time was filtered to
+`status='active'`. A deactivated person kept their overage row but lost their activity rows,
+and would register as an under-utilised seat. That half no longer applies — audit D1 removed
+the filter, so the activity rows stay. The conclusion is unchanged for the other reason: a
+person with no usage at all has no activity row to inherit a state from, so the state filter
+still has to live inside the overage branch. `is_enabled` looked like the candidate when this
+section was written; §16 and audit decision D2 settle it the other way — the gate is
+`credit_limit_cents IS NOT NULL` alone, and `is_enabled` is carried as a dimension. This
+paragraph is kept for the reasoning, not for its conclusion.
 
 ### Other `overage_spend_limits` fields
 
@@ -415,10 +418,13 @@ gap independent of #1607 and should be tracked separately.
 5. **`dbt source freshness` is scheduled nowhere** — see §15. Every connector declares
    thresholds; no workflow runs the command. Platform-wide, not AI-specific; should become
    its own issue linked to `#1607`.
-6. **Vendor pull-request attribution deferred** — `prs_with_cc_count` and `prs_total_count`
-   reach silver unread. Removed from this decomposition as `#1660` territory; no requirement
-   here needs them, and the vendor populates them only where Anthropic's GitHub app is
-   connected — everywhere else both counters read zero without meaning it.
+6. **Vendor pull-request attribution deferred, then served** — `prs_with_cc_count` and
+   `prs_total_count` reached silver unread. Removed from this decomposition as `#1660`
+   territory; no requirement here needed them, and the vendor populates them only where
+   Anthropic's GitHub app is connected — everywhere else both counters read zero without
+   meaning it. Reversed on the counters alone: they are served as `ai.prs_with_assistant` and
+   `ai.prs_total`, emitted only where the vendor supplies a value so that the zeros never
+   become assertions. Anything per-PR remains `#1660`'s and FR-9's.
 7. **#1986 "Verified state" corrections** — the Cursor hard-NULL claim is stale, and
    `ai_cost_person_period` is described as the grain the catalog could read, though the
    unified registry reads `ai_metric_observations`.

--- a/src/backend/services/analytics/src/domain/metric_definitions/builtin.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/builtin.rs
@@ -186,7 +186,7 @@ mod tests {
     #[test]
     fn registry_declares_the_expected_counts() {
         assert_eq!(builtin_sources().len(), 6, "builtin source count");
-        assert_eq!(builtin_metrics().len(), 62, "builtin metric count");
+        assert_eq!(builtin_metrics().len(), 64, "builtin metric count");
     }
 
     #[test]

--- a/src/backend/services/analytics/src/domain/metric_definitions/passports.md
+++ b/src/backend/services/analytics/src/domain/metric_definitions/passports.md
@@ -90,7 +90,7 @@ this file and the registry disagree.
 - Reads: dev_conversations
 - Formula: sum(dev_conversations)
 - Shape: integer, higher_is_better, unit conversations
-- Notes: Person-attributed coding conversations from dev tools that report them.
+- Notes: Person-attributed conversations with coding AI tools, counted as the vendor counts them. For the agent tools this is the session or thread count — a session is the unit of conversation there, and no vendor publishes a separate conversation counter — so the number reads as "times the person started working with the assistant", not as messages exchanged. Tools that report no such unit, inline-completion tools among them, return no value rather than a zero.
 
 ## ai.chat_assistant_conversations — AI chat conversations
 
@@ -99,6 +99,22 @@ this file and the registry disagree.
 - Formula: sum(chat_assistant_conversations)
 - Shape: integer, higher_is_better, unit conversations
 - Notes: Person-attributed chat assistant conversations from supported AI chat tools.
+
+## ai.prs_with_assistant — PRs with AI assistance
+
+- Source: ai_usage (ai_metric_observations)
+- Reads: prs_with_assistant
+- Formula: sum(prs_with_assistant)
+- Shape: integer, higher_is_better, unit PRs
+- Notes: Pull requests where the coding assistant was active at least once, as the vendor attributes them. Reported only by sources that connect to the code host themselves, so a person working without that connection returns no value rather than a zero. Counts pull requests, not commits or lines, and says nothing about how much of the change the assistant wrote.
+
+## ai.prs_total — PRs seen by the AI vendor
+
+- Source: ai_usage (ai_metric_observations)
+- Reads: prs_total
+- Formula: sum(prs_total)
+- Shape: integer, neutral, unit PRs
+- Notes: Pull requests the AI vendor observed for the person, served as the context for PRs with AI assistance rather than as a goal of its own. It is the vendor's count over the vendor's own window, which need not be the day it is reported against and need not agree with the git sources — read it next to that measure, not next to git pull-request metrics.
 
 ## git.commits — Commits
 

--- a/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
+++ b/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
@@ -25,9 +25,14 @@ sources:
         evidence_granularity: source_summary
       - key: chat_assistant_conversations
         evidence_granularity: source_summary
+      - key: prs_with_assistant
+        evidence_granularity: source_summary
+      - key: prs_total
+        evidence_granularity: source_summary
     dimensions:
       - tool
       - surface
+      - seat_status
   - source:
       key: git
       kind: managed_observation
@@ -382,7 +387,7 @@ metrics:
     label: AI dev conversations
     short_label: AI dev chats
     description: Coding tool conversations where the source reports them
-    explanation: Person-attributed coding conversations from dev tools that report them.
+    explanation: Person-attributed conversations with coding AI tools, counted as the vendor counts them. For the agent tools this is the session or thread count — a session is the unit of conversation there, and no vendor publishes a separate conversation counter — so the number reads as "times the person started working with the assistant", not as messages exchanged. Tools that report no such unit, inline-completion tools among them, return no value rather than a zero.
     unit: conversations
     format: integer
     direction: higher_is_better
@@ -413,6 +418,44 @@ metrics:
     dimensions:
       - tool
       - surface
+  - metric_key: ai.prs_with_assistant
+    source_key: ai_usage
+    subject: pull_requests
+    label: PRs with AI assistance
+    short_label: PRs with AI
+    description: Pull requests the coding assistant touched
+    explanation: Pull requests where the coding assistant was active at least once, as the vendor attributes them. Reported only by sources that connect to the code host themselves, so a person working without that connection returns no value rather than a zero. Counts pull requests, not commits or lines, and says nothing about how much of the change the assistant wrote.
+    unit: PRs
+    format: integer
+    direction: higher_is_better
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: prs_with_assistant
+    dimensions:
+      - tool
+      - seat_status
+  - metric_key: ai.prs_total
+    source_key: ai_usage
+    subject: pull_requests
+    label: PRs seen by the AI vendor
+    short_label: PRs seen
+    description: Pull requests the AI vendor counted in the same window
+    explanation: Pull requests the AI vendor observed for the person, served as the context for PRs with AI assistance rather than as a goal of its own. It is the vendor's count over the vendor's own window, which need not be the day it is reported against and need not agree with the git sources — read it next to that measure, not next to git pull-request metrics.
+    unit: PRs
+    format: integer
+    direction: neutral
+    entity_type: person
+    computation: sum
+    peer_cohort_key: org_unit
+    inputs:
+      - input_role: value
+        measure_key: prs_total
+    dimensions:
+      - tool
+      - seat_status
   - metric_key: git.commits
     source_key: git
     subject: commits

--- a/src/ingestion/connectors/ai/chatgpt-team/dbt/chatgpt_team__ai_dev_usage.sql
+++ b/src/ingestion/connectors/ai/chatgpt-team/dbt/chatgpt_team__ai_dev_usage.sql
@@ -12,6 +12,9 @@
 -- Mapping notes:
 --   tool='codex'                  — dev-tool discriminator (cf. 'claude_code', 'cursor').
 --   session_count ← n_threads     — a Codex thread is the closest analogue to a coding session.
+--   conversation_count ← n_threads — the same thread count: a thread IS the
+--                                   unit of conversation, and no separate
+--                                   conversation counter exists upstream.
 --   lines_added ← lines_added     — AI-accepted lines (from code_attribution.lines_of_code.added).
 --   cost_cents ← NULL             — `credits` are Codex usage credits, not a currency amount.
 --   Codex-only counters (credits, n_turns, text_tokens, current_streak) are
@@ -71,7 +74,9 @@ SELECT
     'chatgpt_team'                                      AS source,
     data_source,
     CAST(_airbyte_extracted_at AS Nullable(DateTime64(3))) AS collected_at,
-    toUnixTimestamp64Milli(_airbyte_extracted_at)          AS _version
+    toUnixTimestamp64Milli(_airbyte_extracted_at)          AS _version,
+    -- The usage endpoint carries no seat lifecycle state.
+    CAST(NULL AS Nullable(String))                      AS seat_status
 FROM (
     -- Bronze dedup: keep the latest extract per (email, date). Defensive depth —
     -- becomes a no-op once promote_bronze_to_rmt merges (ADR-0002), but guards

--- a/src/ingestion/connectors/ai/chatgpt-team/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/chatgpt-team/dbt/schema.yml
@@ -42,7 +42,10 @@ models:
       Bronze → Silver: ChatGPT Team per-user per-day Codex usage →
       class_ai_dev_usage (tool='codex', source='chatgpt_team'). Sourced from
       chatgpt_team_codex_user_daily. session_count ← n_threads;
-      lines_added ← lines_added; cost_cents NULL (credits ≠ currency).
+      conversation_count ← n_threads (a thread is the unit of conversation and
+      no separate counter exists upstream, so ai.dev_conversations reports
+      thread counts here); lines_added ← lines_added;
+      cost_cents NULL (credits ≠ currency).
       Codex-only counters (credits/n_turns/text_tokens/current_streak) kept in
       tool_action_breakdown_json. Column contract matches claude_team__ai_dev_usage.
     columns:

--- a/src/ingestion/connectors/ai/chatgpt-team/descriptor.yaml
+++ b/src/ingestion/connectors/ai/chatgpt-team/descriptor.yaml
@@ -16,7 +16,10 @@ name: chatgpt-team
 #   conversation_count and declares tool_label / surface_label — MAJOR per
 #   ADR-0015: pre-existing rows must re-materialize from Bronze to populate
 #   the new columns (one-shot scoped full refresh).
-version: "2.0.0"
+# 2.1.0: emits the new class-contract column seat_status, constant NULL — this
+#   source reports no seat lifecycle state. MINOR per ADR-0015: a full refresh
+#   would reproduce the same NULLs, so there is nothing to re-materialize.
+version: "2.1.0"
 # Daily at 04:00 UTC — off-peak. The customer's proxy runs a single browser
 # instance, so we avoid scheduling chatgpt-team next to anything else that
 # may also hit it (same rationale as claude-team).

--- a/src/ingestion/connectors/ai/claude-enterprise/dbt/claude_enterprise__ai_dev_usage.sql
+++ b/src/ingestion/connectors/ai/claude-enterprise/dbt/claude_enterprise__ai_dev_usage.sql
@@ -54,6 +54,8 @@ SELECT
     toDate(parseDateTimeBestEffortOrNull(date))                        AS day,
     'claude_code'                                                      AS tool,
     toUInt32(coalesce(code_session_count, 0))                          AS session_count,
+    -- Same counter: a Claude Code session is the unit of conversation and the
+    -- analytics API publishes no separate conversation count.
     toUInt32OrNull(toString(code_session_count))                       AS conversation_count,
     toUInt32(coalesce(code_lines_added, 0))                            AS lines_added,
     toNullable(toUInt32(coalesce(code_lines_removed, 0)))              AS lines_removed,
@@ -92,7 +94,9 @@ SELECT
     'claude_enterprise'                                                AS source,
     'insight_claude_enterprise'                                        AS data_source,
     parseDateTime64BestEffortOrNull(coalesce(collected_at, ''), 3)     AS collected_at,
-    toUnixTimestamp64Milli(_airbyte_extracted_at)                      AS _version
+    toUnixTimestamp64Milli(_airbyte_extracted_at)                      AS _version,
+    -- The Enterprise analytics endpoint carries no seat lifecycle state.
+    CAST(NULL AS Nullable(String))                                     AS seat_status
 FROM (
     -- Bronze deduplication: bronze_claude_enterprise.claude_enterprise_users
     -- is plain MergeTree (Airbyte default). Re-emitted days under the 3-day

--- a/src/ingestion/connectors/ai/claude-enterprise/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/claude-enterprise/dbt/schema.yml
@@ -64,6 +64,11 @@ models:
               arguments:
                 values: ['claude_code']
       - name: session_count
+      - name: conversation_count
+        description: >
+          code_session_count again — a Claude Code session is the unit of
+          conversation and the analytics API exposes no separate counter, so
+          ai.dev_conversations reports session counts for this source.
       - name: lines_added
         description: "AI-accepted lines (code_lines_added)"
       - name: lines_removed

--- a/src/ingestion/connectors/ai/claude-enterprise/descriptor.yaml
+++ b/src/ingestion/connectors/ai/claude-enterprise/descriptor.yaml
@@ -4,7 +4,11 @@ name: claude-enterprise
 #   surface_label — MAJOR per ADR-0015: pre-existing rows must
 #   re-materialize from Bronze to populate the new columns (one-shot scoped
 #   full refresh).
-version: "3.0.0"
+# 3.1.0: emits the new class-contract column seat_status, constant NULL — the
+#   analytics API reports no seat lifecycle state. MINOR per ADR-0015: a full
+#   refresh would reproduce the same NULLs, so there is nothing to
+#   re-materialize.
+version: "3.1.0"
 schedule: "0 11 * * *"   # daily at 11:00 UTC — accommodates Anthropic's 10:00 UTC aggregation
 workflow: sync
 

--- a/src/ingestion/connectors/ai/claude-team/README.md
+++ b/src/ingestion/connectors/ai/claude-team/README.md
@@ -69,14 +69,16 @@ These fields are added to every record by the connector — do **not** put them 
 |--------|----------------------|-----------|--------|------|-----------|------------|
 | `claude_team_members` | `GET /api/organizations/{org}/members` | Full refresh | — | — | None (plain array) | `{tenant}-{source}-{account.uuid}` |
 | `claude_team_invites` | `GET /api/organizations/{org}/invites` | Full refresh | — | — | None (plain array) | `{tenant}-{source}-{uuid}` |
-| `claude_team_overage_spend` | `GET /api/organizations/{org}/overage_spend_limits` | Full refresh | — | — | PageIncrement (100/page) | `{tenant}-{source}-{account_uuid}` |
+| `claude_team_overage_spend` | `GET /api/organizations/{org}/overage_spend_limits` | Full refresh | — | — | PageIncrement (100/page) | `{tenant}-{source}-{account_uuid}-{YYYY-MM}` |
 | `claude_team_code_metrics` | `GET /api/claude_code/metrics_aggs/users` | Incremental | `metric_date` | P1D | OffsetIncrement (100/page) | `{tenant}-{source}-{date}-{email}` |
+| `claude_team_code_metrics_org` | `GET /api/claude_code/metrics_aggs/users` | Incremental | `metric_date` | P1D | None (envelope, not the `users` array) | `{tenant}-{source}-{date}` |
 
 ### Notes
 
 - **`claude_team_members` / `claude_team_invites`**: full snapshot — only the current state is returned. Historical invite events (accepted/expired) are not recoverable from this endpoint.
-- **`claude_team_overage_spend`**: requires `billing:view` permission on the sessionKey. Returns HTTP 403 if absent; the error handler marks the stream as empty and continues the sync.
+- **`claude_team_overage_spend`**: requires `billing:view` permission on the sessionKey. Returns HTTP 403 if absent; the error handler marks the stream as empty and continues the sync. The key carries the extraction month because the endpoint reports only the billing month in progress and keeps no history — keyed on the seat alone, Bronze would hold one row per seat and no closed month could be reproduced from it.
 - **`claude_team_code_metrics`**: one API request per day in the backfill window (P1D step). The endpoint is the most expensive (~3–13 s per page due to API-side aggregation). The `metric_date` field is injected by the connector — the API omits it from per-user objects.
+- **`claude_team_code_metrics_org`**: the same request as `claude_team_code_metrics`, but the record is the response envelope rather than its `users` array, so it captures the org-level `pr_attribution` and top-user rankings. One request and one row per day; the per-user array and the paging flag are stripped so the roster is not stored twice. No Silver target — the AI class contracts are per-person, and the vendor keeps no history of these values, so Bronze is where they are retained.
 - **Hard floor `2025-11-24`**: the earliest date for which data exists in the reference org. Going earlier returns empty pages. Operators with older data can override via `start_date`.
 
 ## Silver Targets

--- a/src/ingestion/connectors/ai/claude-team/connector.yaml
+++ b/src/ingestion/connectors/ai/claude-team/connector.yaml
@@ -10,7 +10,7 @@
 # Proxy source code + Dockerfile + deployment docs:
 #   https://gitlab.constr.dev/insight/secure-enclave → proxies/claude_team/
 #
-# Four streams (this commit completes the Phase 5 MVP set):
+# Streams:
 #   1. claude_team_members     — full snapshot, no pagination
 #   2. claude_team_invites     — full snapshot, no pagination
 #   3. claude_team_overage_spend — page-paginated; gracefully tolerates
@@ -18,6 +18,9 @@
 #   4. claude_team_code_metrics — per-day, offset-paginated; uses a
 #                                  DatetimeBasedCursor to walk a
 #                                  configurable backfill window
+#   5. claude_team_code_metrics_org — the org-level half of the same
+#                                  response (PR attribution, top-user
+#                                  rankings); per-day, no pagination
 
 version: "7.0.4"
 type: DeclarativeSource
@@ -293,11 +296,10 @@ streams:
   # response signals more pages but OffsetIncrement also stops when
   # a response returns < page_size rows.
   #
-  # Extras dropped: the response also carries `pr_attribution`,
-  # `top_users_by_prs`, `top_users_by_lines_of_code` — empty in the
-  # test org and not per-user. If they become populated later they
-  # warrant a separate stream rather than denormalisation into every
-  # user row.
+  # The response also carries org-level `pr_attribution`,
+  # `top_users_by_prs` and `top_users_by_lines_of_code`. They are not
+  # per-user, so denormalising them into every user row would be wrong;
+  # claude_team_code_metrics_org below reads them as their own stream.
   - type: DeclarativeStream
     name: claude_team_code_metrics
     primary_key:
@@ -413,6 +415,120 @@ streams:
       # row. The API does not include the date in per-user objects;
       # without this, all rows from different days would collide on the
       # primary key.
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [metric_date]
+            value: "{{ stream_interval.start_time }}"
+
+  # ── Stream 5: claude_team_code_metrics_org ──────────────────────────
+  # The org-level half of the same /claude_code/metrics_aggs/users
+  # response: pull-request attribution and the vendor's own top-user
+  # rankings. One record per day — field_path [] selects the envelope
+  # itself rather than the `users` array, and the org-level keys do not
+  # paginate, so this stream deliberately declares no paginator and
+  # costs one request per day on top of the per-user stream's pages.
+  #
+  # Kept out of claude_team_code_metrics because these values describe
+  # the organisation, not a person: copying them onto every user row
+  # would multiply one fact by the roster and make any sum wrong.
+  #
+  # No Silver target. The class contracts are per-person, and there is
+  # no org-grain AI class to receive an org fact — Bronze retention is
+  # the point: the vendor keeps no history, so a value not captured on
+  # the day it was published is gone.
+  - type: DeclarativeStream
+    name: claude_team_code_metrics_org
+    primary_key:
+      - metric_date
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: http://json-schema.org/schema#
+        type: object
+        additionalProperties: true
+        properties:
+          tenant_id: { type: string }
+          source_id: { type: string }
+          unique_key: { type: string }
+          collected_at: { type: string }
+          data_source: { type: string }
+          metric_date: { type: string }
+          # Vendor-defined shapes, kept whole rather than modelled: they
+          # are undocumented and empty on organisations without the
+          # Anthropic GitHub app, so pinning a shape now would be a guess.
+          pr_attribution: { type: [object, "null"] }
+          top_users_by_prs: { type: [array, "null"] }
+          top_users_by_lines_of_code: { type: [array, "null"] }
+    retriever:
+      type: SimpleRetriever
+      requester:
+        type: HttpRequester
+        url_base: "{{ config['proxy_url'] }}"
+        path: "/api/claude_code/metrics_aggs/users"
+        http_method: GET
+        request_headers:
+          Authorization: "Bearer {{ config['proxy_auth_token'] }}"
+        request_parameters:
+          organization_uuid: "{{ config['claude_org_id'] }}"
+          customer_type: "claude_ai"
+          subscription_type: "team"
+          limit: "1"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: metric_date
+      cursor_datetime_formats:
+        - "%Y-%m-%d"
+      datetime_format: "%Y-%m-%d"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ config.get('start_date') or day_delta(-7, format='%Y-%m-%d') }}"
+        datetime_format: "%Y-%m-%d"
+        min_datetime: "2025-11-24"
+      end_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ day_delta(-1, format='%Y-%m-%d') }}"
+        datetime_format: "%Y-%m-%d"
+      step: P1D
+      cursor_granularity: P1D
+      start_time_option:
+        type: RequestOption
+        field_name: start_date
+        inject_into: request_parameter
+      end_time_option:
+        type: RequestOption
+        field_name: end_date
+        inject_into: request_parameter
+    transformations:
+      # The envelope also holds the per-user array and its paging flag.
+      # Keeping them here would store the roster twice — once per user row
+      # in claude_team_code_metrics and once more inside every org row.
+      - type: RemoveFields
+        field_pointers:
+          - [users]
+          - [has_next]
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [tenant_id]
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path: [source_id]
+            value: "{{ config['insight_source_id'] }}"
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: "{{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ stream_interval.start_time }}"
+          - type: AddedFieldDefinition
+            path: [collected_at]
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+          - type: AddedFieldDefinition
+            path: [data_source]
+            value: insight_claude_team
       - type: AddFields
         fields:
           - type: AddedFieldDefinition

--- a/src/ingestion/connectors/ai/claude-team/dbt/claude_team__ai_dev_usage.sql
+++ b/src/ingestion/connectors/ai/claude-team/dbt/claude_team__ai_dev_usage.sql
@@ -7,13 +7,22 @@
 -- (email, metric_date) — metrics already aggregated to daily grain by the API.
 --
 -- Filters:
---   status = 'active'             — drop deactivated seats (per PR #553)
+--   any activity counter > 0      — the class contract admits a person-day row
+--                                   only for real activity
 --   email IS NOT NULL / != ''     — rows without email cannot be attributed
 --   metric_date IS NOT NULL       — guard against phantom 1970-01-01 rows
 --
--- session_count: `total_sessions`. DQ note: 5/34 sample users had
---   sessions=0 while lines_accepted>0 — headless / `cc -p` invocations are
---   excluded from the session counter by Anthropic. Not a model bug.
+-- seat_status: `status`, carried rather than filtered on. The vendor restates
+--   it on every read of the rolling window, so it describes the seat as of the
+--   read, not as of `day` — filtering on it retroactively erases the whole
+--   history of a person whose seat is later deactivated.
+--
+-- session_count / conversation_count: both `total_sessions`. The Team plan
+--   reports no separate conversation counter — for Claude Code a session IS
+--   the unit of conversation — so the same number feeds the class contract's
+--   activity column and its conversations metric-feed column.
+--   DQ note: a session counter can read 0 while lines_accepted > 0 —
+--   Anthropic excludes headless / `cc -p` invocations from it. Not a model bug.
 --
 -- lines_added: `total_lines_accepted` — AI-accepted lines. Same semantics as
 --   Enterprise `code_lines_added`. Total keystrokes not available → NULL.
@@ -88,14 +97,21 @@ SELECT
     'claude_team'                                       AS source,
     data_source,
     CAST(_airbyte_extracted_at AS Nullable(DateTime64(3))) AS collected_at,
-    toUnixTimestamp64Milli(_airbyte_extracted_at)          AS _version
+    toUnixTimestamp64Milli(_airbyte_extracted_at)          AS _version,
+    nullIf(lower(trim(coalesce(status, ''))), '')          AS seat_status
 FROM {{ source('bronze_claude_team', 'claude_team_code_metrics') }}
-WHERE status = 'active'
-  AND email IS NOT NULL
+WHERE email IS NOT NULL
   AND trim(email) != ''
   -- Guard against NULL metric_date: toDate(NULL) → 1970-01-01 silently
   -- corrupts the incremental boundary (same guard as cursor__ai_dev_usage).
   AND metric_date IS NOT NULL
+  -- Activity gate over the same counters assert_ai_dev_usage_rows_active
+  -- checks, so a roster row with no work on `day` never reaches the class.
+  AND (coalesce(total_sessions, 0) > 0
+       OR coalesce(total_lines_accepted, 0) > 0
+       OR coalesce(toFloat64OrNull(toString(total_cost)), 0) > 0
+       OR coalesce(prs_with_cc, 0) > 0
+       OR coalesce(total_prs, 0) > 0)
 {% if is_incremental() %}
   -- Empty-table guard. Over an empty `this` (the e2e rig resets staging between
   -- tests) `max(day)` is the Date epoch (1970-01-01) and `- INTERVAL 3 DAY`

--- a/src/ingestion/connectors/ai/claude-team/dbt/claude_team__ai_overage.sql
+++ b/src/ingestion/connectors/ai/claude-team/dbt/claude_team__ai_overage.sql
@@ -27,6 +27,14 @@
 -- As months roll over this accrues a monthly history; within the current
 -- month it always reflects the freshest snapshot. unique_key carries the
 -- month so a new month never overwrites a prior month's closing value.
+-- INVARIANT: full_refresh=false is a data-safety guard. This model is the only
+-- place a past month's closing spend exists — the endpoint keeps no history and
+-- Bronze rows keyed on the seat alone collapse to its latest state — so a
+-- rebuild from Bronze deletes those months rather than reproducing them, and
+-- reconcile-connectors dispatches `dbt --full-refresh` automatically on a MAJOR
+-- descriptor bump. Silver still rebuilds freely: it reads this model, not
+-- Bronze. To rebuild deliberately, drop the table — the empty-table guard below
+-- then reloads the whole Bronze window.
 {{ config(
     materialized='incremental',
     incremental_strategy='append',
@@ -35,6 +43,7 @@
     order_by=['unique_key'],
     on_schema_change='append_new_columns',
     settings={'allow_nullable_key': 1},
+    full_refresh=false,
     schema='staging',
     tags=['claude-team', 'silver:class_ai_overage']
 ) }}
@@ -110,7 +119,12 @@ SELECT
         'limit_type',         ifNull(toString(limit_type), ''),
         'used_credits_basis', ifNull(toString(used_credits_basis), ''),
         'out_of_credits',     ifNull(toString(out_of_credits), ''),
-        'seat_tier',          ifNull(toString(seat_tier), '')
+        'seat_tier',          ifNull(toString(seat_tier), ''),
+        -- Why extra usage is off for a seat, and until when: without these a
+        -- zero spend cannot be told apart from a seat the vendor blocked.
+        'disabled_reason',    ifNull(toString(disabled_reason), ''),
+        'disabled_until',     ifNull(toString(disabled_until), ''),
+        'account_name',       ifNull(toString(account_name), '')
     ))                                                  AS overage_metrics_json,
     'claude_team'                                       AS source,
     data_source,

--- a/src/ingestion/connectors/ai/claude-team/dbt/claude_team__bronze_promoted.sql
+++ b/src/ingestion/connectors/ai/claude-team/dbt/claude_team__bronze_promoted.sql
@@ -15,6 +15,7 @@
 
 {% do promote_bronze_to_rmt(table='bronze_claude_team.claude_team_members',         order_by='unique_key') %}
 {% do promote_bronze_to_rmt(table='bronze_claude_team.claude_team_code_metrics',    order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_claude_team.claude_team_code_metrics_org', order_by='unique_key') %}
 {% do promote_bronze_to_rmt(table='bronze_claude_team.claude_team_overage_spend',   order_by='unique_key') %}
 
 SELECT 1 AS promoted

--- a/src/ingestion/connectors/ai/claude-team/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/claude-team/dbt/schema.yml
@@ -28,9 +28,12 @@ models:
       Bronze → Silver step 1: Claude Team per-user per-day Claude Code usage
       → class_ai_dev_usage. Sourced from claude_team_code_metrics (daily
       aggregates pulled via the customer-deployed claude-team-proxy from the
-      claude.ai web API). Filtered to status='active' AND non-empty email.
-      One row per (tenant, email, metric_date).
-      session_count ← total_sessions; lines_added ← total_lines_accepted;
+      claude.ai web API). Filtered to non-empty email AND at least one non-zero
+      activity counter; the vendor `status` is carried in seat_status, not
+      filtered on. One row per (tenant, email, metric_date).
+      session_count ← total_sessions; conversation_count ← total_sessions
+      (the Team plan reports no separate conversation counter);
+      lines_added ← total_lines_accepted;
       cost_cents ← total_cost (decimal-as-string → cents, first per-user-per-day
       cost source in Silver); prs_with_cc_count ← prs_with_cc;
       prs_total_count ← total_prs.
@@ -69,6 +72,12 @@ models:
           even when lines_added > 0 — Anthropic excludes those from the counter.
         tests:
           - not_null
+      - name: conversation_count
+        description: >
+          total_sessions again — for Claude Code a session is the unit of
+          conversation and the Team plan exposes no separate counter. This is
+          the column ai.dev_conversations sums, so that metric reports session
+          counts for this source.
       - name: lines_added
         description: "total_lines_accepted — AI-accepted lines added"
         tests:
@@ -128,6 +137,11 @@ models:
         description: "ReplacingMergeTree version — toUnixTimestamp64Milli(_airbyte_extracted_at) per ADR-0001."
         tests:
           - not_null
+      - name: seat_status
+        description: >
+          Vendor `status`, lower-cased. Describes the seat as of the read, not
+          as of `day` — the endpoint restates it for every day in the rolling
+          window, so it is not a per-day fact and must not be filtered on.
 
   - name: claude_team__ai_overage
     description: >
@@ -202,7 +216,9 @@ models:
           assigned". Not used as a state filter — seat state is credit_limit_cents IS NOT
           NULL.
       - name: overage_metrics_json
-        description: "Raw vendor extras: limit_type, used_credits_basis, out_of_credits, seat_tier"
+        description: >
+          Raw vendor extras: limit_type, used_credits_basis, out_of_credits,
+          seat_tier, disabled_reason, disabled_until, account_name.
       - name: source
         description: "Always 'claude_team'"
         tests:

--- a/src/ingestion/connectors/ai/claude-team/descriptor.yaml
+++ b/src/ingestion/connectors/ai/claude-team/descriptor.yaml
@@ -22,7 +22,15 @@ name: claude-team
 #   dispatches a one-shot `dbt --full-refresh` (reconcile-connectors), which
 #   rebuilds Silver from Bronze — the very operation this change exists to make
 #   safe, and the one that cost the June history.
-version: "2.1.0"
+# 2.2.0: adds the claude_team_code_metrics_org Bronze stream, and dbt staging
+#   stops filtering on the vendor seat status — it carries it in the
+#   class-contract column seat_status instead. MINOR per ADR-0015, not MAJOR:
+#   a major bump dispatches a one-shot `dbt --full-refresh`, and the guard that
+#   makes that safe (full_refresh=false on claude_team__ai_overage) arrives in
+#   this same change — it has to be on main before any major bump reads it.
+#   Rows written before this version keep an empty seat_status and reach gold as
+#   'unknown', which is what they honestly are.
+version: "2.2.0"
 # Daily at 04:00 UTC — off-peak vs other connectors. The customer's
 # proxy runs a single browser instance, so we avoid scheduling
 # claude-team next to anything else that may also hit it.

--- a/src/ingestion/connectors/ai/cursor/dbt/cursor__ai_dev_usage.sql
+++ b/src/ingestion/connectors/ai/cursor/dbt/cursor__ai_dev_usage.sql
@@ -122,7 +122,9 @@ SELECT
     -- coalesce keeps _version non-nullable: an unmatched LEFT JOIN yields NULL
     -- under join_use_nulls=1, and ReplacingMergeTree rejects a Nullable version.
     greatest(toUnixTimestamp64Milli(d._airbyte_extracted_at), coalesce(c.cost_version, toInt64(0)))
-                                                    AS _version
+                                                    AS _version,
+    -- Cursor reports an is-active flag per day, not a seat lifecycle state.
+    CAST(NULL AS Nullable(String))                  AS seat_status
 FROM daily AS d
 LEFT JOIN {{ ref('cursor__event_cost_daily') }} AS c
        ON coalesce(d.tenant_id, '') = c.tenant_key

--- a/src/ingestion/connectors/ai/cursor/descriptor.yaml
+++ b/src/ingestion/connectors/ai/cursor/descriptor.yaml
@@ -1,5 +1,8 @@
 name: cursor
-version: "2.0.0"
+# 2.1.0: emits the new class-contract column seat_status, constant NULL — this
+#   source reports a per-day active flag, not a seat lifecycle state. MINOR per
+#   ADR-0015: a full refresh would reproduce the same NULLs.
+version: "2.1.0"
 schedule: 0 2 * * *
 dbt_select: tag:cursor+
 workflow: sync

--- a/src/ingestion/dbt/macros/materialised_models_for_tag.sql
+++ b/src/ingestion/dbt/macros/materialised_models_for_tag.sql
@@ -1,0 +1,28 @@
+{#-
+  materialised_models_for_tag(tag_name)
+
+  The names of the models carrying `tag_name` whose relation actually exists in
+  the warehouse, as a list. Unlike union_by_tag this returns an empty list
+  instead of raising when nothing is materialised: a caller that only reports on
+  what is there — a completeness test, say — must stay silent on a deployment
+  that runs none of the contributing connectors, not abort the run.
+-#}
+{% macro materialised_models_for_tag(tag_name) %}
+  {%- set names = [] -%}
+  {%- if execute -%}
+    {%- for node in graph.nodes.values() -%}
+      {%- if tag_name in node.tags and node.resource_type == 'model' -%}
+        {%- if node.config.materialized == 'ephemeral' -%}
+          {#- No relation to probe: dbt inlines these as a CTE on ref(). -#}
+          {%- do names.append(node.name) -%}
+        {%- elif adapter.get_relation(
+                   database=none,
+                   schema=node.schema,
+                   identifier=node.alias or node.name) -%}
+          {%- do names.append(node.name) -%}
+        {%- endif -%}
+      {%- endif -%}
+    {%- endfor -%}
+  {%- endif -%}
+  {{ return(names) }}
+{% endmacro %}

--- a/src/ingestion/dbt/macros/silver_incremental_watermark.sql
+++ b/src/ingestion/dbt/macros/silver_incremental_watermark.sql
@@ -1,0 +1,38 @@
+{#-
+  silver_incremental_watermark(source_keys, alias='candidate')
+
+  The incremental boundary for a silver class table, scoped to ONE source
+  instance instead of the whole table.
+
+  A class table is written by every connector that feeds it, and each connector
+  runs on its own schedule. Producers stamp `_version` from their own clock —
+  extraction time, snapshot time, or the source record's own update time — so
+  the values of two producers are not comparable. A single
+  `WHERE _version > (SELECT max(_version) FROM this)` therefore lets whichever
+  producer commits first raise the boundary above another producer's rows, and
+  those rows are then below it FOREVER: they never reach silver, and nothing
+  reports the loss. Per-instance scoping is the same fix already applied to the
+  crm classes and to class_person_attribute_claims.
+
+  `coalesce(max_version, 0)` is load-bearing: a source instance absent from the
+  target has no watermark row, and comparing against NULL would drop every row
+  of every new instance — reintroducing the bug it exists to prevent.
+
+  Emits nothing on a full refresh or a first run, so the model reads its whole
+  union. Re-reading a row is safe: silver is delete+insert on `unique_key`.
+-#}
+{% macro silver_incremental_watermark(source_keys, alias='candidate') %}
+{%- if is_incremental() %}
+LEFT JOIN (
+    SELECT
+        {{ source_keys | join(',\n        ') }},
+        max(_version) AS max_version
+    FROM {{ this }}
+    GROUP BY
+        {{ source_keys | join(',\n        ') }}
+) AS watermarks
+    ON {% for key in source_keys %}{% if not loop.first %}   AND {% endif %}{{ alias }}.{{ key }} = watermarks.{{ key }}
+    {% endfor %}
+WHERE {{ alias }}._version > coalesce(watermarks.max_version, 0)
+{%- endif %}
+{% endmacro %}

--- a/src/ingestion/dbt/tests/ai/assert_ai_staging_rows_reach_silver.sql
+++ b/src/ingestion/dbt/tests/ai/assert_ai_staging_rows_reach_silver.sql
@@ -1,0 +1,54 @@
+{{ config(
+    tags=['data_quality'],
+    severity='warn',
+    store_failures=true,
+    meta={
+        'title': 'every AI staging row reaches its silver class',
+        'domain': 'ai',
+        'category': 'completeness',
+        'tier': 'error',
+        'remediation': 'A staging row a silver class never admitted is lost for good — nothing re-reads it. The usual cause is an incremental boundary that is not scoped to the source instance, so one connector''s run raised the boundary past another connector''s rows: check the class model uses silver_incremental_watermark rather than a table-wide max(_version). The rows are still in staging, so recovery is a re-read of the union — a full refresh of the class, or an anti-join insert from staging.'
+    }
+) }}
+
+{#- One row per (class, source instance) whose staging rows did not arrive.
+    Classes whose contributors are not materialised here are skipped rather than
+    reported empty: this deployment does not run them. -#}
+{%- set ai_classes = [
+    ('silver:class_ai_dev_usage', 'class_ai_dev_usage'),
+    ('silver:class_ai_assistant_usage', 'class_ai_assistant_usage'),
+    ('silver:class_ai_overage', 'class_ai_overage')
+] -%}
+{%- set branches = [] -%}
+{%- for tag_name, class_model in ai_classes -%}
+  {%- set staged_models = materialised_models_for_tag(tag_name) -%}
+  {%- if staged_models | length > 0 -%}
+    {%- do branches.append((class_model, staged_models)) -%}
+  {%- endif -%}
+{%- endfor -%}
+
+{% if branches | length == 0 %}
+SELECT
+    CAST('' AS String)              AS class_name,
+    CAST(NULL AS Nullable(String))  AS source_id,
+    toUInt64(0)                     AS missing_rows
+WHERE 1 = 0
+{% else %}
+{% for class_model, staged_models in branches %}
+SELECT
+    '{{ class_model }}'         AS class_name,
+    staged.source_id            AS source_id,
+    count()                     AS missing_rows
+FROM (
+    {% for staged_model in staged_models %}
+    SELECT DISTINCT unique_key, source_id FROM {{ ref(staged_model) }}
+    {%- if not loop.last %}
+    UNION ALL
+    {%- endif %}
+    {% endfor %}
+) AS staged
+LEFT ANTI JOIN {{ ref(class_model) }} AS served USING (unique_key)
+GROUP BY class_name, source_id
+{% if not loop.last %}UNION ALL{% endif %}
+{% endfor %}
+{% endif %}

--- a/src/ingestion/gold/ai_metric_evidence.sql
+++ b/src/ingestion/gold/ai_metric_evidence.sql
@@ -45,15 +45,22 @@ ai_dev_usage_source AS (
         lower(email) AS entity_id,
         day AS metric_date,
         CAST(
-            [tuple('tool', tool, {{ ai_tool_label('tool') }})]
-            AS Array(Tuple(key String, value String, label Nullable(String)))
+            [
+                tuple('tool', tool, {{ ai_tool_label('tool') }}),
+                -- Seat state as of the last read, not as of metric_date: the
+                -- sources restate it for every day they re-read. 'unknown'
+                -- where the source has no seat lifecycle concept.
+                tuple('seat_status', coalesce(seat_status, 'unknown'), CAST(NULL AS Nullable(String)))
+            ] AS Array(Tuple(key String, value String, label Nullable(String)))
         ) AS tool_dimensions,
         conversation_count,
         lines_added,
         lines_removed,
         tool_use_offered,
         tool_use_accepted,
-        cost_cents
+        cost_cents,
+        prs_with_cc_count,
+        prs_total_count
     FROM {{ ref('class_ai_dev_usage') }}
     WHERE email IS NOT NULL
       AND email != ''
@@ -112,6 +119,14 @@ measure_observations AS (
     UNION ALL
 
     {{ sum_measure('dev_conversations', 'ai_dev_usage_source', 'conversation_count', 'tool_dimensions') }}
+
+    UNION ALL
+
+    {{ sum_measure('prs_with_assistant', 'ai_dev_usage_source', 'prs_with_cc_count', 'tool_dimensions') }}
+
+    UNION ALL
+
+    {{ sum_measure('prs_total', 'ai_dev_usage_source', 'prs_total_count', 'tool_dimensions') }}
 
     UNION ALL
 

--- a/src/ingestion/gold/identity_resolution_coverage.sql
+++ b/src/ingestion/gold/identity_resolution_coverage.sql
@@ -56,6 +56,13 @@ WITH source_rows AS (
 
     UNION ALL
 
+    -- Seat spend: the one evidence relation whose unresolved rows are money,
+    -- so its match rate answers "how much of the billed amount reaches nobody".
+    SELECT source_key, entity_id, source_entity_id
+    FROM {{ ref('ai_cost_metric_evidence') }}
+
+    UNION ALL
+
     SELECT
         'hr_cohorts' AS source_key,
         -- Null-proof under EITHER join_use_nulls setting (models differ): the

--- a/src/ingestion/gold/schema.yml
+++ b/src/ingestion/gold/schema.yml
@@ -239,6 +239,8 @@ models:
                   - assistant_messages
                   - assistant_actions
                   - chat_assistant_conversations
+                  - prs_with_assistant
+                  - prs_total
       - name: value
         description: >
           Measure value. Rows are emitted only when the source provides a
@@ -737,7 +739,7 @@ models:
   - name: identity_resolution_coverage
     description: >
       Identity-resolution match rate measured over ACTIVITY (evidence source
-      rows), one row per source (git/ai_usage/collab/task/wiki) plus
+      rows), one row per source (git/ai_usage/ai_cost/collab/task/wiki) plus
       hr_cohorts for the peer-membership relation. A TABLE materialized in
       the same gold build as the serving relations, reading the resolution
       snapshot stamped into evidence — so coverage answers for exactly what

--- a/src/ingestion/scripts/connectors-ddl/claude-team.sql
+++ b/src/ingestion/scripts/connectors-ddl/claude-team.sql
@@ -30,6 +30,27 @@ ORDER BY unique_key
 SETTINGS allow_nullable_key = 1, index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS bronze_claude_team.claude_team_code_metrics_org
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `unique_key` Nullable(String),
+    `collected_at` Nullable(String),
+    `data_source` Nullable(String),
+    `metric_date` Nullable(String),
+    `pr_attribution` Nullable(String),
+    `top_users_by_prs` Nullable(String),
+    `top_users_by_lines_of_code` Nullable(String)
+)
+ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
+ORDER BY unique_key
+SETTINGS allow_nullable_key = 1, index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS bronze_claude_team.claude_team_invites
 (
     `_airbyte_raw_id` String,

--- a/src/ingestion/scripts/connectors-ddl/silver.sql
+++ b/src/ingestion/scripts/connectors-ddl/silver.sql
@@ -62,7 +62,8 @@ CREATE TABLE IF NOT EXISTS silver.class_ai_dev_usage
     `source` String,
     `data_source` Nullable(String),
     `collected_at` Nullable(DateTime64(3)),
-    `_version` Int64
+    `_version` Int64,
+    `seat_status` Nullable(String)
 )
 ENGINE = ReplacingMergeTree(_version)
 ORDER BY unique_key

--- a/src/ingestion/silver/ai/class_ai_assistant_usage.sql
+++ b/src/ingestion/silver/ai/class_ai_assistant_usage.sql
@@ -13,9 +13,7 @@
 -- depends_on: {{ ref('claude_enterprise__ai_assistant_usage') }}
 -- depends_on: {{ ref('chatgpt_team__ai_assistant_usage') }}
 
-SELECT * FROM (
+SELECT candidate.* FROM (
     {{ union_by_tag('silver:class_ai_assistant_usage') }}
-)
-{% if is_incremental() %}
-WHERE _version > (SELECT max(_version) FROM {{ this }})
-{% endif %}
+) AS candidate
+{{ silver_incremental_watermark(['insight_tenant_id', 'source_id']) }}

--- a/src/ingestion/silver/ai/class_ai_dev_usage.sql
+++ b/src/ingestion/silver/ai/class_ai_dev_usage.sql
@@ -15,9 +15,7 @@
 -- depends_on: {{ ref('claude_team__ai_dev_usage') }}
 -- depends_on: {{ ref('chatgpt_team__ai_dev_usage') }}
 
-SELECT * FROM (
+SELECT candidate.* FROM (
     {{ union_by_tag('silver:class_ai_dev_usage') }}
-)
-{% if is_incremental() %}
-WHERE _version > (SELECT max(_version) FROM {{ this }})
-{% endif %}
+) AS candidate
+{{ silver_incremental_watermark(['insight_tenant_id', 'source_id']) }}

--- a/src/ingestion/silver/ai/class_ai_overage.sql
+++ b/src/ingestion/silver/ai/class_ai_overage.sql
@@ -17,9 +17,7 @@
 --
 -- depends_on: {{ ref('claude_team__ai_overage') }}
 
-SELECT * FROM (
+SELECT candidate.* FROM (
     {{ union_by_tag('silver:class_ai_overage') }}
-)
-{% if is_incremental() %}
-WHERE _version > (SELECT max(_version) FROM {{ this }})
-{% endif %}
+) AS candidate
+{{ silver_incremental_watermark(['insight_tenant_id', 'source_id']) }}

--- a/src/ingestion/silver/ai/schema.yml
+++ b/src/ingestion/silver/ai/schema.yml
@@ -10,8 +10,11 @@ models:
       CONTRACT — activity invariant: a row exists ONLY when the person had real
       activity with the tool that day. Every staging model in the
       silver:class_ai_dev_usage tag must gate emission on a source-appropriate
-      activity signal (cursor: isActive=true; claude-team: status='active';
-      claude-enterprise/copilot/chatgpt-team: activity-counter filters).
+      activity signal (cursor: isActive=true;
+      claude-team/claude-enterprise/copilot/chatgpt-team: activity-counter
+      filters). Seat lifecycle state is NOT an activity signal: it describes
+      the seat as of the last read, so gating on it deletes the history of
+      whoever left — carry it in seat_status instead.
       Downstream consumers (insight.ai_metric_observations active_day) rely on
       row existence and must NOT re-derive activity from counters.
     columns:
@@ -62,14 +65,26 @@ models:
                 values: ['cursor', 'claude_code', 'copilot', 'windsurf', 'codex']
       - name: conversation_count
         description: >
-          Dev-tool conversations/threads on this day, populated ONLY by
-          connectors whose source actually reports them (Claude Code sessions,
-          Codex threads). Structural NULL where the source has no conversation
-          concept (Cursor, Copilot) — never a synthetic marker. Gold
-          dev_conversations sums this column with no tool filter; a connector
-          opts in by mapping the column.
+          Dev-tool conversations/threads on this day — the metric-feed column
+          Gold dev_conversations sums with no tool filter. A connector opts in
+          by mapping it; structural NULL where the source has no conversation
+          concept (Cursor) — never a synthetic marker.
+
+          For the dev-agent tools the vendors do not report conversations
+          separately: one session or thread IS the unit of conversation, so
+          claude_code and codex connectors map their session/thread counter
+          here and the value equals session_count on those rows. That is the
+          intended mapping, not a duplication to collapse — the two columns
+          hold different concepts that coincide for these sources, and they do
+          NOT coincide on class_ai_assistant_usage, where chat reports
+          conversations and the office surfaces report sessions.
       - name: session_count
-        description: "Sessions recorded on this day. For Cursor: 1 per active day (Cursor only exposes an is-active flag, not session counts)."
+        description: >
+          Sessions recorded on this day. For Cursor: 1 per active day (Cursor
+          only exposes an is-active flag, not session counts). Contract and
+          data-quality column only — it feeds the activity guard, and no Gold
+          measure or metric reads it. The conversations metric reads
+          conversation_count.
         tests:
           - not_null
       - name: lines_added
@@ -171,6 +186,15 @@ models:
         description: "When the record was collected"
         tests:
           - not_null
+      - name: seat_status
+        description: >
+          Vendor seat / licence state as reported at the LAST read, lower-cased
+          ('active', 'deactivated', …). Not a property of `day`: sources restate
+          it on every read of their rolling window, so a person whose seat is
+          deactivated today carries the new value on every historical row.
+          Populated by Claude Team only (`status`); NULL where the source has no
+          seat lifecycle concept. Reaches gold as the seat_status dimension.
+          Never use it as an emission filter — see the activity invariant above.
 
   - name: class_ai_assistant_usage
     description: >
@@ -385,7 +409,8 @@ models:
       - name: overage_metrics_json
         description: >
           Raw vendor-specific extras kept out of the positional contract.
-          Claude Team: limit_type / used_credits_basis / out_of_credits / seat_tier.
+          Claude Team: limit_type / used_credits_basis / out_of_credits /
+          seat_tier / disabled_reason / disabled_until / account_name.
       - name: source
         description: "Staging-model discriminator."
         tests:

--- a/src/ingestion/tests/e2e/metrics/ai_pr_attribution.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/ai_pr_attribution.test.yaml
@@ -1,0 +1,96 @@
+spec_version: 1
+description: >
+  Metrics: ai.prs_with_assistant, ai.prs_total.
+  How they're computed (bronze → silver → gold):
+    • bronze: Claude Team per-user daily code metrics carrying the vendor's
+              pull-request attribution counters (prs_with_cc / total_prs)
+    • silver: deduped to one row per user/day; the rows qualify on the PR
+              counters alone, with no lines and no cost
+    • gold:   each metric = sum of its counter over the window
+
+  Team (median/range = the person's department):
+    with-assistant  alice 6 · bob 3 · carol 1
+    total           alice 10 · bob 8 · carol 4
+
+  The seat_status breakdown is asserted here because this is the only metric
+  pair whose source populates it: the vendor status is carried into the class
+  contract rather than filtered on, so it must reach gold as a dimension.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+    - $ref: templates/people.yaml#/templates/bob
+    - $ref: templates/people.yaml#/templates/carol
+  bronze_claude_team.claude_team_code_metrics:
+    - $ref: templates/claude_team_usage.yaml#/templates/alice
+      unique_key: cc-prs-alice-20260105
+      metric_date: "2026-01-05"
+      prs_with_cc: 6
+      total_prs: 10
+    - $ref: templates/claude_team_usage.yaml#/templates/alice   # re-sync dup → must NOT double
+      unique_key: cc-prs-alice-20260105
+      metric_date: "2026-01-05"
+      prs_with_cc: 6
+      total_prs: 10
+    - $ref: templates/claude_team_usage.yaml#/templates/bob
+      unique_key: cc-prs-bob-20260105
+      metric_date: "2026-01-05"
+      prs_with_cc: 3
+      total_prs: 8
+    - $ref: templates/claude_team_usage.yaml#/templates/carol
+      unique_key: cc-prs-carol-20260105
+      metric_date: "2026-01-05"
+      prs_with_cc: 1
+      total_prs: 4
+
+cases:
+  - name: AI pull-request attribution
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: { type: person, ids: [alice@example.com] }
+        period: { from: "2026-01-01", to: "2026-01-31" }
+        metrics:
+          - metric_key: ai.prs_with_assistant
+            views:
+              - { view: period }
+              - { view: peer }
+              - { view: timeseries, bucket: day }
+              - { view: breakdown, dimensions: [seat_status] }
+          - metric_key: ai.prs_total
+            views:
+              - { view: period }
+              - { view: peer }
+              - { view: timeseries, bucket: day }
+              - { view: breakdown, dimensions: [tool] }
+    expect:
+      - assert: "status == 200"
+      - metric: ai.prs_with_assistant
+        view: period
+        find: { entity_id: alice@example.com }
+        equal: { value: 6 }
+      - metric: ai.prs_with_assistant
+        view: peer
+        find: { entity_id: alice@example.com }
+        equal: { target_value: 6, p25: null, median: null, p75: null, min: null, max: null, n: 3 }
+      - metric: ai.prs_with_assistant
+        view: timeseries
+        assert: "items.exists(s, s.entity_id == 'alice@example.com' && s.points.exists(p, p.bucket_start == '2026-01-05' && double(p.value) == 6.0))"
+      - metric: ai.prs_with_assistant
+        view: breakdown
+        assert: "items.exists(v, v.entity_id == 'alice@example.com' && v.dimensions.exists(d, d.key == 'seat_status' && d.value == 'active') && double(v.value) == 6.0)"
+      - metric: ai.prs_total
+        view: period
+        find: { entity_id: alice@example.com }
+        equal: { value: 10 }
+      - metric: ai.prs_total
+        view: peer
+        find: { entity_id: alice@example.com }
+        equal: { target_value: 10, p25: null, median: null, p75: null, min: null, max: null, n: 3 }
+      - metric: ai.prs_total
+        view: timeseries
+        assert: "items.exists(s, s.entity_id == 'alice@example.com' && s.points.exists(p, p.bucket_start == '2026-01-05' && double(p.value) == 10.0))"
+      - metric: ai.prs_total
+        view: breakdown
+        assert: "items.exists(v, v.entity_id == 'alice@example.com' && v.dimensions.exists(d, d.key == 'tool' && d.value == 'claude_code') && double(v.value) == 10.0)"

--- a/src/ingestion/tests/e2e/metrics/templates/claude_team_usage.yaml
+++ b/src/ingestion/tests/e2e/metrics/templates/claude_team_usage.yaml
@@ -1,8 +1,10 @@
 # Reusable Claude Team code-metrics records (bronze_claude_team.claude_team_code_metrics).
 # Base carries every schema column (unused = null) incl. the 4 _airbyte_* CDK
-# columns. status defaults to "active" — claude_team__ai_dev_usage filters
-# `WHERE status = 'active'`. Variants override identity (email) only; the fields
-# under test (metric_date, unique_key, total_*) are set in each test's `bronze`.
+# columns. status defaults to "active" — claude_team__ai_dev_usage carries it
+# into class-contract seat_status and gates emission on the activity counters,
+# so a row needs a non-zero total_* to reach Silver. Variants override identity
+# (email) only; the fields under test (metric_date, unique_key, total_*) are set
+# in each test's `bronze`.
 templates:
   claude_team_metrics:
     _airbyte_raw_id: "00000000-0000-0000-0000-000000000000"

--- a/src/ingestion/tools/seed/insight_seed/generators/ai.py
+++ b/src/ingestion/tools/seed/insight_seed/generators/ai.py
@@ -21,6 +21,7 @@ from .base import (
     anchor_datetime,
     bulk_insert,
     days_window,
+    deterministic_int,
     deterministic_uuid,
     persona_multiplier,
     poisson,
@@ -89,6 +90,7 @@ def seed_ai_dev_usage(
         "prs_total_count",
         "conversation_count",
         "_version",
+        "seat_status",
     ]
     rows: list[tuple[object, ...]] = []
     version = 1
@@ -97,6 +99,12 @@ def seed_ai_dev_usage(
             continue
         profile = TEAM_PROFILES[p.team]
         persona = persona_multiplier(p.uuid)
+        # Seat state is per person, not per day: sources restate it for every
+        # day they re-read. A minority of leavers keeps the gold seat_status
+        # dimension exercised with more than one value.
+        seat_status = (
+            "deactivated" if deterministic_int(p.uuid, "ai.seat_status") % 10 == 0 else "active"
+        )
         for tool, src_key in _DEV_TOOLS:
             weight = profile.weights.get(src_key, 0)
             if weight <= 0:
@@ -138,6 +146,7 @@ def seed_ai_dev_usage(
                         float(rng.randint(0, 4)),
                         float(sessions),
                         version,
+                        seat_status,
                     )
                 )
     return bulk_insert(client, "silver", "class_ai_dev_usage", cols, rows)

--- a/tests/stand/api/analytics/drilldown_matrix.py
+++ b/tests/stand/api/analytics/drilldown_matrix.py
@@ -121,6 +121,8 @@ MATRIX: Sequence[Expectation] = (
     Expectation("ai.dev_conversations", "ai", Tier.EXACT_SUM),
     Expectation("ai.extra_usage_cost", "ai_cost", Tier.EXACT_SUM),
     Expectation("ai.extra_usage_utilisation", "ai_cost", Tier.EXACT_RATIO, scale=100.0),
+    Expectation("ai.prs_total", "ai", Tier.EXACT_SUM),
+    Expectation("ai.prs_with_assistant", "ai", Tier.EXACT_SUM),
     Expectation("ai.removed_lines", "ai", Tier.EXACT_SUM),
     Expectation("ai.tool_acceptance_rate", "ai", Tier.EXACT_RATIO, scale=100.0),
     Expectation("collab.active_days", "collab", Tier.EXACT_DISTINCT_DATES),


### PR DESCRIPTION
Closes #2606. Part of #2479. Depends on #2528 (merged) — the Bronze key it added is what makes the overage half of this safe.

Six findings from reading the Claude Team path end to end. Each is its own commit.

### The seat status was a filter; it is now a column

`WHERE status = 'active'` in Claude Team staging looked like a seat-state gate. It is retroactive: the endpoint restates the status for every day it re-reads, so the value describes the seat as of the read and not as of the metric date. The day a person's seat is deactivated, the filter deletes their entire history — and a rebuild removes it from silver altogether. Nothing about a seat's present state licenses deleting the work it recorded.

The value now rides in the class-contract column `seat_status`, appended last so the contract grows without a rebuild, and emission is gated on the activity counters instead — the same gate every other contributor to the class already uses. Sources with no seat lifecycle concept emit NULL and read as `unknown` at gold, where the value becomes a dimension of the `ai_usage` source.

Audit decision D1 said the opposite (keep the filter, add a check counting non-active rows); the spec now records why that reading was wrong.

### One incremental boundary for several producers

Silver classes carried `WHERE _version > (SELECT max(_version) FROM {{ this }})`. A class is written by every connector that feeds it, and `union_by_tag` rebuilds it from all feeders on whichever connector's run fires. `_version` is a timestamp, but its meaning differs per producer — extraction time for the AI connectors, write time elsewhere — so a single maximum over the whole table lets whichever producer commits first raise the boundary above another producer's rows. Those rows sit below it forever.

The boundary moves to a maximum per (tenant, source instance) — the shape already merged for the crm classes and `class_person_attribute_claims`. `_version`, its values and its role in `ReplacingMergeTree` are untouched; only the group the maximum is taken over. `coalesce(max_version, 0)` is load-bearing: a source absent from the target has no boundary row, and comparing against NULL would drop every row of every new source.

This fixes the future only. Rows already below a boundary stay below it, so recovering them is a separate, deliberate operation.

`assert_ai_staging_rows_reach_silver` is new and reports what staging can prove a class is missing, per source — there was no check for this at all. `check-dbt-conventions` prescribed the table-wide form and would have kept reintroducing it.

### Counts that stopped in silver

`prs_with_cc_count` and `prs_total_count` have been in the class unread since it gained them. They are served as `ai.prs_with_assistant` and `ai.prs_total`, emitted only where the vendor supplies a value, so an organisation without the vendor's code-host connection returns no value rather than a zero asserting "no pull requests involved the assistant". `ai.prs_total` is context for the other measure and not a goal of its own: it is the vendor's count over the vendor's own window, which need not be the day it is reported against.

### Seat spend joins identity coverage

`identity_resolution_coverage` listed every evidence relation except the seat one — the only relation whose unresolved rows are money rather than activity.

### Vendor fields that reached nothing

The code-metrics response carries org-level pull-request attribution and top-user rankings beside the per-user array; they were read and discarded on every sync, and the vendor keeps no history. `claude_team_code_metrics_org` keeps them as their own stream: one request and one row per day, per-user array stripped so the roster is not stored twice. Copying them onto every user row would multiply one organisation fact by the roster and make any sum wrong.

`disabled_reason`, `disabled_until` and `account_name` join the overage extras blob, where a zero spend can now be told apart from a seat the vendor blocked.

### A rebuild that deletes months

`full_refresh=false` guards `claude_team__ai_overage`. That model is the only place a past month's closing spend exists — the endpoint keeps no history — so a rebuild from Bronze deletes those months rather than reproducing them, and reconcile-connectors dispatches exactly that rebuild on a MAJOR descriptor bump. Silver still rebuilds freely: it reads the staging model, not Bronze.

### Also

`conversation_count` is documented for what it holds. For the dev-agent tools no vendor publishes a separate conversation counter, so the connectors map their session or thread count into it and the value equals `session_count` on those rows. That is the intended mapping rather than a duplication to collapse, and it does not hold on the assistant class, where the two differ per surface. `ai.dev_conversations` gains the explanation its number needed.

The connector README described the pre-#2528 shape of the overage key.

### Descriptor versions

claude-team `2.1.0` → `2.2.0`, cursor / chatgpt-team `2.0.0` → `2.1.0`, claude-enterprise `3.0.0` → `3.1.0`. All MINOR, deliberately not MAJOR: a MAJOR dispatches the one-shot `dbt --full-refresh`, and the guard that makes it safe arrives in this same change — it has to be on main before any MAJOR bump reads it. Rows written before this version keep an empty `seat_status` and read as `unknown`, which is what they are.

## Test plan

Automated, run on this branch:

- [x] `dbt parse` — clean
- [x] `dbt compile` of the touched models — the compiled SQL carries `seat_status`, both new measures and the `ai_cost_metric_evidence` branch
- [x] `cargo test -p analytics --bins` — 420 passed, 0 failed
- [x] `cargo fmt --check` and `cargo clippy -- -D warnings` — clean
- [x] `source.sh validate` and `validate-strict` for ai/claude-team — manifest valid; `discover` returns five streams
- [x] both DDL snapshot edits reproduced against a throwaway ClickHouse running the real destination connector and the real promotion, rather than hand-written
- [x] ruff at the pinned version, plus the remaining pre-commit hooks

Needed the CI rig, now run on this PR:

- [x] `e2e-bronze-to-api`, `ai` shard — 4m20s, green, including the new `ai_pr_attribution.test.yaml`. The other three shards are green too, and `Metric coverage gate` passes, so both new metric keys carry the period / peer / timeseries / breakdown coverage that gate requires
- [x] `connectors-ddl` snapshot and field-parity gate — 6m31s, green: a warehouse built from scratch by the real pipeline reproduces both edited snapshots, and every staging contributor still lines up with its silver union target
- [x] `tests/stand` — the `api-smoke` job of the Stand E2E lane, green

`Build runner image` was cancelled on the first attempt at its 30-minute ceiling while the merge queue was saturated; re-running the same commit passed, so the timeout was contention rather than a defect. Every other check is green.

