### PR TITLE
feat(ai-cost): name the two AI cost figures potential and actual

### DIFF
--- a/src/backend/services/analytics/src/domain/metric_definitions/passports.md
+++ b/src/backend/services/analytics/src/domain/metric_definitions/passports.md
@@ -28,7 +28,7 @@ this file and the registry disagree.
 - Shape: integer, higher_is_better, unit days
 - Notes: Distinct days with person-attributed AI activity across dev and assistant tools.
 
-## ai.cost — AI usage cost
+## ai.cost — AI potential usage cost
 
 - Source: ai_usage (ai_metric_observations)
 - Reads: cost_usd
@@ -36,7 +36,7 @@ this file and the registry disagree.
 - Shape: currency, lower_is_better
 - Notes: Person-attributed AI usage priced at the vendor's token or usage rates — what the consumption would cost if billed purely by usage. Includes usage a seat or subscription already covered, and excludes seat and subscription fees, so it is not the amount invoiced. Covers the tools whose connector prices usage per person. Overlaps ai.extra_usage_cost, which is the part of that same consumption the vendor actually billed on top of the seat fee — the two are served side by side and are never added, since adding them counts the billed part twice.
 
-## ai.extra_usage_cost — AI extra usage
+## ai.extra_usage_cost — AI actual usage cost
 
 - Source: ai_cost (ai_cost_metric_observations)
 - Reads: extra_usage_usd

--- a/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
+++ b/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
@@ -251,8 +251,9 @@ metrics:
   - metric_key: ai.cost
     source_key: ai_usage
     subject: cost
-    label: AI usage cost
-    description: AI usage priced at vendor token/usage rates
+    label: AI potential usage cost
+    short_label: Potential cost
+    description: Potential cost of all AI usage at vendor rates, never the actual invoice
     explanation: Person-attributed AI usage priced at the vendor's token or usage rates — what the consumption would cost if billed purely by usage. Includes usage a seat or subscription already covered, and excludes seat and subscription fees, so it is not the amount invoiced. Covers the tools whose connector prices usage per person. Overlaps ai.extra_usage_cost, which is the part of that same consumption the vendor actually billed on top of the seat fee — the two are served side by side and are never added, since adding them counts the billed part twice.
     format: currency
     direction: lower_is_better
@@ -267,9 +268,9 @@ metrics:
   - metric_key: ai.extra_usage_cost
     source_key: ai_cost
     subject: cost
-    label: AI extra usage
-    short_label: Extra usage
-    description: Spend above the usage included in the seat fee
+    label: AI actual usage cost
+    short_label: Actual cost
+    description: Actual cost billed on top of the seat fee, part of the potential total
     explanation: What the vendor billed a person on top of their seat fee, once the usage included in that fee was exhausted, priced at API rates. A monthly fact reported against the day the seat snapshot was last read; a window covering part of a month returns that month in full rather than a fraction. Distinct from ai.cost, which prices all consumption including what the seat fee already covered — the two are never summed. Attribution mode is direct — the vendor reports this amount per seat.
     format: currency
     direction: lower_is_better

