### PR TITLE
fix(ai-cost): scope the invoice layers' incremental boundary to one source

### DIFF
--- a/src/ingestion/connectors/ai/claude-team-invoices/dbt/claude_team__ai_invoice.sql
+++ b/src/ingestion/connectors/ai/claude-team-invoices/dbt/claude_team__ai_invoice.sql
@@ -91,14 +91,24 @@ SELECT
 FROM latest_per_key
 {% if is_incremental() %}
   -- A row only ever changes because a newer read produced it, so rows read since
-  -- the last build are the only ones that can carry anything new. The empty-table
-  -- guard mirrors the sibling models: over an empty `this` the max is the epoch
-  -- and every row would be filtered out.
-  WHERE (
-    (SELECT count() FROM {{ this }}) = 0
-    OR _airbyte_extracted_at > (
-        SELECT coalesce(max(collected_at), toDateTime64('1970-01-01 00:00:00', 3))
-        FROM {{ this }}
-    )
-  )
+  -- the last build are the only ones that can carry anything new.
+  --
+  -- Scoped to ONE source instance, for the reason silver_incremental_watermark
+  -- gives at the class above: two instances of this connector write here, each
+  -- stamping its own extraction clock, and a boundary taken over the whole table
+  -- lets whichever ran first put the other's rows below it FOREVER. `coalesce`
+  -- to the epoch is what admits an instance the table has never seen — comparing
+  -- against NULL would drop every row of every new one.
+  LEFT JOIN (
+      SELECT
+          insight_tenant_id,
+          source_id AS watermark_source_id,
+          max(collected_at) AS max_collected
+      FROM {{ this }}
+      GROUP BY insight_tenant_id, source_id
+  ) AS watermarks
+      ON latest_per_key.tenant_id = watermarks.insight_tenant_id
+     AND latest_per_key.source_id = watermarks.watermark_source_id
+  WHERE latest_per_key._airbyte_extracted_at
+      > coalesce(watermarks.max_collected, toDateTime64('1970-01-01 00:00:00', 3))
 {% endif %}

--- a/src/ingestion/silver/ai/class_ai_invoice.sql
+++ b/src/ingestion/silver/ai/class_ai_invoice.sql
@@ -19,9 +19,7 @@
 --
 -- depends_on: {{ ref('claude_team__ai_invoice') }}
 
-SELECT * FROM (
+SELECT candidate.* FROM (
     {{ union_by_tag('silver:class_ai_invoice') }}
-)
-{% if is_incremental() %}
-WHERE _version > (SELECT max(_version) FROM {{ this }})
-{% endif %}
+) AS candidate
+{{ silver_incremental_watermark(['insight_tenant_id', 'source_id']) }}

--- a/src/ingestion/tests/e2e/metrics/test_ai_invoice_silver.py
+++ b/src/ingestion/tests/e2e/metrics/test_ai_invoice_silver.py
@@ -35,6 +35,7 @@ SOURCE = "claude-team-invoices-test"
 # recovery pair is only legible on its own.
 SOURCE_ONE_BUILD = "claude-team-invoices-recovered-one-build"
 SOURCE_TWO_BUILDS = "claude-team-invoices-recovered-two-builds"
+SOURCE_SECOND_INSTANCE = "claude-team-invoices-second-instance"
 
 # 2026-08-01 and 2026-09-01 UTC — the window a monthly line charges for.
 AUG_START, SEP_START = 1785542400, 1788220800
@@ -42,7 +43,7 @@ AUG_START, SEP_START = 1785542400, 1788220800
 # dating by this instead of by the period would file the row in July.
 RAISED_AT = 1785456000
 
-# Staging admits only rows read strictly after what it already holds, and that
+# Staging admits only rows read strictly after what it already holds, and THAT
 # watermark is table-wide. So every instant below is distinct and ascends in the
 # order the fixtures run: reuse one and the watermark, not the model, decides which
 # rows arrive — an assertion about the model would then hold with the model deleted.
@@ -51,6 +52,11 @@ ONE_BUILD_BROKEN_AT = "2026-09-03T00:00:00Z"
 ONE_BUILD_RECOVERED_AT = "2026-09-04T00:00:00Z"
 TWO_BUILDS_BROKEN_AT = "2026-09-05T00:00:00Z"
 TWO_BUILDS_RECOVERED_AT = "2026-09-06T00:00:00Z"
+
+# The class's own boundary is per source instance, so this one deliberately does
+# NOT ascend: it is read before every instant above, which is what a second
+# connector instance stamping `_version` from its own clock looks like.
+SECOND_INSTANCE_READ_AT = "2026-08-20T00:00:00Z"
 
 
 def _base(source_id: str, read_at: str) -> dict:
