### PR TITLE
fix(frontend): give the phone drawer its own feedback row

### DIFF
--- a/src/frontend/src/components/portal/context-pane.tsx
+++ b/src/frontend/src/components/portal/context-pane.tsx
@@ -1,4 +1,5 @@
 import {
+  Bug,
   ChevronRight,
   Layers,
   LayoutGrid,
@@ -6,8 +7,10 @@ import {
   Settings2,
 } from "lucide-react";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 
 import { AppSidebarFooter } from "@/components/app-sidebar-footer";
+import { useFeedbackDialog } from "@/components/feedback-context";
 import { OrgTree } from "@/components/org-tree";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Input } from "@/components/ui/input";
@@ -146,11 +149,12 @@ export function ContextPane() {
       </SidebarContent>
       {isPhone ? (
         <SidebarFooter>
-          {/* One row, not six: inline the settings menu and it takes a third of
-              the drawer, crowding out the sections that are the point of it.
-              Same affordance the rail gives desktop — an icon that opens the
-              menu on demand. */}
           <SidebarMenu>
+            <FeedbackItem onPicked={dismissDrawer} />
+            {/* One row, not six: inline the settings menu and it takes a third
+                of the drawer, crowding out the sections that are the point of
+                it. Same affordance the rail gives desktop — an icon that opens
+                the menu on demand. */}
             <SidebarMenuItem>
               <Popover open={settingsOpen} onOpenChange={setSettingsOpen}>
                 <PopoverTrigger
@@ -170,6 +174,7 @@ export function ContextPane() {
                       one here does — and the popover with it, which on a phone
                       covers the surface just asked for. */}
                   <AppSidebarFooter
+                    showFeedback={false}
                     onNavigate={() => {
                       setSettingsOpen(false);
                       dismissDrawer();
@@ -182,6 +187,28 @@ export function ContextPane() {
         </SidebarFooter>
       ) : null}
     </Sidebar>
+  );
+}
+
+/** Its own drawer row: inside the settings menu nobody found it. */
+function FeedbackItem({ onPicked }: { onPicked: () => void }) {
+  const { t } = useTranslation();
+  const feedback = useFeedbackDialog();
+
+  if (!feedback) return null;
+
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        onClick={() => {
+          feedback.openFeedback();
+          onPicked();
+        }}
+      >
+        <Bug aria-hidden />
+        <span>{t("feedback.nav_label")}</span>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
   );
 }
 

--- a/src/frontend/src/components/portal/shell-layout.test.tsx
+++ b/src/frontend/src/components/portal/shell-layout.test.tsx
@@ -13,6 +13,8 @@ vi.mock("@tanstack/react-router", async () => {
   return portalRouterMock();
 });
 
+import "@/i18n";
+
 import { portalRouter } from "@/test/portal-router";
 
 import { render, screen, within } from "@testing-library/react";
@@ -23,6 +25,11 @@ const mocks = vi.hoisted(() => ({
   layout: "phone" as "phone" | "narrow" | "wide",
   zone: { activeZone: "overview", activePerson: "boss@x" },
   isManager: true,
+  openFeedback: vi.fn(),
+}));
+
+vi.mock("@/components/feedback-context", () => ({
+  useFeedbackDialog: () => ({ openFeedback: mocks.openFeedback }),
 }));
 
 vi.mock("@/hooks/use-mobile", () => ({ useIsMobile: () => mocks.layout === "phone" }));
@@ -71,8 +78,14 @@ vi.mock("@/auth", () => ({ useViewer: () => ({ email: "boss@x" }) }));
 // The settings menu pulls in viewer/theme/i18n plumbing; its presence is what
 // matters here — on a phone it is only reachable through this drawer.
 vi.mock("@/components/app-sidebar-footer", () => ({
-  AppSidebarFooter: ({ onNavigate }: { onNavigate?: () => void }) => (
-    <div data-testid="settings-menu">
+  AppSidebarFooter: ({
+    onNavigate,
+    showFeedback = true,
+  }: {
+    onNavigate?: () => void;
+    showFeedback?: boolean;
+  }) => (
+    <div data-testid="settings-menu" data-shows-feedback={String(showFeedback)}>
       <button type="button" onClick={onNavigate}>
         Go somewhere
       </button>
@@ -105,6 +118,7 @@ beforeEach(() => {
   mocks.layout = "phone";
   mocks.zone = { activeZone: "overview", activePerson: "boss@x" };
   mocks.isManager = true;
+  mocks.openFeedback.mockClear();
   act(() => {
     portalRouter.set({ item: undefined });
   });
@@ -223,6 +237,36 @@ describe("shell layout: phone", () => {
     await user.click(screen.getByRole("button", { name: "Go somewhere" }));
 
     expect(screen.queryByTestId("settings-menu")).not.toBeInTheDocument();
+  });
+
+  it("offers feedback from the drawer itself, not from inside the settings menu", async () => {
+    render(<Shell />);
+    const user = await openDrawer();
+
+    await user.click(screen.getByRole("button", { name: "Send feedback" }));
+
+    expect(mocks.openFeedback).toHaveBeenCalled();
+  });
+
+  it("closes the drawer with the feedback box, which opens behind it", async () => {
+    render(<Shell />);
+    const user = await openDrawer();
+
+    await user.click(screen.getByRole("button", { name: "Send feedback" }));
+
+    expect(screen.queryByRole("button", { name: "Settings" })).not.toBeInTheDocument();
+  });
+
+  it("leaves feedback out of the settings menu the drawer already offers it beside", async () => {
+    render(<Shell />);
+    const user = await openDrawer();
+
+    await user.click(screen.getByRole("button", { name: "Settings" }));
+
+    expect(screen.getByTestId("settings-menu")).toHaveAttribute(
+      "data-shows-feedback",
+      "false",
+    );
   });
 
   it("drops the header — the zone row already names the zone", async () => {


### PR DESCRIPTION
Closes #2771.

**Why.** Below 768px the feedback control had no row of its own — it sat inside the drawer's Settings popover, three taps from the screen and invisible to anything scanning the page for it.

**What changed.** The phone drawer footer gets the same labelled "Send feedback" row the rail gives every wider tier, beside Settings rather than inside it.

**Dropped from the popover the drawer opens — `showFeedback={false}`, as the rail already passes.** Otherwise the tier offers the same control twice, one of them buried. Reversible by deleting the prop.

The drawer at 390px, and the box it now opens:

| Before | After | The box |
|---|---|---|
| <img src="https://raw.githubusercontent.com/constructorfabric/insight/pr-2777-assets/390-before.png" width="260"> | <img src="https://raw.githubusercontent.com/constructorfabric/insight/pr-2777-assets/390-after.png" width="260"> | <img src="https://raw.githubusercontent.com/constructorfabric/insight/pr-2777-assets/390-dialog.png" width="260"> |

**Verified.** `pnpm test` (1979), lint and `tsc -b` clean. Driven in a browser against a mock-seeded local dev server: counting controls whose text or `aria-label` matches "feedback", the drawer holds exactly one at 767, 640 and 390px where it held none, and the rail's own slot at 768, 1024 and 1280px is untouched.
