### PR TITLE
fix(github): wait out exhausted GitHub rate budgets

### DIFF
--- a/src/ingestion/connectors/git/github/README.md
+++ b/src/ingestion/connectors/git/github/README.md
@@ -111,8 +111,15 @@ identities) reach no account and stay unattributed.
   repository runs many Retry-After cycles). 404/413 skip the repository;
   409 (superseded snapshot) fails the attempt — the rerun resumes from the
   stored cursor.
-- GraphQL errors arrive as HTTP 200: rate-limit-typed errors back off,
-  anything else fails with GitHub's own message.
+- GraphQL errors arrive as HTTP 200. GitHub types an exhausted budget both
+  `RATE_LIMIT` and `RATE_LIMITED`, so the throttle predicates match either and
+  fall back to the message; anything else fails with GitHub's own message.
+- REST and GraphQL are metered as two separate hourly budgets. `api_budget`
+  paces each one against its own `X-RateLimit-*` headers and waits out a
+  window it exhausts. This is not something the error handlers could do:
+  `DefaultErrorHandler` caps total backoff at 600 seconds and the manifest
+  exposes no field to raise it, so a reset further out than that would
+  exhaust the retries and fail the stream.
 
 ## Known NULL columns
 

--- a/src/ingestion/connectors/git/github/connector.yaml
+++ b/src/ingestion/connectors/git/github/connector.yaml
@@ -21,6 +21,33 @@ type: DeclarativeSource
 # computed nullable string field coalesces with `or ''` — a rendered Jinja
 # `none` under value_type: string stores the literal text "None" as a value.
 
+# GitHub meters REST and GraphQL as two separate 5000/hour budgets, both
+# reported through the same X-RateLimit-* headers. An error handler cannot wait
+# one out: DefaultErrorHandler caps total backoff at 600 seconds and the
+# manifest has no field to raise it. The budget paces requests before they are
+# sent and sleeps until the window resets, which a reset an hour away needs.
+# Matchers split the two budgets by method: GET is REST, POST is GraphQL — a
+# policy added without a method would claim both.
+api_budget:
+  type: HTTPAPIBudget
+  ratelimit_reset_header: X-RateLimit-Reset
+  ratelimit_remaining_header: X-RateLimit-Remaining
+  status_codes_for_ratelimit_hit: [403, 429]
+  policies:
+    - type: FixedWindowCallRatePolicy
+      period: PT1H
+      call_limit: 5000
+      matchers:
+        - method: POST
+          url_base: https://api.github.com
+          url_path_pattern: ^/graphql
+    - type: FixedWindowCallRatePolicy
+      period: PT1H
+      call_limit: 5000
+      matchers:
+        - method: GET
+          url_base: https://api.github.com
+
 definitions:
   # The CDK resolves backoff per requester, not per response filter: the first
   # strategy returning a value wins for every retryable response. X-RateLimit-Reset
@@ -78,7 +105,10 @@ definitions:
         http_codes: [429]
       - type: HttpResponseFilter
         action: RATE_LIMITED
-        predicate: "{{ (response.get('errors') or []) | selectattr('type', 'equalto', 'RATE_LIMITED') | list | length > 0 }}"
+        predicate: "{{ (response.get('errors') or []) | selectattr('type', 'in', ['RATE_LIMITED', 'RATE_LIMIT']) | list | length > 0 }}"
+      - type: HttpResponseFilter
+        action: RATE_LIMITED
+        predicate: "{{ 'rate limit' in ((response.get('errors') or []) | map(attribute='message') | join(' ') | lower) }}"
       - type: HttpResponseFilter
         action: FAIL
         http_codes: [401]
@@ -106,7 +136,10 @@ definitions:
         http_codes: [429]
       - type: HttpResponseFilter
         action: RATE_LIMITED
-        predicate: "{{ (response.get('errors') or []) | selectattr('type', 'equalto', 'RATE_LIMITED') | list | length > 0 }}"
+        predicate: "{{ (response.get('errors') or []) | selectattr('type', 'in', ['RATE_LIMITED', 'RATE_LIMIT']) | list | length > 0 }}"
+      - type: HttpResponseFilter
+        action: RATE_LIMITED
+        predicate: "{{ 'rate limit' in ((response.get('errors') or []) | map(attribute='message') | join(' ') | lower) }}"
       - type: HttpResponseFilter
         action: FAIL
         http_codes: [401]

