### PR TITLE
feat(bitbucket): exclude repositories by name pattern

### DIFF
--- a/src/ingestion/connectors/git/bitbucket-cloud/README.md
+++ b/src/ingestion/connectors/git/bitbucket-cloud/README.md
@@ -56,6 +56,7 @@ repository nobody has touched since it is never listed, so never cloned.
 | `bitbucket_token` | Yes | API token with `repository:read` |
 | `bitbucket_workspaces` | Yes | JSON array of workspace slugs |
 | `bitbucket_api_base_url` | No | API base URL (default `https://api.bitbucket.org/2.0`) |
+| `bitbucket_exclude_repositories` | No | JSON array of regular expressions matched against a repository slug; a match is never listed, cloned or walked. Matched with `search`, so anchor with `$` for "ends with" (e.g. `["\\.rospecs$"]`). Empty collects everything |
 | `bitbucket_api_calls_per_hour` | No | Requests per hour spent against the Bitbucket API, as a string (default `"1000"`, the documented floor for repository data). Raise it where the token is granted more; proxy calls are not counted |
 | `bitbucket_start_date` | Yes | Earliest date fetched, by every stream (YYYY-MM-DD); bounds the first-sync cost |
 

--- a/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
@@ -48,6 +48,26 @@ definitions:
     q: >-
       updated_on >= "{{ config['bitbucket_start_date'] }}"
 
+  # Repository listings are also where an operator's exclusions apply. The
+  # vendor's `q` cannot express a pattern — only case-insensitive substring —
+  # so the match is made here, on the record. The listing still pages, but a
+  # filtered repository never becomes a partition, so it is never cloned and
+  # never walked, which is where the cost is.
+  #
+  # `regex_search` returns the FIRST CAPTURE GROUP, or "" when the pattern has
+  # none — so the alternation is wrapped in parentheses or every pattern would
+  # match and filter nothing. `$^` is the unmatchable default that keeps an
+  # empty list collecting everything.
+  repos_selector: &repos_selector
+    type: RecordSelector
+    extractor:
+      type: DpathExtractor
+      field_path: [values]
+    record_filter:
+      type: RecordFilter
+      condition: >-
+        {{ not (record['slug'] | regex_search('(' ~ ((config.get('bitbucket_exclude_repositories') or ['$^']) | join('|')) ~ ')')) }}
+
   # Pull-request listings used as fan-out parents. The start date is a FLOOR,
   # not a window: everything from it to now, nothing older. A rolling window
   # would stop short of it and silently drop pull requests inside the range the
@@ -234,11 +254,7 @@ streams:
           fields: >-
             next,values.uuid,values.slug,values.name,values.full_name,values.is_private,values.has_issues,values.has_wiki,values.language,values.size,values.created_on,values.updated_on,values.mainbranch.name,values.workspace.slug,values.workspace.uuid,values.links.clone,values.description,values.website,values.scm,values.fork_policy,values.enforced_signed_commits,values.owner.username,values.owner.uuid,values.parent.full_name,values.project.key,values.project.name,values.project.uuid
         error_handler: *discovery_error_handler
-      record_selector:
-        type: RecordSelector
-        extractor:
-          type: DpathExtractor
-          field_path: [values]
+      record_selector: *repos_selector
       paginator:
         type: DefaultPaginator
         pagination_strategy:
@@ -465,11 +481,7 @@ streams:
                     <<: *repos_since_start
                     fields: >-
                       next,values.uuid,values.slug,values.updated_on,values.links.clone
-                record_selector:
-                  type: RecordSelector
-                  extractor:
-                    type: DpathExtractor
-                    field_path: [values]
+                record_selector: *repos_selector
                 paginator:
                   type: DefaultPaginator
                   pagination_strategy:
@@ -656,11 +668,7 @@ streams:
                     <<: *repos_since_start
                     fields: >-
                       next,values.uuid,values.slug,values.updated_on,values.links.clone
-                record_selector:
-                  type: RecordSelector
-                  extractor:
-                    type: DpathExtractor
-                    field_path: [values]
+                record_selector: *repos_selector
                 paginator:
                   type: DefaultPaginator
                   pagination_strategy:
