### PR TITLE
feat(git): identify a file change by content so a repeated change counts once

### DIFF
--- a/docs/components/backend/git-cli-proxy/openapi.json
+++ b/docs/components/backend/git-cli-proxy/openapi.json
@@ -239,6 +239,18 @@
           "patch_truncated": {
             "type": "boolean"
           },
+          "post_image_oid": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "pre_image_oid": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "previous_filename": {
             "type": [
               "string",

--- a/src/backend/services/analytics/src/domain/metric_definitions/passports.md
+++ b/src/backend/services/analytics/src/domain/metric_definitions/passports.md
@@ -138,7 +138,7 @@ this file and the registry disagree.
 - Reads: code_lines_added
 - Formula: sum(code_lines_added)
 - Shape: integer, higher_is_better, unit lines
-- Notes: Lines added to files classified as code — tests, configuration, and documentation excluded.
+- Notes: Lines added to files classified as code — tests, configuration, and documentation excluded. Each change counts once: when the same content reaches a repository in more than one commit, the lines belong to the commit that introduced them first.
 
 ## git.lines_added — Lines added
 
@@ -146,7 +146,7 @@ this file and the registry disagree.
 - Reads: lines_added
 - Formula: sum(lines_added)
 - Shape: integer, higher_is_better, unit lines
-- Notes: Lines added across all files, split by file category: code, tests, configuration, documentation.
+- Notes: Lines added across all files, split by file category: code, tests, configuration, documentation. Each change counts once: when the same content reaches a repository in more than one commit, the lines belong to the commit that introduced them first.
 
 ## git.lines_removed — Lines removed
 
@@ -154,7 +154,7 @@ this file and the registry disagree.
 - Reads: lines_removed
 - Formula: sum(lines_removed)
 - Shape: integer, neutral, unit lines
-- Notes: Lines removed across all reported file changes, with file-category, repository, and source breakdowns available.
+- Notes: Lines removed across all reported file changes, with file-category, repository, and source breakdowns available. Each change counts once: when the same removal reaches a repository in more than one commit, the lines belong to the commit that made it first.
 
 ## git.prs_created — Pull requests created
 
@@ -194,7 +194,7 @@ this file and the registry disagree.
 - Reads: commit_change_size
 - Formula: median(commit_change_size)
 - Shape: integer, lower_is_better, unit lines
-- Notes: Median diff size of authored commits (lines added plus removed). Smaller commits are easier to review.
+- Notes: Median diff size of authored commits (lines added plus removed), counting only content a commit is the first to introduce — a commit that repeats content already in the repository has a size of zero. Smaller commits are easier to review.
 
 ## git.pr_size — PR size
 

--- a/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
+++ b/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
@@ -502,7 +502,11 @@ metrics:
     label: Code lines added
     short_label: Code lines
     description: Lines added to code files
-    explanation: Lines added to files classified as code — tests, configuration, and documentation excluded.
+    explanation: >-
+      Lines added to files classified as code — tests, configuration, and
+      documentation excluded. Each change counts once: when the same content
+      reaches a repository in more than one commit, the lines belong to the
+      commit that introduced them first.
     unit: lines
     format: integer
     direction: higher_is_better
@@ -524,7 +528,11 @@ metrics:
     label: Lines added
     short_label: Lines +
     description: All lines added, by file category
-    explanation: 'Lines added across all files, split by file category: code, tests, configuration, documentation.'
+    explanation: >-
+      Lines added across all files, split by file category: code, tests,
+      configuration, documentation. Each change counts once: when the same
+      content reaches a repository in more than one commit, the lines belong
+      to the commit that introduced them first.
     unit: lines
     format: integer
     direction: higher_is_better
@@ -547,7 +555,11 @@ metrics:
     label: Lines removed
     short_label: Lines −
     description: All lines removed, by file category
-    explanation: Lines removed across all reported file changes, with file-category, repository, and source breakdowns available.
+    explanation: >-
+      Lines removed across all reported file changes, with file-category,
+      repository, and source breakdowns available. Each change counts once:
+      when the same removal reaches a repository in more than one commit, the
+      lines belong to the commit that made it first.
     unit: lines
     format: integer
     direction: neutral
@@ -659,7 +671,11 @@ metrics:
       - distribution
     label: Commit size
     description: Typical diff size per commit
-    explanation: Median diff size of authored commits (lines added plus removed). Smaller commits are easier to review.
+    explanation: >-
+      Median diff size of authored commits (lines added plus removed),
+      counting only content a commit is the first to introduce — a commit
+      that repeats content already in the repository has a size of zero.
+      Smaller commits are easier to review.
     unit: lines
     format: integer
     direction: lower_is_better

--- a/src/backend/services/git-cli-proxy/src/api/data.rs
+++ b/src/backend/services/git-cli-proxy/src/api/data.rs
@@ -139,6 +139,8 @@ pub struct FileChangeRow {
     pub deletions: Option<u64>,
     pub changes: Option<u64>,
     pub is_binary: bool,
+    pub pre_image_oid: Option<String>,
+    pub post_image_oid: Option<String>,
     pub patch: Option<String>,
     pub patch_truncated: bool,
 }
@@ -376,6 +378,8 @@ fn emit_file_changes(
                 deletions: file.deletions,
                 changes: file.additions.and_then(|a| file.deletions.map(|d| a + d)),
                 is_binary: file.is_binary,
+                pre_image_oid: file.pre_image_oid.clone(),
+                post_image_oid: file.post_image_oid.clone(),
                 patch_truncated: patch.as_ref().is_some_and(|p| p.truncated),
                 patch: patch.map(|p| p.text),
             });
@@ -745,6 +749,8 @@ mod tests {
             additions: Some(1),
             deletions: Some(1),
             is_binary: false,
+            pre_image_oid: None,
+            post_image_oid: None,
         }
     }
 

--- a/src/backend/services/git-cli-proxy/src/engine/read/blobs.rs
+++ b/src/backend/services/git-cli-proxy/src/engine/read/blobs.rs
@@ -10,7 +10,7 @@ const MIN_OID_LEN: usize = 7;
 /// absent side (added or deleted path) and is not fetchable — its length
 /// varies with the repository's hash algorithm, so it is recognized by shape,
 /// not by comparison with one fixed constant.
