### PR TITLE
ci: run the e2e lanes after the merge, not on every pull request

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -2022,3 +2022,47 @@ jobs:
             echo "recompute the bump against the new tip." >&2
             exit 1
           fi
+
+  # ─── The image gate ────────────────────────────────────────────────────────
+  # INVARIANT: `Images built` is a branch-protection check identity — it is the
+  # only ruleset-visible reporter for this workflow, whose per-service jobs
+  # come and go with the diff and so can never be named there directly.
+  images-built:
+    name: Images built
+    needs:
+      - changes
+      - discover-images
+      - backend-analytics
+      - merge-analytics
+      - backend-authenticator
+      - merge-authenticator
+      - backend-gateway
+      - merge-gateway
+      - backend-git-cli-proxy
+      - merge-git-cli-proxy
+      - backend-identity-resolution
+      - merge-identity-resolution
+      - frontend
+      - merge-frontend
+      - toolbox
+      - merge-toolbox
+      - seed
+      - merge-seed
+      - build-image
+      - merge-image
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require every image job to have passed or been skipped
+        env:
+          RESULTS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          jq -r 'to_entries[] | "\(.key)=\(.value.result)"' <<<"$RESULTS"
+          bad="$(jq -r '[to_entries[] | select(.value.result != "success" and .value.result != "skipped") | .key] | join(", ")' <<<"$RESULTS")"
+          if [ -n "$bad" ]; then
+            echo "::error::image jobs did not pass: $bad"
+            exit 1
+          fi
+          echo "every image job passed or was skipped as irrelevant"

--- a/.github/workflows/e2e-bronze-to-api.yml
+++ b/.github/workflows/e2e-bronze-to-api.yml
@@ -15,12 +15,13 @@ name: E2E — Bronze to API
 # here is what only this rig can do — bronze → dbt → ClickHouse → analytics
 # response, over fixtures it seeds itself.
 #
+# Lane: post-merge on `main`, plus dispatch. A pull request and a queue batch
+# start the workflow only so the required "Run E2E suite" check reports.
+#
 # Topology: a cheap `changes` job decides whether the diff can reach the data
 # path at all and everything expensive hangs off it; a shared upstream `build`
-# job assembles the runner image ONCE —
-# on PRs from the component images build-images.yml already built (or the
-# published :latest for path-skipped components), elsewhere by compiling
-# analytics + each connector's enrich binary via build-only services — and
+# job assembles the runner image ONCE — compiling analytics + each connector's
+# enrich binary via build-only services — and
 # hands it to `e2e-metrics` as a saved image
 # artifact, which also makes `build` the SOLE writer of the GHA BuildKit
 # cache scopes wired in compose/docker-compose.cache.yml (two concurrent
@@ -34,8 +35,9 @@ name: E2E — Bronze to API
 # Code:  src/ingestion/tests/e2e/
 
 on:
-  # PR-only (+ manual dispatch). workflow_dispatch remains for manual reruns
-  # against main.
+  # The lane runs post-merge, on `main`.
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
     # Deliberately NO `paths:` filter. This workflow emits a REQUIRED check
@@ -51,10 +53,11 @@ on:
   workflow_dispatch:
 
 # A new push obsoletes any run still in flight for the same ref — cancel it so a
-# rebase/force-push doesn't leave a slow suite burning minutes.
+# rebase/force-push doesn't leave a slow suite burning minutes. A main run is
+# the only proof that its own commit converges, so that one is never superseded.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 env:
   # NB: forbids developers from running `pytest --update-snapshots` in CI.
@@ -94,8 +97,8 @@ jobs:
   #                   own Dockerfiles into the runner image, and the analytics
   #                   HTTP response is the last hop every metric fixture
   #                   asserts on
-  #   build-images.yml  the PR path consumes its e2e-prebuilt-* artifacts by
-  #                   name, so a change there can break this workflow's build
+  #   build-images.yml  the pull-request path (inert while the lane is
+  #                   post-merge) consumes its e2e-prebuilt-* artifacts by name
   #
   # src/frontend/, deploy/, tests/ (the deployed-stand suite) and docs/ are
   # absent on purpose: nothing in this rig loads them.
@@ -151,7 +154,7 @@ jobs:
   build:
     name: Build runner image
     needs: changes
