### PR TITLE
perf(tests): cut the stand suite from four minutes to under one

### DIFF
--- a/tests/lib/insight_stand/api.py
+++ b/tests/lib/insight_stand/api.py
@@ -24,13 +24,15 @@ and the media-type cases whose whole point is that the body was refused.
 
 from __future__ import annotations
 
+import atexit
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol
 
 from . import coverage
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
+    import httpx
     from pydantic import BaseModel
 
 
@@ -164,8 +166,18 @@ class ApiClient:
     #: wants to must say so.
     edge_fronted: bool = True
 
+    _http: httpx.Client | None = field(default=None, init=False, repr=False, compare=False)
+
     def __post_init__(self) -> None:
         self.base_url = self.base_url.rstrip("/")
+
+    def _transport(self) -> httpx.Client:
+        import httpx
+
+        if self._http is None:
+            self._http = httpx.Client(timeout=self.timeout_s, follow_redirects=False)
+            atexit.register(self._http.close)
+        return self._http
 
     # -- construction ------------------------------------------------------
 
@@ -200,23 +212,23 @@ class ApiClient:
         if json_body is not None and content is not None:
             raise ValueError("pass json_body or content, not both")
 
-        import httpx
-
         checked_path = self._checked_path(path)
         url = f"{self.base_url}{checked_path}"
         merged: dict[str, str] = dict(self.session.headers()) if self.session else {}
         if headers:
             merged.update(headers)
 
-        with httpx.Client(timeout=self.timeout_s, follow_redirects=False) as client:
-            response = client.request(
-                method,
-                url,
-                params=params,
-                json=json_body,
-                content=content,
-                headers=merged,
-            )
+        client = self._transport()
+        # SAFETY: a pooled jar would carry a cookie into the unauthenticated client.
+        client.cookies.clear()
+        response = client.request(
+            method,
+            url,
+            params=params,
+            json=json_body,
+            content=content,
+            headers=merged,
+        )
         # Every request the suite makes passes through here, which is what lets
         # the coverage ledger be a byproduct of the tests rather than a list
         # somebody maintains. Metadata only — never the body.

--- a/tests/stand/api/analytics/test_drilldown.py
+++ b/tests/stand/api/analytics/test_drilldown.py
@@ -84,6 +84,9 @@ _PAGE_LIMIT = 250
 #: than reconciled against a prefix.
 _PAGE_BUDGET = 40
 
+#: At limit=1 the walk costs one round trip per evidence row, so this stays small.
+_SINGLE_ROW_PAGE_BUDGET = 4
+
 #: Aggregation order differs between the service (vectorized `sumIf` over
 #: `Float64`) and this suite (row-ordered `sum`), and that is the only error
 #: source — the transport is lossless both ways.
@@ -884,7 +887,7 @@ def test_git_commit_drilldown_pages_and_reconciles(
         api,
         stand_manifest,
         GIT_COMMITS,
-        limit=1,
+        limit=_PAGE_LIMIT,
         filters=[{"dimension": "source", "values": ["github"]}],
         display_dimensions=["repository"],
     )
@@ -911,12 +914,48 @@ def test_git_commit_drilldown_pages_and_reconciles(
 
 @pytest.mark.requires_seed("dev_lead")
 @pytest.mark.reliability
+def test_git_commit_drilldown_pages_a_row_at_a_time(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """Consecutive one-row pages neither repeat nor skip a row.
+
+    Compared against the prefix of the bulk walk: `_walk` on its own catches a
+    repeated cursor, never a dropped or duplicated row.
+    """
+    filters: Sequence[JsonValue] = [{"dimension": "source", "values": ["github"]}]
+    single = _walk(
+        api,
+        stand_manifest,
+        GIT_COMMITS,
+        limit=1,
+        filters=filters,
+        display_dimensions=["repository"],
+        page_budget=_SINGLE_ROW_PAGE_BUDGET,
+    )
+    bulk = _walk(
+        api,
+        stand_manifest,
+        GIT_COMMITS,
+        limit=_PAGE_LIMIT,
+        filters=filters,
+        display_dimensions=["repository"],
+    )
+
+    assert len(single.rows) == _SINGLE_ROW_PAGE_BUDGET, (
+        "the seeded evidence set is shorter than the budget, so this walk never "
+        "paginated and proves nothing about the cursor"
+    )
+    assert single.rows == bulk.rows[:_SINGLE_ROW_PAGE_BUDGET]
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.reliability
 def test_git_commit_drilldown_exports_all_rows(api: ApiClient, stand_manifest: Manifest) -> None:
     walk = _walk(
         api,
         stand_manifest,
         GIT_COMMITS,
-        limit=1,
+        limit=_PAGE_LIMIT,
         filters=[{"dimension": "source", "values": ["github"]}],
         display_dimensions=["repository"],
     )


### PR DESCRIPTION
**Why.** The deployed-stand suite ran four minutes locally, and two tests were 76% of it — 184s of 242s.

**What changed.** Both walked the whole `git.commits` evidence set at `limit=1`, one HTTP round trip per row. The cost is the round trip, not the page, so they now ask at `_PAGE_LIMIT` (250) like every other walk in the file.

**The one-row page is replaced, not dropped.** The module docstring claims it as covered, so a bounded 4-page walk now checks against the bulk walk's prefix — `_walk` alone catches a repeated cursor, never a dropped row.

**`ApiClient` pools its connection and clears the cookie jar each send.** It built and discarded an `httpx.Client` per call. A pooled jar would otherwise carry a `Set-Cookie` into the fixture that must stay unauthenticated.

Measured on a local compose stand, same 2867 seeded evidence rows either way:

| | before | after |
|---|---|---|
| full suite | 241.9s | 54.8s |
| `..._pages_and_reconciles` | 98.3s | 0.49s |
| `..._exports_all_rows` | 85.6s | 0.84s |
| API subset, median of 3 | 16.34s | 13.84s |

**Verified.** 392 passed / 1 skipped / 2 xfailed, both xfails pre-declared, plus the opt-in `rebuild_lane`. Cookie isolation checked by planting a session cookie and confirming the unauthenticated client still gets 401.