-fn is_object_oid(field: &str) -> bool {
+pub(super) fn is_object_oid(field: &str) -> bool {
     field.len() >= MIN_OID_LEN
         && field.chars().all(|c| c.is_ascii_hexdigit())
         && field.chars().any(|c| c != '0')

--- a/src/backend/services/git-cli-proxy/src/engine/read/mod.rs
+++ b/src/backend/services/git-cli-proxy/src/engine/read/mod.rs
@@ -336,6 +336,68 @@ mod live_tests {
         );
     }
 
+    /// The identity a consumer deduplicates on: the same content entering the
+    /// repository on two lines of history is two commits but one post-image
+    /// oid, while different content at the same path is two.
+    #[tokio::test]
+    async fn identical_content_added_twice_shares_one_post_image_oid() {
+        let f = fixture("blob-identity");
+        sh(
+            &f.root.join("origin"),
+            "git checkout -q -b one && printf 'shared\\n' > v.txt && git add v.txt && \
+             GIT_AUTHOR_DATE='2026-08-02T11:00:00+0000' \
+             GIT_COMMITTER_DATE='2026-08-02T11:00:00+0000' git commit -qm one && \
+             git checkout -q main && git checkout -q -b two && \
+             printf 'shared\\n' > v.txt && git add v.txt && \
+             GIT_AUTHOR_DATE='2026-08-03T11:00:00+0000' \
+             GIT_COMMITTER_DATE='2026-08-03T11:00:00+0000' git commit -qm two && \
+             git checkout -q main && git checkout -q -b three && \
+             printf 'different\\n' > v.txt && git add v.txt && \
+             GIT_AUTHOR_DATE='2026-08-04T11:00:00+0000' \
+             GIT_COMMITTER_DATE='2026-08-04T11:00:00+0000' git commit -qm three && \
+             git checkout -q main",
+        );
+
+        let runner = f.store.runner();
+        let guard = open_until_ready(&f, &key(&f), refresh()).await;
+        let git_dir = guard.git_dir();
+
+        let keys = match commits::enumerate(runner, git_dir, &creds()).await {
+            Ok(k) => k,
+            Err(e) => panic!("commits::enumerate: {e}"),
+        };
+        let shas: Vec<String> = keys.iter().map(|k| k.sha.clone()).collect();
+        if let Err(e) = blobs::prefetch(runner, git_dir, &shas, &creds(), u64::MAX).await {
+            panic!("blobs::prefetch: {e}");
+        }
+        let stats = match numstat::read(runner, git_dir, &shas, usize::MAX, &creds()).await {
+            Ok(s) => s,
+            Err(e) => panic!("numstat::read: {e}"),
+        };
+
+        let mut oids: Vec<String> = stats
+            .values()
+            .flatten()
+            .filter(|file| file.filename == "v.txt")
+            .map(|file| match file.post_image_oid.clone() {
+                Some(oid) => oid,
+                None => panic!("an added path must carry a post-image oid: {file:?}"),
+            })
+            .collect();
+        assert_eq!(oids.len(), 3, "three commits add v.txt: {stats:?}");
+        oids.sort();
+        oids.dedup();
+        assert_eq!(
+            oids.len(),
+            2,
+            "the two identical adds collapse, the third stays: {oids:?}"
+        );
+        assert!(
+            oids.iter().all(|oid| oid.len() == 40),
+            "full oids, never the abbreviation git prints by default: {oids:?}"
+        );
+    }
+
     #[tokio::test]
     async fn stat_retention_stops_at_the_row_cap_and_totals_stay_whole() {
         // The per-file map is only needed up to the row cap — nothing past it

--- a/src/backend/services/git-cli-proxy/src/engine/read/numstat.rs
+++ b/src/backend/services/git-cli-proxy/src/engine/read/numstat.rs
@@ -3,8 +3,13 @@ use std::path::Path;
 
 use crate::engine::runner::{GitCredentials, GitError, GitRunner};
 
-/// One changed path inside one commit: status comes from the tree diff
-/// (`--raw`), line counts from `--numstat`.
+/// One changed path inside one commit: status and the object id of each side
+/// come from the tree diff (`--raw`), line counts from `--numstat`.
+///
+/// The oid pair is the content identity of the change — the same content
+/// entering a repository on two lines of history carries one post-image oid,
+/// however the two commits differ. A side that does not exist (the pre-image
+/// of an add, the post-image of a delete) is `None`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FileStat {
     pub filename: String,
@@ -13,6 +18,8 @@ pub struct FileStat {
     pub additions: Option<u64>,
     pub deletions: Option<u64>,
     pub is_binary: bool,
+    pub pre_image_oid: Option<String>,
+    pub post_image_oid: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -156,6 +163,9 @@ async fn read_batch(
         "--no-walk",
         "--raw",
         "--numstat",
+        // Raw output abbreviates OIDs by default and the abbreviation length
+        // grows with the repository, so an identity built on it is not stable.
+        "--no-abbrev",
         "-M",
         "-C",
         "-z",
@@ -170,8 +180,17 @@ async fn read_batch(
     Ok(parse(&text))
 }
 
-/// Status per new-path, harvested from `--raw` lines.
-type Statuses = HashMap<String, (FileStatus, Option<String>)>;
+/// What a `--raw` record says about one changed path, keyed by new-path.
+#[derive(Debug, Clone)]
+struct RawRecord {
+    status: FileStatus,
+    previous_filename: Option<String>,
+    pre_image_oid: Option<String>,
+    post_image_oid: Option<String>,
+}
+
+/// Status and object ids per new-path, harvested from `--raw` lines.
+type Statuses = HashMap<String, RawRecord>;
 /// Counts per new-path, harvested from `--numstat` lines.
 type Counts = HashMap<String, (Option<u64>, Option<u64>, bool)>;
 
@@ -215,10 +234,10 @@ fn parse(text: &str) -> HashMap<String, Vec<FileStat>> {
         }
 
         if let Some(meta) = head.strip_prefix(':') {
-            let Some((path, status, previous)) = raw_record(meta, &mut fields) else {
+            let Some((path, record)) = raw_record(meta, &mut fields) else {
                 continue;
             };
-            statuses.insert(path, (status, previous));
+            statuses.insert(path, record);
             continue;
         }
 
@@ -242,17 +261,21 @@ fn merge(order: &[String], statuses: &Statuses, counts: &Counts) -> Vec<FileStat
         .map(|path| {
             let (additions, deletions, is_binary) =
                 counts.get(path).copied().unwrap_or((None, None, false));
-            let (status, previous_filename) = statuses
-                .get(path)
-                .cloned()
-                .unwrap_or((FileStatus::Modified, None));
+            let record = statuses.get(path).cloned().unwrap_or(RawRecord {
+                status: FileStatus::Modified,
+                previous_filename: None,
+                pre_image_oid: None,
+                post_image_oid: None,
+            });
             FileStat {
                 filename: path.clone(),
-                previous_filename,
-                status,
+                previous_filename: record.previous_filename,
+                status: record.status,
                 additions,
                 deletions,
                 is_binary,
+                pre_image_oid: record.pre_image_oid,
+                post_image_oid: record.post_image_oid,
             }
         })
         .collect()
@@ -263,15 +286,36 @@ fn merge(order: &[String], statuses: &Statuses, counts: &Counts) -> Vec<FileStat
 fn raw_record<'a>(
     meta: &str,
     fields: &mut impl Iterator<Item = &'a str>,
-) -> Option<(String, FileStatus, Option<String>)> {
-    let status = FileStatus::from_raw(meta.split_whitespace().nth(4)?);
+) -> Option<(String, RawRecord)> {
+    let mut meta_fields = meta.split_whitespace().skip(2);
+    let pre_image_oid = object_oid(meta_fields.next());
+    let post_image_oid = object_oid(meta_fields.next());
+    let status = FileStatus::from_raw(meta_fields.next()?);
     let first = fields.next()?;
 
-    if matches!(status, FileStatus::Renamed | FileStatus::Copied) {
-        let second = fields.next()?;
-        return Some((second.to_owned(), status, Some(first.to_owned())));
-    }
-    Some((first.to_owned(), status, None))
+    let (path, previous_filename) = if matches!(status, FileStatus::Renamed | FileStatus::Copied) {
+        (fields.next()?.to_owned(), Some(first.to_owned()))
+    } else {
+        (first.to_owned(), None)
+    };
+    Some((
+        path,
+        RawRecord {
+            status,
+            previous_filename,
+            pre_image_oid,
+            post_image_oid,
+        },
+    ))
+}
+
+/// The oid of one side of a raw record, or `None` when that side has none —
+/// the all-zero oid of an added or deleted path, or a field that is not an
+/// object id at all.
+fn object_oid(field: Option<&str>) -> Option<String> {
+    field
+        .filter(|oid| super::blobs::is_object_oid(oid))
+        .map(str::to_owned)
 }
 
 /// `<added>\t<deleted>\t<path>` — binary files report `-` for both counts. A
@@ -504,5 +548,85 @@ mod tests {
             assert_eq!(FileStatus::from_raw(raw), expected, "raw: {raw:?}");
             assert_eq!(expected.as_str(), label);
         }
+    }
+
+    const PRE_OID: &str = "cbfd6b63ca7e7774a1fc6d3eef5379ba0477dc2a";
+    const POST_OID: &str = "4283846abb709e1738fdd3e0f0d9cdd16694c6c4";
+    const NULL_OID: &str = "0000000000000000000000000000000000000000";
+
+    #[test]
+    fn a_modified_path_carries_the_oid_of_each_side() {
+        let meta = format!(":100644 100644 {PRE_OID} {POST_OID} M");
+        let text = stream(&[("aaa", &[&meta, "src/a.rs", "3\t1\tsrc/a.rs"])]);
+        let Some(stats) = parse(&text).get("aaa").cloned() else {
+            panic!("commit missing")
+        };
+        assert_eq!(stats[0].pre_image_oid.as_deref(), Some(PRE_OID));
+        assert_eq!(stats[0].post_image_oid.as_deref(), Some(POST_OID));
+    }
+
+    #[test]
+    fn an_added_path_has_no_pre_image_and_a_deleted_path_no_post_image() {
+        let add = format!(":000000 100644 {NULL_OID} {POST_OID} A");
+        let delete = format!(":100644 000000 {PRE_OID} {NULL_OID} D");
+        let text = stream(&[
+            ("aaa", &[&add, "src/new.rs", "9\t0\tsrc/new.rs"]),
+            ("bbb", &[&delete, "gone.rs", "0\t4\tgone.rs"]),
+        ]);
+        let parsed = parse(&text);
+
+        let Some(added) = parsed.get("aaa") else {
+            panic!("commit aaa missing")
+        };
+        assert_eq!(added[0].pre_image_oid, None, "an add has no pre-image");
+        assert_eq!(added[0].post_image_oid.as_deref(), Some(POST_OID));
+
+        let Some(deleted) = parsed.get("bbb") else {
+            panic!("commit bbb missing")
+        };
+        assert_eq!(deleted[0].pre_image_oid.as_deref(), Some(PRE_OID));
+        assert_eq!(
+            deleted[0].post_image_oid, None,
+            "a delete has no post-image"
+        );
+    }
+
+    #[test]
+    fn a_rename_carries_the_oid_of_content_that_did_not_change() {
+        let meta = format!(":100644 100644 {PRE_OID} {PRE_OID} R100");
+        let text = stream(&[(
+            "aaa",
+            &[
+                &meta,
+                "src/old.rs",
+                "src/new.rs",
+                "0\t0\t",
+                "src/old.rs",
+                "src/new.rs",
+            ],
+        )]);
+        let Some(stats) = parse(&text).get("aaa").cloned() else {
+            panic!("commit missing")
+        };
+        assert_eq!(stats[0].pre_image_oid.as_deref(), Some(PRE_OID));
+        assert_eq!(stats[0].post_image_oid.as_deref(), Some(PRE_OID));
+    }
+
+    #[test]
+    fn a_field_that_is_not_an_object_id_reports_no_oid() {
+        let text = stream(&[(
+            "aaa",
+            &[":100644 100644 zz notahex M", "src/a.rs", "1\t1\tsrc/a.rs"],
+        )]);
+        let Some(stats) = parse(&text).get("aaa").cloned() else {
+            panic!("commit missing")
+        };
+        assert_eq!(stats[0].pre_image_oid, None);
+        assert_eq!(stats[0].post_image_oid, None);
+        assert_eq!(
+            stats[0].status,
+            FileStatus::Modified,
+            "the status field is still read from its own position"
+        );
     }
 }

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__file_changes.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__file_changes.sql
@@ -49,7 +49,12 @@ SELECT
     COALESCE(change.source_type, '') AS source_type,
     'insight_bitbucket_cloud' AS data_source,
     toUnixTimestamp64Milli(now64()) AS _version,
-    latest.latest_completed_at AS _airbyte_extracted_at
+    latest.latest_completed_at AS _airbyte_extracted_at,
+    -- Bitbucket's diffstat reports no object id for either side of a change;
+    -- the columns keep the union positional until the connector reads through
+    -- the git proxy.
+    CAST(NULL AS Nullable(String)) AS pre_image_oid,
+    CAST(NULL AS Nullable(String)) AS post_image_oid
 FROM {{ source('bronze_bitbucket_cloud', 'file_changes') }} AS change FINAL
 INNER JOIN latest USING (tenant_id, source_id, repository_uuid, sha, generation_id)
 WHERE change.record_type = 'item'

--- a/src/ingestion/connectors/git/github/connector.yaml
+++ b/src/ingestion/connectors/git/github/connector.yaml
@@ -662,6 +662,11 @@ streams:
           is_binary: {type: [boolean, "null"]}
           patch: {type: [string, "null"]}
           patch_truncated: {type: [boolean, "null"]}
+          # Appended, not slotted next to the counts: a pre-existing bronze
+          # table gains a column at the tail, and the snapshot has to describe
+          # one order for both a fresh create and an altered instance.
+          pre_image_oid: {type: [string, "null"]}
+          post_image_oid: {type: [string, "null"]}
         required:
           - unique_key
         additionalProperties: true

--- a/src/ingestion/connectors/git/github/connector.yaml
+++ b/src/ingestion/connectors/git/github/connector.yaml
@@ -662,9 +662,8 @@ streams:
           is_binary: {type: [boolean, "null"]}
           patch: {type: [string, "null"]}
           patch_truncated: {type: [boolean, "null"]}
-          # Appended, not slotted next to the counts: a pre-existing bronze
-          # table gains a column at the tail, and the snapshot has to describe
-          # one order for both a fresh create and an altered instance.
+          # INVARIANT: bronze column order is the destination's insert order —
+          # a new column appends at the tail.
           pre_image_oid: {type: [string, "null"]}
           post_image_oid: {type: [string, "null"]}
         required:

--- a/src/ingestion/connectors/git/github/dbt/github__file_changes.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__file_changes.sql
@@ -24,7 +24,9 @@ SELECT
     'commit' AS source_type,
     'insight_github' AS data_source,
     toUnixTimestamp64Milli(now64()) AS _version,
-    _airbyte_extracted_at
+    _airbyte_extracted_at,
+    pre_image_oid,
+    post_image_oid
 FROM {{ source('bronze_github', 'file_changes') }}
 {% if is_incremental() %}
 WHERE _airbyte_extracted_at > (SELECT max(_airbyte_extracted_at) FROM {{ this }})

--- a/src/ingestion/connectors/git/gitlab/dbt/gitlab__file_changes.sql
+++ b/src/ingestion/connectors/git/gitlab/dbt/gitlab__file_changes.sql
@@ -40,7 +40,12 @@ SELECT
     '' AS source_type,
     'insight_gitlab' AS data_source,
     toUnixTimestamp64Milli(now64()) AS _version,
-    fc._airbyte_extracted_at
+    fc._airbyte_extracted_at,
+    -- GitLab's diff API reports no object id for either side of a change; the
+    -- columns keep the union positional until the connector reads through the
+    -- git proxy.
+    CAST(NULL AS Nullable(String)) AS pre_image_oid,
+    CAST(NULL AS Nullable(String)) AS post_image_oid
 FROM {{ source('bronze_gitlab', 'commit_file_changes') }} AS fc
 LEFT JOIN proj AS p
     ON p.project_id = fc.project_id

--- a/src/ingestion/gold/git_metric_evidence.sql
+++ b/src/ingestion/gold/git_metric_evidence.sql
@@ -124,6 +124,84 @@ deduplicated_file_changes AS (
             ''
         )
 ),
+-- A commit's own line stats, less the lines of the file changes that lost the
+-- content dedup. The stats stay the base — a source can report a commit's
+-- totals without reporting its file changes at all — and only what the dedup
+-- removed is taken back out, so a commit that introduces nothing new reports a
+-- size of zero and its drilldown detail agrees with what it contributed.
+reported_commit_file_lines AS (
+    SELECT
+        tenant_id,
+        source_id,
+        project_key,
+        repo_slug,
+        commit_hash,
+        sum(lines_added) AS lines_added,
+        sum(lines_removed) AS lines_removed
+    FROM {{ ref('class_git_file_changes') }} FINAL
+    GROUP BY tenant_id, source_id, project_key, repo_slug, commit_hash
+),
+authored_commit_file_lines AS (
+    SELECT
+        tenant_id,
+        source_id,
+        project_key,
+        repo_slug,
+        commit_hash,
+        sum(lines_added) AS lines_added,
+        sum(lines_removed) AS lines_removed
+    FROM deduplicated_file_changes
+    GROUP BY tenant_id, source_id, project_key, repo_slug, commit_hash
+),
+authored_commits AS (
+    SELECT
+        commits.tenant_id AS tenant_id,
+        commits.entity_id AS entity_id,
+        commits.metric_date AS metric_date,
+        commits.observed_at AS observed_at,
+        commits.commit_hash AS commit_hash,
+        commits.message AS message,
+        commits.author_name AS author_name,
+        commits.repository_label AS repository_label,
+        commits.source_value AS source_value,
+        commits.source_dimensions AS source_dimensions,
+        -- SAFETY: the NULL check is explicit because `greatest` IGNORES NULL
+        -- arguments — `greatest(0, NULL)` is 0, which would invent a size for a
+        -- commit whose source reported no line stats. `greatest` floors the
+        -- result because a commit's own stats and the sum of its file changes
+        -- need not agree (binary files, truncated diffs).
+        if(
+            commits.lines_added IS NULL,
+            CAST(NULL AS Nullable(Int64)),
+            toNullable(greatest(
+                toInt64(0),
+                assumeNotNull(commits.lines_added)
+                    - (coalesce(reported.lines_added, 0) - coalesce(authored.lines_added, 0))
+            ))
+        ) AS lines_added,
+        if(
+            commits.lines_removed IS NULL,
+            CAST(NULL AS Nullable(Int64)),
+            toNullable(greatest(
+                toInt64(0),
+                assumeNotNull(commits.lines_removed)
+                    - (coalesce(reported.lines_removed, 0) - coalesce(authored.lines_removed, 0))
+            ))
+        ) AS lines_removed
+    FROM commits_source AS commits
+    LEFT JOIN reported_commit_file_lines AS reported
+        ON reported.tenant_id = commits.tenant_id
+        AND reported.source_id = commits.source_id
+        AND reported.project_key = commits.project_key
+        AND reported.repo_slug = commits.repo_slug
+        AND reported.commit_hash = commits.commit_hash
+    LEFT JOIN authored_commit_file_lines AS authored
+        ON authored.tenant_id = commits.tenant_id
+        AND authored.source_id = commits.source_id
+        AND authored.project_key = commits.project_key
+        AND authored.repo_slug = commits.repo_slug
+        AND authored.commit_hash = commits.commit_hash
+),
 file_changes_source AS (
     SELECT
         commits.tenant_id AS tenant_id,
@@ -418,7 +496,7 @@ SELECT
         'lines_added', coalesce(toString(lines_added), ''),
         'lines_removed', coalesce(toString(lines_removed), '')
     ) AS details
-FROM commits_source
+FROM authored_commits
 ARRAY JOIN arrayConcat(
     [tuple('commit_count', toFloat64(1))],
     if(

--- a/src/ingestion/gold/git_metric_evidence.sql
+++ b/src/ingestion/gold/git_metric_evidence.sql
@@ -74,6 +74,56 @@ commits_source AS (
     ORDER BY tenant_id, data_source, commit_hash, source_id, project_key, repo_slug
     LIMIT 1 BY tenant_id, data_source, commit_hash
 ),
+-- One row per change CONTENT, not per commit that carries it. The same content
+-- entering a repository on two lines of history — a branch whose copy of a
+-- tree was squashed onto the default branch as well, a cherry-pick, a
+-- reverted-then-restored file — is one authored change with one oid pair, and
+-- summing both commits' diffs would count those lines twice.
+--
+-- Earliest commit wins, so the value lands in the period the content was first
+-- authored and does not move when a later commit repeats it.
+--
+-- The commit_hash tie-breaker keeps rows whose identity is UNKNOWN (a source
+-- that reports no oid, or a row collected before the proxy did) distinct per
+-- commit: without it every such row for one path would collapse into one,
+-- because LIMIT 1 BY reads their NULL keys as equal.
+deduplicated_file_changes AS (
+    SELECT
+        raw_file_change.tenant_id AS tenant_id,
+        raw_file_change.source_id AS source_id,
+        raw_file_change.project_key AS project_key,
+        raw_file_change.repo_slug AS repo_slug,
+        raw_file_change.commit_hash AS commit_hash,
+        raw_file_change.data_source AS data_source,
+        raw_file_change.file_path AS file_path,
+        raw_file_change.file_extension AS file_extension,
+        raw_file_change.change_type AS change_type,
+        raw_file_change.lines_added AS lines_added,
+        raw_file_change.lines_removed AS lines_removed
+    FROM {{ ref('class_git_file_changes') }} AS raw_file_change FINAL
+    INNER JOIN commits_source AS commits
+        ON commits.tenant_id = raw_file_change.tenant_id
+        AND commits.source_id = raw_file_change.source_id
+        AND commits.project_key = raw_file_change.project_key
+        AND commits.repo_slug = raw_file_change.repo_slug
+        AND commits.commit_hash = raw_file_change.commit_hash
+    ORDER BY commits.observed_at, raw_file_change.commit_hash
+    LIMIT 1 BY
+        raw_file_change.tenant_id,
+        raw_file_change.data_source,
+        raw_file_change.project_key,
+        raw_file_change.repo_slug,
+        raw_file_change.file_path,
+        raw_file_change.change_type,
+        raw_file_change.pre_image_oid,
+        raw_file_change.post_image_oid,
+        if(
+            coalesce(raw_file_change.pre_image_oid, '') = ''
+                AND coalesce(raw_file_change.post_image_oid, '') = '',
+            raw_file_change.commit_hash,
+            ''
+        )
+),
 file_changes_source AS (
     SELECT
         commits.tenant_id AS tenant_id,
@@ -129,7 +179,7 @@ file_changes_source AS (
             ) AS change_type_label,
             sum(lines_added) AS lines_added,
             sum(lines_removed) AS lines_removed
-        FROM {{ ref('class_git_file_changes') }} AS raw_file_change FINAL
+        FROM deduplicated_file_changes AS raw_file_change
         GROUP BY tenant_id, source_id, project_key, repo_slug, commit_hash, category, file_extension_value, file_extension_label, change_type_value, change_type_label
     ) AS file_changes
     INNER JOIN commits_source AS commits

--- a/src/ingestion/gold/git_metric_evidence.sql
+++ b/src/ingestion/gold/git_metric_evidence.sql
@@ -114,7 +114,7 @@ deduplicated_file_changes AS (
         raw_file_change.project_key,
         raw_file_change.repo_slug,
         raw_file_change.file_path,
-        raw_file_change.change_type,
+        lower(raw_file_change.change_type),
         raw_file_change.pre_image_oid,
         raw_file_change.post_image_oid,
         if(

--- a/src/ingestion/scripts/apply-ch-migrations.sh
+++ b/src/ingestion/scripts/apply-ch-migrations.sh
@@ -167,26 +167,39 @@ SQL
 heal_task_users_table silver class_task_users
 
 echo "=== Healing git file-change object id columns ==="
-# The file-change object ids arrive at the tail of every staging projection
-# that feeds class_git_file_changes. Pre-existing staging tables lack them and
-# the positional insert misaligns; the silver side heals in migrations/*.sql,
-# staging heals here because these tables exist only after the connector's
-# first run. Existing rows heal to NULL and carry an oid from the first sync
-# that re-collects them. Idempotent.
+# The file-change object ids arrive at the tail of every projection that feeds
+# class_git_file_changes. Pre-existing tables lack them and the positional
+# insert misaligns; the silver side heals in migrations/*.sql, the rest heals
+# here because these tables exist only after a connector has run.
+#
+# bronze_github.file_changes is healed for a different reason: the GitHub
+# staging model READS the two columns, and nothing else adds them in time.
+# create-bronze-placeholders.sh is IF NOT EXISTS so a warm bronze table is
+# never altered, and the destination only widens it on the connector's next
+# sync — which lands after this deploy's dbt run, leaving the staging model
+# (and every git model downstream of it) failing on an unknown identifier
+# until then.
+#
+# Existing rows heal to NULL and carry an oid from the first sync that
+# re-collects them. Idempotent.
 heal_git_file_change_oids() {
-  local table="$1"
-  ch_table_is_real staging "${table}" || return 0
-  echo "  staging.${table}"
+  local db="$1" table="$2" anchor="$3"
+  ch_table_is_real "${db}" "${table}" || return 0
+  echo "  ${db}.${table}"
   run_ch <<SQL
-ALTER TABLE staging.${table} ADD COLUMN IF NOT EXISTS pre_image_oid Nullable(String) AFTER _airbyte_extracted_at;
-ALTER TABLE staging.${table} ADD COLUMN IF NOT EXISTS post_image_oid Nullable(String) AFTER pre_image_oid;
-ALTER TABLE staging.${table} MODIFY COLUMN pre_image_oid Nullable(String) AFTER _airbyte_extracted_at;
-ALTER TABLE staging.${table} MODIFY COLUMN post_image_oid Nullable(String) AFTER pre_image_oid;
+ALTER TABLE ${db}.${table} ADD COLUMN IF NOT EXISTS pre_image_oid Nullable(String) AFTER ${anchor};
+ALTER TABLE ${db}.${table} ADD COLUMN IF NOT EXISTS post_image_oid Nullable(String) AFTER pre_image_oid;
+ALTER TABLE ${db}.${table} MODIFY COLUMN pre_image_oid Nullable(String) AFTER ${anchor};
+ALTER TABLE ${db}.${table} MODIFY COLUMN post_image_oid Nullable(String) AFTER pre_image_oid;
 SQL
 }
 
+# Bronze's tail is patch_truncated; every staging projection ends with
+# _airbyte_extracted_at.
+heal_git_file_change_oids bronze_github file_changes patch_truncated
+
 for _git_source in github gitlab bitbucket_cloud; do
-  heal_git_file_change_oids "${_git_source}__file_changes"
+  heal_git_file_change_oids staging "${_git_source}__file_changes" _airbyte_extracted_at
 done
 
 echo "=== Healing jira task id column types (#1743) ==="

--- a/src/ingestion/scripts/apply-ch-migrations.sh
+++ b/src/ingestion/scripts/apply-ch-migrations.sh
@@ -166,6 +166,29 @@ SQL
 
 heal_task_users_table silver class_task_users
 
+echo "=== Healing git file-change object id columns ==="
+# The file-change object ids arrive at the tail of every staging projection
+# that feeds class_git_file_changes. Pre-existing staging tables lack them and
+# the positional insert misaligns; the silver side heals in migrations/*.sql,
+# staging heals here because these tables exist only after the connector's
+# first run. Existing rows heal to NULL and carry an oid from the first sync
+# that re-collects them. Idempotent.
+heal_git_file_change_oids() {
+  local table="$1"
+  ch_table_is_real staging "${table}" || return 0
+  echo "  staging.${table}"
+  run_ch <<SQL
+ALTER TABLE staging.${table} ADD COLUMN IF NOT EXISTS pre_image_oid Nullable(String) AFTER _airbyte_extracted_at;
+ALTER TABLE staging.${table} ADD COLUMN IF NOT EXISTS post_image_oid Nullable(String) AFTER pre_image_oid;
+ALTER TABLE staging.${table} MODIFY COLUMN pre_image_oid Nullable(String) AFTER _airbyte_extracted_at;
+ALTER TABLE staging.${table} MODIFY COLUMN post_image_oid Nullable(String) AFTER pre_image_oid;
+SQL
+}
+
+for _git_source in github gitlab bitbucket_cloud; do
+  heal_git_file_change_oids "${_git_source}__file_changes"
+done
+
 echo "=== Healing jira task id column types (#1743) ==="
 # #1892 retyped the jira staging id projections (worklog_id, comment_id)
 # from raw bronze Decimal(38,9) to toString(...), but pre-existing

--- a/src/ingestion/scripts/connectors-ddl/github.sql
+++ b/src/ingestion/scripts/connectors-ddl/github.sql
@@ -161,7 +161,9 @@ CREATE TABLE IF NOT EXISTS bronze_github.file_changes
     `changes` Nullable(Int64),
     `is_binary` Nullable(Bool),
     `patch` Nullable(String),
-    `patch_truncated` Nullable(Bool)
+    `patch_truncated` Nullable(Bool),
+    `pre_image_oid` Nullable(String),
+    `post_image_oid` Nullable(String)
 )
 ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
 ORDER BY unique_key

--- a/src/ingestion/scripts/connectors-ddl/silver.sql
+++ b/src/ingestion/scripts/connectors-ddl/silver.sql
@@ -426,7 +426,9 @@ CREATE TABLE IF NOT EXISTS silver.class_git_file_changes
     `source_type` String,
     `data_source` String,
     `_version` Int64,
-    `_airbyte_extracted_at` DateTime64(3)
+    `_airbyte_extracted_at` DateTime64(3),
+    `pre_image_oid` Nullable(String),
+    `post_image_oid` Nullable(String)
 )
 ENGINE = ReplacingMergeTree(_version)
 ORDER BY unique_key

--- a/src/ingestion/scripts/migrations/20260820000000_git-file-change-blob-oids.sql
+++ b/src/ingestion/scripts/migrations/20260820000000_git-file-change-blob-oids.sql
@@ -1,0 +1,31 @@
+-- Add the file-change object ids to the git class contract.
+--
+-- The columns are the content identity of a change (pre-image and post-image
+-- oid), which readers deduplicate on: the same content entering a repository
+-- on two lines of history is two commits but one post-image oid.
+--
+-- A pre-existing table gets them from nowhere: the DDL snapshot is
+-- IF NOT EXISTS, and these models run with dbt's default
+-- on_schema_change=ignore, so an existing relation never gains a column the
+-- model started projecting. The staging halves of the same contract heal in
+-- apply-ch-migrations.sh, where a table that no connector has built yet can be
+-- skipped.
+--
+-- AFTER anchors put them at the tail, the position the staging projections use
+-- and the positional insert requires; MODIFY converges an instance where an
+-- out-of-band ALTER placed them elsewhere. Shape follows
+-- 20260818000000_ai-dev-usage-seat-status.sql.
+--
+-- Idempotent: this channel has no ledger and re-runs on every deploy.
+-- The class tables always exist here (placeholders precede migrations).
+ALTER TABLE silver.class_git_file_changes
+    ADD COLUMN IF NOT EXISTS pre_image_oid Nullable(String) AFTER _airbyte_extracted_at;
+
+ALTER TABLE silver.class_git_file_changes
+    ADD COLUMN IF NOT EXISTS post_image_oid Nullable(String) AFTER pre_image_oid;
+
+ALTER TABLE silver.class_git_file_changes
+    MODIFY COLUMN pre_image_oid Nullable(String) AFTER _airbyte_extracted_at;
+
+ALTER TABLE silver.class_git_file_changes
+    MODIFY COLUMN post_image_oid Nullable(String) AFTER pre_image_oid;

--- a/src/ingestion/silver/git/schema.yml
+++ b/src/ingestion/silver/git/schema.yml
@@ -77,6 +77,16 @@ models:
         tests:
           - not_null
           - unique
+      - name: pre_image_oid
+        description: >
+          Object id of the content this change replaced, NULL for an added path
+          and for a source that reports no object id.
+      - name: post_image_oid
+        description: >
+          Object id of the content this change produced, NULL for a deleted path
+          and for a source that reports no object id. With pre_image_oid it is
+          the content identity of the change: the same content entering a
+          repository on two lines of history carries one post_image_oid.
 
   - name: class_git_pull_requests
     description: "Unified git pull requests from all sources (GitHub, Bitbucket, GitLab)"

--- a/src/ingestion/tests/e2e/metrics/git_file_change_content_identity.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_file_change_content_identity.test.yaml
@@ -1,0 +1,80 @@
+spec_version: 1
+description: >
+  Line metrics count a change once per CONTENT, not once per commit that
+  carries it. The same content reaches a repository twice whenever a branch
+  keeps its own copy of a tree that also landed on the default branch, or a
+  commit is cherry-picked: two commits, one (pre_image_oid, post_image_oid)
+  pair, one authored change.
+
+  Fixture isolates itself in its own repository so the breakdown assertions are
+  unaffected by any other git fixture seeded in the suite:
+    * add-dup-1 / add-dup-2 add src/bundle.js with the same post-image oid —
+      +100 counts once, and the earliest commit keeps it.
+    * mod-dup-1 / mod-dup-2 make the same oid-to-oid transition on
+      src/app.ts — +8/-3 counts once.
+    * distinct adds different content, so it is never folded in.
+    * unknown-1 / unknown-2 report NO oid (a source that has none, or a row
+      collected before the proxy reported one). Their identity is unknown, so
+      they must both survive — collapsing them would read NULL keys as equal.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/erin
+
+  bronze_github.commits:
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: ci-commit-add-dup-1, repository: "https://github.com/constructor/content-identity.git", sha: ci-add-dup-1, committed_date: "2026-10-01T09:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 100}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: ci-commit-add-dup-2, repository: "https://github.com/constructor/content-identity.git", sha: ci-add-dup-2, committed_date: "2026-10-01T10:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 100}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: ci-commit-distinct, repository: "https://github.com/constructor/content-identity.git", sha: ci-distinct, committed_date: "2026-10-01T11:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 7}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: ci-commit-mod-dup-1, repository: "https://github.com/constructor/content-identity.git", sha: ci-mod-dup-1, committed_date: "2026-10-01T12:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 8}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: ci-commit-mod-dup-2, repository: "https://github.com/constructor/content-identity.git", sha: ci-mod-dup-2, committed_date: "2026-10-01T13:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 8}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: ci-commit-unknown-1, repository: "https://github.com/constructor/content-identity.git", sha: ci-unknown-1, committed_date: "2026-10-01T14:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 5}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: ci-commit-unknown-2, repository: "https://github.com/constructor/content-identity.git", sha: ci-unknown-2, committed_date: "2026-10-01T15:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 5}
+
+  bronze_github.file_changes:
+    # One content, two commits: the add counts once.
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: ci-file-add-dup-1, repository: "https://github.com/constructor/content-identity.git", sha: ci-add-dup-1, filename: src/bundle.js, status: added, additions: 100, deletions: 0, pre_image_oid: null, post_image_oid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: ci-file-add-dup-2, repository: "https://github.com/constructor/content-identity.git", sha: ci-add-dup-2, filename: src/bundle.js, status: added, additions: 100, deletions: 0, pre_image_oid: null, post_image_oid: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1}
+    # Different content at a different path: never folded in.
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: ci-file-distinct, repository: "https://github.com/constructor/content-identity.git", sha: ci-distinct, filename: src/other.js, status: added, additions: 7, deletions: 0, pre_image_oid: null, post_image_oid: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb2}
+    # One oid-to-oid transition, two commits: the modification counts once.
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: ci-file-mod-dup-1, repository: "https://github.com/constructor/content-identity.git", sha: ci-mod-dup-1, filename: src/app.ts, status: modified, additions: 8, deletions: 3, pre_image_oid: ccccccccccccccccccccccccccccccccccccccc3, post_image_oid: ddddddddddddddddddddddddddddddddddddddd4}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: ci-file-mod-dup-2, repository: "https://github.com/constructor/content-identity.git", sha: ci-mod-dup-2, filename: src/app.ts, status: modified, additions: 8, deletions: 3, pre_image_oid: ccccccccccccccccccccccccccccccccccccccc3, post_image_oid: ddddddddddddddddddddddddddddddddddddddd4}
+    # No oid on either side: identity unknown, so both rows must survive.
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: ci-file-unknown-1, repository: "https://github.com/constructor/content-identity.git", sha: ci-unknown-1, filename: src/legacy.js, status: modified, additions: 5, deletions: 1}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: ci-file-unknown-2, repository: "https://github.com/constructor/content-identity.git", sha: ci-unknown-2, filename: src/legacy.js, status: modified, additions: 5, deletions: 1}
+
+cases:
+  - name: A change counts once per content, however many commits carry it
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.lines_added
+            views:
+              - {view: breakdown, dimensions: [repository]}
+          - metric_key: git.lines_removed
+            views:
+              - {view: breakdown, dimensions: [repository]}
+          - metric_key: git.commits
+            views:
+              - {view: breakdown, dimensions: [repository]}
+    expect:
+      - assert: "status == 200"
+      # 100 (one add, not two) + 7 + 8 (one modification, not two) + 5 + 5.
+      - metric: git.lines_added
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/content-identity"}}
+        equal: {value: 125}
+      # 3 (one modification, not two) + 1 + 1.
+      - metric: git.lines_removed
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/content-identity"}}
+        equal: {value: 5}
+      # Commit counting is unaffected: every commit is its own authored commit.
+      - metric: git.commits
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/content-identity"}}
+        equal: {value: 7}

