### PR TITLE
fix(seed): stop refusing to reseed a stand the suite has run against

### DIFF
--- a/src/ingestion/tools/seed/insight_seed/config.py
+++ b/src/ingestion/tools/seed/insight_seed/config.py
@@ -29,6 +29,16 @@ SEED_REASON_PREFIX = "seed.py "
 #: The persons-seed's email-link reason (AUTO_SEED_LINK_REASON): a rebuildable projection, not foreign data.
 PERSONS_SEED_LINK_REASON = "auto-seed-link"
 
+#: The stand test suite's scratch namespace, and the connector instance it writes
+#: its journal rows under. The suite cannot delete what its resolution round trip
+#: appends (the journal is append-only), so preflight recognises those rows by
+#: this triple — a value prefix alone would exempt anything that writes one.
+#: INVARIANT: must match SCRATCH_PREFIX, SCRATCH_SOURCE_TYPE and
+#: SCRATCH_SOURCE_ID in tests/stand/api/scratch.py.
+STAND_SCRATCH_PREFIX = "stand-scratch"
+STAND_SCRATCH_SOURCE_TYPE = "github"
+STAND_SCRATCH_SOURCE_ID = "01900000-0000-7000-8000-00000000feed"
+
 TENANT_ENV = "TENANT_DEFAULT_ID"
 ANALYTICS_DB_ENV = "MARIADB_ANALYTICS_DB"
 IDENTITY_DB_ENV = "MARIADB_DB"

--- a/src/ingestion/tools/seed/insight_seed/preflight.py
+++ b/src/ingestion/tools/seed/insight_seed/preflight.py
@@ -14,7 +14,14 @@ Two signals, because neither sees everything:
 * `persons` rows in the target tenant whose `reason` is outside this seeder's
   namespace. Identity rows are additive, so this one is about not mixing demo
   people into somebody's directory — but it is also the ONLY signal that works
-  on a single-tenant stand, so the silver step consults it too.
+  on a single-tenant stand, so the silver step consults it too. The stand test
+  suite's own rows are exempt: it cannot delete what its resolution round trip
+  appends (the journal is append-only), and a stand it runs against is
+  disposable by definition. The exemption is its scratch value namespace UNDER
+  its own connector instance, never the value alone — a bare prefix would exempt
+  anything that writes one, and an operator's corrections on that same connector
+  still refuse, which is the point: they carry real account values and are the
+  strongest "somebody curates this stand" signal there is.
 * Rows in the reset surface belonging to a different tenant. Silver rows are
   NOT additive: the generators TRUNCATE each table before writing, across every
   tenant, because a partially rewritten silver table produces metrics that are
