### PR TITLE
fix(metrics): name the work item in task evidence rows

### DIFF
--- a/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
+++ b/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
@@ -1184,7 +1184,8 @@ metrics:
     inputs:
       - input_role: value
         measure_key: dev_time_hours
-    dimensions: []
+    dimensions:
+      - source
   - metric_key: tasks.resolution_time
     source_key: task
     subject: cycle_time
@@ -1204,7 +1205,8 @@ metrics:
     inputs:
       - input_role: value
         measure_key: resolution_days
-    dimensions: []
+    dimensions:
+      - source
   - metric_key: tasks.pickup_time
     source_key: task
     subject: cycle_time
@@ -1224,7 +1226,8 @@ metrics:
     inputs:
       - input_role: value
         measure_key: pickup_days
-    dimensions: []
+    dimensions:
+      - source
   - metric_key: tasks.flow_efficiency
     source_key: task
     subject: cycle_time

--- a/src/backend/services/analytics/src/domain/metric_drilldown/presentation.rs
+++ b/src/backend/services/analytics/src/domain/metric_drilldown/presentation.rs
@@ -201,7 +201,6 @@ fn presentation_column(key: &str, plan: &EvidencePlan) -> MetricDrilldownColumn 
             "Lines removed".to_owned(),
             MetricDrilldownColumnType::Number,
         ),
