### PR TITLE
fix(frontend): keep the ui-kit's own spacing in the built bundle

### DIFF
--- a/src/frontend/vite.ui-kit-layer.test.ts
+++ b/src/frontend/vite.ui-kit-layer.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { uiKitLayer } from "./vite.ui-kit-layer";
+
+const KIT_CSS = "/app/node_modules/@gears-frontx/ui-kit/dist/card.css";
+
+function transform(code: string, id: string): string | null {
+  const plugin = uiKitLayer();
+  const hook = plugin.transform as (
+    this: unknown,
+    code: string,
+    id: string
+  ) => { code: string } | null;
+  return hook.call(null, code, id)?.code ?? null;
+}
+
+describe("uiKitLayer", () => {
+  it("wraps kit CSS in the components layer", () => {
+    const out = transform("._card{padding:1rem}", KIT_CSS);
+    expect(out).toContain("@layer components {\n._card{padding:1rem}\n}");
+  });
+
+  it("declares the layer order before the layer it uses", () => {
+    const out = transform("._card{padding:1rem}", KIT_CSS) ?? "";
+    const order = out.indexOf(
+      "@layer properties, theme, base, components, utilities;"
+    );
+    expect(order).toBeGreaterThanOrEqual(0);
+    expect(order).toBeLessThan(out.indexOf("@layer components {"));
+  });
+
+  it("leaves everything else alone", () => {
+    expect(transform("._x{padding:1rem}", "/app/src/index.css")).toBeNull();
+    expect(
+      transform(
+        "export default {}",
+        "/app/node_modules/@gears-frontx/ui-kit/dist/index.js"
+      )
+    ).toBeNull();
+  });
+});

--- a/src/frontend/vite.ui-kit-layer.ts
+++ b/src/frontend/vite.ui-kit-layer.ts
@@ -2,6 +2,11 @@ import type { Plugin } from "vite";
 
 const KIT = "@gears-frontx/ui-kit";
 
+// Kit CSS chunks load before Tailwind's own sheet, which states no order: the
+// first sheet to name a layer sets it, so without this `components` registers
+// ahead of `base` and preflight's `*{padding:0}` wins over every kit component.
+const ORDER = "@layer properties, theme, base, components, utilities;";
+
 // TODO(#2705): drop this once the kit ships its CSS in a layer.
 // Unlayered kit CSS beats Tailwind's layered utilities at any specificity, so a
 // call site's className is silently dropped without this. Theme tokens are
@@ -13,7 +18,7 @@ export function uiKitLayer(): Plugin {
     transform(code, id) {
       const file = id.split("?")[0];
       if (!file.includes(KIT) || !file.endsWith(".css")) return null;
-      return { code: `@layer components {\n${code}\n}`, map: null };
+      return { code: `${ORDER}\n@layer components {\n${code}\n}`, map: null };
     },
   };
 }

--- a/src/frontend/vitest.config.ts
+++ b/src/frontend/vitest.config.ts
@@ -73,7 +73,7 @@ export default defineConfig({
           globals: false,
           css: false,
           setupFiles: ["./src/test/setup.ts"],
-          include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
+          include: ["src/**/*.test.ts", "src/**/*.test.tsx", "vite.*.test.ts"],
         },
       },
       {


### PR DESCRIPTION
**Why.** On a built stand every ui-kit component lost its own padding, border and margin — the person page's attention rows sat flush against the card edge, hover bleed spilling outside it. `pnpm dev` renders correctly, so it never reproduced locally.

**What changed.** Every kit stylesheet now states the layer order before the `components` block `vite.ui-kit-layer.ts` wraps it in. Nothing else declared one, so the first sheet to name a layer decided it — and the build loads kit CSS chunks before Tailwind's, registering `components` under `base`, where preflight's `*{margin:0;padding:0;border:0}` beat it.

**The order statement — one line, no styles — goes in every kit stylesheet rather than one place.** The entry stylesheet loads last in the built HTML and stories never load that HTML at all, so the sheet that needs the order carries it. Repeats are no-ops.

Built bundle on seeded mock data, same page and viewport, first attention row hovered.

Before:

![Person page before the fix](https://raw.githubusercontent.com/constructorfabric/insight/pr-2716-assets/before-full.png)

After:

![Person page after the fix](https://raw.githubusercontent.com/constructorfabric/insight/pr-2716-assets/after-full.png)

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/constructorfabric/insight/pr-2716-assets/before-crop.png" width="440"> | <img src="https://raw.githubusercontent.com/constructorfabric/insight/pr-2716-assets/after-crop.png" width="440"> |

**Verified.** Built bundle, measured in a browser: card content padding `0px` → `16px`. `pnpm lint`, `pnpm typecheck`, 1836 unit tests, 16 story tests.
