### PR TITLE
feat(identity): list the org roster rather than every observed identity

### DIFF
--- a/docs/components/backend/identity-resolution/openapi.json
+++ b/docs/components/backend/identity-resolution/openapi.json
@@ -4421,6 +4421,7 @@
     },
     "/v1/visible-persons": {
       "get": {
+        "description": "The organisation's roster: persons a connector claims as an account holder. An address seen only in someone else's data — a commit author nobody here holds — is an identity the journal carries, not a member, and is left out. The POST sibling confirms visibility over any person id, so it answers for a wider set than this lists.",
         "operationId": "identity_resolution.visible_persons.list",
         "parameters": [
           {
@@ -4498,7 +4499,7 @@
             "bearerAuth": []
           }
         ],
-        "summary": "List the persons the caller may see"
+        "summary": "List the org members the caller may see"
       },
       "post": {
         "operationId": "identity_resolution.visible_persons.create",

--- a/src/backend/services/identity-resolution/src/api/http_live_tests.rs
+++ b/src/backend/services/identity-resolution/src/api/http_live_tests.rs
@@ -857,8 +857,8 @@ async fn the_roster_lists_the_caller_and_everyone_the_policy_shows_them() -> Tes
     let Some(f) = fixture_or_skip().await? else {
         return Ok(());
     };
-    let caller = f.person("roster-caller@http-live.test").await?;
-    let other = f.person("roster-other@http-live.test").await?;
+    let caller = f.account_holder("roster-caller@http-live.test").await?;
+    let other = f.account_holder("roster-other@http-live.test").await?;
 
     let (status, body) = get(flat_app(&f, caller), "/v1/visible-persons").await?;
 
@@ -875,12 +875,39 @@ async fn the_roster_lists_the_caller_and_everyone_the_policy_shows_them() -> Tes
 }
 
 #[tokio::test]
+async fn the_roster_leaves_out_an_identity_nobody_claims() -> TestResult {
+    // The shape a git-only organisation is full of: an address a commit carried,
+    // which the journal turned into a person because that is what an observation
+    // log does. No connector ever claimed it as an account, so it is not a
+    // member, and a roster listing it is a directory of strangers.
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let holder = f.account_holder("roster-holder@http-live.test").await?;
+    let observed_only = f.person("roster-observed@http-live.test").await?;
+
+    let (status, body) = get(flat_app(&f, holder), "/v1/visible-persons").await?;
+
+    assert_eq!(status, StatusCode::OK);
+    let listed = listed_ids(&body);
+    assert!(
+        listed.contains(&holder.to_string()),
+        "the account holder IS the roster: {body}"
+    );
+    assert!(
+        !listed.contains(&observed_only.to_string()),
+        "an address nobody claims is not a member: {body}"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn a_roster_cursor_resumes_after_the_page_it_was_issued_for() -> TestResult {
     let Some(f) = fixture_or_skip().await? else {
         return Ok(());
     };
-    let first_person = f.person("roster-aaa@http-live.test").await?;
-    let second_person = f.person("roster-bbb@http-live.test").await?;
+    let first_person = f.account_holder("roster-aaa@http-live.test").await?;
+    let second_person = f.account_holder("roster-bbb@http-live.test").await?;
 
     let (status, first) = get(flat_app(&f, first_person), "/v1/visible-persons?limit=1").await?;
     assert_eq!(status, StatusCode::OK);
@@ -934,8 +961,8 @@ async fn a_cursor_from_another_query_is_refused_rather_than_resumed() -> TestRes
     let Some(f) = fixture_or_skip().await? else {
         return Ok(());
     };
-    let caller = f.person("roster-cursor@http-live.test").await?;
-    let _second = f.person("roster-cursor-2@http-live.test").await?;
+    let caller = f.account_holder("roster-cursor@http-live.test").await?;
+    let _second = f.account_holder("roster-cursor-2@http-live.test").await?;
 
     let (_, browsed) = get(flat_app(&f, caller), "/v1/visible-persons?limit=1").await?;
     let cursor = browsed["next_cursor"]

--- a/src/backend/services/identity-resolution/src/api/mod.rs
+++ b/src/backend/services/identity-resolution/src/api/mod.rs
@@ -621,7 +621,14 @@ fn build_operations(router: Router, openapi: &dyn OpenApiRegistry) -> Router {
 
     let router = OperationBuilder::get("/v1/visible-persons")
         .operation_id("identity_resolution.visible_persons.list")
-        .summary("List the persons the caller may see")
+        .summary("List the org members the caller may see")
+        .description(
+            "The organisation's roster: persons a connector claims as an account \
+             holder. An address seen only in someone else's data — a commit author \
+             nobody here holds — is an identity the journal carries, not a member, \
+             and is left out. The POST sibling confirms visibility over any person \
+             id, so it answers for a wider set than this lists.",
+        )
         .authenticated()
         .query_param(
             "q",

--- a/src/backend/services/identity-resolution/src/api/persons.rs
+++ b/src/backend/services/identity-resolution/src/api/persons.rs
@@ -117,9 +117,22 @@ async fn page_of_persons(
         person_id: key.person_id,
     });
 
-    person_listing::list_persons(&state.db, tenant, values, named, None, after, limit + 1)
-        .await
-        .map_err(|e| read_err(&e))
+    // Every identity, claimed or not: an address nobody holds yet is exactly
+    // what an operator opens this picker to attach to someone.
+    person_listing::list_persons(
+        &state.db,
+        tenant,
+        values,
+        named,
+        person_listing::Restrict {
+            listed: person_listing::Listed::EveryIdentity,
+            visible_to: None,
+        },
+        after,
+        limit + 1,
+    )
+    .await
+    .map_err(|e| read_err(&e))
 }
 
 /// Drop the probe row and, when it was there, mint the cursor that resumes

--- a/src/backend/services/identity-resolution/src/api/visible_persons.rs
+++ b/src/backend/services/identity-resolution/src/api/visible_persons.rs
@@ -78,6 +78,11 @@ impl toolkit::api::api_dto::ResponseApiDto for VisiblePersonsPageResponse {}
 
 /// Self-scoped and not admin-gated, like the POST: it enumerates only what the
 /// caller's visible set already contains.
+///
+/// Lists the ROSTER, not the journal: only persons a connector claims as an
+/// account holder. So this answers for a narrower set than the POST confirms —
+/// deliberately, and in the safe direction (a person listed here is a person
+/// that filter would confirm, never the reverse).
 pub async fn list_visible_persons(
     Extension(state): Extension<Arc<AppState>>,
     Extension(ctx): Extension<SecurityContext>,
@@ -99,11 +104,17 @@ pub async fn list_visible_persons(
         tenant,
         &terms,
         &[],
-        Some(VisibleTo {
-            viewer_person_id: caller,
-            org_source_type: &state.config.org_chart_source_type,
-            policy: state.config.visibility_policy,
-        }),
+        // The roster is who the organisation IS. An address a commit carried
+        // becomes a person in the journal without anyone here holding it, and
+        // listing those alongside the members reads as a directory of strangers.
+        person_listing::Restrict {
+            listed: person_listing::Listed::AccountHolders,
+            visible_to: Some(VisibleTo {
+                viewer_person_id: caller,
+                org_source_type: &state.config.org_chart_source_type,
+                policy: state.config.visibility_policy,
+            }),
+        },
         resume.as_ref().map(|key| person_listing::After {
             order_key: &key.order_key,
             person_id: key.person_id,

--- a/src/backend/services/identity-resolution/src/infra/db/person_listing.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/person_listing.rs
@@ -91,6 +91,56 @@ const FILTERABLE_VALUE_TYPES: [&str; 5] = [
     "last_name",
 ];
 
+/// The value type a connector writes for an account it holds — ADR-0002's
+/// canonical binding, and the only thing in the journal that separates a person
+/// some system claims from an address someone else's data merely mentioned.
+const CANONICAL_BINDING: &str = "id";
+
+/// Which persons a listing is about.
+///
+/// The journal is an observation log: a commit author's address enters it and
+/// becomes a person whether or not anybody in the organisation holds that
+/// address. Both readings of that set are legitimate, and they are different
+/// questions, so the caller has to say which one it is asking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Listed {
+    /// Every identity the journal holds, claimed or merely observed. The
+    /// operator's surface: an unclaimed address is precisely what arrives
+    /// needing to be attached to the person it belongs to.
+    EveryIdentity,
+    /// Only persons a connector claims as an account holder — those carrying a
+    /// [`CANONICAL_BINDING`]. The roster: who the organisation IS, rather than
+    /// every address its data has ever named.
+    ///
+    /// Says nothing about whether they still belong to it. Roster removal
+    /// reaches the journal as no observation at all, so a departed member keeps
+    /// the binding they earned; this admits everyone who has ever held an
+    /// account, which is a superset of the current roster.
+    AccountHolders,
+}
+
+/// What narrows a listing: which persons it is about, and whose view of them.
+///
+/// The two are orthogonal — one asks whether an unclaimed address counts as a
+/// person to list, the other whose data this caller may see — and they travel
+/// together everywhere, so they arrive together rather than as two more
+/// positional arguments.
+#[derive(Debug, Clone, Copy)]
+pub struct Restrict<'a> {
+    pub listed: Listed,
+    /// Absent, the listing is the tenant's.
+    pub visible_to: Option<VisibleTo<'a>>,
+}
+
+impl Restrict<'_> {
+    /// The operator's listing: every identity, unfiltered by any viewer.
+    #[cfg(test)]
+    pub(super) const EVERY_IDENTITY: Self = Self {
+        listed: Listed::EveryIdentity,
+        visible_to: None,
+    };
+}
+
 /// Restrict a listing to what one caller may see. Absent, it is the tenant's.
 #[derive(Debug, Clone, Copy)]
 pub struct VisibleTo<'a> {
@@ -155,8 +205,9 @@ pub struct After<'a> {
 ///
 /// `terms` empty lists every person; otherwise every term must match some
 /// current value. `within` (when non-empty) restricts the set to those ids —
-/// the id-named search path. `visible_to` restricts it to one caller's visible
-/// set. `after` resumes a previous page.
+/// the id-named search path. `listed` says whether unclaimed identities count.
+/// `visible_to` restricts it to one caller's visible set. `after` resumes a
+/// previous page.
 ///
 /// Two statements when there are terms and no ids: the probe, then the page over
 /// what it named. One when there is nothing to narrow by.
@@ -169,15 +220,15 @@ pub async fn list_persons(
     tenant_id: Uuid,
     terms: &[String],
     within: &[Uuid],
-    visible_to: Option<VisibleTo<'_>>,
+    restrict: Restrict<'_>,
     after: Option<After<'_>>,
     limit: u64,
 ) -> anyhow::Result<Vec<PersonListRow>> {
     match narrowing(db, tenant_id, terms, within).await? {
         Narrowing::Nobody => Ok(Vec::new()),
-        Narrowing::Tenant => page(db, tenant_id, terms, None, visible_to, after, limit).await,
+        Narrowing::Tenant => page(db, tenant_id, terms, None, restrict, after, limit).await,
         Narrowing::Persons(ids) => {
-            page(db, tenant_id, terms, Some(&ids), visible_to, after, limit).await
+            page(db, tenant_id, terms, Some(&ids), restrict, after, limit).await
         }
     }
 }
@@ -199,11 +250,11 @@ async fn page(
     tenant_id: Uuid,
     terms: &[String],
     narrowed_to: Option<&[Uuid]>,
-    visible_to: Option<VisibleTo<'_>>,
+    restrict: Restrict<'_>,
     after: Option<After<'_>>,
     limit: u64,
 ) -> anyhow::Result<Vec<PersonListRow>> {
-    let (sql, values) = build_query(tenant_id, terms, narrowed_to, visible_to, after, limit);
+    let (sql, values) = build_query(tenant_id, terms, narrowed_to, restrict, after, limit);
     let stmt = Statement::from_sql_and_values(DbBackend::MySql, &sql, values);
     rows_from(db.query_all(stmt).await?)
 }
@@ -314,7 +365,16 @@ pub(super) async fn list_persons_unnarrowed(
     after: Option<After<'_>>,
     limit: u64,
 ) -> anyhow::Result<Vec<PersonListRow>> {
-    page(db, tenant_id, terms, None, None, after, limit).await
+    page(
+        db,
+        tenant_id,
+        terms,
+        None,
+        Restrict::EVERY_IDENTITY,
+        after,
+        limit,
+    )
+    .await
 }
 
 fn searched_types() -> String {
@@ -414,7 +474,7 @@ fn build_query(
     tenant_id: Uuid,
     terms: &[String],
     narrowed_to: Option<&[Uuid]>,
-    visible_to: Option<VisibleTo<'_>>,
+    restrict: Restrict<'_>,
     after: Option<After<'_>>,
     limit: u64,
 ) -> (String, Vec<sea_orm::Value>) {
@@ -436,17 +496,35 @@ fn build_query(
         }
     };
 
+    // In the roster itself rather than the outer filter: it decides who exists
+    // for this listing, so the ranking has less to rank as well. `idx_value_id`
+    // leads on (tenant, value_type), which is exactly this lookup.
+    let claimed = match restrict.listed {
+        Listed::EveryIdentity => String::new(),
+        Listed::AccountHolders => {
+            values.push(tenant_id.as_bytes().to_vec().into());
+            format!(
+                "\n              AND person_id IN (\
+                 \n                  SELECT person_id FROM persons \
+                 \n                  WHERE insight_tenant_id = ? AND value_type = '{CANONICAL_BINDING}'\
+                 \n              )"
+            )
+        }
+    };
+
     values.push(tenant_id.as_bytes().to_vec().into());
     // Ranking a narrowed roster is the whole point; reaching an unnarrowed one
     // through a semi-join is not — with nothing to narrow by, the plain scan the
-    // browse case had all along stays.
-    let ranked_within = if roster.is_empty() {
+    // browse case had all along stays. Either narrowing earns the semi-join: a
+    // roster browsed with no terms is still a fraction of the identities the
+    // journal holds.
+    let ranked_within = if roster.is_empty() && claimed.is_empty() {
         ""
     } else {
         "\n              AND person_id IN (SELECT person_id FROM people)"
     };
 
-    let scope = visible_scope(visible_to, tenant_id);
+    let scope = visible_scope(restrict.visible_to, tenant_id);
     let visible_cte = scope.cte;
     let recursive = scope.recursive;
     values.extend(scope.values);
@@ -475,7 +553,7 @@ fn build_query(
         WITH {recursive}people AS (
             SELECT DISTINCT person_id
             FROM persons
-            WHERE insight_tenant_id = ? AND person_id != ?{roster}
+            WHERE insight_tenant_id = ? AND person_id != ?{roster}{claimed}
         ),
         ranked AS (
             SELECT person_id, value_type, value_effective, created_at, id,
@@ -534,7 +612,15 @@ mod tests {
     use super::*;
 
     fn query(terms: &[String], narrowed_to: Option<&[Uuid]>, after: Option<After<'_>>) -> String {
-        build_query(Uuid::nil(), terms, narrowed_to, None, after, 50).0
+        build_query(
+            Uuid::nil(),
+            terms,
+            narrowed_to,
+            Restrict::EVERY_IDENTITY,
+            after,
+            50,
+        )
+        .0
     }
 
     fn visible_query(policy: VisibilityPolicy) -> String {
@@ -542,15 +628,97 @@ mod tests {
             Uuid::nil(),
             &[],
             None,
-            Some(VisibleTo {
-                viewer_person_id: Uuid::from_u128(7),
-                org_source_type: "bamboohr",
-                policy,
-            }),
+            Restrict {
+                listed: Listed::EveryIdentity,
+                visible_to: Some(VisibleTo {
+                    viewer_person_id: Uuid::from_u128(7),
+                    org_source_type: "bamboohr",
+                    policy,
+                }),
+            },
             None,
             50,
         )
         .0
+    }
+
+    fn listed_query(listed: Listed) -> String {
+        build_query(
+            Uuid::nil(),
+            &[],
+            None,
+            Restrict {
+                listed,
+                visible_to: None,
+            },
+            None,
+            50,
+        )
+        .0
+    }
+
+    #[test]
+    fn a_roster_admits_only_the_persons_a_connector_claims() {
+        // An address a commit carried is an observation, not a member of the
+        // organisation: it reaches the journal without ever earning the
+        // canonical binding a roster connector writes for an account it holds.
+        let sql = listed_query(Listed::AccountHolders);
+
+        assert!(
+            sql.contains("value_type = 'id'"),
+            "the roster must require a canonical binding: {sql}"
+        );
+    }
+
+    #[test]
+    fn the_operator_surface_still_lists_an_identity_nobody_claims() {
+        // The unclaimed address is the whole reason the picker exists — it is
+        // what an operator arrives holding, to attach to the person it belongs
+        // to. Hiding it would hide the work.
+        let sql = listed_query(Listed::EveryIdentity);
+
+        assert!(
+            !sql.contains("value_type = 'id'"),
+            "the picker must not require a binding: {sql}"
+        );
+    }
+
+    #[test]
+    fn the_binding_requirement_binds_after_the_roster_it_narrows() {
+        // Its placeholder sits in the roster CTE, after the ids the caller
+        // named — so its tenant lands there too, or every later value shifts.
+        let tenant = Uuid::from_u128(0xA1);
+        let within = [Uuid::from_u128(0xB2)];
+
+        let (sql, values) = build_query(
+            tenant,
+            &[],
+            Some(&within),
+            Restrict {
+                listed: Listed::AccountHolders,
+                visible_to: None,
+            },
+            None,
+            50,
+        );
+
+        let bytes = |id: Uuid| sea_orm::Value::from(id.as_bytes().to_vec());
+        assert_eq!(sql.matches('?').count(), values.len());
+        assert_eq!(
+            values,
+            vec![
+                // the roster: the tenant, the sentinel, the named ids…
+                bytes(tenant),
+                bytes(EXCLUDED_PERSON),
+                bytes(within[0]),
+                // …then the binding requirement that narrows it
+                bytes(tenant),
+                // the ranking over that roster
+                bytes(tenant),
+                sea_orm::Value::from(50u64),
+            ],
+            "the bind order drifted from the order the placeholders appear in"
+        );
     }
 
     #[test]
@@ -672,7 +840,7 @@ mod tests {
             tenant,
             &terms,
             Some(&within),
-            None,
+            Restrict::EVERY_IDENTITY,
             Some(After {
                 order_key: "0ivanov",
                 person_id: resuming,
@@ -773,11 +941,14 @@ mod tests {
             tenant,
             &["iva".to_owned()],
             Some(&within),
-            Some(VisibleTo {
-                viewer_person_id: viewer,
-                org_source_type: "bamboohr",
-                policy: VisibilityPolicy::Flat,
-            }),
+            Restrict {
+                listed: Listed::EveryIdentity,
+                visible_to: Some(VisibleTo {
+                    viewer_person_id: viewer,
+                    org_source_type: "bamboohr",
+                    policy: VisibilityPolicy::Flat,
+                }),
+            },
             None,
             50,
         );
@@ -821,11 +992,14 @@ mod tests {
                 Uuid::nil(),
                 &[],
                 None,
-                Some(VisibleTo {
-                    viewer_person_id: Uuid::from_u128(7),
-                    org_source_type: "bamboohr",
-                    policy,
-                }),
+                Restrict {
+                    listed: Listed::EveryIdentity,
+                    visible_to: Some(VisibleTo {
+                        viewer_person_id: Uuid::from_u128(7),
+                        org_source_type: "bamboohr",
+                        policy,
+                    }),
+                },
                 None,
                 50,
             );

--- a/src/backend/services/identity-resolution/src/infra/db/person_listing_live_tests.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/person_listing_live_tests.rs
@@ -14,7 +14,7 @@ use uuid::Uuid;
 
 use crate::domain::resolution::EXCLUDED_PERSON;
 
-use super::person_listing::{After, list_persons, list_persons_unnarrowed};
+use super::person_listing::{After, Restrict, list_persons, list_persons_unnarrowed};
 use super::test_fixture::{Fixture, fixture_or_skip};
 
 type TestResult = anyhow::Result<()>;
@@ -23,7 +23,16 @@ const PAGE: u64 = 100;
 
 async fn find(f: &Fixture, query: &str) -> anyhow::Result<Vec<Uuid>> {
     let terms: Vec<String> = query.split_whitespace().map(str::to_owned).collect();
-    let rows = list_persons(&f.db, f.tenant, &terms, &[], None, None, PAGE).await?;
+    let rows = list_persons(
+        &f.db,
+        f.tenant,
+        &terms,
+        &[],
+        Restrict::EVERY_IDENTITY,
+        None,
+        PAGE,
+    )
+    .await?;
     Ok(rows.into_iter().map(|row| row.person_id).collect())
 }
 
@@ -156,13 +165,31 @@ async fn an_id_named_search_answers_exactly_that_person() -> TestResult {
     f.person("other@listing.test").await?;
     let emailless = f.emailless_person().await?;
 
-    let named = list_persons(&f.db, f.tenant, &[], &[wanted], None, None, PAGE).await?;
+    let named = list_persons(
+        &f.db,
+        f.tenant,
+        &[],
+        &[wanted],
+        Restrict::EVERY_IDENTITY,
+        None,
+        PAGE,
+    )
+    .await?;
     assert_eq!(
         named.into_iter().map(|r| r.person_id).collect::<Vec<_>>(),
         vec![wanted]
     );
     // The id is the only way to a person the journal holds no values for.
-    let by_id = list_persons(&f.db, f.tenant, &[], &[emailless], None, None, PAGE).await?;
+    let by_id = list_persons(
+        &f.db,
+        f.tenant,
+        &[],
+        &[emailless],
+        Restrict::EVERY_IDENTITY,
+        None,
+        PAGE,
+    )
+    .await?;
     assert_eq!(
         by_id.into_iter().map(|r| r.person_id).collect::<Vec<_>>(),
         vec![emailless]
@@ -179,7 +206,16 @@ async fn the_excluded_sentinel_is_never_listed_as_a_person() -> TestResult {
     f.person_as(EXCLUDED_PERSON, "excluded@person-listing.test")
         .await?;
 
-    let browsed = list_persons(&f.db, f.tenant, &[], &[], None, None, 1_000).await?;
+    let browsed = list_persons(
+        &f.db,
+        f.tenant,
+        &[],
+        &[],
+        Restrict::EVERY_IDENTITY,
+        None,
+        1_000,
+    )
+    .await?;
 
     assert_eq!(browsed.len(), 1, "the sentinel is a bucket, not a person");
     assert!(
@@ -221,7 +257,16 @@ async fn the_page_is_ordered_by_the_label_the_row_shows() -> TestResult {
     f.observed(byname, "last_name", "Composed").await?;
     let nameless = f.emailless_person().await?;
 
-    let rows = list_persons(&f.db, f.tenant, &[], &[], None, None, PAGE).await?;
+    let rows = list_persons(
+        &f.db,
+        f.tenant,
+        &[],
+        &[],
+        Restrict::EVERY_IDENTITY,
+        None,
+        PAGE,
+    )
+    .await?;
     let order: Vec<Uuid> = rows.into_iter().map(|r| r.person_id).collect();
 
     assert_eq!(
@@ -247,11 +292,19 @@ async fn paging_one_row_at_a_time_retraces_the_same_order() -> TestResult {
         f.observed(person, "display_name", name).await?;
     }
 
-    let whole: Vec<(Uuid, String)> = list_persons(&f.db, f.tenant, &[], &[], None, None, PAGE)
-        .await?
-        .into_iter()
-        .map(|r| (r.person_id, r.order_key))
-        .collect();
+    let whole: Vec<(Uuid, String)> = list_persons(
+        &f.db,
+        f.tenant,
+        &[],
+        &[],
+        Restrict::EVERY_IDENTITY,
+        None,
+        PAGE,
+    )
+    .await?
+    .into_iter()
+    .map(|r| (r.person_id, r.order_key))
+    .collect();
 
     let mut walked: Vec<Uuid> = Vec::new();
     let mut resume: Option<(String, Uuid)> = None;
@@ -260,7 +313,16 @@ async fn paging_one_row_at_a_time_retraces_the_same_order() -> TestResult {
             order_key: key,
             person_id: *id,
         });
-        let page = list_persons(&f.db, f.tenant, &[], &[], None, after, 1).await?;
+        let page = list_persons(
+            &f.db,
+            f.tenant,
+            &[],
+            &[],
+            Restrict::EVERY_IDENTITY,
+            after,
+            1,
+        )
+        .await?;
         let Some(row) = page.into_iter().next() else {
             break;
         };
@@ -302,7 +364,16 @@ async fn the_unnarrowed_fallback_answers_exactly_what_the_probe_narrowed_to() ->
         "comparable fallback-hit@listing.test",
     ] {
         let terms: Vec<String> = query.split_whitespace().map(str::to_owned).collect();
-        let narrowed = list_persons(&f.db, f.tenant, &terms, &[], None, None, PAGE).await?;
+        let narrowed = list_persons(
+            &f.db,
+            f.tenant,
+            &terms,
+            &[],
+            Restrict::EVERY_IDENTITY,
+            None,
+            PAGE,
+        )
+        .await?;
         let whole_tenant = list_persons_unnarrowed(&f.db, f.tenant, &terms, None, PAGE).await?;
 
         assert_eq!(

--- a/src/backend/services/identity-resolution/src/infra/db/roster_live_tests.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/roster_live_tests.rs
@@ -1,6 +1,6 @@
 use uuid::Uuid;
 
-use super::person_listing::{self, After, PersonListRow, VisibleTo};
+use super::person_listing::{self, After, Listed, PersonListRow, Restrict, VisibleTo};
 use super::test_fixture::{SOURCE_TYPE, fixture_or_skip};
 use crate::config::VisibilityPolicy;
 
@@ -8,6 +8,11 @@ type TestResult = anyhow::Result<()>;
 
 const PAGE: u64 = 50;
 
+/// The roster as these cases read it: every identity, so a visibility case is
+/// about visibility alone. The endpoint asks for account holders — the fixture's
+/// `person()` carries no canonical binding, so requiring one here would empty
+/// every case below and prove nothing about the visible set.
+/// [`only_account_holders`] covers the requirement itself.
 async fn page(
     f: &super::test_fixture::Fixture,
     viewer: Uuid,
@@ -16,16 +21,59 @@ async fn page(
     after: Option<After<'_>>,
     limit: u64,
 ) -> anyhow::Result<Vec<PersonListRow>> {
+    listed_page(
+        f,
+        viewer,
+        policy,
+        terms,
+        after,
+        limit,
+        Listed::EveryIdentity,
+    )
+    .await
+}
+
+/// The roster exactly as the endpoint asks for it.
+async fn only_account_holders(
+    f: &super::test_fixture::Fixture,
+    viewer: Uuid,
+    limit: u64,
+) -> anyhow::Result<Vec<PersonListRow>> {
+    listed_page(
+        f,
+        viewer,
+        VisibilityPolicy::Flat,
+        &[],
+        None,
+        limit,
+        Listed::AccountHolders,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn listed_page(
+    f: &super::test_fixture::Fixture,
+    viewer: Uuid,
+    policy: VisibilityPolicy,
+    terms: &[String],
+    after: Option<After<'_>>,
+    limit: u64,
+    listed: Listed,
+) -> anyhow::Result<Vec<PersonListRow>> {
     person_listing::list_persons(
         &f.db,
         f.tenant,
         terms,
         &[],
-        Some(VisibleTo {
-            viewer_person_id: viewer,
-            org_source_type: SOURCE_TYPE,
-            policy,
-        }),
+        Restrict {
+            listed,
+            visible_to: Some(VisibleTo {
+                viewer_person_id: viewer,
+                org_source_type: SOURCE_TYPE,
+                policy,
+            }),
+        },
         after,
         limit,
     )
@@ -163,5 +211,31 @@ async fn a_search_term_narrows_the_roster_within_the_visible_set() -> TestResult
     .await?;
 
     assert_eq!(ids(&rows), vec![viewer]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_roster_of_account_holders_leaves_out_an_identity_nobody_claims() -> TestResult {
+    // The shape a git-only organisation is full of: an address a commit carried,
+    // which the journal turned into a person because that is what the journal
+    // does. Nobody here holds it — no connector ever claimed it as an account —
+    // so it is an observation, and a roster that lists it is a directory of
+    // strangers. The account holder beside it is what the roster IS.
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    let observed_only = f.person("commit-author@roster.test").await?;
+    let account_holder = f.emailless_person().await?;
+
+    let listed = ids(&only_account_holders(&f, account_holder, PAGE).await?);
+
+    assert!(
+        listed.contains(&account_holder),
+        "the account holder must be listed: {listed:?}"
+    );
+    assert!(
+        !listed.contains(&observed_only),
+        "an unclaimed address must not reach the roster: {listed:?}"
+    );
     Ok(())
 }

--- a/src/backend/services/identity-resolution/src/infra/db/test_fixture.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/test_fixture.rs
@@ -78,6 +78,17 @@ impl Fixture {
         .await
     }
 
+    /// A person some connector claims as an account holder: an address AND the
+    /// canonical `id` binding that says a system holds it. What a roster
+    /// connector writes, and what the roster lists — [`Self::person`] alone
+    /// leaves an observation nobody has claimed.
+    pub(crate) async fn account_holder(&self, email: &str) -> anyhow::Result<Uuid> {
+        let person_id = self.person(email).await?;
+        self.observed(person_id, "id", &format!("acct-{}", person_id.simple()))
+            .await?;
+        Ok(person_id)
+    }
+
     /// Append one observation of `value_type` for an existing person — the
     /// building block for "this person's value changed later" scenarios.
     pub(crate) async fn observed(

--- a/tests/stand/api/identity/test_visible_persons.py
+++ b/tests/stand/api/identity/test_visible_persons.py
@@ -124,7 +124,7 @@ def test_more_ids_than_the_cap_is_a_400(api: ApiClient) -> None:
 
 @pytest.mark.requires_seed("dev_lead", "development_ic", "sales_ic", "other_tenant_lead")
 @pytest.mark.security
-def test_the_roster_enumerates_exactly_what_the_filter_would_confirm(
+def test_the_roster_obeys_the_boundary_the_filter_obeys(
     lead_session: PersonaSession, stand_manifest: Manifest
 ) -> None:
     """The enumeration obeys the boundary the filter obeys.
@@ -132,6 +132,11 @@ def test_the_roster_enumerates_exactly_what_the_filter_would_confirm(
     Held to the same seeded pair as the POST case above: an enumeration that
     widened the set, or skipped the tenant intersection, would disclose who
     exists rather than merely who reports to whom.
+
+    A boundary, not an equality: the roster lists only persons a connector
+    claims as an account holder, so it is a SUBSET of what the filter confirms.
+    Every seeded persona carries the login binding that makes them one, which is
+    why naming them here still holds.
     """
     report = stand_manifest.fixture("development_ic").uuid
     outsider = stand_manifest.fixture("sales_ic").uuid


### PR DESCRIPTION
**Why.** `GET /v1/visible-persons` listed every identity the persons journal holds. It is an observation log, so an address a commit merely carried is a person there — and the members list read as a directory of strangers.

**What changed.** The roster now admits only persons a connector claims as an account holder — those carrying ADR-0002's canonical `id` binding. The predicate sits in the roster CTE, so it narrows what the window functions rank, not just what comes back.

**The check is per person, not per source.** A non-member GitHub account arrives under `source_type='github'` too, so filtering by source would have leaked outside collaborators.

**Sign-in-minted persons stay listed.** Login bootstrap writes the same binding, and they already carry `provisional`. One match arm to change if that reads wrong.

**`Restrict` groups two arguments.** Clippy denies eight; grouping `listed` with `visible_to` cleared it without suppressions, touching 12 call sites.

**Out of scope.** Departure. Roster removal reaches the journal as no observation at all, so a leaver keeps their binding — this lists everyone who has *ever* held an account. The roster-diff model that fixes it is unbuilt.

**Verified.** 298 unit tests, clippy (pedantic, deny) and rustfmt clean. The live-journal cases skip without a database, so the exclusion proves in CI rather than locally, and no stand run was done.