@@ -831,11 +839,7 @@ streams:
                     <<: *repos_since_start
                     fields: >-
                       next,values.uuid,values.slug,values.links.clone
-                record_selector:
-                  type: RecordSelector
-                  extractor:
-                    type: DpathExtractor
-                    field_path: [values]
+                record_selector: *repos_selector
                 paginator:
                   type: DefaultPaginator
                   pagination_strategy:
@@ -1040,11 +1044,7 @@ streams:
                   request_parameters:
                     <<: *repos_since_start
                     fields: next,values.uuid,values.full_name,values.updated_on
-                record_selector:
-                  type: RecordSelector
-                  extractor:
-                    type: DpathExtractor
-                    field_path: [values]
+                record_selector: *repos_selector
                 paginator:
                   type: DefaultPaginator
                   pagination_strategy:
@@ -1389,11 +1389,7 @@ streams:
                             request_parameters:
                               <<: *repos_since_start
                               fields: next,values.uuid,values.full_name,values.updated_on
-                          record_selector:
-                            type: RecordSelector
-                            extractor:
-                              type: DpathExtractor
-                              field_path: [values]
+                          record_selector: *repos_selector
                           paginator:
                             type: DefaultPaginator
                             pagination_strategy:
@@ -1714,11 +1710,7 @@ streams:
                             request_parameters:
                               <<: *repos_since_start
                               fields: next,values.uuid,values.full_name,values.updated_on
-                          record_selector:
-                            type: RecordSelector
-                            extractor:
-                              type: DpathExtractor
-                              field_path: [values]
+                          record_selector: *repos_selector
                           paginator:
                             type: DefaultPaginator
                             pagination_strategy:
@@ -2077,11 +2069,7 @@ streams:
                             request_parameters:
                               <<: *repos_since_start
                               fields: next,values.uuid,values.full_name,values.updated_on
-                          record_selector:
-                            type: RecordSelector
-                            extractor:
-                              type: DpathExtractor
-                              field_path: [values]
+                          record_selector: *repos_selector
                           paginator:
                             type: DefaultPaginator
                             pagination_strategy:
@@ -2387,11 +2375,7 @@ streams:
                             request_parameters:
                               <<: *repos_since_start
                               fields: next,values.uuid,values.full_name,values.updated_on
-                          record_selector:
-                            type: RecordSelector
-                            extractor:
-                              type: DpathExtractor
-                              field_path: [values]
+                          record_selector: *repos_selector
                           paginator:
                             type: DefaultPaginator
                             pagination_strategy:
@@ -2807,11 +2791,7 @@ streams:
                   request_parameters:
                     <<: *repos_since_start
                     fields: next,values.uuid,values.full_name,values.updated_on
-                record_selector:
-                  type: RecordSelector
-                  extractor:
-                    type: DpathExtractor
-                    field_path: [values]
+                record_selector: *repos_selector
                 paginator:
                   type: DefaultPaginator
                   pagination_strategy:
@@ -3048,11 +3028,7 @@ streams:
                   request_parameters:
                     <<: *repos_since_start
                     fields: next,values.uuid,values.full_name,values.updated_on
-                record_selector:
-                  type: RecordSelector
-                  extractor:
-                    type: DpathExtractor
-                    field_path: [values]
+                record_selector: *repos_selector
                 paginator:
                   type: DefaultPaginator
                   pagination_strategy:
@@ -3318,11 +3294,7 @@ streams:
                               <<: *repos_since_start
                               fields: >-
                                 next,values.uuid,values.full_name,values.updated_on,values.links.clone
-                          record_selector:
-                            type: RecordSelector
-                            extractor:
-                              type: DpathExtractor
-                              field_path: [values]
+                          record_selector: *repos_selector
                           paginator:
                             type: DefaultPaginator
                             pagination_strategy:
@@ -3542,6 +3514,17 @@ spec:
         title: API Base URL
         default: "https://api.bitbucket.org/2.0"
         order: 9