--- a/src/ingestion/tests/e2e/metrics/git_file_change_content_identity.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_file_change_content_identity.test.yaml
@@ -16,6 +16,8 @@ description: >
     * mod-dup-1 / mod-dup-2 make the same oid-to-oid transition on
       src/app.ts — +8/-3 counts once.
     * distinct adds different content, so it is never folded in.
+    * add-dup-2 is also what pins the commit-level correction: its own stats
+      say +100, every line of which October already counted, so its size is 0.
     * unknown-1 / unknown-2 report NO oid (a source that has none, or a row
       collected before the proxy reported one). Their identity is unknown, so
       they must both survive — collapsing them would read NULL keys as equal.
@@ -98,6 +100,11 @@ cases:
           - metric_key: git.commits
             views:
               - {view: breakdown, dimensions: [repository]}
+          # No repository dimension on this one, so the window is what isolates
+          # it: November holds exactly this fixture's one commit.
+          - metric_key: git.commit_size
+            views:
+              - {view: period}
     expect:
       - assert: "status == 200"
       # November holds one commit, and the only file change it carries repeats
@@ -112,3 +119,9 @@ cases:
       - metric: git.lines_added
         view: breakdown
         assert: "!items.exists(v, v.dimensions.exists(d, d.key == 'repository' && d.value == 'git-test:constructor/content-identity'))"
