### PR TITLE
docs(skills): add probe-merged-change and correct what the pass proved wrong

### DIFF
--- a/.claude/skills/drive-ui/SKILL.md
+++ b/.claude/skills/drive-ui/SKILL.md
@@ -135,9 +135,9 @@ Annotate before capturing rather than describing the element in prose afterwards
 
 A screenshot of a populated stand carries more than the thing you meant to capture. Person names, a scope picker, team metric values and other people's free text all render, and the issue tracker is public.
 
-Two moves, in order. Reproduce on a screen with no person data where the defect allows it — the metric catalog and the other config surfaces show product vocabulary only. Where it doesn't, redact the person column before uploading rather than cropping the layout apart, since the layout is usually part of what the reader needs to see.
+Two moves, in order. Reproduce on a screen carrying no person data where the defect allows it — a config surface beats a populated table, though a metric name, group title or description there can be author-written too, so it is a better starting point rather than a safe one. Where the defect needs the populated screen, redact before uploading rather than cropping the layout apart, since the layout is usually part of what the reader needs to see.
 
-Check the whole frame every time. The offending element is rarely the sensitive part.
+Read the whole frame every time, and treat any free text in it as personal until you have checked. The offending element is rarely the sensitive part.
 
 ### Mock the response instead of writing the content
 

--- a/.claude/skills/drive-ui/SKILL.md
+++ b/.claude/skills/drive-ui/SKILL.md
@@ -129,7 +129,21 @@ For a UI defect, three artifacts answer the three questions a reader has:
 2. **A contrast shot** — the same widget in a state that is correct, or a sibling that behaves. Answers "how do I know it's wrong?"
 3. **The page snapshot** — `playwright-cli snapshot --filename="$EVIDENCE/<case>.yml"`, plus `--boxes` when the complaint is about position or overlap. Answers "what was actually on screen?"
 
-Annotate before capturing rather than describing the element in prose afterwards. Then hand the issue to `file-bug-insight` — and be straight about the constraint it will repeat: GitHub has no API for uploading images to an issue, so the user drags the PNGs in themselves.
+Annotate before capturing rather than describing the element in prose afterwards. Then hand the issue to `file-bug-insight` — it owns attaching the images and has a working upload path, so don't tell the user to drag them in.
+
+### Scrub the frame, not just the widget
+
+A screenshot of a populated stand carries more than the thing you meant to capture. Person names, a scope picker, team metric values and other people's free text all render, and the issue tracker is public.
+
+Two moves, in order. Reproduce on a screen with no person data where the defect allows it — the metric catalog and the other config surfaces show product vocabulary only. Where it doesn't, redact the person column before uploading rather than cropping the layout apart, since the layout is usually part of what the reader needs to see.
+
+Check the whole frame every time. The offending element is rarely the sensitive part.
+
+### Mock the response instead of writing the content
+
+To see how a surface renders hostile or extreme content, mock the response rather than creating it. `playwright-cli route "**/api/..." --body=...` puts XSS payloads, absurd lengths, empty states and error states through the real render path without a row landing in a shared stand's database. `unroute` afterwards.
+
+This is the difference between proving that four payloads render as escaped text and planting scripts in a stand colleagues read.
 
 ## When you can't get a browser
 

--- a/.claude/skills/file-bug-insight/SKILL.md
+++ b/.claude/skills/file-bug-insight/SKILL.md
@@ -35,6 +35,7 @@ Each of these owns a slice of the work. Some are still being built out here, so 
 | `drive-ui` | getting an *authenticated* browser on any stand — the Keycloak realm login and the `DEV_USER_EMAIL` seed locally, a passkey attach on a remote one — plus the routes and the evidence set | any UI defect, local or remote |
 | `metric-parity` | the full bronze → silver → gold walk | collecting the same query at every layer |
 | `release-verify` | install and seed health | settling "product bug, or empty instance?" |
+| `probe-merged-change` | the exploratory pass over a change that just merged | findings arrive here from that pass, already reproduced |
 
 One collection step belongs here rather than in `drive-ui`: whenever a value on screen looks wrong, capture the browser console and the API response behind it (`playwright-cli console`, then `requests` and `request <n>`) and attach both. Whether the wrong number arrived from the API or was rendered wrong is the single most useful fact in the report — and it is an observation, not a diagnosis, as long as you paste what the response actually contained.
 