-    if: ${{ needs.changes.outputs.relevant == 'true' }}
+    if: ${{ needs.changes.outputs.relevant == 'true' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
     runs-on: ubuntu-latest
     # This compile-only job keeps the old combined job's full ceiling: a cold
     # GHA cache (Cargo.lock bump, the 7-day cache eviction, or the 10 GB
@@ -501,19 +504,13 @@ jobs:
     # retirement this workflow has none — those contracts and their gate live in
     # `e2e-stand.yml`, under its own umbrella ("Stand E2E").
     #
-    # It DOES fold in the image-build gate: this required check also goes red
-    # when this SHA's "Build & Push Container Images" run failed, so a PR with
-    # a broken service image can't be merged even though that workflow's own
-    # checks aren't in the ruleset.
     needs:
       - changes
       - build
       - e2e-metrics
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
-    # 5 min sufficed for the needs-check alone; the image-build gate below may
-    # poll a straggling build-images run for up to 10 more.
-    timeout-minutes: 15
+    timeout-minutes: 5
     steps:
       # A skipped lane now has two possible meanings, and they are opposites:
       # `changes` decided the diff cannot reach the data path (a pass), or the
@@ -524,6 +521,7 @@ jobs:
       # result now that it is a `needs` entry.
       - name: Require the build and the data-path lane to have succeeded
         env:
+          EVENT: ${{ github.event_name }}
           CHANGES: ${{ needs.changes.result }}
           RELEVANT: ${{ needs.changes.outputs.relevant }}
           BUILD: ${{ needs.build.result }}
@@ -531,7 +529,16 @@ jobs:
           METRICS: ${{ needs.e2e-metrics.result }}
         run: |
           set -euo pipefail
-          echo "changes=$CHANGES relevant=$RELEVANT build=$BUILD metrics=$METRICS"
+          echo "event=$EVENT changes=$CHANGES relevant=$RELEVANT build=$BUILD metrics=$METRICS"
+
+          # The check still reports where the lane does not run: the name is a
+          # branch-protection identity.
+          case "$EVENT" in
+            pull_request|merge_group)
+              echo "the data-path rig runs post-merge on main — nothing to prove on this event."
+              exit 0
+              ;;
+          esac
 
           # Fail closed. A `changes` job that did not succeed leaves `relevant`
           # empty, which would otherwise read as "irrelevant" and green a
@@ -552,45 +559,3 @@ jobs:
             done
             echo "E2E suite passed: build + the metrics lane succeeded."
           fi
-
-      # Unconditional, including on a PR `changes` found irrelevant: this gate
-      # guards the service images rather than the data path, and a PR touching
-      # only src/frontend/ can still break a build this required check is the
-      # sole ruleset-visible reporter for.
-      #
-      # build-images.yml is a separate workflow, so `needs:` can't reach it;
-      # ask the API for this SHA's run instead. Absent (path-skipped, or a
-      # merge_group SHA — that workflow has no merge_group trigger) passes;
-      # anything but success fails. The image builds finish long before this
-      # job starts, so the poll loop only covers stragglers.
-      - name: Require image builds on this SHA to be green or absent
-        env:
-          GH_TOKEN: ${{ github.token }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-        run: |
-          for attempt in $(seq 1 20); do
-            run_json=$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs?head_sha=${HEAD_SHA}&per_page=100" \
-              --jq '[.workflow_runs[] | select(.name == "Build & Push Container Images")] | sort_by(.run_started_at) | last // empty')
-            if [ -z "$run_json" ]; then
-              echo "No image-build run for ${HEAD_SHA} — builds were path-skipped."
-              exit 0
-            fi
-            conclusion=$(jq -r '.conclusion // ""' <<<"$run_json")
-            run_url=$(jq -r '.html_url' <<<"$run_json")
-            case "$conclusion" in
-              success)
-                echo "Image builds succeeded: ${run_url}"
-                exit 0
-                ;;
-              "")
-                echo "Image-build run still in progress (attempt ${attempt}/20); retrying in 30s…"
-                sleep 30
-                ;;
-              *)
-                echo "::error::Image builds concluded '${conclusion}' on this commit — see ${run_url}"
-                exit 1
-                ;;
-            esac
-          done
-          echo "::error::Image-build run did not finish within the polling window."
-          exit 1

--- a/.github/workflows/e2e-stand.yml
+++ b/.github/workflows/e2e-stand.yml
@@ -21,12 +21,12 @@ name: E2E — Compose stand
 #                the checkout on every event, so the ref's own test code is
 #                what executes.
 #
-# Neither is required on its own; `Stand E2E` below is the one stable context
-# for branch protection. The workflow starts on every pull request so that
-# required context always reports; the cheap `changes` job decides whether the
-# two stand lanes need to run. Relevant changes run on the pull request, once
-# per queue batch on merge_group, nightly, and on dispatch. Superseded PR runs
-# are cancelled by the concurrency group. Wall-clock and flake history are in
+# The `main` ruleset names `api-smoke` and `ui-journeys`; `Stand E2E` below is
+# their umbrella. All three report on every event.
+#
+# The lanes themselves run nightly and on dispatch — not on a pull request and
+# not per queue batch. The same contracts are asserted against the deployed
+# test stand after every publish (deploy-test-stand.yml). Wall-clock and flake history are in
 # .cf-studio/.plans/stage1-compose-e2e-suite/out/ci-wiring.md.
 #
 # Every stand operation goes through ./dev-compose.sh test-stand — never the
@@ -39,15 +39,15 @@ on:
   pull_request:
     branches: [main]
     # Deliberately NO `paths:` filter. This workflow emits the required
