### PR TITLE
fix(frontend): scope the immutable cache to content-hashed assets

### DIFF
--- a/src/frontend/nginx/default.conf.template
+++ b/src/frontend/nginx/default.conf.template
@@ -46,7 +46,9 @@ server {
     # Only content-hashed names may be immutable; a stable-named file pinned
     # here goes stale for the full max-age.
     location ^~ /assets/ {
-        add_header Cache-Control "public, max-age=31536000, immutable" always;
+        # No `always`: nginx then limits the header to 2xx/3xx, keeping the
+        # immutable lifetime off the 404 a request mid-rollout can hit.
+        add_header Cache-Control "public, max-age=31536000, immutable";
         # Re-include security headers — see comment above for why.
         include /etc/nginx/snippets/security-headers.conf;
     }

--- a/src/frontend/nginx/default.conf.template
+++ b/src/frontend/nginx/default.conf.template
@@ -35,15 +35,17 @@ server {
         include /etc/nginx/snippets/security-headers.conf;
     }
 
-    # Exact match so it wins over the immutable-asset regex below — a cached
-    # copy would pin the browser to the DSN of an earlier deploy.
+    # Never cached: a stale copy would pin the browser to the DSN of an earlier
+    # deploy.
     location = /config.js {
         add_header Cache-Control "no-cache" always;
         # Re-include security headers — see comment above for why.
         include /etc/nginx/snippets/security-headers.conf;
     }
 
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
+    # Only content-hashed names may be immutable; a stable-named file pinned
+    # here goes stale for the full max-age.
+    location ^~ /assets/ {
         add_header Cache-Control "public, max-age=31536000, immutable" always;
         # Re-include security headers — see comment above for why.
         include /etc/nginx/snippets/security-headers.conf;


### PR DESCRIPTION
**Why.** The asset rule matched on file extension and carried `always`: files Vite copies verbatim out of `public/` were served `immutable` under names that never change between builds, and so was a 404 for a hashed asset.

**What changed.** It matches on path now — `^~ /assets/`, the only names Vite content-hashes — and the header drops `always`, so nginx stops it at 2xx/3xx. Stable names fall through to `no-cache`.

**Left the `config.js` exact-match block in place.** Redundant once the extension regex is gone, but it guards a regex location added later.

Runtime image over a synthetic bundle tree, `Cache-Control` per path:

| Path | Before | After |
|---|---|---|
| `/index.html` | `no-cache` | `no-cache` |
| `/config.js` | `no-cache` | `no-cache` |
| `/favicon.svg` | `public, max-age=31536000, immutable` | `no-cache` |
| `/assets/app-AAAA1111.js` | `public, max-age=31536000, immutable` | `public, max-age=31536000, immutable` |
| `/assets/style-BBBB2222.css` | `public, max-age=31536000, immutable` | `public, max-age=31536000, immutable` |
| `/assets/font-CCCC3333.woff2` | `public, max-age=31536000, immutable` | `public, max-age=31536000, immutable` |
| `/assets/missing-DEAD0000.js` → `404` | `public, max-age=31536000, immutable` | none |

**Out of scope.** A client already holding an `immutable` copy keeps it until `max-age` expires.

**Verified.** Table above on nginx 1.27, rendered template, both configs; all eight security headers present on every response including the 404; `nginx -t` clean. Frontend build not run — the change is nginx-only.
