### PR TITLE
chore(github): roll out the file-change object ids and sync every four hours

### DIFF
--- a/src/ingestion/connectors/git/github/descriptor.yaml
+++ b/src/ingestion/connectors/git/github/descriptor.yaml
@@ -1,6 +1,6 @@
 name: github
 version: "2.5.0"
-schedule: "0 4 * * *"
+schedule: "0 */4 * * *"
 workflow: sync
 
 # Silver routing via dbt tags on the staging models.

--- a/src/ingestion/connectors/git/github/descriptor.yaml
+++ b/src/ingestion/connectors/git/github/descriptor.yaml
@@ -1,5 +1,5 @@
 name: github
-version: "2.4.0"
+version: "2.5.0"
 schedule: "0 4 * * *"
 workflow: sync
 


### PR DESCRIPTION
**Why.** #2691 added `pre_image_oid` / `post_image_oid` to the GitHub `file_changes` stream schema but left the descriptor version unchanged. Reconcile diffs `descriptor.yaml.version` against the version recorded on the Airbyte definition, and that drift is the only signal it reads — so the new declarative manifest is never rolled out and the stream keeps emitting the previous field set. Everything downstream is already in place, which makes the gap silent: the columns exist through the class contract and the deduplication that consumes them simply never receives an object id.

**What changed.**

- Descriptor version `2.4.0` → `2.5.0`, so reconcile has the drift it needs to publish the manifest. Minor, matching this connector's precedent for additive stream-schema changes.
- Sync schedule `0 4 * * *` → `0 */4 * * *`. The descriptor is the source for the connector's Argo CronWorkflow, and it applies wherever no Secret carries a schedule annotation (precedence: annotation > descriptor > default).

**Trade-off.** Six syncs a day instead of one means six times as many repository walks. Each one only fetches commits past the stored cursor, so the incremental cost is small, but it is the git proxy that absorbs it rather than the vendor API.

**Verified.** Descriptor-only change — no manifest, dbt, or DDL edit. Reconcile picks up both fields on its next pass; a `file_changes` refresh after that is what backfills object ids onto existing rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
