### PR TITLE
fix(analytics): keep the usage records off the authored query path

### DIFF
--- a/src/backend/services/analytics/src/api/mod.rs
+++ b/src/backend/services/analytics/src/api/mod.rs
@@ -51,8 +51,8 @@ pub(crate) fn forwarded_authorization(headers: &axum::http::HeaderMap) -> Option
         .and_then(|value| value.to_str().ok())
 }
 
-/// Whether identity confirms the caller holds an active `admin` role. An
-/// identity that is absent or unreachable is a server error, never a permit.
+// SAFETY: an identity that is absent or unreachable is a server error, never a
+// permit.
 pub(crate) async fn is_admin_caller(
     state: &AppState,
     headers: &axum::http::HeaderMap,

--- a/src/backend/services/analytics/src/api/mod.rs
+++ b/src/backend/services/analytics/src/api/mod.rs
@@ -21,6 +21,7 @@ use std::sync::Arc;
 use toolkit::api::{
     OpenApiInfo, OpenApiRegistry, OpenApiRegistryImpl, OperationBuilder, ResponseSpec,
 };
+use toolkit_canonical_errors::CanonicalError;
 use utoipa::openapi::RefOr;
 use utoipa::openapi::content::ContentBuilder;
 use utoipa::openapi::header::HeaderBuilder;
@@ -48,6 +49,27 @@ pub(crate) fn forwarded_authorization(headers: &axum::http::HeaderMap) -> Option
     headers
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|value| value.to_str().ok())
+}
+
+/// Whether identity confirms the caller holds an active `admin` role. An
+/// identity that is absent or unreachable is a server error, never a permit.
+pub(crate) async fn is_admin_caller(
+    state: &AppState,
+    headers: &axum::http::HeaderMap,
+) -> Result<bool, CanonicalError> {
+    if !state.identity.is_configured() {
+        tracing::error!("identity service is not configured; admin access cannot be verified");
+        return Err(CanonicalError::internal("failed to verify caller permissions").create());
+    }
+
+    state
+        .identity
+        .is_admin(forwarded_authorization(headers))
+        .await
+        .map_err(|error| {
+            tracing::error!(error = %error, "admin role check failed");
+            CanonicalError::internal("failed to verify caller permissions").create()
+        })
 }
 
 /// Register all analytics routes onto the host's stateless router.

--- a/src/backend/services/analytics/src/api/saved_queries.rs
+++ b/src/backend/services/analytics/src/api/saved_queries.rs
@@ -2,7 +2,7 @@
 //!
 //! CRUD is plain metadata over the `saved_queries` service-DB table, mirroring
 //! the metric CRUD in [`super::handlers`]. Every request is tenant-scoped from
-//! the session `SecurityContext`. The `sql` is validated by the single-SELECT
+//! the session `SecurityContext`. The `sql` is validated by the authored-read
 //! gate on create, update, and run. Only `/run` reaches ClickHouse — it
 //! executes the stored SQL as `presentation_ro` and returns untyped JSON rows.
 //!
@@ -23,7 +23,7 @@ use uuid::Uuid;
 
 use super::AppState;
 use super::error::SavedQueryError;
