### PR TITLE
fix(portal): count the signed-in viewer into the flat-org scope

### DIFF
--- a/src/frontend/src/lib/portal/use-org-scope.test.ts
+++ b/src/frontend/src/lib/portal/use-org-scope.test.ts
@@ -105,25 +105,25 @@ describe("flatOrgScope", () => {
     { person_id: "p-c", display_name: "Cyd" },
   ];
 
-  it("counts everyone the viewer may see except the viewer", () => {
-    // The org zones read the roster as "the people this frame is about"; the
-    // viewer reads their own numbers on their Person page, as in a subtree.
-    const scope = flatOrgScope(roster, "p-me");
+  it("counts everyone the viewer may see, the viewer included", () => {
+    // The scope counts the ORGANISATION: a head-count that changed with who
+    // is looking disagreed with the roster listed right beside it (#2724).
+    const scope = flatOrgScope(roster);
 
-    expect(scope.roster?.map((r) => r.person_id)).toEqual(["p-b", "p-c"]);
-    expect(scope.count).toBe(2);
+    expect(scope.roster?.map((r) => r.person_id)).toEqual(["p-me", "p-b", "p-c"]);
+    expect(scope.count).toBe(3);
   });
 
   it("offers no manager nodes and no direct-only cut", () => {
     // Nothing to pick and nothing to narrow: one organisation, one cohort.
-    const scope = flatOrgScope(roster, "p-me");
+    const scope = flatOrgScope(roster);
 
     expect(scope.managerNodes).toEqual([]);
     expect(scope.canDirectOnly).toBe(false);
   });
 
   it("names the organisation rather than a person", () => {
-    const scope = flatOrgScope(roster, "p-me");
+    const scope = flatOrgScope(roster);
 
     expect(scope.label).toBe("Whole organisation");
   });
@@ -131,13 +131,9 @@ describe("flatOrgScope", () => {
   it("carries every naming field a person label reads (#2711)", () => {
     // The roster entry is what the zones label people by; dropping username
     // here would blank every person the org chart never named.
-    const scope = flatOrgScope(
-      [
-        { person_id: "p-me", display_name: "Me" },
-        { person_id: "p-h", display_name: "", username: "handle", email: "" },
-      ],
-      "p-me",
-    );
+    const scope = flatOrgScope([
+      { person_id: "p-h", display_name: "", username: "handle", email: "" },
+    ]);
 
     expect(scope.roster).toEqual([
       {
@@ -151,16 +147,9 @@ describe("flatOrgScope", () => {
     ]);
   });
 
-  it("keeps a roster it cannot place the viewer in", () => {
-    // A viewer absent from their own roster is a bug elsewhere; dropping every
-    // row here would report it as "you can see nobody".
-    const scope = flatOrgScope(roster, "p-unknown");
-
-    expect(scope.count).toBe(3);
-  });
 
   it("has no roster before the answer arrives", () => {
-    const scope = flatOrgScope(null, "p-me");
+    const scope = flatOrgScope(null);
 
     expect(scope.roster).toBeNull();
     expect(scope.count).toBe(0);

--- a/src/frontend/src/lib/portal/use-org-scope.ts
+++ b/src/frontend/src/lib/portal/use-org-scope.ts
@@ -51,13 +51,12 @@ export const WHOLE_ORG_LABEL = "Whole organisation";
  * Scope resolution for an organisation with no reporting lines.
  *
  * There is one cohort — everyone the viewer may see — so there is no pivot to
- * pick and nothing for `directOnly` to narrow. The viewer is left out of the
- * roster for the same reason a manager is left out of their subtree's: they read
- * their own numbers on their Person page.
+ * pick and nothing for `directOnly` to narrow. The viewer stays in: this scope
+ * counts the organisation, and an org-level head-count that changes with who
+ * is looking disagrees with the roster listed right beside it (#2724).
  */
 export function flatOrgScope(
   roster: readonly PersonSummary[] | null,
-  viewerPersonId: string | null,
 ): ResolvedScope {
   if (!roster) {
     return {
@@ -70,18 +69,15 @@ export function flatOrgScope(
     };
   }
 
-  const viewer = viewerPersonId?.toLowerCase() ?? null;
-  const members: RosterEntry[] = roster
-    .filter((person) => person.person_id.toLowerCase() !== viewer)
-    .map((person) => ({
-      person_id: person.person_id,
-      email: person.email ?? "",
-      display_name: person.display_name ?? "",
-      username: person.username ?? "",
-      // No reporting lines to name, and no depth to be at.
-      supervisor_person_id: null,
-      is_direct: false,
-    }));
+  const members: RosterEntry[] = roster.map((person) => ({
+    person_id: person.person_id,
+    email: person.email ?? "",
+    display_name: person.display_name ?? "",
+    username: person.username ?? "",
+    // No reporting lines to name, and no depth to be at.
+    supervisor_person_id: null,
+    is_direct: false,
+  }));
 
   return {
     pivot: null,
@@ -168,7 +164,7 @@ export function useOrgScope(): ResolvedScope & {
   const resolved = useMemo(
     () =>
       isFlat
-        ? flatOrgScope(flatRoster.isPending ? null : flatRoster.roster, personId)
+        ? flatOrgScope(flatRoster.isPending ? null : flatRoster.roster)
         : resolveScopeRoster(viewerQ.data ?? null, personId, scope),
     [isFlat, flatRoster.isPending, flatRoster.roster, viewerQ.data, personId, scope],
   );


### PR DESCRIPTION
Closes #2724.

**Why.** On a flat-visibility installation the team header, Overview, Trend and the attention summary all count one person fewer than the roster beside them — the signed-in viewer — so the org head-count changes with who is looking.

**What changed.** `flatOrgScope` no longer filters the viewer out of the flat-org roster, so every org surface counts the same people the roster lists. The hierarchical path is untouched — a manager still stays out of their own team's table.

**Verified.** tsc, eslint on the touched files, and the full frontend unit suite (1913 tests in 205 files) locally.
