### PR TITLE
fix(reports): support flat report scopes

### DIFF
--- a/src/frontend/src/components/portal/report-builder-view.test.tsx
+++ b/src/frontend/src/components/portal/report-builder-view.test.tsx
@@ -71,6 +71,18 @@ const person = {
   subordinates: [],
 };
 
+const reportPerson = {
+  entityId: "p1",
+  name: "Jane Doe",
+  email: "jane.doe@example.com",
+  division: "",
+  department: "",
+  jobTitle: "",
+  managerName: "",
+  managerEmail: "",
+  status: "",
+};
+
 beforeEach(() => {
   mocks.definitions = [
     definition({}),
@@ -88,6 +100,7 @@ beforeEach(() => {
   mocks.scope = {
     pivot: person,
     roster: [{ person_id: "P1" }],
+    reportPeople: [reportPerson],
     label: "Jane Doe",
     isLoading: false,
     isError: false,
@@ -142,7 +155,7 @@ describe("ReportBuilderView", () => {
 
   it("says when the scope is what blocks the build, once a metric is picked", async () => {
     const user = userEvent.setup();
-    mocks.scope = { ...mocks.scope, roster: [] };
+    mocks.scope = { ...mocks.scope, roster: [], reportPeople: [] };
     render(<ReportBuilderView />);
 
     await user.click(box("Commits"));
@@ -175,6 +188,27 @@ describe("ReportBuilderView", () => {
 
     await user.click(box("Commits"));
     expect(build).not.toBeDisabled();
+  });
+
+  it("builds from a flat scope without a tree pivot", async () => {
+    const user = userEvent.setup();
+    mocks.scope = {
+      ...mocks.scope,
+      pivot: null,
+      roster: [{ person_id: "P1" }],
+      reportPeople: [reportPerson],
+      label: "Whole organisation",
+    };
+    render(<ReportBuilderView />);
+
+    await user.click(box("Commits"));
+    await user.click(screen.getByRole("button", { name: "Build report" }));
+
+    await waitFor(() =>
+      expect(mocks.run).toHaveBeenCalledWith(
+        expect.objectContaining({ entityIds: ["p1"] }),
+      ),
+    );
   });
 
   it("offers the file once the run has finished, stamped with what made it", async () => {
@@ -226,6 +260,7 @@ describe("ReportBuilderView", () => {
       ...mocks.scope,
       pivot: { ...person, person_id: "P2", display_name: "Sam Smith" },
       roster: [{ person_id: "P2" }],
+      reportPeople: [{ ...reportPerson, entityId: "p2", name: "Sam Smith" }],
     };
     rerender(<ReportBuilderView />);
     await waitFor(() =>

--- a/src/frontend/src/components/portal/report-builder-view.test.tsx
+++ b/src/frontend/src/components/portal/report-builder-view.test.tsx
@@ -83,6 +83,29 @@ const reportPerson = {
   status: "",
 };
 
+const decimalResult = (value: number) =>
+  ({
+    metric_key: "git.commits",
+    label: "Commits",
+    format: "decimal",
+    unit: null,
+    direction: "neutral",
+    computation: "sum",
+    views: [
+      {
+        view: "timeseries",
+        bucket: "month",
+        series: [
+          {
+            entity_id: "p1",
+            dimensions: [],
+            points: [{ bucket_start: "2026-05-01", value }],
+          },
+        ],
+      },
+    ],
+  }) as never;
+
 beforeEach(() => {
   mocks.definitions = [
     definition({}),
@@ -209,6 +232,19 @@ describe("ReportBuilderView", () => {
         expect.objectContaining({ entityIds: ["p1"] }),
       ),
     );
+  });
+
+  it("formats rounded metric values in the preview", async () => {
+    const user = userEvent.setup();
+    mocks.run.mockResolvedValueOnce(
+      new Map([["git.commits", decimalResult(1082.1594444444445)]]),
+    );
+    render(<ReportBuilderView />);
+
+    await user.click(box("Commits"));
+    await user.click(screen.getByRole("button", { name: "Build report" }));
+
+    expect(await screen.findByText("1,082.2")).toBeInTheDocument();
   });
 
   it("offers the file once the run has finished, stamped with what made it", async () => {

--- a/src/frontend/src/components/portal/report-builder-view.tsx
+++ b/src/frontend/src/components/portal/report-builder-view.tsx
@@ -29,6 +29,7 @@ import {
 import { ComingSoon } from "@/components/widgets/coming-soon";
 import { usePortalPeriod } from "@/hooks/use-portal-period";
 import { downloadMatrixCsv, downloadMatrixXlsx } from "@/lib/export/matrix";
+import { formatMetricNumber } from "@/lib/format";
 import { useOrgScope } from "@/lib/portal/use-org-scope";
 import { unavailableReason } from "@/lib/reports/availability";
 import { byFamily } from "@/lib/reports/families";
@@ -451,7 +452,9 @@ export function ReportBuilderView() {
                           key={cellIndex}
                           className="whitespace-nowrap tabular-nums"
                         >
-                          {cell ?? "—"}
+                          {typeof cell === "number" && table.formats[cellIndex]
+                            ? formatMetricNumber(cell, table.formats[cellIndex])
+                            : cell ?? "—"}
                         </TableCell>
                       ))}
                     </TableRow>

--- a/src/frontend/src/components/portal/report-builder-view.tsx
+++ b/src/frontend/src/components/portal/report-builder-view.tsx
@@ -29,12 +29,10 @@ import {
 import { ComingSoon } from "@/components/widgets/coming-soon";
 import { usePortalPeriod } from "@/hooks/use-portal-period";
 import { downloadMatrixCsv, downloadMatrixXlsx } from "@/lib/export/matrix";
-import { normalizePersonId } from "@/lib/metrics/entity";
 import { useOrgScope } from "@/lib/portal/use-org-scope";
 import { unavailableReason } from "@/lib/reports/availability";
 import { byFamily } from "@/lib/reports/families";
 import { buildReportTable, type ReportTable } from "@/lib/reports/report-table";
-import { collectReportPeople } from "@/lib/reports/roster-columns";
 import { recordUsageEvent } from "@/telemetry";
 import {
   bucketsInRange,
@@ -107,13 +105,7 @@ export function ReportBuilderView() {
     [catalogue, computations.data, granularity],
   );
 
-  const people = useMemo(() => {
-    const attrs = collectReportPeople(scope.pivot);
-    return (scope.roster ?? []).flatMap((entry) => {
-      const person = attrs.get(normalizePersonId(entry.person_id));
-      return person ? [person] : [];
-    });
-  }, [scope.pivot, scope.roster]);
+  const people = scope.reportPeople ?? [];
 
   const selectedMetrics = useMemo(
     () =>

--- a/src/frontend/src/lib/format.test.ts
+++ b/src/frontend/src/lib/format.test.ts
@@ -9,6 +9,7 @@ import {
   formatUtcClock,
   formatUtcInstant,
   metricDisplayUnit,
+  roundMetricValue,
 } from "@/lib/format";
 
 describe("formatMetricNumber / formatMetricValue / metricDisplayUnit", () => {
@@ -20,6 +21,11 @@ describe("formatMetricNumber / formatMetricValue / metricDisplayUnit", () => {
   it("rounds decimal format to one decimal and integers to whole", () => {
     expect(formatMetricNumber(1.24, "decimal")).toBe("1.2");
     expect(formatMetricNumber(1234.6, "integer")).toBe("1,235");
+  });
+
+  it("rounds numeric values with the metric's display precision", () => {
+    expect(roundMetricValue(1.24, "decimal")).toBe(1.2);
+    expect(roundMetricValue(1234.6, "integer")).toBe(1235);
   });
 
   it("suffixes percent and unit forms", () => {
@@ -83,4 +89,3 @@ describe("small formatters", () => {
     expect(formatUtcAge("2026-08-01T10:15:00Z", now)).toBe("7 days ago");
   });
 });
-

--- a/src/frontend/src/lib/format.ts
+++ b/src/frontend/src/lib/format.ts
@@ -19,6 +19,10 @@ const METRIC_CURRENCY_FORMAT = new Intl.NumberFormat(LOCALE, {
  */
 export const NO_METRIC_VALUE = "—";
 
+export function roundMetricValue(v: number, fmt: MetricFormat): number {
+  return fmt === "decimal" ? Math.round(v * 10) / 10 : Math.round(v);
+}
+
 /**
  * Formatting for `/v1/metric-results` values: the wire `format` decides
  * rounding and presentation; `unit` is a display suffix only. Bare number —
@@ -33,8 +37,8 @@ export function formatMetricNumber(
   fmt: MetricFormat,
 ): string {
   if (v == null || !Number.isFinite(v)) return NO_METRIC_VALUE;
-  if (fmt === "currency") return METRIC_CURRENCY_FORMAT.format(v);
-  const rounded = fmt === "decimal" ? Math.round(v * 10) / 10 : Math.round(v);
+  const rounded = roundMetricValue(v, fmt);
+  if (fmt === "currency") return METRIC_CURRENCY_FORMAT.format(rounded);
   return NF_THOUSANDS.format(rounded);
 }
 

--- a/src/frontend/src/lib/identities/report-person.ts
+++ b/src/frontend/src/lib/identities/report-person.ts
@@ -1,0 +1,69 @@
+import type { PersonSummary } from "@/api/identity-client";
+import { personDisplayName } from "@/lib/identities/person-display";
+import { normalizePersonId } from "@/lib/metrics/entity";
+import type { IdentityPerson } from "@/types/insight";
+
+export interface ReportPerson {
+  entityId: string;
+  name: string;
+  email: string;
+  division: string;
+  department: string;
+  jobTitle: string;
+  managerName: string;
+  managerEmail: string;
+  status: string;
+}
+
+export function collectReportPeople(
+  root: IdentityPerson | null,
+): Map<string, ReportPerson> {
+  const out = new Map<string, ReportPerson>();
+  const walk = (node: IdentityPerson): void => {
+    if (node.person_id) {
+      out.set(normalizePersonId(node.person_id), {
+        entityId: normalizePersonId(node.person_id),
+        name: personDisplayName(node),
+        email: node.email ?? "",
+        division: node.division ?? "",
+        department: node.department ?? "",
+        jobTitle: node.job_title ?? "",
+        managerName: node.supervisor_name ?? "",
+        managerEmail: node.supervisor_email ?? "",
+        status: node.status ?? "",
+      });
+    }
+    node.subordinates.forEach(walk);
+  };
+  if (root) walk(root);
+  return out;
+}
+
+export function reportPeopleInScope(
+  root: IdentityPerson | null,
+  roster: readonly { person_id: string }[] | null,
+): ReportPerson[] | null {
+  if (!roster) return null;
+
+  const attributes = collectReportPeople(root);
+  return roster.flatMap((entry) => {
+    const person = attributes.get(normalizePersonId(entry.person_id));
+    return person ? [person] : [];
+  });
+}
+
+export function reportPeopleInFlatScope(
+  roster: readonly PersonSummary[] | null,
+): ReportPerson[] | null {
+  return roster?.map((person) => ({
+    entityId: normalizePersonId(person.person_id),
+    name: personDisplayName(person),
+    email: person.email ?? "",
+    division: "",
+    department: "",
+    jobTitle: person.job_title ?? "",
+    managerName: "",
+    managerEmail: "",
+    status: person.status ?? "",
+  })) ?? null;
+}

--- a/src/frontend/src/lib/portal/use-org-scope.test.ts
+++ b/src/frontend/src/lib/portal/use-org-scope.test.ts
@@ -51,6 +51,10 @@ describe("resolveScopeRoster", () => {
   it("narrows to direct reports", () => {
     const s = resolveScopeRoster(TREE, "p-ao", { root: "p-lead1", directOnly: true });
     expect(s.roster?.map((r) => r.person_id).sort()).toEqual(["p-ic1", "p-lead2"]);
+    expect(s.reportPeople?.map((person) => person.entityId).sort()).toEqual([
+      "p-ic1",
+      "p-lead2",
+    ]);
   });
   it("falls back to the viewer when root is outside the tree", () => {
     const s = resolveScopeRoster(TREE, "p-ao", { root: "p-stranger", directOnly: false });
@@ -143,6 +147,32 @@ describe("flatOrgScope", () => {
         email: "",
         supervisor_person_id: null,
         is_direct: false,
+      },
+    ]);
+  });
+
+  it("carries report people from the visible roster", () => {
+    const scope = flatOrgScope([
+      {
+        person_id: "p-h",
+        display_name: "Handle",
+        email: "handle@example.com",
+        job_title: "Engineer",
+        status: "active",
+      },
+    ]);
+
+    expect(scope.reportPeople).toEqual([
+      {
+        entityId: "p-h",
+        name: "Handle",
+        email: "handle@example.com",
+        division: "",
+        department: "",
+        jobTitle: "Engineer",
+        managerName: "",
+        managerEmail: "",
+        status: "active",
       },
     ]);
   });

--- a/src/frontend/src/lib/portal/use-org-scope.ts
+++ b/src/frontend/src/lib/portal/use-org-scope.ts
@@ -9,6 +9,11 @@ import {
   type RosterEntry,
 } from "@/lib/insight/identity-tree";
 import {
+  reportPeopleInFlatScope,
+  reportPeopleInScope,
+  type ReportPerson,
+} from "@/lib/identities/report-person";
+import {
   type OrgScope,
 } from "@/lib/portal/portal-store";
 import {
@@ -36,6 +41,7 @@ export interface ResolvedScope {
   pivot: IdentityPerson | null;
   /** Everyone inside the scope (subtree or direct reports). */
   roster: RosterEntry[] | null;
+  reportPeople: ReportPerson[] | null;
   label: string;
   count: number;
   /** All manager nodes of the viewer's tree, for the ScopeSelect picker. */
@@ -62,6 +68,7 @@ export function flatOrgScope(
     return {
       pivot: null,
       roster: null,
+      reportPeople: null,
       label: WHOLE_ORG_LABEL,
       count: 0,
       managerNodes: [],
@@ -82,6 +89,7 @@ export function flatOrgScope(
   return {
     pivot: null,
     roster: members,
+    reportPeople: reportPeopleInFlatScope(roster),
     label: WHOLE_ORG_LABEL,
     count: members.length,
     managerNodes: [],
@@ -100,7 +108,15 @@ export function resolveScopeRoster(
   scope: OrgScope,
 ): ResolvedScope {
   if (!tree) {
-    return { pivot: null, roster: null, label: "", count: 0, managerNodes: [], canDirectOnly: false };
+    return {
+      pivot: null,
+      roster: null,
+      reportPeople: null,
+      label: "",
+      count: 0,
+      managerNodes: [],
+      canDirectOnly: false,
+    };
   }
   // Person id, not email: since the identity cutover that is the only key the
   // tree, the routes and the metric entity ids agree on.
@@ -140,6 +156,7 @@ export function resolveScopeRoster(
   return {
     pivot,
     roster,
+    reportPeople: reportPeopleInScope(pivot, roster),
     label: personDisplayName(pivot),
     count: roster?.length ?? 0,
     managerNodes,

--- a/src/frontend/src/lib/reports/report-table.ts
+++ b/src/frontend/src/lib/reports/report-table.ts
@@ -6,7 +6,7 @@ import {
   rollUp,
   type ReportGranularity,
 } from "@/lib/reports/rollup";
-import { PERSON_COLUMNS } from "@/lib/reports/roster-columns";
+import { reportPersonColumns } from "@/lib/reports/roster-columns";
 
 export type ReportCell = string | number | null;
 
@@ -40,6 +40,7 @@ const cellKey = (metricKey: string, entityId: string, bucket: string): string =>
  * for.
  */
 export function buildReportTable(input: ReportInput): ReportTable {
+  const personColumns = reportPersonColumns(input.people);
   const buckets = bucketsInRange(
     input.range.from,
     input.range.to,
@@ -68,7 +69,7 @@ export function buildReportTable(input: ReportInput): ReportTable {
 
   return {
     columns: [
-      ...PERSON_COLUMNS.map((column) => column.header),
+      ...personColumns.map((column) => column.header),
       "Period",
       "From",
       "To",
@@ -76,7 +77,7 @@ export function buildReportTable(input: ReportInput): ReportTable {
     ],
     rows: input.people.flatMap((person) =>
       buckets.map((bucket) => [
-        ...PERSON_COLUMNS.map((column) => column.of(person)),
+        ...personColumns.map((column) => column.of(person)),
         bucket,
         spans.get(bucket)?.from ?? "",
         spans.get(bucket)?.to ?? "",

--- a/src/frontend/src/lib/reports/report-table.ts
+++ b/src/frontend/src/lib/reports/report-table.ts
@@ -1,11 +1,12 @@
 import type { MetricResult, TimeseriesView } from "@/api/metric-results-client";
+import type { ReportPerson } from "@/lib/identities/report-person";
 import {
   bucketSpan,
   bucketsInRange,
   rollUp,
   type ReportGranularity,
 } from "@/lib/reports/rollup";
-import { PERSON_COLUMNS, type ReportPerson } from "@/lib/reports/roster-columns";
+import { PERSON_COLUMNS } from "@/lib/reports/roster-columns";
 
 export type ReportCell = string | number | null;
 

--- a/src/frontend/src/lib/reports/report-table.ts
+++ b/src/frontend/src/lib/reports/report-table.ts
@@ -1,4 +1,9 @@
-import type { MetricResult, TimeseriesView } from "@/api/metric-results-client";
+import type {
+  MetricFormat,
+  MetricResult,
+  TimeseriesView,
+} from "@/api/metric-results-client";
+import { roundMetricValue } from "@/lib/format";
 import type { ReportPerson } from "@/lib/identities/report-person";
 import {
   bucketSpan,
@@ -12,6 +17,7 @@ export type ReportCell = string | number | null;
 
 export interface ReportTable {
   columns: string[];
+  formats: Array<MetricFormat | null>;
   rows: ReportCell[][];
 }
 
@@ -41,6 +47,10 @@ const cellKey = (metricKey: string, entityId: string, bucket: string): string =>
  */
 export function buildReportTable(input: ReportInput): ReportTable {
   const personColumns = reportPersonColumns(input.people);
+  const metrics = input.metrics.map((metric) => ({
+    ...metric,
+    format: input.results.get(metric.metric_key)?.format ?? null,
+  }));
   const buckets = bucketsInRange(
     input.range.from,
     input.range.to,
@@ -73,7 +83,14 @@ export function buildReportTable(input: ReportInput): ReportTable {
       "Period",
       "From",
       "To",
-      ...input.metrics.map((metric) => metric.label),
+      ...metrics.map((metric) => metric.label),
+    ],
+    formats: [
+      ...personColumns.map(() => null),
+      null,
+      null,
+      null,
+      ...metrics.map((metric) => metric.format),
     ],
     rows: input.people.flatMap((person) =>
       buckets.map((bucket) => [
@@ -81,11 +98,12 @@ export function buildReportTable(input: ReportInput): ReportTable {
         bucket,
         spans.get(bucket)?.from ?? "",
         spans.get(bucket)?.to ?? "",
-        ...input.metrics.map(
-          (metric) =>
-            cells.get(cellKey(metric.metric_key, person.entityId, bucket)) ??
-            null,
-        ),
+        ...metrics.map((metric) => {
+          const value = cells.get(cellKey(metric.metric_key, person.entityId, bucket));
+          return value == null || metric.format == null
+            ? value ?? null
+            : roundMetricValue(value, metric.format);
+        }),
       ]),
     ),
   };

--- a/src/frontend/src/lib/reports/reports.test.ts
+++ b/src/frontend/src/lib/reports/reports.test.ts
@@ -232,6 +232,43 @@ describe("buildReportTable", () => {
     ]);
   });
 
+  it("omits person columns absent from the selected roster", () => {
+    const table = buildReportTable({
+      people: [
+        person({
+          email: "",
+          division: "",
+          department: "",
+          jobTitle: "Engineer",
+          managerName: "",
+          managerEmail: "",
+          status: "",
+        }),
+      ],
+      metrics: [{ metric_key: "git.commits", label: "Commits" }],
+      results: new Map(),
+      range: { from: "2026-01-01", to: "2026-01-31" },
+      granularity: "month",
+    });
+
+    expect(table.columns).toEqual([
+      "Person",
+      "Job title",
+      "Period",
+      "From",
+      "To",
+      "Commits",
+    ]);
+    expect(table.rows[0]).toEqual([
+      "Jane Doe",
+      "Engineer",
+      "2026-01",
+      "2026-01-01",
+      "2026-01-31",
+      null,
+    ]);
+  });
+
   it("leaves a cell empty where the metric said nothing", () => {
     const table = buildReportTable({
       people: [person()],

--- a/src/frontend/src/lib/reports/reports.test.ts
+++ b/src/frontend/src/lib/reports/reports.test.ts
@@ -269,6 +269,45 @@ describe("buildReportTable", () => {
     ]);
   });
 
+  it("rounds metric cells with the metric's declared format", () => {
+    const table = buildReportTable({
+      people: [person()],
+      metrics: [{ metric_key: "git.cycle_time", label: "Cycle time" }],
+      results: new Map([
+        [
+          "git.cycle_time",
+          {
+            metric_key: "git.cycle_time",
+            label: "Cycle time",
+            format: "decimal",
+            views: [
+              {
+                view: "timeseries",
+                bucket: "month",
+                series: [
+                  {
+                    entity_id: "p1",
+                    dimensions: [],
+                    points: [
+                      {
+                        bucket_start: "2026-01-01",
+                        value: 1082.1594444444445,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          } as unknown as MetricResult,
+        ],
+      ]),
+      range: { from: "2026-01-01", to: "2026-01-31" },
+      granularity: "month",
+    });
+
+    expect(table.rows[0]?.at(-1)).toBe(1082.2);
+  });
+
   it("leaves a cell empty where the metric said nothing", () => {
     const table = buildReportTable({
       people: [person()],

--- a/src/frontend/src/lib/reports/reports.test.ts
+++ b/src/frontend/src/lib/reports/reports.test.ts
@@ -19,7 +19,7 @@ import {
 import {
   collectReportPeople,
   type ReportPerson,
-} from "@/lib/reports/roster-columns";
+} from "@/lib/identities/report-person";
 import type { MetricResult } from "@/api/metric-results-client";
 
 const months = (...pairs: Array<[string, number | null]>) =>

--- a/src/frontend/src/lib/reports/roster-columns.ts
+++ b/src/frontend/src/lib/reports/roster-columns.ts
@@ -9,11 +9,14 @@ export type { ReportPerson } from "@/lib/identities/report-person";
  * people who share it — the same reason cohorts key `manager` on the
  * supervisor's email rather than their display name.
  */
-export const PERSON_COLUMNS: ReadonlyArray<{
+interface ReportPersonColumn {
   header: string;
   of: (person: ReportPerson) => string;
-}> = [
-  { header: "Person", of: (p) => p.name },
+  always?: boolean;
+}
+
+const PERSON_COLUMNS: readonly ReportPersonColumn[] = [
+  { header: "Person", of: (p) => p.name, always: true },
   { header: "Email", of: (p) => p.email },
   { header: "Division", of: (p) => p.division },
   { header: "Department", of: (p) => p.department },
@@ -22,3 +25,12 @@ export const PERSON_COLUMNS: ReadonlyArray<{
   { header: "Manager email", of: (p) => p.managerEmail },
   { header: "Status", of: (p) => p.status },
 ];
+
+export function reportPersonColumns(
+  people: readonly ReportPerson[],
+): readonly ReportPersonColumn[] {
+  return PERSON_COLUMNS.filter(
+    (column) =>
+      column.always || people.some((person) => column.of(person).trim() !== ""),
+  );
+}

--- a/src/frontend/src/lib/reports/roster-columns.ts
+++ b/src/frontend/src/lib/reports/roster-columns.ts
@@ -1,18 +1,6 @@
-import { normalizePersonId } from "@/lib/metrics/entity";
-import { personDisplayName } from "@/lib/identities/person-display";
-import type { IdentityPerson } from "@/types/insight";
+import type { ReportPerson } from "@/lib/identities/report-person";
 
-export interface ReportPerson {
-  entityId: string;
-  name: string;
-  email: string;
-  division: string;
-  department: string;
-  jobTitle: string;
-  managerName: string;
-  managerEmail: string;
-  status: string;
-}
+export type { ReportPerson } from "@/lib/identities/report-person";
 
 /**
  * A person and their manager each get a name AND a key.
@@ -34,27 +22,3 @@ export const PERSON_COLUMNS: ReadonlyArray<{
   { header: "Manager email", of: (p) => p.managerEmail },
   { header: "Status", of: (p) => p.status },
 ];
-
-export function collectReportPeople(
-  root: IdentityPerson | null,
-): Map<string, ReportPerson> {
-  const out = new Map<string, ReportPerson>();
-  const walk = (node: IdentityPerson): void => {
-    if (node.person_id) {
-      out.set(normalizePersonId(node.person_id), {
-        entityId: normalizePersonId(node.person_id),
-        name: personDisplayName(node),
-        email: node.email ?? "",
-        division: node.division ?? "",
-        department: node.department ?? "",
-        jobTitle: node.job_title ?? "",
-        managerName: node.supervisor_name ?? "",
-        managerEmail: node.supervisor_email ?? "",
-        status: node.status ?? "",
-      });
-    }
-    node.subordinates.forEach(walk);
-  };
-  if (root) walk(root);
-  return out;
-}


### PR DESCRIPTION
**Why.** Reports showed an empty scope under flat visibility because they derived person attributes only from hierarchy data.

**What changed.** Resolved scopes now expose typed report people from either hierarchy or visible roster; report builder consumes that projection.

**Scope contract.** Hierarchical reports retain exact roster/direct-only selection. Flat reports retain unavailable org-chart fields as empty values.

**Verified.** 59 focused unit tests, `pnpm typecheck`, and `pnpm lint` pass. Full unit suite did not complete after an unrelated jsdom navigation warning.