-use crate::domain::query_gate::validate_single_select;
+use crate::domain::query_gate::validate_authored_read;
 use crate::domain::saved_query::{
     CreateSavedQueryRequest, RunResponse, RunSavedQueryRequest, SavedQuery, SavedQuerySummary,
     UpdateSavedQueryRequest,
@@ -63,7 +63,7 @@ pub async fn create_saved_query(
     Extension(ctx): Extension<SecurityContext>,
     Json(req): Json<CreateSavedQueryRequest>,
 ) -> Result<impl IntoResponse, CanonicalError> {
-    validate_single_select(&req.sql).map_err(invalid_sql)?;
+    validate_authored_read(&req.sql).map_err(invalid_sql)?;
 
     let id = Uuid::now_v7();
     let model = saved_queries::ActiveModel {
@@ -105,7 +105,7 @@ pub async fn update_saved_query(
         model.description = Set(desc);
     }
     if let Some(sql) = req.sql {
-        validate_single_select(&sql).map_err(|e| invalid_sql_for(id, e))?;
+        validate_authored_read(&sql).map_err(|e| invalid_sql_for(id, e))?;
         model.sql = Set(sql);
     }
     model.updated_at = Set(chrono::Utc::now());
@@ -146,10 +146,9 @@ pub async fn run_saved_query(
 ) -> Result<impl IntoResponse, CanonicalError> {
     let saved = find_saved_query(&state, ctx.subject_tenant_id(), id).await?;
 
-    // Re-validate on run: the gate is the write-side barrier, but stored SQL is
-    // gated again here so a run can never reach ClickHouse with anything but a
-    // single read (defense in depth alongside the `presentation_ro` grants).
-    validate_single_select(&saved.sql).map_err(|e| invalid_sql_for(id, e))?;
+    // Re-validate on run: a query stored before a rule existed must not run
+    // under it.
+    validate_authored_read(&saved.sql).map_err(|e| invalid_sql_for(id, e))?;
 
     // Named parameters (#1966): `{tenant}` is always bound from context; the
     // optional `period` binds `{period}`. Both go through ClickHouse's

--- a/src/backend/services/analytics/src/api/saved_queries.rs
+++ b/src/backend/services/analytics/src/api/saved_queries.rs
@@ -3,10 +3,9 @@
 //! CRUD is plain metadata over the `saved_queries` service-DB table, mirroring
 //! the metric CRUD in [`super::handlers`]. Every request is tenant-scoped from
 //! the session `SecurityContext`. The `sql` is validated by the single-SELECT
-//! gate on create, update, and run, and SQL naming an admin-only database is
-//! served on those three only to a caller identity confirms is an admin. Only
-//! `/run` reaches ClickHouse — it executes the stored SQL as `presentation_ro`
-//! and returns untyped JSON rows.
+//! gate on create, update, and run, and a read of an admin-only database is
+//! authorized on all three. Only `/run` reaches ClickHouse — it executes the
+//! stored SQL as `presentation_ro` and returns untyped JSON rows.
 //!
 //! Phase-A scope: `/run` binds named parameters server-side — `{tenant}` always
 //! (from context), `{period}` when supplied (#1966). The injected tenant-row
@@ -153,11 +152,9 @@ pub async fn run_saved_query(
 ) -> Result<impl IntoResponse, CanonicalError> {
     let saved = find_saved_query(&state, ctx.subject_tenant_id(), id).await?;
 
-    // Re-validate on run: a query stored before a rule existed must not run
-    // under it.
+    // INVARIANT: stored SQL is re-gated per run — a saved query has no owner, so
+    // neither the rules nor the caller are the ones it was stored under.
     validate_single_select(&saved.sql).map_err(|e| invalid_sql_for(id, e))?;
-    // INVARIANT: a saved query has no owner, so the role is checked on every run,
-    // not once when the query was stored.
     authorize_read(&state, &headers, &saved.sql).await?;
 
     // Named parameters (#1966): `{tenant}` is always bound from context; the
@@ -280,8 +277,6 @@ async fn find_saved_query(
         })
 }
 
-/// SQL that reads an admin-only database is served only to a caller identity
-/// confirms is an admin.
 async fn authorize_read(
     state: &AppState,
     headers: &HeaderMap,

--- a/src/backend/services/analytics/src/api/saved_queries.rs
+++ b/src/backend/services/analytics/src/api/saved_queries.rs
@@ -2,9 +2,11 @@
 //!
 //! CRUD is plain metadata over the `saved_queries` service-DB table, mirroring
 //! the metric CRUD in [`super::handlers`]. Every request is tenant-scoped from
-//! the session `SecurityContext`. The `sql` is validated by the authored-read
-//! gate on create, update, and run. Only `/run` reaches ClickHouse — it
-//! executes the stored SQL as `presentation_ro` and returns untyped JSON rows.
+//! the session `SecurityContext`. The `sql` is validated by the single-SELECT
+//! gate on create, update, and run, and SQL naming an admin-only database is
+//! served on those three only to a caller identity confirms is an admin. Only
+//! `/run` reaches ClickHouse — it executes the stored SQL as `presentation_ro`
+//! and returns untyped JSON rows.
 //!
 //! Phase-A scope: `/run` binds named parameters server-side — `{tenant}` always
 //! (from context), `{period}` when supplied (#1966). The injected tenant-row
@@ -14,16 +16,16 @@ use std::sync::Arc;
 
 use axum::Json;
 use axum::extract::{Extension, Path};
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, NotSet, QueryFilter, Set};
 use toolkit_canonical_errors::CanonicalError;
 use toolkit_security::SecurityContext;
 use uuid::Uuid;
 
-use super::AppState;
 use super::error::SavedQueryError;
-use crate::domain::query_gate::validate_authored_read;
+use super::{AppState, is_admin_caller};
+use crate::domain::query_gate::{admin_only_database, validate_single_select};
 use crate::domain::saved_query::{
     CreateSavedQueryRequest, RunResponse, RunSavedQueryRequest, SavedQuery, SavedQuerySummary,
     UpdateSavedQueryRequest,
@@ -61,9 +63,11 @@ pub async fn get_saved_query(
 pub async fn create_saved_query(
     Extension(state): Extension<Arc<AppState>>,
     Extension(ctx): Extension<SecurityContext>,
+    headers: HeaderMap,
     Json(req): Json<CreateSavedQueryRequest>,
 ) -> Result<impl IntoResponse, CanonicalError> {
-    validate_authored_read(&req.sql).map_err(invalid_sql)?;
+    validate_single_select(&req.sql).map_err(invalid_sql)?;
+    authorize_read(&state, &headers, &req.sql).await?;
 
     let id = Uuid::now_v7();
     let model = saved_queries::ActiveModel {
@@ -92,6 +96,7 @@ pub async fn update_saved_query(
     Extension(state): Extension<Arc<AppState>>,
     Extension(ctx): Extension<SecurityContext>,
     Path(id): Path<Uuid>,
+    headers: HeaderMap,
     Json(req): Json<UpdateSavedQueryRequest>,
 ) -> Result<impl IntoResponse, CanonicalError> {
     let existing = find_saved_query(&state, ctx.subject_tenant_id(), id).await?;
@@ -105,7 +110,8 @@ pub async fn update_saved_query(
         model.description = Set(desc);
     }
     if let Some(sql) = req.sql {
-        validate_authored_read(&sql).map_err(|e| invalid_sql_for(id, e))?;
+        validate_single_select(&sql).map_err(|e| invalid_sql_for(id, e))?;
+        authorize_read(&state, &headers, &sql).await?;
         model.sql = Set(sql);
     }
     model.updated_at = Set(chrono::Utc::now());
@@ -142,13 +148,17 @@ pub async fn run_saved_query(
     Extension(state): Extension<Arc<AppState>>,
     Extension(ctx): Extension<SecurityContext>,
     Path(id): Path<Uuid>,
+    headers: HeaderMap,
     body: Option<Json<RunSavedQueryRequest>>,
 ) -> Result<impl IntoResponse, CanonicalError> {
     let saved = find_saved_query(&state, ctx.subject_tenant_id(), id).await?;
 
     // Re-validate on run: a query stored before a rule existed must not run
     // under it.
-    validate_authored_read(&saved.sql).map_err(|e| invalid_sql_for(id, e))?;
+    validate_single_select(&saved.sql).map_err(|e| invalid_sql_for(id, e))?;
+    // INVARIANT: a saved query has no owner, so the role is checked on every run,
+    // not once when the query was stored.
+    authorize_read(&state, &headers, &saved.sql).await?;
 
     // Named parameters (#1966): `{tenant}` is always bound from context; the
     // optional `period` binds `{period}`. Both go through ClickHouse's
@@ -268,6 +278,26 @@ async fn find_saved_query(
                 .with_resource(id.to_string())
                 .create()
         })
+}
+
+/// SQL that reads an admin-only database is served only to a caller identity
+/// confirms is an admin.
+async fn authorize_read(
+    state: &AppState,
+    headers: &HeaderMap,
+    sql: &str,
+) -> Result<(), CanonicalError> {
+    let Some(database) = admin_only_database(sql) else {
+        return Ok(());
+    };
+
+    if is_admin_caller(state, headers).await? {
+        return Ok(());
+    }
+
+    Err(SavedQueryError::permission_denied()
+        .with_reason(format!("admin role required to read `{database}`"))
+        .create())
 }
 
 fn invalid_sql(reason: String) -> CanonicalError {

--- a/src/backend/services/analytics/src/api/usage.rs
+++ b/src/backend/services/analytics/src/api/usage.rs
@@ -11,7 +11,7 @@ use toolkit_security::SecurityContext;
 use uuid::Uuid;
 
 use super::error::UsageError;
-use super::{AppState, forwarded_authorization};
+use super::{AppState, is_admin_caller};
 
 /// DDL owned by `scripts/migrations/20260816000000_usage-events.sql`; the
 /// service holds INSERT and SELECT here, never CREATE.
@@ -481,23 +481,10 @@ fn read_error(error: clickhouse::error::Error) -> CanonicalError {
 }
 
 async fn require_admin(state: &AppState, headers: &HeaderMap) -> Result<(), CanonicalError> {
-    if !state.identity.is_configured() {
-        tracing::error!("identity service is not configured; admin access cannot be verified");
-        return Err(CanonicalError::internal("failed to verify caller permissions").create());
-    }
-
-    let is_admin = state
-        .identity
-        .is_admin(forwarded_authorization(headers))
-        .await
-        .map_err(|error| {
-            tracing::error!(error = %error, "admin role check failed");
-            CanonicalError::internal("failed to verify caller permissions").create()
-        })?;
-
-    if is_admin {
+    if is_admin_caller(state, headers).await? {
         return Ok(());
     }
+
     Err(UsageError::permission_denied()
         .with_reason("admin role required for this operation")
         .create())

--- a/src/backend/services/analytics/src/domain/metric_crud.rs
+++ b/src/backend/services/analytics/src/domain/metric_crud.rs
@@ -21,7 +21,7 @@ use crate::domain::metric_definitions::definition::{
     MetricComputation, MetricDirection, MetricFormat, MetricInputRole, ValueTransform,
 };
 use crate::domain::metric_key::parse_metric_key;
-use crate::domain::query_gate::validate_authored_read;
+use crate::domain::query_gate::validate_custom_observation_sql;
 
 #[cfg(test)]
 #[path = "metric_crud_live_tests.rs"]
@@ -281,7 +281,7 @@ fn validate_observation_sql(graph: &CustomMetric) -> Result<(), GraphViolation> 
             format!("must be at most {MAX_OBSERVATION_SQL_BYTES} bytes"),
         ));
     }
-    validate_authored_read(&graph.observation_sql)
+    validate_custom_observation_sql(&graph.observation_sql)
         .map_err(|reason| violation("observation_sql", reason))
 }
 

--- a/src/backend/services/analytics/src/domain/metric_crud.rs
+++ b/src/backend/services/analytics/src/domain/metric_crud.rs
@@ -21,7 +21,7 @@ use crate::domain::metric_definitions::definition::{
     MetricComputation, MetricDirection, MetricFormat, MetricInputRole, ValueTransform,
 };
 use crate::domain::metric_key::parse_metric_key;
-use crate::domain::query_gate::validate_custom_observation_sql;
+use crate::domain::query_gate::validate_authored_read;
 
 #[cfg(test)]
 #[path = "metric_crud_live_tests.rs"]
@@ -281,7 +281,7 @@ fn validate_observation_sql(graph: &CustomMetric) -> Result<(), GraphViolation> 
             format!("must be at most {MAX_OBSERVATION_SQL_BYTES} bytes"),
         ));
     }
-    validate_custom_observation_sql(&graph.observation_sql)
+    validate_authored_read(&graph.observation_sql)
         .map_err(|reason| violation("observation_sql", reason))
 }
 

--- a/src/backend/services/analytics/src/domain/query_gate.rs
+++ b/src/backend/services/analytics/src/domain/query_gate.rs
@@ -5,11 +5,7 @@
 //! unparseable input are rejected. Using a parser (not hand-rolled scanning)
 //! keeps a `;` inside a string/comment/identifier from hiding a second
 //! statement. Defense in depth: the `presentation_ro` grants (#1963) are the
-//! real boundary — except where one account serves both an admin-gated route
-//! and this one, which no grant can separate. Those databases are named here:
-//! [`admin_only_database`] tells a caller-scoped route to check the role, and
-//! [`validate_custom_observation_sql`] refuses them outright, having no reader
-//! to check.
+//! real boundary, except for the databases named in [`ADMIN_ONLY_DATABASES`].
 
 use sqlparser::ast::Statement;
 use sqlparser::dialect::ClickHouseDialect;
@@ -58,8 +54,11 @@ const DENIED_TABLE_FUNCTIONS: &[&str] = &[
 ];
 
 /// Databases only an admin may read. `product_usage` holds the records the
-/// admin-gated usage summary serves, which the service account can read for
-/// that route.
+/// admin-gated usage summary serves, and today one ClickHouse account serves
+/// that route and this path alike, so the grants cannot tell the two readers
+/// apart: a caller-scoped route asks [`admin_only_database`] and then checks the
+/// role, and [`validate_custom_observation_sql`] refuses outright, having no
+/// reader to check.
 const ADMIN_ONLY_DATABASES: &[&str] = &["product_usage"];
 
 /// Reject anything that is not a single read statement (`SELECT`/`WITH`).
@@ -79,11 +78,11 @@ pub fn validate_single_select(sql: &str) -> Result<(), String> {
 
 /// Gate a custom observation source's SQL: a single read (as above) that names
 /// no admin-only database and calls no external/remote table function. The
-/// compiler wraps this SQL as
-/// `FROM (<sql>)` and executes it as `presentation_ro`; the outer tenant
-/// predicate filters the rows it *emits*, not the tables it *reads*, so denying
-/// the functions that escape the warehouse contract is what keeps a custom
-/// source inside the same boundary a managed one has. Tenant-row isolation of
+/// compiler wraps this SQL as `FROM (<sql>)` and executes it as
+/// `presentation_ro`; the outer tenant predicate filters the rows it *emits*,
+/// not the tables it *reads*, so denying the functions that escape the warehouse
+/// contract is what keeps a custom source inside the same boundary a managed one
+/// has. Tenant-row isolation of
 /// the warehouse relations themselves is the authorship-trust + experimental
 /// gate, the same posture as the saved-query console.
 pub fn validate_custom_observation_sql(sql: &str) -> Result<(), String> {
@@ -165,14 +164,31 @@ fn ends_table_factor(token: &Token) -> bool {
 }
 
 /// Return the first admin-only database `sql` names, if any. Matched wherever
-/// the name appears — a table function takes its database as a string argument.
+/// the name appears, not only in qualified-name position: a table function takes
+/// its database as a string argument.
 pub fn admin_only_database(sql: &str) -> Option<&'static str> {
     let lowered = sql.to_ascii_lowercase();
 
     ADMIN_ONLY_DATABASES
         .iter()
         .copied()
-        .find(|database| lowered.contains(database))
+        .find(|database| names(&lowered, database))
+}
+
+/// Whether `lowered` carries `name` as a whole identifier — a longer name that
+/// merely contains it (`product_usage_score`) is a different relation.
+fn names(lowered: &str, name: &str) -> bool {
+    let bytes = lowered.as_bytes();
+
+    lowered.match_indices(name).any(|(at, hit)| {
+        let before = at.checked_sub(1).map(|index| bytes[index]);
+        let after = bytes.get(at + hit.len()).copied();
+        !before.is_some_and(continues_identifier) && !after.is_some_and(continues_identifier)
+    })
+}
+
+fn continues_identifier(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_'
 }
 
 /// Return the first denied table-function name called in `sql`, if any. A call
@@ -211,15 +227,10 @@ mod tests {
     #[test]
     fn a_read_of_the_usage_event_store_is_admin_only() {
         for sql in [
-            "SELECT person_id, session_id, path, ts FROM product_usage.usage_events LIMIT 5",
+            "SELECT person_id, path, ts FROM product_usage.usage_events LIMIT 5",
             "SELECT * FROM Product_Usage.Usage_Events",
-            "SELECT * FROM `product_usage`.usage_events",
             "SELECT * FROM `product_usage.usage_events`",
-            "WITH visits AS (SELECT ts FROM product_usage.usage_events) SELECT * FROM visits",
-            "SELECT s.id FROM silver.t AS s JOIN product_usage.usage_events AS u USING (id)",
-            "SELECT id FROM silver.t WHERE id IN (SELECT person_id FROM product_usage.usage_events)",
             "SELECT * FROM merge('product_usage', 'usage_events')",
-            "SELECT * FROM remote('host:9000', 'product_usage.usage_events')",
         ] {
             assert_eq!(
                 admin_only(sql),
@@ -234,12 +245,9 @@ mod tests {
         for sql in [
             "SELECT 1",
             "SELECT * FROM silver.events",
-            "SELECT count() FROM insight.metric_values",
             "SELECT person_id FROM identity.identity_persons",
-            "SELECT * FROM person.map",
-            "SELECT * FROM presentation.cached_result",
-            "SELECT * FROM events",
             "SELECT usage_events FROM silver.events",
+            "SELECT product_usage_score FROM silver.events",
         ] {
             assert_eq!(admin_only(sql), None, "should need no role: {sql:?}");
         }
@@ -247,7 +255,6 @@ mod tests {
 
     #[test]
     fn a_custom_observation_source_may_not_read_an_admin_only_database() {
-        // A metric definition has no reader whose role could be checked.
         assert!(custom("SELECT ts FROM product_usage.usage_events").is_err());
     }
 

--- a/src/backend/services/analytics/src/domain/query_gate.rs
+++ b/src/backend/services/analytics/src/domain/query_gate.rs
@@ -6,7 +6,10 @@
 //! keeps a `;` inside a string/comment/identifier from hiding a second
 //! statement. Defense in depth: the `presentation_ro` grants (#1963) are the
 //! real boundary — except where one account serves both an admin-gated route
-//! and this one, which no grant can separate and this gate refuses by name.
+//! and this one, which no grant can separate. Those databases are named here:
+//! [`admin_only_database`] tells a caller-scoped route to check the role, and
+//! [`validate_custom_observation_sql`] refuses them outright, having no reader
+//! to check.
 
 use sqlparser::ast::Statement;
 use sqlparser::dialect::ClickHouseDialect;
@@ -54,14 +57,14 @@ const DENIED_TABLE_FUNCTIONS: &[&str] = &[
     "dictionary",
 ];
 
-/// Databases the query path may not read. `product_usage` holds the records
-/// the admin-gated usage summary serves, which the service account can read
-/// for that route.
-const DENIED_DATABASES: &[&str] = &["product_usage"];
+/// Databases only an admin may read. `product_usage` holds the records the
+/// admin-gated usage summary serves, which the service account can read for
+/// that route.
+const ADMIN_ONLY_DATABASES: &[&str] = &["product_usage"];
 
 /// Reject anything that is not a single read statement (`SELECT`/`WITH`).
 /// Returns a short, user-facing reason on rejection.
-fn validate_single_select(sql: &str) -> Result<(), String> {
+pub fn validate_single_select(sql: &str) -> Result<(), String> {
     let statements = parse_read_statements(sql)?;
 
     match statements.as_slice() {
@@ -74,24 +77,9 @@ fn validate_single_select(sql: &str) -> Result<(), String> {
     }
 }
 
-/// Gate SQL a caller authored: a single read (as above) that names no database
-/// the query path may not read. A saved query and a custom observation source
-/// both run under the service's own ClickHouse account, so a database that
-/// account reads for an admin-gated route of its own is refused here.
-pub fn validate_authored_read(sql: &str) -> Result<(), String> {
-    validate_single_select(sql)?;
-
-    if let Some(name) = first_denied_database(sql) {
-        return Err(format!(
-            "database `{name}` is not readable on the query path"
-        ));
-    }
-
-    Ok(())
-}
-
-/// Gate a custom observation source's SQL: an authored read (as above) that
-/// calls no external/remote table function. The compiler wraps this SQL as
+/// Gate a custom observation source's SQL: a single read (as above) that names
+/// no admin-only database and calls no external/remote table function. The
+/// compiler wraps this SQL as
 /// `FROM (<sql>)` and executes it as `presentation_ro`; the outer tenant
 /// predicate filters the rows it *emits*, not the tables it *reads*, so denying
 /// the functions that escape the warehouse contract is what keeps a custom
@@ -99,7 +87,13 @@ pub fn validate_authored_read(sql: &str) -> Result<(), String> {
 /// the warehouse relations themselves is the authorship-trust + experimental
 /// gate, the same posture as the saved-query console.
 pub fn validate_custom_observation_sql(sql: &str) -> Result<(), String> {
-    validate_authored_read(sql)?;
+    validate_single_select(sql)?;
+
+    if let Some(name) = admin_only_database(sql) {
+        return Err(format!(
+            "database `{name}` is not readable by a custom observation source"
+        ));
+    }
 
     if let Some(name) = first_denied_table_function(sql) {
         return Err(format!(
@@ -170,15 +164,15 @@ fn ends_table_factor(token: &Token) -> bool {
     }
 }
 
-/// Return the first denied database `sql` names, if any. Refused wherever the
-/// name appears — a table function takes its database as a string argument.
-fn first_denied_database(sql: &str) -> Option<&'static str> {
+/// Return the first admin-only database `sql` names, if any. Matched wherever
+/// the name appears — a table function takes its database as a string argument.
+pub fn admin_only_database(sql: &str) -> Option<&'static str> {
     let lowered = sql.to_ascii_lowercase();
 
-    DENIED_DATABASES
+    ADMIN_ONLY_DATABASES
         .iter()
         .copied()
-        .find(|denied| lowered.contains(denied))
+        .find(|database| lowered.contains(database))
 }
 
 /// Return the first denied table-function name called in `sql`, if any. A call
@@ -210,12 +204,12 @@ fn first_denied_table_function(sql: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::validate_authored_read as authored;
+    use super::admin_only_database as admin_only;
     use super::validate_custom_observation_sql as custom;
     use super::validate_single_select as check;
 
     #[test]
-    fn the_query_path_refuses_the_usage_event_store() {
+    fn a_read_of_the_usage_event_store_is_admin_only() {
         for sql in [
             "SELECT person_id, session_id, path, ts FROM product_usage.usage_events LIMIT 5",
             "SELECT * FROM Product_Usage.Usage_Events",
@@ -227,16 +221,16 @@ mod tests {
             "SELECT * FROM merge('product_usage', 'usage_events')",
             "SELECT * FROM remote('host:9000', 'product_usage.usage_events')",
         ] {
-            assert!(
-                authored(sql).is_err(),
-                "must refuse the usage store: {sql:?}"
+            assert_eq!(
+                admin_only(sql),
+                Some("product_usage"),
+                "should be admin-only: {sql:?}"
             );
-            assert!(custom(sql).is_err(), "must refuse the usage store: {sql:?}");
         }
     }
 
     #[test]
-    fn the_query_path_still_reads_the_warehouse_contract() {
+    fn a_read_of_the_warehouse_contract_needs_no_role() {
         for sql in [
             "SELECT 1",
             "SELECT * FROM silver.events",
@@ -247,8 +241,14 @@ mod tests {
             "SELECT * FROM events",
             "SELECT usage_events FROM silver.events",
         ] {
-            assert!(authored(sql).is_ok(), "should accept: {sql:?}");
+            assert_eq!(admin_only(sql), None, "should need no role: {sql:?}");
         }
+    }
+
+    #[test]
+    fn a_custom_observation_source_may_not_read_an_admin_only_database() {
+        // A metric definition has no reader whose role could be checked.
+        assert!(custom("SELECT ts FROM product_usage.usage_events").is_err());
     }
 
     #[test]

--- a/src/backend/services/analytics/src/domain/query_gate.rs
+++ b/src/backend/services/analytics/src/domain/query_gate.rs
@@ -1,15 +1,12 @@
-//! The gate every caller-authored read passes before it reaches ClickHouse.
+//! Gate for the SQL a caller authors on the public query path (#1962).
 //!
 //! Requires the SQL to parse (sqlparser, ClickHouse dialect) to exactly one read
 //! statement — a `SELECT`/`WITH` query. Multiple statements, DDL/DML, and
 //! unparseable input are rejected. Using a parser (not hand-rolled scanning)
 //! keeps a `;` inside a string/comment/identifier from hiding a second
-//! statement.
-//!
-//! Shape is not the whole boundary. The service reads ClickHouse under one
-//! account, so every grant it needs for a route of its own — the admin-gated
-//! usage summary among them — is also in reach of SQL a caller wrote. What the
-//! grants cannot separate, this gate refuses by name.
+//! statement. Defense in depth: the `presentation_ro` grants (#1963) are the
+//! real boundary — except where one account serves both an admin-gated route
+//! and this one, which no grant can separate and this gate refuses by name.
 
 use sqlparser::ast::Statement;
 use sqlparser::dialect::ClickHouseDialect;
@@ -17,7 +14,7 @@ use sqlparser::keywords::Keyword;
 use sqlparser::parser::Parser;
 use sqlparser::tokenizer::{Token, Tokenizer};
 
-/// Table functions caller-authored SQL may not call. These reach data
+/// Table functions a custom observation source may not call. These reach data
 /// outside the read-only warehouse contract — remote/clustered nodes, external
 /// systems, and the local filesystem — so a custom SQL that used one could
 /// exfiltrate to, or read tenant-crossing data from, a source the
@@ -57,9 +54,9 @@ const DENIED_TABLE_FUNCTIONS: &[&str] = &[
     "dictionary",
 ];
 
-/// Databases caller-authored SQL may not read. `product_usage` holds the
-/// records the admin-gated usage summary serves, which the service account
-/// can read for that route.
+/// Databases the query path may not read. `product_usage` holds the records
+/// the admin-gated usage summary serves, which the service account can read
+/// for that route.
 const DENIED_DATABASES: &[&str] = &["product_usage"];
 
 /// Reject anything that is not a single read statement (`SELECT`/`WITH`).
@@ -77,14 +74,10 @@ fn validate_single_select(sql: &str) -> Result<(), String> {
     }
 }
 
-/// Gate SQL a caller authored — a saved query or a custom observation source:
-/// a single read (as above) that names no denied database and calls no
-/// external/remote table function. A custom source's SQL is wrapped as
-/// `FROM (<sql>)` and executed as `presentation_ro`; the outer tenant predicate
-/// filters the rows it *emits*, not the tables it *reads*, so denying what
-/// escapes the warehouse contract is what keeps authored SQL inside the same
-/// boundary a managed read has. Tenant-row isolation of the warehouse relations
-/// themselves is the authorship-trust + experimental gate.
+/// Gate SQL a caller authored: a single read (as above) that names no database
+/// the query path may not read. A saved query and a custom observation source
+/// both run under the service's own ClickHouse account, so a database that
+/// account reads for an admin-gated route of its own is refused here.
 pub fn validate_authored_read(sql: &str) -> Result<(), String> {
     validate_single_select(sql)?;
 
@@ -94,9 +87,23 @@ pub fn validate_authored_read(sql: &str) -> Result<(), String> {
         ));
     }
 
+    Ok(())
+}
+
+/// Gate a custom observation source's SQL: an authored read (as above) that
+/// calls no external/remote table function. The compiler wraps this SQL as
+/// `FROM (<sql>)` and executes it as `presentation_ro`; the outer tenant
+/// predicate filters the rows it *emits*, not the tables it *reads*, so denying
+/// the functions that escape the warehouse contract is what keeps a custom
+/// source inside the same boundary a managed one has. Tenant-row isolation of
+/// the warehouse relations themselves is the authorship-trust + experimental
+/// gate, the same posture as the saved-query console.
+pub fn validate_custom_observation_sql(sql: &str) -> Result<(), String> {
+    validate_authored_read(sql)?;
+
     if let Some(name) = first_denied_table_function(sql) {
         return Err(format!(
-            "table function `{name}` is not allowed on the query path"
+            "table function `{name}` is not allowed in a custom observation source"
         ));
     }
 
@@ -204,6 +211,7 @@ fn first_denied_table_function(sql: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::validate_authored_read as authored;
+    use super::validate_custom_observation_sql as custom;
     use super::validate_single_select as check;
 
     #[test]
@@ -223,6 +231,7 @@ mod tests {
                 authored(sql).is_err(),
                 "must refuse the usage store: {sql:?}"
             );
+            assert!(custom(sql).is_err(), "must refuse the usage store: {sql:?}");
         }
     }
 
@@ -243,9 +252,9 @@ mod tests {
     }
 
     #[test]
-    fn authored_gate_accepts_a_contract_shaped_read() {
+    fn custom_gate_accepts_a_contract_shaped_read() {
         assert!(
-            authored(
+            custom(
                 "SELECT tenant_id, source_key, entity_type, entity_id, metric_date, measure_key, \
                  observed_at, value, subject_key, dimensions FROM silver.a JOIN gold.b USING (id)"
             )
@@ -254,7 +263,7 @@ mod tests {
     }
 
     #[test]
-    fn authored_gate_rejects_external_table_functions() {
+    fn custom_gate_rejects_external_table_functions() {
         for sql in [
             "SELECT * FROM remote('host:9000', db.t)",
             "SELECT * FROM url('http://x/y', CSV)",
@@ -271,19 +280,16 @@ mod tests {
             "SELECT * FROM deltaLakeCluster('c', 's3://b/k')",
             "SELECT * FROM hudiCluster('c', 's3://b/k')",
         ] {
-            assert!(
-                authored(sql).is_err(),
-                "must reject external source: {sql:?}"
-            );
+            assert!(custom(sql).is_err(), "must reject external source: {sql:?}");
         }
     }
 
     #[test]
-    fn authored_gate_allows_a_column_named_like_a_function() {
+    fn custom_gate_allows_a_column_named_like_a_function() {
         // A denied name only matters as a `name(` call; a column or alias that
         // merely shares the name is not a table function.
-        assert!(authored("SELECT file FROM gold.events").is_ok());
-        assert!(authored("SELECT value AS url FROM gold.events").is_ok());
+        assert!(custom("SELECT file FROM gold.events").is_ok());
+        assert!(custom("SELECT value AS url FROM gold.events").is_ok());
     }
 
     #[test]
@@ -299,10 +305,7 @@ mod tests {
             "SELECT r.final FROM silver.t AS r FINAL GROUP BY final",
         ] {
             assert!(check(sql).is_ok(), "should accept FINAL read: {sql:?}");
-            assert!(
-                authored(sql).is_ok(),
-                "authored gate should accept: {sql:?}"
-            );
+            assert!(custom(sql).is_ok(), "custom gate should accept: {sql:?}");
         }
     }
 
@@ -316,13 +319,13 @@ mod tests {
     fn final_does_not_relax_the_gate() {
         assert!(check("SELECT a FROM t AS r FINAL; DROP TABLE t").is_err());
         assert!(check("SELECT a FROM t AS r FINAL b").is_err());
-        assert!(authored("SELECT * FROM remote('h:9000', db.t) AS r FINAL").is_err());
+        assert!(custom("SELECT * FROM remote('h:9000', db.t) AS r FINAL").is_err());
     }
 
     #[test]
-    fn authored_gate_still_enforces_single_select() {
-        assert!(authored("SELECT 1; DROP TABLE t").is_err());
-        assert!(authored("INSERT INTO t VALUES (1)").is_err());
+    fn custom_gate_still_enforces_single_select() {
+        assert!(custom("SELECT 1; DROP TABLE t").is_err());
+        assert!(custom("INSERT INTO t VALUES (1)").is_err());
     }
 
     #[test]

--- a/src/backend/services/analytics/src/domain/query_gate.rs
+++ b/src/backend/services/analytics/src/domain/query_gate.rs
@@ -1,11 +1,15 @@
-//! Single-SELECT gate for the public query path (#1962).
+//! The gate every caller-authored read passes before it reaches ClickHouse.
 //!
 //! Requires the SQL to parse (sqlparser, ClickHouse dialect) to exactly one read
 //! statement — a `SELECT`/`WITH` query. Multiple statements, DDL/DML, and
 //! unparseable input are rejected. Using a parser (not hand-rolled scanning)
 //! keeps a `;` inside a string/comment/identifier from hiding a second
-//! statement. Defense in depth: the `presentation_ro` grants (#1963) are the
-//! real boundary.
+//! statement.
+//!
+//! Shape is not the whole boundary. The service reads ClickHouse under one
+//! account, so every grant it needs for a route of its own — the admin-gated
+//! usage summary among them — is also in reach of SQL a caller wrote. What the
+//! grants cannot separate, this gate refuses by name.
 
 use sqlparser::ast::Statement;
 use sqlparser::dialect::ClickHouseDialect;
@@ -13,7 +17,7 @@ use sqlparser::keywords::Keyword;
 use sqlparser::parser::Parser;
 use sqlparser::tokenizer::{Token, Tokenizer};
 
-/// Table functions a custom observation source may not call. These reach data
+/// Table functions caller-authored SQL may not call. These reach data
 /// outside the read-only warehouse contract — remote/clustered nodes, external
 /// systems, and the local filesystem — so a custom SQL that used one could
 /// exfiltrate to, or read tenant-crossing data from, a source the
@@ -53,9 +57,14 @@ const DENIED_TABLE_FUNCTIONS: &[&str] = &[
     "dictionary",
 ];
 
+/// Databases caller-authored SQL may not read. `product_usage` holds the
+/// records the admin-gated usage summary serves, which the service account
+/// can read for that route.
+const DENIED_DATABASES: &[&str] = &["product_usage"];
+
 /// Reject anything that is not a single read statement (`SELECT`/`WITH`).
 /// Returns a short, user-facing reason on rejection.
-pub fn validate_single_select(sql: &str) -> Result<(), String> {
+fn validate_single_select(sql: &str) -> Result<(), String> {
     let statements = parse_read_statements(sql)?;
 
     match statements.as_slice() {
@@ -68,20 +77,26 @@ pub fn validate_single_select(sql: &str) -> Result<(), String> {
     }
 }
 
-/// Gate a custom observation source's SQL: a single read (as above) that calls
-/// no external/remote table function. The compiler wraps this SQL as
-/// `FROM (<sql>)` and executes it as `presentation_ro`; the outer tenant
-/// predicate filters the rows it *emits*, not the tables it *reads*, so denying
-/// the functions that escape the warehouse contract is what keeps a custom
-/// source inside the same boundary a managed one has. Tenant-row isolation of
-/// the warehouse relations themselves is the authorship-trust + experimental
-/// gate, the same posture as the saved-query console.
-pub fn validate_custom_observation_sql(sql: &str) -> Result<(), String> {
+/// Gate SQL a caller authored — a saved query or a custom observation source:
+/// a single read (as above) that names no denied database and calls no
+/// external/remote table function. A custom source's SQL is wrapped as
+/// `FROM (<sql>)` and executed as `presentation_ro`; the outer tenant predicate
+/// filters the rows it *emits*, not the tables it *reads*, so denying what
+/// escapes the warehouse contract is what keeps authored SQL inside the same
+/// boundary a managed read has. Tenant-row isolation of the warehouse relations
+/// themselves is the authorship-trust + experimental gate.
+pub fn validate_authored_read(sql: &str) -> Result<(), String> {
     validate_single_select(sql)?;
+
+    if let Some(name) = first_denied_database(sql) {
+        return Err(format!(
+            "database `{name}` is not readable on the query path"
+        ));
+    }
 
     if let Some(name) = first_denied_table_function(sql) {
         return Err(format!(
-            "table function `{name}` is not allowed in a custom observation source"
+            "table function `{name}` is not allowed on the query path"
         ));
     }
 
@@ -148,6 +163,17 @@ fn ends_table_factor(token: &Token) -> bool {
     }
 }
 
+/// Return the first denied database `sql` names, if any. Refused wherever the
+/// name appears — a table function takes its database as a string argument.
+fn first_denied_database(sql: &str) -> Option<&'static str> {
+    let lowered = sql.to_ascii_lowercase();
+
+    DENIED_DATABASES
+        .iter()
+        .copied()
+        .find(|denied| lowered.contains(denied))
+}
+
 /// Return the first denied table-function name called in `sql`, if any. A call
 /// is a denied identifier token immediately followed by `(`; a column or alias
 /// merely *named* like one is not (it is not followed by a paren).
@@ -177,13 +203,49 @@ fn first_denied_table_function(sql: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::validate_custom_observation_sql as custom;
+    use super::validate_authored_read as authored;
     use super::validate_single_select as check;
 
     #[test]
-    fn custom_gate_accepts_a_contract_shaped_read() {
+    fn the_query_path_refuses_the_usage_event_store() {
+        for sql in [
+            "SELECT person_id, session_id, path, ts FROM product_usage.usage_events LIMIT 5",
+            "SELECT * FROM Product_Usage.Usage_Events",
+            "SELECT * FROM `product_usage`.usage_events",
+            "SELECT * FROM `product_usage.usage_events`",
+            "WITH visits AS (SELECT ts FROM product_usage.usage_events) SELECT * FROM visits",
+            "SELECT s.id FROM silver.t AS s JOIN product_usage.usage_events AS u USING (id)",
+            "SELECT id FROM silver.t WHERE id IN (SELECT person_id FROM product_usage.usage_events)",
+            "SELECT * FROM merge('product_usage', 'usage_events')",
+            "SELECT * FROM remote('host:9000', 'product_usage.usage_events')",
+        ] {
+            assert!(
+                authored(sql).is_err(),
+                "must refuse the usage store: {sql:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_query_path_still_reads_the_warehouse_contract() {
+        for sql in [
+            "SELECT 1",
+            "SELECT * FROM silver.events",
+            "SELECT count() FROM insight.metric_values",
+            "SELECT person_id FROM identity.identity_persons",
+            "SELECT * FROM person.map",
+            "SELECT * FROM presentation.cached_result",
+            "SELECT * FROM events",
+            "SELECT usage_events FROM silver.events",
+        ] {
+            assert!(authored(sql).is_ok(), "should accept: {sql:?}");
+        }
+    }
+
+    #[test]
+    fn authored_gate_accepts_a_contract_shaped_read() {
         assert!(
-            custom(
+            authored(
                 "SELECT tenant_id, source_key, entity_type, entity_id, metric_date, measure_key, \
                  observed_at, value, subject_key, dimensions FROM silver.a JOIN gold.b USING (id)"
             )
@@ -192,7 +254,7 @@ mod tests {
     }
 
     #[test]
-    fn custom_gate_rejects_external_table_functions() {
+    fn authored_gate_rejects_external_table_functions() {
         for sql in [
             "SELECT * FROM remote('host:9000', db.t)",
             "SELECT * FROM url('http://x/y', CSV)",
@@ -209,16 +271,19 @@ mod tests {
             "SELECT * FROM deltaLakeCluster('c', 's3://b/k')",
             "SELECT * FROM hudiCluster('c', 's3://b/k')",
         ] {
-            assert!(custom(sql).is_err(), "must reject external source: {sql:?}");
+            assert!(
+                authored(sql).is_err(),
+                "must reject external source: {sql:?}"
+            );
         }
     }
 
     #[test]
-    fn custom_gate_allows_a_column_named_like_a_function() {
+    fn authored_gate_allows_a_column_named_like_a_function() {
         // A denied name only matters as a `name(` call; a column or alias that
         // merely shares the name is not a table function.
-        assert!(custom("SELECT file FROM gold.events").is_ok());
-        assert!(custom("SELECT value AS url FROM gold.events").is_ok());
+        assert!(authored("SELECT file FROM gold.events").is_ok());
+        assert!(authored("SELECT value AS url FROM gold.events").is_ok());
     }
 
     #[test]
@@ -234,7 +299,10 @@ mod tests {
             "SELECT r.final FROM silver.t AS r FINAL GROUP BY final",
         ] {
             assert!(check(sql).is_ok(), "should accept FINAL read: {sql:?}");
-            assert!(custom(sql).is_ok(), "custom gate should accept: {sql:?}");
+            assert!(
+                authored(sql).is_ok(),
+                "authored gate should accept: {sql:?}"
+            );
         }
     }
 
@@ -248,13 +316,13 @@ mod tests {
     fn final_does_not_relax_the_gate() {
         assert!(check("SELECT a FROM t AS r FINAL; DROP TABLE t").is_err());
         assert!(check("SELECT a FROM t AS r FINAL b").is_err());
-        assert!(custom("SELECT * FROM remote('h:9000', db.t) AS r FINAL").is_err());
+        assert!(authored("SELECT * FROM remote('h:9000', db.t) AS r FINAL").is_err());
     }
 
     #[test]
-    fn custom_gate_still_enforces_single_select() {
-        assert!(custom("SELECT 1; DROP TABLE t").is_err());
-        assert!(custom("INSERT INTO t VALUES (1)").is_err());
+    fn authored_gate_still_enforces_single_select() {
+        assert!(authored("SELECT 1; DROP TABLE t").is_err());
+        assert!(authored("INSERT INTO t VALUES (1)").is_err());
     }
 
     #[test]

--- a/src/ingestion/scripts/bootstrap-db/presentation-role.sql
+++ b/src/ingestion/scripts/bootstrap-db/presentation-role.sql
@@ -20,5 +20,6 @@ GRANT SELECT, INSERT, CREATE ON presentation.* TO presentation_ro;
 
 -- product_usage (append-only): adoption events (#2573). No CREATE — the table
 -- comes from migrations/20260816000000_usage-events.sql. SELECT serves the
--- admin-gated usage summary; the analytics query gate refuses the database.
+-- admin-gated usage summary; analytics checks the admin role itself for reads
+-- of this database that arrive by any other route.
 GRANT SELECT, INSERT ON product_usage.* TO presentation_ro;

--- a/src/ingestion/scripts/bootstrap-db/presentation-role.sql
+++ b/src/ingestion/scripts/bootstrap-db/presentation-role.sql
@@ -19,5 +19,6 @@ GRANT SELECT ON insight.* TO presentation_ro;
 GRANT SELECT, INSERT, CREATE ON presentation.* TO presentation_ro;
 
 -- product_usage (append-only): adoption events (#2573). No CREATE — the table
--- comes from migrations/20260816000000_usage-events.sql.
+-- comes from migrations/20260816000000_usage-events.sql. SELECT serves the
+-- admin-gated usage summary; the analytics query gate refuses the database.
 GRANT SELECT, INSERT ON product_usage.* TO presentation_ro;

--- a/tests/stand/api/analytics/test_queries.py
+++ b/tests/stand/api/analytics/test_queries.py
@@ -180,17 +180,9 @@ def test_an_update_revalidates_the_sql(api: ApiClient, scratch_saved_query: Save
     )
 
 
-@pytest.mark.parametrize(
-    "statement",
-    [
-        "SELECT person_id, session_id, path, ts FROM product_usage.usage_events LIMIT 5",
-        "SELECT * FROM merge('product_usage', 'usage_events')",
-    ],
-    ids=["qualified-read", "table-function"],
-)
 @pytest.mark.security
 def test_a_read_of_the_usage_records_is_refused_without_the_admin_grant(
-    api: ApiClient, statement: str
+    api: ApiClient,
 ) -> None:
     """`GET /v1/usage/summary` is admin-only, and so are the records behind it.
 
@@ -198,13 +190,12 @@ def test_a_read_of_the_usage_records_is_refused_without_the_admin_grant(
     account can read the usage records because the summary route serves them.
     A caller the summary answers 403 would otherwise read the same rows, other
     people's among them, by storing the read here instead.
-
-    The second case takes the database from a string argument rather than a
-    qualified name.
     """
-    response = api.post(QUERIES, json_body={"name": scratch_name("usage-store"), "sql": statement})
+    response = api.post(
+        QUERIES, json_body={"name": scratch_name("usage-store"), "sql": USAGE_RECORDS_SQL}
+    )
     assert response.status_code == 403, (
-        f"{statement!r} was accepted from a caller holding no admin grant "
+        f"a caller holding no admin grant stored a usage read "
         f"({response.status_code}): {response.text[:300]}"
     )
 

--- a/tests/stand/api/analytics/test_queries.py
+++ b/tests/stand/api/analytics/test_queries.py
@@ -177,6 +177,33 @@ def test_an_update_revalidates_the_sql(api: ApiClient, scratch_saved_query: Save
     )
 
 
+@pytest.mark.parametrize(
+    "statement",
+    [
+        "SELECT person_id, session_id, path, ts FROM product_usage.usage_events LIMIT 5",
+        "SELECT * FROM merge('product_usage', 'usage_events')",
+    ],
+    ids=["qualified-read", "table-function"],
+)
+@pytest.mark.security
+def test_the_usage_records_are_not_readable_through_a_saved_query(
+    api: ApiClient, statement: str
+) -> None:
+    """`GET /v1/usage/summary` is admin-only, and so are the records behind it.
+
+    A saved query runs with the service's own ClickHouse account, and that
+    account can read the usage records because the summary route serves them.
+    Nothing about the route the caller took makes that read admin-checked, so
+    the refusal has to come from the gate — otherwise a caller the summary
+    answers 403 reads the same rows, other people's among them, from here.
+    """
+    response = api.post(QUERIES, json_body={"name": scratch_name("usage-store"), "sql": statement})
+    assert response.status_code == 400, (
+        f"{statement!r} was accepted as a saved query ({response.status_code}): "
+        f"{response.text[:300]}"
+    )
+
+
 @pytest.mark.reliability
 def test_a_deleted_query_leaves_the_listing_and_the_id_stops_resolving(
     api: ApiClient,

--- a/tests/stand/api/analytics/test_queries.py
+++ b/tests/stand/api/analytics/test_queries.py
@@ -24,12 +24,15 @@ The 401 half is in `test_gateway.py`, swept over every operation at once.
 from __future__ import annotations
 
 import pytest
-from insight_stand import ApiClient, Manifest, analytics_path
+from insight_stand import ApiClient, Manifest, PersonaSession, analytics_path
 
 from ..schemas import RunResponse, SavedQuery, SavedQueryListResponse
 from ..scratch import SCRATCH_QUERY_REF, UNKNOWN_ID, create_saved_query, scratch_name
 
 QUERIES = analytics_path("/v1/queries")
+
+#: A read of the admin-only usage records.
+USAGE_RECORDS_SQL = "SELECT person_id, path, ts FROM product_usage.usage_events LIMIT 1"
 
 
 def _query_path(query_id: object, suffix: str = "") -> str:
@@ -186,22 +189,52 @@ def test_an_update_revalidates_the_sql(api: ApiClient, scratch_saved_query: Save
     ids=["qualified-read", "table-function"],
 )
 @pytest.mark.security
-def test_the_usage_records_are_not_readable_through_a_saved_query(
+def test_a_read_of_the_usage_records_is_refused_without_the_admin_grant(
     api: ApiClient, statement: str
 ) -> None:
     """`GET /v1/usage/summary` is admin-only, and so are the records behind it.
 
     A saved query runs with the service's own ClickHouse account, and that
     account can read the usage records because the summary route serves them.
-    Nothing about the route the caller took makes that read admin-checked, so
-    the refusal has to come from the gate — otherwise a caller the summary
-    answers 403 reads the same rows, other people's among them, from here.
+    A caller the summary answers 403 would otherwise read the same rows, other
+    people's among them, by storing the read here instead.
+
+    The second case takes the database from a string argument rather than a
+    qualified name.
     """
     response = api.post(QUERIES, json_body={"name": scratch_name("usage-store"), "sql": statement})
-    assert response.status_code == 400, (
-        f"{statement!r} was accepted as a saved query ({response.status_code}): "
-        f"{response.text[:300]}"
+    assert response.status_code == 403, (
+        f"{statement!r} was accepted from a caller holding no admin grant "
+        f"({response.status_code}): {response.text[:300]}"
     )
+
+
+@pytest.mark.requires_seed("admin_operator")
+@pytest.mark.security
+def test_a_usage_query_an_admin_stored_still_refuses_to_run_for_anybody_else(
+    api: ApiClient, admin_operator_session: PersonaSession
+) -> None:
+    """The admin may author the read; the role is checked again on every run.
+
+    A saved query has no owner — the rows are tenant-scoped, so a query one
+    person stores is listable and runnable by everybody else in the tenant.
+    Checking the role only where the SQL is written would hand the records to
+    exactly the callers the summary refuses.
+    """
+    admin = admin_operator_session.client
+    created = create_saved_query(admin, "usage-store-admin", USAGE_RECORDS_SQL)
+
+    try:
+        ran = admin.post(_query_path(created.id, "/run"), json_body={})
+        assert ran.status_code == 200, f"the admin's own run: {ran.status_code} {ran.text[:300]}"
+
+        refused = api.post(_query_path(created.id, "/run"), json_body={})
+        assert refused.status_code == 403, (
+            f"a caller holding no admin grant ran the admin's usage query "
+            f"({refused.status_code}): {refused.text[:300]}"
+        )
+    finally:
+        admin.delete(_query_path(created.id))
 
 
 @pytest.mark.reliability

--- a/tests/stand/api/conftest.py
+++ b/tests/stand/api/conftest.py
@@ -67,10 +67,10 @@ def api(lead_session: PersonaSession) -> ApiClient:
     """An authenticated client, for cases that are not about who is calling.
 
     A lead rather than an admin on purpose: every analytics operation but
-    `/v1/usage/summary` — and a saved query reading an admin-only database — is
-    open to any authenticated caller, so an ordinary persona is what those
-    endpoints actually face. The usage summary takes `admin_operator_session`
-    directly, and uses this client for its refusal case.
+    `/v1/usage/summary`, and every saved query but one reading an admin-only
+    database, is open to any authenticated caller — so an ordinary persona is
+    what those endpoints actually face. The usage summary takes
+    `admin_operator_session` directly, and uses this client for its refusal case.
     """
     return lead_session.client
 

--- a/tests/stand/api/conftest.py
+++ b/tests/stand/api/conftest.py
@@ -67,9 +67,10 @@ def api(lead_session: PersonaSession) -> ApiClient:
     """An authenticated client, for cases that are not about who is calling.
 
     A lead rather than an admin on purpose: every analytics operation but
-    `/v1/usage/summary` is open to any authenticated caller, so an ordinary
-    persona is what those endpoints actually face. The usage summary takes
-    `admin_operator_session` directly, and uses this client for its refusal case.
+    `/v1/usage/summary` — and a saved query reading an admin-only database — is
+    open to any authenticated caller, so an ordinary persona is what those
+    endpoints actually face. The usage summary takes `admin_operator_session`
+    directly, and uses this client for its refusal case.
     """
     return lead_session.client
 


### PR DESCRIPTION
Closes #2683.

**Why.** The usage summary answers 403 to a caller holding no admin grant, yet the same caller could save `SELECT … FROM product_usage.usage_events`, run it, and read those records — rows belonging to other people among them.

**What changed.** One ClickHouse account serves every analytics route, so the `SELECT` the summary needs is in reach of authored SQL and no grant can separate the two readers. `/v1/queries` create, update and run now ask identity for the admin role when the SQL names `product_usage`; a custom observation source refuses such SQL outright, having no reader whose role could be checked. The grant itself is untouched.

**Run checks the role too, not just the author.** `saved_queries` has no owner column — a query one person stores is listable and runnable by everybody else in the tenant, so authorizing only where SQL is written would still hand the records over.

**The name is matched wherever it appears, as a whole identifier.** A table function takes its database as a string argument, so reading qualified-name positions alone would miss that route; a relation named `product_usage_score` is not a match.

**Out of scope.** Splitting the ClickHouse account so the grant is the boundary again, and the external table functions (`url()`, `s3()`, `file()`) the saved-query path still permits — each wants an issue of its own.

**Verified.** `cargo test -p analytics` — 443 pass, rustfmt and clippy clean; the added gate cases fail without the change. The two stand cases — 403 for a non-admin, and a non-admin refused on an admin-stored query — are written but not run, and the fail-closed identity paths have no Rust coverage yet; both need an environment this branch was not built in.