--- a/src/frontend/src/components/portal/ai-cost-view.test.tsx
+++ b/src/frontend/src/components/portal/ai-cost-view.test.tsx
@@ -117,15 +117,21 @@ beforeEach(() => {
   mocks.grid.isPending = false;
   mocks.grid.isError = false;
   mocks.tools.isError = false;
-  // 3 of 4 use AI; costs are Claude-only.
+  // 3 of 4 use AI; costs are Claude-only. Actual (billed) cost is a fraction of
+  // the potential one, which is the relationship the two figures always have.
   mocks.grid.byKey = new Map([
     ["ai.cost", metric("ai.cost", [[pid("a"), 100], [pid("b"), 50], [pid("c"), 0], [pid("d"), 0]], { format: "currency", unit: "USD" } as never)],
+    ["ai.extra_usage_cost", metric("ai.extra_usage_cost", [[pid("a"), 8], [pid("b"), 4], [pid("c"), 0], [pid("d"), 0]], { format: "currency", unit: "USD" } as never)],
     ["ai.active_days", metric("ai.active_days", [[pid("a"), 5], [pid("b"), 3], [pid("c"), 1], [pid("d"), 0]])],
     ["ai.accepted_lines", metric("ai.accepted_lines", [[pid("a"), 700], [pid("b"), 200], [pid("c"), 100], [pid("d"), 0]])],
   ]);
   mocks.grid.previousByKey = new Map();
   mocks.tools.byKey = new Map([
     ["ai.cost", toolBreakdown("ai.cost", [[pid("a"), "claude_code", 100], [pid("b"), "claude_code", 50]])],
+    ["ai.extra_usage_cost", toolBreakdown("ai.extra_usage_cost", [
+      [pid("a"), "claude_code", 8],
+      [pid("b"), "claude_code", 4],
+    ])],
     ["ai.accepted_lines", toolBreakdown("ai.accepted_lines", [
       [pid("a"), "claude_code", 600],
       [pid("b"), "chatgpt", 300],
@@ -141,7 +147,7 @@ beforeEach(() => {
 describe("AiCostView", () => {
   it("renders headline KPIs: Claude-only cost, active users, org lines", () => {
     render(<AiCostView item={null} />);
-    expect(screen.getByText("AI cost")).toBeInTheDocument();
+    expect(screen.getByText("AI potential usage cost")).toBeInTheDocument();
     expect(screen.getByText("Claude Code only")).toBeInTheDocument();
     // 3 of 4 members have active days > 0
     expect(screen.getByText("Active AI users")).toBeInTheDocument();
@@ -149,13 +155,42 @@ describe("AiCostView", () => {
     expect(screen.getByText(/1[,  ]?000/)).toBeInTheDocument(); // 700+200+100 lines
   });
 
+  it("holds the actual cost beside the potential one rather than summing them", () => {
+    render(<AiCostView item={null} />);
+    // Potential 100+50, actual 8+4 — two figures, no 162 anywhere.
+    expect(screen.getAllByText("$150").length).toBeGreaterThan(0);
+    expect(screen.getByText("actual cost $12")).toBeInTheDocument();
+    expect(screen.queryByText("$162")).not.toBeInTheDocument();
+    // The average carries the same pair: 150/3 against 12/3, never 162/3.
+    expect(screen.getAllByText("$50").length).toBeGreaterThan(0);
+    expect(screen.getByText("actual $4 / active user")).toBeInTheDocument();
+    expect(screen.queryByText("$54")).not.toBeInTheDocument();
+  });
+
+  it("omits the actual figure entirely when no seat data reaches us", () => {
+    const drop = <T,>(m: Map<string, T>) =>
+      new Map([...m].filter(([key]) => key !== "ai.extra_usage_cost"));
+    mocks.grid.byKey = drop(mocks.grid.byKey);
+    mocks.tools.byKey = drop(mocks.tools.byKey);
+    render(<AiCostView item={null} />);
+    expect(screen.getByText("AI potential usage cost")).toBeInTheDocument();
+    // A $0 actual cost would assert that nothing was billed.
+    expect(screen.queryByText(/actual cost/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/actual .* \/ active user/)).not.toBeInTheDocument();
+  });
+
   it("shows per-tool cards where untracked cost reads 'not tracked', never $0", () => {
     render(<AiCostView item={null} />);
     expect(screen.getAllByText("Claude Code").length).toBeGreaterThan(0);
     expect(screen.getByText("ChatGPT")).toBeInTheDocument();
     // ChatGPT reports lines but no cost
-    expect(screen.getByText("cost not tracked")).toBeInTheDocument();
-    expect(screen.getByText(/2 users · 400 lines/)).toBeInTheDocument();
+    expect(screen.getByText("potential cost not tracked")).toBeInTheDocument();
+    // ...and no billed amount either, so its card names neither.
+    expect(screen.getByText("2 users · 400 lines")).toBeInTheDocument();
+    // Claude Code carries both, the billed one beside the priced one.
+    expect(
+      screen.getByText("actual cost $12 · 1 users · 600 lines"),
+    ).toBeInTheDocument();
     // the caveat is spelled out for the reader
     expect(screen.getByText(/Only Claude Code is usage-metered/)).toBeInTheDocument();
   });
@@ -185,7 +220,7 @@ describe("AiCostView", () => {
     render(<AiCostView item="autofix" />);
     expect(screen.getByText(/no autofix data is collected/i)).toBeInTheDocument();
     // no fabricated KPI cards behind it
-    expect(screen.queryByText("AI cost")).not.toBeInTheDocument();
+    expect(screen.queryByText("AI potential usage cost")).not.toBeInTheDocument();
   });
 
   it("groups cost and adoption by unit when a slice is active", () => {
@@ -199,6 +234,10 @@ describe("AiCostView", () => {
     render(<AiCostView item="by-unit-role" />);
     expect(screen.getByText("R&D")).toBeInTheDocument();
     expect(screen.getByText("Sales")).toBeInTheDocument();
+    // Both cost columns, with R&D's billed figure in the second one.
+    expect(screen.getByText("Potential cost")).toBeInTheDocument();
+    expect(screen.getByText("Actual cost")).toBeInTheDocument();
+    expect(screen.getByText("$12")).toBeInTheDocument();
   });
 
   it("gates on an empty scope instead of rendering zero KPIs", () => {
@@ -206,6 +245,6 @@ describe("AiCostView", () => {
     mocks.tree = person("boss");
     render(<AiCostView item={null} />);
     expect(screen.getByText(/No people in the current scope/)).toBeInTheDocument();
-    expect(screen.queryByText("AI cost")).not.toBeInTheDocument();
+    expect(screen.queryByText("AI potential usage cost")).not.toBeInTheDocument();
   });
 });

--- a/src/frontend/src/components/portal/ai-cost-view.tsx
+++ b/src/frontend/src/components/portal/ai-cost-view.tsx
@@ -44,10 +44,17 @@ import { cn } from "@/lib/utils";
 
 const EMPTY_COLLECTION: MetricCollectionConfig = { metrics: [] };
 const COST_KEY = "ai.cost";
+const ACTUAL_COST_KEY = "ai.extra_usage_cost";
 const LINES_KEY = "ai.accepted_lines";
 const DAYS_KEY = "ai.active_days";
 /** Grid columns for the cost-leaders scan. */
-const GRID_KEYS = [COST_KEY, DAYS_KEY, LINES_KEY, "ai.dev_conversations"];
+const GRID_KEYS = [
+  COST_KEY,
+  ACTUAL_COST_KEY,
+  DAYS_KEY,
+  LINES_KEY,
+  "ai.dev_conversations",
+];
 
 const TOOL_LABEL: Record<string, string> = {
   claude_code: "Claude Code",
@@ -61,6 +68,8 @@ interface ToolRow {
   lines: number;
   cost: number;
   costTracked: boolean;
+  actual: number;
+  actualTracked: boolean;
 }
 
 /** Sum a breakdown metric across members, grouped by the `tool` dimension. */
@@ -133,7 +142,7 @@ export function AiCostView({ item }: { item: string | null }) {
   );
   const toolCollection = useMemo<MetricCollectionConfig>(
     () => ({
-      metrics: [COST_KEY, LINES_KEY].map((key) => ({
+      metrics: [COST_KEY, ACTUAL_COST_KEY, LINES_KEY].map((key) => ({
         key,
         views: [{ view: "breakdown" as const, dimensions: ["tool"] }],
       })),
@@ -171,11 +180,16 @@ export function AiCostView({ item }: { item: string | null }) {
 
   const toolRows = useMemo<ToolRow[]>(() => {
     const cost = aggregateByTool(toolData.byKey.get(COST_KEY), memberIds);
+    const actual = aggregateByTool(
+      toolData.byKey.get(ACTUAL_COST_KEY),
+      memberIds,
+    );
     const lines = aggregateByTool(toolData.byKey.get(LINES_KEY), memberIds);
-    const tools = new Set([...cost.keys(), ...lines.keys()]);
+    const tools = new Set([...cost.keys(), ...actual.keys(), ...lines.keys()]);
     return [...tools]
       .map((tool) => {
         const c = cost.get(tool);
+        const a = actual.get(tool);
         const l = lines.get(tool);
         return {
           tool,
@@ -183,6 +197,11 @@ export function AiCostView({ item }: { item: string | null }) {
           lines: l?.sum ?? 0,
           cost: c?.sum ?? 0,
           costTracked: (c?.sum ?? 0) > 0,
+          actual: a?.sum ?? 0,
+          // Only vendors that bill above a seat fee report this, so a tool
+          // without it says nothing rather than $0 — the rule the potential
+          // figure already follows.
+          actualTracked: (a?.sum ?? 0) > 0,
         };
       })
       .sort((a, b) => b.lines - a.lines);
@@ -219,20 +238,31 @@ export function AiCostView({ item }: { item: string | null }) {
   const unitRows = useMemo(() => {
     if (!slice || PLANNED_KEYS.has(slice)) return [];
     const costR = grid.byKey.get(COST_KEY);
+    const actualR = grid.byKey.get(ACTUAL_COST_KEY);
     const linesR = grid.byKey.get(LINES_KEY);
     const daysR = grid.byKey.get(DAYS_KEY);
     const val = (r: NormalizedMetricResult | undefined, id: string) =>
       r ? (forEntity(r, id).value ?? 0) : 0;
     const map = new Map<
       string,
-      { unit: string; people: number; active: number; cost: number; lines: number }
+      {
+        unit: string;
+        people: number;
+        active: number;
+        cost: number;
+        actual: number;
+        lines: number;
+      }
     >();
     for (const id of memberIds) {
       const unit = attrByEntity.get(id)?.[slice]?.value ?? "—";
-      const b = map.get(unit) ?? { unit, people: 0, active: 0, cost: 0, lines: 0 };
+      const b =
+        map.get(unit) ??
+        { unit, people: 0, active: 0, cost: 0, actual: 0, lines: 0 };
       b.people += 1;
       if (val(daysR, id) > 0) b.active += 1;
       b.cost += val(costR, id);
+      b.actual += val(actualR, id);
       b.lines += val(linesR, id);
       map.set(unit, b);
     }
@@ -282,13 +312,25 @@ export function AiCostView({ item }: { item: string | null }) {
   if (gate) return gate;
 
   const costR = grid.byKey.get(COST_KEY);
+  const actualR = grid.byKey.get(ACTUAL_COST_KEY);
   const linesR = grid.byKey.get(LINES_KEY);
   const totalCost = sum(COST_KEY);
+  const totalActual = sum(ACTUAL_COST_KEY);
   const totalLines = sum(LINES_KEY);
   const adoptionPct = members.length
     ? Math.round((activeUsers / members.length) * 100)
     : 0;
   const avgCost = activeUsers ? totalCost / activeUsers : 0;
+  const avgActual = activeUsers ? totalActual / activeUsers : 0;
+  const actualMoney = (value: number) =>
+    formatMetricValue(
+      value,
+      actualR?.format ?? "currency",
+      actualR?.unit ?? "USD",
+    );
+  // Absent, not zero: `sum` folds nulls to 0, so a $0 total cannot be told from
+  // no seat data — and printing $0 would claim nothing was billed.
+  const hasActual = !!actualR && totalActual > 0;
 
   const shownGridKeys = GRID_KEYS.filter((k) => {
     const r = grid.byKey.get(k);
@@ -313,8 +355,9 @@ export function AiCostView({ item }: { item: string | null }) {
       {/* Headline */}
       <div className="grid grid-cols-[repeat(auto-fit,minmax(11rem,1fr))] gap-3">
         <Tile
-          label="AI cost"
+          label="AI potential usage cost"
           value={formatMetricValue(totalCost, costR?.format ?? "currency", costR?.unit ?? "USD")}
+          note={hasActual ? `actual cost ${actualMoney(totalActual)}` : null}
           sub="Claude Code only"
         />
         <Tile label="Active AI users" value={String(activeUsers)} sub={`${adoptionPct}% of ${members.length}`} />
@@ -330,6 +373,9 @@ export function AiCostView({ item }: { item: string | null }) {
             costR?.format ?? "currency",
             costR?.unit ?? null,
           )}
+          note={
+            hasActual ? `actual ${actualMoney(avgActual)} / active user` : null
+          }
           sub="Claude Code"
         />
       </div>
@@ -340,6 +386,7 @@ export function AiCostView({ item }: { item: string | null }) {
         <UnitSection
           rows={unitRows}
           costR={costR}
+          actualR={actualR}
           linesR={linesR}
           dim={[...sliceDims, ...PLANNED_SLICES].find((d) => d.key === slice) ?? null}
         />
@@ -372,9 +419,12 @@ export function AiCostView({ item }: { item: string | null }) {
                       : "—"}
                   </div>
                   <div className="text-xs text-muted-foreground">
-                    {t.costTracked ? "cost" : "cost not tracked"}
+                    {t.costTracked ? "potential cost" : "potential cost not tracked"}
                   </div>
                   <div className="mt-1 text-xs text-muted-foreground">
+                    {t.actualTracked
+                      ? `actual cost ${formatMetricValue(t.actual, "currency", "USD")} · `
+                      : ""}
                     {t.users} users · {formatMetricValue(t.lines, "integer", null)} lines
                   </div>
                 </CardContent>
@@ -460,11 +510,20 @@ function FunnelSection({ funnel }: { funnel: { label: string; n: number }[] }) {
 function UnitSection({
   rows,
   costR,
+  actualR,
   linesR,
   dim,
 }: {
-  rows: { unit: string; people: number; active: number; cost: number; lines: number }[];
+  rows: {
+    unit: string;
+    people: number;
+    active: number;
+    cost: number;
+    actual: number;
+    lines: number;
+  }[];
   costR: NormalizedMetricResult | undefined;
+  actualR: NormalizedMetricResult | undefined;
   linesR: NormalizedMetricResult | undefined;
   dim: SliceDim | null;
 }) {
@@ -494,7 +553,8 @@ function UnitSection({
               <TableHead>{dimLabel}</TableHead>
               <TableHead className="text-right">People</TableHead>
               <TableHead className="text-right">AI users</TableHead>
-              <TableHead className="text-right">AI cost</TableHead>
+              <TableHead className="text-right">Potential cost</TableHead>
+              <TableHead className="text-right">Actual cost</TableHead>
               <TableHead className="text-right">Accepted lines</TableHead>
             </TableRow>
           </TableHeader>
@@ -511,6 +571,15 @@ function UnitSection({
                 <TableCell className="text-right tabular-nums">
                   {formatMetricValue(r.cost, costR?.format ?? "currency", costR?.unit ?? "USD")}
                 </TableCell>
+                <TableCell className="text-right tabular-nums">
+                  {actualR
+                    ? formatMetricValue(
+                        r.actual,
+                        actualR.format,
+                        actualR.unit ?? "USD",
+                      )
+                    : "—"}
+                </TableCell>
                 <TableCell className="text-right tabular-nums text-muted-foreground">
                   {formatMetricValue(r.lines, linesR?.format ?? "integer", linesR?.unit ?? null)}
                 </TableCell>
@@ -522,19 +591,35 @@ function UnitSection({
       )}
       {dim && !dim.planned ? (
         <p className="text-xs text-muted-foreground">
-          Cost is Claude Code only (the usage-metered tool).
+          Costs are Claude Code only (the usage-metered tool).
         </p>
       ) : null}
     </section>
   );
 }
 
-function Tile({ label, value, sub }: { label: string; value: string; sub: string }) {
+function Tile({
+  label,
+  value,
+  note,
+  sub,
+}: {
+  label: string;
+  value: string;
+  /** A second figure held beside `value`, never added to it. */
+  note?: string | null;
+  sub: string;
+}) {
   return (
     <Card>
       <CardContent className="p-4">
         <div className="text-xs font-medium text-muted-foreground">{label}</div>
         <div className={cn("mt-1", TEXT_FIGURE)}>{value}</div>
+        {note ? (
+          <div className="text-xs font-medium tabular-nums text-muted-foreground">
+            {note}
+          </div>
+        ) : null}
         <div className="text-xs text-muted-foreground">{sub}</div>
       </CardContent>
     </Card>

--- a/src/frontend/src/lib/insight/groups.ts
+++ b/src/frontend/src/lib/insight/groups.ts
@@ -136,6 +136,10 @@ const AI_ADOPTION_COLLECTION: MetricCollectionConfig = {
     { key: "ai.active_days", views: [{ view: "period" }, { view: "peer" }] },
     { key: "ai.cost", views: [{ view: "period" }, { view: "peer" }] },
     {
+      key: "ai.extra_usage_cost",
+      views: [{ view: "period" }, { view: "peer" }],
+    },
+    {
       key: "ai.accepted_edit_actions",
       views: [{ view: "period" }, { view: "peer" }],
     },
@@ -461,7 +465,16 @@ export const GROUPS: readonly MetricGroup[] = [
     title: "AI adoption",
     collection: AI_ADOPTION_COLLECTION,
     card: {
-      preview: ["ai.active_days", "ai.accepted_lines", "ai.cost"],
+      // The two cost figures are adjacent and ahead of the line count: the card
+      // trims this list to four once a lead row joins it, and a trim that keeps
+      // the potential cost while dropping the actual one leaves the reader with
+      // the half that is not an invoice.
+      preview: [
+        "ai.active_days",
+        "ai.cost",
+        "ai.extra_usage_cost",
+        "ai.accepted_lines",
+      ],
     },
     drilldown: [
       {

--- a/src/frontend/src/lib/portal/overview-configs.ts
+++ b/src/frontend/src/lib/portal/overview-configs.ts
@@ -31,6 +31,7 @@ export const OVERVIEW_ITEMS: Record<string, LensConfig> = {
           "tasks.closed",
           "collab.messages_sent",
           "ai.cost",
+          "ai.extra_usage_cost",
         ],
       },
       // The old header's "N using AI" stat, now an honest participation card


### PR DESCRIPTION
Refs #2479 — action item 5, and the "still to file" note asking that `ai.cost`'s own description say it is potential cost.

**Why.** The catalogue called the two AI cost figures "AI usage cost" and "AI extra usage", so nothing on screen said which of them is money anyone was actually charged. Only the second is.

**What changed.** `ai.cost` becomes "AI potential usage cost" and `ai.extra_usage_cost` becomes "AI actual usage cost" — label, short label and description — and the actual figure is now served beside the potential one everywhere the latter already appeared: the AI & Cost headline tiles, the per-tool cards, the by-unit table, the member grid, the AI adoption card preview and the Overview headline row.

**A missing amount reads as nothing, not $0.** Summing folds nulls to zero, so $0 would claim the vendor billed nothing above the seat fee. This is the rule the potential figure already follows.

**The two cost keys sit adjacent in the card preview, ahead of the line count.** The group card trims that list to four once a lead row joins it, and a trim keeping potential while dropping actual leaves the half that is not an invoice.

**Out of scope.** The pair's differing grain — actual cost is a seat-month fact — is not yet called out on screen. #2673 adds that caveat, stacked on this branch.

**Verified.** Locally: `tsc -b`, `eslint . --max-warnings 0`, the unit suite at 190 files / 1557 tests, and `cargo test -p analytics` at 439 passed / 0 failed — `passports_md_is_in_sync` among them, so the committed passport matches the registry. That Rust run was cargo 1.92 with `--ignore-rust-version`; CI's pinned 1.95.0 is the authority. Screenshots pending, no stand up.