@@ -75,6 +76,10 @@ Collect first, write second. The evidence must let someone else reproduce this.
 - **UI bugs** — reproduce it in a browser first (`drive-ui` owns the stand and the browser; `playwright-cli` owns the commands), then lead with a tight annotated shot of the broken widget plus a contrast shot of something that renders correctly. The stand URL belongs in your commands, never in the issue.
 - **Pipeline / config bugs with no UI** — the failure signal itself: the exact error and stack, or a row-count contrast that runs the code's own filter (returns 0) against the unfiltered count (>0). **If the failure is silent** — completes "successfully" with zero effect — say so explicitly. That is the key symptom.
 - **What the metric is *supposed* to do** lives in the model under `src/ingestion/` and the definition registry in `src/backend/services/analytics/`. Read the intent before calling behaviour wrong.
+
+**Volume and destructive proof belongs on a stand you can throw away.** A cap, a flood, a rate limit, a migration against a warm database — each needs writes nobody else is reading. Stand one up rather than reaching for a shared instance, and expect a mass write to a shared stand to be refused outright.
+
+Split deliberately when a finding has two halves. Prove the volume behaviour where you can write freely, and confirm the half that needs no volume — a response carrying no paging field, a parameter being ignored — where the change is actually deployed. Say in the report which half came from where, naming the state and never the environment.
 
 ## Type and priority
 

--- a/.claude/skills/playwright-cli/SKILL.md
+++ b/.claude/skills/playwright-cli/SKILL.md
@@ -159,6 +159,7 @@ playwright-cli run-code "async page => await page.context().grantPermissions(['g
 playwright-cli run-code --filename=script.js
 playwright-cli tracing-start
 playwright-cli tracing-stop
+# these can report success and write no file — read references/video-recording.md before relying on them
 playwright-cli video-start video.webm
 playwright-cli video-chapter "Chapter Title" --description="Details" --duration=2000
 playwright-cli video-stop

--- a/.claude/skills/playwright-cli/references/annotated-gif.md
+++ b/.claude/skills/playwright-cli/references/annotated-gif.md
@@ -1,0 +1,62 @@
+# Annotated GIF Walkthroughs
+
+Build a step-by-step walkthrough from screenshots when a bug report needs to show a path rather than a moment. Use it when video is unavailable or unreliable (see [video-recording.md](./video-recording.md)) and whenever the destination is an issue tracker — GitHub renders a GIF inline with no player, no controls and no click to start.
+
+A GIF also beats video for this job in two ways: each step holds long enough to read, and a caption bar can state the measurement that makes the step evidence.
+
+## The shape
+
+One screenshot per step, a caption bar burned into each frame, assembled with Pillow.
+
+```python
+from PIL import Image, ImageDraw, ImageFont
+
+BAR = 62
+
+def annotate(src, dst, step, caption, width=1100):
+    im = Image.open(src).convert("RGB")
+    w, h = im.size
+    im = im.resize((width, int(h * width / w)), Image.LANCZOS)
+    out = Image.new("RGB", (width, im.height + BAR), (18, 26, 35))
+    out.paste(im, (0, 0))
+    d = ImageDraw.Draw(out)
+    f = ImageFont.truetype("/System/Library/Fonts/Supplemental/Arial Bold.ttf", 21)
+    d.text((18, im.height + BAR // 2), step, font=f, fill=(224, 121, 111), anchor="lm")
+    d.text((18 + d.textlength(step, font=f) + 14, im.height + BAR // 2),
+           caption, font=f, fill=(232, 238, 244), anchor="lm")
+    out.save(dst)
+
+frames = [Image.open(p).convert("P", palette=Image.ADAPTIVE, colors=128) for p in paths]
+frames[0].save("repro.gif", save_all=True, append_images=frames[1:],
+               duration=[2600, 3200, 4200], loop=0, optimize=True, disposal=2)
+```
+
+`disposal=2` clears each frame before the next. Without it, frames of differing size ghost onto each other.
+
+## Making the frames comparable
+
+Screenshots taken at different viewport widths have different pixel sizes, and a GIF needs one canvas. Paste each onto a common canvas at its natural size rather than scaling to fit — a 390 px shot stretched to 1280 px hides the very thing a responsive bug is about.
+
+```python
+canvas = Image.new("RGB", (1280, 820), (12, 18, 25))
+canvas.paste(Image.open(shot).convert("RGB"), (0, 0))
+```
+
+## Pointing at the defect
+
+Draw the highlight yourself from the element's own box, so it lands exactly where the reader should look:
+
+```bash
+playwright-cli eval "() => { const e = document.querySelector('<sel>'); const r = e.getBoundingClientRect();
+  return [r.left, r.top, r.right, r.bottom].map(Math.round).join(','); }"
+```
+
+Then a rounded rectangle at that box. For an absence — a control that should be there and is not — keep the rectangle in place across frames and strike it through on the frames where the element is gone. The eye tracks one position instead of hunting an empty region.
+
+## Timing
+
+Give each frame long enough to read its caption: roughly 2.5 s for a simple step, 4 s for the frame carrying the result. A closing frame that states the outcome in text — what was typed, what was stored, what was lost — makes the GIF readable without the issue body around it.
+
+## Size
+
+Keep frames near 1100–1300 px wide and the palette at 128 colours. A four-frame walkthrough lands around 500 KB, well inside what a tracker accepts inline.

