### PR TITLE
feat(seed): publish the stand manifest to a durable ConfigMap

### DIFF
--- a/.github/workflows/deploy-test-stand.yml
+++ b/.github/workflows/deploy-test-stand.yml
@@ -553,6 +553,20 @@ jobs:
 
       # BETWEEN capture and upload, and always — a failed run is exactly when a
       # trace exists. A Playwright trace replays a real signed-in session: it
+      # Affirms the durable copy matches what this run emitted, so phase 2 can
+      # let readers depend on it. Last and always(): a broken publish turns the
+      # run red without blocking the smoke or suite stages of a seeded stand.
+      - name: Verify the published seed manifest
+        if: ${{ always() && steps.seed.outcome == 'success' }}
+        run: |
+          set -euo pipefail
+          kubectl -n "$STAND_NAMESPACE" get configmap seed-stand-manifest \
+            -o 'go-template={{index .data "manifest"}}' > "$RUNNER_TEMP/stand-manifest-cm.json"
+          diff -q <(jq -S . "$RUNNER_TEMP/stand-manifest.json") \
+                  <(jq -S . "$RUNNER_TEMP/stand-manifest-cm.json") >/dev/null \
+            || { echo "::error::configmap/seed-stand-manifest does not match the manifest this run emitted."; exit 1; }
+          echo "seed-stand-manifest matches the run's manifest"
+
       # carries the session cookie and every Authorization header. The script
       # fails closed — a trace it cannot rewrite and verify is deleted. It
       # opens `*.zip` and nothing else, which is why no video is captured

--- a/.github/workflows/deploy-test-stand.yml
+++ b/.github/workflows/deploy-test-stand.yml
@@ -463,9 +463,10 @@ jobs:
             "${force_args[@]}" \
             > "$RUNNER_TEMP/seed.log" 2>&1 || seed_rc=$?
 
-          # One sentinel line, written by insight_seed/manifest.py:write_manifest.
+          # One plain sentinel line, or gzipped chunks past ~64 personas;
+          # manifest-from-log.sh normalises either form.
           manifest_rc=0
-          grep -m1 '^SEED_MANIFEST_JSON: ' "$RUNNER_TEMP/seed.log" \
+          ./src/ingestion/tools/seed/manifest-from-log.sh "$RUNNER_TEMP/seed.log" \
             | cut -d' ' -f2- > "$RUNNER_TEMP/stand-manifest.json" || manifest_rc=$?
 
           if [ "$seed_rc" -eq 0 ] && [ "$manifest_rc" -eq 0 ]; then
@@ -480,7 +481,7 @@ jobs:
           # reach the public log, never the pod log it follows.
           echo "::error::the seed stage failed."
           [ "$seed_rc" -eq 0 ] || echo "::error::seed-stand.sh exited $seed_rc."
-          [ "$manifest_rc" -eq 0 ] || echo "::error::no SEED_MANIFEST_JSON line in the seed log — the seeder did not reach the end of its run."
+          [ "$manifest_rc" -eq 0 ] || echo "::error::no manifest sentinel in the seed log — the seeder did not reach the end of its run."
           grep -E '^(==>|ERROR:)' "$RUNNER_TEMP/seed.log" | python3 "$REDACT" || true
           echo "The full seed log (cluster and pod output) stays on the runner in \$RUNNER_TEMP;"
           echo "it is not published. While the Job survives (an hour, backoffLimit 0), read it"

--- a/.github/workflows/run-stand-suite.yml
+++ b/.github/workflows/run-stand-suite.yml
@@ -171,7 +171,7 @@ jobs:
           fi
           echo "reading the manifest from $job"
           kubectl -n "$STAND_NAMESPACE" logs "$job" --tail=-1 2>/dev/null \
-            | grep -m1 '^SEED_MANIFEST_JSON: ' | cut -d' ' -f2- \
+            | ./src/ingestion/tools/seed/manifest-from-log.sh | cut -d' ' -f2- \
             > "$RUNNER_TEMP/stand-manifest.json" || true
           if ! jq -e '.manifest_version' "$RUNNER_TEMP/stand-manifest.json" >/dev/null 2>&1; then
             echo "::error::$job carries no manifest sentinel — it did not reach the end of its run."
@@ -193,7 +193,7 @@ jobs:
           ./src/ingestion/tools/seed/seed-stand.sh \
             -n "$STAND_NAMESPACE" --context "$kube_context" --days 730 \
             > "$RUNNER_TEMP/seed.log" 2>&1 || seed_rc=$?
-          grep -m1 '^SEED_MANIFEST_JSON: ' "$RUNNER_TEMP/seed.log" \
+          ./src/ingestion/tools/seed/manifest-from-log.sh "$RUNNER_TEMP/seed.log" \
             | cut -d' ' -f2- > "$RUNNER_TEMP/stand-manifest.json" || true
           if [ "$seed_rc" -eq 0 ] && jq -e '.manifest_version' "$RUNNER_TEMP/stand-manifest.json" >/dev/null 2>&1; then
             echo "personas=$(jq '.personas | length' "$RUNNER_TEMP/stand-manifest.json") window=$(jq -r '.data_window' "$RUNNER_TEMP/stand-manifest.json")"

--- a/deploy/gitops/Makefile
+++ b/deploy/gitops/Makefile
@@ -900,6 +900,7 @@ verify-ci-credential: vpn-up kube-ctx
 	check yes "create jobs in $(NS_APP) (seed stage renders a Job)"          create jobs -n $(NS_APP); \
 	check yes "get pods/log in $(NS_APP) (seed + diagnostics)"               get pods/log -n $(NS_APP); \
 	check yes "create secrets in $(NS_APP) (helm release storage)"          create secrets -n $(NS_APP); \
+	check yes "create configmaps in $(NS_APP) (seed-stand.sh publishes the manifest)" create configmaps -n $(NS_APP); \
 	check yes "update deployments in $(NS_APP) (helm upgrade, rollout)"     update deployments.apps -n $(NS_APP); \
 	check yes "create Roles in $(NS_APP) (chart renders its own RBAC)"      create roles.rbac.authorization.k8s.io -n $(NS_APP); \
 	check yes "create WorkflowTemplates in $(NS_APP)"                        create workflowtemplates.argoproj.io -n $(NS_APP); \

--- a/deploy/gitops/Makefile
+++ b/deploy/gitops/Makefile
@@ -416,7 +416,9 @@ keycloak-realm: kube-ctx values-present
 	echo "$(C_GRN)→$(C_RST) generating Keycloak realm (dev-lead $$DEV_EMAIL; redirects $$REDIRECT, $$LB_REDIRECT)"; \
 	TENANT_ID="$$(yq -r '.global.tenantDefaultId // ""' $(VALUES))"; \
 	[ -n "$$TENANT_ID" ] || { echo "$(C_RED)global.tenantDefaultId is required to generate the realm$(C_RST)"; exit 1; }; \
-	TENANT_DEFAULT_ID="$$TENANT_ID" uv run --project "$$SEED_DIR" insight-seed-realm --dev-email "$$DEV_EMAIL" \
+	: "$${SEED_ORG_HEADCOUNT:=}"; \
+	[ -z "$$SEED_ORG_HEADCOUNT" ] || echo "$(C_GRN)→$(C_RST) realm sized for SEED_ORG_HEADCOUNT=$$SEED_ORG_HEADCOUNT people"; \
+	SEED_ORG_HEADCOUNT="$$SEED_ORG_HEADCOUNT" TENANT_DEFAULT_ID="$$TENANT_ID" uv run --project "$$SEED_DIR" insight-seed-realm --dev-email "$$DEV_EMAIL" \
 	  --authenticator-redirect "$$REDIRECT" \
 	  --authenticator-redirect "$$LB_REDIRECT" \
 	  --authenticator-secret "$$AUTH_SECRET" \

--- a/deploy/gitops/environments/test-stand/README.md
+++ b/deploy/gitops/environments/test-stand/README.md
@@ -182,8 +182,9 @@ script stops and names `--email` — a statement about the stand (realm absent, 
 step 3 hasn't run), since seeding is downstream of deploying.
 
 The seeder's manifest (personas, fixtures, tenant, window — what the smoke suite
-reads) is printed to the seed Job's stdout. Capture it from the Job log before
-the TTL reaps it, and treat it as run-internal: it carries persona addresses,
+reads) is printed to the seed Job's stdout and, on a completed `--step all`,
+published to `configmap/seed-stand-manifest`, which outlives the Job's TTL.
+Read it from there, and treat it as run-internal: it carries persona addresses,
 UUIDs and in-cluster URLs, so it must never become a CI artifact on a public
 repo.
 

--- a/deploy/gitops/scripts/recreate-test-stand.sh
+++ b/deploy/gitops/scripts/recreate-test-stand.sh
@@ -329,6 +329,8 @@ fi
 
 if [ "$KEEP_DATABASES" != "1" ]; then
   hdr "database wipe"
+  # Unowned by helm, so `uninstall` leaves it describing rows this wipe drops.
+  "${KUBECTL[@]}" -n "$NAMESPACE" delete configmap seed-stand-manifest --ignore-not-found >/dev/null 2>&1 || true
   WIPE_JOB="recreate-wipe-$(date -u +%Y%m%d%H%M%S)"
   wipe_manifest() {
     cat <<YAML

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -734,6 +734,11 @@ services:
       # a test asking about "the seeded period" must clamp — see
       # tests/stand/api/analytics/query_window.
       SEED_DAYS: "${SEED_DAYS:-730}"
+      # Organisation size; empty is the committed 26-person roster. Listed
+      # because compose's `environment` is an allowlist.
+      SEED_ORG_HEADCOUNT: "${SEED_ORG_HEADCOUNT:-}"
+      # Preflight's documented escape hatch; unreachable unless listed here.
+      SEED_FORCE: "${SEED_FORCE:-}"
       # The issuer the authenticator resolved for this run. `test-stand up`
       # persists it after cmd_up so the manifest
       # records the real IdP instead of assuming the default.

--- a/src/ingestion/scripts/apply-ch-migrations.sh
+++ b/src/ingestion/scripts/apply-ch-migrations.sh
@@ -25,7 +25,28 @@
 #   CLICKHOUSE_URL       e.g. http://ch-host:8123  (selects the HTTP backend)
 #   CLICKHOUSE_USER, CLICKHOUSE_PASSWORD
 #   CLICKHOUSE_DATABASE  the Insight app database
+#
+# Options:
+#   --full-refresh   rebuild the selected dbt models from source instead of
+#                    appending to them. The deploy Hook never passes it; the
+#                    seed's silver step does, because a seed REPLACES the org
+#                    and the incremental identity feeders would otherwise
+#                    carry the previous roster forward (see below).
 set -euo pipefail
+
+FULL_REFRESH=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --full-refresh) FULL_REFRESH=1; shift ;;
+    -h|--help)
+      awk 'NR>1 && /^#/ {sub(/^# ?/, ""); print; next} NR>1 {exit}' "${BASH_SOURCE[0]}"
+      exit 0 ;;
+    *)
+      echo "apply-ch-migrations.sh: unknown argument: $1" >&2
+      echo "usage: apply-ch-migrations.sh [--full-refresh]" >&2
+      exit 2 ;;
+  esac
+done
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
@@ -236,7 +257,13 @@ else
 # DBT_GOLD_SELECT widens the selection (space-separated dbt selectors);
 # the seed's silver step adds +identity_inputs, deploys leave it unset.
 read -r -a _dbt_select <<<"${DBT_GOLD_SELECT:-tag:gold}"
-echo "=== Building gold models (dbt run --select ${_dbt_select[*]}) ==="
+# INVARIANT: never export DBT_FULL_REFRESH — reconcile-connectors owns that
+# name, and env reaches every child.
+_dbt_flags=()
+if [[ "$FULL_REFRESH" == "1" ]]; then
+  _dbt_flags+=(--full-refresh)
+fi
+echo "=== Building gold models (dbt run --select ${_dbt_select[*]} ${_dbt_flags[*]:-}) ==="
 # Gold views are dbt-owned but must exist at DEPLOY time, not first-sync
 # time: the analytics service marks metric definitions schema-error while
 # an observation view is missing, which blanks those metrics for every
