### PR TITLE
feat: name the issue type in task evidence lists and modals

### DIFF
--- a/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
+++ b/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
@@ -1205,6 +1205,7 @@ metrics:
       - input_role: value
         measure_key: dev_time_hours
     dimensions:
+      - type
       - source
   - metric_key: tasks.resolution_time
     source_key: task
@@ -1226,6 +1227,7 @@ metrics:
       - input_role: value
         measure_key: resolution_days
     dimensions:
+      - type
       - source
   - metric_key: tasks.pickup_time
     source_key: task
@@ -1247,6 +1249,7 @@ metrics:
       - input_role: value
         measure_key: pickup_days
     dimensions:
+      - type
       - source
   - metric_key: tasks.flow_efficiency
     source_key: task

--- a/src/frontend/src/components/metric-evidence-dialog.test.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog.test.tsx
@@ -346,6 +346,38 @@ describe("MetricEvidenceDialog", () => {
     ).not.toContain("source");
   });
 
+  it("asks for the issue type and exports it, since the reader can see it", async () => {
+    const user = userEvent.setup();
+    const taskSelection = { ...selection, metric_key: "tasks.closed" };
+    mocks.declaredDimensions = new Map([
+      ["tasks.closed", new Set(["source", "type"])],
+    ]);
+
+    render(
+      <MetricEvidenceDialog
+        state={{
+          targets: [{ selection: taskSelection, label: "Issues closed" }],
+          activeMetricKey: "tasks.closed",
+        }}
+        onMetricChange={vi.fn()}
+        onClose={vi.fn()}
+      />
+    );
+
+    const requested = (mocks.queryOptions?.queryKey as unknown[])[2] as {
+      display_dimensions: string[];
+    };
+    expect(requested.display_dimensions).toEqual(["source", "type"]);
+
+    await user.click(screen.getByRole("button", { name: /CSV/ }));
+    await waitFor(() => expect(mocks.downloadMetricDrilldown).toHaveBeenCalled());
+    const [exported] = mocks.downloadMetricDrilldown.mock.calls[0]!;
+    const dimensions = (exported as { display_dimensions: string[] })
+      .display_dimensions;
+    // The type is a column on screen; the source only backs a link.
+    expect(dimensions).toEqual(["type"]);
+  });
+
   describe("what the dialog is named", () => {
     const twoTargets = [
       { selection, label: "Commits" },

--- a/src/frontend/src/components/metric-evidence-dialog.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog.tsx
@@ -14,6 +14,7 @@ import { MetricEvidenceTable } from "@/components/metric-evidence-table";
 import {
   SOURCE_DIMENSION,
   withSourceDimension,
+  withTypeDimension,
 } from "@/lib/metrics/provider-links";
 import { useDeclaredMetricDimensions } from "@/queries/metric-definitions";
 import { Button } from "@/components/ui/button";
@@ -65,14 +66,17 @@ export function MetricEvidenceDialog({
     ) ??
     state?.targets[0] ??
     null;
-  // INVARIANT: the catalog decides whether `source` may be asked for, so the
+  // INVARIANT: the catalog decides which dimensions may be asked for, so the
   // read waits for it — resolving later would change the selection mid-dialog
   // and refetch every row.
   const declaredDimensions = useDeclaredMetricDimensions();
+  const declared = activeTarget
+    ? declaredDimensions.byMetricKey?.get(activeTarget.selection.metric_key)
+    : null;
   const selection = activeTarget
-    ? withSourceDimension(
-        activeTarget.selection,
-        declaredDimensions.byMetricKey?.get(activeTarget.selection.metric_key)
+    ? withTypeDimension(
+        withSourceDimension(activeTarget.selection, declared),
+        declared
       )
     : null;
   const query = useInfiniteQuery({
@@ -176,11 +180,12 @@ export function MetricEvidenceDialog({
   }
 
   async function exportRows(format: "csv" | "xlsx") {
-    // INVARIANT: the export carries the caller's OWN selection, never the one
-    // widened for links. `source` rides along only so a row can be linked, and
-    // it is hidden from the table — exporting it would put a column in the file
-    // that is not on the screen it came from.
-    const exported = activeTarget?.selection;
+    // INVARIANT: the file holds the columns the screen holds. `source` rides
+    // along only so a row can be linked and is hidden from the table, so it is
+    // dropped here; `type` is a column the reader can see, so it is kept.
+    const exported = activeTarget
+      ? withTypeDimension(activeTarget.selection, declared)
+      : null;
     if (!exported) return;
     exportController.current?.abort();
     const controller = new AbortController();

--- a/src/frontend/src/components/metric-evidence-table.tsx
+++ b/src/frontend/src/components/metric-evidence-table.tsx
@@ -39,6 +39,7 @@ import { cn } from "@/lib/utils";
 function columnLayout(column: MetricEvidenceColumn) {
   if (column.key === "ref") return { basisRem: 9, grow: 0 };
   if (column.key === "title") return { basisRem: 24, grow: 4 };
+  if (column.key === "type") return { basisRem: 8, grow: 0 };
   if (column.key === "repository") return { basisRem: 12, grow: 0.5 };
   if (column.key === "author") return { basisRem: 10, grow: 0.25 };
   if (column.key === "date") return { basisRem: 8, grow: 0 };

--- a/src/frontend/src/components/widgets/metric-views/metric-activity.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-activity.test.tsx
@@ -96,6 +96,7 @@ function draw(m: ReturnType<typeof metric>) {
 }
 
 beforeEach(() => {
+  declared.byMetricKey = new Map();
   detail.calls = [];
   detail.collectedThrough = null;
   detail.revisionWindowDays = null;
@@ -149,6 +150,53 @@ describe("MetricActivity", () => {
     expect(rows[0]).toContain("Fix the thing");
     expect(rows[0]).not.toContain("body");
     expect(rows[1]).toContain("Another change");
+  });
+
+  it("names the kind of issue beside each one", () => {
+    // A count of closed issues reads differently once the bugs in it are
+    // visible, and the tracker's own type is the only thing on a row that says
+    // which is which.
+    declared.byMetricKey.set("tasks.closed", new Set(["source", "type"]));
+    detail.state.data = {
+      columns: [],
+      rows: [
+        {
+          values: {
+            date: "2026-03-04",
+            title: "Login fails on retry",
+            ref: "example/app#12",
+            type: "Bug",
+          },
+        },
+      ],
+    };
+    draw(metric("tasks.closed", ["event"], 1));
+    const row = screen.getAllByRole("listitem")[0]?.textContent ?? "";
+    expect(row).toContain("Bug");
+    expect(row).toContain("Login fails on retry");
+    // Asked for on the read itself, or the rows would never carry it.
+    const asked = detail.calls.at(-1) as {
+      selection: { display_dimensions: string[] };
+    };
+    expect(asked.selection.display_dimensions).toContain("type");
+  });
+
+  it("spends no width on a type where the records have none", () => {
+    detail.state.data = {
+      columns: [],
+      rows: [
+        {
+          values: {
+            date: "2026-03-04",
+            title: "Fix the thing",
+            repository: "example/app",
+            ref: "abc",
+          },
+        },
+      ],
+    };
+    draw(metric("git.commits", ["event"], 1));
+    expect(screen.getAllByRole("listitem")[0]?.textContent).not.toContain("—");
   });
 
   it("draws days at counter grain, and names the days with no reading", () => {

--- a/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
@@ -284,7 +284,8 @@ function EventList({
 function eventType(values: Readonly<Record<string, unknown>>): string | null {
   const value = values[TYPE_DIMENSION];
   if (typeof value !== "string") return null;
-  return value.trim() === "" ? null : value;
+  const type = value.trim();
+  return type === "" ? null : type;
 }
 
 /** A ratio's daily value is a fraction; the metric says what to scale it by. */

--- a/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
@@ -1,6 +1,9 @@
 import { useMemo, useState } from "react";
 
-import { evidenceSelection } from "@/api/metric-drilldown-client";
+import {
+  evidenceSelection,
+  type MetricEvidenceSelection,
+} from "@/api/metric-drilldown-client";
 import {
   useEvidenceScope,
   useMetricEvidenceOptional,
@@ -31,7 +34,9 @@ import {
 import {
   activityEventLabel,
   evidenceRecordLinks,
+  TYPE_DIMENSION,
   withSourceDimension,
+  withTypeDimension,
 } from "@/lib/metrics/provider-links";
 import { RecordLink } from "@/components/record-link";
 import { useMetricDetail } from "@/queries/metric-detail";
@@ -72,10 +77,17 @@ export function MetricActivity({
     ? evidenceSelection(metric.selection, entityId)
     : null;
   // INVARIANT: the same gate the evidence dialog applies — `source` is what
-  // makes a link safe, and asking for it where a metric does not declare it is
-  // rejected outright, so the read waits for the catalogue.
+  // makes a link safe, `type` is what says which kind of issue a row is, and
+  // asking for either where a metric does not declare it is rejected outright,
+  // so the read waits for the catalogue.
+  const declaredForMetric = base
+    ? declared.byMetricKey?.get(base.metric_key)
+    : null;
   const selection = base
-    ? withSourceDimension(base, declared.byMetricKey?.get(base.metric_key))
+    ? withTypeDimension(
+        withSourceDimension(base, declaredForMetric),
+        declaredForMetric
+      )
     : null;
   const detail = useMetricDetail(
     selection,
@@ -121,7 +133,12 @@ export function MetricActivity({
           </div>
         </div>
       </header>
-      <Body grain={grain} metric={metric} entityId={entityId} detail={detail} />
+      <Body
+        grain={grain}
+        metric={metric}
+        selection={selection}
+        detail={detail}
+      />
     </section>
   );
 }
@@ -129,12 +146,13 @@ export function MetricActivity({
 function Body({
   grain,
   metric,
-  entityId,
+  selection,
   detail,
 }: {
   grain: ReturnType<typeof finestGrain>;
   metric: NormalizedMetricResult;
-  entityId: string;
+  /** The read's own selection — the dialog opens on exactly what was listed. */
+  selection: MetricEvidenceSelection | null;
   detail: ReturnType<typeof useMetricDetail>;
 }) {
   if (grain == null) {
@@ -179,27 +197,29 @@ function Body({
     );
   }
   if (grain === "event") {
-    return <EventList metric={metric} entityId={entityId} rows={rows} />;
+    return <EventList metric={metric} selection={selection} rows={rows} />;
   }
   return <DayStrip metric={metric} rows={rows} columns={columns} />;
 }
 
 function EventList({
   metric,
-  entityId,
+  selection,
   rows,
 }: {
   metric: NormalizedMetricResult;
-  entityId: string;
+  selection: MetricEvidenceSelection | null;
   rows: NonNullable<ReturnType<typeof useMetricDetail>["data"]>["rows"];
 }) {
   const evidence = useMetricEvidenceOptional();
   const scope = useEvidenceScope();
-  const selection = evidenceSelection(metric.selection, entityId);
   const metricKey = metric.selection?.metric_key ?? "";
   const events = useMemo(() => activityEvents(rows), [rows]);
   const shown = events.slice(0, EVENTS_SHOWN);
   const rest = events.length - shown.length;
+  // A column only where the rows have one to fill it: a metric whose records
+  // carry no type would otherwise reserve width for a strip of dashes.
+  const typed = events.some((event) => eventType(event.values) != null);
 
   return (
     <div className="flex flex-col gap-1">
@@ -215,6 +235,14 @@ function EventList({
               <span className="w-14 shrink-0 text-muted-foreground tabular-nums">
                 {formatDate(event.date)}
               </span>
+              {typed ? (
+                <span
+                  className="w-24 shrink-0 truncate text-muted-foreground"
+                  title={eventType(event.values) ?? undefined}
+                >
+                  {eventType(event.values) ?? "—"}
+                </span>
+              ) : null}
               <span className="min-w-0 flex-1 truncate">
                 {label ? (
                   <RecordLink href={links.title}>{label}</RecordLink>
@@ -250,6 +278,13 @@ function EventList({
       ) : null}
     </div>
   );
+}
+
+/** What kind of thing a row is, when the row says — "Bug", "Story". */
+function eventType(values: Readonly<Record<string, unknown>>): string | null {
+  const value = values[TYPE_DIMENSION];
+  if (typeof value !== "string") return null;
+  return value.trim() === "" ? null : value;
 }
 
 /** A ratio's daily value is a fraction; the metric says what to scale it by. */

--- a/src/frontend/src/lib/metrics/provider-links.test.ts
+++ b/src/frontend/src/lib/metrics/provider-links.test.ts
@@ -129,20 +129,20 @@ describe("isGitMetric", () => {
   );
 });
 
-describe("withSourceDimension", () => {
-  function selection(
-    metricKey: string,
-    displayDimensions: string[] = []
-  ): MetricEvidenceSelection {
-    return {
-      metric_key: metricKey,
-      entity: { type: "person", id: "person-1" },
-      period: { from: "2026-01-01", to: "2026-01-31" },
-      filters: [],
-      display_dimensions: displayDimensions,
-    };
-  }
+function selection(
+  metricKey: string,
+  displayDimensions: string[] = []
+): MetricEvidenceSelection {
+  return {
+    metric_key: metricKey,
+    entity: { type: "person", id: "person-1" },
+    period: { from: "2026-01-01", to: "2026-01-31" },
+    filters: [],
+    display_dimensions: displayDimensions,
+  };
+}
 
+describe("withSourceDimension", () => {
   it("asks for the source a git metric declares", () => {
     const result = withSourceDimension(
       selection("git.commits"),
@@ -200,19 +200,6 @@ describe("withSourceDimension", () => {
 });
 
 describe("withTypeDimension", () => {
-  function selection(
-    metricKey: string,
-    displayDimensions: string[] = []
-  ): MetricEvidenceSelection {
-    return {
-      metric_key: metricKey,
-      entity: { type: "person", id: "person-1" },
-      period: { from: "2026-01-01", to: "2026-01-31" },
-      filters: [],
-      display_dimensions: displayDimensions,
-    };
-  }
-
   it("asks for the type a task metric declares", () => {
     const result = withTypeDimension(
       selection("tasks.closed"),
@@ -231,10 +218,8 @@ describe("withTypeDimension", () => {
     expect(result.display_dimensions).toEqual(["source", "type"]);
   });
 
-  // A duration metric's rows carry no issue type; asking anyway is refused
-  // outright, which would cost the reader the whole dialog.
   it("leaves a task metric that declares no type untouched", () => {
-    const original = selection("tasks.dev_time_hours");
+    const original = selection("tasks.flow_efficiency");
 
     expect(withTypeDimension(original, new Set(["source"]))).toBe(original);
   });

--- a/src/frontend/src/lib/metrics/provider-links.test.ts
+++ b/src/frontend/src/lib/metrics/provider-links.test.ts
@@ -20,6 +20,7 @@ import {
   githubRepoUrl,
   isGitMetric,
   withSourceDimension,
+  withTypeDimension,
 } from "@/lib/metrics/provider-links";
 
 const SHA1 = "e0f4823a55ac28276cf068f066ebf66f872a059c";
@@ -195,6 +196,66 @@ describe("withSourceDimension", () => {
     expect(withSourceDimension(original, new Set(["source"]))).toBe(
       original
     );
+  });
+});
+
+describe("withTypeDimension", () => {
+  function selection(
+    metricKey: string,
+    displayDimensions: string[] = []
+  ): MetricEvidenceSelection {
+    return {
+      metric_key: metricKey,
+      entity: { type: "person", id: "person-1" },
+      period: { from: "2026-01-01", to: "2026-01-31" },
+      filters: [],
+      display_dimensions: displayDimensions,
+    };
+  }
+
+  it("asks for the type a task metric declares", () => {
+    const result = withTypeDimension(
+      selection("tasks.closed"),
+      new Set(["source", "type"])
+    );
+
+    expect(result.display_dimensions).toEqual(["type"]);
+  });
+
+  it("keeps the requested dimensions sorted, so one selection is one query key", () => {
+    const result = withTypeDimension(
+      selection("tasks.closed", ["source"]),
+      new Set(["source", "type"])
+    );
+
+    expect(result.display_dimensions).toEqual(["source", "type"]);
+  });
+
+  // A duration metric's rows carry no issue type; asking anyway is refused
+  // outright, which would cost the reader the whole dialog.
+  it("leaves a task metric that declares no type untouched", () => {
+    const original = selection("tasks.dev_time_hours");
+
+    expect(withTypeDimension(original, new Set(["source"]))).toBe(original);
+  });
+
+  it("leaves everything untouched while the catalogue is unknown", () => {
+    const original = selection("tasks.closed");
+
+    expect(withTypeDimension(original, null)).toBe(original);
+    expect(withTypeDimension(original, undefined)).toBe(original);
+  });
+
+  it("leaves a metric of a family that has no issue types untouched", () => {
+    const original = selection("git.commits");
+
+    expect(withTypeDimension(original, new Set(["type"]))).toBe(original);
+  });
+
+  it("does not ask twice for a type the caller already grouped by", () => {
+    const original = selection("tasks.closed", ["type"]);
+
+    expect(withTypeDimension(original, new Set(["type"]))).toBe(original);
   });
 });
 

--- a/src/frontend/src/lib/metrics/provider-links.ts
+++ b/src/frontend/src/lib/metrics/provider-links.ts
@@ -118,11 +118,6 @@ export const SOURCE_DIMENSION = "source";
 /**
  * Adds `source` to a metric's requested display dimensions, so its
  * evidence rows carry the per-row connector a link needs to be safe.
- *
- * SAFETY: only when the metric DECLARES the dimension — a drilldown that asks
- * for an undeclared one is rejected outright, so asking on spec would trade a
- * missing link for an unopenable dialog. `declared` is null while the catalog
- * is unknown, which is also a no-op.
  */
 export function withSourceDimension(
   selection: MetricEvidenceSelection,
@@ -131,14 +126,44 @@ export function withSourceDimension(
   if (!isGitMetric(selection.metric_key) && !isTaskMetric(selection.metric_key)) {
     return selection;
   }
-  if (!declared?.has(SOURCE_DIMENSION)) return selection;
-  if (selection.display_dimensions.includes(SOURCE_DIMENSION)) return selection;
+  return withDimension(selection, SOURCE_DIMENSION, declared);
+}
+
+/** The dimension key naming what kind of issue a row is — "Bug", "Story". */
+export const TYPE_DIMENSION = "type";
+
+/**
+ * Adds `type` to a task metric's requested display dimensions, so an issue row
+ * says which kind of issue it was.
+ *
+ * A count of closed issues reads differently once the bugs in it are visible,
+ * and the tracker's own type is the only thing on the row that says which is
+ * which. Same gate as `withSourceDimension`: only when the metric declares it.
+ */
+export function withTypeDimension(
+  selection: MetricEvidenceSelection,
+  declared: ReadonlySet<string> | null | undefined
+): MetricEvidenceSelection {
+  if (!isTaskMetric(selection.metric_key)) return selection;
+  return withDimension(selection, TYPE_DIMENSION, declared);
+}
+
+/**
+ * SAFETY: only when the metric DECLARES the dimension — a drilldown that asks
+ * for an undeclared one is rejected outright, so asking on spec would trade a
+ * missing column for an unopenable dialog. `declared` is null while the catalog
+ * is unknown, which is also a no-op.
+ */
+function withDimension(
+  selection: MetricEvidenceSelection,
+  dimension: string,
+  declared: ReadonlySet<string> | null | undefined
+): MetricEvidenceSelection {
+  if (!declared?.has(dimension)) return selection;
+  if (selection.display_dimensions.includes(dimension)) return selection;
   return {
     ...selection,
-    display_dimensions: [
-      ...selection.display_dimensions,
-      SOURCE_DIMENSION,
-    ].sort(),
+    display_dimensions: [...selection.display_dimensions, dimension].sort(),
   };
 }
 

--- a/src/ingestion/gold/task_metric_evidence.sql
+++ b/src/ingestion/gold/task_metric_evidence.sql
@@ -74,12 +74,26 @@ issue_facts AS (
            toFloat64(greatest(toInt64(0),
                dateDiff('second', any(s.created_at),
                         minIf(i.interval_start, i.interval_start < s.final_close_at))))) AS pickup_seconds,
-        -- The duration measures carry no breakdown, but a row still has to
-        -- name its tracker: `source` is what makes its ref addressable.
+        -- The population measures taken off these rows carry no breakdown, but
+        -- a row still has to name its tracker: `source` is what makes its ref
+        -- addressable.
         CAST(
             [tuple('source', any(s.data_source), any(s.data_source))]
             AS Array(Tuple(key String, value String, label Nullable(String)))
-        ) AS no_dimensions
+        ) AS no_dimensions,
+        -- The per-issue duration rows carry the issue's own type as well, so a
+        -- median reads the same way a count of closed issues does: which kinds
+        -- of work it was taken over.
+        CAST(
+            [
+                tuple(
+                    'type',
+                    ifNull(any(s.issue_type_key), '__unknown__'),
+                    ifNull(any(s.issue_type_name), 'Type unknown')
+                ),
+                tuple('source', any(s.data_source), any(s.data_source))
+            ] AS Array(Tuple(key String, value String, label Nullable(String)))
+        ) AS type_dimensions
     FROM issue_state AS s
     LEFT JOIN status_intervals AS i
         ON i.insight_source_id = s.insight_source_id
@@ -318,7 +332,7 @@ SELECT
     id_readable AS record_label,
     toNullable(toFloat64(duration_measure.2)) AS contribution,
     CAST(NULL AS Nullable(String)) AS subject_key,
-    no_dimensions AS dimensions,
+    type_dimensions AS dimensions,
     map('ref', id_readable, 'title', ifNull(title, '')) AS details
 FROM issue_facts
 ARRAY JOIN arrayConcat(

--- a/src/ingestion/tests/e2e/metrics/tasks_dev_time.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/tasks_dev_time.test.yaml
@@ -95,6 +95,28 @@ cases:
         view: breakdown
         assert: "size(items.filter(v, v.entity_id == 'erin@example.com')) == 1"
 
+  - name: tasks.dev_time by issue type
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: { type: person, ids: [erin@example.com] }
+        period: { from: "2026-03-20", to: "2026-03-31" }
+        metrics:
+          - metric_key: tasks.dev_time
+            views:
+              - { view: breakdown, dimensions: [type] }
+    expect:
+      - assert: "status == 200"
+      # A median says which kinds of work it was taken over; every fixture issue
+      # is one Task, so the whole figure sits under that one type.
+      - metric: tasks.dev_time
+        view: breakdown
+        assert: "items.exists(v, v.entity_id == 'erin@example.com' && v.dimensions.exists(d, d.key == 'type' && d.value == 'Task') && double(v.value) == 5.0)"
+      - metric: tasks.dev_time
+        view: breakdown
+        assert: "size(items.filter(v, v.entity_id == 'erin@example.com')) == 1"
+
   - name: tasks.dev_time empty window
     request:
       url: /v1/metric-results

--- a/src/ingestion/tests/e2e/metrics/tasks_dev_time.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/tasks_dev_time.test.yaml
@@ -108,8 +108,6 @@ cases:
               - { view: breakdown, dimensions: [type] }
     expect:
       - assert: "status == 200"
-      # A median says which kinds of work it was taken over; every fixture issue
-      # is one Task, so the whole figure sits under that one type.
       - metric: tasks.dev_time
         view: breakdown
         assert: "items.exists(v, v.entity_id == 'erin@example.com' && v.dimensions.exists(d, d.key == 'type' && d.value == 'Task') && double(v.value) == 5.0)"

--- a/src/ingestion/tests/e2e/metrics/tasks_pickup_time.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/tasks_pickup_time.test.yaml
@@ -104,6 +104,28 @@ cases:
         view: breakdown
         assert: "size(items.filter(v, v.entity_id == 'erin@example.com')) == 1"
 
+  - name: tasks.pickup_time by issue type
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: { type: person, ids: [erin@example.com] }
+        period: { from: "2026-03-20", to: "2026-03-31" }
+        metrics:
+          - metric_key: tasks.pickup_time
+            views:
+              - { view: breakdown, dimensions: [type] }
+    expect:
+      - assert: "status == 200"
+      # A median says which kinds of work it was taken over; every fixture issue
+      # is one Task, so the whole figure sits under that one type.
+      - metric: tasks.pickup_time
+        view: breakdown
+        assert: "items.exists(v, v.entity_id == 'erin@example.com' && v.dimensions.exists(d, d.key == 'type' && d.value == 'Task') && double(v.value) == 5.0)"
+      - metric: tasks.pickup_time
+        view: breakdown
+        assert: "size(items.filter(v, v.entity_id == 'erin@example.com')) == 1"
+
   - name: tasks.pickup_time empty window
     request:
       url: /v1/metric-results

--- a/src/ingestion/tests/e2e/metrics/tasks_pickup_time.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/tasks_pickup_time.test.yaml
@@ -117,8 +117,6 @@ cases:
               - { view: breakdown, dimensions: [type] }
     expect:
       - assert: "status == 200"
-      # A median says which kinds of work it was taken over; every fixture issue
-      # is one Task, so the whole figure sits under that one type.
       - metric: tasks.pickup_time
         view: breakdown
         assert: "items.exists(v, v.entity_id == 'erin@example.com' && v.dimensions.exists(d, d.key == 'type' && d.value == 'Task') && double(v.value) == 5.0)"

--- a/src/ingestion/tests/e2e/metrics/tasks_resolution_time.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/tasks_resolution_time.test.yaml
@@ -98,6 +98,28 @@ cases:
         view: breakdown
         assert: "size(items.filter(v, v.entity_id == 'erin@example.com')) == 1"
 
+  - name: tasks.resolution_time by issue type
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: { type: person, ids: [erin@example.com] }
+        period: { from: "2026-12-20", to: "2026-12-31" }
+        metrics:
+          - metric_key: tasks.resolution_time
+            views:
+              - { view: breakdown, dimensions: [type] }
+    expect:
+      - assert: "status == 200"
+      # A median says which kinds of work it was taken over; every fixture issue
+      # is one Task, so the whole figure sits under that one type.
+      - metric: tasks.resolution_time
+        view: breakdown
+        assert: "items.exists(v, v.entity_id == 'erin@example.com' && v.dimensions.exists(d, d.key == 'type' && d.value == 'Task') && double(v.value) == 5.0)"
+      - metric: tasks.resolution_time
+        view: breakdown
+        assert: "size(items.filter(v, v.entity_id == 'erin@example.com')) == 1"
+
   - name: tasks.resolution_time empty window
     request:
       url: /v1/metric-results

--- a/src/ingestion/tests/e2e/metrics/tasks_resolution_time.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/tasks_resolution_time.test.yaml
@@ -111,8 +111,6 @@ cases:
               - { view: breakdown, dimensions: [type] }
     expect:
       - assert: "status == 200"
-      # A median says which kinds of work it was taken over; every fixture issue
-      # is one Task, so the whole figure sits under that one type.
       - metric: tasks.resolution_time
         view: breakdown
         assert: "items.exists(v, v.entity_id == 'erin@example.com' && v.dimensions.exists(d, d.key == 'type' && d.value == 'Task') && double(v.value) == 5.0)"


### PR DESCRIPTION
**Why.** A count of closed issues and a median cycle time read differently once you can see which kinds of work are behind them, and the tracker's issue type was on none of the rows that explain those numbers.

**What changed.** The activity list and the evidence dialog now ask for `type` as a display dimension wherever a task metric declares it — the same catalogue gate `source` already passes through. Gold puts the type on the per-issue duration rows so the three cycle-time metrics can declare it too.

**The export keeps the column; `source` still doesn't.** The file holds what the screen holds, and `type` is a column a reader sees, unlike `source`, which only backs a link. One line to revert.

**Duration metrics gain a type breakdown as a side effect.** Declaring the dimension also offers it as a chart group-by for dev time, resolution and pickup. Dropping the three registry lines takes it back out.

**Verified.** analytics `cargo test --bins` (486) and clippy; frontend unit suite (1976 passed — `metric-editor-dialog` times out identically on a clean tree). No screenshots and the new e2e cases unrun: Docker is down here, and the only stand I can reach carries real data, which cannot go in a public PR body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added issue-type breakdowns for task development, pickup, and resolution time metrics.
  * Task activity evidence now displays issue types when available.
  * Metric evidence exports include the visible issue-type dimension.
  * Issue duration evidence now includes both issue type and source details.

* **Bug Fixes**
  * Improved dimension handling to prevent duplicates and omit unavailable values.
  * Adjusted evidence table sizing for clearer issue-type display.

* **Tests**
  * Added coverage for issue-type breakdowns, evidence requests, exports, and activity rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->