-    # `Stand E2E` check, and GitHub leaves a required check whose workflow never
-    # ran pending forever. Relevance is decided by the cheap `changes` job.
+    # `api-smoke`, `ui-journeys` and `Stand E2E` checks, and GitHub leaves a
+    # required check whose workflow never ran pending forever.
   # Merge-queue builds: the queue's gh-readonly-queue/* branches emit
   # merge_group, and a required check must report there or every queued PR
   # times out and is evicted.
   merge_group:
   # A scheduled run always evaluates against the default branch, so this is the
-  # main-branch lane whatever ref the file is authored on. Nightly rather than
-  # per-push: the stand is expensive and nothing here is a merge gate.
+  # main-branch lane whatever ref the file is authored on, and now the only
+  # event that brings the stand up besides a dispatch.
   schedule:
     - cron: "0 3 * * *"
   workflow_dispatch:
@@ -147,7 +147,7 @@ jobs:
   resolve-target:
     name: resolve-target
     needs: changes
-    if: ${{ needs.changes.outputs.relevant == 'true' }}
+    if: ${{ needs.changes.outputs.relevant == 'true' && github.event_name != 'pull_request' && github.event_name != 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -436,11 +436,16 @@ jobs:
     steps:
       - name: Report the API lane
         env:
+          EVENT: ${{ github.event_name }}
           CHANGES: ${{ needs.changes.result }}
           RELEVANT: ${{ needs.changes.outputs.relevant }}
           LANE: ${{ needs.stand-runner.outputs.api }}
         run: |
           set -euo pipefail
+          if [ "$EVENT" = pull_request ] || [ "$EVENT" = merge_group ]; then
+            echo "the stand lanes run nightly and against the deployed stand after publish — not on this event"
+            exit 0
+          fi
           if [ "$CHANGES" != success ]; then
             echo "::error::stand relevance is unknown because the changes job did not pass"
             exit 1
@@ -464,11 +469,16 @@ jobs:
     steps:
       - name: Report the UI lane
         env:
+          EVENT: ${{ github.event_name }}
           CHANGES: ${{ needs.changes.result }}
           RELEVANT: ${{ needs.changes.outputs.relevant }}
           LANE: ${{ needs.stand-runner.outputs.ui }}
         run: |
           set -euo pipefail
+          if [ "$EVENT" = pull_request ] || [ "$EVENT" = merge_group ]; then
+            echo "the stand lanes run nightly and against the deployed stand after publish — not on this event"
+            exit 0
+          fi
           if [ "$CHANGES" != success ]; then
             echo "::error::stand relevance is unknown because the changes job did not pass"
             exit 1
@@ -499,13 +509,19 @@ jobs:
     steps:
       - name: Require both lanes to have passed, or to have been skipped as irrelevant
         env:
+          EVENT: ${{ github.event_name }}
           CHANGES: ${{ needs.changes.result }}
           RELEVANT: ${{ needs.changes.outputs.relevant }}
           API: ${{ needs.api-smoke.result }}
           UI: ${{ needs.ui-journeys.result }}
         run: |
           set -euo pipefail
-          echo "changes=$CHANGES relevant=$RELEVANT api-smoke=$API ui-journeys=$UI"
+          echo "event=$EVENT changes=$CHANGES relevant=$RELEVANT api-smoke=$API ui-journeys=$UI"
+
+          if [ "$EVENT" = pull_request ] || [ "$EVENT" = merge_group ]; then
+            echo "the stand lanes run nightly and against the deployed stand after publish — not on this event"
+            exit 0
+          fi
 
           if [ "$CHANGES" != "success" ]; then
             echo "::error::the changes job did not succeed ($CHANGES) — stand relevance is unknown."


### PR DESCRIPTION
**Why.** Three of the four required checks on `main` are e2e suites, while the unit/integration gate (`Coverage gate`) is not required at all — a pull request waits on the slowest proof and skips the fastest one.

**What changed.** Each e2e lane now starts only where it is the cheapest proof available: `E2E — Bronze to API` on push to `main`, `E2E — Compose stand` on its nightly schedule. The check names still report on `pull_request` and `merge_group` — jobs skip, umbrella passes — because a required check whose workflow never ran stays pending forever.

**No merge-queue lane either.** A batch is the same code a second time. One trigger line per file to reverse.

**`Images built` instead of a poll.** "Run E2E suite" polled this SHA's image-build run for up to ten minutes; `build-images.yml` now carries its own `needs:` aggregate, where a skipped job passes. Add it to the ruleset to gate on it.

PR-run durations here, p50 / p90 over the last ~50 runs each: compose stand 29 / 58 min, bronze-to-api 21 / 44, over a 15 / 45 image build.

**Out of scope.** The ruleset swap; the now-inert pull-request prebuilt-image path in the rig; `Functional K3s Smoke`, which already self-gates to deploy-surface changes at ~2 min p50.

**Verified.** `actionlint` on all three files, no finding the base does not already have. The rest is this PR's own checks: the e2e names green in minutes, no suite running.
