### PR TITLE
feat(frontend): default the portal's planned sections off

### DIFF
--- a/src/frontend/src/lib/portal/portal-store.test.ts
+++ b/src/frontend/src/lib/portal/portal-store.test.ts
@@ -43,9 +43,19 @@ describe("portal preferences", () => {
     expect(readPortalEnabled()).toBe(false);
   });
 
-  it("show-planned defaults ON when the key is absent", () => {
+  it("show-planned defaults OFF when the key is absent", async () => {
     window.localStorage.removeItem("insight.portal.showPlanned");
-    const { result } = renderHook(() => usePortalShowPlanned());
+    vi.resetModules();
+    const fresh = await import("./portal-store");
+    const { result } = renderHook(() => fresh.usePortalShowPlanned());
+    expect(result.current).toBe(false);
+  });
+
+  it("an explicit opt-in is what a fresh load reads back", async () => {
+    window.localStorage.setItem("insight.portal.showPlanned", "true");
+    vi.resetModules();
+    const fresh = await import("./portal-store");
+    const { result } = renderHook(() => fresh.usePortalShowPlanned());
     expect(result.current).toBe(true);
   });
 

--- a/src/frontend/src/lib/portal/portal-store.ts
+++ b/src/frontend/src/lib/portal/portal-store.ts
@@ -27,12 +27,7 @@ const SHOW_PLANNED_KEY = "insight.portal.showPlanned";
 
 interface PortalState {
   enabled: boolean;
-  /**
-   * Whether navigation shows entries we have not built yet (`unbuilt` in the
-   * nav model). Default ON: for us and for demos the dead entries ARE the
-   * roadmap. Flip it before a reader has to tell our backlog apart from their
-   * own missing data.
-   */
+  /** Whether navigation shows entries we have not built yet (`unbuilt` in the nav model). */
   showPlanned: boolean;
 }
 
@@ -56,14 +51,18 @@ function readKey(key: string): string | null {
   }
 }
 
-/** Absent key = ON; both preferences are opt-OUT, so only "false" turns one off. */
+/** Absent key = ON; the portal is opt-OUT, so only "false" turns it off. */
 function readBoolPref(key: string): boolean {
   return readKey(key) !== "false";
 }
 
+function readOptInPref(key: string): boolean {
+  return readKey(key) === "true";
+}
+
 let state: PortalState = {
   enabled: readBoolPref(ENABLED_KEY),
-  showPlanned: readBoolPref(SHOW_PLANNED_KEY),
+  showPlanned: readOptInPref(SHOW_PLANNED_KEY),
 };
 
 const listeners = new Set<() => void>();
@@ -116,6 +115,6 @@ export function usePortalShowPlanned(): boolean {
   return useSyncExternalStore(
     subscribe,
     () => state.showPlanned,
-    () => true,
+    () => false,
   );
 }

--- a/tests/stand/ui/test_platform_usage.py
+++ b/tests/stand/ui/test_platform_usage.py
@@ -20,7 +20,7 @@ from .pages.platform_usage_page import PAGES_TABLE, PEOPLE_TABLE, PlatformUsageP
 
 PERSON, VISITS, PAGES = 0, 1, 2
 
-#: `readBoolPref` treats anything but `"false"` as true, so unbuilt zones render.
+#: The sweep must not walk unbuilt zones, whatever the app default is.
 SHOW_PLANNED_OFF = "window.localStorage.setItem('insight.portal.showPlanned', 'false')"
 
 


### PR DESCRIPTION
**Why.** Planned nav entries were listed for every reader unless they opted out, so a reader had to tell our unbuilt backlog apart from their own missing data.

**What changed.** `insight.portal.showPlanned` is opt-in now: only an explicit `"true"` lists planned entries, and the server snapshot returns `false` to agree with it. We and demos turn it on from the settings switch.

**Worth knowing:** planned paths come only from `nav.planned` in runtime config, and both `src/frontend/helm/values.yaml` and the chart ship it empty — an install that lists nothing planned looks the same before and after.

**Verified.** `npm test` (1977 tests, 211 files), `npm run typecheck`, `npm run lint` green in `src/frontend`; `ruff check` clean on the touched stand test. No screenshot: with `nav.planned` empty there is nothing planned on screen to capture. The default test now re-imports the store with the key absent — it used to assert on in-memory state the setup had just written, so it could not have failed on a default change.