+      bitbucket_exclude_repositories:
+        type: array
+        items:
+          type: string
+        default: []
+        description: >-
+          Regular expressions matched against a repository's slug; a repository matching any of them is never listed, cloned or walked. A workspace can carry thousands of mirrors whose updated_on moves without anyone committing, and the vendor exposes nothing that separates them — no archived flag, and they are not forks — so their name is the only signal. Matched with `search`, so anchor with `$` to mean "ends with". Empty collects everything.
+        title: Exclude Repositories Matching
+        examples:
+          - ['\.rospecs$', '\.vhispecs$']
+        order: 11
       bitbucket_api_calls_per_hour:
         # A string, not an integer: a Secret's values reach the source config as
         # strings, and the spec is validated against them, so an integer here

--- a/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
@@ -1043,7 +1043,7 @@ streams:
                   http_method: GET
                   request_parameters:
                     <<: *repos_since_start
-                    fields: next,values.uuid,values.full_name,values.updated_on
+                    fields: next,values.uuid,values.slug,values.full_name,values.updated_on
                 record_selector: *repos_selector
                 paginator:
                   type: DefaultPaginator
@@ -1388,7 +1388,7 @@ streams:
                             http_method: GET
                             request_parameters:
                               <<: *repos_since_start
-                              fields: next,values.uuid,values.full_name,values.updated_on
+                              fields: next,values.uuid,values.slug,values.full_name,values.updated_on
                           record_selector: *repos_selector
                           paginator:
                             type: DefaultPaginator
@@ -1709,7 +1709,7 @@ streams:
                             http_method: GET
                             request_parameters:
                               <<: *repos_since_start
-                              fields: next,values.uuid,values.full_name,values.updated_on
+                              fields: next,values.uuid,values.slug,values.full_name,values.updated_on
                           record_selector: *repos_selector
                           paginator:
                             type: DefaultPaginator
@@ -2068,7 +2068,7 @@ streams:
                             http_method: GET
                             request_parameters:
                               <<: *repos_since_start
-                              fields: next,values.uuid,values.full_name,values.updated_on
+                              fields: next,values.uuid,values.slug,values.full_name,values.updated_on
                           record_selector: *repos_selector
                           paginator:
                             type: DefaultPaginator
@@ -2374,7 +2374,7 @@ streams:
                             http_method: GET
                             request_parameters:
                               <<: *repos_since_start
-                              fields: next,values.uuid,values.full_name,values.updated_on
+                              fields: next,values.uuid,values.slug,values.full_name,values.updated_on
                           record_selector: *repos_selector
                           paginator:
                             type: DefaultPaginator
@@ -2790,7 +2790,7 @@ streams:
                   http_method: GET
                   request_parameters:
                     <<: *repos_since_start
-                    fields: next,values.uuid,values.full_name,values.updated_on
+                    fields: next,values.uuid,values.slug,values.full_name,values.updated_on
                 record_selector: *repos_selector
                 paginator:
                   type: DefaultPaginator
@@ -3027,7 +3027,7 @@ streams:
                   http_method: GET
                   request_parameters:
                     <<: *repos_since_start
-                    fields: next,values.uuid,values.full_name,values.updated_on
+                    fields: next,values.uuid,values.slug,values.full_name,values.updated_on
                 record_selector: *repos_selector
                 paginator:
                   type: DefaultPaginator
@@ -3293,7 +3293,7 @@ streams:
                             request_parameters:
                               <<: *repos_since_start
                               fields: >-
-                                next,values.uuid,values.full_name,values.updated_on,values.links.clone
+                                next,values.uuid,values.slug,values.full_name,values.updated_on,values.links.clone
                           record_selector: *repos_selector
                           paginator:
                             type: DefaultPaginator

--- a/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_manifest.py
+++ b/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_manifest.py
@@ -148,3 +148,49 @@ def test_the_call_budget_limit_survives_a_string_valued_config() -> None:
     rate = manifest["api_budget"]["policies"][0]["rates"][0]
     # The fallback covers the key being absent entirely, which is the default path.
     assert "or 1000" in rate["limit"]
