### PR TITLE
fix(ai): read Claude usage up to today and re-read the days the vendor revises

### DIFF
--- a/src/ingestion/connectors/ai/claude-enterprise/README.md
+++ b/src/ingestion/connectors/ai/claude-enterprise/README.md
@@ -97,9 +97,8 @@ Routing is tag-driven via `dbt_select: "tag:claude-enterprise+"` in `descriptor.
 ## Operational Constraints
 
 - **Rate limits**: organization-level, default values not documented; adjustable via Anthropic CSM. The connector honours `Retry-After` on HTTP 429 with exponential backoff, and retries on 5xx.
-- **Reporting lag**: 3 days. The connector's effective upper bound is `today − 3 days`; later dates are deferred to the next run.
+- **Reporting lag**: a day keeps being revised for about 3 days after it closes. The streams read up to today and re-read that tail on every run (`lookback_window: P3D`) rather than waiting for it to settle: a revised day returns with a later `_airbyte_extracted_at`, and `ReplacingMergeTree(_version)` keeps it. Reading recent days late instead left them absent until they settled, which reads downstream as no activity rather than as no data (#2682).
 - **Minimum date**: 2026-01-01. Earlier `start_date` values are silently clamped.
-- **`start_date` edge case**: if `start_date` is within the 3-day lag window (e.g. yesterday), the cursor window is empty (`start > end`). Airbyte's `DatetimeBasedCursor` skips empty windows silently — no error, zero records. Set `start_date` to at least 4 days in the past to guarantee data on first run.
 - **`/summaries`**: uses P1D step with `starting_date` only (no `ending_date`). The API supports 31-day ranges, but `ending_date` is exclusive — P31D would silently skip boundary days. One request per day is safe and fast (tiny payload).
 - **Concurrency**: `default_concurrency: 1` (sequential streams). Intentional to avoid rate-limit exhaustion during backfill; can be bumped to 2-3 after observing real API behavior.
 

--- a/src/ingestion/connectors/ai/claude-enterprise/connector.yaml
+++ b/src/ingestion/connectors/ai/claude-enterprise/connector.yaml
@@ -116,10 +116,9 @@ streams:
         datetime: "{{ config.get('start_date') or day_delta(-14, format='%Y-%m-%d') }}"
         datetime_format: "%Y-%m-%d"
         min_datetime: "2026-01-01"
-      end_datetime:
-        type: MinMaxDatetime
-        datetime: "{{ day_delta(-3, format='%Y-%m-%d') }}"
-        datetime_format: "%Y-%m-%d"
+      # Re-read the tail the vendor may still revise; no end bound.
+      # See README "Operational Constraints".
+      lookback_window: P3D
       # P1D step: one request per day. The /summaries endpoint supports multi-day
       # ranges via starting_date + ending_date, but ending_date is EXCLUSIVE — using
       # P31D with Airbyte's inclusive-inclusive cursor arithmetic causes silent data
@@ -298,10 +297,7 @@ streams:
         datetime: "{{ config.get('start_date') or day_delta(-14, format='%Y-%m-%d') }}"
         datetime_format: "%Y-%m-%d"
         min_datetime: "2026-01-01"
-      end_datetime:
-        type: MinMaxDatetime
-        datetime: "{{ day_delta(-3, format='%Y-%m-%d') }}"
-        datetime_format: "%Y-%m-%d"
+      lookback_window: P3D
       step: P1D
       cursor_granularity: P1D
       start_time_option:
@@ -680,10 +676,7 @@ streams:
         datetime: "{{ config.get('start_date') or day_delta(-14, format='%Y-%m-%d') }}"
         datetime_format: "%Y-%m-%d"
         min_datetime: "2026-01-01"
-      end_datetime:
-        type: MinMaxDatetime
-        datetime: "{{ day_delta(-3, format='%Y-%m-%d') }}"
-        datetime_format: "%Y-%m-%d"
+      lookback_window: P3D
       step: P1D
       cursor_granularity: P1D
       start_time_option:
@@ -837,10 +830,7 @@ streams:
         datetime: "{{ config.get('start_date') or day_delta(-14, format='%Y-%m-%d') }}"
         datetime_format: "%Y-%m-%d"
         min_datetime: "2026-01-01"
-      end_datetime:
-        type: MinMaxDatetime
-        datetime: "{{ day_delta(-3, format='%Y-%m-%d') }}"
-        datetime_format: "%Y-%m-%d"
+      lookback_window: P3D
       step: P1D
       cursor_granularity: P1D
       start_time_option:
@@ -1014,10 +1004,7 @@ streams:
         datetime: "{{ config.get('start_date') or day_delta(-14, format='%Y-%m-%d') }}"
         datetime_format: "%Y-%m-%d"
         min_datetime: "2026-01-01"
-      end_datetime:
-        type: MinMaxDatetime
-        datetime: "{{ day_delta(-3, format='%Y-%m-%d') }}"
-        datetime_format: "%Y-%m-%d"
+      lookback_window: P3D
       step: P1D
       cursor_granularity: P1D
       start_time_option:

--- a/src/ingestion/connectors/ai/claude-enterprise/descriptor.yaml
+++ b/src/ingestion/connectors/ai/claude-enterprise/descriptor.yaml
@@ -8,7 +8,13 @@ name: claude-enterprise
 #   analytics API reports no seat lifecycle state. MINOR per ADR-0015: a full
 #   refresh would reproduce the same NULLs, so there is nothing to
 #   re-materialize.
-version: "3.1.0"
+# 3.2.0: every daily stream reads up to today instead of stopping three days
+#   short, and re-reads the last three days via lookback_window. The vendor
+#   revises a day after it closes; the old end bound waited for that instead of
+#   re-asking, so the newest days never arrived at all. MINOR per ADR-0015 —
+#   no schema or dbt output change, so nothing re-materializes; the re-read
+#   lands as a newer _version and ReplacingMergeTree keeps it.
+version: "3.2.0"
 schedule: "0 11 * * *"   # daily at 11:00 UTC — accommodates Anthropic's 10:00 UTC aggregation
 workflow: sync
 

--- a/src/ingestion/connectors/ai/claude-team/README.md
+++ b/src/ingestion/connectors/ai/claude-team/README.md
@@ -91,6 +91,7 @@ Silver transformations are out of scope for this MVP (Phase 6+). `dbt_select` in
 - **Cloudflare challenge**: the proxy solves the CF challenge during `setSessionKey`, not at startup. First call after a key rotation may take up to 60 s. Insight retries on transient 503/502.
 - **Token rotation**: `proxy_auth_token` rotation requires updating both the K8s Secret here and the `PROXY_AUTH_TOKEN` env on the proxy container. Coordinate via the customer.
 - **One proxy = one org**: the proxy container is bound to a single `CLAUDE_ORG_ID`. Multiple claude organisations require multiple proxy deployments and multiple Insight connector instances.
+- **Reporting lag**: a day keeps being revised for a while after it closes. The daily-metrics streams read up to today and re-read that tail on every run (`lookback_window: P2D`) rather than waiting for it to settle: a revised day returns with a later `_airbyte_extracted_at`, and `ReplacingMergeTree(_version)` keeps it. Reading recent days late instead left them absent until they settled, which reads downstream as no activity rather than as no data (#2682).
 
 ## Validation
 

--- a/src/ingestion/connectors/ai/claude-team/connector.yaml
+++ b/src/ingestion/connectors/ai/claude-team/connector.yaml
@@ -379,10 +379,9 @@ streams:
         # Earliest data point observed in data_collector audit for this
         # org. Going earlier returns empty pages.
         min_datetime: "2025-11-24"
-      end_datetime:
-        type: MinMaxDatetime
-        datetime: "{{ day_delta(-1, format='%Y-%m-%d') }}"
-        datetime_format: "%Y-%m-%d"
+      # Re-read the tail the vendor may still revise; no end bound.
+      # See README "Operational Constraints".
+      lookback_window: P2D
       step: P1D
       cursor_granularity: P1D
       start_time_option:
@@ -490,10 +489,7 @@ streams:
         datetime: "{{ config.get('start_date') or day_delta(-7, format='%Y-%m-%d') }}"
         datetime_format: "%Y-%m-%d"
         min_datetime: "2025-11-24"
-      end_datetime:
-        type: MinMaxDatetime
-        datetime: "{{ day_delta(-1, format='%Y-%m-%d') }}"
-        datetime_format: "%Y-%m-%d"
+      lookback_window: P2D
       step: P1D
       cursor_granularity: P1D
       start_time_option:

--- a/src/ingestion/connectors/ai/claude-team/descriptor.yaml
+++ b/src/ingestion/connectors/ai/claude-team/descriptor.yaml
@@ -42,7 +42,13 @@ name: claude-team
 #   Safe now and not before: full_refresh=false on claude_team__ai_overage
 #   landed in 2.2.0, so the one relation holding a past month's closing spend is
 #   skipped by the rebuild while class_ai_overage re-materialises from it.
-version: "3.0.0"
+# 3.1.0: the two daily-metrics streams read up to today instead of stopping a
+#   day short, and re-read the last two days via lookback_window. The vendor
+#   revises a day after it closes; the old end bound waited for that instead of
+#   re-asking, so the newest days never arrived at all. MINOR per ADR-0015 —
+#   no schema or dbt output change, so nothing re-materializes; the re-read
+#   lands as a newer _version and ReplacingMergeTree keeps it.
+version: "3.1.0"
 # Daily at 23:50 UTC, as late in the day as the boundary allows. The seat
 # endpoint reports the billing month in progress and carries no history, so a
 # month's spend is frozen at the last read INSIDE it and whatever follows is


### PR DESCRIPTION
Refs #2682 — the follow-up that marks the uncollected days closes it.

**Why.** Every AI usage metric stopped short of the period end while Collaboration and git did not. Both Claude connectors bounded the end of their read window — `day_delta(-1)` for Claude Team, `day_delta(-3)` for Claude Enterprise — so a day was requested only once it had settled. It did arrive, roughly that many days late; meanwhile the newest days held no rows, which reads as no activity rather than as no data yet. They are the only connector family that bounds its end: `collab` and `git` declare no `end_datetime` anywhere.

**What changed.** The end bound is gone and the tail is re-read instead: `lookback_window: P2D` on Claude Team's two daily-metrics streams, `P3D` on Claude Enterprise's five.

**Re-reading rather than waiting is what the prototype does.** Its `incrementalSync` steps back N days from the newest stored date and fetches through to `now`, re-asking for a day the vendor may since have revised. Same number, spent the other way round.

**Nothing downstream had to learn about revisions.** Staging stamps `_version` from `_airbyte_extracted_at`, and staging and class relations are both `ReplacingMergeTree(_version)`, so a later extraction of the same day wins on its own. `chatgpt-team` (`P2D`), `zoom` (`P7D`) and `github` (`P1M`) already rely on this.

**The rationale lives in the READMEs, not in seven copies of a comment.** Each connector's Operational Constraints section carries it; the manifests hold one short pointer. Claude Enterprise's README documented the old upper bound and a `start_date` edge case that existed only because of it — both are gone.

**Descriptors bumped MINOR per ADR-0015.** Reconcile re-discovers the catalog; with no schema or dbt output change nothing re-materializes. A manifest edit without a descriptor bump never reaches Airbyte, so the bump is load-bearing rather than bookkeeping.

**Out of scope.** Two follow-ups land on this branch: a connector-declared revision window carried through to the API, and drawing days nobody has collected apart from days that carry no reading. The day strip already separates a null day from a measured zero; it cannot yet say why a day is null.

**Verified.** `source.sh validate` — both manifests valid. `source.sh validate-strict` — Claude Team strictly valid; Claude Enterprise reports 5 `authenticator: 'type' is a required property` errors that are **identical on `main`** (re-ran against the stashed change to confirm) and untouched here. `scripts/ci/connector_wiring.py` — OK; its one warning is a pre-existing legacy version on an unrelated connector. Neither connector has a mock-test package, so the L1 ladder has nothing to run. Not run: a live sync, which is the real proof and needs a stand with these credentials.