### PR TITLE
fix(ai-cost): put the billed figure on the tool's card, not a card of its own

### DIFF
--- a/src/frontend/src/components/portal/ai-cost-view.test.tsx
+++ b/src/frontend/src/components/portal/ai-cost-view.test.tsx
@@ -128,9 +128,10 @@ beforeEach(() => {
   mocks.grid.previousByKey = new Map();
   mocks.tools.byKey = new Map([
     ["ai.cost", toolBreakdown("ai.cost", [[pid("a"), "claude_code", 100], [pid("b"), "claude_code", 50]])],
+    // `claude`, the code seat billing actually reports — not `claude_code`.
     ["ai.extra_usage_cost", toolBreakdown("ai.extra_usage_cost", [
-      [pid("a"), "claude_code", 8],
-      [pid("b"), "claude_code", 4],
+      [pid("a"), "claude", 8],
+      [pid("b"), "claude", 4],
     ])],
     ["ai.accepted_lines", toolBreakdown("ai.accepted_lines", [
       [pid("a"), "claude_code", 600],

--- a/src/frontend/src/components/portal/ai-cost-view.tsx
+++ b/src/frontend/src/components/portal/ai-cost-view.tsx
@@ -182,9 +182,12 @@ export function AiCostView({ item }: { item: string | null }) {
 
   const toolRows = useMemo<ToolRow[]>(() => {
     const cost = aggregateByTool(toolData.byKey.get(COST_KEY), memberIds);
-    const actual = aggregateByTool(
-      toolData.byKey.get(ACTUAL_COST_KEY),
-      memberIds,
+    // Claude Team bills the seat under `claude`; the coding usage that seat
+    // paid for arrives as `claude_code`. One card, not two.
+    const actual = new Map(
+      [...aggregateByTool(toolData.byKey.get(ACTUAL_COST_KEY), memberIds)].map(
+        ([tool, sums]) => [tool === "claude" ? "claude_code" : tool, sums] as const,
+      ),
     );
     const lines = aggregateByTool(toolData.byKey.get(LINES_KEY), memberIds);
     const tools = new Set([...cost.keys(), ...actual.keys(), ...lines.keys()]);


### PR DESCRIPTION
Refs #2479. Follows #2672, which introduced this.

**Why.** Claude Team bills the seat under `claude`, while the coding usage that seat paid for arrives as `claude_code`. The per-tool section groups by the reported code, so the billed amount became a card of its own — titled with the raw code, a real charge beside `0 users · 0 lines` — and the Claude Code card lost it.

**What changed.** One line: the key is renamed when the billed sums are collected, so the figure lands on the tool's own card and the third card stops existing.

**The priced figures keep the code they arrive with.** `cost_usd` also reaches gold from assistant usage under `claude`, and that row is Claude chat — a different tool. Renaming it too would silently add chat spend to Claude Code, which is why this touches only the billed map and not `aggregateByTool`.

Rendered from the component, on fixture values:

```
before                                  after
──────────────────────────────────      ──────────────────────────────────
Claude Code                             Claude Code
$150                                    $150
potential cost                          potential cost
1 users · 600 lines                     actual cost $12 · 1 users · 600 lines

claude                                  (no third card)
—
potential cost not tracked
actual cost $12 · 0 users · 0 lines
```

**Verified.** No test was added — the existing one passed on the bug because its fixture claimed both metrics report `claude_code`, a consistency the warehouse does not have. It now carries the code seat billing sends, and fails 1 when the rename is removed. `tsc -b`, `eslint . --max-warnings 0`, and 195 files / 1716 tests pass. Not run: a stand — MSW mocks emit only `claude_code` and `cursor`, so they cannot reproduce the split.