### PR TITLE
chore(claude-team): bump to 3.0.0 to dispatch the rebuild 2.0.0 and 2.2.0 deferred

### DIFF
--- a/src/ingestion/connectors/ai/claude-team/descriptor.yaml
+++ b/src/ingestion/connectors/ai/claude-team/descriptor.yaml
@@ -30,7 +30,19 @@ name: claude-team
 #   this same change — it has to be on main before any major bump reads it.
 #   Rows written before this version keep an empty seat_status and reach gold as
 #   'unknown', which is what they honestly are.
-version: "2.2.0"
+# 3.0.0: no schema change of its own. MAJOR is the only way to dispatch the
+#   one-shot scoped `dbt --full-refresh` (reconcile-connectors) that 2.0.0 and
+#   2.2.0 each deferred, and four things need it. Rows written before 2.2.0
+#   carry an empty seat_status; the seats the pre-2.2.0 `status = 'active'`
+#   filter dropped at staging time are still in Bronze and reach the class only
+#   on a re-read; the roster rows written before the activity gate violate the
+#   contract assert_ai_dev_usage_rows_active states; and the rows the old
+#   table-wide silver watermark stranded return only when staging re-emits them
+#   — the per-source boundary stopped the loss, it does not undo it.
+#   Safe now and not before: full_refresh=false on claude_team__ai_overage
+#   landed in 2.2.0, so the one relation holding a past month's closing spend is
+#   skipped by the rebuild while class_ai_overage re-materialises from it.
+version: "3.0.0"
 # Daily at 23:50 UTC, as late in the day as the boundary allows. The seat
 # endpoint reports the billing month in progress and carries no history, so a
 # month's spend is frozen at the last read INSIDE it and whatever follows is


### PR DESCRIPTION
Closes #2665.

**Why.** Three Claude Team changes each needed rows to re-materialise and each shipped as MINOR to avoid a rebuild that was not yet safe. A MAJOR descriptor version is the only thing that dispatches the one-shot `dbt --full-refresh` scoped to `tag:claude-team+`.

**What changed.** `descriptor.yaml` 2.2.0 → 3.0.0, and the comment records the four effects: `seat_status` on rows written before 2.2.0, the seats the pre-2.2.0 `status = 'active'` filter dropped at staging time while Bronze kept them, the roster rows admitted before 2.2.0's activity gate, and the rows the old table-wide silver watermark stranded — #2607 stopped that loss without undoing it.

**Safe now and not before.** `full_refresh=false` on `claude_team__ai_overage` landed in 2.2.0, so the one relation holding a past month's closing spend is skipped while `class_ai_overage` re-materialises from it.

**Set by hand, deliberately.** `claude-team` is declarative and carries no `images:` block, so the build's automatic minor bump never touches this descriptor.

**Out of scope.** The classes this rebuild does not reach; the recovery procedure for those is tracked under #1607.

**Verified.** `classify_bump.py 3.0.0 2.2.0` returns `major` where `2.3.0` returns `minor`, so the dispatch fires. `scripts/ci/connector_wiring.py` passes, with only the pre-existing slack warning. Descriptor parses; `dbt_select` unchanged.
