### PR TITLE
fix(feedback): keep a long report whole, and readable in the listing

### DIFF
--- a/src/backend/services/analytics/src/api/feedback.rs
+++ b/src/backend/services/analytics/src/api/feedback.rs
@@ -121,11 +121,19 @@ fn to_row(
         return Err(violation("message", "message must not be empty"));
     }
 
+    let budget = feedback_schema::max_message();
+    if message.chars().count() > budget {
+        return Err(violation(
+            "message",
+            &format!("message must be at most {budget} characters"),
+        ));
+    }
+
     Ok(feedback::ActiveModel {
         id: Set(Uuid::now_v7()),
         insight_tenant_id: Set(tenant_id),
         person_id: Set(person_id),
-        message: Set(clip(message, feedback_schema::max_message())),
+        message: Set(message.to_owned()),
         path: Set(clip(&req.path, feedback_schema::max_path())),
         created_at: Set(now),
     })

--- a/src/backend/services/analytics/src/api/feedback/tests.rs
+++ b/src/backend/services/analytics/src/api/feedback/tests.rs
@@ -15,6 +15,10 @@ fn row_of(req: &FeedbackRequest) -> Option<feedback::ActiveModel> {
     to_row(req, Uuid::now_v7(), Uuid::now_v7(), Utc::now()).ok()
 }
 
