### PR TITLE
fix(frontend): chart the year-long org trend instead of suppressing it

### DIFF
--- a/src/frontend/src/components/portal/domain-lens-view.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.tsx
@@ -166,8 +166,8 @@ export function DomainLensView({
     [config]
   );
   const trendBucket = useMemo(
-    () => pickTrendBucket(memberIds.length, trendKeys.length, dateRange),
-    [memberIds.length, trendKeys.length, dateRange]
+    () => pickTrendBucket(memberIds.length, dateRange),
+    [memberIds.length, dateRange]
   );
   const trendCollection = useMemo<MetricCollectionConfig>(
     () => ({

--- a/src/frontend/src/lib/portal/trend-data.test.ts
+++ b/src/frontend/src/lib/portal/trend-data.test.ts
@@ -6,40 +6,54 @@ import { buildTrendData, pickTrendBucket } from "./trend-data";
 const RANGE_30D = { from: "2026-06-24", to: "2026-07-23" };
 
 describe("pickTrendBucket", () => {
-  it("keeps daily buckets for a small team", () =>
-    expect(pickTrendBucket(5, 2, RANGE_30D)).toBe("day"));
-  it("coarsens to weekly for the org root (152×2×30 > row limit)", () =>
-    expect(pickTrendBucket(152, 2, RANGE_30D)).toBe("week"));
-  it("falls to monthly for a year at org scale", () =>
-    expect(pickTrendBucket(152, 2, { from: "2025-07-24", to: "2026-07-23" })).toBe("month"));
+  const YEAR = { from: "2025-07-24", to: "2026-07-23" };
 
-  it("gives up when the roster alone exceeds one bucket", () => {
-    // 4000 × 2 = 8000 rows before any time dimension. A `Math.max(1, …)` floor
-    // used to pretend one bucket always fits and answer "week" here.
-    expect(pickTrendBucket(4000, 2, { from: "2026-01-01", to: "2026-01-07" })).toBeNull();
+  it("keeps daily buckets for a small team", () =>
+    expect(pickTrendBucket(5, RANGE_30D)).toBe("day"));
+
+  it("coarsens to weekly once daily rows outgrow the limit", () =>
+    expect(pickTrendBucket(200, RANGE_30D)).toBe("week"));
+
+  it("charts a year monthly for a roster the backend can still answer", () => {
+    // The budget is per metric, so a three-series trend does not divide it.
+    // This roster used to be refused outright at a year.
+    expect(pickTrendBucket(300, YEAR)).toBe("month");
   });
 
-  it("gives up when even monthly does not fit", () => {
-    // 4000 people over a year is ~12 buckets × 4000 × 2 metrics = 96k rows
-    // against a 4500 limit. The old version answered "month" and the request
-    // 400'd; there is no bucket to answer with, so say so.
-    expect(pickTrendBucket(4000, 2, { from: "2025-07-24", to: "2026-07-23" })).toBeNull();
+  it("gives up when the roster alone exceeds one bucket", () => {
+    // 4000 rows per bucket against a 4500 limit: nothing to answer with.
+    expect(pickTrendBucket(4000, { from: "2026-01-01", to: "2026-01-07" })).toBeNull();
+  });
+
+  it("gives up when even monthly does not fit", () =>
+    expect(pickTrendBucket(4000, YEAR)).toBeNull());
+
+  it("counts the months a window touches, not the months it is long", () => {
+    // 365 days spanning 13 calendar months; days / 30.44 says 12. A roster
+    // that fits 12 buckets but not 13 must be refused, not charted against a
+    // projection one bucket short of what the response carries.
+    const tooWideForThirteen = Math.floor(4500 / 13) - 1;
+
+    expect(pickTrendBucket(tooWideForThirteen, YEAR)).toBeNull();
   });
 
   it("never claims a bucket whose projection exceeds the limit", () => {
-    // The property behind all four outcomes, checked across scales rather than
-    // at the two thresholds a hand-picked example happens to sit on.
-    const perBucketDays = { day: 1, week: 7, month: 30.44 };
+    // The property behind all four outcomes, checked against the backend's own
+    // row count — one row per (member, bucket) plus a total row per member.
+    const bucketDays = { day: 1, week: 7, month: 28 };
     for (const members of [1, 10, 152, 900, 4000]) {
       for (const days of [7, 30, 180, 365, 1000]) {
         const range = {
           from: "2026-01-01",
           to: new Date(Date.UTC(2026, 0, days)).toISOString().slice(0, 10),
         };
-        const bucket = pickTrendBucket(members, 2, range);
+        const bucket = pickTrendBucket(members, range);
         if (bucket === null) continue;
-        const buckets = Math.ceil(days / perBucketDays[bucket]);
-        expect(members * 2 * buckets, `${members}p/${days}d → ${bucket}`).toBeLessThanOrEqual(4500);
+        const buckets = Math.floor(days / bucketDays[bucket]) + 1;
+        expect(
+          members * (buckets + 1),
+          `${members}p/${days}d → ${bucket}`,
+        ).toBeLessThanOrEqual(4500);
       }
     }
   });

--- a/src/frontend/src/lib/portal/trend-data.ts
+++ b/src/frontend/src/lib/portal/trend-data.ts
@@ -6,42 +6,70 @@ import {
   type NormalizedMetricResult,
 } from "@/lib/metrics/collection";
 
+const DAY_MS = 86_400_000;
+
+const BUCKETS: readonly MetricBucket[] = ["day", "week", "month"];
+
 /**
- * Finest bucket (day → week → month) whose projected rows
- * (members × metrics × buckets) fit the backend's all-or-nothing row limit —
- * so a large org still gets a coarser trend rather than a failed request.
+ * Finest bucket (day → week → month) whose projected rows fit the backend's
+ * all-or-nothing row limit — so a large org still gets a coarser trend rather
+ * than a failed request.
+ *
+ * The budget is PER METRIC, not shared across them: the backend checks each
+ * view of each metric on its own (`validate_projected_view_limits`) and
+ * compiles one query per metric, each carrying its own LIMIT. Dividing the
+ * limit by the number of plotted metrics refused windows the backend would
+ * have answered — a three-series trend gave up at a third of the roster it
+ * could actually chart.
  *
  * `null` is the fourth outcome and the important one: past a certain
- * members × metrics × months, even monthly does not fit, and returning "month"
- * anyway just sends a request the backend is guaranteed to reject. A suppressed
- * trend with a stated reason beats a 400 the reader has to interpret.
+ * members × buckets, even monthly does not fit, and returning "month" anyway
+ * just sends a request the backend is guaranteed to reject. A suppressed trend
+ * with a stated reason beats a 400 the reader has to interpret.
  */
 export function pickTrendBucket(
   members: number,
-  metrics: number,
   range: { from: string; to: string },
 ): MetricBucket | null {
-  const days = Math.max(1, daysBetween(range.from, range.to));
-  const perBucket = Math.max(1, members * Math.max(1, metrics));
-  // Headroom below the hard limit so we never sit exactly on the cliff.
-  // NO `Math.max(1, …)` floor here: it used to claim that one bucket always
-  // fits, which is false once the roster alone exceeds the limit — 4000 people
-  // × 2 metrics is 8000 rows in a SINGLE bucket. That floor turned "impossible"
-  // into a confident "week" and a guaranteed 400.
-  const maxBuckets = Math.floor((MAX_PROJECTED_ROWS * 0.85) / perBucket);
+  // A timeseries view answers one row per (member, bucket) plus a total row
+  // per member — the backend's own projection, mirrored here.
+  const rowsPerBucket = Math.max(1, members);
+  const maxBuckets = Math.floor(MAX_PROJECTED_ROWS / rowsPerBucket) - 1;
   if (maxBuckets < 1) return null;
-  if (days <= maxBuckets) return "day";
-  if (Math.ceil(days / 7) <= maxBuckets) return "week";
-  // ~30.44 days per month: overestimating buckets here is the safe direction.
-  if (Math.ceil(days / 30.44) <= maxBuckets) return "month";
-  return null;
+
+  return BUCKETS.find((bucket) => bucketCount(range, bucket) <= maxBuckets) ?? null;
 }
 
-function daysBetween(from: string, to: string): number {
-  const a = Date.parse(`${from}T00:00:00Z`);
-  const b = Date.parse(`${to}T00:00:00Z`);
-  if (Number.isNaN(a) || Number.isNaN(b) || b < a) return 1;
-  return Math.floor((b - a) / 86_400_000) + 1;
+/**
+ * Buckets the backend will enumerate for this range, by its rule (weeks start
+ * Monday, months on the 1st) rather than by dividing the span: a 365-day
+ * window touches 13 months, and days/30.44 says 12. Undercounting means
+ * checking a smaller projection than the response actually carries, which
+ * spends the headroom this budget keeps below the hard limit.
+ */
+function bucketCount(range: { from: string; to: string }, bucket: MetricBucket): number {
+  const from = Date.parse(`${range.from}T00:00:00Z`);
+  const to = Date.parse(`${range.to}T00:00:00Z`);
+  if (Number.isNaN(from) || Number.isNaN(to) || to < from) return 1;
+
+  switch (bucket) {
+    case "day":
+      return Math.round((to - from) / DAY_MS) + 1;
+    case "week":
+      return Math.round((mondayOf(to) - mondayOf(from)) / (DAY_MS * 7)) + 1;
+    case "month":
+      return monthIndex(to) - monthIndex(from) + 1;
+  }
+}
+
+function mondayOf(timestamp: number): number {
+  const weekday = new Date(timestamp).getUTCDay();
+  return timestamp - ((weekday + 6) % 7) * DAY_MS;
+}
+
+function monthIndex(timestamp: number): number {
+  const date = new Date(timestamp);
+  return date.getUTCFullYear() * 12 + date.getUTCMonth();
 }
 
 /**


### PR DESCRIPTION
Related to #2764.

**Why.** An org trend over a year-long window renders a "too many people over too long a period" placeholder rather than a chart — it reads as missing data, and no request is ever sent.

**What changed.** `pickTrendBucket` divided its row budget by the number of plotted metrics, but the backend applies that limit per metric view — one query, one LIMIT each. The budget is now per metric, and buckets follow the backend's own rule instead of `days / 30.44`, which undercounts a year by a calendar month.

Largest roster a year-long trend can chart: 106 → 321 people.

**Out of scope.** The per-person fan-out behind it — any roster still multiplies into the row limit, so a large enough org cannot chart a year. Tracked in #2764.

**Verified.** `pnpm typecheck`, `pnpm lint`, `pnpm test` (1970 tests). No browser run: the change is a pure function, covered by unit tests including a property check against the backend's row formula.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Trend data now selects daily, weekly, or monthly buckets based on the selected date range and number of people included.
  - Bucket calculations now align more closely with calendar boundaries and backend data limits.
  - Trend views provide more reliable results across different roster sizes and reporting periods.
  - Invalid or unsupported date ranges continue to receive a safe fallback selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->