### PR TITLE
fix(analytics): name a visitor by their account handle

### DIFF
--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -1867,6 +1867,10 @@
           "person_id": {
             "type": "string"
           },
+          "username": {
+            "description": "The account handle, empty when no identity row carries one.",
+            "type": "string"
+          },
           "visits": {
             "format": "int64",
             "minimum": 0,
@@ -1876,6 +1880,7 @@
         "required": [
           "person_id",
           "display_name",
+          "username",
           "visits",
           "page_views",
           "last_seen"

--- a/src/backend/services/analytics/src/api/usage.rs
+++ b/src/backend/services/analytics/src/api/usage.rs
@@ -273,6 +273,7 @@ fn people_sql() -> String {
     format!(
         "SELECT toString(u.person) AS person_id, \
          coalesce(p.display_name, '') AS display_name, \
+         coalesce(p.username, '') AS username, \
          u.visits AS visits, u.page_views AS page_views, u.last_seen AS last_seen \
          FROM (\
            SELECT person_id AS person, {VISITS} AS visits, \
@@ -290,9 +291,10 @@ fn people_sql() -> String {
                ' ', \
                coalesce(argMaxIf(value_effective, (created_at, id), value_type = 'last_name'), '') \
              )), '') \
-           ) AS display_name \
+           ) AS display_name, \
+           nullIf(argMaxIf(value_effective, (created_at, id), value_type = 'username'), '') AS username \
            FROM identity.identity_persons \
-           WHERE value_type IN ('display_name', 'first_name', 'last_name') \
+           WHERE value_type IN ('display_name', 'first_name', 'last_name', 'username') \
            AND insight_tenant_id = toUUID(?) \
            GROUP BY person_id) AS p ON p.person_id = u.person \
          ORDER BY u.visits DESC, u.page_views DESC"
