### PR TITLE
fix(ai-cost): ask the invoice proxy whether it is ready before blaming the network

### DIFF
--- a/src/ingestion/connectors/ai/claude-team-invoices/source_claude_team_invoices/source.py
+++ b/src/ingestion/connectors/ai/claude-team-invoices/source_claude_team_invoices/source.py
@@ -27,10 +27,46 @@ logger = logging.getLogger("airbyte")
 
 _SCHEMAS = Path(__file__).parent / "schemas"
 
+_NO_SESSION_KEY = (
+    "the proxy holds no claude.ai session key (HTTP 503). It is kept in memory "
+    "only, so a proxy restart clears it and every /api/ call answers 503 until "
+    "one is installed with POST /admin/session-key on the proxy."
+)
+
+# What the proxy itself answers, as opposed to what claude.ai answers through
+# it. A bare status code sends an operator to the egress and Stripe-Version
+# checks, neither of which is the fault in any of these.
+_PROXY_STATUS_HELP = {
+    401: (
+        "the proxy rejected the bearer token (HTTP 401). proxy_auth_token must "
+        "match the PROXY_AUTH_TOKEN the proxy was deployed with."
+    ),
+    502: "the proxy could not reach claude.ai (HTTP 502)",
+    503: _NO_SESSION_KEY,
+    504: "claude.ai did not answer the proxy in time (HTTP 504)",
+}
+
 
 def load_stream_schema(name: str) -> Mapping[str, Any]:
     """Read a stream's JSON schema from the packaged `schemas/` directory."""
     return json.loads((_SCHEMAS / f"{name}.json").read_text(encoding="utf-8"))
+
+
+def proxy_readiness_error(proxy_url: str) -> str | None:
+    """What the proxy says about itself, before any credential is spent.
+
+    `/health` is the one route the proxy leaves unauthenticated, so a proxy that
+    is up but holds no session key is named as that instead of being masked by an
+    authentication failure on the listing. A build that does not serve the route
+    answers something else and the listing decides.
+    """
+    try:
+        response = requests.get(f"{proxy_url}/health", timeout=15)
+    except requests.RequestException as error:
+        return f"proxy unreachable at {proxy_url}: {error}"
+    if response.status_code == 503:
+        return _NO_SESSION_KEY
+    return None
 
 
 class SourceClaudeTeamInvoices(AbstractSource):
@@ -60,6 +96,11 @@ class SourceClaudeTeamInvoices(AbstractSource):
 
         proxy_url = str(config["proxy_url"]).rstrip("/")
         org_id = config["claude_org_id"]
+
+        not_ready = proxy_readiness_error(proxy_url)
+        if not_ready:
+            return False, not_ready
+
         try:
             response = requests.get(
                 f"{proxy_url}/api/stripe/{org_id}/invoices?limit=1&page=",
@@ -75,6 +116,9 @@ class SourceClaudeTeamInvoices(AbstractSource):
                 "(HTTP 403). Rotate a billing-capable cookie in via the proxy's "
                 "POST /admin/session-key."
             )
+        proxy_fault = _PROXY_STATUS_HELP.get(response.status_code)
+        if proxy_fault:
+            return False, proxy_fault
         if response.status_code != 200:
             return False, f"invoice list returned HTTP {response.status_code}"
         try:

--- a/src/ingestion/connectors/ai/claude-team-invoices/tests/test_source.py
+++ b/src/ingestion/connectors/ai/claude-team-invoices/tests/test_source.py
@@ -22,6 +22,7 @@ CONFIG = {
     "insight_source_id": "claude-team-invoices-1",
 }
 INVOICES_URL = f"https://proxy.example/api/stripe/{CONFIG['claude_org_id']}/invoices"
+HEALTH_URL = "https://proxy.example/health"
 STRIPE_PING = "https://api.stripe.com/v1"
 
 
@@ -33,6 +34,8 @@ def source() -> SourceClaudeTeamInvoices:
 @pytest.fixture
 def http() -> Iterator[rm_module.Mocker]:
     with rm_module.Mocker() as mocker:
+        # A ready proxy by default; the cases about readiness re-register it.
+        mocker.get(HEALTH_URL, json={"status": "ok", "ready": True})
         yield mocker
 
 
