### PR TITLE
fix(ingestion): declare the Python floor these projects actually run on

### DIFF
--- a/src/ingestion/connectors/ai/claude-team-invoices/pyproject.toml
+++ b/src/ingestion/connectors/ai/claude-team-invoices/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "source-claude-team-invoices"
 version = "0.1.0"
 description = "Airbyte source connector for Claude Team invoices via the claude-team proxy and the Stripe hosted chain (CDK)"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
     "airbyte-cdk>=7.16.0",
     "requests>=2.31.0",

--- a/src/ingestion/connectors/crm/hubspot/pyproject.toml
+++ b/src/ingestion/connectors/crm/hubspot/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "source-hubspot-insight"
 version = "1.0.0"
 description = "Airbyte source connector for HubSpot (CDK-native, CRM Search API with v4 associations)"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
     "airbyte-cdk>=7.16.0",
     "requests>=2.31.0",

--- a/src/ingestion/connectors/git/bitbucket-cloud/pyproject.toml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "source-bitbucket-cloud-insight"
 version = "0.2.0"
 description = "Airbyte source connector for Bitbucket Cloud (CDK-native)"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
     "airbyte-cdk>=7.16.0",
     "requests>=2.31.0",

--- a/src/ingestion/connectors/git/gitlab/pyproject.toml
+++ b/src/ingestion/connectors/git/gitlab/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "source-gitlab-insight"
 version = "0.1.0"
 description = "Airbyte source connector for self-hosted GitLab (CDK, typed)"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
     "airbyte-cdk>=7.23.1",
     "requests>=2.34.2",
@@ -43,7 +43,7 @@ source_gitlab = ["spec.json"]
 "source_gitlab.streams" = ["*.schema.json"]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.12"
 strict = true
 warn_unused_configs = true
 warn_redundant_casts = true
@@ -55,7 +55,7 @@ ignore_missing_imports = true
 implicit_reexport = true
 
 [tool.ruff]
-target-version = "py310"
+target-version = "py312"
 line-length = 100
 
 [tool.ruff.lint]

--- a/src/ingestion/connectors/git/gitlab/source_gitlab/streams/base.py
+++ b/src/ingestion/connectors/git/gitlab/source_gitlab/streams/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping, MutableMapping
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from functools import cache
 from pathlib import Path
 from typing import Any
@@ -23,7 +23,7 @@ MAX_TITLE_CHARS = 1024
 
 
 def _now_iso() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def trim_text(value: Any, limit: int) -> tuple[str | None, bool]:

--- a/src/ingestion/connectors/git/gitlab/source_gitlab/streams/timeutil.py
+++ b/src/ingestion/connectors/git/gitlab/source_gitlab/streams/timeutil.py
@@ -1,17 +1,17 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 
 def parse_iso(value: str) -> datetime:
     parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=timezone.utc)
+        return parsed.replace(tzinfo=UTC)
     return parsed
 
 
 def to_utc_z(moment: datetime) -> str:
-    return moment.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return moment.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def subtract_minutes(iso_timestamp: str, minutes: int) -> str:

--- a/src/ingestion/connectors/git/gitlab/source_gitlab/streams/windowing.py
+++ b/src/ingestion/connectors/git/gitlab/source_gitlab/streams/windowing.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from source_gitlab.streams.errors import UnwindowableWindow
@@ -85,9 +85,9 @@ class CommittedDateWindowing(WindowStrategy):
     def _window_split(
         self, window: Mapping[str, Any], last_value: str | None
     ) -> list[dict[str, Any]]:
-        epoch = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        epoch = datetime(1970, 1, 1, tzinfo=UTC)
         since = _parse(window["since"]) if window.get("since") else epoch
-        until = _parse(window["until"]) if window.get("until") else datetime.now(timezone.utc)
+        until = _parse(window["until"]) if window.get("until") else datetime.now(UTC)
         since_str = _to_utc_z(since)
         mid_str = _to_utc_z(since + (until - since) / 2)
         if mid_str in (since_str, _to_utc_z(until)):

--- a/src/ingestion/connectors/hr-directory/active-directory/pyproject.toml
+++ b/src/ingestion/connectors/hr-directory/active-directory/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 name = "source-active-directory"
 version = "0.1.0"
 description = "Airbyte source connector for on-prem Active Directory user directory over LDAP (CDK)"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
     "airbyte-cdk>=7.16.0",
     "ldap3>=2.9.1",

--- a/src/ingestion/connectors/hr-directory/bamboohr/pyproject.toml
+++ b/src/ingestion/connectors/hr-directory/bamboohr/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "source-bamboohr"
 version = "0.1.0"
 description = "Airbyte source connector for BambooHR (CDK)"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 dependencies = [
     "airbyte-cdk>=7.16.0",
     "requests>=2.31.0",

--- a/src/ingestion/scripts/pyproject.toml
+++ b/src/ingestion/scripts/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "insight-ingestion-scripts"
 version = "0.1.0"
 description = "Deploy-time ClickHouse schema tooling shipped in the ingestion toolbox image"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 # Deliberately dependency-free: this runs in the migration Job, which talks to
 # ClickHouse over HTTP with nothing but the standard library.
 dependencies = []


### PR DESCRIPTION
Closes #2541.

**Why.** Seven Python projects declare `requires-python = ">=3.10"` and none runs there. One provably: `claude-team-invoices` imports `datetime.UTC`, a 3.11+ name, so a 3.10 install passes the metadata check and dies at import.

**What changed.** The floor becomes `>=3.12` in all seven — what CI, the toolbox image and `ruff.toml`'s `target-version` already assume. `gitlab` also loses its own `py310` ruff and mypy overrides, which uncovers five `UP017` sites.

**`ruff format` is deliberately not run on `gitlab`.** 27 of its 40 files already fail `format --check` on an untouched tree, and that drift would bury a 17-line change.

**Out of scope.** The pre-existing `ruff check` debt under the root py312 config, and `tests/connectors`, whose `>=3.10,<3.13` is a documented harness pin. The issue's `uv.lock` item is void — `uv.lock` is gitignored repo-wide, so no lock file of the seven is tracked.

**Verified.** `gitlab` 194 passed and `mypy --strict` clean across 24 source files under `python_version = 3.12`; `src/ingestion/scripts` 24 passed / 22 skipped; `ruff check` clean on every changed file and `--select UP017` clear.
