### PR TITLE
feat(ai-cost): chain only the invoices this connector has not enriched

### DIFF
--- a/src/ingestion/connectors/ai/claude-team-invoices/README.md
+++ b/src/ingestion/connectors/ai/claude-team-invoices/README.md
@@ -79,3 +79,19 @@ badly), `unparsable_url` (a hosted URL was offered but no longer matches), and
 URLs that were offered count towards drift: if more than half of them fail to
 parse the run fails instead, because that is a format change, and a run of
 unpriced rows would read as the vendor having stopped charging for seats.
+
+## What a later sync repeats
+
+The listing is read in full every sync, and every invoice emits its own row from
+it — so the money the wrapper reports is always current, and source freshness,
+which watches how recently anything arrived, keeps its anchor.
+
+The chain is what a later sync skips. An invoice it has already followed to the
+end is recognised by the identity decoded from its hosted URL, and the two Stripe
+hops are not repeated: its lines are in bronze, and a settled invoice's lines do
+not move. The connector remembers only what the listing cannot supply — the
+invoice id its bronze rows are keyed under, and the period those lines gave.
+
+A chain that failed is not remembered, so it is tried again on the next sync.
+Losing the memory entirely — a connection recreated, say — costs one expensive
+sync and nothing else: every invoice is simply chained again.

--- a/src/ingestion/connectors/ai/claude-team-invoices/source_claude_team_invoices/streams.py
+++ b/src/ingestion/connectors/ai/claude-team-invoices/source_claude_team_invoices/streams.py
@@ -36,13 +36,22 @@ from datetime import UTC, datetime
 from typing import Any
 
 import requests
-from airbyte_cdk.sources.streams import Stream
+from airbyte_cdk.sources.streams import CheckpointMixin, Stream
 
-from source_claude_team_invoices.stripe_chain import StripeChainError, build_records, read_bootstrap, unique_key_parts
+from source_claude_team_invoices.stripe_chain import (
+    CHAIN_OK,
+    StripeChainError,
+    build_records,
+    read_bootstrap,
+    unique_key_parts,
+)
 
 STRIPE_VERSION = "2026-06-24.dahlia"
 BOOTSTRAP_HOST = "https://invoicedata.stripe.com"
 STRIPE_API = "https://api.stripe.com/v1"
+
+# The one key in the stream's state blob.
+STATE_ENRICHED = "enriched"
 
 PER_PAGE = 12
 # Bounds on the two cursor walks, far above any real history. They guard
@@ -59,10 +68,16 @@ def _now_iso() -> str:
     return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-class InvoiceLines(Stream):
+class InvoiceLines(Stream, CheckpointMixin):
     """`claude_team_invoice_lines` — one record per invoice, plus one per line."""
 
     primary_key = "unique_key"
+    # What survives between syncs is not a field of a record but the set of
+    # invoices already chained, so the cursor is source-defined. Declaring one at
+    # all is what makes the platform give this connection `syncMode: incremental`
+    # and therefore keep that set (reconcile-connectors' catalogue normaliser);
+    # `destinationSyncMode` stays `append`, so bronze is written as before.
+    cursor_field = "collected_at"
 
     def __init__(self, config: Mapping[str, Any]) -> None:
         self._proxy_url = str(config["proxy_url"]).rstrip("/")
@@ -72,6 +87,11 @@ class InvoiceLines(Stream):
         self._source_id = config["insight_source_id"]
         self._session = requests.Session()
         self._chained = False
+        # INVARIANT: `_known` is the map as of the start of the run and is never
+        # written to during one. What a run learns goes to `_learned`, so which
+        # invoices it chains cannot depend on the order of its own records.
+        self._known: dict[str, dict[str, Any]] = {}
+        self._learned: dict[str, dict[str, Any]] = {}
 
     @property
     def name(self) -> str:
@@ -141,6 +161,44 @@ class InvoiceLines(Stream):
         record["unique_key"] = "-".join([self._tenant_id, self._source_id, *(str(p) for p in unique_key_parts(record))])
         return record
 
