### PR TITLE
fix(bitbucket): project the slug every repository listing is filtered on

### DIFF
--- a/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
@@ -1043,7 +1043,7 @@ streams:
                   http_method: GET
                   request_parameters:
                     <<: *repos_since_start
-                    fields: next,values.uuid,values.full_name,values.updated_on
+                    fields: next,values.uuid,values.slug,values.full_name,values.updated_on
                 record_selector: *repos_selector
                 paginator:
                   type: DefaultPaginator
@@ -1388,7 +1388,7 @@ streams:
                             http_method: GET
                             request_parameters:
                               <<: *repos_since_start
-                              fields: next,values.uuid,values.full_name,values.updated_on
+                              fields: next,values.uuid,values.slug,values.full_name,values.updated_on
                           record_selector: *repos_selector
                           paginator:
                             type: DefaultPaginator
@@ -1709,7 +1709,7 @@ streams:
                             http_method: GET
                             request_parameters:
                               <<: *repos_since_start
-                              fields: next,values.uuid,values.full_name,values.updated_on
+                              fields: next,values.uuid,values.slug,values.full_name,values.updated_on
                           record_selector: *repos_selector
                           paginator:
                             type: DefaultPaginator
@@ -2068,7 +2068,7 @@ streams:
                             http_method: GET
                             request_parameters:
                               <<: *repos_since_start
-                              fields: next,values.uuid,values.full_name,values.updated_on
+                              fields: next,values.uuid,values.slug,values.full_name,values.updated_on
                           record_selector: *repos_selector
                           paginator:
                             type: DefaultPaginator
@@ -2374,7 +2374,7 @@ streams:
                             http_method: GET
                             request_parameters:
                               <<: *repos_since_start
-                              fields: next,values.uuid,values.full_name,values.updated_on
+                              fields: next,values.uuid,values.slug,values.full_name,values.updated_on
                           record_selector: *repos_selector
                           paginator:
                             type: DefaultPaginator
@@ -2790,7 +2790,7 @@ streams:
                   http_method: GET
                   request_parameters:
                     <<: *repos_since_start
-                    fields: next,values.uuid,values.full_name,values.updated_on
+                    fields: next,values.uuid,values.slug,values.full_name,values.updated_on
                 record_selector: *repos_selector
                 paginator:
                   type: DefaultPaginator
@@ -3027,7 +3027,7 @@ streams:
                   http_method: GET
                   request_parameters:
                     <<: *repos_since_start
-                    fields: next,values.uuid,values.full_name,values.updated_on
+                    fields: next,values.uuid,values.slug,values.full_name,values.updated_on
                 record_selector: *repos_selector
                 paginator:
                   type: DefaultPaginator
@@ -3293,7 +3293,7 @@ streams:
                             request_parameters:
                               <<: *repos_since_start
                               fields: >-
-                                next,values.uuid,values.full_name,values.updated_on,values.links.clone
+                                next,values.uuid,values.slug,values.full_name,values.updated_on,values.links.clone
                           record_selector: *repos_selector
                           paginator:
                             type: DefaultPaginator

--- a/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_manifest.py
+++ b/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_manifest.py
@@ -148,3 +148,49 @@ def test_the_call_budget_limit_survives_a_string_valued_config() -> None:
     rate = manifest["api_budget"]["policies"][0]["rates"][0]
     # The fallback covers the key being absent entirely, which is the default path.
     assert "or 1000" in rate["limit"]
+
+
+_REPO_LISTING_PATH = "/repositories/{{ stream_partition.workspace }}"
+
+
+def _repository_listings(streams: list[dict]) -> list[tuple[str, str]]:
+    """(owner, fields) for every requester that lists a workspace's repositories.
+
+    Eleven of the twelve are fan-out parents inlined inside a substream's
+    partition router — the Builder's strict validator rejects a whole-object
+    `$ref` for a substream parent — so they cannot share one definition and
+    have to be audited instead.
+    """
+    found: list[tuple[str, str]] = []
+
+    def walk(node: object, owner: str | None) -> None:
+        if isinstance(node, dict):
+            name = node.get("name") if isinstance(node.get("name"), str) else owner
+            requester = node.get("requester")
+            if isinstance(requester, dict) and requester.get("path") == _REPO_LISTING_PATH:
+                params = requester.get("request_parameters") or {}
+                found.append((name or "?", str(params.get("fields", ""))))
+            for value in node.values():
+                walk(value, name)
+        elif isinstance(node, list):
+            for value in node:
+                walk(value, owner)
+
+    walk(streams, None)
+    return found
+
+
+def test_every_repository_listing_projects_the_field_the_exclusion_reads() -> None:
+    """`bitbucket_exclude_repositories` matches on `slug`, and Bitbucket's
+    `fields` is an exact projection. A listing that omits it hands the filter an
+    absent key: the Jinja render aborts, the condition evaluates to the raw
+    template string, and a truthy string keeps the record — so the exclusion is
+    silently ignored for that stream and its repositories are cloned anyway.
+    """
+    listings = _repository_listings(_streams())
+    assert listings, "no repository listing found — the audit is not looking at anything"
+    missing = sorted(owner for owner, fields in listings if "values.slug" not in fields)
+    assert not missing, (
+        "these repository listings do not project values.slug, so the exclusion "
+        f"filter cannot see it: {missing}"
+    )


### PR DESCRIPTION
**Why.** `bitbucket_exclude_repositories` (#2763) matches on a repository's `slug`, but eight of the twelve repository listings never asked the vendor for it — the fan-out parents only ever needed `uuid`, `full_name` and `updated_on`. Bitbucket's `fields` is an exact projection, so those records arrived without the key.

**It failed silently, not loudly.** The Jinja render aborts on the absent key, the interpolation returns the raw template string, and a non-empty string is truthy — so `RecordFilter` kept the record. Exclusions therefore applied to the four listings whose streams happen to store the slug, and were ignored by every stream that clones: `commits`, `file_changes`, `branches`, `pipelines`, `deployments`, `commit_authors` and the pull-request parents. That is precisely the work the filter exists to avoid, so on a large workspace the feature would have looked configured and changed nothing.

**What changed.** `values.slug` is projected by all twelve listings, and a manifest test audits it. Eleven of them are inlined because the Builder's strict validator rejects a whole-object `$ref` for a substream parent, so they cannot share one definition — a thirteenth listing would repeat the omission, and the test names any listing that drops the field.

No schema, bronze or DDL impact: the eleven parents are inline fan-out definitions with no `schema_loader`, and their records never reach the destination — only their partition values do. The single declared stream among the twelve, `repositories`, already projected and stored the slug.

**Verified.** Connector suite 23/23. The audit was confirmed non-vacuous by removing the field from one listing and watching it fail with that listing named.
