### PR TITLE
fix(ingestion): run the identity seed on the image the identity chart ships

### DIFF
--- a/charts/insight/templates/ingestion/dbt-run.yaml
+++ b/charts/insight/templates/ingestion/dbt-run.yaml
@@ -130,18 +130,31 @@ spec:
           # output is the unambiguous signal and a non-zero exit is a genuine
           # failure to resolve. An empty DBT_SELECT is deliberately left alone —
           # it means "run everything" for manual triggers.
+          # Resolved WITHOUT --exclude on purpose: a selection a previous step
+          # already covered (a roster-only connector's models ARE the excluded
+          # ones) would otherwise be indistinguishable from a typo.
+          SKIP_RUN=0
           if [[ -n "${DBT_SELECT:-}" ]]; then
             LS_RC=0
-            SELECTED="$(dbt --quiet ls --profiles-dir . --resource-type model --select "$DBT_SELECT" ${DBT_EXCLUDE:+--exclude "$DBT_EXCLUDE"})" || LS_RC=$?
+            SELECTED="$(dbt --quiet ls --profiles-dir . --resource-type model --select "$DBT_SELECT")" || LS_RC=$?
             if [[ "$LS_RC" -ne 0 ]]; then
               echo "ERROR: could not resolve dbt selector '${DBT_SELECT}' (dbt ls exited ${LS_RC})" >&2
               RC="$LS_RC"
             elif [[ -z "$SELECTED" ]]; then
               echo "ERROR: dbt selector '${DBT_SELECT}' matches no models — refusing to report success for a transform that runs nothing. The pipeline derives this selector as tag:<connector>+, so the connector's models must carry a tag equal to its slug (#2362)." >&2
               RC=1
+            elif [[ -n "${DBT_EXCLUDE:-}" ]]; then
+              REMAINING="$(dbt --quiet ls --profiles-dir . --resource-type model --select "$DBT_SELECT" --exclude "$DBT_EXCLUDE")" || LS_RC=$?
+              if [[ "$LS_RC" -ne 0 ]]; then
+                echo "ERROR: could not resolve dbt exclusion '${DBT_EXCLUDE}' (dbt ls exited ${LS_RC})" >&2
+                RC="$LS_RC"
+              elif [[ -z "$REMAINING" ]]; then
+                echo "Nothing to run: every model in '${DBT_SELECT}' is covered by '${DBT_EXCLUDE}', which an earlier step already built."
+                SKIP_RUN=1
+              fi
             fi
           fi
-          if [[ "$RC" -eq 0 ]]; then
+          if [[ "$RC" -eq 0 && "${SKIP_RUN:-0}" -eq 0 ]]; then
             if [[ "${DBT_FULL_REFRESH:-false}" == "true" ]]; then
               dbt run --profiles-dir . --log-format json --full-refresh ${DBT_SELECT:+--select "$DBT_SELECT"} ${DBT_EXCLUDE:+--exclude "$DBT_EXCLUDE"} || RC=$?
             else
@@ -151,7 +164,7 @@ spec:
           # Lifecycle event for the high-level "dbt run finished after N
           # minutes, success/failed" view; python3 keeps the JSON safe
           # against whatever characters ride in DBT_SELECT.
-          DBT_RC="$RC" DBT_DURATION_MS=$(( ($(date +%s) - T0) * 1000 )) python3 - <<'PY'
+          DBT_RC="$RC" DBT_SKIPPED="$SKIP_RUN" DBT_DURATION_MS=$(( ($(date +%s) - T0) * 1000 )) python3 - <<'PY'
           import json, os, time
           rc = int(os.environ["DBT_RC"])
           print(json.dumps({
@@ -164,6 +177,7 @@ spec:
               "duration_ms": int(os.environ["DBT_DURATION_MS"]),
               "select": os.environ.get("DBT_SELECT", ""),
               "exclude": os.environ.get("DBT_EXCLUDE", ""),
+              "skipped": os.environ.get("DBT_SKIPPED", "0") == "1",
               "full_refresh": os.environ.get("DBT_FULL_REFRESH", "false") == "true",
           }), flush=True)
           PY

--- a/charts/insight/templates/ingestion/dbt-run.yaml
+++ b/charts/insight/templates/ingestion/dbt-run.yaml
@@ -130,10 +130,11 @@ spec:
           # output is the unambiguous signal and a non-zero exit is a genuine
           # failure to resolve. An empty DBT_SELECT is deliberately left alone —
           # it means "run everything" for manual triggers.
