### PR TITLE
feat(frontend): let an install gate metrics, not just menu entries

### DIFF
--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -663,6 +663,11 @@ frontend:
     #   - "zone:directions/dir:sales"               (a whole direction)
     #   - "zone:directions/dir:dev/lens:git-output" (one lens, by URL slug)
     #   - "zone:person/section:git_output"          (a Person-zone section)
+    #   - "metric:tasks.resolution_time"            (one metric, everywhere)
+    #   - "metric:ai.*"                             (a whole metric family)
+    # A metric path is not a menu entry: it gates the key itself, so the metric
+    # reaches no tile, attention row, heatmap column, drilldown block or report
+    # column, and no request asks for it.
     # Unknown paths are ignored (the browser console warns). Presentation
     # only — the API authorizes independently of what the menu shows.
     hide: []

--- a/src/frontend/helm/values.yaml
+++ b/src/frontend/helm/values.yaml
@@ -39,6 +39,11 @@ nav:
   #   - "zone:directions/dir:sales"               (a whole direction)
   #   - "zone:directions/dir:dev/lens:git-output" (one lens, by URL slug)
   #   - "zone:person/section:git_output"          (a Person-zone section)
+  #   - "metric:tasks.resolution_time"            (one metric, everywhere)
+  #   - "metric:ai.*"                             (a whole metric family)
+  # A metric path is not a menu entry: it gates the key itself, so the metric
+  # reaches no tile, attention row, heatmap column, drilldown block or report
+  # column, and no request asks for it.
   # Unknown paths are ignored (the browser console warns). Presentation
   # only — the API authorizes independently of what the menu shows.
   hide: []

