### PR TITLE
ci(functional): run the k3s smoke post-merge, not on every pull request

### DIFF
--- a/.github/workflows/functional-k3s.yml
+++ b/.github/workflows/functional-k3s.yml
@@ -1,6 +1,6 @@
 name: Functional K3s Smoke
 
-# Fork-safe deployment smoke for the Insight gitops path:
+# Deployment smoke for the Insight gitops path, run after the merge:
 # 1. create a GitHub-hosted ephemeral K3s cluster
 # 2. use the committed functional-ci gitops environment
 # 3. run deploy/gitops Makefile targets for bootstrap, sealing, L2, and L3
@@ -8,20 +8,28 @@ name: Functional K3s Smoke
 
 on:
   workflow_dispatch:
-  # Merge-queue builds always bring the cluster up. The pull_request trigger
-  # stays unfiltered so the check reports on every PR — `changes` below decides
-  # which PRs get a cluster, and branch protection counts the skip as a pass
-  # for the ones that do not.
-  merge_group:
-  pull_request:
+  # Post-merge lane: the smoke deploys published images, so a pull request's
+  # unbuilt code cannot change its outcome — main is the cheapest place to
+  # prove the deploy surface. The check is not in the ruleset, so a plain
+  # paths filter can decide which pushes get a cluster; a push that skips
+  # reports nothing and blocks nothing.
+  push:
     branches: [main]
-    types: [opened, synchronize, reopened, ready_for_review]
+    # Everything the deploy reads: the gitops environment and the Makefile
+    # that drives it, the umbrella chart plus the service subcharts it
+    # packages, and this workflow. Service SOURCE is out — the smoke deploys
+    # published images, which reach the chart through a descriptor bump.
+    paths:
+      - "deploy/gitops/**"
+      - "charts/**"
+      - "src/backend/services/*/helm/**"
+      - ".github/workflows/functional-k3s.yml"
 
-# One run per PR; merge-queue builds get a unique group so a queue rebuild
-# can never cancel a batch mid-run.
+# A main run is the only proof that its own commit deploys — later pushes
+# queue behind it instead of cancelling it.
 concurrency:
-  group: functional-k3s-${{ github.event_name == 'merge_group' && github.run_id || github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+  group: functional-k3s-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -44,44 +52,8 @@ env:
   REDIS_PASSWORD: insightpass123
 
 jobs:
-  # Filtering here rather than with `paths:` on the trigger is deliberate: a
-  # workflow that never starts never reports a check, and this one is required.
-  changes:
-    name: Detect deploy-surface changes
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      run: ${{ steps.decide.outputs.run }}
-    steps:
-      - id: decide
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          # Everything the deploy reads: the gitops environment and the Makefile
-          # that drives it, the umbrella chart plus the service subcharts it
-          # packages, and this workflow. Service SOURCE is out — the smoke
-          # deploys published images, which reach it through a descriptor bump.
-          SURFACE: '^(deploy/gitops/|charts/|src/backend/services/[^/]+/helm/|\.github/workflows/functional-k3s\.yml$)'
-        run: |
-          set -euo pipefail
-
-          if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          touched=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
-            --jq '.[].filename' | grep -cE "${SURFACE}" || true)
-          [[ "${touched}" -gt 0 ]] && run=true || run=false
-
-          echo "run=${run}" >> "$GITHUB_OUTPUT"
-          echo "${touched} deploy-surface file(s) changed — cluster: ${run}" >> "$GITHUB_STEP_SUMMARY"
-
   cluster-smoke:
     name: K3s GitOps Deploy
-    needs: changes
-    if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/docs/testing/TESTING.md
+++ b/docs/testing/TESTING.md
@@ -108,8 +108,8 @@ cd src/ingestion/tests/e2e
 
 - Real ingestion (Airbyte → Argo/Kestra → bronze → API), the umbrella-chart deployment, and UI flows (Playwright,
   role + accessible-name locators — no accessibility or contrast checking).
-- On PR, only the **deployment smoke** runs (chart installs + rollout). Full ingestion + UI run in **Test**; a
-  **shallow acceptance validation** runs in **Beta**.
+- The **deployment smoke** (chart installs + rollout) runs post-merge on `main`. Full ingestion + UI run in
+  **Test**; a **shallow acceptance validation** runs in **Beta**.
 - Every user-facing surface **should** have at least one smoke assertion.
 - A separate **compose-stand suite** (`tests/stand`, documented in `tests/stand/README.md`) drives a real Keycloak
   login and a set of browser journeys against the SPA, plus an API-contract suite — all against a local
@@ -118,8 +118,9 @@ cd src/ingestion/tests/e2e
   `golden_metrics` is empty by design, and a harness for it is being migrated separately. It does reconcile every
   metric's drilldown evidence against that metric's own served value, which needs no declared expectation.
 
-**CI:** `functional-k3s.yml` — ephemeral k3d install. Today it only *installs*; a real smoke must build + import the
-PR's images and assert `/health` + a few golden metrics.
+**CI:** `functional-k3s.yml` — ephemeral k3d install, post-merge on pushes to `main` that touch the deploy surface.
+Today it deploys published images and asserts the edge answers; a real smoke must also assert `/health` + a few
+golden metrics.
 
 **CI:** `e2e-stand.yml` — two **non-required** checks against the compose-stand suite: `api-smoke` (the HTTP
 contract tests, no browser) and `ui-journeys` (the browser journeys, run host-side from the checkout).


### PR DESCRIPTION
**Why.** The smoke deploys published images — service source reaches it only through a descriptor bump — so nothing in a pull request's unbuilt code can change its outcome. Running it per-PR and again per merge-queue batch proves the same thing twice before proving it once where it matters. Companion to #2631; #2667 left this lane out of scope, this picks it up.

**What changed.** The lane triggers on `push` to `main` (plus dispatch). The `changes` job is deleted: it existed only because a required check must report on every PR, and `K3s GitOps Deploy` is no longer in the ruleset — a plain `paths:` filter on the push trigger now decides which pushes get a cluster, and a skipped push reports nothing and blocks nothing. Concurrency stops cancelling: a main run is the only proof its own commit deploys, so later pushes queue behind it.

**What the lane no longer covers.** A deploy-surface PR merges without cluster proof; the proof lands minutes later as a run on `main`, and a red one is a revert candidate rather than a blocked merge. Release descriptor bumps carry `[skip ci]` and never triggered this lane on any event, so image-bump coverage is unchanged (dispatch remains the manual route).

**Verified.** `actionlint` is clean. The trigger itself can only be exercised after merge; the deploy body is untouched since #2611's green end-to-end run.