-          # Resolved WITHOUT --exclude on purpose: a selection a previous step
-          # already covered (a roster-only connector's models ARE the excluded
-          # ones) would otherwise be indistinguishable from a typo.
-          SKIP_RUN=0
+          # Resolved WITHOUT --exclude on purpose: the guard judges the
+          # SELECTOR, and a selection an earlier step already covered (a
+          # roster-only connector's models ARE the excluded ones) would
+          # otherwise be indistinguishable from a typo. The run below then
+          # exits 0 on the empty remainder, per the note above.
           if [[ -n "${DBT_SELECT:-}" ]]; then
             LS_RC=0
             SELECTED="$(dbt --quiet ls --profiles-dir . --resource-type model --select "$DBT_SELECT")" || LS_RC=$?
@@ -143,18 +144,9 @@ spec:
             elif [[ -z "$SELECTED" ]]; then
               echo "ERROR: dbt selector '${DBT_SELECT}' matches no models — refusing to report success for a transform that runs nothing. The pipeline derives this selector as tag:<connector>+, so the connector's models must carry a tag equal to its slug (#2362)." >&2
               RC=1
-            elif [[ -n "${DBT_EXCLUDE:-}" ]]; then
-              REMAINING="$(dbt --quiet ls --profiles-dir . --resource-type model --select "$DBT_SELECT" --exclude "$DBT_EXCLUDE")" || LS_RC=$?
-              if [[ "$LS_RC" -ne 0 ]]; then
-                echo "ERROR: could not resolve dbt exclusion '${DBT_EXCLUDE}' (dbt ls exited ${LS_RC})" >&2
-                RC="$LS_RC"
-              elif [[ -z "$REMAINING" ]]; then
-                echo "Nothing to run: every model in '${DBT_SELECT}' is covered by '${DBT_EXCLUDE}', which an earlier step already built."
-                SKIP_RUN=1
-              fi
             fi
           fi
-          if [[ "$RC" -eq 0 && "${SKIP_RUN:-0}" -eq 0 ]]; then
+          if [[ "$RC" -eq 0 ]]; then
             if [[ "${DBT_FULL_REFRESH:-false}" == "true" ]]; then
               dbt run --profiles-dir . --log-format json --full-refresh ${DBT_SELECT:+--select "$DBT_SELECT"} ${DBT_EXCLUDE:+--exclude "$DBT_EXCLUDE"} || RC=$?
             else
@@ -164,7 +156,7 @@ spec:
           # Lifecycle event for the high-level "dbt run finished after N
           # minutes, success/failed" view; python3 keeps the JSON safe
           # against whatever characters ride in DBT_SELECT.
-          DBT_RC="$RC" DBT_SKIPPED="$SKIP_RUN" DBT_DURATION_MS=$(( ($(date +%s) - T0) * 1000 )) python3 - <<'PY'
+          DBT_RC="$RC" DBT_DURATION_MS=$(( ($(date +%s) - T0) * 1000 )) python3 - <<'PY'
           import json, os, time
           rc = int(os.environ["DBT_RC"])
           print(json.dumps({
@@ -177,7 +169,6 @@ spec:
               "duration_ms": int(os.environ["DBT_DURATION_MS"]),
               "select": os.environ.get("DBT_SELECT", ""),
               "exclude": os.environ.get("DBT_EXCLUDE", ""),
-              "skipped": os.environ.get("DBT_SKIPPED", "0") == "1",
               "full_refresh": os.environ.get("DBT_FULL_REFRESH", "false") == "true",
           }), flush=True)
           PY

--- a/charts/insight/templates/ingestion/identity-seed-run.yaml
+++ b/charts/insight/templates/ingestion/identity-seed-run.yaml
@@ -7,6 +7,8 @@ from the umbrella's `.Chart.AppVersion` yields one no build ever pushed.
 */}}
 {{- $identity := index .Subcharts "identityResolution" -}}
 {{- if not $identity -}}
+{{/* The chart refuses deploy=false anyway, but this template renders FIRST,
+     so without this the operator gets a nil-deref on .Chart instead. */}}
 {{-   fail "identityResolution.deploy must be true when ingestion.templates.enabled: every connector pipeline runs an identity-seed step on that service's image and mounts its config." -}}
 {{- end -}}
 {{- $identityTag := .Values.identityResolution.image.tag | default $identity.Chart.AppVersion -}}

