### PR TITLE
feat(analytics): calculate exact metrics across people

### DIFF
--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -1252,6 +1252,34 @@
           },
           {
             "properties": {
+              "dimensions": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "values": {
+                "items": {
+                  "$ref": "#/components/schemas/RollupValueDto"
+                },
+                "type": "array"
+              },
+              "view": {
+                "enum": [
+                  "rollup"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "dimensions",
+              "values",
+              "view"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
               "values": {
                 "items": {
                   "$ref": "#/components/schemas/HistogramValueDto"
@@ -1525,6 +1553,37 @@
           },
           {
             "properties": {
+              "dimensions": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "group_limit": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/MetricGroupLimitRequest"
+                  }
+                ]
+              },
+              "view": {
+                "enum": [
+                  "rollup"
+                ],
+                "type": "string"
+              }
+            },
+            "required": [
+              "dimensions",
+              "view"
+            ],
+            "type": "object"
+          },
+          {
+            "properties": {
               "view": {
                 "enum": [
                   "histogram"
@@ -1648,6 +1707,53 @@
           "status",
           "detail",
           "context"
+        ],
+        "type": "object"
+      },
+      "RollupValueDto": {
+        "properties": {
+          "contributing_entity_count": {
+            "format": "int64",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "dimensions": {
+            "items": {
+              "$ref": "#/components/schemas/MetricDimensionDto"
+            },
+            "type": "array"
+          },
+          "label": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "rank": {
+            "format": "int32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "remainder": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          "value": {
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "dimensions",
+          "contributing_entity_count"
         ],
         "type": "object"
       },

--- a/src/backend/services/analytics/src/api/metric_results.rs
+++ b/src/backend/services/analytics/src/api/metric_results.rs
@@ -18,11 +18,11 @@ use crate::domain::metric_drilldown::load_capabilities;
 use crate::domain::metric_results::{
     BatchItem, BreakdownQueryRow, CompiledQuery, HistogramQueryRow, MetricResultViewDto,
     MetricResultsRequest, MetricResultsResponse, PeerPopulation, PeerWideRow, PeriodWideRow,
-    PlannedQuery, RankingQueryRow, TimeseriesQueryRow, UnbatchedView,
+    PlannedQuery, RankingQueryRow, RollupQueryRow, TimeseriesQueryRow, UnbatchedView,
     ValidatedMetricResultsRequest, build_breakdown_view, build_histogram_view, build_metric_result,
-    build_peer_view, build_period_view, build_ranked_groups, build_timeseries_view,
-    demux_peer_rows, demux_period_rows, enforce_view_row_limit, plan_queries, plan_rankings,
-    validate_request,
+    build_peer_view, build_period_view, build_ranked_groups, build_rollup_view,
+    build_timeseries_view, demux_peer_rows, demux_period_rows, enforce_view_row_limit,
+    plan_queries, plan_rankings, validate_request,
 };
 use crate::domain::person_visibility::authorize_person_ids;
 
@@ -232,6 +232,11 @@ async fn execute_planned(
                     let comment = format!("metric-results:breakdown:{}", def.key());
                     let rows = fetch_rows::<BreakdownQueryRow>(state, query, &comment).await?;
                     build_breakdown_view(req, &dimensions, rows)?
+                }
+                UnbatchedView::Rollup { dimensions } => {
+                    let comment = format!("metric-results:rollup:{}", def.key());
+                    let rows = fetch_rows::<RollupQueryRow>(state, query, &comment).await?;
+                    build_rollup_view(&dimensions, rows)?
                 }
                 UnbatchedView::Histogram => {
                     let comment = format!("metric-results:histogram:{}", def.key());

--- a/src/backend/services/analytics/src/domain/metric_results/batch.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/batch.rs
@@ -10,7 +10,7 @@ use crate::domain::metric_definitions::MetricDefinition;
 use super::compiler::{
     CompiledQuery, PeerQueryRow, PeriodQueryRow, compile_breakdown_query,
     compile_group_ranking_query, compile_histogram_query, compile_peer_batch_query,
-    compile_period_batch_query, compile_timeseries_query,
+    compile_period_batch_query, compile_rollup_query, compile_timeseries_query,
 };
 use super::validation::{
     ValidatedDimensionFilter, ValidatedGroupLimit, ValidatedMetricRequest,
@@ -38,6 +38,9 @@ pub enum UnbatchedView {
         dimensions: Vec<String>,
     },
     Breakdown {
+        dimensions: Vec<String>,
+    },
+    Rollup {
         dimensions: Vec<String>,
     },
     // Histogram bins one entity's own per-event values; it never batches with
@@ -101,11 +104,15 @@ pub fn plan_rankings(req: &ValidatedMetricResultsRequest) -> Vec<PlannedRanking>
     let mut policies = BTreeMap::new();
     for metric in &req.metrics {
         for view in &metric.views {
-            let ValidatedMetricView::Timeseries {
+            let (ValidatedMetricView::Timeseries {
                 dimensions,
                 group_limit: Some(limit),
                 ..
-            } = view
+            }
+            | ValidatedMetricView::Rollup {
+                dimensions,
+                group_limit: Some(limit),
+            }) = view
             else {
                 continue;
             };
@@ -194,6 +201,15 @@ pub fn plan_queries(
                         ),
                     });
                 }
+                ValidatedMetricView::Rollup { .. } => {
+                    singles.push(plan_rollup(
+                        req,
+                        rankings,
+                        metric,
+                        (metric_index, view_index),
+                        view,
+                    )?);
+                }
                 ValidatedMetricView::Histogram => {
                     singles.push(PlannedQuery::Single {
                         metric_index,
@@ -220,6 +236,40 @@ pub fn plan_queries(
     }
     planned.extend(singles);
     Ok(planned)
+}
+
+fn plan_rollup(
+    req: &ValidatedMetricResultsRequest,
+    rankings: &BTreeMap<RankingPolicyKey, Vec<RankedGroup>>,
+    metric: &ValidatedMetricRequest,
+    indexes: (usize, usize),
+    view: &ValidatedMetricView,
+) -> Result<PlannedQuery, CanonicalError> {
+    let ValidatedMetricView::Rollup {
+        dimensions,
+        group_limit,
+    } = view
+    else {
+        unreachable!("plan_rollup requires a rollup view")
+    };
+    let resolved =
+        resolve_group_limit(group_limit.as_ref(), dimensions, &metric.filters, rankings)?;
+
+    Ok(PlannedQuery::Single {
+        metric_index: indexes.0,
+        view_index: indexes.1,
+        def: Box::new(metric.def.clone()),
+        view: UnbatchedView::Rollup {
+            dimensions: dimensions.clone(),
+        },
+        query: compile_rollup_query(
+            &metric.def,
+            req,
+            dimensions,
+            &metric.filters,
+            resolved.as_ref(),
+        ),
+    })
 }
 
 fn plan_timeseries(
@@ -584,6 +634,32 @@ mod tests {
                     .iter()
                     .any(|value| value == "00000000-0000-0000-0000-000000000001")
         }));
+    }
+
+    #[test]
+    fn rollup_and_timeseries_share_identical_ranking_policy() {
+        let rank_by = def("m_rank", Some("org_unit"));
+        let limit = || ValidatedGroupLimit {
+            count: 10,
+            rank_by: Box::new(rank_by.clone()),
+            include_remainder: true,
+        };
+        let req = request(vec![views(
+            vec![
+                ValidatedMetricView::Timeseries {
+                    bucket: Bucket::Week,
+                    dimensions: vec!["tool".to_owned()],
+                    group_limit: Some(limit()),
+                },
+                ValidatedMetricView::Rollup {
+                    dimensions: vec!["tool".to_owned()],
+                    group_limit: Some(limit()),
+                },
+            ],
+            "m_a",
+        )]);
+
+        assert_eq!(plan_rankings(&req).len(), 1);
     }
 
     fn items(count: usize) -> Vec<BatchItem> {

--- a/src/backend/services/analytics/src/domain/metric_results/builder.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/builder.rs
@@ -7,12 +7,13 @@ use crate::domain::metric_definitions::{ComputationSpec, MetricDefinition};
 use super::batch::{RankedDimension, RankedGroup};
 use super::compiler::{
     BreakdownQueryRow, HistogramQueryRow, PeerQueryRow, PeriodQueryRow, RankingQueryRow,
-    TimeseriesQueryRow, UNKNOWN_DIMENSION_LABEL, UNKNOWN_DIMENSION_VALUE, dimension_aliases,
+    RollupQueryRow, TimeseriesQueryRow, UNKNOWN_DIMENSION_LABEL, UNKNOWN_DIMENSION_VALUE,
+    dimension_aliases,
 };
 use super::dto::{
     BreakdownValueDto, ComputationDto, HistogramBinDto, HistogramValueDto, MetricDimensionDto,
-    MetricResultDto, MetricResultViewDto, PeerValueDto, PeriodValueDto, TimeseriesDto,
-    TimeseriesPointDto,
+    MetricResultDto, MetricResultViewDto, PeerValueDto, PeriodValueDto, RollupValueDto,
+    TimeseriesDto, TimeseriesPointDto,
 };
 use super::validation::{
     HISTOGRAM_BINS, ValidatedMetricResultsRequest, enumerate_buckets, metric_result_too_large,
@@ -204,6 +205,38 @@ pub fn build_breakdown_view(
     })
 }
 
+pub fn build_rollup_view(
+    dimensions: &[String],
+    rows: Vec<RollupQueryRow>,
+) -> Result<MetricResultViewDto, CanonicalError> {
+    let values = rows
+        .into_iter()
+        .map(|row| {
+            let remainder = row.remainder != 0;
+            let dimensions = if remainder {
+                Vec::new()
+            } else {
+                row_dimensions(&row.extra, dimensions)?
+                    .into_iter()
+                    .map(|(key, value, label)| MetricDimensionDto { key, value, label })
+                    .collect()
+            };
+            Ok(RollupValueDto {
+                dimensions,
+                value: row.value,
+                contributing_entity_count: row.contributing_entity_count.unwrap_or(0),
+                rank: row.rank,
+                remainder: remainder.then_some(true),
+                label: row.group_label,
+            })
+        })
+        .collect::<Result<Vec<_>, CanonicalError>>()?;
+    Ok(MetricResultViewDto::Rollup {
+        dimensions: dimensions.to_vec(),
+        values,
+    })
+}
+
 /// Densifies histogram rows into the full fixed-bin shape. The SQL reports
 /// only observed (entity, bin) pairs plus each entity's exact bounds; edge
 /// math lives here alone so empty and observed bins can never disagree.
@@ -315,6 +348,7 @@ fn view_size(view: &MetricResultViewDto) -> usize {
         }
         MetricResultViewDto::Peer { values } => values.len(),
         MetricResultViewDto::Breakdown { values, .. } => values.len(),
+        MetricResultViewDto::Rollup { values, .. } => values.len(),
         MetricResultViewDto::Histogram { values } => {
             values.iter().map(|value| value.bins.len()).sum()
         }
@@ -866,6 +900,42 @@ mod tests {
             values[0].dimensions[0].label.as_deref(),
             Some(UNKNOWN_DIMENSION_LABEL)
         );
+    }
+
+    #[test]
+    fn rollup_keeps_contributor_count_and_marks_remainder() {
+        let rows = vec![
+            RollupQueryRow {
+                value: Some(4.0),
+                contributing_entity_count: Some(2),
+                rank: Some(1),
+                remainder: 0,
+                group_label: None,
+                extra: HashMap::from([
+                    ("dim_0_value".to_owned(), json!("example/repository")),
+                    ("dim_0_label".to_owned(), json!("Example repository")),
+                ]),
+            },
+            RollupQueryRow {
+                value: Some(3.0),
+                contributing_entity_count: Some(2),
+                rank: None,
+                remainder: 1,
+                group_label: Some("Other".to_owned()),
+                extra: HashMap::new(),
+            },
+        ];
+
+        let Ok(MetricResultViewDto::Rollup { values, .. }) =
+            build_rollup_view(&["repository".to_owned()], rows)
+        else {
+            panic!("expected rollup view");
+        };
+        assert_eq!(values[0].contributing_entity_count, 2);
+        assert_eq!(values[0].rank, Some(1));
+        assert_eq!(values[1].dimensions.len(), 0);
+        assert_eq!(values[1].remainder, Some(true));
+        assert_eq!(values[1].label.as_deref(), Some("Other"));
     }
 
     fn selection(metric_key: &str) -> super::super::dto::MetricResultSelectionDto {

--- a/src/backend/services/analytics/src/domain/metric_results/compiler.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/compiler.rs
@@ -77,6 +77,18 @@ pub struct BreakdownQueryRow {
     pub extra: HashMap<String, serde_json::Value>,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct RollupQueryRow {
+    pub value: Option<f64>,
+    #[serde(default, deserialize_with = "optional_u64")]
+    pub contributing_entity_count: Option<u64>,
+    pub rank: Option<u32>,
+    pub remainder: u8,
+    pub group_label: Option<String>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
 /// One observed (entity, bin) pair plus the entity's exact value bounds.
 /// The SQL owns bin membership only; the builder derives all bin edges from
 /// the bounds so displayed edges of empty and observed bins cannot drift.
@@ -406,6 +418,136 @@ pub(crate) fn compile_breakdown_query(
         metric_where = metric_where(def, req.enforce_tenant_scope),
     );
     let sql = transformed_single(def, inner);
+    CompiledQuery { sql, params }
+}
+
+pub(crate) fn compile_rollup_query(
+    def: &MetricDefinition,
+    req: &ValidatedMetricResultsRequest,
+    dimensions: &[String],
+    filters: &[ValidatedDimensionFilter],
+    group_limit: Option<&ResolvedGroupLimit>,
+) -> CompiledQuery {
+    match group_limit {
+        Some(group_limit) => {
+            compile_capped_rollup_query(def, req, dimensions, filters, group_limit)
+        }
+        None => compile_uncapped_rollup_query(def, req, dimensions, filters),
+    }
+}
+
+fn compile_uncapped_rollup_query(
+    def: &MetricDefinition,
+    req: &ValidatedMetricResultsRequest,
+    dimensions: &[String],
+    filters: &[ValidatedDimensionFilter],
+) -> CompiledQuery {
+    let mut params = metric_params(def, req);
+    let filter_where = dimension_filter_where(filters, &mut params);
+    let entity_predicate = selected_entity_predicate(req, &mut params);
+    let (dim_select, dim_group, dim_order) = ranking_dimension_select_group(dimensions);
+    let observation_table = observation_table(def.observation_source());
+    let value_expr = grouped_value_expr(def);
+    let limit = query_row_limit();
+    let inner = format!(
+        r"
+        SELECT
+            {dim_select},
+            {value_expr} AS value,
+            uniqExact(entity_id) AS contributing_entity_count,
+            CAST(NULL AS Nullable(UInt32)) AS rank,
+            toUInt8(0) AS remainder,
+            CAST(NULL AS Nullable(String)) AS group_label
+        FROM {observation_table}
+        WHERE {metric_where}
+          {filter_where}
+          AND {entity_predicate}
+        GROUP BY {dim_group}
+        ORDER BY {dim_order}
+        LIMIT {limit}
+        ",
+        metric_where = metric_where(def, req.enforce_tenant_scope),
+    );
+    let sql = transformed_single(def, inner);
+    CompiledQuery { sql, params }
+}
+
+fn compile_capped_rollup_query(
+    def: &MetricDefinition,
+    req: &ValidatedMetricResultsRequest,
+    dimensions: &[String],
+    filters: &[ValidatedDimensionFilter],
+    group_limit: &ResolvedGroupLimit,
+) -> CompiledQuery {
+    let mut params = metric_where_params(def, req);
+    let filter_where = dimension_filter_where(filters, &mut params);
+    let entity_predicate = selected_entity_predicate(req, &mut params);
+    let raw_dimensions = dimensions.iter().enumerate().fold(
+        String::new(),
+        |mut raw_dimensions, (index, dimension)| {
+            let _ = write!(
+                raw_dimensions,
+                ", {} AS raw_dim_{index}",
+                dimension_value_expr(dimension)
+            );
+            raw_dimensions
+        },
+    );
+    let rank_expr = capped_rank_expr(group_limit, dimensions.len(), &mut params);
+    params.extend(grouped_value_params(def));
+    let dimension_select = capped_dimension_select(group_limit, dimensions, &mut params);
+    let observation_table = observation_table(def.observation_source());
+    let value_expr = grouped_value_expr(def);
+    let value = transformed(def, "value".to_owned());
+    let remainder_filter = if group_limit.include_remainder {
+        ""
+    } else {
+        "WHERE group_rank > 0"
+    };
+    let limit = query_row_limit();
+    let sql = format!(
+        r"
+        WITH scoped AS (
+            SELECT
+                *
+                {raw_dimensions}
+            FROM {observation_table}
+            WHERE {metric_where}
+              {filter_where}
+              AND {entity_predicate}
+        ),
+        ranked AS (
+            SELECT
+                *,
+                {rank_expr} AS group_rank
+            FROM scoped
+        ),
+        filtered AS (
+            SELECT *
+            FROM ranked
+            {remainder_filter}
+        ),
+        aggregated AS (
+            SELECT
+                group_rank,
+                {value_expr} AS value,
+                uniqExact(entity_id) AS contributing_entity_count
+            FROM filtered
+            GROUP BY group_rank
+        )
+        SELECT
+            group_rank{dimension_select},
+            {value} AS value,
+            contributing_entity_count,
+            if(group_rank = 0, CAST(NULL AS Nullable(UInt32)), toNullable(group_rank)) AS rank,
+            toUInt8(group_rank = 0) AS remainder,
+            if(group_rank = 0, toNullable('Other'), CAST(NULL AS Nullable(String))) AS group_label
+        FROM aggregated
+        ORDER BY group_rank = 0, group_rank
+        LIMIT {limit}
+        ",
+        metric_where = metric_where(def, req.enforce_tenant_scope),
+    );
     CompiledQuery { sql, params }
 }
 
@@ -1566,6 +1708,45 @@ mod tests {
         assert_eq!(query.sql.matches("nullIf(sumIf(value").count(), 1);
         assert_eq!(query.sql.matches("aggregated AS").count(), 1);
         assert!(query.sql.contains("WHERE group_rank > 0"));
+        assert_eq!(query.sql.matches('?').count(), query.params.len());
+    }
+
+    #[test]
+    fn rollup_aggregates_values_and_entity_counts_without_entity_grain() {
+        for def in [sum_metric(), ratio_metric(), median_metric()] {
+            let query = compile_rollup_query(&def, &request(), &["tool".to_owned()], &[], None);
+
+            assert!(
+                query
+                    .sql
+                    .contains("uniqExact(entity_id) AS contributing_entity_count")
+            );
+            assert!(query.sql.contains("GROUP BY dim_0_value"));
+            assert!(!query.sql.contains("GROUP BY entity_id"));
+            assert_eq!(query.sql.matches('?').count(), query.params.len());
+        }
+    }
+
+    #[test]
+    fn capped_rollup_recomputes_values_and_entity_counts_for_remainder() {
+        let query = compile_rollup_query(
+            &ratio_metric(),
+            &request(),
+            &["tool".to_owned()],
+            &[],
+            Some(&resolved_limit(true)),
+        );
+
+        assert!(query.sql.contains("AS group_rank"));
+        assert!(query.sql.contains("GROUP BY group_rank"));
+        assert!(
+            query
+                .sql
+                .contains("uniqExact(entity_id) AS contributing_entity_count")
+        );
+        assert!(query.sql.contains("toNullable('Other')"));
+        assert!(query.sql.contains("ORDER BY group_rank = 0, group_rank"));
+        assert_eq!(query.sql.matches("sumIfOrNull(value").count(), 1);
         assert_eq!(query.sql.matches('?').count(), query.params.len());
     }
 

--- a/src/backend/services/analytics/src/domain/metric_results/dto.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/dto.rs
@@ -74,6 +74,10 @@ pub enum MetricViewRequest {
     Breakdown {
         dimensions: Vec<String>,
     },
+    Rollup {
+        dimensions: Vec<String>,
+        group_limit: Option<MetricGroupLimitRequest>,
+    },
     Histogram,
 }
 
@@ -84,6 +88,7 @@ impl MetricViewRequest {
             Self::Peer { .. } => MetricResultViewKind::Peer,
             Self::Timeseries { .. } => MetricResultViewKind::Timeseries,
             Self::Breakdown { .. } => MetricResultViewKind::Breakdown,
+            Self::Rollup { .. } => MetricResultViewKind::Rollup,
             Self::Histogram => MetricResultViewKind::Histogram,
         }
     }
@@ -168,6 +173,10 @@ pub enum MetricResultViewDto {
         dimensions: Vec<String>,
         values: Vec<BreakdownValueDto>,
     },
+    Rollup {
+        dimensions: Vec<String>,
+        values: Vec<RollupValueDto>,
+    },
     Histogram {
         values: Vec<HistogramValueDto>,
     },
@@ -242,6 +251,19 @@ pub struct BreakdownValueDto {
     pub value: Option<f64>,
 }
 
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct RollupValueDto {
+    pub dimensions: Vec<MetricDimensionDto>,
+    pub value: Option<f64>,
+    pub contributing_entity_count: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rank: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remainder: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+}
+
 impl toolkit::api::api_dto::RequestApiDto for MetricResultsRequest {}
 impl toolkit::api::api_dto::ResponseApiDto for MetricResultsResponse {}
 
@@ -279,6 +301,31 @@ mod tests {
             "entity": { "type": "team", "ids": ["team"] },
             "period": { "from": "2026-01-01", "to": "2026-01-31" },
             "metrics": [{ "metric_key": "ci.runs", "views": [{ "view": "period" }] }]
+        }));
+
+        assert!(request.is_ok());
+    }
+
+    #[test]
+    fn rollup_view_deserializes_with_an_optional_group_limit() {
+        let request = serde_json::from_value::<MetricResultsRequest>(json!({
+            "entity": {
+                "type": "person",
+                "ids": ["019e27bc-dec0-7626-81a9-c5524662a6a9"]
+            },
+            "period": { "from": "2026-01-01", "to": "2026-01-31" },
+            "metrics": [{
+                "metric_key": "git.commits",
+                "views": [{
+                    "view": "rollup",
+                    "dimensions": ["repository"],
+                    "group_limit": {
+                        "count": 25,
+                        "rank_by_metric": "git.commits",
+                        "include_remainder": true
+                    }
+                }]
+            }]
         }));
 
         assert!(request.is_ok());

--- a/src/backend/services/analytics/src/domain/metric_results/mod.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/mod.rs
@@ -11,10 +11,12 @@ pub use batch::{
 };
 pub use builder::{
     build_breakdown_view, build_histogram_view, build_metric_result, build_peer_view,
-    build_period_view, build_ranked_groups, build_timeseries_view, enforce_view_row_limit,
+    build_period_view, build_ranked_groups, build_rollup_view, build_timeseries_view,
+    enforce_view_row_limit,
 };
 pub use compiler::{
-    BreakdownQueryRow, CompiledQuery, HistogramQueryRow, RankingQueryRow, TimeseriesQueryRow,
+    BreakdownQueryRow, CompiledQuery, HistogramQueryRow, RankingQueryRow, RollupQueryRow,
+    TimeseriesQueryRow,
 };
 pub use dto::{
     MetricDimensionFilterDto, MetricResultSelectionDto, MetricResultViewDto,

--- a/src/backend/services/analytics/src/domain/metric_results/validation.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/validation.rs
@@ -137,6 +137,10 @@ pub enum ValidatedMetricView {
     Breakdown {
         dimensions: Vec<String>,
     },
+    Rollup {
+        dimensions: Vec<String>,
+        group_limit: Option<ValidatedGroupLimit>,
+    },
     Histogram,
 }
 
@@ -163,15 +167,18 @@ pub async fn validate_request(
     let mut definition_keys = metric_keys.clone();
     for metric in &req.metrics {
         for view in &metric.views {
-            if let MetricViewRequest::Timeseries {
-                group_limit:
-                    Some(MetricGroupLimitRequest {
-                        rank_by_metric: Some(rank_by_metric),
-                        ..
-                    }),
-                ..
-            } = view
-            {
+            let rank_by_metric = match view {
+                MetricViewRequest::Timeseries {
+                    group_limit: Some(limit),
+                    ..
+                }
+                | MetricViewRequest::Rollup {
+                    group_limit: Some(limit),
+                    ..
+                } => limit.rank_by_metric.as_deref(),
+                _ => None,
+            };
+            if let Some(rank_by_metric) = rank_by_metric {
                 definition_keys.push(normalize_metric_key(
                     "metrics.views.group_limit.rank_by_metric",
                     rank_by_metric,
@@ -406,6 +413,25 @@ fn validate_view_with_context(
             }
             Ok(ValidatedMetricView::Breakdown {
                 dimensions: validate_dimensions(def, "metrics.views.dimensions", dimensions)?,
+            })
+        }
+        MetricViewRequest::Rollup {
+            dimensions,
+            group_limit,
+        } => {
+            if dimensions.is_empty() {
+                return invalid(
+                    "metrics.views.dimensions",
+                    format!("metric {} rollup dimensions must not be empty", def.key()),
+                );
+            }
+            let dimensions = validate_dimensions(def, "metrics.views.dimensions", dimensions)?;
+            let group_limit = group_limit
+                .map(|limit| validate_group_limit(def, definitions, filters, &dimensions, limit))
+                .transpose()?;
+            Ok(ValidatedMetricView::Rollup {
+                dimensions,
+                group_limit,
             })
         }
         MetricViewRequest::Histogram => {
@@ -669,6 +695,11 @@ fn validate_projected_view_limits(
                 }
                 ValidatedMetricView::Histogram => req.entity.len().saturating_mul(HISTOGRAM_BINS),
                 ValidatedMetricView::Breakdown { .. } => 0,
+                ValidatedMetricView::Rollup { group_limit, .. } => {
+                    group_limit.as_ref().map_or(0, |limit| {
+                        limit.count + usize::from(limit.include_remainder)
+                    })
+                }
             };
             if projected > ROW_LIMIT {
                 return Err(metric_result_too_large(format!(
@@ -1001,6 +1032,37 @@ mod tests {
         let view = MetricViewRequest::Breakdown {
             dimensions: vec!["surface".to_owned()],
         };
+        assert!(validate_view(&def, view).is_err());
+    }
+
+    #[test]
+    fn validate_view_accepts_dimension_only_rollup() {
+        let def = sum_definition(vec!["repository"]);
+        let view = MetricViewRequest::Rollup {
+            dimensions: vec!["repository".to_owned()],
+            group_limit: None,
+        };
+
+        match validate_view(&def, view) {
+            Ok(ValidatedMetricView::Rollup {
+                dimensions,
+                group_limit,
+            }) => {
+                assert_eq!(dimensions, vec!["repository"]);
+                assert!(group_limit.is_none());
+            }
+            other => panic!("expected rollup, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_view_rejects_rollup_without_dimensions() {
+        let def = sum_definition(vec!["repository"]);
+        let view = MetricViewRequest::Rollup {
+            dimensions: vec![],
+            group_limit: None,
+        };
+
         assert!(validate_view(&def, view).is_err());
     }
 

--- a/src/backend/services/analytics/src/domain/metric_results/view.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/view.rs
@@ -37,5 +37,6 @@ pub enum MetricResultViewKind {
     Timeseries,
     Peer,
     Breakdown,
+    Rollup,
     Histogram,
 }

--- a/src/frontend/src/api/metric-results-client.ts
+++ b/src/frontend/src/api/metric-results-client.ts
@@ -14,6 +14,7 @@ export type MetricResultViewKind =
   | "timeseries"
   | "peer"
   | "breakdown"
+  | "rollup"
   | "histogram";
 export type MetricBucket = "day" | "week" | "month";
 export type MetricComputation = "sum" | "ratio" | "median" | "distinct_count";
@@ -69,6 +70,11 @@ export type MetricViewRequest =
       view: "breakdown";
       dimensions: string[];
     }
+  | {
+      view: "rollup";
+      dimensions: string[];
+      group_limit?: MetricGroupLimit;
+    }
   | { view: "histogram" };
 
 export interface MetricDimension {
@@ -120,6 +126,7 @@ export type MetricResultView =
   | TimeseriesView
   | PeerView
   | BreakdownView
+  | RollupView
   | HistogramView;
 
 export interface PeriodView {
@@ -162,6 +169,19 @@ export interface BreakdownView {
     entity_id: string;
     dimensions: MetricDimension[];
     value: number | null;
+  }>;
+}
+
+export interface RollupView {
+  view: "rollup";
+  dimensions: string[];
+  values: Array<{
+    dimensions: MetricDimension[];
+    value: number | null;
+    contributing_entity_count: number;
+    rank?: number;
+    remainder?: boolean;
+    label?: string;
   }>;
 }
 

--- a/src/frontend/src/mocks/metric-results-factory.ts
+++ b/src/frontend/src/mocks/metric-results-factory.ts
@@ -138,6 +138,20 @@ export function buildMetricResultsResponse(
               })),
             ),
           };
+        case "rollup":
+          return {
+            view: "rollup",
+            dimensions: view.dimensions,
+            values: MOCK_TOOLS.map((dimension) => ({
+              dimensions: view.dimensions.map((key) => ({
+                key,
+                value: dimension.value,
+                label: dimension.label,
+              })),
+              value: valueFor("rollup", key, dimension.value),
+              contributing_entity_count: ids.length,
+            })),
+          };
         case "histogram":
           return {
             view: "histogram",

--- a/src/ingestion/gold/git_metric_evidence.sql
+++ b/src/ingestion/gold/git_metric_evidence.sql
@@ -375,8 +375,12 @@ pull_request_measures AS (
             []
         ),
         if(
-            created_on IS NOT NULL AND state = 'MERGED',
-            [tuple('pr_created_merged', toFloat64(1), toDateTime64(assumeNotNull(created_on), 3))],
+            created_on IS NOT NULL,
+            [tuple(
+                'pr_created_merged',
+                toFloat64(state = 'MERGED'),
+                toDateTime64(assumeNotNull(created_on), 3)
+            )],
             []
         ),
         if(

--- a/src/ingestion/tests/e2e/lib/expect_engine.py
+++ b/src/ingestion/tests/e2e/lib/expect_engine.py
@@ -18,6 +18,7 @@ _VIEW_ITEMS = {
     "peer": "values",
     "timeseries": "series",
     "breakdown": "values",
+    "rollup": "values",
     "histogram": "values",
 }
 _REQUIRED_VIEW_FIELDS = {
@@ -25,6 +26,7 @@ _REQUIRED_VIEW_FIELDS = {
     "peer": {"target_value", "p25", "median", "p75", "min", "max", "n"},
     "timeseries": {"points"},
     "breakdown": {"value"},
+    "rollup": {"value", "contributing_entity_count"},
     "histogram": {"bins"},
 }
 

--- a/src/ingestion/tests/e2e/metrics/git_metrics.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_metrics.test.yaml
@@ -8,6 +8,7 @@ bronze:
     - $ref: templates/people.yaml#/templates/carol
     - $ref: templates/people.yaml#/templates/dave
     - $ref: templates/people.yaml#/templates/erin
+    - {$ref: templates/people.yaml#/templates/bamboohr_employee, id: e006, unique_key: bamboohr-test-e006, firstName: Frank, lastName: Zeta, displayName: Frank Zeta, workEmail: frank@example.com, department: Quality}
   bronze_github.commits:
     - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: commit-alice, sha: hash-alice, author_name: alice, author_email: alice@example.com, committer_name: alice, committer_email: alice@example.com, additions: 10}
     - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: commit-bob, sha: hash-bob, author_name: bob, author_email: bob@example.com, committer_name: bob, committer_email: bob@example.com, additions: 20}
@@ -26,14 +27,59 @@ bronze:
     - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: pr-carol, id: 3, number: 3, author_login: carol, closed_at: "2026-10-01T11:00:00Z", merged_at: "2026-10-01T11:00:00Z", merge_commit_sha: merge-carol}
     - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: pr-dave, id: 4, number: 4, author_login: dave, closed_at: "2026-10-01T12:00:00Z", merged_at: "2026-10-01T12:00:00Z", merge_commit_sha: merge-dave}
     - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: pr-erin, id: 5, number: 5, author_login: erin, closed_at: "2026-10-01T13:00:00Z", merged_at: "2026-10-01T13:00:00Z", merge_commit_sha: merge-erin}
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: pr-frank, id: 6, number: 6, author_login: frank, state: open, closed_at: "", merged_at: "", merge_commit_sha: ""}
   bronze_github.pull_request_diff_stats:
     - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-alice, pull_number: 1, additions: 10, author_email: alice@example.com}
     - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-bob, pull_number: 2, additions: 20, author_email: bob@example.com}
     - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-carol, pull_number: 3, additions: 30, author_email: carol@example.com}
     - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-dave, pull_number: 4, additions: 40, author_email: dave@example.com}
     - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-erin, pull_number: 5, additions: 50, author_email: erin@example.com}
+    - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-frank, pull_number: 6, additions: 10, author_email: frank@example.com}
 
 cases:
+  - name: Repository rollups pool observations across people
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [alice@example.com, bob@example.com, carol@example.com, dave@example.com, erin@example.com, frank@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.merge_rate
+            views:
+              - {view: rollup, dimensions: [repository]}
+          - metric_key: git.pr_cycle_time_h
+            views:
+              - {view: rollup, dimensions: [repository]}
+    expect:
+      - assert: "status == 200"
+      - metric: git.merge_rate
+        view: rollup
+        find: {dimensions: {key: repository, value: "git-test:constructor/insight"}}
+        equal: {value: 83.33333333333333, contributing_entity_count: 6}
+      - metric: git.pr_cycle_time_h
+        view: rollup
+        find: {dimensions: {key: repository, value: "git-test:constructor/insight"}}
+        equal: {value: 3, contributing_entity_count: 5}
+
+  - name: Merge rate is zero when created pull requests never merge
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [frank@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.merge_rate
+            views:
+              - {view: period}
+    expect:
+      - assert: "status == 200"
+      - metric: git.merge_rate
+        view: period
+        find: {entity_id: frank@example.com}
+        equal: {value: 0}
+
   - name: Unified Git metrics
     request:
       url: /v1/metric-results

--- a/tests/stand/api/schemas/analytics.py
+++ b/tests/stand/api/schemas/analytics.py
@@ -388,15 +388,19 @@ class View3(StrEnum):
 
 
 class View4(StrEnum):
+    rollup = 'rollup'
+
+
+class View5(StrEnum):
     histogram = 'histogram'
 
 
-class MetricResultViewDto5(BaseModel):
+class MetricResultViewDto6(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
     values: list[HistogramValueDto]
-    view: View4
+    view: View5
 
 
 class Type2(StrEnum):
@@ -476,7 +480,7 @@ class MetricSchemaErrorCode(StrEnum):
     unknown = 'unknown'
 
 
-class View5(StrEnum):
+class View6(StrEnum):
     period = 'period'
 
 
@@ -484,10 +488,10 @@ class MetricViewRequest1(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    view: View5
+    view: View6
 
 
-class View6(StrEnum):
+class View7(StrEnum):
     peer = 'peer'
 
 
@@ -496,10 +500,10 @@ class MetricViewRequest2(BaseModel):
         extra='forbid',
     )
     cohort_key: str | None = None
-    view: View6
+    view: View7
 
 
-class View7(StrEnum):
+class View8(StrEnum):
     timeseries = 'timeseries'
 
 
@@ -510,10 +514,10 @@ class MetricViewRequest3(BaseModel):
     bucket: Bucket | None = None
     dimensions: list[str] | None = None
     group_limit: MetricGroupLimitRequest | None = None
-    view: View7
+    view: View8
 
 
-class View8(StrEnum):
+class View9(StrEnum):
     breakdown = 'breakdown'
 
 
@@ -522,22 +526,35 @@ class MetricViewRequest4(BaseModel):
         extra='forbid',
     )
     dimensions: list[str]
-    view: View8
+    view: View9
 
 
-class View9(StrEnum):
-    histogram = 'histogram'
+class View10(StrEnum):
+    rollup = 'rollup'
 
 
 class MetricViewRequest5(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
-    view: View9
+    dimensions: list[str]
+    group_limit: MetricGroupLimitRequest | None = None
+    view: View10
 
 
-class MetricViewRequest(RootModel[MetricViewRequest1 | MetricViewRequest2 | MetricViewRequest3 | MetricViewRequest4 | MetricViewRequest5]):
-    root: MetricViewRequest1 | MetricViewRequest2 | MetricViewRequest3 | MetricViewRequest4 | MetricViewRequest5
+class View11(StrEnum):
+    histogram = 'histogram'
+
+
+class MetricViewRequest6(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    view: View11
+
+
+class MetricViewRequest(RootModel[MetricViewRequest1 | MetricViewRequest2 | MetricViewRequest3 | MetricViewRequest4 | MetricViewRequest5 | MetricViewRequest6]):
+    root: MetricViewRequest1 | MetricViewRequest2 | MetricViewRequest3 | MetricViewRequest4 | MetricViewRequest5 | MetricViewRequest6
 
 
 class PeerValueDto(BaseModel):
@@ -576,6 +593,18 @@ class Problem(BaseModel):
     title: str
     trace_id: str | None = None
     type: str
+
+
+class RollupValueDto(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    contributing_entity_count: int = Field(..., ge=0)
+    dimensions: list[MetricDimensionDto]
+    label: str | None = None
+    rank: int | None = Field(None, ge=0)
+    remainder: bool | None = None
+    value: float | None = None
 
 
 class RunResponse(BaseModel):
@@ -896,6 +925,15 @@ class MetricResultViewDto4(BaseModel):
     view: View3
 
 
+class MetricResultViewDto5(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    dimensions: list[str]
+    values: list[RollupValueDto]
+    view: View4
+
+
 class MetricResultsRequest(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
@@ -1025,8 +1063,8 @@ class MetricResultViewDto2(BaseModel):
     view: View1
 
 
-class MetricResultViewDto(RootModel[MetricResultViewDto1 | MetricResultViewDto2 | MetricResultViewDto3 | MetricResultViewDto4 | MetricResultViewDto5]):
-    root: MetricResultViewDto1 | MetricResultViewDto2 | MetricResultViewDto3 | MetricResultViewDto4 | MetricResultViewDto5
+class MetricResultViewDto(RootModel[MetricResultViewDto1 | MetricResultViewDto2 | MetricResultViewDto3 | MetricResultViewDto4 | MetricResultViewDto5 | MetricResultViewDto6]):
+    root: MetricResultViewDto1 | MetricResultViewDto2 | MetricResultViewDto3 | MetricResultViewDto4 | MetricResultViewDto5 | MetricResultViewDto6
 
 
 class MetricResultDto5(BaseModel):


### PR DESCRIPTION
**Why.** The API returns one row per person, so clients cannot safely combine rates or medians for a repository, source, tool, or other grouping.

**What changed.** Adds a `rollup` view that calculates metrics across all selected people, grouped by any dimension supported by that metric. Each result also reports how many people contributed.

**Existing breakdowns stay unchanged.** They continue serving person-level results; rollups provide exact totals, rates, and medians for the whole group.

**Evidence.** A synthetic Git scenario verifies grouped merge rate, PR cycle-time median, unmerged pull requests as zero, and contributor count.

**Out of scope.** Grouped trends and new repository active-day and review metrics remain separate changes.

**Verified.** Analytics clippy and 532 tests; Git metrics E2E; frontend typecheck/lint; OpenAPI and generated-model drift checks.