+
+
+_REPO_LISTING_PATH = "/repositories/{{ stream_partition.workspace }}"
+
+
+def _repository_listings(streams: list[dict]) -> list[tuple[str, str]]:
+    """(owner, fields) for every requester that lists a workspace's repositories.
+
+    Eleven of the twelve are fan-out parents inlined inside a substream's
+    partition router — the Builder's strict validator rejects a whole-object
+    `$ref` for a substream parent — so they cannot share one definition and
+    have to be audited instead.
+    """
+    found: list[tuple[str, str]] = []
+
+    def walk(node: object, owner: str | None) -> None:
+        if isinstance(node, dict):
+            name = node.get("name") if isinstance(node.get("name"), str) else owner
+            requester = node.get("requester")
+            if isinstance(requester, dict) and requester.get("path") == _REPO_LISTING_PATH:
+                params = requester.get("request_parameters") or {}
+                found.append((name or "?", str(params.get("fields", ""))))
+            for value in node.values():
+                walk(value, name)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value, owner)
+
+    walk(streams, None)
+    return found
+
+
+def test_every_repository_listing_projects_the_field_the_exclusion_reads() -> None:
+    """`bitbucket_exclude_repositories` matches on `slug`, and Bitbucket's
+    `fields` is an exact projection. A listing that omits it hands the filter an
+    absent key: the Jinja render aborts, the condition evaluates to the raw
+    template string, and a truthy string keeps the record — so the exclusion is
+    silently ignored for that stream and its repositories are cloned anyway.
+    """
+    listings = _repository_listings(_streams())
+    assert listings, "no repository listing found — the audit is not looking at anything"
+    missing = sorted(owner for owner, fields in listings if "values.slug" not in fields)
+    assert not missing, (
+        "these repository listings do not project values.slug, so the exclusion "
+        f"filter cannot see it: {missing}"
+    )

--- a/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_vendor_streams.py
+++ b/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_vendor_streams.py
@@ -723,3 +723,99 @@ def test_a_resumed_sync_asks_for_less_than_the_first(http_mocker: HttpMocker) ->
     assert 'updated_on >= "2026-06-19' in asked[-1], (
         f"a resumed run starts at stored state, not the floor: {asked[-1]}"
     )
+
+
+def _repo_named(slug: str) -> dict[str, Any]:
+    return {
+        "uuid": "{r-%s}" % slug,
+        "slug": slug,
+        "full_name": f"acme/{slug}",
+        "updated_on": "2026-06-20T10:00:00.000000+00:00",
+        "mainbranch": {"name": "main"},
+        "workspace": {"slug": "acme", "uuid": "{w-1}"},
+        "links": {"clone": [{"name": "https", "href": f"https://bitbucket.org/acme/{slug}.git"}]},
+    }
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_a_repository_matching_an_exclusion_pattern_is_not_collected(
+    http_mocker: HttpMocker,
+) -> None:
+    """A workspace can carry thousands of mirrors whose `updated_on` moves
+    without anyone committing. The operator names them by pattern; the vendor
+    cannot, so the listing is filtered before a repository becomes a partition
+    and before its clone is ever asked for."""
+    config = BitbucketCloudConfigBuilder().build()
+    config["bitbucket_exclude_repositories"] = [r"\.rospecs$", r"\.vhispecs$"]
+    http_mocker.get(
+        HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps(
+                {"values": [_repo_named("app"), _repo_named("plocate.rospecs"),
+                            _repo_named("c4core.vhispecs"), _repo_named("rospecs-tooling")]}
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "repositories", config)
+
+    assert not output.errors
+    kept = sorted(r.record.data["slug"] for r in output.records)
+    # `rospecs-tooling` survives: the pattern is anchored, not a substring.
+    assert kept == ["app", "rospecs-tooling"], kept
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_every_repository_is_collected_when_no_pattern_is_configured(
+    http_mocker: HttpMocker,
+) -> None:
+    """The field is optional and silence means collect everything — an empty
+    pattern list must not compile into a regex that matches every name."""
+    config = BitbucketCloudConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps({"values": [_repo_named("app"), _repo_named("plocate.rospecs")]}),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, "repositories", config)
+
+    assert not output.errors
+    assert len(output.records) == 2
+
+
+@freezegun.freeze_time(_FROZEN)
+def test_an_excluded_repository_is_never_asked_of_the_proxy(
+    http_mocker: HttpMocker,
+) -> None:
+    """Dropping the record is not the point — not cloning it is. A filtered
+    repository must never become a partition, so the proxy is never asked to
+    walk it and its clone never enters the cache."""
+    config = BitbucketCloudConfigBuilder().build()
+    config["bitbucket_exclude_repositories"] = [r"\.rospecs$"]
+    http_mocker.get(
+        HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps({"values": [_repo_named("app"), _repo_named("plocate.rospecs")]}),
+            status_code=200,
+        ),
+    )
+    http_mocker.get(
+        HttpRequest(f"{PROXY_URL}/v1/commits", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"items": [], "next_page_token": None}), status_code=200),
+    )
+
+    output = read_stream(_CONNECTOR, "commits", config)
+
+    assert not output.errors
+    walked = [
+        unquote_plus(r.url)
+        for r in http_mocker._mocker.request_history
+        if "/v1/commits" in r.url
+    ]
+    assert walked, "the kept repository was never walked"
+    assert all("acme/app.git" in u for u in walked), walked
+    assert not any("rospecs" in u for u in walked), walked

