### PR TITLE
feat(github)!: major bump to dispatch a full refresh for the new title column

### DIFF
--- a/src/ingestion/connectors/git/github/descriptor.yaml
+++ b/src/ingestion/connectors/git/github/descriptor.yaml
@@ -1,5 +1,5 @@
 name: github
-version: "2.6.0"
+version: "3.0.0"
 schedule: "0 */4 * * *"
 workflow: sync
 


### PR DESCRIPTION
**Why.** #2739 added a `title` column to `silver.class_task_field_history`, but that model is incremental and sets no `on_schema_change`, so dbt's default `ignore` applies: a deployed table keeps its existing column list and never gains the new one. Gold reads `title`, so the next ordinary transform would run against a relation that does not have it.

**What changed.** The github descriptor goes `2.6.0` → `3.0.0`. Reconcile classifies that as a major bump and renders the one-shot sync trigger with `DBT_FULL_REFRESH=true` (`classify_bump.py`, `render_sync_trigger.py:60`), which rebuilds the relation with the widened column list.

**Major rather than a hand-run `dbt --full-refresh`.** The mechanism already exists and is the documented one — `bump-descriptor-version.sh` states that a minor bump only re-discovers the source catalog and stays "below the major-bump threshold that would dispatch a `dbt --full-refresh`". Doing it by hand would leave the same need undocumented for the next deployment.

**The refresh covers the connector's whole selector.** `dbt_select` is `tag:github+`, so bronze-promoted, staging, silver and gold are all rebuilt, not just the one relation. That is the cost of the mechanism, and it has a useful side effect: the stale issue-era rows in `staging.github__item_events` / `silver.class_git_item_events` — which incremental models never delete — go with it, and the tightened `accepted_values: ['pull_request']` test on `item_type` stops failing.

**Verified.** Nothing to run: this is one descriptor field. The behaviour it relies on is read from `classify_bump.py` (major when the major component increases) and from the trigger template, which is a one-shot Workflow — so the flag applies to this dispatch only and the 4-hourly cron keeps running incrementally. Connector wiring and descriptor gates run in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GitHub connector to version 3.0.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->