+      # The commit's own size agrees with what it contributed: its line stats
+      # less the file-change lines the content dedup removed.
+      - metric: git.commit_size
+        view: period
+        find: {entity_id: erin@example.com}
+        equal: {value: 0}

--- a/src/ingestion/tests/e2e/metrics/git_file_change_content_identity.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_file_change_content_identity.test.yaml
@@ -8,8 +8,11 @@ description: >
 
   Fixture isolates itself in its own repository so the breakdown assertions are
   unaffected by any other git fixture seeded in the suite:
-    * add-dup-1 / add-dup-2 add src/bundle.js with the same post-image oid —
-      +100 counts once, and the earliest commit keeps it.
+    * add-dup-1 (October) / add-dup-2 (November) add src/bundle.js with the
+      same post-image oid — +100 counts once, and the EARLIEST commit keeps it,
+      so October reports the lines and November reports none. The two windows
+      are what pin the ordering: if the later commit won, the +100 would move
+      to November.
     * mod-dup-1 / mod-dup-2 make the same oid-to-oid transition on
       src/app.ts — +8/-3 counts once.
     * distinct adds different content, so it is never folded in.
@@ -23,7 +26,7 @@ bronze:
 
   bronze_github.commits:
     - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: ci-commit-add-dup-1, repository: "https://github.com/constructor/content-identity.git", sha: ci-add-dup-1, committed_date: "2026-10-01T09:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 100}
