### PR TITLE
feat(identity): add a flat-tenant visibility policy

### DIFF
--- a/docs/components/backend/identity-resolution/openapi.json
+++ b/docs/components/backend/identity-resolution/openapi.json
@@ -490,12 +490,16 @@
               "$ref": "#/components/schemas/MeRoleResponse"
             },
             "type": "array"
+          },
+          "visibility_policy": {
+            "$ref": "#/components/schemas/VisibilityPolicy"
           }
         },
         "required": [
           "person_id",
           "insight_tenant_id",
-          "roles"
+          "roles",
+          "visibility_policy"
         ],
         "type": "object"
       },
@@ -1455,6 +1459,13 @@
           "items"
         ],
         "type": "object"
+      },
+      "VisibilityPolicy": {
+        "enum": [
+          "org_chart",
+          "flat"
+        ],
+        "type": "string"
       },
       "VisibilityResponse": {
         "description": "One visibility grant.",

--- a/src/backend/services/identity-resolution/helm/templates/configmap.yaml
+++ b/src/backend/services/identity-resolution/helm/templates/configmap.yaml
@@ -122,6 +122,7 @@ data:
           org_chart_source_type: {{ .Values.orgChartSourceType | quote }}
           expand_subordinates: {{ .Values.expandSubordinates }}
           max_depth: {{ .Values.maxDepth }}
+          visibility_policy: {{ .Values.visibilityPolicy | default "org_chart" | quote }}
           clickhouse_url: ""
           clickhouse_database: "identity"
           clickhouse_user: ""

--- a/src/backend/services/identity-resolution/helm/tests/test_gears_config_contract.py
+++ b/src/backend/services/identity-resolution/helm/tests/test_gears_config_contract.py
@@ -64,3 +64,20 @@ def test_a_top_level_override_reaches_the_gear_config(
     config = _gear_config("--set", flag)
 
     assert config[key] == expected, f"should honour --set {flag}"
+
+@pytest.mark.parametrize(
+    ("flag", "expected"),
+    [(None, "org_chart"), ("visibilityPolicy=flat", "flat"), ("visibilityPolicy=org_chart", "org_chart")],
+)
+def test_the_visibility_policy_reaches_the_gear_config(
+    flag: str | None, expected: str
+) -> None:
+    config = _gear_config(*(("--set", flag) if flag else ()))
+
+    assert config["visibility_policy"] == expected
+
+
+def test_the_visibility_policy_is_never_rendered_empty() -> None:
+    config = _gear_config("--set", "visibilityPolicy=")
+
+    assert config["visibility_policy"] == "org_chart"

--- a/src/backend/services/identity-resolution/helm/values.yaml
+++ b/src/backend/services/identity-resolution/helm/values.yaml
@@ -64,6 +64,11 @@ orgChartSourceType: "bamboohr"
 expandSubordinates: true
 maxDepth: 16
 
+# Whose data a caller may see: "org_chart" (the reporting line plus explicit
+# visibility grants) or "flat" (every person in the tenant). An unreadable
+# value stops the service rather than resolving to a policy.
+visibilityPolicy: "org_chart"
+
 # Scheduled persons-seed (#1690): a CronJob runs `identity-resolution seed`
 # to rebuild the identity org projection from ClickHouse identity_inputs.
 # Requires tenant_default_id in the config Secret (the seed refuses to run

--- a/src/backend/services/identity-resolution/src/api/handlers.rs
+++ b/src/backend/services/identity-resolution/src/api/handlers.rs
@@ -123,6 +123,7 @@ async fn visible_person_ids(
             person_id,
             &state.config.org_chart_source_type,
             None,
+            state.config.visibility_policy,
         )
         .await
         .map_err(|e| {

--- a/src/backend/services/identity-resolution/src/api/http_live_tests.rs
+++ b/src/backend/services/identity-resolution/src/api/http_live_tests.rs
@@ -27,7 +27,7 @@ use toolkit::api::OpenApiRegistryImpl;
 use toolkit_security::SecurityContext;
 
 use super::AppState;
-use crate::config::GearConfig;
+use crate::config::{GearConfig, VisibilityPolicy};
 use crate::domain::resolution::EXCLUDED_PERSON;
 use crate::infra::db::test_fixture::{FIXTURE_REASON, Fixture, fixture_or_skip};
 use crate::infra::db::{person_roles_repo, roles_repo};
@@ -42,20 +42,36 @@ struct Caller {
 }
 
 fn app(f: &Fixture, caller: Uuid) -> Router {
+    app_with(f, caller, GearConfig::default())
+}
+
+fn flat_app(f: &Fixture, caller: Uuid) -> Router {
+    app_with(
+        f,
+        caller,
+        GearConfig {
+            visibility_policy: VisibilityPolicy::Flat,
+            ..GearConfig::default()
+        },
+    )
+}
+
+fn app_with(f: &Fixture, caller: Uuid, config: GearConfig) -> Router {
     app_for(
         f,
         Caller {
             person_id: caller,
             tenant: f.tenant,
         },
+        config,
     )
 }
 
-fn app_for(f: &Fixture, caller: Caller) -> Router {
+fn app_for(f: &Fixture, caller: Caller, config: GearConfig) -> Router {
     let openapi = OpenApiRegistryImpl::new();
     let state = Arc::new(AppState {
         db: f.db.clone(),
-        config: GearConfig::default(),
+        config,
     });
     let api = super::build_operations(Router::new(), &openapi)
         .layer(from_fn_with_state(caller, inject_host_context))
@@ -778,5 +794,47 @@ async fn a_cut_page_offers_the_next_one_and_a_whole_answer_does_not() -> TestRes
         full["next_cursor"].is_null(),
         "a whole answer offers no next page: {full}"
     );
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_flat_policy_resolves_a_profile_outside_the_reporting_line() -> TestResult {
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let caller = f.person("flat-caller@http-live.test").await?;
+    let unrelated = f.person("flat-unrelated@http-live.test").await?;
+
+    let (org_chart, _) = post(app(&f, caller), "/v1/profiles", &by_person_id(unrelated)).await?;
+    let (flat, _) = post(
+        flat_app(&f, caller),
+        "/v1/profiles",
+        &by_person_id(unrelated),
+    )
+    .await?;
+
+    assert_eq!(
+        org_chart,
+        StatusCode::NOT_FOUND,
+        "reporting-line rule hides them"
+    );
+    assert_eq!(flat, StatusCode::OK, "flat policy resolves them");
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_flat_policy_keeps_another_tenants_profile_not_found() -> TestResult {
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let caller = f.person("flat-boundary@http-live.test").await?;
+    let foreign = f
+        .in_another_tenant()
+        .person("flat-foreign@http-live.test")
+        .await?;
+
+    let (status, _) = post(flat_app(&f, caller), "/v1/profiles", &by_person_id(foreign)).await?;
+
+    assert_eq!(status, StatusCode::NOT_FOUND);
     Ok(())
 }

--- a/src/backend/services/identity-resolution/src/api/me.rs
+++ b/src/backend/services/identity-resolution/src/api/me.rs
@@ -18,6 +18,7 @@ use uuid::Uuid;
 
 use super::AppState;
 use super::gate::require_caller;
+use crate::config::VisibilityPolicy;
 use crate::infra::db::roles_repo::{self, Role};
 
 /// One active role assignment of the caller.
@@ -42,6 +43,7 @@ pub struct MeResponse {
     pub person_id: Uuid,
     pub insight_tenant_id: Uuid,
     pub roles: Vec<MeRoleResponse>,
+    pub visibility_policy: VisibilityPolicy,
 }
 impl toolkit::api::api_dto::ResponseApiDto for MeResponse {}
 
@@ -61,6 +63,7 @@ pub async fn get_me(
         person_id: caller,
         insight_tenant_id: tenant,
         roles: roles.into_iter().map(MeRoleResponse::from).collect(),
+        visibility_policy: state.config.visibility_policy,
     }))
 }
 
@@ -68,4 +71,27 @@ pub async fn get_me(
 fn read_err(e: anyhow::Error) -> CanonicalError {
     tracing::error!(error = %e, "caller roles query failed");
     CanonicalError::internal("failed to read caller roles").create()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_policy_is_named_on_the_wire_as_the_config_names_it() -> anyhow::Result<()> {
+        for (policy, expected) in [
+            (VisibilityPolicy::OrgChart, "org_chart"),
+            (VisibilityPolicy::Flat, "flat"),
+        ] {
+            let body = serde_json::to_value(MeResponse {
+                person_id: Uuid::from_u128(1),
+                insight_tenant_id: Uuid::from_u128(2),
+                roles: Vec::new(),
+                visibility_policy: policy,
+            })?;
+
+            assert_eq!(body["visibility_policy"], expected);
+        }
+        Ok(())
+    }
 }

--- a/src/backend/services/identity-resolution/src/api/subchart.rs
+++ b/src/backend/services/identity-resolution/src/api/subchart.rs
@@ -59,10 +59,17 @@ pub async fn get_forest(
     let valid_at = resolve_valid_at(params.valid_at.as_deref())?;
     let source = &state.config.org_chart_source_type;
 
-    let flat =
-        subchart_repo::get_forest_flat(&state.db, tenant, caller, source, max_depth, valid_at)
-            .await
-            .map_err(read_err)?;
+    let flat = subchart_repo::get_forest_flat(
+        &state.db,
+        tenant,
+        caller,
+        source,
+        max_depth,
+        valid_at,
+        state.config.visibility_policy,
+    )
+    .await
+    .map_err(read_err)?;
     Ok(Json(SubchartForestResponse {
         roots: assemble_forest(flat),
     }))
@@ -86,7 +93,13 @@ pub async fn get_subchart(
     let source = &state.config.org_chart_source_type;
 
     let can_see = subchart_repo::is_target_in_visible_set(
-        &state.db, tenant, caller, person_id, source, valid_at,
+        &state.db,
+        tenant,
+        caller,
+        person_id,
+        source,
+        valid_at,
+        state.config.visibility_policy,
     )
     .await
     .map_err(read_err)?;

--- a/src/backend/services/identity-resolution/src/api/visible_persons.rs
+++ b/src/backend/services/identity-resolution/src/api/visible_persons.rs
@@ -53,10 +53,13 @@ pub async fn filter_visible_persons(
     // as visible — and analytics treats this answer as authorization. Not an
     // existence oracle beyond what the grant already implies: a wildcard
     // holder may see every person the tenant has.
-    let visible = if subchart_repo::has_wildcard_grant(&state.db, tenant, caller)
-        .await
-        .map_err(read_err)?
-    {
+    let policy = state.config.visibility_policy;
+    let whole_tenant = policy.is_flat()
+        || subchart_repo::has_wildcard_grant(&state.db, tenant, caller)
+            .await
+            .map_err(read_err)?;
+
+    let visible = if whole_tenant {
         persons_repo::persons_in_tenant(&state.db, tenant, &requested)
             .await
             .map_err(read_err)?
@@ -67,6 +70,7 @@ pub async fn filter_visible_persons(
             caller,
             &requested,
             &state.config.org_chart_source_type,
+            policy,
         )
         .await
         .map_err(read_err)?

--- a/src/backend/services/identity-resolution/src/config.rs
+++ b/src/backend/services/identity-resolution/src/config.rs
@@ -4,7 +4,22 @@
 //! `gears.identity-resolution.config` YAML section. Env overrides are
 //! `APP__gears__identity_resolution__config__<field>`.
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum VisibilityPolicy {
+    #[default]
+    OrgChart,
+    Flat,
+}
+
+impl VisibilityPolicy {
+    #[must_use]
+    pub fn is_flat(self) -> bool {
+        matches!(self, Self::Flat)
+    }
+}
 
 /// Configuration consumed by the identity-resolution gear. Deserialized from
 /// `gears.identity-resolution.config`.
@@ -38,6 +53,10 @@ pub struct GearConfig {
     /// active `admin` assignment in `tenant_default_id` unless one already
     /// exists. Empty = disabled.
     pub bootstrap_admin_person_id: String,
+    /// Whose data a caller may see: the reporting line plus explicit grants
+    /// (`org_chart`), or every person in the tenant (`flat`). Nothing is
+    /// written to `visibility`, so the choice is reversible.
+    pub visibility_policy: VisibilityPolicy,
 }
 
 impl Default for GearConfig {
@@ -53,6 +72,55 @@ impl Default for GearConfig {
             clickhouse_password: String::new(),
             tenant_default_id: String::new(),
             bootstrap_admin_person_id: String::new(),
+            visibility_policy: VisibilityPolicy::OrgChart,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(json: serde_json::Value) -> Result<GearConfig, serde_json::Error> {
+        serde_json::from_value(json)
+    }
+
+    #[test]
+    fn an_absent_policy_reads_as_org_chart() -> anyhow::Result<()> {
+        let config = config(serde_json::json!({}))?;
+
+        assert_eq!(config.visibility_policy, VisibilityPolicy::OrgChart);
+        Ok(())
+    }
+
+    #[test]
+    fn each_policy_is_named_as_the_wire_names_it() -> anyhow::Result<()> {
+        for (value, expected) in [
+            ("org_chart", VisibilityPolicy::OrgChart),
+            ("flat", VisibilityPolicy::Flat),
+        ] {
+            let config = config(serde_json::json!({ "visibility_policy": value }))?;
+
+            assert_eq!(config.visibility_policy, expected, "for: {value}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn a_value_that_is_not_a_policy_refuses_to_load() {
+        // A policy decides who may see whom, so an unreadable one must stop the
+        // service rather than resolve to whichever branch the type defaults to.
+        for value in ["Flat", "FLAT", "flatt", "", "org-chart"] {
+            assert!(
+                config(serde_json::json!({ "visibility_policy": value })).is_err(),
+                "should refuse: {value:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn only_the_flat_policy_reports_itself_flat() {
+        assert!(VisibilityPolicy::Flat.is_flat());
+        assert!(!VisibilityPolicy::OrgChart.is_flat());
     }
 }

--- a/src/backend/services/identity-resolution/src/infra/db/subchart_repo.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/subchart_repo.rs
@@ -19,6 +19,8 @@ use sea_orm::prelude::DateTime;
 use sea_orm::{ConnectionTrait, DatabaseConnection, DbBackend, Statement, Value};
 use uuid::Uuid;
 
+use crate::config::VisibilityPolicy;
+
 use super::sql_named::bind_named;
 
 /// One flat node of a subchart traversal. `parent_person_id` is `None` for a
@@ -66,6 +68,7 @@ pub async fn is_target_in_visible_set(
     target_person_id: Uuid,
     org_source_type: &str,
     valid_at: Option<DateTime>,
+    policy: VisibilityPolicy,
 ) -> anyhow::Result<bool> {
     const SQL: &str = r"
         WITH RECURSIVE visible_set (person_id) AS (
@@ -89,6 +92,14 @@ pub async fn is_target_in_visible_set(
                   AND (valid_to IS NULL OR valid_to > COALESCE(@valid_at, UTC_TIMESTAMP(6)))
             )
             UNION
+            -- SAFETY: scoped to the tenant's persons, not to the id asked
+            -- about — an unscoped arm confirms any UUID a caller can type.
+            SELECT person_id
+            FROM persons
+            WHERE insight_tenant_id = @tenant_id
+              AND person_id         = @target_person_id
+              AND @flat_tenant
+            UNION
             SELECT oc.child_person_id
             FROM visible_set vs
             JOIN org_chart oc
@@ -109,6 +120,7 @@ pub async fn is_target_in_visible_set(
             ("valid_at", valid_at.into()),
             ("target_person_id", bytes(target_person_id)),
             ("org_source_type", org_source_type.into()),
+            ("flat_tenant", policy.is_flat().into()),
         ],
     )?;
 
@@ -169,6 +181,7 @@ pub async fn visible_targets(
     viewer_person_id: Uuid,
     candidates: &[Uuid],
     org_source_type: &str,
+    policy: VisibilityPolicy,
 ) -> anyhow::Result<Vec<Uuid>> {
     const SQL: &str = r"
         WITH RECURSIVE visible_set (person_id) AS (
@@ -185,14 +198,14 @@ pub async fn visible_targets(
             SELECT DISTINCT person_id
             FROM persons
             WHERE insight_tenant_id = @tenant_id
-              AND EXISTS (
+              AND (@flat_tenant OR EXISTS (
                   SELECT 1 FROM visibility
                   WHERE insight_tenant_id = @tenant_id
                     AND viewer_person_id  = @viewer_person_id
                     AND viewed_person_id  IS NULL
                     AND valid_from <= UTC_TIMESTAMP(6)
                     AND (valid_to IS NULL OR valid_to > UTC_TIMESTAMP(6))
-              )
+              ))
             UNION
             SELECT oc.child_person_id
             FROM visible_set vs
@@ -223,6 +236,7 @@ pub async fn visible_targets(
         ("viewer_person_id", bytes(viewer_person_id)),
         ("tenant_id", bytes(tenant_id)),
         ("org_source_type", org_source_type.into()),
+        ("flat_tenant", policy.is_flat().into()),
     ];
     params.extend(
         names
@@ -351,6 +365,7 @@ pub async fn get_forest_flat(
     source_type: &str,
     max_depth: Option<i32>,
     valid_at: Option<DateTime>,
+    policy: VisibilityPolicy,
 ) -> anyhow::Result<Vec<SubchartFlatNode>> {
     const SQL: &str = r"
         WITH RECURSIVE
@@ -367,14 +382,14 @@ pub async fn get_forest_flat(
             UNION
             SELECT DISTINCT person_id FROM persons
             WHERE insight_tenant_id = @tenant_id
-              AND EXISTS (
+              AND (@flat_tenant OR EXISTS (
                   SELECT 1 FROM visibility
                   WHERE insight_tenant_id = @tenant_id
                     AND viewer_person_id  = @viewer_person_id
                     AND viewed_person_id  IS NULL
                     AND valid_from <= COALESCE(@valid_at, UTC_TIMESTAMP(6))
                     AND (valid_to IS NULL OR valid_to > COALESCE(@valid_at, UTC_TIMESTAMP(6)))
-              )
+              ))
             UNION
             SELECT oc.child_person_id
             FROM visible_set vs
@@ -469,6 +484,7 @@ pub async fn get_forest_flat(
             ("valid_at", valid_at.into()),
             ("source_type", source_type.into()),
             ("max_depth", max_depth.into()),
+            ("flat_tenant", policy.is_flat().into()),
         ],
     )?;
 

--- a/src/backend/services/identity-resolution/src/infra/db/test_fixture.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/test_fixture.rs
@@ -14,6 +14,7 @@ use uuid::Uuid;
 use crate::domain::seed::SourceAccountKey;
 
 use super::{connect_single, roles_repo, subchart_repo};
+use crate::config::VisibilityPolicy;
 
 /// The all-zero author every automatic binding carries.
 const AUTOMATION: Uuid = Uuid::nil();
@@ -240,7 +241,47 @@ impl Fixture {
         viewer: Uuid,
         candidates: &[Uuid],
     ) -> anyhow::Result<Vec<Uuid>> {
-        subchart_repo::visible_targets(&self.db, self.tenant, viewer, candidates, SOURCE_TYPE).await
+        self.visible_under(viewer, candidates, VisibilityPolicy::OrgChart)
+            .await
+    }
+
+    pub(crate) async fn visible_flat(
+        &self,
+        viewer: Uuid,
+        candidates: &[Uuid],
+    ) -> anyhow::Result<Vec<Uuid>> {
+        self.visible_under(viewer, candidates, VisibilityPolicy::Flat)
+            .await
+    }
+
+    async fn visible_under(
+        &self,
+        viewer: Uuid,
+        candidates: &[Uuid],
+        policy: VisibilityPolicy,
+    ) -> anyhow::Result<Vec<Uuid>> {
+        subchart_repo::visible_targets(
+            &self.db,
+            self.tenant,
+            viewer,
+            candidates,
+            SOURCE_TYPE,
+            policy,
+        )
+        .await
+    }
+
+    pub(crate) async fn can_see_flat(&self, viewer: Uuid, target: Uuid) -> anyhow::Result<bool> {
+        subchart_repo::is_target_in_visible_set(
+            &self.db,
+            self.tenant,
+            viewer,
+            target,
+            SOURCE_TYPE,
+            None,
+            VisibilityPolicy::Flat,
+        )
+        .await
     }
 
     async fn exec(&self, sql: &str, values: impl IntoIterator<Item = Value>) -> anyhow::Result<()> {

--- a/src/backend/services/identity-resolution/src/infra/db/visible_set_live_tests.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/visible_set_live_tests.rs
@@ -170,3 +170,53 @@ async fn the_admin_role_confers_no_visibility() -> TestResult {
     );
     Ok(())
 }
+
+#[tokio::test]
+async fn a_flat_policy_shows_a_caller_with_no_reports_the_whole_tenant() -> TestResult {
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let leaf = f.person("leaf@flat-policy.test").await?;
+    let stranger = f.person("stranger@flat-policy.test").await?;
+
+    let mut visible = f.visible_flat(leaf, &[leaf, stranger]).await?;
+    visible.sort();
+    let mut expected = vec![leaf, stranger];
+    expected.sort();
+
+    assert_eq!(visible, expected);
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_flat_policy_covers_the_tenants_persons_not_every_id_asked_about() -> TestResult {
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let viewer = f.person("viewer@flat-policy.test").await?;
+    let elsewhere = f.in_another_tenant();
+    let foreign = elsewhere.person("foreign@flat-policy.test").await?;
+    let never_a_person = Uuid::now_v7();
+
+    let visible = f
+        .visible_flat(viewer, &[viewer, foreign, never_a_person])
+        .await?;
+
+    assert_eq!(visible, vec![viewer]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_flat_policy_answers_the_single_target_probe_within_the_tenant() -> TestResult {
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let viewer = f.person("probe-viewer@flat-policy.test").await?;
+    let stranger = f.person("probe-stranger@flat-policy.test").await?;
+    let elsewhere = f.in_another_tenant();
+    let foreign = elsewhere.person("probe-foreign@flat-policy.test").await?;
+
+    assert!(f.can_see_flat(viewer, stranger).await?);
+    assert!(!f.can_see_flat(viewer, foreign).await?);
+    Ok(())
+}

--- a/tests/stand/api/identity/test_me.py
+++ b/tests/stand/api/identity/test_me.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import pytest
 from insight_stand import ADMIN_ROLE, ApiClient, PersonaSession, identity_path
 
-from ..schemas import MeResponse
+from ..schemas import MeResponse, VisibilityPolicy
 from .test_admin import _admin_role_id
 
 ME = identity_path("/v1/me")
@@ -99,4 +99,24 @@ def test_the_realm_admin_role_does_not_leak_into_the_answer(
     assert me.roles == [], (
         f"{realm_admin_session.name} holds {ADMIN_ROLE} in the realm only, yet "
         f"/v1/me lists {me.roles}"
+    )
+
+
+@pytest.mark.reliability
+def test_the_visibility_policy_this_stand_runs_is_named_in_the_answer(
+    lead_session: PersonaSession,
+) -> None:
+    """The SPA reads the policy here instead of inferring it from an empty tree.
+
+    A leaf IC and a member of a hierarchy-less organisation are served the same
+    empty `subordinates`, so the two are indistinguishable to a consumer that
+    guesses. This stand seeds a reporting line, and every persona-reach
+    assertion in this suite presumes the reporting-line rule — `flat` here
+    would mean those tests describe a different product.
+    """
+    me = _me(lead_session.client)
+
+    assert me.visibility_policy == VisibilityPolicy.org_chart, (
+        f"stand serves {me.visibility_policy}, but the suite's reach "
+        f"assertions presume {VisibilityPolicy.org_chart}"
     )

--- a/tests/stand/api/schemas/__init__.py
+++ b/tests/stand/api/schemas/__init__.py
@@ -74,6 +74,7 @@ from .identity import (
     PersonAccountsResponse,
     PersonListResponse,
     SubchartNode,
+    VisibilityPolicy,
 )
 from .identity import (
     PersonRoleListResponse as PersonRoleList,
@@ -157,5 +158,6 @@ __all__: Sequence[str] = (
     "UsageSummaryResponse",
     "Visibility",
     "VisibilityList",
+    "VisibilityPolicy",
     "VisiblePersons",
 )

--- a/tests/stand/api/schemas/identity.py
+++ b/tests/stand/api/schemas/identity.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 from pydantic import AwareDatetime, BaseModel, ConfigDict, Field
 from uuid import UUID
 from typing import Any
+from enum import StrEnum
 
 
 class AccountRef(BaseModel):
@@ -427,6 +428,11 @@ class SubchartResponse(BaseModel):
     root: SubchartNode
 
 
+class VisibilityPolicy(StrEnum):
+    org_chart = 'org_chart'
+    flat = 'flat'
+
+
 class VisibilityResponse(BaseModel):
     """
     One visibility grant.
@@ -557,6 +563,7 @@ class MeResponse(BaseModel):
     insight_tenant_id: UUID
     person_id: UUID
     roles: list[MeRoleResponse]
+    visibility_policy: VisibilityPolicy
 
 
 class PersonListResponse(BaseModel):


### PR DESCRIPTION
Stacked on #2618 — review that one first; this PR's base is its branch.

## Problem

Visibility is derived from the org chart: a caller sees themselves, their explicit grants, and the `org_chart` descendants of both. An organisation with no reporting lines has no descendants to derive, so every person sees only themselves. The only existing way out is a wildcard grant per person — N rows that outlive the policy and have no bulk revoke.

## Fix

`visibility_policy` decides it at query time:

- `org_chart` (default) — the reporting-line rule, unchanged.
- `flat` — the tenant's persons are in every caller's visible set.

It is bound into the three visible-set queries as one parameter, so each keeps a single SQL constant rather than branching into a second statement. Nothing is written to `visibility`: flipping back restores the reporting-line rule with no rows to revoke. Roles still confer no visibility (ADR-0015) and explicit grants are untouched.

The flat arm is scoped to the tenant's `persons`, not to the id asked about, so a caller cannot have an arbitrary UUID confirmed.

`GET /v1/me` reports the policy. A leaf IC and a member of a hierarchy-less organisation are both served an empty `subordinates`, so a consumer that infers flatness from that cannot tell the two apart.

Config is an enum rather than a boolean: it shares the wire's vocabulary, and an unreadable value stops the service instead of resolving to whichever branch a default picks.

## Verification

Against a live MariaDB, both branches:

- `flat` — a caller with no reports and no grants sees the whole tenant; the answer is bounded by the tenant; the single-target probe is tenant-scoped.
- `POST /v1/profiles` for the same unrelated person is 404 under `org_chart` and 200 under `flat`; another tenant's person stays 404 under `flat`.
- `org_chart` — every pre-existing live case unchanged: transitive descendants yes, strangers no, explicit grants reach outside the reporting line, the wildcard echo stays inside the tenant, `admin` confers nothing.

190 Rust tests (unit + live), 26 chart render-contract tests, `cargo fmt` clean, clippy 0 findings. The committed OpenAPI document and the generated stand models are regenerated; both drift gates verified locally.

## Not in this PR

- A roster endpoint. Under `flat` a caller may now see everyone, but the SPA builds its roster from `subordinates`, so there is nothing to navigate yet.
- Frontend consumption of `visibility_policy`.
- Persons for accounts the seed skips for want of an e-mail.