### PR TITLE
feat(analytics): support tenant-scoped metrics such as CI

### DIFF
--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -483,6 +483,8 @@ analytics:
   resources:
     requests: {cpu: 100m, memory: 128Mi}
     limits: {cpu: 500m, memory: 512Mi}
+  metricCatalog:
+    tenantMetricsEnabled: false
   # The umbrella generates `insight-analytics-config` with every
   # APP__gears__analytics__config__* env var filled in from the
   # auto-generated credentials (see templates/secrets.yaml). The subchart

--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -311,6 +311,13 @@
         ],
         "type": "object"
       },
+      "EntityType": {
+        "enum": [
+          "person",
+          "tenant"
+        ],
+        "type": "string"
+      },
       "EvidenceGranularity": {
         "enum": [
           "event",
@@ -463,6 +470,9 @@
               }
             ]
           },
+          "entity_type": {
+            "$ref": "#/components/schemas/EntityType"
+          },
           "explanation": {
             "type": [
               "string",
@@ -546,6 +556,7 @@
         },
         "required": [
           "metric_key",
+          "entity_type",
           "label",
           "format",
           "direction",
@@ -664,19 +675,40 @@
         "type": "string"
       },
       "MetricDrilldownEntity": {
-        "properties": {
-          "id": {
-            "type": "string"
+        "oneOf": [
+          {
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "type": {
+                "enum": [
+                  "person"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "id",
+              "type"
+            ],
+            "type": "object"
           },
-          "type": {
-            "type": "string"
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "tenant"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
           }
-        },
-        "required": [
-          "type",
-          "id"
-        ],
-        "type": "object"
+        ]
       },
       "MetricDrilldownExportFormat": {
         "enum": [
@@ -1168,42 +1200,82 @@
         ]
       },
       "MetricResultsEntity": {
-        "properties": {
-          "ids": {
-            "description": "Canonical person UUIDs (since the identity cutover; the\npre-cutover email shape is rejected with a 400).",
-            "items": {
-              "type": "string"
+        "oneOf": [
+          {
+            "properties": {
+              "ids": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "type": {
+                "enum": [
+                  "person"
+                ],
+                "type": "string"
+              }
             },
-            "type": "array"
+            "required": [
+              "ids",
+              "type"
+            ],
+            "type": "object"
           },
-          "type": {
-            "type": "string"
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "tenant"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
           }
-        },
-        "required": [
-          "type",
-          "ids"
-        ],
-        "type": "object"
+        ]
       },
       "MetricResultsEntityDto": {
-        "properties": {
-          "ids": {
-            "description": "Canonical person UUIDs (since the identity cutover; the\npre-cutover email shape is rejected with a 400).",
-            "items": {
-              "type": "string"
+        "oneOf": [
+          {
+            "properties": {
+              "ids": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "type": {
+                "enum": [
+                  "person"
+                ],
+                "type": "string"
+              }
             },
-            "type": "array"
+            "required": [
+              "ids",
+              "type"
+            ],
+            "type": "object"
           },
-          "type": {
-            "type": "string"
+          {
+            "properties": {
+              "type": {
+                "enum": [
+                  "tenant"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "type": "object"
           }
-        },
-        "required": [
-          "type",
-          "ids"
-        ],
-        "type": "object"
+        ]
       },
       "MetricResultsPeriod": {
         "properties": {

--- a/src/backend/services/analytics/config/insight.yaml
+++ b/src/backend/services/analytics/config/insight.yaml
@@ -141,6 +141,7 @@ gears:
       identity_url: ""
       redis_url: ""
       metric_catalog:
+        tenant_metrics_enabled: false
         # Per-tenant observation filter on metric reads. Off until the ingest
         # tenant is aligned with the session tenant.
         enforce_tenant_scope: false

--- a/src/backend/services/analytics/helm/templates/configmap.yaml
+++ b/src/backend/services/analytics/helm/templates/configmap.yaml
@@ -120,4 +120,6 @@ data:
       # Leaf values (database_url, clickhouse_*, redis_url, identity_url)
       # come from the Secret via envFrom.
       analytics:
-        config: {}
+        config:
+          metric_catalog:
+            tenant_metrics_enabled: {{ .Values.metricCatalog.tenantMetricsEnabled }}

--- a/src/backend/services/analytics/helm/values.yaml
+++ b/src/backend/services/analytics/helm/values.yaml
@@ -19,6 +19,9 @@ resources:
     cpu: 500m
     memory: 512Mi
 
+metricCatalog:
+  tenantMetricsEnabled: false
+
 # Pre-provisioned Secret carrying the gears-rust host's leaf-config overrides
 # (injected via envFrom; they override the mounted config ConfigMap):
 #   APP__gears__analytics__config__database_url

--- a/src/backend/services/analytics/src/api/metric_definitions.rs
+++ b/src/backend/services/analytics/src/api/metric_definitions.rs
@@ -24,6 +24,11 @@ pub async fn list_metric_definitions(
     Extension(state): Extension<Arc<AppState>>,
     Extension(ctx): Extension<SecurityContext>,
 ) -> Result<impl IntoResponse, CanonicalError> {
-    let response = listing::list_definition_views(&state.db, ctx.subject_tenant_id()).await?;
+    let response = listing::list_definition_views(
+        &state.db,
+        ctx.subject_tenant_id(),
+        state.config.metric_catalog.tenant_metrics_enabled,
+    )
+    .await?;
     Ok(Json(response))
 }

--- a/src/backend/services/analytics/src/api/metric_drilldown.rs
+++ b/src/backend/services/analytics/src/api/metric_drilldown.rs
@@ -126,6 +126,11 @@ async fn authorize_metric_entity(
     if matches!(entity, MetricDrilldownEntity::Tenant {}) {
         return authorize_tenant_metrics(state.config.metric_catalog.tenant_metrics_enabled);
     }
+    if matches!(entity, MetricDrilldownEntity::Unknown) {
+        return Err(MetricError::invalid_argument()
+            .with_field_violation("entity.type", "unsupported entity type", "INVALID")
+            .create());
+    }
 
     let (_, person_id) = parse_person_entity(entity)?;
 

--- a/src/backend/services/analytics/src/api/metric_drilldown.rs
+++ b/src/backend/services/analytics/src/api/metric_drilldown.rs
@@ -12,6 +12,7 @@ use toolkit_security::SecurityContext;
 
 use super::AppState;
 use crate::api::error::MetricError;
+use crate::domain::metric_access::authorize_tenant_metrics;
 use crate::domain::metric_drilldown::{
     EVIDENCE_QUERY_TIMEOUT_SECS, EvidenceQueryRow, MAX_EXPORT_BYTES, MAX_EXPORT_ROWS,
     MetricDrilldownColumn, MetricDrilldownEntity, MetricDrilldownExportFormat,
@@ -21,7 +22,7 @@ use crate::domain::metric_drilldown::{
     parse_person_entity, presentation, validate_export_request, validate_request,
     verify_evidence_snapshot, with_evidence_query_limits,
 };
-use crate::domain::person_visibility::authorize_entity_ids;
+use crate::domain::person_visibility::authorize_person_ids;
 
 const QUERY_TIMEOUT: Duration = Duration::from_secs(EVIDENCE_QUERY_TIMEOUT_SECS);
 const EXPORT_TIMEOUT: Duration = Duration::from_mins(1);
@@ -41,7 +42,7 @@ pub async fn query_metric_drilldown(
     Json(req): Json<MetricDrilldownRequest>,
 ) -> Result<Json<MetricDrilldownResponse>, CanonicalError> {
     let started = Instant::now();
-    authorize_person_entity(&state, &ctx, &headers, &req.entity).await?;
+    authorize_metric_entity(&state, &ctx, &headers, &req.entity).await?;
 
     let mut req = validate_request(&state.db, &state.ch, ctx.subject_tenant_id(), req).await?;
     req.enforce_tenant_scope = state.config.metric_catalog.enforce_tenant_scope;
@@ -71,12 +72,12 @@ pub async fn export_metric_drilldown(
     let started = Instant::now();
     // Ahead of the permit: a caller who may not see this person must not occupy
     // one of MAX_CONCURRENT_EXPORTS slots.
-    authorize_person_entity(&state, &ctx, &headers, &req.entity).await?;
+    authorize_metric_entity(&state, &ctx, &headers, &req.entity).await?;
 
     let permit = acquire_export_permit().await?;
     let deadline = tokio::time::Instant::now() + EXPORT_TIMEOUT;
 
-    let validated = validate_export_request(
+    let mut validated = validate_export_request(
         &state.db,
         &state.ch,
         ctx.subject_tenant_id(),
@@ -84,6 +85,7 @@ pub async fn export_metric_drilldown(
         MAX_EXPORT_ROWS + 1,
     )
     .await?;
+    validated.enforce_tenant_scope = state.config.metric_catalog.enforce_tenant_scope;
     let evidence = collect_export_rows(&state, &validated, deadline).await?;
     let exported_rows = evidence.len();
 
@@ -113,24 +115,24 @@ pub async fn export_metric_drilldown(
     attachment_response(body, content_type, &export_name(&validated, extension))
 }
 
-// INVARIANT: both drilldown routes call this before validation touches MariaDB
-// or ClickHouse. They serve per-person evidence — names, record labels,
-// contributions — so an unchecked id is the IDOR `/v1/metric-results` answers
-// 403 for. Gating ahead of validation also stops its error codes (404 unknown
-// metric, 400 unhealthy evidence) from describing a person the caller cannot see.
-async fn authorize_person_entity(
+// INVARIANT: both drilldown routes authorize the typed entity before validation
+// touches MariaDB or ClickHouse, preventing person IDORs and tenant-gate bypasses.
+async fn authorize_metric_entity(
     state: &AppState,
     ctx: &SecurityContext,
     headers: &HeaderMap,
     entity: &MetricDrilldownEntity,
 ) -> Result<(), CanonicalError> {
-    let (entity_type, person_id) = parse_person_entity(entity)?;
+    if matches!(entity, MetricDrilldownEntity::Tenant {}) {
+        return authorize_tenant_metrics(state.config.metric_catalog.tenant_metrics_enabled);
+    }
 
-    authorize_entity_ids(
+    let (_, person_id) = parse_person_entity(entity)?;
+
+    authorize_person_ids(
         &state.identity,
         ctx,
         super::forwarded_authorization(headers),
-        &entity_type,
         &[person_id],
     )
     .await

--- a/src/backend/services/analytics/src/api/metric_drilldown.rs
+++ b/src/backend/services/analytics/src/api/metric_drilldown.rs
@@ -123,24 +123,25 @@ async fn authorize_metric_entity(
     headers: &HeaderMap,
     entity: &MetricDrilldownEntity,
 ) -> Result<(), CanonicalError> {
-    if matches!(entity, MetricDrilldownEntity::Tenant {}) {
-        return authorize_tenant_metrics(state.config.metric_catalog.tenant_metrics_enabled);
-    }
-    if matches!(entity, MetricDrilldownEntity::Unknown) {
-        return Err(MetricError::invalid_argument()
+    match entity {
+        MetricDrilldownEntity::Tenant {} => {
+            authorize_tenant_metrics(state.config.metric_catalog.tenant_metrics_enabled)
+        }
+        MetricDrilldownEntity::Unknown => Err(MetricError::invalid_argument()
             .with_field_violation("entity.type", "unsupported entity type", "INVALID")
-            .create());
+            .create()),
+        MetricDrilldownEntity::Person { .. } => {
+            let (_, person_id) = parse_person_entity(entity)?;
+
+            authorize_person_ids(
+                &state.identity,
+                ctx,
+                super::forwarded_authorization(headers),
+                &[person_id],
+            )
+            .await
+        }
     }
-
-    let (_, person_id) = parse_person_entity(entity)?;
-
-    authorize_person_ids(
-        &state.identity,
-        ctx,
-        super::forwarded_authorization(headers),
-        &[person_id],
-    )
-    .await
 }
 
 async fn acquire_export_permit() -> Result<tokio::sync::SemaphorePermit<'static>, CanonicalError> {

--- a/src/backend/services/analytics/src/api/metric_results.rs
+++ b/src/backend/services/analytics/src/api/metric_results.rs
@@ -11,6 +11,7 @@ use toolkit_canonical_errors::CanonicalError;
 
 use super::AppState;
 use super::error::MetricError;
+use crate::domain::metric_access::authorize_tenant_metrics;
 use crate::domain::metric_drilldown::load_capabilities;
 use crate::domain::metric_results::{
     BatchItem, BreakdownQueryRow, CompiledQuery, HistogramQueryRow, MetricResultViewDto,
@@ -20,7 +21,7 @@ use crate::domain::metric_results::{
     build_period_view, build_ranked_groups, build_timeseries_view, demux_peer_rows,
     demux_period_rows, enforce_view_row_limit, plan_queries, plan_rankings, validate_request,
 };
-use crate::domain::person_visibility::authorize_entity_ids;
+use crate::domain::person_visibility::authorize_person_ids;
 use toolkit_security::SecurityContext;
 
 const QUERY_CONCURRENCY: usize = 4;
@@ -37,20 +38,10 @@ pub async fn query_metric_results(
     Json(req): Json<MetricResultsRequest>,
 ) -> Result<Json<MetricResultsResponse>, CanonicalError> {
     let tenant_id = ctx.subject_tenant_id();
+    authorize_tenant_request(&state, &req)?;
     let mut req = validate_request(&state.db, tenant_id, req).await?;
     req.enforce_tenant_scope = state.config.metric_catalog.enforce_tenant_scope;
-
-    // Visibility gate BEFORE any ClickHouse work: the caller may only query
-    // persons inside their visible set (identity /v1/visible-persons, by
-    // person UUID since the cutover). Service principals bypass.
-    authorize_entity_ids(
-        &state.identity,
-        &ctx,
-        super::forwarded_authorization(&headers),
-        req.entity.entity_type(),
-        req.entity.person_ids(),
-    )
-    .await?;
+    authorize_person_request(&state, &ctx, &headers, &req).await?;
 
     let metric_keys = req
         .metrics
@@ -118,9 +109,12 @@ pub async fn query_metric_results(
         }
         let selection = crate::domain::metric_results::MetricResultSelectionDto {
             metric_key: metric.def.key().to_owned(),
-            entity: crate::domain::metric_results::MetricResultsEntityDto {
-                r#type: req.entity.entity_type().to_owned(),
-                ids: req.entity.entity_ids(),
+            entity: if req.entity.is_tenant() {
+                crate::domain::metric_results::MetricResultsEntityDto::Tenant {}
+            } else {
+                crate::domain::metric_results::MetricResultsEntityDto::Person {
+                    ids: req.entity.entity_ids(),
+                }
             },
             period: crate::domain::metric_results::MetricResultsPeriodDto {
                 from: req.from.to_string(),
@@ -145,6 +139,36 @@ pub async fn query_metric_results(
 
     let response = MetricResultsResponse { metrics };
     Ok(Json(response))
+}
+
+fn authorize_tenant_request(
+    state: &AppState,
+    req: &MetricResultsRequest,
+) -> Result<(), CanonicalError> {
+    if req.entity.is_tenant() {
+        authorize_tenant_metrics(state.config.metric_catalog.tenant_metrics_enabled)?;
+    }
+
+    Ok(())
+}
+
+async fn authorize_person_request(
+    state: &AppState,
+    ctx: &SecurityContext,
+    headers: &HeaderMap,
+    req: &ValidatedMetricResultsRequest,
+) -> Result<(), CanonicalError> {
+    let Some(person_ids) = req.entity.person_ids() else {
+        return Ok(());
+    };
+
+    authorize_person_ids(
+        &state.identity,
+        ctx,
+        super::forwarded_authorization(headers),
+        person_ids,
+    )
+    .await
 }
 
 struct MetricViewResult {
@@ -197,7 +221,7 @@ async fn execute_planned(
                 UnbatchedView::Breakdown { dimensions } => {
                     let comment = format!("metric-results:breakdown:{}", def.key());
                     let rows = fetch_rows::<BreakdownQueryRow>(state, query, &comment).await?;
-                    build_breakdown_view(&dimensions, rows)?
+                    build_breakdown_view(req, &dimensions, rows)?
                 }
                 UnbatchedView::Histogram => {
                     let comment = format!("metric-results:histogram:{}", def.key());

--- a/src/backend/services/analytics/src/config.rs
+++ b/src/backend/services/analytics/src/config.rs
@@ -73,6 +73,12 @@ impl Default for GearConfig {
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
 pub struct MetricCatalogConfig {
+    /// Permit authenticated callers to read tenant-level metric definitions,
+    /// results, evidence, and exports.
+    ///
+    /// Env: `APP__gears__analytics__config__metric_catalog__tenant_metrics_enabled`.
+    pub tenant_metrics_enabled: bool,
+
     /// Enforce the per-tenant observation filter (#1967) on metric reads.
     /// Defaults to `false`: the ingested `tenant_id` in the bronze/silver/gold
     /// pipeline is not yet aligned to the JWT tenant, so an exact

--- a/src/backend/services/analytics/src/domain/metric_access.rs
+++ b/src/backend/services/analytics/src/domain/metric_access.rs
@@ -1,0 +1,35 @@
+use toolkit_canonical_errors::CanonicalError;
+
+use crate::api::error::MetricError;
+
+pub(crate) fn authorize_tenant_metrics(enabled: bool) -> Result<(), CanonicalError> {
+    if enabled {
+        return Ok(());
+    }
+
+    Err(MetricError::permission_denied()
+        .with_reason("tenant_metrics_disabled")
+        .create())
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::StatusCode;
+    use axum::response::IntoResponse;
+
+    use super::*;
+
+    #[test]
+    fn tenant_metrics_are_denied_when_installation_gate_is_off() {
+        let Err(error) = authorize_tenant_metrics(false) else {
+            panic!("disabled tenant metrics must be denied");
+        };
+
+        assert_eq!(error.into_response().status(), StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn tenant_metrics_are_allowed_when_installation_gate_is_on() {
+        assert!(authorize_tenant_metrics(true).is_ok());
+    }
+}

--- a/src/backend/services/analytics/src/domain/metric_definitions/builtin.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/builtin.rs
@@ -1,22 +1,32 @@
 use std::sync::OnceLock;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::domain::metric_definitions::definition::{
     EvidenceGranularity, MetricComputation, MetricDirection, MetricFormat, MetricInputRole,
     SourceKind, ValueTransform,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum EntityType {
     Person,
+    Tenant,
 }
 
 impl EntityType {
     pub fn as_db(self) -> &'static str {
         match self {
             Self::Person => "person",
+            Self::Tenant => "tenant",
+        }
+    }
+
+    pub fn from_db(value: &str) -> Option<Self> {
+        match value {
+            "person" => Some(Self::Person),
+            "tenant" => Some(Self::Tenant),
+            _ => None,
         }
     }
 }
@@ -195,6 +205,13 @@ mod tests {
     fn registry_declares_the_expected_counts() {
         assert_eq!(builtin_sources().len(), 6, "builtin source count");
         assert_eq!(builtin_metrics().len(), 65, "builtin metric count");
+    }
+
+    #[test]
+    fn entity_types_round_trip_through_storage_values() {
+        for entity_type in [EntityType::Person, EntityType::Tenant] {
+            assert_eq!(EntityType::from_db(entity_type.as_db()), Some(entity_type));
+        }
     }
 
     #[test]

--- a/src/backend/services/analytics/src/domain/metric_definitions/listing.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/listing.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 use toolkit_canonical_errors::CanonicalError;
 use uuid::Uuid;
 
-use crate::domain::metric_definitions::builtin::{builtin_metrics, builtin_sources};
+use crate::domain::metric_definitions::builtin::{EntityType, builtin_metrics, builtin_sources};
 use crate::domain::metric_definitions::definition::{MetricDirection, MetricFormat, MetricOrigin};
 use crate::domain::metric_definitions::error_code::{MetricSchemaErrorCode, SchemaStatus};
 use crate::domain::metric_definitions::repository::{fetch_dimensions, fetch_tags};
@@ -34,6 +34,7 @@ pub struct MetricDefinitionListResponse {
 #[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct MetricDefinitionView {
     pub metric_key: String,
+    pub entity_type: EntityType,
     pub label: String,
     /// Compact label for dense surfaces; absent when the full label is
     /// already compact enough.
@@ -86,6 +87,7 @@ struct ListingRow {
     definition_id: Uuid,
     tenant_id: Option<Uuid>,
     metric_key: String,
+    entity_type: String,
     label: String,
     short_label: Option<String>,
     subject: Option<String>,
@@ -104,11 +106,12 @@ struct ListingRow {
 pub async fn list_definition_views(
     db: &DatabaseConnection,
     tenant_id: Uuid,
+    tenant_metrics_enabled: bool,
 ) -> Result<MetricDefinitionListResponse, CanonicalError> {
     let rows = fetch_listing_rows(db, tenant_id)
         .await
         .map_err(|error| db_error(&error))?;
-    let selected = select_rows(rows);
+    let selected = select_rows(rows, tenant_metrics_enabled);
     let metric_keys = selected
         .iter()
         .map(|row| row.metric_key.clone())
@@ -142,7 +145,7 @@ pub async fn list_definition_views(
 /// Collapse the tenant + product rows per `metric_key` to the one that wins:
 /// a tenant-scoped row overrides the product default. Input order is
 /// irrelevant; output is sorted by `metric_key` (`BTreeMap` key order).
-fn select_rows(rows: Vec<ListingRow>) -> Vec<ListingRow> {
+fn select_rows(rows: Vec<ListingRow>, tenant_metrics_enabled: bool) -> Vec<ListingRow> {
     let mut grouped: BTreeMap<String, Vec<ListingRow>> = BTreeMap::new();
     for row in rows {
         grouped.entry(row.metric_key.clone()).or_default().push(row);
@@ -151,7 +154,10 @@ fn select_rows(rows: Vec<ListingRow>) -> Vec<ListingRow> {
     for (_, mut candidates) in grouped {
         // Tenant override (tenant_id = Some) sorts before the product default.
         candidates.sort_by_key(|row| row.tenant_id.is_none());
-        selected.push(candidates.remove(0));
+        let row = candidates.remove(0);
+        if row.entity_type != "tenant" || tenant_metrics_enabled {
+            selected.push(row);
+        }
     }
     selected
 }
@@ -169,6 +175,8 @@ fn build_views(
     for row in selected {
         let format = MetricFormat::from_db(&row.format)
             .ok_or_else(|| config_error(&row.metric_key, "format", &row.format))?;
+        let entity_type = EntityType::from_db(&row.entity_type)
+            .ok_or_else(|| config_error(&row.metric_key, "entity_type", &row.entity_type))?;
         let direction = MetricDirection::from_db(&row.direction)
             .ok_or_else(|| config_error(&row.metric_key, "direction", &row.direction))?;
         let origin = MetricOrigin::from_db(&row.origin)
@@ -186,6 +194,7 @@ fn build_views(
         let revision_window_days = revision_windows.get(row.metric_key.as_str()).copied();
         metrics.push(MetricDefinitionView {
             metric_key: row.metric_key,
+            entity_type,
             label: row.label,
             short_label: row.short_label,
             subject: row.subject,
@@ -244,6 +253,7 @@ async fn fetch_listing_rows(
             d.id AS definition_id, \
             d.tenant_id AS tenant_id, \
             d.metric_key AS metric_key, \
+            d.entity_type AS entity_type, \
             d.label AS label, \
             d.short_label AS short_label, \
             d.subject AS subject, \
@@ -290,6 +300,7 @@ mod tests {
             definition_id: Uuid::now_v7(),
             tenant_id,
             metric_key: metric_key.to_owned(),
+            entity_type: "person".to_owned(),
             label: label.to_owned(),
             short_label: None,
             subject: None,
@@ -314,7 +325,7 @@ mod tests {
             row("git.commits", Some(tenant), "override"),
             row("ai.cost", None, "product-ai"),
         ];
-        let selected = select_rows(rows);
+        let selected = select_rows(rows, false);
         assert_eq!(
             selected
                 .iter()
@@ -326,6 +337,18 @@ mod tests {
             panic!("git.commits must be selected");
         };
         assert_eq!(commits.label, "override");
+    }
+
+    #[test]
+    fn tenant_definitions_follow_the_installation_gate() {
+        let tenant_metric = || {
+            let mut metric = row("ci.runs", None, "CI runs");
+            metric.entity_type = "tenant".to_owned();
+            metric
+        };
+
+        assert!(select_rows(vec![tenant_metric()], false).is_empty());
+        assert_eq!(select_rows(vec![tenant_metric()], true).len(), 1);
     }
 
     #[test]
@@ -346,6 +369,7 @@ mod tests {
             panic!("one view");
         };
         assert_eq!(view.format, MetricFormat::Integer);
+        assert_eq!(view.entity_type, EntityType::Person);
         assert_eq!(view.direction, MetricDirection::HigherIsBetter);
         assert_eq!(view.origin, MetricOrigin::Builtin);
         assert_eq!(view.schema_status, SchemaStatus::Error);
@@ -356,6 +380,14 @@ mod tests {
         assert_eq!(view.dimensions, vec!["repo".to_owned()]);
         assert_eq!(view.subject.as_deref(), Some("commits"));
         assert_eq!(view.tags, vec!["rate".to_owned()]);
+    }
+
+    #[test]
+    fn build_views_rejects_unknown_entity_types() {
+        let mut r = row("git.commits", None, "Commits");
+        r.entity_type = "repository".to_owned();
+
+        assert!(build_views(vec![r], HashMap::new(), HashMap::new()).is_err());
     }
 
     #[test]

--- a/src/backend/services/analytics/src/domain/metric_definitions/live_tests.rs
+++ b/src/backend/services/analytics/src/domain/metric_definitions/live_tests.rs
@@ -102,7 +102,7 @@ async fn listing_resolves_tenant_override_over_product() -> anyhow::Result<()> {
     let label = format!("override-{}", Uuid::now_v7().simple());
     insert_definition(&db, tenant, &metric_key, &label).await?;
 
-    let response = list_definition_views(&db, tenant).await?;
+    let response = list_definition_views(&db, tenant, false).await?;
 
     let keys = response
         .metrics

--- a/src/backend/services/analytics/src/domain/metric_drilldown/compiler.rs
+++ b/src/backend/services/analytics/src/domain/metric_drilldown/compiler.rs
@@ -11,11 +11,8 @@ use super::dto::{
 };
 use super::error::config_error;
 
-/// `entity_id` on the evidence relations is the canonical person id since the
-/// identity cutover, resolved ONCE per gold build — the same snapshot the
-/// observation the user clicked was attributed with, so drilldown explains
-/// exactly that selection (no read-time re-resolution, no drift between an
-/// identity sync and the next rebuild; the snapshot check covers both).
+/// Person evidence uses the canonical person id resolved by the gold build;
+/// tenant evidence repeats its tenant key as the entity id.
 pub fn compile_query(
     req: &ValidatedMetricDrilldown,
 ) -> Result<(String, Vec<String>), CanonicalError> {
@@ -43,11 +40,12 @@ fn compile_value_query(req: &ValidatedMetricDrilldown) -> (String, Vec<String>) 
     params.extend([
         req.tenant_id.to_string(),
         req.plan.source_key.clone(),
-        req.selection.entity.r#type.clone(),
-        req.selection.entity.id.clone(),
-        req.from.to_string(),
-        req.to.to_string(),
+        req.selection.entity.entity_type().to_owned(),
     ]);
+    if let Some(person_id) = req.selection.entity.person_id() {
+        params.push(person_id.to_owned());
+    }
+    params.extend([req.from.to_string(), req.to.to_string()]);
     params.extend(
         req.plan
             .inputs
@@ -73,11 +71,12 @@ fn compile_value_query(req: &ValidatedMetricDrilldown) -> (String, Vec<String>) 
                 ifNull(evidence.subject_key, '') AS subject_key, \
                 toJSONString(evidence.dimensions) AS dimensions_json, evidence.details \
          FROM {database}.{table} AS evidence \
-         WHERE {tenant} AND evidence.source_key = ? AND evidence.entity_type = ? AND evidence.entity_id = ? \
+         WHERE {tenant} AND evidence.source_key = ? AND evidence.entity_type = ? AND {entity} \
            AND evidence.metric_date >= toDate(?) AND evidence.metric_date <= toDate(?) \
            AND evidence.measure_key IN ({measures}){filter_sql}{cursor_sql} \
          ORDER BY role, metric_date, ifNull(toString(observed_at), ''), source_key, measure_key, record_id, record_kind, ifNull(subject_key, '') \
-         LIMIT {limit}"
+         LIMIT {limit}",
+        entity = entity_predicate(&req.selection.entity),
     );
     (sql, params)
 }
@@ -103,13 +102,17 @@ fn compile_ratio_query(
         denominator.measure_key.clone(),
         req.tenant_id.to_string(),
         req.plan.source_key.clone(),
-        req.selection.entity.r#type.clone(),
-        req.selection.entity.id.clone(),
+        req.selection.entity.entity_type().to_owned(),
+    ];
+    if let Some(person_id) = req.selection.entity.person_id() {
+        params.push(person_id.to_owned());
+    }
+    params.extend([
         req.from.to_string(),
         req.to.to_string(),
         numerator.measure_key.clone(),
         denominator.measure_key.clone(),
-    ];
+    ]);
     let filter_sql = filter_predicate(&req.selection.filters, &mut params);
     let cursor_sql = cursor_predicate(
         req.cursor.as_ref(),
@@ -132,15 +135,23 @@ fn compile_ratio_query(
                    '' AS subject_key, any(toJSONString(evidence.dimensions)) AS dimensions_json, \
                    CAST(map() AS Map(String, String)) AS details \
             FROM {database}.{table} AS evidence \
-            WHERE {tenant} AND evidence.source_key = ? AND evidence.entity_type = ? AND evidence.entity_id = ? \
+            WHERE {tenant} AND evidence.source_key = ? AND evidence.entity_type = ? AND {entity} \
               AND evidence.metric_date >= toDate(?) AND evidence.metric_date <= toDate(?) \
               AND evidence.measure_key IN (?, ?){filter_sql} \
             GROUP BY evidence.metric_date\
          ){cursor_sql} \
          ORDER BY role, metric_date, observed_at, source_key, measure_key, record_id, record_kind, subject_key \
-         LIMIT {limit}"
+         LIMIT {limit}",
+        entity = entity_predicate(&req.selection.entity),
     );
     Ok((sql, params))
+}
+
+fn entity_predicate(entity: &super::dto::MetricDrilldownEntity) -> &'static str {
+    match entity {
+        super::dto::MetricDrilldownEntity::Person { .. } => "evidence.entity_id = ?",
+        super::dto::MetricDrilldownEntity::Tenant {} => "evidence.entity_id = evidence.tenant_id",
+    }
 }
 
 fn filter_predicate(filters: &[MetricDrilldownFilter], params: &mut Vec<String>) -> String {
@@ -273,6 +284,34 @@ mod tests {
                 "",
             ]
         );
+    }
+
+    #[test]
+    fn tenant_query_matches_the_entity_to_its_storage_partition() {
+        let value = input(MetricInputRole::Value, "commit_count");
+        let plan = plan(
+            ComputationSpec::Sum {
+                value: value.clone(),
+            },
+            vec![EvidenceInput {
+                role: MetricInputRole::Value,
+                measure_key: value.measure_key,
+                presentation: evidence_presentation(
+                    "git",
+                    "commit_count",
+                    EvidenceGranularity::Event,
+                ),
+            }],
+        );
+        let mut request = validated(plan);
+        request.selection.entity = super::super::dto::MetricDrilldownEntity::Tenant {};
+
+        let (sql, params) =
+            compile_query(&request).unwrap_or_else(|error| panic!("query must compile: {error}"));
+
+        assert!(sql.contains("evidence.entity_id = evidence.tenant_id"));
+        assert!(!params.iter().any(|value| value == "default"));
+        assert_eq!(sql.matches('?').count(), params.len());
     }
 
     #[test]

--- a/src/backend/services/analytics/src/domain/metric_drilldown/compiler.rs
+++ b/src/backend/services/analytics/src/domain/metric_drilldown/compiler.rs
@@ -151,6 +151,7 @@ fn entity_predicate(entity: &super::dto::MetricDrilldownEntity) -> &'static str 
     match entity {
         super::dto::MetricDrilldownEntity::Person { .. } => "evidence.entity_id = ?",
         super::dto::MetricDrilldownEntity::Tenant {} => "evidence.entity_id = evidence.tenant_id",
+        super::dto::MetricDrilldownEntity::Unknown => "1 = 0",
     }
 }
 

--- a/src/backend/services/analytics/src/domain/metric_drilldown/dto.rs
+++ b/src/backend/services/analytics/src/domain/metric_drilldown/dto.rs
@@ -22,9 +22,26 @@ pub const EVIDENCE_QUERY_READ_BYTES: usize = 512 * 1024 * 1024;
 pub const EVIDENCE_QUERY_RESULT_BYTES: usize = 32 * 1024 * 1024;
 
 #[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
-pub struct MetricDrilldownEntity {
-    pub r#type: String,
-    pub id: String,
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum MetricDrilldownEntity {
+    Person { id: String },
+    Tenant {},
+}
+
+impl MetricDrilldownEntity {
+    pub(crate) fn entity_type(&self) -> &'static str {
+        match self {
+            Self::Person { .. } => "person",
+            Self::Tenant {} => "tenant",
+        }
+    }
+
+    pub(crate) fn person_id(&self) -> Option<&str> {
+        match self {
+            Self::Person { id } => Some(id),
+            Self::Tenant {} => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
@@ -116,6 +133,37 @@ pub struct MetricDrilldownResponse {
 impl toolkit::api::api_dto::RequestApiDto for MetricDrilldownRequest {}
 impl toolkit::api::api_dto::RequestApiDto for MetricDrilldownExportRequest {}
 impl toolkit::api::api_dto::ResponseApiDto for MetricDrilldownResponse {}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::MetricDrilldownRequest;
+
+    #[test]
+    fn tenant_entity_needs_no_client_supplied_identifier() {
+        let request = serde_json::from_value::<MetricDrilldownRequest>(json!({
+            "metric_key": "ci.runs",
+            "entity": { "type": "tenant" },
+            "period": { "from": "2026-01-01", "to": "2026-01-31" },
+            "limit": 100
+        }));
+
+        assert!(request.is_ok());
+    }
+
+    #[test]
+    fn tenant_entity_rejects_client_supplied_identifier() {
+        let request = serde_json::from_value::<MetricDrilldownRequest>(json!({
+            "metric_key": "ci.runs",
+            "entity": { "type": "tenant", "id": "default" },
+            "period": { "from": "2026-01-01", "to": "2026-01-31" },
+            "limit": 100
+        }));
+
+        assert!(request.is_err());
+    }
+}
 
 #[derive(Debug)]
 pub struct ValidatedMetricDrilldown {

--- a/src/backend/services/analytics/src/domain/metric_drilldown/dto.rs
+++ b/src/backend/services/analytics/src/domain/metric_drilldown/dto.rs
@@ -24,8 +24,12 @@ pub const EVIDENCE_QUERY_RESULT_BYTES: usize = 32 * 1024 * 1024;
 #[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
 #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum MetricDrilldownEntity {
-    Person { id: String },
+    Person {
+        id: String,
+    },
     Tenant {},
+    #[serde(other, skip_serializing)]
+    Unknown,
 }
 
 impl MetricDrilldownEntity {
@@ -33,13 +37,14 @@ impl MetricDrilldownEntity {
         match self {
             Self::Person { .. } => "person",
             Self::Tenant {} => "tenant",
+            Self::Unknown => "unknown",
         }
     }
 
     pub(crate) fn person_id(&self) -> Option<&str> {
         match self {
             Self::Person { id } => Some(id),
-            Self::Tenant {} => None,
+            Self::Tenant {} | Self::Unknown => None,
         }
     }
 }
@@ -162,6 +167,18 @@ mod tests {
         }));
 
         assert!(request.is_err());
+    }
+
+    #[test]
+    fn unknown_entity_type_reaches_domain_validation() {
+        let request = serde_json::from_value::<MetricDrilldownRequest>(json!({
+            "metric_key": "ci.runs",
+            "entity": { "type": "team", "id": "team" },
+            "period": { "from": "2026-01-01", "to": "2026-01-31" },
+            "limit": 100
+        }));
+
+        assert!(request.is_ok());
     }
 }
 

--- a/src/backend/services/analytics/src/domain/metric_drilldown/test_support.rs
+++ b/src/backend/services/analytics/src/domain/metric_drilldown/test_support.rs
@@ -86,8 +86,7 @@ pub(super) const TEST_TENANT: Uuid = Uuid::from_u128(0x019e_2830_0000_7000_8000_
 pub(super) fn validated(plan: EvidencePlan) -> ValidatedMetricDrilldown {
     let selection = MetricDrilldownSelection {
         metric_key: plan.definition.key().to_owned(),
-        entity: MetricDrilldownEntity {
-            r#type: "person".to_owned(),
+        entity: MetricDrilldownEntity::Person {
             id: TEST_PERSON.to_string(),
         },
         period: MetricDrilldownPeriod {

--- a/src/backend/services/analytics/src/domain/metric_drilldown/validation.rs
+++ b/src/backend/services/analytics/src/domain/metric_drilldown/validation.rs
@@ -7,7 +7,7 @@ use crate::domain::metric_definitions::definition::MetricInputRole;
 use crate::domain::metric_definitions::{
     EvidenceGranularity, MetricDefinition, load_definitions_with_ids,
 };
-use crate::domain::metric_results::{normalize_entity_type, normalize_key, normalize_metric_key};
+use crate::domain::metric_results::{normalize_key, normalize_metric_key};
 
 use super::capability::EvidenceInputRow;
 use super::capability::healthy_evidence;
@@ -96,20 +96,16 @@ pub async fn validate_export_request(
 pub(crate) fn parse_person_entity(
     entity: &MetricDrilldownEntity,
 ) -> Result<(String, Uuid), CanonicalError> {
-    let entity_type = normalize_entity_type(&entity.r#type)?;
-    if entity_type != "person" {
-        return Err(invalid_error(
-            "entity.type",
-            "only person entities are supported",
-        ));
-    }
+    let Some(id) = entity.person_id() else {
+        return Err(invalid_error("entity.type", "entity must select a person"));
+    };
 
-    let person_id = Uuid::parse_str(entity.id.trim())
+    let person_id = Uuid::parse_str(id.trim())
         .ok()
         .filter(|id| !id.is_nil())
         .ok_or_else(|| invalid_error("entity.id", "entity.id must be a person UUID"))?;
 
-    Ok((entity_type, person_id))
+    Ok(("person".to_owned(), person_id))
 }
 
 async fn validate_common(
@@ -129,8 +125,16 @@ async fn validate_common(
         cursor,
     } = request;
     let metric_key = normalize_metric_key("metric_key", &metric_key)?;
-    let (entity_type, person_id) = parse_person_entity(&entity)?;
-    let entity_id = person_id.to_string();
+    let entity = match entity {
+        MetricDrilldownEntity::Person { id } => {
+            let (_, person_id) = parse_person_entity(&MetricDrilldownEntity::Person { id })?;
+            MetricDrilldownEntity::Person {
+                id: person_id.to_string(),
+            }
+        }
+        MetricDrilldownEntity::Tenant {} => MetricDrilldownEntity::Tenant {},
+    };
+    let entity_type = entity.entity_type();
     if limit == 0 || limit > max_limit {
         return invalid("limit", format!("limit must be between 1 and {max_limit}"));
     }
@@ -161,10 +165,7 @@ async fn validate_common(
     let snapshot_id = evidence_snapshot_id(ch, &plan.relation).await?;
     let selection = MetricDrilldownSelection {
         metric_key,
-        entity: MetricDrilldownEntity {
-            r#type: entity_type,
-            id: entity_id,
-        },
+        entity,
         period: MetricDrilldownPeriod {
             from: from.to_string(),
             to: to.to_string(),

--- a/src/backend/services/analytics/src/domain/metric_drilldown/validation.rs
+++ b/src/backend/services/analytics/src/domain/metric_drilldown/validation.rs
@@ -133,6 +133,9 @@ async fn validate_common(
             }
         }
         MetricDrilldownEntity::Tenant {} => MetricDrilldownEntity::Tenant {},
+        MetricDrilldownEntity::Unknown => {
+            return invalid("entity.type", "unsupported entity type");
+        }
     };
     let entity_type = entity.entity_type();
     if limit == 0 || limit > max_limit {

--- a/src/backend/services/analytics/src/domain/metric_results/builder.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/builder.rs
@@ -51,7 +51,7 @@ pub fn build_period_view(
 ) -> MetricResultViewDto {
     let values_by_entity: HashMap<String, Option<f64>> = rows
         .into_iter()
-        .map(|row| (row.entity_id, row.value))
+        .map(|row| (req.entity.canonicalize_entity_id(row.entity_id), row.value))
         .collect();
     // `entity_id` IS the canonical contract on the wire and in the relations;
     // the selection renders the ids in that form, one rule for every view
@@ -93,8 +93,9 @@ pub fn build_timeseries_view(
         } else {
             row_dimensions(&row.extra, dimensions)?
         };
+        let entity_id = req.entity.canonicalize_entity_id(row.entity_id);
         let data = by_series
-            .entry((row.entity_id, remainder, dims))
+            .entry((entity_id, remainder, dims))
             .or_insert_with(|| SeriesData::new(row.rank, remainder, row.group_label.clone()));
         if row.is_total != 0 {
             data.total = row.value;
@@ -180,6 +181,7 @@ pub fn build_peer_view(rows: Vec<PeerQueryRow>) -> MetricResultViewDto {
 }
 
 pub fn build_breakdown_view(
+    req: &ValidatedMetricResultsRequest,
     dimensions: &[String],
     rows: Vec<BreakdownQueryRow>,
 ) -> Result<MetricResultViewDto, CanonicalError> {
@@ -187,7 +189,7 @@ pub fn build_breakdown_view(
         .into_iter()
         .map(|row| {
             Ok(BreakdownValueDto {
-                entity_id: row.entity_id,
+                entity_id: req.entity.canonicalize_entity_id(row.entity_id),
                 dimensions: row_dimensions(&row.extra, dimensions)?
                     .into_iter()
                     .map(|(key, value, label)| MetricDimensionDto { key, value, label })
@@ -219,7 +221,8 @@ pub fn build_histogram_view(
 
     let mut by_entity: HashMap<String, EntityBins> = HashMap::new();
     for row in rows {
-        let entry = by_entity.entry(row.entity_id).or_insert(EntityBins {
+        let entity_id = req.entity.canonicalize_entity_id(row.entity_id);
+        let entry = by_entity.entry(entity_id).or_insert(EntityBins {
             lo: row.entity_lo,
             hi: row.entity_hi,
             counts: HashMap::new(),
@@ -501,6 +504,25 @@ mod tests {
         assert_eq!(values[0].value, None);
         assert_eq!(values[1].entity_id, "00000000-0000-0000-0000-00000000000a");
         assert_eq!(values[1].value, Some(5.0));
+    }
+
+    #[test]
+    fn tenant_period_view_exposes_the_session_tenant_not_the_storage_key() {
+        let tenant_id = Uuid::from_u128(0x1967);
+        let mut req = request(Vec::new(), "2026-01-01", "2026-01-31");
+        req.entity = ValidatedEntitySelection::Tenant { id: tenant_id };
+        let rows = vec![PeriodQueryRow {
+            entity_id: "default".to_owned(),
+            value: Some(5.0),
+        }];
+
+        let MetricResultViewDto::Period { values } = build_period_view(&sum_metric(), &req, rows)
+        else {
+            panic!("expected period view");
+        };
+
+        assert_eq!(values[0].entity_id, tenant_id.to_string());
+        assert_eq!(values[0].value, Some(5.0));
     }
 
     #[test]
@@ -829,8 +851,13 @@ mod tests {
             extra,
         }];
         let dimensions = vec!["tool".to_owned()];
+        let req = request(
+            vec!["00000000-0000-0000-0000-00000000000a"],
+            "2026-01-01",
+            "2026-01-31",
+        );
         let Ok(MetricResultViewDto::Breakdown { values, .. }) =
-            build_breakdown_view(&dimensions, rows)
+            build_breakdown_view(&req, &dimensions, rows)
         else {
             panic!("expected breakdown view");
         };
@@ -844,8 +871,7 @@ mod tests {
     fn selection(metric_key: &str) -> super::super::dto::MetricResultSelectionDto {
         super::super::dto::MetricResultSelectionDto {
             metric_key: metric_key.to_owned(),
-            entity: super::super::dto::MetricResultsEntityDto {
-                r#type: "person".to_owned(),
+            entity: super::super::dto::MetricResultsEntityDto::Person {
                 ids: vec!["person@example.com".to_owned()],
             },
             period: super::super::dto::MetricResultsPeriodDto {

--- a/src/backend/services/analytics/src/domain/metric_results/compiler.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/compiler.rs
@@ -2,11 +2,13 @@ use std::collections::{BTreeSet, HashMap};
 use std::fmt::Write;
 
 use serde::Deserialize;
+use uuid::Uuid;
 
 use super::batch::ResolvedGroupLimit;
 use super::batch::{peer_aliases, period_alias};
 use super::validation::{
-    HISTOGRAM_BINS, ValidatedDimensionFilter, ValidatedMetricResultsRequest, query_row_limit,
+    HISTOGRAM_BINS, ValidatedDimensionFilter, ValidatedEntitySelection,
+    ValidatedMetricResultsRequest, query_row_limit,
 };
 use super::view::Bucket;
 use crate::domain::metric_definitions::{
@@ -97,8 +99,7 @@ pub(crate) fn compile_period_batch_query(
     let mut params = Vec::new();
     let selects = item_value_selects(defs, &mut params, period_alias);
     let metric_scope = shared_observation_where(defs, req, filters, &mut params);
-    params.extend(req.entity.entity_ids());
-    let entity_id_params = placeholders(req.entity.len());
+    let entity_predicate = selected_entity_predicate(req, &mut params);
     let observation_table = batch_observation_table(defs);
     let limit = query_row_limit();
     let inner = format!(
@@ -107,7 +108,7 @@ pub(crate) fn compile_period_batch_query(
             entity_id{selects}
         FROM {observation_table}
         WHERE {metric_scope}
-          AND entity_id IN ({entity_id_params})
+          AND {entity_predicate}
         GROUP BY entity_id
         LIMIT {limit}
         "
@@ -129,8 +130,7 @@ pub(crate) fn compile_timeseries_query(
     }
     let mut params = metric_params(def, req);
     let filter_where = dimension_filter_where(filters, &mut params);
-    params.extend(req.entity.entity_ids());
-    let entity_id_params = placeholders(req.entity.len());
+    let entity_predicate = selected_entity_predicate(req, &mut params);
     let bucket = bucket_expr(bucket);
     let (dim_select, dim_group) = dimension_select_group(dimensions);
     let bucket_group = if dim_group.is_empty() {
@@ -159,7 +159,7 @@ pub(crate) fn compile_timeseries_query(
         FROM {observation_table}
         WHERE {metric_where}
           {filter_where}
-          AND entity_id IN ({entity_id_params})
+          AND {entity_predicate}
         GROUP BY GROUPING SETS (({bucket_group}), ({total_group}))
         ORDER BY entity_id, is_total, bucket_start
         LIMIT {limit}
@@ -180,8 +180,7 @@ pub(crate) fn compile_group_ranking_query(
     let mut params = grouped_value_params(def);
     params.extend(metric_where_params(def, req));
     let filter_where = dimension_filter_where(filters, &mut params);
-    params.extend(req.entity.entity_ids());
-    let entity_id_params = placeholders(req.entity.len());
+    let entity_predicate = selected_entity_predicate(req, &mut params);
     let (dim_select, dim_group, dim_order) = ranking_dimension_select_group(dimensions);
     let observation_table = observation_table(def.observation_source());
     let value_expr = grouped_value_expr(def);
@@ -193,7 +192,7 @@ pub(crate) fn compile_group_ranking_query(
         FROM {observation_table}
         WHERE {metric_where}
           {filter_where}
-          AND entity_id IN ({entity_id_params})
+          AND {entity_predicate}
         GROUP BY {dim_group}
         ",
         metric_where = metric_where(def, req.enforce_tenant_scope),
@@ -221,8 +220,7 @@ fn compile_capped_timeseries_query(
 ) -> CompiledQuery {
     let mut params = metric_where_params(def, req);
     let filter_where = dimension_filter_where(filters, &mut params);
-    params.extend(req.entity.entity_ids());
-    let entity_id_params = placeholders(req.entity.len());
+    let entity_predicate = selected_entity_predicate(req, &mut params);
     let bucket = bucket_expr(bucket);
     let raw_dimensions = dimensions.iter().enumerate().fold(
         String::new(),
@@ -257,7 +255,7 @@ fn compile_capped_timeseries_query(
             FROM {observation_table}
             WHERE {metric_where}
               {filter_where}
-              AND entity_id IN ({entity_id_params})
+              AND {entity_predicate}
         ),
         ranked AS (
             SELECT
@@ -383,8 +381,7 @@ pub(crate) fn compile_breakdown_query(
 ) -> CompiledQuery {
     let mut params = metric_params(def, req);
     let filter_where = dimension_filter_where(filters, &mut params);
-    params.extend(req.entity.entity_ids());
-    let entity_id_params = placeholders(req.entity.len());
+    let entity_predicate = selected_entity_predicate(req, &mut params);
     let (dim_select, dim_group) = dimension_select_group(dimensions);
     let group = if dim_group.is_empty() {
         "entity_id".to_owned()
@@ -402,7 +399,7 @@ pub(crate) fn compile_breakdown_query(
         FROM {observation_table}
         WHERE {metric_where}
           {filter_where}
-          AND entity_id IN ({entity_id_params})
+          AND {entity_predicate}
         GROUP BY {group}
         ORDER BY entity_id
         LIMIT {limit}
@@ -446,8 +443,7 @@ pub(crate) fn compile_histogram_query(
 ) -> CompiledQuery {
     let mut params = metric_params(def, req);
     let filter_where = dimension_filter_where(filters, &mut params);
-    params.extend(req.entity.entity_ids());
-    let entity_id_params = placeholders(req.entity.len());
+    let entity_predicate = selected_entity_predicate(req, &mut params);
     let observation_table = observation_table(def.observation_source());
     let bins = HISTOGRAM_BINS;
     let max_bin = HISTOGRAM_BINS - 1;
@@ -461,7 +457,7 @@ pub(crate) fn compile_histogram_query(
             FROM {observation_table}
             WHERE {metric_where}
               {filter_where}
-              AND entity_id IN ({entity_id_params})
+              AND {entity_predicate}
               AND value IS NOT NULL
         ),
         events AS (
@@ -931,6 +927,19 @@ fn placeholders(count: usize) -> String {
     vec!["?"; count].join(", ")
 }
 
+fn selected_entity_predicate(
+    req: &ValidatedMetricResultsRequest,
+    params: &mut Vec<String>,
+) -> String {
+    match &req.entity {
+        ValidatedEntitySelection::Person { ids } => {
+            params.extend(ids.iter().map(Uuid::to_string));
+            format!("entity_id IN ({})", placeholders(ids.len()))
+        }
+        ValidatedEntitySelection::Tenant { .. } => "entity_id = tenant_id".to_owned(),
+    }
+}
+
 fn bucket_expr(bucket: Bucket) -> &'static str {
     match bucket {
         Bucket::Day => "metric_date",
@@ -1188,6 +1197,19 @@ mod tests {
                 "00000000-0000-0000-0000-00000000000b",
             ]
         );
+    }
+
+    #[test]
+    fn tenant_queries_match_the_entity_to_its_storage_partition() {
+        let sum = sum_metric();
+        let mut req = request();
+        req.entity = ValidatedEntitySelection::Tenant { id: TEST_TENANT };
+
+        let query = compile_period_batch_query(&[&sum], &req, &[]);
+
+        assert!(query.sql.contains("AND entity_id = tenant_id"));
+        assert!(!query.params.iter().any(|value| value == "default"));
+        assert_eq!(query.sql.matches('?').count(), query.params.len());
     }
 
     const CUSTOM_SQL: &str = "SELECT tenant_id, source_key, entity_type, entity_id, \

--- a/src/backend/services/analytics/src/domain/metric_results/dto.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/dto.rs
@@ -14,15 +14,19 @@ pub struct MetricResultsRequest {
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 pub enum MetricResultsEntity {
-    Person { ids: Vec<String> },
+    Person {
+        ids: Vec<String>,
+    },
     Tenant {},
+    #[serde(other, skip_serializing)]
+    Unknown,
 }
 
 impl MetricResultsEntity {
     pub(crate) fn is_tenant(&self) -> bool {
         match self {
-            Self::Person { .. } => false,
             Self::Tenant {} => true,
+            Self::Person { .. } | Self::Unknown => false,
         }
     }
 }
@@ -267,5 +271,16 @@ mod tests {
         }));
 
         assert!(request.is_err());
+    }
+
+    #[test]
+    fn unknown_entity_type_reaches_domain_validation() {
+        let request = serde_json::from_value::<MetricResultsRequest>(json!({
+            "entity": { "type": "team", "ids": ["team"] },
+            "period": { "from": "2026-01-01", "to": "2026-01-31" },
+            "metrics": [{ "metric_key": "ci.runs", "views": [{ "view": "period" }] }]
+        }));
+
+        assert!(request.is_ok());
     }
 }

--- a/src/backend/services/analytics/src/domain/metric_results/dto.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/dto.rs
@@ -12,11 +12,19 @@ pub struct MetricResultsRequest {
 }
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
-pub struct MetricResultsEntity {
-    pub r#type: String,
-    /// Canonical person UUIDs (since the identity cutover; the
-    /// pre-cutover email shape is rejected with a 400).
-    pub ids: Vec<String>,
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum MetricResultsEntity {
+    Person { ids: Vec<String> },
+    Tenant {},
+}
+
+impl MetricResultsEntity {
+    pub(crate) fn is_tenant(&self) -> bool {
+        match self {
+            Self::Person { .. } => false,
+            Self::Tenant {} => true,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
@@ -112,11 +120,10 @@ pub struct MetricResultSelectionDto {
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
-pub struct MetricResultsEntityDto {
-    pub r#type: String,
-    /// Canonical person UUIDs (since the identity cutover; the
-    /// pre-cutover email shape is rejected with a 400).
-    pub ids: Vec<String>,
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum MetricResultsEntityDto {
+    Person { ids: Vec<String> },
+    Tenant {},
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -233,3 +240,32 @@ pub struct BreakdownValueDto {
 
 impl toolkit::api::api_dto::RequestApiDto for MetricResultsRequest {}
 impl toolkit::api::api_dto::ResponseApiDto for MetricResultsResponse {}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::MetricResultsRequest;
+
+    #[test]
+    fn tenant_entity_needs_no_client_supplied_identifier() {
+        let request = serde_json::from_value::<MetricResultsRequest>(json!({
+            "entity": { "type": "tenant" },
+            "period": { "from": "2026-01-01", "to": "2026-01-31" },
+            "metrics": [{ "metric_key": "ci.runs", "views": [{ "view": "period" }] }]
+        }));
+
+        assert!(request.is_ok());
+    }
+
+    #[test]
+    fn tenant_entity_rejects_client_supplied_identifiers() {
+        let request = serde_json::from_value::<MetricResultsRequest>(json!({
+            "entity": { "type": "tenant", "ids": ["default"] },
+            "period": { "from": "2026-01-01", "to": "2026-01-31" },
+            "metrics": [{ "metric_key": "ci.runs", "views": [{ "view": "period" }] }]
+        }));
+
+        assert!(request.is_err());
+    }
+}

--- a/src/backend/services/analytics/src/domain/metric_results/mod.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/mod.rs
@@ -21,4 +21,4 @@ pub use dto::{
     MetricResultsEntityDto, MetricResultsPeriodDto, MetricResultsRequest, MetricResultsResponse,
 };
 pub use validation::{ValidatedMetricResultsRequest, validate_request};
-pub(crate) use validation::{normalize_entity_type, normalize_key, normalize_metric_key};
+pub(crate) use validation::{normalize_key, normalize_metric_key};

--- a/src/backend/services/analytics/src/domain/metric_results/validation.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/validation.rs
@@ -277,6 +277,9 @@ fn validate_request_shape(
         super::dto::MetricResultsEntity::Tenant {} => {
             ValidatedEntitySelection::Tenant { id: tenant_id }
         }
+        super::dto::MetricResultsEntity::Unknown => {
+            return invalid("entity.type", "unsupported entity type");
+        }
     };
     if entity.is_tenant()
         && req

--- a/src/backend/services/analytics/src/domain/metric_results/validation.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/validation.rs
@@ -37,16 +37,18 @@ pub(crate) const HISTOGRAM_BINS: usize = 10;
 /// `entity_type + entity_id` is the one polymorphic contract, and a person's
 /// ids are UUIDs — a variant carries its own id shape instead of a generic
 /// type string sitting next to person-only fields. A first non-person entity
-/// type adds a variant here AND its own authorization rule in the gate.
+/// type has its own variant and authorization rule in the gate.
 #[derive(Debug, Clone)]
 pub enum ValidatedEntitySelection {
     Person { ids: Vec<Uuid> },
+    Tenant { id: Uuid },
 }
 
 impl ValidatedEntitySelection {
     pub fn entity_type(&self) -> &'static str {
         match self {
             Self::Person { .. } => "person",
+            Self::Tenant { .. } => "tenant",
         }
     }
 
@@ -55,18 +57,35 @@ impl ValidatedEntitySelection {
     pub fn entity_ids(&self) -> Vec<String> {
         match self {
             Self::Person { ids } => ids.iter().map(Uuid::to_string).collect(),
+            Self::Tenant { id } => vec![id.to_string()],
         }
     }
 
-    pub fn person_ids(&self) -> &[Uuid] {
+    pub fn person_ids(&self) -> Option<&[Uuid]> {
         match self {
-            Self::Person { ids } => ids,
+            Self::Person { ids } => Some(ids),
+            Self::Tenant { .. } => None,
         }
     }
 
     pub fn len(&self) -> usize {
         match self {
             Self::Person { ids } => ids.len(),
+            Self::Tenant { .. } => 1,
+        }
+    }
+
+    pub fn is_tenant(&self) -> bool {
+        match self {
+            Self::Person { .. } => false,
+            Self::Tenant { .. } => true,
+        }
+    }
+
+    pub fn canonicalize_entity_id(&self, observed: String) -> String {
+        match self {
+            Self::Person { .. } => observed,
+            Self::Tenant { id } => id.to_string(),
         }
     }
 }
@@ -133,7 +152,7 @@ pub async fn validate_request(
     tenant_id: Uuid,
     req: MetricResultsRequest,
 ) -> Result<ValidatedMetricResultsRequest, CanonicalError> {
-    let shape = validate_request_shape(&req)?;
+    let shape = validate_request_shape(&req, tenant_id)?;
     let RequestShape {
         entity,
         from,
@@ -229,7 +248,10 @@ pub async fn validate_request(
     Ok(validated)
 }
 
-fn validate_request_shape(req: &MetricResultsRequest) -> Result<RequestShape, CanonicalError> {
+fn validate_request_shape(
+    req: &MetricResultsRequest,
+    tenant_id: Uuid,
+) -> Result<RequestShape, CanonicalError> {
     if req.metrics.is_empty() {
         return invalid("metrics", "metrics must not be empty");
     }
@@ -240,23 +262,31 @@ fn validate_request_shape(req: &MetricResultsRequest) -> Result<RequestShape, Ca
         );
     }
 
-    let entity_type = normalize_entity_type(&req.entity.r#type)?;
-    if entity_type != "person" {
-        return invalid("entity.type", "only person entities are supported");
-    }
-    // The cap counts SUBMITTED ids, and is checked before parsing them: the
-    // parsed count is smaller (blanks are skipped, duplicates collapse), so
-    // capping it would let a caller pad a request past the bound and pay for
-    // the parse of every entry first.
-    if req.entity.ids.len() > MAX_PERSON_IDS {
-        return invalid(
-            "entity.ids",
-            format!("at most {MAX_PERSON_IDS} entity ids per request"),
-        );
-    }
-    let entity = ValidatedEntitySelection::Person {
-        ids: parse_person_ids(&req.entity.ids)?,
+    let entity = match &req.entity {
+        super::dto::MetricResultsEntity::Person { ids } => {
+            if ids.len() > MAX_PERSON_IDS {
+                return invalid(
+                    "entity.ids",
+                    format!("at most {MAX_PERSON_IDS} entity ids per request"),
+                );
+            }
+            ValidatedEntitySelection::Person {
+                ids: parse_person_ids(ids)?,
+            }
+        }
+        super::dto::MetricResultsEntity::Tenant {} => {
+            ValidatedEntitySelection::Tenant { id: tenant_id }
+        }
     };
+    if entity.is_tenant()
+        && req
+            .metrics
+            .iter()
+            .flat_map(|metric| &metric.views)
+            .any(|view| matches!(view, MetricViewRequest::Peer { .. }))
+    {
+        return invalid("metrics.views", "tenant metrics do not support peer views");
+    }
     let from = parse_date("period.from", &req.period.from)?;
     let to = parse_date("period.to", &req.period.to)?;
     if from > to {
@@ -555,18 +585,9 @@ fn validate_filters(
     Ok(out)
 }
 
-pub(crate) fn normalize_entity_type(entity_type: &str) -> Result<String, CanonicalError> {
-    normalize_key("entity.type", entity_type)
-}
-
 // Person ids are UUIDs since the identity cutover (the pre-cutover key was
 // the lowercased email); `Uuid::parse_str` accepts any casing and hyphenless
 // forms, and re-rendering canonicalizes — no bespoke normalization left.
-//
-// INVARIANT: ids are parsed as person UUIDs for EVERY entity type, which holds
-// only while every registry entity type is `person`. The other half of the
-// invariant lives in the visibility gate, pinned by
-// `an_entity_type_with_no_authorization_rule_fails_closed`.
 fn parse_person_ids(ids: &[String]) -> Result<Vec<Uuid>, CanonicalError> {
     let mut seen = BTreeSet::new();
     let mut out = Vec::with_capacity(ids.len());
@@ -704,8 +725,7 @@ mod tests {
         metric_keys: Vec<&str>,
     ) -> MetricResultsRequest {
         MetricResultsRequest {
-            entity: MetricResultsEntity {
-                r#type: "person".to_owned(),
+            entity: MetricResultsEntity::Person {
                 ids: person_ids.into_iter().map(str::to_owned).collect(),
             },
             period: super::super::dto::MetricResultsPeriod {
@@ -792,20 +812,39 @@ mod tests {
 
     #[test]
     fn shape_accepts_valid_request() {
-        let Ok(shape) = validate_request_shape(&shape_request(
-            vec![" 019E27BC-DEC0-7626-81A9-C5524662A6A9 "],
-            "2026-01-01",
-            "2026-01-31",
-            vec!["ai.x"],
-        )) else {
+        let Ok(shape) = validate_request_shape(
+            &shape_request(
+                vec![" 019E27BC-DEC0-7626-81A9-C5524662A6A9 "],
+                "2026-01-01",
+                "2026-01-31",
+                vec!["ai.x"],
+            ),
+            Uuid::nil(),
+        ) else {
             panic!("expected valid shape");
         };
         assert_eq!(shape.entity.entity_type(), "person");
         assert_eq!(
             shape.entity.person_ids(),
-            [Uuid::from_u128(0x019e_27bc_dec0_7626_81a9_c552_4662_a6a9)]
+            Some([Uuid::from_u128(0x019e_27bc_dec0_7626_81a9_c552_4662_a6a9)].as_slice())
         );
         assert_eq!(shape.metric_keys, vec!["ai.x".to_owned()]);
+    }
+
+    #[test]
+    fn tenant_shape_uses_session_tenant_and_rejects_peer_views() {
+        let tenant_id = Uuid::now_v7();
+        let mut req = shape_request(vec!["ignored"], "2026-01-01", "2026-01-31", vec!["ci.runs"]);
+        req.entity = MetricResultsEntity::Tenant {};
+
+        let Ok(shape) = validate_request_shape(&req, tenant_id) else {
+            panic!("tenant period request must be valid");
+        };
+        assert_eq!(shape.entity.entity_type(), "tenant");
+        assert_eq!(shape.entity.entity_ids(), vec![tenant_id.to_string()]);
+
+        req.metrics[0].views = vec![MetricViewRequest::Peer { cohort_key: None }];
+        assert!(validate_request_shape(&req, tenant_id).is_err());
     }
 
     #[test]
@@ -817,7 +856,7 @@ mod tests {
             "2026-01-31",
             keys.iter().map(String::as_str).collect(),
         );
-        assert!(validate_request_shape(&req).is_err());
+        assert!(validate_request_shape(&req, Uuid::nil()).is_err());
     }
 
     #[test]
@@ -831,7 +870,7 @@ mod tests {
             "2026-01-31",
             vec!["ai.x"],
         );
-        assert!(validate_request_shape(&req).is_err());
+        assert!(validate_request_shape(&req, Uuid::nil()).is_err());
     }
 
     #[test]
@@ -846,7 +885,7 @@ mod tests {
             "2026-01-31",
             vec!["ai.x"],
         );
-        assert!(validate_request_shape(&req).is_err());
+        assert!(validate_request_shape(&req, Uuid::nil()).is_err());
     }
 
     #[test]
@@ -859,7 +898,7 @@ mod tests {
             "2026-01-31",
             vec!["ai.x"],
         );
-        assert!(validate_request_shape(&req).is_err());
+        assert!(validate_request_shape(&req, Uuid::nil()).is_err());
     }
 
     #[test]
@@ -870,7 +909,7 @@ mod tests {
             "9999-12-31",
             vec!["ai.x"],
         );
-        assert!(validate_request_shape(&req).is_err());
+        assert!(validate_request_shape(&req, Uuid::nil()).is_err());
     }
 
     #[test]
@@ -881,7 +920,7 @@ mod tests {
             "2026-01-01",
             vec!["ai.x"],
         );
-        assert!(validate_request_shape(&req).is_err());
+        assert!(validate_request_shape(&req, Uuid::nil()).is_err());
     }
 
     #[test]
@@ -892,13 +931,13 @@ mod tests {
             "2026-01-31",
             vec!["ai.x", "ai.x"],
         );
-        assert!(validate_request_shape(&req).is_err());
+        assert!(validate_request_shape(&req, Uuid::nil()).is_err());
     }
 
     #[test]
     fn shape_rejects_all_blank_person_ids() {
         let req = shape_request(vec![" ", ""], "2026-01-01", "2026-01-31", vec!["ai.x"]);
-        assert!(validate_request_shape(&req).is_err());
+        assert!(validate_request_shape(&req, Uuid::nil()).is_err());
     }
 
     #[test]

--- a/src/backend/services/analytics/src/domain/mod.rs
+++ b/src/backend/services/analytics/src/domain/mod.rs
@@ -1,4 +1,5 @@
 pub mod contract_version;
+pub(crate) mod metric_access;
 pub mod metric_crud;
 pub mod metric_definitions;
 pub mod metric_drilldown;

--- a/src/backend/services/analytics/src/domain/person_visibility.rs
+++ b/src/backend/services/analytics/src/domain/person_visibility.rs
@@ -7,41 +7,20 @@ use crate::infra::identity::IdentityClient;
 
 const SERVICE_SUBJECT_TYPE: &str = "service";
 
-#[derive(Debug)]
-enum GatedEntity {
-    Person,
-    Unsupported,
-}
-
-impl GatedEntity {
-    fn parse(entity_type: &str) -> Self {
-        match entity_type {
-            "person" => Self::Person,
-            _ => Self::Unsupported,
-        }
-    }
-}
-
-pub(crate) async fn authorize_entity_ids(
+pub(crate) async fn authorize_person_ids(
     identity: &IdentityClient,
     ctx: &SecurityContext,
     authorization: Option<&str>,
-    entity_type: &str,
     person_ids: &[Uuid],
 ) -> Result<(), CanonicalError> {
     if ctx.subject_type() == Some(SERVICE_SUBJECT_TYPE) {
         return Ok(());
     }
 
-    match GatedEntity::parse(entity_type) {
-        GatedEntity::Person => {
-            authorize_person_ids(identity, ctx.subject_id(), authorization, person_ids).await
-        }
-        GatedEntity::Unsupported => Err(no_authorization_rule(entity_type)),
-    }
+    authorize_visible_person_ids(identity, ctx.subject_id(), authorization, person_ids).await
 }
 
-async fn authorize_person_ids(
+async fn authorize_visible_person_ids(
     identity: &IdentityClient,
     caller: Uuid,
     authorization: Option<&str>,
@@ -94,11 +73,6 @@ fn denied(caller: Uuid, unmatched: usize) -> CanonicalError {
     MetricError::permission_denied()
         .with_reason("entity_not_visible")
         .create()
-}
-
-fn no_authorization_rule(entity_type: &str) -> CanonicalError {
-    tracing::error!(entity_type, "no authorization rule for this entity type");
-    unavailable()
 }
 
 // `internal`, not `service_unavailable`: 500 is in the operation's declared
@@ -195,43 +169,16 @@ mod tests {
         ctx: &SecurityContext,
         person_ids: &[Uuid],
     ) -> StatusCode {
-        status_of(
-            authorize_entity_ids(identity, ctx, Some("Bearer tok"), "person", person_ids).await,
-        )
+        status_of(authorize_person_ids(identity, ctx, Some("Bearer tok"), person_ids).await)
     }
 
     #[tokio::test]
-    async fn an_entity_type_with_no_authorization_rule_fails_closed() {
-        let identity = spawn_identity(&[SELF_PERSON]).await;
-        let ctx = ctx_for("user", CALLER);
-
-        // Ids are parsed as person UUIDs for every entity type, but only
-        // `person` has a rule here. A first non-person type must land its own
-        // rule rather than inherit person semantics silently.
-        assert_eq!(
-            status_of(
-                authorize_entity_ids(
-                    &identity,
-                    &ctx,
-                    Some("Bearer tok"),
-                    "org_unit",
-                    &[SELF_PERSON]
-                )
-                .await,
-            ),
-            StatusCode::INTERNAL_SERVER_ERROR,
-        );
-    }
-
-    #[tokio::test]
-    async fn a_service_principal_bypasses_the_gate_for_any_entity_type() {
+    async fn a_service_principal_bypasses_person_visibility() {
         let identity = spawn_identity(&[]).await;
         let ctx = ctx_for(SERVICE_SUBJECT_TYPE, CALLER);
 
         assert_eq!(
-            status_of(
-                authorize_entity_ids(&identity, &ctx, None, "org_unit", &[STRANGER_PERSON]).await,
-            ),
+            status_of(authorize_person_ids(&identity, &ctx, None, &[STRANGER_PERSON]).await),
             StatusCode::OK,
         );
     }
@@ -335,27 +282,11 @@ mod tests {
         let identity = spawn_identity(&[SELF_PERSON]).await;
         let ctx = ctx_for("user", CALLER);
 
-        let status =
-            status_of(authorize_entity_ids(&identity, &ctx, None, "person", &[SELF_PERSON]).await);
+        let status = status_of(authorize_person_ids(&identity, &ctx, None, &[SELF_PERSON]).await);
         assert_eq!(
             status,
             StatusCode::INTERNAL_SERVER_ERROR,
             "a broken authn path is not a visibility denial"
-        );
-    }
-
-    #[tokio::test]
-    async fn entity_type_without_an_authorization_rule_is_not_a_denial() {
-        let identity = spawn_identity(&[SELF_PERSON]).await;
-        let ctx = ctx_for("user", CALLER);
-
-        let status = status_of(
-            authorize_entity_ids(&identity, &ctx, Some("Bearer tok"), "team", &[SELF_PERSON]).await,
-        );
-        assert_eq!(
-            status,
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "an entity type with no authorization rule is a server-side gap"
         );
     }
 }

--- a/src/backend/services/identity-resolution/helm/tests/test_umbrella_analytics_config_contract.py
+++ b/src/backend/services/identity-resolution/helm/tests/test_umbrella_analytics_config_contract.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import pytest
+import yaml
+from conftest import TENANT, UMBRELLA_BASE, render
+
+
+def _analytics_config(manifests: str) -> dict:
+    docs = [doc for doc in yaml.safe_load_all(manifests) if isinstance(doc, dict)]
+    configs = [
+        doc
+        for doc in docs
+        if doc.get("kind") == "ConfigMap" and doc["metadata"]["name"].endswith("-analytics-gears-config")
+    ]
+    assert len(configs) == 1, f"expected one analytics gears ConfigMap, got {len(configs)}"
+
+    host = yaml.safe_load(configs[0]["data"]["analytics.yaml"])
+    return host["gears"]["analytics"]["config"]
+
+
+@pytest.mark.parametrize(
+    ("extra", "expected"), [((), False), (("--set", "analytics.metricCatalog.tenantMetricsEnabled=true"), True)]
+)
+def test_tenant_metrics_are_opt_in_per_installation(umbrella_deps, extra: tuple[str, ...], expected: bool) -> None:
+    code, out, err = render(umbrella_deps, *UMBRELLA_BASE, "--set", f"global.tenantDefaultId={TENANT}", *extra)
+    assert code == 0, err
+
+    assert _analytics_config(out)["metric_catalog"]["tenant_metrics_enabled"] is expected

--- a/src/frontend/src/api/metric-definitions-client.test.ts
+++ b/src/frontend/src/api/metric-definitions-client.test.ts
@@ -18,6 +18,7 @@ function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
 
 const METRIC: MetricDefinition = {
   metric_key: "git.commits",
+  entity_type: "person",
   label: "Commits",
   short_label: null,
   description: "Commits authored in the period.",

--- a/src/frontend/src/api/metric-definitions-client.ts
+++ b/src/frontend/src/api/metric-definitions-client.ts
@@ -13,6 +13,7 @@ import { fetchWithAuth } from "@/api/fetch-with-auth";
 import type {
   MetricDrilldownCapability,
   MetricDirection,
+  MetricEntityType,
   MetricFormat,
 } from "@/api/metric-results-client";
 
@@ -25,6 +26,7 @@ export type MetricDefinitionOrigin = "builtin" | "custom";
 
 export interface MetricDefinition {
   metric_key: string;
+  entity_type: MetricEntityType;
   label: string;
   short_label: string | null;
   description: string | null;

--- a/src/frontend/src/api/metric-drilldown-client.test.ts
+++ b/src/frontend/src/api/metric-drilldown-client.test.ts
@@ -163,5 +163,20 @@ describe("metric drilldown client", () => {
       filters: [{ dimension: "repository", values: ["org/repo"] }],
       display_dimensions: ["category", "repository"],
     });
+
+    expect(
+      evidenceSelection({
+        metric_key: "ci.runs",
+        entity: { type: "tenant" },
+        period: selection.period,
+        filters: [],
+      }),
+    ).toEqual({
+      metric_key: "ci.runs",
+      entity: { type: "tenant" },
+      period: selection.period,
+      filters: [],
+      display_dimensions: [],
+    });
   });
 });

--- a/src/frontend/src/api/metric-drilldown-client.ts
+++ b/src/frontend/src/api/metric-drilldown-client.ts
@@ -11,7 +11,7 @@ const BASE =
 
 export interface MetricEvidenceSelection {
   metric_key: string;
-  entity: { type: "person"; id: string };
+  entity: { type: "person"; id: string } | { type: "tenant" };
   period: { from: string; to: string };
   filters: MetricDimensionFilter[];
   display_dimensions: string[];
@@ -107,15 +107,23 @@ export async function downloadMetricDrilldown(
 
 export function evidenceSelection(
   canonical: MetricCanonicalSelection | undefined,
-  entityId: string,
+  entityId?: string,
   period?: { from: string; to: string },
   filters?: MetricDimensionFilter[],
   displayDimensions: string[] = []
 ): MetricEvidenceSelection | null {
   if (!canonical) return null;
+  const entity =
+    canonical.entity.type === "tenant"
+      ? ({ type: "tenant" } as const)
+      : entityId
+        ? ({ type: "person", id: entityId } as const)
+        : null;
+  if (!entity) return null;
+
   return {
     metric_key: canonical.metric_key,
-    entity: { type: "person", id: entityId },
+    entity,
     period: period ?? canonical.period,
     filters: filters ?? canonical.filters,
     display_dimensions: [...new Set(displayDimensions)].sort(),

--- a/src/frontend/src/api/metric-results-client.test.ts
+++ b/src/frontend/src/api/metric-results-client.test.ts
@@ -51,6 +51,23 @@ describe("queryMetricResults", () => {
     );
   });
 
+  it("sends tenant requests without a client-supplied identifier", async () => {
+    mockFetch.mockResolvedValue(
+      response({ ok: true, json: async () => ({ metrics: [] }) }),
+    );
+    const request: MetricResultsRequest = {
+      ...REQUEST,
+      entity: { type: "tenant" },
+    };
+
+    await queryMetricResults(request);
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/metric-results"),
+      expect.objectContaining({ body: JSON.stringify(request) }),
+    );
+  });
+
   it("throws AnalyticsApiError with status + body on a non-ok response", async () => {
     mockFetch.mockResolvedValue(
       response({ ok: false, status: 400, json: async () => ({ error: "bad" }) }),

--- a/src/frontend/src/api/metric-results-client.ts
+++ b/src/frontend/src/api/metric-results-client.ts
@@ -17,10 +17,13 @@ export type MetricResultViewKind =
   | "histogram";
 export type MetricBucket = "day" | "week" | "month";
 export type MetricComputation = "sum" | "ratio" | "median" | "distinct_count";
-export type MetricEntityType = "person";
+export type MetricEntityType = "person" | "tenant";
+export type MetricResultsEntity =
+  | { type: "person"; ids: string[] }
+  | { type: "tenant" };
 
 export interface MetricResultsRequest {
-  entity: { type: MetricEntityType; ids: string[] };
+  entity: MetricResultsEntity;
   period: { from: string; to: string };
   metrics: MetricRequest[];
 }
@@ -42,7 +45,7 @@ export interface MetricDrilldownCapability {
 
 export interface MetricCanonicalSelection {
   metric_key: string;
-  entity: { type: MetricEntityType; ids: string[] };
+  entity: MetricResultsEntity;
   period: { from: string; to: string };
   filters: MetricDimensionFilter[];
 }
@@ -188,7 +191,7 @@ export async function queryMetricResults(
   // "entity.ids must not be empty"). Callers are expected to keep the query
   // disabled until they have entities; failing here names the real cause
   // instead of surfacing a server validation error in the network log.
-  if (body.entity.ids.length === 0) {
+  if (body.entity.type === "person" && body.entity.ids.length === 0) {
     throw new Error(
       "metric-results: refusing to request an empty entity list — the caller should stay disabled until the roster resolves",
     );

--- a/src/frontend/src/lib/metrics/collection.ts
+++ b/src/frontend/src/lib/metrics/collection.ts
@@ -6,7 +6,6 @@ import type {
   MetricComputation,
   MetricDirection,
   MetricDimensionFilter,
-  MetricEntityType,
   MetricFormat,
   MetricGroupLimit,
   MetricResult,
@@ -80,7 +79,7 @@ export function filterCollectionToAvailable(
 }
 
 export interface MetricCollectionEntity {
-  type: MetricEntityType;
+  type: "person";
   ids: string[];
 }
 

--- a/src/frontend/src/mocks/handlers.test.ts
+++ b/src/frontend/src/mocks/handlers.test.ts
@@ -1,0 +1,26 @@
+import { setupServer } from "msw/node";
+import { afterAll, beforeAll, expect, it } from "vitest";
+
+import { handlers } from "./handlers";
+
+const server = setupServer(...handlers);
+
+beforeAll(() => server.listen({ onUnhandledRequest: "error" }));
+afterAll(() => server.close());
+
+it("rejects unsupported metric result entity types", async () => {
+  const response = await fetch(
+    new URL("/api/analytics/v1/metric-results", window.location.href),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        entity: { type: "other" },
+        period: { from: "2026-01-01", to: "2026-01-31" },
+        metrics: [],
+      }),
+    },
+  );
+
+  expect(response.status).toBe(400);
+});

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -380,7 +380,7 @@ export const handlers = [
       .catch(() => null)) as MetricResultsRequest | null;
     if (
       !body ||
-      !Array.isArray(body.entity?.ids) ||
+      !body.entity ||
       !Array.isArray(body.metrics)
     ) {
       return HttpResponse.json({ error: "invalid_argument" }, { status: 400 });
@@ -389,9 +389,24 @@ export const handlers = [
     // person UUIDs and an email is a 400. Without this the mock would happily
     // answer a stale email fixture and hide the very regression it exists to
     // catch.
-    if (!body.entity.ids.every((id) => typeof id === "string" && isPersonId(id))) {
+    if (
+      body.entity.type === "person" &&
+      (!Array.isArray(body.entity.ids) ||
+        !body.entity.ids.every((id) => typeof id === "string" && isPersonId(id)))
+    ) {
       return HttpResponse.json(
         { error: "invalid_argument", field: "entity.ids" },
+        { status: 400 },
+      );
+    }
+    if (
+      body.entity.type === "tenant" &&
+      body.metrics.some((metric) =>
+        metric.views.some((view) => view.view === "peer"),
+      )
+    ) {
+      return HttpResponse.json(
+        { error: "invalid_argument", field: "metrics.views" },
         { status: 400 },
       );
     }

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -385,6 +385,15 @@ export const handlers = [
     ) {
       return HttpResponse.json({ error: "invalid_argument" }, { status: 400 });
     }
+
+    const entityType: unknown = (body.entity as { type?: unknown }).type;
+    if (entityType !== "person" && entityType !== "tenant") {
+      return HttpResponse.json(
+        { error: "invalid_argument", field: "entity.type" },
+        { status: 400 },
+      );
+    }
+
     // Mirror the real endpoint since the identity cutover: entity ids are
     // person UUIDs and an email is a 400. Without this the mock would happily
     // answer a stale email fixture and hide the very regression it exists to

--- a/src/frontend/src/mocks/metric-definitions-factory.ts
+++ b/src/frontend/src/mocks/metric-definitions-factory.ts
@@ -70,6 +70,7 @@ function define(metricKey: string, today: string): MetricDefinition {
 
   return {
     metric_key: metricKey,
+    entity_type: "person",
     label: meta.label,
     short_label: null,
     description: family

--- a/src/frontend/src/mocks/metric-results-factory.ts
+++ b/src/frontend/src/mocks/metric-results-factory.ts
@@ -67,7 +67,10 @@ const MOCK_TOOLS = [
 export function buildMetricResultsResponse(
   request: MetricResultsRequest,
 ): MetricResultsResponse {
-  const ids = request.entity.ids;
+  const ids =
+    request.entity.type === "person"
+      ? request.entity.ids
+      : ["00000000-0000-4000-8000-00000000c0de"];
   const metrics: MetricResult[] = request.metrics.map((metricRequest) => {
     const meta = metaFor(metricRequest.metric_key);
     const key = metricRequest.metric_key;

--- a/src/frontend/src/queries/member-grid.test.tsx
+++ b/src/frontend/src/queries/member-grid.test.tsx
@@ -21,6 +21,9 @@ const mock = vi.mocked(queryMetricResults);
 // Every requested view echoed back so the current (period+peer) and previous
 // (period-only) twins both resolve to real data.
 function respond(req: MetricResultsRequest): MetricResultsResponse {
+  if (req.entity.type !== "person") throw new Error("person request expected");
+  const ids = req.entity.ids;
+
   return {
     metrics: req.metrics.map((m) => ({
       metric_key: m.metric_key,
@@ -33,11 +36,11 @@ function respond(req: MetricResultsRequest): MetricResultsResponse {
         v.view === "period"
           ? {
               view: "period",
-              values: req.entity.ids.map((id) => ({ entity_id: id, value: 1 })),
+              values: ids.map((id) => ({ entity_id: id, value: 1 })),
             }
           : {
               view: "peer",
-              values: req.entity.ids.map((id) => ({
+              values: ids.map((id) => ({
                 entity_id: id,
                 target_value: 1,
                 p25: 0,

--- a/src/frontend/src/queries/metric-definitions.test.ts
+++ b/src/frontend/src/queries/metric-definitions.test.ts
@@ -28,6 +28,7 @@ function wrapper() {
 function metric(metric_key: string): MetricDefinition {
   return {
     metric_key,
+    entity_type: "person",
     label: metric_key,
     short_label: null,
     description: null,

--- a/src/frontend/src/queries/metric-results.test.tsx
+++ b/src/frontend/src/queries/metric-results.test.tsx
@@ -36,6 +36,9 @@ function offers(...keys: string[]) {
 // Echo the requested metrics/entities back as a valid response so merges and
 // pairing have real data to operate on.
 function respond(req: MetricResultsRequest): MetricResultsResponse {
+  if (req.entity.type !== "person") throw new Error("person request expected");
+  const ids = req.entity.ids;
+
   return {
     metrics: req.metrics.map((m) => ({
       metric_key: m.metric_key,
@@ -48,7 +51,7 @@ function respond(req: MetricResultsRequest): MetricResultsResponse {
         v.view === "peer"
           ? {
               view: "peer",
-              values: req.entity.ids.map((id) => ({
+              values: ids.map((id) => ({
                 entity_id: id,
                 target_value: 1,
                 p25: 0,
@@ -61,7 +64,7 @@ function respond(req: MetricResultsRequest): MetricResultsResponse {
             }
           : {
               view: "period",
-              values: req.entity.ids.map((id) => ({ entity_id: id, value: 1 })),
+              values: ids.map((id) => ({ entity_id: id, value: 1 })),
             },
       ),
     })),

--- a/src/frontend/src/screens/metric-definitions.test.tsx
+++ b/src/frontend/src/screens/metric-definitions.test.tsx
@@ -26,6 +26,7 @@ import { MetricDefinitionsScreen } from "./metric-definitions";
 function metric(over: Partial<MetricDefinition> = {}): MetricDefinition {
   return {
     metric_key: "git.commits",
+    entity_type: "person",
     label: "Commits",
     short_label: null,
     description: "Commits authored in the period.",

--- a/tests/stand/api/analytics/test_drilldown.py
+++ b/tests/stand/api/analytics/test_drilldown.py
@@ -64,6 +64,8 @@ from ..schemas import (
 from ..schemas.analytics import (
     MetricDrilldownCapability,
     MetricDrilldownColumnType,
+    MetricDrilldownEntity,
+    MetricDrilldownEntity1,
     MetricDrilldownResponse,
 )
 from . import query_window
@@ -476,10 +478,16 @@ def _close(actual: float, expected: float) -> bool:
     return math.isclose(actual, expected, rel_tol=_REL_TOL, abs_tol=_ABS_TOL)
 
 
+def _person_entity_id(entity: MetricDrilldownEntity) -> str:
+    person = entity.root
+    assert isinstance(person, MetricDrilldownEntity1), f"expected person entity, got {person.type}"
+    return person.id
+
+
 def _assert_shape(walk: _Walk, expectation: Expectation, person_id: str) -> None:
     selection = walk.first.selection
     assert selection.metric_key == expectation.metric_key
-    assert selection.entity.id == person_id
+    assert _person_entity_id(selection.entity) == person_id
     assert selection.filters == []
     assert selection.display_dimensions == []
 
@@ -891,7 +899,7 @@ def test_git_commit_drilldown_pages_and_reconciles(
     person_id = stand_manifest.fixture("dev_lead").uuid
 
     assert walk.first.selection.metric_key == GIT_COMMITS
-    assert walk.first.selection.entity.id == person_id
+    assert _person_entity_id(walk.first.selection.entity) == person_id
     assert walk.first.selection.display_dimensions == ["repository"]
     assert [(item.dimension, item.values) for item in walk.first.selection.filters] == [
         ("source", ["github"])

--- a/tests/stand/api/schemas/analytics.py
+++ b/tests/stand/api/schemas/analytics.py
@@ -99,6 +99,11 @@ class CreateSavedQueryRequest(BaseModel):
     sql: str
 
 
+class EntityType(StrEnum):
+    person = 'person'
+    tenant = 'tenant'
+
+
 class EvidenceGranularity(StrEnum):
     event = 'event'
     source_summary = 'source_summary'
@@ -185,12 +190,31 @@ class MetricDrilldownColumnType(StrEnum):
     number = 'number'
 
 
-class MetricDrilldownEntity(BaseModel):
+class Type(StrEnum):
+    person = 'person'
+
+
+class MetricDrilldownEntity1(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
     id: str
-    type: str
+    type: Type
+
+
+class Type1(StrEnum):
+    tenant = 'tenant'
+
+
+class MetricDrilldownEntity2(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    type: Type1
+
+
+class MetricDrilldownEntity(RootModel[MetricDrilldownEntity1 | MetricDrilldownEntity2]):
+    root: MetricDrilldownEntity1 | MetricDrilldownEntity2
 
 
 class MetricDrilldownExportFormat(StrEnum):
@@ -345,20 +369,58 @@ class MetricResultViewDto5(BaseModel):
     view: View4
 
 
-class MetricResultsEntity(BaseModel):
+class Type2(StrEnum):
+    person = 'person'
+
+
+class MetricResultsEntity1(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    ids: list[str] = Field(..., description='Canonical person UUIDs (since the identity cutover; the\npre-cutover email shape is rejected with a 400).')
-    type: str
+    ids: list[str]
+    type: Type2
 
 
-class MetricResultsEntityDto(BaseModel):
+class Type3(StrEnum):
+    tenant = 'tenant'
+
+
+class MetricResultsEntity2(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    ids: list[str] = Field(..., description='Canonical person UUIDs (since the identity cutover; the\npre-cutover email shape is rejected with a 400).')
-    type: str
+    type: Type3
+
+
+class MetricResultsEntity(RootModel[MetricResultsEntity1 | MetricResultsEntity2]):
+    root: MetricResultsEntity1 | MetricResultsEntity2
+
+
+class Type4(StrEnum):
+    person = 'person'
+
+
+class MetricResultsEntityDto1(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    ids: list[str]
+    type: Type4
+
+
+class Type5(StrEnum):
+    tenant = 'tenant'
+
+
+class MetricResultsEntityDto2(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    type: Type5
+
+
+class MetricResultsEntityDto(RootModel[MetricResultsEntityDto1 | MetricResultsEntityDto2]):
+    root: MetricResultsEntityDto1 | MetricResultsEntityDto2
 
 
 class MetricResultsPeriod(BaseModel):
@@ -712,6 +774,7 @@ class MetricDefinitionView(BaseModel):
     dimensions: list[str]
     direction: MetricDirection
     drilldown: MetricDrilldownCapability | None = None
+    entity_type: EntityType
     explanation: str | None = None
     format: MetricFormat
     is_enabled: bool


### PR DESCRIPTION
**Why.** Metrics could only target people, leaving organization-wide measures—such as CI reliability, deployment outcomes, or repository activity—without a valid entity scope.

**What changed.** Added discriminated person and tenant contracts across backend, OpenAPI, and frontend. Tenant identity comes from the session; definitions, results, drilldowns, and exports use a default-disabled installation gate.

**Tenant requests carry no identifier.** The server owns tenant identity, while person requests still require identifiers at compile time.

**Contract only.** Concrete CI and other tenant-level metrics, tenant UI, and per-user authorization remain out of scope.

OpenAPI exposes two entity variants: person requires `id` or `ids`; tenant permits neither.

**Verified.** Backend fmt, clippy, and 455 tests; frontend typecheck, lint, and 1,915 tests; generated OpenAPI drift check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tenant-scoped analytics metrics alongside person-scoped metrics.
  * Tenant metric definitions, results, drilldowns, evidence, and exports now support tenant selections.
  * Added configuration to enable or disable tenant metrics, disabled by default.
  * Updated metric APIs to distinguish person and tenant entities.

* **Bug Fixes**
  * Improved authorization and validation for person and tenant metric requests.
  * Corrected tenant entity handling and identifier formatting in metric responses.
  * Unsupported entity types and tenant peer views are now rejected with clearer errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->