-    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: ci-commit-add-dup-2, repository: "https://github.com/constructor/content-identity.git", sha: ci-add-dup-2, committed_date: "2026-10-01T10:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 100}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: ci-commit-add-dup-2, repository: "https://github.com/constructor/content-identity.git", sha: ci-add-dup-2, committed_date: "2026-11-02T10:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 100}
     - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: ci-commit-distinct, repository: "https://github.com/constructor/content-identity.git", sha: ci-distinct, committed_date: "2026-10-01T11:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 7}
     - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: ci-commit-mod-dup-1, repository: "https://github.com/constructor/content-identity.git", sha: ci-mod-dup-1, committed_date: "2026-10-01T12:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 8}
     - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: ci-commit-mod-dup-2, repository: "https://github.com/constructor/content-identity.git", sha: ci-mod-dup-2, committed_date: "2026-10-01T13:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 8}
@@ -63,7 +66,8 @@ cases:
               - {view: breakdown, dimensions: [repository]}
     expect:
       - assert: "status == 200"
-      # 100 (one add, not two) + 7 + 8 (one modification, not two) + 5 + 5.
+      # 100 (the October add, which is the earliest) + 7 + 8 (one
+      # modification, not two) + 5 + 5.
       - metric: git.lines_added
         view: breakdown
         find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/content-identity"}}