+    @property
+    def state(self) -> MutableMapping[str, Any]:
+        """An index into bronze: identity -> the keys its rows are already under.
+
+        `invoice_id` is what bronze stores this invoice's own row and its
+        `(invoice_id, line_id)` lines under, so every entry names the rows it
+        stands for. The period rides along because it is the one thing on the
+        invoice's row that the listing cannot supply — it comes from the lines.
+        Nothing here is a credential: the ephemeral key and the hosted URL that
+        carries it are never written to state.
+        """
+        return {STATE_ENRICHED: {**self._known, **self._learned}}
+
+    @state.setter
+    def state(self, value: Mapping[str, Any]) -> None:
+        stored = value.get(STATE_ENRICHED) if isinstance(value, Mapping) else None
+        self._known = dict(stored) if isinstance(stored, Mapping) else {}
+        self._learned = {}
+
+    def _remember(self, record: Mapping[str, Any]) -> None:
+        """Record what a completed chain found, so the next sync can skip it.
+
+        Only an invoice's own row, and only on `ok`: a chain that failed one way
+        is not remembered and is tried again, which is what makes a transient
+        failure clear itself.
+        """
+        if record.get("line_id") or record.get("chain_status") != CHAIN_OK:
+            return
+        identity, invoice_id = record.get("invoice_ref"), record.get("invoice_id")
+        if not identity or not invoice_id:
+            return
+        self._learned[str(identity)] = {
+            "invoice_id": invoice_id,
+            "period_start_ts": record.get("period_start_ts"),
+            "period_end_ts": record.get("period_end_ts"),
+        }
+
     def read_records(self, sync_mode: Any, **kwargs: Any) -> Iterable[MutableMapping[str, Any]]:
-        for record in build_records(self._walk_invoices(), self._fetch_lines):
+        for record in build_records(self._walk_invoices(), self._fetch_lines, enriched=self._known):
+            self._remember(record)
             yield self._envelope(record)

