### PR TITLE
fix(identity): stop minting persons no account can be bound to

### DIFF
--- a/docs/components/backend/identity-resolution/openapi.json
+++ b/docs/components/backend/identity-resolution/openapi.json
@@ -1214,7 +1214,7 @@
             ]
           },
           "kind": {
-            "description": "`contested` | `binding_conflict` | `provisioned_at_login` |\n`minted_from_roster` | `no_evidence`.",
+            "description": "`contested` | `binding_conflict` | `provisioned_at_login` |\n`minted_from_roster` | `no_source_id` | `no_evidence`.",
             "type": "string"
           },
           "manager_email": {
@@ -1267,6 +1267,10 @@
             "minimum": 0,
             "type": "integer"
           },
+          "no_source_id": {
+            "minimum": 0,
+            "type": "integer"
+          },
           "observed": {
             "minimum": 0,
             "type": "integer"
@@ -1280,6 +1284,7 @@
           "observed",
           "bound",
           "pending",
+          "no_source_id",
           "no_evidence",
           "excluded"
         ],

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -679,7 +679,7 @@ pub struct AttentionParams {
 #[derive(Debug, Serialize, ToSchema)]
 pub struct QueueItemResponse {
     /// `contested` | `binding_conflict` | `provisioned_at_login` |
-    /// `minted_from_roster` | `no_evidence`.
+    /// `minted_from_roster` | `no_source_id` | `no_evidence`.
     pub kind: String,
     pub source: String,
     pub source_id: Uuid,
@@ -773,6 +773,7 @@ pub struct ResolutionRatesResponse {
     pub observed: usize,
     pub bound: usize,
     pub pending: usize,
+    pub no_source_id: usize,
     pub no_evidence: usize,
     pub excluded: usize,
 }
@@ -860,6 +861,7 @@ pub async fn attention(
             observed: review.rates.observed,
             bound: review.rates.bound,
             pending: review.rates.pending,
+            no_source_id: review.rates.no_source_id,
             no_evidence: review.rates.no_evidence,
             excluded: review.rates.excluded,
         },
@@ -1304,6 +1306,7 @@ fn kind_label(kind: ItemKind) -> &'static str {
         ItemKind::BindingConflict => "binding_conflict",
         ItemKind::ProvisionedAtLogin => "provisioned_at_login",
         ItemKind::MintedFromRoster => "minted_from_roster",
+        ItemKind::NoSourceId => "no_source_id",
         ItemKind::NoEvidence => "no_evidence",
     }
 }
@@ -1343,6 +1346,7 @@ async fn build_review(state: &AppState, tenant: Uuid) -> Result<(Review, bool), 
             username: e.username,
             description: e.description,
             is_closed: e.is_closed,
+            states_binding_id: e.states_binding_id,
         })
         .collect();
 
@@ -1401,6 +1405,7 @@ mod tests {
             (ItemKind::BindingConflict, "binding_conflict"),
             (ItemKind::ProvisionedAtLogin, "provisioned_at_login"),
             (ItemKind::MintedFromRoster, "minted_from_roster"),
+            (ItemKind::NoSourceId, "no_source_id"),
             (ItemKind::NoEvidence, "no_evidence"),
         ] {
             assert_eq!(kind_label(kind), expected, "wrong label for {kind:?}");

--- a/src/backend/services/identity-resolution/src/api/resolution.rs
+++ b/src/backend/services/identity-resolution/src/api/resolution.rs
@@ -24,7 +24,7 @@ use crate::domain::person_card::{self, PersonCard};
 use crate::domain::resolution::{self, EXCLUDED_PERSON, Target, Verb};
 use crate::domain::review_queue::{self, EvidenceAccount, ItemKind, Review};
 use crate::domain::seed::{KnownBinding, SourceAccountKey};
-use crate::infra::db::{ops_repo, persons_repo, resolution_repo};
+use crate::infra::db::{ops_repo, persons_repo, resolution_repo, seed_repo};
 use crate::infra::identity_evidence::{
     AccountEvidence, AfterAccount, ClickHouseEvidenceReader, EvidenceSnapshot, ListedAccount,
 };
@@ -1350,8 +1350,15 @@ async fn build_review(state: &AppState, tenant: Uuid) -> Result<(Review, bool), 
         })
         .collect();
 
+    // The seed's own map, not one derived from the evidence: an address stays
+    // claimed after the account that carried it closes, and the seed still
+    // attaches new accounts to that person. See `review_queue::build`.
+    let claimed_addresses = seed_repo::latest_email_to_person(&state.db, tenant)
+        .await
+        .map_err(|e| internal(&e, "failed to read claimed addresses"))?;
+
     Ok((
-        review_queue::build(observed, &bindings.by_account),
+        review_queue::build(observed, &bindings.by_account, &claimed_addresses),
         truncated,
     ))
 }

