### PR TITLE
fix(ingestion): heal the task field-history title column on warm clusters

### DIFF
--- a/src/ingestion/scripts/apply-ch-migrations.sh
+++ b/src/ingestion/scripts/apply-ch-migrations.sh
@@ -166,6 +166,24 @@ SQL
 
 heal_task_users_table silver class_task_users
 
+# Same positional invariant, one relation further along: class_task_field_history
+# gained `title` after `id_readable` (#2739) so evidence rows can name the work
+# item. The connectors-ddl snapshot only CREATEs IF NOT EXISTS, so a warm
+# installation keeps the old column list, and the gold build fails resolving
+# `fh.title`. Staging needs no heal — github's member is a table rebuilt every
+# run, and jira's is altered by the DDL macro that owns it.
+heal_task_field_history_table() {
+  local db="$1" table="$2"
+  ch_table_is_real "$db" "$table" || return 0
+  echo "  ${db}.${table}"
+  run_ch <<SQL
+ALTER TABLE ${db}.${table} ADD COLUMN IF NOT EXISTS title Nullable(String) AFTER id_readable;
+ALTER TABLE ${db}.${table} MODIFY COLUMN title Nullable(String) AFTER id_readable;
+SQL
+}
+
+heal_task_field_history_table silver class_task_field_history
+
 echo "=== Healing git file-change object id columns ==="
 # The file-change object ids arrive at the tail of every projection that feeds
 # class_git_file_changes. Pre-existing tables lack them and the positional


### PR DESCRIPTION
**Why.** Upgrading a warm installation fails at the post-upgrade hook: the gold build dies with `Code: 47 … Identifier 'fh.title' cannot be resolved`, and Helm marks the whole release failed. #2739 added `title` to `silver.class_task_field_history`, but the only DDL path for that relation is the connectors-ddl snapshot, which `CREATE`s `IF NOT EXISTS` — an existing table keeps its old column list. The model is incremental and sets no `on_schema_change`, so dbt's default `ignore` drops the column from the insert rather than adding it. Fresh installs are fine; every warm one breaks.

**What changed.** An idempotent heal before the gold build, in the same place and shape as the two that precede it (`heal_collab_chat_table`, `heal_task_users_table`): `ADD COLUMN IF NOT EXISTS title … AFTER id_readable`, then `MODIFY COLUMN … AFTER id_readable` so a column added by hand at the tail lands in the contract's position. Guarded by `ch_table_is_real`, which skips placeholder tables that have no `id_readable` to anchor to.

**Staging needs no heal, and the comment says why.** github's member of the union is a table rebuilt on every run; jira's is altered by the DDL macro that owns it, which #2739 already updated. Only the silver class table persists across deploys with a stale shape.

**Out of scope.** This is the fourth instance of one failure mode — a new column in an incremental silver model, invisible to a snapshot that only creates. The general fix, and why neither existing gate caught it, is #2753; this PR unblocks the deployments failing now.

**Verified.** `bash -n` on the script. The mechanism is the one already exercised by the neighbouring heals on every deploy, and the failure it addresses is reproduced in cfabric's release history (revisions 38 and 39, both `post-upgrade hooks failed: Job/insight/insight-clickhouse-migrate … Failed`) and in the test-stand deploy that went red 14 minutes after #2739 merged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration reliability by automatically repairing the task field history table when its structure is incomplete or inconsistent.
  * Ensures the optional title field is available and consistently positioned after the readable ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->