-        "issue_type" => ("Issue type".to_owned(), MetricDrilldownColumnType::String),
         "billing_month" => (
             "Billing month".to_owned(),
             MetricDrilldownColumnType::String,
@@ -241,21 +240,20 @@ pub(super) fn evidence_presentation(
             detail_keys: &["ref", "title", "repository", "author"],
             show_value: true,
         },
+        // A counting measure needs no value column — the row IS the one it
+        // counted; a duration or a page count is only readable with its number.
         (
             "task",
             "tasks_closed" | "bugs_fixed" | "closed_non_bug" | "due_date_on_time"
             | "due_date_with_due" | "late_count",
-        ) => EvidencePresentation {
-            detail_keys: &["ref", "issue_type"],
+        )
+        | ("wiki", "pages_created") => EvidencePresentation {
+            detail_keys: &["ref", "title"],
             show_value: false,
         },
         ("task", _) if granularity == EvidenceGranularity::Event => EvidencePresentation {
-            detail_keys: &["ref", "issue_type"],
-            show_value: true,
-        },
-        ("wiki", "pages_created") => EvidencePresentation {
             detail_keys: &["ref", "title"],
-            show_value: false,
+            show_value: true,
         },
         // A seat-month row is dated at the day its snapshot was last read, not
         // at the month it bills for, so the month has to be a column of its own

--- a/src/frontend/src/components/metric-evidence-dialog.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog.tsx
@@ -13,8 +13,8 @@ import type { EvidenceDialogState } from "@/components/metric-evidence-context";
 import { MetricEvidenceTable } from "@/components/metric-evidence-table";
 import {
   SOURCE_DIMENSION,
-  withGitSourceDimension,
-} from "@/lib/metrics/git-links";
+  withSourceDimension,
+} from "@/lib/metrics/provider-links";
 import { useDeclaredMetricDimensions } from "@/queries/metric-definitions";
 import { Button } from "@/components/ui/button";
 import {
@@ -70,7 +70,7 @@ export function MetricEvidenceDialog({
   // and refetch every row.
   const declaredDimensions = useDeclaredMetricDimensions();
   const selection = activeTarget
-    ? withGitSourceDimension(
+    ? withSourceDimension(
         activeTarget.selection,
         declaredDimensions.byMetricKey?.get(activeTarget.selection.metric_key)
       )
@@ -100,7 +100,7 @@ export function MetricEvidenceDialog({
     [pages]
   );
   const columns = useMemo(() => {
-    // `source` rides along purely to back a link (see withGitSourceDimension) —
+    // `source` rides along purely to back a link (see withSourceDimension) —
     // it is not a column anyone asked to see.
     const columns = (query.data?.pages[0]?.columns ?? []).filter(
       (column) => column.key !== SOURCE_DIMENSION

--- a/src/frontend/src/components/metric-evidence-table.tsx
+++ b/src/frontend/src/components/metric-evidence-table.tsx
@@ -30,7 +30,10 @@ import {
   summaryLine,
   type EvidenceSort,
 } from "@/lib/metrics/evidence-rows";
-import { evidenceRecordLinks } from "@/lib/metrics/git-links";
+import {
+  evidenceRecordLinks,
+  evidenceRefText,
+} from "@/lib/metrics/provider-links";
 import { cn } from "@/lib/utils";
 
 function columnLayout(column: MetricEvidenceColumn) {
@@ -263,7 +266,14 @@ export function MetricEvidenceTable({
                   const layout = columnLayout(column);
                   const value = row.values[column.key];
                   const text = cellText(value, column.type);
-                  const line = summaryLine(text);
+                  const full = summaryLine(text);
+                  // The ref column shows the issue number alone; the tooltip
+                  // keeps the repository, which is the only place a row states
+                  // it when the metric declares no `source` to link from.
+                  const line =
+                    column.key === "ref"
+                      ? evidenceRefText(metricKey ?? "", full)
+                      : full;
                   return (
                     <TableCell
                       role="cell"
@@ -275,7 +285,7 @@ export function MetricEvidenceTable({
                       style={{
                         flex: `${layout.grow} 0 ${layout.basisRem}rem`,
                       }}
-                      title={line}
+                      title={full}
                     >
                       {column.key === "ref" && value != null ? (
                         <div className="flex min-w-0 items-center gap-1">

--- a/src/frontend/src/components/portal/domain-lens-view.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.tsx
@@ -49,7 +49,7 @@ import type {
   MetricDirection,
 } from "@/api/metric-results-client";
 import { normalizePersonId } from "@/lib/metrics/entity";
-import { githubRepoUrl } from "@/lib/metrics/git-links";
+import { githubRepoUrl } from "@/lib/metrics/provider-links";
 import { formatMetricValue } from "@/lib/format";
 import { seriesColors } from "@/lib/series-colors";
 import { mergeEventHistogram } from "@/lib/portal/event-histogram";

--- a/src/frontend/src/components/record-link.tsx
+++ b/src/frontend/src/components/record-link.tsx
@@ -2,7 +2,7 @@
  * A record's text, linked when the record has a page to link to.
  *
  * Metric evidence is only sometimes addressable — it depends on the provider
- * and on what the row carries (see `lib/metrics/git-links`). Callers pass the
+ * and on what the row carries (see `lib/metrics/provider-links`). Callers pass the
  * href they resolved and this decides nothing except how to render it, so an
  * unlinkable row is plain text rather than a dead anchor.
  */

--- a/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
@@ -29,9 +29,10 @@ import {
   type NormalizedMetricResult,
 } from "@/lib/metrics/collection";
 import {
+  activityEventLabel,
   evidenceRecordLinks,
-  withGitSourceDimension,
-} from "@/lib/metrics/git-links";
+  withSourceDimension,
+} from "@/lib/metrics/provider-links";
 import { RecordLink } from "@/components/record-link";
 import { useMetricDetail } from "@/queries/metric-detail";
 import {
@@ -74,7 +75,7 @@ export function MetricActivity({
   // makes a link safe, and asking for it where a metric does not declare it is
   // rejected outright, so the read waits for the catalogue.
   const selection = base
-    ? withGitSourceDimension(base, declared.byMetricKey?.get(base.metric_key))
+    ? withSourceDimension(base, declared.byMetricKey?.get(base.metric_key))
     : null;
   const detail = useMetricDetail(
     selection,
@@ -205,6 +206,7 @@ function EventList({
       <ul className="flex flex-col">
         {shown.map((event, index) => {
           const links = evidenceRecordLinks(metricKey, event.values);
+          const label = activityEventLabel(metricKey, event.ref, event.title);
           return (
             <li
               key={event.ref ?? `${event.date}-${index}`}
@@ -214,8 +216,8 @@ function EventList({
                 {formatDate(event.date)}
               </span>
               <span className="min-w-0 flex-1 truncate">
-                {event.title ? (
-                  <RecordLink href={links.title}>{event.title}</RecordLink>
+                {label ? (
+                  <RecordLink href={links.title}>{label}</RecordLink>
                 ) : (
                   <span className="text-muted-foreground">—</span>
                 )}

--- a/src/frontend/src/lib/metrics/provider-links.test.ts
+++ b/src/frontend/src/lib/metrics/provider-links.test.ts
@@ -1,5 +1,5 @@
 /**
- * When a git metric's evidence addresses something outside the product.
+ * When a metric's evidence addresses something outside the product.
  *
  * The rule these pin is that a link is only ever built from what a row
  * actually says. Every case below is a way of NOT knowing: a provider whose
@@ -12,12 +12,15 @@ import { describe, expect, it } from "vitest";
 
 import type { MetricEvidenceSelection } from "@/api/metric-drilldown-client";
 import {
+  activityEventLabel,
   evidenceRecordLinks,
+  evidenceRefText,
+  githubIssueUrl,
   githubRecordUrl,
   githubRepoUrl,
   isGitMetric,
-  withGitSourceDimension,
-} from "@/lib/metrics/git-links";
+  withSourceDimension,
+} from "@/lib/metrics/provider-links";
 
 const SHA1 = "e0f4823a55ac28276cf068f066ebf66f872a059c";
 const SHA256 = `${SHA1}${SHA1.slice(0, 24)}`;
@@ -125,7 +128,7 @@ describe("isGitMetric", () => {
   );
 });
 
-describe("withGitSourceDimension", () => {
+describe("withSourceDimension", () => {
   function selection(
     metricKey: string,
     displayDimensions: string[] = []
@@ -140,7 +143,7 @@ describe("withGitSourceDimension", () => {
   }
 
   it("asks for the source a git metric declares", () => {
-    const result = withGitSourceDimension(
+    const result = withSourceDimension(
       selection("git.commits"),
       new Set(["repository", "source"])
     );
@@ -149,7 +152,7 @@ describe("withGitSourceDimension", () => {
   });
 
   it("keeps the requested dimensions sorted, so one selection is one query key", () => {
-    const result = withGitSourceDimension(
+    const result = withSourceDimension(
       selection("git.commits", ["repository"]),
       new Set(["repository", "source"])
     );
@@ -162,28 +165,34 @@ describe("withGitSourceDimension", () => {
   it("leaves a git metric that declares no source untouched", () => {
     const original = selection("git.commits_per_active_day");
 
-    expect(withGitSourceDimension(original, new Set())).toBe(original);
+    expect(withSourceDimension(original, new Set())).toBe(original);
   });
 
   it("leaves everything untouched while the catalogue is unknown", () => {
     const original = selection("git.commits");
 
-    expect(withGitSourceDimension(original, null)).toBe(original);
-    expect(withGitSourceDimension(original, undefined)).toBe(original);
+    expect(withSourceDimension(original, null)).toBe(original);
+    expect(withSourceDimension(original, undefined)).toBe(original);
   });
 
-  it("leaves a metric of another family untouched", () => {
+  it("leaves a metric of a family that links nothing untouched", () => {
+    const original = selection("wiki.pages_created");
+
+    expect(withSourceDimension(original, new Set(["source"]))).toBe(original);
+  });
+
+  it("asks for source on a task metric too, since its ref links out", () => {
     const original = selection("tasks.closed");
 
-    expect(withGitSourceDimension(original, new Set(["source"]))).toBe(
-      original
-    );
+    expect(
+      withSourceDimension(original, new Set(["source"])).display_dimensions
+    ).toContain("source");
   });
 
   it("does not ask twice for a source the caller already wanted", () => {
     const original = selection("git.commits", ["source"]);
 
-    expect(withGitSourceDimension(original, new Set(["source"]))).toBe(
+    expect(withSourceDimension(original, new Set(["source"]))).toBe(
       original
     );
   });
@@ -253,5 +262,87 @@ describe("evidenceRecordLinks", () => {
         ref: SHA1,
       })
     ).toEqual({});
+  });
+});
+
+describe("githubIssueUrl", () => {
+  it("addresses the issue's own page from the readable key", () => {
+    expect(githubIssueUrl("github", "constructorfabric/insight#2717")).toBe(
+      "https://github.com/constructorfabric/insight/issues/2717"
+    );
+  });
+
+  it("accepts the label form the drilldown projects", () => {
+    expect(githubIssueUrl("GitHub", "owner/repo#1")).toBe(
+      "https://github.com/owner/repo/issues/1"
+    );
+  });
+
+  it("refuses a tracker whose address is not derivable", () => {
+    expect(githubIssueUrl("jira", "PROJ-7")).toBeNull();
+    expect(githubIssueUrl("youtrack", "owner/repo#1")).toBeNull();
+  });
+
+  it("refuses a key that does not name a repository and a number", () => {
+    for (const ref of ["PROJ-7", "4884190007", "owner/repo", "#12", ""]) {
+      expect(githubIssueUrl("github", ref)).toBeNull();
+    }
+  });
+});
+
+describe("evidenceRefText", () => {
+  it("drops the repository prefix a whole drilldown shares", () => {
+    expect(evidenceRefText("tasks.closed", "constructorfabric/insight#2717")).toBe(
+      "#2717"
+    );
+  });
+
+  it("leaves a ref of another shape alone", () => {
+    expect(evidenceRefText("tasks.closed", "PROJ-7")).toBe("PROJ-7");
+  });
+
+  it("leaves other families alone, pull request numbers included", () => {
+    expect(evidenceRefText("git.prs", "2717")).toBe("2717");
+  });
+});
+
+describe("evidenceRecordLinks for task evidence", () => {
+  it("links both the ref and the title at the issue", () => {
+    const issue = "https://github.com/owner/repo/issues/12";
+
+    expect(
+      evidenceRecordLinks("tasks.closed", {
+        source: "github",
+        ref: "owner/repo#12",
+      })
+    ).toEqual({ ref: issue, title: issue });
+  });
+
+  it("says nothing when the row does not carry its source", () => {
+    expect(evidenceRecordLinks("tasks.closed", { ref: "owner/repo#12" })).toEqual(
+      {}
+    );
+  });
+});
+
+describe("activityEventLabel", () => {
+  it("names an issue by number and summary", () => {
+    expect(
+      activityEventLabel("tasks.closed", "owner/repo#12", "Fix the importer")
+    ).toBe("#12: Fix the importer");
+  });
+
+  it("falls back to whichever half the row has", () => {
+    expect(activityEventLabel("tasks.closed", "owner/repo#12", null)).toBe("#12");
+    expect(activityEventLabel("tasks.closed", null, "Fix the importer")).toBe(
+      "Fix the importer"
+    );
+    expect(activityEventLabel("tasks.closed", null, null)).toBeNull();
+  });
+
+  it("leaves other families reading as they did", () => {
+    expect(activityEventLabel("git.commits", "e0f4823", "Fix the importer")).toBe(
+      "Fix the importer"
+    );
   });
 });

--- a/src/frontend/src/lib/metrics/provider-links.ts
+++ b/src/frontend/src/lib/metrics/provider-links.ts
@@ -1,5 +1,6 @@
 /**
- * Links into the provider a git metric came from.
+ * Links into the provider a metric's record came from — git records and
+ * tracker issues alike.
  *
  * Only GitHub, and only because its web layout is derivable from data we
  * already hold: `https://github.com/{owner}/{repo}`. GitLab and Bitbucket can
@@ -64,19 +65,58 @@ export function githubRecordUrl(
   return null;
 }
 
-/** Two-part `family.name` metric keys namespace by family; git's is fixed. */
+/** Two-part `family.name` metric keys namespace by family; these are fixed. */
 const GIT_METRIC_PREFIX = "git.";
+const TASK_METRIC_PREFIX = "tasks.";
 
 /** Whether links are worth attempting at all for this metric's evidence. */
 export function isGitMetric(metricKey: string): boolean {
   return metricKey.startsWith(GIT_METRIC_PREFIX);
 }
 
+export function isTaskMetric(metricKey: string): boolean {
+  return metricKey.startsWith(TASK_METRIC_PREFIX);
+}
+
+/**
+ * A tracker states an issue's readable key its own way — GitHub as
+ * `owner/repo#12`, Jira as `PROJ-7` — and only the GitHub shape carries the
+ * repository the URL needs. Matching the shape is what keeps a Jira key from
+ * being linked to a github.com path that does not exist.
+ */
+const GITHUB_ISSUE_REF = /^([A-Za-z0-9._-]+\/[A-Za-z0-9._-]+)#([0-9]+)$/;
+
+/** The issue's own page, or null when the row is not linkable. */
+export function githubIssueUrl(
+  source: string | null | undefined,
+  ref: string | null | undefined
+): string | null {
+  if (source?.trim().toLowerCase() !== GITHUB_SOURCE) return null;
+  const matched = GITHUB_ISSUE_REF.exec(ref?.trim() ?? "");
+  if (!matched) return null;
+  return `${GITHUB_WEB_BASE}/${matched[1]}/issues/${matched[2]}`;
+}
+
+/**
+ * How an issue ref reads in a column: the repository prefix is the same for
+ * nearly every row of one drilldown, so it costs width and says nothing —
+ * `#12` is what distinguishes rows, and the repository stays in the link and
+ * in what the copy button yields. A ref of any other shape reads as-is.
+ */
+export function evidenceRefText(
+  metricKey: string,
+  value: string
+): string {
+  if (!isTaskMetric(metricKey)) return value;
+  const matched = GITHUB_ISSUE_REF.exec(value.trim());
+  return matched ? `#${matched[2]}` : value;
+}
+
 /** The dimension key requested so a row's own connector rides along. */
 export const SOURCE_DIMENSION = "source";
 
 /**
- * Adds `source` to a git metric's requested display dimensions, so its
+ * Adds `source` to a metric's requested display dimensions, so its
  * evidence rows carry the per-row connector a link needs to be safe.
  *
  * SAFETY: only when the metric DECLARES the dimension — a drilldown that asks
@@ -84,11 +124,13 @@ export const SOURCE_DIMENSION = "source";
  * missing link for an unopenable dialog. `declared` is null while the catalog
  * is unknown, which is also a no-op.
  */
-export function withGitSourceDimension(
+export function withSourceDimension(
   selection: MetricEvidenceSelection,
   declared: ReadonlySet<string> | null | undefined
 ): MetricEvidenceSelection {
-  if (!isGitMetric(selection.metric_key)) return selection;
+  if (!isGitMetric(selection.metric_key) && !isTaskMetric(selection.metric_key)) {
+    return selection;
+  }
   if (!declared?.has(SOURCE_DIMENSION)) return selection;
   if (selection.display_dimensions.includes(SOURCE_DIMENSION)) return selection;
   return {
@@ -109,6 +151,13 @@ export function evidenceRecordLinks(
   metricKey: string,
   values: Readonly<Record<string, unknown>>
 ): Readonly<Record<string, string | undefined>> {
+  if (isTaskMetric(metricKey)) {
+    const issue = githubIssueUrl(
+      asString(values[SOURCE_DIMENSION]),
+      asString(values.ref)
+    );
+    return issue ? { ref: issue, title: issue } : {};
+  }
   if (!isGitMetric(metricKey)) return {};
   const repoUrl = githubRepoUrl(
     asString(values[SOURCE_DIMENSION]),
@@ -121,4 +170,23 @@ export function evidenceRecordLinks(
 
 function asString(value: unknown): string | undefined {
   return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * One line naming an issue in an activity list: `#12: what it is about`.
+ *
+ * The list has one column for the thing itself, so the number and the summary
+ * share it — the number alone does not say what the work was, and the summary
+ * alone cannot be told apart from another issue with a similar name. Either
+ * half may be missing; what is left still reads.
+ */
+export function activityEventLabel(
+  metricKey: string,
+  ref: string | null | undefined,
+  title: string | null | undefined
+): string | null {
+  const shortRef = ref ? evidenceRefText(metricKey, ref) : null;
+  if (!isTaskMetric(metricKey)) return title ?? null;
+  if (shortRef && title) return `${shortRef}: ${title}`;
+  return title ?? shortRef ?? null;
 }

--- a/src/ingestion/connectors/git/github/dbt/github__task_field_history.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__task_field_history.sql
@@ -32,6 +32,7 @@ issues AS (
         source_id,
         toString(id)                                            AS issue_id,
         concat(repo_full_name, '#', toString(number))           AS id_readable,
+        title,
         repo_full_name,
         number,
         parseDateTimeBestEffortOrNull(created_at)               AS created_at,
@@ -334,6 +335,10 @@ SELECT
     CAST('github' AS String)                                    AS data_source,
     CAST(issue_id AS String)                                    AS issue_id,
     CAST(id_readable AS String)                                 AS id_readable,
+    -- One row per (issue x field x event) all share the issue's summary; it is
+    -- an issue attribute, not an event one, so it is joined in rather than
+    -- repeated by every branch of the union above.
+    CAST(nullIf(issue_title.title, '') AS Nullable(String))     AS title,
     CAST(event_id AS String)                                    AS event_id,
     -- The WHERE below already excludes the unparseable ones; the class declares
     -- a non-Nullable column and `union_by_tag` fails the shared relation for
@@ -358,4 +363,6 @@ SELECT
     toDateTime64(_airbyte_extracted_at, 3)                      AS collected_at,
     CAST(toUnixTimestamp64Milli(toDateTime64(_airbyte_extracted_at, 3)) AS UInt64) AS _version
 FROM every_row
+LEFT JOIN (SELECT issue_id, title FROM issues) AS issue_title
+    ON issue_title.issue_id = every_row.issue_id
 WHERE event_at IS NOT NULL

--- a/src/ingestion/dbt/macros/create_task_field_history_staging.sql
+++ b/src/ingestion/dbt/macros/create_task_field_history_staging.sql
@@ -22,6 +22,7 @@
             data_source         String,
             issue_id            String,
             id_readable         String,
+            title               Nullable(String),
             event_id            String,
             event_at            DateTime64(3),
             event_kind          Enum8('changelog' = 1, 'synthetic_initial' = 2),
@@ -46,6 +47,11 @@
         )
         ENGINE = ReplacingMergeTree(_version)
         ORDER BY (unique_key)
+    ") %}
+
+    {% do run_query("
+        ALTER TABLE staging.jira__task_field_history
+        ADD COLUMN IF NOT EXISTS title Nullable(String) AFTER id_readable
     ") %}
 
     {% if execute %}

--- a/src/ingestion/gold/task_issue_state.sql
+++ b/src/ingestion/gold/task_issue_state.sql
@@ -94,8 +94,11 @@ issue_pivot AS (
         minIf(event_at, event_kind = 'synthetic_initial')                    AS created_at,
         -- The key the tracker itself shows a human ('owner/repo#12', 'PROJ-7');
         -- the only field an issue's own page can be addressed from.
-        any(id_readable)                                                     AS id_readable,
-        any(title)                                                           AS title,
+        -- INVARIANT: argMax, never any() — `id_readable` is part of `unique_key`,
+        -- so a renamed repository or an issue moved between projects leaves rows
+        -- under BOTH keys and FINAL collapses neither. The latest event wins.
+        argMax(id_readable, (event_at, _version))                            AS id_readable,
+        argMax(title, (event_at, _version))                                  AS title,
         maxIf(event_at, role = 'status' AND delta_action = 'set')        AS last_status_event_at,
         any(data_source)                                                     AS data_source
     FROM history

--- a/src/ingestion/gold/task_issue_state.sql
+++ b/src/ingestion/gold/task_issue_state.sql
@@ -46,6 +46,8 @@ history AS (
         fh.insight_source_id                                                  AS insight_source_id,
         fh.data_source                                                        AS data_source,
         fh.issue_id                                                           AS issue_id,
+        fh.id_readable                                                        AS id_readable,
+        fh.title                                                              AS title,
         fh.event_at                                                           AS event_at,
         fh.event_kind                                                         AS event_kind,
         fh.delta_action                                                       AS delta_action,
@@ -90,6 +92,10 @@ issue_pivot AS (
             * argMaxIf(unit_multiplier, (event_at, _version),
                  role = 'spent' AND delta_action = 'set')                    AS time_spent_seconds,
         minIf(event_at, event_kind = 'synthetic_initial')                    AS created_at,
+        -- The key the tracker itself shows a human ('owner/repo#12', 'PROJ-7');
+        -- the only field an issue's own page can be addressed from.
+        any(id_readable)                                                     AS id_readable,
+        any(title)                                                           AS title,
         maxIf(event_at, role = 'status' AND delta_action = 'set')        AS last_status_event_at,
         any(data_source)                                                     AS data_source
     FROM history
@@ -116,6 +122,8 @@ SELECT
     p.insight_source_id                                                      AS insight_source_id,
     p.data_source                                                            AS data_source,
     p.issue_id                                                               AS issue_id,
+    p.id_readable                                                            AS id_readable,
+    p.title                                                                  AS title,
     cur.status_category                                                      AS status_category,
     p.issue_type                                                             AS issue_type,
     ifNull(it.issue_kind, 'unknown')                                         AS issue_kind,

--- a/src/ingestion/gold/task_metric_evidence.sql
+++ b/src/ingestion/gold/task_metric_evidence.sql
@@ -56,7 +56,8 @@ issue_facts AS (
         any(s.final_close_at)                                                AS observed_at,
         s.issue_id                                                           AS issue_id,
         any(s.data_source)                                                   AS data_source,
-        any(s.issue_type)                                                    AS issue_type,
+        any(s.id_readable)                                                   AS id_readable,
+        any(s.title)                                                         AS title,
         any(s.status_category) = 'done'                                      AS is_done,
         toDate(s.final_close_at)                                             AS close_date,
         any(s.due_date)                                                      AS due_date,
@@ -73,7 +74,12 @@ issue_facts AS (
            toFloat64(greatest(toInt64(0),
                dateDiff('second', any(s.created_at),
                         minIf(i.interval_start, i.interval_start < s.final_close_at))))) AS pickup_seconds,
-        CAST([] AS Array(Tuple(key String, value String, label Nullable(String)))) AS no_dimensions
+        -- The duration measures carry no breakdown, but a row still has to
+        -- name its tracker: `source` is what makes its ref addressable.
+        CAST(
+            [tuple('source', any(s.data_source), any(s.data_source))]
+            AS Array(Tuple(key String, value String, label Nullable(String)))
+        ) AS no_dimensions
     FROM issue_state AS s
     LEFT JOIN status_intervals AS i
         ON i.insight_source_id = s.insight_source_id
@@ -90,7 +96,8 @@ issue_item_evidence AS (
         toDate(final_close_at) AS metric_date,
         final_close_at AS observed_at,
         issue_id,
-        issue_type,
+        id_readable,
+        title,
         item_measure.1 AS measure_key,
         toFloat64(item_measure.2) AS contribution,
         CAST(
@@ -284,14 +291,11 @@ SELECT
     concat(toString(insight_source_id), ':', toString(issue_id), ':', measure_key) AS record_id,
     'issue' AS record_kind,
     'event' AS granularity,
-    toString(issue_id) AS record_label,
+    id_readable AS record_label,
     toNullable(contribution) AS contribution,
     CAST(NULL AS Nullable(String)) AS subject_key,
     type_dimensions AS dimensions,
-    map(
-        'ref', toString(issue_id),
-        'issue_type', ifNull(issue_type, '')
-    ) AS details
+    map('ref', id_readable, 'title', ifNull(title, '')) AS details
 FROM issue_item_evidence
 WHERE tenant_id IS NOT NULL
   AND entity_id IS NOT NULL
@@ -311,14 +315,11 @@ SELECT
     concat(toString(insight_source_id), ':', toString(issue_id), ':', duration_measure.1) AS record_id,
     'issue' AS record_kind,
     'event' AS granularity,
-    toString(issue_id) AS record_label,
+    id_readable AS record_label,
     toNullable(toFloat64(duration_measure.2)) AS contribution,
     CAST(NULL AS Nullable(String)) AS subject_key,
     no_dimensions AS dimensions,
-    map(
-        'ref', toString(issue_id),
-        'issue_type', ifNull(issue_type, '')
-    ) AS details
+    map('ref', id_readable, 'title', ifNull(title, '')) AS details
 FROM issue_facts
 ARRAY JOIN arrayConcat(
     if(ifNull(dev_seconds, 0) > 0, [tuple('dev_time_hours', toFloat64(dev_seconds / 3600.0))], []),

--- a/src/ingestion/scripts/connectors-ddl/insight.sql
+++ b/src/ingestion/scripts/connectors-ddl/insight.sql
@@ -251,6 +251,8 @@ CREATE TABLE IF NOT EXISTS insight.task_issue_state
     `insight_source_id` String,
     `data_source` String,
     `issue_id` String,
+    `id_readable` String,
+    `title` Nullable(String),
     `status_category` String,
     `issue_type` String,
     `issue_kind` String,

--- a/src/ingestion/scripts/connectors-ddl/silver.sql
+++ b/src/ingestion/scripts/connectors-ddl/silver.sql
@@ -756,6 +756,7 @@ CREATE TABLE IF NOT EXISTS silver.class_task_field_history
     `data_source` String,
     `issue_id` String,
     `id_readable` String,
+    `title` Nullable(String),
     `event_id` String,
     `event_at` DateTime64(3),
     `event_kind` Enum8('changelog' = 1, 'synthetic_initial' = 2),

--- a/src/ingestion/silver/task-tracking/schema.yml
+++ b/src/ingestion/silver/task-tracking/schema.yml
@@ -29,8 +29,8 @@ models:
         description: >
           The issue's own summary as the tracker states it, repeated on every
           event of that issue — an issue attribute, not an event one. NULL when
-          the source does not report one; gold reads it for the record label a
-          person recognises, never for matching.
+          the source does not report one. Gold surfaces it as `details.title` in
+          task evidence; the record label is `id_readable`.
       - name: event_id
         description: "Natural identifier of the event. For `event_kind='changelog'` this is `jira_issue_history.changelog_id` (shared across all fields changed in one changelog). For `event_kind='synthetic_initial'` it is `'initial:<issue_id>'` (shared across all initial fields of one issue). Per ADR-005, operator audit JOIN key is (insight_source_id, id_readable, event_id, field_id)."
         tests:

--- a/src/ingestion/silver/task-tracking/schema.yml
+++ b/src/ingestion/silver/task-tracking/schema.yml
@@ -25,6 +25,12 @@ models:
         description: "Source system discriminator (e.g. 'jira')"
         tests:
           - not_null
+      - name: title
+        description: >
+          The issue's own summary as the tracker states it, repeated on every
+          event of that issue — an issue attribute, not an event one. NULL when
+          the source does not report one; gold reads it for the record label a
+          person recognises, never for matching.
       - name: event_id
         description: "Natural identifier of the event. For `event_kind='changelog'` this is `jira_issue_history.changelog_id` (shared across all fields changed in one changelog). For `event_kind='synthetic_initial'` it is `'initial:<issue_id>'` (shared across all initial fields of one issue). Per ADR-005, operator audit JOIN key is (insight_source_id, id_readable, event_id, field_id)."
         tests:


### PR DESCRIPTION
Closes #2723.

**Why.** Every task evidence row read `<date> —`, so the panel that explains a number never said which issues it counted, and the drilldown showed an internal database id beside a raw GitHub node id.

**What changed.** The tracker's own readable key and the issue summary now travel through the class contract into `details.ref` / `details.title`, and the frontend builds the issue URL from the key's shape — a row reads `#12: what it is about`, linked, the same way commits and pull requests already do.

**The raw `issue_type` detail is dropped, not repaired.** It projected `value_displays`, which for a synthetic-initial event falls back to the node id, while the resolved type name already sat beside it in the `type` dimension. Reversible in two lines of gold.

**Duration measures now declare `source`.** Their rows carried no dimension at all, and without one a link cannot be built safely — a Jira key would be sent to a github.com path. Revert by dropping the declaration.

**The staging contract widens in place.** `CREATE TABLE IF NOT EXISTS` leaves an existing deployment's table untouched, and `union_by_tag` matches branches by position, so a missing column would fail the shared relation for every source at once — hence `ADD COLUMN IF NOT EXISTS`.

**Out of scope.** Jira rows show their key but no summary and no link; that needs `jira-enrich` to carry the summary and the instance host to reach the contract — #2738. The type name shown for an issue whose tracker states none stays "Type unknown" (#2726).

**Verified.** e2e task fixtures 16/16, frontend suite green (two unrelated 5s timeouts re-run clean), `cargo clippy` pedantic and `tsc -b` clean, and the rendered panel checked in a browser against a local stand. No screenshots: the only local data carrying issues is a copy of a deployed slice, which AGENTS.md keeps off GitHub.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task metrics can now be filtered and broken down by source.
  * Task evidence and activity views now display issue references and titles, with links to GitHub issues.
  * Evidence tables provide clearer provider context and full-text tooltips.
  * Task history and evidence now retain readable issue identifiers and titles.

* **Bug Fixes**
  * Improved metric drilldowns by replacing issue-type labels with task references and titles.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->