### PR TITLE
fix(frontend): label a nameless person by their username, never a blank row

### DIFF
--- a/docs/components/backend/identity-resolution/openapi.json
+++ b/docs/components/backend/identity-resolution/openapi.json
@@ -620,7 +620,7 @@
         "type": "object"
       },
       "PersonResponse": {
-        "description": "A person node in the org tree (subordinate of a profile), matching the .NET\n`PersonResponse`. Unlike `ProfileResponse`, the attribute fields are plain\nstrings (empty when absent, not omitted) and the `supervisor_*`/`parent_*`\nfields serialize as `null` rather than being dropped.",
+        "description": "A person node in the org tree (subordinate of a profile), matching the .NET\n`PersonResponse` plus `username`, which the .NET shape never carried — the\nUI labels a nameless person by their handle (#2711). Unlike\n`ProfileResponse`, the attribute fields are plain strings (empty when\nabsent, not omitted) and the `supervisor_*`/`parent_*` fields serialize as\n`null` rather than being dropped.",
         "properties": {
           "department": {
             "type": "string"
@@ -686,6 +686,9 @@
               "string",
               "null"
             ]
+          },
+          "username": {
+            "type": "string"
           }
         },
         "required": [
@@ -698,6 +701,7 @@
           "division",
           "job_title",
           "status",
+          "username",
           "subordinates"
         ],
         "type": "object"

--- a/src/backend/services/identity-resolution/src/domain/profile.rs
+++ b/src/backend/services/identity-resolution/src/domain/profile.rs
@@ -78,9 +78,11 @@ pub struct ProfileResponse {
 }
 
 /// A person node in the org tree (subordinate of a profile), matching the .NET
