### PR TITLE
feat(analytics): support flat peer comparisons

### DIFF
--- a/charts/insight/templates/secrets.yaml
+++ b/charts/insight/templates/secrets.yaml
@@ -184,6 +184,7 @@ stringData:
   APP__gears__analytics__config__clickhouse_password: {{ $chPass | quote }}
   APP__gears__analytics__config__redis_url:           {{ $redisUrl | quote }}
   APP__gears__analytics__config__identity_url:        {{ printf "http://%s:8082" (include "insight.identityResolution.host" .) | quote }}
+  APP__gears__analytics__config__visibility_policy:   {{ .Values.identityResolution.visibilityPolicy | default "org_chart" | quote }}
 
 ---
 # Authenticator leaf config (NGINX_BFF). The gears-rust host reads these

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -584,6 +584,7 @@ gitCliProxy:
 identityResolution:
   deploy: true
   replicaCount: 1
+  visibilityPolicy: "org_chart"
   image:
     repository: ghcr.io/constructorfabric/insight-identity-resolution
     tag: "" # MUST be set (e.g. "0.1.0")

--- a/src/backend/services/analytics/config/insight.yaml
+++ b/src/backend/services/analytics/config/insight.yaml
@@ -139,6 +139,7 @@ gears:
       clickhouse_database: "insight"
       # clickhouse_user / clickhouse_password: omit for no-auth ClickHouse.
       identity_url: ""
+      visibility_policy: "org_chart"
       redis_url: ""
       metric_catalog:
         tenant_metrics_enabled: false

--- a/src/backend/services/analytics/helm/templates/configmap.yaml
+++ b/src/backend/services/analytics/helm/templates/configmap.yaml
@@ -121,5 +121,6 @@ data:
       # come from the Secret via envFrom.
       analytics:
         config:
+          visibility_policy: {{ .Values.visibilityPolicy | default "org_chart" | quote }}
           metric_catalog:
             tenant_metrics_enabled: {{ .Values.metricCatalog.tenantMetricsEnabled }}

--- a/src/backend/services/analytics/helm/values.yaml
+++ b/src/backend/services/analytics/helm/values.yaml
@@ -34,6 +34,8 @@ metricCatalog:
 # sets `existingSecret` to its name.
 existingSecret: ""
 
+visibilityPolicy: "org_chart"
+
 # Gateway-JWT verification (cf-gears-oidc-authn-plugin, NGINX_BFF R1). These
 # render into the plugin's `jwt.trusted_issuers` / `expected_audience` in the
 # ConfigMap (nested/list-shaped, so not env-injectable). The plugin resolves the

--- a/src/backend/services/analytics/src/api/metric_results.rs
+++ b/src/backend/services/analytics/src/api/metric_results.rs
@@ -8,21 +8,23 @@ use axum::http::HeaderMap;
 use futures::stream::{self, StreamExt};
 use serde::de::DeserializeOwned;
 use toolkit_canonical_errors::CanonicalError;
+use toolkit_security::SecurityContext;
 
 use super::AppState;
 use super::error::MetricError;
+use crate::config::VisibilityPolicy;
 use crate::domain::metric_access::authorize_tenant_metrics;
 use crate::domain::metric_drilldown::load_capabilities;
 use crate::domain::metric_results::{
     BatchItem, BreakdownQueryRow, CompiledQuery, HistogramQueryRow, MetricResultViewDto,
-    MetricResultsRequest, MetricResultsResponse, PeerWideRow, PeriodWideRow, PlannedQuery,
-    RankingQueryRow, TimeseriesQueryRow, UnbatchedView, ValidatedMetricResultsRequest,
-    build_breakdown_view, build_histogram_view, build_metric_result, build_peer_view,
-    build_period_view, build_ranked_groups, build_timeseries_view, demux_peer_rows,
-    demux_period_rows, enforce_view_row_limit, plan_queries, plan_rankings, validate_request,
+    MetricResultsRequest, MetricResultsResponse, PeerPopulation, PeerWideRow, PeriodWideRow,
+    PlannedQuery, RankingQueryRow, TimeseriesQueryRow, UnbatchedView,
+    ValidatedMetricResultsRequest, build_breakdown_view, build_histogram_view, build_metric_result,
+    build_peer_view, build_period_view, build_ranked_groups, build_timeseries_view,
+    demux_peer_rows, demux_period_rows, enforce_view_row_limit, plan_queries, plan_rankings,
+    validate_request,
 };
 use crate::domain::person_visibility::authorize_person_ids;
-use toolkit_security::SecurityContext;
 
 const QUERY_CONCURRENCY: usize = 4;
 // Client-side bound on one view query, network stalls included. The