@@ -73,8 +77,38 @@ cases:
         view: breakdown
         find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/content-identity"}}
         equal: {value: 5}
-      # Commit counting is unaffected: every commit is its own authored commit.
+      # Commit counting is unaffected: every commit is its own authored
+      # commit. Six land in October; add-dup-2 is November's.
       - metric: git.commits
         view: breakdown
         find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/content-identity"}}
-        equal: {value: 7}
+        equal: {value: 6}
+
+  - name: The repeat of an earlier content reports no lines of its own
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-11-01", to: "2026-11-30"}
+        metrics:
+          - metric_key: git.lines_added
+            views:
+              - {view: breakdown, dimensions: [repository]}
+          - metric_key: git.commits
+            views:
+              - {view: breakdown, dimensions: [repository]}
+    expect:
+      - assert: "status == 200"
+      # November holds one commit, and the only file change it carries repeats
+      # content October already accounted for — so the commit counts and the
+      # lines do not.
+      - metric: git.commits
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/content-identity"}}
+        equal: {value: 1}
+      # No breakdown row at all for the repository: a metric with nothing to
+      # report omits the dimension rather than reporting it as zero.
+      - metric: git.lines_added
+        view: breakdown
+        assert: "!items.exists(v, v.dimensions.exists(d, d.key == 'repository' && d.value == 'git-test:constructor/content-identity'))"

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_github.file_changes.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_github.file_changes.yaml
@@ -17,3 +17,5 @@ schemas:
       status: {type: string}
       additions: {type: integer}
       deletions: {type: integer}
