### PR TITLE
chore(tests): cover the feedback round trip in the stand UI suite

### DIFF
--- a/tests/stand/ui/pages/feedback_dialog.py
+++ b/tests/stand/ui/pages/feedback_dialog.py
@@ -1,0 +1,50 @@
+"""The feedback dialog and the rail control that opens it. Locators and navigation only.
+
+The control is a rail button: an icon plus its name in an `sr-only` span, so it is
+reached by role and accessible name like everything else here. The rail is collapsed
+until hovered, so opening it is hover-then-click — the same sequence `portal_shell.py`
+documents for a zone.
+
+The dialog is not the button's child. `FeedbackDialogProvider` mounts it at the router
+root, which is why it is addressed from the page rather than from the rail.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Locator, Page
+
+from .portal_shell import RAIL
+
+
+class FeedbackDialog:
+    OPEN = "Send feedback"
+
+    TITLE = "Submit feedback / bug report"
+
+    MESSAGE = "Your feedback"
+
+    SEND = "Send"
+
+    SENT = "Thanks — your feedback was sent."
+
+    def __init__(self, page: Page) -> None:
+        self.page = page
+
+    def control(self) -> Locator:
+        return self.page.locator(RAIL).get_by_role("button", name=self.OPEN)
+
+    def open(self) -> None:
+        self.page.locator(RAIL).hover()
+        self.control().click()
+
+    def dialog(self) -> Locator:
+        return self.page.get_by_role("dialog", name=self.TITLE)
+
+    def message(self) -> Locator:
+        return self.dialog().get_by_role("textbox", name=self.MESSAGE)
+
+    def send(self) -> Locator:
+        return self.dialog().get_by_role("button", name=self.SEND, exact=True)
+
+    def sent_toast(self) -> Locator:
+        return self.page.get_by_text(self.SENT)

--- a/tests/stand/ui/pages/platform_usage_page.py
+++ b/tests/stand/ui/pages/platform_usage_page.py
@@ -15,6 +15,8 @@ PEOPLE_TABLE = "Who opened it"
 
 PAGES_TABLE = "What they opened"
 
+FEEDBACK_TABLE = "What people told us"
+
 
 class PlatformUsagePage:
     ITEM = "Platform usage"

--- a/tests/stand/ui/test_feedback_round_trip.py
+++ b/tests/stand/ui/test_feedback_round_trip.py
@@ -1,0 +1,146 @@
+"""Journey — what a reader types into the feedback dialog reaches the operator's table.
+
+Why this is a browser test and not an API test, measured rather than asserted: the
+screen a report carries is computed in the page and nowhere else. `api/analytics/
+test_feedback.py` sends a submission and reads it back, and the screen it sends is a
+constant typed into the test (`SENT_FROM = "/ic/:id/personal"`) — so what it proves is
+that the server stores the path it is handed. The dialog does not hand it a constant:
+it reads `currentScreen()` from telemetry.ts, which holds whatever the router
+subscription in usage-collection.ts last recorded, reduced by `screenPath()` — the one
+thing that turns `/ic/<uuid>/personal` into `/ic/:id/personal`. Drive the SPA to a
+person's screen and the value below is produced rather than declared.
+
+The way in is browser-only too. `FeedbackDialogProvider` mounts the dialog at the
+router root rather than under the control that opens it, because the rail's settings
+popover unmounts anything it owns the moment the dialog takes focus. Whether the rail's
+button reaches a mounted dialog is a statement about the rendered shell.
+
+Feedback rows cannot be removed — no operation deletes a submission, so `api/scratch.py`'s
+create-then-delete policy does not reach them. This journey's message carries
+`SCRATCH_PREFIX` and the run tag for the reason the API module's does: a row left on the
+stand stays attributable to the run that wrote it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import pytest
+from api import scratch
+from insight_stand import PersonaSession, wait_for
+from playwright.sync_api import Browser, BrowserContext, Page, expect
+
+from .flows import collect_rows, revisit_usage, sign_in
+from .pages.feedback_dialog import FeedbackDialog
+from .pages.platform_usage_page import FEEDBACK_TABLE, PlatformUsagePage
+from .pages.portal_shell import recorded_path_of
+
+pytestmark = pytest.mark.reliability
+
+PERSON, MESSAGE, SCREEN = 1, 2, 3
+
+SENT_FROM = "/ic/:id/personal"
+
+SENT_FROM_LABEL = "Person › Personal"  # noqa: RUF001 (screen-label.ts's own separator)
+
+
+@dataclass(frozen=True)
+class Report:
+    message: str
+    row: list[str]
+
+
+def _message() -> str:
+    return f"{scratch.SCRATCH_PREFIX}-{scratch.RUN_TAG} sent from the feedback dialog"
+
+
+def _portal_context(browser: Browser, base_url: str) -> BrowserContext:
+    """A context the suite's `insight.portal` opt-out never reaches — the rail and the
+    listing are both portal surfaces."""
+    return browser.new_context(base_url=base_url)
+
+
+def _send(page: Page, message: str) -> None:
+    """The dialog closes in `onSuccess` alone — a refused send keeps it open and says
+    why — so it going away is the browser's own account of an accepted submission."""
+    dialog = FeedbackDialog(page)
+    dialog.open()
+    expect(dialog.dialog()).to_be_visible()
+    dialog.message().fill(message)
+    dialog.send().click()
+    expect(dialog.sent_toast()).to_be_visible()
+    expect(dialog.dialog()).not_to_be_visible()
+
+
+def _row_for(usage: PlatformUsagePage, message: str) -> list[str] | None:
+    """A remount, not a reload: reloading re-asks `/auth/me` and a poll trips the
+    gateway's `auth_per_ip` limiter. A period holding no feedback renders no table at
+    all, so the walk is gated on one existing."""
+    revisit_usage(usage.page)
+    if usage.table(FEEDBACK_TABLE).count() == 0:
+        return None
+    for row in collect_rows(usage.table(FEEDBACK_TABLE)):
+        if row[MESSAGE] == message:
+            return row
+    return None
+
+
+@pytest.fixture(scope="module")
+def reported(
+    browser: Browser,
+    base_url: str,
+    session_for: Callable[[str], PersonaSession],
+) -> Report:
+    """Two contexts: one browser profile holds one session, and only the admin is served
+    the listing. Module-scoped so the run leaves one undeletable row rather than one per
+    test, and so both assertions describe the same submission."""
+    lead = session_for("dev_lead")
+    operator = session_for("admin_operator")
+
+    lead_context = _portal_context(browser, base_url)
+    lead_page = lead_context.new_page()
+    sign_in(lead_page, base_url, lead)
+    lead_page.goto(f"/ic/{lead.person.uuid}/personal", wait_until="domcontentloaded")
+    recorded = recorded_path_of(lead_page.url)
+    assert recorded == SENT_FROM, (
+        f"the sender is on {recorded!r}, so the assertion below would not be about "
+        f"a redacted person key ({SENT_FROM!r})"
+    )
+
+    message = _message()
+    _send(lead_page, message)
+    lead_context.close()
+
+    admin_context = _portal_context(browser, base_url)
+    admin_page = admin_context.new_page()
+    sign_in(admin_page, base_url, operator)
+    usage = PlatformUsagePage(admin_page)
+    usage.go()
+    expect(usage.chart_heading()).to_be_visible()
+    row = wait_for(
+        lambda: _row_for(usage, message),
+        timeout_s=45,
+        description=f"the report {lead.person.display_name} sent from {SENT_FROM}",
+    )
+    admin_context.close()
+
+    return Report(message=message, row=row)
+
+
+@pytest.mark.requires_seed("dev_lead", "admin_operator")
+def test_the_listing_names_the_person_who_sent_it(
+    reported: Report, session_for: Callable[[str], PersonaSession]
+) -> None:
+    expected = session_for("dev_lead").person.display_name
+    assert reported.row[PERSON] == expected, (
+        f"the row for {reported.message!r} names {reported.row[PERSON]!r}, not {expected!r}"
+    )
+
+
+@pytest.mark.requires_seed("dev_lead", "admin_operator")
+def test_the_report_names_the_screen_its_sender_was_on(reported: Report) -> None:
+    assert reported.row[SCREEN] == SENT_FROM_LABEL, (
+        f"the row for {reported.message!r} was sent from {SENT_FROM!r} and is listed "
+        f"as {reported.row[SCREEN]!r}, not {SENT_FROM_LABEL!r}"
+    )


### PR DESCRIPTION
**Why.** The stand suite had no browser coverage of feedback: its API test types the screen in itself, so nothing proved the shipped SPA sends the screen its sender was actually on.

**What changed.** A lead sends a report from the rail dialog on a person's screen; the admin operator reads it back on Platform usage. The journey asserts the sender's name and the screen label — read back on a local stand as `Liam Nguyen | stand-scratch-… | Person › Personal`.

**Out of scope.** The listing's empty and error states and the dialog's refusal path — covered by the frontend component tests.

**Verified.** `tests/stand/ui` green on a local compose stand (20 passed). Ruff and format clean. Both expectations mutation-checked: a wrong screen label and a wrong column each fail.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for submitting feedback from a personal screen.
  * Verified feedback appears in the usage listing with the sender’s name and associated screen.
  * Confirmed recorded screen paths are displayed safely and sensitive details are redacted.
  * Added coverage for the feedback dialog, submission action, confirmation message, and feedback table.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->