-/// `PersonResponse`. Unlike `ProfileResponse`, the attribute fields are plain
-/// strings (empty when absent, not omitted) and the `supervisor_*`/`parent_*`
-/// fields serialize as `null` rather than being dropped.
+/// `PersonResponse` plus `username`, which the .NET shape never carried — the
+/// UI labels a nameless person by their handle (#2711). Unlike
+/// `ProfileResponse`, the attribute fields are plain strings (empty when
+/// absent, not omitted) and the `supervisor_*`/`parent_*` fields serialize as
+/// `null` rather than being dropped.
 #[derive(Debug, Serialize, ToSchema)]
 pub struct PersonResponse {
     pub person_id: Uuid,
@@ -92,6 +94,7 @@ pub struct PersonResponse {
     pub division: String,
     pub job_title: String,
     pub status: String,
+    pub username: String,
     pub supervisor_email: Option<String>,
     pub supervisor_name: Option<String>,
     pub parent_email: Option<String>,
@@ -250,6 +253,7 @@ pub fn assemble_person(
         division: get("division"),
         job_title: get("job_title"),
         status: get("status"),
+        username: get("username"),
         supervisor_email,
         supervisor_name,
         parent_email,
@@ -590,12 +594,16 @@ mod tests {
         let t: DateTime = "2026-01-01T00:00:00".parse()?;
         let leaf = assemble_person(
             Uuid::from_u128(30),
-            vec![obs("email", "leaf@example.com", t)],
+            vec![
+                obs("email", "leaf@example.com", t),
+                obs("username", "leafhandle", t),
+            ],
             None,
             Vec::new(),
         );
         // Absent attributes are empty strings (not omitted), per .NET PersonResponse.
         assert_eq!(leaf.email, "leaf@example.com");
+        assert_eq!(leaf.username, "leafhandle");
         assert_eq!(leaf.department, "");
         assert_eq!(leaf.first_name, "");
         assert!(leaf.subordinates.is_empty());

--- a/src/frontend/src/api/identity-client.ts
+++ b/src/frontend/src/api/identity-client.ts
@@ -595,6 +595,7 @@ function toIdentityPerson(p: ProfileResponse): IdentityPerson {
     division: p.division ?? "",
     job_title: p.job_title ?? "",
     status: p.status ?? "",
+    username: p.username ?? "",
     parent_email: p.parent_email ?? null,
     // `parent_id` has no ProfileResponse source; preserve the prior default.
     parent_id: null,

--- a/src/frontend/src/components/app-sidebar-footer.tsx
+++ b/src/frontend/src/components/app-sidebar-footer.tsx
@@ -3,6 +3,7 @@ import { BookOpenText, Megaphone, type LucideIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import { useViewer } from "@/auth";
+import { personName } from "@/lib/identities/person-display";
 import { SidebarSettings } from "@/components/sidebar-settings";
 import { ThemeSwitcher } from "@/components/theme-switcher";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
@@ -36,7 +37,7 @@ export function AppSidebarFooter({ onNavigate }: { onNavigate?: () => void }) {
   const viewer = viewerQ.data ?? null;
 
   const primaryEmail = viewer?.email ?? viewerEmail;
-  const primary = viewer?.display_name || primaryEmail;
+  const primary = (viewer ? personName(viewer) : null) ?? primaryEmail;
   const showSecondary = primary !== primaryEmail;
 
   return (

--- a/src/frontend/src/components/app-sidebar.tsx
+++ b/src/frontend/src/components/app-sidebar.tsx
@@ -21,6 +21,7 @@ import {
   SidebarMenuButton,
   SidebarMenuItem,
 } from "@/components/ui/sidebar";
+import { personName } from "@/lib/identities/person-display";
 import { personIdFromPath } from "@/lib/metrics/entity";
 import { useIcPerson } from "@/queries/ic-dashboard";
 import type { IdentityPerson } from "@/types/insight";
@@ -80,7 +81,7 @@ function PersonNode({
           )}
           {hasReports ? <Users /> : <User />}
           <span className="truncate">
-            {node.display_name || node.email || UNNAMED_PERSON}
+            {personName(node) ?? UNNAMED_PERSON}
           </span>
         </SidebarMenuButton>
       </SidebarMenuItem>

--- a/src/frontend/src/components/org-tree.tsx
+++ b/src/frontend/src/components/org-tree.tsx
@@ -90,7 +90,7 @@ function PersonNode({
             <span className="w-4 shrink-0" />
           )}
           {hasReports ? <Users /> : <User />}
-          <span className="truncate">{node.display_name || node.email}</span>
+          <span className="truncate">{personDisplayName(node)}</span>
         </SidebarMenuButton>
       </SidebarMenuItem>
       {hasReports && open

--- a/src/frontend/src/components/portal/ai-cost-view.tsx
+++ b/src/frontend/src/components/portal/ai-cost-view.tsx
@@ -4,6 +4,7 @@ import { CenteredSpinner } from "@/components/widgets/centered-spinner";
 import { ComingSoon } from "@/components/widgets/coming-soon";
 import { PANE_ITEM_COMING_SOON } from "@/lib/portal/aicost-configs";
 import { orgScopeGate } from "@/components/portal/org-scope-gate";
+import { personDisplayName } from "@/lib/identities/person-display";
 import { MembersGrid } from "@/components/widgets/dashboard/members-grid";
 import { Card, CardContent } from "@/components/ui/card";
 import {
@@ -121,7 +122,7 @@ export function AiCostView({ item }: { item: string | null }) {
     () =>
       (roster ?? []).map((entry) => ({
         person_id: entry.person_id,
-        name: entry.display_name,
+        name: personDisplayName(entry),
       })),
     [roster],
   );

--- a/src/frontend/src/components/portal/domain-lens-view.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from "react";
 import { MetricName } from "@/components/widgets/metric-help-tooltip";
 import { ArrowDownRight, ArrowUpRight } from "lucide-react";
 import { AttentionList } from "@/components/portal/attention-list";
+import { personDisplayName } from "@/lib/identities/person-display";
 import { ComingSoon } from "@/components/widgets/coming-soon";
 import { orgScopeGate } from "@/components/portal/org-scope-gate";
 import { SectionTrend } from "@/components/portal/section-trend";
@@ -116,7 +117,7 @@ export function DomainLensView({
     () =>
       (roster ?? []).map((entry) => ({
         person_id: entry.person_id,
-        name: entry.display_name,
+        name: personDisplayName(entry),
       })),
     [roster]
   );

--- a/src/frontend/src/components/portal/employees-view.tsx
+++ b/src/frontend/src/components/portal/employees-view.tsx
@@ -50,7 +50,7 @@ function collectEmployees(root: IdentityPerson): EmployeeRow[] {
       if (!byId.has(key)) {
         byId.set(key, {
           personId: node.person_id,
-          displayName: node.display_name || node.email || UNNAMED_PERSON,
+          displayName: personName(node) ?? UNNAMED_PERSON,
           jobTitle: node.job_title ?? "",
           department: node.department ?? "",
           division: node.division ?? "",

--- a/src/frontend/src/components/portal/person-header.tsx
+++ b/src/frontend/src/components/portal/person-header.tsx
@@ -16,6 +16,7 @@ import {
   usePortalNavActions,
 } from "@/lib/portal/portal-nav";
 import { useOrgScope } from "@/lib/portal/use-org-scope";
+import { personDisplayName } from "@/lib/identities/person-display";
 import { cn } from "@/lib/utils";
 
 /**
@@ -77,7 +78,7 @@ export function PersonHeader({ person }: { person: string }) {
   const peers = [...(manager?.subordinates ?? [])]
     .filter((p) => p.person_id)
     .sort((a, b) =>
-      (a.display_name || a.email).localeCompare(b.display_name || b.email),
+      personDisplayName(a).localeCompare(personDisplayName(b)),
     );
   const hasPeers = peers.length > 1;
 
@@ -95,7 +96,7 @@ export function PersonHeader({ person }: { person: string }) {
 
   const title = (
     <h1 className="truncate text-lg font-semibold tracking-tight">
-      {data.display_name || data.email}
+      {personDisplayName(data)}
     </h1>
   );
 
@@ -140,7 +141,7 @@ export function PersonHeader({ person }: { person: string }) {
                         )}
                       />
                       <span className="truncate">
-                        {p.display_name || p.email}
+                        {personDisplayName(p)}
                       </span>
                     </DropdownMenuItem>
                   );

--- a/src/frontend/src/components/portal/team-state-view.tsx
+++ b/src/frontend/src/components/portal/team-state-view.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 
 import { AttentionList } from "@/components/portal/attention-list";
+import { personDisplayName } from "@/lib/identities/person-display";
 import { orgScopeGate } from "@/components/portal/org-scope-gate";
 import { MembersGrid } from "@/components/widgets/dashboard/members-grid";
 import { Card, CardContent } from "@/components/ui/card";
@@ -59,7 +60,7 @@ export function TeamStateView() {
     () =>
       (roster ?? []).map((entry) => ({
         person_id: entry.person_id,
-        name: entry.display_name,
+        name: personDisplayName(entry),
       })),
     [roster],
   );

--- a/src/frontend/src/lib/identities/person-display.test.ts
+++ b/src/frontend/src/lib/identities/person-display.test.ts
@@ -1,0 +1,59 @@
+/**
+ * One precedence for every person label: display name → username → e-mail →
+ * person id (#2711). A blank or whitespace-only value does not count as
+ * present, so a person with an empty display name is still named by their
+ * handle instead of rendering a blank row.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  personDisplayName,
+  personName,
+  type PersonNaming,
+} from "./person-display";
+
+describe("person naming precedence", () => {
+  it.each<[string, PersonNaming, string]>([
+    [
+      "display name wins over every other field",
+      { display_name: "Ann Smith", username: "asmith", email: "a@example.com" },
+      "Ann Smith",
+    ],
+    [
+      "an empty display name falls back to the username",
+      { display_name: "", username: "asmith", email: "a@example.com" },
+      "asmith",
+    ],
+    [
+      "a whitespace-only display name is not a name",
+      { display_name: "   ", username: "asmith" },
+      "asmith",
+    ],
+    [
+      "the e-mail comes only after the username",
+      { display_name: "", username: "", email: "1+a@noreply.example.com" },
+      "1+a@noreply.example.com",
+    ],
+    [
+      "absent fields read the same as empty ones",
+      { username: "asmith" },
+      "asmith",
+    ],
+    [
+      "null fields read the same as empty ones",
+      { display_name: null, username: null, email: "a@example.com" },
+      "a@example.com",
+    ],
+  ])("%s", (_rule, fields, expected) => {
+    expect(personName(fields)).toBe(expected);
+  });
+
+  it("knows no name when every field is blank", () => {
+    expect(personName({ display_name: "", username: " ", email: "" })).toBeNull();
+  });
+
+  it("falls back to the person id only after every named field", () => {
+    const anonymous = { person_id: "p-anon", display_name: "", username: "" };
+    expect(personDisplayName(anonymous)).toBe("p-anon");
+  });
+});

--- a/src/frontend/src/lib/identities/person-display.ts
+++ b/src/frontend/src/lib/identities/person-display.ts
@@ -1,5 +1,5 @@
 /**
- * The one name a person goes by across every identity-console surface.
+ * The one name a person goes by across every surface that labels a person.
  *
  * Precedence: display name, else the source-native username, else the e-mail.
  * The address comes LAST on purpose — a source that hides a member's e-mail
@@ -7,7 +7,13 @@
  * account (`<id>+<handle>@…`) is not what anybody calls that person. The handle
  * is.
  */
-import type { PersonSummary } from "@/api/identity-client";
+
+/** The naming fields the precedence reads — any person shape can supply them. */
+export interface PersonNaming {
+  display_name?: string | null;
+  username?: string | null;
+  email?: string | null;
+}
 
 /**
  * The name the journal knows, or null when it knows none.
@@ -16,7 +22,7 @@ import type { PersonSummary } from "@/api/identity-client";
  * roster listing's own order key (`person_listing`'s `LABEL_CTES`) — a row
  * shown under one name and sorted under another pages unpredictably.
  */
-export function personName(person: PersonSummary): string | null {
+export function personName(person: PersonNaming): string | null {
   return (
     person.display_name?.trim() ||
     person.username?.trim() ||
@@ -26,6 +32,8 @@ export function personName(person: PersonSummary): string | null {
 }
 
 /** The same name, falling back to the id — always something to render. */
-export function personDisplayName(person: PersonSummary): string {
+export function personDisplayName(
+  person: PersonNaming & { person_id: string },
+): string {
   return personName(person) ?? person.person_id;
 }

--- a/src/frontend/src/lib/insight/identity-tree.ts
+++ b/src/frontend/src/lib/insight/identity-tree.ts
@@ -21,6 +21,7 @@ export interface RosterEntry {
   person_id: string;
   email: string;
   display_name: string;
+  username: string;
   supervisor_person_id: string | null;
   /** True when the person is a direct report of the pivot (depth 1). */
   is_direct: boolean;
@@ -44,6 +45,7 @@ export function flattenSubordinates(pivot: IdentityPerson): RosterEntry[] {
         person_id: sub.person_id,
         email: sub.email,
         display_name: sub.display_name,
+        username: sub.username ?? "",
         supervisor_person_id: supervisorPersonId,
         is_direct: isDirect,
       });

--- a/src/frontend/src/lib/portal/org-tree-filter.ts
+++ b/src/frontend/src/lib/portal/org-tree-filter.ts
@@ -10,6 +10,8 @@ export interface OrgTreeFilter {
 function haystack(person: IdentityPerson): string {
   return [
     person.display_name,
+    person.username,
+    person.email,
     person.job_title,
     person.department,
     person.division,

--- a/src/frontend/src/lib/portal/use-org-scope.test.ts
+++ b/src/frontend/src/lib/portal/use-org-scope.test.ts
@@ -128,6 +128,29 @@ describe("flatOrgScope", () => {
     expect(scope.label).toBe("Whole organisation");
   });
 
+  it("carries every naming field a person label reads (#2711)", () => {
+    // The roster entry is what the zones label people by; dropping username
+    // here would blank every person the org chart never named.
+    const scope = flatOrgScope(
+      [
+        { person_id: "p-me", display_name: "Me" },
+        { person_id: "p-h", display_name: "", username: "handle", email: "" },
+      ],
+      "p-me",
+    );
+
+    expect(scope.roster).toEqual([
+      {
+        person_id: "p-h",
+        display_name: "",
+        username: "handle",
+        email: "",
+        supervisor_person_id: null,
+        is_direct: false,
+      },
+    ]);
+  });
+
   it("keeps a roster it cannot place the viewer in", () => {
     // A viewer absent from their own roster is a bug elsewhere; dropping every
     // row here would report it as "you can see nobody".

--- a/src/frontend/src/lib/portal/use-org-scope.ts
+++ b/src/frontend/src/lib/portal/use-org-scope.ts
@@ -15,6 +15,7 @@ import {
   usePortalScope,
 } from "@/lib/portal/portal-nav";
 import type { PersonSummary } from "@/api/identity-client";
+import { personDisplayName } from "@/lib/identities/person-display";
 import { useIcPerson } from "@/queries/ic-dashboard";
 import { useVisibilityPolicy } from "@/queries/identity-me";
 import { useVisibleRoster } from "@/queries/visible-roster";
@@ -76,6 +77,7 @@ export function flatOrgScope(
       person_id: person.person_id,
       email: person.email ?? "",
       display_name: person.display_name ?? "",
+      username: person.username ?? "",
       // No reporting lines to name, and no depth to be at.
       supervisor_person_id: null,
       is_direct: false,
@@ -126,7 +128,7 @@ export function resolveScopeRoster(
       node.subordinates.length > 0
         ? {
             person_id: node.person_id,
-            name: node.display_name || node.email,
+            name: personDisplayName(node),
             depth,
             teamSize: 0,
           }
@@ -142,7 +144,7 @@ export function resolveScopeRoster(
   return {
     pivot,
     roster,
-    label: pivot.display_name || pivot.email,
+    label: personDisplayName(pivot),
     count: roster?.length ?? 0,
     managerNodes,
     canDirectOnly,

--- a/src/frontend/src/lib/reports/roster-columns.ts
+++ b/src/frontend/src/lib/reports/roster-columns.ts
@@ -1,4 +1,5 @@
 import { normalizePersonId } from "@/lib/metrics/entity";
+import { personDisplayName } from "@/lib/identities/person-display";
 import type { IdentityPerson } from "@/types/insight";
 
 export interface ReportPerson {
@@ -42,7 +43,7 @@ export function collectReportPeople(
     if (node.person_id) {
       out.set(normalizePersonId(node.person_id), {
         entityId: normalizePersonId(node.person_id),
-        name: node.display_name ?? "",
+        name: personDisplayName(node),
         email: node.email ?? "",
         division: node.division ?? "",
         department: node.department ?? "",

--- a/src/frontend/src/screens/dashboard.tsx
+++ b/src/frontend/src/screens/dashboard.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import { CenteredSpinner } from "@/components/widgets/centered-spinner";
+import { personName } from "@/lib/identities/person-display";
 import { ComingSoon } from "@/components/widgets/coming-soon";
 import { DashboardHeader } from "@/components/widgets/dashboard/dashboard-header";
 import { IcNeedsAttention } from "@/components/widgets/dashboard/ic-needs-attention";
@@ -108,7 +109,7 @@ export function DashboardScreen({ personId }: DashboardScreenProps) {
 
   // Never fall back to the raw id (a UUID) — a person outside the viewer's
   // cached tree resolves in a beat; the title stays blank until then.
-  const displayName = person?.display_name ?? "";
+  const displayName = person ? (personName(person) ?? "") : "";
   const role = person?.job_title;
 
   // The one loading gate: a single page spinner while any of the screen's

--- a/src/frontend/src/screens/team-view.test.tsx
+++ b/src/frontend/src/screens/team-view.test.tsx
@@ -12,6 +12,8 @@
  *     upstream of it, not as a client-side row filter.
  *   - the toggle is hidden when the team has no indirect reports, where it
  *     could never change the roster (#1756).
+ *   - a member with no display name is labelled by their username, then
+ *     their e-mail — never a blank row (#2711).
  *
  * Child widgets are stubbed: this file tests the roster/toggle wiring, not
  * widget render rules (those have their own component tests).
@@ -241,5 +243,23 @@ describe("TeamViewScreen direct-reports scoping", () => {
     expect(screen.getByTestId("heatmap")).toHaveTextContent("Fay,Gil");
 
     expect(heatmapFetchedIds()).toEqual([PERSON_IDS.fay, PERSON_IDS.gil]);
+  });
+});
+
+describe("TeamViewScreen member labels", () => {
+  it("labels a member with no display name by username, then e-mail (#2711)", () => {
+    trees[PERSON_IDS.alice] = person(PERSON_IDS.alice, "alice@x.io", "Alice", [
+      {
+        ...person(PERSON_IDS.bob, "42+bee@noreply.x.io", ""),
+        username: "bee",
+      },
+      person(PERSON_IDS.erin, "erin@x.io", ""),
+    ]);
+
+    renderScreen();
+
+    expect(screen.getByTestId("heatmap")).toHaveTextContent(
+      "bee,erin@x.io",
+    );
   });
 });

--- a/src/frontend/src/screens/team-view.tsx
+++ b/src/frontend/src/screens/team-view.tsx
@@ -1,6 +1,10 @@
 import { useMemo, useState } from "react";
 
 import { IdentityApiError } from "@/api/identity-client";
+import {
+  personDisplayName,
+  personName,
+} from "@/lib/identities/person-display";
 import { ComingSoon } from "@/components/widgets/coming-soon";
 import { DashboardEmptyState } from "@/components/widgets/dashboard/dashboard-empty-state";
 import { DashboardHeader } from "@/components/widgets/dashboard/dashboard-header";
@@ -94,7 +98,7 @@ export function TeamViewScreen({ teamId }: TeamViewScreenProps) {
   );
   // Never fall back to the raw id (a UUID) — the shell prefetches the viewer
   // tree, so the pivot resolves synchronously in practice.
-  const teamName = pivot?.display_name ?? "";
+  const teamName = pivot ? (personName(pivot) ?? "") : "";
 
   // The roster IS the member list: identity owns who is on the team, and
   // every metric for them comes from `/v1/metric-results` below. There is no
@@ -103,7 +107,7 @@ export function TeamViewScreen({ teamId }: TeamViewScreenProps) {
     () =>
       (roster ?? []).map((entry) => ({
         person_id: entry.person_id,
-        name: entry.display_name,
+        name: personDisplayName(entry),
       })),
     [roster],
   );

--- a/src/frontend/src/types/insight.ts
+++ b/src/frontend/src/types/insight.ts
@@ -18,6 +18,7 @@ export interface IdentityPerson {
   division?: string;
   job_title?: string;
   status?: string;
+  username?: string;
   parent_email?: string | null;
   parent_id?: string | null;
   parent_person_id?: string | null;

--- a/tests/stand/api/schemas/identity.py
+++ b/tests/stand/api/schemas/identity.py
@@ -164,9 +164,11 @@ class PersonAccountsResponse(BaseModel):
 class PersonResponse(BaseModel):
     """
     A person node in the org tree (subordinate of a profile), matching the .NET
-    `PersonResponse`. Unlike `ProfileResponse`, the attribute fields are plain
-    strings (empty when absent, not omitted) and the `supervisor_*`/`parent_*`
-    fields serialize as `null` rather than being dropped.
+    `PersonResponse` plus `username`, which the .NET shape never carried — the
+    UI labels a nameless person by their handle (#2711). Unlike
+    `ProfileResponse`, the attribute fields are plain strings (empty when
+    absent, not omitted) and the `supervisor_*`/`parent_*` fields serialize as
+    `null` rather than being dropped.
     """
     model_config = ConfigDict(
         extra='forbid',
@@ -186,6 +188,7 @@ class PersonResponse(BaseModel):
     subordinates: list[PersonResponse]
     supervisor_email: str | None = None
     supervisor_name: str | None = None
+    username: str
 
 
 class PersonRoleResponse(BaseModel):


### PR DESCRIPTION
Closes #2711.

**Why.** A person with no display name renders as a blank label — on the team members matrix and every other surface that names a person — so a row full of metrics identifies nobody.

**What changed.** Every person label now goes through the one `personName` precedence: display name → username → e-mail → id. Profile subordinate nodes now carry `username` on the wire (the observation existed; the response dropped it), and the visible-persons roster mapping keeps it. **Account rows in the identity console keep their address-first labels on purpose** — they name the account, not the person.

**Verified.** Backend: unit tests, clippy pedantic, fmt. Frontend: tsc, eslint, 1924 vitest tests including new precedence and blank-name regression cases. OpenAPI doc and stand schemas regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