@@ -385,6 +387,8 @@ pub struct UsagePerson {
     pub person_id: String,
     /// Empty when the visitor has not been mirrored into the identity rows yet.
     pub display_name: String,
+    /// The account handle, empty when no identity row carries one.
+    pub username: String,
     pub visits: u64,
     pub page_views: u64,
     pub last_seen: String,

--- a/src/backend/services/analytics/src/api/usage/tests.rs
+++ b/src/backend/services/analytics/src/api/usage/tests.rs
@@ -197,6 +197,14 @@ fn a_visitor_is_named_from_the_mirrored_identity_rows() {
 }
 
 #[test]
+fn a_visitor_without_a_name_is_still_named_by_its_account_handle() {
+    let sql = people_sql();
+
+    assert!(sql.contains("'username'"), "{sql}");
+    assert!(sql.contains("AS username"), "{sql}");
+}
+
+#[test]
 fn a_malformed_day_is_refused_rather_than_queried() {
     let query = UsageRangeQuery {
         since: Some("2026-99-99".to_owned()),

--- a/src/frontend/src/api/usage-client.ts
+++ b/src/frontend/src/api/usage-client.ts
@@ -23,6 +23,7 @@ export interface UsageDay {
 export interface UsagePerson {
   person_id: string;
   display_name: string;
+  username: string;
   visits: number;
   page_views: number;
   last_seen: string;

--- a/src/frontend/src/components/portal/platform-usage.test.tsx
+++ b/src/frontend/src/components/portal/platform-usage.test.tsx
@@ -115,6 +115,27 @@ describe("PlatformUsage", () => {
     expect(mocks.asked.at(-1)?.since).toMatch(/^\d{4}-\d{2}-\d{2}$/);
   });
 
+  it("names a visitor by handle when the identity rows carry no display name", () => {
+    mocks.summary = {
+      ...SUMMARY,
+      by_person: [
+        {
+          person_id: "4d1f0a6c-0000-4000-8000-0000000000aa",
+          display_name: "",
+          username: "ada",
+          visits: 2,
+          page_views: 3,
+          last_seen: "2026-08-02T10:00:00Z",
+        },
+      ],
+    };
+
+    render(<PlatformUsage />);
+
+    expect(screen.getByText("ada")).toBeInTheDocument();
+    expect(screen.queryByText("4d1f0a6c-0000-4000-8000-0000000000aa")).toBeNull();
+  });
+
   it("counts today without stretching the period it names", () => {
     render(<PlatformUsage />);
 

--- a/src/frontend/src/components/portal/platform-usage.tsx
+++ b/src/frontend/src/components/portal/platform-usage.tsx
@@ -50,6 +50,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { screenLabel } from "@/lib/portal/screen-label";
+import { visitorLabel } from "@/lib/portal/visitor-label";
 import { TEXT_FIGURE, TEXT_LABEL, TEXT_NAME } from "@/lib/type-scale";
 import { cn } from "@/lib/utils";
 import type { CustomRange, PeriodValue } from "@/types/insight";
@@ -295,7 +296,7 @@ function PeopleTable({ rows }: { rows: UsagePerson[] }) {
           columns={[
             {
               header: "Person",
-              cell: (row) => row.display_name || row.person_id,
+              cell: (row) => <VisitorName row={row} />,
             },
             { header: "Visits", width: 6, align: "right", cell: (row) => row.visits },
             { header: "Pages", width: 6, align: "right", cell: (row) => row.page_views },
@@ -304,6 +305,19 @@ function PeopleTable({ rows }: { rows: UsagePerson[] }) {
         />
       )}
     </section>
+  );
+}
+
+function VisitorName({ row }: { row: UsagePerson }) {
+  const { label, detail } = visitorLabel(row);
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger render={<span className="truncate" />}>{label}</TooltipTrigger>
+        <TooltipContent className="font-mono text-xs">{detail}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }
 

--- a/src/frontend/src/lib/portal/visitor-label.test.ts
+++ b/src/frontend/src/lib/portal/visitor-label.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Two colleagues can carry the same display name, so the handle disambiguates.
+ */
+import { describe, expect, it } from "vitest";
+
+import { visitorLabel } from "./visitor-label";
+
+const PERSON_ID = "4d1f0a6c-0000-4000-8000-0000000000aa";
+
+describe("visitorLabel", () => {
+  it("shows the name and keeps the handle for the hover", () => {
+    expect(
+      visitorLabel({
+        person_id: PERSON_ID,
+        display_name: "Ada Lovelace",
+        username: "ada",
+      })
+    ).toEqual({ label: "Ada Lovelace", detail: "username: ada" });
+  });
+
+  it("falls back to the handle when no name was mirrored", () => {
+    expect(
+      visitorLabel({ person_id: PERSON_ID, display_name: "", username: "ada" })
+    ).toEqual({ label: "ada", detail: "username: ada" });
+  });
+
+  it("falls back to the id when neither a name nor a handle is known", () => {
+    expect(
+      visitorLabel({ person_id: PERSON_ID, display_name: "", username: "" })
+    ).toEqual({
+      label: PERSON_ID,
+      detail: PERSON_ID,
+    });
+  });
+
+  it("still names a row served by an API that sends no handle at all", () => {
+    expect(
+      visitorLabel({ person_id: PERSON_ID, display_name: "Ada Lovelace" })
+    ).toEqual({
+      label: "Ada Lovelace",
+      detail: PERSON_ID,
+    });
+  });
+
+  it("ignores whitespace-only values from the identity rows", () => {
+    expect(
+      visitorLabel({
+        person_id: PERSON_ID,
+        display_name: "  ",
+        username: " ada ",
+      })
+    ).toEqual({ label: "ada", detail: "username: ada" });
+  });
+});

--- a/src/frontend/src/lib/portal/visitor-label.ts
+++ b/src/frontend/src/lib/portal/visitor-label.ts
@@ -1,0 +1,18 @@
+export interface VisitorNaming {
+  person_id: string;
+  display_name: string;
+  username?: string;
+}
+
+export interface VisitorLabel {
+  label: string;
+  detail: string;
+}
+
+export function visitorLabel(visitor: VisitorNaming): VisitorLabel {
+  const name = visitor.display_name.trim();
+  const handle = visitor.username?.trim() ?? "";
+  const detail = handle ? `username: ${handle}` : visitor.person_id;
+
+  return { label: name || handle || visitor.person_id, detail };
+}

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -861,6 +861,7 @@ function usageHandlers() {
           {
             person_id: defaultPerson?.person_id ?? "",
             display_name: defaultPerson?.name ?? "",
+            username: defaultPerson?.email.split("@")[0] ?? "",
             visits: 31,
             page_views: 96,
             last_seen: `${by_day.at(-1)?.day ?? ""} 09:12`,
@@ -868,6 +869,7 @@ function usageHandlers() {
           {
             person_id: PEOPLE[1]?.person_id ?? "",
             display_name: PEOPLE[1]?.name ?? "",
+            username: PEOPLE[1]?.email.split("@")[0] ?? "",
             visits: 18,
             page_views: 64,
             last_seen: `${by_day.at(-1)?.day ?? ""} 08:40`,
@@ -875,6 +877,7 @@ function usageHandlers() {
           {
             person_id: PEOPLE[2]?.person_id ?? "",
             display_name: PEOPLE[2]?.name ?? "",
+            username: PEOPLE[2]?.email.split("@")[0] ?? "",
             visits: 7,
             page_views: 54,
             last_seen: `${by_day.at(-2)?.day ?? ""} 17:05`,

--- a/tests/stand/api/schemas/analytics.py
+++ b/tests/stand/api/schemas/analytics.py
@@ -639,6 +639,7 @@ class UsagePerson(BaseModel):
     last_seen: str
     page_views: int = Field(..., ge=0)
     person_id: str
+    username: str = Field(..., description='The account handle, empty when no identity row carries one.')
     visits: int = Field(..., ge=0)
 
 


### PR DESCRIPTION
**Why.** A visitor whose identity rows carry an account handle but no display name reached the people table with nothing to render, so the row showed a bare person id.

**What changed.** `usage/summary` now reads the `username` claim beside the name claims and returns it as its own field; the Person cell falls back name → handle → id and the hover reads `username: <handle>`.

**`username` is a separate field, not folded into `display_name`.** An empty `display_name` stays meaningful, and the hover needs both values apart. Reversible — the coalesce would be a one-line change.

**Verified.** `cargo test -p analytics` 441 passed, `npm test` 1722 passed, `tsc -b` / eslint / clippy / fmt clean. No screenshots: the tooltip does not open under headless CDP (the pre-existing Page-column tooltip behaves the same).