@@ -41,6 +48,9 @@ from . import config
 from .config import (
     PERSONS_SEED_LINK_REASON,
     SEED_REASON_PREFIX,
+    STAND_SCRATCH_PREFIX,
+    STAND_SCRATCH_SOURCE_ID,
+    STAND_SCRATCH_SOURCE_TYPE,
     ClickHouse,
     EnvContractError,
     MariaDb,
@@ -77,7 +87,9 @@ def foreign_rows_problem(count: int, tenant: str, database: str) -> str:
     return (
         f"tenant {tenant} already holds {count} `{database}.persons` row(s) this seeder "
         f"did not write (their `reason` does not start with {SEED_REASON_PREFIX!r} and is "
-        f"not the persons-seed's {PERSONS_SEED_LINK_REASON!r}), so this stand carries "
+        f"not the persons-seed's {PERSONS_SEED_LINK_REASON!r}, and they are not the stand "
+        f"suite's {STAND_SCRATCH_PREFIX!r} rows under "
+        f"{STAND_SCRATCH_SOURCE_TYPE}/{STAND_SCRATCH_SOURCE_ID}), so this stand carries "
         "identity data from somewhere else. Seed a tenant of your own, "
         f"or set {config.FORCE_ENV}=1 to add demo people to this one anyway."
     )
@@ -93,11 +105,29 @@ def _table_exists(cur: pymysql.cursors.Cursor, database: str, table: str) -> boo
 
 
 def _count_foreign_persons(cur: pymysql.cursors.Cursor, tenant: str) -> int:
+    # The suite's exemption is ONE negated conjunction. Three separately negated
+    # terms would subtract each attribute on its own — every row under the
+    # suite's connector, every row carrying the prefix wherever it came from —
+    # which is a weaker guard, not a narrower one.
+    #
+    # `value_id` and `value_effective` are the two nullable columns the predicate
+    # reads, and LIKE against a NULL yields NULL, so the row would fall out of
+    # the conjunction rather than count: COALESCE keeps it in. The three source
+    # and tenant columns are NOT NULL in the schema.
     cur.execute(
         "SELECT COUNT(*) FROM persons "
         "WHERE insight_tenant_id = %s "
-        "AND (reason IS NULL OR (reason NOT LIKE %s AND reason != %s))",
-        (uuid_mod.UUID(tenant).bytes, f"{SEED_REASON_PREFIX}%", PERSONS_SEED_LINK_REASON),
+        "AND (reason IS NULL OR (reason NOT LIKE %s AND reason != %s)) "
+        "AND NOT (insight_source_type = %s AND insight_source_id = %s "
+        "AND COALESCE(value_id, value_effective, '') LIKE %s)",
+        (
+            uuid_mod.UUID(tenant).bytes,
+            f"{SEED_REASON_PREFIX}%",
+            PERSONS_SEED_LINK_REASON,
+            STAND_SCRATCH_SOURCE_TYPE,
+            uuid_mod.UUID(STAND_SCRATCH_SOURCE_ID).bytes,
+            f"{STAND_SCRATCH_PREFIX}%",
+        ),
     )
     row = cur.fetchone()
     return int(row[0]) if row else 0

--- a/src/ingestion/tools/seed/seed-stand.sh
+++ b/src/ingestion/tools/seed/seed-stand.sh
@@ -541,7 +541,15 @@ wait_for_job() {
       return 0
     fi
     if [[ "${failed:-0}" -ge 1 ]]; then
-      echo "ERROR: Job $job_name failed. Its logs above hold the reason; it is not" >&2
+      # CI publishes only `==>`/`ERROR:` lines from this script's output, so
+      # re-emit the preflight refusal from the failed Job's log with an
+      # ERROR: prefix — otherwise the reason never reaches the CI log.
+      # Bounded on purpose: this is the one place pod output crosses into the
+      # allowlisted channel of a public repository, and a refusal is a handful
+      # of lines. Anything past the cap stays where the rest of the log is.
+      kube -n "$NAMESPACE" logs "job/$job_name" --tail=-1 2>/dev/null \
+        | sed -n '/PreflightError: /,$p' | head -40 | sed 's/^/ERROR: /' >&2 || true
+      echo "ERROR: Job $job_name failed. Its full log holds the reason; it is not" >&2
       echo "       retried (backoffLimit 0) and survives for an hour" >&2
       echo "       (ttlSecondsAfterFinished), so it can be read again until then:" >&2
       echo "         $(kubectl_hint) -n $NAMESPACE logs job/$job_name" >&2

--- a/src/ingestion/tools/seed/tests/test_preflight.py
+++ b/src/ingestion/tools/seed/tests/test_preflight.py
@@ -1,8 +1,13 @@
 """Env-contract and preflight-message tests.
 
-Stdlib `unittest` against the real package: env parsing, the SQL a guard
-issues, and the messages a refusal carries — the half that has to stay true
-for an operator who reads only the error. No database is touched.
+Stdlib `unittest` against the real package: env parsing, what a guard counts,
+and the messages a refusal carries — the half that has to stay true for an
+operator who reads only the error. No server is reached: the one predicate whose
+meaning lives in SQL runs against an in-memory sqlite table.
+
+Every case belongs to a `TestCase`, deliberately: `unittest discover` (the
+documented local command) collects nothing else, so a bare test function would
+run in CI and silently not run here.
 
 Run against the installed package (see the README's develop section):
 
@@ -14,8 +19,10 @@ from __future__ import annotations
 import datetime as _dt
 import pathlib
 import re
+import sqlite3
 import unittest
 import uuid as uuid_mod
+from dataclasses import dataclass
 
 from insight_seed import config, identity, preflight
 from insight_seed.generators import base
@@ -365,20 +372,200 @@ class SeedReasonNamespaceTests(unittest.TestCase):
             with self.subTest(reason=reason):
                 self.assertTrue(reason.startswith(config.SEED_REASON_PREFIX))
 
-    def test_the_foreign_row_query_excludes_exactly_that_prefix(self) -> None:
-        cursor = _CapturingCursor(result=(3,))
-        self.assertEqual(preflight._count_foreign_persons(cursor, _TENANT), 3)  # type: ignore[arg-type]
-
-        sql, params = cursor.executed[-1]
-        self.assertIn("reason NOT LIKE", sql)
-        self.assertEqual(params[0], uuid_mod.UUID(_TENANT).bytes)
-        self.assertEqual(params[1], f"{config.SEED_REASON_PREFIX}%")
-
     def test_a_tenant_with_no_foreign_rows_reads_as_zero(self) -> None:
         self.assertEqual(
             preflight._count_foreign_persons(_CapturingCursor(result=None), _TENANT),  # type: ignore[arg-type]
             0,
         )
+
+
+@dataclass(frozen=True)
+class _PersonsRow:
+    """One journal row. The defaults are the stand suite's own: its resolution
+    round trip binds a scratch account under its fixed connector instance."""
+
+    tenant: str = _TENANT
+    source_type: str = config.STAND_SCRATCH_SOURCE_TYPE
+    source_id: str = config.STAND_SCRATCH_SOURCE_ID
+    value_id: str | None = f"{config.STAND_SCRATCH_PREFIX}-a1b2c3d4-resolution-e5f6a7b8"
+    value_full_text: str | None = None
+    value: str | None = None
+    reason: str = "operator-bind"
+
+
+class _SqlitePersons:
+    """`persons` under an engine, over the columns the guard's predicate reads.
+
+    Not a schema replica: the table belongs to the identity service's migrations
+    (`001_persons.sql`), which this package cannot see at test time. What is
+    modelled is what the predicate reads — `value_effective` as the generated
+    column it really is, so a row cannot disagree with its own `value_id`, and
+    the uuid columns as the bytes `BINARY(16)` compares.
+
+    Set semantics only: sqlite compares TEXT case-sensitively where MariaDB's
+    `utf8mb4_unicode_ci` does not, so no case here turns on letter case.
+    """
+
+    def __init__(self) -> None:
+        self._db = sqlite3.connect(":memory:")
+        self._db.execute(
+            "CREATE TABLE persons ("
+            " insight_tenant_id BLOB NOT NULL,"
+            " insight_source_type TEXT NOT NULL,"
+            " insight_source_id BLOB NOT NULL,"
+            " value_id TEXT,"
+            " value_full_text TEXT,"
+            " value TEXT,"
+            " value_effective TEXT GENERATED ALWAYS AS"
+            "  (COALESCE(value_id, value_full_text, value)) STORED,"
+            " reason TEXT NOT NULL DEFAULT ''"
+            ")"
+        )
+        self._answer: tuple[object, ...] | None = None
+
+    def insert(self, row: _PersonsRow) -> None:
+        self._db.execute(
+            "INSERT INTO persons (insight_tenant_id, insight_source_type, insight_source_id,"
+            " value_id, value_full_text, value, reason)"
+            " VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                uuid_mod.UUID(row.tenant).bytes,
+                row.source_type,
+                uuid_mod.UUID(row.source_id).bytes,
+                row.value_id,
+                row.value_full_text,
+                row.value,
+                row.reason,
+            ),
+        )
+
+    def execute(self, sql: str, params: tuple[object, ...] = ()) -> None:
+        self._answer = self._db.execute(sql.replace("%s", "?"), params).fetchone()
+
+    def fetchone(self) -> tuple[object, ...] | None:
+        return self._answer
+
+
+#: `(what the row is, the row, whether the guard must count it)`.
+_FOREIGN_ROW_CASES: tuple[tuple[str, _PersonsRow, int], ...] = (
+    ("the suite's bind row", _PersonsRow(), 0),
+    ("the suite's exclude row", _PersonsRow(reason="operator-exclude"), 0),
+    (
+        "the suite's prefix carried in value_full_text rather than value_id",
+        _PersonsRow(value_id=None, value_full_text=f"{config.STAND_SCRATCH_PREFIX}-a1b2-name"),
+        0,
+    ),
+    ("the same prefix from another connector type", _PersonsRow(source_type="gitlab"), 1),
+    (
+        "the same prefix from another instance of the same connector",
+        _PersonsRow(source_id="01900000-0000-7000-8000-0000000000ff"),
+        1,
+    ),
+    (
+        "an operator correction on the suite's own connector instance",
+        _PersonsRow(value_id="someone@example.com"),
+        1,
+    ),
+    (
+        "a foreign row carrying no value at all",
+        _PersonsRow(
+            source_type="bamboohr",
+            source_id="01900000-0000-7000-8000-0000000000aa",
+            value_id=None,
+            reason="directory sync",
+        ),
+        1,
+    ),
+    (
+        "the persons-seed's email link",
+        _PersonsRow(value_id="someone@example.com", reason=config.PERSONS_SEED_LINK_REASON),
+        0,
+    ),
+    (
+        "this seeder's own roster row",
+        _PersonsRow(value_id="someone@example.com", reason=f"{config.SEED_REASON_PREFIX}roster"),
+        0,
+    ),
+    (
+        "another tenant's operator correction",
+        _PersonsRow(tenant="ffffffff-ffff-4fff-8fff-ffffffffffff", value_id="a@example.com"),
+        0,
+    ),
+)
+
+
+class ForeignPersonsPredicateTests(unittest.TestCase):
+    """What the guard counts, run against an engine rather than asserted about
+    the SQL text. The refusal it drives destroys nothing by itself, but it is
+    the only thing standing between the silver step's TRUNCATE and a stand that
+    holds somebody's directory — so both directions are the contract: a writer
+    this seeder accounts for must not refuse, and everything else must."""
+
+    def test_each_row_is_counted_only_when_no_known_writer_accounts_for_it(self) -> None:
+        for description, row, expected in _FOREIGN_ROW_CASES:
+            with self.subTest(row=description):
+                persons = _SqlitePersons()
+                persons.insert(row)
+                self.assertEqual(
+                    preflight._count_foreign_persons(persons, _TENANT),  # type: ignore[arg-type]
+                    expected,
+                    f"should count as foreign: {bool(expected)} — {description}",
+                )
+
+    def test_the_whole_table_at_once_counts_the_same_rows(self) -> None:
+        """Every case above meets the predicate alone; together they also must,
+        or one exemption is subtracting rows another writer owns."""
+        persons = _SqlitePersons()
+        for _, row, _ in _FOREIGN_ROW_CASES:
+            persons.insert(row)
+
+        self.assertEqual(
+            preflight._count_foreign_persons(persons, _TENANT),  # type: ignore[arg-type]
+            sum(expected for _, _, expected in _FOREIGN_ROW_CASES),
+        )
+
+
+def _constant_in(path: pathlib.Path, name: str) -> str | None:
+    """The string a `NAME = "value"` assignment binds, annotation or not. The
+    name is anchored on both sides: without the `\\s*(?::...)?=`, `SCRATCH_PREFIX`
+    also matches a `SCRATCH_PREFIX_ANYTHING` declared above the real one."""
+    match = re.search(rf'^{name}\s*(?::[^=]*)?=\s*"([^"]+)"', path.read_text(), re.MULTILINE)
+    return match.group(1) if match else None
+
+
+def _find_upwards(*parts: str) -> pathlib.Path | None:
+    """The named file in the nearest ancestor that holds it, searching no
+    further than the repository root — outside a checkout (the seed image runs
+    these tests from the installed package) there is nothing to find, and a
+    same-named file above the root would be somebody else's."""
+    for parent in pathlib.Path(__file__).resolve().parents:
+        candidate = parent.joinpath(*parts)
+        if candidate.is_file():
+            return candidate
+        if (parent / ".git").exists():
+            break
+    return None
+
+
+class WriterNamespaceParityTests(unittest.TestCase):
+    """Each accounted-for writer spells its namespace out on its own side, and a
+    drift brings the refusal back with no test failing anywhere near the change.
+    Read the other trees rather than import them: only one language of the three
+    is importable here, and the seed image ships none of them — which is a skip,
+    not an error."""
+
+    def test_every_scratch_constant_matches_the_stand_suite_s_own(self) -> None:
+        scratch = _find_upwards("tests", "stand", "api", "scratch.py")
+        if scratch is None:
+            self.skipTest("tests/stand/api/scratch.py is not in this tree")
+
+        for mine, theirs in (
+            (config.STAND_SCRATCH_PREFIX, "SCRATCH_PREFIX"),
+            (config.STAND_SCRATCH_SOURCE_TYPE, "SCRATCH_SOURCE_TYPE"),
+            (config.STAND_SCRATCH_SOURCE_ID, "SCRATCH_SOURCE_ID"),
+        ):
+            with self.subTest(constant=theirs):
+                self.assertEqual(_constant_in(scratch, theirs), mine, f"{theirs} drifted")
 
 
 if __name__ == "__main__":

--- a/tests/stand/api/identity/test_resolution.py
+++ b/tests/stand/api/identity/test_resolution.py
@@ -37,6 +37,7 @@ from ..schemas import (
     CorrectionResponse,
     PersonAccountsResponse,
 )
+from ..scratch import SCRATCH_SOURCE_ID, SCRATCH_SOURCE_TYPE
 
 ATTENTION = identity_path("/v1/resolution/attention")
 ACCOUNT_SEARCH = identity_path("/v1/resolution/accounts")
@@ -47,14 +48,17 @@ ACCOUNT_SEARCH = identity_path("/v1/resolution/accounts")
 #: guard.
 EXCLUDED_PERSON = "ffffffff-ffff-ffff-ffff-ffffffffffff"
 
-#: A connector-instance id for accounts that exist only in this module. Fixed,
-#: not random: the coverage template folds `{id}` per path segment either way,
-#: and a stable value keeps journal rows attributable to this suite.
-SCRATCH_SOURCE_ID = "01900000-0000-7000-8000-00000000feed"
+
+def _account(account_id: str) -> dict[str, str]:
+    """One account under the suite's own connector instance — the only place a
+    correction this module writes may land (`scratch.py` rule 5)."""
+    return {"source": SCRATCH_SOURCE_TYPE, "source_id": SCRATCH_SOURCE_ID, "id": account_id}
 
 
 def _account_path(account_id: str) -> str:
-    return identity_path(f"/v1/resolution/accounts/github/{SCRATCH_SOURCE_ID}/{account_id}")
+    return identity_path(
+        f"/v1/resolution/accounts/{SCRATCH_SOURCE_TYPE}/{SCRATCH_SOURCE_ID}/{account_id}"
+    )
 
 
 @pytest.mark.security
@@ -326,7 +330,7 @@ def test_bind_confirm_and_exclude_round_trip(
     client = admin_operator_session.client
     lead = stand_manifest.fixture("dev_lead")
     account_id = scratch.scratch_name("resolution")
-    account = {"source": "github", "source_id": SCRATCH_SOURCE_ID, "id": account_id}
+    account = _account(account_id)
 
     bind = client.post(
         identity_path("/v1/resolution/bind"),
@@ -399,11 +403,7 @@ def test_the_excluded_sentinel_is_not_a_bind_target(
         json_body={
             "bindings": [
                 {
-                    "account": {
-                        "source": "github",
-                        "source_id": SCRATCH_SOURCE_ID,
-                        "id": "never-observed-account",
-                    },
+                    "account": _account("never-observed-account"),
                     "person_id": EXCLUDED_PERSON,
                 }
             ]
@@ -439,12 +439,6 @@ def test_detach_refuses_an_account_nobody_ever_saw(
     is not — there is nothing to detach. 404, and no write happens."""
     response = admin_operator_session.client.post(
         identity_path("/v1/resolution/detach"),
-        json_body={
-            "account": {
-                "source": "github",
-                "source_id": SCRATCH_SOURCE_ID,
-                "id": "never-observed-account",
-            }
-        },
+        json_body={"account": _account("never-observed-account")},
     )
     assert response.status_code == 404, f"{response.status_code} {response.text[:300]}"

--- a/tests/stand/api/scratch.py
+++ b/tests/stand/api/scratch.py
@@ -12,6 +12,11 @@ exception to that, and this is its exact shape:
    universe, and a stand suite has no business editing it.
 4. Teardown deletes are best-effort — a delete-case test has already removed its
    row, so a 404 there is expected rather than a failure.
+5. The correction journal cannot be deleted from, so its rows are made
+   recognisable instead: every correction goes under `SCRATCH_SOURCE_TYPE` /
+   `SCRATCH_SOURCE_ID`, the pair the seed preflight exempts. One written under
+   any other connector blocks the next seed of the stand — which is what a
+   `merge` or `detach` happy-path would write, so those stay out of bounds.
 
 Rule 2 exists to make rule 1 checkable. Every name is registered here, and
 `conftest.py`'s session-scoped detector fails the run if any survives it. The
@@ -37,7 +42,23 @@ from .schemas import CustomMetric, ListResponse, SavedQuery
 _Named = ListResponse[dict[str, object]]
 
 #: Marks every row this suite creates, so a leak is identifiable on sight.
+#: INVARIANT: must match insight_seed.config.STAND_SCRATCH_PREFIX — the seed
+#: preflight uses it to recognise this suite's leftover journal rows.
 SCRATCH_PREFIX: Final[str] = "stand-scratch"
+
+#: The connector instance every correction this suite writes is filed under — the
+#: other half of what makes an undeletable journal row recognisable (rule 5).
+#: Fixed, not random: a stable pair keeps those rows attributable to this suite.
+#: INVARIANT: must match insight_seed.config.STAND_SCRATCH_SOURCE_TYPE, and the
+#: literal `github` segment in `operations.py`'s account-read template — the
+#: coverage gate folds a recorded path onto a template by exact segment equality,
+#: so a divergence here makes that operation read as never exercised.
+SCRATCH_SOURCE_TYPE: Final[str] = "github"
+
+#: INVARIANT: must match insight_seed.config.STAND_SCRATCH_SOURCE_ID. Unlike the
+#: type, this segment is a `{source_id}` in the coverage template, so it folds
+#: whatever its value.
+SCRATCH_SOURCE_ID: Final[str] = "01900000-0000-7000-8000-00000000feed"
 
 #: One token per session: a leak becomes attributable to the run that made it.
 RUN_TAG: Final[str] = uuid.uuid4().hex[:8]
@@ -281,6 +302,8 @@ __all__: Sequence[str] = (
     "SCRATCH_OBSERVATION_SQL",
     "SCRATCH_PREFIX",
     "SCRATCH_QUERY_REF",
+    "SCRATCH_SOURCE_ID",
+    "SCRATCH_SOURCE_TYPE",
     "UNKNOWN_ID",
     "UNKNOWN_METRIC_KEY",
     "create_custom_metric",


### PR DESCRIPTION
`Deploy test stand after publish` fails at `Stage 3/5 — seed the stand` on every run, and stages 4 and 5 skip behind it — so smoke and the full stand suite have not run since the suite started running per merge. This restores the pipeline and makes a guard refusal legible in the CI log.

## The defect

Two contracts, each correct alone, first met when the suite began running after every merge:

- The suite's resolution round trip binds a scratch account and "cleans up" by excluding it — but both verbs append to identity's append-only journal, so two `persons` rows carrying `operator-bind` / `operator-exclude` survive every run **by design**. Their value carries the suite's `stand-scratch` mark, which exists precisely so its rows are identifiable on sight.
- The seed preflight counts any `persons` row whose `reason` is outside the seeder's namespace as "this stand is somebody's directory" and refuses — the guard that keeps the silver step's TRUNCATE off a stand that genuinely holds someone's data.

So one full suite run permanently blocked every later seed. The refusal never reached the log: the workflow republishes only `==>`/`ERROR:` lines, and the Job is reaped an hour later, so a guard refusal read exactly like a crash.

## What changed

| Piece | Now |
| --- | --- |
| `_count_foreign_persons` | exempts the suite's rows by its `stand-scratch` value namespace **under its own connector instance**, as ONE negated conjunction |
| `scratch.py` | owns that connector identity (`SCRATCH_SOURCE_TYPE` / `SCRATCH_SOURCE_ID`) beside `SCRATCH_PREFIX`, with the rule that produced it; `insight_seed.config` mirrors all three and a drift test fails at the edit rather than weeks later as a refused seed |
| `seed-stand.sh` | on a failed Job, re-emits everything from `PreflightError:` onward under an `ERROR:` prefix — capped at 40 lines, since this is the one place pod output crosses into the allowlisted channel |

The exemption is deliberately not keyed on the value alone: that would exempt anything writing a `stand-scratch` value, whoever wrote it. Nor as three separately negated terms — that would subtract every row under the suite's connector and every row carrying the prefix independently, which is a weaker guard rather than a narrower one. An operator's real corrections on that same connector still refuse, which is the guard's whole purpose.

## Verification

- The predicate is tested against an engine rather than asserted about as SQL text: an in-memory sqlite `persons` table (with `value_effective` as the generated column it really is) over nine rows — the suite's bind and exclude rows, the prefix carried in `value_full_text`, the same prefix from another connector type and from another instance of the same type, an operator correction on the suite's own instance, a foreign row with no value at all, the seeder's own row, another tenant's. Each row alone, then all at once, so no exemption steals another writer's rows.
- End to end on a stand, before and after: with the round trip's rows present, the pre-change guard refuses with `PreflightError` naming exactly 2 rows and the seed aborts; with the change, the same stand and the same rows give `preflight ok` and the seed completes. One file different.
- The full suite then ran against the deployed CI test stand: **api 354 passed / 19 skipped / 2 xfailed**, **ui 18 passed**. Skips are stand-shape (no service principals, no second tenant, opt-in rebuild lane); both xfails are known and referenced.
- Seed package: 42 `unittest discover` / 47 pytest, ruff, `ruff format --check`, mypy clean. The exact CI invocation inside the built image passes with the checkout-only drift test skipping, as designed. `bash -n` and shellcheck clean.

## Notes for review

- **The identity projection has the same class of gap and is deliberately left alone.** `AssignmentKind::MintedFromRoster` stamps `roster-mint` and a binding the projection did not have to decide is stamped with nothing at all — both outside the reasons this guard accounts for, so a projection run that minted or reused could resurrect the refusal from the other side. It has not fired because the seeded roster all carry addresses, so the projection stamps `auto-seed-link`, which was already exempt. Widening the guard for it belongs in its own change, not in one asked to narrow.
- Nothing in the code stops a future stand test from writing a correction under a different connector, and the seed refuses again when one does. `merge` and `detach` happy-paths would do exactly that. The constant's comment says so; enforcing it needs a check that does not exist yet.
