### PR TITLE
fix(ai-cost): heal seat_status onto the AI dev-usage contract on upgrade

### DIFF
--- a/src/ingestion/scripts/apply-ch-migrations.sh
+++ b/src/ingestion/scripts/apply-ch-migrations.sh
@@ -60,7 +60,9 @@ echo "=== Healing AI staging contract schemas ==="
 # Physical column order must equal the model's SELECT order (positional
 # incremental inserts, positional union). Labels left the contract (they
 # derive in gold — macros/ai_labels.sql): DROP converges every table
-# state. conversation_count is data: ADD/MODIFY pin its position.
+# state. conversation_count and seat_status are data: ADD/MODIFY pin their
+# position. All four contributors in one deploy — a class unions them
+# positionally, so healing per-sync mismatches the column counts.
 # Guarded (staging tables exist only after the connector's first run);
 # idempotent (re-runs are no-ops).
 heal_ai_dev_staging() {
@@ -71,6 +73,8 @@ heal_ai_dev_staging() {
 ALTER TABLE staging.${table} DROP COLUMN IF EXISTS tool_label;
 ALTER TABLE staging.${table} ADD COLUMN IF NOT EXISTS conversation_count Nullable(UInt32) AFTER session_count;
 ALTER TABLE staging.${table} MODIFY COLUMN conversation_count Nullable(UInt32) AFTER session_count;
+ALTER TABLE staging.${table} ADD COLUMN IF NOT EXISTS seat_status Nullable(String) AFTER _version;
+ALTER TABLE staging.${table} MODIFY COLUMN seat_status Nullable(String) AFTER _version;
 SQL
 }
 

--- a/src/ingestion/scripts/migrations/20260818000000_ai-dev-usage-seat-status.sql
+++ b/src/ingestion/scripts/migrations/20260818000000_ai-dev-usage-seat-status.sql
@@ -1,0 +1,18 @@
+-- Add seat_status to the AI dev-usage class contract.
+--
+-- A pre-existing table got it from nowhere: the DDL snapshot is IF NOT EXISTS,
+-- and dbt appends it (append_new_columns) only when the silver model runs —
+-- after the deploy whose gold build already reads it (ai_metric_evidence).
+--
+-- AFTER _version is last, the position the staging projections use and the
+-- positional insert requires; MODIFY converges an instance where an
+-- out-of-band ALTER placed it elsewhere. Shape follows
+-- 20260716000000_class_contract_heal.sql.
+--
+-- Idempotent: this channel has no ledger and re-runs on every deploy.
+-- The class tables always exist here (placeholders precede migrations).
+ALTER TABLE silver.class_ai_dev_usage
+    ADD COLUMN IF NOT EXISTS seat_status Nullable(String) AFTER _version;
+
+ALTER TABLE silver.class_ai_dev_usage
+    MODIFY COLUMN seat_status Nullable(String) AFTER _version;


### PR DESCRIPTION
Closes #2617.

Two defects from #2607: one broke `helm upgrade`, the other breaks a connector sync.

### The column never reached an existing installation

`seat_status` entered the class contract in three places — the staging projections, the DDL snapshot, the gold model that reads it — and in no migration. So only a fresh cluster ever had it: the snapshot is `CREATE TABLE IF NOT EXISTS`, and dbt appends the column (`on_schema_change=append_new_columns`) only when the silver model runs, which is connector-sync time. The migrate hook builds gold in between, `ai_metric_evidence` reads the column, and the hook fails the release.

A migration adds it to `silver.class_ai_dev_usage`, `AFTER _version` — the position it holds in the staging projections and in the snapshot, and the one the positional incremental insert requires. `MODIFY` follows the `ADD` so an instance where an out-of-band `ALTER` placed it elsewhere converges too, which is the state at least one environment is in.

### A class heals one contributor at a time, and the union does not tolerate that

The silver class unions its staging members with a positional `SELECT * UNION ALL`, and each member gains the column on its own connector's sync. Between the first such sync and the last, the union has members of different widths:

```
DB::Exception: UNION different number of columns in queries. (TYPE_MISMATCH)
```

So a migration on silver alone would have traded the deploy failure for a sync failure on any installation with more than one AI vendor. The staging heal already in the hook now carries the same two `ALTER`s, converging all four contributors in one deploy. Staging is healed there rather than by a migration because those tables are absent from the DDL snapshot and exist only after their connector's first sync, so the statements need the `ch_table_exists` guard.

### Scope

An earlier revision also had the hook build the silver classes before gold, so that a release adding a silver column could not fail on its own gold model. Dropped on review: the migration and the heal are sufficient (re-verified below with the selector unchanged), and the hook change bought little — the column enters the contract through staging, which heals only on its own sync, so the `ALTER` has to be written by hand either way. It cost a three-term selector, 48 incremental models on the deploy path, and a wider blast radius for a mechanism `drop_silver_placeholders_at_start` already records a plan to retire.

No DDL snapshot regeneration: `silver.sql` already carries `seat_status` from #2607, and the AI staging tables are deliberately absent from the snapshot. Gold needs nothing — every gold model is `materialized: table`, rebuilt whole on each run.

## Test plan

Against a throwaway `clickhouse/clickhouse-server:25.7` and the deployed toolbox image (`insight-toolbox:2026.08.18.02.16-0297cb1`) with this tree mounted, running the real `apply-ch-migrations.sh` end to end — the same script the Hook Job runs, with its selector untouched:

- [x] **Fresh cluster** — empty ClickHouse: exit 0. Nothing to heal; the snapshot creates the table with the column
- [x] **Pre-change cluster, code from `main`** — a warm install rolled back to the pre-#2607 shape (silver and both staging tables at 27 columns, rows in silver): exit 1, `PASS=18 ERROR=1 SKIP=2`, `code: 47 … Unknown expression or function identifier seat_status … ai_metric_evidence`. The reported failure, reproduced
- [x] **Pre-change cluster, this branch** — same state: exit 0; silver and both staging tables at 28 columns, position 28, `Nullable(String)`; the rows that were in silver survived; `ai_metric_evidence` rebuilt
- [x] **Staging desync** — silver and one staging member healed, the other not, code from `main`: the silver build fails with `UNION different number of columns (TYPE_MISMATCH)`
- [x] **Column already added out of band** — silver healed, staging not (the state one environment is in): exit 0, the heal converges both staging tables, and a subsequent run of the silver model — the connector sync that used to fail — passes
- [x] **Idempotence** — re-run over the converged state: exit 0
- [x] `bash -n`, `git diff --check`

Not verified: a real `helm upgrade`, which needs a release through gitops.