--- a/src/backend/services/identity-resolution/src/domain/login_bootstrap.rs
+++ b/src/backend/services/identity-resolution/src/domain/login_bootstrap.rs
@@ -153,6 +153,13 @@ pub fn decide(
     // person minted first takes the binding, and the seed then reads the group
     // as a conflict between two persons with no operator decision to settle it
     // — it keeps both, so one human stays split until somebody merges by hand.
+    //
+    // The deferral is to the batch OR to the operator, not to the batch alone:
+    // where the account's source states no id, no seed run can bind it either
+    // (`seed::resolve_assignments`), and it waits on the review queue as
+    // `no_source_id` instead. Refusing here is still right — a login may not
+    // decide who a claimed address belongs to — but nothing about the refusal
+    // promises automation will.
     if observed.email.is_some() {
         return Err(Refusal::Addressed);
     }

--- a/src/backend/services/identity-resolution/src/domain/review_queue.rs
+++ b/src/backend/services/identity-resolution/src/domain/review_queue.rs
@@ -33,13 +33,13 @@ pub enum ItemKind {
     /// may duplicate one already on the roster under a different account, and
     /// only an operator can say which it is.
     MintedFromRoster,
-    /// The account has evidence to match on, but no connector states an id for
-    /// it AND no bound account shares its address — so no seed run can reach it
-    /// from either side. Only an operator, or a sign-in through the account,
-    /// can decide it, which is why it belongs on the queue rather than in
-    /// `pending`. An id-less account whose address IS already held stays in
-    /// `pending`: the seed folds it into that person, and its activity resolves
-    /// through the sibling's binding.
+    /// No route to a person exists for the account: no connector states an id
+    /// to write a binding from, and nobody holds its address for the seed to
+    /// fold it into. Only an operator, or a sign-in through the account, can
+    /// decide it — which is why it belongs on the queue rather than in
+    /// `pending`. An id-less account whose address IS held stays in `pending`:
+    /// the seed attaches it to that person, and its activity resolves through
+    /// the binding that person already has.
     NoSourceId,
     /// The account carries no identity evidence automation can match on —
     /// e-mail is the only matching key today, so a username-only account is
@@ -116,7 +116,15 @@ pub struct EvidenceAccount {
     pub states_binding_id: bool,
 }
 
-/// Build the review from folded evidence and current bindings.
+/// Build the review from folded evidence, current bindings, and the addresses
+/// the persons journal already names an owner for.
+///
+/// `claimed_addresses` is the seed's own `email -> person` map, passed in rather
+/// than re-derived: it is the second of the two routes automation has to a
+/// person, and it reaches further than the evidence does — an address stays
+/// claimed after the account that carried it closes or leaves the roster.
+/// Deriving it from evidence instead would queue accounts the next seed run
+/// resolves by itself.
 ///
 /// Closed accounts are skipped entirely: their latest evidence event is a
 /// closure, so there is nothing to decide. Everything else is classified in one
@@ -125,6 +133,7 @@ pub struct EvidenceAccount {
 pub fn build(
     evidence: Vec<EvidenceAccount>,
     bindings: &HashMap<SourceAccountKey, KnownBinding>,
+    claimed_addresses: &HashMap<String, Uuid>,
 ) -> Review {
     let active: Vec<EvidenceAccount> = evidence.into_iter().filter(|e| !e.is_closed).collect();
 
@@ -157,11 +166,14 @@ pub fn build(
                 if candidates.len() > 1 {
                     rates.pending += 1;
                     items.push(item(ItemKind::Contested, account, None, candidates));
-                } else if !account.states_binding_id && candidates.is_empty() {
+                } else if !account.states_binding_id
+                    && candidates.is_empty()
+                    && !address_is_claimed(account, claimed_addresses)
+                {
                     // Neither route to a person exists: the source states no id
-                    // to write a binding from, and no bound account shares the
-                    // address to fold it into. Every later run answers the same,
-                    // so an operator is the only way out.
+                    // to write a binding from, and nobody holds the address to
+                    // fold it into. Every later run answers the same, so an
+                    // operator is the only way out.
                     rates.no_source_id += 1;
                     items.push(item(ItemKind::NoSourceId, account, None, candidates));
                 } else {
@@ -262,6 +274,23 @@ fn candidates_for(
 // invisible forever: pending, never surfaced, never auto-bound.
 fn has_matchable_evidence(account: &EvidenceAccount) -> bool {
     account.email.is_some()
+}
+
+/// Whether the persons journal already names an owner for this account's
+/// address — the seed's second route to a person (`resolve_assignments` step 2,
+/// its `claimed_by`).
+///
+/// INVARIANT: the lookup mirrors that one exactly — same normalization, the
+/// same map as handed to the seed, and the same sentinel exclusion. Answering
+/// it differently here would either hide an account the seed skips or queue one
+/// the seed resolves; both are states nobody can see from the other side.
+fn address_is_claimed(account: &EvidenceAccount, claimed: &HashMap<String, Uuid>) -> bool {
+    account
+        .email
+        .as_deref()
+        .map(normalize_email)
+        .and_then(|email| claimed.get(&email).copied())
+        .is_some_and(|person| person != EXCLUDED_PERSON)
 }
 
 /// The item an already-bound account earns, when its binding still awaits a
@@ -393,7 +422,11 @@ mod tests {
         let mut bindings = HashMap::new();
         bindings.insert(account("bamboohr", "e-1"), roster_bound(7));
 
-        let review = build(vec![described("bamboohr", "e-1", "Sam Example")], &bindings);
+        let review = build(
+            vec![described("bamboohr", "e-1", "Sam Example")],
+            &bindings,
+            &HashMap::new(),
+        );
 
         assert_eq!(review.items.len(), 1);
         assert_eq!(review.items[0].kind, ItemKind::MintedFromRoster);
@@ -427,7 +460,11 @@ mod tests {
             },
         );
 
-        let review = build(vec![observed("bamboohr", "e-1", None)], &bindings);
+        let review = build(
+            vec![observed("bamboohr", "e-1", None)],
+            &bindings,
+            &HashMap::new(),
+        );
 
         assert!(
             review.items.is_empty(),
@@ -443,6 +480,7 @@ mod tests {
         let review = build(
             vec![observed("bamboohr", "e-1", Some("sam@example.com"))],
             &bindings,
+            &HashMap::new(),
         );
 
         assert!(
@@ -484,6 +522,7 @@ mod tests {
                 orphan,
             ],
             &bindings,
+            &HashMap::new(),
         );
 
         let kinds: Vec<ItemKind> = review.items.iter().map(|i| i.kind).collect();
@@ -520,6 +559,7 @@ mod tests {
                 Some("sam@corp.com"),
             )],
             &HashMap::new(),
+            &HashMap::new(),
         );
 
         assert_eq!(review.items.len(), 1);
@@ -534,6 +574,7 @@ mod tests {
         // the operator for a decision automation is about to make.
         let review = build(
             vec![observed("bamboohr", "e-1", Some("sam@corp.com"))],
+            &HashMap::new(),
             &HashMap::new(),
         );
 
@@ -553,11 +594,44 @@ mod tests {
         let mut bindings = HashMap::new();
         bindings.insert(held.account.clone(), seed_bound(17));
 
-        let review = build(vec![held, claim], &bindings);
+        let review = build(vec![held, claim], &bindings, &HashMap::new());
 
         assert!(review.items.is_empty(), "got {:?}", review.items);
         assert_eq!(review.rates.no_source_id, 0);
         assert_eq!(review.rates.pending, 1, "the claim waits on the next run");
+    }
+
+    #[test]
+    fn an_address_the_journal_already_owns_keeps_its_account_with_automation() {
+        // The account that carried this address has closed, so it is out of the
+        // evidence and no candidate can be derived from it — but the journal
+        // still names its person, and the seed attaches this new account to them
+        // on its next run. Deriving the answer from evidence alone would queue
+        // an account automation resolves by itself, and keep queueing it.
+        let claim = without_source_id("github-commit-email", "sam@corp.com", Some("Sam@Corp.com"));
+        let mut claimed = HashMap::new();
+        claimed.insert("sam@corp.com".to_owned(), Uuid::from_u128(17));
+
+        let review = build(vec![claim], &HashMap::new(), &claimed);
+
+        assert!(review.items.is_empty(), "got {:?}", review.items);
+        assert_eq!(review.rates.no_source_id, 0);
+        assert_eq!(review.rates.pending, 1);
+    }
+
+    #[test]
+    fn an_address_held_only_by_the_excluded_sentinel_is_held_by_nobody() {
+        // An exclusion is not a person: the seed drops such an account before
+        // any linking decision, so it reaches the mint branch, which now skips
+        // it — the account really does need an operator.
+        let claim = without_source_id("github-commit-email", "bot@corp.com", Some("bot@corp.com"));
+        let mut claimed = HashMap::new();
+        claimed.insert("bot@corp.com".to_owned(), EXCLUDED_PERSON);
+
+        let review = build(vec![claim], &HashMap::new(), &claimed);
+
+        assert_eq!(review.items.len(), 1);
+        assert_eq!(review.items[0].kind, ItemKind::NoSourceId);
     }
 
     #[test]
@@ -576,7 +650,7 @@ mod tests {
         bindings.insert(a.account.clone(), seed_bound(17));
         bindings.insert(b.account.clone(), seed_bound(23));
 
-        let review = build(vec![a, b, claim.clone()], &bindings);
+        let review = build(vec![a, b, claim.clone()], &bindings, &HashMap::new());
 
         let claim_items: Vec<ItemKind> = review
             .items
@@ -593,7 +667,11 @@ mod tests {
 
     #[test]
     fn accounts_without_identity_evidence_are_surfaced_not_hidden() {
-        let review = build(vec![observed("jira", "jr-1", None)], &HashMap::new());
+        let review = build(
+            vec![observed("jira", "jr-1", None)],
+            &HashMap::new(),
+            &HashMap::new(),
+        );
 
         assert_eq!(review.items.len(), 1);
         assert_eq!(review.items[0].kind, ItemKind::NoEvidence);
@@ -609,7 +687,7 @@ mod tests {
         let mut orphan = observed("github", "gh-1", None);
         orphan.username = Some("octocat".to_owned());
 
-        let review = build(vec![orphan], &HashMap::new());
+        let review = build(vec![orphan], &HashMap::new(), &HashMap::new());
 
         assert_eq!(review.items.len(), 1);
         assert_eq!(review.items[0].kind, ItemKind::NoEvidence);
@@ -624,6 +702,7 @@ mod tests {
         // bound by a person or by nobody, and a person needs to recognise one.
         let review = build(
             vec![described("bamboohr", "921", "Ann Lee")],
+            &HashMap::new(),
             &HashMap::new(),
         );
 
@@ -647,7 +726,11 @@ mod tests {
         bindings.insert(anna.account.clone(), seed_bound(5));
         bindings.insert(boris.account.clone(), operator_bound(6));
 
-        let review = build(vec![anna, boris, newcomer.clone()], &bindings);
+        let review = build(
+            vec![anna, boris, newcomer.clone()],
+            &bindings,
+            &HashMap::new(),
+        );
 
         let contested: Vec<&QueueItem> = review
             .items
@@ -672,7 +755,7 @@ mod tests {
         bindings.insert(anna.account.clone(), seed_bound(5));
         bindings.insert(boris.account.clone(), operator_bound(6));
 
-        let review = build(vec![anna, boris], &bindings);
+        let review = build(vec![anna, boris], &bindings, &HashMap::new());
 
         assert!(
             !review
@@ -697,6 +780,7 @@ mod tests {
                 observed("chat", "2", Some("a@example.com")),
             ],
             &bindings,
+            &HashMap::new(),
         );
 
         let hr: Vec<&QueueItem> = review
@@ -718,7 +802,11 @@ mod tests {
         let mut bindings = HashMap::new();
         bindings.insert(account("github", "gh-1"), login_bound(7));
 
-        let review = build(vec![observed("github", "gh-1", None)], &bindings);
+        let review = build(
+            vec![observed("github", "gh-1", None)],
+            &bindings,
+            &HashMap::new(),
+        );
 
         assert_eq!(review.items.len(), 1);
         assert_eq!(review.items[0].kind, ItemKind::ProvisionedAtLogin);
@@ -744,7 +832,11 @@ mod tests {
             },
         );
 
-        let review = build(vec![observed("github", "gh-1", None)], &bindings);
+        let review = build(
+            vec![observed("github", "gh-1", None)],
+            &bindings,
+            &HashMap::new(),
+        );
 
         assert!(
             review.items.is_empty(),
@@ -754,7 +846,11 @@ mod tests {
 
     #[test]
     fn an_unbound_queue_item_is_bound_to_nobody() {
-        let review = build(vec![observed("jira", "jr-1", None)], &HashMap::new());
+        let review = build(
+            vec![observed("jira", "jr-1", None)],
+            &HashMap::new(),
+            &HashMap::new(),
+        );
 
         assert_eq!(review.items[0].bound_to, None);
     }
@@ -767,7 +863,7 @@ mod tests {
         bindings.insert(a.account.clone(), seed_bound(17));
         bindings.insert(b.account.clone(), seed_bound(23));
 
-        let review = build(vec![a, b], &bindings);
+        let review = build(vec![a, b], &bindings, &HashMap::new());
 
         let conflicts: Vec<&QueueItem> = review
             .items
@@ -790,8 +886,12 @@ mod tests {
         bindings.insert(a.account.clone(), seed_bound(17));
         bindings.insert(b.account.clone(), seed_bound(23));
 
-        let first = build(vec![a.clone(), b.clone(), orphan.clone()], &bindings);
-        let again = build(vec![orphan, b, a], &bindings);
+        let first = build(
+            vec![a.clone(), b.clone(), orphan.clone()],
+            &bindings,
+            &HashMap::new(),
+        );
+        let again = build(vec![orphan, b, a], &bindings, &HashMap::new());
 
         assert_eq!(
             first.items, again.items,
@@ -804,7 +904,7 @@ mod tests {
         let mut closed = observed("github", "gh-9", None);
         closed.is_closed = true;
 
-        let review = build(vec![closed], &HashMap::new());
+        let review = build(vec![closed], &HashMap::new(), &HashMap::new());
 
         assert!(
             review.items.is_empty(),
@@ -826,7 +926,7 @@ mod tests {
             },
         );
 
-        let review = build(vec![bot], &bindings);
+        let review = build(vec![bot], &bindings, &HashMap::new());
 
         assert!(review.items.is_empty());
         assert_eq!(review.rates.excluded, 1);

--- a/src/backend/services/identity-resolution/src/domain/review_queue.rs
+++ b/src/backend/services/identity-resolution/src/domain/review_queue.rs
@@ -34,9 +34,12 @@ pub enum ItemKind {
     /// only an operator can say which it is.
     MintedFromRoster,
     /// The account has evidence to match on, but no connector states an id for
-    /// it, so no seed run can write it a binding however well its address
-    /// matches. Only an operator — or a sign-in through the account — can bind
-    /// it, which is why it belongs on the queue rather than in `pending`.
+    /// it AND no bound account shares its address — so no seed run can reach it
+    /// from either side. Only an operator, or a sign-in through the account,
+    /// can decide it, which is why it belongs on the queue rather than in
+    /// `pending`. An id-less account whose address IS already held stays in
+    /// `pending`: the seed folds it into that person, and its activity resolves
+    /// through the sibling's binding.
     NoSourceId,
     /// The account carries no identity evidence automation can match on —
     /// e-mail is the only matching key today, so a username-only account is
@@ -154,17 +157,18 @@ pub fn build(
                 if candidates.len() > 1 {
                     rates.pending += 1;
                     items.push(item(ItemKind::Contested, account, None, candidates));
-                } else if !account.states_binding_id {
-                    // No source-stated id, so the seed has nothing to write a
-                    // binding from — however well the address matches, no run
-                    // will ever bind it. Surfaced with whatever candidate the
-                    // address does name, so the decision is one click.
+                } else if !account.states_binding_id && candidates.is_empty() {
+                    // Neither route to a person exists: the source states no id
+                    // to write a binding from, and no bound account shares the
+                    // address to fold it into. Every later run answers the same,
+                    // so an operator is the only way out.
                     rates.no_source_id += 1;
                     items.push(item(ItemKind::NoSourceId, account, None, candidates));
                 } else {
-                    // The source states an id and the address names at most one
-                    // person, so the next seed run binds it — not the
-                    // operator's problem yet.
+                    // Automation still has a route: either the source states an
+                    // id it can bind, or one person already holds the address and
+                    // the seed folds this account into them. Not the operator's
+                    // problem yet.
                     rates.pending += 1;
                 }
             }
@@ -536,6 +540,24 @@ mod tests {
         assert!(review.items.is_empty());
         assert_eq!(review.rates.pending, 1);
         assert_eq!(review.rates.no_source_id, 0);
+    }
+
+    #[test]
+    fn an_id_less_account_whose_address_is_already_held_stays_with_automation() {
+        // The seed folds it into the person holding the address, and its
+        // activity resolves through that person's own binding — so showing it
+        // would ask an operator to confirm what automation already did, forever.
+        let held = observed("bamboohr", "e-1", Some("sam@corp.com"));
+        let claim = without_source_id("github-commit-email", "sam@corp.com", Some("sam@corp.com"));
+
+        let mut bindings = HashMap::new();
+        bindings.insert(held.account.clone(), seed_bound(17));
+
+        let review = build(vec![held, claim], &bindings);
+
+        assert!(review.items.is_empty(), "got {:?}", review.items);
+        assert_eq!(review.rates.no_source_id, 0);
+        assert_eq!(review.rates.pending, 1, "the claim waits on the next run");
     }
 
     #[test]

--- a/src/backend/services/identity-resolution/src/domain/review_queue.rs
+++ b/src/backend/services/identity-resolution/src/domain/review_queue.rs
@@ -33,6 +33,11 @@ pub enum ItemKind {
     /// may duplicate one already on the roster under a different account, and
     /// only an operator can say which it is.
     MintedFromRoster,
+    /// The account has evidence to match on, but no connector states an id for
+    /// it, so no seed run can write it a binding however well its address
+    /// matches. Only an operator — or a sign-in through the account — can bind
+    /// it, which is why it belongs on the queue rather than in `pending`.
+    NoSourceId,
     /// The account carries no identity evidence automation can match on —
     /// e-mail is the only matching key today, so a username-only account is
     /// here too (shown with its username). Visible, never hidden: nothing
@@ -79,6 +84,9 @@ pub struct ResolutionRates {
     pub observed: usize,
     pub bound: usize,
     pub pending: usize,
+    /// Unbound accounts no seed run can bind — an operator decision is the only
+    /// way out. Counted apart from `pending`, which promises the opposite.
+    pub no_source_id: usize,
     pub no_evidence: usize,
     pub excluded: usize,
 }
@@ -98,6 +106,11 @@ pub struct EvidenceAccount {
     pub username: Option<String>,
     pub description: AccountDescription,
     pub is_closed: bool,
+    /// A connector states an account id for it — the seed's only route to a
+    /// binding. See [`AccountEvidence::states_binding_id`].
+    ///
+    /// [`AccountEvidence::states_binding_id`]: crate::infra::identity_evidence::AccountEvidence::states_binding_id
+    pub states_binding_id: bool,
 }
 
 /// Build the review from folded evidence and current bindings.
@@ -141,9 +154,16 @@ pub fn build(
                 if candidates.len() > 1 {
                     rates.pending += 1;
                     items.push(item(ItemKind::Contested, account, None, candidates));
+                } else if !account.states_binding_id {
+                    // No source-stated id, so the seed has nothing to write a
+                    // binding from — however well the address matches, no run
+                    // will ever bind it. Surfaced with whatever candidate the
+                    // address does name, so the decision is one click.
+                    rates.no_source_id += 1;
+                    items.push(item(ItemKind::NoSourceId, account, None, candidates));
                 } else {
-                    // One candidate or none: the account has an e-mail, so
-                    // automation will bind it on its next run — not the
+                    // The source states an id and the address names at most one
+                    // person, so the next seed run binds it — not the
                     // operator's problem yet.
                     rates.pending += 1;
                 }
@@ -294,6 +314,9 @@ mod tests {
         }
     }
 
+    /// The ordinary case: a connector states an id for the account, so the seed
+    /// can bind it. The accounts that state none are built by
+    /// [`without_source_id`].
     fn observed(source_type: &str, id: &str, email: Option<&str>) -> EvidenceAccount {
         EvidenceAccount {
             account: account(source_type, id),
@@ -301,6 +324,14 @@ mod tests {
             username: None,
             description: AccountDescription::default(),
             is_closed: false,
+            states_binding_id: true,
+        }
+    }
+
+    fn without_source_id(source_type: &str, id: &str, email: Option<&str>) -> EvidenceAccount {
+        EvidenceAccount {
+            states_binding_id: false,
+            ..observed(source_type, id, email)
         }
     }
 
@@ -427,6 +458,9 @@ mod tests {
         let newcomer = observed("slack", "slk-1", Some("shared@example.com"));
         let login = observed("github", "gh-9", None);
         let roster = observed("bamboohr", "e-1", None);
+        // Addressed, unbound, and its source states no id: the seed can never
+        // bind it, so it ranks above the accounts nothing describes at all.
+        let unbindable = without_source_id("gitlab", "gl-1", Some("solo@example.com"));
         let orphan = observed("zoom", "z-1", None);
 
         let mut bindings = HashMap::new();
@@ -436,7 +470,15 @@ mod tests {
         bindings.insert(roster.account.clone(), roster_bound(37));
 
         let review = build(
-            vec![contested_a, contested_b, newcomer, login, roster, orphan],
+            vec![
+                contested_a,
+                contested_b,
+                newcomer,
+                login,
+                roster,
+                unbindable,
+                orphan,
+            ],
             &bindings,
         );
 
@@ -455,9 +497,76 @@ mod tests {
                 ItemKind::BindingConflict,
                 ItemKind::ProvisionedAtLogin,
                 ItemKind::MintedFromRoster,
+                ItemKind::NoSourceId,
                 ItemKind::NoEvidence,
             ],
         );
+    }
+
+    #[test]
+    fn an_account_whose_source_states_no_id_is_queued_not_left_to_automation() {
+        // `pending` promises the next seed run will bind it. Nothing can: the
+        // binding row is written from a source-stated id, and this account has
+        // none — so leaving it there hides it from the only party who can
+        // resolve it, forever.
+        let review = build(
+            vec![without_source_id(
+                "github-commit-email",
+                "sam@corp.com",
+                Some("sam@corp.com"),
+            )],
+            &HashMap::new(),
+        );
+
+        assert_eq!(review.items.len(), 1);
+        assert_eq!(review.items[0].kind, ItemKind::NoSourceId);
+        assert_eq!(review.rates.no_source_id, 1);
+        assert_eq!(review.rates.pending, 0, "it is not waiting on automation");
+    }
+
+    #[test]
+    fn a_source_stated_id_keeps_an_unbound_account_off_the_queue() {
+        // The counterpart: the seed WILL bind this one, so showing it would ask
+        // the operator for a decision automation is about to make.
+        let review = build(
+            vec![observed("bamboohr", "e-1", Some("sam@corp.com"))],
+            &HashMap::new(),
+        );
+
+        assert!(review.items.is_empty());
+        assert_eq!(review.rates.pending, 1);
+        assert_eq!(review.rates.no_source_id, 0);
+    }
+
+    #[test]
+    fn a_contested_address_outranks_a_missing_source_id() {
+        // Both conditions hold; the operator needs the more specific one — which
+        // person claims it — and the candidate list that comes with it.
+        let a = observed("github", "gh-1", Some("shared@example.com"));
+        let b = observed("jira", "jr-1", Some("shared@example.com"));
+        let claim = without_source_id(
+            "github-commit-email",
+            "shared@example.com",
+            Some("shared@example.com"),
+        );
+
+        let mut bindings = HashMap::new();
+        bindings.insert(a.account.clone(), seed_bound(17));
+        bindings.insert(b.account.clone(), seed_bound(23));
+
+        let review = build(vec![a, b, claim.clone()], &bindings);
+
+        let claim_items: Vec<ItemKind> = review
+            .items
+            .iter()
+            .filter(|i| i.account == claim.account)
+            .map(|i| i.kind)
+            .collect();
+        assert!(
+            claim_items.contains(&ItemKind::Contested),
+            "expected the contested kind for the claim-only account, got {claim_items:?}"
+        );
+        assert_eq!(review.rates.no_source_id, 0);
     }
 
     #[test]

--- a/src/backend/services/identity-resolution/src/domain/seed.rs
+++ b/src/backend/services/identity-resolution/src/domain/seed.rs
@@ -300,28 +300,31 @@ pub fn resolve_assignments(
             continue;
         }
 
-        // 3/4. No binding, no email match — mint only if some account here
-        //      states an id the seed can bind. Without one the person would be a
-        //      bag of observations no account belongs to, and no later run could
-        //      fix that: the queue surfaces the account for an operator instead.
+        // 3/4. No binding and no email match. A wholly-closed group creates no
+        //      person — tested first, because a closed account never reaches the
+        //      review queue and counting it as unbindable would promise operator
+        //      work that never appears there.
+        if !group.profiles.iter().any(|p| !p.is_closed) {
+            out.skipped_closed += group.profiles.len();
+            continue;
+        }
+
+        //      Mint only if some account here states an id the seed can bind.
+        //      Without one the person would be a bag of observations no account
+        //      belongs to, and no later run could fix that: the queue surfaces
+        //      the account for an operator instead.
         if !group.profiles.iter().any(states_a_bindable_id) {
             out.skipped_no_source_id += group.profiles.len();
             continue;
         }
 
-        //      Mint only if at least one profile is active; a wholly-closed
-        //      group creates no person.
-        if group.profiles.iter().any(|p| !p.is_closed) {
-            out.minted += group.profiles.len();
-            let person_id = mint();
-            out.assignments.push(PersonAssignment {
-                person_id,
-                kind: AssignmentKind::Minted,
-                profiles: group.profiles,
-            });
-        } else {
-            out.skipped_closed += group.profiles.len();
-        }
+        out.minted += group.profiles.len();
+        let person_id = mint();
+        out.assignments.push(PersonAssignment {
+            person_id,
+            kind: AssignmentKind::Minted,
+            profiles: group.profiles,
+        });
     }
 
     out
@@ -1321,6 +1324,28 @@ mod tests {
         assert_eq!(out.minted, 0, "no person for an account nothing can bind");
         assert_eq!(out.skipped_no_source_id, 1);
         assert!(out.assignments.is_empty());
+    }
+
+    #[test]
+    fn a_closed_id_less_group_is_counted_closed_not_unbindable() {
+        // Closed accounts never reach the review queue, so counting one as
+        // unbindable would promise operator work that never shows up there.
+        let mut gone = claim_only("github-commit-email", "gone@corp.com", "gone@corp.com");
+        gone.is_closed = true;
+
+        let out = resolve_without_roster(
+            group_by_email(vec![gone]),
+            &HashMap::new(),
+            &HashMap::new(),
+            counter(),
+        );
+
+        assert_eq!(out.skipped_closed, 1);
+        assert_eq!(
+            out.skipped_no_source_id, 0,
+            "closure is the reason, not the id"
+        );
+        assert_eq!(out.minted, 0);
     }
 
     #[test]

--- a/src/backend/services/identity-resolution/src/domain/seed.rs
+++ b/src/backend/services/identity-resolution/src/domain/seed.rs
@@ -130,6 +130,10 @@ pub struct ResolveOutcome {
     pub minted: usize,
     pub skipped_closed: usize,
     pub skipped_no_email: usize,
+    /// Accounts left unbound because no connector states an id for them. Minting
+    /// a person here would create one no account can ever belong to; the review
+    /// queue surfaces the account instead.
+    pub skipped_no_source_id: usize,
     /// Email groups whose accounts are bound to *more than one* person with no
     /// operator-authored binding explaining it. Each account keeps its own
     /// binding (never collapsed); the group is counted + logged for review.
@@ -296,8 +300,17 @@ pub fn resolve_assignments(
             continue;
         }
 
-        // 3/4. No binding, no email match — mint only if at least one profile is
-        //      active; a wholly-closed group creates no person.
+        // 3/4. No binding, no email match — mint only if some account here
+        //      states an id the seed can bind. Without one the person would be a
+        //      bag of observations no account belongs to, and no later run could
+        //      fix that: the queue surfaces the account for an operator instead.
+        if !group.profiles.iter().any(states_a_bindable_id) {
+            out.skipped_no_source_id += group.profiles.len();
+            continue;
+        }
+
+        //      Mint only if at least one profile is active; a wholly-closed
+        //      group creates no person.
         if group.profiles.iter().any(|p| !p.is_closed) {
             out.minted += group.profiles.len();
             let person_id = mint();
@@ -626,6 +639,9 @@ mod tests {
         resolve_assignments(groups, known, email_to_person, None, mint)
     }
 
+    /// A profile as a connector describes one: it states its own account id,
+    /// which is what becomes the binding row. Use [`claim_only`] for an account
+    /// whose connector states none.
     fn prof(source_type: &str, account_id: &str, email: Option<&str>, closed: bool) -> SeedProfile {
         SeedProfile {
             account: SourceAccountKey {
@@ -635,8 +651,30 @@ mod tests {
             },
             latest_email: email.map(str::to_owned),
             is_closed: closed,
-            observations: Vec::new(),
+            observations: vec![input(
+                source_type,
+                account_id,
+                BINDING_VALUE_TYPE,
+                account_id,
+                false,
+                epoch(),
+            )],
         }
+    }
+
+    /// An account a connector only makes claims ABOUT — an address, a name —
+    /// without stating an account id: the shape with no route to a binding.
+    fn claim_only(source_type: &str, account_id: &str, email: &str) -> SeedProfile {
+        let mut profile = prof(source_type, account_id, Some(email), false);
+        profile.observations = vec![input(
+            source_type,
+            account_id,
+            "email",
+            email,
+            false,
+            epoch(),
+        )];
+        profile
     }
 
     /// A minting factory yielding Uuid(1), Uuid(2), … deterministically.
@@ -1130,8 +1168,10 @@ mod tests {
         let t: DateTime = "2026-01-01T00:00:00".parse()?;
         // Anna across two sources sharing an email; empty persons → mint once.
         let profiles = build_profiles(vec![
+            input("bamboohr", "5001", "id", "5001", false, t),
             input("bamboohr", "5001", "email", "anna@corp.com", false, t),
             input("bamboohr", "5001", "display_name", "Anna P", false, t),
+            input("slack", "U777", "id", "U777", false, t),
             input("slack", "U777", "email", "anna@corp.com", false, t),
         ]);
         let out = resolve_without_roster(
@@ -1161,17 +1201,9 @@ mod tests {
 
     /// An addressless profile whose source states the account's own id — what a
     /// roster emits, and the shape roster minting requires.
+    /// An addressless roster profile: it states its id and nothing else.
     fn rostered(source_type: &str, account_id: &str, closed: bool) -> SeedProfile {
-        let mut profile = prof(source_type, account_id, None, closed);
-        profile.observations = vec![input(
-            source_type,
-            account_id,
-            BINDING_VALUE_TYPE,
-            account_id,
-            false,
-            epoch(),
-        )];
-        profile
+        prof(source_type, account_id, None, closed)
     }
 
     #[test]
@@ -1266,6 +1298,49 @@ mod tests {
         assert_eq!(out.minted_from_roster, 0);
         assert_eq!(out.skipped_closed, 1);
         assert!(out.assignments.is_empty());
+    }
+
+    #[test]
+    fn an_account_that_states_no_id_is_not_minted_on_the_address_path_either() {
+        // The same rule as the roster path below, on the address-matched branch.
+        // An account whose connector states no id has no route to a binding, so
+        // a person minted here is one no account can ever belong to: invisible
+        // to every later run, and left for an operator to repair. The review
+        // queue surfaces the account instead.
+        let out = resolve_without_roster(
+            group_by_email(vec![claim_only(
+                "github-commit-email",
+                "sam@corp.com",
+                "sam@corp.com",
+            )]),
+            &HashMap::new(),
+            &HashMap::new(),
+            counter(),
+        );
+
+        assert_eq!(out.minted, 0, "no person for an account nothing can bind");
+        assert_eq!(out.skipped_no_source_id, 1);
+        assert!(out.assignments.is_empty());
+    }
+
+    #[test]
+    fn a_group_still_mints_when_any_of_its_accounts_states_an_id() {
+        // The person is anchored by the account that CAN be bound; the
+        // claim-only account rides along on the shared address rather than
+        // holding the group back.
+        let out = resolve_without_roster(
+            group_by_email(vec![
+                prof("bamboohr", "1", Some("anna@corp.com"), false),
+                claim_only("github-commit-email", "anna@corp.com", "anna@corp.com"),
+            ]),
+            &HashMap::new(),
+            &HashMap::new(),
+            counter(),
+        );
+
+        assert_eq!(out.minted, 2, "both accounts join the minted person");
+        assert_eq!(out.skipped_no_source_id, 0);
+        assert_eq!(out.assignments.len(), 1, "one person for the address");
     }
 
     #[test]

--- a/src/backend/services/identity-resolution/src/domain/seed_service.rs
+++ b/src/backend/services/identity-resolution/src/domain/seed_service.rs
@@ -73,6 +73,9 @@ pub struct SeedSummary {
     pub skipped_closed: usize,
     #[serde(rename = "accounts_skipped_no_email")]
     pub skipped_no_email: usize,
+    /// Accounts no connector states an id for — left unbound, never minted.
+    #[serde(rename = "accounts_skipped_no_source_id")]
+    pub skipped_no_source_id: usize,
     pub observations_inserted: u64,
     pub org_chart_rows_rebuilt: u64,
     /// Divergent e-mail groups with no operator-authored binding (surfaced).
@@ -153,6 +156,7 @@ where
         minted: outcome.minted,
         skipped_closed: outcome.skipped_closed,
         skipped_no_email: outcome.skipped_no_email,
+        skipped_no_source_id: outcome.skipped_no_source_id,
         observations_inserted: counts.observations_inserted,
         org_chart_rows_rebuilt: counts.org_chart_rows_rebuilt,
         known_binding_conflicts: outcome.known_binding_conflicts,
@@ -274,10 +278,16 @@ mod tests {
     async fn seed_from_rows_wires_pipeline_end_to_end() -> anyhow::Result<()> {
         let t: DateTime = "2026-01-01T00:00:00".parse()?;
         // Anna across two sources (shared email) + Boris; empty store → all mint.
+        // Every account states its own id, as a connector's identity inputs do:
+        // that row is what becomes the binding, and without one the seed mints
+        // nobody.
         let rows = vec![
+            input("bamboohr", "5001", "id", "5001", t),
             input("bamboohr", "5001", "email", "anna@corp.com", t),
             input("bamboohr", "5001", "display_name", "Anna P", t),
+            input("slack", "U777", "id", "U777", t),
             input("slack", "U777", "email", "anna@corp.com", t),
+            input("bamboohr", "5000", "id", "5000", t),
             input("bamboohr", "5000", "email", "boris@corp.com", t),
         ];
         let store = FakeStore {
@@ -302,8 +312,9 @@ mod tests {
         );
         assert_eq!(summary.reused_known, 0);
         assert_eq!(summary.linked_by_email, 0);
-        // Anna: email+display_name (5001) + email (U777) = 3; Boris: email = 1.
-        assert_eq!(summary.observations_inserted, 4);
+        // Anna: id+email+display_name (5001) + id+email (U777) = 5;
+        // Boris: id+email = 2.
+        assert_eq!(summary.observations_inserted, 7);
         Ok(())
     }
 

--- a/src/backend/services/identity-resolution/src/infra/identity_evidence.rs
+++ b/src/backend/services/identity-resolution/src/infra/identity_evidence.rs
@@ -13,6 +13,7 @@ use insight_clickhouse::{Client, Config};
 use serde::Deserialize;
 use uuid::Uuid;
 
+use crate::domain::login_bootstrap::MAX_VALUE_ID_CHARS;
 use crate::domain::review_queue::AccountDescription;
 use crate::domain::seed::SourceAccountKey;
 
@@ -64,7 +65,8 @@ pub struct EvidenceSnapshot {
 ///
 /// No ORDER BY: both readers wrap this and order it their own way, and a sort
 /// here would be thrown away by one of them.
-const FOLD_SQL: &str = r"
+/// The fold, with `{MAX_ID_CHARS}` still to substitute — [`fold_sql`] does it.
+const FOLD_SQL_TEMPLATE: &str = r"
     SELECT
         ifNull(insight_source_type, '')                 AS source_type,
         ifNull(toString(insight_source_id), '')         AS source_id,
@@ -109,11 +111,20 @@ const FOLD_SQL: &str = r"
         argMaxIf(
             ifNull(value, ''), (_synced_at, _version),
             value_type = 'id' AND operation_type = 'UPSERT' AND value != ''
+            AND lengthUTF8(value) <= {MAX_ID_CHARS}
         )                                               AS binding_id
     FROM identity.identity_inputs
     WHERE source_account_id IS NOT NULL AND source_account_id != ''
     GROUP BY source_type, source_id, account_id
 ";
+
+/// INVARIANT: the id cap is the seed's, not a second opinion. `route_value`
+/// DROPS an over-long `id`, so the seed reads such an account as stating none;
+/// a fold that called it bindable would classify it `pending` and hide from the
+/// operator the one account nothing will ever bind.
+fn fold_sql() -> String {
+    FOLD_SQL_TEMPLATE.replace("{MAX_ID_CHARS}", &MAX_VALUE_ID_CHARS.to_string())
+}
 
 /// The fold's own columns, named rather than `SELECT *`: the row struct is
 /// decoded positionally, so a reordered or added fold column would otherwise
@@ -280,8 +291,9 @@ impl ClickHouseEvidenceReader {
         // ceiling over an unordered read takes whichever rows arrive first, so
         // two reads could describe different subsets and the rates would move
         // with no data behind it.
+        let fold = fold_sql();
         let sql = format!(
-            "SELECT {FOLD_COLUMNS}, '' AS order_label FROM ({FOLD_SQL}) \
+            "SELECT {FOLD_COLUMNS}, '' AS order_label FROM ({fold}) \
              ORDER BY source_type, source_id, account_id LIMIT {MAX_EVIDENCE_ACCOUNTS}"
         );
         let rows: Vec<FoldedRow> = match self.client.query(&sql).fetch_all().await {
@@ -424,7 +436,7 @@ fn list_sql(filtered: bool, resuming: bool) -> String {
     // be substituted after the resume clause is spliced in.
     LIST_SQL
         .replace("{COLUMNS}", FOLD_COLUMNS)
-        .replace("{FOLD}", FOLD_SQL)
+        .replace("{FOLD}", &fold_sql())
         .replace("{FILTER}", if filtered { FILTER_SQL } else { "" })
         .replace("{RESUME}", if resuming { RESUME_SQL } else { "" })
         .replace("{LABEL}", ORDER_LABEL_SQL)
@@ -610,6 +622,30 @@ fn non_empty(value: String) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn the_fold_reads_a_stated_id_as_bindable_and_a_missing_one_as_not() -> anyhow::Result<()> {
+        assert!(map_row(folded("UPSERT", "sam@corp.com", "sam"))?.states_binding_id);
+
+        let mut silent = folded("UPSERT", "sam@corp.com", "sam");
+        silent.binding_id = String::new();
+        assert!(
+            !map_row(silent)?.states_binding_id,
+            "an account no connector states an id for is not bindable"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn the_fold_caps_the_id_at_the_seed_s_limit() {
+        // `route_value` DROPS an over-long id, so the seed reads such an account
+        // as stating none. A fold that called it bindable would classify it
+        // `pending` and hide the one account nothing will ever bind.
+        assert!(
+            fold_sql().contains(&format!("lengthUTF8(value) <= {MAX_VALUE_ID_CHARS}")),
+            "the fold must carry the seed's cap, not a second opinion"
+        );
+    }
 
     fn folded(latest_op: &str, email: &str, username: &str) -> FoldedRow {
         FoldedRow {

--- a/src/backend/services/identity-resolution/src/infra/identity_evidence.rs
+++ b/src/backend/services/identity-resolution/src/infra/identity_evidence.rs
@@ -29,6 +29,10 @@ pub struct AccountEvidence {
     /// The account's latest event is a closure signal — it is deactivated at
     /// the source and must not be surfaced for review.
     pub is_closed: bool,
+    /// A connector states an account id for it, so the persons-seed can write
+    /// a binding. False means no seed run ever will: the only paths left are an
+    /// operator decision and a sign-in through the account.
+    pub states_binding_id: bool,
 }
 
 /// The whole evidence read, with the one fact about the read itself a consumer
@@ -101,7 +105,11 @@ const FOLD_SQL: &str = r"
         argMaxIf(
             ifNull(value, ''), (_synced_at, _version),
             value_type = 'parent_email' AND operation_type = 'UPSERT' AND value != ''
-        )                                               AS manager_email
+        )                                               AS manager_email,
+        argMaxIf(
+            ifNull(value, ''), (_synced_at, _version),
+            value_type = 'id' AND operation_type = 'UPSERT' AND value != ''
+        )                                               AS binding_id
     FROM identity.identity_inputs
     WHERE source_account_id IS NOT NULL AND source_account_id != ''
     GROUP BY source_type, source_id, account_id
@@ -111,7 +119,8 @@ const FOLD_SQL: &str = r"
 /// decoded positionally, so a reordered or added fold column would otherwise
 /// mis-decode in silence.
 const FOLD_COLUMNS: &str = "source_type, source_id, account_id, latest_op, email, username, \
-     display_name, first_name, last_name, job_title, department, status, manager_email";
+     display_name, first_name, last_name, job_title, department, status, manager_email, \
+     binding_id";
 
 /// The name a source sends in parts, as [`compose_name`] assembles it. The
 /// order key needs it because a row described by parts alone still shows one.
@@ -197,6 +206,9 @@ struct FoldedRow {
     department: String,
     status: String,
     manager_email: String,
+    /// The `value_type='id'` value the source itself states for this account
+    /// (ADR-0002's binding row). Empty when no connector emits one.
+    binding_id: String,
     /// The listing's order key, computed by the query so no second definition
     /// of it can drift from the one that sorted the rows. Empty on reads that
     /// do not order (the whole-tenant fold).
@@ -401,6 +413,7 @@ fn map_row(row: FoldedRow) -> anyhow::Result<AccountEvidence> {
         username: non_empty(row.username),
         description,
         is_closed: row.latest_op == "DELETE",
+        states_binding_id: !row.binding_id.trim().is_empty(),
     })
 }
 
@@ -613,6 +626,7 @@ mod tests {
             department: String::new(),
             status: String::new(),
             manager_email: String::new(),
+            binding_id: "gh-1".to_owned(),
             order_label: String::new(),
         }
     }

--- a/src/frontend/src/api/identity-client.ts
+++ b/src/frontend/src/api/identity-client.ts
@@ -123,7 +123,7 @@ export interface PersonSummary {
 /** One account awaiting an operator decision. */
 export interface AttentionItem {
   /** `contested` | `binding_conflict` | `provisioned_at_login` |
-   *  `minted_from_roster` | `no_evidence` — open vocabulary. */
+   *  `minted_from_roster` | `no_source_id` | `no_evidence` — open vocabulary. */
   kind: string;
   source: string;
   source_id: string;
@@ -149,6 +149,8 @@ export interface ResolutionRates {
   observed: number;
   bound: number;
   pending: number;
+  /** Unbound accounts no seed run can bind — an operator decides, or nobody. */
+  no_source_id: number;
   no_evidence: number;
   excluded: number;
 }

--- a/src/frontend/src/components/portal/identities-view.test.tsx
+++ b/src/frontend/src/components/portal/identities-view.test.tsx
@@ -96,7 +96,7 @@ import { portalRouter } from "@/test/portal-router";
 
 import { IdentitiesView } from "./identities-view";
 
-const RATES = { observed: 60, bound: 55, pending: 3, no_evidence: 1, excluded: 1 };
+const RATES = { observed: 60, bound: 55, pending: 3, no_source_id: 1, no_evidence: 1, excluded: 1 };
 
 function item(over: Partial<AttentionItem>): AttentionItem {
   return {
@@ -623,6 +623,31 @@ describe("IdentitiesView", () => {
     ).toBeInTheDocument();
     // Its own group, not the catch-all: an unknown kind falls into "Needs
     // review", which is exactly what dropping it from KIND_ORDER would do.
+    expect(screen.queryByText(/needs review/i)).not.toBeInTheDocument();
+  });
+
+  it("gives an account no source states an id for its own group", () => {
+    // It is not waiting on automation — nothing will ever bind it — so it must
+    // read as the operator's work, not fall into the catch-all.
+    attention.q.data = {
+      items: [
+        item({
+          kind: "no_source_id",
+          account_id: "sam@example.com",
+          email: "sam@example.com",
+          username: null,
+          display_name: "Sam Rivera",
+          bound_to: null,
+          candidates: [],
+        }),
+      ],
+      rates: RATES,
+    };
+    render(<IdentitiesView />);
+
+    expect(
+      screen.getByText(/the source names no account of its own/i),
+    ).toBeInTheDocument();
     expect(screen.queryByText(/needs review/i)).not.toBeInTheDocument();
   });
 

--- a/src/frontend/src/components/portal/identities-view.tsx
+++ b/src/frontend/src/components/portal/identities-view.tsx
@@ -78,6 +78,7 @@ const KIND_ORDER = [
   "binding_conflict",
   "provisioned_at_login",
   "minted_from_roster",
+  "no_source_id",
   "no_evidence",
 ] as const;
 

--- a/src/frontend/src/locales/en/translation.json
+++ b/src/frontend/src/locales/en/translation.json
@@ -419,6 +419,7 @@
       "binding_conflict": "Binding conflicts — evidence disagrees with the current binding",
       "provisioned_at_login": "Given a person at first sign-in — not yet confirmed",
       "minted_from_roster": "Added from the roster without an address — not yet confirmed",
+      "no_source_id": "The source names no account of its own — only an operator can bind these",
       "no_evidence": "No address to match on — only an operator can bind these",
       "other": "Needs review"
     },

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -797,7 +797,7 @@ export const handlers = [
           candidates: [],
         },
       ],
-      rates: { observed: 60, bound: 55, pending: 3, no_evidence: 2, excluded: 1 },
+      rates: { observed: 60, bound: 55, pending: 3, no_source_id: 0, no_evidence: 2, excluded: 1 },
       truncated: false,
       items_truncated: false,
     });

--- a/src/frontend/src/queries/identity-resolution.test.tsx
+++ b/src/frontend/src/queries/identity-resolution.test.tsx
@@ -93,7 +93,7 @@ describe("useBindAccount cache behavior", () => {
     const { queryClient, wrapper } = harness();
     queryClient.setQueryData(ATTENTION_KEY, {
       items: [item("a1"), item("a2")],
-      rates: { persons: 2, observed: 2, bound: 0, pending: 2, no_evidence: 0, excluded: 0 },
+      rates: { persons: 2, observed: 2, bound: 0, pending: 2, no_source_id: 0, no_evidence: 0, excluded: 0 },
     });
     bindAccount.mockResolvedValueOnce(outcome("applied"));
 
@@ -117,7 +117,7 @@ describe("useBindAccount cache behavior", () => {
     const { queryClient, wrapper } = harness();
     queryClient.setQueryData(ATTENTION_KEY, {
       items: [item("a1")],
-      rates: { persons: 1, observed: 1, bound: 0, pending: 1, no_evidence: 0, excluded: 0 },
+      rates: { persons: 1, observed: 1, bound: 0, pending: 1, no_source_id: 0, no_evidence: 0, excluded: 0 },
     });
     bindAccount.mockResolvedValueOnce(outcome("refused"));
 
@@ -383,7 +383,7 @@ describe("the prune across cached limits", () => {
     for (const key of [ATTENTION_KEY, longer]) {
       queryClient.setQueryData(key, {
         items: [item("a1"), item("a2")],
-        rates: { persons: 2, observed: 2, bound: 0, pending: 2, no_evidence: 0, excluded: 0 },
+        rates: { persons: 2, observed: 2, bound: 0, pending: 2, no_source_id: 0, no_evidence: 0, excluded: 0 },
       });
     }
     bindAccount.mockResolvedValue(outcome("applied"));
@@ -410,7 +410,7 @@ describe("useAttention", () => {
   it("asks the service for the limit it is keyed on", async () => {
     vi.mocked(identityClient.getAttention).mockResolvedValue({
       items: [],
-      rates: { observed: 0, bound: 0, pending: 0, no_evidence: 0, excluded: 0 },
+      rates: { observed: 0, bound: 0, pending: 0, no_source_id: 0, no_evidence: 0, excluded: 0 },
     });
     const { queryClient, wrapper } = harness();
 
@@ -431,7 +431,7 @@ describe("useAttention", () => {
   it("keeps the shorter answer on screen while the longer one is read", async () => {
     vi.mocked(identityClient.getAttention).mockResolvedValue({
       items: [],
-      rates: { observed: 0, bound: 0, pending: 0, no_evidence: 0, excluded: 0 },
+      rates: { observed: 0, bound: 0, pending: 0, no_source_id: 0, no_evidence: 0, excluded: 0 },
     });
     const { queryClient, wrapper } = harness();
     const { result, rerender } = renderHook(({ limit }) => useAttention(limit), {
@@ -453,7 +453,7 @@ describe("useAttention", () => {
     expect(result.current.isPlaceholderData).toBe(true);
     resolve({
       items: [],
-      rates: { observed: 0, bound: 0, pending: 0, no_evidence: 0, excluded: 0 },
+      rates: { observed: 0, bound: 0, pending: 0, no_source_id: 0, no_evidence: 0, excluded: 0 },
     });
     await waitFor(() => expect(result.current.isPlaceholderData).toBe(false));
     queryClient.clear();

--- a/src/ingestion/connectors/git/github/README.md
+++ b/src/ingestion/connectors/git/github/README.md
@@ -105,11 +105,14 @@ Three things to know before deploying:
   accounts, and a member with no published e-mail can end up as two persons.
   The id comes from the Secret's `insight.cyberfabric.com/source-id`
   annotation, so this is a deployment decision, not a code one.
-- **An unmatched active account is minted as a new person.** An outside
-  contributor, or a member committing under an address no roster carries,
-  becomes a fresh person and shows up in the seed's `accounts_minted_new`
-  counter. Merging a minted person into the right one (or excluding it) is the
-  operator's manual-resolution workflow, and an operator-authored binding wins
+- **An unmatched active account is not minted a person — it is queued.** This
+  connector states no account id (see the last point), so the seed has nothing
+  to write a binding from: minting here would create a person no account can
+  ever belong to. An outside contributor, or a member committing under an
+  address no roster carries, is instead counted under
+  `accounts_skipped_no_source_id` and surfaced on the operator's review queue
+  as `no_source_id`. Binding it to the right person (or excluding it as a bot)
+  is the manual-resolution workflow, and an operator-authored binding wins
   every later seed.
 - **Only `value_type='email'` rows are emitted, never the `value_type='id'`
   binding.** Bindings are the seed's decision to make; emitting them here

--- a/src/ingestion/tests/e2e/identity/test_operator_corrections.py
+++ b/src/ingestion/tests/e2e/identity/test_operator_corrections.py
@@ -196,7 +196,14 @@ def test_the_queue_reports_items_and_rates_over_observed_accounts(identity_svc, 
     rates = body["rates"]
     assert rates["observed"] >= rates["bound"] + rates["excluded"], rates
     for item in body["items"]:
-        assert item["kind"] in {"contested", "binding_conflict", "no_evidence"}, item
+        assert item["kind"] in {
+            "contested",
+            "binding_conflict",
+            "provisioned_at_login",
+            "minted_from_roster",
+            "no_source_id",
+            "no_evidence",
+        }, item
 
 
 def test_the_queue_honours_the_limit_without_narrowing_the_rates(identity_svc, api: httpx.Client) -> None:

--- a/tests/stand/api/identity/test_resolution.py
+++ b/tests/stand/api/identity/test_resolution.py
@@ -245,10 +245,11 @@ def test_account_search_finds_a_seeded_account_and_names_its_holder(
 def test_the_queue_answers_with_coherent_tenant_wide_rates(
     admin_operator_session: PersonaSession,
 ) -> None:
-    """`rates` counts every observed account, and the states partition it:
-    an account is bound, pending, evidence-less or excluded — never two at
-    once and never none. A sum mismatch means the fold dropped or
-    double-counted accounts, which the UI would show as a lying match rate.
+    """`rates` counts every observed account, and the states partition it: an
+    account is bound, pending, unbindable without an operator, evidence-less or
+    excluded — never two at once and never none. A sum mismatch means the fold
+    dropped or double-counted accounts, which the UI would show as a lying
+    match rate.
     """
     response = admin_operator_session.client.get(ATTENTION)
     assert response.status_code == 200, f"{response.status_code} {response.text[:300]}"
@@ -261,9 +262,10 @@ def test_the_queue_answers_with_coherent_tenant_wide_rates(
     # this test requires materializes identity evidence for the roster, so a
     # seeded stand always has observed accounts.
     assert rates.observed > 0, f"a seeded stand reports zero observed accounts: {rates}"
-    assert rates.observed == rates.bound + rates.pending + rates.no_evidence + rates.excluded, (
-        f"resolution states do not partition the observed set: {rates}"
-    )
+    assert (
+        rates.observed
+        == rates.bound + rates.pending + rates.no_source_id + rates.no_evidence + rates.excluded
+    ), f"resolution states do not partition the observed set: {rates}"
     # Over distinct ACCOUNTS, and only the unbound ones. Two reasons the naive
     # count is not an invariant: an item can be a bound account still awaiting a
     # human (an automatic mint, which `rates` counts under `bound`), and one
@@ -276,7 +278,7 @@ def test_the_queue_answers_with_coherent_tenant_wide_rates(
         for item in queue.items
         if item.bound_to is None
     }
-    assert len(unbound_accounts) <= rates.pending + rates.no_evidence, (
+    assert len(unbound_accounts) <= rates.pending + rates.no_source_id + rates.no_evidence, (
         "more unbound accounts in the queue than undecided accounts"
     )
     assert queue.truncated is False, (

--- a/tests/stand/api/schemas/identity.py
+++ b/tests/stand/api/schemas/identity.py
@@ -341,7 +341,7 @@ class QueueItemResponse(BaseModel):
     display_name: str | None = Field(None, description='How the source describes the account. Nothing here is matchable — it is\nwhat lets an operator recognise whose account this is when automation\ncannot, which is exactly the case for the ones only they can bind.')
     email: str | None = None
     job_title: str | None = None
-    kind: str = Field(..., description='`contested` | `binding_conflict` | `provisioned_at_login` |\n`minted_from_roster` | `no_evidence`.')
+    kind: str = Field(..., description='`contested` | `binding_conflict` | `provisioned_at_login` |\n`minted_from_roster` | `no_source_id` | `no_evidence`.')
     manager_email: str | None = None
     source: str
     source_id: UUID
@@ -364,6 +364,7 @@ class ResolutionRatesResponse(BaseModel):
     bound: int = Field(..., ge=0)
     excluded: int = Field(..., ge=0)
     no_evidence: int = Field(..., ge=0)
+    no_source_id: int = Field(..., ge=0)
     observed: int = Field(..., ge=0)
     pending: int = Field(..., ge=0)
 


### PR DESCRIPTION
**Why.** The persons-seed minted a person for any addressed account, including those whose connector states no account id — the row a binding is written from. Nothing could ever bind such an account to the person it created, and the review queue hid the account too: its `pending` branch promises a next seed run that, for these, never comes.

**What changed.** The seed skips a group no account of which states a bindable id; the queue surfaces those accounts under a new `no_source_id` kind, with its own rates bucket so `pending` keeps its promise.

**An account automation can still reach stays out of the queue.** Either the source states an id, or the persons journal already names an owner for its address — the seed's own map, read exactly as `resolve_assignments` reads it, since two predicates for one question is what produced the bug.

**Out of scope.** Existing phantom persons; `persons` is append-only, so they need an operator merge or a wipe.

**Verified.** 310 crate tests, clippy, fmt; OpenAPI and stand schemas regenerated; frontend typecheck and lint. The `identities-view` suite needs a registry dep this machine cannot install — CI runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