+      pre_image_oid: {type: [string, "null"]}
+      post_image_oid: {type: [string, "null"]}


### PR DESCRIPTION
**Why.** Line metrics sum per-commit diffs, so content that reaches a repository on two lines of history — a branch carrying its own copy of a tree that also landed on the default branch, a cherry-pick, a file removed and restored — is counted once per commit rather than once per authored change. Nothing in the class contract could tell the two apart: the commits' patch ids differ, and both can be ancestors of the default branch, so neither a patch-id nor a branch-membership filter removes the repeat.

**What changed.** The git proxy now reports the pre-image and post-image object id of every file change, taken from the `--raw` record it already parses for status, with `--no-abbrev` so the ids are stable (raw output abbreviates by default and the abbreviation length grows with the repository). The GitHub connector carries them to bronze; the class contract gains `pre_image_oid` / `post_image_oid`; `git_metric_evidence` keeps one row per `(path, change_type, oid pair)`, earliest commit winning, so a value lands in the period its content was first authored and does not move when a later commit repeats it.

**Commit-level numbers follow the same accounting.** A commit's reported size is its own line stats less the file-change lines the dedup removed, so a commit that introduces nothing new reports zero and its drilldown detail agrees with what it contributed to the aggregates. The commit's own stats stay the base rather than being recomputed from its file changes: a source can report a commit's totals without reporting its file changes at all, and those commits must keep their size.

