### PR TITLE
fix(ai-cost): name which cost the AI & Cost average tile averages

### DIFF
--- a/src/frontend/src/components/portal/ai-cost-view.test.tsx
+++ b/src/frontend/src/components/portal/ai-cost-view.test.tsx
@@ -164,7 +164,7 @@ describe("AiCostView", () => {
     expect(screen.queryByText("$162")).not.toBeInTheDocument();
     // The average carries the same pair: 150/3 against 12/3, never 162/3.
     expect(screen.getAllByText("$50").length).toBeGreaterThan(0);
-    expect(screen.getByText("actual $4 / active user")).toBeInTheDocument();
+    expect(screen.getByText("avg actual $4 / active user")).toBeInTheDocument();
     expect(screen.queryByText("$54")).not.toBeInTheDocument();
   });
 

--- a/src/frontend/src/components/portal/ai-cost-view.tsx
+++ b/src/frontend/src/components/portal/ai-cost-view.tsx
@@ -372,14 +372,16 @@ export function AiCostView({ item }: { item: string | null }) {
           sub="org total"
         />
         <Tile
-          label="Avg cost / active user"
+          label="Avg potential cost / active user"
           value={formatMetricValue(
             avgCost,
             costR?.format ?? "currency",
             costR?.unit ?? null,
           )}
           note={
-            hasActual ? `actual ${actualMoney(avgActual)} / active user` : null
+            hasActual
+              ? `avg actual ${actualMoney(avgActual)} / active user`
+              : null
           }
           sub="Claude Code"
         />


### PR DESCRIPTION
Closes #2692.

**Why.** Since #2672 the AI & Cost headline row holds the potential and the actual cost side by side, but the fourth tile kept its old wording. `Avg cost` does not say which of the two it averages, and `actual $32 / active user` reads as a total placed next to an average.

**What changed.** Two strings in that tile — `Avg potential cost / active user`, and `avg actual … / active user`. The figures are untouched: `avgCost` and `avgActual` were already both per active user, so this is what they were always showing.

**Verified.** `tsc -b`, `eslint . --max-warnings 0`, and the unit suite at 195 files / 1727 tests, all passing — the existing assertion updated to the new wording. Screenshots pending, no stand up.
