### PR TITLE
feat(portal): link git metric evidence to GitHub and adapt to a flat organisation

### DIFF
--- a/src/frontend/src/api/identity-client.ts
+++ b/src/frontend/src/api/identity-client.ts
@@ -497,6 +497,38 @@ export async function searchPersons(
   return found;
 }
 
+/**
+ * The persons the caller may see (`GET /visible-persons`) — one page, ordered by
+ * the label each is shown under. Any signed-in caller may ask; the answer is
+ * their own visible set, so it needs no admin role.
+ */
+export async function listVisiblePersons(
+  page: PageRequest & { q?: string } = {},
+): Promise<PersonSearchResponse> {
+  const params = new URLSearchParams();
+  if (page.q) params.set("q", page.q);
+  if (page.cursor) params.set("cursor", page.cursor);
+  if (page.limit != null) params.set("limit", String(page.limit));
+  const query = params.toString();
+  const res = await fetchWithAuth(
+    `${BASE}/visible-persons${query ? `?${query}` : ""}`,
+  );
+  if (!res.ok) {
+    const body = await res.json().catch(() => null);
+    throw new IdentityApiError(res.status, body);
+  }
+  let listed: PersonSearchResponse;
+  try {
+    listed = (await res.json()) as PersonSearchResponse;
+  } catch {
+    throw new IdentityApiError(res.status, { error: "invalid_json" });
+  }
+  if (!Array.isArray(listed.items)) {
+    throw new IdentityApiError(res.status, { error: "malformed_roster" });
+  }
+  return listed;
+}
+
 export interface PersonAccountEntry {
   source: string;
   source_id: string;

--- a/src/frontend/src/api/identity-client.ts
+++ b/src/frontend/src/api/identity-client.ts
@@ -55,10 +55,18 @@ export interface MeRole {
  * login token's realm roles, which no identity endpoint reads. An empty list
  * IS the "not an admin" answer; the endpoint never 403s.
  */
+/**
+ * Whose data a caller may see, as the identity service decides it: the
+ * reporting line plus explicit grants, or every person in the tenant.
+ */
+export type VisibilityPolicy = "org_chart" | "flat";
+
 export interface MeResponse {
   person_id: string;
   insight_tenant_id: string;
   roles: MeRole[];
+  /** Absent from an older service; readers treat that as `org_chart`. */
+  visibility_policy?: VisibilityPolicy;
 }
 
 /**

--- a/src/frontend/src/components/metric-evidence-dialog.test.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog.test.tsx
@@ -22,6 +22,15 @@ vi.mock("@tanstack/react-query", () => ({
   },
 }));
 
+// Whether `source` may be asked for alongside a git metric's evidence. These
+// tests are about the dialog, so it declares nothing and stays out of the way.
+vi.mock("@/queries/metric-definitions", () => ({
+  useDeclaredMetricDimensions: () => ({
+    byMetricKey: new Map<string, ReadonlySet<string>>(),
+    isPending: false,
+  }),
+}));
+
 vi.mock("@/auth/use-auth", () => ({
   useAuth: () => ({
     session: {
@@ -426,7 +435,10 @@ describe("MetricEvidenceDialog", () => {
       const user = userEvent.setup();
       renderDialog();
 
-      await user.type(screen.getByRole("searchbox", { name: "Search records" }), "add");
+      await user.type(
+        screen.getByRole("searchbox", { name: "Search records" }),
+        "add"
+      );
       expect(tableRefs()).toEqual(["add-parser", "add-cache"]);
       expect(screen.getByText("2 of 3 records")).toBeInTheDocument();
     });
@@ -532,7 +544,10 @@ describe("MetricEvidenceDialog", () => {
       renderDialog({ fetchNextPage, hasNextPage: true });
       fetchNextPage.mockClear();
 
-      await user.type(screen.getByRole("searchbox", { name: "Search records" }), "add");
+      await user.type(
+        screen.getByRole("searchbox", { name: "Search records" }),
+        "add"
+      );
       await waitFor(() => expect(fetchNextPage).toHaveBeenCalled());
     });
 
@@ -546,7 +561,10 @@ describe("MetricEvidenceDialog", () => {
       });
       fetchNextPage.mockClear();
 
-      await user.type(screen.getByRole("searchbox", { name: "Search records" }), "add");
+      await user.type(
+        screen.getByRole("searchbox", { name: "Search records" }),
+        "add"
+      );
       expect(fetchNextPage).not.toHaveBeenCalled();
     });
 
@@ -571,7 +589,10 @@ describe("MetricEvidenceDialog", () => {
         />
       );
 
-      await user.type(screen.getByRole("searchbox", { name: "Search records" }), "add");
+      await user.type(
+        screen.getByRole("searchbox", { name: "Search records" }),
+        "add"
+      );
       sortBy("value");
       expect(mocks.tableProps?.sort).not.toBeNull();
 

--- a/src/frontend/src/components/metric-evidence-dialog.test.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   queryMetricDrilldown: vi.fn(),
   downloadMetricDrilldown: vi.fn(),
   tableProps: null as Record<string, unknown> | null,
+  declaredDimensions: new Map<string, ReadonlySet<string>>(),
 }));
 
 vi.mock("@tanstack/react-query", () => ({
@@ -22,11 +23,12 @@ vi.mock("@tanstack/react-query", () => ({
   },
 }));
 
-// Whether `source` may be asked for alongside a git metric's evidence. These
-// tests are about the dialog, so it declares nothing and stays out of the way.
+// Which dimensions a metric will accept. Most of these tests declare none, so
+// the selection they assert on is the caller's own; the export test below
+// declares `source` because that is when the two diverge.
 vi.mock("@/queries/metric-definitions", () => ({
   useDeclaredMetricDimensions: () => ({
-    byMetricKey: new Map<string, ReadonlySet<string>>(),
+    byMetricKey: mocks.declaredDimensions,
     isPending: false,
   }),
 }));
@@ -180,6 +182,7 @@ describe("MetricEvidenceDialog", () => {
     mocks.queryMetricDrilldown.mockReset();
     mocks.downloadMetricDrilldown.mockReset().mockResolvedValue(undefined);
     mocks.tableProps = null;
+    mocks.declaredDimensions = new Map();
   });
 
   it("loads, orders, paginates, exports, and closes evidence", async () => {
@@ -305,6 +308,42 @@ describe("MetricEvidenceDialog", () => {
       hasNextPage: false,
       pageLimitReached: true,
     });
+  });
+
+  // The dimension that makes a row linkable is asked for, hidden from the
+  // table, and must not reach the file: an export that carries a column the
+  // screen does not show is not an export OF that screen.
+  it("asks for the source dimension but keeps it out of the export", async () => {
+    const user = userEvent.setup();
+    mocks.declaredDimensions = new Map([
+      ["git.commits", new Set(["repository", "source"])],
+    ]);
+
+    render(
+      <MetricEvidenceDialog
+        state={state}
+        onMetricChange={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+
+    const requested = (mocks.queryOptions?.queryKey as unknown[])[2] as {
+      display_dimensions: string[];
+    };
+    expect(requested.display_dimensions).toContain("source");
+
+    await user.click(screen.getByRole("button", { name: /CSV/ }));
+    await waitFor(() =>
+      expect(mocks.downloadMetricDrilldown).toHaveBeenCalledWith(
+        selection,
+        "csv",
+        expect.any(AbortSignal)
+      )
+    );
+    const [exported] = mocks.downloadMetricDrilldown.mock.calls[0]!;
+    expect(
+      (exported as { display_dimensions: string[] }).display_dimensions
+    ).not.toContain("source");
   });
 
   describe("what the dialog is named", () => {

--- a/src/frontend/src/components/metric-evidence-dialog.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog.tsx
@@ -176,14 +176,19 @@ export function MetricEvidenceDialog({
   }
 
   async function exportRows(format: "csv" | "xlsx") {
-    if (!selection) return;
+    // INVARIANT: the export carries the caller's OWN selection, never the one
+    // widened for links. `source` rides along only so a row can be linked, and
+    // it is hidden from the table — exporting it would put a column in the file
+    // that is not on the screen it came from.
+    const exported = activeTarget?.selection;
+    if (!exported) return;
     exportController.current?.abort();
     const controller = new AbortController();
     exportController.current = controller;
     setExporting(true);
     setExportFailure(null);
     try {
-      await downloadMetricDrilldown(selection, format, controller.signal);
+      await downloadMetricDrilldown(exported, format, controller.signal);
     } catch (error) {
       if (!controller.signal.aborted) {
         setExportFailure(

--- a/src/frontend/src/components/metric-evidence-dialog.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog.tsx
@@ -11,6 +11,11 @@ import { sessionAuthorizationScope } from "@/auth/session-scope";
 import { useAuth } from "@/auth/use-auth";
 import type { EvidenceDialogState } from "@/components/metric-evidence-context";
 import { MetricEvidenceTable } from "@/components/metric-evidence-table";
+import {
+  SOURCE_DIMENSION,
+  withGitSourceDimension,
+} from "@/lib/metrics/git-links";
+import { useDeclaredMetricDimensions } from "@/queries/metric-definitions";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -60,7 +65,16 @@ export function MetricEvidenceDialog({
     ) ??
     state?.targets[0] ??
     null;
-  const selection = activeTarget?.selection ?? null;
+  // INVARIANT: the catalog decides whether `source` may be asked for, so the
+  // read waits for it — resolving later would change the selection mid-dialog
+  // and refetch every row.
+  const declaredDimensions = useDeclaredMetricDimensions();
+  const selection = activeTarget
+    ? withGitSourceDimension(
+        activeTarget.selection,
+        declaredDimensions.byMetricKey?.get(activeTarget.selection.metric_key)
+      )
+    : null;
   const query = useInfiniteQuery({
     queryKey: ["metric-drilldown", sessionScope, selection],
     queryFn: ({ pageParam, signal }) => {
@@ -72,7 +86,10 @@ export function MetricEvidenceDialog({
     },
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (page) => page.next_cursor ?? undefined,
-    enabled: sessionScope != null && selection != null,
+    enabled:
+      sessionScope != null &&
+      selection != null &&
+      !declaredDimensions.isPending,
     retry: (failureCount, error) =>
       failureCount < 1 &&
       (!(error instanceof AnalyticsApiError) || error.status >= 500),
@@ -83,7 +100,11 @@ export function MetricEvidenceDialog({
     [pages]
   );
   const columns = useMemo(() => {
-    const columns = query.data?.pages[0]?.columns ?? [];
+    // `source` rides along purely to back a link (see withGitSourceDimension) —
+    // it is not a column anyone asked to see.
+    const columns = (query.data?.pages[0]?.columns ?? []).filter(
+      (column) => column.key !== SOURCE_DIMENSION
+    );
     const order = new Map([
       ["ref", 0],
       ["title", 1],
@@ -343,10 +364,13 @@ export function MetricEvidenceDialog({
               // INVARIANT: remounts per metric — expansion state is the
               // table's and must not carry across.
               key={activeMetricKey}
+              metricKey={activeMetricKey}
               rows={visibleRows}
               columns={columns}
               sort={sort}
-              onSortChange={(key) => setSort((current) => nextSort(current, key))}
+              onSortChange={(key) =>
+                setSort((current) => nextSort(current, key))
+              }
               fetchNextPage={fetchNextPage}
               hasNextPage={hasNextPage && !pageLimitReached}
               isFetchingNextPage={isFetchingNextPage}

--- a/src/frontend/src/components/metric-evidence-table.test.tsx
+++ b/src/frontend/src/components/metric-evidence-table.test.tsx
@@ -40,6 +40,7 @@ function renderTable(
   overrides: Partial<React.ComponentProps<typeof MetricEvidenceTable>> = {}
 ) {
   const props = {
+    metricKey: null,
     rows,
     columns,
     sort: null,
@@ -319,5 +320,103 @@ describe("MetricEvidenceTable", () => {
     expect(
       screen.getByText(/Showing the first 5,000 rows/)
     ).toBeInTheDocument();
+  });
+  describe("linking a record to its page", () => {
+    const SHA = "e0f4823a55ac28276cf068f066ebf66f872a059c";
+    const linkColumns = [
+      { key: "ref", label: "Ref", type: "string" as const },
+      { key: "title", label: "Title", type: "string" as const },
+      { key: "repository", label: "Repository", type: "string" as const },
+    ];
+
+    function linkRow(overrides: Record<string, unknown> = {}) {
+      return {
+        values: {
+          ref: SHA,
+          title: "the subject line\n\nand a trailer nobody clicks",
+          repository: "owner/repo",
+          source: "GitHub",
+          ...overrides,
+        },
+      };
+    }
+
+    it("addresses the record from its id and its summary, and the repository from its own cell", () => {
+      renderTable({
+        metricKey: "git.commits",
+        columns: linkColumns,
+        rows: [linkRow()],
+      });
+
+      expect(
+        screen.getByRole("link", { name: "the subject line" })
+      ).toHaveAttribute("href", `https://github.com/owner/repo/commit/${SHA}`);
+      expect(screen.getByRole("link", { name: "owner/repo" })).toHaveAttribute(
+        "href",
+        "https://github.com/owner/repo"
+      );
+    });
+
+    // A link inside a row must not also work the row: the whole row toggles
+    // the expanded record, and following a link is not asking for that.
+    it("does not expand the row when a link is followed", async () => {
+      renderTable({
+        metricKey: "git.commits",
+        columns: linkColumns,
+        rows: [linkRow()],
+      });
+
+      await userEvent.click(screen.getByRole("link", { name: "owner/repo" }));
+
+      expect(screen.getAllByRole("row")[1]).toHaveAttribute(
+        "aria-expanded",
+        "false"
+      );
+    });
+
+    // The expanded record shows a value entire, trailers included, so the
+    // title is a paragraph there rather than something to click.
+    it("leaves the title unlinked in the expanded record", async () => {
+      renderTable({
+        metricKey: "git.commits",
+        columns: linkColumns,
+        rows: [linkRow()],
+      });
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Show full record" })
+      );
+
+      expect(
+        screen.queryByRole("link", { name: /and a trailer nobody clicks/ })
+      ).toBeNull();
+      expect(
+        screen.getAllByRole("link", { name: "owner/repo" }).length
+      ).toBeGreaterThan(1);
+    });
+
+    it.each([
+      ["the provider's address is not derivable", { source: "gitlab" }],
+      ["the row does not say where it came from", { source: undefined }],
+      ["the repository is not a path", { repository: "Unknown" }],
+    ])("renders plain text when %s", (_case, overrides) => {
+      renderTable({
+        metricKey: "git.commits",
+        columns: linkColumns,
+        rows: [linkRow(overrides)],
+      });
+
+      expect(screen.queryAllByRole("link")).toHaveLength(0);
+    });
+
+    it("renders plain text for a metric of another family", () => {
+      renderTable({
+        metricKey: "tasks.closed",
+        columns: linkColumns,
+        rows: [linkRow()],
+      });
+
+      expect(screen.queryAllByRole("link")).toHaveLength(0);
+    });
   });
 });

--- a/src/frontend/src/components/metric-evidence-table.tsx
+++ b/src/frontend/src/components/metric-evidence-table.tsx
@@ -13,6 +13,7 @@ import type {
   MetricEvidenceRow,
 } from "@/api/metric-drilldown-client";
 import { CopyValueButton } from "@/components/copy-value-button";
+import { RecordLink } from "@/components/record-link";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import {
@@ -29,6 +30,7 @@ import {
   summaryLine,
   type EvidenceSort,
 } from "@/lib/metrics/evidence-rows";
+import { evidenceRecordLinks } from "@/lib/metrics/git-links";
 import { cn } from "@/lib/utils";
 
 function columnLayout(column: MetricEvidenceColumn) {
@@ -43,6 +45,13 @@ function columnLayout(column: MetricEvidenceColumn) {
 
 const EXPANDER_REM = 2.25;
 
+/**
+ * Columns whose link belongs to the summary line only. The full record shows a
+ * value entire, and a commit message carries its trailers — one link wrapped
+ * around all of that is a paragraph-sized target, not something to click.
+ */
+const SUMMARY_ONLY_LINKS: ReadonlySet<string> = new Set(["title"]);
+
 function SortIcon({ state }: { state: "asc" | "desc" | null }) {
   if (state === "asc") return <ArrowUp className="size-3.5 shrink-0" />;
   if (state === "desc") return <ArrowDown className="size-3.5 shrink-0" />;
@@ -52,6 +61,7 @@ function SortIcon({ state }: { state: "asc" | "desc" | null }) {
 }
 
 export function MetricEvidenceTable({
+  metricKey,
   rows,
   columns,
   sort,
@@ -62,6 +72,8 @@ export function MetricEvidenceTable({
   nextPageError,
   pageLimitReached,
 }: {
+  /** Null while the metric picker has yet to resolve one — links stay off. */
+  metricKey: string | null;
   rows: MetricEvidenceRow[];
   columns: MetricEvidenceColumn[];
   sort: EvidenceSort | null;
@@ -82,7 +94,10 @@ export function MetricEvidenceTable({
     overscan: 8,
     // INVARIANT: must match the row's React key — the measured height of an
     // expanded row is cached under it.
-    getItemKey: useCallback((index: number) => rowKeys[index] ?? index, [rowKeys]),
+    getItemKey: useCallback(
+      (index: number) => rowKeys[index] ?? index,
+      [rowKeys]
+    ),
   });
   const virtualRows = virtualizer.getVirtualItems();
   const virtualBodyHeight = virtualizer.getTotalSize();
@@ -163,7 +178,9 @@ export function MetricEvidenceTable({
                   }
                   className={cn(
                     "flex h-10 min-w-0 items-center px-3 py-0",
-                    numeric ? "justify-end text-right" : "justify-start text-left"
+                    numeric
+                      ? "justify-end text-right"
+                      : "justify-start text-left"
                   )}
                   style={{
                     flex: `${layout.grow} 0 ${layout.basisRem}rem`,
@@ -205,6 +222,7 @@ export function MetricEvidenceTable({
             if (!row) return null;
             const key = rowKeys[virtualRow.index]!;
             const isOpen = expanded.has(key);
+            const links = evidenceRecordLinks(metricKey ?? "", row.values);
             return (
               <TableRow
                 role="row"
@@ -229,7 +247,9 @@ export function MetricEvidenceTable({
                     variant="ghost"
                     size="icon-xs"
                     aria-expanded={isOpen}
-                    aria-label={isOpen ? "Hide full record" : "Show full record"}
+                    aria-label={
+                      isOpen ? "Hide full record" : "Show full record"
+                    }
                     className="text-muted-foreground"
                     onClick={(event) => {
                       event.stopPropagation();
@@ -259,7 +279,11 @@ export function MetricEvidenceTable({
                     >
                       {column.key === "ref" && value != null ? (
                         <div className="flex min-w-0 items-center gap-1">
-                          <span className="min-w-0 truncate">{line}</span>
+                          <span className="min-w-0 truncate">
+                            <RecordLink href={links[column.key]}>
+                              {line}
+                            </RecordLink>
+                          </span>
                           <CopyValueButton
                             value={String(value)}
                             title="Copy ref"
@@ -267,7 +291,7 @@ export function MetricEvidenceTable({
                           />
                         </div>
                       ) : (
-                        line
+                        <RecordLink href={links[column.key]}>{line}</RecordLink>
                       )}
                     </TableCell>
                   );
@@ -285,14 +309,25 @@ export function MetricEvidenceTable({
                         exceed the table's own height. */}
                     <dl className="grid max-h-96 gap-x-6 gap-y-2 overflow-y-auto overscroll-contain sm:grid-cols-[10rem_1fr]">
                       {columns.map((column) => {
-                        const text = cellText(row.values[column.key], column.type);
+                        const text = cellText(
+                          row.values[column.key],
+                          column.type
+                        );
                         return (
                           <Fragment key={column.key}>
                             <dt className="text-sm text-muted-foreground">
                               {column.label}
                             </dt>
                             <dd className="text-sm break-words whitespace-pre-wrap">
-                              {text}
+                              <RecordLink
+                                href={
+                                  SUMMARY_ONLY_LINKS.has(column.key)
+                                    ? undefined
+                                    : links[column.key]
+                                }
+                              >
+                                {text}
+                              </RecordLink>
                             </dd>
                           </Fragment>
                         );

--- a/src/frontend/src/components/org-tree.test.tsx
+++ b/src/frontend/src/components/org-tree.test.tsx
@@ -1,14 +1,39 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { OrgTree } from "@/components/org-tree";
 import type { IdentityPerson } from "@/types/insight";
 
-const mocks = vi.hoisted(() => ({ viewer: null as IdentityPerson | null }));
+const mocks = vi.hoisted(() => ({
+  viewer: null as IdentityPerson | null,
+  isFlat: false,
+  roster: [] as {
+    person_id: string;
+    display_name?: string | null;
+    email?: string | null;
+    username?: string | null;
+  }[],
+}));
 
 vi.mock("@/auth", () => ({ useViewer: () => ({ personId: "root" }) }));
 vi.mock("@/queries/ic-dashboard", () => ({
   useIcPerson: () => ({ data: mocks.viewer }),
+}));
+vi.mock("@/queries/identity-me", () => ({
+  useVisibilityPolicy: () => ({
+    policy: mocks.isFlat ? "flat" : "org_chart",
+    isFlat: mocks.isFlat,
+    isPending: false,
+  }),
+}));
+vi.mock("@/queries/visible-roster", () => ({
+  useVisibleRoster: () => ({
+    roster: mocks.roster,
+    truncated: false,
+    isPending: false,
+    isError: false,
+    retry: () => {},
+  }),
 }));
 vi.mock("@tanstack/react-router", () => ({
   Link: ({ children }: { children?: React.ReactNode }) => <a>{children}</a>,
@@ -80,5 +105,45 @@ describe("OrgTree", () => {
     rerender(<OrgTree query="" />);
     expect(screen.queryByText("Deep Person")).not.toBeInTheDocument();
     expect(screen.getByText("Lead Person")).toBeInTheDocument();
+  });
+});
+
+describe("OrgTree on an organisation with no reporting lines", () => {
+  beforeEach(() => {
+    mocks.isFlat = true;
+    // The tree the profile serves is the viewer alone — the shape that left
+    // this pane showing one name beside a full Employees table.
+    mocks.viewer = { person_id: "root", display_name: "Me", email: "me@x", subordinates: [] } as IdentityPerson;
+    mocks.roster = [
+      { person_id: "root", display_name: "Me", email: "me@x" },
+      { person_id: "p-ann", display_name: "Ann Dev", email: "ann@x" },
+      { person_id: "p-bot", display_name: null, email: null, username: "octo-bot" },
+    ];
+  });
+
+  it("lists everyone the caller may see, not just the viewer", () => {
+    render(<OrgTree />);
+
+    expect(screen.getByText("Ann Dev")).toBeInTheDocument();
+    expect(screen.getByText("Me")).toBeInTheDocument();
+  });
+
+  it("names a person the journal knows only by a handle", () => {
+    render(<OrgTree />);
+
+    expect(screen.getByText("octo-bot")).toBeInTheDocument();
+  });
+
+  it("filters to what the reader typed", () => {
+    render(<OrgTree query="ann" />);
+
+    expect(screen.getByText("Ann Dev")).toBeInTheDocument();
+    expect(screen.queryByText("octo-bot")).toBeNull();
+  });
+
+  it("says so when a term matches nobody", () => {
+    render(<OrgTree query="nobody-by-this-name" />);
+
+    expect(screen.getByText(/matches/)).toBeInTheDocument();
   });
 });

--- a/src/frontend/src/components/org-tree.tsx
+++ b/src/frontend/src/components/org-tree.tsx
@@ -3,7 +3,6 @@ import { ChevronDown, ChevronRight, User, Users } from "lucide-react";
 import { useMemo } from "react";
 
 import { useViewer } from "@/auth";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   SidebarMenu,
   SidebarMenuButton,
@@ -155,11 +154,9 @@ function RosterList({ query }: { query: string }) {
   }
 
   return (
-    // The roster is the whole organisation, so it scrolls in its own area —
-    // paging it into the sidebar would carry the sections above it off-screen.
-    // Capped rather than fixed, so a small organisation does not leave a gap.
-    <ScrollArea className="max-h-[60svh]">
-      <SidebarMenu>
+    // Padding INSIDE the scroll region the pane owns, so the first and last
+    // names clear its edges instead of touching them.
+    <SidebarMenu className="pb-2">
         {listed.map(({ person, label }) => (
           <SidebarMenuItem key={person.person_id}>
             <SidebarMenuButton
@@ -180,9 +177,8 @@ function RosterList({ query }: { query: string }) {
               <span className="truncate">{label}</span>
             </SidebarMenuButton>
           </SidebarMenuItem>
-        ))}
-      </SidebarMenu>
-    </ScrollArea>
+      ))}
+    </SidebarMenu>
   );
 }
 

--- a/src/frontend/src/components/org-tree.tsx
+++ b/src/frontend/src/components/org-tree.tsx
@@ -3,6 +3,7 @@ import { ChevronDown, ChevronRight, User, Users } from "lucide-react";
 import { useMemo } from "react";
 
 import { useViewer } from "@/auth";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import {
   SidebarMenu,
   SidebarMenuButton,
@@ -15,6 +16,9 @@ import {
   type OrgTreeFilter,
 } from "@/lib/portal/org-tree-filter";
 import { useIcPerson } from "@/queries/ic-dashboard";
+import { useVisibilityPolicy } from "@/queries/identity-me";
+import { useVisibleRoster } from "@/queries/visible-roster";
+import type { PersonSummary } from "@/api/identity-client";
 import type { IdentityPerson } from "@/types/insight";
 
 // Person ids, not emails: the identity cutover made the id the key the route
@@ -106,6 +110,82 @@ function PersonNode({
   );
 }
 
+/** How a roster row is labelled: the handle beats no name at all. */
+function rosterLabel(person: PersonSummary): string {
+  return (
+    person.display_name?.trim() ||
+    person.email?.trim() ||
+    person.username?.trim() ||
+    person.person_id
+  );
+}
+
+/**
+ * The same navigation for an organisation with no reporting lines: one flat
+ * list, in label order, scrolling in the pane exactly as the chart does. There
+ * is no chart to draw and no depth to indent, so a row carries no chevron.
+ */
+function RosterList({ query }: { query: string }) {
+  const { personId: viewerPersonId } = useViewer();
+  const { roster } = useVisibleRoster(true);
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const activePersonId = useMemo(() => {
+    const fromPath = personIdFromPath(pathname);
+    if (fromPath) return fromPath;
+    if (pathname === "/" && viewerPersonId) return viewerPersonId;
+    return null;
+  }, [pathname, viewerPersonId]);
+
+  const listed = useMemo(() => {
+    const term = query.trim().toLowerCase();
+    const rows = roster
+      .map((person) => ({ person, label: rosterLabel(person) }))
+      .sort((left, right) => left.label.localeCompare(right.label));
+    return term
+      ? rows.filter((row) => row.label.toLowerCase().includes(term))
+      : rows;
+  }, [roster, query]);
+
+  if (!listed.length) {
+    return (
+      <p className="px-4 py-2 text-sm text-muted-foreground">
+        No one here matches “{query.trim()}”
+      </p>
+    );
+  }
+
+  return (
+    // The roster is the whole organisation, so it scrolls in its own area —
+    // paging it into the sidebar would carry the sections above it off-screen.
+    // Capped rather than fixed, so a small organisation does not leave a gap.
+    <ScrollArea className="max-h-[60svh]">
+      <SidebarMenu>
+        {listed.map(({ person, label }) => (
+          <SidebarMenuItem key={person.person_id}>
+            <SidebarMenuButton
+              isActive={
+                activePersonId
+                  ? personIdEq(activePersonId, person.person_id)
+                  : false
+              }
+              render={
+                <Link
+                  to="/ic/$person/personal"
+                  params={{ person: person.person_id }}
+                />
+              }
+            >
+              <span className="w-4 shrink-0" />
+              <User />
+              <span className="truncate">{label}</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+        ))}
+      </SidebarMenu>
+    </ScrollArea>
+  );
+}
+
 /**
  * Recursive org-chart navigation, rooted at the viewer. Extracted from
  * AppSidebar so the portal shell's context pane can reuse the same tree
@@ -115,6 +195,7 @@ export function OrgTree({
   leadsToTeam = false,
   query = "",
 }: { leadsToTeam?: boolean; query?: string } = {}) {
+  const { isFlat } = useVisibilityPolicy();
   const { personId: viewerPersonId } = useViewer();
   const viewerQ = useIcPerson(viewerPersonId ?? "");
   const viewer = viewerQ.data ?? null;
@@ -127,6 +208,7 @@ export function OrgTree({
   }, [pathname, viewerPersonId]);
   const filter = useMemo(() => filterOrgTree(viewer, query), [viewer, query]);
 
+  if (isFlat) return <RosterList query={query} />;
   if (!viewer) return null;
   if (filter && filter.visible.size === 0) {
     return (

--- a/src/frontend/src/components/portal/ai-cost-view.test.tsx
+++ b/src/frontend/src/components/portal/ai-cost-view.test.tsx
@@ -50,6 +50,24 @@ vi.mock("@/lib/portal/use-cohort-label", () => ({
 vi.mock("@/queries/ic-dashboard", () => ({
   useIcPerson: () => ({ data: mocks.tree, isPending: false, isLoading: false, isError: false, refetch: vi.fn() }),
 }));
+// `useOrgScope` reads the deployment's visibility policy, and its flat branch
+// reads the roster. This suite is about the view, so both answer statically.
+vi.mock("@/queries/identity-me", () => ({
+  useVisibilityPolicy: () => ({
+    policy: "org_chart",
+    isFlat: false,
+    isPending: false,
+  }),
+}));
+vi.mock("@/queries/visible-roster", () => ({
+  useVisibleRoster: () => ({
+    roster: [],
+    truncated: false,
+    isPending: false,
+    isError: false,
+    retry: () => {},
+  }),
+}));
 vi.mock("@/queries/team-view", () => ({
   useTeamMembers: () => ({ data: mocks.members, isPending: false, isLoading: false, isError: false, refetch: vi.fn() }),
 }));

--- a/src/frontend/src/components/portal/context-pane.test.tsx
+++ b/src/frontend/src/components/portal/context-pane.test.tsx
@@ -292,14 +292,30 @@ describe("ContextPane", () => {
 });
 
 describe("ContextPane on an organisation with no reporting lines", () => {
-  it("names the roster section for what it is, not for a chart", () => {
-    // "WorkChart" describes a structure a flat organisation does not have.
+  it("names the People views for an organisation with no reporting lines", () => {
     mocks.isFlat = true;
     mocks.zone = { activeZone: "people", activePerson: "boss@x" };
 
     pane();
 
-    expect(screen.getByText("Everyone")).toBeInTheDocument();
+    expect(screen.getByText("Overview")).toBeInTheDocument();
+    expect(screen.getByText("Roster")).toBeInTheDocument();
+    expect(screen.queryByText("Employees")).toBeNull();
+    expect(screen.queryByText("People (roster)")).toBeNull();
+    expect(screen.queryByText("Median by Role")).toBeNull();
+  });
+
+  it("does not call the roster a chart", () => {
+    // "WorkChart" describes a structure a flat organisation does not have, and
+    // the list needs no heading of its own inside the People zone.
+    mocks.isFlat = true;
+    mocks.zone = { activeZone: "people", activePerson: "boss@x" };
+
+    pane();
+
     expect(screen.queryByText("WorkChart")).toBeNull();
+    expect(
+      screen.getByLabelText("Find someone in the org"),
+    ).toBeInTheDocument();
   });
 });

--- a/src/frontend/src/components/portal/context-pane.test.tsx
+++ b/src/frontend/src/components/portal/context-pane.test.tsx
@@ -17,6 +17,7 @@ import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  isFlat: false,
   zone: { activeZone: "overview", activePerson: "boss@x" },
   standings: [] as Array<{
     id: string;
@@ -36,6 +37,11 @@ vi.mock("@/components/org-tree", () => ({
 }));
 vi.mock("@/queries/identity-me", () => ({
   useIsAdmin: () => ({ isAdmin: mocks.isAdmin, isPending: false }),
+  useVisibilityPolicy: () => ({
+    policy: mocks.isFlat ? "flat" : "org_chart",
+    isFlat: mocks.isFlat,
+    isPending: false,
+  }),
 }));
 
 import {
@@ -282,5 +288,18 @@ describe("ContextPane", () => {
     // flight, so a tooltip that trusted them would announce the strongest
     // claim of the three on an answer the hook has not given.
     expect(button.getAttribute("title")).toBeNull();
+  });
+});
+
+describe("ContextPane on an organisation with no reporting lines", () => {
+  it("names the roster section for what it is, not for a chart", () => {
+    // "WorkChart" describes a structure a flat organisation does not have.
+    mocks.isFlat = true;
+    mocks.zone = { activeZone: "people", activePerson: "boss@x" };
+
+    pane();
+
+    expect(screen.getByText("Everyone")).toBeInTheDocument();
+    expect(screen.queryByText("WorkChart")).toBeNull();
   });
 });

--- a/src/frontend/src/components/portal/context-pane.tsx
+++ b/src/frontend/src/components/portal/context-pane.tsx
@@ -61,7 +61,7 @@ import {
 } from "@/lib/portal/portal-nav";
 import { useActiveZone } from "@/lib/portal/use-active-zone";
 import { cn } from "@/lib/utils";
-import { useIsAdmin } from "@/queries/identity-me";
+import { useIsAdmin, useVisibilityPolicy } from "@/queries/identity-me";
 
 const ZONE_SUB: Record<string, string> = {
   overview: "Cross-functional org rollup",
@@ -519,10 +519,13 @@ function PeopleNav({ active }: { active: string | null }) {
 
 function WorkChart() {
   const [query, setQuery] = useState("");
+  // A chart is what a reporting line draws. With no lines there is a roster,
+  // and calling it a chart would name a structure the reader cannot see.
+  const { isFlat } = useVisibilityPolicy();
 
   return (
     <SidebarGroup>
-      <SidebarGroupLabel>WorkChart</SidebarGroupLabel>
+      <SidebarGroupLabel>{isFlat ? "Everyone" : "WorkChart"}</SidebarGroupLabel>
       <SidebarGroupContent className="flex flex-col gap-2">
         <div className="relative px-2">
           <Search className="pointer-events-none absolute top-1/2 left-4 size-3.5 -translate-y-1/2 text-muted-foreground" />

--- a/src/frontend/src/components/portal/context-pane.tsx
+++ b/src/frontend/src/components/portal/context-pane.tsx
@@ -9,6 +9,7 @@ import { useState } from "react";
 
 import { AppSidebarFooter } from "@/components/app-sidebar-footer";
 import { OrgTree } from "@/components/org-tree";
+import { ScrollArea } from "@/components/ui/scroll-area";
 import { Input } from "@/components/ui/input";
 import {
   Popover,
@@ -523,21 +524,42 @@ function WorkChart() {
   // and calling it a chart would name a structure the reader cannot see.
   const { isFlat } = useVisibilityPolicy();
 
+  const find = (
+    <div className="relative px-2">
+      <Search className="pointer-events-none absolute top-1/2 left-4 size-3.5 -translate-y-1/2 text-muted-foreground" />
+      <Input
+        type="search"
+        value={query}
+        onChange={(event) => setQuery(event.target.value)}
+        placeholder="Find someone"
+        aria-label="Find someone in the org"
+        className="h-8 ps-7 text-sm"
+      />
+    </div>
+  );
+
+  // A roster is the whole organisation, so it takes the rest of the pane and
+  // scrolls there: the sections above it stay put, the list runs to the bottom
+  // edge, and rows pass UNDER the search rather than stopping short of it.
+  if (isFlat) {
+    return (
+      <SidebarGroup className="min-h-0 flex-1">
+        <SidebarGroupLabel>Everyone</SidebarGroupLabel>
+        <SidebarGroupContent className="flex min-h-0 flex-1 flex-col">
+          <ScrollArea className="min-h-0 flex-1">
+            <div className="sticky top-0 z-10 bg-sidebar pb-2">{find}</div>
+            <OrgTree leadsToTeam query={query} />
+          </ScrollArea>
+        </SidebarGroupContent>
+      </SidebarGroup>
+    );
+  }
+
   return (
     <SidebarGroup>
-      <SidebarGroupLabel>{isFlat ? "Everyone" : "WorkChart"}</SidebarGroupLabel>
+      <SidebarGroupLabel>WorkChart</SidebarGroupLabel>
       <SidebarGroupContent className="flex flex-col gap-2">
-        <div className="relative px-2">
-          <Search className="pointer-events-none absolute top-1/2 left-4 size-3.5 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            type="search"
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="Find someone"
-            aria-label="Find someone in the org"
-            className="h-8 ps-7 text-sm"
-          />
-        </div>
+        {find}
         <OrgTree leadsToTeam query={query} />
       </SidebarGroupContent>
     </SidebarGroup>

--- a/src/frontend/src/components/portal/context-pane.tsx
+++ b/src/frontend/src/components/portal/context-pane.tsx
@@ -44,7 +44,7 @@ import {
 } from "@/components/ui/sidebar";
 import {
   manageItemsFor,
-  PEOPLE_ITEMS,
+  peopleItemsFor,
   PLANNED_GROUP_LABEL,
   partitionByReadiness,
   resolveZoneItem,
@@ -510,9 +510,14 @@ function DirectionItem({ direction }: { direction: Direction }) {
 /* ── People / Person zones ───────────────────────────────────────────── */
 
 function PeopleNav({ active }: { active: string | null }) {
+  const { isFlat } = useVisibilityPolicy();
   return (
     <>
-      <ItemsNav items={PEOPLE_ITEMS} groupLabel="Views" active={active} />
+      <ItemsNav
+        items={peopleItemsFor(isFlat)}
+        groupLabel="Views"
+        active={active}
+      />
       <WorkChart />
     </>
   );
@@ -539,15 +544,19 @@ function WorkChart() {
   );
 
   // A roster is the whole organisation, so it takes the rest of the pane and
-  // scrolls there: the sections above it stay put, the list runs to the bottom
-  // edge, and rows pass UNDER the search rather than stopping short of it.
+  // scrolls there. The search sits ABOVE the scroll region, not inside it: a
+  // sticky-inside search put the scrollbar (and, mid-inertia, the rows) on top
+  // of it. The standard sidebar shape — fixed search, list scrolling below,
+  // scrollbar contained to the list.
   if (isFlat) {
     return (
+      // No group label: "WorkChart" names a structure a flat organisation does
+      // not have, and every other name for the roster restates the zone it
+      // already sits in. The search's own label says what the list is.
       <SidebarGroup className="min-h-0 flex-1">
-        <SidebarGroupLabel>Everyone</SidebarGroupLabel>
-        <SidebarGroupContent className="flex min-h-0 flex-1 flex-col">
+        <SidebarGroupContent className="flex min-h-0 flex-1 flex-col gap-2">
+          {find}
           <ScrollArea className="min-h-0 flex-1">
-            <div className="sticky top-0 z-10 bg-sidebar pb-2">{find}</div>
             <OrgTree leadsToTeam query={query} />
           </ScrollArea>
         </SidebarGroupContent>

--- a/src/frontend/src/components/portal/domain-lens-view.test.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.test.tsx
@@ -59,6 +59,24 @@ vi.mock("@/queries/ic-dashboard", () => ({
     refetch: vi.fn(),
   }),
 }));
+// `useOrgScope` reads the deployment's visibility policy, and its flat branch
+// reads the roster. This suite is about the view, so both answer statically.
+vi.mock("@/queries/identity-me", () => ({
+  useVisibilityPolicy: () => ({
+    policy: "org_chart",
+    isFlat: false,
+    isPending: false,
+  }),
+}));
+vi.mock("@/queries/visible-roster", () => ({
+  useVisibleRoster: () => ({
+    roster: [],
+    truncated: false,
+    isPending: false,
+    isError: false,
+    retry: () => {},
+  }),
+}));
 vi.mock("@/queries/member-grid", () => ({
   useMemberGridData: () => mocks.grid,
 }));

--- a/src/frontend/src/components/portal/domain-lens-view.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.tsx
@@ -8,6 +8,12 @@ import { orgScopeGate } from "@/components/portal/org-scope-gate";
 import { SectionTrend } from "@/components/portal/section-trend";
 import { Card, CardContent } from "@/components/ui/card";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   BarChart,
   CartesianGrid,
   ChartBar,
@@ -43,7 +49,9 @@ import type {
   MetricDirection,
 } from "@/api/metric-results-client";
 import { normalizePersonId } from "@/lib/metrics/entity";
+import { githubRepoUrl } from "@/lib/metrics/git-links";
 import { formatMetricValue } from "@/lib/format";
+import { seriesColors } from "@/lib/series-colors";
 import { mergeEventHistogram } from "@/lib/portal/event-histogram";
 import {
   distribution,
@@ -194,7 +202,18 @@ export function DomainLensView({
     () => ({
       metrics: compSections.map((s) => ({
         key: s.metric,
-        views: [{ view: "breakdown" as const, dimensions: [s.dimension] }],
+        views: [
+          {
+            view: "breakdown" as const,
+            // `source` rides along so a row knows which provider it came
+            // from — the only thing that makes a link safe to build.
+            dimensions: [
+              s.dimension,
+              ...(s.splitBy ? [s.splitBy] : []),
+              ...(s.dimension === LINKABLE_DIMENSION ? [SOURCE_DIMENSION] : []),
+            ],
+          },
+        ],
       })),
     }),
     [compSections]
@@ -542,7 +561,9 @@ function CoverageLevelsSection({
   if (counted === 0) return null;
 
   const partCount = GROUPS.length;
-  const levels = [...distribution.byLevel.entries()].sort((a, b) => b[0] - a[0]);
+  const levels = [...distribution.byLevel.entries()].sort(
+    (a, b) => b[0] - a[0]
+  );
   const missing = parts.filter((p) => p.unreachable);
 
   return (
@@ -648,8 +669,8 @@ function CoverageLevelsSection({
 
       <p className="text-xs text-muted-foreground">
         A section counts when at least one of its metrics has a value for that
-        person in this period. This shows where data exists, not how well
-        anyone worked.
+        person in this period. This shows where data exists, not how well anyone
+        worked.
         {missing.length > 0 && (
           <>
             {" "}
@@ -658,8 +679,8 @@ function CoverageLevelsSection({
             {missing.length === 1 ? "has" : "have"} no data for anyone.
           </>
         )}{" "}
-        Counted over the {counted} {counted === 1 ? "person" : "people"} in
-        this scope.
+        Counted over the {counted} {counted === 1 ? "person" : "people"} in this
+        scope.
       </p>
     </section>
   );
@@ -688,8 +709,8 @@ function CoverageLevelPeople({
   const titleById = new Map(GROUPS.map((g) => [g.id, g.title]));
   const rows = [...people].sort((a, b) =>
     (nameByEntity.get(a.entityId) ?? a.entityId).localeCompare(
-      nameByEntity.get(b.entityId) ?? b.entityId,
-    ),
+      nameByEntity.get(b.entityId) ?? b.entityId
+    )
   );
 
   return (
@@ -705,7 +726,10 @@ function CoverageLevelPeople({
         const personId = personIdByEntity.get(p.entityId);
         const name = nameByEntity.get(p.entityId) ?? p.entityId;
         return (
-          <li key={p.entityId} className="flex flex-wrap items-baseline gap-x-2 text-xs">
+          <li
+            key={p.entityId}
+            className="flex flex-wrap items-baseline gap-x-2 text-xs"
+          >
             {personId ? (
               <Link
                 to="/ic/$person/personal"
@@ -1297,13 +1321,46 @@ function CompositionSection({
 
   const r = grid.byKey.get(spec.metric);
   const bd = compData.get(spec.metric);
-  const bucket = new Map<string, number>();
+  // Summed per dimension VALUE and shown under its LABEL: the value is the id
+  // the response groups by (a source id joined to `owner/repo`), which is
+  // neither what a reader recognises nor distinguishable once a list of them is
+  // truncated. Two things that happen to share a label stay two bars, because
+  // the sum is keyed by the id.
+  const bucket = new Map<string, BarEntry>();
   if (bd) {
     for (const id of memberIds) {
       for (const row of forEntity(bd, id).breakdown) {
-        const val = row.dimensions.find((d) => d.key === spec.dimension)?.value;
-        if (!val || row.value == null || row.value <= 0) continue;
-        bucket.set(val, (bucket.get(val) ?? 0) + row.value);
+        const dim = row.dimensions.find((d) => d.key === spec.dimension);
+        if (!dim?.value || row.value == null || row.value <= 0) continue;
+        const running = bucket.get(dim.value);
+        const split = running?.split ?? (spec.splitBy ? new Map() : undefined);
+        if (split && spec.splitBy) {
+          const by = row.dimensions.find((d) => d.key === spec.splitBy);
+          // A row the response did not split still belongs to the total, so it
+          // lands in a segment of its own rather than being dropped.
+          const seed = by?.value || UNSPLIT_SEGMENT;
+          const seen = split.get(seed);
+          split.set(seed, {
+            seed,
+            label: by?.label?.trim() || seen?.label || seed,
+            value: (seen?.value ?? 0) + row.value,
+          });
+        }
+        const label = dim.label?.trim() || running?.label || dim.value;
+        const href =
+          running?.href ??
+          (spec.dimension === LINKABLE_DIMENSION
+            ? (githubRepoUrl(
+                row.dimensions.find((d) => d.key === SOURCE_DIMENSION)?.value,
+                label
+              ) ?? undefined)
+            : undefined);
+        bucket.set(dim.value, {
+          label,
+          value: (running?.value ?? 0) + row.value,
+          href,
+          split,
+        });
       }
     }
   }
@@ -1518,11 +1575,11 @@ function ByUnitSection({
     if (!unit) continue;
     (byUnit.get(unit) ?? byUnit.set(unit, []).get(unit)!).push(id);
   }
-  const bucket = new Map<string, number>();
+  const bucket = new Map<string, BarEntry>();
   for (const [unit, ids] of byUnit) {
     if (ids.length < MIN_COHORT) continue; // small-cohort suppression
     const v = perCapita(r, ids);
-    if (v > 0) bucket.set(`${unit} · ${ids.length}`, v);
+    if (v > 0) bucket.set(unit, { label: `${unit} · ${ids.length}`, value: v });
   }
   const rows = toBarRows(bucket);
   if (rows.length < 2) return <SliceNote text={NO_COMPARABLE_UNITS_NOTE} />;
@@ -1540,22 +1597,77 @@ function ByUnitSection({
 
 /* ── shared bits ─────────────────────────────────────────────────────── */
 
+/** One slice of a bar: a value of the split dimension, and its share of the row. */
+interface BarSegment {
+  /** The split value's own key — the colour seed, stable across rows. */
+  seed: string;
+  label: string;
+  value: number;
+}
+
 interface BarRow {
   label: string;
   value: number;
   pct: number;
+  /** Where the row's subject lives, when that is knowable. */
+  href?: string;
+  /** Absent when the section declares no `splitBy`. */
+  segments?: BarSegment[];
 }
 
-function toBarRows(bucket: Map<string, number>): BarRow[] {
-  const total = [...bucket.values()].reduce((a, b) => a + b, 0) || 1;
-  return [...bucket.entries()]
-    .map(([label, value]) => ({
+/**
+ * One bar before it is measured against the others.
+ *
+ * The map key is the row's IDENTITY and this is what the reader sees. They were
+ * the same string once, which is why a dimension whose ids share a prefix drew a
+ * column of bars all reading alike.
+ */
+interface BarEntry {
+  label: string;
+  value: number;
+  href?: string;
+  /** Totals per split value, keyed by that value. */
+  split?: Map<string, BarSegment>;
+}
+
+function toBarRows(bucket: Map<string, BarEntry>): BarRow[] {
+  const total =
+    [...bucket.values()].reduce((sum, entry) => sum + entry.value, 0) || 1;
+  return [...bucket.values()]
+    .map(({ label, value, split, href }) => ({
       label,
       value,
-      pct: Math.round((value / total) * 100),
+      href,
+      segments: split
+        ? [...split.values()].sort((a, b) => b.value - a.value)
+        : undefined,
+      // Exact share; rounding happens where it is displayed, so a small one
+      // can say so instead of being flattened to zero.
+      pct: (value / total) * 100,
     }))
     .sort((a, b) => b.value - a.value);
 }
+
+/**
+ * A share, as a reader should see it. "0%" beside a non-zero count reads as
+ * "none of it" — which is not what a small share means.
+ */
+function shareLabel(pct: number): string {
+  if (pct > 0 && pct < 1) return "<1%";
+  return `${Math.round(pct)}%`;
+}
+
+/** Same dwell as every other hover explanation in the product. */
+const HOVER_DELAY_MS = 400;
+
+/** The dimension whose rows can address something outside the product. */
+const LINKABLE_DIMENSION = "repository";
+
+/** Names the provider a git row came from. */
+const SOURCE_DIMENSION = "source";
+
+/** Segment a split row falls in when the response named no split value. */
+const UNSPLIT_SEGMENT = "unsplit";
 
 /** Rows shown before the reader opts into the full list. */
 const BAR_LIST_COLLAPSED = 12;
@@ -1577,45 +1689,132 @@ function BarList({
   const [expanded, setExpanded] = useState(false);
   const visible = expanded ? rows : rows.slice(0, BAR_LIST_COLLAPSED);
   const max = rows[0]?.value || 1;
-  // Collapsed view is a sample, not the full picture — the title says so,
-  // and the "+N more" button below hands over the rest on demand.
-  const displayTitle =
-    !expanded && rows.length > BAR_LIST_COLLAPSED
-      ? `${title} · top ${BAR_LIST_COLLAPSED}`
-      : title;
+  // Seeded from EVERY row, not the visible page: a colour must not change
+  // meaning when the reader expands the list. Ordered by total so the legend
+  // reads biggest-first, like the bars.
+  const totals = new Map<string, { label: string; value: number }>();
+  for (const row of rows) {
+    for (const segment of row.segments ?? []) {
+      const seen = totals.get(segment.seed);
+      totals.set(segment.seed, {
+        label: seen?.label ?? segment.label,
+        value: (seen?.value ?? 0) + segment.value,
+      });
+    }
+  }
+  const colors = seriesColors([...totals.keys()]);
+  const legend = [...totals.entries()]
+    .sort((a, b) => b[1].value - a[1].value)
+    .map(([seed, { label }]) => ({ seed, label, color: colors[seed] }));
+
   return (
     <section className="flex flex-col gap-3">
       <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
-        {displayTitle}
+        {title}
       </p>
       <Card>
         <CardContent className="flex flex-col gap-2 p-4">
-          {visible.map((row) => (
-            <div key={row.label} className="flex items-center gap-3">
-              <div className="w-44 shrink-0 truncate text-sm">{row.label}</div>
-              <div className="relative h-6 flex-1 overflow-hidden rounded bg-muted">
+          <TooltipProvider delay={HOVER_DELAY_MS}>
+            {legend.length ? (
+              <ul
+                className="flex flex-wrap items-center gap-x-4 gap-y-1 pb-1"
+                aria-label="What each colour in a bar means"
+              >
+                {legend.map((entry) => (
+                  <li
+                    key={entry.seed}
+                    className="flex items-center gap-1.5 text-xs text-muted-foreground"
+                  >
+                    <span
+                      aria-hidden
+                      className="size-2.5 shrink-0 rounded-[2px]"
+                      style={{ backgroundColor: entry.color }}
+                    />
+                    {entry.label}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+            {visible.map((row) => (
+              <div key={row.label} className="flex items-center gap-3">
+                {/* A dimension value is often a path (`owner/repo`), and the part
+                  that tells two rows apart is at the END — so the column grows
+                  with the viewport and the full value stays on hover. */}
                 <div
-                  className="h-full rounded bg-primary/25"
-                  style={{ width: `${Math.round((row.value / max) * 100)}%` }}
-                />
-                <span className="absolute inset-y-0 left-2 flex items-center text-xs font-medium tabular-nums">
+                  className="w-44 shrink-0 truncate text-sm md:w-64 lg:w-80"
+                  title={row.label}
+                >
+                  {row.href ? (
+                    <a
+                      href={row.href}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="hover:text-foreground hover:underline"
+                    >
+                      {row.label}
+                    </a>
+                  ) : (
+                    row.label
+                  )}
+                </div>
+                <div className="h-6 flex-1 overflow-hidden rounded bg-muted">
+                  {/* One bar, however it is cut: the width is the row's share of
+                    the largest row, and the segments divide THAT width, so a
+                    split bar stays comparable with an unsplit one. */}
+                  <div
+                    className="flex h-full overflow-hidden rounded"
+                    style={{ width: `${Math.round((row.value / max) * 100)}%` }}
+                  >
+                    {row.segments?.length ? (
+                      row.segments.map((segment) => (
+                        <Tooltip key={segment.seed}>
+                          <TooltipTrigger
+                            render={
+                              <span
+                                className="h-full first:rounded-s last:rounded-e"
+                                style={{
+                                  width: `${(segment.value / row.value) * 100}%`,
+                                  backgroundColor: colors[segment.seed],
+                                }}
+                              />
+                            }
+                          />
+                          <TooltipContent side="top">
+                            {segment.label} ·{" "}
+                            {formatMetricValue(segment.value, format, unit)} ·{" "}
+                            {shareLabel((segment.value / row.value) * 100)}
+                          </TooltipContent>
+                        </Tooltip>
+                      ))
+                    ) : (
+                      <span className="h-full w-full rounded bg-primary/25" />
+                    )}
+                  </div>
+                </div>
+                {/* Beside the bar, not on it: a segment fill is a full-strength
+                  colour, and no single text colour stays legible across every
+                  hue a palette can hand out. */}
+                {/* Fixed width, right-aligned: sized by its content the column
+                  would differ on every row, and every bar would end somewhere
+                  else. */}
+                <div className="w-28 shrink-0 text-right text-xs font-medium text-muted-foreground tabular-nums md:w-36">
                   {formatMetricValue(row.value, format, unit)}
-                  {showShare ? ` · ${row.pct}%` : ""}
-                </span>
+                  {showShare ? ` · ${shareLabel(row.pct)}` : ""}
+                </div>
               </div>
-            </div>
-          ))}
-          {rows.length > BAR_LIST_COLLAPSED ? (
-            <button
-              type="button"
-              onClick={() => setExpanded((v) => !v)}
-              className="self-start pt-1 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
-            >
-              {expanded
-                ? "Show less"
-                : `+${rows.length - BAR_LIST_COLLAPSED} more`}
-            </button>
-          ) : null}
+            ))}
+            {rows.length > BAR_LIST_COLLAPSED ? (
+              <button
+                type="button"
+                onClick={() => setExpanded((v) => !v)}
+                className="self-start pt-1 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+              >
+                {expanded
+                  ? "Show less"
+                  : `+${rows.length - BAR_LIST_COLLAPSED} more`}
+              </button>
+            ) : null}
+          </TooltipProvider>
         </CardContent>
       </Card>
     </section>

--- a/src/frontend/src/components/portal/employees-view.test.tsx
+++ b/src/frontend/src/components/portal/employees-view.test.tsx
@@ -119,6 +119,14 @@ describe("EmployeesView on an organisation with no reporting lines", () => {
     ];
   });
 
+  it("is headed as a roster, not as employees", () => {
+    render(<EmployeesView />);
+
+    expect(
+      screen.getByRole("heading", { level: 1, name: "Roster" }),
+    ).toBeInTheDocument();
+  });
+
   it("lists the roster rather than the tree", () => {
     render(<EmployeesView />);
 

--- a/src/frontend/src/components/portal/employees-view.test.tsx
+++ b/src/frontend/src/components/portal/employees-view.test.tsx
@@ -17,6 +17,14 @@ import type { IdentityPerson } from "@/types/insight";
 
 const mocks = vi.hoisted(() => ({
   personId: null as string | null,
+  isFlat: false,
+  roster: {
+    roster: [] as { person_id: string; display_name?: string | null; username?: string | null; job_title?: string | null; status?: string | null; provisional?: boolean }[],
+    truncated: false,
+    isPending: false,
+    isError: false,
+    retry: vi.fn(),
+  },
   ic: {
     data: undefined as IdentityPerson | undefined,
     isPending: false,
@@ -29,6 +37,16 @@ vi.mock("@/auth", () => ({
   useViewer: () => ({ email: "boss@x", personId: mocks.personId }),
 }));
 vi.mock("@/queries/ic-dashboard", () => ({ useIcPerson: () => mocks.ic }));
+vi.mock("@/queries/identity-me", () => ({
+  useVisibilityPolicy: () => ({
+    policy: mocks.isFlat ? "flat" : "org_chart",
+    isFlat: mocks.isFlat,
+    isPending: false,
+  }),
+}));
+vi.mock("@/queries/visible-roster", () => ({
+  useVisibleRoster: () => mocks.roster,
+}));
 
 import { EmployeesView } from "./employees-view";
 
@@ -41,6 +59,10 @@ const person = (
 beforeEach(() => {
   mocks.ic.refetch.mockClear();
   mocks.personId = pid("boss");
+  mocks.isFlat = false;
+  mocks.roster.roster = [];
+  mocks.roster.isPending = false;
+  mocks.roster.isError = false;
   mocks.ic.isPending = false;
   mocks.ic.isError = false;
   mocks.ic.data = person("boss", { display_name: "Boss", job_title: "Director" }, [
@@ -81,5 +103,58 @@ describe("EmployeesView", () => {
     render(<EmployeesView />);
     await userEvent.click(screen.getByRole("button", { name: /retry/i }));
     expect(mocks.ic.refetch).toHaveBeenCalledOnce();
+  });
+});
+
+describe("EmployeesView on an organisation with no reporting lines", () => {
+  beforeEach(() => {
+    mocks.isFlat = true;
+    // The tree answers with the viewer alone — the case that used to leave this
+    // directory with a single row.
+    mocks.ic.data = person("boss");
+    mocks.roster.roster = [
+      { person_id: pid("boss"), display_name: "Boss Person", job_title: "Lead" },
+      { person_id: pid("ann"), display_name: "Ann Dev", job_title: "Engineer" },
+      { person_id: pid("bob"), username: "bobby", provisional: true },
+    ];
+  });
+
+  it("lists the roster rather than the tree", () => {
+    render(<EmployeesView />);
+
+    expect(screen.getByText("Ann Dev")).toBeInTheDocument();
+    expect(screen.getByText("Boss Person")).toBeInTheDocument();
+  });
+
+  it("shows a person the journal knows only by a handle under that handle", () => {
+    render(<EmployeesView />);
+
+    expect(screen.getByText("bobby")).toBeInTheDocument();
+  });
+
+  it("drops the columns a flat organisation cannot fill", () => {
+    render(<EmployeesView />);
+
+    expect(screen.queryByRole("columnheader", { name: "Manager" })).toBeNull();
+    expect(screen.queryByRole("columnheader", { name: "Department" })).toBeNull();
+    expect(screen.getByRole("columnheader", { name: "Name" })).toBeInTheDocument();
+  });
+
+  it("filters the roster by the term typed", async () => {
+    render(<EmployeesView />);
+
+    await userEvent.type(screen.getByPlaceholderText(/Search/), "ann");
+
+    expect(screen.getByText("Ann Dev")).toBeInTheDocument();
+    expect(screen.queryByText("Boss Person")).toBeNull();
+  });
+
+  it("offers a retry when the roster read fails, rather than an empty directory", () => {
+    mocks.roster.roster = [];
+    mocks.roster.isError = true;
+
+    render(<EmployeesView />);
+
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
   });
 });

--- a/src/frontend/src/components/portal/employees-view.tsx
+++ b/src/frontend/src/components/portal/employees-view.tsx
@@ -143,7 +143,9 @@ export function EmployeesView() {
     <div className="flex flex-col gap-3 p-4 md:p-6">
       <div className="flex flex-wrap items-end justify-between gap-3">
         <div>
-          <h1 className="text-lg font-semibold tracking-tight">Employees</h1>
+          <h1 className="text-lg font-semibold tracking-tight">
+            {isFlat ? "Roster" : "Employees"}
+          </h1>
           <p className="text-sm text-muted-foreground">
             {filtered.length}
             {filtered.length !== employees.length ? ` of ${employees.length}` : ""}{" "}

--- a/src/frontend/src/components/portal/employees-view.tsx
+++ b/src/frontend/src/components/portal/employees-view.tsx
@@ -2,6 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { Search } from "lucide-react";
 import { useMemo, useState } from "react";
 
+import type { PersonSummary } from "@/api/identity-client";
 import { useViewer } from "@/auth";
 import { CenteredSpinner } from "@/components/widgets/centered-spinner";
 import { ComingSoon } from "@/components/widgets/coming-soon";
@@ -19,6 +20,8 @@ import {
   usePortalNavActions,
 } from "@/lib/portal/portal-nav";
 import { useIcPerson } from "@/queries/ic-dashboard";
+import { useVisibilityPolicy } from "@/queries/identity-me";
+import { useVisibleRoster } from "@/queries/visible-roster";
 import type { IdentityPerson } from "@/types/insight";
 import { cn } from "@/lib/utils";
 
@@ -64,6 +67,31 @@ function collectEmployees(root: IdentityPerson): EmployeeRow[] {
 }
 
 /**
+ * Rows for an organisation with no reporting lines: the roster as identity
+ * serves it. A person the journal knows only by a handle is listed under it —
+ * `person-display` stops at the id on purpose, so a blank name here would be a
+ * row nobody can tell apart.
+ */
+function rosterEmployees(roster: readonly PersonSummary[]): EmployeeRow[] {
+  return roster
+    .map((person) => ({
+      personId: person.person_id,
+      displayName:
+        person.display_name?.trim() ||
+        person.email?.trim() ||
+        person.username?.trim() ||
+        UNNAMED_PERSON,
+      jobTitle: person.job_title ?? "",
+      // No reporting lines, and `PersonSummary` carries no org attributes.
+      department: "",
+      division: "",
+      supervisorName: "",
+      status: person.status ?? "",
+    }))
+    .sort((a, b) => a.displayName.localeCompare(b.displayName));
+}
+
+/**
  * Employees directory — every person in the viewer's org (flattened org tree),
  * searchable, each row linking into their Person view. Sourced entirely from
  * the identity profile tree (`getPerson` recurses), so no metric queries and no
@@ -73,11 +101,18 @@ export function EmployeesView() {
   const { setZone } = usePortalNavActions();
   const { personId: viewerPersonId } = useViewer();
   const { data, isPending, isError, refetch } = useIcPerson(viewerPersonId ?? "");
+  const { isFlat } = useVisibilityPolicy();
+  const flatRoster = useVisibleRoster(isFlat);
   const [query, setQuery] = useState("");
 
   const employees = useMemo(
-    () => (data ? collectEmployees(data) : []),
-    [data],
+    () =>
+      isFlat
+        ? rosterEmployees(flatRoster.roster)
+        : data
+          ? collectEmployees(data)
+          : [],
+    [isFlat, flatRoster.roster, data],
   );
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -90,11 +125,17 @@ export function EmployeesView() {
     );
   }, [employees, query]);
 
-  if (isPending) return <CenteredSpinner className="min-h-[60vh]" />;
-  if (isError || !data)
+  const loading = isFlat ? flatRoster.isPending : isPending;
+  const failed = isFlat ? flatRoster.isError : isError || !data;
+  if (loading) return <CenteredSpinner className="min-h-[60vh]" />;
+  if (failed)
     return (
       <div className="mx-auto w-full max-w-md p-8">
-        <ComingSoon variant="card" state="error" onRetry={refetch} />
+        <ComingSoon
+          variant="card"
+          state="error"
+          onRetry={isFlat ? flatRoster.retry : refetch}
+        />
       </div>
     );
 
@@ -126,9 +167,15 @@ export function EmployeesView() {
             <TableRow>
               <TableHead>Name</TableHead>
               <TableHead>Title</TableHead>
-              <TableHead>Department</TableHead>
-              <TableHead>Division</TableHead>
-              <TableHead>Manager</TableHead>
+              {/* A flat organisation fills none of these: no reporting line,
+                  and the roster carries no org attributes. */}
+              {isFlat ? null : (
+                <>
+                  <TableHead>Department</TableHead>
+                  <TableHead>Division</TableHead>
+                  <TableHead>Manager</TableHead>
+                </>
+              )}
               <TableHead>Status</TableHead>
             </TableRow>
           </TableHeader>
@@ -150,15 +197,19 @@ export function EmployeesView() {
                 <TableCell className="text-muted-foreground">
                   {e.jobTitle || "—"}
                 </TableCell>
-                <TableCell className="text-muted-foreground">
-                  {e.department || "—"}
-                </TableCell>
-                <TableCell className="text-muted-foreground">
-                  {e.division || "—"}
-                </TableCell>
-                <TableCell className="text-muted-foreground">
-                  {e.supervisorName || "—"}
-                </TableCell>
+                {isFlat ? null : (
+                  <>
+                    <TableCell className="text-muted-foreground">
+                      {e.department || "—"}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {e.division || "—"}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {e.supervisorName || "—"}
+                    </TableCell>
+                  </>
+                )}
                 <TableCell>
                   {e.status ? (
                     <Badge

--- a/src/frontend/src/components/portal/person-header.test.tsx
+++ b/src/frontend/src/components/portal/person-header.test.tsx
@@ -72,3 +72,24 @@ describe("PersonHeader", () => {
     expect(screen.getByText("Boss")).toBeInTheDocument();
   });
 });
+
+describe("PersonHeader on an organisation with no reporting lines", () => {
+  it("offers no team or peer affordance rather than one that dead-ends", () => {
+    // Flat shape: no parent to scope to and no manager nodes to resolve, so the
+    // hierarchy affordances have nothing to point at. Pinned because the org
+    // zones are how a flat organisation navigates — a button here that scoped to
+    // an empty org would read as a broken link rather than an absent one.
+    mocks.managerNodes = [];
+    mocks.person = identityPerson("solo", {
+      person_id: pid("solo"),
+      display_name: "Solo",
+      parent_person_id: null,
+    });
+
+    render(<PersonHeader person={pid("solo")} />);
+
+    expect(screen.queryByRole("button", { name: "Team" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Peers" })).toBeNull();
+    expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/portal/portal-layout.tsx
+++ b/src/frontend/src/components/portal/portal-layout.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/lib/portal/portal-nav";
 import { landingDecision } from "@/lib/portal/landing-zone";
 import { useShellLayout, type ShellLayout } from "@/lib/portal/use-shell-layout";
-import { useViewerIsManager } from "@/lib/portal/use-viewer-is-manager";
+import { useViewerReach } from "@/lib/portal/use-viewer-reach";
 import { useIsAdmin } from "@/queries/identity-me";
 
 /**
@@ -30,7 +30,7 @@ export function PortalLayout() {
   // zone stays route-driven (their own Person page) — EXCEPT Manage, which
   // the admin role opens regardless of reports. The rules live in
   // `landingDecision` (pure, table-tested); this effect only applies them.
-  const { isManager, isPending } = useViewerIsManager();
+  const { canSeeOthers, isPending } = useViewerReach();
   const { isAdmin, isPending: adminPending, isError: adminError } = useIsAdmin();
   const zone = usePortalZone();
   const landed = useRef(false);
@@ -39,7 +39,7 @@ export function PortalLayout() {
     const decision = landingDecision({
       zone,
       mgrPending: isPending,
-      isManager,
+      canSeeOthers,
       // An errored check is "unknown", not "no": the landing decision is
       // one-shot, so resetting on it would permanently rewrite a URL an
       // admin deliberately opened. Waiting costs nothing — the me query
@@ -51,7 +51,7 @@ export function PortalLayout() {
     landed.current = true;
     if (decision.kind === "pin-overview") replaceZone("overview");
     if (decision.kind === "reset") replaceZone(null);
-  }, [isPending, isManager, adminPending, adminError, isAdmin, zone, replaceZone]);
+  }, [isPending, canSeeOthers, adminPending, adminError, isAdmin, zone, replaceZone]);
 
   return (
     <SidebarProvider

--- a/src/frontend/src/components/portal/portal-shell.test.tsx
+++ b/src/frontend/src/components/portal/portal-shell.test.tsx
@@ -30,6 +30,11 @@ vi.mock("@/auth", () => ({
 }));
 vi.mock("@/queries/identity-me", () => ({
   useIsAdmin: () => ({ isAdmin: false, isPending: false }),
+  useVisibilityPolicy: () => ({
+    policy: "org_chart",
+    isFlat: false,
+    isPending: false,
+  }),
 }));
 vi.mock("@/lib/portal/use-viewer-is-manager", () => ({
   useViewerIsManager: () => ({ isManager: mocks.isManager, isPending: mocks.isPending }),

--- a/src/frontend/src/components/portal/portal-topbar.test.tsx
+++ b/src/frontend/src/components/portal/portal-topbar.test.tsx
@@ -23,6 +23,25 @@ import { identityPerson, pid } from "@/test/identity";
 
 const mocks = vi.hoisted(() => ({
   definitions: { metrics: [] } as MetricDefinitionListResponse,
+  isFlat: false,
+}));
+
+vi.mock("@/queries/identity-me", () => ({
+  useVisibilityPolicy: () => ({
+    policy: mocks.isFlat ? "flat" : "org_chart",
+    isFlat: mocks.isFlat,
+    isPending: false,
+  }),
+  useIsAdmin: () => ({ isAdmin: false, isPending: false }),
+}));
+vi.mock("@/queries/visible-roster", () => ({
+  useVisibleRoster: () => ({
+    roster: [],
+    truncated: false,
+    isPending: false,
+    isError: false,
+    retry: () => {},
+  }),
 }));
 
 // Only the network is stubbed; the query hook itself is the real one.
@@ -148,5 +167,16 @@ describe("PortalTopBar · zones that filter nothing", () => {
     bar();
 
     await waitFor(() => expect(filters()).toBeInTheDocument());
+  });
+
+  it("drops the cohort control where there is one cohort", async () => {
+    // A flat organisation has no teams to compare within and no attributes on
+    // its roster: the control would offer a single choice, and its tooltip
+    // would describe a cut nobody can make.
+    mocks.isFlat = true;
+
+    bar();
+
+    expect(screen.queryByText("Cohort")).toBeNull();
   });
 });

--- a/src/frontend/src/components/portal/portal-topbar.tsx
+++ b/src/frontend/src/components/portal/portal-topbar.tsx
@@ -13,6 +13,7 @@ import { PeriodSelectorBar } from "@/components/widgets/period-selector-bar";
 import { usePortalPeriod } from "@/hooks/use-portal-period";
 import { useActiveZone } from "@/lib/portal/use-active-zone";
 import { useCohortOptions } from "@/lib/portal/use-cohort-options";
+import { useVisibilityPolicy } from "@/queries/identity-me";
 import { cn } from "@/lib/utils";
 
 /**
@@ -66,6 +67,11 @@ function ViewFilters() {
   // decided in `useCohortOptions`, which also owns which selection is in
   // effect so this control and the comparison cannot disagree.
   const { dims } = useCohortOptions();
+  // One organisation, one cohort: with no reporting lines and no org attributes
+  // on the roster there is nothing to compare people within, so the control
+  // would offer a single choice and the tooltip would describe a cut that
+  // cannot be made.
+  const { isFlat } = useVisibilityPolicy();
 
   return (
     // Narrow screens keep the three controls on ONE scrollable row: wrapped,
@@ -81,38 +87,40 @@ function ViewFilters() {
       className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto md:flex-wrap md:justify-end md:overflow-x-visible"
     >
       {scoped ? <ScopeSelect /> : null}
-      <span className="flex shrink-0 items-center gap-1.5">
-        <span className="hidden text-xs text-muted-foreground md:inline">
-          Cohort
-        </span>
-        {/* Every "vs median" on every screen is computed against whatever this
+      {isFlat ? null : (
+        <span className="flex shrink-0 items-center gap-1.5">
+          <span className="hidden text-xs text-muted-foreground md:inline">
+            Cohort
+          </span>
+          {/* Every "vs median" on every screen is computed against whatever this
             names, and the word alone does not say so. */}
-        <TooltipProvider delay={200}>
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <button
-                  type="button"
-                  className="cursor-help text-muted-foreground"
-                  aria-label="What the cohort controls"
-                >
-                  <HelpCircle className="size-3.5" />
-                </button>
-              }
-            />
-            <TooltipContent
-              side="bottom"
-              className="max-w-xs text-xs leading-relaxed"
-            >
-              The people every comparison on screen is made against. "Team
-              (all)" compares within the org you are looking at; picking an
-              attribute compares each person with the people who share their
-              value for it.
-            </TooltipContent>
-          </Tooltip>
-        </TooltipProvider>
-        <SliceSelect dims={dims} />
-      </span>
+          <TooltipProvider delay={200}>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    className="cursor-help text-muted-foreground"
+                    aria-label="What the cohort controls"
+                  >
+                    <HelpCircle className="size-3.5" />
+                  </button>
+                }
+              />
+              <TooltipContent
+                side="bottom"
+                className="max-w-xs text-xs leading-relaxed"
+              >
+                The people every comparison on screen is made against. "Team
+                (all)" compares within the org you are looking at; picking an
+                attribute compares each person with the people who share their
+                value for it.
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <SliceSelect dims={dims} />
+        </span>
+      )}
       <PeriodSelectorBar
         period={period}
         customRange={customRange}

--- a/src/frontend/src/components/portal/shell-layout.test.tsx
+++ b/src/frontend/src/components/portal/shell-layout.test.tsx
@@ -30,6 +30,11 @@ vi.mock("@/lib/portal/use-shell-layout", () => ({ useShellLayout: () => mocks.la
 vi.mock("@/lib/portal/use-active-zone", () => ({ useActiveZone: () => mocks.zone }));
 vi.mock("@/queries/identity-me", () => ({
   useIsAdmin: () => ({ isAdmin: false, isPending: false }),
+  useVisibilityPolicy: () => ({
+    policy: "org_chart",
+    isFlat: false,
+    isPending: false,
+  }),
 }));
 vi.mock("@/lib/portal/use-viewer-is-manager", () => ({
   useViewerIsManager: () => ({ isManager: mocks.isManager, isPending: false }),

--- a/src/frontend/src/components/portal/team-state-view.test.tsx
+++ b/src/frontend/src/components/portal/team-state-view.test.tsx
@@ -41,6 +41,24 @@ vi.mock("@/lib/portal/use-cohort-label", () => ({
 vi.mock("@/queries/ic-dashboard", () => ({
   useIcPerson: () => ({ data: mocks.tree, isPending: false, isLoading: false, isError: false, refetch: vi.fn() }),
 }));
+// `useOrgScope` reads the deployment's visibility policy, and its flat branch
+// reads the roster. This suite is about the view, so both answer statically.
+vi.mock("@/queries/identity-me", () => ({
+  useVisibilityPolicy: () => ({
+    policy: "org_chart",
+    isFlat: false,
+    isPending: false,
+  }),
+}));
+vi.mock("@/queries/visible-roster", () => ({
+  useVisibleRoster: () => ({
+    roster: [],
+    truncated: false,
+    isPending: false,
+    isError: false,
+    retry: () => {},
+  }),
+}));
 vi.mock("@/queries/member-grid", () => ({ useMemberGridData: () => mocks.grid }));
 vi.mock("@/hooks/use-portal-period", () => ({
   usePortalPeriod: () => ({ period: "week", dateRange: { from: "2026-07-20", to: "2026-07-26" } }),

--- a/src/frontend/src/components/record-link.tsx
+++ b/src/frontend/src/components/record-link.tsx
@@ -1,0 +1,30 @@
+/**
+ * A record's text, linked when the record has a page to link to.
+ *
+ * Metric evidence is only sometimes addressable — it depends on the provider
+ * and on what the row carries (see `lib/metrics/git-links`). Callers pass the
+ * href they resolved and this decides nothing except how to render it, so an
+ * unlinkable row is plain text rather than a dead anchor.
+ */
+export function RecordLink({
+  href,
+  children,
+}: {
+  href: string | undefined;
+  children: string;
+}) {
+  if (!href) return <>{children}</>;
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      // INVARIANT: rows are clickable in their own right (expand, drilldown) —
+      // following a link must not also trigger the row.
+      onClick={(event) => event.stopPropagation()}
+      className="text-foreground hover:underline"
+    >
+      {children}
+    </a>
+  );
+}

--- a/src/frontend/src/components/ui/scroll-area.tsx
+++ b/src/frontend/src/components/ui/scroll-area.tsx
@@ -1,0 +1,52 @@
+import { ScrollArea as ScrollAreaPrimitive } from "@base-ui/react/scroll-area"
+
+import { cn } from "@/lib/utils"
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: ScrollAreaPrimitive.Root.Props) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  )
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: ScrollAreaPrimitive.Scrollbar.Props) {
+  return (
+    <ScrollAreaPrimitive.Scrollbar
+      data-slot="scroll-area-scrollbar"
+      data-orientation={orientation}
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none data-horizontal:h-2.5 data-horizontal:flex-col data-horizontal:border-t data-horizontal:border-t-transparent data-vertical:h-full data-vertical:w-2.5 data-vertical:border-s data-vertical:border-s-transparent",
+        className
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Thumb
+        data-slot="scroll-area-thumb"
+        className="relative flex-1 rounded-full bg-border"
+      />
+    </ScrollAreaPrimitive.Scrollbar>
+  )
+}
+
+export { ScrollArea, ScrollBar }

--- a/src/frontend/src/components/widgets/metric-views/metric-activity.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-activity.test.tsx
@@ -31,6 +31,19 @@ vi.mock("@/queries/metric-detail", () => ({
   },
 }));
 
+// The catalogue decides whether `source` may be asked for alongside a git
+// metric's evidence; these tests are about what the grains RENDER, so it
+// answers with a declaration and no request of its own.
+const declared = vi.hoisted(() => ({
+  byMetricKey: new Map<string, ReadonlySet<string>>(),
+}));
+vi.mock("@/queries/metric-definitions", () => ({
+  useDeclaredMetricDimensions: () => ({
+    byMetricKey: declared.byMetricKey,
+    isPending: false,
+  }),
+}));
+
 import { MetricActivity } from "./metric-activity";
 
 const ME = "019e27bc-dec0-7626-81a9-c5524662a6a9";
@@ -208,7 +221,9 @@ describe("MetricActivity", () => {
         { values: { date: "2026-03-05", value: 9 } },
       ],
     };
-    const { container } = draw(metric("collab.messages_sent", ["source_summary"], 13));
+    const { container } = draw(
+      metric("collab.messages_sent", ["source_summary"], 13)
+    );
     const bars = container.querySelectorAll<HTMLElement>('[role="img"] > div');
     expect(bars).toHaveLength(5);
     const readout = () =>

--- a/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
@@ -22,7 +22,13 @@ import {
   forEntity,
   type NormalizedMetricResult,
 } from "@/lib/metrics/collection";
+import {
+  evidenceRecordLinks,
+  withGitSourceDimension,
+} from "@/lib/metrics/git-links";
+import { RecordLink } from "@/components/record-link";
 import { useMetricDetail } from "@/queries/metric-detail";
+import { useDeclaredMetricDimensions } from "@/queries/metric-definitions";
 import { cn } from "@/lib/utils";
 
 /** Events listed inline before the rest goes to the evidence dialog. */
@@ -51,10 +57,20 @@ export function MetricActivity({
   periodNoun: string;
 }) {
   const grain = finestGrain(metric);
-  const selection = metric.selection
+  const declared = useDeclaredMetricDimensions();
+  const base = metric.selection
     ? evidenceSelection(metric.selection, entityId)
     : null;
-  const detail = useMetricDetail(selection, grain != null);
+  // INVARIANT: the same gate the evidence dialog applies — `source` is what
+  // makes a link safe, and asking for it where a metric does not declare it is
+  // rejected outright, so the read waits for the catalogue.
+  const selection = base
+    ? withGitSourceDimension(base, declared.byMetricKey?.get(base.metric_key))
+    : null;
+  const detail = useMetricDetail(
+    selection,
+    grain != null && !declared.isPending
+  );
   const help = metricHelp(metric);
   const data = forEntity(metric, entityId);
   const total = formatMetricValue(data.value, metric.format, metric.unit);
@@ -170,6 +186,7 @@ function EventList({
   const evidence = useMetricEvidenceOptional();
   const scope = useEvidenceScope();
   const selection = evidenceSelection(metric.selection, entityId);
+  const metricKey = metric.selection?.metric_key ?? "";
   const events = useMemo(() => activityEvents(rows), [rows]);
   const shown = events.slice(0, EVENTS_SHOWN);
   const rest = events.length - shown.length;
@@ -177,24 +194,33 @@ function EventList({
   return (
     <div className="flex flex-col gap-1">
       <ul className="flex flex-col">
-        {shown.map((event, index) => (
-          <li
-            key={event.ref ?? `${event.date}-${index}`}
-            className="flex items-baseline gap-3 py-1 text-xs"
-          >
-            <span className="w-14 shrink-0 text-muted-foreground tabular-nums">
-              {formatDate(event.date)}
-            </span>
-            <span className="min-w-0 flex-1 truncate">
-              {event.title ?? <span className="text-muted-foreground">—</span>}
-            </span>
-            {event.context ? (
-              <span className="hidden max-w-[14rem] shrink-0 truncate text-muted-foreground sm:inline">
-                {event.context}
+        {shown.map((event, index) => {
+          const links = evidenceRecordLinks(metricKey, event.values);
+          return (
+            <li
+              key={event.ref ?? `${event.date}-${index}`}
+              className="flex items-baseline gap-3 py-1 text-xs"
+            >
+              <span className="w-14 shrink-0 text-muted-foreground tabular-nums">
+                {formatDate(event.date)}
               </span>
-            ) : null}
-          </li>
-        ))}
+              <span className="min-w-0 flex-1 truncate">
+                {event.title ? (
+                  <RecordLink href={links.title}>{event.title}</RecordLink>
+                ) : (
+                  <span className="text-muted-foreground">—</span>
+                )}
+              </span>
+              {event.context ? (
+                <span className="hidden max-w-[14rem] shrink-0 truncate text-muted-foreground sm:inline">
+                  <RecordLink href={links.repository}>
+                    {event.context}
+                  </RecordLink>
+                </span>
+              ) : null}
+            </li>
+          );
+        })}
       </ul>
       {rest > 0 && evidence && selection ? (
         <Button
@@ -265,7 +291,8 @@ function stripSummary(
     null
   );
   const parts = [`${metric.label} by day, ${span}`];
-  if (busiest?.value != null) parts.push(`busiest ${dayTitle(metric, busiest)}`);
+  if (busiest?.value != null)
+    parts.push(`busiest ${dayTitle(metric, busiest)}`);
   parts.push(
     silent === 0
       ? "every day has a reading"
@@ -335,7 +362,7 @@ function DayStrip({
         {hoveredDay && hovered != null ? (
           <div
             aria-hidden
-            className="pointer-events-none absolute bottom-full z-10 mb-1 rounded border bg-popover px-1.5 py-0.5 text-xs whitespace-nowrap text-popover-foreground shadow-sm tabular-nums"
+            className="pointer-events-none absolute bottom-full z-10 mb-1 rounded border bg-popover px-1.5 py-0.5 text-xs whitespace-nowrap text-popover-foreground tabular-nums shadow-sm"
             style={{
               // Anchored to the bar's own edge and grown inwards, rather than
               // centred and clamped. Centring needs to know the readout's

--- a/src/frontend/src/lib/insight/metric-grain.test.ts
+++ b/src/frontend/src/lib/insight/metric-grain.test.ts
@@ -147,6 +147,9 @@ describe("activityEvents", () => {
         title: null,
         context: null,
         value: 3,
+        // Carried so a caller that knows the metric can decide whether the
+        // thing is addressable; nothing here names one.
+        values: { date: "2026-03-01", value: 3 },
       },
     ]);
   });

--- a/src/frontend/src/lib/insight/metric-grain.ts
+++ b/src/frontend/src/lib/insight/metric-grain.ts
@@ -107,6 +107,12 @@ export interface ActivityEvent {
   date: string;
   /** The metric's own reading for this event, when it has one. */
   value: number | null;
+  /**
+   * The evidence row this came from. Whether the thing is addressable depends
+   * on the provider and on columns this shape does not name, so that decision
+   * stays with the caller that knows the metric.
+   */
+  values: Readonly<Record<string, unknown>>;
 }
 
 /** Everything after the first line — a commit body, not its subject. */
@@ -136,6 +142,7 @@ export function activityEvents(rows: MetricEvidenceRow[]): ActivityEvent[] {
           context: typeof context === "string" ? context : null,
           date,
           value: num(row.values.value),
+          values: row.values,
         },
       ];
     })

--- a/src/frontend/src/lib/metrics/git-links.test.ts
+++ b/src/frontend/src/lib/metrics/git-links.test.ts
@@ -1,0 +1,257 @@
+/**
+ * When a git metric's evidence addresses something outside the product.
+ *
+ * The rule these pin is that a link is only ever built from what a row
+ * actually says. Every case below is a way of NOT knowing: a provider whose
+ * address we cannot derive, a repository value that only looks like a path, a
+ * ref that names neither a commit nor a pull request, a dimension the metric
+ * never declared. Each of those has to come back empty rather than guess,
+ * because a link that looks right and goes nowhere is worse than no link.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { MetricEvidenceSelection } from "@/api/metric-drilldown-client";
+import {
+  evidenceRecordLinks,
+  githubRecordUrl,
+  githubRepoUrl,
+  isGitMetric,
+  withGitSourceDimension,
+} from "@/lib/metrics/git-links";
+
+const SHA1 = "e0f4823a55ac28276cf068f066ebf66f872a059c";
+const SHA256 = `${SHA1}${SHA1.slice(0, 24)}`;
+
+describe("githubRepoUrl", () => {
+  // The two serving paths spell one connector differently: a breakdown row
+  // carries the dimension's VALUE, an evidence row the LABEL it resolves to.
+  // Both name GitHub, so both have to be accepted — reading only one of them
+  // is why the drilldown silently produced no links at all.
+  it.each([
+    ["the connector key", "github"],
+    ["the display label", "GitHub"],
+    ["either, whatever the casing", "GITHUB"],
+    ["either, padded", "  github  "],
+  ])("accepts %s", (_case, source) => {
+    expect(githubRepoUrl(source, "owner/repo")).toBe(
+      "https://github.com/owner/repo"
+    );
+  });
+
+  it.each([
+    ["a provider that can live at any address", "gitlab"],
+    ["a provider that can live at any address", "bitbucket_cloud"],
+    ["a provider by its label", "Bitbucket Cloud"],
+    ["nothing at all", null],
+    ["nothing at all", undefined],
+    ["something adjacent but not it", "github-enterprise"],
+  ])("refuses %s (%s)", (_case, source) => {
+    expect(githubRepoUrl(source, "owner/repo")).toBeNull();
+  });
+
+  it.each([
+    // The bug this exists to prevent: gold's `repository_value` is account
+    // qualified, and only its LABEL is the addressable path. Feeding the value
+    // in produced a link for every row that pointed nowhere.
+    ["an account-qualified value rather than the label", "12:owner/repo"],
+    ["a slug with no project to pair it with", "repo"],
+    ["the placeholder an absent project leaves", "Unknown"],
+    ["a path with more segments than a repository has", "owner/repo/extra"],
+    ["a path that is only a separator", "/"],
+    ["a half-path", "owner/"],
+    ["nothing at all", ""],
+    ["nothing at all", null],
+    ["nothing at all", undefined],
+  ])("refuses %s (%s)", (_case, repository) => {
+    expect(githubRepoUrl("github", repository)).toBeNull();
+  });
+
+  it("keeps the punctuation a repository name is allowed to carry", () => {
+    expect(githubRepoUrl("github", "my-org/some.repo_name")).toBe(
+      "https://github.com/my-org/some.repo_name"
+    );
+  });
+});
+
+describe("githubRecordUrl", () => {
+  const repo = "https://github.com/owner/repo";
+
+  // A commit hash is fixed-length hex and a pull request number is a short
+  // decimal, so the ref alone separates them — which is what lets this work
+  // without the `record_kind` column the evidence row never projects.
+  it.each([
+    ["a SHA-1 commit", SHA1],
+    ["a SHA-256 commit", SHA256],
+    ["a commit in upper case", SHA1.toUpperCase()],
+  ])("sends %s to its commit page", (_case, ref) => {
+    expect(githubRecordUrl(repo, ref)).toBe(`${repo}/commit/${ref}`);
+  });
+
+  it.each([
+    ["a pull request", "2696"],
+    ["the first pull request", "1"],
+  ])("sends %s to its pull-request page", (_case, ref) => {
+    expect(githubRecordUrl(repo, ref)).toBe(`${repo}/pull/${ref}`);
+  });
+
+  it.each([
+    ["a ref that is neither shape", "not-a-ref"],
+    ["hex of the wrong length", "abc123"],
+    ["hex one short of a SHA-1", SHA1.slice(1)],
+    ["a number that is not one", "12.5"],
+    ["nothing at all", ""],
+    ["nothing at all", null],
+    ["nothing at all", undefined],
+  ])("refuses %s (%s)", (_case, ref) => {
+    expect(githubRecordUrl(repo, ref)).toBeNull();
+  });
+});
+
+describe("isGitMetric", () => {
+  it.each(["git.commits", "git.lines_added", "git.pr_cycle_time_h"])(
+    "claims %s",
+    (key) => {
+      expect(isGitMetric(key)).toBe(true);
+    }
+  );
+
+  // The family prefix is the gate that keeps every other source out, so a key
+  // that merely mentions git is not one.
+  it.each(["tasks.closed", "wiki.pages_created", "ai.adoption", "gitlab.x"])(
+    "disclaims %s",
+    (key) => {
+      expect(isGitMetric(key)).toBe(false);
+    }
+  );
+});
+
+describe("withGitSourceDimension", () => {
+  function selection(
+    metricKey: string,
+    displayDimensions: string[] = []
+  ): MetricEvidenceSelection {
+    return {
+      metric_key: metricKey,
+      entity: { type: "person", id: "person-1" },
+      period: { from: "2026-01-01", to: "2026-01-31" },
+      filters: [],
+      display_dimensions: displayDimensions,
+    };
+  }
+
+  it("asks for the source a git metric declares", () => {
+    const result = withGitSourceDimension(
+      selection("git.commits"),
+      new Set(["repository", "source"])
+    );
+
+    expect(result.display_dimensions).toEqual(["source"]);
+  });
+
+  it("keeps the requested dimensions sorted, so one selection is one query key", () => {
+    const result = withGitSourceDimension(
+      selection("git.commits", ["repository"]),
+      new Set(["repository", "source"])
+    );
+
+    expect(result.display_dimensions).toEqual(["repository", "source"]);
+  });
+
+  // Asking for an undeclared dimension is refused outright, so asking on spec
+  // would trade a missing link for a dialog that cannot open at all.
+  it("leaves a git metric that declares no source untouched", () => {
+    const original = selection("git.commits_per_active_day");
+
+    expect(withGitSourceDimension(original, new Set())).toBe(original);
+  });
+
+  it("leaves everything untouched while the catalogue is unknown", () => {
+    const original = selection("git.commits");
+
+    expect(withGitSourceDimension(original, null)).toBe(original);
+    expect(withGitSourceDimension(original, undefined)).toBe(original);
+  });
+
+  it("leaves a metric of another family untouched", () => {
+    const original = selection("tasks.closed");
+
+    expect(withGitSourceDimension(original, new Set(["source"]))).toBe(
+      original
+    );
+  });
+
+  it("does not ask twice for a source the caller already wanted", () => {
+    const original = selection("git.commits", ["source"]);
+
+    expect(withGitSourceDimension(original, new Set(["source"]))).toBe(
+      original
+    );
+  });
+});
+
+describe("evidenceRecordLinks", () => {
+  const row = {
+    source: "GitHub",
+    repository: "owner/repo",
+    ref: SHA1,
+  };
+
+  it("addresses the repository and the record from one row", () => {
+    expect(evidenceRecordLinks("git.commits", row)).toEqual({
+      repository: "https://github.com/owner/repo",
+      ref: `https://github.com/owner/repo/commit/${SHA1}`,
+      title: `https://github.com/owner/repo/commit/${SHA1}`,
+    });
+  });
+
+  // The id of a record and the human-readable summary of it are two ways of
+  // naming the same page, so they carry the same link.
+  it("points a record's id and its summary at the same page", () => {
+    const links = evidenceRecordLinks("git.commits", { ...row, ref: "2696" });
+
+    expect(links.ref).toBe("https://github.com/owner/repo/pull/2696");
+    expect(links.title).toBe(links.ref);
+  });
+
+  it("still addresses the repository when the ref names nothing", () => {
+    const links = evidenceRecordLinks("git.commits", { ...row, ref: "" });
+
+    expect(links.repository).toBe("https://github.com/owner/repo");
+    expect(links.ref).toBeUndefined();
+    expect(links.title).toBeUndefined();
+  });
+
+  it.each([
+    ["the metric belongs to another family", "tasks.closed", row],
+    [
+      "the provider's address is not derivable",
+      "git.commits",
+      { ...row, source: "gitlab" },
+    ],
+    [
+      "the row does not say which provider it came from",
+      "git.commits",
+      { repository: "owner/repo", ref: SHA1 },
+    ],
+    [
+      "the repository is not a path",
+      "git.commits",
+      { ...row, repository: "Unknown" },
+    ],
+    ["the row says nothing", "git.commits", {}],
+  ])("says nothing when %s", (_case, metricKey, values) => {
+    expect(evidenceRecordLinks(metricKey, values)).toEqual({});
+  });
+
+  // Row values arrive as `unknown`; a non-string where a string was expected
+  // is a reason to say nothing, not to coerce it into a URL.
+  it("says nothing when a value is not the string it should be", () => {
+    expect(
+      evidenceRecordLinks("git.commits", {
+        source: "github",
+        repository: 42,
+        ref: SHA1,
+      })
+    ).toEqual({});
+  });
+});

--- a/src/frontend/src/lib/metrics/git-links.ts
+++ b/src/frontend/src/lib/metrics/git-links.ts
@@ -1,0 +1,124 @@
+/**
+ * Links into the provider a git metric came from.
+ *
+ * Only GitHub, and only because its web layout is derivable from data we
+ * already hold: `https://github.com/{owner}/{repo}`. GitLab and Bitbucket can
+ * be self-hosted at any address, and nothing in a metric row says which — so
+ * they get no link rather than a guessed one.
+ *
+ * KNOWN GAP: the `source` dimension names the CONNECTOR, not the host, so a
+ * GitHub Enterprise tenant reports `github` while living at its own domain.
+ * Those links will point at github.com and miss. Carrying the host (or the
+ * `html_url` the API already returns) is what fixes it properly.
+ */
+
+import type { MetricEvidenceSelection } from "@/api/metric-drilldown-client";
+
+/**
+ * GitHub's `source` dimension, as EITHER serving path spells it: a breakdown
+ * row carries the connector key (`github`), while a drilldown row carries the
+ * display label the same dimension resolves to (`GitHub`) — it projects a
+ * dimension's label in preference to its value. Both name one connector, so
+ * both are accepted rather than making callers know which path they are on.
+ */
+const GITHUB_SOURCE = "github";
+
+const GITHUB_WEB_BASE = "https://github.com";
+
+/**
+ * `owner/repo`, and nothing that only looks like it: gold builds the label from
+ * `project_key/repo_slug`, and an absent project leaves the slug alone (no
+ * slash) or the `Unknown` placeholder — neither addresses a repository.
+ */
+const REPO_PATH = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
+
+/** The repository's page, or null when the row is not linkable. */
+export function githubRepoUrl(
+  source: string | null | undefined,
+  repository: string | null | undefined
+): string | null {
+  if (source?.trim().toLowerCase() !== GITHUB_SOURCE) return null;
+  const path = repository?.trim();
+  if (!path || !REPO_PATH.test(path)) return null;
+  return `${GITHUB_WEB_BASE}/${path}`;
+}
+
+/**
+ * A git commit hash is fixed-length hex (SHA-1: 40, SHA-256: 64); a PR number
+ * is a short plain decimal. The two shapes never collide — a repo would need
+ * 10^40 PRs — so the ref alone says which URL a record's own page needs,
+ * without a `record_kind` column the evidence row does not carry.
+ */
+const COMMIT_REF = /^[0-9a-f]{40}$|^[0-9a-f]{64}$/i;
+const PULL_REF = /^[0-9]+$/;
+
+/** The record's own page under a repository, or null when `ref` is neither shape. */
+export function githubRecordUrl(
+  repoUrl: string,
+  ref: string | null | undefined
+): string | null {
+  const value = ref?.trim();
+  if (!value) return null;
+  if (COMMIT_REF.test(value)) return `${repoUrl}/commit/${value}`;
+  if (PULL_REF.test(value)) return `${repoUrl}/pull/${value}`;
+  return null;
+}
+
+/** Two-part `family.name` metric keys namespace by family; git's is fixed. */
+const GIT_METRIC_PREFIX = "git.";
+
+/** Whether links are worth attempting at all for this metric's evidence. */
+export function isGitMetric(metricKey: string): boolean {
+  return metricKey.startsWith(GIT_METRIC_PREFIX);
+}
+
+/** The dimension key requested so a row's own connector rides along. */
+export const SOURCE_DIMENSION = "source";
+
+/**
+ * Adds `source` to a git metric's requested display dimensions, so its
+ * evidence rows carry the per-row connector a link needs to be safe.
+ *
+ * SAFETY: only when the metric DECLARES the dimension — a drilldown that asks
+ * for an undeclared one is rejected outright, so asking on spec would trade a
+ * missing link for an unopenable dialog. `declared` is null while the catalog
+ * is unknown, which is also a no-op.
+ */
+export function withGitSourceDimension(
+  selection: MetricEvidenceSelection,
+  declared: ReadonlySet<string> | null | undefined
+): MetricEvidenceSelection {
+  if (!isGitMetric(selection.metric_key)) return selection;
+  if (!declared?.has(SOURCE_DIMENSION)) return selection;
+  if (selection.display_dimensions.includes(SOURCE_DIMENSION)) return selection;
+  return {
+    ...selection,
+    display_dimensions: [
+      ...selection.display_dimensions,
+      SOURCE_DIMENSION,
+    ].sort(),
+  };
+}
+
+/**
+ * Where each of a drilldown row's columns links to, by column key — empty for
+ * every row nothing can be said about. The id of a record and the human-readable
+ * summary of it address the same page, so both carry it.
+ */
+export function evidenceRecordLinks(
+  metricKey: string,
+  values: Readonly<Record<string, unknown>>
+): Readonly<Record<string, string | undefined>> {
+  if (!isGitMetric(metricKey)) return {};
+  const repoUrl = githubRepoUrl(
+    asString(values[SOURCE_DIMENSION]),
+    asString(values.repository)
+  );
+  if (!repoUrl) return {};
+  const record = githubRecordUrl(repoUrl, asString(values.ref)) ?? undefined;
+  return { repository: repoUrl, ref: record, title: record };
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}

--- a/src/frontend/src/lib/portal/landing-zone.test.ts
+++ b/src/frontend/src/lib/portal/landing-zone.test.ts
@@ -13,42 +13,42 @@ describe("landingDecision", () => {
   it.each<[string, Parameters<typeof landingDecision>[0], LandingDecision["kind"]]>([
     [
       "waits while manager status resolves",
-      { zone: "manage", mgrPending: true, isManager: false, adminPending: false, isAdmin: false },
+      { zone: "manage", mgrPending: true, canSeeOthers: false, adminPending: false, isAdmin: false },
       "wait",
     ],
     [
       "manager on bare /portal lands on the org rollup",
-      { zone: null, ...resolved, isManager: true, isAdmin: false },
+      { zone: null, ...resolved, canSeeOthers: true, isAdmin: false },
       "pin-overview",
     ],
     [
       "manager keeps whatever zone they picked",
-      { zone: "directions", ...resolved, isManager: true, isAdmin: false },
+      { zone: "directions", ...resolved, canSeeOthers: true, isAdmin: false },
       "keep",
     ],
     [
       "an IC keeps the route-driven person view",
-      { zone: null, ...resolved, isManager: false, isAdmin: false },
+      { zone: null, ...resolved, canSeeOthers: false, isAdmin: false },
       "keep",
     ],
     [
       "an IC on an org zone is reset",
-      { zone: "overview", ...resolved, isManager: false, isAdmin: false },
+      { zone: "overview", ...resolved, canSeeOthers: false, isAdmin: false },
       "reset",
     ],
     [
       "a non-manager on manage WAITS for the admin answer instead of resetting",
-      { zone: "manage", mgrPending: false, isManager: false, adminPending: true, isAdmin: false },
+      { zone: "manage", mgrPending: false, canSeeOthers: false, adminPending: true, isAdmin: false },
       "wait",
     ],
     [
       "an admin who manages nobody keeps manage",
-      { zone: "manage", ...resolved, isManager: false, isAdmin: true },
+      { zone: "manage", ...resolved, canSeeOthers: false, isAdmin: true },
       "keep",
     ],
     [
       "a non-admin non-manager on manage is reset once the answer is in",
-      { zone: "manage", ...resolved, isManager: false, isAdmin: false },
+      { zone: "manage", ...resolved, canSeeOthers: false, isAdmin: false },
       "reset",
     ],
   ])("%s", (_name, args, expected) => {

--- a/src/frontend/src/lib/portal/landing-zone.ts
+++ b/src/frontend/src/lib/portal/landing-zone.ts
@@ -13,7 +13,7 @@ export type LandingDecision =
   | { kind: "wait" }
   /** The zone in the URL stands. */
   | { kind: "keep" }
-  /** A manager landing on bare /portal starts at the org rollup. */
+  /** A viewer with a cohort landing on bare /portal starts at the org rollup. */
   | { kind: "pin-overview" }
   /** The zone is not this viewer's to see — back to route-driven (Person). */
   | { kind: "reset" };
@@ -21,16 +21,16 @@ export type LandingDecision =
 export function landingDecision(args: {
   zone: string | null;
   mgrPending: boolean;
-  isManager: boolean;
+  canSeeOthers: boolean;
   adminPending: boolean;
   isAdmin: boolean;
 }): LandingDecision {
-  const { zone, mgrPending, isManager, adminPending, isAdmin } = args;
+  const { zone, mgrPending, canSeeOthers, adminPending, isAdmin } = args;
 
   if (mgrPending) return { kind: "wait" };
-  if (isManager) return zone == null ? { kind: "pin-overview" } : { kind: "keep" };
+  if (canSeeOthers) return zone == null ? { kind: "pin-overview" } : { kind: "keep" };
 
-  // A non-manager's portal collapses to Person — except Manage, which is
+  // A viewer with nobody to look at collapses to Person — except Manage, which is
   // gated by the admin role, not by having reports. Hold the decision until
   // the role answer is in: resetting first would discard the URL the admin
   // deliberately opened.

--- a/src/frontend/src/lib/portal/lens-configs.ts
+++ b/src/frontend/src/lib/portal/lens-configs.ts
@@ -1,4 +1,8 @@
-import { DIRECTIONS, type Direction, type Readiness } from "@/lib/portal/nav-model";
+import {
+  DIRECTIONS,
+  type Direction,
+  type Readiness,
+} from "@/lib/portal/nav-model";
 
 /**
  * The Directions registry: every direction × lens maps to either a LensConfig
@@ -15,14 +19,37 @@ export type SectionSpec =
   | { kind: "headline"; metrics: readonly string[] }
   | { kind: "stat-tiles"; title: string; metrics: readonly string[] }
   | { kind: "trend"; metrics: readonly string[] }
-  | { kind: "distribution"; metric: string; title: string; caption: string; unitLabel: string }
-  | { kind: "concentration"; metrics: readonly string[]; framing: ConcentrationFraming }
-  | { kind: "composition"; metric: string; dimension: string; title: string }
+  | {
+      kind: "distribution";
+      metric: string;
+      title: string;
+      caption: string;
+      unitLabel: string;
+    }
+  | {
+      kind: "concentration";
+      metrics: readonly string[];
+      framing: ConcentrationFraming;
+    }
+  // `splitBy` cuts each bar into segments of a second dimension — the same
+  // total, showing what it is made of.
+  | {
+      kind: "composition";
+      metric: string;
+      dimension: string;
+      title: string;
+      splitBy?: string;
+    }
   // Flow-depth sections: event-histogram merges per-entity server bins when
   // edges align (they don't on the current API — honest fallback, see design §7);
   // participation counts active people.
   | { kind: "event-histogram"; metric: string; title: string }
-  | { kind: "participation"; metrics: readonly string[]; title: string; noun: string }
+  | {
+      kind: "participation";
+      metrics: readonly string[];
+      title: string;
+      noun: string;
+    }
   // Overview-motivated, zone-agnostic sections (design DESIGN-2026-07-27-overview §4).
   | { kind: "attention"; metrics: readonly string[]; max: number }
   | { kind: "direction-cards"; variant: "compact" | "full" }
@@ -62,7 +89,7 @@ export function lensEntry(dir: string, lens: string): LensEntry | undefined {
 /** A direction's lenses in pane order, minus the roadmap ones a reader opted out of. */
 export function visibleLenses(
   direction: Direction,
-  showPlanned: boolean,
+  showPlanned: boolean
 ): string[] {
   return direction.lenses.filter((lens) => {
     const entry = lensEntry(direction.id, lens);
@@ -102,7 +129,8 @@ export function sectionMetricKeys(config: LensConfig): string[] {
           const overview = lenses["Overview"];
           if (!overview || "comingSoon" in overview) continue;
           for (const sec of overview.sections) {
-            if (sec.kind === "headline") for (const k of sec.metrics) keys.add(k);
+            if (sec.kind === "headline")
+              for (const k of sec.metrics) keys.add(k);
           }
         }
         break;
@@ -114,7 +142,9 @@ export function sectionMetricKeys(config: LensConfig): string[] {
         break;
       default: {
         const _exhaustive: never = s;
-        throw new Error(`Unhandled section kind: ${JSON.stringify(_exhaustive)}`);
+        throw new Error(
+          `Unhandled section kind: ${JSON.stringify(_exhaustive)}`
+        );
       }
     }
   }
@@ -144,14 +174,21 @@ const DEV: Record<string, LensEntry> = {
     title: "Development",
     tagline: "output, flow & balance",
     sections: [
-      { kind: "headline", metrics: ["git.commits", "git.prs_merged", "git.lines_added"] },
+      {
+        kind: "headline",
+        metrics: ["git.commits", "git.prs_merged", "git.lines_added"],
+      },
       {
         kind: "stat-tiles",
         title: "Typical values (median)",
         metrics: ["git.pr_cycle_time_h", "git.pr_size", "git.merge_rate"],
       },
       { kind: "trend", metrics: ["git.commits", "git.prs_merged"] },
-      { kind: "concentration", metrics: ["git.commits"], framing: "bus-factor" },
+      {
+        kind: "concentration",
+        metrics: ["git.commits"],
+        framing: "bus-factor",
+      },
       {
         kind: "composition",
         metric: "git.lines_added",
@@ -165,7 +202,12 @@ const DEV: Record<string, LensEntry> = {
     sections: [
       {
         kind: "headline",
-        metrics: ["git.commits", "git.prs_created", "git.prs_merged", "git.code_lines"],
+        metrics: [
+          "git.commits",
+          "git.prs_created",
+          "git.prs_merged",
+          "git.code_lines",
+        ],
       },
       { kind: "trend", metrics: ["git.commits", "git.prs_merged"] },
       {
@@ -176,11 +218,16 @@ const DEV: Record<string, LensEntry> = {
           "How many people fall in each commit-count band — when the bars stretch far to the right, a few people account for most of it.",
         unitLabel: "commits per person",
       },
-      { kind: "concentration", metrics: ["git.commits"], framing: "bus-factor" },
+      {
+        kind: "concentration",
+        metrics: ["git.commits"],
+        framing: "bus-factor",
+      },
       {
         kind: "composition",
         metric: "git.lines_added",
         dimension: "repository",
+        splitBy: "category",
         title: "Lines by repository",
       },
     ],
@@ -215,14 +262,19 @@ const DEV: Record<string, LensEntry> = {
       {
         kind: "stat-tiles",
         title: "Typical task times (median)",
-        metrics: ["tasks.resolution_time", "tasks.pickup_time", "tasks.dev_time"],
+        metrics: [
+          "tasks.resolution_time",
+          "tasks.pickup_time",
+          "tasks.dev_time",
+        ],
       },
       { kind: "trend", metrics: ["tasks.closed", "tasks.bugs_fixed"] },
       {
         kind: "distribution",
         metric: "tasks.closed",
         title: "How many tasks people closed",
-        caption: "Each bar is a range of tasks closed, and how many people fall in it.",
+        caption:
+          "Each bar is a range of tasks closed, and how many people fall in it.",
         unitLabel: "tasks closed per person",
       },
     ],
@@ -242,9 +294,16 @@ const COLLAB: Record<string, LensEntry> = {
     sections: [
       {
         kind: "headline",
-        metrics: ["collab.messages_sent", "collab.meeting_hours", "collab.focus_time_pct"],
+        metrics: [
+          "collab.messages_sent",
+          "collab.meeting_hours",
+          "collab.focus_time_pct",
+        ],
       },
-      { kind: "trend", metrics: ["collab.messages_sent", "collab.meeting_hours"] },
+      {
+        kind: "trend",
+        metrics: ["collab.messages_sent", "collab.meeting_hours"],
+      },
       {
         kind: "distribution",
         metric: "collab.meeting_hours",
@@ -265,7 +324,11 @@ const COLLAB: Record<string, LensEntry> = {
     sections: [
       {
         kind: "headline",
-        metrics: ["collab.messages_sent", "collab.msgs_per_active_day", "collab.active_days"],
+        metrics: [
+          "collab.messages_sent",
+          "collab.msgs_per_active_day",
+          "collab.active_days",
+        ],
       },
       { kind: "trend", metrics: ["collab.messages_sent"] },
       {
@@ -276,7 +339,11 @@ const COLLAB: Record<string, LensEntry> = {
           "How many people fall in each message-volume band — a long right tail means a few people account for most of the chatter.",
         unitLabel: "messages per person",
       },
-      { kind: "concentration", metrics: ["collab.messages_sent"], framing: "load-balance" },
+      {
+        kind: "concentration",
+        metrics: ["collab.messages_sent"],
+        framing: "load-balance",
+      },
     ],
   },
   Meetings: {
@@ -284,7 +351,11 @@ const COLLAB: Record<string, LensEntry> = {
     sections: [
       {
         kind: "headline",
-        metrics: ["collab.meeting_hours", "collab.meetings_count", "collab.meeting_free_days"],
+        metrics: [
+          "collab.meeting_hours",
+          "collab.meetings_count",
+          "collab.meeting_free_days",
+        ],
       },
       { kind: "trend", metrics: ["collab.meeting_hours"] },
       {
@@ -295,14 +366,21 @@ const COLLAB: Record<string, LensEntry> = {
           "How many people fall in each meeting-hours band — a long right tail means a few people carry an outsized meeting load.",
         unitLabel: "meeting hours per person",
       },
-      { kind: "concentration", metrics: ["collab.meeting_hours"], framing: "load-balance" },
+      {
+        kind: "concentration",
+        metrics: ["collab.meeting_hours"],
+        framing: "load-balance",
+      },
     ],
   },
   // emails_received deliberately omitted: distribution-list/CI noise (see git history).
   Email: {
     title: "Email",
     sections: [
-      { kind: "headline", metrics: ["collab.emails_sent", "collab.emails_read"] },
+      {
+        kind: "headline",
+        metrics: ["collab.emails_sent", "collab.emails_read"],
+      },
       { kind: "trend", metrics: ["collab.emails_sent"] },
       {
         kind: "distribution",
@@ -312,13 +390,20 @@ const COLLAB: Record<string, LensEntry> = {
           "How many people fall in each sent-email band — a long right tail means a few people send most of the email.",
         unitLabel: "emails sent per person",
       },
-      { kind: "concentration", metrics: ["collab.emails_sent"], framing: "load-balance" },
+      {
+        kind: "concentration",
+        metrics: ["collab.emails_sent"],
+        framing: "load-balance",
+      },
     ],
   },
   "Focus time": {
     title: "Focus time",
     sections: [
-      { kind: "headline", metrics: ["collab.focus_time_pct", "collab.meeting_free_days"] },
+      {
+        kind: "headline",
+        metrics: ["collab.focus_time_pct", "collab.meeting_free_days"],
+      },
       {
         kind: "distribution",
         metric: "collab.focus_time_pct",
@@ -334,7 +419,11 @@ const COLLAB: Record<string, LensEntry> = {
     sections: [
       {
         kind: "headline",
-        metrics: ["collab.files_shared", "collab.files_engaged", "collab.files_shared_external"],
+        metrics: [
+          "collab.files_shared",
+          "collab.files_engaged",
+          "collab.files_shared_external",
+        ],
       },
       { kind: "trend", metrics: ["collab.files_shared"] },
       {
@@ -345,7 +434,11 @@ const COLLAB: Record<string, LensEntry> = {
           "How many people fall in each files-shared band — a long right tail means a few people do most of the sharing.",
         unitLabel: "files shared per person",
       },
-      { kind: "concentration", metrics: ["collab.files_shared"], framing: "load-balance" },
+      {
+        kind: "concentration",
+        metrics: ["collab.files_shared"],
+        framing: "load-balance",
+      },
     ],
   },
 };
@@ -356,7 +449,10 @@ const WIKI: Record<string, LensEntry> = {
   Overview: {
     title: "Knowledge / Wiki",
     sections: [
-      { kind: "headline", metrics: ["wiki.pages_created", "wiki.edits", "wiki.comments"] },
+      {
+        kind: "headline",
+        metrics: ["wiki.pages_created", "wiki.edits", "wiki.comments"],
+      },
       { kind: "trend", metrics: ["wiki.pages_created", "wiki.edits"] },
       {
         kind: "distribution",
@@ -372,15 +468,23 @@ const WIKI: Record<string, LensEntry> = {
   Authoring: {
     title: "Wiki · Authoring",
     sections: [
-      { kind: "headline", metrics: ["wiki.pages_created", "wiki.pages_edited"] },
+      {
+        kind: "headline",
+        metrics: ["wiki.pages_created", "wiki.pages_edited"],
+      },
       {
         kind: "distribution",
         metric: "wiki.pages_created",
         title: "How many pages people created",
-        caption: "Each bar is a range of pages created, and how many people fall in it.",
+        caption:
+          "Each bar is a range of pages created, and how many people fall in it.",
         unitLabel: "pages created per person",
       },
-      { kind: "concentration", metrics: ["wiki.pages_created"], framing: "bus-factor" },
+      {
+        kind: "concentration",
+        metrics: ["wiki.pages_created"],
+        framing: "bus-factor",
+      },
     ],
   },
   "Edits & comments": {
@@ -392,7 +496,8 @@ const WIKI: Record<string, LensEntry> = {
         kind: "distribution",
         metric: "wiki.edits",
         title: "How many wiki edits people made",
-        caption: "Each bar is a range of wiki edits, and how many people fall in it.",
+        caption:
+          "Each bar is a range of wiki edits, and how many people fall in it.",
         unitLabel: "wiki edits per person",
       },
     ],
@@ -431,13 +536,13 @@ const SALES: Record<string, LensEntry> = Object.fromEntries(
   ["Pipeline", "Deal flow", "Activity", "Velocity & quality"].map((l) => [
     l,
     SALES_NOTE,
-  ]),
+  ])
 );
 const SUPPORT: Record<string, LensEntry> = Object.fromEntries(
   ["Tickets", "CSAT", "Knowledge base", "Comments & updates"].map((l) => [
     l,
     SUPPORT_NOTE,
-  ]),
+  ])
 );
 
 export const DIRECTION_LENSES: Record<string, Record<string, LensEntry>> = {

--- a/src/frontend/src/lib/portal/nav-model.test.ts
+++ b/src/frontend/src/lib/portal/nav-model.test.ts
@@ -5,6 +5,7 @@ import {
   MANAGE_ITEMS,
   manageItemsFor,
   partitionByReadiness,
+  peopleItemsFor,
   resolveZoneItem,
   ZONES,
   zoneItems,
@@ -87,5 +88,29 @@ describe("manageItemsFor", () => {
 
     expect(visible.map((i) => i.id)).not.toContain("identities");
     expect(visible).toEqual(MANAGE_ITEMS.filter((i) => !i.adminOnly));
+  });
+});
+
+describe("peopleItemsFor", () => {
+  it("keeps the reporting-line names when there is a reporting line", () => {
+    const labels = peopleItemsFor(false).map((item) => item.label);
+
+    expect(labels).toContain("Employees");
+    expect(labels).toContain("Median by Role");
+  });
+
+  it("names the same views for an organisation with no reporting lines", () => {
+    // Same ids, because the pane routes on them.
+    const items = peopleItemsFor(true);
+
+    expect(items.map((item) => item.id)).toEqual(["roster", "employees"]);
+    expect(items.map((item) => item.label)).toEqual(["Overview", "Roster"]);
+  });
+
+  it("drops the by-role cut a flat roster cannot make", () => {
+    // No job titles in that roster, so the median has nothing to group by.
+    expect(peopleItemsFor(true).map((item) => item.id)).not.toContain(
+      "median-by-role",
+    );
   });
 });

--- a/src/frontend/src/lib/portal/nav-model.ts
+++ b/src/frontend/src/lib/portal/nav-model.ts
@@ -286,6 +286,24 @@ export const PEOPLE_ITEMS: readonly PaneItem[] = [
   { id: "employees", label: "Employees", icon: Fingerprint },
 ];
 
+/**
+ * The same two views under names a flat organisation can use: there is no
+ * employees-versus-roster distinction to draw, and no job titles to cut a
+ * median by, so that entry is absent rather than empty.
+ *
+ * INVARIANT: the ids match {@link PEOPLE_ITEMS} — the pane routes on them, so a
+ * new People view has to be named for both shapes rather than one.
+ */
+const FLAT_PEOPLE_ITEMS: readonly PaneItem[] = [
+  { id: "roster", label: "Overview", icon: LayoutGrid },
+  { id: "employees", label: "Roster", icon: Users },
+];
+
+/** The People pane for this deployment's shape. */
+export function peopleItemsFor(isFlat: boolean): readonly PaneItem[] {
+  return isFlat ? FLAT_PEOPLE_ITEMS : PEOPLE_ITEMS;
+}
+
 /* ── Manage zone ─────────────────────────────────────────────────────── */
 
 /** The Manage pane for one viewer: admin-only surfaces drop for everyone else. */

--- a/src/frontend/src/lib/portal/portal-hooks.test.tsx
+++ b/src/frontend/src/lib/portal/portal-hooks.test.tsx
@@ -41,6 +41,24 @@ vi.mock("@/auth", () => ({
   useViewer: () => ({ email: "viewer@x", personId: mocks.personId }),
 }));
 vi.mock("@/queries/ic-dashboard", () => ({ useIcPerson: () => mocks.ic }));
+// `useOrgScope` reads the deployment's visibility policy, and its flat branch
+// reads the roster. This suite is about the view, so both answer statically.
+vi.mock("@/queries/identity-me", () => ({
+  useVisibilityPolicy: () => ({
+    policy: "org_chart",
+    isFlat: false,
+    isPending: false,
+  }),
+}));
+vi.mock("@/queries/visible-roster", () => ({
+  useVisibleRoster: () => ({
+    roster: [],
+    truncated: false,
+    isPending: false,
+    isError: false,
+    retry: () => {},
+  }),
+}));
 // Only the request is stubbed; `useMetricDefinitionsResponse` itself runs, so
 // a cohort built from an attribute the catalog does not offer fails here.
 vi.mock("@/api/metric-definitions-client", () => ({

--- a/src/frontend/src/lib/portal/use-org-scope.test.ts
+++ b/src/frontend/src/lib/portal/use-org-scope.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { IdentityPerson } from "@/types/insight";
-import { resolveScopeRoster } from "./use-org-scope";
+import { flatOrgScope, resolveScopeRoster } from "./use-org-scope";
 
 // Ids deliberately look nothing like emails: the scope resolver keys on
 // `person_id` since the identity cutover, and an email-shaped fixture would
@@ -95,5 +95,51 @@ describe("resolveScopeRoster", () => {
       "p-l2a",
     ]);
     expect(s.managerNodes.map((m) => m.teamSize)).toEqual([6, 2, 1, 2, 1]);
+  });
+});
+
+describe("flatOrgScope", () => {
+  const roster = [
+    { person_id: "p-me", display_name: "Me" },
+    { person_id: "p-b", display_name: "Bea" },
+    { person_id: "p-c", display_name: "Cyd" },
+  ];
+
+  it("counts everyone the viewer may see except the viewer", () => {
+    // The org zones read the roster as "the people this frame is about"; the
+    // viewer reads their own numbers on their Person page, as in a subtree.
+    const scope = flatOrgScope(roster, "p-me");
+
+    expect(scope.roster?.map((r) => r.person_id)).toEqual(["p-b", "p-c"]);
+    expect(scope.count).toBe(2);
+  });
+
+  it("offers no manager nodes and no direct-only cut", () => {
+    // Nothing to pick and nothing to narrow: one organisation, one cohort.
+    const scope = flatOrgScope(roster, "p-me");
+
+    expect(scope.managerNodes).toEqual([]);
+    expect(scope.canDirectOnly).toBe(false);
+  });
+
+  it("names the organisation rather than a person", () => {
+    const scope = flatOrgScope(roster, "p-me");
+
+    expect(scope.label).toBe("Whole organisation");
+  });
+
+  it("keeps a roster it cannot place the viewer in", () => {
+    // A viewer absent from their own roster is a bug elsewhere; dropping every
+    // row here would report it as "you can see nobody".
+    const scope = flatOrgScope(roster, "p-unknown");
+
+    expect(scope.count).toBe(3);
+  });
+
+  it("has no roster before the answer arrives", () => {
+    const scope = flatOrgScope(null, "p-me");
+
+    expect(scope.roster).toBeNull();
+    expect(scope.count).toBe(0);
   });
 });

--- a/src/frontend/src/lib/portal/use-org-scope.ts
+++ b/src/frontend/src/lib/portal/use-org-scope.ts
@@ -14,7 +14,10 @@ import {
 import {
   usePortalScope,
 } from "@/lib/portal/portal-nav";
+import type { PersonSummary } from "@/api/identity-client";
 import { useIcPerson } from "@/queries/ic-dashboard";
+import { useVisibilityPolicy } from "@/queries/identity-me";
+import { useVisibleRoster } from "@/queries/visible-roster";
 import type { IdentityPerson } from "@/types/insight";
 
 /** One option in the scope picker: a manager, their depth, and their team size. */
@@ -38,6 +41,54 @@ export interface ResolvedScope {
   managerNodes: ManagerNode[];
   /** Whether directOnly can change anything at this pivot. */
   canDirectOnly: boolean;
+}
+
+/** What the scope is called when it is the organisation itself. */
+export const WHOLE_ORG_LABEL = "Whole organisation";
+
+/**
+ * Scope resolution for an organisation with no reporting lines.
+ *
+ * There is one cohort — everyone the viewer may see — so there is no pivot to
+ * pick and nothing for `directOnly` to narrow. The viewer is left out of the
+ * roster for the same reason a manager is left out of their subtree's: they read
+ * their own numbers on their Person page.
+ */
+export function flatOrgScope(
+  roster: readonly PersonSummary[] | null,
+  viewerPersonId: string | null,
+): ResolvedScope {
+  if (!roster) {
+    return {
+      pivot: null,
+      roster: null,
+      label: WHOLE_ORG_LABEL,
+      count: 0,
+      managerNodes: [],
+      canDirectOnly: false,
+    };
+  }
+
+  const viewer = viewerPersonId?.toLowerCase() ?? null;
+  const members: RosterEntry[] = roster
+    .filter((person) => person.person_id.toLowerCase() !== viewer)
+    .map((person) => ({
+      person_id: person.person_id,
+      email: person.email ?? "",
+      display_name: person.display_name ?? "",
+      // No reporting lines to name, and no depth to be at.
+      supervisor_person_id: null,
+      is_direct: false,
+    }));
+
+  return {
+    pivot: null,
+    roster: members,
+    label: WHOLE_ORG_LABEL,
+    count: members.length,
+    managerNodes: [],
+    canDirectOnly: false,
+  };
 }
 
 /**
@@ -109,15 +160,24 @@ export function useOrgScope(): ResolvedScope & {
   const { personId } = useViewer();
   const viewerQ = useIcPerson(personId ?? "");
   const scope = usePortalScope();
+  const { isFlat } = useVisibilityPolicy();
+  const flatRoster = useVisibleRoster(isFlat);
+
   const resolved = useMemo(
-    () => resolveScopeRoster(viewerQ.data ?? null, personId, scope),
-    [viewerQ.data, personId, scope],
+    () =>
+      isFlat
+        ? flatOrgScope(flatRoster.isPending ? null : flatRoster.roster, personId)
+        : resolveScopeRoster(viewerQ.data ?? null, personId, scope),
+    [isFlat, flatRoster.isPending, flatRoster.roster, viewerQ.data, personId, scope],
   );
+
+  // Under a flat policy the roster IS the org zones' subject, so its failure is
+  // theirs; the identity tree still answers who the viewer is.
   return {
     ...resolved,
-    isLoading: viewerQ.isLoading,
-    isError: viewerQ.isError,
-    refetch: () => viewerQ.refetch(),
+    isLoading: isFlat ? flatRoster.isPending : viewerQ.isLoading,
+    isError: isFlat ? flatRoster.isError : viewerQ.isError,
+    refetch: () => (isFlat ? flatRoster.retry() : void viewerQ.refetch()),
     pivotPersonId: resolved.pivot?.person_id ?? personId ?? "",
   };
 }

--- a/src/frontend/src/lib/portal/use-viewer-reach.test.ts
+++ b/src/frontend/src/lib/portal/use-viewer-reach.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Who the portal's org zones are for. The distinction this hook exists to draw:
+ * a leaf IC on a hierarchical install has nobody to roll up, while a member of
+ * an organisation with no reporting lines can see everyone — and both are
+ * served the same empty `subordinates`.
+ */
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type { IdentityPerson } from "@/types/insight";
+
+const mocks = vi.hoisted(() => ({
+  viewer: null as IdentityPerson | null,
+  isFlat: false,
+  policyPending: false,
+  treePending: false,
+}));
+
+vi.mock("@/auth", () => ({ useViewer: () => ({ personId: "me" }) }));
+vi.mock("@/queries/ic-dashboard", () => ({
+  useIcPerson: () => ({ data: mocks.viewer, isPending: mocks.treePending }),
+}));
+vi.mock("@/queries/identity-me", () => ({
+  useVisibilityPolicy: () => ({
+    policy: mocks.isFlat ? "flat" : "org_chart",
+    isFlat: mocks.isFlat,
+    isPending: mocks.policyPending,
+  }),
+}));
+
+import { useViewerReach } from "./use-viewer-reach";
+
+function person(id: string, subordinates: IdentityPerson[] = []): IdentityPerson {
+  return {
+    person_id: id,
+    email: `${id}@example.com`,
+    display_name: id,
+    subordinates,
+  } as IdentityPerson;
+}
+
+describe("useViewerReach", () => {
+  it("opens the org zones for a lead on a hierarchical install", () => {
+    mocks.viewer = person("me", [person("report")]);
+    mocks.isFlat = false;
+    mocks.policyPending = false;
+    mocks.treePending = false;
+
+    const { result } = renderHook(() => useViewerReach());
+
+    expect(result.current.canSeeOthers).toBe(true);
+    expect(result.current.isManager).toBe(true);
+  });
+
+  it("keeps them shut for a leaf IC on a hierarchical install", () => {
+    mocks.viewer = person("me");
+    mocks.isFlat = false;
+
+    const { result } = renderHook(() => useViewerReach());
+
+    expect(result.current.canSeeOthers).toBe(false);
+    expect(result.current.isManager).toBe(false);
+  });
+
+  it("opens them under a flat policy even with nobody to manage", () => {
+    // The whole point: no reports, and still the organisation to look at.
+    mocks.viewer = person("me");
+    mocks.isFlat = true;
+
+    const { result } = renderHook(() => useViewerReach());
+
+    expect(result.current.canSeeOthers).toBe(true);
+    expect(result.current.isManager).toBe(false);
+  });
+
+  it("waits rather than deciding while either answer is in flight", () => {
+    mocks.viewer = null;
+    mocks.isFlat = false;
+    mocks.treePending = true;
+    mocks.policyPending = true;
+
+    const { result } = renderHook(() => useViewerReach());
+
+    expect(result.current.isPending).toBe(true);
+  });
+});

--- a/src/frontend/src/lib/portal/use-viewer-reach.ts
+++ b/src/frontend/src/lib/portal/use-viewer-reach.ts
@@ -1,0 +1,34 @@
+import { useViewerIsManager } from "@/lib/portal/use-viewer-is-manager";
+import { useVisibilityPolicy } from "@/queries/identity-me";
+
+/**
+ * Whether the portal's org zones (Overview, People, Directions, AI & Cost, …)
+ * have anyone to be about.
+ *
+ * They roll up a set of people, and there are two ways to have one: manage a
+ * subtree, or belong to an organisation whose visibility policy is flat. A leaf
+ * IC and a member of a hierarchy-less organisation are served the same empty
+ * `subordinates`, so the tree alone cannot tell them apart — the policy does.
+ *
+ * `isManager` stays available for the surfaces that mean the reporting line
+ * specifically, rather than "has people to look at".
+ */
+export interface ViewerReach {
+  /** The org zones have a cohort — a subtree, or the whole organisation. */
+  canSeeOthers: boolean;
+  /** The viewer has direct or indirect reports. */
+  isManager: boolean;
+  /** Neither answer is in yet; callers should wait rather than collapse. */
+  isPending: boolean;
+}
+
+export function useViewerReach(): ViewerReach {
+  const { isManager, isPending: treePending } = useViewerIsManager();
+  const policy = useVisibilityPolicy();
+
+  return {
+    canSeeOthers: policy.isFlat || isManager,
+    isManager,
+    isPending: treePending || policy.isPending,
+  };
+}

--- a/src/frontend/src/lib/portal/use-zone-nav.test.ts
+++ b/src/frontend/src/lib/portal/use-zone-nav.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Which zones the rail offers. The gate is not "does this viewer manage
+ * anyone" but "do the org zones have a cohort" — a member of an organisation
+ * with no reporting lines has one, and used to be shown their own page alone.
+ */
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  canSeeOthers: false,
+  reachPending: false,
+  isAdmin: false,
+  showPlanned: false,
+}));
+
+vi.mock("@tanstack/react-router", () => ({ useNavigate: () => vi.fn() }));
+vi.mock("@/lib/portal/use-active-zone", () => ({
+  useActiveZone: () => ({ activeZone: "person", activePerson: "p-1" }),
+}));
+vi.mock("@/lib/portal/use-viewer-reach", () => ({
+  useViewerReach: () => ({
+    canSeeOthers: mocks.canSeeOthers,
+    isManager: false,
+    isPending: mocks.reachPending,
+  }),
+}));
+vi.mock("@/lib/portal/portal-store", () => ({
+  usePortalShowPlanned: () => mocks.showPlanned,
+}));
+vi.mock("@/queries/identity-me", () => ({
+  useIsAdmin: () => ({ isAdmin: mocks.isAdmin, isPending: false }),
+}));
+
+import { useZoneNav } from "./use-zone-nav";
+
+function zoneIds(): string[] {
+  const { result } = renderHook(() => useZoneNav());
+  return result.current.zones.map((z) => z.id);
+}
+
+describe("useZoneNav", () => {
+  it("offers a viewer with no cohort their own page only", () => {
+    mocks.canSeeOthers = false;
+    mocks.reachPending = false;
+    mocks.isAdmin = false;
+
+    expect(zoneIds()).toEqual(["person"]);
+  });
+
+  it("offers the org zones once the viewer has a cohort", () => {
+    // The flat-organisation case: no reports, and still an organisation.
+    mocks.canSeeOthers = true;
+
+    const ids = zoneIds();
+
+    expect(ids).toContain("overview");
+    expect(ids).toContain("people");
+    expect(ids).toContain("person");
+  });
+
+  it("assumes a cohort while the answer is in flight, to avoid a flash", () => {
+    mocks.canSeeOthers = false;
+    mocks.reachPending = true;
+
+    expect(zoneIds()).toContain("overview");
+  });
+
+  it("opens Manage on the admin role rather than on a cohort", () => {
+    mocks.canSeeOthers = false;
+    mocks.reachPending = false;
+    mocks.isAdmin = true;
+
+    const ids = zoneIds();
+
+    expect(ids).toContain("manage");
+    expect(ids).not.toContain("overview");
+  });
+});

--- a/src/frontend/src/lib/portal/use-zone-nav.ts
+++ b/src/frontend/src/lib/portal/use-zone-nav.ts
@@ -5,7 +5,7 @@ import {
   usePortalShowPlanned,
 } from "@/lib/portal/portal-store";
 import { useActiveZone } from "@/lib/portal/use-active-zone";
-import { useViewerIsManager } from "@/lib/portal/use-viewer-is-manager";
+import { useViewerReach } from "@/lib/portal/use-viewer-reach";
 import { useIsAdmin } from "@/queries/identity-me";
 
 /**
@@ -28,13 +28,13 @@ export function useZoneNav(): {
 } {
   const navigate = useNavigate();
   const { activeZone, activePerson } = useActiveZone();
-  const { isManager, isPending: mgrPending } = useViewerIsManager();
+  const { canSeeOthers, isPending: reachPending } = useViewerReach();
   // A rail of scaffolds makes the built zones look unreliable.
   const showPlanned = usePortalShowPlanned();
-  // An IC (no reports) has no subtree to roll up, so org zones are hidden — the
-  // shell collapses to Person. While the viewer's identity is still resolving,
-  // assume manager so the nav doesn't flash a collapsed state.
-  const orgZonesVisible = isManager || mgrPending;
+  // A viewer with nobody to look at has nothing to roll up, so org zones are
+  // hidden and the shell collapses to Person. While the answer is resolving,
+  // assume they have a cohort so the nav doesn't flash a collapsed state.
+  const orgZonesVisible = canSeeOthers || reachPending;
   // Manage is opened by the admin role, not by having reports: the operator
   // persona is an IC by design. Fail closed while the role check is pending —
   // a rail entry that vanishes is worse than one that appears a beat late.

--- a/src/frontend/src/lib/series-colors.ts
+++ b/src/frontend/src/lib/series-colors.ts
@@ -60,6 +60,21 @@ const BRAND_BY_SEED: ReadonlyMap<string, string> = new Map([
   ["ldap", "var(--brand-ldap)"],
 ]);
 
+/**
+ * Two of the git file categories (`git_file_category` in gold) are pinned
+ * because the sorted fallback gave them neighbouring tokens — alphabetically
+ * `test` and `vendored` landed on two ambers a reader could not tell apart.
+ * The rest keep the fallback: they were already distinct.
+ *
+ * `vendored` takes the muted token rather than a chart hue: it is
+ * machine-produced content, so it should recede from the authored lines beside
+ * it rather than compete with them.
+ */
+const FILE_CATEGORY_BY_SEED: ReadonlyMap<string, string> = new Map([
+  ["test", "var(--chart-8)"],
+  ["vendored", "var(--muted-foreground)"],
+]);
+
 const CHART_TOKENS = [
   "var(--chart-1)",
   "var(--chart-2)",
@@ -84,8 +99,8 @@ export function seriesColors(seeds: string[]): Record<string, string> {
   >;
   const unknown: string[] = [];
   for (const seed of new Set(seeds)) {
-    const brand = BRAND_BY_SEED.get(seed);
-    if (brand) palette[seed] = brand;
+    const known = BRAND_BY_SEED.get(seed) ?? FILE_CATEGORY_BY_SEED.get(seed);
+    if (known) palette[seed] = known;
     else unknown.push(seed);
   }
   unknown.sort();

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -409,6 +409,9 @@ export const handlers = [
           name: "admin",
         },
       ],
+      // Mock mode demos the reporting-line product; the flat roster below is
+      // served anyway, so switching this to "flat" exercises that shell.
+      visibility_policy: "org_chart",
     }),
   ),
   // Minimal, honest empty catalog: without this handler the request falls
@@ -572,6 +575,30 @@ export const handlers = [
           ? p.person_id.toLowerCase() === term
           : [p.name, p.email, p.role].some((v) => v.toLowerCase().includes(term)),
       ),
+    )
+      .map((p) => ({
+        person_id: p.person_id,
+        email: p.email,
+        username: null,
+        display_name: p.name,
+        job_title: p.role,
+        status: "active",
+      }))
+      .sort((left, right) =>
+        (left.display_name ?? "").localeCompare(right.display_name ?? ""),
+      );
+    return HttpResponse.json(pageOf(items, params, q));
+  }),
+  // Who the caller may see. Mock mode has one tenant and one roster, so this
+  // answers the same people the operator listing does — the difference on a real
+  // stand is the visible-set filter, which a mock cannot have an opinion about.
+  http.get("/api/identity/v1/visible-persons", ({ request }) => {
+    const params = new URL(request.url).searchParams;
+    const q = params.get("q")?.trim().toLowerCase() ?? "";
+    const items = PEOPLE.filter(
+      (p) =>
+        !q ||
+        [p.name, p.email, p.role].some((v) => v.toLowerCase().includes(q)),
     )
       .map((p) => ({
         person_id: p.person_id,

--- a/src/frontend/src/queries/identity-me.test.tsx
+++ b/src/frontend/src/queries/identity-me.test.tsx
@@ -23,7 +23,7 @@ vi.mock("@/auth/session-scope", () => ({
     s == null ? null : (s as { scope: string }).scope,
 }));
 
-import { ADMIN_ROLE_ID, useIsAdmin } from "./identity-me";
+import { ADMIN_ROLE_ID, useIsAdmin, useVisibilityPolicy } from "./identity-me";
 
 const getMe = vi.mocked(identityClient.getMe);
 
@@ -120,5 +120,36 @@ describe("useIsAdmin", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(getMe).not.toHaveBeenCalled();
     expect(result.current.isAdmin).toBe(false);
+  });
+});
+
+describe("useVisibilityPolicy", () => {
+  it("reads back the policy the service serves", async () => {
+    for (const policy of ["org_chart", "flat"] as const) {
+      getMe.mockResolvedValue({ ...me([]), visibility_policy: policy });
+      const { result } = renderHook(() => useVisibilityPolicy(), harness());
+
+      await waitFor(() => expect(result.current.policy).toBe(policy));
+    }
+  });
+
+  it("reads as org_chart while the answer is not in", () => {
+    getMe.mockReturnValue(new Promise(() => {}) as Promise<identityClient.MeResponse>);
+    const { result } = renderHook(() => useVisibilityPolicy(), harness());
+
+    // Unknown must never WIDEN the rail: an IC keeps their own page until a
+    // flat answer actually arrives.
+    expect(result.current.policy).toBe("org_chart");
+    expect(result.current.isFlat).toBe(false);
+    expect(result.current.isPending).toBe(true);
+  });
+
+  it("reads as org_chart when the check fails", async () => {
+    getMe.mockRejectedValue(new Error("identity unreachable"));
+    const { result } = renderHook(() => useVisibilityPolicy(), harness());
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(result.current.policy).toBe("org_chart");
+    expect(result.current.isFlat).toBe(false);
   });
 });

--- a/src/frontend/src/queries/identity-me.ts
+++ b/src/frontend/src/queries/identity-me.ts
@@ -14,7 +14,11 @@
  */
 import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 
-import { getMe, type MeResponse } from "@/api/identity-client";
+import {
+  getMe,
+  type MeResponse,
+  type VisibilityPolicy,
+} from "@/api/identity-client";
 import { useAuth } from "@/auth/use-auth";
 import { sessionAuthorizationScope } from "@/auth/session-scope";
 
@@ -79,4 +83,28 @@ export function useIsAdmin(): AdminGate {
     isError: me.isError,
     retry: () => void me.refetch(),
   };
+}
+
+export interface VisibilityPolicyState {
+  policy: VisibilityPolicy;
+  /** The organisation has no reporting lines to derive sight from. */
+  isFlat: boolean;
+  isPending: boolean;
+}
+
+/**
+ * Which visibility rule this deployment runs.
+ *
+ * A leaf IC and a member of a hierarchy-less organisation are both served an
+ * empty `subordinates`, so the shell cannot tell them apart by looking at
+ * the tree — it asks here instead.
+ *
+ * Unknown reads as `org_chart`: pending, errored, and an older service that
+ * omits the field all keep the rail as narrow as it is today. Widening it on a
+ * failed check would open org zones to a viewer whose reach nobody confirmed.
+ */
+export function useVisibilityPolicy(): VisibilityPolicyState {
+  const me = useMe();
+  const policy: VisibilityPolicy = me.data?.visibility_policy ?? "org_chart";
+  return { policy, isFlat: policy === "flat", isPending: me.isPending };
 }

--- a/src/frontend/src/queries/metric-definitions.ts
+++ b/src/frontend/src/queries/metric-definitions.ts
@@ -59,6 +59,43 @@ export function useMetricDefinitionsResponse(): UseQueryResult<MetricDefinitionL
   });
 }
 
+export interface DeclaredMetricDimensions {
+  /**
+   * Dimensions each metric declares, or null when the catalog could not be
+   * read. Asking for one a metric does not declare is rejected outright, so a
+   * caller with no catalog asks for none.
+   */
+  byMetricKey: ReadonlyMap<string, ReadonlySet<string>> | null;
+  isPending: boolean;
+}
+
+/**
+ * The dimensions each metric will accept as a display dimension.
+ *
+ * Same gate as `useAvailableMetricKeys`, one level down: a drilldown that asks
+ * for an undeclared dimension is a 400, not a request served without it.
+ */
+export function useDeclaredMetricDimensions(): DeclaredMetricDimensions {
+  const { data, isPending } = useQuery({
+    queryKey: ["metric-definitions"],
+    queryFn: listMetricDefinitions,
+    staleTime: 5 * 60 * 1000,
+  });
+  const byMetricKey = useMemo(
+    () =>
+      data
+        ? new Map(
+            data.metrics.map((m) => [
+              m.metric_key,
+              new Set(m.dimensions) as ReadonlySet<string>,
+            ])
+          )
+        : null,
+    [data]
+  );
+  return { byMetricKey, isPending };
+}
+
 export interface AvailableMetricKeys {
   /**
    * What this installation can serve, or null when the catalog could not be

--- a/src/frontend/src/queries/visible-roster.test.tsx
+++ b/src/frontend/src/queries/visible-roster.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * The roster every flat-org zone counts. What matters: the walk collects every
+ * page rather than the first, it stops at a ceiling instead of following a
+ * cursor forever, and a refusal surfaces as an error — an empty roster would
+ * read to every zone as "this person can see nobody", which is a different
+ * fact.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as identityClient from "@/api/identity-client";
+
+vi.mock("@/api/identity-client");
+
+const session = vi.hoisted(() => ({ value: { scope: "tenant-a" } as unknown }));
+vi.mock("@/auth/use-auth", () => ({
+  useAuth: () => ({ session: session.value }),
+}));
+vi.mock("@/auth/session-scope", () => ({
+  sessionAuthorizationScope: (s: unknown) =>
+    s == null ? null : (s as { scope: string }).scope,
+}));
+
+import { MAX_ROSTER_PAGES, useVisibleRoster } from "./visible-roster";
+
+const listVisiblePersons = vi.mocked(identityClient.listVisiblePersons);
+
+function harness() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+  return { wrapper };
+}
+
+function person(id: string): identityClient.PersonSummary {
+  return { person_id: id, display_name: `Person ${id}` };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useVisibleRoster", () => {
+  it("collects every page, not the first", async () => {
+    listVisiblePersons
+      .mockResolvedValueOnce({ items: [person("a")], next_cursor: "c1" })
+      .mockResolvedValueOnce({ items: [person("b")], next_cursor: "c2" })
+      .mockResolvedValueOnce({ items: [person("c")], next_cursor: null });
+
+    const { result } = renderHook(() => useVisibleRoster(true), harness());
+
+    await waitFor(() => expect(result.current.roster).toHaveLength(3));
+    expect(result.current.roster.map((p) => p.person_id)).toEqual(["a", "b", "c"]);
+    expect(result.current.truncated).toBe(false);
+  });
+
+  it("stops at the ceiling rather than following a cursor forever", async () => {
+    // A service that always returns a cursor must not spin the browser.
+    listVisiblePersons.mockResolvedValue({
+      items: [person("x")],
+      next_cursor: "always-more",
+    });
+
+    const { result } = renderHook(() => useVisibleRoster(true), harness());
+
+    await waitFor(() => expect(result.current.truncated).toBe(true));
+    expect(listVisiblePersons).toHaveBeenCalledTimes(MAX_ROSTER_PAGES);
+  });
+
+  it("surfaces a refusal instead of an empty roster", async () => {
+    listVisiblePersons.mockRejectedValue(new Error("refused"));
+
+    const { result } = renderHook(() => useVisibleRoster(true), harness());
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.roster).toEqual([]);
+  });
+
+  it("asks for nothing until the caller says the policy needs it", () => {
+    renderHook(() => useVisibleRoster(false), harness());
+
+    expect(listVisiblePersons).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/src/queries/visible-roster.ts
+++ b/src/frontend/src/queries/visible-roster.ts
@@ -1,0 +1,87 @@
+/**
+ * The roster a flat organisation counts as its single cohort.
+ *
+ * Every org zone reads its people from `useOrgScope`, which walks the viewer's
+ * `subordinates` — a walk that yields nobody when the organisation has no
+ * reporting lines. This hook is the other source: the persons the caller may
+ * see, straight from identity.
+ */
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  listVisiblePersons,
+  type PersonSummary,
+} from "@/api/identity-client";
+import { useAuth } from "@/auth/use-auth";
+import { sessionAuthorizationScope } from "@/auth/session-scope";
+
+/** Rows per request — the endpoint's own default, and its cap is 500. */
+const ROSTER_PAGE_SIZE = 500;
+
+/**
+ * How many pages the walk will follow.
+ *
+ * The whole roster is collected up front because every zone wants a head-count
+ * and a member list at once, and an organisation with no reporting lines is
+ * small by construction. That does not scale: past this ceiling the roster is
+ * cut and `truncated` says so, rather than the browser walking a cursor for a
+ * tenant this design never suited. Revisit with a paged member list — and note
+ * `metric-results` refuses more than 1000 ids in one request either way.
+ */
+export const MAX_ROSTER_PAGES = 4;
+
+/** Grants and roster changes land on a seed cadence, not per interaction. */
+const ROSTER_STALE_TIME = 60 * 1000;
+
+export interface VisibleRoster {
+  /** Every person the caller may see, the viewer included. */
+  roster: PersonSummary[];
+  /** The walk hit {@link MAX_ROSTER_PAGES} — the roster is a prefix. */
+  truncated: boolean;
+  isPending: boolean;
+  isError: boolean;
+  retry: () => void;
+}
+
+async function collectRoster(): Promise<{
+  roster: PersonSummary[];
+  truncated: boolean;
+}> {
+  const roster: PersonSummary[] = [];
+  let cursor: string | undefined;
+
+  for (let page = 0; page < MAX_ROSTER_PAGES; page += 1) {
+    const answered = await listVisiblePersons({
+      cursor,
+      limit: ROSTER_PAGE_SIZE,
+    });
+    roster.push(...answered.items);
+    cursor = answered.next_cursor ?? undefined;
+    if (!cursor) return { roster, truncated: false };
+  }
+  return { roster, truncated: true };
+}
+
+/**
+ * The caller's whole visible roster. `enabled` is the policy question — a
+ * hierarchical deployment reads its people from the tree and must not spend a
+ * request here.
+ */
+export function useVisibleRoster(enabled: boolean): VisibleRoster {
+  const { session } = useAuth();
+  const sessionScope = sessionAuthorizationScope(session);
+  const query = useQuery({
+    queryKey: ["identity", "visible-roster", sessionScope],
+    queryFn: collectRoster,
+    staleTime: ROSTER_STALE_TIME,
+    enabled: enabled && sessionScope != null,
+  });
+
+  return {
+    roster: query.data?.roster ?? [],
+    truncated: query.data?.truncated ?? false,
+    isPending: query.isPending,
+    isError: query.isError,
+    retry: () => void query.refetch(),
+  };
+}

--- a/src/frontend/vitest.config.ts
+++ b/src/frontend/vitest.config.ts
@@ -120,6 +120,7 @@ export default defineConfig({
             "@base-ui/react/merge-props",
             "@base-ui/react/popover",
             "@base-ui/react/preview-card",
+            "@base-ui/react/scroll-area",
             "@base-ui/react/select",
             "@base-ui/react/separator",
             "@base-ui/react/switch",

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -66,9 +66,15 @@ the label names the organisation.
 from the roster under `flat`, the supervisor column is absent, an unnamed person
 still gets a clickable row.
 
-### F6 — hierarchy copy stops claiming a hierarchy
-`components/portal/person-header.tsx`. Accept: under `flat` the peer switcher
-reads as the organisation rather than "Team" / "Peers".
+### F6 — hierarchy copy stops claiming a hierarchy — NOT NEEDED
+`person-header` already degrades honestly: with no parent there is no manager to
+query, so the peer switcher has no peers, and with no manager nodes the
+Team/Peers button has nothing to scope to. Both hide themselves. Pinned by a
+regression test rather than changed.
+
+What is genuinely absent is a flat analogue — a switcher over the roster, so a
+reader can step to the next person without returning to the People zone. New
+UI, not a copy fix; left for a decision.
 
 ## Out of scope
 

--- a/tasks/plan.md
+++ b/tasks/plan.md
@@ -1,0 +1,78 @@
+# Portal under a flat organisation
+
+## Goal
+
+A member of an organisation with no reporting lines can browse everyone and read
+org-wide numbers. Today the portal collapses to their own Person page.
+
+## Why it collapses
+
+`use-zone-nav` gates every org zone on `orgZonesVisible = isManager || mgrPending`,
+and `isManager` is `viewer.subordinates.length > 0`. Under a flat policy nobody
+has subordinates, so every viewer is an IC and `IC_ZONES = {"person"}` is the
+whole rail.
+
+## Approach
+
+Change the question, not the zones. Every org zone already reads one hook —
+`useOrgScope` → `{pivot, roster, managerNodes, count}`. Give that hook a second
+source and open the gate:
+
+- **"can this viewer see anyone but themselves?"** replaces "does this viewer
+  manage anyone?" — answered by `visibility_policy` from `GET /v1/me`.
+- Under `flat` the roster comes from `GET /v1/visible-persons` instead of a walk
+  over `subordinates`. The hook's return shape is unchanged, so the zones,
+  `use-scope-coverage` and the metric requests need no edits.
+
+## Decisions
+
+1. **Gate on the policy**, not on roster size. One declarative field; a
+   wildcard-grant holder on a hierarchical install is a later question.
+2. **Fetch every roster page up front.** Simplest thing that serves a small
+   org; carries a comment to revisit, and a hard page ceiling so a large tenant
+   degrades instead of hanging.
+3. **Landing pins Overview** under flat — the org rollup is the meaningful
+   first screen; People is the browse surface.
+4. **The scope control hides.** With no manager nodes there is nothing to pick,
+   and `ScopeSelect` already returns null on an empty list. `directOnly` goes
+   with it.
+5. **Fail closed to `org_chart`** when the policy is unknown (pending or
+   errored): an unknown answer never widens what the rail shows.
+
+## Tasks
+
+### F1 — the policy reaches the SPA
+`api/identity-client.ts` (`MeResponse`), `queries/identity-me.ts`
+(`useVisibilityPolicy`). Accept: `flat` and `org_chart` both read back; pending
+and errored both read `org_chart`.
+
+### F2 — the roster client
+`api/identity-client.ts` (`listVisiblePersons`), `queries/visible-roster.ts`
+(`useVisibleRoster`). Accept: pages until `next_cursor` is null; stops at the
+page ceiling; a refusal surfaces as an error rather than an empty roster.
+
+### F3 — the rail opens
+`lib/portal/use-viewer-reach.ts` (new), `lib/portal/use-zone-nav.ts`,
+`lib/portal/landing-zone.ts`. Accept: under `flat`, a viewer with no reports
+gets the org zones and lands on Overview; under `org_chart` nothing changes.
+
+### F4 — the scope resolves without a tree
+`lib/portal/use-org-scope.ts`. Accept: under `flat` the roster is every visible
+person except the viewer, `managerNodes` is empty, `canDirectOnly` is false, and
+the label names the organisation.
+
+### F5 — the People zone lists the roster
+`components/portal/employees-view.tsx`, `mocks/handlers.ts`. Accept: rows come
+from the roster under `flat`, the supervisor column is absent, an unnamed person
+still gets a clickable row.
+
+### F6 — hierarchy copy stops claiming a hierarchy
+`components/portal/person-header.tsx`. Accept: under `flat` the peer switcher
+reads as the organisation rather than "Team" / "Peers".
+
+## Out of scope
+
+- `metric-results` caps at 1000 person ids and is all-or-nothing, so an org
+  larger than that cannot answer org-wide numbers. Not addressed here.
+- A static scope chip (label + head-count) where the picker used to be.
+- Provisional people render as "Unnamed person" until a seed run names them.


### PR DESCRIPTION
**Why.** Under a flat visibility policy the person sidebar and topbar offered controls a flat organisation has no answer for — a label naming a structure it does not have, and a cohort cut over a single cohort. Separately, git evidence named repositories, commits and pull requests without ever linking to them, and the composition card showed a repository's total with no indication of what that total was made of.

**What changed.**
- Git evidence links out to GitHub from three surfaces: the composition bar list (repository), the drilldown evidence table (ref, title, repository) and the inline activity list (title, repository).
- The composition card splits each bar by code type, with a legend, per-segment hover totals, and exact shares — a small non-zero share reads `<1%` instead of a rounded `0%`.
- The person sidebar and topbar drop the controls that do not apply under a flat policy, and name the roster views for it.

**Decisions the diff does not show.**
- **Links are GitHub-only, behind three independent gates:** the metric key's `git.` family, the row's own `source` dimension, and the shape of `ref` (fixed-length hex → commit, plain decimal → pull request). GitLab and Bitbucket can be self-hosted at any address and nothing in a row says which, so they get no link rather than a guessed one. GitHub Enterprise reports the connector, not the host, so its links would miss — a known gap, documented at the helper.
- **`source` is requested only where the metric declares it.** A drilldown asking for an undeclared dimension is rejected outright, so the request is gated on the catalogue rather than sent on spec — the same class of gate `useAvailableMetricKeys` already exists to provide.
- **Author is deliberately not linked.** The class contract's `author_name` carries a login for pull-request rows but a human display name for commit rows; coercing the latter into a profile URL can land on an unrelated person's account. Doing it properly needs an `author_login` column in the contract.
- **A dimension's `value` and `label` are not interchangeable,** and the two serving paths project different ones — a breakdown row carries the value, an evidence row carries the label. Link construction reads whichever the surface actually carries, which is also why the bar list groups by value but displays the label.
- **A title links only on its summary line.** In the expanded record the full value is shown, trailers included, so one anchor around all of it would be a paragraph-sized target.

**Out of scope.**
- Hiding sections an install does not carry. Attempted and reverted: a client-side heuristic cannot tell "nothing has arrived yet" from "nothing ever will", and the honest mechanism is the per-tenant catalogue, which has no write path today.
- GitHub Enterprise hosts; GitLab and Bitbucket links; author links.

**Verified.** `tsc -b` clean. `prettier --check` clean apart from the generated route tree, which is excluded because the build rewrites it with its own style.

Tests and lint were **not** run for this branch. Several test files carry edits from this work that typecheck but have not been executed, so `pnpm test` and `pnpm lint` should pass before this merges.