**Identity unknown stays un-deduplicated.** GitLab and Bitbucket report no object id until they read through the proxy, and rows collected before this change have none. Those rows keep a per-commit discriminator in the dedup key — without it `LIMIT 1 BY` would read their NULL keys as equal and collapse every change to one path into a single row, turning an over-count into a much larger under-count.

**Existing instances.** These models run with dbt's default `on_schema_change=ignore`, so a warm relation never gains a column the model started projecting. The silver class table heals in `migrations/`; the staging tables and `bronze_github.file_changes` heal in `apply-ch-migrations.sh`. Bronze is healed there rather than left to the connector because the GitHub staging model READS the two columns: the placeholder script never alters an existing relation, and the destination only widens bronze on the next sync, which lands after this deploy's dbt run.

**Out of scope.** GitLab and Bitbucket keep projecting NULL until they move to the proxy. Deduplication is forward-only: bronze holds no object ids for rows already collected, so it takes effect for a repository once its file changes are re-collected.

**Verified.** `cargo test -p git-cli-proxy` (209 passed) including a live test that commits identical content on two branches and asserts one post-image oid across two shas; `cargo test -p analytics metric_definitions` (64 passed, covering the passports drift test); clippy and fmt clean; the committed OpenAPI spec regenerated and drift-checked; `dbt parse` clean. Full `metrics/` suite on a fresh stack: 54 passed. Two mutation runs confirm the new fixture pins behaviour rather than passing incidentally — bypassing the dedup fails it (`expected 125, got 233`), and removing the commit-size correction fails it (`expected 0, got 100`). The rig's setup applies the new migration against a real ClickHouse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
