### PR TITLE
fix(chart): namespace-qualify the git proxy URL given to connectors

### DIFF
--- a/charts/insight/templates/ingestion/reconcile-cron.yaml
+++ b/charts/insight/templates/ingestion/reconcile-cron.yaml
@@ -130,8 +130,12 @@ spec:
             # descriptor sets platform_config.git_proxy — the chart owns the
             # address and the token, so no connector Secret carries either and
             # a port change cannot desync them.
+            #
+            # Namespace-qualified: the connector pods that resolve this run in
+            # the Airbyte namespace, not this release's, where the bare service
+            # name does not resolve.
             - name: GIT_PROXY_URL
-              value: {{ printf "http://%s-git-cli-proxy:%v" .Release.Name .Values.gitCliProxy.service.port | quote }}
+              value: {{ printf "http://%s-git-cli-proxy.%s.svc.cluster.local:%v" .Release.Name .Release.Namespace .Values.gitCliProxy.service.port | quote }}
             - name: GIT_PROXY_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/src/ingestion/connectors/git/github/connector.yaml
+++ b/src/ingestion/connectors/git/github/connector.yaml
@@ -3356,9 +3356,12 @@ spec:
       git_proxy_url:
         type: string
         description: >-
-          Base URL of the git-cli-proxy service (cluster-internal, e.g.
-          http://insight-git-cli-proxy:8085). No default: a wrong or absent
-          value must fail the check, not fall back somewhere.
+          Base URL of the git-cli-proxy service. Cluster-internal and
+          namespace-qualified, because the connector pod resolving it runs in
+          the Airbyte namespace rather than the proxy's, e.g.
+          http://insight-git-cli-proxy.insight.svc.cluster.local:8084. No
+          default: a wrong or absent value must fail the check, not fall back
+          somewhere.
         title: Git Proxy URL
         order: 4
       git_proxy_token:


### PR DESCRIPTION
## Problem

The reconcile job injects `git_proxy_url` into the Airbyte source config of every connector whose descriptor sets `platform_config.git_proxy`. It built that URL from the service name alone:

```
http://<release>-git-cli-proxy:<port>
```

The pods that resolve it are Airbyte connector pods, which run in the Airbyte namespace, not the release namespace. A bare service name only resolves within its own namespace, so the value never resolved for the caller it was written for.

The failure is a hang rather than an error. `check` covers the `branches` stream, which is proxy-backed, and the proxy-backed streams set `max_retries: 100`; the CDK retries the name-resolution failure until the platform's check timeout kills the workload, with no connector output to say why.

## Fix

Qualify the URL with the release namespace, matching how the chart already addresses services across namespaces (`_helpers.tpl` builds the Airbyte server URL the same way):

```
http://<release>-git-cli-proxy.<namespace>.svc.cluster.local:<port>
```

Verified by rendering the chart with `gitCliProxy.deploy: true`, and by resolving both spellings from a pod in the Airbyte namespace — the bare name fails to resolve, the qualified one answers 200 on `/healthz`.

The GitHub connector's `git_proxy_url` spec description carried the same mistake in its example, plus the wrong port (`8085`; the service listens on `8084`). Since a value must be supplied by hand wherever reconcile does not run, that example is corrected too.