+fn refusal_for(req: &FeedbackRequest) -> Option<CanonicalError> {
+    to_row(req, Uuid::now_v7(), Uuid::now_v7(), Utc::now()).err()
+}
+
 #[test]
 fn the_session_decides_identity_not_the_payload() {
     let tenant = Uuid::now_v7();
@@ -49,11 +53,41 @@ fn a_stored_message_carries_no_surrounding_whitespace() {
 }
 
 #[test]
-fn an_oversized_message_is_clipped_to_the_column_budget() {
-    let budget = feedback_schema::max_message();
-    let long = "x".repeat(budget * 2);
+fn a_message_past_the_budget_is_refused_rather_than_shortened_in_silence() {
+    let long = "x".repeat(feedback_schema::max_message() + 1);
 
-    let row = row_of(&request(&long));
+    assert!(row_of(&request(&long)).is_none());
+}
+
+#[test]
+fn the_refusal_of_a_long_message_names_the_field_and_the_budget() -> Result<(), serde_json::Error> {
+    let long = "x".repeat(feedback_schema::max_message() + 1);
+
+    let Some(error) = refusal_for(&request(&long)) else {
+        panic!("an over-long message is refused")
+    };
+    let refused = problem(error)?;
+
+    assert_eq!(refused["status"], 400);
+    assert_eq!(
+        refused["context"]["field_violations"][0]["field"],
+        "message"
+    );
+    assert!(
+        refused
+            .to_string()
+            .contains(&feedback_schema::max_message().to_string()),
+        "the sender is told what the limit is: {refused}"
+    );
+    Ok(())
+}
+
+#[test]
+fn a_message_that_exactly_fills_the_budget_is_stored_whole() {
+    let budget = feedback_schema::max_message();
+    let full = "x".repeat(budget);
+
+    let row = row_of(&request(&full));
 
     assert_eq!(
         row.as_ref()
@@ -61,6 +95,13 @@ fn an_oversized_message_is_clipped_to_the_column_budget() {
             .map(|m| m.chars().count()),
         Some(budget)
     );
+}
+
+#[test]
+fn the_budget_counts_characters_not_the_bytes_they_take() {
+    let full = "\u{1f642}".repeat(feedback_schema::max_message());
+
+    assert!(row_of(&request(&full)).is_some());
 }
 
 #[test]

--- a/src/backend/services/analytics/src/migration/m20260822_000001_feedback.rs
+++ b/src/backend/services/analytics/src/migration/m20260822_000001_feedback.rs
@@ -7,7 +7,7 @@
 
 use sea_orm_migration::prelude::*;
 
-/// The column budgets, read by the writer that clips to them.
+/// The column budgets, read by the writer that holds submissions to them.
 pub mod feedback_schema {
     /// `message` is TEXT; this is the product's own limit on one submission.
     pub const MESSAGE: u32 = 4000;

--- a/src/frontend/src/api/feedback-client.ts
+++ b/src/frontend/src/api/feedback-client.ts
@@ -6,6 +6,9 @@ const BASE =
 
 const JSON_HEADERS = { "Content-Type": "application/json" };
 
+/** The service's own budget for one submission; past it the write is refused. */
+export const FEEDBACK_MESSAGE_MAX = 4000;
+
 export interface FeedbackSubmission {
   message: string;
   path: string;

--- a/src/frontend/src/components/feedback-dialog.test.tsx
+++ b/src/frontend/src/components/feedback-dialog.test.tsx
@@ -24,6 +24,7 @@ vi.mock("@/telemetry", () => ({
   currentScreen: () => hooks.screen,
 }));
 
+import { FEEDBACK_MESSAGE_MAX } from "@/api/feedback-client";
 import { FeedbackDialog } from "./feedback-dialog";
 
 function sendButton(): HTMLElement {
@@ -84,6 +85,43 @@ describe("FeedbackDialog", () => {
     expect(hooks.toast.success).toHaveBeenCalled();
     expect(onOpenChange).toHaveBeenCalledWith(false);
     expect(message).toHaveValue("");
+  });
+
+  it("stops the box at the longest message the service stores", async () => {
+    render(<FeedbackDialog open onOpenChange={() => {}} />);
+
+    const message = screen.getByLabelText("Your feedback");
+    await userEvent.click(message);
+    await userEvent.paste("x".repeat(FEEDBACK_MESSAGE_MAX + 50));
+
+    expect(message).toHaveValue("x".repeat(FEEDBACK_MESSAGE_MAX));
+  });
+
+  it("keeps the box inside the dialog however much is written", () => {
+    render(<FeedbackDialog open onOpenChange={() => {}} />);
+
+    expect(screen.getByLabelText("Your feedback")).toHaveClass(
+      "max-h-[40vh]",
+      "overflow-y-auto",
+    );
+  });
+
+  it("counts what is written against the budget", async () => {
+    render(<FeedbackDialog open onOpenChange={() => {}} />);
+
+    await userEvent.type(screen.getByLabelText("Your feedback"), "empty");
+
+    expect(
+      screen.getByText(`5 / ${FEEDBACK_MESSAGE_MAX}`),
+    ).toBeInTheDocument();
+  });
+
+  it("announces the budget to whoever cannot see the counter", () => {
+    render(<FeedbackDialog open onOpenChange={() => {}} />);
+
+    expect(screen.getByLabelText("Your feedback")).toHaveAccessibleDescription(
+      `0 / ${FEEDBACK_MESSAGE_MAX}`,
+    );
   });
 
   it("keeps the dialog open on a refusal, and says why", () => {

--- a/src/frontend/src/components/feedback-dialog.tsx
+++ b/src/frontend/src/components/feedback-dialog.tsx
@@ -2,9 +2,10 @@
  * The screen rides along as the redacted `lastPath` the usage rows carry, so a
  * report is placed without the sender having to describe where they were.
  */
-import { useState } from "react";
+import { useId, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { FEEDBACK_MESSAGE_MAX } from "@/api/feedback-client";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { toast } from "@/components/ui/sonner";
 import { Textarea } from "@/components/ui/textarea";
@@ -21,6 +22,7 @@ export function FeedbackDialog({
 }) {
   const { t } = useTranslation();
   const [message, setMessage] = useState("");
+  const counterId = useId();
   const submit = useSubmitFeedback();
 
   const close = () => {
@@ -59,13 +61,24 @@ export function FeedbackDialog({
       }
       onConfirm={send}
     >
-      <Textarea
-        aria-label={t("feedback.message")}
-        rows={5}
-        value={message}
-        placeholder={t("feedback.placeholder")}
-        onChange={(event) => setMessage(event.target.value)}
-      />
+      <div className="flex flex-col gap-1">
+        <Textarea
+          className="max-h-[40vh] overflow-y-auto"
+          aria-label={t("feedback.message")}
+          aria-describedby={counterId}
+          maxLength={FEEDBACK_MESSAGE_MAX}
+          rows={5}
+          value={message}
+          placeholder={t("feedback.placeholder")}
+          onChange={(event) => setMessage(event.target.value)}
+        />
+        <p id={counterId} className="self-end text-xs text-muted-foreground">
+          {t("feedback.counter", {
+            used: message.length,
+            max: FEEDBACK_MESSAGE_MAX,
+          })}
+        </p>
+      </div>
     </ConfirmDialog>
   );
 }

--- a/src/frontend/src/components/portal/usage-table.test.tsx
+++ b/src/frontend/src/components/portal/usage-table.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+/**
+ * A cell's detail can be a whole feedback submission: what does not fit in the
+ * window is unreachable unless the tooltip is bounded and scrolls.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+
+import { TruncatedCell } from "./usage-table";
+
+async function popupFor(trigger: string) {
+  await userEvent.hover(screen.getByText(trigger));
+
+  return waitFor(() => {
+    const popup = document.querySelector('[data-slot="tooltip-content"]');
+    if (!popup) throw new Error("the tooltip has not opened");
+    return popup;
+  });
+}
+
+describe("TruncatedCell", () => {
+  it("bounds a long detail to the room the window has, and scrolls the rest", async () => {
+    render(
+      <TruncatedCell detail={"the whole report. ".repeat(300)}>
+        the whole report.
+      </TruncatedCell>,
+    );
+
+    const popup = await popupFor("the whole report.");
+
+    expect(popup).toHaveClass(
+      "max-h-[var(--available-height)]",
+      "overflow-y-auto",
+    );
+  });
+
+  it("keeps the bound when the caller styles the detail", async () => {
+    render(
+      <TruncatedCell detail="a long message" detailClassName="max-w-sm text-xs">
+        a long message
+      </TruncatedCell>,
+    );
+
+    const popup = await popupFor("a long message");
+
+    expect(popup).toHaveClass("max-h-[var(--available-height)]", "max-w-sm");
+  });
+});

--- a/src/frontend/src/components/portal/usage-table.tsx
+++ b/src/frontend/src/components/portal/usage-table.tsx
@@ -129,7 +129,12 @@ export function TruncatedCell({
       <TooltipTrigger render={<span className="truncate" />}>
         {children}
       </TooltipTrigger>
-      <TooltipContent className={detailClassName ?? "font-mono text-xs"}>
+      <TooltipContent
+        className={cn(
+          "max-h-[var(--available-height)] items-start overflow-y-auto overscroll-contain",
+          detailClassName ?? "font-mono text-xs",
+        )}
+      >
         {detail}
       </TooltipContent>
     </Tooltip>

--- a/src/frontend/src/locales/en/translation.json
+++ b/src/frontend/src/locales/en/translation.json
@@ -585,6 +585,7 @@
     "title": "Submit feedback / bug report",
     "message": "Your feedback",
     "placeholder": "Describe the issue",
+    "counter": "{{used}} / {{max}}",
     "send": "Send",
     "sent": "Thanks — your feedback was sent.",
     "failed": "Could not send your feedback. Try again."

--- a/src/frontend/src/mocks/handlers.test.ts
+++ b/src/frontend/src/mocks/handlers.test.ts
@@ -1,6 +1,8 @@
 import { setupServer } from "msw/node";
 import { afterAll, beforeAll, expect, it } from "vitest";
 
+import { FEEDBACK_MESSAGE_MAX } from "@/api/feedback-client";
+
 import { handlers } from "./handlers";
 
 const server = setupServer(...handlers);
@@ -18,6 +20,38 @@ it("rejects unsupported metric result entity types", async () => {
         entity: { type: "other" },
         period: { from: "2026-01-01", to: "2026-01-31" },
         metrics: [],
+      }),
+    },
+  );
+
+  expect(response.status).toBe(400);
+});
+
+it("takes a feedback message the service takes: the budget counts characters", async () => {
+  const response = await fetch(
+    new URL("/api/analytics/v1/feedback", window.location.href),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        message: "🙂".repeat(FEEDBACK_MESSAGE_MAX),
+        path: "/portal/overview",
+      }),
+    },
+  );
+
+  expect(response.status).toBe(204);
+});
+
+it("refuses a feedback message past the budget", async () => {
+  const response = await fetch(
+    new URL("/api/analytics/v1/feedback", window.location.href),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        message: "x".repeat(FEEDBACK_MESSAGE_MAX + 1),
+        path: "/portal/overview",
       }),
     },
   );

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from "msw";
 
+import { FEEDBACK_MESSAGE_MAX } from "@/api/feedback-client";
 import type { MetricResultsRequest } from "@/api/metric-results-client";
 import type {
   CustomMetric,
@@ -924,15 +925,16 @@ function feedbackHandlers() {
         message?: string;
         path?: string;
       } | null;
-      if (!body?.message?.trim()) {
+      const message = body?.message?.trim();
+      if (!message || message.length > FEEDBACK_MESSAGE_MAX) {
         return HttpResponse.json({ error: "invalid_argument" }, { status: 400 });
       }
       feedbackStore.unshift({
         feedback_id: `mock-${feedbackStore.length + 1}`,
         ts: new Date().toISOString().replace("T", " ").slice(0, 19),
         ...mockSender(defaultPerson),
-        message: body.message.trim(),
-        path: body.path ?? "",
+        message,
+        path: body?.path ?? "",
       });
       return new HttpResponse(null, { status: 204 });
     }),

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -926,7 +926,7 @@ function feedbackHandlers() {
         path?: string;
       } | null;
       const message = body?.message?.trim();
-      if (!message || message.length > FEEDBACK_MESSAGE_MAX) {
+      if (!message || [...message].length > FEEDBACK_MESSAGE_MAX) {
         return HttpResponse.json({ error: "invalid_argument" }, { status: 400 });
       }
       feedbackStore.unshift({

--- a/tests/stand/api/analytics/test_feedback.py
+++ b/tests/stand/api/analytics/test_feedback.py
@@ -1,6 +1,7 @@
 """The `/v1/feedback` pair on analytics — product feedback in and back out.
 
-    POST /v1/feedback   204 · any signed-in caller · 400 empty message
+    POST /v1/feedback   204 · any signed-in caller · 400 empty or over-long
+                        message
     GET  /v1/feedback   200 for the admin operator · 400 malformed day ·
                         403 for everybody else
 
@@ -37,6 +38,9 @@ FEEDBACK = analytics_path("/v1/feedback")
 #: The screen the sender was on, in the shape the SPA sends: the person the page
 #: is about is already reduced to `:id` before it leaves the browser.
 SENT_FROM = "/ic/:id/personal"
+
+#: The service's own budget for one submission, from the feedback migration.
+MESSAGE_BUDGET = 4000
 
 
 def _message() -> str:
@@ -109,6 +113,23 @@ def test_an_empty_message_is_refused_rather_than_stored(api: ApiClient) -> None:
     response = api.post(FEEDBACK, json_body={"message": "   ", "path": SENT_FROM})
     assert response.status_code == 400, (
         f"a blank message answered {response.status_code}: {response.text[:300]}"
+    )
+    assert response.parse(ProblemDocument).status == 400
+
+
+@pytest.mark.reliability
+def test_a_message_past_the_budget_is_refused_rather_than_stored_in_part(
+    api: ApiClient,
+) -> None:
+    """Answering 204 to a message the service shortened tells the sender it
+    arrived whole, and nothing deletes a submission to send it again.
+    """
+    response = api.post(
+        FEEDBACK,
+        json_body={"message": "x" * (MESSAGE_BUDGET + 1), "path": SENT_FROM},
+    )
+    assert response.status_code == 400, (
+        f"an over-long message answered {response.status_code}: {response.text[:300]}"
     )
     assert response.parse(ProblemDocument).status == 400
 


### PR DESCRIPTION
Closes #2768.

**Why.** A report over 4,000 characters lost its ending at send, under a success
toast; what survived rendered in a tooltip taller than the window, with no scroll.

**What changed.** `POST /v1/feedback` refuses a message past the budget instead of
clipping it, the box stops at 4,000 characters with a counter that is its
accessible description, and the tooltip takes `--available-height` and scrolls.

**204 → 400 past 4,000 characters — a contract change.** Only the SPA sends, and it
now caps; the msw mock mirrors the refusal.

**The box is capped at 40vh as well.** The kit textarea sizes to its content, so a
long report grew the dialog past Send.

Pasting 4,269 characters leaves 4,000 and the counter reads `4000 / 4000`. The
tooltip fits 1,331px of content into an 889px box in a 900px window and scrolls to
the end.

**Verified.** `cargo test -p analytics` (489), `pnpm test` (1982), clippy pedantic,
rustfmt, `tsc -b`, eslint, ruff — all clean. Drove the flow in Chrome against the
mock stand. The stand suite's new contract test was not exercised: it needs a
deployed stand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible character counter and 4,000-character limit to feedback messages.
  * Feedback text is trimmed before submission and preserved without truncation when within the limit.
  * Long feedback messages now receive a clear validation error instead of being silently shortened.
  * Long usage details are displayed in bounded, vertically scrollable tooltips.

* **Bug Fixes**
  * Improved accessibility by announcing the feedback character budget.
  * Added support for correctly counting Unicode characters in feedback limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->