### PR TITLE
ci: scope OpenAPI checks to affected services

### DIFF
--- a/.github/workflows/openapi-specs.yml
+++ b/.github/workflows/openapi-specs.yml
@@ -29,8 +29,57 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect affected OpenAPI checks
+    runs-on: ubuntu-latest
+    outputs:
+      analytics: ${{ steps.all.outputs.all || steps.filter.outputs.analytics || steps.filter.outputs.shared_backend }}
+      authenticator: ${{ steps.all.outputs.all || steps.filter.outputs.authenticator || steps.filter.outputs.shared_backend }}
+      identity_resolution: ${{ steps.all.outputs.all || steps.filter.outputs.identity_resolution || steps.filter.outputs.shared_backend }}
+      git_cli_proxy: ${{ steps.all.outputs.all || steps.filter.outputs.git_cli_proxy || steps.filter.outputs.shared_backend }}
+      generated_models: ${{ steps.all.outputs.all || steps.filter.outputs.generated_models }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        if: github.event_name != 'workflow_dispatch'
+        id: filter
+        with:
+          filters: |
+            analytics:
+              - 'src/backend/services/analytics/**'
+              - 'docs/components/backend/analytics/openapi.json'
+            authenticator:
+              - 'src/backend/services/authenticator/**'
+              - 'docs/components/backend/authenticator/openapi.json'
+            identity_resolution:
+              - 'src/backend/services/identity-resolution/**'
+              - 'docs/components/backend/identity-resolution/openapi.json'
+            git_cli_proxy:
+              - 'src/backend/services/git-cli-proxy/**'
+              - 'docs/components/backend/git-cli-proxy/openapi.json'
+            shared_backend:
+              - 'src/backend/libs/**'
+              - 'src/backend/plugins/**'
+              - 'src/backend/Cargo.*'
+              - 'scripts/ci/openapi_spec.py'
+              - '.github/workflows/openapi-specs.yml'
+            generated_models:
+              - 'docs/components/backend/**/openapi.json'
+              - 'tests/generate_schemas.py'
+              - 'tests/stand/api/schemas/**'
+              - '.github/workflows/openapi-specs.yml'
+      - name: Select every check
+        if: github.event_name == 'workflow_dispatch'
+        id: all
+        run: |
+          echo "all=true" >> "$GITHUB_OUTPUT"
+
   # ─── analytics — offline emit via the `openapi` subcommand ───────────────
   analytics:
+    needs: changes
+    if: needs.changes.outputs.analytics == 'true'
     name: OpenAPI spec drift gate
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -65,6 +114,8 @@ jobs:
 
   # ─── authenticator — offline emit via the `openapi` subcommand ────────────
   authenticator:
+    needs: changes
+    if: needs.changes.outputs.authenticator == 'true'
     name: Authenticator OpenAPI spec drift gate
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -104,6 +155,8 @@ jobs:
 
   # ─── identity-resolution — offline emit via the `openapi` subcommand ──────
   identity-resolution:
+    needs: changes
+    if: needs.changes.outputs.identity_resolution == 'true'
     name: Identity Resolution OpenAPI spec drift gate
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -146,6 +199,8 @@ jobs:
   # and this is where that commit is already being checked. No Rust — it reads
   # the committed documents, not the services.
   generated-models:
+    needs: changes
+    if: needs.changes.outputs.generated_models == 'true'
     name: Generated schema models drift gate
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -169,6 +224,8 @@ jobs:
 
   # ─── git-cli-proxy — offline emit via the `openapi` subcommand ────────────
   git-cli-proxy:
+    needs: changes
+    if: needs.changes.outputs.git_cli_proxy == 'true'
     name: Git CLI Proxy OpenAPI spec drift gate
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
**Why.** Every pull request currently starts all OpenAPI generators even when only one service can be affected.

**What changed.** A lightweight path detector selects service-specific checks. Shared backend changes still run every generator, committed spec changes run model validation, and manual dispatch remains a full run.

**Keep check identities stable.** Existing job names remain unchanged; only their relevance conditions change.

**Evidence.** An isolated service change now selects one OpenAPI emitter instead of four.

**Verified.** Actionlint passes, the diff is clean, and the commit is signed off.
