### PR TITLE
fix(ai): let the AI staging models replace a key instead of appending beside it

### DIFF
--- a/src/ingestion/connectors/ai/chatgpt-team/dbt/chatgpt_team__ai_assistant_usage.sql
+++ b/src/ingestion/connectors/ai/chatgpt-team/dbt/chatgpt_team__ai_assistant_usage.sql
@@ -20,7 +20,7 @@
 --   dedicated columns for them).
 {{ config(
     materialized='incremental',
-    incremental_strategy='append',
+    incremental_strategy='delete+insert',
     unique_key='unique_key',
     engine='ReplacingMergeTree(_version)',
     order_by=['unique_key'],

--- a/src/ingestion/connectors/ai/chatgpt-team/dbt/chatgpt_team__ai_dev_usage.sql
+++ b/src/ingestion/connectors/ai/chatgpt-team/dbt/chatgpt_team__ai_dev_usage.sql
@@ -21,7 +21,7 @@
 --   preserved in tool_action_breakdown_json so nothing is lost.
 {{ config(
     materialized='incremental',
-    incremental_strategy='append',
+    incremental_strategy='delete+insert',
     unique_key='unique_key',
     engine='ReplacingMergeTree(_version)',
     order_by=['unique_key'],

--- a/src/ingestion/connectors/ai/claude-enterprise/dbt/claude_enterprise__ai_assistant_usage.sql
+++ b/src/ingestion/connectors/ai/claude-enterprise/dbt/claude_enterprise__ai_assistant_usage.sql
@@ -21,7 +21,7 @@
 
 {{ config(
     materialized='incremental',
-    incremental_strategy='append',
+    incremental_strategy='delete+insert',
     unique_key='unique_key',
     engine='ReplacingMergeTree(_version)',
     order_by=['unique_key'],

--- a/src/ingestion/connectors/ai/claude-enterprise/dbt/claude_enterprise__ai_dev_usage.sql
+++ b/src/ingestion/connectors/ai/claude-enterprise/dbt/claude_enterprise__ai_dev_usage.sql
@@ -34,7 +34,7 @@
 
 {{ config(
     materialized='incremental',
-    incremental_strategy='append',
+    incremental_strategy='delete+insert',
     unique_key='unique_key',
     engine='ReplacingMergeTree(_version)',
     order_by=['unique_key'],

--- a/src/ingestion/connectors/ai/claude-team/dbt/claude_team__ai_dev_usage.sql
+++ b/src/ingestion/connectors/ai/claude-team/dbt/claude_team__ai_dev_usage.sql
@@ -37,7 +37,7 @@
 --   verify against a tenant with a connected GitHub app.
 {{ config(
     materialized='incremental',
-    incremental_strategy='append',
+    incremental_strategy='delete+insert',
     unique_key='unique_key',
     engine='ReplacingMergeTree(_version)',
     order_by=['unique_key'],

--- a/src/ingestion/connectors/ai/claude-team/dbt/claude_team__ai_overage.sql
+++ b/src/ingestion/connectors/ai/claude-team/dbt/claude_team__ai_overage.sql
@@ -35,9 +35,12 @@
 -- descriptor bump. Silver still rebuilds freely: it reads this model, not
 -- Bronze. To rebuild deliberately, drop the table — the empty-table guard below
 -- then reloads the whole Bronze window.
+-- The `delete+insert` strategy does not weaken that: it deletes only the keys
+-- the incoming set carries, which is the re-evaluated window below, so a month
+-- outside it is never in the delete's scope.
 {{ config(
     materialized='incremental',
-    incremental_strategy='append',
+    incremental_strategy='delete+insert',
     unique_key='unique_key',
     engine='ReplacingMergeTree(_version)',
     order_by=['unique_key'],

--- a/src/ingestion/connectors/ai/cursor/dbt/cursor__ai_dev_usage.sql
+++ b/src/ingestion/connectors/ai/cursor/dbt/cursor__ai_dev_usage.sql
@@ -19,7 +19,7 @@
 -- is summed alone.
 {{ config(
     materialized='incremental',
-    incremental_strategy='append',
+    incremental_strategy='delete+insert',
     unique_key='unique_key',
     engine='ReplacingMergeTree(_version)',
     order_by=['unique_key'],


### PR DESCRIPTION
> **Draft — do not merge on the reasoning below it.** The test this fixes runs in one
> place only: the e2e rig. A deployed install runs `dbt run`; the scheduled
> data-quality job runs `dbt test --selector data_quality` with
> `indirect_selection: empty`, which admits only tagged checks; CI runs `dbt parse`.
> So no deployed surface observes the duplicate, and the rig is green today because
> `conftest.py` already truncates these tables at session start.
>
> The change also crosses a live convention: `check-dbt-conventions` prescribes
> `delete+insert` for **silver** and `append` for **staging**, and that split was
> written by #622 itself — its own summary says `union_by_tag` exists so "transient
> staging duplicates never reach silver". `architecture.md` still lists
> `delete+insert` with RMT as an anti-pattern, in a rule scoped to
> `connectors/*/dbt/`. And `claude_team__ai_invoice` is not the precedent it looked
> like: it landed days ago in #2432, so citing it is circular.
>
> Merging this as written would need the convention amended in the same PR, with its
> author reviewing. The discussion is in #2668; the larger finding it uncovered — that
> 710 generic tests never run outside the rig — is #2663.

---

Closes #2668. The five models outside the AI classes stay in #2663.

**Why.** The seven staging models behind the `class_ai_*` classes re-emit keys they already hold — a rolling window, or the current and previous billing month. `append` inserts beside the old row and `ReplacingMergeTree` collapses the pair only on a background merge, so the dbt `unique` test fails on the second run, for a benign reason.

**What changed.** `incremental_strategy='delete+insert'` keyed on `unique_key`, the shape `claude_team__ai_invoice` already uses. One config line per model.

**Silver was never affected and is untouched.** `union_by_tag` deduplicates at read time and the classes have been `delete+insert` since #955 — which is why this surfaced as a failing test rather than as wrong numbers.

**`claude_team__ai_overage` is the one that needed proving.** It carries `full_refresh=false` because it is the only place a past month's closing spend exists. `delete+insert` deletes only the keys the incoming set carries — the re-evaluated window — so an older month is never in the delete's scope. A note beside the invariant records that, since the word "delete" invites the worry.

**Out of scope.** The five models outside the AI classes; four of them carry no incremental filter, so the same change alters what a run removes rather than only what it rewrites, and each needs its own argument.

**Verified.** Three consecutive runs over two months of seeded bronze: 3 rows, 3 distinct keys, 0 duplicates, the out-of-window month unchanged, `unique` PASS every time — against `FAIL 2` on the second run before the change. Then `metrics/ -k ai_`: 23 passed, covering all ten AI metric fixtures across the four classes plus `test_ai_seat_extra_usage_history`, which drives the pipeline twice and replaces bronze between runs.