--- a/.claude/skills/playwright-cli/references/annotated-gif.md
+++ b/.claude/skills/playwright-cli/references/annotated-gif.md
@@ -12,24 +12,50 @@ One screenshot per step, a caption bar burned into each frame, assembled with Pi
 from PIL import Image, ImageDraw, ImageFont
 
 BAR = 62
+FONTS = ("/System/Library/Fonts/Supplemental/Arial Bold.ttf",
+         "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+         "DejaVuSans-Bold.ttf")
 
-def annotate(src, dst, step, caption, width=1100):
+def bar_font(size=21):
+    for path in FONTS:
+        try:
+            return ImageFont.truetype(path, size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+def annotate(src, dst, step, caption, width=None):
     im = Image.open(src).convert("RGB")
-    w, h = im.size
-    im = im.resize((width, int(h * width / w)), Image.LANCZOS)
-    out = Image.new("RGB", (width, im.height + BAR), (18, 26, 35))
+    if width:
+        w, h = im.size
+        im = im.resize((width, int(h * width / w)), Image.LANCZOS)
+    out = Image.new("RGB", (im.width, im.height + BAR), (18, 26, 35))
     out.paste(im, (0, 0))
     d = ImageDraw.Draw(out)
-    f = ImageFont.truetype("/System/Library/Fonts/Supplemental/Arial Bold.ttf", 21)
+    f = bar_font()
     d.text((18, im.height + BAR // 2), step, font=f, fill=(224, 121, 111), anchor="lm")
     d.text((18 + d.textlength(step, font=f) + 14, im.height + BAR // 2),
            caption, font=f, fill=(232, 238, 244), anchor="lm")
     out.save(dst)
 
-frames = [Image.open(p).convert("P", palette=Image.ADAPTIVE, colors=128) for p in paths]
+shots = ["step1.png", "step2.png", "step3.png"]
+steps = [("Step 1", "what you did", 2600),
+         ("Step 2", "what came back", 3200),
+         ("Step 3", "what was stored", 4200)]
+
+assert len(shots) == len(steps), "one caption per screenshot"
+
+annotated = []
+for i, (src, (step, caption, _)) in enumerate(zip(shots, steps)):
+    annotate(src, f"frame{i}.png", step, caption)
+    annotated.append(f"frame{i}.png")
+
+frames = [Image.open(p).convert("P", palette=Image.ADAPTIVE, colors=128) for p in annotated]
 frames[0].save("repro.gif", save_all=True, append_images=frames[1:],
-               duration=[2600, 3200, 4200], loop=0, optimize=True, disposal=2)
+               duration=[ms for *_, ms in steps], loop=0, optimize=True, disposal=2)
 ```
+
+`annotate` keeps each screenshot at its natural size; pass `width=` only when the shots are far larger than the tracker needs and the defect is not about layout. The length assert is what stops a missing caption from silently dropping a step — `zip` would truncate to the shorter list — and taking the durations from `steps` keeps one per frame however many there are.
 
 `disposal=2` clears each frame before the next. Without it, frames of differing size ghost onto each other.
 
@@ -59,4 +85,4 @@ Give each frame long enough to read its caption: roughly 2.5 s for a simple step
 
 ## Size
 
-Keep frames near 1100–1300 px wide and the palette at 128 colours. A four-frame walkthrough lands around 500 KB, well inside what a tracker accepts inline.
+Keep the palette at 128 colours, and frames near 1100–1300 px wide where the source shots are wider than that and the defect is not a layout one. A four-frame walkthrough lands around 500 KB, well inside what a tracker accepts inline.

--- a/.claude/skills/playwright-cli/references/session-management.md
+++ b/.claude/skills/playwright-cli/references/session-management.md
@@ -2,6 +2,8 @@
 
 Run multiple isolated browser sessions concurrently with state persistence.
 
+A session can die immediately after `open`, with no error until the next command reports the browser is not open. Confirm a new session with a cheap `eval` before building on it, and prefer reusing one healthy session over opening a second.
+
 ## Named Browser Sessions
 
 Use `-s` flag to isolate browser contexts:

--- a/.claude/skills/playwright-cli/references/video-recording.md
+++ b/.claude/skills/playwright-cli/references/video-recording.md
@@ -141,3 +141,5 @@ Embrace creativity, overlays are powerful.
 
 - Recording adds slight overhead to automation
 - Large recordings can consume significant disk space
+- `video-start` / `video-stop` can report success and leave no file behind. `video-stop` prints a path whether or not one was written, so check the file exists before you rely on it. For anything you intend to hand to someone, use the `run-code` + `page.screencast` path above — it writes the file itself.
+- When no video survives, an annotated GIF built from per-step screenshots beats retrying: see [annotated-gif.md](./annotated-gif.md). GitHub and most trackers render a GIF inline with no player.

--- a/.claude/skills/probe-merged-change/SKILL.md
+++ b/.claude/skills/probe-merged-change/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: probe-merged-change
+description: >-
+  Run an exploratory quality pass over a change that has ALREADY merged in
+  constructorfabric/insight — research the diff, smoke it on a stand carrying that exact build,
+  then execute a test plan across the five quality vectors (Efficiency, Reliability, Performance,
+  Security, Versatility) and hand each surviving finding to file-bug-insight. Use for "test what
+  just merged", "exploratory pass on #N", "check this change across the quality vectors",
+  "we shipped X, go break it", or a QA sweep of a release candidate's new feature. NOT for
+  planning tests before implementation (scope-feature-tests), NOT for writing the Testing section
+  into an issue body (quality-vector-tests), NOT for validating a whole stand
+  (insight-stand-validate), and NOT for confirming a known defect is fixed (verify-fix).
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob, Skill
+---
+
+# Probe a merged change
+
+A change is in `main`. Nobody has tried to break it yet. Your job is to find what the author's own tests could not, and to leave behind reports someone can act on.
+
+**The change is not on trial for existing — it is on trial for its claims.** The author already believes it works; they ran their suite. What has not happened is somebody reading the merge description as a set of assertions and driving each one until it gives.
+
+## Where this sits
+
+The other four testing skills each stop short of this:
+
+| Skill | Owns | Not this because |
+|---|---|---|
+| `scope-feature-tests` | reasoning out coverage before implementation | the code does not exist yet |
+| `quality-vector-tests` | authoring the Testing section into the issue | it formats scenarios, it does not run them |
+| `insight-stand-validate` | validating a whole stand | scoped to an instance, not to a diff |
+| `verify-fix` | confirming a known defect is fixed | the defect is already named |
+
+Take vector semantics from `quality-vector-tests/references/vector-mapping.md` rather than re-deriving them. Take the axes catalogue from `scope-feature-tests` — exact-limit probing, tenant isolation, contract compatibility and URL-state lifecycle are already enumerated there. This skill owns execution order, the probes below, and the judgement about what is worth filing.
+
+## Order
+
+1. **Research** — read the diff and the merge description.
+2. **Smoke** — three commands on a stand carrying that build.
+3. **Plan** — vector by vector, against what you read.
+4. **Execute**, collecting as you go.
+5. **File** through `file-bug-insight`.
+
+### Smoke before you plan
+
+Three checks decide whether a plan is worth writing: the migration applied, one round trip stores and reads back what you sent, and one gated read refuses the wrong caller. If any of those fails, that is the report — stop and write it.
+
+Run this on a stand carrying the **exact build the change shipped in**, not on `main` built locally. Pin the images to the build tag from the release commit and reuse an existing compose project so the named volumes survive: the migration then runs against a populated database, which is the case that actually breaks. A fresh instance only proves the migration works on empty.
+
+## Read the change's own claims as testable assertions
+
+A merge description states things the author believes. Each is a check. Quote it, then try to break it.
+
+- **A documented workaround is a claim.** One change said "narrowing the period reaches the rest" of a capped listing. The narrowest window the endpoint accepted was a single day, so once a day held more than the cap the workaround reached nothing — 65 rows unreachable by any request. That was the strongest finding of the pass and it came from reading one sentence sceptically.
+- **A stated limit is a claim.** Drive it to its edge and past it.
+- **A "verified end to end" line is a claim.** Repeat the run described and check it says what the author says it says.
+- **A deferred item is not a claim.** The change that lists what it does not do yet has told you the truth. Do not file it as a defect.
+
+## Probe for the third state at every limit
+
+Boundary testing usually asks for the last accepted value and the first refused one. That framing has two states and misses the one that hurts: **accepted, reported success, silently modified**.
+
+For every cap, send a value far past it and then read the stored record back. A 100,000-character message returned `204` and kept 4,000 of it. Nothing in the response, the interface or the log said so.
+
+Where a write is silently clipped, check the client too. A field with no `maxLength` and no counter means nothing warned before, and a success message means nothing warned after.
+
+The same question generalises: for any input the system narrows — truncates, rounds, coerces, de-duplicates, drops an unknown field — does anything tell the person who sent it?
+
+## Look for findings that only exist in combination
+
+Two limitations can each be defensible and together be a defect.
+
+Rate limiting absent is a capacity note. A listing capped at 200 with no paging is a documented limit. Together, any signed-in caller makes everyone else's rows unreachable in about three seconds.
+
+Before writing anything up, put the individual findings side by side and ask what one caller can do holding all of them at once. File the combination as its own report when the combined consequence is worse than the sum — and say plainly what each half contributes.
+
+## Check what the client sends against what the server declares
+
+Cheap, mechanical, and routinely wrong in a change that touched both sides.
+
+Capture one real request body from the interface, then compare its keys against the request type in the published OpenAPI and against the stored columns. One change had the SPA sending `app_name` and `app_version` on every submission while the server declared neither and dropped both — so no report could be tied to the build it came from.
+
+Read the same seam in the other direction: fields the response promises that the interface never renders.
+
+## Collecting
+
+`drive-ui` owns getting an authenticated browser and the evidence set; `playwright-cli` owns the commands. Two things belong here.
+
+**Mock the response rather than writing the content.** Hostile input — XSS payloads, absurd lengths, empty and error states — goes through the real render path via `playwright-cli route` without a row landing in a shared stand's database.
+
+**Volume proof needs a stand you can throw away.** Floods, caps and rate limits need writes nobody else is reading. Expect a mass write to a shared stand to be refused. Where a finding has a volume half and a shape half, prove each where it belongs and say which came from where.
+
+## What not to file
+
+The pass will surface more than it should report.
+
+- **Pre-existing platform behaviour.** Before filing an envelope or framework oddity, run the same probe against an endpoint the change did not touch. A bare `422` from the body deserialiser reproduced everywhere; it was not this change's doing and went in the report as a note, not an issue.
+- **Environment artifacts.** The `layer: stand` rule in `file-bug-insight` applies unchanged.
+- **Deferred work the change names.**
+- **Design decisions you disagree with.** A choice the author documented and defended is a conversation, not a bug. Where it carries a risk they did not weigh — the person on the other side of it, usually — say so once, in the report, and let them decide.
+
+Report the passes too. Tenant isolation holding, injection landing as literal text, latency inside budget — a reader who sees only findings cannot tell a thorough pass from a shallow one.

--- a/.claude/skills/probe-merged-change/SKILL.md
+++ b/.claude/skills/probe-merged-change/SKILL.md
@@ -42,7 +42,7 @@ Take vector semantics from `quality-vector-tests/references/vector-mapping.md` r
 
 ### Smoke before you plan
 
-Three checks decide whether a plan is worth writing: the migration applied, one round trip stores and reads back what you sent, and one gated read refuses the wrong caller. If any of those fails, that is the report — stop and write it.
+Three checks decide whether a plan is worth writing: the migration applied, one round trip stores and reads back what you sent, and one gated read refuses the wrong caller. If any of those fails, stop — but classify before you file. Re-run the failed check on a stand you have confirmed healthy and seeded, still on that same build. What reproduces there is the report; what does not is `layer: stand`, and the pass has learned nothing about the change yet.
 
 Run this on a stand carrying the **exact build the change shipped in**, not on `main` built locally. Pin the images to the build tag from the release commit and reuse an existing compose project so the named volumes survive: the migration then runs against a populated database, which is the case that actually breaks. A fresh instance only proves the migration works on empty.
 
@@ -59,7 +59,9 @@ A merge description states things the author believes. Each is a check. Quote it
 
 Boundary testing usually asks for the last accepted value and the first refused one. That framing has two states and misses the one that hurts: **accepted, reported success, silently modified**.
 
-For every cap, send a value far past it and then read the stored record back. A 100,000-character message returned `204` and kept 4,000 of it. Nothing in the response, the interface or the log said so.
+For a cap on something stored, send a value far past it and then read the record back. A 100,000-character message returned `204` and kept 4,000 of it. Nothing in the response, the interface or the log said so.
+
+Where the cap is not a write — a page size, a rate limit, a result set — the same question lands on the response instead: does the payload, its metadata or the next request admit that anything was withheld? A truncated list that looks identical to a complete one is the same defect wearing different clothes.
 
 Where a write is silently clipped, check the client too. A field with no `maxLength` and no counter means nothing warned before, and a success message means nothing warned after.
 

--- a/.claude/skills/quality-vector-tests/SKILL.md
+++ b/.claude/skills/quality-vector-tests/SKILL.md
@@ -139,6 +139,10 @@ For the deeper grounding discipline (feature shapes, differential tags, per-sour
 matrices, deferred-behavior handling), read the sibling skill `scope-feature-tests` — this skill
 reuses its reasoning and only differs in the **output format and location**.
 
+To *run* the vectors against a change that has already merged rather than write scenarios into an
+issue, hand over to `probe-merged-change`. It takes vector semantics from
+[vector-mapping.md](./references/vector-mapping.md) and owns execution.
+
 ### 3. Verify every tool you are about to name
 This is where drafts quietly lie. "Semgrep + Trivy in CI" is a sentence anyone can type; whether
 those scanners exist in this repo's pipeline is a fact you can check in about ten seconds. Run only


### PR DESCRIPTION
**Why.** An exploratory pass over an already-merged change had no skill to run — the four adjacent testing skills each stop short — and the pass then exposed three of them documenting behaviour that is no longer true.

**What changed.** A new skill, `probe-merged-change`, runs research → smoke → plan → execute → file over a merged diff, reusing vector semantics from `quality-vector-tests` and the axes catalogue from `scope-feature-tests`.

**A fifth skill rather than a mode on `quality-vector-tests`.** That one authors scenarios into an issue; this one runs them against a build. Easy to fold back in if it stays thin.

**The three corrections land here, not in a follow-up.** Each is a behaviour fact this same pass produced, and each is wrong in the tree today.

## How it works

Four probes, each of which produced a filed bug during the pass:

- **Claims are assertions.** #2740 documented narrowing the period to reach past a capped listing; the narrowest window is one day, so a day over the cap reaches nothing.
- **The third state at every limit** — not accept/refuse, but accepted, reported success, silently modified (#2768).
- **Findings that exist only in combination.** No rate limit plus a 200-row cap with no paging: one caller hides everyone else's rows.
- **Client request against server contract.** The SPA sent two fields the server declared neither of.

**Out of scope.** Two further corrections live in a workspace checkout with no remote, so they can't ride along.

**Verified.** The flow ran end to end over #2740 before it was written down, producing #2768 and #2771; the written form has not itself been re-run. The annotated-GIF snippet was executed verbatim out of the markdown — 3 frames in, 3 out, mixed-width sources keeping their natural widths — after review caught that it referenced an undefined name.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an exploratory quality-check workflow for recently released changes.
  - Added guidance for testing edge cases, hostile responses, data limits, and combined scenarios.
  - Added support for creating annotated GIF walkthroughs from screenshots.

- **Documentation**
  - Improved evidence-capture guidance, including sensitive-data checks and screenshot redaction.
  - Documented reliable video-output verification and session validation.
  - Added guidance for safely testing high-volume or destructive scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->