@@ -388,3 +394,34 @@ def test_a_recovery_across_two_builds_leaves_no_gap_behind(recovered_across_two_
     assert invoice["invoice_id"] == "in_RECOVERED", "the gap row became the enriched one"
     assert invoice["invoice_net_cents"] == 16_000
     assert recovered_across_two_builds[1]["invoice_net_cents"] is None, "counted once, not twice"
+
+
+@pytest.fixture
+def second_instance_silver(
+    ch_migrations_applied: SessionConfig, ch_seeder: CHSeeder, dbt_runner: DbtRunner, worker_ctx: WorkerContext
+) -> list[dict]:
+    """A second source instance, read BEFORE everything the class already holds."""
+    rows = [
+        _invoice_row(
+            "pi_second",
+            4_200,
+            4_000,
+            source_id=SOURCE_SECOND_INSTANCE,
+            read_at=SECOND_INSTANCE_READ_AT,
+            invoice_id="in_SECOND",
+            period_start_ts=AUG_START,
+            period_end_ts=SEP_START,
+        )
+    ]
+    _seed_and_build(ch_seeder, dbt_runner, worker_ctx, rows)
+    return _read_class(ch_migrations_applied, SOURCE_SECOND_INSTANCE)
+
+
+def test_a_second_source_instance_is_not_shut_out_by_the_first(second_instance_silver):
+    """The class is written by every connector feeding it, each stamping `_version`
+    from its own clock. A boundary taken over the whole table would leave this
+    instance's rows below whatever the first instance committed — forever, and
+    silently. The boundary is per instance, so an instance the class has never
+    seen has no boundary to clear."""
+    assert [r["invoice_id"] for r in second_instance_silver] == ["in_SECOND"]
+    assert second_instance_silver[0]["invoice_net_cents"] == 4_000


### PR DESCRIPTION
Closes #2620. Follow-up to #2607, which #2432 crossed with in flight.

#2607 replaced the table-wide `_version > max(_version)` on the AI silver classes with
`silver_incremental_watermark`, and taught the convention checker to forbid the old form.
#2432 landed the invoice path a few hours later from a branch that predated that fix, so
`class_ai_invoice` is the last AI class carrying the shape #2607 removed. This restores it
to the convention.

For the record, since the ordering is what caused this: #2607 is not a new connector — it
fixes the existing Claude Team path. #2432 did not disagree with it; it was simply written
first and merged second.

## The defect, in #2607's own words

> A class table is written by every connector that feeds it, and each runs on its own
> schedule. `_version` is a timestamp whose meaning differs per producer […] so a single
> `max(_version)` over the whole table lets whichever producer commits first raise the
> boundary above another producer's rows. Those rows are then below it forever: nothing
> re-reads them, and until now nothing reported the loss either.

That precondition is this class's stated purpose — "Unified vendor invoices **across AI
vendors**", with the staging model documenting itself as defining the contract future
vendors emit into.

**Nothing is being lost today**: one contributor means the table-wide maximum is its own.
This is preventive.

## Two layers

`silver/ai/class_ai_invoice.sql` is the obvious half. The other is
`claude_team__ai_invoice.sql`, whose boundary is the same shape over `collected_at`.

Fixing only the class would change nothing observable — a second instance's rows are dropped
at staging before silver ever sees them. Two instances of one connector do write to one
staging table: that is why `insight_source_id` is part of every `unique_key`, and why
`check_connection` refuses an empty one with "would collide unique_keys across connector
instances".

Both layers now take the shared macro rather than a second implementation of it. Staging's
empty-table guard goes with the change: `coalesce` to the epoch already admits an instance
the table has never seen, which is exactly what the guard stood in for.

## Test plan

Automated, run:

- [x] `metrics/test_ai_invoice_silver.py` + `metrics/test_ai_seat_extra_usage_history.py` —
  13 passed against a stand built from wiped volumes.
- [x] The new case has teeth. It seeds a second source instance read **before** everything
  the class already holds — the shape a per-table boundary silently drops — and reverting
  either layer alone fails it with `assert [] == ['in_SECOND']`. Both reverts were run over
  the full module: with a `-k` filter the earlier fixtures never run, staging is empty, and
  the empty-table guard hides the bug.
- [x] `ruff check` + `ruff format --check` at the pinned version — clean.
- [x] `connectors-ddl` snapshot unchanged, and expected to be: the column list is untouched
  and the snapshots hold bronze DDL only.

Manual, needs a stand — please tick these yourself:

- [ ] After a deploy, confirm `staging.claude_team__ai_invoice` and `silver.class_ai_invoice`
  keep accepting rows on the next scheduled sync (the boundary changes shape, not meaning,
  so an in-place upgrade needs no full refresh).

## Not in this PR

`assert_ai_staging_rows_reach_silver` — the completeness check #2607 added to report exactly
this loss — cannot run: its `ref()` calls sit inside a loop over
`materialised_models_for_tag`, which is empty at parse time, so dbt records no dependencies
and fails the test at run time with "unable to infer all dependencies … ref() is placed
within a conditional block". Reproduced against a live stand with
`dbt test --selector data_quality`.

`class_ai_invoice` is deliberately **not** added to its list: a fourth entry would only widen
the set of stands whose scheduled data-quality run turns red. Written up in #2620 for whoever
owns the check — `-- depends_on:` hints cannot be written for refs chosen at run time, so it
needs a design call rather than a one-liner.
