### PR TITLE
fix(github): put the roster and the commit claims on one source id

### DIFF
--- a/deploy/CONNECTORS.md
+++ b/deploy/CONNECTORS.md
@@ -32,7 +32,7 @@ Connectors pull data from your tools — Jira issues, Slack messages, GitHub pul
 Every connector Secret needs three things for the reconcile loop to discover and wire it up:
 
 - **A label**, `app.kubernetes.io/part-of: insight` — the selector the reconcile loop uses to find connector Secrets.
-- **Two annotations**: `insight.cyberfabric.com/connector: <name>` identifies which connector definition to use, and `insight.cyberfabric.com/source-id: <id>` names this specific source instance (the convention is `<name>-main`).
+- **Two annotations**: `insight.cyberfabric.com/connector: <name>` identifies which connector definition to use, and `insight.cyberfabric.com/source-id: <id>` names this specific source instance (the convention is `<name>-main`). Two connectors that describe accounts of the SAME vendor instance must share one source id — an account is keyed on (source type, source id, account id), so a different id makes one account into two. `github` and `github-directory` are such a pair: both use `github-main`.
 - **`stringData`** holding the connector's required fields — credentials, base URLs, and similar settings specific to that tool.
 
 For example, the Jira connector Secret (`connectors/jira.yaml`) looks like this:
@@ -172,13 +172,17 @@ stringData:
 ```yaml
 # GitHub org roster -> identity_inputs. Required for GitHub-brokered SSO:
 # without it a GitHub login resolves to no person and the callback returns 403.
+# source-id is `github-main`, NOT `github-directory-main`: this connector and
+# the `github` connector describe accounts of the same organization, and the
+# roster's login binding only meets the commit e-mails claimed against that
+# login when both carry one source id.
 apiVersion: v1
 kind: Secret
 metadata:
   name: insight-github-directory-main
   namespace: insight
   labels: { app.kubernetes.io/part-of: insight }
-  annotations: { insight.cyberfabric.com/connector: github-directory, insight.cyberfabric.com/source-id: github-directory-main }
+  annotations: { insight.cyberfabric.com/connector: github-directory, insight.cyberfabric.com/source-id: github-main }
 type: Opaque
 stringData:
   github_token:         "ghp_CHANGE_ME"   # read:org (+ user:email for member emails)

--- a/src/ingestion/connectors/git/github-directory/README.md
+++ b/src/ingestion/connectors/git/github-directory/README.md
@@ -9,6 +9,14 @@ the separate `github` connector. The split is deliberate: identity is a
 prerequisite for logging in at all, and it should not wait on a connector with
 a much larger surface and its own dependencies.
 
+Split in deployment, however, the two are one identity space: an account is
+keyed on (source type, source id, login), and this roster binds a login to a
+person while the `github` connector claims the e-mails that login commits
+under. Both Secrets therefore carry the SAME
+`insight.cyberfabric.com/source-id` — `github-main`, not this connector's own
+name. Given different ids the two halves never meet, and a member whose profile
+hides their e-mail resolves to nobody or to a second, nameless person.
+
 ## Stream
 
 | Stream | Mode | Source |

--- a/src/ingestion/connectors/git/github-directory/connector.yaml
+++ b/src/ingestion/connectors/git/github-directory/connector.yaml
@@ -252,7 +252,7 @@ spec:
       insight_source_id:
         type: string
         title: Source Instance ID
-        description: Connector instance identifier (e.g. `github-directory-main`). Set by the reconcile loop from the K8s Secret annotation `insight.cyberfabric.com/source-id`.
+        description: Connector instance identifier, shared with the `github` connector (`github-main`) because both describe accounts of the same organization. Set by the reconcile loop from the K8s Secret annotation `insight.cyberfabric.com/source-id`.
         default: ""
         order: 1
       github_token:

--- a/src/ingestion/connectors/git/github/README.md
+++ b/src/ingestion/connectors/git/github/README.md
@@ -83,10 +83,12 @@ source joins an HR-rostered organization.
 Three things to know before deploying:
 
 - **When `github-directory` is deployed, both connectors must share one
-  `insight_source_id`.** The seed and the resolver key an account on (source
-  type, source id, login); under different ids the roster bindings and these
-  claims describe different accounts, and a member with no published e-mail
-  can end up as two persons.
+  `insight_source_id` — `github-main` in the shipped examples.** The seed and
+  the resolver key an account on (source type, source id, login); under
+  different ids the roster bindings and these claims describe different
+  accounts, and a member with no published e-mail can end up as two persons.
+  The id comes from the Secret's `insight.cyberfabric.com/source-id`
+  annotation, so this is a deployment decision, not a code one.
 - **An unmatched active account is minted as a new person.** An outside
   contributor, or a member committing under an address no roster carries,
   becomes a fresh person and shows up in the seed's `accounts_minted_new`

--- a/src/ingestion/secrets/connectors/github-directory.yaml.example
+++ b/src/ingestion/secrets/connectors/github-directory.yaml.example
@@ -6,7 +6,14 @@ metadata:
     app.kubernetes.io/part-of: insight
   annotations:
     insight.cyberfabric.com/connector: github-directory
-    insight.cyberfabric.com/source-id: github-directory-main
+    # DELIBERATELY `github-main`, matching the github connector's Secret and
+    # NOT this connector's own name. An account is keyed on (source type,
+    # source id, login), and both connectors describe accounts of the same
+    # GitHub organization: the roster binds a login to a person, while the
+    # github connector claims the e-mails that login commits under. Under two
+    # different source ids those are two unrelated accounts, and a member
+    # whose profile hides their e-mail ends up as two persons.
+    insight.cyberfabric.com/source-id: github-main
 type: Opaque
 stringData:
   # Needs BOTH `read:org` and `user:email` (or `read:user`). The second is not


### PR DESCRIPTION
**Why.** A GitHub member whose profile hides their e-mail resolved to nobody, or to a second nameless person — with nothing wrong in the ingested data.

**What changed.** The `github-directory` Secret example now carries `source-id: github-main` rather than its own name. An account is keyed on (source type, source id, login), so the roster's login binding and the e-mails claimed against that login have to sit under one id.

**Not retroactive.** Existing rows keep the old hashed id, so a deployment already running on split ids needs a persons-seed re-run and the persons minted under the abandoned id merged.

**Out of scope.** Enforcing the pairing — a descriptor-declared identity space that reconcile validates — instead of documenting it.

**Verified.** Both examples parse to one source id; the connector-wiring gate passes. No code changed: reconcile reads the annotation and injects it.