@@ -289,7 +316,7 @@ profile = {
 with open(os.path.join(os.environ["DBT_PROFILES_DIR"], "profiles.yml"), "w") as f:
     yaml.safe_dump(profile, f)
 PY
-(cd "$SCRIPT_DIR/../dbt" && dbt run --profiles-dir "$DBT_PROFILES_DIR" --log-format json --select "${_dbt_select[@]}")
+(cd "$SCRIPT_DIR/../dbt" && dbt run --profiles-dir "$DBT_PROFILES_DIR" --log-format json --select "${_dbt_select[@]}" ${_dbt_flags[@]+"${_dbt_flags[@]}"})
 rm -rf "$DBT_PROFILES_DIR"
 fi
 

--- a/src/ingestion/tools/seed/PROFILE.md
+++ b/src/ingestion/tools/seed/PROFILE.md
@@ -17,7 +17,7 @@ builder that writes `manifest.json`, so the two cannot disagree.
 | realm | `insight` |
 | anchor_date | `2026-06-30` |
 | data_window | `2026-05-02..2026-06-30` |
-| seed_revision | `1f48ce4dd429d88d` |
+| seed_revision | `aabf82c1080e831c` |
 | manifest_version | 1 |
 
 `anchor_date` is the last day carrying seeded activity. It is resolved

--- a/src/ingestion/tools/seed/README.md
+++ b/src/ingestion/tools/seed/README.md
@@ -249,6 +249,15 @@ Four things to know before pointing it at a stand:
     | ./src/ingestion/tools/seed/manifest-from-log.sh | cut -d' ' -f2- | jq .
   ```
 
+  A completed `--step all` on a cluster stand also publishes the compact
+  document to `configmap/seed-stand-manifest` (key `manifest`), which outlives
+  the Job's one-hour TTL — the copy to prefer once the Job is reaped:
+
+  ```bash
+  kubectl -n <ns> get configmap seed-stand-manifest \
+    -o 'go-template={{index .data "manifest"}}' | jq .
+  ```
+
   The two stand workflows (`run-stand-suite.yml`, `deploy-test-stand.yml`) read
   the manifest through this script, so a CI stand recovers it at any roster
   size. `seed-stand.sh` reassembles it for you as well — a run prints one plain

--- a/src/ingestion/tools/seed/README.md
+++ b/src/ingestion/tools/seed/README.md
@@ -1,7 +1,8 @@
 # Insight sample-data seeder
 
 Populates a stand with a 25-person demo organisation (4 teams + CEO) and
-per-team activity in ClickHouse silver tables. `profiles.py` documents the
+per-team activity in ClickHouse silver tables. That roster is the default and
+the floor; [a bigger organisation](#a-bigger-organisation) is one variable away. `profiles.py` documents the
 roster and the per-team source-type weights; the per-domain generators under
 `generators/` document the row shapes they emit. See
 [PROFILE.md](PROFILE.md) for what a freshly seeded stand actually contains
@@ -128,7 +129,8 @@ the seed writes.
 Useful flags — `--dry-run` prints the rendered Job instead of applying it,
 `--step identity|silver|analytics` runs one step (identity alone needs no
 ClickHouse and finishes in seconds), `--tenant` seeds a tenant of your choosing,
-and `--days` / `--anchor` pin the activity window. `--help` lists the rest.
+`--days` / `--anchor` pin the activity window, and `--org-headcount` seeds a
+[bigger organisation](#a-bigger-organisation). `--help` lists the rest.
 
 Anything the script cannot discover is a hard error naming the flag that supplies
 it — it never falls back to a guess.
@@ -189,6 +191,69 @@ Unset (or the literal `today`), the anchor is yesterday UTC, so the developer
 loop stays populated as the calendar moves. Whichever applied is recorded in
 `manifest.json`, so a stand always reports how to recreate it.
 
+## A bigger organisation
+
+26 people is the committed roster, and it is a *fixture*: CI and the compose
+stand suite resolve named personas out of it by uuid, so nothing may renumber
+it. `SEED_ORG_HEADCOUNT` seeds a larger organisation without disturbing them —
+the committed 26 keep their uuids, emails, names and build order, and the extra
+people are appended after them.
+
+```bash
+SEED_ORG_HEADCOUNT=250 ./dev-compose.sh seed                     # compose
+./src/ingestion/tools/seed/seed-stand.sh -n insight --org-headcount 250
+```
+
+| `SEED_ORG_HEADCOUNT` | Result |
+|---|---|
+| unset, empty, `0`, or `26` | the committed roster, byte for byte |
+| `27`..`3000` | exactly that many people |
+| `1`..`25` | refused — the roster only grows |
+| above `3000`, or not a whole number | refused, naming the ceiling |
+
+The extra people join the four EXISTING teams, round-robin, so the per-team
+source weights keep their ratios. Each team gets squads of at most 8 growth ICs
+under a squad manager, and the squad managers report to that team's existing
+lead; the committed ICs keep reporting to theirs. No new team and no new role is
+invented — `TEAM_PROFILES` and three separate role tables are indexed directly,
+and an unknown key there fails mid-seed.
+
+Four things to know before pointing it at a stand:
+
+- **The ceiling is 3000, and it is about blast radius.** Every person multiplies
+  the per-day rows the generators write, across ten domains and the whole
+  window, so a mistyped headcount is the difference between a stand and an
+  incident. Raise `config.MAX_ORG_HEADCOUNT` deliberately if a stand needs more.
+- **There is no shrink.** The silver step truncates what it writes, so activity
+  rows do follow the roster down — but `identity.py` only ever inserts, so the
+  extra people's `persons`, `org_chart` and login rows in MariaDB survive a
+  re-seed at the default. Re-seed a downgraded stand into a fresh database, or
+  clear those rows yourself.
+- **The realm must be sized with the seed.** Keycloak users come from the
+  same roster, but Keycloak imports its realm when its container is created —
+  a realm generated without `SEED_ORG_HEADCOUNT` in the environment holds only
+  the committed 26 users, and every growth person gets a valid database row
+  and no login. Compose handles this (`test-stand up` generates the realm in
+  the same environment); a gitops-deployed stand must export the same
+  `SEED_ORG_HEADCOUNT` when running the `keycloak-realm` make target, then
+  recreate the Keycloak pod.
+- **The manifest gets big, and switches transport.** Past ~64 personas the
+  compact document outgrows the 16 KiB a CRI log line survives, so the seeder
+  emits ordered `SEED_MANIFEST_GZ: <i>/<n> <base64 gzip>` chunks instead of the
+  single `SEED_MANIFEST_JSON:` line. Nothing is trimmed. Pipe a Job log through
+  [`manifest-from-log.sh`](manifest-from-log.sh) to get one plain sentinel line
+  back, whichever form it was:
+
+  ```bash
+  kubectl -n <ns> logs job/<job> --tail=-1 \
+    | ./src/ingestion/tools/seed/manifest-from-log.sh | cut -d' ' -f2- | jq .
+  ```
+
+  The two stand workflows (`run-stand-suite.yml`, `deploy-test-stand.yml`) read
+  the manifest through this script, so a CI stand recovers it at any roster
+  size. `seed-stand.sh` reassembles it for you as well — a run prints one plain
+  sentinel line whichever transport the seeder chose.
+
 ## [PROFILE.md](PROFILE.md)
 
 [`PROFILE.md`](PROFILE.md) is generated and committed. Regenerate it after any change to the
@@ -205,7 +270,7 @@ uv run python -m insight_seed.render_profile --check # verify (no database neede
 ```bash
 cd src/ingestion/tools/seed
 
-uv run --extra dev python -m unittest discover -s tests -t .   # tests
+uv run --extra dev pytest tests                                # tests
 uv run --extra dev ruff check .                                # package + tests
 uv run --extra dev mypy .
 ```
@@ -245,14 +310,17 @@ src/ingestion/tools/seed/
 │   ├── silver.py            ClickHouse: placeholders → generators → gold build
 │   ├── analytics.py         the catalogue rows no endpoint can create
 │   ├── profiles.py          demo roster + per-team activity weights
+│   ├── scale.py             grows the roster past it; opt-in, never imported
+│   │                        on the default path
 │   ├── manifest.py          builds `manifest.json`, the stand's description
 │   ├── golden_metrics.py    the only source for the manifest's golden set
 │   ├── profile_md.py        renders `PROFILE.md` from a manifest
 │   ├── render_profile.py    regenerates / verifies `PROFILE.md`; no database
 │   ├── keycloak_realm.py    the `insight-seed-realm` entry point, same roster
 │   └── generators/          one module per activity domain, `base.py` shared
-├── tests/                   stdlib unittest against the installed package
+├── tests/                   pytest against the installed package
 ├── seed-stand.sh            seeds a Kubernetes stand (discover → render → apply)
+├── manifest-from-log.sh     recovers a manifest from a Job log, either transport
 ├── seed-job.yaml.tpl        the Job it renders — and the reference manifest
 ├── Dockerfile               the `insight-seed` image, for both callers
 ├── pyproject.toml           package metadata, deps, ruff + mypy config

--- a/src/ingestion/tools/seed/insight_seed/config.py
+++ b/src/ingestion/tools/seed/insight_seed/config.py
@@ -303,7 +303,8 @@ def parse_org_headcount(env: Mapping[str, str]) -> int:
                 f"{ORG_HEADCOUNT_ENV}={headcount} is over the {MAX_ORG_HEADCOUNT}-person "
                 "ceiling. Every extra person multiplies the per-day rows the silver "
                 "generators write, so the ceiling is deliberate; raise "
-                "`config.MAX_ORG_HEADCOUNT` if a stand really needs more.",
+                "`config.MAX_ORG_HEADCOUNT` if a stand really needs more — and check the "
+                "manifest still fits a ConfigMap (see the seeder's tests).",
             )
         )
     return headcount

--- a/src/ingestion/tools/seed/insight_seed/config.py
+++ b/src/ingestion/tools/seed/insight_seed/config.py
@@ -49,9 +49,21 @@ ANCHOR_ENV = "SEED_ANCHOR_DATE"
 MANIFEST_PATH_ENV = "SEED_MANIFEST_PATH"
 DAYS_ENV = "SEED_DAYS"
 DEV_USER_EMAIL_ENV = "DEV_USER_EMAIL"
+ORG_HEADCOUNT_ENV = "SEED_ORG_HEADCOUNT"
+PERSONA_PASSWORD_ENV = "INSIGHT_SEED_PERSONA_PASSWORD"
 
 #: Length of the seeded activity window when nobody pins one.
 DEFAULT_SEED_DAYS = 60
+
+#: Headcount sentinel meaning "the committed demo roster, untouched".
+DEFAULT_ORG_HEADCOUNT = 0
+
+#: How many people `profiles.build_roster` returns: 25 plus the operator.
+CANONICAL_ROSTER_SIZE = 26
+
+#: Blast-radius ceiling: the generators emit per-person rows for every day
+#: of the window, so a mistyped headcount is expensive.
+MAX_ORG_HEADCOUNT = 3000
 
 #: The clock is read once; see `parse_anchor_date`.
 _DERIVED_ANCHOR: _dt.date | None = None
@@ -244,6 +256,57 @@ def parse_seed_days(env: Mapping[str, str], default: int = DEFAULT_SEED_DAYS) ->
     if days < 1:
         raise EnvContractError((f"{DAYS_ENV}={days} must be at least 1.",))
     return days
+
+
+def parse_org_headcount(env: Mapping[str, str]) -> int:
+    """How many people the roster should hold. Opt-in; the default is inert.
+
+    Unset, empty, `0` or the canonical size all mean "the committed demo roster,
+    exactly as it is" — the roster CI and the compose stand suite assert
+    against. Only a value above it asks for a bigger organisation, and the
+    grown one is built by appending (`profiles.build_seeded_roster`), so the
+    committed 26 keep their uuids, emails, names and build order.
+
+    The roster never shrinks. A smaller number is refused rather than honoured
+    because the committed people are fixtures, not filler: `manifest._fixtures`
+    names them, and a stand missing one turns every test that declares it from
+    a skip into a failure.
+    """
+    raw = (env.get(ORG_HEADCOUNT_ENV) or "").strip()
+    if not raw:
+        return DEFAULT_ORG_HEADCOUNT
+    try:
+        headcount = int(raw)
+    except ValueError as exc:
+        raise EnvContractError(
+            (
+                f"{ORG_HEADCOUNT_ENV}={raw!r} is not a whole number of people. Leave it "
+                f"unset (or 0) for the committed {CANONICAL_ROSTER_SIZE}-person demo "
+                f"roster, or ask for {CANONICAL_ROSTER_SIZE + 1}..{MAX_ORG_HEADCOUNT}.",
+            )
+        ) from exc
+    if headcount in (DEFAULT_ORG_HEADCOUNT, CANONICAL_ROSTER_SIZE):
+        return headcount
+    if headcount < CANONICAL_ROSTER_SIZE:
+        raise EnvContractError(
+            (
+                f"{ORG_HEADCOUNT_ENV}={headcount} is below the committed roster's "
+                f"{CANONICAL_ROSTER_SIZE} people, and the roster only grows: those people "
+                "are the named fixtures the test suites resolve by uuid. Use 0 (or leave "
+                f"it unset) for the committed roster, or {CANONICAL_ROSTER_SIZE + 1}"
+                f"..{MAX_ORG_HEADCOUNT} for a bigger one.",
+            )
+        )
+    if headcount > MAX_ORG_HEADCOUNT:
+        raise EnvContractError(
+            (
+                f"{ORG_HEADCOUNT_ENV}={headcount} is over the {MAX_ORG_HEADCOUNT}-person "
+                "ceiling. Every extra person multiplies the per-day rows the silver "
+                "generators write, so the ceiling is deliberate; raise "
+                "`config.MAX_ORG_HEADCOUNT` if a stand really needs more.",
+            )
+        )
+    return headcount
 
 
 def parse_manifest_path(env: Mapping[str, str]) -> Path:

--- a/src/ingestion/tools/seed/insight_seed/identity.py
+++ b/src/ingestion/tools/seed/insight_seed/identity.py
@@ -27,7 +27,7 @@ from .profiles import (
     TENANT_OTHER,
     Person,
     build_other_tenant_roster,
-    build_roster,
+    build_seeded_roster,
     get_dev_user_email,
     get_idp_source_type,
     get_login_id_pairs,
@@ -436,7 +436,7 @@ def run() -> None:
 
     tenant = config.parse_tenant_id(os.environ)
     dev_email = get_dev_user_email()
-    roster = build_roster(dev_email)
+    roster = build_seeded_roster(dev_email, config.parse_org_headcount(os.environ))
     LOG.info(
         "seeding %d persons under tenant %s (dev lead = %s)",
         len(roster),

--- a/src/ingestion/tools/seed/insight_seed/keycloak_realm.py
+++ b/src/ingestion/tools/seed/insight_seed/keycloak_realm.py
@@ -1,6 +1,6 @@
 """Generate the `insight` Keycloak realm from the seeded 25-person org.
 
-Built from the SAME roster the database seed writes (`profiles.build_roster`),
+Built from the SAME roster the database seed writes (`profiles.build_seeded_roster`),
 so every user in the realm matches a row in `identity.persons`, and emits an
 importable Keycloak realm JSON: 26 users (the 25-person org plus the admin
 operator), the `insight` + `insight-authenticator` clients, their 5 shared
@@ -30,14 +30,14 @@ from .profiles import (
     TENANT_OTHER,
     Person,
     build_other_tenant_roster,
-    build_roster,
+    build_seeded_roster,
     get_dev_user_email,
 )
 
 REALM_NAME = "insight"
 # Every seeded user's login credential. An internet-reachable stand MUST set
 # INSIGHT_SEED_PERSONA_PASSWORD here, and TEST_STAND_PERSONA_PASSWORD in CI.
-_ENV_PASSWORD = os.environ.get("INSIGHT_SEED_PERSONA_PASSWORD")
+_ENV_PASSWORD = (os.environ.get(config.PERSONA_PASSWORD_ENV) or "").strip() or None
 if _ENV_PASSWORD is not None and len(_ENV_PASSWORD) < 16:
     # A short/common value would also poison the manifest's substring scrub
     # (_FORBIDDEN_LITERALS) and fail every seed at its final write.
@@ -237,8 +237,9 @@ def build_realm(
     tenant_id: str,
     authenticator_redirects: list[str],
     authenticator_secret: str,
+    headcount: int,
 ) -> dict[str, Any]:
-    roster = build_roster(dev_user_email)
+    roster = build_seeded_roster(dev_user_email, headcount)
     # The second tenant's single person, in the SAME realm. One realm because
     # the authenticator is configured with one issuer and one client — a second
     # realm would need a second authenticator. Tenancy is a claim, not an
@@ -299,13 +300,15 @@ def main() -> None:
     # parser. A default here could mint realm users whose tenant claim matches
     # nothing the seed then writes: they would authenticate and resolve to
     # nobody, which is the failure this whole roster-sharing exists to avoid.
+    # INVARIANT: the realm must describe the same roster the seed writes.
     try:
         tenant_id = config.parse_tenant_id(os.environ)
+        headcount = config.parse_org_headcount(os.environ)
     except config.EnvContractError as exc:
         raise SystemExit(f"ERROR: cannot generate the realm.\n{exc}") from exc
 
     redirects = args.authenticator_redirects or DEFAULT_AUTHENTICATOR_REDIRECTS
-    realm = build_realm(dev_user_email, tenant_id, redirects, args.authenticator_secret)
+    realm = build_realm(dev_user_email, tenant_id, redirects, args.authenticator_secret, headcount)
 
     out_path = Path(args.out)
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/ingestion/tools/seed/insight_seed/manifest.py
+++ b/src/ingestion/tools/seed/insight_seed/manifest.py
@@ -19,11 +19,13 @@ of committed bytes rather than of whoever last ran it.
 
 from __future__ import annotations
 
+import base64
 import datetime as _dt
+import gzip
 import hashlib
 import json
 import os
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -88,19 +90,30 @@ CANONICAL_ENV: dict[str, str] = {
 # Literals that must never reach the manifest. Checked before the file is
 # written, so a future field that accidentally carries a secret fails loudly
 # instead of shipping.
-_FORBIDDEN_LITERALS = frozenset(
+_STATIC_FORBIDDEN_LITERALS = frozenset(
     {
         "insight-dev",  # keycloak_realm dev password (the default)
-        # The runtime persona password too, when a stand overrides the default —
-        # mirrors keycloak_realm.DEV_PASSWORD without importing it (no cycle).
-        os.environ.get(
-            "INSIGHT_SEED_PERSONA_PASSWORD", "insight-dev"
-        ),  # RULE-DEFAULTS-OK: same tagged default as keycloak_realm.DEV_PASSWORD
         "insight-authenticator-dev-secret",  # keycloak_realm client secret
         "insight-local",  # MariaDB / ClickHouse dev password
         "root-local",  # MariaDB root password
     }
 )
+
+
+def _forbidden_literals(env: Mapping[str, str]) -> frozenset[str]:
+    """The dev credentials, plus the persona password when a stand overrides it.
+
+    SAFETY: an empty override is dropped rather than added. The scan is a
+    substring test, so `""` matches every document — and it runs after every
+    database write, in a Job with `backoffLimit: 0`, where refusing reports a
+    correctly seeded stand as a failure that cannot be retried.
+    """
+    override = (env.get(config.PERSONA_PASSWORD_ENV) or "").strip()
+    if not override:
+        return _STATIC_FORBIDDEN_LITERALS
+    return _STATIC_FORBIDDEN_LITERALS | {override}
+
+
 _FORBIDDEN_KEY_SUBSTRINGS = ("password", "secret", "token", "credential", "passwd")
 
 
@@ -268,7 +281,7 @@ def build_manifest(
     # wrote them (`identity.py` reads the same switch). Advertising a fixture
     # whose row does not exist would turn every test that declares
     # `requires_seed("other_tenant_lead")` from a skip into a failure.
-    roster = list(profiles.build_roster(dev_email))
+    roster = list(profiles.build_seeded_roster(dev_email, config.parse_org_headcount(env)))
     if config.cross_tenant_fixture_enabled(env):
         roster += profiles.build_other_tenant_roster()
 
@@ -312,10 +325,10 @@ def build_manifest(
     }
 
 
-def assert_no_credentials(doc: dict[str, Any]) -> None:
+def assert_no_credentials(doc: dict[str, Any], env: Mapping[str, str] | None = None) -> None:
     """Fail loudly if a secret ever reaches the document."""
     blob = json.dumps(doc, ensure_ascii=False)
-    for literal in _FORBIDDEN_LITERALS:
+    for literal in _forbidden_literals(os.environ if env is None else env):
         if literal in blob:
             raise RuntimeError(
                 f"manifest would contain the credential literal {literal!r}; "
@@ -345,23 +358,95 @@ def render_manifest(doc: dict[str, Any]) -> str:
 #: A single physical line, so the pod-log transport needs no parser.
 SENTINEL_PREFIX = "SEED_MANIFEST_JSON: "
 
+#: The chunked fallback, for a manifest too big to survive as one log line:
+#: `SEED_MANIFEST_GZ: <i>/<n> <base64(gzip(compact json))>`, 1-based, in order.
+#: `manifest-from-log.sh` turns either form back into one plain sentinel line.
+GZ_SENTINEL_PREFIX = "SEED_MANIFEST_GZ: "
+
 #: CRI reassembles a container's log line up to this many bytes; longer and
 #: `grep -m1` on the far side would capture a fragment, not the document.
 _SENTINEL_MAX_BYTES = 16 * 1024
 
+#: Payload per chunk, inside that bound once prefix and counter are added.
+_GZ_CHUNK_BYTES = 12 * 1024
+
 
 def emit_manifest_sentinel(doc: dict[str, Any]) -> None:
-    """Print the compact-JSON sentinel line the CI capture step greps for."""
-    line = SENTINEL_PREFIX + json.dumps(
-        doc, separators=(",", ":"), sort_keys=True, ensure_ascii=False
-    )
-    size = len(line.encode("utf-8"))
-    if size > _SENTINEL_MAX_BYTES:
-        raise RuntimeError(
-            f"manifest sentinel line is {size} bytes, over the {_SENTINEL_MAX_BYTES}-byte "
-            "CRI line-reassembly bound"
+    """Print the manifest to stdout as sentinel lines a log reader can recover.
+
+    One plain `SEED_MANIFEST_JSON:` line while the document fits the CRI
+    line-reassembly bound — which the committed roster does, at ~9 KB — and
+    gzipped base64 chunks when it does not.
+
+    Refusing an oversized manifest was the alternative, and it is the wrong one:
+    this runs at the END of a seed, after every database write, in a Job with
+    `backoffLimit: 0`. A 250-person stand would have been seeded correctly and
+    then reported as a failure, with nothing to retry and nothing to fix. The
+    personas array is not trimmed either — the stand suite resolves its fixtures
+    out of it, so a shortened manifest is a broken one.
+    """
+    compact = json.dumps(doc, separators=(",", ":"), sort_keys=True, ensure_ascii=False)
+    line = SENTINEL_PREFIX + compact
+    if len(line.encode("utf-8")) <= _SENTINEL_MAX_BYTES:
+        print(line)
+        return
+
+    # INVARIANT: mtime=0 keeps the sentinel a function of the document only.
+    blob = base64.b64encode(gzip.compress(compact.encode("utf-8"), mtime=0)).decode("ascii")
+    chunks = [blob[i : i + _GZ_CHUNK_BYTES] for i in range(0, len(blob), _GZ_CHUNK_BYTES)]
+    for index, chunk in enumerate(chunks, start=1):
+        print(f"{GZ_SENTINEL_PREFIX}{index}/{len(chunks)} {chunk}")
+
+
+def decode_manifest_sentinel(lines: Iterable[str]) -> dict[str, Any]:
+    """Recover the manifest from log lines carrying either sentinel form.
+
+    The Python half of `manifest-from-log.sh`, kept beside the emitter so the
+    two halves of one format cannot drift. Chunks may arrive in any order and
+    interleaved with other output, and an identical line read twice (a re-read
+    log) is tolerated. Everything else is an error rather than a best-effort
+    splice — a missing chunk, a conflicting total or a differing duplicate all
+    mean the input mixes two emissions, and a spliced document is not a
+    manifest.
+    """
+    chunks: dict[int, str] = {}
+    total: int | None = None
+    for raw in lines:
+        line = raw.rstrip("\n")
+        if line.startswith(SENTINEL_PREFIX):
+            plain: dict[str, Any] = json.loads(line[len(SENTINEL_PREFIX) :])
+            return plain
+        if not line.startswith(GZ_SENTINEL_PREFIX):
+            continue
+        counter, _, payload = line[len(GZ_SENTINEL_PREFIX) :].partition(" ")
+        index_text, _, total_text = counter.partition("/")
+        index, chunk_total = int(index_text), int(total_text)
+        if total is None:
+            total = chunk_total
+        elif chunk_total != total:
+            raise ValueError(
+                f"chunk lines advertise conflicting totals {total} and {chunk_total}; "
+                "the input mixes two emissions"
+            )
+        if not 1 <= index <= chunk_total:
+            raise ValueError(f"chunk index {index} is outside 1..{chunk_total}")
+        if index in chunks and chunks[index] != payload:
+            raise ValueError(
+                f"chunk {index} appears twice with different payloads; "
+                "the input mixes two emissions"
+            )
+        chunks[index] = payload
+
+    if total is None:
+        raise ValueError(
+            f"no '{SENTINEL_PREFIX.strip()}' or '{GZ_SENTINEL_PREFIX.strip()}' line in the input"
         )
-    print(line)
+    missing = sorted(set(range(1, total + 1)) - set(chunks))
+    if missing:
+        raise ValueError(f"manifest chunks {missing} are missing; got {len(chunks)} of {total}")
+    blob = "".join(chunks[i] for i in range(1, total + 1))
+    document: dict[str, Any] = json.loads(gzip.decompress(base64.b64decode(blob)).decode("utf-8"))
+    return document
 
 
 def write_manifest(doc: dict[str, Any], path: Path | None = None) -> Path:

--- a/src/ingestion/tools/seed/insight_seed/profiles.py
+++ b/src/ingestion/tools/seed/insight_seed/profiles.py
@@ -13,6 +13,12 @@ so the admin-gated API surface has a caller, and it is kept outside the
 org so that granting it cannot move a single metric or change what any
 other person can see. See `build_roster`.
 
+That roster is a fixture, so it is also FIXED: `build_roster` is the
+committed one and nothing may renumber it. A stand that needs a bigger
+organisation asks for one with `SEED_ORG_HEADCOUNT`, and
+`build_seeded_roster` appends the extra people (see `scale.py`) after the
+committed 26 rather than rebuilding them.
+
 `TEAM_PROFILES` below maps a per-team source-type to a numeric
 multiplier (0 = no rows; 1 = baseline; >1 = heavier). The row
 generators consult these weights to decide which silver rows a given
@@ -23,6 +29,8 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field, replace
+
+from . import config
 
 # ─── Fixed UUIDs ────────────────────────────────────────────────────────
 # The dev lead's UUID matches the value the original dev-compose.sh seed
@@ -351,6 +359,36 @@ def build_roster(dev_user_email: str) -> list[Person]:
         for i, p in enumerate([ceo, *leads, *ics, admin_operator])
         for fn, ln in [_name_at(i)]
     ]
+
+
+#: What `build_roster` returns; re-exported from `config`, which owns it.
+CANONICAL_ROSTER_SIZE = config.CANONICAL_ROSTER_SIZE
+
+
+def build_seeded_roster(dev_user_email: str, headcount: int) -> list[Person]:
+    """The roster a seed run writes: the committed one, or a grown one.
+
+    This is the entry point every WRITER uses (identity, silver, the realm, the
+    manifest); each parses `SEED_ORG_HEADCOUNT` at its own boundary with
+    `config.parse_org_headcount` and passes the resulting int here, so raw
+    environment state never crosses into roster construction. `build_roster`
+    stays what it always was and is still the right call for anything asserting
+    on the committed fixtures.
+
+    The default path returns `build_roster`'s own object, and `scale` is not
+    even imported: growing the roster is opt-in via `SEED_ORG_HEADCOUNT`, and a
+    stand that did not ask for it must get byte-identical data to the one CI
+    asserts against.
+    """
+    base = build_roster(dev_user_email)
+    if headcount in (config.DEFAULT_ORG_HEADCOUNT, CANONICAL_ROSTER_SIZE):
+        return base
+
+    # INVARIANT: imported inside the branch — the committed path must not run
+    # scale.py's import-time work.
+    from .scale import extend_roster
+
+    return extend_roster(base, headcount)
 
 
 def build_other_tenant_roster() -> list[Person]:

--- a/src/ingestion/tools/seed/insight_seed/scale.py
+++ b/src/ingestion/tools/seed/insight_seed/scale.py
@@ -1,0 +1,238 @@
+"""Grow the demo roster past its committed size, by appending only.
+
+Imported only when `SEED_ORG_HEADCOUNT` asks for more people than the
+committed roster holds, so the default seed stays byte-identical to the one CI
+asserts against. The committed people keep their uuids, emails, names and
+build order — `manifest._fixtures` resolves them by uuid.
+
+Growth people take namespaces of their own for uuid, email and display name:
+dbt's `resolve_person_id` resolves a duplicated email to NOBODY, silently
+dropping both people from every metric. Growth splits round-robin over the
+existing teams as squads of at most `SQUAD_SPAN` ICs under a squad manager
+reporting to the team's existing lead. See the seeder README for the shape.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from . import config, profiles
+from .profiles import Person
+
+#: Most growth ICs under one squad manager; also drives the manager/IC split.
+SQUAD_SPAN = 8
+
+#: Existing teams only: a team absent from `TEAM_PROFILES` seeds people who
+#: generate no rows.
+GROWTH_TEAMS: tuple[str, ...] = ("development", "sales", "hr", "support")
+
+#: The EXISTING `lead` role: several tables index `Person.role` directly, and
+#: an unknown role string raises `KeyError` mid-seed.
+SQUAD_MANAGER_ROLE = "lead"
+
+#: Growth uuids get their own block; `a`/`b`/`c`/`d` are taken.
+_UUID_PREFIX = "eeeeeeee-0000-0000-0000-"
+
+#: INVARIANT: this seed plus the exact Faker pin in pyproject keep growth
+#: names stable across runs; changing either renames a re-seeded stand's
+#: whole growth population.
+_BULK_NAME_SEED = 0x5EED
+
+#: Draws before concluding Faker's surname pool cannot fill the name grid.
+_MAX_NAME_DRAWS = 100_000
+
+
+def _generate_bulk_last_names() -> list[str]:
+    """Surnames for the growth population, drawn from Faker deterministically.
+
+    Each draw is filtered against `profiles._LAST_NAMES` and deduplicated, so
+    the properties the module docstring claims — disjoint from the committed
+    surnames, no duplicates — hold by construction. Drawing continues until
+    the first-name grid can name a roster at the ceiling.
+    """
+    from faker import Faker
+
+    fake = Faker("en_US")
+    fake.seed_instance(_BULK_NAME_SEED)
+
+    committed = set(profiles._LAST_NAMES)
+    names: list[str] = []
+    seen: set[str] = set()
+    needed = config.MAX_ORG_HEADCOUNT - config.CANONICAL_ROSTER_SIZE
+
+    for _ in range(_MAX_NAME_DRAWS):
+        if len(profiles._FIRST_NAMES) * len(names) >= needed:
+            return names
+        surname = fake.last_name()
+        if surname in committed or surname in seen:
+            continue
+        seen.add(surname)
+        names.append(surname)
+
+    raise RuntimeError(
+        f"Faker yielded only {len(names)} usable surnames in {_MAX_NAME_DRAWS} draws, "
+        f"short of what a roster at the {config.MAX_ORG_HEADCOUNT}-person ceiling needs."
+    )
+
+
+_BULK_LAST_NAMES = _generate_bulk_last_names()
+
+
+@dataclass(frozen=True)
+class TeamPlan:
+    """How many growth people one team takes, and in what shape."""
+
+    team: str
+    managers: int
+    ics: int
+
+    @property
+    def total(self) -> int:
+        return self.managers + self.ics
+
+
+def _managers_for(slots: int) -> int:
+    """Squad managers needed so no squad carries more than `SQUAD_SPAN` ICs."""
+    squad = SQUAD_SPAN + 1
+    return (slots + squad - 1) // squad
+
+
+def plan(total_target: int, teams: Sequence[str] = GROWTH_TEAMS) -> list[TeamPlan]:
+    """Split the growth over the teams, and each team's share into a squad shape.
+
+    Round-robin rather than proportional: the four teams are equal-sized in the
+    committed roster, so equal shares keep them that way, and the remainder goes
+    to the first teams in order rather than being dropped — the totals must add
+    up to `total_target` exactly.
+
+    Within a team, the slots divide into squads of one manager plus at most
+    `SQUAD_SPAN` ICs. One slot therefore buys a manager with no reports yet,
+    which is the honest shape of a team that just started growing.
+    """
+    if not teams:
+        raise ValueError("plan needs at least one team to grow.")
+    grow = total_target - config.CANONICAL_ROSTER_SIZE
+    if grow < 0:
+        raise ValueError(
+            f"total_target={total_target} is below the committed roster's "
+            f"{config.CANONICAL_ROSTER_SIZE} people; the roster only grows."
+        )
+
+    plans: list[TeamPlan] = []
+    for index, team in enumerate(teams):
+        slots = grow // len(teams) + (1 if index < grow % len(teams) else 0)
+        managers = _managers_for(slots)
+        plans.append(TeamPlan(team=team, managers=managers, ics=slots - managers))
+    return plans
+
+
+def _growth_name(index: int) -> tuple[str, str]:
+    """Name for the `index`-th growth person, 0-based across every team.
+
+    First names cycle fastest so consecutive people in one squad differ by first
+    name; the surname advances once per full cycle. The pair is unique for any
+    index a roster at the ceiling can reach — `_generate_bulk_last_names` sizes
+    the grid to exactly that.
+    """
+    firsts = profiles._FIRST_NAMES
+    return (
+        firsts[index % len(firsts)],
+        _BULK_LAST_NAMES[(index // len(firsts)) % len(_BULK_LAST_NAMES)],
+    )
+
+
+def extend_roster(base: list[Person], total_target: int) -> list[Person]:
+    """`base` plus enough growth people to reach exactly `total_target`.
+
+    The result starts with `base`, element for element. Every invariant the
+    callers depend on is checked HERE rather than only in the tests: this
+    function runs inside a Job that writes to a real stand, and a duplicated
+    email resolves to nobody in gold instead of failing loudly.
+    """
+    if len(base) != config.CANONICAL_ROSTER_SIZE:
+        raise RuntimeError(
+            f"extend_roster expects the committed {config.CANONICAL_ROSTER_SIZE}-person "
+            f"roster, got {len(base)}. Growth is appended to it, so a different base "
+            "means the plan's arithmetic no longer describes the result."
+        )
+    if total_target <= len(base):
+        raise RuntimeError(
+            f"extend_roster was asked for {total_target} people, which is not more than "
+            f"the {len(base)} it starts from; the inert path belongs in "
+            "`profiles.build_seeded_roster`."
+        )
+
+    leads = {p.team: p for p in base if p.role == "lead" and p.team is not None}
+    grown = list(base)
+    index = 0  # 0-based across every team: drives names; +1 is the uuid sequence
+
+    for team_plan in plan(total_target):
+        lead = leads.get(team_plan.team)
+        if lead is None:
+            raise RuntimeError(
+                f"team {team_plan.team!r} has no lead in the committed roster; growth "
+                "reports to the existing leads and cannot invent one."
+            )
+
+        managers: list[Person] = []
+        for n in range(1, team_plan.managers + 1):
+            first, last = _growth_name(index)
+            index += 1
+            managers.append(
+                Person(
+                    uuid=f"{_UUID_PREFIX}{index:012d}",
+                    email=profiles.build_email(f"email_{team_plan.team}_mgr_{n:03d}"),
+                    team=team_plan.team,
+                    role=SQUAD_MANAGER_ROLE,
+                    parent_uuid=lead.uuid,
+                    first_name=first,
+                    last_name=last,
+                )
+            )
+
+        ics: list[Person] = []
+        for n in range(1, team_plan.ics + 1):
+            first, last = _growth_name(index)
+            index += 1
+            # INVARIANT: plan() keeps ics <= managers * SQUAD_SPAN, so this index
+            # stays in range.
+            ics.append(
+                Person(
+                    uuid=f"{_UUID_PREFIX}{index:012d}",
+                    email=profiles.build_email(f"email_{team_plan.team}_b{n:04d}"),
+                    team=team_plan.team,
+                    role="ic",
+                    parent_uuid=managers[(n - 1) // SQUAD_SPAN].uuid,
+                    first_name=first,
+                    last_name=last,
+                )
+            )
+
+        grown += managers + ics
+
+    _assert_grown(base, grown, total_target)
+    return grown
+
+
+def _assert_grown(base: list[Person], grown: list[Person], total_target: int) -> None:
+    """Every property the rest of the seeder is allowed to assume."""
+    if len(grown) != total_target:
+        raise RuntimeError(f"grown roster holds {len(grown)} people, expected {total_target}.")
+    if grown[: len(base)] != base:
+        raise RuntimeError(
+            "grown roster does not start with the committed roster; the named fixtures "
+            "would move and every test resolving one by uuid would break."
+        )
+    for label, values in (
+        ("uuid", [p.uuid for p in grown]),
+        ("email", [p.email for p in grown]),
+        ("display_name", [p.display_name for p in grown]),
+    ):
+        if len(set(values)) != len(grown):
+            duplicates = sorted(v for v, n in Counter(values).items() if n > 1)
+            raise RuntimeError(
+                f"grown roster repeats {label}: {duplicates[:5]}. Two people sharing an "
+                "address resolve to nobody in gold rather than failing loudly."
+            )

--- a/src/ingestion/tools/seed/insight_seed/silver.py
+++ b/src/ingestion/tools/seed/insight_seed/silver.py
@@ -42,7 +42,7 @@ import clickhouse_connect
 from . import config
 from .generators import ai, ai_cost, collab, crm, git, hr, people, support, task, wiki
 from .generators.base import seed_days
-from .profiles import build_roster, get_dev_user_email
+from .profiles import build_seeded_roster, get_dev_user_email
 
 LOG = logging.getLogger("seed.silver")
 
@@ -118,7 +118,7 @@ IDENTITY_INPUTS_SELECT = "+identity_inputs"
 AI_INVOICE_SELECT = "claude_team__ai_invoice+"
 
 
-def apply_ch_migrations(dbt_select: str | None = None) -> None:
+def apply_ch_migrations(dbt_select: str | None = None, *, full_refresh: bool = False) -> None:
     """Apply gold-view migrations + build dbt-owned gold models.
 
     Runs the ingestion repo's apply-ch-migrations.sh — the exact script the
@@ -127,6 +127,16 @@ def apply_ch_migrations(dbt_select: str | None = None) -> None:
     `dbt run --select tag:gold` (widened by `dbt_select` when given). Must
     run AFTER seeding so the materialized gold model reflects seeded silver
     (see module docstring).
+
+    `full_refresh` rebuilds the selected models from source rather than
+    appending to them. The silver step needs it whenever the roster can
+    differ from the one already on the stand: a seed REPLACES the org, but
+    the identity feeders are incremental (bamboohr__employees_snapshot
+    appends; identity_inputs admits only rows past the current max _version),
+    so people who are new to this stand never cross that boundary. The
+    failure is silent — bronze holds the new roster, identity_inputs keeps
+    describing the previous accounts, persons-seed resolves that stale set,
+    and gold serves the old org with no error at any layer.
     """
     script = _ingestion_scripts_dir() / "apply-ch-migrations.sh"
     if not script.is_file():
@@ -143,7 +153,12 @@ def apply_ch_migrations(dbt_select: str | None = None) -> None:
         env.pop("DBT_GOLD_SELECT", None)
     else:
         env["DBT_GOLD_SELECT"] = dbt_select
-    subprocess.run(["bash", str(script)], env=env, check=True)
+    # INVARIANT: a flag, never DBT_FULL_REFRESH — that name is
+    # reconcile-connectors' and env reaches every child.
+    argv = ["bash", str(script)]
+    if full_refresh:
+        argv.append("--full-refresh")
+    subprocess.run(argv, env=env, check=True)
     LOG.info("migrations + gold: %s applied", script.name)
 
 
@@ -153,7 +168,7 @@ def generate_rows(
     """Populate silver tables with per-team activity for the demo roster."""
     tenant_uuid = config.parse_tenant_id(os.environ)
     dev_email = get_dev_user_email()
-    roster = build_roster(dev_email)
+    roster = build_seeded_roster(dev_email, config.parse_org_headcount(os.environ))
     # The generators' own reader, not a second copy of it: they date every row
     # from this window, and a `SEED_DAYS` the two disagreed on would put rows
     # outside the range this function logs. It also treats an empty value as
@@ -198,7 +213,10 @@ def run() -> None:
         # 3. Real deploy mechanism: migrations + gold + identity inputs. Gold
         #    builds unresolved here — the orchestrator runs the persons-seed/
         #    sync pair and then the `gold` subcommand to rebuild it.
-        apply_ch_migrations(dbt_select=f"tag:gold {IDENTITY_INPUTS_SELECT} {AI_INVOICE_SELECT}")
+        apply_ch_migrations(
+            dbt_select=f"tag:gold {IDENTITY_INPUTS_SELECT} {AI_INVOICE_SELECT}",
+            full_refresh=True,
+        )
     finally:
         client.close()
     LOG.info("DONE: silver rows seeded + gold layer built via deploy scripts.")

--- a/src/ingestion/tools/seed/manifest-from-log.sh
+++ b/src/ingestion/tools/seed/manifest-from-log.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Recover a seed manifest from a Job log and print it as one plain
+# `SEED_MANIFEST_JSON:` line, whichever sentinel form the seeder emitted
+# (see the README's "Reading the manifest back" section).
+#
+#   kubectl -n <ns> logs job/<job> --tail=-1 | manifest-from-log.sh
+#   manifest-from-log.sh seed.log | cut -d' ' -f2- | jq .
+set -euo pipefail
+
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+log="$(cat -- "${1:--}")"
+
+plain="$(grep -m1 '^SEED_MANIFEST_JSON: ' <<<"$log" || true)"
+if [[ -n "$plain" ]]; then
+  printf '%s\n' "$plain"
+  exit 0
+fi
+
+# `sort -u` forgives an identical line read twice; a duplicate index with a
+# DIFFERENT payload survives it and fails the index check below.
+chunks="$(grep '^SEED_MANIFEST_GZ: ' <<<"$log" | sort -u || true)"
+[[ -n "$chunks" ]] || die "no SEED_MANIFEST_JSON / SEED_MANIFEST_GZ line in the input."
+
+# One emission has one <n>; two totals means the log mixes two runs.
+totals="$(awk '{split($2, c, "/"); print c[2]}' <<<"$chunks" | sort -u)"
+[[ "$(wc -l <<<"$totals" | tr -d ' ')" == "1" ]] \
+  || die "chunk lines advertise conflicting totals ($(tr '\n' ' ' <<<"$totals")) — the input mixes two emissions."
+total="$totals"
+[[ "$total" =~ ^[0-9]+$ ]] || die "malformed chunk counter '<i>/$total'."
+
+# SAFETY: exactly the indexes 1..n, each once — a missing, duplicated or
+# out-of-range chunk must fail rather than decode a spliced document.
+indexes="$(awk '{split($2, c, "/"); print c[1]}' <<<"$chunks" | sort -n)"
+[[ "$indexes" == "$(seq 1 "$total")" ]] \
+  || die "chunk indexes ($(tr '\n' ' ' <<<"$indexes")) are not exactly 1..$total — the log is truncated or mixes two emissions."
+
+# Sorted numerically by <i>: a merged or filtered log may not preserve order,
+# and 10 sorts before 2 as text.
+payload="$(awk '{split($2, c, "/"); print c[1], $3}' <<<"$chunks" \
+  | sort -n -k1,1 \
+  | awk '{printf "%s", $2}')"
+
+# WORKAROUND: `base64 -d` on GNU coreutils, `-D` on macOS.
+decode_base64() {
+  if base64 -d </dev/null >/dev/null 2>&1; then base64 -d; else base64 -D; fi
+}
+
+# SAFETY: decode through an assignment, not into printf's argument list — a
+# command substitution used as an argument discards its status, and an empty
+# `SEED_MANIFEST_JSON: ` line still matches every consumer's grep.
+json="$(printf '%s' "$payload" | decode_base64 | gzip -dc)"
+[[ -n "$json" ]] || die "the chunks decoded to an empty document."
+
+printf 'SEED_MANIFEST_JSON: %s\n' "$json"

--- a/src/ingestion/tools/seed/pyproject.toml
+++ b/src/ingestion/tools/seed/pyproject.toml
@@ -25,6 +25,9 @@ requires-python = ">=3.12"
 dependencies = [
     "PyMySQL==1.2.0",
     "clickhouse-connect==1.7.1",
+    # INVARIANT: exact pin — Faker's en_US pool changes between releases, and a
+    # float pin would rename a stand's whole growth population on a rebuild.
+    "Faker==40.1.2",
 ]
 
 [project.optional-dependencies]

--- a/src/ingestion/tools/seed/seed-job.yaml.tpl
+++ b/src/ingestion/tools/seed/seed-job.yaml.tpl
@@ -23,6 +23,7 @@
 #   SEED_FORCE                0 | 1 — seed a tenant holding foreign person rows
 #   SEED_WINDOW_DAYS          activity-window length, empty for the seeder's own
 #   SEED_ANCHOR_DATE          last day of activity, empty for the seeder's own
+#   SEED_ORG_HEADCOUNT        organisation size, empty for the committed roster
 #   SEED_PULL_SECRETS         YAML flow sequence of pull secrets, `[]` for none
 apiVersion: batch/v1
 kind: Job
@@ -129,6 +130,10 @@ spec:
               value: "${SEED_WINDOW_DAYS}"
             - name: SEED_ANCHOR_DATE
               value: "${SEED_ANCHOR_DATE}"
+            # Empty (or 0) is the committed roster; a larger value APPENDS, so
+            # the committed personas keep their uuids, emails and names.
+            - name: SEED_ORG_HEADCOUNT
+              value: "${SEED_ORG_HEADCOUNT}"
             # The pod's filesystem dies with it and the manifest is echoed to
             # the log, so this only has to be somewhere writable — the package
             # is installed in the image and its working directory is not.

--- a/src/ingestion/tools/seed/seed-stand.sh
+++ b/src/ingestion/tools/seed/seed-stand.sh
@@ -16,6 +16,10 @@ STEP="all"
 DEADLINE_SECONDS="3600"
 
 NAMESPACE=""
+# The durable copy of the manifest; deliberately outside the chart's name
+# prefix so a future chart template cannot fail to adopt it.
+MANIFEST_CONFIGMAP="seed-stand-manifest"
+SEED_MANIFEST_SENTINEL=""
 CONTEXT=""
 RELEASE=""
 DEV_EMAIL=""
@@ -87,6 +91,9 @@ Output:
       --dry-run            print the rendered Job manifest and exit
       --no-follow          apply the Job without following its logs
   -h, --help               this text
+
+  A completed --step all run also publishes the manifest to
+  configmap/seed-stand-manifest, which outlives the Job's log.
 
 Examples:
   seed-stand.sh -n insight --dry-run
@@ -514,11 +521,11 @@ render_seed_manifest() {
   ' < "$JOB_TEMPLATE"
 }
 
-# print_manifest_sentinel NAME — re-read the finished Job's log and print the
+# recover_manifest_sentinel NAME — re-read the finished Job's log and print the
 # manifest, or nothing for a step that writes none. Read from the finished
 # Job: `logs -f` can end without the container's final lines, and a consumer
 # that lost the manifest cannot tell a seeded stand from an attempt.
-print_manifest_sentinel() {
+recover_manifest_sentinel() {
   local log
   log="$(kube -n "$NAMESPACE" logs "job/$1" --tail=-1 2>/dev/null || true)"
   if grep -m1 '^SEED_MANIFEST_JSON: ' <<<"$log"; then
@@ -534,6 +541,46 @@ print_manifest_sentinel() {
   fi
   echo "ERROR: the Job's $chunks gzipped manifest chunk(s) could not be reassembled." >&2
   return 1
+}
+
+# INVARIANT: only a step that produced a manifest may overwrite the remembered
+# one — wait_for_job runs this for the gold and persons-seed jobs too.
+print_manifest_sentinel() {
+  local line
+  line="$(recover_manifest_sentinel "$1")" || return 1
+  [[ -n "$line" ]] || return 0
+  SEED_MANIFEST_SENTINEL="$line"
+  printf '%s\n' "$line"
+}
+
+# clear_manifest_configmap / publish_manifest_configmap — the durable copy of
+# the manifest. The Job's log carries it for one hour (ttlSecondsAfterFinished);
+# the stand it describes lives until someone tears it down.
+clear_manifest_configmap() {
+  kube -n "$NAMESPACE" delete configmap "$MANIFEST_CONFIGMAP" --ignore-not-found >/dev/null 2>&1 \
+    || echo "ERROR: could not clear configmap/$MANIFEST_CONFIGMAP; a reader may still see the previous seed." >&2
+}
+
+publish_manifest_configmap() {
+  local tmp status=0
+  [[ -n "$SEED_MANIFEST_SENTINEL" ]] || return 0
+  tmp="$(mktemp)"
+  printf '%s' "${SEED_MANIFEST_SENTINEL#SEED_MANIFEST_JSON: }" >"$tmp"
+  # WORKAROUND: --from-file needs a path, not a stream. --server-side because a
+  # client-side apply stamps last-applied-configuration, whose 256 KiB cap the
+  # document crosses well inside the supported roster range.
+  kube -n "$NAMESPACE" create configmap "$MANIFEST_CONFIGMAP" \
+        --from-file=manifest="$tmp" --dry-run=client -o yaml \
+    | kube -n "$NAMESPACE" apply --server-side --force-conflicts \
+        --field-manager=seed-stand.sh -f - >/dev/null || status=$?
+  rm -f "$tmp"
+  if [[ "$status" -ne 0 ]]; then
+    echo "ERROR: could not publish the manifest to configmap/$MANIFEST_CONFIGMAP in $NAMESPACE." >&2
+    echo "       The stand IS seeded; only the durable copy is missing. The document is on" >&2
+    echo "       stdout above and in the Job's log until it is reaped." >&2
+    return 0
+  fi
+  echo "==> manifest published: configmap/$MANIFEST_CONFIGMAP"
 }
 
 # wait_for_job NAME — follow the pod's logs, then read the verdict from the Job
@@ -681,7 +728,9 @@ fi
 # the identity projection and rebuild gold, so the stand serves resolved metrics
 # instead of a null for every person — the k8s analogue of dev-compose.sh's
 # cmd_seed, which does the same for the compose stand.
+case "$STEP" in all) clear_manifest_configmap ;; esac
 run_seed_step "$STEP" || exit 1
+case "$STEP" in all) publish_manifest_configmap ;; esac
 
 case "$STEP" in
   all|silver)

--- a/src/ingestion/tools/seed/seed-stand.sh
+++ b/src/ingestion/tools/seed/seed-stand.sh
@@ -28,6 +28,7 @@ PULL_SECRETS=""
 IDP_SOURCE_TYPE=""
 WINDOW_DAYS=""
 ANCHOR_DATE=""
+ORG_HEADCOUNT=""
 CROSS_TENANT="0"
 FORCE="0"
 DRY_RUN=0
@@ -72,6 +73,12 @@ Seed options:
                            alone just rebuilds over the map as it stands now.
       --days <n>           activity-window length in days
       --anchor <date>      last day carrying activity (YYYY-MM-DD)
+      --org-headcount <n>  seed an organisation of n people instead of the
+                           committed 26-person demo roster. Opt-in and additive:
+                           the committed people keep their uuids, emails and
+                           names, and the extra ones are appended in squads under
+                           the existing team leads. 27..3000; omit it (or 0) for
+                           the committed roster, which is what CI asserts against.
       --cross-tenant       also write the second-tenant refusal fixture
       --force              seed a tenant that already holds foreign person rows
       --deadline <secs>    pod wall-clock ceiling                  [default: 3600]
@@ -127,6 +134,7 @@ while [[ $# -gt 0 ]]; do
     --step)              STEP="${2:?--step needs a value}"; shift 2 ;;
     --days)              WINDOW_DAYS="${2:?--days needs a value}"; shift 2 ;;
     --anchor)            ANCHOR_DATE="${2:?--anchor needs a value}"; shift 2 ;;
+    --org-headcount)     ORG_HEADCOUNT="${2:?--org-headcount needs a value}"; shift 2 ;;
     --deadline)          DEADLINE_SECONDS="${2:?--deadline needs a value}"; shift 2 ;;
     --cross-tenant)      CROSS_TENANT="1"; shift ;;
     --force)             FORCE="1"; shift ;;
@@ -150,6 +158,9 @@ esac
 # Also the poll loop's own budget; a non-numeric value would silently zero it.
 [[ "$DEADLINE_SECONDS" =~ ^[0-9]+$ && "$DEADLINE_SECONDS" -gt 0 ]] \
   || die "--deadline must be a positive whole number of seconds (got '$DEADLINE_SECONDS')."
+# Shape only; the seeder's own contract owns the range and reports it.
+[[ -z "$ORG_HEADCOUNT" || "$ORG_HEADCOUNT" =~ ^[0-9]+$ ]] \
+  || die "--org-headcount must be a whole number of people (got '$ORG_HEADCOUNT')."
 
 # Assumed from the namespace; every value below is verified, so a wrong
 # guess fails naming --release.
@@ -480,6 +491,10 @@ export SEED_FORCE="$FORCE"
 # Allowed to be empty: the seeder has its own default window.
 export SEED_WINDOW_DAYS="$WINDOW_DAYS"
 export SEED_ANCHOR_DATE="$ANCHOR_DATE"
+# Empty means the committed roster. Resolved here rather than in the template:
+# WORKAROUND: GNU envsubst emits `${VAR:-default}` verbatim, so a default
+# written in the template would reach the cluster as that literal.
+export SEED_ORG_HEADCOUNT="$ORG_HEADCOUNT"
 export SEED_PULL_SECRETS="$PULL_SECRETS"
 
 # Renders the Job manifest for the step in $SEED_STEP / name in $SEED_JOB_NAME.
@@ -494,18 +509,31 @@ render_seed_manifest() {
     ${SEED_CLICKHOUSE_DATABASE}
     ${SEED_TENANT_ID} ${SEED_DEV_USER_EMAIL} ${SEED_IDP_SOURCE_TYPE}
     ${SEED_CROSS_TENANT} ${SEED_FORCE} ${SEED_WINDOW_DAYS} ${SEED_ANCHOR_DATE}
+    ${SEED_ORG_HEADCOUNT}
     ${SEED_PULL_SECRETS}
   ' < "$JOB_TEMPLATE"
 }
 
 # print_manifest_sentinel NAME — re-read the finished Job's log and print the
-# one manifest line, or nothing for a step that writes no manifest. Read from
-# the completed Job rather than taken from the stream below, because the
-# seeder prints it last and `logs -f` can end without the container's final
-# lines; a consumer that lost it cannot tell a seeded stand from an attempt.
+# manifest, or nothing for a step that writes none. Read from the finished
+# Job: `logs -f` can end without the container's final lines, and a consumer
+# that lost the manifest cannot tell a seeded stand from an attempt.
 print_manifest_sentinel() {
-  kube -n "$NAMESPACE" logs "job/$1" --tail=-1 2>/dev/null \
-    | grep -m1 '^SEED_MANIFEST_JSON: ' || true
+  local log
+  log="$(kube -n "$NAMESPACE" logs "job/$1" --tail=-1 2>/dev/null || true)"
+  if grep -m1 '^SEED_MANIFEST_JSON: ' <<<"$log"; then
+    return 0
+  fi
+  grep -q '^SEED_MANIFEST_GZ: ' <<<"$log" || return 0
+
+  local chunks
+  chunks="$(grep -c '^SEED_MANIFEST_GZ: ' <<<"$log")"
+  echo "==> manifest emitted in $chunks gzipped chunk(s); reassembling" >&2
+  if printf '%s\n' "$log" | "$SCRIPT_DIR/manifest-from-log.sh"; then
+    return 0
+  fi
+  echo "ERROR: the Job's $chunks gzipped manifest chunk(s) could not be reassembled." >&2
+  return 1
 }
 
 # wait_for_job NAME — follow the pod's logs, then read the verdict from the Job
@@ -523,9 +551,9 @@ wait_for_job() {
     sleep 2
   done
 
-  # The sentinel is filtered out here and re-emitted from the finished Job on
-  # success, so the log carries it exactly once and never a truncated copy.
-  kube -n "$NAMESPACE" logs -f "job/$job_name" | grep -v '^SEED_MANIFEST_JSON: ' || true
+  # Filtered here and re-emitted from the finished Job, so the log carries
+  # the manifest once and never truncated.
+  kube -n "$NAMESPACE" logs -f "job/$job_name" | grep -Ev '^SEED_MANIFEST_(JSON|GZ): ' || true
 
   # Polled, not `kubectl wait --for=condition=complete`, which only waits for
   # success. `|| true`: a transient apiserver hiccup must not kill the loop.
@@ -582,7 +610,8 @@ run_seed_step() {
   job_name="insight-seed-${step}-$(date -u +%Y%m%d%H%M%S)"
   export SEED_STEP="$step"
   export SEED_JOB_NAME="$job_name"
-  render_seed_manifest | kube apply -f -
+  render_seed_manifest | kube apply -f - \
+    || die "kubectl apply failed for step $step; no Job was created."
   echo "==> applied Job $SEED_JOB_NAME (step: $step)"
   wait_for_job "$SEED_JOB_NAME"
 }
@@ -610,7 +639,10 @@ project_identity() {
   fi
   job_name="${cronjob}-ci-$(date -u +%Y%m%d%H%M%S)"
   echo "==> identity projection: $component (job/$job_name from cronjob/$cronjob)"
-  kube -n "$NAMESPACE" create job --from="cronjob/$cronjob" "$job_name"
+  kube -n "$NAMESPACE" create job --from="cronjob/$cronjob" "$job_name" || {
+    echo "ERROR: could not create $job_name from cronjob/$cronjob." >&2
+    return 1
+  }
   wait_for_job "$job_name" || {
     echo "ERROR: $component did not complete; gold would stay unresolved." >&2
     return 1

--- a/src/ingestion/tools/seed/tests/test_credential_scrub.py
+++ b/src/ingestion/tools/seed/tests/test_credential_scrub.py
@@ -1,0 +1,57 @@
+"""Tests for the manifest's credential scrub and what counts as an override.
+
+The scrub is a substring test that runs at the very END of a seed, after every
+database write, in a Job with `backoffLimit: 0`. Anything it refuses reports a
+correctly seeded stand as a failure with nothing left to retry — so what lands
+in the blocklist matters as much as the scan itself.
+
+Run against the installed package (see the README's develop section):
+
+    uv run --extra dev pytest tests
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from insight_seed import config, manifest
+
+_ENV = config.PERSONA_PASSWORD_ENV
+_DOC = {"tenant": "00000000-df51-5b42-9538-d2b56b7ee953", "personas": [{"name": "Luna Gonzalez"}]}
+
+
+@pytest.mark.parametrize("raw", ["", "   "])
+def test_an_empty_override_is_not_a_credential(raw: str) -> None:
+    """A blank value must read as unset, not as a literal every document holds."""
+    manifest.assert_no_credentials(_DOC, {_ENV: raw})
+
+
+def test_an_unset_override_leaves_the_static_literals() -> None:
+    assert manifest._forbidden_literals({}) == manifest._STATIC_FORBIDDEN_LITERALS
+
+
+def test_a_real_override_joins_the_blocklist() -> None:
+    literals = manifest._forbidden_literals({_ENV: "a-long-enough-persona-pw"})
+
+    assert "a-long-enough-persona-pw" in literals
+    assert literals >= manifest._STATIC_FORBIDDEN_LITERALS
+
+
+def test_a_document_carrying_the_override_is_refused() -> None:
+    doc = {**_DOC, "leaked": "a-long-enough-persona-pw"}
+
+    with pytest.raises(RuntimeError, match="credential literal"):
+        manifest.assert_no_credentials(doc, {_ENV: "a-long-enough-persona-pw"})
+
+
+def test_the_committed_default_is_always_refused() -> None:
+    """Even on a stand that overrides it — the default must never ship."""
+    doc = {**_DOC, "leaked": "insight-dev"}
+
+    with pytest.raises(RuntimeError, match="credential literal"):
+        manifest.assert_no_credentials(doc, {_ENV: "a-long-enough-persona-pw"})
+
+
+def test_a_credential_bearing_key_is_refused_whatever_its_value() -> None:
+    with pytest.raises(RuntimeError, match="credential-bearing"):
+        manifest.assert_no_credentials({**_DOC, "db_password": "anything"}, {})

--- a/src/ingestion/tools/seed/tests/test_full_refresh.py
+++ b/src/ingestion/tools/seed/tests/test_full_refresh.py
@@ -1,0 +1,190 @@
+"""Tests for the seed's `--full-refresh` of the incremental identity feeders.
+
+The defect these protect against is silent, which is why it needs a test rather
+than a reviewer's attention. A seed REPLACES the org, but two models it depends
+on are incremental — `bamboohr__employees_snapshot` appends, and
+`identity_inputs` admits only rows past the current max `_version`. Seed a stand
+with a roster whose people are NEW to it and nothing errors anywhere: bronze
+holds the new people, the feeders keep describing the previous accounts,
+persons-seed resolves that stale set, and gold goes on serving the old org.
+
+Two halves are asserted here:
+  * the silver step asks for a full refresh (the fix), and
+  * the deploy path does not (the Helm migrate Hook runs the same script with
+    no arguments, and its incremental models must keep their boundary).
+
+Run against the installed package (see the README's develop section):
+
+    uv run --extra dev pytest tests
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from insight_seed import silver
+
+_SCRIPTS = Path(__file__).resolve().parents[3] / "scripts"
+_MIGRATIONS = _SCRIPTS / "apply-ch-migrations.sh"
+
+_STUB_SCRIPT_ENV = {"CLICKHOUSE_URL": "http://clickhouse.nonpresent:8123"}
+
+ScriptRun = tuple[list[str], dict[str, str]]
+
+
+class _StubClient:
+    """Stands in for the ClickHouse client `silver.run` opens and closes."""
+
+    server_version = "0.0.0-stub"
+
+    def close(self) -> None:
+        pass
+
+
+@pytest.fixture
+def script_runs(monkeypatch: pytest.MonkeyPatch) -> list[ScriptRun]:
+    """argv and env of every shell script the module would have run."""
+    runs: list[ScriptRun] = []
+
+    def record(argv: list[str], **kwargs: Any) -> None:
+        runs.append((list(argv), dict(kwargs["env"])))
+
+    monkeypatch.setattr("insight_seed.silver.subprocess.run", record)
+    monkeypatch.setattr(silver, "_script_env", lambda: dict(_STUB_SCRIPT_ENV))
+    return runs
+
+
+@pytest.fixture
+def refresh_requests(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """What each seed step asks `apply_ch_migrations` for, without running it."""
+    requests: list[dict[str, Any]] = []
+
+    def record(**kwargs: Any) -> None:
+        requests.append(kwargs)
+
+    monkeypatch.setattr(silver, "apply_ch_migrations", record)
+    return requests
+
+
+@pytest.fixture
+def offline_silver_step(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Everything `silver.run` touches besides the migration script."""
+    monkeypatch.setattr(silver, "apply_create_bronze_placeholders", lambda: None)
+    monkeypatch.setattr(silver, "_ch_client", _StubClient)
+    monkeypatch.setattr(silver, "generate_rows", lambda client: None)
+
+
+def _only(items: list[Any], what: str) -> Any:
+    assert len(items) == 1, f"expected exactly one {what}, got {len(items)}"
+    return items[0]
+
+
+def _run_migration_script(
+    *args: str, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(_MIGRATIONS), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def test_default_passes_no_flag(script_runs: list[ScriptRun]) -> None:
+    """The deploy path: bash <script>, nothing else."""
+    silver.apply_ch_migrations()
+
+    argv, _ = _only(script_runs, "script run")
+    assert argv[0] == "bash"
+    assert "--full-refresh" not in argv
+
+
+def test_full_refresh_appends_the_flag(script_runs: list[ScriptRun]) -> None:
+    silver.apply_ch_migrations(full_refresh=True)
+
+    argv, _ = _only(script_runs, "script run")
+    assert argv[-1] == "--full-refresh"
+
+
+def test_flag_never_leaks_into_the_environment(script_runs: list[ScriptRun]) -> None:
+    """DBT_FULL_REFRESH is reconcile-connectors' name; we must not set it.
+
+    It is exported per sync there ("true" on a major bump), and env is
+    inherited by every child — reusing it would couple the two subsystems.
+    """
+    silver.apply_ch_migrations(full_refresh=True)
+
+    _, env = _only(script_runs, "script run")
+    assert "DBT_FULL_REFRESH" not in env
+
+
+def test_selector_still_travels_by_env(script_runs: list[ScriptRun]) -> None:
+    silver.apply_ch_migrations(dbt_select="tag:gold +identity_inputs")
+
+    _, env = _only(script_runs, "script run")
+    assert env["DBT_GOLD_SELECT"] == "tag:gold +identity_inputs"
+
+
+@pytest.mark.usefixtures("offline_silver_step")
+def test_silver_step_full_refreshes_the_identity_feeders(
+    refresh_requests: list[dict[str, Any]],
+) -> None:
+    silver.run()
+
+    request = _only(refresh_requests, "migration request")
+    assert request.get("full_refresh"), (
+        "the silver step must full-refresh: it just replaced every silver "
+        "relation the seed owns, so the incremental identity feeders have "
+        "to be rebuilt from it rather than appended to"
+    )
+    assert silver.IDENTITY_INPUTS_SELECT in request["dbt_select"]
+
+
+def test_gold_step_does_not_full_refresh(refresh_requests: list[dict[str, Any]]) -> None:
+    """`gold` rebuilds serving tables over an unchanged silver."""
+    silver.run_gold()
+
+    request = _only(refresh_requests, "migration request")
+    assert not request.get("full_refresh", False)
+
+
+def test_unknown_argument_is_refused() -> None:
+    done = _run_migration_script("--nope")
+
+    assert done.returncode == 2
+    assert "unknown argument" in done.stderr
+
+
+def test_help_prints_the_entire_header_block() -> None:
+    """A fixed-line slice truncates silently as soon as the header grows."""
+    header = []
+    for line in _MIGRATIONS.read_text().splitlines()[1:]:
+        if not line.startswith("#"):
+            break
+        header.append(line.removeprefix("#").removeprefix(" "))
+
+    done = _run_migration_script("--help")
+
+    assert done.returncode == 0
+    assert "--full-refresh" in done.stdout
+    assert done.stdout.splitlines() == header, (
+        "help output is not the whole header — the slice must end at the "
+        "first non-comment line, not a hardcoded line number"
+    )
+
+
+def test_accepted_flag_falls_through_to_the_env_asserts() -> None:
+    """Parsing --full-refresh must not short-circuit the script's contract.
+
+    The stripped env is the point: the script must still reach its own
+    CLICKHOUSE_* asserts rather than exit happy on a parsed flag.
+    """
+    done = _run_migration_script("--full-refresh", env={"PATH": "/usr/bin:/bin"})
+
+    assert done.returncode != 0
+    assert "CLICKHOUSE_URL" in done.stderr

--- a/src/ingestion/tools/seed/tests/test_org_headcount.py
+++ b/src/ingestion/tools/seed/tests/test_org_headcount.py
@@ -353,6 +353,18 @@ def test_a_missing_chunk_is_an_error_not_a_partial_document() -> None:
         manifest.decode_manifest_sentinel(lines[:-1])
 
 
+#: The apiserver's cap on the summed length of a ConfigMap's `data` entries.
+_CONFIGMAP_DATA_MAX_BYTES = 1024 * 1024
+
+
+def test_the_largest_roster_still_fits_a_configmap() -> None:
+    """`seed-stand.sh` publishes this document; raising the ceiling can break it."""
+    doc = manifest.build_manifest(_env(str(config.MAX_ORG_HEADCOUNT)))
+    compact = json.dumps(doc, separators=(",", ":"), ensure_ascii=False)
+
+    assert len(compact.encode("utf-8")) < _CONFIGMAP_DATA_MAX_BYTES
+
+
 def test_input_without_a_sentinel_is_an_error() -> None:
     with pytest.raises(ValueError):
         manifest.decode_manifest_sentinel(["nothing to see here"])

--- a/src/ingestion/tools/seed/tests/test_org_headcount.py
+++ b/src/ingestion/tools/seed/tests/test_org_headcount.py
@@ -1,0 +1,422 @@
+"""Tests for the opt-in org-size knob (`SEED_ORG_HEADCOUNT`).
+
+The knob exists so a stand can be seeded with a realistic headcount; the thing
+these tests actually protect is the OTHER side of it — that a stand which did
+not ask for one gets the committed 26-person roster, unchanged, because CI and
+the compose stand suite assert against exactly those people.
+
+Run against the installed package (see the README's develop section):
+
+    uv run --extra dev pytest tests
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from insight_seed import config, manifest, profiles, scale
+
+_EMAIL = "dev@company.nonpresent"
+_TENANT = "00000000-df51-5b42-9538-d2b56b7ee953"
+
+_SEED_DIR = Path(__file__).resolve().parent.parent
+_REASSEMBLER = _SEED_DIR / "manifest-from-log.sh"
+_needs_reassembler = pytest.mark.skipif(
+    not (_REASSEMBLER.is_file() and shutil.which("bash")),
+    reason="manifest-from-log.sh needs bash",
+)
+
+_ENV = config.ORG_HEADCOUNT_ENV
+_COMMITTED = config.CANONICAL_ROSTER_SIZE
+_GROWN = 250
+_PLAN_TARGETS = (27, 30, 100, _GROWN, 999, config.MAX_ORG_HEADCOUNT)
+
+
+@pytest.fixture(scope="module")
+def committed_roster() -> list[profiles.Person]:
+    return profiles.build_roster(_EMAIL)
+
+
+@pytest.fixture(scope="module")
+def grown_roster() -> list[profiles.Person]:
+    return profiles.build_seeded_roster(_EMAIL, _GROWN)
+
+
+def _growth(grown_roster: list[profiles.Person]) -> list[profiles.Person]:
+    return grown_roster[_COMMITTED:]
+
+
+@pytest.mark.parametrize("raw", ["", "   ", "0"])
+def test_an_unasked_for_headcount_parses_to_no_growth(raw: str) -> None:
+    assert config.parse_org_headcount({_ENV: raw}) == 0
+
+
+def test_an_absent_variable_parses_to_no_growth() -> None:
+    assert config.parse_org_headcount({}) == 0
+
+
+@pytest.mark.parametrize(
+    ("raw", "want"),
+    [("26", 26), ("27", 27), ("250", 250), (" 250 ", 250), ("3000", 3000)],
+)
+def test_a_headcount_at_or_above_the_committed_roster_passes_through(raw: str, want: int) -> None:
+    assert config.parse_org_headcount({_ENV: raw}) == want
+
+
+@pytest.mark.parametrize("value", range(1, _COMMITTED))
+def test_below_the_committed_roster_is_refused(value: int) -> None:
+    """The roster only grows: the committed people are named fixtures."""
+    with pytest.raises(config.EnvContractError) as refusal:
+        config.parse_org_headcount({_ENV: str(value)})
+
+    assert str(_COMMITTED) in str(refusal.value), f"refusal should name the floor: {value}"
+
+
+def test_over_the_ceiling_is_refused_by_name() -> None:
+    with pytest.raises(config.EnvContractError) as refusal:
+        config.parse_org_headcount({_ENV: str(config.MAX_ORG_HEADCOUNT + 1)})
+
+    assert str(config.MAX_ORG_HEADCOUNT) in str(refusal.value)
+
+
+@pytest.mark.parametrize("raw", ["abc", "26.5", "1e3", " twenty ", "0x1a"])
+def test_a_non_integer_is_refused(raw: str) -> None:
+    with pytest.raises(config.EnvContractError):
+        config.parse_org_headcount({_ENV: raw})
+
+
+def test_a_negative_headcount_is_refused() -> None:
+    """An integer, so it reaches the floor check rather than the parse one."""
+    with pytest.raises(config.EnvContractError):
+        config.parse_org_headcount({_ENV: "-1"})
+
+
+def test_the_empty_environment_matches_build_roster_exactly(
+    committed_roster: list[profiles.Person],
+) -> None:
+    got = profiles.build_seeded_roster(_EMAIL, config.parse_org_headcount({}))
+
+    assert len(got) == _COMMITTED
+    assert got == committed_roster
+    # Names are assigned by build-order index, so order is part of the contract.
+    assert [p.uuid for p in got] == [p.uuid for p in committed_roster]
+    assert [p.email for p in got] == [p.email for p in committed_roster]
+    assert [p.display_name for p in got] == [p.display_name for p in committed_roster]
+
+
+@pytest.mark.parametrize("raw", ["0", "26", ""])
+def test_an_inert_value_builds_the_committed_roster(
+    raw: str, committed_roster: list[profiles.Person]
+) -> None:
+    """Parsed exactly as a run would parse it, then built from the result."""
+    headcount = config.parse_org_headcount({_ENV: raw})
+
+    assert profiles.build_seeded_roster(_EMAIL, headcount) == committed_roster
+
+
+def test_the_default_path_never_imports_scale() -> None:
+    """In a fresh interpreter, so this test's own import cannot mask it.
+
+    `build_seeded_roster` imports `scale` inside the grown branch precisely
+    so the committed path cannot be affected by anything in that module.
+    """
+    source = (
+        "import sys\n"
+        "from insight_seed import profiles\n"
+        f"roster = profiles.build_seeded_roster({_EMAIL!r}, 0)\n"
+        f"assert len(roster) == {_COMMITTED}, len(roster)\n"
+        "assert 'insight_seed.scale' not in sys.modules, 'scale.py was imported'\n"
+    )
+
+    subprocess.run([sys.executable, "-c", source], check=True)
+
+
+def test_a_grown_roster_has_exactly_the_asked_for_size(
+    grown_roster: list[profiles.Person],
+) -> None:
+    assert len(grown_roster) == _GROWN
+
+
+def test_the_committed_roster_is_the_prefix_of_a_grown_one(
+    committed_roster: list[profiles.Person], grown_roster: list[profiles.Person]
+) -> None:
+    assert grown_roster[:_COMMITTED] == committed_roster
+
+
+@pytest.mark.parametrize("field", ["uuid", "email", "display_name"])
+def test_every_identifier_stays_unique_across_a_grown_roster(
+    field: str, grown_roster: list[profiles.Person]
+) -> None:
+    values = [getattr(person, field) for person in grown_roster]
+
+    assert len(set(values)) == len(values), f"duplicate {field}"
+
+
+def test_growth_uses_its_own_identifier_namespaces(
+    committed_roster: list[profiles.Person], grown_roster: list[profiles.Person]
+) -> None:
+    committed_emails = {p.email for p in committed_roster}
+    committed_uuids = {p.uuid for p in committed_roster}
+
+    for person in _growth(grown_roster):
+        assert person.email not in committed_emails
+        assert person.uuid not in committed_uuids
+        assert person.uuid.startswith("eeeeeeee-"), person.uuid
+        assert person.email.endswith(f"@{profiles.COMPANY_EMAIL_SUFFIX}")
+
+
+def test_growth_reuses_the_existing_roles_and_teams(
+    grown_roster: list[profiles.Person],
+) -> None:
+    """An unknown role or team KeyErrors mid-seed; there must be neither."""
+    for person in _growth(grown_roster):
+        assert person.role in {"lead", "ic"}
+        assert person.team in profiles.TEAM_PROFILES
+        assert person.role in manifest.ROLE_TO_REALM_ROLES
+
+
+def test_the_org_chart_stays_connected(grown_roster: list[profiles.Person]) -> None:
+    """Every growth person reports to somebody already in the roster."""
+    by_uuid = {p.uuid: p for p in grown_roster}
+
+    for person in _growth(grown_roster):
+        assert person.parent_uuid is not None
+        parent = by_uuid[str(person.parent_uuid)]
+        assert parent.team == person.team
+        assert parent.role == "lead"
+
+
+def test_no_squad_exceeds_the_span(grown_roster: list[profiles.Person]) -> None:
+    reports: dict[str, int] = {}
+    for person in _growth(grown_roster):
+        if person.role == "ic":
+            reports[str(person.parent_uuid)] = reports.get(str(person.parent_uuid), 0) + 1
+
+    assert reports
+    assert max(reports.values()) <= scale.SQUAD_SPAN
+
+
+def test_committed_ics_keep_their_lead(
+    committed_roster: list[profiles.Person], grown_roster: list[profiles.Person]
+) -> None:
+    for before, after in zip(committed_roster, grown_roster, strict=False):
+        assert before.parent_uuid == after.parent_uuid
+
+
+def test_team_shares_stay_balanced(grown_roster: list[profiles.Person]) -> None:
+    counts = dict.fromkeys(scale.GROWTH_TEAMS, 0)
+    for person in _growth(grown_roster):
+        counts[str(person.team)] += 1
+
+    assert max(counts.values()) - min(counts.values()) <= 1
+
+
+@pytest.mark.parametrize("target", [_COMMITTED + 1, config.MAX_ORG_HEADCOUNT])
+def test_the_growth_extremes_stay_unique(target: int) -> None:
+    roster = profiles.build_seeded_roster(_EMAIL, target)
+
+    assert len(roster) == target
+    assert len({p.email for p in roster}) == target
+    assert len({p.display_name for p in roster}) == target
+
+
+@pytest.mark.parametrize("target", _PLAN_TARGETS)
+def test_planned_slots_add_up_to_the_growth(target: int) -> None:
+    plans = scale.plan(target)
+
+    assert sum(p.total for p in plans) == target - _COMMITTED
+
+
+@pytest.mark.parametrize("target", _PLAN_TARGETS)
+def test_every_planned_ic_fits_a_squad(target: int) -> None:
+    for team_plan in scale.plan(target):
+        if team_plan.ics:
+            assert team_plan.managers >= 1, f"{team_plan.team} has ics and no lead"
+        assert team_plan.ics <= team_plan.managers * scale.SQUAD_SPAN, team_plan.team
+
+
+def test_a_base_that_is_not_the_committed_roster_is_refused() -> None:
+    """`extend_roster` runs inside a Job against a real stand.
+
+    A duplicated email resolves to nobody in gold rather than failing, so the
+    writer has to refuse before it writes anything.
+    """
+    with pytest.raises(RuntimeError):
+        scale.extend_roster(profiles.build_roster(_EMAIL)[:10], _GROWN)
+
+
+def test_a_target_that_is_not_growth_is_refused() -> None:
+    with pytest.raises(RuntimeError):
+        scale.extend_roster(profiles.build_roster(_EMAIL), _COMMITTED)
+
+
+def test_bulk_names_cannot_collide_with_the_committed_ones() -> None:
+    assert not set(scale._BULK_LAST_NAMES) & set(profiles._LAST_NAMES)
+
+
+def test_bulk_names_are_deterministic() -> None:
+    """Same Faker seed, same pool: a re-seeded stand keeps its people's names."""
+    regenerated = scale._generate_bulk_last_names()
+
+    assert regenerated == scale._BULK_LAST_NAMES
+    assert len(set(regenerated)) == len(regenerated)
+
+
+def _env(headcount: str | None = None) -> dict[str, str]:
+    env = {
+        "DEV_USER_EMAIL": _EMAIL,
+        "TENANT_DEFAULT_ID": _TENANT,
+        "SEED_ANCHOR_DATE": "2026-06-30",
+        "SEED_DAYS": "60",
+        config.CROSS_TENANT_FIXTURE_ENV: "0",
+    }
+    if headcount is not None:
+        env[_ENV] = headcount
+    return env
+
+
+def _emit(doc: dict[str, Any]) -> list[str]:
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        manifest.emit_manifest_sentinel(doc)
+    return buffer.getvalue().splitlines()
+
+
+@pytest.fixture(scope="module")
+def default_manifest() -> dict[str, Any]:
+    return manifest.build_manifest(_env())
+
+
+@pytest.fixture(scope="module")
+def grown_manifest() -> dict[str, Any]:
+    return manifest.build_manifest(_env(str(_GROWN)))
+
+
+def test_the_default_roster_still_emits_one_plain_line(
+    default_manifest: dict[str, Any],
+) -> None:
+    """The manifest is printed after every write, in a Job with backoffLimit 0.
+
+    Refusing an oversized document there would report a correctly seeded stand
+    as a failure, with nothing left to retry.
+    """
+    lines = _emit(default_manifest)
+
+    assert len(lines) == 1
+    assert lines[0].startswith(manifest.SENTINEL_PREFIX)
+    assert len(lines[0].encode("utf-8")) <= manifest._SENTINEL_MAX_BYTES
+    assert json.loads(lines[0][len(manifest.SENTINEL_PREFIX) :]) == default_manifest
+    assert manifest.decode_manifest_sentinel(lines) == default_manifest
+
+
+def test_a_grown_roster_round_trips_through_the_chunked_form(
+    grown_manifest: dict[str, Any],
+) -> None:
+    assert len(grown_manifest["personas"]) == _GROWN
+
+    lines = _emit(grown_manifest)
+
+    assert lines
+    for line in lines:
+        assert line.startswith(manifest.GZ_SENTINEL_PREFIX), line[:40]
+        assert len(line.encode("utf-8")) <= manifest._SENTINEL_MAX_BYTES
+    assert manifest.decode_manifest_sentinel(lines) == grown_manifest
+
+
+def test_chunks_survive_reordering_and_surrounding_log_noise(
+    grown_manifest: dict[str, Any],
+) -> None:
+    lines = [
+        "2026-06-30 INFO seed.silver generating rows",
+        *reversed(_emit(grown_manifest)),
+        "done",
+    ]
+
+    assert manifest.decode_manifest_sentinel(lines) == grown_manifest
+
+
+def test_a_missing_chunk_is_an_error_not_a_partial_document() -> None:
+    doc = manifest.build_manifest(_env(str(config.MAX_ORG_HEADCOUNT)))
+    lines = _emit(doc)
+    assert len(lines) > 1, "the largest roster should need several chunks"
+
+    with pytest.raises(ValueError):
+        manifest.decode_manifest_sentinel(lines[:-1])
+
+
+def test_input_without_a_sentinel_is_an_error() -> None:
+    with pytest.raises(ValueError):
+        manifest.decode_manifest_sentinel(["nothing to see here"])
+
+
+def test_an_identical_line_read_twice_is_tolerated(grown_manifest: dict[str, Any]) -> None:
+    """A re-read log repeats lines; the same bytes are the same chunk."""
+    lines = _emit(grown_manifest)
+
+    assert manifest.decode_manifest_sentinel(lines + lines) == grown_manifest
+
+
+def test_conflicting_totals_are_an_error_not_a_splice(grown_manifest: dict[str, Any]) -> None:
+    """Two emissions in one log must fail, not decode whichever came last."""
+    lines = _emit(grown_manifest)
+    foreign = f"{manifest.GZ_SENTINEL_PREFIX}1/{len(lines) + 1} AAAA"
+
+    with pytest.raises(ValueError):
+        manifest.decode_manifest_sentinel([foreign, *lines])
+
+
+def test_a_differing_duplicate_chunk_is_an_error(grown_manifest: dict[str, Any]) -> None:
+    lines = _emit(grown_manifest)
+    forged = f"{manifest.GZ_SENTINEL_PREFIX}1/{len(lines)} AAAA"
+
+    with pytest.raises(ValueError):
+        manifest.decode_manifest_sentinel([*lines, forged])
+
+
+@_needs_reassembler
+@pytest.mark.parametrize("manifest_fixture", ["default_manifest", "grown_manifest"])
+def test_the_shell_reassembler_agrees_with_the_python_one(
+    manifest_fixture: str, request: pytest.FixtureRequest
+) -> None:
+    doc = request.getfixturevalue(manifest_fixture)
+    log = "\n".join(["starting", *_emit(doc), "done"]) + "\n"
+
+    result = subprocess.run(
+        ["bash", str(_REASSEMBLER)],
+        input=log,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    out = result.stdout.strip()
+    assert out.startswith(manifest.SENTINEL_PREFIX), out[:60]
+    assert json.loads(out[len(manifest.SENTINEL_PREFIX) :]) == doc
+
+
+@_needs_reassembler
+def test_the_shell_reassembler_refuses_a_corrupt_payload() -> None:
+    """A failed decode must not print a bare sentinel — it matches the grep.
+
+    Consumers select the manifest with `grep -m1 '^SEED_MANIFEST_JSON: '`, so
+    an empty line under that prefix reads as a valid, empty manifest.
+    """
+    result = subprocess.run(
+        ["bash", str(_REASSEMBLER)],
+        input=f"{manifest.GZ_SENTINEL_PREFIX}1/1 !!!!notbase64!!!!\n",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert manifest.SENTINEL_PREFIX not in result.stdout

--- a/tests/stand/README.md
+++ b/tests/stand/README.md
@@ -77,8 +77,9 @@ stand it exists only in the seed Job's log — recover it from there while the
 Job survives:
 
 ```bash
-kubectl -n <namespace> logs job/<the seed job> \
-  | grep -m1 '^SEED_MANIFEST_JSON: ' | cut -d' ' -f2- > stand-manifest.json
+kubectl -n <namespace> logs job/<the seed job> --tail=-1 \
+  | src/ingestion/tools/seed/manifest-from-log.sh \
+  | cut -d' ' -f2- > stand-manifest.json
 ```
 
 It names personas and in-cluster addresses, so it stays on the machine that

--- a/tests/stand/README.md
+++ b/tests/stand/README.md
@@ -72,9 +72,17 @@ uv run --project tests --frozen pytest tests/stand -ra \
   --stand-manifest /path/to/stand-manifest.json
 ```
 
-The manifest is the seed's own record of what it wrote, and on a cluster
-stand it exists only in the seed Job's log — recover it from there while the
-Job survives:
+The manifest is the seed's own record of what it wrote. A completed
+`--step all` publishes it to a ConfigMap that outlives the seed Job, so read it
+from there:
+
+```bash
+kubectl -n <namespace> get configmap seed-stand-manifest \
+  -o 'go-template={{index .data "manifest"}}' > stand-manifest.json
+```
+
+On a stand seeded before that existed, recover it from the Job log instead —
+only while the Job survives its one-hour TTL:
 
 ```bash
 kubectl -n <namespace> logs job/<the seed job> --tail=-1 \


### PR DESCRIPTION
Stacked on #2735 — review that first; this branch's own diff is the second commit.

**Why.** The manifest describes a stand that lives until someone tears it down, but its only copy outliving the seed pod was the Job log, which Kubernetes deletes an hour later. Recovering it after that meant re-seeding the stand — replacing its data to read a description of it.

**What changed.** A completed `--step all` publishes the compact manifest to `configmap/seed-stand-manifest`. `seed-stand.sh` already recovers the document into a shell variable and already runs under a credential granted `configmaps create/update`, so the writer is the script.

**Nothing is added to the seed pod.** No ServiceAccount, no RBAC object, no Kubernetes client, no image or dependency change. An in-pod writer would have needed all four, plus a preflight access review, to reach a capability the script already has.

**Publishing is warn-only.** It happens after every database write in a Job with `backoffLimit: 0`, and the log sentinel still carries the document — a failed publish must not report a seeded stand as broken.

**The compact rendering is stored, not the file rendering.** Measured at the roster ceiling: compact 624 KB (59% of the 1 MiB object cap), file 871 KB (83%). The apply is server-side because a client-side one stamps `last-applied-configuration`, whose 256 KiB cap the document crosses inside the supported range.

**Out of scope.** Readers still parse the log; moving them, and then deleting the chunked transport, are separate changes.

**Verified.** 150 seed tests, ruff, mypy, shellcheck clean; a new test fails if a ceiling bump pushes the manifest past the ConfigMap cap. Stand behaviour is unverified until this deploys.
