### PR TITLE
fix(analytics): stamp a usage event with its own time, not the batch's arrival

### DIFF
--- a/src/backend/services/analytics/src/api/usage.rs
+++ b/src/backend/services/analytics/src/api/usage.rs
@@ -133,8 +133,15 @@ const MAX_BUFFERED_MS: i64 = 24 * 60 * 60 * 1000;
 /// record waited to be flushed — survives a clock that is hours out. Anchoring
 /// that to the arrival instant keeps the timestamp ours while still separating
 /// records the SDK sent in one beacon.
-fn event_time(record: &TelemetryRecord, arrival: DateTime<Utc>) -> DateTime<Utc> {
-    let (Some(triggered), Some(sent)) = (record.time_triggered, record.time_sent) else {
+fn event_time(
+    record: &TelemetryRecord,
+    meta: &TelemetryRecord,
+    arrival: DateTime<Utc>,
+) -> DateTime<Utc> {
+    let (Some(triggered), Some(sent)) = (
+        record.time_triggered.or(meta.time_triggered),
+        record.time_sent.or(meta.time_sent),
+    ) else {
         return arrival;
     };
     match sent.checked_sub(triggered) {
@@ -160,7 +167,7 @@ fn to_row(
 ) -> UsageEventRow {
     let data = record.data.as_ref().or(meta.data.as_ref());
     UsageEventRow {
-        ts: event_time(record, arrival),
+        ts: event_time(record, meta, arrival),
         tenant_id,
         person_id,
         session_id: shared(

--- a/src/backend/services/analytics/src/api/usage/tests.rs
+++ b/src/backend/services/analytics/src/api/usage/tests.rs
@@ -308,3 +308,27 @@ fn an_event_held_longer_than_a_day_is_not_trusted() {
 
     assert_eq!(row.ts, arrival);
 }
+
+#[test]
+fn a_batch_whose_flush_stamp_was_hoisted_into_meta_keeps_its_own_times() {
+    let arrival = Utc::now();
+    let sent = arrival.timestamp_millis();
+
+    let meta = TelemetryRecord {
+        time_sent: Some(sent),
+        ..TelemetryRecord::default()
+    };
+
+    let mut first = record("session_start", serde_json::json!({}));
+    first.time_triggered = Some(sent - 4_000);
+    let mut second = record("page_view", serde_json::json!({ "path": "/portal" }));
+    second.time_triggered = Some(sent - 1_000);
+
+    let rows = [
+        to_row(&first, &meta, Uuid::now_v7(), Uuid::now_v7(), arrival),
+        to_row(&second, &meta, Uuid::now_v7(), Uuid::now_v7(), arrival),
+    ];
+
+    assert_eq!(rows[0].ts, arrival - Duration::milliseconds(4_000));
+    assert_eq!(rows[1].ts, arrival - Duration::milliseconds(1_000));
+}


### PR DESCRIPTION
**Why.** Every event in one telemetry beacon landed on the same millisecond, so a session's screens shared one timestamp instead of their own. The flush is debounced rather than periodic, so the collapsed span is not bounded by the flush delay.

**What changed.** `event_time` read both browser stamps off the record. The SDK hoists fields its records agree on into `meta` and drops them from the records, so `time_sent` was never there and every row fell through to the arrival instant. Both stamps now fall back to `meta`, the way `shared()` already does.

**Forward-only, no migration.** The browser trigger time was never persisted, so existing rows keep the stamps they have.

**Verified.** The new test fails without the fix and passes with it; 439 analytics tests, `cargo fmt --check` and `cargo clippy --all-targets` clean.