--- a/src/ingestion/connectors/git/github/tests/test_github_streams.py
+++ b/src/ingestion/connectors/git/github/tests/test_github_streams.py
@@ -3,12 +3,13 @@
 GitHub-specific hazards under test: secondary rate limits arriving as 403
 (must retry, not skip), per-repository 403/404 skipping on repo-scoped
 streams, the issues endpoint returning PRs (filtered out), GraphQL errors
-arriving as HTTP 200 (must FAIL loudly), the proxy 429 retry loop, and the
-literal-"None" guard.
+arriving as HTTP 200 (a rate limit must retry, a query error must FAIL
+loudly), the proxy 429 retry loop, and the literal-"None" guard.
 
 Coverage matrix rows: full_refresh_single_page, incremental_state,
 tenant_source_stamping, schema_conformance, substream_partition,
-record_filter, error_retry (403-as-throttle, proxy 429), error_ignore (404),
+record_filter, error_retry (403-as-throttle, GraphQL rate limit in a 200,
+proxy 429), error_ignore (404),
 transformations (None-guard).
 """
 
@@ -17,6 +18,7 @@ from __future__ import annotations
 import json
 
 import freezegun
+import pytest
 from config import GH_URL, PROXY_URL, GithubConfigBuilder
 
 from connector_tests import (
@@ -776,6 +778,76 @@ def test_workflow_runs_key_carries_run_attempt(http_mocker: HttpMocker) -> None:
     rec = output.records[0].record.data
     assert rec["unique_key"].endswith(":run:500:2"), rec["unique_key"]
     _no_literal_none(output.records)
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(
+            {"type": "RATE_LIMIT", "code": "graphql_rate_limit", "message": "API quota exhausted."},
+            id="typed_rate_limit",
+        ),
+        pytest.param(
+            {"type": "SERVICE_UNAVAILABLE", "message": "API rate limit already exceeded."},
+            id="untyped_message",
+        ),
+    ],
+)
+@freezegun.freeze_time(_FROZEN)
+def test_graphql_rate_limit_in_a_200_retries(http_mocker: HttpMocker, error: dict) -> None:
+    """An exhausted GraphQL budget arrives as HTTP 200. GitHub types it
+    RATE_LIMIT as well as RATE_LIMITED, so the throttle predicates match both
+    spellings and fall back to the message — otherwise a throttle is mistaken
+    for a query error and fails the stream."""
+    config = GithubConfigBuilder().build()
+    http_mocker.get(HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS), _repos_page())
+    http_mocker.post(
+        HttpRequest(f"{GH_URL}/graphql", body=_diff_stats_body()),
+        [
+            HttpResponse(
+                body=json.dumps({"errors": [error]}),
+                status_code=200,
+                headers={"Retry-After": "0"},
+            ),
+            HttpResponse(
+                body=json.dumps(
+                    {
+                        "data": {
+                            "repository": {
+                                "pullRequests": {
+                                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                                    "nodes": [
+                                        {
+                                            "number": 31,
+                                            "updatedAt": "2026-06-20T00:00:00Z",
+                                            "additions": 120,
+                                            "deletions": 7,
+                                            "changedFiles": 3,
+                                            "author": {
+                                                "login": "alice",
+                                                "databaseId": 4242,
+                                                "email": "alice@example.com",
+                                            },
+                                            "mergedBy": {"login": "bob", "databaseId": 77},
+                                            "reviewDecision": "APPROVED",
+                                            "totalCommentsCount": 5,
+                                            "isCrossRepository": False,
+                                        }
+                                    ],
+                                }
+                            }
+                        }
+                    }
+                ),
+                status_code=200,
+            ),
+        ],
+    )
+
+    output = read_stream(_CONNECTOR, "pull_request_diff_stats", config)
+
+    assert not output.errors, "a rate-limit error must retry, not fail the stream"
+    assert len(output.records) == 1
 
 
 @freezegun.freeze_time(_FROZEN)


### PR DESCRIPTION
**Why.** A GraphQL stream fails outright when its hourly budget runs out: every remaining partition errors on its first request instead of waiting for the reset.

**What changed.** GitHub types an exhausted budget `RATE_LIMIT`, which the throttle predicate never matched; both GraphQL handlers now match either spelling and fall back to the message. An `api_budget` paces REST and GraphQL against their own hourly budgets, split by method.

**`api_budget` rather than a longer backoff.** `DefaultErrorHandler` caps total backoff at 600 seconds and the manifest exposes no field to raise it.

**Verified.** Predicates across seven payload shapes and routing across four request shapes, both through the CDK's own components; manifest validates against the declarative component schema. Mock suite not run here — no harness venv.
