### PR TITLE
fix(seed): stop the operator journal reading as a foreign directory

### DIFF
--- a/src/backend/services/identity-resolution/src/domain/resolution.rs
+++ b/src/backend/services/identity-resolution/src/domain/resolution.rs
@@ -443,6 +443,10 @@ mod tests {
                 "operator-exclude"
             ]
         );
+        // INVARIANT: the seeder's preflight tells its own rows from a foreign
+        // directory's by this prefix (config.OPERATOR_REASON_PREFIX). A verb
+        // spelled without it makes every later seed of that stand refuse.
+        assert!(codes.iter().all(|code| code.starts_with("operator-")));
     }
 
     #[test]

--- a/src/ingestion/tools/seed/insight_seed/config.py
+++ b/src/ingestion/tools/seed/insight_seed/config.py
@@ -29,6 +29,12 @@ SEED_REASON_PREFIX = "seed.py "
 #: The persons-seed's email-link reason (AUTO_SEED_LINK_REASON): a rebuildable projection, not foreign data.
 PERSONS_SEED_LINK_REASON = "auto-seed-link"
 
+#: Prefix on the `reason` identity-resolution writes for an operator decision
+#: (`operator-bind`, `-merge`, `-detach`, `-exclude`). A decision is not identity
+#: data from elsewhere: the service refuses one whose person it does not already
+#: know, so the person it acts on is counted on its own rows.
+OPERATOR_REASON_PREFIX = "operator-"
+
 TENANT_ENV = "TENANT_DEFAULT_ID"
 ANALYTICS_DB_ENV = "MARIADB_ANALYTICS_DB"
 IDENTITY_DB_ENV = "MARIADB_DB"

--- a/src/ingestion/tools/seed/insight_seed/preflight.py
+++ b/src/ingestion/tools/seed/insight_seed/preflight.py
@@ -14,7 +14,9 @@ Two signals, because neither sees everything:
 * `persons` rows in the target tenant whose `reason` is outside this seeder's
   namespace. Identity rows are additive, so this one is about not mixing demo
   people into somebody's directory — but it is also the ONLY signal that works
-  on a single-tenant stand, so the silver step consults it too.
+  on a single-tenant stand, so the silver step consults it too. An operator
+  decision does not count: it is a judgement about a person already in the
+  tenant, so whoever put that person there is what this counts instead.
 * Rows in the reset surface belonging to a different tenant. Silver rows are
   NOT additive: the generators TRUNCATE each table before writing, across every
   tenant, because a partially rewritten silver table produces metrics that are
