### PR TITLE
identity console: open a person in a window, and read the trail as events

### DIFF
--- a/src/frontend/src/components/portal/account-actions.test.tsx
+++ b/src/frontend/src/components/portal/account-actions.test.tsx
@@ -83,8 +83,10 @@ function binding(over: Partial<AccountBinding> = {}): AccountBinding {
 
 beforeEach(() => {
   for (const verb of [hooks.bind, hooks.detach, hooks.exclude]) {
-    verb.mutate.mockClear();
-    verb.reset.mockClear();
+    // Reset, not clear: `mockClear` keeps an implementation a case installed,
+    // and the outcomes wired mid-file would then fire in every case after them.
+    verb.mutate.mockReset();
+    verb.reset.mockReset();
     verb.isError = false;
     verb.error = null;
     verb.isPending = false;
@@ -168,6 +170,29 @@ describe("AccountActions", () => {
     expect(
       screen.queryByRole("button", { name: /carol chen/i }),
     ).not.toBeInTheDocument();
+  });
+
+  // A candidate is already named above with a Bind of their own; offering them
+  // in the search too would list the same decision twice.
+  it("keeps the candidates out of the search that names them already", async () => {
+    hooks.search.data = { pages: [{ items: [BOB, CAROL] }] };
+    render(
+      <AccountActions
+        accountRef={REF}
+        binding={binding({ person_id: null })}
+        candidates={[CAROL]}
+      />,
+    );
+
+    await userEvent.type(screen.getByRole("searchbox"), "chen");
+
+    // Named once, on the candidate row that carries her own Bind — and not
+    // offered a second time as a search hit.
+    expect(screen.getByText("Carol Chen")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /carol chen/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /bob park/i })).toBeInTheDocument();
   });
 
   // The search is the only way to a person this window does not already name.

--- a/src/frontend/src/components/portal/account-actions.test.tsx
+++ b/src/frontend/src/components/portal/account-actions.test.tsx
@@ -149,66 +149,16 @@ describe("AccountActions", () => {
     ).not.toBeInTheDocument();
   });
 
-  // Opened from inside a person: they are the whole reason the reader is here,
-  // so binding to them is one press and the search for a person is gone —
-  // finding somebody you already have open is being asked twice.
-  it("binds straight to the person the surface has open, with no search", async () => {
-    render(
-      <AccountActions
-        accountRef={REF}
-        binding={binding({ person_id: null })}
-        candidates={[]}
-        bindTo={CAROL}
-      />,
-    );
-
-    expect(screen.queryByRole("searchbox")).not.toBeInTheDocument();
-    await userEvent.click(
-      screen.getByRole("button", { name: /bind to selected person/i }),
-    );
-    await userEvent.click(screen.getByRole("button", { name: /^bind$/i }));
-
-    expect(hooks.bind.mutate).toHaveBeenCalledWith(
-      expect.objectContaining({ person_id: CAROL.person_id }),
-      expect.anything(),
-    );
-  });
-
-  // A press that re-binds an account to the person who already holds it reads
-  // like a decision and changes nothing. Moving it to somebody ELSE is the one
-  // decision left, and it is why an operator opens an account from a person's
-  // own list — so the search takes the button's place rather than the section
-  // disappearing with it.
-  it("offers the search, not a no-op bind, when the account is already that person's", () => {
-    render(
-      <AccountActions
-        accountRef={REF}
-        binding={binding({ person_id: CAROL.person_id })}
-        candidates={[]}
-        bindTo={CAROL}
-      />,
-    );
-
-    expect(
-      screen.queryByRole("button", { name: /bind to selected person/i }),
-    ).not.toBeInTheDocument();
-    expect(screen.getByRole("searchbox")).toBeInTheDocument();
-    expect(screen.getByText(/assign to someone else/i)).toBeInTheDocument();
-    // The other verbs are untouched — it is still an account under review.
-    expect(screen.getByRole("button", { name: /detach/i })).toBeInTheDocument();
-  });
-
-  // The search that replaced the no-op button must not offer the no-op itself.
-  // No `holder` here on purpose: a surface whose row carries no person card
-  // still knows who holds the account, and that is the case this guards.
-  it("keeps the open person out of that search, card or no card", async () => {
+  // The holder is excluded from the search whether or not the surface could
+  // hydrate their card: a listing that carries no person card still knows the
+  // id, and without that the search offers a bind that moves nothing.
+  it("keeps the holder out of the search with no card to name them by", async () => {
     hooks.search.data = { pages: [{ items: [BOB, CAROL] }] };
     render(
       <AccountActions
         accountRef={REF}
         binding={binding({ person_id: CAROL.person_id })}
         candidates={[]}
-        bindTo={CAROL}
       />,
     );
 
@@ -220,17 +170,27 @@ describe("AccountActions", () => {
     ).not.toBeInTheDocument();
   });
 
-  // Without a person behind the window the picker is the only way in, and the
-  // accounts mode is entered with no person at all.
-  it("keeps the person search where no person is open", () => {
-    render(
+  // The search is the only way to a person this window does not already name.
+  // Binding to the person a SURFACE has open is not this window's job any more:
+  // the person window binds its own accounts, from the person's side.
+  it("offers the person search whatever the account's state", () => {
+    const { rerender } = render(
+      <AccountActions
+        accountRef={REF}
+        binding={binding({ person_id: null })}
+        candidates={[]}
+      />,
+    );
+
+    expect(screen.getByRole("searchbox")).toBeInTheDocument();
+    expect(screen.getByText(/assign to a person/i)).toBeInTheDocument();
+
+    rerender(
       <AccountActions accountRef={REF} binding={binding()} candidates={[]} />,
     );
 
     expect(screen.getByRole("searchbox")).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: /bind to/i }),
-    ).not.toBeInTheDocument();
+    expect(screen.getByText(/assign to someone else/i)).toBeInTheDocument();
   });
 
   // A detach mints a person and moves the account there. Taking somebody's ONLY
@@ -574,14 +534,11 @@ describe("AccountActions", () => {
       <AccountActions
         accountRef={REF}
         binding={binding({ person_id: null })}
-        candidates={[]}
-        bindTo={CAROL}
+        candidates={[CAROL]}
       />,
     );
 
-    await userEvent.click(
-      screen.getByRole("button", { name: /bind to selected person/i }),
-    );
+    await userEvent.click(screen.getByRole("button", { name: /^bind$/i }));
     expect(
       within(screen.getByRole("dialog")).queryByText(/leaves the queue/i),
     ).not.toBeInTheDocument();
@@ -593,14 +550,11 @@ describe("AccountActions", () => {
       <AccountActions
         accountRef={REF}
         binding={binding({ person_id: null })}
-        candidates={[]}
-        bindTo={CAROL}
+        candidates={[CAROL]}
         queued
       />,
     );
-    await userEvent.click(
-      screen.getByRole("button", { name: /bind to selected person/i }),
-    );
+    await userEvent.click(screen.getByRole("button", { name: /^bind$/i }));
     expect(
       within(screen.getByRole("dialog")).getByText(/leaves the queue/i),
     ).toBeInTheDocument();
@@ -614,14 +568,11 @@ describe("AccountActions", () => {
       <AccountActions
         accountRef={REF}
         binding={binding({ person_id: null })}
-        candidates={[]}
-        bindTo={CAROL}
+        candidates={[CAROL]}
       />,
     );
 
-    await userEvent.click(
-      screen.getByRole("button", { name: /bind to selected person/i }),
-    );
+    await userEvent.click(screen.getByRole("button", { name: /^bind$/i }));
     expect(
       within(screen.getByRole("dialog")).getByText(
         /^The account is bound to this person\.$/,
@@ -635,13 +586,10 @@ describe("AccountActions", () => {
       <AccountActions
         accountRef={REF}
         binding={binding({ person_id: BOB.person_id })}
-        candidates={[]}
-        bindTo={CAROL}
+        candidates={[CAROL]}
       />,
     );
-    await userEvent.click(
-      screen.getByRole("button", { name: /bind to selected person/i }),
-    );
+    await userEvent.click(screen.getByRole("button", { name: /^bind$/i }));
     expect(
       within(screen.getByRole("dialog")).getByText(/is re-bound to this person/i),
     ).toBeInTheDocument();

--- a/src/frontend/src/components/portal/account-actions.tsx
+++ b/src/frontend/src/components/portal/account-actions.tsx
@@ -31,7 +31,6 @@
  */
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { toast } from "@/components/ui/sonner";
 
 import type {
   AccountBinding,
@@ -40,14 +39,13 @@ import type {
   WireAccountRef,
 } from "@/api/identity-client";
 import { ConfirmDialog } from "@/components/confirm-dialog";
+import { OutcomeAlert } from "@/components/portal/outcome-alert";
 import { PersonCell } from "@/components/portal/person-cell";
 import { PersonId } from "@/components/portal/person-id";
 import { PersonPicker } from "@/components/portal/person-picker";
-import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { useCorrectionReport } from "@/hooks/use-correction-report";
 import type { AccountRef } from "@/lib/identities/account-key";
-import { fullyDecided, refusedCount } from "@/lib/identities/outcomes";
 import { apiErrorReason } from "@/lib/query-console/api-error";
 import {
   useBindAccount,
@@ -63,9 +61,6 @@ function SectionLabel({ children }: { children: React.ReactNode }) {
     </div>
   );
 }
-
-/** Long enough to read a UUID off and paste it somewhere. */
-const MINTED_ID_TOAST_MS = 15_000;
 
 /** Join the sentences a description is built from, skipping the absent ones. */
 function sentences(...parts: (string | null)[]): string {
@@ -83,7 +78,6 @@ export function AccountActions({
   binding,
   candidates,
   holder,
-  bindTo,
   queued = false,
   onDecided,
 }: {
@@ -95,16 +89,10 @@ export function AccountActions({
   /** Whoever holds it now, when the surface knows their card. */
   holder?: PersonSummary | null;
   /**
-   * The person the surface behind this window has open. Binding to them is then
-   * one press, and the search for a person is gone: the reader is already
-   * inside that person, so asking them to find them again is asking twice.
-   */
-  bindTo?: PersonSummary | null;
-  /**
    * This account really is on the review queue, so a verb really does take it
-   * off. The same window opens over settled accounts from the search and from a
-   * person's own list, and promising them the queue would describe a queue they
-   * were never in.
+   * off. The same window opens over settled accounts found in the accounts
+   * mode, and promising those the queue would describe a queue they were never
+   * in.
    */
   queued?: boolean;
   /**
@@ -117,6 +105,7 @@ export function AccountActions({
   const { t } = useTranslation();
   const [action, setAction] = useState<PendingAction>({ kind: "closed" });
   const [outcome, setOutcome] = useState<CorrectionResponse | null>(null);
+  const report = useCorrectionReport();
 
   const bind = useBindAccount();
   const detach = useDetachAccount();
@@ -174,38 +163,16 @@ export function AccountActions({
   };
   const done = (result: CorrectionResponse) => {
     close();
-
-    // Not "no refusals": the outcome vocabulary is open by contract, so a value
-    // this build has never heard of must not pass for success.
-    if (!fullyDecided(result)) {
+    if (!report(result)) {
       // The account kept its binding, so the window keeps its verbs: the
       // operator has something left to decide and needs the counters to see it.
       setOutcome(result);
-      const refused = refusedCount(result);
-      toast.error(
-        refused > 0
-          ? t("identities.outcomes.toast_refused", { count: refused })
-          : t("identities.dialogs.failed"),
-      );
       return;
     }
 
     // An earlier attempt's counters have nothing to say about this one. Today
     // `onDecided` unmounts this window, but the prop is optional.
     setOutcome(null);
-    const message =
-      result.applied > 0
-        ? t("identities.outcomes.toast_applied", { count: result.applied })
-        : t("identities.outcomes.toast_already");
-    // The minted person's id is the one thing a detach reports that nothing else
-    // on the page can name yet, and the window that used to hold it now closes —
-    // so the toast carrying it stays up long enough to be copied out.
-    toast.success(message, {
-      description: result.new_person_id
-        ? `${t("identities.outcomes.new_person")} ${result.new_person_id}`
-        : undefined,
-      duration: result.new_person_id ? MINTED_ID_TOAST_MS : undefined,
-    });
     onDecided?.();
   };
 
@@ -270,44 +237,25 @@ export function AccountActions({
         </section>
       ) : null}
 
-      {/* One section, two ways in. With a person open behind the window and the
-          account not yet theirs, one press is the whole decision — the reader
-          is already inside that person, and asking them to search for them
-          again is asking twice. Once the account IS theirs that press would
-          change nothing, so the search comes back: moving it to somebody else
-          is the only decision left, and it is exactly the one an operator
-          opened the account to make. */}
       <section>
-        <div className="mb-1.5 text-xs font-medium tracking-wide text-muted-foreground uppercase">
+        <SectionLabel>
           {boundId
             ? t("identities.actions.assign_other")
             : t("identities.actions.assign_person")}
-        </div>
-        {bindTo && boundId !== bindTo.person_id ? (
-          <Button
-            type="button"
-            size="sm"
-            disabled={busy}
-            onClick={() => setAction({ kind: "bind", person: bindTo })}
-          >
-            {t("identities.actions.bind_to")}
-          </Button>
-        ) : (
-          <PersonPicker
-            // The holder too: this picker moves an account to somebody else,
-            // and the one person it cannot move it to is the one who already
-            // has it. Named by ID rather than by card — a surface that could
-            // not hydrate the holder still knows who they are, and without
-            // this the search would offer a bind that moves nothing.
-            excludeIds={[
-              ...candidates.map((c) => c.person_id),
-              ...(boundCard ? [boundCard.person_id] : []),
-              ...(boundId ? [boundId] : []),
-              ...(bindTo ? [bindTo.person_id] : []),
-            ]}
-            onPick={(person) => setAction({ kind: "bind", person })}
-          />
-        )}
+        </SectionLabel>
+        <PersonPicker
+          // The holder too: this picker moves an account to somebody else, and
+          // the one person it cannot move it to is the one who already has it.
+          // Named by ID rather than by card — a surface that could not hydrate
+          // the holder still knows who they are, and without this the search
+          // would offer a bind that moves nothing.
+          excludeIds={[
+            ...candidates.map((c) => c.person_id),
+            ...(boundCard ? [boundCard.person_id] : []),
+            ...(boundId ? [boundId] : []),
+          ]}
+          onPick={(person) => setAction({ kind: "bind", person })}
+        />
       </section>
 
       <section className="flex flex-wrap gap-2">
@@ -413,37 +361,5 @@ export function AccountActions({
         />
       ) : null}
     </div>
-  );
-}
-
-/** The server's answer, verbatim — three counters, never a bare "done". */
-function OutcomeAlert({ outcome }: { outcome: CorrectionResponse }) {
-  const { t } = useTranslation();
-  const refused = outcome.items.filter((i) => i.outcome === "refused").length;
-  return (
-    <Alert variant={refused > 0 ? "destructive" : "default"} role="status">
-      <AlertTitle className="flex flex-wrap items-center gap-1.5">
-        <Badge variant="secondary">
-          {t("identities.outcomes.applied", { count: outcome.applied })}
-        </Badge>
-        {outcome.already_decided > 0 ? (
-          <Badge variant="outline">
-            {t("identities.outcomes.already_decided", {
-              count: outcome.already_decided,
-            })}
-          </Badge>
-        ) : null}
-        {refused > 0 ? (
-          <Badge variant="secondary" className="bg-destructive/15 text-destructive">
-            {t("identities.outcomes.refused", { count: refused })}
-          </Badge>
-        ) : null}
-      </AlertTitle>
-      {outcome.new_person_id ? (
-        <AlertDescription className="font-mono text-xs">
-          {t("identities.outcomes.new_person")} {outcome.new_person_id}
-        </AlertDescription>
-      ) : null}
-    </Alert>
   );
 }

--- a/src/frontend/src/components/portal/account-detail.test.tsx
+++ b/src/frontend/src/components/portal/account-detail.test.tsx
@@ -123,7 +123,7 @@ describe("AccountDetail", () => {
   // The resolver writes no reason at all — as an empty string, which is not
   // null, so a nullish fallback left the badge blank on every automatic entry.
   // Machine decision versus human decision is the one thing the badge carries.
-  it("says a reasonless entry was automatic instead of rendering a blank badge", () => {
+  it("says what a reasonless entry did instead of rendering a blank label", () => {
     binding.q.data = bound({
       history: [
         {
@@ -137,7 +137,10 @@ describe("AccountDetail", () => {
     });
     render(<AccountDetail accountRef={REF} queueItem={queueItem()} />);
 
-    expect(screen.getByText(/automatic/i)).toBeInTheDocument();
+    expect(screen.getByText(/^linked$/i)).toBeInTheDocument();
+    // And who did it, on the other end of the same row: a blank there read as
+    // "unknown", when the answer is the resolver.
+    expect(screen.getByText(/by automation/i)).toBeInTheDocument();
   });
 
   // First-login provisioning mints the binding during the sign-in itself; an
@@ -181,16 +184,20 @@ describe("AccountDetail", () => {
     expect(screen.queryByText("roster-mint")).not.toBeInTheDocument();
   });
 
-  // The comment is the one thing no other record holds — why a human did
-  // this — and it was written to the operations journal from the first verb,
-  // never read back. The reach matters beside it: a merge lands one row here
-  // and one in every other account it moved.
-  it("shows the operator call behind a decision: who, why and how far", () => {
+  // The comment is the one thing no binding row holds — why a human did this —
+  // and it lives only on the call. The call is not a row of its own: it is
+  // journalled once and returned on every account it named, so beside the row
+  // it produced it said the same thing twice, with a reach counted over other
+  // accounts.
+  it("carries the comment onto the decision it explains, without a row for the call", () => {
     binding.q.data = bound({
       history: [
         {
           person_id: BOB.person_id,
           author_person_id: CAROL.person_id,
+          // The service hydrates the author on the binding row too, so losing
+          // the call's row loses no name.
+          author: CAROL,
           by_operator: true,
           reason: "operator-merge",
           recorded_at: "2026-08-01T10:15:00.000000",
@@ -212,13 +219,36 @@ describe("AccountDetail", () => {
     render(<AccountDetail accountRef={REF} queueItem={queueItem()} />);
 
     expect(screen.getByText(/same person — confirmed with HR/i)).toBeInTheDocument();
-    expect(screen.getByText(/12 accounts in this call/i)).toBeInTheDocument();
     expect(screen.getAllByText(/Carol Chen/).length).toBeGreaterThan(0);
-    expect(screen.getByText("applied")).toBeInTheDocument();
+    // One event, one row — and nothing about the other eleven accounts the
+    // call moved, or about a call whose own outcome is not this account's.
+    expect(screen.getAllByRole("listitem")).toHaveLength(1);
+    expect(screen.queryByText(/12 accounts/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("applied")).not.toBeInTheDocument();
   });
 
   // The service resolves the people a trail names, so an entry pointing at
   // somebody who is not a candidate stops being a bare id.
+  // The seed writes this literal for a binding it made by matching the address;
+  // unmapped, the row rendered the raw code at the reader.
+  it("names the resolver's own link instead of printing its code", () => {
+    binding.q.data = bound({
+      history: [
+        {
+          person_id: BOB.person_id,
+          author_person_id: "00000000-0000-0000-0000-000000000000",
+          by_operator: false,
+          reason: "auto-seed-link",
+          recorded_at: "2026-07-01T10:15:00.000000",
+        },
+      ],
+    });
+    render(<AccountDetail accountRef={REF} queueItem={queueItem()} />);
+
+    expect(screen.getByText(/linked by address/i)).toBeInTheDocument();
+    expect(screen.queryByText("auto-seed-link")).not.toBeInTheDocument();
+  });
+
   it("names the person an entry points at, candidate or not", () => {
     binding.q.data = bound({
       history: [
@@ -250,10 +280,10 @@ describe("AccountDetail", () => {
     expect(screen.getByTestId("account-actions")).toBeInTheDocument();
   });
 
-  // The two records interleave by instant, newest first — an audit trail
-  // that reads backwards, or shuffles a call away from its decision, tells a
-  // false story. Ties keep the decision above its own call.
-  it("interleaves decisions and calls newest-first", () => {
+  // An audit trail that reads backwards tells a false story. And a call that
+  // moved nothing HERE — this one detached a different account of the same
+  // person — is not an event on this account's trail.
+  it("reads newest first, and lists no event for a call that moved nothing here", () => {
     binding.q.data = bound({
       history: [
         {
@@ -286,11 +316,13 @@ describe("AccountDetail", () => {
     });
     render(<AccountDetail accountRef={REF} queueItem={queueItem()} />);
 
-    const rows = screen.getAllByRole("listitem");
-    const texts = rows.map((row) => row.textContent ?? "");
+    const texts = screen
+      .getAllByRole("listitem")
+      .map((row) => row.textContent ?? "");
+    expect(texts).toHaveLength(2);
     expect(texts[0]).toMatch(/Bound/);
-    expect(texts[1]).toMatch(/Detached/);
-    expect(texts[2]).toMatch(/Automatic/);
+    expect(texts[1]).toMatch(/Linked/);
+    expect(texts.join(" ")).not.toMatch(/Detached/);
   });
 
   it("reads an off-queue empty journal as a stale link, offering no verbs", () => {

--- a/src/frontend/src/components/portal/account-detail.tsx
+++ b/src/frontend/src/components/portal/account-detail.tsx
@@ -13,15 +13,15 @@
  * or decided answers 200 with an empty journal, so "not in the queue, no
  * binding, no history" is the stale-link state — it says so instead of
  * offering verbs whose bind would pre-register a typo as a real account.
- * The trail keeps two records in one order: a binding row says what changed,
- * an operator call says who ran it and why. They stay separate rows — one call
- * can move a dozen accounts, and folding it into this account's row would
- * invent a link the journal does not record.
+ *
+ * The trail is one row per event that changed something about THIS account.
+ * Both reads carry rows that changed nothing — a sync re-observing a binding
+ * that never moved, a call returned on every account it named — and
+ * `accountTrail` is where those are dropped.
  */
 import { useTranslation } from "react-i18next";
 
 import type {
-  AccountOperation,
   AttentionItem,
   BindingHistoryEntry,
   PersonSummary,
@@ -34,6 +34,7 @@ import { ComingSoon } from "@/components/widgets/coming-soon";
 import type { AccountRef } from "@/lib/identities/account-key";
 import { isQueueItem } from "@/lib/identities/cases";
 import { personDisplayName } from "@/lib/identities/person-display";
+import { accountTrail } from "@/lib/identities/trail";
 import { formatUtcAge, formatUtcInstant } from "@/lib/format";
 import { useAccountBinding } from "@/queries/identity-resolution";
 
@@ -45,6 +46,7 @@ const VERB_KEYS: Record<string, string> = {
   "operator-exclude": "identities.history.exclude",
   "login-bootstrap": "identities.history.login_bootstrap",
   "roster-mint": "identities.history.roster_mint",
+  "auto-seed-link": "identities.history.auto_seed_link",
 };
 
 export function AccountDetail({
@@ -113,6 +115,7 @@ export function AccountDetail({
     holder?.person_id === binding.data.person_id
       ? holder
       : candidates.find((c) => c.person_id === binding.data.person_id);
+  const events = accountTrail(binding.data.history, binding.data.operations);
 
   return (
     // One column, not two: the people are what an operator reads across, and
@@ -134,7 +137,7 @@ export function AccountDetail({
       </div>
       <section className="flex min-h-0 flex-1 flex-col">
         <SectionLabel>{t("identities.detail.history")}</SectionLabel>
-        {binding.data.history.length === 0 ? (
+        {events.length === 0 ? (
           <p className="text-sm text-muted-foreground">
             {t("identities.detail.no_history")}
           </p>
@@ -143,17 +146,14 @@ export function AccountDetail({
           // remaining space collapses to a sliver, and a one-line history is
           // unreadable. Below the floor the window itself scrolls.
           <ol className="flex min-h-48 flex-1 flex-col gap-2 overflow-y-auto pe-1">
-            {trail(binding.data.history, binding.data.operations).map((row) =>
-              row.kind === "decision" ? (
-                <HistoryRow
-                  key={row.key}
-                  entry={row.entry}
-                  known={boundCard ? [...candidates, boundCard] : candidates}
-                />
-              ) : (
-                <OperationRow key={row.key} operation={row.operation} />
-              ),
-            )}
+            {events.map((event) => (
+              <HistoryRow
+                key={event.key}
+                entry={event.entry}
+                comment={event.comment}
+                known={boundCard ? [...candidates, boundCard] : candidates}
+              />
+            ))}
           </ol>
         )}
       </section>
@@ -161,99 +161,22 @@ export function AccountDetail({
   );
 }
 
-type TrailRow =
-  | { kind: "decision"; key: string; entry: BindingHistoryEntry }
-  | { kind: "call"; key: string; operation: AccountOperation };
-
-/**
- * The two records an account's past is kept in, in one order.
- *
- * A binding row says what changed; an operator call says who ran it and why.
- * They are deliberately not merged into one another — the call may have moved
- * a dozen other accounts, and claiming otherwise would invent a link the
- * journal does not record. Shown side by side in time, the pair reads itself.
- */
-function trail(
-  history: BindingHistoryEntry[],
-  operations: AccountOperation[] | undefined,
-): TrailRow[] {
-  const rows: TrailRow[] = [
-    ...history.map((entry, index) => ({
-      kind: "decision" as const,
-      key: `d-${entry.recorded_at}-${index}`,
-      entry,
-    })),
-    ...(operations ?? []).map((operation) => ({
-      kind: "call" as const,
-      key: `c-${operation.operation_id}`,
-      operation,
-    })),
-  ];
-  const at = (row: TrailRow) =>
-    row.kind === "decision" ? row.entry.recorded_at : row.operation.recorded_at;
-  return rows.sort((a, b) => at(b).localeCompare(at(a)));
-}
-
-function OperationRow({ operation }: { operation: AccountOperation }) {
-  const { t } = useTranslation();
-  const verbKey = VERB_KEYS[operation.verb];
-  return (
-    <li className="rounded-md border border-dashed p-2">
-      <div className="flex items-center gap-2">
-        <span className="text-xs font-medium">
-          {verbKey ? t(verbKey) : operation.verb}
-        </span>
-        <Badge variant="outline" className="font-normal">
-          {t("identities.history.call")}
-        </Badge>
-        {operation.accounts_touched > 1 ? (
-          <Badge variant="outline" className="font-normal">
-            {t("identities.history.accounts_touched", {
-              count: operation.accounts_touched,
-            })}
-          </Badge>
-        ) : null}
-        <span className="ms-auto text-xs text-muted-foreground">
-          {formatUtcInstant(operation.recorded_at, "d MMM yyyy, HH:mm")}
-          <span className="opacity-70">
-            {` (${formatUtcAge(operation.recorded_at)})`}
-          </span>
-        </span>
-      </div>
-      <div className="mt-1.5 flex flex-wrap items-center gap-x-1.5 text-xs text-muted-foreground">
-        <span>{t("identities.history.by")}</span>
-        {operation.author ? (
-          <span className="font-medium text-foreground">
-            {personDisplayName(operation.author)}
-          </span>
-        ) : null}
-        <PersonId id={operation.author_person_id} />
-        {operation.outcome ? (
-          <span className="ms-auto font-mono">{operation.outcome}</span>
-        ) : null}
-      </div>
-      {/* The one thing no other record holds: why a human did this. */}
-      {operation.comment ? (
-        <p className="mt-1.5 border-s-2 ps-2 text-xs text-foreground italic select-text">
-          {operation.comment}
-        </p>
-      ) : null}
-    </li>
-  );
-}
-
 function HistoryRow({
   entry,
+  comment,
   known,
 }: {
   entry: BindingHistoryEntry;
+  /** Why a human did this, when the call that did it could be named. */
+  comment?: string;
   /** Cards the surface already holds, to name a row the service left as an id. */
   known: PersonSummary[];
 }) {
   const { t } = useTranslation();
   // The resolver stores no reason for its own rows — as an empty string, not
-  // as null, so a nullish fallback leaves the badge blank on every automatic
-  // entry, which is most of them.
+  // as null, so a nullish fallback leaves the label blank on every row the seed
+  // wrote, which is most of them. It says what happened, not who did it: who is
+  // on the other end of the row.
   const reason = entry.reason?.trim() || undefined;
   const verbKey = reason ? VERB_KEYS[reason] : undefined;
   // The card the service resolved wins; whatever cards the surface already has
@@ -263,8 +186,13 @@ function HistoryRow({
   return (
     <li className="rounded-md border p-2">
       <div className="flex items-center gap-2">
-        <Badge variant={entry.by_operator ? "secondary" : "outline"}>
-          {verbKey ? t(verbKey) : (reason ?? t("identities.history.automatic"))}
+        {/* A line, not a plaque. Who decided it is already on the row in
+            words — an operator's name, or nothing — so a filled shape carried
+            nothing the reader could not already read, while the automatic rows
+            beside it rendered as bare text and the pair read as two different
+            kinds of thing. */}
+        <Badge variant="outline">
+          {verbKey ? t(verbKey) : (reason ?? t("identities.history.linked"))}
         </Badge>
         {/* The instant is what an operator compares between entries and pastes
             into a ticket; the age answers the question the trail is usually
@@ -284,16 +212,25 @@ function HistoryRow({
           </span>
         ) : null}
         <PersonId id={entry.person_id} />
-        {entry.by_operator ? (
-          <span className="ms-auto">
-            {entry.author
+        {/* Always answered. A blank here read as "unknown", and the one thing
+            an operator needs from a trail is whether a human or the resolver
+            put the account where it is. */}
+        <span className="ms-auto">
+          {!entry.by_operator
+            ? t("identities.history.by_automation")
+            : entry.author
               ? t("identities.history.by_name", {
                   name: personDisplayName(entry.author),
                 })
               : t("identities.history.by_operator")}
-          </span>
-        ) : null}
+        </span>
       </div>
+      {/* The one thing no binding row holds: why a human did this. */}
+      {comment ? (
+        <p className="mt-1.5 border-s-2 ps-2 text-xs text-foreground italic select-text">
+          {comment}
+        </p>
+      ) : null}
     </li>
   );
 }

--- a/src/frontend/src/components/portal/account-detail.tsx
+++ b/src/frontend/src/components/portal/account-detail.tsx
@@ -52,17 +52,16 @@ export function AccountDetail({
   queueItem,
   observed = false,
   holder,
-  bindTo,
   onDecided,
 }: {
   accountRef: AccountRef;
   /** The queue row for this account, when it is still in the queue — the
    *  source of hydrated candidate cards and observed evidence. */
   queueItem: AttentionItem | undefined;
-  /** The caller vouches the account exists (a queue row, a search hit, a
-   *  person's account list). Without a voucher, an account with no binding
-   *  and no history reads as a stale link — offering verbs there would let a
-   *  mistyped `?acct=` pre-register a typo as a real account. */
+  /** The caller vouches the account exists (a queue row, a search hit).
+   *  Without a voucher, an account with no binding and no history reads as a
+   *  stale link — offering verbs there would let a mistyped `?acct=`
+   *  pre-register a typo as a real account. */
   observed?: boolean;
   /**
    * Whoever holds the account, for the surfaces that know it without having any
@@ -71,8 +70,6 @@ export function AccountDetail({
    * queue's candidates.
    */
   holder?: PersonSummary | null;
-  /** Bind straight to the person the surface has open. See `AccountActions`. */
-  bindTo?: PersonSummary | null;
   /** A verb decided every account it named. See `AccountActions`. */
   onDecided?: () => void;
 }) {
@@ -129,10 +126,9 @@ export function AccountDetail({
           binding={binding.data}
           candidates={candidates}
           holder={boundCard ?? null}
-          // The accounts and persons modes reuse this window for settled
-          // accounts, and their rows carry a kind of the console's own making.
+          // The accounts mode reuses this window for settled accounts, and its
+          // rows carry a kind of the console's own making.
           queued={queueItem != null && isQueueItem(queueItem.kind)}
-          bindTo={bindTo}
           onDecided={onDecided}
         />
       </div>

--- a/src/frontend/src/components/portal/account-picker.test.tsx
+++ b/src/frontend/src/components/portal/account-picker.test.tsx
@@ -5,12 +5,13 @@
  * to search says so instead of going quiet; and every row names whoever holds
  * the account, since binding one somebody else holds takes it off them.
  */
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import "@/i18n";
 import type { AccountMatch } from "@/api/identity-client";
+import { scrollEndIntoView } from "@/test/intersection-observer";
 
 const hooks = vi.hoisted(() => ({
   search: {
@@ -63,6 +64,8 @@ function pick(over: { excludeKeys?: string[] } = {}) {
 
 const field = () => screen.getByRole("searchbox", { name: PLACEHOLDER });
 
+afterEach(() => vi.restoreAllMocks());
+
 beforeEach(() => {
   hooks.search.data = undefined;
   hooks.search.isFetching = false;
@@ -74,11 +77,16 @@ beforeEach(() => {
 });
 
 describe("AccountPicker", () => {
-  it("lists nothing until the field is asked something", () => {
+  it("lists nothing until the field is asked something", async () => {
     hooks.search.data = { pages: [{ items: [match()] }] };
     pick();
 
     expect(screen.queryByText("annlee")).not.toBeInTheDocument();
+    // And the same rows DO arrive once asked — without this the case passes for
+    // a picker that lists nothing ever.
+    await userEvent.type(field(), "annlee");
+
+    expect(screen.getByText("annlee")).toBeInTheDocument();
   });
 
   // The answer to "why is nothing happening" should not wait for a debounce.
@@ -95,7 +103,7 @@ describe("AccountPicker", () => {
     const onPick = pick();
 
     await userEvent.type(field(), "annlee");
-    await userEvent.click(screen.getByRole("button", { name: /^annlee$/ }));
+    await userEvent.click(screen.getByRole("button", { name: /^annlee,/ }));
 
     expect(onPick).toHaveBeenCalledWith(expect.objectContaining({ account_id: "zm-9" }));
   });
@@ -133,6 +141,111 @@ describe("AccountPicker", () => {
 
     expect(screen.queryByText("annlee")).not.toBeInTheDocument();
     expect(screen.getByText("other")).toBeInTheDocument();
+  });
+
+  // The rows answer the term the query key carries, not the one in the field,
+  // until the fetch lands. Marked rather than hidden, so the list does not
+  // blank between keystrokes — and never read as the answer.
+  it("marks the rows that still answer the previous term", async () => {
+    hooks.search.data = { pages: [{ items: [match()] }] };
+    hooks.search.isPlaceholderData = true;
+    pick();
+
+    await userEvent.type(field(), "annlee");
+
+    expect(screen.getByRole("list")).toHaveAttribute("aria-busy", "true");
+    expect(screen.getByText("annlee")).toBeInTheDocument();
+  });
+
+  // The marker asks for the next page, and it has to live INSIDE the scroller:
+  // an observer never reports a target that is not a descendant of its root.
+  it("asks for the next page when the end of the list comes into view", async () => {
+    hooks.search.data = { pages: [{ items: [match()] }] };
+    hooks.search.hasNextPage = true;
+    pick();
+
+    await userEvent.type(field(), "annlee");
+    scrollEndIntoView();
+
+    expect(hooks.search.fetchNextPage).toHaveBeenCalled();
+  });
+
+  // A page whose every row was filtered out has no rows to scroll, so the
+  // marker is the only thing left that can ask for the page that does.
+  it("keeps asking with every row filtered out", async () => {
+    hooks.search.data = { pages: [{ items: [match()] }] };
+    hooks.search.hasNextPage = true;
+    pick({ excludeKeys: ["zoom:01900000-0000-7000-8000-00000000aa03:zm-9"] });
+
+    await userEvent.type(field(), "annlee");
+    scrollEndIntoView();
+
+    expect(hooks.search.fetchNextPage).toHaveBeenCalled();
+  });
+
+  // Labelling an idle list "loading" is a lie the reader cannot dismiss.
+  it("says it is loading only while the next page is on its way", async () => {
+    hooks.search.data = { pages: [{ items: [match()] }] };
+    hooks.search.hasNextPage = true;
+    pick();
+    await userEvent.type(field(), "annlee");
+
+    expect(screen.queryByText(/loading/i)).not.toBeInTheDocument();
+  });
+
+  // Not a <button>: the holder's card carries its own copy control, and a
+  // button may neither nest one nor let its text be selected.
+  it("picks on Enter from the row, and not from a control inside it", async () => {
+    hooks.search.data = {
+      pages: [
+        {
+          items: [
+            match({
+              person: {
+                person_id: "01900000-0000-7000-8000-0000000000b0",
+                display_name: "Bob Park",
+              },
+            }),
+          ],
+        },
+      ],
+    };
+    const onPick = pick();
+    await userEvent.type(field(), "annlee");
+    const row = screen.getByRole("button", { name: /^annlee,/ });
+
+    await userEvent.click(within(row).getByRole("button", { name: /copy/i }));
+    expect(onPick).not.toHaveBeenCalled();
+
+    row.focus();
+    await userEvent.keyboard("{Enter}");
+    expect(onPick).toHaveBeenCalledTimes(1);
+  });
+
+  // Binding an account somebody else holds takes it off them, so the name the
+  // row is reached by has to say so — not just the address.
+  it("names the holder in the row's accessible name", async () => {
+    hooks.search.data = {
+      pages: [
+        {
+          items: [
+            match({
+              person: {
+                person_id: "01900000-0000-7000-8000-0000000000b0",
+                display_name: "Bob Park",
+              },
+            }),
+          ],
+        },
+      ],
+    };
+    pick();
+
+    await userEvent.type(field(), "annlee");
+
+    expect(
+      screen.getByRole("button", { name: /^annlee, zoom, held by Bob Park$/ }),
+    ).toBeInTheDocument();
   });
 
   it("states a failed search rather than an empty list", async () => {

--- a/src/frontend/src/components/portal/account-picker.test.tsx
+++ b/src/frontend/src/components/portal/account-picker.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * The account picker. What matters: it is a FINDING tool — the click hands the
+ * account back and never writes; a blank field asks nothing, because the whole
+ * fold would bury the accounts the caller is already showing; a term too short
+ * to search says so instead of going quiet; and every row names whoever holds
+ * the account, since binding one somebody else holds takes it off them.
+ */
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import "@/i18n";
+import type { AccountMatch } from "@/api/identity-client";
+
+const hooks = vi.hoisted(() => ({
+  search: {
+    data: undefined as { pages: { items: AccountMatch[] }[] } | undefined,
+    isFetching: false,
+    isFetchingNextPage: false,
+    isPlaceholderData: false,
+    isError: false,
+    hasNextPage: false,
+    fetchNextPage: vi.fn(),
+  },
+}));
+vi.mock("@/hooks/use-debounced-value", () => ({
+  useDebouncedValue: <T,>(value: T) => value,
+}));
+vi.mock("@/queries/identity-resolution", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/queries/identity-resolution")>()),
+  useAccountList: () => hooks.search,
+}));
+
+import { AccountPicker } from "./account-picker";
+
+const PLACEHOLDER = "Find an account…";
+
+function match(over: Partial<AccountMatch> = {}): AccountMatch {
+  return {
+    source: "zoom",
+    source_id: "01900000-0000-7000-8000-00000000aa03",
+    account_id: "zm-9",
+    email: null,
+    username: "annlee",
+    display_name: null,
+    person: null,
+    bound_by_operator: false,
+    ...over,
+  };
+}
+
+function pick(over: { excludeKeys?: string[] } = {}) {
+  const onPick = vi.fn();
+  render(
+    <AccountPicker
+      onPick={onPick}
+      placeholder={PLACEHOLDER}
+      excludeKeys={over.excludeKeys}
+    />,
+  );
+  return onPick;
+}
+
+const field = () => screen.getByRole("searchbox", { name: PLACEHOLDER });
+
+beforeEach(() => {
+  hooks.search.data = undefined;
+  hooks.search.isFetching = false;
+  hooks.search.isFetchingNextPage = false;
+  hooks.search.isPlaceholderData = false;
+  hooks.search.isError = false;
+  hooks.search.hasNextPage = false;
+  hooks.search.fetchNextPage.mockClear();
+});
+
+describe("AccountPicker", () => {
+  it("lists nothing until the field is asked something", () => {
+    hooks.search.data = { pages: [{ items: [match()] }] };
+    pick();
+
+    expect(screen.queryByText("annlee")).not.toBeInTheDocument();
+  });
+
+  // The answer to "why is nothing happening" should not wait for a debounce.
+  it("says a single character is too short to search", async () => {
+    pick();
+
+    await userEvent.type(field(), "a");
+
+    expect(screen.getByText(/at least 2 characters/i)).toBeInTheDocument();
+  });
+
+  it("hands the picked account back and writes nothing itself", async () => {
+    hooks.search.data = { pages: [{ items: [match()] }] };
+    const onPick = pick();
+
+    await userEvent.type(field(), "annlee");
+    await userEvent.click(screen.getByRole("button", { name: /^annlee$/ }));
+
+    expect(onPick).toHaveBeenCalledWith(expect.objectContaining({ account_id: "zm-9" }));
+  });
+
+  // Binding an account somebody else holds takes it off them; that has to be
+  // visible before the click, not in the confirmation after it.
+  it("names the holder on the row, and states the two other answers", async () => {
+    hooks.search.data = {
+      pages: [
+        {
+          items: [
+            match({ person: { person_id: "01900000-0000-7000-8000-0000000000b0", display_name: "Bob Park" } }),
+            match({ account_id: "zm-10", username: "orphan" }),
+            match({ account_id: "zm-11", username: "ci-bot", excluded: true }),
+          ],
+        },
+      ],
+    };
+    pick();
+
+    await userEvent.type(field(), "zm");
+
+    expect(screen.getByText("Bob Park")).toBeInTheDocument();
+    expect(screen.getByText(/bound to nobody/i)).toBeInTheDocument();
+    expect(screen.getByText(/excluded — bot \/ CI/i)).toBeInTheDocument();
+  });
+
+  it("drops the accounts the caller excluded", async () => {
+    hooks.search.data = {
+      pages: [{ items: [match(), match({ account_id: "zm-10", username: "other" })] }],
+    };
+    pick({ excludeKeys: ["zoom:01900000-0000-7000-8000-00000000aa03:zm-9"] });
+
+    await userEvent.type(field(), "zm");
+
+    expect(screen.queryByText("annlee")).not.toBeInTheDocument();
+    expect(screen.getByText("other")).toBeInTheDocument();
+  });
+
+  it("states a failed search rather than an empty list", async () => {
+    hooks.search.isError = true;
+    pick();
+
+    await userEvent.type(field(), "annlee");
+
+    expect(screen.getByText(/search failed/i)).toBeInTheDocument();
+  });
+
+  it("says nothing matched once the terms have been answered", async () => {
+    hooks.search.data = { pages: [{ items: [] }] };
+    pick();
+
+    await userEvent.type(field(), "annlee");
+
+    expect(screen.getByText(/no observed account carries that/i)).toBeInTheDocument();
+  });
+
+  // A page whose every row was excluded is not "nothing matches" while more
+  // pages are unread — the next page is the answer, not the message.
+  it("claims nothing while a further page is still unread", async () => {
+    hooks.search.data = { pages: [{ items: [] }] };
+    hooks.search.hasNextPage = true;
+    pick();
+
+    await userEvent.type(field(), "annlee");
+
+    expect(
+      screen.queryByText(/no observed account carries that/i),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/frontend/src/components/portal/account-picker.tsx
+++ b/src/frontend/src/components/portal/account-picker.tsx
@@ -1,0 +1,208 @@
+/**
+ * The account picker: find an observed account by any value a source reports
+ * and hand the choice back to the caller.
+ *
+ * The mirror of {@link PersonPicker}, and a finding tool for the same reason:
+ * it never fires a verb itself. Inside the person window a click on a row
+ * means "bind this one to the person I have open" — the same gesture the person
+ * picker carries inside the account window, pointing the other way.
+ *
+ * A blank field lists nothing on purpose. The tenant's whole fold would bury
+ * the handful of accounts the person actually holds, which is what the reader
+ * is looking at right above this.
+ */
+import { Search } from "lucide-react";
+import { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type { AccountMatch } from "@/api/identity-client";
+import { PersonCell } from "@/components/portal/person-cell";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Spinner } from "@/components/ui/spinner";
+import { useAutoLoadOnScroll } from "@/hooks/use-auto-load-on-scroll";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { accountKey } from "@/lib/identities/account-key";
+import { activatesRow, activatesRowByKey } from "@/lib/identities/row-activation";
+import {
+  belowAccountFloor,
+  listsAnyAccount,
+  MIN_SEARCH_CHARS,
+  SEARCH_DEBOUNCE_MS,
+  useAccountList,
+} from "@/queries/identity-resolution";
+import { cn } from "@/lib/utils";
+
+export function AccountPicker({
+  onPick,
+  /** Accounts already listed by the caller — filtered out, not repeated. */
+  excludeKeys = [],
+  placeholder,
+}: {
+  onPick: (account: AccountMatch) => void;
+  excludeKeys?: string[];
+  placeholder: string;
+}) {
+  const { t } = useTranslation();
+  const [query, setQuery] = useState("");
+  const debounced = useDebouncedValue(query, SEARCH_DEBOUNCE_MS);
+  const search = useAccountList(debounced, "match");
+
+  const excluded = new Set(excludeKeys);
+  // The shared rule, never a second spelling of it: a list rendered for terms
+  // the query never asked for is another caller's cache.
+  const asked = listsAnyAccount(debounced, "match");
+  const items = asked
+    ? (search.data?.pages ?? [])
+        .flatMap((page) => page.items)
+        .filter((item) => !excluded.has(accountKey(item)))
+    : [];
+  const loading = search.isFetching && !search.isFetchingNextPage;
+  // Reads the live field rather than the debounced one: the answer to "why is
+  // nothing happening" should not wait for the debounce to expire. Only while
+  // nothing is listed, though — for one debounce the rows still answer the
+  // shorter term, and a notice above them contradicts them.
+  const tooShort = items.length === 0 && belowAccountFloor(query);
+  // These rows answer the term the query key carries, not the one in the field,
+  // until the debounce fires AND the fetch lands. Marked rather than hidden, so
+  // the list does not blank between keystrokes — and never read as the answer.
+  const behind = query !== debounced || search.isPlaceholderData;
+  // A page whose every row was filtered out is not "nothing matches" while more
+  // pages are unread — the next page is the answer, not the message.
+  const exhausted = !search.hasNextPage;
+  const scroller = useRef<HTMLDivElement>(null);
+  const loadMore = useAutoLoadOnScroll({
+    hasNextPage: Boolean(asked && search.hasNextPage),
+    isFetchingNextPage: search.isFetchingNextPage,
+    fetchNextPage: () => void search.fetchNextPage(),
+    root: scroller,
+  });
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="relative w-full shrink-0">
+        <Search className="absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          type="search"
+          className="ps-8"
+          placeholder={placeholder}
+          aria-label={placeholder}
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+        />
+        {loading ? (
+          <Spinner className="absolute end-2.5 top-1/2 size-4 -translate-y-1/2" />
+        ) : null}
+      </div>
+      {tooShort ? (
+        <p className="text-sm text-muted-foreground">
+          {t("identities.accounts.min_chars", { min: MIN_SEARCH_CHARS })}
+        </p>
+      ) : null}
+      {asked && search.isError ? (
+        <p className="text-sm text-destructive">
+          {t("identities.accounts.failed")}
+        </p>
+      ) : null}
+      {asked &&
+      search.data &&
+      items.length === 0 &&
+      !loading &&
+      !behind &&
+      exhausted ? (
+        <p className="text-sm text-muted-foreground">
+          {t("identities.accounts.no_matches")}
+        </p>
+      ) : null}
+      {/* Rendered for an unread next page even with nothing visible: a page
+          whose every row was filtered out has no rows to scroll, and the marker
+          is the only thing that can ask for the page that does. It has to live
+          INSIDE the scroller — an observer never reports a target that is not a
+          descendant of its root. */}
+      {items.length > 0 || (asked && search.hasNextPage) ? (
+        <div ref={scroller} className="max-h-64 overflow-y-auto">
+          <ul
+            aria-busy={behind}
+            className={cn("flex flex-col gap-1", behind && "opacity-60")}
+          >
+            {items.map((item) => (
+              <li key={accountKey(item)}>
+                <AccountOption item={item} onPick={() => onPick(item)} />
+              </li>
+            ))}
+          </ul>
+          {asked && search.hasNextPage ? (
+            <p
+              ref={loadMore}
+              aria-live="polite"
+              className="p-2 text-sm text-muted-foreground"
+            >
+              {search.isFetchingNextPage
+                ? t("identities.accounts.loading_more")
+                : null}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * One account offered for binding — with whoever holds it now.
+ *
+ * The holder is the whole reason this row is not a plain label: binding an
+ * account somebody else holds takes it off them, and that has to be visible
+ * before the click, not in the confirmation after it.
+ */
+function AccountOption({
+  item,
+  onPick,
+}: {
+  item: AccountMatch;
+  onPick: () => void;
+}) {
+  const { t } = useTranslation();
+  const label =
+    item.email?.trim() ||
+    item.username?.trim() ||
+    item.display_name?.trim() ||
+    item.account_id;
+  return (
+    // Not a <button>: the holder's card carries its own copy control, and a
+    // button may neither nest one nor let its text be selected — the same rule
+    // the queue rows and the person picker follow.
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={(event) => {
+        if (activatesRow(event)) onPick();
+      }}
+      onKeyDown={(event) => {
+        if (!activatesRowByKey(event)) return;
+        event.preventDefault();
+        onPick();
+      }}
+      aria-label={label}
+      className="grid w-full cursor-pointer grid-cols-1 items-center gap-2 rounded-md border border-transparent p-2 text-start select-text hover:bg-muted/60 lg:grid-cols-[minmax(0,1fr)_minmax(0,18rem)]"
+    >
+      <div className="min-w-0">
+        <div className="truncate text-sm font-medium">{label}</div>
+        <div className="truncate font-mono text-xs text-muted-foreground">
+          {item.source} · {item.account_id}
+        </div>
+      </div>
+      {item.person ? (
+        <PersonCell person={item.person} />
+      ) : item.excluded ? (
+        <Badge variant="secondary" className="justify-self-start font-normal">
+          {t("identities.accounts.excluded")}
+        </Badge>
+      ) : (
+        <span className="text-xs text-muted-foreground">
+          {t("identities.accounts.unbound")}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/frontend/src/components/portal/account-picker.tsx
+++ b/src/frontend/src/components/portal/account-picker.tsx
@@ -23,6 +23,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { useAutoLoadOnScroll } from "@/hooks/use-auto-load-on-scroll";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { accountKey } from "@/lib/identities/account-key";
+import { personDisplayName } from "@/lib/identities/person-display";
 import { activatesRow, activatesRowByKey } from "@/lib/identities/row-activation";
 import {
   belowAccountFloor,
@@ -79,7 +80,7 @@ export function AccountPicker({
   });
 
   return (
-    <div className="flex flex-col gap-2">
+    <div className="flex min-h-0 flex-col gap-2">
       <div className="relative w-full shrink-0">
         <Search className="absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground" />
         <Input
@@ -120,7 +121,7 @@ export function AccountPicker({
           INSIDE the scroller — an observer never reports a target that is not a
           descendant of its root. */}
       {items.length > 0 || (asked && search.hasNextPage) ? (
-        <div ref={scroller} className="max-h-64 overflow-y-auto">
+        <div ref={scroller} className="min-h-0 max-h-64 overflow-y-auto">
           <ul
             aria-busy={behind}
             className={cn("flex flex-col gap-1", behind && "opacity-60")}
@@ -183,8 +184,21 @@ function AccountOption({
         event.preventDefault();
         onPick();
       }}
-      aria-label={label}
-      className="grid w-full cursor-pointer grid-cols-1 items-center gap-2 rounded-md border border-transparent p-2 text-start select-text hover:bg-muted/60 lg:grid-cols-[minmax(0,1fr)_minmax(0,18rem)]"
+      // The holder is the whole reason this row is not a plain label, so the
+      // name has to carry them: without it a reader hears the address, presses
+      // Enter, and only learns in the confirmation that it is somebody else's.
+      aria-label={[
+        label,
+        item.source,
+        item.person
+          ? t("identities.queue.bound_to", {
+              name: personDisplayName(item.person),
+            })
+          : item.excluded
+            ? t("identities.accounts.excluded")
+            : t("identities.accounts.unbound"),
+      ].join(", ")}
+      className="grid w-full cursor-pointer grid-cols-1 items-center gap-2 rounded-md border border-transparent p-2 text-start select-text hover:bg-muted/60 md:grid-cols-[minmax(0,1fr)_minmax(0,18rem)]"
     >
       <div className="min-w-0">
         <div className="truncate text-sm font-medium">{label}</div>

--- a/src/frontend/src/components/portal/account-picker.tsx
+++ b/src/frontend/src/components/portal/account-picker.tsx
@@ -209,7 +209,7 @@ function AccountOption({
       {item.person ? (
         <PersonCell person={item.person} />
       ) : item.excluded ? (
-        <Badge variant="secondary" className="justify-self-start font-normal">
+        <Badge variant="outline" className="justify-self-start font-normal">
           {t("identities.accounts.excluded")}
         </Badge>
       ) : (

--- a/src/frontend/src/components/portal/account-search-view.test.tsx
+++ b/src/frontend/src/components/portal/account-search-view.test.tsx
@@ -3,11 +3,12 @@
  * The account mode. What matters: an operator holding a handle or an address
  * learns whose it is — the question neither other mode can answer, since both
  * are entered through a person; unbound is stated as an answer rather than
- * left blank; the account opens in the same case window, so the verbs are one
- * click away; and with nothing typed the mode lists what the connectors
- * reported instead of waiting to be asked.
+ * left blank; the ROW itself opens the account in the same case window, the way
+ * the queue's rows do, so one gesture means one thing across the console; and
+ * with nothing typed the mode lists what the connectors reported instead of
+ * waiting to be asked.
  */
-import { render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -103,6 +104,11 @@ function match(over: Partial<AccountMatch> = {}): AccountMatch {
 
 function page(items: AccountMatch[]) {
   return { pages: [{ items }] };
+}
+
+/** The row for {@link match}, addressed the way a reader reaches it. */
+function row() {
+  return screen.getByRole("button", { name: /^octocat,/ });
 }
 
 beforeEach(() => {
@@ -210,7 +216,7 @@ describe("AccountSearchView", () => {
     hooks.binding.isLoading = false;
     render(<AccountSearchView />);
 
-    await userEvent.click(screen.getByRole("button", { name: /^open$/i }));
+    await userEvent.click(row());
 
     const dialog = screen.getByRole("dialog");
     // The verbs are on screen — so an absent candidate list means absent, not
@@ -255,12 +261,59 @@ describe("AccountSearchView", () => {
     hooks.search.data = page([match()]);
     render(<AccountSearchView />);
 
-    await userEvent.click(screen.getByRole("button", { name: /^open$/i }));
+    await userEvent.click(row());
 
     expect(portalRouter.search.acct).toContain("gh-main");
     expect(
       within(screen.getByRole("dialog")).getByText(/github · gh-main/),
     ).toBeInTheDocument();
+  });
+
+  // The row IS the door, so a button beside it would be a second way through
+  // the same one — and the queue's rows have never had one.
+  it("carries no open button beside the row that already opens", () => {
+    hooks.search.data = page([match()]);
+    render(<AccountSearchView />);
+
+    expect(
+      screen.queryByRole("button", { name: /^open$/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // The addresses and ids on these rows are what an operator copies into a
+  // ticket. A row that opens on the mouse-up of a drag makes them unreadable.
+  it("does not open on the click that ends a text selection", () => {
+    hooks.search.data = page([match()]);
+    render(<AccountSearchView />);
+    const selected = document.createRange();
+    selected.selectNodeContents(screen.getByText("octocat"));
+    const selection = window.getSelection();
+    // A Selection holds one range: adding to a stale one from an earlier case
+    // is a no-op, and this case would then be asserting nothing.
+    selection?.removeAllRanges();
+    selection?.addRange(selected);
+
+    // The bare click, not a full press: a real drag ends in a mouseup with the
+    // selection still standing, and a synthesized mousedown would clear it
+    // before the handler ever sees it.
+    fireEvent.click(row());
+
+    expect(portalRouter.search.acct).toBeUndefined();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  // The holder's card carries a copy control, and pressing it is not a request
+  // to leave the list.
+  it("does not open when a control inside the row is pressed", async () => {
+    hooks.search.data = page([match()]);
+    render(<AccountSearchView />);
+
+    await userEvent.click(
+      within(row()).getByRole("button", { name: /copy/i }),
+    );
+
+    expect(portalRouter.search.acct).toBeUndefined();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   // The search itself proves the account exists — an unbound, never-decided
@@ -278,7 +331,7 @@ describe("AccountSearchView", () => {
     hooks.binding.isLoading = false;
     render(<AccountSearchView />);
 
-    await userEvent.click(screen.getByRole("button", { name: /^open$/i }));
+    await userEvent.click(row());
 
     const dialog = screen.getByRole("dialog");
     expect(

--- a/src/frontend/src/components/portal/account-search-view.test.tsx
+++ b/src/frontend/src/components/portal/account-search-view.test.tsx
@@ -10,7 +10,7 @@
  */
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import "@/i18n";
 import type { AccountMatch } from "@/api/identity-client";
@@ -110,6 +110,8 @@ function page(items: AccountMatch[]) {
 function row() {
   return screen.getByRole("button", { name: /^octocat,/ });
 }
+
+afterEach(() => window.getSelection()?.removeAllRanges());
 
 beforeEach(() => {
   hooks.search.data = undefined;
@@ -275,6 +277,9 @@ describe("AccountSearchView", () => {
     hooks.search.data = page([match()]);
     render(<AccountSearchView />);
 
+    // The positive control: without it this case also passes for a row that
+    // failed to render at all.
+    expect(row()).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /^open$/i }),
     ).not.toBeInTheDocument();
@@ -300,6 +305,13 @@ describe("AccountSearchView", () => {
 
     expect(portalRouter.search.acct).toBeUndefined();
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    // The same click with nothing selected DOES open — without this the case
+    // would still pass for a row that never opens at all.
+    selection?.removeAllRanges();
+    fireEvent.click(row());
+
+    expect(portalRouter.search.acct).toContain("gh-main");
   });
 
   // The holder's card carries a copy control, and pressing it is not a request
@@ -314,6 +326,12 @@ describe("AccountSearchView", () => {
 
     expect(portalRouter.search.acct).toBeUndefined();
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    // The row itself still opens, so the guard above is a guard and not a row
+    // that never worked.
+    await userEvent.click(row());
+
+    expect(portalRouter.search.acct).toContain("gh-main");
   });
 
   // The search itself proves the account exists — an unbound, never-decided

--- a/src/frontend/src/components/portal/account-search-view.tsx
+++ b/src/frontend/src/components/portal/account-search-view.tsx
@@ -109,7 +109,6 @@ export function AccountSearchView() {
     candidates: [],
     holder: m.person ?? null,
   }));
-  const ordered = openable.map((item) => accountKey(item));
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-4">
@@ -218,8 +217,6 @@ export function AccountSearchView() {
       <CaseDialog
         acct={acct}
         items={openable}
-        ordered={ordered}
-        onSelect={setAcct}
         onClose={() => setAcct(null)}
       />
     </div>

--- a/src/frontend/src/components/portal/account-search-view.tsx
+++ b/src/frontend/src/components/portal/account-search-view.tsx
@@ -1,23 +1,24 @@
 /**
  * Finding an account, and the window it is decided in.
  *
- * Two surfaces use one field. The accounts mode arrives with a value in hand —
- * a git login from a review, an address from a ticket — the question neither
- * other mode can answer, because both are entered through a person; there a
- * blank field lists what the connectors reported, since the accounts nobody
- * asks about are exactly the ones nobody finds by searching. Inside one person
- * the same field is how an account gets re-bound to them, and a blank field
- * lists nothing: the whole fold would bury the accounts they actually hold.
+ * The mode arrives with a value in hand — a git login from a review, an address
+ * from a ticket — the question neither other mode can answer, because both are
+ * entered through a person. A blank field lists what the connectors reported,
+ * since the accounts nobody asks about are exactly the ones nobody finds by
+ * searching.
+ *
+ * A row opens the account, on the click itself: the queue's rows behave that
+ * way, and a listing one tab across that demanded a button instead made the
+ * same gesture mean two things.
  */
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ScanSearch, Search } from "lucide-react";
 
-import type { AccountMatch, PersonSummary } from "@/api/identity-client";
+import type { AccountMatch } from "@/api/identity-client";
 import { CaseDialog, type CaseRow } from "@/components/portal/case-dialog";
 import { PersonCell } from "@/components/portal/person-cell";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   Empty,
@@ -34,6 +35,8 @@ import { useAutoLoadOnScroll } from "@/hooks/use-auto-load-on-scroll";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { accountKey } from "@/lib/identities/account-key";
 import { KIND_SEARCH_MATCH } from "@/lib/identities/cases";
+import { personDisplayName } from "@/lib/identities/person-display";
+import { activatesRow, activatesRowByKey } from "@/lib/identities/row-activation";
 import { usePortalNavActions } from "@/lib/portal/portal-nav";
 import { usePortalSearch } from "@/lib/portal/portal-search";
 import {
@@ -42,54 +45,27 @@ import {
   MIN_SEARCH_CHARS,
   SEARCH_DEBOUNCE_MS,
   useAccountList,
-  type AccountListIntent,
 } from "@/queries/identity-resolution";
 import { cn } from "@/lib/utils";
-
-/** The accounts mode: the field over the whole fold, nothing else on screen. */
-export function AccountSearchView() {
-  const { t } = useTranslation();
-  return (
-    <AccountFinder
-      intent="browse"
-      placeholder={t("identities.accounts.placeholder")}
-    />
-  );
-}
 
 /**
  * The field, its results, and the one case window they open into.
  *
  * INVARIANT: the window lives here and nowhere else on the surface. It is
  * opened by `?acct=` alone, so a second one on the same screen would open
- * beside this one on the same link. A surface that lists accounts of its own
- * hands them over as `alsoOpenable` instead of rendering a window for them.
+ * beside this one on the same link.
  */
-export function AccountFinder({
-  intent,
-  placeholder,
-  /** Rows the surface already lists, so its own accounts open in this window. */
-  alsoOpenable = [],
-  /** Offer binding straight to this person — the one the surface has open. */
-  bindTo,
-  className,
-}: {
-  intent: AccountListIntent;
-  placeholder: string;
-  alsoOpenable?: CaseRow[];
-  bindTo?: PersonSummary | null;
-  className?: string;
-}) {
+export function AccountSearchView() {
   const { t } = useTranslation();
   const { acct } = usePortalSearch();
   const { setAcct } = usePortalNavActions();
   const [query, setQuery] = useState("");
   const debounced = useDebouncedValue(query, SEARCH_DEBOUNCE_MS);
-  const search = useAccountList(debounced, intent);
+  const search = useAccountList(debounced, "browse");
 
   // Never rows the query did not ask for: under the floor the listing is not
   // this field's answer, and kept pages would be the previous term's.
-  const lists = listsAnyAccount(debounced, intent);
+  const lists = listsAnyAccount(debounced, "browse");
   const items = lists
     ? (search.data?.pages ?? []).flatMap((page) => page.items)
     : [];
@@ -122,7 +98,7 @@ export function AccountFinder({
   // No candidates: this list answers "whose is it", not "whose could it be".
   // The holder travels as the holder, so the window names them without the
   // window mistaking them for somebody to bind the account to.
-  const asCases: CaseRow[] = items.map((m) => ({
+  const openable: CaseRow[] = items.map((m) => ({
     kind: KIND_SEARCH_MATCH,
     source: m.source,
     source_id: m.source_id,
@@ -133,26 +109,18 @@ export function AccountFinder({
     candidates: [],
     holder: m.person ?? null,
   }));
-  // Matches first: they are what the reader just went looking for, and the
-  // prev/next footer walks this order.
-  //
-  // INVARIANT: one entry per account. A match can also be a row the surface
-  // already lists — searching inside a person finds the accounts they hold — and
-  // the footer walks `ordered` by index, so a key listed twice sends `next` back
-  // to the first copy instead of onward.
-  const openable = uniqueByAccount([...asCases, ...alsoOpenable]);
   const ordered = openable.map((item) => accountKey(item));
 
   return (
-    <div className={cn("flex min-h-0 min-w-0 flex-1 flex-col gap-4", className)}>
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-4">
       <div className="relative shrink-0">
         <Search className="pointer-events-none absolute start-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
         <Input
           type="search"
           value={query}
           onChange={(event) => setQuery(event.target.value)}
-          placeholder={placeholder}
-          aria-label={placeholder}
+          placeholder={t("identities.accounts.placeholder")}
+          aria-label={t("identities.accounts.placeholder")}
           className="ps-9"
         />
         {loading ? (
@@ -177,15 +145,12 @@ export function AccountFinder({
       {/* Two different emptinesses: terms that matched nothing, and nothing to
           list. The second one does not claim the tenant is empty — the service
           answers an empty list for a fold it cannot read yet, and an operator
-          cannot tell that from a tenant nobody has connected. A field that
-          lists nothing until asked is a third thing: it is simply waiting, and
-          says so by showing nothing at all. */}
+          cannot tell that from a tenant nobody has connected. */}
       {!loading &&
       !tooShort &&
       !stale &&
       items.length === 0 &&
-      !search.isError &&
-      (asked || intent === "browse") ? (
+      !search.isError ? (
         <Empty className="rounded-lg border">
           <EmptyHeader>
             {asked ? null : (
@@ -254,23 +219,11 @@ export function AccountFinder({
         acct={acct}
         items={openable}
         ordered={ordered}
-        bindTo={bindTo}
         onSelect={setAcct}
         onClose={() => setAcct(null)}
       />
     </div>
   );
-}
-
-/** The first row for each account wins — the earlier one carries the match. */
-function uniqueByAccount(rows: CaseRow[]): CaseRow[] {
-  const seen = new Set<string>();
-  return rows.filter((row) => {
-    const key = accountKey(row);
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
 }
 
 function AccountRow({
@@ -290,21 +243,46 @@ function AccountRow({
     item.account_id;
   return (
     // Fixed columns, not content-sized ones: a list is read down a column, and
-    // holders whose names differ in length would otherwise step the cards and
-    // the verbs sideways on every row. Only where there is room for all four —
-    // the trailing tracks are ~29rem, and taking them from a narrower window
-    // would leave the address, the one value this mode answers with, an
-    // ellipsis. Below that the row stacks instead.
+    // holders whose names differ in length would otherwise step the cards
+    // sideways on every row. Only where there is room — taking the trailing
+    // tracks from a narrower window would leave the address, the one value this
+    // mode answers with, an ellipsis. Below that the row stacks instead.
     <div
+      role="button"
+      tabIndex={0}
+      onClick={(event) => {
+        if (activatesRow(event)) onOpen();
+      }}
+      onKeyDown={(event) => {
+        if (!activatesRowByKey(event)) return;
+        event.preventDefault();
+        onOpen();
+      }}
+      aria-pressed={selected}
+      // Without a label the accessible name is computed from everything inside,
+      // which reads out the holder's whole card before the account is named.
+      aria-label={[
+        label,
+        item.source,
+        item.person
+          ? t("identities.queue.bound_to", {
+              name: personDisplayName(item.person),
+            })
+          : item.excluded
+            ? t("identities.accounts.excluded")
+            : t("identities.accounts.unbound"),
+      ]
+        .filter(Boolean)
+        .join(", ")}
       className={cn(
-        "grid grid-cols-1 items-center gap-2 rounded-md border p-3",
-        "lg:grid-cols-[minmax(0,1fr)_minmax(0,18rem)_minmax(0,11rem)_auto]",
-        selected ? "border-ring bg-muted" : "border-transparent",
+        "grid cursor-pointer grid-cols-1 items-center gap-2 rounded-md border p-3 text-start select-text",
+        "lg:grid-cols-[minmax(0,1fr)_minmax(0,18rem)_minmax(0,11rem)]",
+        selected ? "border-ring bg-muted" : "border-transparent hover:bg-muted/60",
       )}
     >
       <div className="min-w-0">
-        <div className="truncate text-sm font-medium select-text">{label}</div>
-        <div className="truncate font-mono text-xs text-muted-foreground select-text">
+        <div className="truncate text-sm font-medium">{label}</div>
+        <div className="truncate font-mono text-xs text-muted-foreground">
           {item.source} · {item.account_id}
         </div>
       </div>
@@ -330,9 +308,6 @@ function AccountRow({
           ? t("identities.person_accounts.by_operator")
           : t("identities.person_accounts.by_automation")}
       </Badge>
-      <Button type="button" size="xs" variant="outline" onClick={onOpen}>
-        {t("identities.person_accounts.open")}
-      </Button>
     </div>
   );
 }

--- a/src/frontend/src/components/portal/account-search-view.tsx
+++ b/src/frontend/src/components/portal/account-search-view.tsx
@@ -289,7 +289,7 @@ function AccountRow({
       {item.person ? (
         <PersonCell person={item.person} />
       ) : item.excluded ? (
-        <Badge variant="secondary" className="justify-self-start font-normal">
+        <Badge variant="outline" className="justify-self-start font-normal">
           {t("identities.accounts.excluded")}
         </Badge>
       ) : (
@@ -297,10 +297,9 @@ function AccountRow({
           {t("identities.accounts.unbound")}
         </span>
       )}
-      <Badge
-        variant={item.bound_by_operator ? "secondary" : "outline"}
-        className="justify-self-start font-normal"
-      >
+      {/* Who decided the binding, as a line: the two answers are two states
+          of one fact, and only one of them used to carry a shape. */}
+      <Badge variant="outline" className="justify-self-start font-normal">
         {item.bound_by_operator
           ? t("identities.person_accounts.by_operator")
           : t("identities.person_accounts.by_automation")}

--- a/src/frontend/src/components/portal/case-dialog.tsx
+++ b/src/frontend/src/components/portal/case-dialog.tsx
@@ -1,9 +1,7 @@
 import { useRef, useState } from "react";
-import { useTranslation } from "react-i18next";
 
 import type { AttentionItem, PersonSummary } from "@/api/identity-client";
 import { AccountDetail } from "@/components/portal/account-detail";
-import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -35,7 +33,6 @@ export interface CaseRow extends AttentionItem {
 interface HeldCase {
   acct?: string;
   item?: CaseRow;
-  at?: number;
 }
 
 /**
@@ -48,40 +45,32 @@ interface HeldCase {
  *
  * A decision prunes its row from the list at once (see `useCorrection`), and
  * that list feeds this window: taken literally, the operator's own success
- * would yank the candidates, the outcome alert and the prev/next footer out
- * from under them. The window therefore HOLDS what it knew about the open
- * case — the row and its position — and lets the list move underneath.
+ * would yank the candidates and the outcome alert out from under them. The
+ * window therefore HOLDS the row it was opened on and lets the list move
+ * underneath.
  */
 export function CaseDialog({
   acct,
   items,
-  ordered,
-  onSelect,
   onClose,
 }: {
   acct: string | undefined;
   items: CaseRow[];
-  /** Account keys in the order the queue renders them. */
-  ordered: string[];
-  onSelect: (key: string) => void;
   onClose: () => void;
 }) {
-  const { t } = useTranslation();
   const popupRef = useRef<HTMLDivElement>(null);
   const ref = parseAccountKey(acct);
 
   const live = items.find((i) => itemKey(i) === acct);
-  const liveAt = acct ? ordered.indexOf(acct) : -1;
 
   // Held via state adjusted during render (the sanctioned previous-render
-  // pattern), so the freshest row and position stick for the open case.
+  // pattern), so the freshest row sticks for the open case.
   const [held, setHeld] = useState<HeldCase>({});
   const fresh: HeldCase = {
     acct,
     item: live ?? (held.acct === acct ? held.item : undefined),
-    at: liveAt >= 0 ? liveAt : held.acct === acct ? held.at : undefined,
   };
-  if (held.acct !== fresh.acct || held.item !== fresh.item || held.at !== fresh.at) {
+  if (held.acct !== fresh.acct || held.item !== fresh.item) {
     setHeld(fresh);
   }
   const queueItem = fresh.item;
@@ -94,14 +83,7 @@ export function CaseDialog({
   // The caller vouching for the account (a queue row, a search hit) is what
   // separates a real account from a mistyped link; the vouching survives the
   // row being pruned, since the account did not stop existing.
-  const observed = queueItem != null || liveAt >= 0;
-
-  // When the open row was pruned, everything after it shifted left — so the
-  // held index now points at the NEXT account, which is where a conveyor
-  // should go, and one before it is still the previous one.
-  const at = liveAt >= 0 ? liveAt : (fresh.at ?? -1);
-  const previous = at > 0 ? ordered[at - 1] : undefined;
-  const next = liveAt >= 0 ? ordered[at + 1] : at >= 0 ? ordered[at] : undefined;
+  const observed = queueItem != null;
 
   return (
     <Dialog
@@ -110,8 +92,8 @@ export function CaseDialog({
         if (!open) onClose();
       }}
     >
-      {/* A fixed height, not a fitted one: an operator walks from case to case
-          and a window that resizes to each one moves the verbs under their
+      {/* A fixed height, not a fitted one: an operator moves between windows
+          and one that resizes to each subject moves the verbs under their
           cursor. The history takes the slack instead. */}
       <DialogContent
         ref={popupRef}
@@ -149,30 +131,6 @@ export function CaseDialog({
             // window back shows the new state instead of the one just replaced.
             onDecided={onClose}
           />
-        ) : null}
-        {/* Working a backlog is a conveyor: the next case is one press away,
-            without a trip back through the list. */}
-        {previous || next ? (
-          <div className="flex shrink-0 justify-between gap-2 border-t pt-3">
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              disabled={!previous}
-              onClick={() => previous && onSelect(previous)}
-            >
-              {t("identities.queue.previous_case")}
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              disabled={!next}
-              onClick={() => next && onSelect(next)}
-            >
-              {t("identities.queue.next_case")}
-            </Button>
-          </div>
         ) : null}
       </DialogContent>
     </Dialog>

--- a/src/frontend/src/components/portal/case-dialog.tsx
+++ b/src/frontend/src/components/portal/case-dialog.tsx
@@ -17,10 +17,10 @@ import { itemKey, parseAccountKey } from "@/lib/identities/account-key";
  * A row this window can open.
  *
  * `candidates` is a QUEUE concept — the persons the evidence says could own the
- * account, which is a question only an undecided account has. The surfaces that
- * list settled accounts have no such question, so they carry `holder` instead:
- * the card of whoever holds it, which the binding read answers with an id alone.
- * Without that channel those surfaces had to pass the holder AS a candidate, and
+ * account, which is a question only an undecided account has. The accounts mode
+ * lists settled accounts and has no such question, so it carries `holder`
+ * instead: the card of whoever holds it, which the binding read answers with an
+ * id alone. Without that channel it had to pass the holder AS a candidate, and
  * the window then offered to bind the account to the person already holding it.
  * That offer belongs in the queue: re-asserting a binding the resolver made is
  * the confirm act, and the accounts it matters for are queued for exactly that.
@@ -56,7 +56,6 @@ export function CaseDialog({
   acct,
   items,
   ordered,
-  bindTo,
   onSelect,
   onClose,
 }: {
@@ -64,9 +63,6 @@ export function CaseDialog({
   items: CaseRow[];
   /** Account keys in the order the queue renders them. */
   ordered: string[];
-  /** The person the surface behind this window has open, when it has one:
-   *  binding to them is then one press rather than a search. */
-  bindTo?: PersonSummary | null;
   onSelect: (key: string) => void;
   onClose: () => void;
 }) {
@@ -147,7 +143,6 @@ export function CaseDialog({
             queueItem={queueItem}
             observed={observed}
             holder={queueItem?.holder ?? null}
-            bindTo={bindTo}
             // A decided account has nothing left to answer here: its candidate
             // list and its binding are both reads the server has moved past.
             // The surface behind re-reads (see `useCorrection`), so handing the

--- a/src/frontend/src/components/portal/identities-view.test.tsx
+++ b/src/frontend/src/components/portal/identities-view.test.tsx
@@ -767,27 +767,10 @@ describe("IdentitiesView", () => {
     expect(row).toHaveFocus();
   });
 
-  it("offers the next account without a trip back to the list", async () => {
-    attention.q.data = {
-      items: [
-        item({ account_id: "a1", email: "ann@example.com" }),
-        item({ account_id: "a2", email: "bob@example.com" }),
-      ],
-      rates: RATES,
-    };
-    render(<IdentitiesView />);
-
-    await userEvent.click(screen.getByRole("button", { name: /ann@example\.com/i }));
-    await userEvent.click(screen.getByRole("button", { name: /next account/i }));
-
-    expect(portalRouter.search.acct).toContain("a2");
-  });
-
-  // A decision prunes its row from the list at once. The window must hold
-  // what it knew — the case and its position — or the operator's own success
-  // kills the outcome they are reading and the Next button they are about to
-  // press.
-  it("keeps the open case and the conveyor when the decided row is pruned", async () => {
+  // A decision prunes its row from the list at once. The window must hold the
+  // row it was opened on, or the operator's own success turns the case they are
+  // reading into a stale-link apology.
+  it("keeps the open case when the decided row is pruned", async () => {
     attention.q.data = {
       items: [
         item({ account_id: "a1", email: "ann@example.com" }),
@@ -809,18 +792,22 @@ describe("IdentitiesView", () => {
     // The case still names what was decided, not a stale-link apology.
     expect(within(dialog).getByText(/ann@example\.com/)).toBeInTheDocument();
     expect(within(dialog).queryByText(/link may be stale/i)).not.toBeInTheDocument();
-    // And the conveyor still moves: the row that shifted into this slot is next.
-    await userEvent.click(within(dialog).getByRole("button", { name: /next account/i }));
-    expect(portalRouter.search.acct).toContain("a2");
   });
 
   // Modes are ways IN to the same decisions; the mode rides in the URL so a
   // link opens the one it was sent from.
-  it("switches modes through the URL, dropping the account selected in the old one", async () => {
+  it("switches modes through the URL, dropping what was open in the old one", async () => {
     attention.q.data = { items: [item({})], rates: RATES };
-    // A selection the window cannot open (a mistyped link) leaves the value in
+    // Selections the window cannot open (mistyped links) leave the values in
     // the URL with no modal over the tabs — the state the switch must clear.
-    portalRouter.set({ zone: "manage", item: "identities", acct: "malformed" });
+    // A person is carried the same way an account is: leaving it behind would
+    // reopen a window over a list that does not contain them.
+    portalRouter.set({
+      zone: "manage",
+      item: "identities",
+      acct: "malformed",
+      person: "not-a-person",
+    });
     render(<IdentitiesView />);
 
     await userEvent.click(screen.getByRole("tab", { name: /a person and their accounts/i }));
@@ -828,6 +815,7 @@ describe("IdentitiesView", () => {
     expect(portalRouter.search.mode).toBe("person");
     // A case picked in the queue means nothing in a list it is not part of.
     expect(portalRouter.search.acct).toBeUndefined();
+    expect(portalRouter.search.person).toBeUndefined();
     // The mode it switched TO is on screen, so the cleared selection is not
     // just an empty URL over the old surface.
     expect(

--- a/src/frontend/src/components/portal/identities-view.tsx
+++ b/src/frontend/src/components/portal/identities-view.tsx
@@ -59,6 +59,7 @@ import {
 } from "@/lib/portal/portal-search";
 import { usePortalNavActions } from "@/lib/portal/portal-nav";
 import { itemKey } from "@/lib/identities/account-key";
+import { activatesRow, activatesRowByKey } from "@/lib/identities/row-activation";
 import { MODES, resolveMode } from "@/lib/portal/identity-modes";
 import { personDisplayName } from "@/lib/identities/person-display";
 import {
@@ -82,15 +83,6 @@ const KIND_ORDER = [
   "no_evidence",
 ] as const;
 
-/** A click selects the case — unless it pressed a control or ended a selection. */
-function opensTheCase(event: React.MouseEvent<HTMLElement>): boolean {
-  if (event.target instanceof Element && event.target.closest("button, a")) {
-    return false;
-  }
-  const selection = window.getSelection();
-  return !selection || selection.isCollapsed;
-}
-
 export function IdentitiesView() {
   const { t } = useTranslation();
   const { mode } = usePortalSearch();
@@ -110,11 +102,11 @@ export function IdentitiesView() {
       <Tabs
         className="shrink-0"
         value={active}
-        // A mode change drops the open account: a case picked in one mode
-        // means nothing in another, and carrying it would open a window the
-        // list behind it does not contain.
+        // A mode change closes whatever was open: a case or a person picked in
+        // one mode means nothing in another, and carrying either would open a
+        // window over a list that does not contain it.
         onValueChange={(next) =>
-          setSearch({ mode: String(next), acct: undefined })
+          setSearch({ mode: String(next), acct: undefined, person: undefined })
         }
       >
         <TabsList>
@@ -640,11 +632,10 @@ function CaseBlock({
               tabIndex={0}
               data-queue-row={key}
               onClick={(event) => {
-                if (opensTheCase(event)) onSelect(key);
+                if (activatesRow(event)) onSelect(key);
               }}
               onKeyDown={(event) => {
-                if (event.key !== "Enter" && event.key !== " ") return;
-                if (event.target !== event.currentTarget) return;
+                if (!activatesRowByKey(event)) return;
                 event.preventDefault();
                 onSelect(key);
               }}

--- a/src/frontend/src/components/portal/identities-view.tsx
+++ b/src/frontend/src/components/portal/identities-view.tsx
@@ -307,12 +307,6 @@ function Queue({
   const other = items.filter((i) => !known.has(i.kind));
   if (other.length > 0) groups.push({ kind: "other", items: other });
 
-  // The rendered order, flattened: what "the next case" means to someone
-  // working down the queue, and it must not be re-derived differently here.
-  const ordered = groups.flatMap((group) =>
-    groupIntoCases(group.items).flatMap((c) => c.items.map(itemKey)),
-  );
-
   const select = (key: string | null) => {
     if (key) setVisited((seen) => new Set(seen).add(key));
     setAcct(key);
@@ -405,8 +399,6 @@ function Queue({
       <CaseDialog
         acct={acct}
         items={items}
-        ordered={ordered}
-        onSelect={select}
         onClose={() => {
           const opened = acct;
           setAcct(null);

--- a/src/frontend/src/components/portal/outcome-alert.tsx
+++ b/src/frontend/src/components/portal/outcome-alert.tsx
@@ -1,0 +1,45 @@
+/**
+ * The server's answer to a correction, verbatim — three counters, never a bare
+ * "done".
+ *
+ * Shown where a verb did NOT settle everything it named: those accounts kept
+ * their bindings, so the operator still has a decision to take and needs the
+ * counters to see it. The toast beside it comes from `useCorrectionReport`.
+ */
+import { useTranslation } from "react-i18next";
+
+import type { CorrectionResponse } from "@/api/identity-client";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { refusedCount } from "@/lib/identities/outcomes";
+
+export function OutcomeAlert({ outcome }: { outcome: CorrectionResponse }) {
+  const { t } = useTranslation();
+  const refused = refusedCount(outcome);
+  return (
+    <Alert variant={refused > 0 ? "destructive" : "default"} role="status">
+      <AlertTitle className="flex flex-wrap items-center gap-1.5">
+        <Badge variant="secondary">
+          {t("identities.outcomes.applied", { count: outcome.applied })}
+        </Badge>
+        {outcome.already_decided > 0 ? (
+          <Badge variant="outline">
+            {t("identities.outcomes.already_decided", {
+              count: outcome.already_decided,
+            })}
+          </Badge>
+        ) : null}
+        {refused > 0 ? (
+          <Badge variant="secondary" className="bg-destructive/15 text-destructive">
+            {t("identities.outcomes.refused", { count: refused })}
+          </Badge>
+        ) : null}
+      </AlertTitle>
+      {outcome.new_person_id ? (
+        <AlertDescription className="font-mono text-xs">
+          {t("identities.outcomes.new_person")} {outcome.new_person_id}
+        </AlertDescription>
+      ) : null}
+    </Alert>
+  );
+}

--- a/src/frontend/src/components/portal/person-accounts-view.test.tsx
+++ b/src/frontend/src/components/portal/person-accounts-view.test.tsx
@@ -2,9 +2,11 @@
 /**
  * The console's second mode. What matters: an operator arrives holding a name
  * and reaches accounts the queue never shows, because a settled binding is not
- * a problem — until someone asks about it; who decided each binding is on the
- * row, since undoing automation is routine and overruling a colleague is not;
+ * a problem — until someone asks about it; the roster STAYS on screen while a
+ * person is open, exactly as the account listing does behind its own window;
  * and the person rides in the URL, so the view is shareable like the rest.
+ *
+ * What the window itself does belongs to `person-dialog.test.tsx`.
  */
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -42,13 +44,6 @@ const hooks = vi.hoisted(() => ({
     isError: false,
     error: null as unknown,
   },
-  binding: {
-    data: undefined as unknown,
-    isLoading: true,
-    isError: false,
-    error: null as unknown,
-    refetch: vi.fn(),
-  },
   accountSearch: {
     data: undefined as { pages: { items: unknown[] }[] } | undefined,
     isFetching: false,
@@ -64,13 +59,9 @@ vi.mock("@/queries/identity-resolution", async (importOriginal) => ({
   usePersonAccounts: () => hooks.accounts,
   usePersonList: () => hooks.search,
   useAccountList: () => hooks.accountSearch,
-  // The window's own behaviour belongs to account-detail.test; a case that needs
-  // the verbs on screen sets a binding for itself.
-  useAccountBinding: () => hooks.binding,
-  // The verbs themselves belong to account-actions.test; stubbed so the window
-  // can render them without this suite standing up a query client.
+  // The verbs belong to person-dialog.test; stubbed so the window can render
+  // them without this suite standing up a query client.
   useBindAccount: () => hooks.verb,
-  useMergePersons: () => hooks.verb,
   useDetachAccount: () => hooks.verb,
   useExcludeAccount: () => hooks.verb,
 }));
@@ -93,14 +84,24 @@ function entry(over: Partial<PersonAccountEntry> = {}): PersonAccountEntry {
   };
 }
 
+function roster() {
+  hooks.search.data = {
+    pages: [
+      {
+        items: [
+          { person_id: ANN, display_name: "Ann Lee", email: "ann@example.com" },
+        ],
+      },
+    ],
+  };
+}
+
 beforeEach(() => {
   hooks.accounts.data = undefined;
   hooks.accounts.isLoading = false;
   hooks.accounts.isError = false;
   hooks.accounts.refetch.mockClear();
   hooks.search.data = undefined;
-  hooks.binding.data = undefined;
-  hooks.binding.isLoading = true;
   hooks.accountSearch.data = undefined;
   hooks.accountSearch.hasNextPage = false;
   hooks.accountSearch.isPlaceholderData = false;
@@ -113,48 +114,15 @@ describe("PersonAccountsView", () => {
   // With nobody chosen the mode IS the roster: an operator reviewing
   // identities needs to see who exists, not guess a name to type.
   it("lists the roster before anyone is chosen", () => {
-    hooks.search.data = {
-      pages: [
-        { items: [{ person_id: ANN, display_name: "Ann Lee", email: "ann@example.com" }] },
-      ],
-    };
+    roster();
     render(<PersonAccountsView />);
 
     expect(screen.getByText("Ann Lee")).toBeInTheDocument();
-  });
-
-  // Choosing a person swaps the roster for their accounts and clears the terms
-  // that found them, so nothing on screen leads back — an operator comparing
-  // two people would be retyping, or editing the URL.
-  it("offers the way back to the roster once a person is chosen", async () => {
-    // A value the window cannot open, so the control is not under a modal: a
-    // live account key opens the case dialog, whose own Close is the way out of
-    // that. What this pins is that returning to the roster leaves no account
-    // selection behind, not that it can dismiss an open one.
-    portalRouter.set({ person: ANN, acct: "malformed" });
-    hooks.accounts.data = { person_id: ANN, accounts: [] };
-    render(<PersonAccountsView />);
-
-    await userEvent.click(screen.getByRole("button", { name: /back to the roster/i }));
-
-    expect(portalRouter.search.person).toBeUndefined();
-    expect(portalRouter.search.acct).toBeUndefined();
-  });
-
-  it("shows no way back while the roster itself is on screen", () => {
-    render(<PersonAccountsView />);
-
-    expect(
-      screen.queryByRole("button", { name: /back to the roster/i }),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
   it("puts the chosen person in the URL, so the view is a link", async () => {
-    hooks.search.data = {
-      pages: [
-        { items: [{ person_id: ANN, display_name: "Ann Lee", email: "ann@example.com" }] },
-      ],
-    };
+    roster();
     render(<PersonAccountsView />);
 
     await userEvent.type(screen.getByRole("searchbox"), "ann");
@@ -163,142 +131,48 @@ describe("PersonAccountsView", () => {
     expect(portalRouter.search.person).toBe(ANN);
   });
 
-  it("lists every account bound to the person, saying who decided each", () => {
-    portalRouter.set({ person: ANN });
-    hooks.accounts.data = {
-      person_id: ANN,
-      accounts: [
-        entry(),
-        entry({
-          source: "gitlab",
-          account_id: "gl-alt",
-          email: null,
-          username: "alee",
-          bound_by_operator: true,
-        }),
-      ],
-    };
-    render(<PersonAccountsView />);
-
-    expect(screen.getByText("ann@example.com")).toBeInTheDocument();
-    expect(screen.getByText(/github · gh-main/)).toBeInTheDocument();
-    expect(screen.getByText(/bound automatically/i)).toBeInTheDocument();
-    expect(screen.getByText(/decided by an operator/i)).toBeInTheDocument();
-  });
-
-  // The whole point of the mode: these accounts are settled, so the queue
-  // never shows them — and the verbs are still available for them.
-  it("opens a settled account in the same case window", async () => {
+  // The point of the redesign: the roster does not go away. Both listings in
+  // this console now behave the same — a window opens over what you were
+  // reading, rather than replacing the screen and needing a way back drawn on
+  // it.
+  it("keeps the roster behind the window a person opens", () => {
+    roster();
     portalRouter.set({ person: ANN });
     hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
     render(<PersonAccountsView />);
 
-    await userEvent.click(screen.getByRole("button", { name: /^open$/i }));
-
-    expect(portalRouter.search.acct).toContain("gh-main");
-    expect(within(screen.getByRole("dialog")).getByText(/github · gh-main/)).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Ann Lee")).toBeInTheDocument();
   });
 
-  // Inside a person the people search is the wrong question — they are already
-  // open, and the back link is the way out. What is useful here is finding an
-  // ACCOUNT, to bind it to them.
-  it("searches accounts, not people, once a person is open", () => {
+  // Closing IS the way back, so no second control has to say so.
+  it("clears the person from the URL when the window closes", async () => {
     portalRouter.set({ person: ANN });
     hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
     render(<PersonAccountsView />);
 
-    const fields = screen.getAllByRole("searchbox");
-    expect(fields).toHaveLength(1);
-    expect(fields[0]).toHaveAccessibleName(/find an account/i);
+    await userEvent.click(screen.getByRole("button", { name: /close/i }));
+
+    expect(portalRouter.search.person).toBeUndefined();
   });
 
-  // The whole fold would bury the handful of accounts the person actually
-  // holds, which is what the reader opened them for.
-  it("lists no account until the field is asked something", () => {
-    portalRouter.set({ person: ANN });
-    hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
-    hooks.accountSearch.data = {
-      pages: [
-        {
-          items: [
-            {
-              source: "zoom",
-              source_id: "01900000-0000-7000-8000-00000000aa03",
-              account_id: "zm-9",
-              email: "someone.else@example.com",
-              username: null,
-              display_name: null,
-              person: null,
-              bound_by_operator: false,
-            },
-          ],
-        },
-      ],
-    };
-    render(<PersonAccountsView />);
-
-    // Whatever the hook holds, a blank field asked nothing and shows nothing.
-    expect(screen.queryByText("someone.else@example.com")).not.toBeInTheDocument();
-    expect(screen.getByText("ann@example.com")).toBeInTheDocument();
-  });
-
-  // One window per surface: `?acct=` opens by itself, so a second one would
-  // open beside the first on the same link.
-  it("opens a found account in the same window the person's own rows use", async () => {
+  // Two different questions, so two different fields — and never one field
+  // pointed at both. The surface finds PEOPLE; the window over it finds
+  // ACCOUNTS, to bind them to the person it is about.
+  it("searches people on the surface and accounts inside the window", () => {
+    roster();
     portalRouter.set({ person: ANN });
     hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
     render(<PersonAccountsView />);
 
-    await userEvent.click(screen.getByRole("button", { name: /^open$/i }));
-
-    expect(screen.getAllByRole("dialog")).toHaveLength(1);
-  });
-
-  // Every account here is already this person's, so a candidate list saying so
-  // invites re-asserting the binding — the confirm act, which belongs in the
-  // queue. The holder is named in its own section instead.
-  it("opens one of the person's accounts with no candidates to confirm", async () => {
-    portalRouter.set({ person: ANN });
-    hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
-    // A real binding, or the window body is a spinner and this proves nothing.
-    hooks.binding.data = {
-      source: "github",
-      source_id: "01900000-0000-7000-8000-00000000aa01",
-      account_id: "gh-main",
-      person_id: ANN,
-      history: [],
-    };
-    hooks.binding.isLoading = false;
-    render(<PersonAccountsView />);
-
-    await userEvent.click(screen.getByRole("button", { name: /^open$/i }));
-
-    const dialog = screen.getByRole("dialog");
-    // The verbs are on screen — so an absent candidate list means absent, not
-    // "still loading".
     expect(
-      within(dialog).getByRole("button", { name: /exclude \(bot/i }),
+      within(screen.getByRole("dialog")).getByRole("searchbox", {
+        name: /find an account/i,
+      }),
     ).toBeInTheDocument();
-    expect(within(dialog).queryByText(/candidates/i)).not.toBeInTheDocument();
-    expect(
-      within(dialog).queryByRole("button", { name: /^confirm$/i }),
-    ).not.toBeInTheDocument();
-  });
-
-  it("states an empty result rather than an empty card", () => {
-    portalRouter.set({ person: ANN });
-    hooks.accounts.data = { person_id: ANN, accounts: [] };
-    render(<PersonAccountsView />);
-
-    expect(screen.getByText(/no account is bound to this person/i)).toBeInTheDocument();
-  });
-
-  it("offers a retry when the read fails", async () => {
-    portalRouter.set({ person: ANN });
-    hooks.accounts.isError = true;
-    render(<PersonAccountsView />);
-
-    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
-    expect(hooks.accounts.refetch).toHaveBeenCalled();
+    // By placeholder, not by role: the window marks the page behind it hidden
+    // from assistive tech, which is exactly what an open dialog should do — the
+    // roster is still mounted and still holds its own terms.
+    expect(screen.getByPlaceholderText(/search people/i)).toBeInTheDocument();
   });
 });

--- a/src/frontend/src/components/portal/person-accounts-view.test.tsx
+++ b/src/frontend/src/components/portal/person-accounts-view.test.tsx
@@ -20,7 +20,15 @@ vi.mock("@tanstack/react-router", async () => {
   return portalRouterMock();
 });
 
-const hooks = vi.hoisted(() => ({
+const hooks = vi.hoisted(() => {
+  const verb = () => ({
+    mutate: vi.fn(),
+    reset: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null as unknown,
+  });
+  return {
   accounts: {
     data: undefined as
       | { person_id: string; accounts: PersonAccountEntry[] }
@@ -37,13 +45,9 @@ const hooks = vi.hoisted(() => ({
     hasNextPage: false,
     fetchNextPage: vi.fn(),
   },
-  verb: {
-    mutate: vi.fn(),
-    reset: vi.fn(),
-    isPending: false,
-    isError: false,
-    error: null as unknown,
-  },
+  bind: verb(),
+  detach: verb(),
+  exclude: verb(),
   accountSearch: {
     data: undefined as { pages: { items: unknown[] }[] } | undefined,
     isFetching: false,
@@ -53,7 +57,8 @@ const hooks = vi.hoisted(() => ({
     hasNextPage: false,
     fetchNextPage: vi.fn(),
   },
-}));
+  };
+});
 vi.mock("@/queries/identity-resolution", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/queries/identity-resolution")>()),
   usePersonAccounts: () => hooks.accounts,
@@ -61,9 +66,9 @@ vi.mock("@/queries/identity-resolution", async (importOriginal) => ({
   useAccountList: () => hooks.accountSearch,
   // The verbs belong to person-dialog.test; stubbed so the window can render
   // them without this suite standing up a query client.
-  useBindAccount: () => hooks.verb,
-  useDetachAccount: () => hooks.verb,
-  useExcludeAccount: () => hooks.verb,
+  useBindAccount: () => hooks.bind,
+  useDetachAccount: () => hooks.detach,
+  useExcludeAccount: () => hooks.exclude,
 }));
 
 import { portalRouter } from "@/test/portal-router";
@@ -102,10 +107,25 @@ beforeEach(() => {
   hooks.accounts.isError = false;
   hooks.accounts.refetch.mockClear();
   hooks.search.data = undefined;
+  hooks.search.isFetching = false;
+  hooks.search.isFetchingNextPage = false;
+  hooks.search.isError = false;
+  hooks.search.hasNextPage = false;
+  hooks.search.fetchNextPage.mockClear();
   hooks.accountSearch.data = undefined;
+  hooks.accountSearch.isFetching = false;
+  hooks.accountSearch.isFetchingNextPage = false;
+  hooks.accountSearch.isError = false;
   hooks.accountSearch.hasNextPage = false;
   hooks.accountSearch.isPlaceholderData = false;
   hooks.accountSearch.fetchNextPage.mockClear();
+  for (const verb of [hooks.bind, hooks.detach, hooks.exclude]) {
+    verb.mutate.mockReset();
+    verb.reset.mockReset();
+    verb.isPending = false;
+    verb.isError = false;
+    verb.error = null;
+  }
   portalRouter.reset();
   portalRouter.set({ zone: "manage", item: "identities", mode: "person" });
 });

--- a/src/frontend/src/components/portal/person-accounts-view.tsx
+++ b/src/frontend/src/components/portal/person-accounts-view.tsx
@@ -1,5 +1,6 @@
 /**
- * The console's second mode: one person and every account bound to them.
+ * The console's second mode: the roster, and the window one person is worked
+ * in.
  *
  * The review queue only ever shows what automation could not decide, so a
  * settled binding is invisible — and the questions that actually arrive are
@@ -10,216 +11,48 @@
  * Entered through a person rather than through a list of every binding: the
  * roster is browsable here, but a decision still starts from whose accounts
  * these are, so it stays attached to the question that prompted it.
+ *
+ * The roster stays on screen while a person is open, exactly as the account
+ * listing does — the person rides in `?person=`, the window over it is
+ * {@link PersonDialog}, and closing it IS the way back.
  */
 import { useState } from "react";
-import { useTranslation } from "react-i18next";
 
-import type {
-  PersonAccountEntry,
-  PersonSummary,
-} from "@/api/identity-client";
-import { PersonCell } from "@/components/portal/person-cell";
-import { AccountFinder } from "@/components/portal/account-search-view";
-import type { CaseRow } from "@/components/portal/case-dialog";
+import type { PersonSummary } from "@/api/identity-client";
+import { PersonDialog } from "@/components/portal/person-dialog";
 import { PersonPicker } from "@/components/portal/person-picker";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { CenteredSpinner } from "@/components/widgets/centered-spinner";
-import { ComingSoon } from "@/components/widgets/coming-soon";
-import { accountKey } from "@/lib/identities/account-key";
-import { KIND_PERSON_MEMBER } from "@/lib/identities/cases";
-import { usePortalNavActions } from "@/lib/portal/portal-nav";
 import { usePortalSearch, useSetPortalSearch } from "@/lib/portal/portal-search";
-import { usePersonAccounts } from "@/queries/identity-resolution";
-import { cn } from "@/lib/utils";
 
 export function PersonAccountsView() {
-  const { t } = useTranslation();
   const { person, find } = usePortalSearch();
   const setSearch = useSetPortalSearch();
   // The URL owns which person is open; this remembers the card the operator
-  // picked, so the heading names them. Arriving by link there is no card —
+  // picked, so the window names them. Arriving by link there is no card —
   // search resolves values, not ids — and the id stands alone, honestly.
   const [picked, setPicked] = useState<PersonSummary | null>(null);
 
   return (
     <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-4">
-      {/* Choosing a person replaces the roster with their accounts, so the way
-          back is not on screen anywhere: without this, leaving a person means
-          editing the URL. The terms that found them are kept, so coming back
-          lands on the same list rather than on a blank field. */}
-      {person ? (
-        <Button
-          type="button"
-          variant="ghost"
-          size="sm"
-          className="-ms-2 self-start"
-          onClick={() => setSearch({ person: undefined, acct: undefined })}
-        >
-          {t("identities.person_accounts.back")}
-        </Button>
-      ) : null}
-      {/* Two different questions, so two different fields — never both. With
-          nobody chosen the roster IS this mode, and it takes the surface: the
-          card and the full height the other two modes' listings have. Inside a
-          person, searching for people again is asking the reader to find
-          somebody they already have open; what they need there is an ACCOUNT,
-          to bind it to them. */}
-      {person ? (
-        <PersonAccounts
-          personId={person}
-          card={picked?.person_id === person ? picked : null}
-        />
-      ) : (
-        <PersonPicker
-          browseWhenEmpty
-          asSurface
-          // The roster's terms live in the URL: picking a person unmounts this
-          // field, and a reader who comes back should not have to find the same
-          // person twice. `replace`, because typing is not a place to go back to.
-          initialQuery={find ?? ""}
-          onSettled={(query) =>
-            setSearch({ find: query || undefined }, { replace: true })
-          }
-          onPick={(next: PersonSummary) => {
-            setPicked(next);
-            setSearch({ person: next.person_id, acct: undefined });
-          }}
-        />
-      )}
-    </div>
-  );
-}
-
-function PersonAccounts({
-  personId,
-  card,
-}: {
-  personId: string;
-  card: PersonSummary | null;
-}) {
-  const { t } = useTranslation();
-  const { acct } = usePortalSearch();
-  const { setAcct } = usePortalNavActions();
-  const accounts = usePersonAccounts(personId);
-
-  if (accounts.isLoading) return <CenteredSpinner className="min-h-40" />;
-  if (accounts.isError || !accounts.data) {
-    return (
-      <ComingSoon
-        variant="card"
-        state="error"
-        label={t("identities.person_accounts.load_failed")}
-        onRetry={() => void accounts.refetch()}
+      <PersonPicker
+        browseWhenEmpty
+        asSurface
+        // The roster's terms live in the URL: a reader who comes back to this
+        // mode should not have to find the same person twice. `replace`,
+        // because typing is not a place to go back to.
+        initialQuery={find ?? ""}
+        onSettled={(query) =>
+          setSearch({ find: query || undefined }, { replace: true })
+        }
+        onPick={(next: PersonSummary) => {
+          setPicked(next);
+          setSearch({ person: next.person_id });
+        }}
       />
-    );
-  }
-
-  const entries = accounts.data.accounts;
-  const person = card ?? { person_id: personId };
-  // Queue-shaped rows for the window: the voucher that each account exists
-  // (they are read from the person's own bindings), plus the person as the
-  // HOLDER so the current binding renders as a card rather than a bare id.
-  // Never as a candidate: every account here is already theirs, and a candidate
-  // list saying so invites re-asserting the binding — the confirm act, which the
-  // queue lists the accounts for.
-  const asCases: CaseRow[] = entries.map((entry) => ({
-    kind: KIND_PERSON_MEMBER,
-    source: entry.source,
-    source_id: entry.source_id,
-    account_id: entry.account_id,
-    email: entry.email,
-    username: entry.username,
-    candidates: [],
-    holder: person,
-  }));
-
-  return (
-    <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-4">
-      {/* The field here searches ACCOUNTS, and it owns the one case window on
-          this surface — so the rows below open in it too, rather than in a
-          second window `?acct=` would open beside the first. */}
-      <AccountFinder
-        intent="match"
-        placeholder={t("identities.person_accounts.find_account")}
-        alsoOpenable={asCases}
-        bindTo={person}
-        className="flex-none"
+      <PersonDialog
+        personId={person}
+        card={picked}
+        onClose={() => setSearch({ person: undefined })}
       />
-      {/* Shrinkable, not fixed: with more accounts than fit, a card that refuses
-          to shrink runs off the bottom of the mode and takes the field and the
-          tabs above it out of reach. Sized to its rows while they fit. */}
-      <Card className="min-h-0 overflow-hidden">
-        <CardHeader>
-          <CardTitle className="flex flex-wrap items-center gap-2 text-sm">
-            {t("identities.person_accounts.accounts")}
-            <Badge variant="secondary">{entries.length}</Badge>
-            <PersonCell person={person} className="ms-auto" />
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="flex min-h-0 flex-col gap-1 overflow-y-auto p-2 pt-0">
-          {entries.length === 0 ? (
-            <p className="p-3 text-sm text-muted-foreground">
-              {t("identities.person_accounts.no_accounts")}
-            </p>
-          ) : (
-            entries.map((entry) => (
-              <AccountRow
-                key={accountKey(entry)}
-                entry={entry}
-                selected={accountKey(entry) === acct}
-                onOpen={() => setAcct(accountKey(entry))}
-              />
-            ))
-          )}
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-function AccountRow({
-  entry,
-  selected,
-  onOpen,
-}: {
-  entry: PersonAccountEntry;
-  selected: boolean;
-  onOpen: () => void;
-}) {
-  const { t } = useTranslation();
-  const label = entry.email?.trim() || entry.username?.trim() || entry.account_id;
-  return (
-    // Same fixed columns, and the same width to earn them, as the account
-    // listing: the two lists sit one tab apart and reading either one down a
-    // column should feel the same.
-    <div
-      className={cn(
-        "grid grid-cols-1 items-center gap-2 rounded-md border p-3",
-        "lg:grid-cols-[minmax(0,1fr)_minmax(0,11rem)_auto]",
-        selected ? "border-ring bg-muted" : "border-transparent",
-      )}
-    >
-      <div className="min-w-0">
-        <div className="truncate text-sm font-medium select-text">{label}</div>
-        <div className="truncate font-mono text-xs text-muted-foreground select-text">
-          {entry.source} · {entry.account_id}
-        </div>
-      </div>
-      {/* Who decided this binding is the first thing to know before changing
-          it: undoing automation is routine, overruling a colleague is not. */}
-      <Badge
-        variant={entry.bound_by_operator ? "secondary" : "outline"}
-        className="justify-self-start font-normal"
-      >
-        {entry.bound_by_operator
-          ? t("identities.person_accounts.by_operator")
-          : t("identities.person_accounts.by_automation")}
-      </Badge>
-      <Button type="button" size="xs" variant="outline" onClick={onOpen}>
-        {t("identities.person_accounts.open")}
-      </Button>
     </div>
   );
 }

--- a/src/frontend/src/components/portal/person-cell.tsx
+++ b/src/frontend/src/components/portal/person-cell.tsx
@@ -73,40 +73,7 @@ export function PersonCell({
           >
             {name}
           </span>
-          {/* One word on the badge, the warning behind it: a badge never wraps
-              and never shrinks, so a sentence in one pushes the name out of a
-              narrow column and spills across the row. The trigger takes a tab
-              stop of its own on purpose — this mark is what says a person is
-              the wrong side of a merge, and a hover-only carrier tells a
-              keyboard reader nothing. */}
-          {person.provisional ? (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger
-                  render={
-                    <Badge
-                      variant="outline"
-                      className="cursor-help font-normal"
-                      tabIndex={0}
-                    />
-                  }
-                >
-                  {t("identities.person.provisional")}
-                </TooltipTrigger>
-                <TooltipContent side="top">
-                  {t("identities.person.provisional_hint")}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          ) : null}
-          {person.status?.trim().toLowerCase() === TERMINATED ? (
-            <Badge
-              variant="secondary"
-              className="bg-destructive/15 text-destructive"
-            >
-              {t("identities.person.terminated")}
-            </Badge>
-          ) : null}
+          <PersonMarks person={person} />
         </div>
         {detail ? (
           <div className="truncate text-xs text-muted-foreground">{detail}</div>
@@ -125,5 +92,48 @@ export function PersonCell({
         </div>
       </div>
     </div>
+  );
+}
+
+/**
+ * What makes a person the wrong one to act on: a stub automation minted, or a
+ * leaver. Wherever a person is named for a decision — a cell in a listing, the
+ * heading of the window they are decided in — these travel with the name.
+ */
+export function PersonMarks({ person }: { person: PersonSummary }) {
+  const { t } = useTranslation();
+  return (
+    <>
+      {/* One word on the badge, the warning behind it: a badge never wraps and
+          never shrinks, so a sentence in one pushes the name out of a narrow
+          column and spills across the row. The trigger takes a tab stop of its
+          own on purpose — this mark is what says a person is the wrong side of a
+          merge, and a hover-only carrier tells a keyboard reader nothing. */}
+      {person.provisional ? (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Badge
+                  variant="outline"
+                  className="cursor-help font-normal"
+                  tabIndex={0}
+                />
+              }
+            >
+              {t("identities.person.provisional")}
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              {t("identities.person.provisional_hint")}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : null}
+      {person.status?.trim().toLowerCase() === TERMINATED ? (
+        <Badge variant="secondary" className="bg-destructive/15 text-destructive">
+          {t("identities.person.terminated")}
+        </Badge>
+      ) : null}
+    </>
   );
 }

--- a/src/frontend/src/components/portal/person-dialog.test.tsx
+++ b/src/frontend/src/components/portal/person-dialog.test.tsx
@@ -103,15 +103,28 @@ function open(card: { person_id: string; display_name?: string } | null = null) 
   );
 }
 
-/** The innermost dialog: a confirmation opens over the window, not beside it. */
+/**
+ * The confirmation over the window.
+ *
+ * An open confirmation hides the window behind it from role queries, so this is
+ * normally the only dialog left — but when none opened, `at(-1)` hands back the
+ * window itself and the case fails further down for the wrong reason. Its
+ * Cancel button is what tells the two apart.
+ */
 function confirmation() {
-  return screen.getAllByRole("dialog").at(-1) as HTMLElement;
+  const asked = screen.getAllByRole("dialog").at(-1) as HTMLElement;
+  expect(
+    within(asked).getByRole("button", { name: "Cancel" }),
+  ).toBeInTheDocument();
+  return asked;
 }
 
 beforeEach(() => {
   for (const verb of [hooks.bind, hooks.detach, hooks.exclude]) {
-    verb.mutate.mockClear();
-    verb.reset.mockClear();
+    // Reset, not clear: `mockClear` keeps an implementation a case installed,
+    // and a refusal wired for one verb would then fire in every case after it.
+    verb.mutate.mockReset();
+    verb.reset.mockReset();
     verb.isPending = false;
     verb.isError = false;
     verb.error = null;
@@ -123,8 +136,12 @@ beforeEach(() => {
   hooks.accounts.isError = false;
   hooks.accounts.refetch.mockClear();
   hooks.search.data = undefined;
+  hooks.search.isFetching = false;
+  hooks.search.isFetchingNextPage = false;
   hooks.search.isPlaceholderData = false;
+  hooks.search.isError = false;
   hooks.search.hasNextPage = false;
+  hooks.search.fetchNextPage.mockClear();
 });
 
 describe("PersonDialog", () => {
@@ -162,6 +179,24 @@ describe("PersonDialog", () => {
     expect(screen.getByText(/terminated/i)).toBeInTheDocument();
   });
 
+  // `cn(..., named || fallback)` puts the NAME in the class list when there is
+  // one: a display name a connector reported as "hidden" would then hide
+  // itself from the heading of the window it is about.
+  it("keeps the person's name out of the heading's class list", () => {
+    hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
+    render(
+      <PersonDialog
+        personId={ANN}
+        card={{ person_id: ANN, display_name: "hidden Lee" }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const heading = screen.getByText("hidden Lee");
+    expect(heading).toBeVisible();
+    expect(heading.className).not.toMatch(/hidden/);
+  });
+
   it("lists every account they hold, saying who decided each", () => {
     hooks.accounts.data = {
       person_id: ANN,
@@ -186,12 +221,30 @@ describe("PersonDialog", () => {
 
   // The governing rule of the redesign: a row here is not a door. Walking into
   // an account from inside a person would stack two windows over one decision.
-  it("opens nothing from the accounts it lists", () => {
-    hooks.accounts.data = { person_id: ANN, accounts: [entry(), entry({ account_id: "gh-alt" })] };
+  // Pressed and keyed, because a row wired as a button answers both.
+  it("opens nothing from the accounts it lists", async () => {
+    hooks.accounts.data = {
+      person_id: ANN,
+      accounts: [entry(), entry({ account_id: "gh-alt", email: "alt@example.com" })],
+    };
     open();
 
+    const body = screen.getByText("ann@example.com");
+    await userEvent.click(body);
+    await userEvent.type(body, "{Enter}");
+
     expect(screen.queryByRole("button", { name: /^open$/i })).not.toBeInTheDocument();
-    expect(screen.getAllByRole("dialog")).toHaveLength(1);
+    // No confirmation and no second window: a Cancel button anywhere means
+    // something opened. (Counting dialogs would not catch it — an open
+    // confirmation hides the window behind it from role queries, so the count
+    // stays at one either way.)
+    expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^detach ann@example\.com/i }),
+    ).toBeInTheDocument();
+    for (const verb of [hooks.bind, hooks.detach, hooks.exclude]) {
+      expect(verb.mutate).not.toHaveBeenCalled();
+    }
   });
 
   it("states an empty result rather than an empty list", () => {
@@ -213,14 +266,16 @@ describe("PersonDialog", () => {
 
   // A detach mints a person and moves the account there. Taking somebody's ONLY
   // account replaces them with an identical person and leaves their name behind
-  // with nothing attached — which is how the accountless persons got made. Said
-  // out loud, because a button that is simply absent reads as a fault.
-  it("withholds the detach that would leave them with nothing, and says why", () => {
+  // with nothing attached — which is how the accountless persons got made.
+  it("withholds the detach that would leave them with nothing", () => {
     hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
     open();
 
-    expect(screen.queryByRole("button", { name: /^detach$/i })).not.toBeInTheDocument();
-    expect(screen.getByText(/their only account/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^detach /i })).not.toBeInTheDocument();
+    // The row is there, so the verb is withheld rather than the list empty.
+    expect(
+      screen.getByRole("button", { name: /^exclude ann@example\.com/i }),
+    ).toBeInTheDocument();
   });
 
   it("detaches one of several accounts, in the wire shape, behind a confirmation", async () => {
@@ -230,10 +285,12 @@ describe("PersonDialog", () => {
     };
     open();
 
-    await userEvent.click(screen.getAllByRole("button", { name: /^detach$/i })[0]);
-    expect(
-      within(confirmation()).getByText(/a new person is created/i),
-    ).toBeInTheDocument();
+    await userEvent.click(screen.getAllByRole("button", { name: /^detach ann@example\.com/i })[0]);
+    // This window's own wording, not the account window's: it has to say the
+    // person keeps the rest, or the verb reads as "remove from everywhere".
+    const asked = within(confirmation());
+    expect(asked.getByText(/take this account off this person/i)).toBeInTheDocument();
+    expect(asked.getByText(/keeps their other accounts/i)).toBeInTheDocument();
     await userEvent.click(
       within(confirmation()).getByRole("button", { name: /^detach$/i }),
     );
@@ -244,11 +301,32 @@ describe("PersonDialog", () => {
     );
   });
 
+  // The modal covers the row that was pressed, and the window's subject is the
+  // PERSON — so a confirmation naming only them says nothing about which of
+  // several accounts is about to move.
+  it.each([/^detach ann@example\.com/i, /^exclude ann@example\.com/i])(
+    "names the account the %s confirmation acts on",
+    async (verb) => {
+      hooks.accounts.data = {
+        person_id: ANN,
+        accounts: [entry(), entry({ account_id: "gh-alt", email: "alt@example.com" })],
+      };
+      open();
+
+      await userEvent.click(screen.getAllByRole("button", { name: verb })[0]);
+
+      const asked = within(confirmation());
+      expect(asked.getByText("ann@example.com")).toBeInTheDocument();
+      expect(asked.getByText(/github · gh-main/)).toBeInTheDocument();
+      expect(asked.queryByText("alt@example.com")).not.toBeInTheDocument();
+    },
+  );
+
   it("excludes an account behind a confirmation", async () => {
     hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
     open();
 
-    await userEvent.click(screen.getByRole("button", { name: /^exclude$/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^exclude ann@example\.com/i }));
     await userEvent.click(
       within(confirmation()).getByRole("button", { name: /^exclude$/i }),
     );
@@ -270,8 +348,11 @@ describe("PersonDialog", () => {
       screen.getByRole("searchbox", { name: /find an account/i }),
       "annlee",
     );
-    await userEvent.click(screen.getByRole("button", { name: /^annlee$/ }));
+    await userEvent.click(screen.getByRole("button", { name: /^annlee,/ }));
     expect(hooks.bind.mutate).not.toHaveBeenCalled();
+    // Both sides of the binding, since the modal hides the list and the field.
+    expect(within(confirmation()).getByText(/zoom · zm-9/)).toBeInTheDocument();
+    expect(within(confirmation()).getByText("Ann Lee")).toBeInTheDocument();
 
     await userEvent.click(
       within(confirmation()).getByRole("button", { name: /^bind$/i }),
@@ -301,7 +382,7 @@ describe("PersonDialog", () => {
       screen.getByRole("searchbox", { name: /find an account/i }),
       "annlee",
     );
-    await userEvent.click(screen.getByRole("button", { name: /^annlee$/ }));
+    await userEvent.click(screen.getByRole("button", { name: /^annlee,/ }));
 
     expect(
       within(confirmation()).getByText(/taken from Bob Park/i),
@@ -322,7 +403,7 @@ describe("PersonDialog", () => {
       "ann",
     );
 
-    expect(screen.getByRole("button", { name: /^annlee$/ })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^annlee,/ })).toBeInTheDocument();
     // The held account is listed once — above, as theirs, with its own verbs.
     expect(screen.getAllByText(/github · gh-main/)).toHaveLength(1);
   });
@@ -336,6 +417,205 @@ describe("PersonDialog", () => {
 
     expect(screen.queryByText("annlee")).not.toBeInTheDocument();
     expect(screen.getByText("ann@example.com")).toBeInTheDocument();
+  });
+
+  // Nothing may be fired twice while the first attempt is in flight, and the
+  // list behind the confirmation must not offer the same verb again.
+  it("locks the verbs while one is in flight", async () => {
+    hooks.accounts.data = {
+      person_id: ANN,
+      accounts: [entry(), entry({ account_id: "gh-alt", email: "alt@example.com" })],
+    };
+    hooks.exclude.isPending = true;
+    open();
+
+    // Every row's verbs, not just the one that fired: the list stays on screen
+    // behind the confirmation, and a write in flight is not a moment to start
+    // a second one.
+    for (const name of [
+      /^detach ann@example\.com/i,
+      /^exclude ann@example\.com/i,
+      /^exclude alt@example\.com/i,
+    ]) {
+      expect(screen.getByRole("button", { name })).toBeDisabled();
+    }
+  });
+
+  it("locks the confirmation's own button while its write is in flight", async () => {
+    hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
+    const { rerender } = open();
+
+    // Opened before the flag is set: the row verb that reaches this dialog is
+    // itself disabled while a write is in flight.
+    await userEvent.click(
+      screen.getByRole("button", { name: /^exclude ann@example\.com/i }),
+    );
+    hooks.exclude.isPending = true;
+    rerender(<PersonDialog personId={ANN} card={null} onClose={vi.fn()} />);
+
+    expect(
+      within(confirmation()).getByRole("button", { name: /^exclude$/i }),
+    ).toBeDisabled();
+  });
+
+  // Closing over an unshown error would read as success.
+  it("states a failed verb inside the confirmation it was fired from", async () => {
+    hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
+    hooks.exclude.isError = true;
+    hooks.exclude.error = new Error("boom");
+    open();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /^exclude ann@example\.com/i }),
+    );
+
+    expect(
+      within(confirmation()).getByText(/was not applied/i),
+    ).toBeInTheDocument();
+  });
+
+  // A dialog's error belongs to the attempt made in THAT dialog: without the
+  // reset the next one opens already wearing the previous failure.
+  it("resets every verb when a confirmation is dismissed", async () => {
+    hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
+    open();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /^exclude ann@example\.com/i }),
+    );
+    await userEvent.click(
+      within(confirmation()).getByRole("button", { name: "Cancel" }),
+    );
+
+    for (const verb of [hooks.bind, hooks.detach, hooks.exclude]) {
+      expect(verb.reset).toHaveBeenCalled();
+    }
+  });
+
+  // The window stays open — the list under it re-reads and that IS the answer —
+  // but the confirmation goes, and nothing claims a refusal that did not happen.
+  it("closes the confirmation and shows no counters when everything applied", async () => {
+    hooks.exclude.mutate.mockImplementation(
+      (_args: unknown, opts?: { onSuccess?: (r: CorrectionResponse) => void }) =>
+        opts?.onSuccess?.({
+          applied: 1,
+          already_decided: 0,
+          items: [{ ...entry(), outcome: "applied" }],
+        }),
+    );
+    hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
+    open();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /^exclude ann@example\.com/i }),
+    );
+    await userEvent.click(
+      within(confirmation()).getByRole("button", { name: /^exclude$/i }),
+    );
+
+    expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
+    expect(screen.queryByText(/refused/i)).not.toBeInTheDocument();
+    expect(hooks.toast.success).toHaveBeenCalled();
+    expect(hooks.toast.error).not.toHaveBeenCalled();
+  });
+
+  // A detach mints a person, and this window stays open rather than handing the
+  // id to a window that closes — the toast is the only place it can be read, so
+  // it carries the id and stays up long enough to copy it.
+  it("reports the minted person id, and keeps that toast up", async () => {
+    const minted = "01900000-0000-7000-8000-0000000000c0";
+    hooks.detach.mutate.mockImplementation(
+      (_args: unknown, opts?: { onSuccess?: (r: CorrectionResponse) => void }) =>
+        opts?.onSuccess?.({
+          applied: 1,
+          already_decided: 0,
+          items: [{ ...entry(), outcome: "applied" }],
+          new_person_id: minted,
+        }),
+    );
+    hooks.accounts.data = {
+      person_id: ANN,
+      accounts: [entry(), entry({ account_id: "gh-alt", email: "alt@example.com" })],
+    };
+    open();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /^detach ann@example\.com/i }),
+    );
+    await userEvent.click(
+      within(confirmation()).getByRole("button", { name: /^detach$/i }),
+    );
+
+    expect(hooks.toast.success).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        description: expect.stringContaining(minted),
+        duration: expect.any(Number),
+      }),
+    );
+  });
+
+  // Nothing was decided, so the counters are the answer and the window keeps
+  // its verbs.
+  it("reports an account that had already moved without claiming a refusal", async () => {
+    hooks.exclude.mutate.mockImplementation(
+      (_args: unknown, opts?: { onSuccess?: (r: CorrectionResponse) => void }) =>
+        opts?.onSuccess?.({
+          applied: 0,
+          already_decided: 1,
+          items: [{ ...entry(), outcome: "already_decided" }],
+        }),
+    );
+    hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
+    open();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /^exclude ann@example\.com/i }),
+    );
+    await userEvent.click(
+      within(confirmation()).getByRole("button", { name: /^exclude$/i }),
+    );
+
+    expect(hooks.toast.success).toHaveBeenCalled();
+    expect(screen.queryByText(/refused/i)).not.toBeInTheDocument();
+  });
+
+  it("spins while the accounts are still being read", () => {
+    hooks.accounts.isLoading = true;
+    open();
+
+    expect(within(screen.getByRole("dialog")).getByRole("status")).toBeInTheDocument();
+  });
+
+  // A card for a DIFFERENT person is not this person's card: captioning the
+  // window with it would name the person the reader looked at before.
+  it("ignores a card that belongs to somebody else", () => {
+    hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
+    render(
+      <PersonDialog
+        personId={ANN}
+        card={{ person_id: BOB, display_name: "Bob Park" }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText("Bob Park")).not.toBeInTheDocument();
+    expect(screen.getByText(/unnamed person/i)).toBeInTheDocument();
+  });
+
+  // Binding accounts onto a stub automation minted is the wrong direction —
+  // the history is on the other side.
+  it("marks a provisional person in the heading", () => {
+    hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
+    render(
+      <PersonDialog
+        personId={ANN}
+        card={{ person_id: ANN, display_name: "Ann Lee", provisional: true }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/provisional/i)).toBeInTheDocument();
   });
 
   // A refusal means the account kept its binding, so the counters stay on
@@ -353,7 +633,7 @@ describe("PersonDialog", () => {
     hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
     open();
 
-    await userEvent.click(screen.getByRole("button", { name: /^exclude$/i }));
+    await userEvent.click(screen.getByRole("button", { name: /^exclude ann@example\.com/i }));
     await userEvent.click(
       within(confirmation()).getByRole("button", { name: /^exclude$/i }),
     );

--- a/src/frontend/src/components/portal/person-dialog.test.tsx
+++ b/src/frontend/src/components/portal/person-dialog.test.tsx
@@ -1,0 +1,364 @@
+// @vitest-environment jsdom
+/**
+ * The person window. What matters: it mirrors the account window rather than
+ * inventing a second idiom — the subject is a person, the list is what they
+ * hold, the field searches ACCOUNTS, and a click on a found account BINDS it
+ * instead of walking into it; nothing opens a second window over this one; a
+ * verb goes through a confirmation and sends the account in the WIRE shape;
+ * and a detach that would leave the person with nothing is not offered, with
+ * the reason said rather than the button silently missing.
+ */
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import "@/i18n";
+import type {
+  AccountMatch,
+  CorrectionResponse,
+  PersonAccountEntry,
+} from "@/api/identity-client";
+
+const hooks = vi.hoisted(() => {
+  const verb = () => ({
+    mutate: vi.fn(),
+    reset: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null as unknown,
+  });
+  return {
+    toast: { success: vi.fn(), error: vi.fn() },
+    accounts: {
+      data: undefined as
+        | { person_id: string; accounts: PersonAccountEntry[] }
+        | undefined,
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    },
+    search: {
+      data: undefined as { pages: { items: AccountMatch[] }[] } | undefined,
+      isFetching: false,
+      isFetchingNextPage: false,
+      isPlaceholderData: false,
+      isError: false,
+      hasNextPage: false,
+      fetchNextPage: vi.fn(),
+    },
+    bind: verb(),
+    detach: verb(),
+    exclude: verb(),
+  };
+});
+// The picker debounces its field; identity here keeps the suite about the
+// verbs rather than about timers.
+vi.mock("@/hooks/use-debounced-value", () => ({
+  useDebouncedValue: <T,>(value: T) => value,
+}));
+vi.mock("@/components/ui/sonner", () => ({ toast: hooks.toast }));
+vi.mock("@/queries/identity-resolution", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/queries/identity-resolution")>()),
+  usePersonAccounts: () => hooks.accounts,
+  useAccountList: () => hooks.search,
+  useBindAccount: () => hooks.bind,
+  useDetachAccount: () => hooks.detach,
+  useExcludeAccount: () => hooks.exclude,
+}));
+
+import { PersonDialog } from "./person-dialog";
+
+const ANN = "01900000-0000-7000-8000-0000000000a0";
+const BOB = "01900000-0000-7000-8000-0000000000b0";
+
+function entry(over: Partial<PersonAccountEntry> = {}): PersonAccountEntry {
+  return {
+    source: "github",
+    source_id: "01900000-0000-7000-8000-00000000aa01",
+    account_id: "gh-main",
+    email: "ann@example.com",
+    username: null,
+    bound_by_operator: false,
+    ...over,
+  };
+}
+
+function match(over: Partial<AccountMatch> = {}): AccountMatch {
+  return {
+    source: "zoom",
+    source_id: "01900000-0000-7000-8000-00000000aa03",
+    account_id: "zm-9",
+    email: null,
+    username: "annlee",
+    display_name: null,
+    person: null,
+    bound_by_operator: false,
+    ...over,
+  };
+}
+
+function open(card: { person_id: string; display_name?: string } | null = null) {
+  return render(
+    <PersonDialog personId={ANN} card={card} onClose={vi.fn()} />,
+  );
+}
+
+/** The innermost dialog: a confirmation opens over the window, not beside it. */
+function confirmation() {
+  return screen.getAllByRole("dialog").at(-1) as HTMLElement;
+}
+
+beforeEach(() => {
+  for (const verb of [hooks.bind, hooks.detach, hooks.exclude]) {
+    verb.mutate.mockClear();
+    verb.reset.mockClear();
+    verb.isPending = false;
+    verb.isError = false;
+    verb.error = null;
+  }
+  hooks.toast.success.mockClear();
+  hooks.toast.error.mockClear();
+  hooks.accounts.data = undefined;
+  hooks.accounts.isLoading = false;
+  hooks.accounts.isError = false;
+  hooks.accounts.refetch.mockClear();
+  hooks.search.data = undefined;
+  hooks.search.isPlaceholderData = false;
+  hooks.search.hasNextPage = false;
+});
+
+describe("PersonDialog", () => {
+  it("names the person it is about, and their id", () => {
+    hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
+    open({ person_id: ANN, display_name: "Ann Lee" });
+
+    const dialog = screen.getByRole("dialog");
+    expect(within(dialog).getByText("Ann Lee")).toBeInTheDocument();
+    expect(within(dialog).getByText(ANN)).toBeInTheDocument();
+  });
+
+  // A link resolves an id, not a card — search answers values. The window says
+  // what it knows rather than printing the id where a name belongs.
+  it("stands the id alone when it arrived without a card", () => {
+    hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
+    open(null);
+
+    expect(screen.getByText(/unnamed person/i)).toBeInTheDocument();
+  });
+
+  // Moving accounts onto a leaver, or onto a stub automation minted, is the
+  // mistake these marks exist to stop — and this window is now where it would
+  // be made.
+  it("marks a leaver in the heading, the way the roster does", () => {
+    hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
+    render(
+      <PersonDialog
+        personId={ANN}
+        card={{ person_id: ANN, display_name: "Ann Lee", status: "terminated" }}
+        onClose={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/terminated/i)).toBeInTheDocument();
+  });
+
+  it("lists every account they hold, saying who decided each", () => {
+    hooks.accounts.data = {
+      person_id: ANN,
+      accounts: [
+        entry(),
+        entry({
+          source: "gitlab",
+          account_id: "gl-alt",
+          email: null,
+          username: "alee",
+          bound_by_operator: true,
+        }),
+      ],
+    };
+    open();
+
+    expect(screen.getByText("ann@example.com")).toBeInTheDocument();
+    expect(screen.getByText(/github · gh-main/)).toBeInTheDocument();
+    expect(screen.getByText(/bound automatically/i)).toBeInTheDocument();
+    expect(screen.getByText(/decided by an operator/i)).toBeInTheDocument();
+  });
+
+  // The governing rule of the redesign: a row here is not a door. Walking into
+  // an account from inside a person would stack two windows over one decision.
+  it("opens nothing from the accounts it lists", () => {
+    hooks.accounts.data = { person_id: ANN, accounts: [entry(), entry({ account_id: "gh-alt" })] };
+    open();
+
+    expect(screen.queryByRole("button", { name: /^open$/i })).not.toBeInTheDocument();
+    expect(screen.getAllByRole("dialog")).toHaveLength(1);
+  });
+
+  it("states an empty result rather than an empty list", () => {
+    hooks.accounts.data = { person_id: ANN, accounts: [] };
+    open();
+
+    expect(
+      screen.getByText(/no account is bound to this person/i),
+    ).toBeInTheDocument();
+  });
+
+  it("offers a retry when the read fails", async () => {
+    hooks.accounts.isError = true;
+    open();
+
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(hooks.accounts.refetch).toHaveBeenCalled();
+  });
+
+  // A detach mints a person and moves the account there. Taking somebody's ONLY
+  // account replaces them with an identical person and leaves their name behind
+  // with nothing attached — which is how the accountless persons got made. Said
+  // out loud, because a button that is simply absent reads as a fault.
+  it("withholds the detach that would leave them with nothing, and says why", () => {
+    hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
+    open();
+
+    expect(screen.queryByRole("button", { name: /^detach$/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/their only account/i)).toBeInTheDocument();
+  });
+
+  it("detaches one of several accounts, in the wire shape, behind a confirmation", async () => {
+    hooks.accounts.data = {
+      person_id: ANN,
+      accounts: [entry(), entry({ account_id: "gh-alt" })],
+    };
+    open();
+
+    await userEvent.click(screen.getAllByRole("button", { name: /^detach$/i })[0]);
+    expect(
+      within(confirmation()).getByText(/a new person is created/i),
+    ).toBeInTheDocument();
+    await userEvent.click(
+      within(confirmation()).getByRole("button", { name: /^detach$/i }),
+    );
+
+    expect(hooks.detach.mutate).toHaveBeenCalledWith(
+      { account: { source: "github", source_id: entry().source_id, id: "gh-main" } },
+      expect.anything(),
+    );
+  });
+
+  it("excludes an account behind a confirmation", async () => {
+    hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
+    open();
+
+    await userEvent.click(screen.getByRole("button", { name: /^exclude$/i }));
+    await userEvent.click(
+      within(confirmation()).getByRole("button", { name: /^exclude$/i }),
+    );
+
+    expect(hooks.exclude.mutate).toHaveBeenCalledWith(
+      { account: { source: "github", source_id: entry().source_id, id: "gh-main" } },
+      expect.anything(),
+    );
+  });
+
+  // The mirror of the account window's person search: the click picks the other
+  // side of a binding. Nothing is written until the confirmation.
+  it("binds a found account to this person, and only after a confirmation", async () => {
+    hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
+    hooks.search.data = { pages: [{ items: [match()] }] };
+    open({ person_id: ANN, display_name: "Ann Lee" });
+
+    await userEvent.type(
+      screen.getByRole("searchbox", { name: /find an account/i }),
+      "annlee",
+    );
+    await userEvent.click(screen.getByRole("button", { name: /^annlee$/ }));
+    expect(hooks.bind.mutate).not.toHaveBeenCalled();
+
+    await userEvent.click(
+      within(confirmation()).getByRole("button", { name: /^bind$/i }),
+    );
+
+    expect(hooks.bind.mutate).toHaveBeenCalledWith(
+      {
+        account: { source: "zoom", source_id: match().source_id, id: "zm-9" },
+        person_id: ANN,
+      },
+      expect.anything(),
+    );
+  });
+
+  // Taking an account off somebody else is a different decision from placing an
+  // orphan, and the confirmation has to say which one is being taken.
+  it("names the person an account would be taken from", async () => {
+    hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
+    hooks.search.data = {
+      pages: [
+        { items: [match({ person: { person_id: BOB, display_name: "Bob Park" } })] },
+      ],
+    };
+    open();
+
+    await userEvent.type(
+      screen.getByRole("searchbox", { name: /find an account/i }),
+      "annlee",
+    );
+    await userEvent.click(screen.getByRole("button", { name: /^annlee$/ }));
+
+    expect(
+      within(confirmation()).getByText(/taken from Bob Park/i),
+    ).toBeInTheDocument();
+  });
+
+  // The accounts listed above are already theirs: binding one of them again
+  // changes nothing, and offering it invites a decision that is not one.
+  it("keeps the accounts they already hold out of the search", async () => {
+    hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
+    hooks.search.data = {
+      pages: [{ items: [match(), match({ ...entry(), display_name: null })] }],
+    };
+    open();
+
+    await userEvent.type(
+      screen.getByRole("searchbox", { name: /find an account/i }),
+      "ann",
+    );
+
+    expect(screen.getByRole("button", { name: /^annlee$/ })).toBeInTheDocument();
+    // The held account is listed once — above, as theirs, with its own verbs.
+    expect(screen.getAllByText(/github · gh-main/)).toHaveLength(1);
+  });
+
+  // The whole fold would bury the handful of accounts the person actually
+  // holds, which is what the reader opened them for.
+  it("lists no account until the field is asked something", () => {
+    hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
+    hooks.search.data = { pages: [{ items: [match()] }] };
+    open();
+
+    expect(screen.queryByText("annlee")).not.toBeInTheDocument();
+    expect(screen.getByText("ann@example.com")).toBeInTheDocument();
+  });
+
+  // A refusal means the account kept its binding, so the counters stay on
+  // screen: the operator still has a decision to take.
+  it("keeps the server's counters when an account was refused", async () => {
+    const refusal: CorrectionResponse = {
+      applied: 0,
+      already_decided: 0,
+      items: [{ ...entry(), outcome: "refused" }],
+    };
+    hooks.exclude.mutate.mockImplementation(
+      (_args: unknown, opts?: { onSuccess?: (r: CorrectionResponse) => void }) =>
+        opts?.onSuccess?.(refusal),
+    );
+    hooks.accounts.data = { person_id: ANN, accounts: [entry()] };
+    open();
+
+    await userEvent.click(screen.getByRole("button", { name: /^exclude$/i }));
+    await userEvent.click(
+      within(confirmation()).getByRole("button", { name: /^exclude$/i }),
+    );
+
+    expect(screen.getByText(/1 refused/i)).toBeInTheDocument();
+    expect(hooks.toast.error).toHaveBeenCalled();
+  });
+});

--- a/src/frontend/src/components/portal/person-dialog.tsx
+++ b/src/frontend/src/components/portal/person-dialog.tsx
@@ -1,0 +1,399 @@
+/**
+ * One person and every account bound to them — the window the person mode
+ * decides in.
+ *
+ * The mirror of the account window. There the subject is an account, the list
+ * is who could hold it, and the field searches PEOPLE; here the subject is a
+ * person, the list is what they hold, and the field searches ACCOUNTS. A click
+ * on a row means the same thing in both: it picks the other side of a binding,
+ * never a door to walk through. One gesture, learnt once.
+ *
+ * So the rows here open nothing. An account a person holds is acted on in
+ * place, by the verbs on its own row — a second window over this one would
+ * stack two decisions an operator has to keep apart.
+ *
+ * The layout mirrors that window too: the field sits high and stays put, and
+ * the long section under it takes the slack and scrolls.
+ *
+ * Opened by `?person=` alone, so a link lands a colleague on the same person.
+ */
+import { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import type {
+  AccountMatch,
+  CorrectionResponse,
+  PersonAccountEntry,
+  PersonSummary,
+  WireAccountRef,
+} from "@/api/identity-client";
+import { ConfirmDialog } from "@/components/confirm-dialog";
+import { AccountPicker } from "@/components/portal/account-picker";
+import { OutcomeAlert } from "@/components/portal/outcome-alert";
+import { PersonCell, PersonMarks } from "@/components/portal/person-cell";
+import { PersonId } from "@/components/portal/person-id";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { CenteredSpinner } from "@/components/widgets/centered-spinner";
+import { ComingSoon } from "@/components/widgets/coming-soon";
+import { useCorrectionReport } from "@/hooks/use-correction-report";
+import { accountKey } from "@/lib/identities/account-key";
+import { personName } from "@/lib/identities/person-display";
+import { apiErrorReason } from "@/lib/query-console/api-error";
+import {
+  useBindAccount,
+  useDetachAccount,
+  useExcludeAccount,
+  usePersonAccounts,
+} from "@/queries/identity-resolution";
+import { cn } from "@/lib/utils";
+
+type PendingAction =
+  | { kind: "closed" }
+  | { kind: "bind"; account: AccountMatch }
+  | { kind: "detach"; account: PersonAccountEntry }
+  | { kind: "exclude"; account: PersonAccountEntry };
+
+function wireRef(account: {
+  source: string;
+  source_id: string;
+  account_id: string;
+}): WireAccountRef {
+  return {
+    source: account.source,
+    source_id: account.source_id,
+    // The wire calls the account id `id` (unlike the read shapes).
+    id: account.account_id,
+  };
+}
+
+export function PersonDialog({
+  personId,
+  card,
+  onClose,
+}: {
+  personId: string | undefined;
+  /** The roster row the operator picked, when there is one. Arriving by link
+   *  there is none — search resolves values, not ids — and the id stands alone,
+   *  honestly. */
+  card: PersonSummary | null;
+  onClose: () => void;
+}) {
+  const { t } = useTranslation();
+  const popupRef = useRef<HTMLDivElement>(null);
+  const person: PersonSummary | null = personId
+    ? (card?.person_id === personId ? card : { person_id: personId })
+    : null;
+  const named = person ? personName(person) : null;
+
+  return (
+    <Dialog
+      open={person != null}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      {/* The same fixed height as the account window: an operator moves between
+          the two, and a window that sizes itself to each subject moves the verbs
+          under their cursor. */}
+      <DialogContent
+        ref={popupRef}
+        className="flex h-[85vh] flex-col gap-4 sm:max-w-3xl"
+        // Focus the window itself, not its first tabbable — that is a verb that
+        // takes an account off somebody, and a decision should not be one
+        // keypress from arriving. `initialFocus={false}` is not the alternative:
+        // it does not move focus AT ALL, stranding it in the aria-hidden page
+        // behind the dialog.
+        tabIndex={-1}
+        initialFocus={popupRef}
+      >
+        <DialogHeader>
+          <DialogTitle
+            render={<div className="flex min-w-0 items-center gap-2" />}
+          >
+            <span
+              className={cn(
+                "truncate select-text",
+                named || "text-muted-foreground italic",
+              )}
+            >
+              {named ?? t("identities.person.unnamed")}
+            </span>
+            {/* A leaver and a stub minted by automation are the two people an
+                operator should not be moving accounts onto — marked here for the
+                same reason the roster marks them. */}
+            {person ? <PersonMarks person={person} /> : null}
+          </DialogTitle>
+          <DialogDescription render={<div className="flex items-center gap-1" />}>
+            {person ? <PersonId id={person.person_id} /> : null}
+          </DialogDescription>
+        </DialogHeader>
+        {/* Keyed by the person: the body holds per-person state (a pending verb,
+            the counters of the last one), and a cached read renders the next
+            person synchronously — unkeyed, that state would follow them. */}
+        {person ? (
+          <PersonBody key={person.person_id} person={person} />
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function PersonBody({ person }: { person: PersonSummary }) {
+  const { t } = useTranslation();
+  const accounts = usePersonAccounts(person.person_id);
+  const [action, setAction] = useState<PendingAction>({ kind: "closed" });
+  const [outcome, setOutcome] = useState<CorrectionResponse | null>(null);
+  const report = useCorrectionReport();
+
+  const bind = useBindAccount();
+  const detach = useDetachAccount();
+  const exclude = useExcludeAccount();
+
+  const close = () => {
+    setAction({ kind: "closed" });
+    // A dialog's error belongs to the attempt made in THAT dialog; without a
+    // reset the next one opens already wearing the previous failure.
+    bind.reset();
+    detach.reset();
+    exclude.reset();
+  };
+  const done = (result: CorrectionResponse) => {
+    close();
+    // A refusal means the account kept its binding, so the counters stay on
+    // screen: the operator has something left to decide. The window itself
+    // stays either way — the list under it re-reads, and that IS the answer.
+    setOutcome(report(result) ? null : result);
+  };
+
+  if (accounts.isLoading) return <CenteredSpinner className="min-h-40" />;
+  if (accounts.isError || !accounts.data) {
+    return (
+      <ComingSoon
+        variant="card"
+        state="error"
+        label={t("identities.person_accounts.load_failed")}
+        onRetry={() => void accounts.refetch()}
+      />
+    );
+  }
+
+  const entries = accounts.data.accounts;
+  // A detach mints a person and moves the account to them. Taking somebody's
+  // ONLY account does that and nothing else: the account still has one holder,
+  // and the person it left keeps their name with nothing to attach it to.
+  const detachable = entries.length > 1;
+  const busy = bind.isPending || detach.isPending || exclude.isPending;
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4">
+      {outcome ? <OutcomeAlert outcome={outcome} /> : null}
+
+      {/* The field sits high and fixed, the list takes the slack and scrolls —
+          the account window's geometry, where the search is right under the
+          subject and the history behind it absorbs the height. A field pinned
+          to the bottom of a window this tall reads as a footer. */}
+      <section className="shrink-0">
+        <SectionLabel>{t("identities.person_window.bind_section")}</SectionLabel>
+        <AccountPicker
+          placeholder={t("identities.person_window.find_account")}
+          // The accounts already listed below: binding one of them to the
+          // person who already holds it changes nothing.
+          excludeKeys={entries.map(accountKey)}
+          onPick={(account) => setAction({ kind: "bind", account })}
+        />
+      </section>
+
+      <section className="flex min-h-0 flex-1 flex-col">
+        <SectionLabel>
+          {t("identities.person_accounts.accounts")}
+          <Badge variant="secondary">{entries.length}</Badge>
+        </SectionLabel>
+        {entries.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            {t("identities.person_accounts.no_accounts")}
+          </p>
+        ) : (
+          <ul className="flex min-h-24 flex-1 flex-col gap-1 overflow-y-auto pe-1">
+            {entries.map((entry) => (
+              <li key={accountKey(entry)}>
+                <AccountRow
+                  entry={entry}
+                  detachable={detachable}
+                  busy={busy}
+                  onDetach={() => setAction({ kind: "detach", account: entry })}
+                  onExclude={() => setAction({ kind: "exclude", account: entry })}
+                />
+              </li>
+            ))}
+          </ul>
+        )}
+        {/* Said, not silently omitted: a verb that is simply absent reads as a
+            missing button rather than as an answer. */}
+        {entries.length === 1 ? (
+          <p className="mt-1.5 text-xs text-muted-foreground">
+            {t("identities.person_window.only_account")}
+          </p>
+        ) : null}
+      </section>
+
+      {action.kind === "bind" ? (
+        <ConfirmDialog
+          open
+          onOpenChange={(open) => !open && close()}
+          title={t("identities.person_window.bind_title")}
+          description={
+            action.account.person &&
+            action.account.person.person_id !== person.person_id
+              ? t("identities.person_window.bind_from_description", {
+                  name: personName(action.account.person) ??
+                    action.account.person.person_id,
+                })
+              : t("identities.person_window.bind_description")
+          }
+          confirmLabel={t("identities.actions.bind")}
+          isPending={bind.isPending}
+          error={
+            bind.isError
+              ? apiErrorReason(bind.error, t("identities.dialogs.failed"))
+              : null
+          }
+          onConfirm={() =>
+            bind.mutate(
+              {
+                account: wireRef(action.account),
+                person_id: person.person_id,
+              },
+              { onSuccess: done },
+            )
+          }
+        >
+          <PersonCell person={person} />
+        </ConfirmDialog>
+      ) : null}
+
+      {action.kind === "detach" ? (
+        <ConfirmDialog
+          open
+          onOpenChange={(open) => !open && close()}
+          title={t("identities.person_window.detach_title")}
+          description={t("identities.person_window.detach_description")}
+          confirmLabel={t("identities.actions.detach_confirm")}
+          isPending={detach.isPending}
+          error={
+            detach.isError
+              ? apiErrorReason(detach.error, t("identities.dialogs.failed"))
+              : null
+          }
+          onConfirm={() =>
+            detach.mutate({ account: wireRef(action.account) }, { onSuccess: done })
+          }
+        />
+      ) : null}
+
+      {action.kind === "exclude" ? (
+        <ConfirmDialog
+          open
+          onOpenChange={(open) => !open && close()}
+          title={t("identities.dialogs.exclude_title")}
+          description={t("identities.dialogs.exclude_description")}
+          confirmLabel={t("identities.actions.exclude_confirm")}
+          destructive
+          isPending={exclude.isPending}
+          error={
+            exclude.isError
+              ? apiErrorReason(exclude.error, t("identities.dialogs.failed"))
+              : null
+          }
+          onConfirm={() =>
+            exclude.mutate({ account: wireRef(action.account) }, { onSuccess: done })
+          }
+        />
+      ) : null}
+    </div>
+  );
+}
+
+/**
+ * One account this person holds, and the verbs that take it off them.
+ *
+ * Deliberately not clickable: nothing opens from here, so the row carries no
+ * hover state either — a row that invites a press and answers nothing reads as
+ * a fault.
+ */
+function AccountRow({
+  entry,
+  detachable,
+  busy,
+  onDetach,
+  onExclude,
+}: {
+  entry: PersonAccountEntry;
+  detachable: boolean;
+  busy: boolean;
+  onDetach: () => void;
+  onExclude: () => void;
+}) {
+  const { t } = useTranslation();
+  const label = entry.email?.trim() || entry.username?.trim() || entry.account_id;
+  return (
+    // Fixed columns, and the same first two as the account listing: the two
+    // lists sit one tab apart, and reading either one down a column should feel
+    // the same.
+    <div className="grid grid-cols-1 items-center gap-2 rounded-md border border-transparent p-3 lg:grid-cols-[minmax(0,1fr)_minmax(0,11rem)_auto]">
+      <div className="min-w-0">
+        <div className="truncate text-sm font-medium select-text">{label}</div>
+        <div className="truncate font-mono text-xs text-muted-foreground select-text">
+          {entry.source} · {entry.account_id}
+        </div>
+      </div>
+      {/* Who decided this binding is the first thing to know before changing
+          it: undoing automation is routine, overruling a colleague is not. */}
+      <Badge
+        variant={entry.bound_by_operator ? "secondary" : "outline"}
+        className="justify-self-start font-normal"
+      >
+        {entry.bound_by_operator
+          ? t("identities.person_accounts.by_operator")
+          : t("identities.person_accounts.by_automation")}
+      </Badge>
+      <div className="flex shrink-0 flex-wrap gap-2">
+        {detachable ? (
+          <Button
+            type="button"
+            size="xs"
+            variant="outline"
+            disabled={busy}
+            onClick={onDetach}
+          >
+            {t("identities.person_window.detach")}
+          </Button>
+        ) : null}
+        <Button
+          type="button"
+          size="xs"
+          variant="destructive"
+          disabled={busy}
+          onClick={onExclude}
+        >
+          {t("identities.person_window.exclude")}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mb-1.5 flex items-center gap-2 text-xs font-medium tracking-wide text-muted-foreground uppercase">
+      {children}
+    </div>
+  );
+}

--- a/src/frontend/src/components/portal/person-dialog.tsx
+++ b/src/frontend/src/components/portal/person-dialog.tsx
@@ -74,6 +74,12 @@ function wireRef(account: {
   };
 }
 
+/** The open subject, kept across the close animation. See below. */
+interface HeldPerson {
+  id: string;
+  card: PersonSummary | null;
+}
+
 export function PersonDialog({
   personId,
   card,
@@ -88,14 +94,29 @@ export function PersonDialog({
 }) {
   const { t } = useTranslation();
   const popupRef = useRef<HTMLDivElement>(null);
-  const person: PersonSummary | null = personId
-    ? (card?.person_id === personId ? card : { person_id: personId })
+  const liveId = personId ?? null;
+  // Only a card for the person actually open: a stale one would caption this
+  // window with the person the reader looked at before.
+  const liveCard = card?.person_id === liveId ? card : null;
+
+  // The popup plays a close transition after `?person=` is already gone, so the
+  // subject has to outlive the URL by that much — otherwise the heading renames
+  // itself to "Unnamed person" on the way out. Held via state adjusted during
+  // render (the sanctioned previous-render pattern), keyed by id rather than by
+  // object, or a freshly built card would loop.
+  const [held, setHeld] = useState<HeldPerson | null>(null);
+  if (liveId && (held?.id !== liveId || held.card !== liveCard)) {
+    setHeld({ id: liveId, card: liveCard });
+  }
+  const shown = liveId ? { id: liveId, card: liveCard } : held;
+  const person: PersonSummary | null = shown
+    ? (shown.card ?? { person_id: shown.id })
     : null;
   const named = person ? personName(person) : null;
 
   return (
     <Dialog
-      open={person != null}
+      open={liveId != null}
       onOpenChange={(open) => {
         if (!open) onClose();
       }}
@@ -105,6 +126,7 @@ export function PersonDialog({
           under their cursor. */}
       <DialogContent
         ref={popupRef}
+        closeLabel={t("common.actions.close")}
         className="flex h-[85vh] flex-col gap-4 sm:max-w-3xl"
         // Focus the window itself, not its first tabbable — that is a verb that
         // takes an account off somebody, and a decision should not be one
@@ -115,13 +137,19 @@ export function PersonDialog({
         initialFocus={popupRef}
       >
         <DialogHeader>
+          {/* An `h2`, which is what the primitive renders by default: a reader
+              navigating an open window by heading should find the person it is
+              about. */}
           <DialogTitle
-            render={<div className="flex min-w-0 items-center gap-2" />}
+            render={<h2 className="flex min-w-0 items-center gap-2" />}
           >
             <span
               className={cn(
                 "truncate select-text",
-                named || "text-muted-foreground italic",
+                // A ternary, not `named || ...`: `named` is the NAME, and an
+                // `||` fallback puts it in the class list — a display name
+                // carrying a utility word would then restyle or hide itself.
+                named ? undefined : "text-muted-foreground italic",
               )}
             >
               {named ?? t("identities.person.unnamed")}
@@ -139,14 +167,35 @@ export function PersonDialog({
             the counters of the last one), and a cached read renders the next
             person synchronously — unkeyed, that state would follow them. */}
         {person ? (
-          <PersonBody key={person.person_id} person={person} />
+          <PersonBody
+            key={person.person_id}
+            person={person}
+            onDecided={() => {
+              // The control just pressed is about to be unmounted by the
+              // refetch — the row goes, or the last detach takes every Detach
+              // with it — and focus would fall to `body`, restarting Tab from
+              // the top of the document.
+              //
+              // INVARIANT: after a frame, never in the handler itself. The list
+              // has not settled yet inside it.
+              requestAnimationFrame(() => popupRef.current?.focus());
+            }}
+          />
         ) : null}
       </DialogContent>
     </Dialog>
   );
 }
 
-function PersonBody({ person }: { person: PersonSummary }) {
+function PersonBody({
+  person,
+  onDecided,
+}: {
+  person: PersonSummary;
+  /** A verb settled everything it named, so the control that fired it is going
+   *  away with the row it sat on. */
+  onDecided: () => void;
+}) {
   const { t } = useTranslation();
   const accounts = usePersonAccounts(person.person_id);
   const [action, setAction] = useState<PendingAction>({ kind: "closed" });
@@ -170,7 +219,11 @@ function PersonBody({ person }: { person: PersonSummary }) {
     // A refusal means the account kept its binding, so the counters stay on
     // screen: the operator has something left to decide. The window itself
     // stays either way — the list under it re-reads, and that IS the answer.
-    setOutcome(report(result) ? null : result);
+    const settled = report(result);
+    setOutcome(settled ? null : result);
+    // Only when the row really is going. A refused account keeps its row, and
+    // its verbs are where the operator's hand already is.
+    if (settled) onDecided();
   };
 
   if (accounts.isLoading) return <CenteredSpinner className="min-h-40" />;
@@ -200,7 +253,7 @@ function PersonBody({ person }: { person: PersonSummary }) {
           the account window's geometry, where the search is right under the
           subject and the history behind it absorbs the height. A field pinned
           to the bottom of a window this tall reads as a footer. */}
-      <section className="shrink-0">
+      <section className="flex min-h-0 flex-col">
         <SectionLabel>{t("identities.person_window.bind_section")}</SectionLabel>
         <AccountPicker
           placeholder={t("identities.person_window.find_account")}
@@ -235,13 +288,6 @@ function PersonBody({ person }: { person: PersonSummary }) {
             ))}
           </ul>
         )}
-        {/* Said, not silently omitted: a verb that is simply absent reads as a
-            missing button rather than as an answer. */}
-        {entries.length === 1 ? (
-          <p className="mt-1.5 text-xs text-muted-foreground">
-            {t("identities.person_window.only_account")}
-          </p>
-        ) : null}
       </section>
 
       {action.kind === "bind" ? (
@@ -275,6 +321,7 @@ function PersonBody({ person }: { person: PersonSummary }) {
             )
           }
         >
+          <AccountLine account={action.account} />
           <PersonCell person={person} />
         </ConfirmDialog>
       ) : null}
@@ -295,7 +342,9 @@ function PersonBody({ person }: { person: PersonSummary }) {
           onConfirm={() =>
             detach.mutate({ account: wireRef(action.account) }, { onSuccess: done })
           }
-        />
+        >
+          <AccountLine account={action.account} />
+        </ConfirmDialog>
       ) : null}
 
       {action.kind === "exclude" ? (
@@ -315,8 +364,33 @@ function PersonBody({ person }: { person: PersonSummary }) {
           onConfirm={() =>
             exclude.mutate({ account: wireRef(action.account) }, { onSuccess: done })
           }
-        />
+        >
+          <AccountLine account={action.account} />
+        </ConfirmDialog>
       ) : null}
+    </div>
+  );
+}
+
+/**
+ * The account a confirmation is about.
+ *
+ * The window's subject is the PERSON, so a confirmation that names only them
+ * restates what the operator already knows while the modal covers the row they
+ * pressed. Every verb here acts on one account; this is which one.
+ */
+function AccountLine({
+  account,
+}: {
+  account: { source: string; account_id: string; email?: string | null; username?: string | null };
+}) {
+  const label = account.email?.trim() || account.username?.trim() || account.account_id;
+  return (
+    <div className="min-w-0 rounded-md border p-2">
+      <div className="truncate text-sm font-medium select-text">{label}</div>
+      <div className="truncate font-mono text-xs text-muted-foreground select-text">
+        {account.source} · {account.account_id}
+      </div>
     </div>
   );
 }
@@ -343,11 +417,16 @@ function AccountRow({
 }) {
   const { t } = useTranslation();
   const label = entry.email?.trim() || entry.username?.trim() || entry.account_id;
+  // Every row's verbs read alike, so their labels have to carry the account:
+  // six accounts otherwise produce six identical "Detach" buttons, and the
+  // row's own text is announced by nothing.
+  const names = { account: label, source: entry.source };
   return (
     // Fixed columns, and the same first two as the account listing: the two
     // lists sit one tab apart, and reading either one down a column should feel
-    // the same.
-    <div className="grid grid-cols-1 items-center gap-2 rounded-md border border-transparent p-3 lg:grid-cols-[minmax(0,1fr)_minmax(0,11rem)_auto]">
+    // the same. `md`, not `lg`: this row lives in a window capped at 48rem, so
+    // a viewport wider than that buys it nothing.
+    <div className="grid grid-cols-1 items-center gap-2 rounded-md border border-transparent p-3 md:grid-cols-[minmax(0,1fr)_minmax(0,11rem)_auto]">
       <div className="min-w-0">
         <div className="truncate text-sm font-medium select-text">{label}</div>
         <div className="truncate font-mono text-xs text-muted-foreground select-text">
@@ -371,6 +450,7 @@ function AccountRow({
             size="xs"
             variant="outline"
             disabled={busy}
+            aria-label={t("identities.person_window.detach_account", names)}
             onClick={onDetach}
           >
             {t("identities.person_window.detach")}
@@ -381,6 +461,7 @@ function AccountRow({
           size="xs"
           variant="destructive"
           disabled={busy}
+          aria-label={t("identities.person_window.exclude_account", names)}
           onClick={onExclude}
         >
           {t("identities.person_window.exclude")}

--- a/src/frontend/src/components/portal/person-dialog.tsx
+++ b/src/frontend/src/components/portal/person-dialog.tsx
@@ -435,10 +435,7 @@ function AccountRow({
       </div>
       {/* Who decided this binding is the first thing to know before changing
           it: undoing automation is routine, overruling a colleague is not. */}
-      <Badge
-        variant={entry.bound_by_operator ? "secondary" : "outline"}
-        className="justify-self-start font-normal"
-      >
+      <Badge variant="outline" className="justify-self-start font-normal">
         {entry.bound_by_operator
           ? t("identities.person_accounts.by_operator")
           : t("identities.person_accounts.by_automation")}

--- a/src/frontend/src/components/portal/person-picker.tsx
+++ b/src/frontend/src/components/portal/person-picker.tsx
@@ -20,6 +20,7 @@ import { useTranslation } from "react-i18next";
 import type { PersonSummary } from "@/api/identity-client";
 import { PersonCell } from "@/components/portal/person-cell";
 import { personDisplayName } from "@/lib/identities/person-display";
+import { activatesRow, activatesRowByKey } from "@/lib/identities/row-activation";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
@@ -182,17 +183,10 @@ export function PersonPicker({
                     role="button"
                     tabIndex={0}
                     onClick={(event) => {
-                      if (
-                        event.target instanceof Element &&
-                        event.target.closest("button, a")
-                      ) {
-                        return;
-                      }
-                      onPick(person);
+                      if (activatesRow(event)) onPick(person);
                     }}
                     onKeyDown={(event) => {
-                      if (event.key !== "Enter" && event.key !== " ") return;
-                      if (event.target !== event.currentTarget) return;
+                      if (!activatesRowByKey(event)) return;
                       event.preventDefault();
                       onPick(person);
                     }}

--- a/src/frontend/src/hooks/use-correction-report.ts
+++ b/src/frontend/src/hooks/use-correction-report.ts
@@ -1,0 +1,55 @@
+/**
+ * Reporting the server's answer to an identity correction, the same way from
+ * every surface that fires one.
+ *
+ * A verb answers with three counters plus a per-account outcome, and that
+ * vocabulary is open by contract — so success is only ever "every account the
+ * call named ended up decided", never "no refusals". A refusal means the
+ * account kept its binding, which is a decision the operator still has to
+ * take, so the caller is told to keep its verbs on screen rather than being
+ * handed a generic failure.
+ */
+import { useTranslation } from "react-i18next";
+
+import type { CorrectionResponse } from "@/api/identity-client";
+import { toast } from "@/components/ui/sonner";
+import { fullyDecided, refusedCount } from "@/lib/identities/outcomes";
+
+/** Long enough to read a UUID off and paste it somewhere. */
+const MINTED_ID_TOAST_MS = 15_000;
+
+/**
+ * Report one answer and say whether it settled everything it named.
+ *
+ * `false` is the caller's cue to keep its window and its verbs on screen, and
+ * to show the counters verbatim — see `OutcomeAlert`.
+ */
+export function useCorrectionReport(): (result: CorrectionResponse) => boolean {
+  const { t } = useTranslation();
+  return (result: CorrectionResponse) => {
+    if (!fullyDecided(result)) {
+      const refused = refusedCount(result);
+      toast.error(
+        refused > 0
+          ? t("identities.outcomes.toast_refused", { count: refused })
+          : t("identities.dialogs.failed"),
+      );
+      return false;
+    }
+
+    const message =
+      result.applied > 0
+        ? t("identities.outcomes.toast_applied", { count: result.applied })
+        : t("identities.outcomes.toast_already");
+    // The minted person's id is the one thing a detach reports that nothing
+    // else on the page can name yet, and the window that held it is closing —
+    // so the toast carrying it stays up long enough to be copied out.
+    toast.success(message, {
+      description: result.new_person_id
+        ? `${t("identities.outcomes.new_person")} ${result.new_person_id}`
+        : undefined,
+      duration: result.new_person_id ? MINTED_ID_TOAST_MS : undefined,
+    });
+    return true;
+  };
+}

--- a/src/frontend/src/lib/identities/cases.ts
+++ b/src/frontend/src/lib/identities/cases.ts
@@ -25,19 +25,18 @@ export interface QueueCase {
 }
 
 /**
- * Kinds the console invents for a row that is NOT a queue item.
+ * The kind the console invents for a row that is NOT a queue item.
  *
- * The accounts and persons modes reuse the case window to show a settled
- * account, so their rows travel in the same shape as a queue row. Naming OUR
- * kinds rather than the server's is what keeps the test safe: the server's
- * vocabulary is open, and a kind this build has never seen is a queue item.
+ * The accounts mode reuses the case window to show a settled account, so its
+ * rows travel in the same shape as a queue row. Naming OUR kind rather than the
+ * server's is what keeps the test safe: the server's vocabulary is open, and a
+ * kind this build has never seen is a queue item.
  */
 export const KIND_SEARCH_MATCH = "match";
-export const KIND_PERSON_MEMBER = "member";
 
 /** Whether this row is a real queue item, and so really leaves the queue. */
 export function isQueueItem(kind: string): boolean {
-  return kind !== KIND_SEARCH_MATCH && kind !== KIND_PERSON_MEMBER;
+  return kind !== KIND_SEARCH_MATCH;
 }
 
 /**

--- a/src/frontend/src/lib/identities/row-activation.test.ts
+++ b/src/frontend/src/lib/identities/row-activation.test.ts
@@ -1,9 +1,11 @@
 /**
  * One rule for every console listing. What matters: a press on a control inside
- * a row is that control's, a click that ends a text selection is a copy rather
- * than a navigation, and only Enter and Space from the row itself activate it.
+ * a row is that control's — including a press that landed on the icon INSIDE
+ * the control, which is what a real click reports; a click that ends a text
+ * selection is a copy rather than a navigation; and only Enter and Space from
+ * the row itself activate it.
  */
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { activatesRow, activatesRowByKey } from "./row-activation";
 
@@ -18,11 +20,26 @@ function press(key: string, target: Element, currentTarget: Element): KeyLike {
   return { key, target, currentTarget } as unknown as KeyLike;
 }
 
+/** A row with one control in it, and whatever the control wraps. */
+function row(control: "button" | "a", inner?: "svg" | "span") {
+  const host = document.createElement("div");
+  const el = document.createElement(control);
+  host.append(el);
+  if (!inner) return { host, target: el };
+  const child = document.createElement(inner);
+  el.append(child);
+  return { host, target: child };
+}
+
 function selecting(collapsed: boolean) {
   vi.spyOn(window, "getSelection").mockReturnValue({
     isCollapsed: collapsed,
   } as Selection);
 }
+
+// The stub outlives the case that installed it otherwise, and the next case
+// reads another one's selection state as its own.
+afterEach(() => vi.restoreAllMocks());
 
 describe("activatesRow", () => {
   it("activates on a click with nothing selected", () => {
@@ -30,12 +47,33 @@ describe("activatesRow", () => {
     expect(activatesRow(click(document.createElement("span")))).toBe(true);
   });
 
+  // A document with no selection at all is not a document with a selection
+  // standing: the row still opens.
+  it("activates where the platform reports no selection object", () => {
+    vi.spyOn(window, "getSelection").mockReturnValue(null);
+    expect(activatesRow(click(document.createElement("span")))).toBe(true);
+  });
+
   it("leaves a press on a control inside the row to that control", () => {
     selecting(true);
-    const row = document.createElement("div");
-    const button = document.createElement("button");
-    row.append(button);
-    expect(activatesRow(click(button))).toBe(false);
+    expect(activatesRow(click(row("button").target))).toBe(false);
+  });
+
+  // What a real click reports is the deepest element under the cursor — the
+  // icon inside the copy button, never the button itself. A check on the
+  // target's own tag would let every icon press open the row.
+  it.each(["svg", "span"] as const)(
+    "leaves a press on the %s inside a control to that control",
+    (inner) => {
+      selecting(true);
+      expect(activatesRow(click(row("button", inner).target))).toBe(false);
+    },
+  );
+
+  it("leaves a press on a link, and on what a link wraps, to the link", () => {
+    selecting(true);
+    expect(activatesRow(click(row("a").target))).toBe(false);
+    expect(activatesRow(click(row("a", "span").target))).toBe(false);
   });
 
   // The addresses and ids on these rows are what an operator copies into a
@@ -48,19 +86,18 @@ describe("activatesRow", () => {
 
 describe("activatesRowByKey", () => {
   it.each(["Enter", " "])("activates on %s from the row itself", (key) => {
-    const row = document.createElement("div");
-    expect(activatesRowByKey(press(key, row, row))).toBe(true);
+    const host = document.createElement("div");
+    expect(activatesRowByKey(press(key, host, host))).toBe(true);
   });
 
   it("ignores every other key", () => {
-    const row = document.createElement("div");
-    expect(activatesRowByKey(press("ArrowDown", row, row))).toBe(false);
+    const host = document.createElement("div");
+    expect(activatesRowByKey(press("ArrowDown", host, host))).toBe(false);
   });
 
   // A control inside the row has its own answer to both keys.
   it("ignores the same keys pressed inside a control", () => {
-    const row = document.createElement("div");
-    const button = document.createElement("button");
-    expect(activatesRowByKey(press("Enter", button, row))).toBe(false);
+    const { host, target } = row("button");
+    expect(activatesRowByKey(press("Enter", target, host))).toBe(false);
   });
 });

--- a/src/frontend/src/lib/identities/row-activation.test.ts
+++ b/src/frontend/src/lib/identities/row-activation.test.ts
@@ -1,0 +1,66 @@
+/**
+ * One rule for every console listing. What matters: a press on a control inside
+ * a row is that control's, a click that ends a text selection is a copy rather
+ * than a navigation, and only Enter and Space from the row itself activate it.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { activatesRow, activatesRowByKey } from "./row-activation";
+
+type MouseLike = React.MouseEvent<HTMLElement>;
+type KeyLike = React.KeyboardEvent<HTMLElement>;
+
+function click(target: EventTarget | null): MouseLike {
+  return { target } as MouseLike;
+}
+
+function press(key: string, target: Element, currentTarget: Element): KeyLike {
+  return { key, target, currentTarget } as unknown as KeyLike;
+}
+
+function selecting(collapsed: boolean) {
+  vi.spyOn(window, "getSelection").mockReturnValue({
+    isCollapsed: collapsed,
+  } as Selection);
+}
+
+describe("activatesRow", () => {
+  it("activates on a click with nothing selected", () => {
+    selecting(true);
+    expect(activatesRow(click(document.createElement("span")))).toBe(true);
+  });
+
+  it("leaves a press on a control inside the row to that control", () => {
+    selecting(true);
+    const row = document.createElement("div");
+    const button = document.createElement("button");
+    row.append(button);
+    expect(activatesRow(click(button))).toBe(false);
+  });
+
+  // The addresses and ids on these rows are what an operator copies into a
+  // ticket; opening on the mouse-up of a drag makes them unreadable.
+  it("does not activate on the click that ends a selection", () => {
+    selecting(false);
+    expect(activatesRow(click(document.createElement("span")))).toBe(false);
+  });
+});
+
+describe("activatesRowByKey", () => {
+  it.each(["Enter", " "])("activates on %s from the row itself", (key) => {
+    const row = document.createElement("div");
+    expect(activatesRowByKey(press(key, row, row))).toBe(true);
+  });
+
+  it("ignores every other key", () => {
+    const row = document.createElement("div");
+    expect(activatesRowByKey(press("ArrowDown", row, row))).toBe(false);
+  });
+
+  // A control inside the row has its own answer to both keys.
+  it("ignores the same keys pressed inside a control", () => {
+    const row = document.createElement("div");
+    const button = document.createElement("button");
+    expect(activatesRowByKey(press("Enter", button, row))).toBe(false);
+  });
+});

--- a/src/frontend/src/lib/identities/row-activation.ts
+++ b/src/frontend/src/lib/identities/row-activation.ts
@@ -1,0 +1,34 @@
+/**
+ * When a gesture on a console row means "activate this row".
+ *
+ * The rows of every identity listing are not `<button>`s, and cannot be: their
+ * text is what an operator copies out — an address, an account id, a person id
+ * — and they carry copy controls of their own, which a button may neither nest
+ * nor let be selected. So each row handles the gesture itself, and has to tell
+ * an activation apart from the two things that look like one: a press on a
+ * control inside it, and the end of a selection dragged across its text.
+ *
+ * INVARIANT: one rule for every listing. A row that opens on the mouse-up of a
+ * text selection makes the addresses unreadable — and the reader cannot tell
+ * which of the four lists behaves which way.
+ */
+
+/** A click activates the row — unless it pressed a control or ended a selection. */
+export function activatesRow(event: React.MouseEvent<HTMLElement>): boolean {
+  if (event.target instanceof Element && event.target.closest("button, a")) {
+    return false;
+  }
+  const selection = window.getSelection();
+  return !selection || selection.isCollapsed;
+}
+
+/**
+ * Enter and Space activate the row — but only from the row itself, never from a
+ * control it contains, which has its own answer to both keys.
+ */
+export function activatesRowByKey(
+  event: React.KeyboardEvent<HTMLElement>,
+): boolean {
+  if (event.key !== "Enter" && event.key !== " ") return false;
+  return event.target === event.currentTarget;
+}

--- a/src/frontend/src/lib/identities/trail.test.ts
+++ b/src/frontend/src/lib/identities/trail.test.ts
@@ -1,0 +1,274 @@
+/**
+ * One row per event that changed something about the account. What matters: a
+ * sync re-observing a binding that never moved is not an event; an operator row
+ * always is, even when it moved nobody, because that row is the confirm act;
+ * the call is never a row of its own; and its comment is carried across only
+ * when the pairing is not a guess, since nothing in the journal links the two
+ * records.
+ */
+import { describe, expect, it } from "vitest";
+
+import type {
+  AccountOperation,
+  BindingHistoryEntry,
+} from "@/api/identity-client";
+import { accountTrail } from "./trail";
+
+const ANN = "01900000-0000-7000-8000-0000000000a0";
+const BOB = "01900000-0000-7000-8000-0000000000b0";
+const OPERATOR = "01900000-0000-7000-8000-0000000000f0";
+const AUTOMATION = "00000000-0000-0000-0000-000000000000";
+
+/** A binding row. The wire sends these newest first. */
+function seen(
+  at: string,
+  person: string,
+  over: Partial<BindingHistoryEntry> = {},
+): BindingHistoryEntry {
+  return {
+    person_id: person,
+    author_person_id: AUTOMATION,
+    by_operator: false,
+    reason: "",
+    recorded_at: at,
+    ...over,
+  };
+}
+
+function decided(
+  at: string,
+  person: string,
+  reason: string,
+  over: Partial<BindingHistoryEntry> = {},
+): BindingHistoryEntry {
+  return seen(at, person, {
+    author_person_id: OPERATOR,
+    by_operator: true,
+    reason,
+    ...over,
+  });
+}
+
+function call(
+  at: string,
+  verb: string,
+  over: Partial<AccountOperation> = {},
+): AccountOperation {
+  return {
+    operation_id: `op-${at}`,
+    verb,
+    author_person_id: OPERATOR,
+    accounts_touched: 1,
+    recorded_at: at,
+    ...over,
+  };
+}
+
+/** Newest first, so this reads the trail top-down. */
+const persons = (rows: ReturnType<typeof accountTrail>) =>
+  rows.map((row) => row.entry.person_id);
+
+describe("accountTrail", () => {
+  it("keeps nothing for an account with no journal", () => {
+    expect(accountTrail([], [])).toEqual([]);
+  });
+
+  // The seed reads the whole connector history every run, so an account that
+  // never moved collects one automatic row per sync. Twelve identical rows are
+  // one fact.
+  it("collapses a binding re-observed by every sync into the one that made it", () => {
+    const trail = accountTrail(
+      [
+        seen("2026-08-03T00:00:00.000000", ANN),
+        seen("2026-08-02T00:00:00.000000", ANN),
+        seen("2026-08-01T00:00:00.000000", ANN),
+      ],
+      [],
+    );
+
+    expect(trail).toHaveLength(1);
+    expect(trail[0].entry.recorded_at).toBe("2026-08-01T00:00:00.000000");
+  });
+
+  it("keeps every row where the account changed hands", () => {
+    const trail = accountTrail(
+      [
+        seen("2026-08-04T00:00:00.000000", BOB),
+        seen("2026-08-03T00:00:00.000000", BOB),
+        seen("2026-08-02T00:00:00.000000", ANN),
+        seen("2026-08-01T00:00:00.000000", ANN),
+      ],
+      [],
+    );
+
+    expect(persons(trail)).toEqual([BOB, ANN]);
+  });
+
+  // Re-observations of the SEEN person, not of the last kept one: otherwise the
+  // sync rows following an operator row come back.
+  it("does not resurrect a duplicate after an operator row", () => {
+    const trail = accountTrail(
+      [
+        seen("2026-08-04T00:00:00.000000", ANN),
+        decided("2026-08-03T00:00:00.000000", ANN, "operator-bind"),
+        seen("2026-08-02T00:00:00.000000", ANN),
+      ],
+      [],
+    );
+
+    expect(trail).toHaveLength(2);
+    expect(trail[0].entry.by_operator).toBe(true);
+  });
+
+  // Binding an account to the person automation already gave it changes no
+  // binding, and IS the decision: it records that a human vouched for the
+  // resolver's guess, and the trail is what says who is answerable.
+  it("keeps an operator row that moved nobody", () => {
+    const trail = accountTrail(
+      [
+        decided("2026-08-02T00:00:00.000000", ANN, "operator-bind"),
+        seen("2026-08-01T00:00:00.000000", ANN),
+      ],
+      [],
+    );
+
+    expect(trail).toHaveLength(2);
+    expect(persons(trail)).toEqual([ANN, ANN]);
+  });
+
+  it("reads newest first", () => {
+    const trail = accountTrail(
+      [
+        seen("2026-08-02T00:00:00.000000", BOB),
+        seen("2026-08-01T00:00:00.000000", ANN),
+      ],
+      [],
+    );
+
+    expect(persons(trail)).toEqual([BOB, ANN]);
+  });
+
+  // One call is journalled once and returned on every account it named, so it
+  // used to appear beside the row it produced, saying the same thing twice.
+  it("never renders a call as a row of its own", () => {
+    const trail = accountTrail(
+      [decided("2026-08-01T00:00:00.000000", ANN, "operator-bind")],
+      [
+        call("2026-08-01T00:00:01.000000", "operator-bind", {
+          comment: "Same person.",
+          accounts_touched: 110,
+        }),
+      ],
+    );
+
+    expect(trail).toHaveLength(1);
+    expect(trail[0].comment).toBe("Same person.");
+  });
+
+  // A call that changed nothing here — already decided, refused, or an account
+  // a merge merely swept along — has no row to carry it.
+  it("drops a call that produced no movement here", () => {
+    const trail = accountTrail(
+      [],
+      [
+        call("2026-08-01T00:00:00.000000", "operator-merge", {
+          comment: "Merging the other one.",
+          accounts_touched: 30,
+          outcome: "already_decided",
+        }),
+      ],
+    );
+
+    expect(trail).toEqual([]);
+  });
+
+  it("carries each comment to its own decision when the calls line up", () => {
+    const trail = accountTrail(
+      [
+        decided("2026-08-02T00:00:00.000000", BOB, "operator-bind"),
+        decided("2026-08-01T00:00:00.000000", ANN, "operator-bind"),
+      ],
+      [
+        call("2026-08-02T00:00:01.000000", "operator-bind", { comment: "second" }),
+        call("2026-08-01T00:00:01.000000", "operator-bind", { comment: "first" }),
+      ],
+    );
+
+    expect(trail.map((row) => row.comment)).toEqual(["second", "first"]);
+  });
+
+  // Nothing links a binding row to the call that wrote it, so an unequal count
+  // means at least one call wrote nothing here — and any pairing would be a
+  // guess. A missing comment is recoverable; a comment on the wrong decision is
+  // a false audit trail.
+  it("attributes nothing when the counts disagree", () => {
+    const trail = accountTrail(
+      [
+        decided("2026-08-02T00:00:00.000000", BOB, "operator-bind"),
+        decided("2026-08-01T00:00:00.000000", ANN, "operator-bind"),
+      ],
+      [call("2026-08-02T00:00:01.000000", "operator-bind", { comment: "which?" })],
+    );
+
+    expect(trail.map((row) => row.comment)).toEqual([undefined, undefined]);
+  });
+
+  // The verb and the author are all the two records share, so they are what the
+  // groups are cut on: a detach's comment must not caption a bind.
+  it("keeps the verbs and the authors apart", () => {
+    const trail = accountTrail(
+      [
+        decided("2026-08-02T00:00:00.000000", BOB, "operator-detach"),
+        decided("2026-08-01T00:00:00.000000", ANN, "operator-bind", {
+          author_person_id: "01900000-0000-7000-8000-0000000000f1",
+        }),
+      ],
+      [
+        call("2026-08-02T00:00:01.000000", "operator-detach", { comment: "not theirs" }),
+        call("2026-08-01T00:00:01.000000", "operator-bind", { comment: "somebody else's call" }),
+      ],
+    );
+
+    expect(trail[0].comment).toBe("not theirs");
+    // The bind was authored by a different operator, so its group has one
+    // decision and no call.
+    expect(trail[1].comment).toBeUndefined();
+  });
+
+  it("treats a blank comment as no comment", () => {
+    const trail = accountTrail(
+      [decided("2026-08-01T00:00:00.000000", ANN, "operator-bind")],
+      [call("2026-08-01T00:00:01.000000", "operator-bind", { comment: "   " })],
+    );
+
+    expect(trail[0].comment).toBeUndefined();
+  });
+
+  it("carries no comment to an automatic row", () => {
+    const trail = accountTrail(
+      [seen("2026-08-01T00:00:00.000000", ANN, { reason: "auto-seed-link" })],
+      [
+        {
+          operation_id: "op-1",
+          verb: "auto-seed-link",
+          author_person_id: AUTOMATION,
+          accounts_touched: 1,
+          comment: "should not appear",
+          recorded_at: "2026-08-01T00:00:01.000000",
+        },
+      ],
+    );
+
+    expect(trail[0].comment).toBeUndefined();
+  });
+
+  it("survives a read that carries no operations array at all", () => {
+    const trail = accountTrail(
+      [decided("2026-08-01T00:00:00.000000", ANN, "operator-bind")],
+      undefined,
+    );
+
+    expect(trail).toHaveLength(1);
+    expect(trail[0].comment).toBeUndefined();
+  });
+});

--- a/src/frontend/src/lib/identities/trail.ts
+++ b/src/frontend/src/lib/identities/trail.ts
@@ -1,0 +1,138 @@
+/**
+ * What actually happened to one account, from the two records the service
+ * keeps.
+ *
+ * Those reads are append-only logs, not an event stream: they hold rows that
+ * changed nothing about this account, and the console used to render every one
+ * of them.
+ *
+ * Two sources of noise, both dropped here:
+ *
+ * 1. Re-observations. The seed reads the whole connector history every run and
+ *    appends a binding row per observation, so an account that never moved
+ *    collects one automatic row per sync — same person, no reason. Only a row
+ *    that changed who holds the account survives.
+ * 2. The call. One operator request is journalled once and then returned on
+ *    every account it named, so it sits beside the binding row it produced
+ *    saying the same thing twice — and it appears on accounts it changed
+ *    nothing about at all (already decided, refused, or an account a merge
+ *    merely swept along). Its `accounts_touched` counts the whole call, which
+ *    for a merge is every account of the absorbed person: a number about other
+ *    accounts, on this account's trail.
+ *
+ * An operator row always survives, even when the person did not change: that
+ * row IS the confirm act, a human deciding the resolver's guess stands, and the
+ * trail is what says who is answerable for it.
+ *
+ * The comment is the one thing no binding row holds — why a human did this — so
+ * it is carried across onto the row it explains. Nothing links the two records
+ * (see `attribute`), so the join is refused wherever it would be a guess: an
+ * unattributed comment is invisible rather than attached to the wrong decision.
+ */
+import type {
+  AccountOperation,
+  BindingHistoryEntry,
+} from "@/api/identity-client";
+
+export interface TrailEvent {
+  /** Stable within one read — a render key, never an identifier. */
+  key: string;
+  entry: BindingHistoryEntry;
+  /** Why a human did this, when the call that did it can be named. */
+  comment?: string;
+}
+
+/** Newest first, as the trail reads. */
+export function accountTrail(
+  history: BindingHistoryEntry[],
+  operations: AccountOperation[] | undefined,
+): TrailEvent[] {
+  const moved = movements(history);
+  const comments = attribute(moved, operations ?? []);
+  return moved
+    .map((entry, index) => {
+      const comment = comments.get(entry);
+      return {
+        key: `${entry.recorded_at}-${index}`,
+        entry,
+        ...(comment ? { comment } : {}),
+      };
+    })
+    .reverse();
+}
+
+/**
+ * The rows that changed something, oldest first.
+ *
+ * INVARIANT: compared against the previously SEEN person, not the previously
+ * kept one. A dropped row is a re-observation of the person it names, so the
+ * two hold the same value — and reading the kept one would resurrect a
+ * duplicate after every operator row.
+ */
+function movements(history: BindingHistoryEntry[]): BindingHistoryEntry[] {
+  const oldestFirst = [...history].reverse();
+  const kept: BindingHistoryEntry[] = [];
+  let held: string | undefined;
+  for (const entry of oldestFirst) {
+    if (entry.by_operator || entry.person_id !== held) kept.push(entry);
+    held = entry.person_id;
+  }
+  return kept;
+}
+
+/**
+ * Which call explains which decision.
+ *
+ * Nothing links them: a binding row carries no operation id, and the two
+ * timestamps come from different clocks — the app's for the binding, the
+ * database's for the call, written afterwards and re-stamped later still on a
+ * retry. What the two records DO share is the author and the verb: an operator
+ * binding row's `reason` is the same literal the call stores as its `verb`.
+ *
+ * So the pairing is per (author, verb) group, and only where it is not a guess.
+ * One call writes one binding row for this account, so equal counts mean the
+ * two sequences are the same calls and pair in time order. Unequal counts mean
+ * at least one call wrote nothing here — it was already decided, or refused, or
+ * it fell outside the service's cap on how many calls it returns — and then no
+ * row in that group gets a comment rather than the wrong one.
+ */
+function attribute(
+  moved: BindingHistoryEntry[],
+  operations: AccountOperation[],
+): Map<BindingHistoryEntry, string> {
+  const named = new Map<BindingHistoryEntry, string>();
+  const decisions = groupBy(
+    moved.filter((entry) => entry.by_operator),
+    (entry) => group(entry.author_person_id, entry.reason),
+  );
+  const calls = groupBy(operations, (op) => group(op.author_person_id, op.verb));
+
+  for (const [at, rows] of decisions) {
+    const made = calls.get(at);
+    if (!made || made.length !== rows.length) continue;
+    const ordered = [...made].sort((a, b) =>
+      a.recorded_at.localeCompare(b.recorded_at),
+    );
+    // Both oldest-first, so the nth decision in the group is the nth call.
+    rows.forEach((entry, index) => {
+      const comment = ordered[index]?.comment?.trim();
+      if (comment) named.set(entry, comment);
+    });
+  }
+  return named;
+}
+
+function group(author: string, verb: string | null | undefined): string {
+  return `${author} ${verb?.trim() ?? ""}`;
+}
+
+function groupBy<T>(items: T[], of: (item: T) => string): Map<string, T[]> {
+  const groups = new Map<string, T[]>();
+  for (const item of items) {
+    const at = of(item);
+    const existing = groups.get(at);
+    if (existing) existing.push(item);
+    else groups.set(at, [item]);
+  }
+  return groups;
+}

--- a/src/frontend/src/lib/portal/portal-search.ts
+++ b/src/frontend/src/lib/portal/portal-search.ts
@@ -33,9 +33,9 @@ export interface PortalSearch {
   /**
    * What was typed into the Identities person roster.
    *
-   * In the URL rather than in the field's own state because choosing a person
-   * replaces the roster with their accounts — the field unmounts, and coming
-   * back to a blank one means finding the same person twice.
+   * In the URL rather than in the field's own state so the terms survive
+   * leaving the mode and coming back: an operator comparing two people should
+   * not have to find the same list twice.
    */
   find?: string;
   /** Expanded direction + its active lens, within the Directions zone. */

--- a/src/frontend/src/locales/en/translation.json
+++ b/src/frontend/src/locales/en/translation.json
@@ -485,7 +485,6 @@
       "exclude": "Exclude (bot / CI)",
       "exclude_confirm": "Exclude",
       "assign_other": "Assign to someone else",
-      "bind_to": "Bind to selected person",
       "assign_person": "Assign to a person",
       "merge_into_person": "Merge into this person",
       "confirm_group_one": "Confirm 1 account",
@@ -557,10 +556,19 @@
       "no_accounts": "No account is bound to this person.",
       "by_operator": "decided by an operator",
       "by_automation": "bound automatically",
-      "open": "Open",
-      "load_failed": "Unable to load this person’s accounts",
-      "back": "‹ Back to the roster",
-      "find_account": "Find an account to bind to this person…"
+      "load_failed": "Unable to load this person’s accounts"
+    },
+    "person_window": {
+      "bind_section": "Bind an account to this person",
+      "find_account": "Find an account by source, address, handle or id…",
+      "detach": "Detach",
+      "exclude": "Exclude",
+      "detach_title": "Take this account off this person?",
+      "detach_description": "A new person is created and the account is bound to them. This person keeps their other accounts.",
+      "bind_title": "Bind this account to this person?",
+      "bind_description": "The account is bound to this person.",
+      "bind_from_description": "The account is taken from {{name}} and bound to this person.",
+      "only_account": "Their only account — detaching it would move it to a copy of them and leave this person with nothing."
     },
     "accounts": {
       "placeholder": "Find an account by source, address, handle, id or observed name…",

--- a/src/frontend/src/locales/en/translation.json
+++ b/src/frontend/src/locales/en/translation.json
@@ -434,8 +434,6 @@
       "loading_more": "Loading…",
       "case_count_one": "{{count}} case · {{accounts}} accounts",
       "case_count_other": "{{count}} cases · {{accounts}} accounts",
-      "previous_case": "‹ Previous account",
-      "next_case": "Next account ›",
       "reports_to": "reports to {{manager}}",
       "bound_to": "held by {{name}}",
       "case_people_one": "{{count}} person",
@@ -560,15 +558,16 @@
     },
     "person_window": {
       "bind_section": "Bind an account to this person",
-      "find_account": "Find an account by source, address, handle or id…",
+      "find_account": "Find an account by source, address, handle, id or observed name…",
       "detach": "Detach",
       "exclude": "Exclude",
+      "detach_account": "Detach {{account}} on {{source}} from this person",
+      "exclude_account": "Exclude {{account}} on {{source}}",
       "detach_title": "Take this account off this person?",
       "detach_description": "A new person is created and the account is bound to them. This person keeps their other accounts.",
       "bind_title": "Bind this account to this person?",
       "bind_description": "The account is bound to this person.",
-      "bind_from_description": "The account is taken from {{name}} and bound to this person.",
-      "only_account": "Their only account — detaching it would move it to a copy of them and leave this person with nothing."
+      "bind_from_description": "The account is taken from {{name}} and bound to this person."
     },
     "accounts": {
       "placeholder": "Find an account by source, address, handle, id or observed name…",

--- a/src/frontend/src/locales/en/translation.json
+++ b/src/frontend/src/locales/en/translation.json
@@ -463,16 +463,14 @@
       "merge": "Merged",
       "detach": "Detached",
       "exclude": "Excluded",
-      "automatic": "Automatic",
+      "linked": "Linked",
+      "auto_seed_link": "Linked by address",
       "to": "to",
       "by_operator": "by an operator",
       "login_bootstrap": "First sign-in",
       "roster_mint": "Added from the roster",
-      "by": "by",
       "by_name": "by {{name}}",
-      "accounts_touched_one": "{{count}} account in this call",
-      "accounts_touched_other": "{{count}} accounts in this call",
-      "call": "the call"
+      "by_automation": "by automation"
     },
     "actions": {
       "bind": "Bind",

--- a/src/frontend/src/queries/identity-resolution.ts
+++ b/src/frontend/src/queries/identity-resolution.ts
@@ -152,9 +152,10 @@ export type PersonListIntent = "browse" | "match";
 
 /**
  * The same for {@link useAccountList}. The accounts mode browses — reviewing
- * what the connectors reported is the point there. Inside one person a blank
- * field asks nothing: the tenant's whole fold would bury the handful of accounts
- * that person actually holds, which is what the reader opened them for.
+ * what the connectors reported is the point there. The picker inside the person
+ * window asks nothing on a blank field: the tenant's whole fold would bury the
+ * handful of accounts that person actually holds, which is what the reader
+ * opened them for.
  */
 export type AccountListIntent = "browse" | "match";
 
@@ -306,7 +307,8 @@ export function useAccountList(
   });
 }
 
-/** The accounts a merge would move — fetched only while the preview is open. */
+/** Every account one person holds: the person window's list, and what a merge
+ *  preview says would move. */
 export function usePersonAccounts(
   personId: string | null,
 ): UseQueryResult<{ person_id: string; accounts: PersonAccountEntry[] }> {


### PR DESCRIPTION
The identity console had two idioms for one gesture: the accounts tab opened an account in a window over its list, while the person tab replaced the whole screen and needed a "back to the roster" link drawn on it. A person now opens in a window mirroring the account window — only what the search field looks for flips, and a click inside either window picks the other side of a binding rather than walking into it. In a listing, the row itself opens; the accounts tab's `Open` button is gone.

The per-account decision history now shows one row per event that changed something. It was rendering both source logs verbatim, so a binding re-observed by every sync looked like a decision nobody took, and the operator call appeared beside the row it produced saying the same thing twice — with a reach counted over other accounts.

**Where:** `src/frontend` only. No API change.

**Verify:** `cd src/frontend && pnpm typecheck && pnpm lint && pnpm test`, then Manage → Identities and work both tabs.

**Follow-up:** the comment on a decision is paired to its call by (author, verb) and skipped when that would be a guess — a binding row carries no operation id. An `operation_id` column would make it exact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a person-focused dialog for reviewing accounts and performing bind, detach, and exclude actions.
  * Added account search with filtering, pagination, loading, error, and empty states.
  * Added clearer correction outcome alerts, including applied, refused, and already-decided totals.
  * Added richer account history showing linked actions, automation, operators, and comments.

* **Improvements**
  * Account and identity rows now open by clicking or keyboard activation, while nested controls remain safe to use.
  * Search selections and open cases are preserved more reliably during navigation and refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->