--- a/charts/insight/templates/ingestion/identity-seed-run.yaml
+++ b/charts/insight/templates/ingestion/identity-seed-run.yaml
@@ -1,4 +1,15 @@
 {{- if .Values.ingestion.templates.enabled }}
+{{/*
+INVARIANT: this step must run the image the identity Deployment runs. The
+release pipeline stamps each subchart's appVersion with the tag it actually
+built for that service, independently of the umbrella's — so deriving the tag
+from the umbrella's `.Chart.AppVersion` yields one no build ever pushed.
+*/}}
+{{- $identity := index .Subcharts "identityResolution" -}}
+{{- if not $identity -}}
+{{-   fail "identityResolution.deploy must be true when ingestion.templates.enabled: every connector pipeline runs an identity-seed step on that service's image and mounts its config." -}}
+{{- end -}}
+{{- $identityTag := .Values.identityResolution.image.tag | default $identity.Chart.AppVersion -}}
 # One persons-seed as a pipeline step: resolve the identity claims a connector
 # sync just landed, and publish them (the `seed` subcommand publishes as its
 # own final step). Runs in every connector pipeline. `--guard-ok` keeps an
@@ -20,7 +31,7 @@ spec:
       inputs:
         parameters:
           - name: identity_image
-            default: "{{ .Values.identityResolution.image.repository }}:{{ .Values.identityResolution.image.tag | default .Chart.AppVersion }}"
+            default: "{{ .Values.identityResolution.image.repository }}:{{ $identityTag }}"
       activeDeadlineSeconds: 900
       retryStrategy:
         # Safe to repeat: the advisory lock and the operations journal make a

--- a/src/backend/services/identity-resolution/helm/tests/conftest.py
+++ b/src/backend/services/identity-resolution/helm/tests/conftest.py
@@ -1,0 +1,93 @@
+"""Shared render harness for the Helm contract tests in this directory.
+
+The umbrella must be rendered from a SYNTHETIC values set, never from a
+`deploy/gitops/environments/*` overlay: an overlay is free to change what it
+enables, and a contract test that follows it stops asserting silently instead
+of failing.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve()
+SUBCHART = HERE.parents[1]  # .../identity-resolution/helm
+REPO_ROOT = HERE.parents[6]
+UMBRELLA = REPO_ROOT / "charts" / "insight"
+
+TENANT = "3e1d5a65-434c-95b4-8c1b-eb8f53a39bab"
+
+# Minimum viable umbrella install on the credentials.autoGenerate path (the
+# only path where the umbrella composes the identity-resolution config Secret
+# and can therefore vouch for the tenant inside it).
+UMBRELLA_BASE = [
+    "--set",
+    "identityResolution.deploy=true",
+    "--set",
+    "clickhouse.host=ch",
+    "--set",
+    "clickhouse.username=u",
+    "--set",
+    "clickhouse.password=p",
+    "--set",
+    "clickhouse.database=insight",
+    "--set",
+    "mariadb.host=m",
+    "--set",
+    "mariadb.username=insight",
+    "--set",
+    "mariadb.password=pw",
+    "--set",
+    "mariadb.database=insight",
+    "--set",
+    "redis.host=redis",
+    "--set",
+    "redis.password=rp",
+    "--set",
+    "redpanda.brokers=rp:9092",
+    "--set",
+    "ingestion.reconcile.tenantId=default",
+    "--set",
+    "authenticator.oidc.issuerUrl=https://idp",
+    "--set",
+    "authenticator.oidc.clientId=c",
+    "--set",
+    "authenticator.oidc.clientSecret=s",
+    "--set",
+    "authenticator.oidc.redirectUri=https://x/cb",
+    "--set",
+    "authenticator.oidc.sourceType=ms-entra",
+]
+
+
+def render(chart: Path, *extra: str) -> tuple[int, str, str]:
+    """`helm template` a chart; returns (returncode, stdout, stderr)."""
+    proc = subprocess.run(
+        ["helm", "template", "contract-test", str(chart), *extra],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+@pytest.fixture(scope="session")
+def umbrella_deps() -> Path:
+    """Vendor the subcharts once per session.
+
+    Session-scoped on purpose: every module that renders the umbrella needs
+    this, and each run rewrites `charts/insight/charts/`.
+    """
+    proc = subprocess.run(
+        ["helm", "dependency", "update", str(UMBRELLA)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return UMBRELLA

--- a/src/backend/services/identity-resolution/helm/tests/test_ingestion_identity_seed_contract.py
+++ b/src/backend/services/identity-resolution/helm/tests/test_ingestion_identity_seed_contract.py
@@ -1,67 +1,52 @@
 """Helm render-contract for the ingestion pipeline's identity-seed step.
 
