### PR TITLE
feat(frontend): identity console — the whole queue, and windows that hold their contents

### DIFF
--- a/src/frontend/src/api/identity-client.ts
+++ b/src/frontend/src/api/identity-client.ts
@@ -157,12 +157,26 @@ export interface AttentionResponse {
   items_truncated?: boolean;
 }
 
+/** The queue's first read — a healthy backlog arrives whole. */
+export const QUEUE_FIRST_PAGE = 200;
+
+/** The service's own ceiling on `limit`: asking past it answers the same page,
+ *  so a reader who has reached it is told to work the backlog down instead.
+ *
+ *  INVARIANT: mirrors `MAX_QUEUE_LIMIT` in the identity-resolution service. */
+export const QUEUE_MAX_ITEMS = 1000;
+
 /**
  * The operator review queue (`GET /resolution/attention`) — accounts the
  * resolver could not decide, with the tenant-wide match rate. Admin-gated
  * server-side; the caller is expected to sit behind `useIsAdmin`.
+ *
+ * There is no cursor: the queue is derived from the whole tenant on every
+ * read, so asking for more of it is a larger `limit`, not a next page.
  */
-export async function getAttention(limit = 200): Promise<AttentionResponse> {
+export async function getAttention(
+  limit: number = QUEUE_FIRST_PAGE,
+): Promise<AttentionResponse> {
   const res = await fetchWithAuth(`${BASE}/resolution/attention?limit=${limit}`);
   if (!res.ok) {
     const body = await res.json().catch(() => null);

--- a/src/frontend/src/components/portal/account-actions.test.tsx
+++ b/src/frontend/src/components/portal/account-actions.test.tsx
@@ -174,10 +174,12 @@ describe("AccountActions", () => {
     );
   });
 
-  // A button that reads like a decision and changes nothing is worse than no
-  // button: the account is already theirs, and the trail would gain a row
-  // saying so twice.
-  it("offers nothing to bind when the account is already that person's", () => {
+  // A press that re-binds an account to the person who already holds it reads
+  // like a decision and changes nothing. Moving it to somebody ELSE is the one
+  // decision left, and it is why an operator opens an account from a person's
+  // own list — so the search takes the button's place rather than the section
+  // disappearing with it.
+  it("offers the search, not a no-op bind, when the account is already that person's", () => {
     render(
       <AccountActions
         accountRef={REF}
@@ -188,11 +190,34 @@ describe("AccountActions", () => {
     );
 
     expect(
-      screen.queryByRole("button", { name: /bind to/i }),
+      screen.queryByRole("button", { name: /bind to selected person/i }),
     ).not.toBeInTheDocument();
-    expect(screen.queryByRole("searchbox")).not.toBeInTheDocument();
+    expect(screen.getByRole("searchbox")).toBeInTheDocument();
+    expect(screen.getByText(/assign to someone else/i)).toBeInTheDocument();
     // The other verbs are untouched — it is still an account under review.
     expect(screen.getByRole("button", { name: /detach/i })).toBeInTheDocument();
+  });
+
+  // The search that replaced the no-op button must not offer the no-op itself.
+  // No `holder` here on purpose: a surface whose row carries no person card
+  // still knows who holds the account, and that is the case this guards.
+  it("keeps the open person out of that search, card or no card", async () => {
+    hooks.search.data = { pages: [{ items: [BOB, CAROL] }] };
+    render(
+      <AccountActions
+        accountRef={REF}
+        binding={binding({ person_id: CAROL.person_id })}
+        candidates={[]}
+        bindTo={CAROL}
+      />,
+    );
+
+    await userEvent.type(screen.getByRole("searchbox"), "park");
+
+    expect(screen.getByRole("button", { name: /bob park/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /carol chen/i }),
+    ).not.toBeInTheDocument();
   });
 
   // Without a person behind the window the picker is the only way in, and the

--- a/src/frontend/src/components/portal/account-actions.tsx
+++ b/src/frontend/src/components/portal/account-actions.tsx
@@ -270,40 +270,45 @@ export function AccountActions({
         </section>
       ) : null}
 
-      {/* One section, two ways in. With a person open behind the window the
-          search is gone — the reader is already inside them, and asking them to
-          find them again is asking twice. Nothing at all once the account is
-          ALREADY theirs: a button that reads like a decision and changes nothing
-          is worse than no button. */}
-      {bindTo === undefined || bindTo === null || boundId !== bindTo.person_id ? (
-        <section>
-          <div className="mb-1.5 text-xs font-medium tracking-wide text-muted-foreground uppercase">
-            {boundId
-              ? t("identities.actions.assign_other")
-              : t("identities.actions.assign_person")}
-          </div>
-          {bindTo ? (
-            <Button
-              type="button"
-              size="sm"
-              disabled={busy}
-              onClick={() => setAction({ kind: "bind", person: bindTo })}
-            >
-              {t("identities.actions.bind_to")}
-            </Button>
-          ) : (
-            <PersonPicker
-              // The holder too: this picker moves an account to somebody
-              // else, and the one person it cannot move it to is the one who
-              // already has it.
-              excludeIds={[...candidates, ...(boundCard ? [boundCard] : [])].map(
-                (c) => c.person_id,
-              )}
-              onPick={(person) => setAction({ kind: "bind", person })}
-            />
-          )}
-        </section>
-      ) : null}
+      {/* One section, two ways in. With a person open behind the window and the
+          account not yet theirs, one press is the whole decision — the reader
+          is already inside that person, and asking them to search for them
+          again is asking twice. Once the account IS theirs that press would
+          change nothing, so the search comes back: moving it to somebody else
+          is the only decision left, and it is exactly the one an operator
+          opened the account to make. */}
+      <section>
+        <div className="mb-1.5 text-xs font-medium tracking-wide text-muted-foreground uppercase">
+          {boundId
+            ? t("identities.actions.assign_other")
+            : t("identities.actions.assign_person")}
+        </div>
+        {bindTo && boundId !== bindTo.person_id ? (
+          <Button
+            type="button"
+            size="sm"
+            disabled={busy}
+            onClick={() => setAction({ kind: "bind", person: bindTo })}
+          >
+            {t("identities.actions.bind_to")}
+          </Button>
+        ) : (
+          <PersonPicker
+            // The holder too: this picker moves an account to somebody else,
+            // and the one person it cannot move it to is the one who already
+            // has it. Named by ID rather than by card — a surface that could
+            // not hydrate the holder still knows who they are, and without
+            // this the search would offer a bind that moves nothing.
+            excludeIds={[
+              ...candidates.map((c) => c.person_id),
+              ...(boundCard ? [boundCard.person_id] : []),
+              ...(boundId ? [boundId] : []),
+              ...(bindTo ? [bindTo.person_id] : []),
+            ]}
+            onPick={(person) => setAction({ kind: "bind", person })}
+          />
+        )}
+      </section>
 
       <section className="flex flex-wrap gap-2">
         {detachable ? (

--- a/src/frontend/src/components/portal/identities-view.test.tsx
+++ b/src/frontend/src/components/portal/identities-view.test.tsx
@@ -14,6 +14,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import "@/i18n";
 import type { AttentionItem, AttentionResponse } from "@/api/identity-client";
+import { QUEUE_FIRST_PAGE, QUEUE_MAX_ITEMS } from "@/api/identity-client";
 
 vi.mock("@tanstack/react-router", async () => {
   const { portalRouterMock } = await import("@/test/portal-router");
@@ -21,10 +22,16 @@ vi.mock("@tanstack/react-router", async () => {
 });
 
 const attention = vi.hoisted(() => ({
+  /** The limit the queue last asked the service for. */
+  limit: 0,
   q: {
     data: undefined as AttentionResponse | undefined,
     isLoading: false,
     isError: false,
+    /** A read is in flight — of ANY kind, including a background refetch. */
+    isFetching: false,
+    /** …and this one is showing the previous answer, i.e. a longer read. */
+    isPlaceholderData: false,
     refetch: vi.fn(),
   },
   merge: { mutateAsync: vi.fn() },
@@ -33,7 +40,10 @@ const attention = vi.hoisted(() => ({
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 vi.mock("@/queries/identity-resolution", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/queries/identity-resolution")>()),
-  useAttention: () => attention.q,
+  useAttention: (limit: number) => {
+    attention.limit = limit;
+    return attention.q;
+  },
   useMergePersons: () => attention.merge,
   useBindAccounts: () => attention.bulkBind,
   usePersonAccountsMany: () => ({
@@ -107,10 +117,31 @@ function strip(): string[] {
   return [...(grid?.children ?? [])].map((tile) => tile.textContent ?? "");
 }
 
+/** Presses for more until the service's own ceiling leaves nothing to ask for.
+ *  Bounded by the presses doubling takes to cross the range, so a step that
+ *  stops doubling shows up here rather than looping. */
+const PRESSES_TO_THE_CEILING = Math.ceil(
+  Math.log2(QUEUE_MAX_ITEMS / QUEUE_FIRST_PAGE),
+);
+
+async function readToTheCeiling(user: ReturnType<typeof userEvent.setup>) {
+  for (let press = 0; press <= PRESSES_TO_THE_CEILING; press += 1) {
+    const more = screen.queryByRole("button", { name: /show more cases/i });
+    if (!more) return;
+    await user.click(more);
+  }
+  throw new Error(
+    `still offering a longer read after ${PRESSES_TO_THE_CEILING + 1} presses, at limit ${attention.limit}`,
+  );
+}
+
 beforeEach(() => {
+  attention.limit = 0;
   attention.q.data = undefined;
   attention.q.isLoading = false;
   attention.q.isError = false;
+  attention.q.isFetching = false;
+  attention.q.isPlaceholderData = false;
   attention.q.refetch.mockClear();
   portalRouter.reset();
   portalRouter.set({ zone: "manage", item: "identities" });
@@ -195,26 +226,110 @@ describe("IdentitiesView", () => {
     expect(screen.getByText(/cover only part of the observed accounts/i)).toBeInTheDocument();
   });
 
-  // Two different facts: the evidence read hit its ceiling (rates are a
-  // prefix) versus the item cap cut the list (rates still whole-tenant).
-  it("says the list was cut when only the item cap was hit", () => {
+  // The item cap is no dead end while the service will still answer a longer
+  // read — and a longer read is what the button asks for, since the queue is
+  // derived per request and has no cursor to resume from.
+  it("asks for a longer queue when the item cap cut the list", async () => {
+    attention.q.data = { items: [item({})], rates: RATES, items_truncated: true };
+    const user = userEvent.setup();
+    render(<IdentitiesView />);
+
+    expect(attention.limit).toBe(QUEUE_FIRST_PAGE);
+    await user.click(screen.getByRole("button", { name: /show more cases/i }));
+
+    // Doubling, exactly: a smaller step turns the button into a treadmill on
+    // the backlogs it exists for.
+    expect(attention.limit).toBe(QUEUE_FIRST_PAGE * 2);
+    // Nothing to warn about while the reader can still ask for the rest.
+    expect(
+      screen.queryByText(/only the first accounts needing review/i),
+    ).not.toBeInTheDocument();
+  });
+
+  // Every decision invalidates this query. A button that greys out on the
+  // background refetch reads as "your press is working" over a read nobody
+  // asked for.
+  it("says it is loading for a longer read and stays put for a background one", () => {
+    attention.q.data = { items: [item({})], rates: RATES, items_truncated: true };
+    attention.q.isFetching = true;
+    attention.q.isPlaceholderData = true;
+    const { rerender } = render(<IdentitiesView />);
+
+    expect(screen.getByRole("button", { name: /loading/i })).toBeDisabled();
+
+    attention.q.isPlaceholderData = false;
+    rerender(<IdentitiesView />);
+
+    expect(screen.getByRole("button", { name: /show more cases/i })).toBeEnabled();
+  });
+
+  // Working the visible page to zero does not empty the tenant: the server is
+  // still saying there is more, and celebrating over a button that asks for it
+  // is two answers to one question.
+  it("does not celebrate an empty page while a longer read is on offer", () => {
     attention.q.data = { items: [], rates: RATES, items_truncated: true };
     render(<IdentitiesView />);
 
+    expect(screen.queryByText(/everything is resolved/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/only the first accounts needing review/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /show more cases/i })).toBeInTheDocument();
+  });
+
+  // The rows the operator was working are still cached under the shorter read.
+  // Retrying the read that just failed would only fail again.
+  it("offers the way back to the shorter list when the longer read fails", async () => {
+    attention.q.data = { items: [item({})], rates: RATES, items_truncated: true };
+    const user = userEvent.setup();
+    const view = render(<IdentitiesView />);
+    await user.click(screen.getByRole("button", { name: /show more cases/i }));
+    expect(attention.limit).toBe(QUEUE_FIRST_PAGE * 2);
+
+    attention.q.isError = true;
+    attention.q.data = undefined;
+    view.rerender(<IdentitiesView />);
+    expect(screen.getByText(/the longer read failed/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+
+    expect(attention.limit).toBe(QUEUE_FIRST_PAGE);
+    expect(attention.q.refetch).not.toHaveBeenCalled();
+  });
+
+  it("offers no longer read when the whole queue is listed", () => {
+    attention.q.data = { items: [item({})], rates: RATES };
+    render(<IdentitiesView />);
+
+    expect(
+      screen.queryByRole("button", { name: /show more cases/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // Two different facts: the evidence read hit its ceiling (rates are a
+  // prefix) versus the item cap cut the list (rates still whole-tenant).
+  it("says the list was cut once the service will answer nothing longer", async () => {
+    attention.q.data = { items: [item({})], rates: RATES, items_truncated: true };
+    const user = userEvent.setup();
+    render(<IdentitiesView />);
+
+    await readToTheCeiling(user);
+
+    expect(attention.limit).toBe(QUEUE_MAX_ITEMS);
     expect(screen.getByText(/only the first accounts needing review/i)).toBeInTheDocument();
     expect(
       screen.queryByText(/cover only part of the observed accounts/i),
     ).not.toBeInTheDocument();
   });
 
-  it("does not repeat the item-cap notice when the evidence read was truncated too", () => {
+  it("does not repeat the item-cap notice when the evidence read was truncated too", async () => {
     attention.q.data = {
-      items: [],
+      items: [item({})],
       rates: RATES,
       truncated: true,
       items_truncated: true,
     };
+    const user = userEvent.setup();
     render(<IdentitiesView />);
+
+    await readToTheCeiling(user);
 
     expect(screen.getByText(/cover only part of the observed accounts/i)).toBeInTheDocument();
     expect(
@@ -248,6 +363,27 @@ describe("IdentitiesView", () => {
     expect(screen.getByText(/no address to match on/i)).toBeInTheDocument();
     // Unknown kind lands in the catch-all group rather than vanishing.
     expect(screen.getByText("q-1")).toBeInTheDocument();
+  });
+
+  // The whole queue arrives in one read, so a button between the reader and
+  // rows the client already holds buys nothing — the heading collapses the
+  // group for anyone who wants it out of the way.
+  it("lists every case of a group at once", () => {
+    attention.q.data = {
+      items: Array.from({ length: 25 }, (_, n) =>
+        item({ account_id: `a${n}`, email: `dev${n}@example.com` }),
+      ),
+      rates: RATES,
+    };
+    render(<IdentitiesView />);
+
+    expect(screen.getAllByRole("button", { name: /@example\.com/i })).toHaveLength(25);
+    // The group's own pager is gone. Matched by the exact copy it used, so a
+    // fixture that later trips the server's cap cannot pass this vacuously on
+    // the list-wide button.
+    expect(
+      screen.queryByRole("button", { name: /show \d+ more cases/i }),
+    ).not.toBeInTheDocument();
   });
 
   // Five rows repeating the same two candidates read as five problems. The
@@ -299,7 +435,7 @@ describe("IdentitiesView", () => {
   // The merge lives on the CASE, not on the account: the case is where the
   // people are listed, and pressing a person's row is what states the
   // direction — that one stays and the rest go into them.
-  it("offers a merge on each person of a disputed case, naming what it absorbs", () => {
+  it("offers a merge on each person of a disputed case, saying which way it goes", () => {
     const candidates = [
       { person_id: "01900000-0000-7000-8000-0000000000a0", display_name: "Ann Lee" },
       { person_id: "01900000-0000-7000-8000-0000000000b0", display_name: "Bob Park" },
@@ -311,15 +447,17 @@ describe("IdentitiesView", () => {
     render(<IdentitiesView />);
 
     expect(
-      screen.getAllByRole("button", { name: /keep this person/i }),
+      screen.getAllByRole("button", { name: /merge into this person/i }),
     ).toHaveLength(2);
-    // Two people, so the caption can name the other one rather than count them.
-    expect(screen.getByText(/Bob Park's accounts move here/i)).toBeInTheDocument();
-    expect(screen.getByText(/Ann Lee's accounts move here/i)).toBeInTheDocument();
+    // The caption states the direction under every candidate, so a reader
+    // never has to work out which way the press goes from the label alone.
+    expect(
+      screen.getAllByText(/everyone else in this case merges into them/i),
+    ).toHaveLength(2);
   });
 
   // The one place a click becomes a merge DIRECTION. Without this, swapping the
-  // survivor and the absorbed here — "Keep Ann Lee" erasing Ann — leaves every
+  // survivor and the absorbed here — "Merge into Ann Lee" erasing Ann — leaves every
   // other test in the repo green, because the dialog is only ever tested with
   // props handed to it directly.
   it("merges the rest into the person whose row was pressed", async () => {
@@ -349,13 +487,13 @@ describe("IdentitiesView", () => {
     };
     render(<IdentitiesView />);
 
-    const rows = screen.getAllByRole("button", { name: /keep this person/i });
+    const rows = screen.getAllByRole("button", { name: /merge into this person/i });
     // Ann is listed first, so her row's button is the first one.
     await userEvent.click(rows[0]);
 
     const dialog = screen.getByRole("dialog");
     expect(
-      within(dialog).getByText(/keep ann lee and merge the rest/i),
+      within(dialog).getByText(/merge the rest into ann lee/i),
     ).toBeInTheDocument();
 
     await userEvent.click(
@@ -392,7 +530,7 @@ describe("IdentitiesView", () => {
     render(<IdentitiesView />);
 
     expect(
-      screen.queryByRole("button", { name: /keep this person/i }),
+      screen.queryByRole("button", { name: /merge into this person/i }),
     ).not.toBeInTheDocument();
   });
 

--- a/src/frontend/src/components/portal/identities-view.tsx
+++ b/src/frontend/src/components/portal/identities-view.tsx
@@ -26,6 +26,7 @@ import type {
   PersonSummary,
   ResolutionRates,
 } from "@/api/identity-client";
+import { QUEUE_FIRST_PAGE, QUEUE_MAX_ITEMS } from "@/api/identity-client";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { CenteredSpinner } from "@/components/widgets/centered-spinner";
 import { AccountSearchView } from "@/components/portal/account-search-view";
@@ -132,7 +133,17 @@ export function IdentitiesView() {
 
 function ReviewQueue() {
   const { t } = useTranslation();
-  const attention = useAttention();
+  // Asking for more is a longer read, not a next page: the service derives the
+  // queue from the whole tenant, so a cursor would cost the same as this and
+  // cut cases in half — the rows of one case are spread across sources.
+  const [limit, setLimit] = useState(QUEUE_FIRST_PAGE);
+  const attention = useAttention(limit);
+
+  // A longer read that fails takes its own answer down with it — the rows the
+  // operator was working are still cached under the shorter one, so the way
+  // out of the error is back to it, not another attempt at the read that just
+  // failed.
+  const askedForMore = limit > QUEUE_FIRST_PAGE;
 
   if (attention.isLoading) return <CenteredSpinner className="min-h-[60vh]" />;
   if (attention.isError || !attention.data) {
@@ -141,8 +152,16 @@ function ReviewQueue() {
         <ComingSoon
           variant="card"
           state="error"
-          label={t("identities.queue.load_failed")}
-          onRetry={() => void attention.refetch()}
+          label={t(
+            askedForMore
+              ? "identities.queue.longer_read_failed"
+              : "identities.queue.load_failed",
+          )}
+          onRetry={() =>
+            askedForMore
+              ? setLimit(QUEUE_FIRST_PAGE)
+              : void attention.refetch()
+          }
         />
       </div>
     );
@@ -150,6 +169,10 @@ function ReviewQueue() {
 
   const { items, rates, truncated, items_truncated: itemsTruncated } =
     attention.data;
+  const loadMore =
+    itemsTruncated && limit < QUEUE_MAX_ITEMS
+      ? () => setLimit((asked) => Math.min(asked * 2, QUEUE_MAX_ITEMS))
+      : null;
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-6">
       {truncated ? (
@@ -159,9 +182,10 @@ function ReviewQueue() {
         </Alert>
       ) : null}
       {/* The list was cut by the server's item cap while the rates stay
-          whole-tenant — a different fact from `truncated`, and one an
-          operator working to zero has to know. */}
-      {itemsTruncated && !truncated ? (
+          whole-tenant — a different fact from `truncated`. Said only once the
+          reader can do nothing about it: while a longer read is still allowed,
+          the button at the end of the list is the answer. */}
+      {itemsTruncated && !truncated && (!loadMore || items.length === 0) ? (
         <Alert role="status">
           <TriangleAlert />
           <AlertDescription>
@@ -174,7 +198,14 @@ function ReviewQueue() {
         decisions={items.length}
         decisionsCapped={Boolean(itemsTruncated)}
       />
-      <Queue items={items} />
+      <Queue
+        items={items}
+        onLoadMore={loadMore}
+        // The LONGER read specifically, not any fetch: every decision
+        // invalidates this query, and a background refetch that greys the
+        // button out would read as "your press is working".
+        loadingMore={attention.isFetching && attention.isPlaceholderData}
+      />
     </div>
   );
 }
@@ -257,7 +288,17 @@ function AllResolved() {
   );
 }
 
-function Queue({ items }: { items: AttentionItem[] }) {
+function Queue({
+  items,
+  onLoadMore,
+  loadingMore,
+}: {
+  items: AttentionItem[];
+  /** Ask the service for a longer queue; absent when nothing more can come. */
+  onLoadMore: (() => void) | null;
+  loadingMore: boolean;
+}) {
+  const { t } = useTranslation();
   const { acct } = usePortalSearch();
   const { setAcct } = usePortalNavActions();
   const listRef = useRef<HTMLDivElement>(null);
@@ -334,7 +375,10 @@ function Queue({ items }: { items: AttentionItem[] }) {
         onKeyDown={onArrow}
         className="min-h-0 min-w-0 flex-1 space-y-4 overflow-y-auto"
       >
-        {items.length === 0 ? <AllResolved /> : null}
+        {/* The goal state is an empty queue with nothing left to ask for. With
+            a longer read still on offer the emptiness is this page's, not the
+            tenant's, and the notice above says so instead. */}
+        {items.length === 0 && !onLoadMore ? <AllResolved /> : null}
         {groups.map((group) => (
           <QueueGroup
             key={group.kind}
@@ -345,6 +389,24 @@ function Queue({ items }: { items: AttentionItem[] }) {
             onSelect={(key) => select(key === acct ? null : key)}
           />
         ))}
+        {/* Deliberate rather than loaded on scroll, unlike the searches: every
+            press re-derives the tenant's whole queue, and the count it would
+            add is not on the wire to promise. */}
+        {onLoadMore ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={loadingMore}
+            onClick={onLoadMore}
+          >
+            {t(
+              loadingMore
+                ? "identities.queue.loading_more"
+                : "identities.queue.load_more",
+            )}
+          </Button>
+        ) : null}
       </div>
       <ScrollToEnds scroller={listRef} rows={items.length} />
       <CaseDialog
@@ -362,9 +424,6 @@ function Queue({ items }: { items: AttentionItem[] }) {
   );
 }
 
-/** Cases rendered before the group asks to be expanded further. */
-const CASE_PAGE = 10;
-
 function QueueGroup({
   kind,
   items,
@@ -379,10 +438,9 @@ function QueueGroup({
   onSelect: (key: string) => void;
 }) {
   const { t } = useTranslation();
-  const [shownCases, setShownCases] = useState(CASE_PAGE);
+  // Every case the group holds, at once: the whole queue is already on the
+  // client, and a reader who does not want this group collapses its heading.
   const cases = useMemo(() => groupIntoCases(items), [items]);
-  const visible = cases.slice(0, shownCases);
-  const hidden = cases.length - visible.length;
 
   return (
     <Card className="overflow-hidden">
@@ -417,7 +475,7 @@ function QueueGroup({
             {groupIsConfirmable(kind, items) ? (
               <ConfirmGroupButton items={items} className="self-start" />
             ) : null}
-            {visible.map((queueCase) => (
+            {cases.map((queueCase) => (
               <CaseBlock
                 key={queueCase.key}
                 queueCase={queueCase}
@@ -426,17 +484,6 @@ function QueueGroup({
                 onSelect={onSelect}
               />
             ))}
-            {hidden > 0 ? (
-              <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="self-start"
-                onClick={() => setShownCases((n) => n + CASE_PAGE)}
-              >
-                {t("identities.queue.show_more", { count: hidden })}
-              </Button>
-            ) : null}
           </CardContent>
         </CollapsibleContent>
       </Collapsible>
@@ -515,41 +562,29 @@ function CaseBlock({
               count: queueCase.items.length,
             })}
           </div>
-          {queueCase.candidates.map((candidate) => {
-            const others = queueCase.candidates.filter(
-              (c) => c.person_id !== candidate.person_id,
-            );
-            return (
-              <div key={candidate.person_id} className="flex items-center gap-2">
-                <PersonCell person={candidate} className="min-w-0 flex-1" />
-                {/* The row's own button, so the choice IS the direction: this
-                    person stays and the rest of the case merges into them.
-                    Keeping rather than removing is deliberate — a mis-click
-                    preserves a person instead of erasing one. */}
-                {mergeable ? (
-                  <div className="flex shrink-0 flex-col items-end gap-0.5">
-                    <Button
-                      type="button"
-                      size="xs"
-                      variant="outline"
-                      onClick={() => setSurvivor(candidate)}
-                    >
-                      {t("identities.actions.keep_person")}
-                    </Button>
-                    <span className="text-xs text-muted-foreground">
-                      {others.length === 1
-                        ? t("identities.queue.absorb_named", {
-                            name: personDisplayName(others[0]),
-                          })
-                        : t("identities.queue.absorb_count", {
-                            count: others.length,
-                          })}
-                    </span>
-                  </div>
-                ) : null}
-              </div>
-            );
-          })}
+          {queueCase.candidates.map((candidate) => (
+            <div key={candidate.person_id} className="flex items-center gap-2">
+              <PersonCell person={candidate} className="min-w-0 flex-1" />
+              {/* The row's own button, so the choice IS the direction: this
+                  person is the one that survives, and the rest of the case
+                  merges into them. */}
+              {mergeable ? (
+                <div className="flex shrink-0 flex-col items-end gap-0.5">
+                  <Button
+                    type="button"
+                    size="xs"
+                    variant="outline"
+                    onClick={() => setSurvivor(candidate)}
+                  >
+                    {t("identities.actions.merge_into_person")}
+                  </Button>
+                  <span className="text-xs text-muted-foreground">
+                    {t("identities.queue.absorb_all")}
+                  </span>
+                </div>
+              ) : null}
+            </div>
+          ))}
         </div>
       ) : null}
 

--- a/src/frontend/src/components/portal/merge-case-dialog.test.tsx
+++ b/src/frontend/src/components/portal/merge-case-dialog.test.tsx
@@ -101,7 +101,7 @@ describe("MergeCaseDialog", () => {
 
     const dialog = screen.getByRole("dialog");
     expect(
-      within(dialog).getByText(/keep bob park and merge the rest/i),
+      within(dialog).getByText(/merge the rest into bob park/i),
     ).toBeInTheDocument();
     // Order carries the meaning: the first person named is the one that remains.
     const labels = within(dialog)
@@ -370,4 +370,19 @@ describe("MergeCaseDialog", () => {
     expect(hooks.toast.success).not.toHaveBeenCalled();
     expect(hooks.toast.error).toHaveBeenCalledOnce();
   });
+
+  // The panel is a grid, and a grid item will not shrink below its own
+  // content. An address and a person id are exactly the values that do not
+  // wrap, so without these two classes the body pushes itself out through the
+  // side — invisible in jsdom, in a review, and to every other test here.
+  it("lays the panel out so a value too wide for it truncates instead of escaping", () => {
+    render(
+      <MergeCaseDialog survivor={BOB} absorbed={[CAROL]} onClose={vi.fn()} />,
+    );
+
+    const panel = screen.getByRole("dialog");
+    expect(panel).toHaveClass("grid-cols-[minmax(0,1fr)]");
+    expect(panel).toHaveClass("[&>*]:min-w-0");
+  });
+
 });

--- a/src/frontend/src/components/portal/merge-case-dialog.tsx
+++ b/src/frontend/src/components/portal/merge-case-dialog.tsx
@@ -9,8 +9,8 @@
  * screen said which way round it went.
  *
  * Choosing only the survivor is what makes the direction unambiguous: there is
- * no "from", because everyone else is the from. Which is also why the row's
- * button keeps a person rather than removing one — a mis-click preserves.
+ * no "from", because everyone else is the from. The row's button says the same
+ * thing in words — it merges INTO the person whose row it sits in.
  *
  * A case can argue over more than two people, and then all-or-nothing is the
  * wrong offer: two of them may be one human while the third is a different one
@@ -212,7 +212,7 @@ export function MergeCaseDialog({
               {moving.accounts.slice(0, PREVIEW_ROWS).map((account) => (
                 <li
                   key={`${account.source}:${account.source_id}:${account.account_id}`}
-                  className="font-mono text-xs text-muted-foreground"
+                  className="truncate font-mono text-xs text-muted-foreground"
                 >
                   {account.source} ·{" "}
                   {account.email ?? account.username ?? account.account_id}

--- a/src/frontend/src/components/portal/person-cell.test.tsx
+++ b/src/frontend/src/components/portal/person-cell.test.tsx
@@ -5,6 +5,7 @@
  * never repeats the name, and a leaver marked so nobody merges into them.
  */
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 
 import "@/i18n";
@@ -74,13 +75,21 @@ describe("PersonCell", () => {
   // minted is the wrong side of a merge — its counterpart holds the history.
   // The badge must not name one origin: a sign-in and a roster listing both
   // produce such a person, and the wording is the same warning either way.
-  it("marks a person the journal knows only from an automatic mint", () => {
+  it("marks a person the journal knows only from an automatic mint", async () => {
     render(
       <PersonCell person={person({ display_name: "New Joiner", provisional: true })} />,
     );
 
+    // One word, so the badge cannot widen the row it sits in — and the warning
+    // it stands for is reachable, not hover-only: this mark is what says a
+    // person is the wrong side of a merge.
+    const badge = screen.getByText(/^provisional$/i);
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute("tabindex", "0");
+
+    await userEvent.hover(badge);
     expect(
-      screen.getByText(/created by automation, not confirmed/i),
+      await screen.findByText(/created by automation, not confirmed/i),
     ).toBeInTheDocument();
     // A roster mint is not a sign-in. Naming one origin tells an operator the
     // wrong story about half of these people.

--- a/src/frontend/src/components/portal/person-cell.tsx
+++ b/src/frontend/src/components/portal/person-cell.tsx
@@ -24,6 +24,12 @@ import type { PersonSummary } from "@/api/identity-client";
 import { CopyValueButton } from "@/components/copy-value-button";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { personDisplayName } from "@/lib/identities/person-display";
 import { getInitials } from "@/lib/insight/get-initials";
 import { cn } from "@/lib/utils";
@@ -67,10 +73,31 @@ export function PersonCell({
           >
             {name}
           </span>
+          {/* One word on the badge, the warning behind it: a badge never wraps
+              and never shrinks, so a sentence in one pushes the name out of a
+              narrow column and spills across the row. The trigger takes a tab
+              stop of its own on purpose — this mark is what says a person is
+              the wrong side of a merge, and a hover-only carrier tells a
+              keyboard reader nothing. */}
           {person.provisional ? (
-            <Badge variant="outline" className="font-normal">
-              {t("identities.person.provisional")}
-            </Badge>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Badge
+                      variant="outline"
+                      className="cursor-help font-normal"
+                      tabIndex={0}
+                    />
+                  }
+                >
+                  {t("identities.person.provisional")}
+                </TooltipTrigger>
+                <TooltipContent side="top">
+                  {t("identities.person.provisional_hint")}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           ) : null}
           {person.status?.trim().toLowerCase() === TERMINATED ? (
             <Badge

--- a/src/frontend/src/components/ui/dialog.tsx
+++ b/src/frontend/src/components/ui/dialog.tsx
@@ -51,7 +51,11 @@ function DialogContent({
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 start-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2 gap-6 rounded-xl bg-popover p-6 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-md data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          // `grid-cols-[minmax(0,1fr)]` + `[&>*]:min-w-0`: a grid track is
+          // content-sized and a grid item refuses to shrink below its own
+          // content, so an address or an id — neither of which wraps — would
+          // otherwise push itself out through the side of the panel.
+          "fixed top-1/2 start-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] grid-cols-[minmax(0,1fr)] -translate-x-1/2 rtl:translate-x-1/2 -translate-y-1/2 gap-6 rounded-xl bg-popover p-6 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-md data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 [&>*]:min-w-0",
           className
         )}
         {...props}
@@ -119,7 +123,10 @@ function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("font-heading leading-none font-medium", className)}
+      // An e-mail is the name a person without one falls back to, and `.`/`@`
+      // are not break opportunities — without this the heading is the one line
+      // that still overflows.
+      className={cn("font-heading leading-none font-medium break-words", className)}
       {...props}
     />
   )
@@ -133,7 +140,7 @@ function DialogDescription({
     <DialogPrimitive.Description
       data-slot="dialog-description"
       className={cn(
-        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        "text-sm break-words text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
         className
       )}
       {...props}

--- a/src/frontend/src/locales/en/translation.json
+++ b/src/frontend/src/locales/en/translation.json
@@ -421,12 +421,13 @@
     },
     "queue": {
       "load_failed": "Unable to load the review queue",
-      "items_truncated": "Only the first accounts needing review are listed — resolve these and reload to see the rest.",
+      "longer_read_failed": "The longer read failed — go back to the first accounts",
+      "items_truncated": "Only the first accounts needing review are listed — resolve these to see the rest.",
       "truncated": "The evidence read hit its cap — these counts and this queue cover only part of the observed accounts, not the whole tenant.",
       "empty_title": "Everything is resolved",
       "empty_description": "Every observed account is bound to a person. New conflicts will appear here.",
-      "show_more_one": "Show {{count}} more case",
-      "show_more_other": "Show {{count}} more cases",
+      "load_more": "Show more cases",
+      "loading_more": "Loading…",
       "case_count_one": "{{count}} case · {{accounts}} accounts",
       "case_count_other": "{{count}} cases · {{accounts}} accounts",
       "previous_case": "‹ Previous account",
@@ -437,9 +438,7 @@
       "case_people_other": "{{count}} people",
       "case_accounts_one": "{{count}} account",
       "case_accounts_other": "{{count}} accounts",
-      "absorb_named": "{{name}}'s accounts move here",
-      "absorb_count_one": "1 other person's accounts move here",
-      "absorb_count_other": "{{count}} other people's accounts move here"
+      "absorb_all": "Everyone else in this case merges into them"
     },
     "detail": {
       "not_found": "This account is unknown — the link may be stale.",
@@ -454,7 +453,8 @@
       "terminated": "terminated",
       "unnamed": "Unnamed person",
       "copy_id": "Copy the person id",
-      "provisional": "provisional — created by automation, not confirmed"
+      "provisional": "provisional",
+      "provisional_hint": "Created by automation, not confirmed"
     },
     "history": {
       "bind": "Bound",
@@ -483,7 +483,7 @@
       "assign_other": "Assign to someone else",
       "bind_to": "Bind to selected person",
       "assign_person": "Assign to a person",
-      "keep_person": "Keep this person",
+      "merge_into_person": "Merge into this person",
       "confirm_group_one": "Confirm 1 account",
       "confirm_group_other": "Confirm all {{count}} accounts"
     },
@@ -502,7 +502,7 @@
       "exclude_description": "Bots, CI and service accounts are excluded from every person metric.",
       "failed": "The correction was not applied. Try again.",
       "confirm_description": "The account stays bound to the current person.",
-      "merge_case_title": "Keep {{name}} and merge the rest?",
+      "merge_case_title": "Merge the rest into {{name}}?",
       "merge_case_description": "Every account ticked below moves to {{name}}.",
       "merge_case_stays": "Stays",
       "merge_case_absorbed_one": "Merged into them",

--- a/src/frontend/src/queries/identity-resolution.test.tsx
+++ b/src/frontend/src/queries/identity-resolution.test.tsx
@@ -26,6 +26,7 @@ vi.mock("@/auth/session-scope", () => ({
 
 import {
   listsAnyAccount,
+  useAttention,
   listsAnyone,
   useAccountList,
   useBindAccount,
@@ -36,7 +37,16 @@ const searchPersons = vi.mocked(identityClient.searchPersons);
 
 const bindAccount = vi.mocked(identityClient.bindAccount);
 
-const ATTENTION_KEY = ["identity", "resolution", "attention", "tenant-a"];
+// The key `useAttention` really writes, limit segment included — a cache entry
+// under a shorter key would prove nothing about the surgery reaching the queue
+// an operator is looking at.
+const ATTENTION_KEY = [
+  "identity",
+  "resolution",
+  "attention",
+  "tenant-a",
+  identityClient.QUEUE_FIRST_PAGE,
+];
 
 const REF = {
   source: "github",
@@ -360,5 +370,92 @@ describe("usePersonList while a term is being typed", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(searchPersons.mock.calls[0][2]).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe("the prune across cached limits", () => {
+  // `keepPreviousData` leaves one cache entry per limit the operator reached.
+  // A filter narrowed to the first page would leave the row they just decided
+  // sitting in the longer list they are actually looking at.
+  it("drops the decided row from every cached limit", async () => {
+    const { queryClient, wrapper } = harness();
+    const longer = ["identity", "resolution", "attention", "tenant-a", 400];
+    for (const key of [ATTENTION_KEY, longer]) {
+      queryClient.setQueryData(key, {
+        items: [item("a1"), item("a2")],
+        rates: { persons: 2, observed: 2, bound: 0, pending: 2, no_evidence: 0, excluded: 0 },
+      });
+    }
+    bindAccount.mockResolvedValue(outcome("applied"));
+
+    const { result } = renderHook(() => useBindAccount(), { wrapper });
+    result.current.mutate({
+      account: { source: REF.source, source_id: REF.source_id, id: REF.account_id },
+      person_id: "01900000-0000-7000-8000-0000000000b0",
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    for (const key of [ATTENTION_KEY, longer]) {
+      const cached = queryClient.getQueryData(key) as { items: unknown[] };
+      expect(cached.items, `under ${JSON.stringify(key)}`).toHaveLength(1);
+    }
+  });
+});
+
+describe("useAttention", () => {
+  // The limit is the whole load-more feature. Keyed on it but not PASSED, every
+  // press would fire a fresh request, blank nothing (`keepPreviousData`) and
+  // answer the same 200 rows for ever — with every other test still green,
+  // because they all mock this hook away.
+  it("asks the service for the limit it is keyed on", async () => {
+    vi.mocked(identityClient.getAttention).mockResolvedValue({
+      items: [],
+      rates: { observed: 0, bound: 0, pending: 0, no_evidence: 0, excluded: 0 },
+    });
+    const { queryClient, wrapper } = harness();
+
+    const { result } = renderHook(() => useAttention(400), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(identityClient.getAttention).toHaveBeenCalledWith(400);
+    expect(
+      queryClient
+        .getQueryCache()
+        .find({ queryKey: ["identity", "resolution", "attention", "tenant-a", 400] }),
+    ).toBeDefined();
+  });
+
+  // A longer read is a NEW key, and a new key is pending. Without the previous
+  // answer standing in, the queue an operator is working blanks to a spinner
+  // on every press.
+  it("keeps the shorter answer on screen while the longer one is read", async () => {
+    vi.mocked(identityClient.getAttention).mockResolvedValue({
+      items: [],
+      rates: { observed: 0, bound: 0, pending: 0, no_evidence: 0, excluded: 0 },
+    });
+    const { queryClient, wrapper } = harness();
+    const { result, rerender } = renderHook(({ limit }) => useAttention(limit), {
+      wrapper,
+      initialProps: { limit: 200 },
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    let resolve: (value: identityClient.AttentionResponse) => void = () => {};
+    vi.mocked(identityClient.getAttention).mockReturnValueOnce(
+      new Promise((r) => {
+        resolve = r;
+      }),
+    );
+    rerender({ limit: 400 });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeDefined();
+    expect(result.current.isPlaceholderData).toBe(true);
+    resolve({
+      items: [],
+      rates: { observed: 0, bound: 0, pending: 0, no_evidence: 0, excluded: 0 },
+    });
+    await waitFor(() => expect(result.current.isPlaceholderData).toBe(false));
+    queryClient.clear();
   });
 });

--- a/src/frontend/src/queries/identity-resolution.ts
+++ b/src/frontend/src/queries/identity-resolution.ts
@@ -27,6 +27,7 @@ import {
   getAttention,
   getPersonAccounts,
   mergePersons,
+  QUEUE_FIRST_PAGE,
   searchAccounts,
   searchPersons,
   type AccountBinding,
@@ -44,13 +45,25 @@ import { sessionAuthorizationScope } from "@/auth/session-scope";
 /** An operator works a queue; a minute of staleness is fine, losing edits is not. */
 const ATTENTION_STALE_TIME = 60 * 1000;
 
-export function useAttention(): UseQueryResult<AttentionResponse> {
+/**
+ * The review queue, capped at `limit` items.
+ *
+ * Raising the limit is what "load more" means here — the service derives the
+ * queue from the whole tenant on every read, so there is no cursor to resume
+ * from, and a bigger ask returns a longer prefix of the same order.
+ */
+export function useAttention(
+  limit: number = QUEUE_FIRST_PAGE,
+): UseQueryResult<AttentionResponse> {
   const { session } = useAuth();
   const sessionScope = sessionAuthorizationScope(session);
   return useQuery({
-    queryKey: ["identity", "resolution", "attention", sessionScope],
-    queryFn: () => getAttention(),
+    queryKey: ["identity", "resolution", "attention", sessionScope, limit],
+    queryFn: () => getAttention(limit),
     staleTime: ATTENTION_STALE_TIME,
+    // A longer ask re-reads the rows already on screen: without this the queue
+    // an operator is working blanks to a spinner every time they ask for more.
+    placeholderData: keepPreviousData,
     enabled: sessionScope != null,
   });
 }


### PR DESCRIPTION
Five fixes to the identity console (Manage → Identities). Frontend only, no wire change.

- **The queue shows every case.** The old "+N more" button only revealed rows the client already had. When the *server* cut the list, a button at the end now asks for a longer read, up to the service's 1000-item ceiling.
- **The merge control states the direction:** "Merge into this person", with a caption and dialog title to match. "Keep this person" left it to be inferred.
- **Dialog panels hold their contents.** A long address or person id used to push out through the side of a dialog; fixed in the shared primitive, so every dialog gains it.
- **An account opened from a person can be moved again.** The search disappeared once the account was already that person's — which is exactly when moving it elsewhere is the only decision left.
- **The "provisional" mark is a one-word badge** with the warning in a tooltip. As a full sentence it pushed the person's name out of every fixed-width column.

198 files / 1743 tests green, `tsc` and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
