### PR TITLE
perf(bitbucket): stop fetching the diff text nothing reads

### DIFF
--- a/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
@@ -596,8 +596,11 @@ streams:
         request_parameters:
           repo: "{{ stream_partition.repo_clone_url }}"
           page_size: "500"
-          include_patch: "true"
-          max_patch_bytes: "1048576"
+          # The diff text is not stored: it arrives truncated past
+          # max_patch_bytes and nothing downstream reads it, while producing it
+          # is the proxy's most expensive work — every page fetches the blobs
+          # behind each diff. Filenames, statuses and line counts are unaffected.
+          include_patch: "false"
       record_selector:
         type: RecordSelector
         extractor:


### PR DESCRIPTION
**Why.** `file_changes` asked the proxy for diff text capped at 1 MiB. Anything past the cap arrived truncated — unusable to a reader that needs the whole diff — and no staging model selects the column, so the work bought nothing.

**What changed.** `include_patch: "false"` on the `file_changes` requester. The proxy then skips reading patches entirely, which is its most expensive per-page operation: a blobless clone must fetch the blobs on both sides of every change before it can render a diff, for every repository in the workspace.

**`patch` and `patch_truncated` stay in the schema and are now always null.** Removing them changes the bronze column shape and the committed DDL snapshot for no functional gain, so they are left in place rather than churned.

Filenames, statuses, line counts and the object ids are unaffected — nothing that reaches silver changes.

**Verified.** Connector mock suite 19/19. Not run: a sync against a live instance.
