### PR TITLE
fix(identity): label a person by their handle before their e-mail

### DIFF
--- a/src/backend/services/identity-resolution/src/infra/db/person_listing.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/person_listing.rs
@@ -6,10 +6,15 @@
 //! list, and a page boundary must fall in the same place either way.
 //!
 //! **The order is the card's own label** — display name, else the composed
-//! first/last, else the address, else the source-native handle — folded to
+//! first/last, else the source-native handle, else the address — folded to
 //! lower case, with the people the journal knows by nothing but an id last.
 //! Ordering by anything else would sort the list by a value the rows do not
 //! show.
+//!
+//! The address is the LAST resort, behind the handle: a source that hides a
+//! member's e-mail still reports one for their commits, and a generated address
+//! naming an account (`<id>+<handle>@…`) is not what anybody calls that person.
+//! The handle is.
 //!
 //! INVARIANT: the label follows `person_card`'s rule exactly, including where
 //! that rule leaves an attribute absent. Both rank every observation of a value
@@ -412,8 +417,8 @@ const LABEL_CTES: &str = r"
                        NULLIF(TRIM(CONCAT_WS(' ',
                            NULLIF(TRIM(first_name), ''),
                            NULLIF(TRIM(last_name), ''))), ''),
-                       NULLIF(TRIM(email), ''),
-                       NULLIF(TRIM(username), '')
+                       NULLIF(TRIM(username), ''),
+                       NULLIF(TRIM(email), '')
                    ) AS label
             FROM (
                 SELECT person_id,

--- a/src/backend/services/identity-resolution/src/infra/db/person_listing_live_tests.rs
+++ b/src/backend/services/identity-resolution/src/infra/db/person_listing_live_tests.rs
@@ -278,6 +278,41 @@ async fn the_page_is_ordered_by_the_label_the_row_shows() -> TestResult {
 }
 
 #[tokio::test]
+async fn the_handle_labels_a_person_the_source_gave_no_name() -> TestResult {
+    // A source that hides a member's e-mail still reports one for their
+    // commits, and it is generated from the account rather than chosen by the
+    // human: `<id>+<handle>@…` names nobody. The handle does, so it labels the
+    // row and the address only breaks a tie nothing else can.
+    let Some(f) = fixture_or_skip().await? else {
+        return Ok(());
+    };
+    // The address sorts LAST and the handle FIRST, so only the handle winning
+    // produces this order — an address-labelled row would come back second.
+    let handled = f.person("zzz-generated@users.noreply.example").await?;
+    f.observed(handled, "username", "aaa-handle").await?;
+    let addressed = f.person("mmm-address-only@listing.test").await?;
+
+    let rows = list_persons(
+        &f.db,
+        f.tenant,
+        &[],
+        &[handled, addressed],
+        Restrict::EVERY_IDENTITY,
+        None,
+        PAGE,
+    )
+    .await?;
+    let order: Vec<Uuid> = rows.into_iter().map(|r| r.person_id).collect();
+
+    assert_eq!(
+        order,
+        vec![handled, addressed],
+        "the handle labels and orders the row, not the generated address"
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn paging_one_row_at_a_time_retraces_the_same_order() -> TestResult {
     let Some(f) = fixture_or_skip().await? else {
         return Ok(());

--- a/src/frontend/src/components/org-tree.tsx
+++ b/src/frontend/src/components/org-tree.tsx
@@ -8,6 +8,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import { personDisplayName } from "@/lib/identities/person-display";
 import { usePortalNavActions } from "@/lib/portal/portal-nav";
 import { personIdFromPath } from "@/lib/metrics/entity";
 import {
@@ -17,7 +18,6 @@ import {
 import { useIcPerson } from "@/queries/ic-dashboard";
 import { useVisibilityPolicy } from "@/queries/identity-me";
 import { useVisibleRoster } from "@/queries/visible-roster";
-import type { PersonSummary } from "@/api/identity-client";
 import type { IdentityPerson } from "@/types/insight";
 
 // Person ids, not emails: the identity cutover made the id the key the route
@@ -109,16 +109,6 @@ function PersonNode({
   );
 }
 
-/** How a roster row is labelled: the handle beats no name at all. */
-function rosterLabel(person: PersonSummary): string {
-  return (
-    person.display_name?.trim() ||
-    person.email?.trim() ||
-    person.username?.trim() ||
-    person.person_id
-  );
-}
-
 /**
  * The same navigation for an organisation with no reporting lines: one flat
  * list, in label order, scrolling in the pane exactly as the chart does. There
@@ -138,7 +128,7 @@ function RosterList({ query }: { query: string }) {
   const listed = useMemo(() => {
     const term = query.trim().toLowerCase();
     const rows = roster
-      .map((person) => ({ person, label: rosterLabel(person) }))
+      .map((person) => ({ person, label: personDisplayName(person) }))
       .sort((left, right) => left.label.localeCompare(right.label));
     return term
       ? rows.filter((row) => row.label.toLowerCase().includes(term))

--- a/src/frontend/src/components/portal/employees-view.tsx
+++ b/src/frontend/src/components/portal/employees-view.tsx
@@ -23,6 +23,7 @@ import { useIcPerson } from "@/queries/ic-dashboard";
 import { useVisibilityPolicy } from "@/queries/identity-me";
 import { useVisibleRoster } from "@/queries/visible-roster";
 import type { IdentityPerson } from "@/types/insight";
+import { personName } from "@/lib/identities/person-display";
 import { cn } from "@/lib/utils";
 
 // Mirrors the rail: a person with neither display name nor email is still a row.
@@ -68,19 +69,15 @@ function collectEmployees(root: IdentityPerson): EmployeeRow[] {
 
 /**
  * Rows for an organisation with no reporting lines: the roster as identity
- * serves it. A person the journal knows only by a handle is listed under it —
- * `person-display` stops at the id on purpose, so a blank name here would be a
- * row nobody can tell apart.
+ * serves it. Named through `personName` so the precedence has one definition,
+ * with its own last resort — `person-display` stops at the id on purpose, and a
+ * raw id in this column is a row nobody can tell apart.
  */
 function rosterEmployees(roster: readonly PersonSummary[]): EmployeeRow[] {
   return roster
     .map((person) => ({
       personId: person.person_id,
-      displayName:
-        person.display_name?.trim() ||
-        person.email?.trim() ||
-        person.username?.trim() ||
-        UNNAMED_PERSON,
+      displayName: personName(person) ?? UNNAMED_PERSON,
       jobTitle: person.job_title ?? "",
       // No reporting lines, and `PersonSummary` carries no org attributes.
       department: "",

--- a/src/frontend/src/components/portal/person-cell.test.tsx
+++ b/src/frontend/src/components/portal/person-cell.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 /**
  * One person must read the same everywhere: name by the card's precedence
- * (display name → email → username → id), an identifying second line that
- * never repeats the name, and a leaver marked so nobody merges into them.
+ * (display name, then username, then email, then the id), an identifying second
+ * line that never repeats the name, and a leaver marked so nobody merges into
+ * them.
  */
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -22,8 +23,8 @@ function person(over: Partial<PersonSummary>): PersonSummary {
 describe("personDisplayName", () => {
   it.each<[string, Partial<PersonSummary>, string]>([
     ["display name first", { display_name: "Ann Lee", email: "a@example.com" }, "Ann Lee"],
-    ["email when unnamed", { email: "a@example.com", username: "alee" }, "a@example.com"],
-    ["username for a git-only identity", { username: "alee" }, "alee"],
+    ["the handle over the address", { email: "a@example.com", username: "alee" }, "alee"],
+    ["the address when there is no handle", { email: "a@example.com" }, "a@example.com"],
     ["the id when nothing else exists", {}, "01900000-0000-7000-8000-000000000001"],
   ])("picks %s", (_name, fields, expected) => {
     expect(personDisplayName(person(fields))).toBe(expected);

--- a/src/frontend/src/components/portal/person-cell.tsx
+++ b/src/frontend/src/components/portal/person-cell.tsx
@@ -4,9 +4,9 @@
  * identity-console surface (queue candidates, detail panel, picker) so the
  * same person always reads the same way.
  *
- * Field precedence mirrors the backend card: `display_name`, else email, else
- * a source-native username — a git-only identity is recognisable by its
- * handle. A `terminated` status is marked so nobody merges INTO a leaver by
+ * Field precedence mirrors the backend card: `display_name`, else a
+ * source-native username, else email — a git-only identity is recognisable
+ * by its handle, and a generated address is not what anybody calls them. A `terminated` status is marked so nobody merges INTO a leaver by
  * accident.
  *
  * A person minted at a first sign-in is marked wherever they appear: the

--- a/src/frontend/src/lib/identities/person-display.ts
+++ b/src/frontend/src/lib/identities/person-display.ts
@@ -1,15 +1,31 @@
 /**
- * The one name a person goes by across every identity-console surface —
- * the card's precedence: display name, else email, else the source-native
- * username (a git-only identity is recognisable by its handle), else the id.
+ * The one name a person goes by across every identity-console surface.
+ *
+ * Precedence: display name, else the source-native username, else the e-mail.
+ * The address comes LAST on purpose — a source that hides a member's e-mail
+ * still reports one for their commits, and an address generated from the
+ * account (`<id>+<handle>@…`) is not what anybody calls that person. The handle
+ * is.
  */
 import type { PersonSummary } from "@/api/identity-client";
 
-export function personDisplayName(person: PersonSummary): string {
+/**
+ * The name the journal knows, or null when it knows none.
+ *
+ * INVARIANT: the one place this precedence is written down. It matches the
+ * roster listing's own order key (`person_listing`'s `LABEL_CTES`) — a row
+ * shown under one name and sorted under another pages unpredictably.
+ */
+export function personName(person: PersonSummary): string | null {
   return (
     person.display_name?.trim() ||
-    person.email?.trim() ||
     person.username?.trim() ||
-    person.person_id
+    person.email?.trim() ||
+    null
   );
+}
+
+/** The same name, falling back to the id — always something to render. */
+export function personDisplayName(person: PersonSummary): string {
+  return personName(person) ?? person.person_id;
 }


### PR DESCRIPTION
**Why.** A person the source gives no profile name to was labelled by their e-mail, and for a git account that address is generated from the account itself (`<id>+<handle>@…`). The roster listed machine addresses where it should have listed handles.

**What changed.** The label precedence puts the handle ahead of the address everywhere it is decided: display name, else composed first/last, else username, else e-mail. Backend order key (`person_listing`'s `LABEL_CTES`) and the frontend helper move together — a row shown under one name and sorted under another pages unpredictably.

**The precedence now has one definition.** `personName` in `person-display.ts`; `org-tree`'s `rosterLabel` was a byte-identical copy and is gone, and the roster table calls the helper with its own last resort. Four copies is how the order drifted in the first place.

**Out of scope.** The org-chart paths (`use-org-scope`, the tree branch of the roster table) label from `IdentityPerson`, which carries no username — nothing to reorder there.

**Verified.** Backend: 300 tests, clippy (pedantic, deny) and rustfmt clean, including a new live case that fails under the old order. Frontend: **not built or tested locally** — this worktree has no `node_modules` and the frontend package changed on main, so CI's frontend job is the first real check. Changes there are a reorder, one deleted duplicate and its import.