--- a/src/ingestion/connectors/ai/claude-team-invoices/source_claude_team_invoices/stripe_chain.py
+++ b/src/ingestion/connectors/ai/claude-team-invoices/source_claude_team_invoices/stripe_chain.py
@@ -328,6 +328,7 @@ def build_records(
     fetch_lines: Callable[[str, str], tuple[str, Sequence[Mapping[str, Any]]]],
     *,
     drift_ratio: float = DRIFT_RATIO,
+    enriched: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> Iterator[dict[str, Any]]:
     """Turn wrapper invoices into records, degrading per invoice.
 
@@ -349,6 +350,11 @@ def build_records(
       * the chain returned         -> `ok`, plus one row per line
     and if more than `drift_ratio` of the URLs the vendor did offer failed to
     parse, the run raises rather than writing rows that carry money but no prices.
+
+    `enriched` maps an invoice's identity to what an earlier chain found for it —
+    the invoice id its bronze rows are keyed under, and the period its lines gave.
+    An invoice listed there yields its own row and no hops: the classification is
+    made for every invoice up front, so the drift guards still see the whole run.
     """
     invoiced = [inv for inv in invoices if not is_draft(inv)]
     skipped = len(invoices) - len(invoiced)
@@ -383,6 +389,19 @@ def build_records(
             absent = not invoice.get("hosted_invoice_url")
             yield invoice_row(invoice, CHAIN_NO_URL if absent else CHAIN_UNPARSABLE, None)
             continue
+
+        identity = stable_invoice_ref(invoice.get("hosted_invoice_url"))
+        known = (enriched or {}).get(identity) if identity else None
+        if known:
+            # Chained by an earlier run: bronze already holds this invoice's lines
+            # under the invoice id below, and a settled invoice's lines do not
+            # move. The row is rebuilt from the listing, so the wrapper's money is
+            # as fresh as a chained one's — only the two hops are skipped.
+            yield invoice_row(
+                invoice, CHAIN_OK, known.get("invoice_id"), (known.get("period_start_ts"), known.get("period_end_ts"))
+            )
+            continue
+
         try:
             invoice_id, lines = fetch_lines(ref.acct, ref.token)
             unreadable = unreadable_seat_prices(lines)

--- a/src/ingestion/connectors/ai/claude-team-invoices/tests/test_build_records.py
+++ b/src/ingestion/connectors/ai/claude-team-invoices/tests/test_build_records.py
@@ -310,3 +310,51 @@ def test_two_gaps_of_one_batch_stay_two_rows() -> None:
 def test_two_lines_of_one_invoice_get_different_keys() -> None:
     lines = [r for r in build_records([invoice()], lines_ok) if r["line_id"]]
     assert unique_key_parts(lines[0]) != unique_key_parts(lines[1])
+
+
+# An invoice the connector has already chained. Bronze holds its lines under the
+# invoice id below, and a settled invoice's lines do not move — so the two hops
+# are what a later run skips, never the row.
+ENRICHED = {"acct_1ABC,_ent1ABC": {"invoice_id": "in_1ABC", "period_start_ts": 1756684800, "period_end_ts": 1759276800}}
+
+
+def lines_never(acct: str, token: str) -> tuple[str, Sequence[Mapping[str, Any]]]:
+    raise AssertionError("the chain ran for an invoice that was already enriched")
+
+
+def test_an_already_enriched_invoice_is_not_chained_again() -> None:
+    rows = list(build_records([invoice()], lines_never, enriched=ENRICHED))
+    assert [r["chain_status"] for r in rows] == ["ok"]
+    assert rows[0]["invoice_id"] == "in_1ABC"
+
+
+def test_it_carries_the_period_the_chain_found_because_the_listing_has_none() -> None:
+    """The period comes from the lines, so skipping the hops would lose it — and a
+    row without it would replace a good row with a worse one."""
+    row = next(iter(build_records([invoice()], lines_never, enriched=ENRICHED)))
+    assert (row["period_start_ts"], row["period_end_ts"]) == (1756684800, 1759276800)
+
+
+def test_the_wrappers_money_is_read_again_rather_than_remembered() -> None:
+    """Only the two hops are skipped. A total the vendor restates still lands."""
+    row = next(iter(build_records([invoice(total=9900, total_excluding_tax=9000)], lines_never, enriched=ENRICHED)))
+    assert (row["invoice_total"], row["invoice_total_excluding_tax"]) == (9900, 9000)
+
+
+def test_an_enriched_invoice_repeats_the_key_it_already_has() -> None:
+    """Same identity, so the row replaces its own rather than standing beside it."""
+    chained = next(iter(build_records([invoice()], lines_ok)))
+    skipped = next(iter(build_records([invoice()], lines_never, enriched=ENRICHED)))
+    assert unique_key_parts(chained) == unique_key_parts(skipped)
+
+
+def test_an_invoice_absent_from_the_map_still_chains() -> None:
+    other = {"acct_1ABC,_someone_else": {"invoice_id": "in_OTHER"}}
+    rows = list(build_records([invoice()], lines_ok, enriched=other))
+    assert [r["chain_status"] for r in rows] == ["ok", "ok", "ok"], "its own row plus one per line"
+
+
+def test_no_map_at_all_chains_everything() -> None:
+    """The first sync after a deploy carries no state and behaves as before."""
+    rows = list(build_records([invoice()], lines_ok, enriched={}))
+    assert len([r for r in rows if r["line_id"]]) == 2

--- a/src/ingestion/connectors/ai/claude-team-invoices/tests/test_stream_over_http.py
+++ b/src/ingestion/connectors/ai/claude-team-invoices/tests/test_stream_over_http.py
@@ -201,3 +201,82 @@ def test_the_ephemeral_key_reaches_neither_a_record_nor_a_log_line(
     blob = json.dumps(records) + ours
     assert EPHEMERAL_KEY not in blob
     assert TOKEN not in blob, "the hosted-invoice token authorises the bootstrap hop and is a credential too"
+
+
+def test_a_sync_remembers_what_the_chain_found_so_the_next_one_can_skip_it(
+    stream: InvoiceLines, http: rm_module.Mocker
+) -> None:
+    """State is an index into bronze: the invoice id is the key its rows carry."""
+    register_chain(http, [{"data": [subscription_line()], "has_more": False}])
+
+    list(stream.read_records(sync_mode="incremental"))
+
+    remembered = stream.state["enriched"]
+    assert list(remembered) == [f"{ACCT},_entEXAMPLE"]
+    assert remembered[f"{ACCT},_entEXAMPLE"]["invoice_id"] == INVOICE_ID
+
+
+def test_a_remembered_invoice_costs_no_stripe_request(stream: InvoiceLines, http: rm_module.Mocker) -> None:
+    """The saving, asserted by request count rather than by how long a run took."""
+    stream.state = {
+        "enriched": {f"{ACCT},_entEXAMPLE": {"invoice_id": INVOICE_ID, "period_start_ts": 1, "period_end_ts": 2}}
+    }
+    listing = http.get(INVOICES_URL, json={"invoices": [wrapper_invoice()], "next_page": None})
+
+    records = list(stream.read_records(sync_mode="incremental"))
+
+    assert listing.call_count == 1, "the listing is still read in full"
+    stripe_calls = [r for r in http.request_history if r.netloc != "proxy.example"]
+    assert stripe_calls == [], "neither the bootstrap nor the line hop was issued"
+    assert [r["chain_status"] for r in records] == ["ok"], "its own row, and no line rows"
+    assert records[0]["invoice_id"] == INVOICE_ID
+
+
+def test_an_empty_state_chains_everything(stream: InvoiceLines, http: rm_module.Mocker) -> None:
+    """The first sync after a deploy carries nothing, so it behaves as before."""
+    assert stream.state == {"enriched": {}}
+    register_chain(http, [{"data": [subscription_line()], "has_more": False}])
+
+    records = list(stream.read_records(sync_mode="incremental"))
+
+    assert len(records) == 2
+    assert any(r.netloc == "invoicedata.stripe.com" for r in http.request_history)
+
+
+def test_a_failed_chain_is_not_remembered_and_is_tried_again(
+    stream: InvoiceLines, http: rm_module.Mocker, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Otherwise a transient failure would freeze that invoice unenriched."""
+    http.get(INVOICES_URL, json={"invoices": [wrapper_invoice()], "next_page": None})
+    http.get(BOOTSTRAP_URL, status_code=502)
+
+    with caplog.at_level(logging.WARNING):
+        records = list(stream.read_records(sync_mode="incremental"))
+
+    assert [r["chain_status"] for r in records] == ["failed"]
+    assert stream.state == {"enriched": {}}
+
+
+def test_state_carries_no_credential(stream: InvoiceLines, http: rm_module.Mocker) -> None:
+    """It rides the same wire as a record, so the same rule applies to it."""
+    register_chain(http, [{"data": [subscription_line()], "has_more": False}])
+
+    list(stream.read_records(sync_mode="incremental"))
+
+    blob = json.dumps(stream.state)
+    assert EPHEMERAL_KEY not in blob
+    assert TOKEN not in blob, "the token authorises the bootstrap hop"
+
+
+def test_what_a_run_learns_does_not_change_what_that_run_chains(stream: InvoiceLines, http: rm_module.Mocker) -> None:
+    """The map is read as it stood when the run began. Written to mid-run, an
+    invoice would be skipped because an earlier record in the same run had just
+    enriched it — letting a run's own output decide its own behaviour."""
+    two = [wrapper_invoice(), wrapper_invoice(payment_intent="pi_2")]
+    http.get(INVOICES_URL, json={"invoices": two, "next_page": None})
+    bootstrap = http.get(BOOTSTRAP_URL, json={"invoice_id": INVOICE_ID, "ephemeral_key": EPHEMERAL_KEY})
+    http.get(LINES_URL, json={"data": [subscription_line()], "has_more": False})
+
+    list(stream.read_records(sync_mode="incremental"))
+
+    assert bootstrap.call_count == 2, "both were chained; neither was skipped by the other"


### PR DESCRIPTION
Closes #2664.

**Why.** Every sync runs two Stripe hops for every invoice, paced 250 ms apart and bounded at 600 invoices, so the nightly cost grows for the life of an account — and a settled invoice, which cannot change, is re-fetched forever.

**What changed.** The stream remembers, per invoice identity, what an earlier chain found. A listed invoice already there yields its own row and no hops; everything else chains exactly as before.

## How it works

The listing is read in full every sync and every invoice is classified before a single hop is issued, so both drift guards still see the whole run. What a later sync repeats is the row, not the chain: the invoice's own row is rebuilt from the listing, so the wrapper's money stays current and source freshness — which watches how recently anything arrived, on the stated premise that the full list is re-read daily — keeps its anchor. Line rows are not re-emitted; bronze holds them, and a settled invoice's lines do not move. That premise is the reference implementation's, stated at its `updateMatchedInvoice`: amounts and lines immutable, only the wrapper's own fields refreshed.

**State is an index into bronze, not a second source of truth.** Every entry names the rows it stands for — the `invoice_id` they are keyed under — plus the period, the one thing on the invoice's row the listing cannot supply. No credential: neither the ephemeral key nor the hosted URL carrying it. Losing it costs one expensive sync and nothing else. The reference rebuilds its map from its own stored rows each run; an Airbyte source cannot read its destination, and that is the one part of its mechanism this cannot copy.

**The map is read as it stood when the run began.** Written to mid-run, an invoice would be skipped because an earlier record of the same run had just enriched it — letting a run's own output decide its own behaviour. The existing pacing test caught exactly that.

**The descriptor version is left alone.** CI bumps it by one minor when it rebuilds the image, which reconcile classifies as `minor` and which dispatches no rebuild. Declaring a cursor is what makes the connection `syncMode: incremental`; `destinationSyncMode` stays `append`.

**Out of scope.** Re-chaining a recognised invoice when the wrapper restates it. The reference treats a completed chain as final, and here the wrapper's fields refresh anyway because the row is rebuilt from the listing every sync.

**Verified.** Connector suite 96 passed, 12 of them new. A recognised invoice issues zero requests to `invoicedata.stripe.com` and `api.stripe.com` while the listing is still read once — asserted by request count, not by timing. An empty state chains everything, so the first sync after deploy behaves as today; a failed chain is not remembered and is retried. State holds neither the ephemeral key nor the token. Feeding the new catalogue through `normalize_catalog_to_append.py` returns `syncMode: incremental` with `destinationSyncMode: append`. `metrics/test_ai_invoice_silver.py` 12 passed from wiped volumes; ruff clean at the pinned version.