-Two production incidents motivate every assertion here, both invisible to a
-`helm lint` and to any test that does not compare the umbrella's two version
-sources against each other:
+Two production defects motivate this file, neither visible to `helm lint`:
 
   * the step's image tag came from the UMBRELLA's `.Chart.AppVersion`, while
-    the identity Deployment resolves the identity SUBCHART's — the release
-    pipeline stamps those independently, so the pipeline pulled a tag that was
-    never built (`ImagePullBackOff`, every connector's gold build blocked);
-  * the gold dbt step excludes what the staging step just built, which empties
-    the selection entirely for a roster-only connector (its only models ARE
-    the ones excluded), and an empty selection is what the #2362 guard exists
-    to reject — so a pipeline that had nothing left to do failed instead.
+    the identity Deployment resolves the identity SUBCHART's. The release
+    pipeline sets the umbrella's to whichever service built last, so the
+    pipeline pulled a tag that was never pushed (`ImagePullBackOff`, and every
+    connector's gold build blocked behind it);
+  * the gold step's `--exclude` was folded into the selector guard, so a
+    connector whose only models ARE the excluded ones (a roster-only source)
+    resolved to nothing and tripped the #2362 typo guard — a pipeline with
+    nothing left to do failed instead.
 
-Both are contract, not plumbing: nothing else in CI renders the umbrella and
-compares these values, and the functional lane does not run a connector
-pipeline end to end.
+The dbt-run assertions are behavioural: the rendered script is executed
+against a stub `dbt`, so a rewrite that preserves the text but breaks the
+wiring fails here.
 """
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
 import pytest
 import yaml
+from conftest import TENANT, UMBRELLA, UMBRELLA_BASE, render
 
-HERE = Path(__file__).resolve()
-REPO_ROOT = HERE.parents[6]
-UMBRELLA = REPO_ROOT / "charts" / "insight"
-VALUES = REPO_ROOT / "deploy" / "gitops" / "environments" / "test-stand" / "values.yaml"
+INGESTION = [
+    "--set",
+    "ingestion.templates.enabled=true",
+    "--set",
+    "ingestion.toolboxImage=ghcr.io/example/insight-toolbox:0.0.0-test",
+    # The umbrella refuses to render an enabled seed CronJob without a tenant.
+    "--set",
+    f"global.tenantDefaultId={TENANT}",
+]
 
 
-def _render(*extra: str) -> list[dict]:
-    proc = subprocess.run(  # noqa: S603 — test-controlled argv
-        [  # noqa: S607
-            "helm",
-            "template",
-            "contract-test",
-            str(UMBRELLA),
-            "--values",
-            str(VALUES),
-            *extra,
-        ],
-        capture_output=True,
-        text=True,
-        timeout=300,
-        check=False,
-    )
-    assert proc.returncode == 0, proc.stderr
-    return [d for d in yaml.safe_load_all(proc.stdout) if isinstance(d, dict)]
+def _docs(*extra: str) -> list[dict]:
+    rc, out, err = render(UMBRELLA, *UMBRELLA_BASE, *INGESTION, *extra)
+    assert rc == 0, err
+    return [d for d in yaml.safe_load_all(out) if isinstance(d, dict)]
 
 
 @pytest.fixture(scope="module")
-def docs() -> list[dict]:
-    subprocess.run(  # noqa: S603, S607 — refresh the vendored subcharts
-        ["helm", "dependency", "update", str(UMBRELLA)],
-        capture_output=True,
-        text=True,
-        timeout=300,
-        check=True,
-    )
-    return _render()
+def docs(umbrella_deps) -> list[dict]:
+    return _docs()
 
 
 def _named(docs: list[dict], kind: str, suffix: str) -> dict:
@@ -78,61 +63,172 @@ def _seed_step_image(docs: list[dict]) -> str:
     return param["default"]
 
 
-def _dbt_run_script(docs: list[dict]) -> str:
-    template = _named(docs, "WorkflowTemplate", "dbt-run")["spec"]["templates"][0]
-    return template["script"]["source"]
+def _identity_deployment_image(docs: list[dict]) -> str:
+    deployment = _named(docs, "Deployment", "-identity-resolution")
+    # `migrate` is an initContainer, so the app container is the only one here.
+    (container,) = deployment["spec"]["template"]["spec"]["containers"]
+    return container["image"]
 
 
 def test_the_seed_step_runs_the_same_image_as_the_identity_deployment(docs) -> None:
-    """The one assertion the ImagePullBackOff needed.
-
-    The step must not derive a tag of its own: the umbrella and the identity
-    subchart carry independently-stamped appVersions, so any expression that
-    reaches for the wrong one produces a tag no build ever pushed.
-    """
-    deployment = _named(docs, "Deployment", "-identity-resolution")
-    (container,) = deployment["spec"]["template"]["spec"]["containers"]
-    assert _seed_step_image(docs) == container["image"]
+    """The one assertion the ImagePullBackOff needed: the step must not derive
+    a tag of its own, because the umbrella's appVersion names a different
+    service's build."""
+    assert _seed_step_image(docs) == _identity_deployment_image(docs)
 
 
-def test_an_explicit_image_tag_still_wins(docs) -> None:
-    """An operator pinning `identityResolution.image.tag` pins BOTH."""
-    pinned = _render("--set", "identityResolution.image.tag=0.0.0-pinned")
-    deployment = _named(pinned, "Deployment", "-identity-resolution")
-    (container,) = deployment["spec"]["template"]["spec"]["containers"]
-    assert _seed_step_image(pinned) == container["image"]
-    assert container["image"].endswith(":0.0.0-pinned")
+def test_an_explicit_tag_pins_both_sides(umbrella_deps) -> None:
+    """An operator pinning `identityResolution.image.tag` must move the step
+    and the Deployment together, not one of them."""
+    docs = _docs("--set", "identityResolution.image.tag=0.0.0-pinned")
+    assert _seed_step_image(docs) == _identity_deployment_image(docs)
+    assert _identity_deployment_image(docs).endswith(":0.0.0-pinned")
 
 
 def test_the_gold_step_excludes_what_the_staging_step_built(docs) -> None:
     """The dedup this contract keeps: a `tag:X+` graph walk would otherwise
     rebuild the staging models the pipeline just built."""
-    template = _named(docs, "WorkflowTemplate", "ingestion-pipeline")["spec"]["templates"]
-    (transform,) = [t for t in template if t["name"] == "transform"]
+    templates = _named(docs, "WorkflowTemplate", "ingestion-pipeline")["spec"]["templates"]
+    (transform,) = [t for t in templates if t["name"] == "transform"]
     (gold,) = [t for t in transform["dag"]["tasks"] if t["name"] == "transform-legacy"]
     excludes = [p["value"] for p in gold["arguments"]["parameters"] if p["name"] == "dbt_exclude"]
     assert excludes == ["tag:{{inputs.parameters.data_source}} identity_inputs"]
 
 
-def test_the_selector_guard_resolves_the_selection_without_the_exclusion(docs) -> None:
-    """#2362's guard must judge the SELECTOR, not what survives the exclusion.
+# ── dbt-run: the selector guard, executed ────────────────────────────────────
 
-    Resolving `--select` together with `--exclude` conflates two different
-    failures: a misspelled selector (nothing to run, and nobody meant that)
-    and a selection fully covered by an earlier step (nothing to run, and that
-    is correct — a roster-only connector's models are exactly the excluded
-    ones).
+
+def _dbt_run_script(docs: list[dict]) -> str:
+    template = _named(docs, "WorkflowTemplate", "dbt-run")["spec"]["templates"][0]
+    return template["script"]["source"]
+
+
+def _run_script(
+    tmp_path: Path,
+    script: str,
+    *,
+    selected: str,
+    remaining: str,
+    select: str,
+    exclude: str,
+) -> tuple[int, str]:
+    """Execute the rendered script with a stub `dbt` on PATH.
+
+    Two lines cannot run outside the toolbox image and are replaced: the `cd`
+    into the image's dbt project, and the profiles.yml heredoc (it needs a
+    real adapter). Everything the guard does is executed verbatim.
     """
-    script = _dbt_run_script(docs)
-    assert 'ls --profiles-dir . --resource-type model --select "$DBT_SELECT")' in script, (
-        "the typo guard must resolve --select on its own"
+    stub = tmp_path / "bin"
+    stub.mkdir()
+    # The stub distinguishes the two resolutions, which is the whole point:
+    # `ls --select X` answers with the selection, `ls --select X --exclude Y`
+    # with what survives it. A stub blind to --exclude cannot reproduce the
+    # roster-only failure at all.
+    (stub / "dbt").write_text(
+        "#!/usr/bin/env bash\n"
+        'case "$*" in\n'
+        '  *" ls "*--exclude*) printf "%s" "$STUB_LS_REMAINING" ;;\n'
+        '  *" ls "*) printf "%s" "$STUB_LS_SELECTED" ;;\n'
+        '  *) echo "DBT_RUN_INVOKED $*" ;;\n'
+        "esac\n"
+        "exit 0\n"
     )
+    (stub / "dbt").chmod(0o755)
+
+    # Strip ONLY the first heredoc — the profiles.yml writer, which needs a
+    # real adapter. The trailing one emits the lifecycle event and must run.
+    keep, skipping, stripped = [], False, False
+    for line in script.replace("cd /ingestion/dbt", f"cd {tmp_path}").splitlines():
+        if not stripped and line.strip() == "python3 - <<'PY'":
+            skipping, stripped = True, True
+            continue
+        if skipping:
+            if line.strip() == "PY":
+                skipping = False
+            continue
+        keep.append(line)
+    script_file = tmp_path / "script.sh"
+    script_file.write_text("\n".join(keep))
+
+    env = {
+        **os.environ,
+        "PATH": f"{stub}:{os.environ['PATH']}",
+        "STUB_LS_SELECTED": selected,
+        "STUB_LS_REMAINING": remaining,
+        "DBT_SELECT": select,
+        "DBT_EXCLUDE": exclude,
+        "DBT_FULL_REFRESH": "false",
+        "CLICKHOUSE_HOST": "h",
+        "CLICKHOUSE_PORT": "8123",
+        "CLICKHOUSE_USER": "u",
+        "CLICKHOUSE_PASSWORD": "p",
+    }
+    proc = subprocess.run(
+        ["bash", str(script_file)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        env=env,
+        check=False,
+    )
+    return proc.returncode, proc.stdout + proc.stderr
 
 
-def test_a_selection_fully_covered_by_an_earlier_step_succeeds(docs) -> None:
-    """...and it must skip the run rather than invoke dbt with nothing to do."""
-    script = _dbt_run_script(docs)
-    assert "SKIP_RUN=1" in script, "an empty post-exclusion selection must skip the run"
-    assert 'if [[ "$RC" -eq 0 && "${SKIP_RUN:-0}" -eq 0 ]]; then' in script, (
-        "the skip must bypass `dbt run`, not merely log"
+def test_a_selection_an_earlier_step_covered_is_not_an_error(docs, tmp_path) -> None:
+    """The roster-only case that failed in production: the selector resolves,
+    the exclusion covers all of it, and the step must still succeed."""
+    rc, output = _run_script(
+        tmp_path,
+        _dbt_run_script(docs),
+        selected="model.ingestion.github_directory__org_members",
+        remaining="",  # the exclusion covers every model the selector matched
+        select="tag:github-directory+",
+        exclude="tag:github-directory identity_inputs",
     )
+    assert rc == 0, output
+    assert "DBT_RUN_INVOKED" in output, "the run must still be attempted"
+    assert "--exclude" in output, "the exclusion must reach dbt run"
+
+
+def test_a_selector_matching_nothing_still_fails(docs, tmp_path) -> None:
+    """#2362's guard, intact: a typo'd selector must not report success."""
+    rc, output = _run_script(
+        tmp_path,
+        _dbt_run_script(docs),
+        selected="",
+        remaining="",
+        select="tag:typo+",
+        exclude="",
+    )
+    assert rc == 1, output
+    assert "matches no models" in output
+    assert "DBT_RUN_INVOKED" not in output, "nothing may run behind a failed guard"
+
+
+def test_a_normal_connector_runs_with_both_flags(docs, tmp_path) -> None:
+    rc, output = _run_script(
+        tmp_path,
+        _dbt_run_script(docs),
+        selected="model.a\nmodel.b",
+        remaining="model.b",
+        select="tag:github+",
+        exclude="tag:github identity_inputs",
+    )
+    assert rc == 0, output
+    assert "--select tag:github+" in output
+    assert "--exclude tag:github identity_inputs" in output
+
+
+def test_an_empty_selector_still_runs_everything(docs, tmp_path) -> None:
+    """Manual triggers submit no selector; the guard must stay out of the way."""
+    rc, output = _run_script(
+        tmp_path,
+        _dbt_run_script(docs),
+        selected="",
+        remaining="",
+        select="",
+        exclude="",
+    )
+    assert rc == 0, output
+    assert "DBT_RUN_INVOKED" in output
+    assert "--select" not in output

--- a/src/backend/services/identity-resolution/helm/tests/test_ingestion_identity_seed_contract.py
+++ b/src/backend/services/identity-resolution/helm/tests/test_ingestion_identity_seed_contract.py
@@ -1,0 +1,138 @@
+"""Helm render-contract for the ingestion pipeline's identity-seed step.
+
+Two production incidents motivate every assertion here, both invisible to a
+`helm lint` and to any test that does not compare the umbrella's two version
+sources against each other:
+
+  * the step's image tag came from the UMBRELLA's `.Chart.AppVersion`, while
+    the identity Deployment resolves the identity SUBCHART's — the release
+    pipeline stamps those independently, so the pipeline pulled a tag that was
+    never built (`ImagePullBackOff`, every connector's gold build blocked);
+  * the gold dbt step excludes what the staging step just built, which empties
+    the selection entirely for a roster-only connector (its only models ARE
+    the ones excluded), and an empty selection is what the #2362 guard exists
+    to reject — so a pipeline that had nothing left to do failed instead.
+
+Both are contract, not plumbing: nothing else in CI renders the umbrella and
+compares these values, and the functional lane does not run a connector
+pipeline end to end.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+HERE = Path(__file__).resolve()
+REPO_ROOT = HERE.parents[6]
+UMBRELLA = REPO_ROOT / "charts" / "insight"
+VALUES = REPO_ROOT / "deploy" / "gitops" / "environments" / "test-stand" / "values.yaml"
+
+
+def _render(*extra: str) -> list[dict]:
+    proc = subprocess.run(  # noqa: S603 — test-controlled argv
+        [  # noqa: S607
+            "helm",
+            "template",
+            "contract-test",
+            str(UMBRELLA),
+            "--values",
+            str(VALUES),
+            *extra,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return [d for d in yaml.safe_load_all(proc.stdout) if isinstance(d, dict)]
+
+
+@pytest.fixture(scope="module")
+def docs() -> list[dict]:
+    subprocess.run(  # noqa: S603, S607 — refresh the vendored subcharts
+        ["helm", "dependency", "update", str(UMBRELLA)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=True,
+    )
+    return _render()
+
+
+def _named(docs: list[dict], kind: str, suffix: str) -> dict:
+    matches = [
+        d for d in docs if d.get("kind") == kind and d["metadata"]["name"].endswith(suffix)
+    ]
+    assert len(matches) == 1, f"expected one {kind} ending {suffix}, got {len(matches)}"
+    return matches[0]
+
+
+def _seed_step_image(docs: list[dict]) -> str:
+    template = _named(docs, "WorkflowTemplate", "identity-seed-run")["spec"]["templates"][0]
+    (param,) = [p for p in template["inputs"]["parameters"] if p["name"] == "identity_image"]
+    return param["default"]
+
+
+def _dbt_run_script(docs: list[dict]) -> str:
+    template = _named(docs, "WorkflowTemplate", "dbt-run")["spec"]["templates"][0]
+    return template["script"]["source"]
+
+
+def test_the_seed_step_runs_the_same_image_as_the_identity_deployment(docs) -> None:
+    """The one assertion the ImagePullBackOff needed.
+
+    The step must not derive a tag of its own: the umbrella and the identity
+    subchart carry independently-stamped appVersions, so any expression that
+    reaches for the wrong one produces a tag no build ever pushed.
+    """
+    deployment = _named(docs, "Deployment", "-identity-resolution")
+    (container,) = deployment["spec"]["template"]["spec"]["containers"]
+    assert _seed_step_image(docs) == container["image"]
+
+
+def test_an_explicit_image_tag_still_wins(docs) -> None:
+    """An operator pinning `identityResolution.image.tag` pins BOTH."""
+    pinned = _render("--set", "identityResolution.image.tag=0.0.0-pinned")
+    deployment = _named(pinned, "Deployment", "-identity-resolution")
+    (container,) = deployment["spec"]["template"]["spec"]["containers"]
+    assert _seed_step_image(pinned) == container["image"]
+    assert container["image"].endswith(":0.0.0-pinned")
+
+
+def test_the_gold_step_excludes_what_the_staging_step_built(docs) -> None:
+    """The dedup this contract keeps: a `tag:X+` graph walk would otherwise
+    rebuild the staging models the pipeline just built."""
+    template = _named(docs, "WorkflowTemplate", "ingestion-pipeline")["spec"]["templates"]
+    (transform,) = [t for t in template if t["name"] == "transform"]
+    (gold,) = [t for t in transform["dag"]["tasks"] if t["name"] == "transform-legacy"]
+    excludes = [p["value"] for p in gold["arguments"]["parameters"] if p["name"] == "dbt_exclude"]
+    assert excludes == ["tag:{{inputs.parameters.data_source}} identity_inputs"]
+
+
+def test_the_selector_guard_resolves_the_selection_without_the_exclusion(docs) -> None:
+    """#2362's guard must judge the SELECTOR, not what survives the exclusion.
+
+    Resolving `--select` together with `--exclude` conflates two different
+    failures: a misspelled selector (nothing to run, and nobody meant that)
+    and a selection fully covered by an earlier step (nothing to run, and that
+    is correct — a roster-only connector's models are exactly the excluded
+    ones).
+    """
+    script = _dbt_run_script(docs)
+    assert 'ls --profiles-dir . --resource-type model --select "$DBT_SELECT")' in script, (
+        "the typo guard must resolve --select on its own"
+    )
+
+
+def test_a_selection_fully_covered_by_an_earlier_step_succeeds(docs) -> None:
+    """...and it must skip the run rather than invoke dbt with nothing to do."""
+    script = _dbt_run_script(docs)
+    assert "SKIP_RUN=1" in script, "an empty post-exclusion selection must skip the run"
+    assert 'if [[ "$RC" -eq 0 && "${SKIP_RUN:-0}" -eq 0 ]]; then' in script, (
+        "the skip must bypass `dbt run`, not merely log"
+    )

--- a/src/backend/services/identity-resolution/helm/tests/test_seed_cronjob_contract.py
+++ b/src/backend/services/identity-resolution/helm/tests/test_seed_cronjob_contract.py
@@ -280,16 +280,7 @@ def test_job_pod_labels_never_match_the_service_selector(default_docs, job: str)
 # ── umbrella: the tenant render guard ─────────────────────────────────────
 
 
-@pytest.fixture(scope="module")
-def umbrella_deps() -> Path:
-    subprocess.run(  # noqa: S603, S607 — refresh the vendored subcharts
-        ["helm", "dependency", "update", str(UMBRELLA)],
-        capture_output=True,
-        text=True,
-        timeout=300,
-        check=True,
-    )
-    return UMBRELLA
+# `umbrella_deps` is session-scoped in conftest.py — one vendor per run.
 
 
 def test_umbrella_refuses_enabled_seed_without_a_tenant(umbrella_deps) -> None:


### PR DESCRIPTION
**Why.** Two defects from #2675, both live: every connector pipeline's `identity-seed` step lands in `ImagePullBackOff`, and a roster-only connector's pipeline fails after its identity work already succeeded.

**What changed.** The step's image now comes from the identity subchart's own `appVersion` instead of the umbrella's — the release pipeline sets the umbrella's to whichever service built last, so it named a tag no build ever pushed. And `dbt-run` resolves `--select` alone in its guard: an empty *selector* is still the error #2362 made it, while a selection an earlier step already covered reaches `dbt run`, which exits 0 on an empty remainder (the behaviour the template already documents).

**The exclusion stays.** Reverting it would restore a duplicate staging build in every pipeline (github: 32 models per gold pass instead of 18); only the guard was wrong, not the dedup.

**`identityResolution.deploy=false` fails with its own message.** The chart already refused that combination, but this template renders first, so without the check the operator gets a nil-deref on `.Chart` instead of a cause.

**Verified.** The dbt assertions execute the rendered script against a stub `dbt` that answers `ls --select` and `ls --select --exclude` differently — four cases: exclusion covers everything (exit 0, run still attempted), typo'd selector (exit 1, nothing runs), normal connector (both flags reach dbt), no selector (runs everything). Both defects reproduce RED against `origin/main` and pass here. Blast radius measured with real `dbt ls`: `github-directory` 5 → 0 models was the only connector that emptied (ms-entra 12 → 5, active-directory 13 → 5, bamboohr 19 → 10). 31 render-contract tests pass; `helm lint` and both gitops overlays render. No live pipeline run.