@@ -58,10 +61,67 @@ def test_an_empty_source_id_is_refused_before_any_request(
 
 
 def test_an_unreachable_proxy_names_the_url(source: SourceClaudeTeamInvoices, http: rm_module.Mocker) -> None:
-    http.get(INVOICES_URL, exc=requests.ConnectionError("no route"))
+    http.get(HEALTH_URL, exc=requests.ConnectionError("no route"))
     ok, message = source.check_connection(None, CONFIG)
     assert ok is False
     assert "proxy unreachable at https://proxy.example" in message
+
+
+def test_a_proxy_holding_no_session_key_is_named_before_the_listing_is_called(
+    source: SourceClaudeTeamInvoices, http: rm_module.Mocker
+) -> None:
+    """The cookie lives in the proxy's memory, so a restart leaves the proxy up
+    and every `/api/` call refusing. Read from the listing alone that is a bare
+    503; `/health` says which of the two it is."""
+    http.get(HEALTH_URL, status_code=503, json={"status": "init", "ready": False})
+    listing = http.get(INVOICES_URL, json={"invoices": []})
+    ok, message = source.check_connection(None, CONFIG)
+    assert ok is False
+    assert "holds no claude.ai session key" in message
+    assert "POST /admin/session-key" in message, "the refusal carries the fix"
+    assert listing.call_count == 0, "a proxy that cannot answer is not asked"
+
+
+def test_the_readiness_probe_carries_no_credential(source: SourceClaudeTeamInvoices, http: rm_module.Mocker) -> None:
+    """`/health` is the one route the proxy leaves open, and it is reached before
+    the token is known to be good — so the token is not offered to it."""
+    http.get(INVOICES_URL, json={"invoices": []})
+    http.get(STRIPE_PING, status_code=401)
+    source.check_connection(None, CONFIG)
+    probe = next(r for r in http.request_history if r.path == "/health")
+    assert "Authorization" not in probe.headers
+
+
+def test_a_proxy_build_without_the_route_lets_the_listing_decide(
+    source: SourceClaudeTeamInvoices, http: rm_module.Mocker
+) -> None:
+    """An older proxy answers 404 there; that is not a reason to refuse a sync."""
+    http.get(HEALTH_URL, status_code=404, json={"error": "not found"})
+    http.get(INVOICES_URL, json={"invoices": []})
+    http.get(STRIPE_PING, status_code=401)
+    assert source.check_connection(None, CONFIG) == (True, None)
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (401, "proxy_auth_token must match"),
+        (502, "could not reach claude.ai"),
+        (503, "holds no claude.ai session key"),
+        (504, "did not answer the proxy in time"),
+    ],
+    ids=["bad-token", "upstream-unreachable", "key-lost-after-the-probe", "upstream-timeout"],
+)
+def test_the_proxys_own_failures_are_named_rather_than_numbered(
+    source: SourceClaudeTeamInvoices, http: rm_module.Mocker, status: int, expected: str
+) -> None:
+    """These four come from the proxy, not from claude.ai through it. A bare code
+    sends an operator to the egress and Stripe-Version checks, which are never
+    the fault here."""
+    http.get(INVOICES_URL, status_code=status)
+    ok, message = source.check_connection(None, CONFIG)
+    assert ok is False
+    assert expected in message
 
 
 def test_a_forbidden_listing_names_the_rotation_it_needs(
@@ -75,10 +135,10 @@ def test_a_forbidden_listing_names_the_rotation_it_needs(
 
 
 def test_any_other_status_is_reported_with_its_code(source: SourceClaudeTeamInvoices, http: rm_module.Mocker) -> None:
-    http.get(INVOICES_URL, status_code=502)
+    http.get(INVOICES_URL, status_code=500)
     ok, message = source.check_connection(None, CONFIG)
     assert ok is False
-    assert "HTTP 502" in message
+    assert "HTTP 500" in message
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #2659.

**Why.** The proxy keeps the claude.ai session cookie in memory, so a restart leaves it running and every `/api/` call answering 503. `check_connection` reported that as `invoice list returned HTTP 503` — a number naming neither the cause nor the fix.

**What changed.** `GET {proxy}/health` — the proxy's one unauthenticated route, `200 {"ready": true}` or `503 {"ready": false}` — is probed before the listing and without the bearer token, and 401, 502, 503 and 504 on the listing are named instead of printed as a code.

**The probe carries no credential, deliberately.** Reached first and unauthenticated, a proxy that is up but holds no cookie is named as that rather than masked by a token failure.

**A proxy that does not serve `/health` is not refused.** An older build answers something else there and the listing decides, so the probe can only add a diagnosis, never a new way to fail.

**Out of scope.** Installing the cookie. That is the customer's action on their own container, and nothing in this repository can perform it.

**Verified.** Connector suite 69 passed. Reverting the source change alone fails 7 of the 19 `check_connection` cases, so the new ones assert the behaviour rather than the mocks.