--- a/src/frontend/src/components/portal/context-pane.tsx
+++ b/src/frontend/src/components/portal/context-pane.tsx
@@ -19,7 +19,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { GROUPS } from "@/lib/insight/groups";
+import { visibleGroups } from "@/lib/insight/groups";
 import { usePersonSectionStandings } from "@/lib/portal/use-person-sections";
 import { STATUS_BG_CLASS } from "@/lib/status";
 import {
@@ -58,7 +58,6 @@ import {
 } from "@/lib/portal/nav-model";
 import {
   personSectionPlanned,
-  personSectionVisible,
 } from "@/lib/portal/nav-policy";
 import { usePortalShowPlanned } from "@/lib/portal/portal-store";
 import {
@@ -617,7 +616,7 @@ function PersonSectionsNav() {
   const standings = usePersonSectionStandings(activePerson);
   const standingById = new Map(standings.map((st) => [st.id as string, st]));
   const showPlanned = usePortalShowPlanned();
-  const groups = GROUPS.filter((g) => personSectionVisible(g.id, showPlanned));
+  const groups = visibleGroups(showPlanned);
   const groupIds = groups.map((g) => g.id) as string[];
   const glance = active == null || !groupIds.includes(active);
   return (

--- a/src/frontend/src/components/portal/domain-lens-view.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.tsx
@@ -67,8 +67,8 @@ import {
 } from "@/lib/portal/metric-stats";
 import {
   lensEntry,
+  overviewCardDirections,
   sectionMetricKeys,
-  visibleDirections,
   visibleSections,
   type ConcentrationFraming,
   type LensConfig,
@@ -1469,10 +1469,7 @@ function DirectionCardsSection({
 }) {
   const { openDirection } = usePortalNavActions();
   const showPlanned = usePortalShowPlanned();
-  // The same directions the pane lists. A card for a direction the menu does
-  // not offer is a dead end that also announces a source is missing — which is
-  // exactly what an install marking that direction planned has said not to say.
-  const cards = visibleDirections(showPlanned)
+  const cards = overviewCardDirections(showPlanned)
     .map((d) => {
       const entry = lensEntry(d.id, "Overview");
       if (!entry || "comingSoon" in entry) return null;

--- a/src/frontend/src/components/portal/domain-lens-view.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.tsx
@@ -30,7 +30,7 @@ import {
   attentionSummary,
   computeAttentionFlags,
 } from "@/lib/insight/attention-flags";
-import { GROUPS } from "@/lib/insight/groups";
+import { GROUPS, visibleGroups } from "@/lib/insight/groups";
 import type { PersonCoverage } from "@/lib/insight/coverage";
 import { useScopeCoverage } from "@/lib/portal/use-scope-coverage";
 import { useVisibilityPolicy } from "@/queries/identity-me";
@@ -68,13 +68,15 @@ import {
 import {
   lensEntry,
   sectionMetricKeys,
+  visibleDirections,
+  visibleSections,
   type ConcentrationFraming,
   type LensConfig,
   type SectionSpec,
 } from "@/lib/portal/lens-configs";
-import { DIRECTIONS } from "@/lib/portal/nav-model";
 import { buildTrendData, pickTrendBucket } from "@/lib/portal/trend-data";
 import { usePortalNavActions, usePortalSlice } from "@/lib/portal/portal-nav";
+import { usePortalShowPlanned } from "@/lib/portal/portal-store";
 import type { TeamMember } from "@/types/insight";
 import { useOrgScope } from "@/lib/portal/use-org-scope";
 import { useMetricCollection } from "@/queries/metric-results";
@@ -92,7 +94,7 @@ const EMPTY_COLLECTION: MetricCollectionConfig = { metrics: [] };
  * (rule 6), and no individual is ever named (rule 10).
  */
 export function DomainLensView({
-  config,
+  config: declared,
   gridKeys: gridKeysProp,
 }: {
   config: LensConfig;
@@ -108,6 +110,15 @@ export function DomainLensView({
   gridKeys?: readonly string[];
 }) {
   const { period, dateRange } = usePortalPeriod();
+
+  // What this install shows, not what the registry declares: a gated metric
+  // takes its tile with it, and a section left with none of its own is gone
+  // rather than drawn empty (`visibleSections`).
+  const showPlanned = usePortalShowPlanned();
+  const config = useMemo(
+    () => visibleSections(declared, showPlanned),
+    [declared, showPlanned]
+  );
 
   const orgScope = useOrgScope();
   const { isFlat } = useVisibilityPolicy();
@@ -552,6 +563,7 @@ function CoverageLevelsSection({
   personIdByEntity: Map<string, string>;
 }) {
   const [openLevel, setOpenLevel] = useState<number | null>(null);
+  const showPlanned = usePortalShowPlanned();
   const { distribution, parts, people, thin, isPending, isError } =
     useScopeCoverage(memberIds);
   if (isPending) return <Pending label="Reading coverage…" />;
@@ -567,7 +579,9 @@ function CoverageLevelsSection({
   const counted = distribution.counted;
   if (counted === 0) return null;
 
-  const partCount = GROUPS.length;
+  // The same sections the coverage hook counted, or the denominator would name
+  // sections this install does not show.
+  const partCount = visibleGroups(showPlanned).length;
   const levels = [...distribution.byLevel.entries()].sort(
     (a, b) => b[0] - a[0]
   );
@@ -713,6 +727,8 @@ function CoverageLevelPeople({
   nameByEntity: Map<string, string>;
   personIdByEntity: Map<string, string>;
 }) {
+  // Every title, not just the visible ones: this only resolves ids that are
+  // already in a person's coverage states, which the hook gated on its way in.
   const titleById = new Map(GROUPS.map((g) => [g.id, g.title]));
   const rows = [...people].sort((a, b) =>
     (nameByEntity.get(a.entityId) ?? a.entityId).localeCompare(
@@ -1452,23 +1468,30 @@ function DirectionCardsSection({
   memberIds: readonly string[];
 }) {
   const { openDirection } = usePortalNavActions();
-  const cards = DIRECTIONS.map((d) => {
-    const entry = lensEntry(d.id, "Overview");
-    if (!entry || "comingSoon" in entry) return null;
-    const headline = entry.sections.find(
-      (s): s is Extract<SectionSpec, { kind: "headline" }> =>
-        s.kind === "headline"
-    );
-    if (!headline) return null;
-    const keys =
-      variant === "compact" ? headline.metrics.slice(0, 2) : headline.metrics;
-    const observed = familyObserved(
-      grid.byKey,
-      sectionMetricKeys(entry),
-      memberIds
-    );
-    return { id: d.id, name: d.name, keys, observed };
-  }).filter((c): c is NonNullable<typeof c> => c != null);
+  const showPlanned = usePortalShowPlanned();
+  // The same directions the pane lists. A card for a direction the menu does
+  // not offer is a dead end that also announces a source is missing — which is
+  // exactly what an install marking that direction planned has said not to say.
+  const cards = visibleDirections(showPlanned)
+    .map((d) => {
+      const entry = lensEntry(d.id, "Overview");
+      if (!entry || "comingSoon" in entry) return null;
+      const gated = visibleSections(entry, showPlanned);
+      const headline = gated.sections.find(
+        (s): s is Extract<SectionSpec, { kind: "headline" }> =>
+          s.kind === "headline"
+      );
+      if (!headline) return null;
+      const keys =
+        variant === "compact" ? headline.metrics.slice(0, 2) : headline.metrics;
+      const observed = familyObserved(
+        grid.byKey,
+        sectionMetricKeys(gated),
+        memberIds
+      );
+      return { id: d.id, name: d.name, keys, observed };
+    })
+    .filter((c): c is NonNullable<typeof c> => c != null);
   if (!cards.length) return null;
 
   const go = (dir: string) => openDirection(dir, "Overview");

--- a/src/frontend/src/components/portal/person-view.tsx
+++ b/src/frontend/src/components/portal/person-view.tsx
@@ -1,8 +1,7 @@
 import { MetricGroupsView } from "@/components/portal/metric-groups-view";
 import { PersonHeader } from "@/components/portal/person-header";
 import { SingleGroupView } from "@/components/portal/single-group-view";
-import { GROUPS, type GroupId } from "@/lib/insight/groups";
-import { visiblePersonSections } from "@/lib/portal/nav-policy";
+import { visibleGroups, type GroupId } from "@/lib/insight/groups";
 import { usePortalItem, usePortalNavActions } from "@/lib/portal/portal-nav";
 import { usePortalShowPlanned } from "@/lib/portal/portal-store";
 
@@ -22,9 +21,7 @@ export function PersonView({ person }: { person: string }) {
   const item = usePortalItem();
   const { setItem } = usePortalNavActions();
   const showPlanned = usePortalShowPlanned();
-  const groupIds = visiblePersonSections(GROUPS, showPlanned).map(
-    (group) => group.id
-  );
+  const groupIds = visibleGroups(showPlanned).map((group) => group.id);
   const isSection = item != null && (groupIds as string[]).includes(item);
 
   return (

--- a/src/frontend/src/components/portal/report-builder-view.tsx
+++ b/src/frontend/src/components/portal/report-builder-view.tsx
@@ -30,6 +30,8 @@ import { ComingSoon } from "@/components/widgets/coming-soon";
 import { usePortalPeriod } from "@/hooks/use-portal-period";
 import { downloadMatrixCsv, downloadMatrixXlsx } from "@/lib/export/matrix";
 import { formatMetricNumber } from "@/lib/format";
+import { metricVisible } from "@/lib/portal/nav-policy";
+import { usePortalShowPlanned } from "@/lib/portal/portal-store";
 import { useOrgScope } from "@/lib/portal/use-org-scope";
 import { unavailableReason } from "@/lib/reports/availability";
 import { byFamily } from "@/lib/reports/families";
@@ -81,9 +83,18 @@ export function ReportBuilderView() {
   // unreachable key outright, so it must not be selectable — but dropping it
   // silently takes whole families off the screen and leaves the reader hunting
   // for a section that is simply not measured here.
+  //
+  // A metric the INSTALL gates is different, and is dropped: it is not offered
+  // anywhere else on the screen either, so listing it here as unavailable would
+  // advertise the one place a reader could still name it.
+  const showPlanned = usePortalShowPlanned();
   const catalogue = useMemo(
-    () => (definitions.data?.metrics ?? []).filter((metric) => metric.is_enabled),
-    [definitions.data],
+    () =>
+      (definitions.data?.metrics ?? []).filter(
+        (metric) =>
+          metric.is_enabled && metricVisible(metric.metric_key, showPlanned),
+      ),
+    [definitions.data, showPlanned],
   );
   // The additivity restriction belongs to the rollup, not to the report. At a
   // bucket the server has, it computed each value itself — a ratio is that

--- a/src/frontend/src/lib/insight/groups.test.ts
+++ b/src/frontend/src/lib/insight/groups.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "vitest";
 
+import { parseNavPaths } from "@/lib/portal/nav-policy";
 import {
   GROUPS,
   groupIdForMetricKey,
+  visibleGroups,
   type DrilldownBlock,
   type GroupId,
   type MetricGroup,
@@ -88,5 +90,61 @@ describe("groups registry", () => {
         ],
       },
     ]);
+  });
+});
+
+describe("visibleGroups", () => {
+  const gate = (planned: string[], hide: string[] = []) => ({
+    hide: parseNavPaths(hide, "hide"),
+    planned: parseNavPaths(planned, "planned"),
+  });
+
+  it("returns the registry itself when the install gates nothing", () => {
+    expect(visibleGroups(false, gate(["zone:scorecard"]))).toBe(GROUPS);
+  });
+
+  it("drops a group whose every metric is gated", () => {
+    const groups = visibleGroups(false, gate(["metric:ai.*"]));
+
+    expect(groups.map((g) => g.id)).not.toContain("ai_adoption");
+    expect(groups.map((g) => g.id)).toContain("task_delivery");
+  });
+
+  it("drops a group whose Person-zone section the install marks planned", () => {
+    const groups = visibleGroups(false, gate(["zone:person/section:wiki"]));
+
+    expect(groups.map((g) => g.id)).not.toContain("wiki");
+  });
+
+  it("takes a gated metric out of the collection, the card and the drilldown", () => {
+    const groups = visibleGroups(false, gate(["metric:tasks.resolution_time"]));
+    const tasks = groups.find((g) => g.id === "task_delivery");
+
+    expect(tasks?.collection.metrics.map((m) => m.key)).not.toContain(
+      "tasks.resolution_time"
+    );
+    expect(tasks?.card.preview).not.toContain("tasks.resolution_time");
+    expect(
+      tasks?.drilldown.flatMap((b) => ("metrics" in b ? b.metrics : []))
+    ).not.toContain("tasks.resolution_time");
+  });
+
+  it("drops a drilldown block left with no metric of its own", () => {
+    const before = groupById("task_delivery").drilldown.length;
+    const after = visibleGroups(
+      false,
+      gate(["metric:tasks.resolution_time", "metric:tasks.pickup_time"])
+    ).find((g) => g.id === "task_delivery")?.drilldown.length;
+
+    expect(after).toBe(before - 2);
+  });
+
+  it("shows everything gated as planned to a reader who asked for it", () => {
+    const groups = visibleGroups(
+      true,
+      gate(["metric:ai.*", "zone:person/section:wiki"])
+    );
+
+    expect(groups).toEqual(GROUPS);
   });
 });

--- a/src/frontend/src/lib/insight/groups.ts
+++ b/src/frontend/src/lib/insight/groups.ts
@@ -7,6 +7,13 @@ import type {
   MetricTimeseriesTableConfig,
 } from "@/lib/metrics/timeseries-table";
 import type { MetricTimeseriesChartConfig } from "@/lib/metrics/timeseries-chart";
+import {
+  gatesAnyMetric,
+  metricVisible,
+  navPolicy,
+  visiblePersonSections,
+  type InstanceNavPolicy,
+} from "@/lib/portal/nav-policy";
 
 /**
  * Dashboard composition registry: named groups of metrics and the KPI row.
@@ -594,4 +601,44 @@ export function groupIdForMetricKey(metricKey: string): GroupId | null {
     if (def.collection.metrics.some((m) => m.key === metricKey)) return def.id;
   }
   return null;
+}
+
+/**
+ * The groups this install shows, with the metrics it gates removed.
+ *
+ * Two gates, both from the per-install nav policy: a group whose Person-zone
+ * section the install hides or marks planned is not part of what this
+ * deployment measures, and neither is a group left with no visible metric of
+ * its own. Both matter beyond the menu — the coverage screen counts sections to
+ * say how much of a person's work the product can see, and counting a section
+ * this install does not show would report our own backlog as a gap in their
+ * data.
+ */
+export function visibleGroups(
+  showPlanned: boolean,
+  policy: InstanceNavPolicy = navPolicy()
+): readonly MetricGroup[] {
+  if (!gatesAnyMetric(policy) && policy.hide.personSections.size === 0 &&
+      policy.planned.personSections.size === 0) {
+    return GROUPS;
+  }
+
+  const kept: MetricGroup[] = [];
+  for (const group of visiblePersonSections(GROUPS, showPlanned, policy)) {
+    const metrics = group.collection.metrics.filter((m) =>
+      metricVisible(m.key, showPlanned, policy)
+    );
+    if (!metrics.length) continue;
+    const keep = (key: string) => metricVisible(key, showPlanned, policy);
+    kept.push({
+      ...group,
+      collection: { ...group.collection, metrics },
+      card: { preview: group.card.preview.filter(keep) },
+      drilldown: group.drilldown.flatMap((block) => {
+        const blockMetrics = block.metrics.filter(keep);
+        return blockMetrics.length ? [{ ...block, metrics: blockMetrics }] : [];
+      }),
+    });
+  }
+  return kept;
 }

--- a/src/frontend/src/lib/metrics/collection.ts
+++ b/src/frontend/src/lib/metrics/collection.ts
@@ -74,7 +74,18 @@ export function filterCollectionToAvailable(
   available: ReadonlySet<string> | null,
 ): MetricCollectionConfig {
   if (!available) return collection;
-  const kept = collection.metrics.filter((m) => available.has(m.key));
+  return filterCollectionByKey(collection, (key) => available.has(key));
+}
+
+/**
+ * Drop every metric the predicate rejects, keeping the config object identical
+ * when nothing is dropped so query keys stay stable.
+ */
+export function filterCollectionByKey(
+  collection: MetricCollectionConfig,
+  keep: (metricKey: string) => boolean,
+): MetricCollectionConfig {
+  const kept = collection.metrics.filter((m) => keep(m.key));
   return kept.length === collection.metrics.length ? collection : { metrics: kept };
 }
 

--- a/src/frontend/src/lib/portal/instance-hiding.test.ts
+++ b/src/frontend/src/lib/portal/instance-hiding.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import { GROUPS, visibleGroups } from "@/lib/insight/groups";
-import { visibleDirections, visibleLenses, visibleSections } from "./lens-configs";
+import {
+  overviewCardDirections,
+  visibleDirections,
+  visibleLenses,
+  visibleSections,
+} from "./lens-configs";
 import { DEFAULT_OVERVIEW_ITEM, OVERVIEW_ITEMS } from "./overview-configs";
 import { landingDecision } from "./landing-zone";
 import { parseNavPolicy, visiblePersonSections } from "./nav-policy";
@@ -209,6 +214,26 @@ describe("directions under the install policy", () => {
     expect(visibleDirections(false, policy).map((d) => d.id)).not.toContain(
       "dev"
     );
+  });
+
+  it("offers no Overview card for a direction whose Overview lens is hidden", () => {
+    const policy = hide(["zone:directions/dir:dev/lens:overview"]);
+
+    expect(visibleDirections(true, policy).map((d) => d.id)).toContain("dev");
+    expect(overviewCardDirections(true, policy).map((d) => d.id)).not.toContain(
+      "dev"
+    );
+  });
+
+  it("toggles the Overview card of a planned Overview lens with the reader's choice", () => {
+    const policy = planned(["zone:directions/dir:dev/lens:overview"]);
+
+    expect(overviewCardDirections(true, policy).map((d) => d.id)).toContain(
+      "dev"
+    );
+    expect(
+      overviewCardDirections(false, policy).map((d) => d.id)
+    ).not.toContain("dev");
   });
 });
 

--- a/src/frontend/src/lib/portal/instance-hiding.test.ts
+++ b/src/frontend/src/lib/portal/instance-hiding.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 
-import { visibleDirections, visibleLenses } from "./lens-configs";
+import { GROUPS, visibleGroups } from "@/lib/insight/groups";
+import { visibleDirections, visibleLenses, visibleSections } from "./lens-configs";
+import { DEFAULT_OVERVIEW_ITEM, OVERVIEW_ITEMS } from "./overview-configs";
 import { landingDecision } from "./landing-zone";
 import { parseNavPolicy, visiblePersonSections } from "./nav-policy";
 import {
@@ -239,5 +241,63 @@ describe("landing under nav.hide", () => {
     });
 
     expect(decision.kind).toBe("pin-overview");
+  });
+});
+
+describe("metric gating across the surfaces a metric reaches", () => {
+  // The shape an install takes when a metric family is declared but not yet
+  // trusted: the family and three individual keys under the reader's toggle.
+  const policy = planned([
+    "metric:ai.*",
+    "metric:tasks.resolution_time",
+    "metric:tasks.pickup_time",
+    "metric:tasks.on_time_delivery",
+  ]);
+
+  it("takes the participation card off the Overview with its own section", () => {
+    const overview = OVERVIEW_ITEMS[DEFAULT_OVERVIEW_ITEM]!;
+
+    const kinds = visibleSections(overview, false, policy).sections.map(
+      (s) => s.kind
+    );
+
+    expect(kinds).not.toContain("participation");
+    expect(kinds).toContain("headline");
+  });
+
+  it("leaves the headline with only the metrics the install still shows", () => {
+    const overview = OVERVIEW_ITEMS[DEFAULT_OVERVIEW_ITEM]!;
+    const headline = visibleSections(overview, false, policy).sections.find(
+      (s) => s.kind === "headline"
+    );
+
+    expect(headline).toBeDefined();
+    expect(headline && "metrics" in headline ? headline.metrics : []).not.toContain(
+      "ai.cost"
+    );
+  });
+
+  it("stops the attention scan from ranking a gated metric", () => {
+    const overview = OVERVIEW_ITEMS["attention"]!;
+    const attention = visibleSections(overview, false, policy).sections.find(
+      (s) => s.kind === "attention"
+    );
+    const keys = attention && "metrics" in attention ? attention.metrics : [];
+
+    expect(keys).not.toContain("tasks.resolution_time");
+    expect(keys.length).toBeGreaterThan(0);
+  });
+
+  it("drops the section a coverage count would otherwise call a gap", () => {
+    expect(visibleGroups(false, policy).map((g) => g.id)).not.toContain(
+      "ai_adoption"
+    );
+  });
+
+  it("gives the reader everything back with planned sections on", () => {
+    const overview = OVERVIEW_ITEMS[DEFAULT_OVERVIEW_ITEM]!;
+
+    expect(visibleSections(overview, true, policy)).toEqual(overview);
+    expect(visibleGroups(true, policy)).toEqual(GROUPS);
   });
 });

--- a/src/frontend/src/lib/portal/lens-configs.test.ts
+++ b/src/frontend/src/lib/portal/lens-configs.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, it } from "vitest";
 
 import { GROUPS } from "@/lib/insight/groups";
 import { DIRECTIONS } from "@/lib/portal/nav-model";
+import { parseNavPaths } from "@/lib/portal/nav-policy";
 import {
   DIRECTION_LENSES,
   directionMetricKeys,
   lensEntry,
   sectionMetricKeys,
+  visibleSections,
   type SectionSpec,
 } from "./lens-configs";
 
@@ -107,5 +109,86 @@ describe("sectionMetricKeys — Overview section kinds", () => {
     expect(keys).toContain("git.commits");
     expect(keys).toContain("collab.messages_sent");
     expect(keys).toContain("wiki.pages_created");
+  });
+});
+
+describe("visibleSections", () => {
+  const gate = (planned: string[], hide: string[] = []) => ({
+    hide: parseNavPaths(hide, "hide"),
+    planned: parseNavPaths(planned, "planned"),
+  });
+
+  const config = {
+    title: "Test",
+    sections: [
+      { kind: "headline", metrics: ["tasks.closed", "ai.cost"] },
+      {
+        kind: "stat-tiles",
+        title: "Typical",
+        metrics: ["tasks.resolution_time", "tasks.pickup_time"],
+      },
+      {
+        kind: "participation",
+        metrics: ["ai.active_days"],
+        title: "AI adoption",
+        noun: "People using AI",
+      },
+      {
+        kind: "distribution",
+        metric: "tasks.resolution_time",
+        title: "Resolution",
+        caption: "c",
+        unitLabel: "u",
+      },
+      { kind: "direction-cards", variant: "compact" },
+    ] as const satisfies readonly SectionSpec[],
+  };
+
+  it("returns the declared config untouched when the install gates no metric", () => {
+    expect(visibleSections(config, false, gate(["zone:scorecard"]))).toBe(
+      config
+    );
+  });
+
+  it("drops a gated metric and keeps the rest of its section", () => {
+    const gated = visibleSections(config, false, gate(["metric:ai.*"]));
+    const headline = gated.sections[0];
+
+    expect(headline).toMatchObject({
+      kind: "headline",
+      metrics: ["tasks.closed"],
+    });
+  });
+
+  it("drops a section left with none of its own metrics", () => {
+    const gated = visibleSections(config, false, gate(["metric:ai.*"]));
+
+    expect(gated.sections.map((s) => s.kind)).not.toContain("participation");
+  });
+
+  it("drops a single-metric section whose metric is gated", () => {
+    const gated = visibleSections(
+      config,
+      false,
+      gate(["metric:tasks.resolution_time"])
+    );
+
+    expect(gated.sections.map((s) => s.kind)).not.toContain("distribution");
+  });
+
+  it("keeps the sections that name no metric of their own", () => {
+    const gated = visibleSections(
+      config,
+      false,
+      gate(["metric:ai.*", "metric:tasks.resolution_time"])
+    );
+
+    expect(gated.sections.map((s) => s.kind)).toContain("direction-cards");
+  });
+
+  it("shows every gated section to a reader who asked for planned ones", () => {
+    const gated = visibleSections(config, true, gate(["metric:ai.*"]));
+
+    expect(gated.sections).toEqual(config.sections);
   });
 });

--- a/src/frontend/src/lib/portal/lens-configs.ts
+++ b/src/frontend/src/lib/portal/lens-configs.ts
@@ -1,9 +1,12 @@
 import {
   directionHidden,
   directionPlanned,
+  gatesAnyMetric,
   lensHidden,
   lensPlanned,
+  metricVisible,
   navPolicy,
+  visibleMetricKeys,
   type InstanceNavPolicy,
 } from "@/lib/portal/nav-policy";
 import {
@@ -168,6 +171,58 @@ export function sectionMetricKeys(config: LensConfig): string[] {
     }
   }
   return [...keys];
+}
+
+/**
+ * The lens as this install shows it: sections lose the metrics it gates, and a
+ * section left with none of its own is dropped rather than drawn empty.
+ *
+ * The data layer already refuses to fetch a gated metric, so a tile or a row
+ * would simply not appear — but a section that draws its own frame (a title, a
+ * participation card counting people rather than reading a value) would keep
+ * standing over the hole. Composition is where that is settled.
+ */
+export function visibleSections(
+  config: LensConfig,
+  showPlanned: boolean,
+  policy: InstanceNavPolicy = navPolicy()
+): LensConfig {
+  if (!gatesAnyMetric(policy)) return config;
+
+  const sections: SectionSpec[] = [];
+  for (const s of config.sections) {
+    switch (s.kind) {
+      case "headline":
+      case "stat-tiles":
+      case "trend":
+      case "concentration":
+      case "participation":
+      case "attention": {
+        const metrics = visibleMetricKeys(s.metrics, showPlanned, policy);
+        if (metrics.length) sections.push({ ...s, metrics });
+        break;
+      }
+      case "distribution":
+      case "composition":
+      case "event-histogram":
+        if (metricVisible(s.metric, showPlanned, policy)) sections.push(s);
+        break;
+      case "direction-cards":
+      case "coverage-levels":
+        // Neither names a metric of its own: the cards read each direction's
+        // own Overview lens (gated where that lens is composed) and coverage
+        // counts sections.
+        sections.push(s);
+        break;
+      default: {
+        const _exhaustive: never = s;
+        throw new Error(
+          `Unhandled section kind: ${JSON.stringify(_exhaustive)}`
+        );
+      }
+    }
+  }
+  return { ...config, sections };
 }
 
 /* ── Development ─────────────────────────────────────────────────────── */

--- a/src/frontend/src/lib/portal/lens-configs.ts
+++ b/src/frontend/src/lib/portal/lens-configs.ts
@@ -127,6 +127,15 @@ export function visibleDirections(
   );
 }
 
+export function overviewCardDirections(
+  showPlanned: boolean,
+  policy: InstanceNavPolicy = navPolicy()
+): Direction[] {
+  return visibleDirections(showPlanned, policy).filter((d) =>
+    visibleLenses(d, showPlanned, policy).includes("Overview")
+  );
+}
+
 /** Unique metric keys a config needs in its period+peer grid. */
 export function sectionMetricKeys(config: LensConfig): string[] {
   const keys = new Set<string>();

--- a/src/frontend/src/lib/portal/nav-policy.test.ts
+++ b/src/frontend/src/lib/portal/nav-policy.test.ts
@@ -5,15 +5,19 @@ import {
   directionPlanned,
   EMPTY_NAV_PATHS,
   EMPTY_NAV_POLICY,
+  gatesAnyMetric,
   itemHidden,
   itemPlanned,
   lensHidden,
   lensPlanned,
+  metricPlanned,
+  metricVisible,
   parseNavPaths,
   parseNavPolicy,
   personSectionHidden,
   personSectionPlanned,
   personSectionVisible,
+  visibleMetricKeys,
   zoneHidden,
   zonePlanned,
 } from "./nav-policy";
@@ -160,5 +164,87 @@ describe("personSectionVisible", () => {
         true,
       );
     }
+  });
+});
+
+describe("metric paths", () => {
+  const policyWith = (planned: string[], hide: string[] = []) => ({
+    hide: parseNavPaths(hide, "hide"),
+    planned: parseNavPaths(planned, "planned"),
+  });
+
+  it("reads a whole key and a family into their own tiers", () => {
+    const paths = parseNavPaths(
+      ["metric:tasks.resolution_time", "metric:ai.*"],
+      "planned"
+    );
+
+    expect(paths.metrics).toEqual(new Set(["tasks.resolution_time"]));
+    expect(paths.metricFamilies).toEqual(new Set(["ai."]));
+  });
+
+  it("takes every key of a family named with a star", () => {
+    const policy = policyWith(["metric:ai.*"]);
+
+    expect(metricPlanned("ai.cost", policy)).toBe(true);
+    expect(metricPlanned("ai.accepted_lines", policy)).toBe(true);
+    // A family is a prefix up to the dot, so a key that merely starts with
+    // the same letters is a different family.
+    expect(metricPlanned("airflow.runs", policy)).toBe(false);
+  });
+
+  it("keeps a hidden metric off screen whatever the reader toggled", () => {
+    const policy = policyWith([], ["metric:tasks.on_time_delivery"]);
+
+    expect(metricVisible("tasks.on_time_delivery", false, policy)).toBe(false);
+    expect(metricVisible("tasks.on_time_delivery", true, policy)).toBe(false);
+  });
+
+  it("shows a planned metric only to a reader who asked for planned sections", () => {
+    const policy = policyWith(["metric:tasks.pickup_time"]);
+
+    expect(metricVisible("tasks.pickup_time", false, policy)).toBe(false);
+    expect(metricVisible("tasks.pickup_time", true, policy)).toBe(true);
+    expect(metricVisible("tasks.closed", false, policy)).toBe(true);
+  });
+
+  it("filters a key list in place, preserving order", () => {
+    const policy = policyWith(["metric:ai.*"], ["metric:tasks.pickup_time"]);
+    const keys = ["git.commits", "ai.cost", "tasks.pickup_time", "tasks.closed"];
+
+    expect(visibleMetricKeys(keys, false, policy)).toEqual([
+      "git.commits",
+      "tasks.closed",
+    ]);
+    expect(visibleMetricKeys(keys, true, policy)).toEqual([
+      "git.commits",
+      "ai.cost",
+      "tasks.closed",
+    ]);
+  });
+
+  it("reports whether the install gates any metric at all", () => {
+    expect(gatesAnyMetric(EMPTY_NAV_POLICY)).toBe(false);
+    expect(gatesAnyMetric(policyWith(["metric:ai.*"]))).toBe(true);
+    expect(
+      gatesAnyMetric(policyWith([], ["metric:tasks.resolution_time"]))
+    ).toBe(true);
+    // A navigation path is not a metric gate.
+    expect(gatesAnyMetric(policyWith(["zone:scorecard"]))).toBe(false);
+  });
+
+  it.each([
+    ["a metric with no family", "metric:commits"],
+    ["a bare star", "metric:*"],
+    ["a star inside the family", "metric:*.cost"],
+    ["a three-part key", "metric:ai.cost.usd"],
+    ["an uppercase key", "metric:AI.cost"],
+    ["a metric nested under a zone", "zone:overview/metric:ai.cost"],
+  ])("ignores and warns on %s", (_label, entry) => {
+    const warn = silenceWarnings();
+    const paths = parseNavPaths([entry], "planned");
+
+    expect(paths.metrics.size + paths.metricFamilies.size).toBe(0);
+    expect(warn).toHaveBeenCalled();
   });
 });

--- a/src/frontend/src/lib/portal/nav-policy.ts
+++ b/src/frontend/src/lib/portal/nav-policy.ts
@@ -6,6 +6,10 @@ export interface NavPathSet {
   directions: ReadonlySet<string>;
   lenses: ReadonlySet<string>;
   personSections: ReadonlySet<string>;
+  /** Whole metric keys, e.g. `tasks.resolution_time`. */
+  metrics: ReadonlySet<string>;
+  /** Family prefixes from `metric:ai.*`, stored WITH the dot (`ai.`). */
+  metricFamilies: ReadonlySet<string>;
 }
 
 export interface InstanceNavPolicy {
@@ -19,6 +23,8 @@ export const EMPTY_NAV_PATHS: NavPathSet = {
   directions: new Set(),
   lenses: new Set(),
   personSections: new Set(),
+  metrics: new Set(),
+  metricFamilies: new Set(),
 };
 
 export const EMPTY_NAV_POLICY: InstanceNavPolicy = {
@@ -31,11 +37,30 @@ type NavPath =
   | { kind: "item"; zone: string; item: string }
   | { kind: "direction"; direction: string }
   | { kind: "lens"; direction: string; lens: string }
-  | { kind: "section"; section: string };
+  | { kind: "section"; section: string }
+  | { kind: "metric"; metric: string }
+  | { kind: "metricFamily"; family: string };
 
 const SEGMENT = /^(zone|item|dir|lens|section):([a-z0-9][a-z0-9_-]*)$/;
 
+/**
+ * A metric path names a key of the analytics catalog, not a menu node, so it
+ * is a root form rather than a segment under `zone:` — and its value carries
+ * the dotted family (`tasks.resolution_time`). The trailing `.*` form takes a
+ * whole family, because "every AI metric" is a standing product statement and
+ * a list of today's keys would silently stop covering tomorrow's.
+ */
+const METRIC = /^metric:([a-z0-9][a-z0-9_]*)\.([a-z0-9][a-z0-9_]*|\*)$/;
+
 function parsePath(raw: string): NavPath | null {
+  const metric = METRIC.exec(raw);
+  if (metric) {
+    const [, family, leaf] = metric;
+    return leaf === "*"
+      ? { kind: "metricFamily", family: `${family}.` }
+      : { kind: "metric", metric: `${family}.${leaf}` };
+  }
+
   const parts: [kind: string, value: string][] = [];
   for (const segment of raw.split("/")) {
     const match = SEGMENT.exec(segment);
@@ -73,6 +98,8 @@ export function parseNavPaths(raw: unknown, field: string): NavPathSet {
   const directions = new Set<string>();
   const lenses = new Set<string>();
   const personSections = new Set<string>();
+  const metrics = new Set<string>();
+  const metricFamilies = new Set<string>();
   for (const entry of raw) {
     const path = typeof entry === "string" ? parsePath(entry) : null;
     if (!path) {
@@ -95,9 +122,23 @@ export function parseNavPaths(raw: unknown, field: string): NavPathSet {
       case "section":
         personSections.add(path.section);
         break;
+      case "metric":
+        metrics.add(path.metric);
+        break;
+      case "metricFamily":
+        metricFamilies.add(path.family);
+        break;
     }
   }
-  return { zones, items, directions, lenses, personSections };
+  return {
+    zones,
+    items,
+    directions,
+    lenses,
+    personSections,
+    metrics,
+    metricFamilies,
+  };
 }
 
 export function parseNavPolicy(nav: unknown): InstanceNavPolicy {
@@ -204,5 +245,63 @@ export function visiblePersonSections<T extends { id: string }>(
 ): T[] {
   return sections.filter((section) =>
     personSectionVisible(section.id, showPlanned, policy)
+  );
+}
+
+/* ── Metrics ─────────────────────────────────────────────────────────── */
+
+function matches(set: NavPathSet, metricKey: string): boolean {
+  if (set.metrics.has(metricKey)) return true;
+  for (const family of set.metricFamilies) {
+    if (metricKey.startsWith(family)) return true;
+  }
+  return false;
+}
+
+export function metricHidden(
+  metricKey: string,
+  policy = navPolicy()
+): boolean {
+  return matches(policy.hide, metricKey);
+}
+
+export function metricPlanned(
+  metricKey: string,
+  policy = navPolicy()
+): boolean {
+  return matches(policy.planned, metricKey);
+}
+
+/**
+ * Whether a metric may appear on screen at all.
+ *
+ * Applied to the metric KEY rather than to each surface, so a metric this
+ * install does not show cannot reach a tile, an attention row, a heatmap
+ * column or a report column by a route nobody remembered to gate.
+ */
+export function metricVisible(
+  metricKey: string,
+  showPlanned: boolean,
+  policy = navPolicy()
+): boolean {
+  if (metricHidden(metricKey, policy)) return false;
+  return showPlanned || !metricPlanned(metricKey, policy);
+}
+
+export function visibleMetricKeys(
+  keys: readonly string[],
+  showPlanned: boolean,
+  policy = navPolicy()
+): string[] {
+  return keys.filter((key) => metricVisible(key, showPlanned, policy));
+}
+
+/** Whether this install gates any metric at all — lets callers skip the walk. */
+export function gatesAnyMetric(policy = navPolicy()): boolean {
+  return (
+    policy.hide.metrics.size > 0 ||
+    policy.hide.metricFamilies.size > 0 ||
+    policy.planned.metrics.size > 0 ||
+    policy.planned.metricFamilies.size > 0
   );
 }

--- a/src/frontend/src/lib/portal/use-person-sections.ts
+++ b/src/frontend/src/lib/portal/use-person-sections.ts
@@ -1,4 +1,4 @@
-import { GROUPS, type GroupId } from "@/lib/insight/groups";
+import { visibleGroups, type GroupId } from "@/lib/insight/groups";
 import { groupHasData } from "@/lib/insight/group-data";
 import { partState, reachableMetricKeys } from "@/lib/insight/coverage";
 import { injectCohortPeer } from "@/lib/insight/within-team-peer";
@@ -13,6 +13,7 @@ import { derivePeerStanding } from "@/lib/metrics/peer-standing";
 import { usePersonCohort } from "@/lib/portal/use-person-cohort";
 import type { Status } from "@/lib/status";
 import { usePortalPeriod } from "@/hooks/use-portal-period";
+import { usePortalShowPlanned } from "@/lib/portal/portal-store";
 import { useMetricDefinitionsResponse } from "@/queries/metric-definitions";
 import { useMetricCollectionSet } from "@/queries/metric-results";
 
@@ -59,9 +60,11 @@ export function usePersonSectionStandings(personId: string): SectionStanding[] {
   const { dateRange } = usePortalPeriod();
   const entityId = normalizePersonId(personId);
   const entity = { type: "person" as const, ids: [entityId] };
+  const showPlanned = usePortalShowPlanned();
+  const groups = visibleGroups(showPlanned);
 
   const groupData = useMetricCollectionSet(
-    GROUPS.map((def) => ({
+    groups.map((def) => ({
       key: def.id,
       collection: projectViews(def.collection, ["period", "peer"]),
     })),
@@ -77,7 +80,7 @@ export function usePersonSectionStandings(personId: string): SectionStanding[] {
   const cohortIds = usePersonCohort(entityId);
   const cohortGroup = useMetricCollectionSet(
     cohortIds.length
-      ? GROUPS.map((def) => ({
+      ? groups.map((def) => ({
           key: def.id,
           collection: projectViews(def.collection, ["period"]),
         }))
@@ -88,7 +91,7 @@ export function usePersonSectionStandings(personId: string): SectionStanding[] {
 
   const reachable = reachableMetricKeys(definitions.data?.metrics ?? []);
 
-  return GROUPS.map((def) => {
+  return groups.map((def) => {
     const result = groupData.get(def.id);
     const cohort = cohortGroup.get(def.id);
     const byKey =

--- a/src/frontend/src/lib/portal/use-scope-coverage.ts
+++ b/src/frontend/src/lib/portal/use-scope-coverage.ts
@@ -10,9 +10,10 @@ import {
   type PartCoverage,
   type PersonCoverage,
 } from "@/lib/insight/coverage";
-import { GROUPS } from "@/lib/insight/groups";
+import { visibleGroups } from "@/lib/insight/groups";
 import { projectViews } from "@/lib/metrics/collection";
 import { usePortalPeriod } from "@/hooks/use-portal-period";
+import { usePortalShowPlanned } from "@/lib/portal/portal-store";
 import { useMetricDefinitionsResponse } from "@/queries/metric-definitions";
 import { useMetricCollectionSet } from "@/queries/metric-results";
 
@@ -62,6 +63,10 @@ export function useScopeCoverage(
   memberIds: readonly string[],
 ): ScopeCoverage {
   const { dateRange } = usePortalPeriod();
+  // Sections this install does not show are not gaps in anyone's data, so they
+  // are not counted — see `visibleGroups`.
+  const showPlanned = usePortalShowPlanned();
+  const groups = useMemo(() => visibleGroups(showPlanned), [showPlanned]);
   // The scope selector owns who is in view, so this takes the member list
   // rather than deriving one. Deriving it would leave the tab answering about
   // the viewer's whole reach while every other tab answered about the selected
@@ -75,7 +80,7 @@ export function useScopeCoverage(
   // chunk-and-merge path available at roster scale.
   const data = useMetricCollectionSet(
     rosterIds.length
-      ? GROUPS.map((def) => ({
+      ? groups.map((def) => ({
           key: def.id,
           collection: projectViews(def.collection, ["period"]),
         }))
@@ -94,16 +99,16 @@ export function useScopeCoverage(
 
   return useMemo(() => {
     const byKey = new Map(
-      GROUPS.flatMap((def) => [...(data.get(def.id)?.byKey ?? new Map())]),
+      groups.flatMap((def) => [...(data.get(def.id)?.byKey ?? new Map())]),
     );
     const people = rosterIds.map((id) =>
-      personCoverage(GROUPS, byKey, id, reachable),
+      personCoverage(groups, byKey, id, reachable),
     );
     return {
-      distribution: coverageDistribution(people, GROUPS.length),
+      distribution: coverageDistribution(people, groups.length),
       people,
-      thin: thinlyCovered(people, GROUPS.length),
-      parts: partCoverage(GROUPS, people),
+      thin: thinlyCovered(people, groups.length),
+      parts: partCoverage(groups, people),
       // An empty roster is an answer, not a wait. With no members the hook
       // sends no collections, so no group has an entry and the `?? true`
       // below would hold every one of them pending forever — the section
@@ -112,10 +117,17 @@ export function useScopeCoverage(
       isPending:
         definitions.isPending ||
         (rosterIds.length > 0 &&
-          GROUPS.some((def) => data.get(def.id)?.isPending ?? true)),
+          groups.some((def) => data.get(def.id)?.isPending ?? true)),
       isError:
         definitions.isError ||
-        GROUPS.some((def) => data.get(def.id)?.isError ?? false),
+        groups.some((def) => data.get(def.id)?.isError ?? false),
     };
-  }, [data, rosterIds, reachable, definitions.isPending, definitions.isError]);
+  }, [
+    data,
+    groups,
+    rosterIds,
+    reachable,
+    definitions.isPending,
+    definitions.isError,
+  ]);
 }

--- a/src/frontend/src/queries/metric-results-install-gate.test.tsx
+++ b/src/frontend/src/queries/metric-results-install-gate.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * The install's metric gate, at the layer every surface fetches through.
+ *
+ * Its own file because `navPolicy()` reads `/config.js` once and memoises the
+ * answer — a per-test policy would have to defeat that cache, and a gate that
+ * only works when the cache is cold is not the gate the app runs.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.stubGlobal("__INSIGHT_CONFIG__", {
+  nav: { planned: ["metric:ai.*"], hide: ["metric:tasks.pickup_time"] },
+});
+
+import { queryMetricResults } from "@/api/metric-results-client";
+import type { MetricCollectionConfig } from "@/lib/metrics/collection";
+import { setPortalShowPlanned } from "@/lib/portal/portal-store";
+import { pid } from "@/test/identity";
+import { useMetricCollection } from "@/queries/metric-results";
+
+vi.mock("@/api/metric-results-client", async (orig) => ({
+  ...(await orig<typeof import("@/api/metric-results-client")>()),
+  queryMetricResults: vi.fn(),
+}));
+vi.mock("@/api/metric-definitions-client", () => ({
+  listMetricDefinitions: vi.fn(async () => ({
+    metrics: [
+      { metric_key: "git.commits", is_enabled: true },
+      { metric_key: "ai.cost", is_enabled: true },
+      { metric_key: "tasks.pickup_time", is_enabled: true },
+    ],
+  })),
+}));
+
+const mock = vi.mocked(queryMetricResults);
+
+const COLLECTION: MetricCollectionConfig = {
+  metrics: [
+    { key: "git.commits", views: [{ view: "period" }] },
+    { key: "ai.cost", views: [{ view: "period" }] },
+    { key: "tasks.pickup_time", views: [{ view: "period" }] },
+  ],
+};
+const ENTITY = { type: "person" as const, ids: [pid("ic")] };
+const RANGE = { from: "2026-06-01", to: "2026-06-30" };
+
+function wrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client }, children);
+}
+
+async function askedFor(): Promise<string[]> {
+  const { result } = renderHook(
+    () => useMetricCollection(COLLECTION, ENTITY, RANGE),
+    { wrapper: wrapper() }
+  );
+  await waitFor(() => expect(result.current.isPending).toBe(false));
+  return mock.mock.calls[0]![0].metrics.map((m) => m.metric_key);
+}
+
+describe("the install's metric gate", () => {
+  beforeEach(() => {
+    mock.mockReset();
+    mock.mockImplementation(async (req) => ({
+      metrics: req.metrics.map((m) => ({
+        metric_key: m.metric_key,
+        label: m.metric_key,
+        unit: null,
+        format: "integer" as const,
+        direction: "higher_is_better" as const,
+        computation: "sum" as const,
+        views: [
+          {
+            view: "period" as const,
+            values: [{ entity_id: ENTITY.ids[0]!, value: 1 }],
+          },
+        ],
+      })),
+    }));
+  });
+
+  it("never asks for a metric the install hides, whatever the reader toggled", async () => {
+    setPortalShowPlanned(true);
+
+    expect(await askedFor()).not.toContain("tasks.pickup_time");
+  });
+
+  it("drops a planned family for a reader with planned sections off", async () => {
+    setPortalShowPlanned(false);
+
+    expect(await askedFor()).toEqual(["git.commits"]);
+  });
+
+  it("serves a planned family to a reader who asked for planned sections", async () => {
+    setPortalShowPlanned(true);
+
+    expect(await askedFor()).toEqual(["git.commits", "ai.cost"]);
+  });
+});

--- a/src/frontend/src/queries/metric-results.ts
+++ b/src/frontend/src/queries/metric-results.ts
@@ -12,6 +12,7 @@ import {
 import {
   buildMetricCollectionRequest,
   chunkEntityIds,
+  filterCollectionByKey,
   filterCollectionToAvailable,
   entityChunkSize,
   mergeNormalizedResults,
@@ -21,8 +22,28 @@ import {
   type NormalizedMetricResult,
 } from "@/lib/metrics/collection";
 import { normalizePersonId } from "@/lib/metrics/entity";
+import { metricVisible } from "@/lib/portal/nav-policy";
+import { usePortalShowPlanned } from "@/lib/portal/portal-store";
 import { useAvailableMetricKeys } from "@/queries/metric-definitions";
 import type { PeriodValue } from "@/types/insight";
+
+/**
+ * The install's metric gate, as a predicate over metric keys.
+ *
+ * Applied to every collection request, so a metric this install hides — or
+ * marks planned while the reader has planned sections off — reaches no surface
+ * at all: not a tile, not an attention row, not a heatmap column, not a
+ * drilldown block. Surfaces already render only the keys that came back, so
+ * they need no gate of their own; the ones that draw a shell around a missing
+ * metric (a section title, a card) gate their own composition instead.
+ */
+function useMetricGate(): (metricKey: string) => boolean {
+  const showPlanned = usePortalShowPlanned();
+  return useMemo(
+    () => (metricKey: string) => metricVisible(metricKey, showPlanned),
+    [showPlanned]
+  );
+}
 
 export interface MetricCollectionOptions {
   /**
@@ -82,7 +103,11 @@ export function useMetricCollection(
   // rejects the WHOLE request over one unknown key, so a compiled-in key that
   // a tenant does not have would blank the screen instead of its own tile.
   const catalog = useAvailableMetricKeys();
-  const asked = filterCollectionToAvailable(collection, catalog.keys);
+  const gate = useMetricGate();
+  const asked = filterCollectionByKey(
+    filterCollectionToAvailable(collection, catalog.keys),
+    gate
+  );
   const request = buildMetricCollectionRequest(
     asked,
     { type: entity.type, ids },
@@ -196,6 +221,7 @@ export function useMetricCollectionSet(
 ): Map<string, MetricCollectionResult> {
   const ids = canonicalEntityIds(entity);
   const catalog = useAvailableMetricKeys();
+  const gate = useMetricGate();
   const enabled =
     ids.length > 0 && !catalog.isPending && Boolean(range.from && range.to);
 
@@ -203,8 +229,11 @@ export function useMetricCollectionSet(
   // never exceeds the backend's all-or-nothing projected-row limit; chunk
   // results merge back into one collection result per key.
   const requests = collections.flatMap(({ key, collection: raw }) => {
-    // Same catalog gate as `useMetricCollection` — see the note there.
-    const collection = filterCollectionToAvailable(raw, catalog.keys);
+    // Same catalog and install gates as `useMetricCollection` — see the notes there.
+    const collection = filterCollectionByKey(
+      filterCollectionToAvailable(raw, catalog.keys),
+      gate
+    );
     const chunkSize = entityChunkSize(collection);
     const chunks = chunkSize === null ? [ids] : chunkEntityIds(ids, chunkSize);
     return chunks.map((chunkIds) => {


### PR DESCRIPTION
**Why.** An install can hide or demote a menu entry but not a metric, so a deployment whose task-tracker or AI numbers are not trusted yet still shows them — in headline tiles, attention rows, heatmap columns, drilldown blocks and the report catalogue.

**What changed.** `nav.hide` / `nav.planned` take a new path form: `metric:tasks.resolution_time` for one key, `metric:ai.*` for a family. Both metric-collection hooks drop gated keys before the request is built, and lens composition drops a section left with none of its own.

**Gated at the metric key, not per surface.** A surface that renders only the keys that came back needs no gate of its own; only the ones drawing a frame around a missing metric — a participation card, a coverage denominator — gate their own composition. Reversible by deleting the path from an install's values.

**Direction cards now read the nav policy.** They walked the raw registry, so an install that had already dropped a direction from the menu still got its "this data source is not connected yet" card on the Overview.

Mock stand, one install policy marking three task metrics and the `ai.*` family planned. Left: the reader has planned sections on. Right: off.

| Planned sections on | Planned sections off |
|---|---|
| <img src="https://raw.githubusercontent.com/constructorfabric/insight/pr-2779-assets/overview-planned-on.png" width="420"> | <img src="https://raw.githubusercontent.com/constructorfabric/insight/pr-2779-assets/overview-planned-off.png" width="420"> |

Six headline tiles become four, the AI-adoption card and its section title go, the attention scan stops ranking a gated metric, and the Overview keeps only the direction the menu still offers.

**Out of scope.** The legacy `/ic` screens still read the unfiltered group registry. They render only with the portal switched off, and the fetch gate covers them there.

**Verified.** 2012 unit tests (45 new), `tsc` and eslint. Drove the mock stand with a per-install policy and checked each surface: Overview, Directions, Person, Reports, Data coverage, report catalogue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configuration support for hiding individual metrics and metric families.
  - Hidden metrics are removed from navigation, reports, cards, drilldowns, coverage views, and other portal surfaces.
  - Planned metrics now respect the portal’s planned-feature visibility setting.
  - Hidden or unavailable metrics are excluded from data requests.

- **Bug Fixes**
  - Prevented empty sections, groups, and drilldown blocks from appearing after metrics are hidden.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->