@@ -39,6 +41,7 @@ import pymysql
 
 from . import config
 from .config import (
+    OPERATOR_REASON_PREFIX,
     PERSONS_SEED_LINK_REASON,
     SEED_REASON_PREFIX,
     ClickHouse,
@@ -76,10 +79,11 @@ def table_missing_problem(database: str, table: str, *, needed_for: str) -> str:
 def foreign_rows_problem(count: int, tenant: str, database: str) -> str:
     return (
         f"tenant {tenant} already holds {count} `{database}.persons` row(s) this seeder "
-        f"did not write (their `reason` does not start with {SEED_REASON_PREFIX!r} and is "
-        f"not the persons-seed's {PERSONS_SEED_LINK_REASON!r}), so this stand carries "
-        "identity data from somewhere else. Seed a tenant of your own, "
-        f"or set {config.FORCE_ENV}=1 to add demo people to this one anyway."
+        f"did not write (their `reason` does not start with {SEED_REASON_PREFIX!r} or "
+        f"{OPERATOR_REASON_PREFIX!r} and is not the persons-seed's "
+        f"{PERSONS_SEED_LINK_REASON!r}), so this stand carries identity data from "
+        f"somewhere else. Seed a tenant of your own, or set {config.FORCE_ENV}=1 to add "
+        "demo people to this one anyway."
     )
 
 
@@ -96,8 +100,13 @@ def _count_foreign_persons(cur: pymysql.cursors.Cursor, tenant: str) -> int:
     cur.execute(
         "SELECT COUNT(*) FROM persons "
         "WHERE insight_tenant_id = %s "
-        "AND (reason IS NULL OR (reason NOT LIKE %s AND reason != %s))",
-        (uuid_mod.UUID(tenant).bytes, f"{SEED_REASON_PREFIX}%", PERSONS_SEED_LINK_REASON),
+        "AND (reason IS NULL OR (reason NOT LIKE %s AND reason != %s AND reason NOT LIKE %s))",
+        (
+            uuid_mod.UUID(tenant).bytes,
+            f"{SEED_REASON_PREFIX}%",
+            PERSONS_SEED_LINK_REASON,
+            f"{OPERATOR_REASON_PREFIX}%",
+        ),
     )
     row = cur.fetchone()
     return int(row[0]) if row else 0

--- a/src/ingestion/tools/seed/tests/test_preflight.py
+++ b/src/ingestion/tools/seed/tests/test_preflight.py
@@ -374,6 +374,24 @@ class SeedReasonNamespaceTests(unittest.TestCase):
         self.assertEqual(params[0], uuid_mod.UUID(_TENANT).bytes)
         self.assertEqual(params[1], f"{config.SEED_REASON_PREFIX}%")
 
+    def test_an_operator_decision_is_not_counted_as_identity_data_from_elsewhere(self) -> None:
+        cursor = _CapturingCursor(result=(0,))
+        preflight._count_foreign_persons(cursor, _TENANT)  # type: ignore[arg-type]
+
+        _, params = cursor.executed[-1]
+        self.assertIn(f"{config.OPERATOR_REASON_PREFIX}%", params)
+
+    def test_the_operator_prefix_covers_every_verb_the_resolution_api_records(self) -> None:
+        for verb in ("bind", "merge", "detach", "exclude"):
+            with self.subTest(verb=verb):
+                self.assertTrue(f"operator-{verb}".startswith(config.OPERATOR_REASON_PREFIX))
+
+    def test_a_refusal_names_both_namespaces_it_forgave(self) -> None:
+        message = preflight.foreign_rows_problem(2, _TENANT, "identity")
+        self.assertIn(config.SEED_REASON_PREFIX, message)
+        self.assertIn(config.OPERATOR_REASON_PREFIX, message)
+        self.assertIn(config.PERSONS_SEED_LINK_REASON, message)
+
     def test_a_tenant_with_no_foreign_rows_reads_as_zero(self) -> None:
         self.assertEqual(
             preflight._count_foreign_persons(_CapturingCursor(result=None), _TENANT),  # type: ignore[arg-type]


### PR DESCRIPTION
`preflight` refuses to seed a tenant whose `persons` rows carry a `reason` outside
the seeder's namespace — its signal for "this stand's directory came from somewhere
else". Identity-resolution's operator decisions (`operator-bind`, `-merge`,
`-detach`, `-exclude`) are outside it, so they count as foreign.

They aren't. A decision is a judgement about a person the tenant already holds — the
API refuses one whose person it does not know — so that person is already counted on
its own rows and the guard loses nothing by forgiving the decision.

The journal is append-only, so the rows cannot be retracted;
`tests/stand/api/identity/test_resolution.py` says as much where it explains why its
round trip ends in `exclude` rather than a delete. The consequence is that **a stand
which has run the deployed-stand suite once refuses every seed after it**, so
`deploy → seed → smoke → suite` cannot run twice against the same stand.

**The change** — the foreign-row count forgives the `operator-` prefix. The refusal
names all three namespaces it forgave, so whoever reads it can tell which rows are
theirs. An assertion in identity-resolution pins the prefix where those strings are
written, because a verb spelled without it re-breaks seeding silently.

**Verification** — 43 seeder unit tests pass, including new cases for the prefix and
for the refusal text. Both predicates were run against a database carrying seeded
rows and operator rows: the count goes from the journal rows to zero, while a row
outside all three namespaces still counts.

**Not here** — the seed step's log allowlist prints only the wrapper's own lines, so a
preflight refusal reaches the console as a bare "Job failed" and is unrecoverable
once the Job is reaped. That deserves its own change.
