### PR TITLE
feat(ai-cost): report an enriched invoice that carries no money

### DIFF
--- a/src/ingestion/dbt/tests/ai/assert_ai_invoice_carries_its_money.sql
+++ b/src/ingestion/dbt/tests/ai/assert_ai_invoice_carries_its_money.sql
@@ -1,0 +1,34 @@
+{{ config(
+    tags=['data_quality'],
+    severity='warn',
+    store_failures=true,
+    meta={
+        'title': 'A vendor invoice whose chain completed carries the money it charged',
+        'domain': 'ai',
+        'category': 'completeness',
+        'tier': 'error',
+        'remediation': 'A row here is an invoice the connector enriched successfully and that still has no money on it: the wrapper reported no total_excluding_tax for it, so invoice_net_cents is NULL and that invoice contributes nothing to invoiced spend. The gross total the wrapper did report is shown beside it — if that is present too, the field is absent rather than the invoice being empty, and the wrapper changed shape. Compare the invoice on the vendor portal against what invoice_metrics_json carries; a genuinely zero-value invoice reports 0 and does not appear here.'
+    }
+) }}
+{#- The coverage check beside this one reports invoices whose chain did NOT
+    complete. This reports the opposite shape, which that one cannot see: a chain
+    that completed over an invoice the wrapper never priced. Nothing on such a row
+    says it is incomplete — chain_status reads `ok`, the lines are there, and only
+    the sum is quietly short.
+
+    Bounded to the same three billing months and for the same reason: the wrapper
+    either reports the field for an invoice or it never will, so an unbounded
+    check would report the same historical rows forever and stop being a signal. -#}
+
+SELECT
+    insight_tenant_id,
+    source,
+    invoice_id,
+    period_month,
+    currency,
+    JSONExtractString(invoice_metrics_json, 'invoice_total') AS wrapper_total
+FROM {{ ref('class_ai_invoice') }} FINAL
+WHERE ifNull(line_id, '') = ''
+  AND chain_status = 'ok'
+  AND invoice_net_cents IS NULL
+  AND period_month >= toStartOfMonth(today()) - INTERVAL 2 MONTH


### PR DESCRIPTION
Closes #2661.

**Why.** An invoice whose chain completed can still carry no money: `invoice_net_cents` is the wrapper's `total_excluding_tax` carried straight through, so where the wrapper reports no such field the row reads `ok`, carries its lines, and contributes NULL to invoiced spend.

**What changed.** A second data-quality check selects the invoice's own rows with `chain_status = 'ok'` and `invoice_net_cents IS NULL`. Its neighbour selects `chain_status != 'ok'` and so cannot see this shape; together they cover both ways an invoice arrives incomplete.

**The gross total rides in the failure row.** Present, it says the field is absent rather than the invoice empty — a vendor-shape change, not a zero invoice, which reports 0 and never appears.

**Degrading such an invoice to `failed` was the alternative.** It would discard the lines the chain did fetch, whose per-seat prices are the reason the chain runs.

**Verified.** Selected and green in `dbt build --select tag:claude-team-invoices+` against the e2e cluster. Seeded three rows — the gap, a line row with the same NULL, and a priced invoice — and the check reported exactly the gap, carrying `wrapper_total 4200`.