@@ -71,7 +73,8 @@ pub async fn query_metric_results(
     };
     let (ranking_results, capabilities) = tokio::join!(rankings, capabilities);
     let ranking_results = ranking_results?;
-    let planned = plan_queries(&req, &ranking_results)?;
+    let peer_population = peer_population(state.config.visibility_policy);
+    let planned = plan_queries(&req, &ranking_results, peer_population)?;
 
     let mut views_by_metric: Vec<Vec<Option<MetricResultViewDto>>> = req
         .metrics
@@ -139,6 +142,13 @@ pub async fn query_metric_results(
 
     let response = MetricResultsResponse { metrics };
     Ok(Json(response))
+}
+
+fn peer_population(visibility_policy: VisibilityPolicy) -> PeerPopulation {
+    match visibility_policy {
+        VisibilityPolicy::OrgChart => PeerPopulation::DeclaredCohort,
+        VisibilityPolicy::Flat => PeerPopulation::Tenant,
+    }
 }
 
 fn authorize_tenant_request(
@@ -326,7 +336,22 @@ mod tests {
     use axum::http::StatusCode;
     use axum::response::IntoResponse;
 
-    use super::map_query_error;
+    use crate::config::VisibilityPolicy;
+    use crate::domain::metric_results::PeerPopulation;
+
+    use super::{map_query_error, peer_population};
+
+    #[test]
+    fn visibility_policy_selects_peer_population() {
+        assert_eq!(
+            peer_population(VisibilityPolicy::OrgChart),
+            PeerPopulation::DeclaredCohort
+        );
+        assert_eq!(
+            peer_population(VisibilityPolicy::Flat),
+            PeerPopulation::Tenant
+        );
+    }
 
     #[test]
     fn missing_relation_maps_to_precondition_failure_not_500() {

--- a/src/backend/services/analytics/src/config.rs
+++ b/src/backend/services/analytics/src/config.rs
@@ -9,6 +9,14 @@
 
 use serde::Deserialize;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VisibilityPolicy {
+    #[default]
+    OrgChart,
+    Flat,
+}
+
 /// Configuration consumed by the analytics gear. Deserialized from
 /// `gears.analytics.config`.
 #[derive(Debug, Clone, Deserialize)]
@@ -40,6 +48,9 @@ pub struct GearConfig {
     /// `ClickHouse` without alias resolution (MVP mode).
     pub identity_url: String,
 
+    /// Deployment-wide person visibility and peer-population policy.
+    pub visibility_policy: VisibilityPolicy,
+
     /// Redis URL (e.g., `redis://localhost:6379`). Empty disables every
     /// Redis-backed path; multi-replica deploys configure it so a cache added
     /// here is coordinated across replicas rather than per-process.
@@ -62,6 +73,7 @@ impl Default for GearConfig {
             clickhouse_user: None,
             clickhouse_password: None,
             identity_url: String::new(),
+            visibility_policy: VisibilityPolicy::default(),
             redis_url: String::new(),
             metric_catalog: MetricCatalogConfig::default(),
             usage: UsageConfig::default(),
@@ -112,4 +124,41 @@ fn default_bind_addr() -> String {
 
 fn default_clickhouse_database() -> String {
     "insight".to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn visibility_policy_defaults_to_org_chart() -> anyhow::Result<()> {
+        let config: GearConfig = serde_json::from_value(serde_json::json!({}))?;
+
+        assert_eq!(config.visibility_policy, VisibilityPolicy::OrgChart);
+        Ok(())
+    }
+
+    #[test]
+    fn visibility_policy_accepts_only_wire_values() -> anyhow::Result<()> {
+        for (value, expected) in [
+            ("org_chart", VisibilityPolicy::OrgChart),
+            ("flat", VisibilityPolicy::Flat),
+        ] {
+            let config: GearConfig =
+                serde_json::from_value(serde_json::json!({ "visibility_policy": value }))?;
+
+            assert_eq!(config.visibility_policy, expected, "for: {value}");
+        }
+
+        for value in ["OrgChart", "org-chart", "Flat", "unknown", ""] {
+            assert!(
+                serde_json::from_value::<GearConfig>(
+                    serde_json::json!({ "visibility_policy": value })
+                )
+                .is_err(),
+                "should reject: {value}"
+            );
+        }
+        Ok(())
+    }
 }

--- a/src/backend/services/analytics/src/domain/metric_results/batch.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/batch.rs
@@ -18,6 +18,12 @@ use super::validation::{
 };
 use super::view::Bucket;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PeerPopulation {
+    DeclaredCohort,
+    Tenant,
+}
+
 #[derive(Debug)]
 pub struct BatchItem {
     pub metric_index: usize,
@@ -128,6 +134,7 @@ pub fn plan_rankings(req: &ValidatedMetricResultsRequest) -> Vec<PlannedRanking>
 pub fn plan_queries(
     req: &ValidatedMetricResultsRequest,
     rankings: &BTreeMap<RankingPolicyKey, Vec<RankedGroup>>,
+    peer_population: PeerPopulation,
 ) -> Result<Vec<PlannedQuery>, CanonicalError> {
     let mut period_groups: BTreeMap<(String, Vec<ValidatedDimensionFilter>), Vec<BatchItem>> =
         BTreeMap::new();
@@ -208,7 +215,7 @@ pub fn plan_queries(
     }
     for ((_, cohort_key, filters), items) in peer_groups {
         let defs: Vec<&MetricDefinition> = items.iter().map(|item| &item.def).collect();
-        let query = compile_peer_batch_query(&defs, req, &cohort_key, &filters);
+        let query = compile_peer_batch_query(&defs, req, &cohort_key, peer_population, &filters);
         planned.push(PlannedQuery::PeerBatch { items, query });
     }
     planned.extend(singles);
@@ -475,7 +482,7 @@ mod tests {
                 })
                 .collect(),
         );
-        let planned = plan_queries(&req, &BTreeMap::new())?;
+        let planned = plan_queries(&req, &BTreeMap::new(), PeerPopulation::DeclaredCohort)?;
         assert_eq!(planned.len(), 5);
         let (mut period_batches, mut peer_batches, mut singles) = (0, 0, 0);
         for query in &planned {
@@ -533,7 +540,7 @@ mod tests {
                 "m_b",
             ),
         ]);
-        let planned = plan_queries(&req, &BTreeMap::new())?;
+        let planned = plan_queries(&req, &BTreeMap::new(), PeerPopulation::DeclaredCohort)?;
         assert_eq!(planned.len(), 2);
         assert!(
             planned

--- a/src/backend/services/analytics/src/domain/metric_results/compiler.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/compiler.rs
@@ -4,8 +4,7 @@ use std::fmt::Write;
 use serde::Deserialize;
 use uuid::Uuid;
 
-use super::batch::ResolvedGroupLimit;
-use super::batch::{peer_aliases, period_alias};
+use super::batch::{PeerPopulation, ResolvedGroupLimit, peer_aliases, period_alias};
 use super::validation::{
     HISTOGRAM_BINS, ValidatedDimensionFilter, ValidatedEntitySelection,
     ValidatedMetricResultsRequest, query_row_limit,
@@ -500,6 +499,21 @@ pub(crate) fn compile_peer_batch_query(
     defs: &[&MetricDefinition],
     req: &ValidatedMetricResultsRequest,
     cohort_key: &str,
+    peer_population: PeerPopulation,
+    filters: &[ValidatedDimensionFilter],
+) -> CompiledQuery {
+    match peer_population {
+        PeerPopulation::DeclaredCohort => {
+            compile_declared_cohort_peer_batch_query(defs, req, cohort_key, filters)
+        }
+        PeerPopulation::Tenant => compile_tenant_peer_batch_query(defs, req, filters),
+    }
+}
+
+fn compile_declared_cohort_peer_batch_query(
+    defs: &[&MetricDefinition],
+    req: &ValidatedMetricResultsRequest,
+    cohort_key: &str,
     filters: &[ValidatedDimensionFilter],
 ) -> CompiledQuery {
     let mut params = Vec::new();
@@ -570,41 +584,110 @@ pub(crate) fn compile_peer_batch_query(
     CompiledQuery { sql, params }
 }
 
+fn compile_tenant_peer_batch_query(
+    defs: &[&MetricDefinition],
+    req: &ValidatedMetricResultsRequest,
+    filters: &[ValidatedDimensionFilter],
+) -> CompiledQuery {
+    let mut params = req.entity.entity_ids();
+    let value_selects = item_value_selects(defs, &mut params, period_alias);
+    let metric_scope = shared_observation_where(defs, req, filters, &mut params);
+
+    let entity_id_params = placeholders(req.entity.len());
+    let observation_table = batch_observation_table(defs);
+    let limit = query_row_limit();
+
+    let carried = peer_carried_selects(defs);
+    let (population_stat_selects, result_selects) = tenant_peer_item_selects(defs);
+
+    let sql = format!(
+        r"
+        WITH
+        targets AS (
+            SELECT arrayJoin([{entity_id_params}]) AS entity_id
+        ),
+        metric_values AS (
+            SELECT
+                entity_id{value_selects}
+            FROM {observation_table}
+            WHERE {metric_scope}
+            GROUP BY entity_id
+        ),
+        entity_values AS (
+            SELECT
+                entity_id{carried}
+            FROM metric_values
+        ),
+        population_stats AS (
+            SELECT
+                1 AS join_key{population_stat_selects}
+            FROM entity_values AS peer
+        )
+        SELECT
+            targets.entity_id AS entity_id{result_selects}
+        FROM targets
+        LEFT JOIN entity_values AS target_values
+            ON target_values.entity_id = targets.entity_id
+        CROSS JOIN population_stats
+        LIMIT {limit}
+        SETTINGS join_use_nulls = 1
+        "
+    );
+    CompiledQuery { sql, params }
+}
+
 // Per-item select fragments of the peer query: the carried (transformed)
 // value column, the guarded stats block, and the GROUP BY tail.
 fn peer_item_selects(defs: &[&MetricDefinition]) -> (String, String, String) {
-    let mut carried = String::new();
+    let carried = peer_carried_selects(defs);
     let mut stats_selects = String::new();
     let mut target_group = String::new();
-    for (item_index, def) in defs.iter().enumerate() {
+    for item_index in 0..defs.len() {
         let value = period_alias(item_index);
         let aliases = peer_aliases(item_index);
-        // Transform before the percentile pass — peer pools must rank the
-        // shaped values, not the raw artifact.
+        let _ = write!(
+            stats_selects,
+            ",
+            target_values.{value} AS {target}",
+            target = aliases.target,
+        );
+        push_peer_stat_selects(&mut stats_selects, item_index);
+        let _ = write!(target_group, ", target_values.{value}");
+    }
+    (carried, stats_selects, target_group)
+}
+
+fn peer_carried_selects(defs: &[&MetricDefinition]) -> String {
+    let mut carried = String::new();
+    for (item_index, def) in defs.iter().enumerate() {
+        let value = period_alias(item_index);
         let carried_value = transformed(def, format!("metric_values.{value}"));
         let _ = write!(
             carried,
             ",
                 {carried_value} AS {value}"
         );
-        let observed = format!("peer.{value} IS NOT NULL");
-        let pool = format!("uniqExactIf(peer.entity_id, {observed})");
-        // One `quantilesExactIf` over the pool yields all three quartiles in a
-        // single sort; the three `[i]` indexes reference the identical
-        // aggregate, which ClickHouse computes once. min/max come back from
-        // `*IfOrNull` already Nullable, so the disclosure guard's NULL branch
-        // needs no `toNullable`; the quartile elements are non-nullable and do.
-        let quantiles = format!("quantilesExactIf(0.25, 0.5, 0.75)(peer.{value}, {observed})");
+    }
+    carried
+}
+
+fn tenant_peer_item_selects(defs: &[&MetricDefinition]) -> (String, String) {
+    let mut population_stat_selects = String::new();
+    let mut result_selects = String::new();
+    for item_index in 0..defs.len() {
+        let value = period_alias(item_index);
+        let aliases = peer_aliases(item_index);
+        push_peer_stat_selects(&mut population_stat_selects, item_index);
         let _ = write!(
-            stats_selects,
+            result_selects,
             ",
             target_values.{value} AS {target},
-            if({pool} >= {min_peer_n}, toNullable({quantiles}[1]), NULL) AS {p25},
-            if({pool} >= {min_peer_n}, toNullable({quantiles}[2]), NULL) AS {median},
-            if({pool} >= {min_peer_n}, toNullable({quantiles}[3]), NULL) AS {p75},
-            if({pool} >= {min_peer_n}, minIfOrNull(peer.{value}, {observed}), NULL) AS {min},
-            if({pool} >= {min_peer_n}, maxIfOrNull(peer.{value}, {observed}), NULL) AS {max},
-            toUInt64({pool}) AS {n}",
+            population_stats.{p25} AS {p25},
+            population_stats.{median} AS {median},
+            population_stats.{p75} AS {p75},
+            population_stats.{min} AS {min},
+            population_stats.{max} AS {max},
+            population_stats.{n} AS {n}",
             target = aliases.target,
             p25 = aliases.p25,
             median = aliases.median,
@@ -612,11 +695,34 @@ fn peer_item_selects(defs: &[&MetricDefinition]) -> (String, String, String) {
             min = aliases.min,
             max = aliases.max,
             n = aliases.n,
-            min_peer_n = MIN_PEER_N,
         );
-        let _ = write!(target_group, ", target_values.{value}");
     }
-    (carried, stats_selects, target_group)
+    (population_stat_selects, result_selects)
+}
+
+fn push_peer_stat_selects(selects: &mut String, item_index: usize) {
+    let value = period_alias(item_index);
+    let aliases = peer_aliases(item_index);
+    let observed = format!("peer.{value} IS NOT NULL");
+    let pool = format!("uniqExactIf(peer.entity_id, {observed})");
+    let quantiles = format!("quantilesExactIf(0.25, 0.5, 0.75)(peer.{value}, {observed})");
+    let _ = write!(
+        selects,
+        ",
+            if({pool} >= {min_peer_n}, toNullable({quantiles}[1]), NULL) AS {p25},
+            if({pool} >= {min_peer_n}, toNullable({quantiles}[2]), NULL) AS {median},
+            if({pool} >= {min_peer_n}, toNullable({quantiles}[3]), NULL) AS {p75},
+            if({pool} >= {min_peer_n}, minIfOrNull(peer.{value}, {observed}), NULL) AS {min},
+            if({pool} >= {min_peer_n}, maxIfOrNull(peer.{value}, {observed}), NULL) AS {max},
+            toUInt64({pool}) AS {n}",
+        p25 = aliases.p25,
+        median = aliases.median,
+        p75 = aliases.p75,
+        min = aliases.min,
+        max = aliases.max,
+        n = aliases.n,
+        min_peer_n = MIN_PEER_N,
+    );
 }
 
 fn item_value_selects(
@@ -1304,7 +1410,13 @@ mod tests {
 
         // The peer query reads the contract three times (targets, cohort,
         // metric_values); each must carry the tenant predicate and its value.
-        let peer = compile_peer_batch_query(&[&sum], &request(), "org_unit", &[]);
+        let peer = compile_peer_batch_query(
+            &[&sum],
+            &request(),
+            "org_unit",
+            PeerPopulation::DeclaredCohort,
+            &[],
+        );
         assert_eq!(peer.sql.matches("tenant_id = ?").count(), 3);
         assert_eq!(
             peer.params
@@ -1338,7 +1450,13 @@ mod tests {
         assert_eq!(ts.params.first().map(String::as_str), Some(TEST_TENANT_STR));
 
         // All three peer reads (targets, cohort, metric_values) bypass together.
-        let peer = compile_peer_batch_query(&[&sum], &req, "org_unit", &[]);
+        let peer = compile_peer_batch_query(
+            &[&sum],
+            &req,
+            "org_unit",
+            PeerPopulation::DeclaredCohort,
+            &[],
+        );
         assert_eq!(peer.sql.matches("(tenant_id = ? OR 1 = 1)").count(), 3);
         assert_eq!(peer.sql.matches('?').count(), peer.params.len());
     }
@@ -1485,7 +1603,13 @@ mod tests {
     #[test]
     fn peer_batch_keeps_cohort_ctes_and_param_order() {
         let sum = sum_metric();
-        let query = compile_peer_batch_query(&[&sum], &request(), "org_unit", &[]);
+        let query = compile_peer_batch_query(
+            &[&sum],
+            &request(),
+            "org_unit",
+            PeerPopulation::DeclaredCohort,
+            &[],
+        );
         assert!(
             query
                 .sql
@@ -1519,13 +1643,59 @@ mod tests {
     }
 
     #[test]
+    fn flat_peer_batch_uses_every_measured_person_as_one_population() {
+        let sum = sum_metric();
+        let query =
+            compile_peer_batch_query(&[&sum], &request(), "org_unit", PeerPopulation::Tenant, &[]);
+
+        assert!(!query.sql.contains("metric_entity_cohorts_current"));
+        assert!(query.sql.contains("arrayJoin([?, ?]) AS entity_id"));
+        assert!(
+            query.sql.contains(
+                "population_stats AS (\n            SELECT\n                1 AS join_key"
+            )
+        );
+        assert!(query.sql.contains("CROSS JOIN population_stats"));
+        assert!(!query.sql.contains("ON 1 = 1"));
+        assert!(query.sql.contains("target_values.m0 AS m0_target"));
+        assert!(
+            query
+                .sql
+                .contains("population_stats.m0_median AS m0_median")
+        );
+        assert_eq!(query.sql.matches("tenant_id = ?").count(), 1);
+        assert_eq!(
+            query.params,
+            vec![
+                "00000000-0000-0000-0000-00000000000a",
+                "00000000-0000-0000-0000-00000000000b",
+                "ai_usage",
+                "accepted_lines",
+                TEST_TENANT_STR,
+                "person",
+                "2026-01-01",
+                "2026-01-31",
+                "ai_usage",
+                "accepted_lines",
+            ]
+        );
+        assert_eq!(query.sql.matches('?').count(), query.params.len());
+    }
+
+    #[test]
     fn peer_batch_never_fabricates_zero_observations() {
         // Honest-null through the runtime: cohort members without observed
         // values stay NULL and drop out of the pool per metric — absence of
         // rows cannot be distinguished from "not covered by the source", so
         // the peer query must not invent zeros for them.
         let (sum, ratio) = (sum_metric(), ratio_metric());
-        let query = compile_peer_batch_query(&[&sum, &ratio], &request(), "org_unit", &[]);
+        let query = compile_peer_batch_query(
+            &[&sum, &ratio],
+            &request(),
+            "org_unit",
+            PeerPopulation::DeclaredCohort,
+            &[],
+        );
         assert!(query.sql.contains("sumIfOrNull"));
         assert!(!query.sql.contains("coalesce"));
         assert!(query.sql.contains("metric_values.m0 AS m0"));
@@ -1534,7 +1704,13 @@ mod tests {
     #[test]
     fn peer_batch_guards_every_percentile_per_item() {
         let (sum, ratio) = (sum_metric(), ratio_metric());
-        let query = compile_peer_batch_query(&[&sum, &ratio], &request(), "org_unit", &[]);
+        let query = compile_peer_batch_query(
+            &[&sum, &ratio],
+            &request(),
+            "org_unit",
+            PeerPopulation::DeclaredCohort,
+            &[],
+        );
         for item in 0..2 {
             let guard =
                 format!("uniqExactIf(peer.entity_id, peer.m{item} IS NOT NULL) >= {MIN_PEER_N}");
@@ -1588,9 +1764,15 @@ mod tests {
                 .contains(&limit)
         );
         assert!(
-            compile_peer_batch_query(&[&ratio], &request(), "org_unit", &[])
-                .sql
-                .contains(&limit)
+            compile_peer_batch_query(
+                &[&ratio],
+                &request(),
+                "org_unit",
+                PeerPopulation::DeclaredCohort,
+                &[],
+            )
+            .sql
+            .contains(&limit)
         );
     }
 
@@ -1613,6 +1795,7 @@ mod tests {
                 &[&sum, &median, &ratio, &distinct],
                 &request(),
                 "org_unit",
+                PeerPopulation::DeclaredCohort,
                 &[],
             ),
         ] {
@@ -1628,7 +1811,13 @@ mod tests {
         // medians). Placeholder/param lockstep still holds.
         for query in [
             compile_period_batch_query(&[&median_metric()], &request(), &[]),
-            compile_peer_batch_query(&[&median_metric()], &request(), "org_unit", &[]),
+            compile_peer_batch_query(
+                &[&median_metric()],
+                &request(),
+                "org_unit",
+                PeerPopulation::DeclaredCohort,
+                &[],
+            ),
         ] {
             assert!(
                 query.sql.contains(
@@ -1664,7 +1853,13 @@ mod tests {
         // the builder zero-fills distinct counts like sums. Lockstep holds.
         for query in [
             compile_period_batch_query(&[&distinct_count_metric()], &request(), &[]),
-            compile_peer_batch_query(&[&distinct_count_metric()], &request(), "org_unit", &[]),
+            compile_peer_batch_query(
+                &[&distinct_count_metric()],
+                &request(),
+                "org_unit",
+                PeerPopulation::DeclaredCohort,
+                &[],
+            ),
         ] {
             assert!(
                 query
@@ -1802,7 +1997,13 @@ mod tests {
             period.sql
         );
         assert_eq!(period.sql.matches('?').count(), period.params.len());
-        let peer = compile_peer_batch_query(&[&def], &request(), "org_unit", &[]);
+        let peer = compile_peer_batch_query(
+            &[&def],
+            &request(),
+            "org_unit",
+            PeerPopulation::DeclaredCohort,
+            &[],
+        );
         assert!(
             peer.sql.contains("if((metric_values.m0) IS NULL, NULL,"),
             "peer carry must transform before percentiles: {}",

--- a/src/backend/services/analytics/src/domain/metric_results/mod.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/mod.rs
@@ -6,8 +6,8 @@ mod validation;
 mod view;
 
 pub use batch::{
-    BatchItem, PeerWideRow, PeriodWideRow, PlannedQuery, UnbatchedView, demux_peer_rows,
-    demux_period_rows, plan_queries, plan_rankings,
+    BatchItem, PeerPopulation, PeerWideRow, PeriodWideRow, PlannedQuery, UnbatchedView,
+    demux_peer_rows, demux_period_rows, plan_queries, plan_rankings,
 };
 pub use builder::{
     build_breakdown_view, build_histogram_view, build_metric_result, build_peer_view,

--- a/src/backend/services/identity-resolution/helm/tests/test_umbrella_analytics_config_contract.py
+++ b/src/backend/services/identity-resolution/helm/tests/test_umbrella_analytics_config_contract.py
@@ -18,6 +18,16 @@ def _analytics_config(manifests: str) -> dict:
     return host["gears"]["analytics"]["config"]
 
 
+def _analytics_secret(manifests: str) -> dict:
+    docs = [doc for doc in yaml.safe_load_all(manifests) if isinstance(doc, dict)]
+    secrets = [
+        doc for doc in docs if doc.get("kind") == "Secret" and doc["metadata"]["name"] == "insight-analytics-config"
+    ]
+    assert len(secrets) == 1, f"expected one analytics config Secret, got {len(secrets)}"
+
+    return secrets[0]["stringData"]
+
+
 @pytest.mark.parametrize(
     ("extra", "expected"), [((), False), (("--set", "analytics.metricCatalog.tenantMetricsEnabled=true"), True)]
 )
@@ -26,3 +36,18 @@ def test_tenant_metrics_are_opt_in_per_installation(umbrella_deps, extra: tuple[
     assert code == 0, err
 
     assert _analytics_config(out)["metric_catalog"]["tenant_metrics_enabled"] is expected
+
+
+def test_analytics_visibility_policy_reuses_identity_resolution_setting(umbrella_deps) -> None:
+    code, out, err = render(
+        umbrella_deps,
+        *UMBRELLA_BASE,
+        "--set",
+        f"global.tenantDefaultId={TENANT}",
+        "--set",
+        "identityResolution.visibilityPolicy=flat",
+    )
+    assert code == 0, err
+
+    key = "APP__gears__analytics__config__visibility_policy"
+    assert _analytics_secret(out)[key] == "flat"

--- a/src/frontend/src/components/portal/domain-lens-view.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.tsx
@@ -33,6 +33,7 @@ import {
 import { GROUPS } from "@/lib/insight/groups";
 import type { PersonCoverage } from "@/lib/insight/coverage";
 import { useScopeCoverage } from "@/lib/portal/use-scope-coverage";
+import { useVisibilityPolicy } from "@/queries/identity-me";
 import {
   availableSlices,
   cohortKey,
@@ -54,6 +55,7 @@ import { githubRepoUrl } from "@/lib/metrics/provider-links";
 import { formatMetricValue } from "@/lib/format";
 import { seriesColors } from "@/lib/series-colors";
 import { mergeEventHistogram } from "@/lib/portal/event-histogram";
+import { peerPopulationLabel } from "@/lib/portal/use-cohort-label";
 import {
   distribution,
   familyObserved,
@@ -108,6 +110,7 @@ export function DomainLensView({
   const { period, dateRange } = usePortalPeriod();
 
   const orgScope = useOrgScope();
+  const { isFlat } = useVisibilityPolicy();
   const { pivot, roster } = orgScope;
   // The roster IS the member list: identity owns who is on the team and
   // every metric for them comes from `/v1/metric-results`. There is no second
@@ -285,7 +288,10 @@ export function DomainLensView({
     () => (id: string) => cohortKey(attrByEntity.get(id), slice),
     [attrByEntity, slice]
   );
-  const cohortLabel = slice ? (sliceLabel ?? "cohort").toLowerCase() : "team";
+  const cohortLabel = peerPopulationLabel(
+    slice ? (sliceLabel ?? "cohort") : null,
+    isFlat
+  );
 
   const gate = orgScopeGate({
     viewerLoading: orgScope.isLoading,

--- a/src/frontend/src/lib/portal/use-cohort-label.test.tsx
+++ b/src/frontend/src/lib/portal/use-cohort-label.test.tsx
@@ -17,13 +17,23 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { identityPerson, pid } from "@/test/identity";
 import type { IdentityPerson } from "@/types/insight";
 
-const mocks = vi.hoisted(() => ({ tree: undefined as IdentityPerson | undefined }));
+const mocks = vi.hoisted(() => ({
+  tree: undefined as IdentityPerson | undefined,
+  isFlat: false,
+}));
 
 vi.mock("@/auth", () => ({
   useViewer: () => ({ email: "boss@x", personId: pid("boss") }),
 }));
 vi.mock("@/queries/ic-dashboard", () => ({
   useIcPerson: () => ({ data: mocks.tree }),
+}));
+vi.mock("@/queries/identity-me", () => ({
+  useVisibilityPolicy: () => ({
+    policy: mocks.isFlat ? "flat" : "org_chart",
+    isFlat: mocks.isFlat,
+    isPending: false,
+  }),
 }));
 
 import { portalRouter } from "@/test/portal-router";
@@ -33,11 +43,12 @@ import { useCohortLabel } from "./use-cohort-label";
 const person = (
   label: string,
   attrs: Partial<IdentityPerson> = {},
-  subs: IdentityPerson[] = [],
+  subs: IdentityPerson[] = []
 ): IdentityPerson => identityPerson(label, attrs, subs);
 
 beforeEach(() => {
   portalRouter.reset();
+  mocks.isFlat = false;
   // A roster that offers two real dimensions, so a slice has something to name.
   mocks.tree = person("boss", {}, [
     person("a", { division: "R&D", job_title: "Engineer" }),
@@ -49,6 +60,14 @@ beforeEach(() => {
 describe("useCohortLabel", () => {
   it("says 'team' when the roster is one undivided cohort", () => {
     expect(renderHook(() => useCohortLabel()).result.current).toBe("team");
+  });
+
+  it("says 'organisation' when flat visibility makes the whole org the cohort", () => {
+    mocks.isFlat = true;
+
+    expect(renderHook(() => useCohortLabel()).result.current).toBe(
+      "organisation"
+    );
   });
 
   it("names the active slice's own dimension", () => {

--- a/src/frontend/src/lib/portal/use-cohort-label.ts
+++ b/src/frontend/src/lib/portal/use-cohort-label.ts
@@ -5,20 +5,8 @@ import { availableSlices, collectRosterAttrs } from "@/lib/insight/slices";
 import { normalizePersonId } from "@/lib/metrics/entity";
 import { usePortalSlice } from "@/lib/portal/portal-nav";
 import { useIcPerson } from "@/queries/ic-dashboard";
+import { useVisibilityPolicy } from "@/queries/identity-me";
 
-/**
- * The noun a peer comparison should use: the active slice's own label, or
- * "team" when the roster is one undivided cohort.
- *
- * It exists because three surfaces hardcoded a label while injecting peer stats
- * from whatever cohort the slice defined — so with slice=Manager the UI read
- * "vs department median" over manager-cohort numbers. A comparison that names
- * the wrong pool is worse than one that names none: the reader draws a
- * conclusion about the wrong group of people.
- *
- * Derived from the viewer's whole org, like the slice control itself, so every
- * surface says the same thing about the same slice.
- */
 /**
  * The label reads mid-sentence ("above the division median"), so a plain
  * capitalised word is lowered. Anything else is left as authored: identity
@@ -29,18 +17,26 @@ function midSentence(label: string): string {
   return /^[A-Z][a-z]*$/.test(label) ? label.toLowerCase() : label;
 }
 
-/**
- * The noun every peer comparison uses: the slice's own dimension when one is
- * active, "team" otherwise. One source, so no two surfaces name it differently.
- */
+export function peerPopulationLabel(
+  sliceLabel: string | null,
+  isFlat: boolean
+): string {
+  if (sliceLabel) return midSentence(sliceLabel);
+  return isFlat ? "organisation" : "team";
+}
+
 export function useCohortLabel(): string {
   const slice = usePortalSlice();
+  const { isFlat } = useVisibilityPolicy();
   const { personId } = useViewer();
   const tree = useIcPerson(personId ?? "").data ?? null;
   const dims = useMemo(
     () => availableSlices(collectRosterAttrs(tree, normalizePersonId).values()),
-    [tree],
+    [tree]
   );
-  if (!slice) return "team";
-  return midSentence(dims.find((d) => d.key === slice)?.label ?? "cohort");
+  const sliceLabel = slice
+    ? (dims.find((dimension) => dimension.key === slice)?.label ?? "cohort")
+    : null;
+
+  return peerPopulationLabel(sliceLabel, isFlat);
 }


### PR DESCRIPTION
Depends on #2743.

**Why.** Flat installations have no org-unit cohort rows, so peer comparisons return no distribution even though everyone belongs to one visible organisation.

**What changed.** Analytics shares identity's visibility policy: `org_chart` retains declared cohorts; `flat` uses all measured tenant people and computes their distribution once per batch. Peer labels say "organisation" in flat mode.

**Flat is deployment-wide.** This keeps human and service callers consistent; switching to `org_chart` restores declared-cohort behavior.

**Evidence.** A compiler regression verifies one tenant-population aggregate per batch without reading org-unit cohorts. UI wording is unit-tested; no browser screenshot was captured.

**Verified.** Cargo fmt/clippy and 461 tests; frontend lint/typecheck and 1,917 tests; Helm lint plus 31 contracts; generated models. OpenAPI drift was not rerun.