--- a/src/ingestion/secrets/connectors/bitbucket-cloud.yaml.example
+++ b/src/ingestion/secrets/connectors/bitbucket-cloud.yaml.example
@@ -25,3 +25,4 @@ stringData:
   bitbucket_workspaces: '["acme"]'   # JSON array of workspace slugs
   bitbucket_start_date: "2026-01-01"   # nothing older than this is fetched, by any stream
   # bitbucket_api_calls_per_hour: "1000"   # raise where the token is granted more than the documented floor
+  # bitbucket_exclude_repositories: '["\\.rospecs$"]'   # regexes on the slug; a match is never listed or cloned


### PR DESCRIPTION
**Why.** A workspace can carry thousands of repositories whose `updated_on` moves without anyone committing — a bulk import or an automated refresh touches the metadata, and the listing cannot tell that apart from development. Every one is then cloned and walked for nothing, which is what exhausts the proxy's cache budget on a large workspace.

The vendor exposes nothing that separates them: Bitbucket Cloud has no archived flag, and they need not be forks. The name is the only signal, and only the operator knows the convention.

**What changed.** `bitbucket_exclude_repositories` — a list of regular expressions matched against a repository's slug. The filter sits on the shared listing selector, so all twelve repository listings inherit it and no stream can silently opt out.

**It filters before a record becomes a partition**, so an excluded repository is never cloned and never walked. A test asserts that directly rather than only asserting the record is dropped.

**Matched client-side, deliberately.** `q` can only do case-insensitive substring, which cannot express "ends with" — `.rospecs` as a substring would also exclude `rospecs-tooling`. The listing still pages; the clones avoided are worth far more than the pages that are not.

**One trap worth knowing if you touch the condition.** The CDK's `regex_search` returns the *first capture group*, or `""` when the pattern has none — so the joined alternation is wrapped in parentheses. Without that, every pattern would evaluate falsey and filter nothing. `$^` is the unmatchable default that keeps an empty list collecting everything.

**Verified.** Connector suite 22/22, including: an anchored pattern drops `plocate.rospecs` while keeping `rospecs-tooling`; an absent or empty list collects everything; and an excluded repository is never requested from the proxy. Full connector suite 99 passed, 1 skipped. `connector_wiring.py` OK. Not run: a sync against a live instance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional setting to exclude Bitbucket Cloud repositories using repository-slug regular expressions.
  * Excluded repositories are omitted from discovery, cloning, and commit processing.
  * Patterns use search matching and default to no exclusions.

* **Tests**
  * Added coverage for repository filtering, default behavior, and preventing excluded repositories from commit discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->