### PR TITLE
ci: restore end-to-end checks on pull requests

### DIFF
--- a/.github/workflows/e2e-stand.yml
+++ b/.github/workflows/e2e-stand.yml
@@ -9,8 +9,8 @@ name: E2E — Compose stand
 # Nothing here builds by default: `test-stand up` pulls the frontend and the
 # four backend services at their charts' appVersions, which name main's build.
 # A ref that changes one of those trees has to run it or the lane reports on
-# code it never tested. Merge-queue runs load backend images already built for
-# the same commit; events without that image workflow retain the source-build path.
+# code it never tested. Pull requests load backend images already built for the
+# same commit; events without that image workflow retain the source-build path.
 # Frontend changes continue to build the SPA in this job.
 #
 # INVARIANT: Both lane checks report independently from one stand lifecycle.
@@ -21,10 +21,12 @@ name: E2E — Compose stand
 #                the checkout on every event, so the ref's own test code is
 #                what executes.
 #
-# The two lane names are stable required contexts. The workflow starts on every
-# pull request so those contexts report as skipped, but the stand runs only for
-# merge groups, nightly runs, and manual dispatches. Superseded PR runs are
-# cancelled by the concurrency group. Wall-clock and flake history are in
+# Neither is required on its own; `Stand E2E` below is the one stable context
+# for branch protection. The workflow starts on every pull request so that
+# required context always reports; the cheap `changes` job decides whether the
+# two stand lanes need to run. Relevant changes run on the pull request, once
+# per queue batch on merge_group, nightly, and on dispatch. Superseded PR runs
+# are cancelled by the concurrency group. Wall-clock and flake history are in
 # .cf-studio/.plans/stage1-compose-e2e-suite/out/ci-wiring.md.
 #
 # Every stand operation goes through ./dev-compose.sh test-stand — never the
@@ -173,7 +175,7 @@ jobs:
           if echo "$changed" | grep -qE '^(src/backend/services/identity-resolution/|src/backend/libs/insight-clickhouse/|src/backend/docker-entrypoint\.sh$|src/backend/Cargo\.(toml|lock)$|\.github/workflows/(build-images|e2e-stand)\.yml$)'; then identity_resolution=true; fi
           if echo "$changed" | grep -qE '^(src/backend/services/gateway/|src/backend/tools/routegen/|src/backend/Cargo\.(toml|lock)$|\.github/workflows/(gateway|build-images|e2e-stand)\.yml$|scripts/ci/prebuilt_images\.py$)'; then gateway=true; fi
           if echo "$changed" | grep -qE '^(src/backend/tools/routegen/|src/backend/services/gateway/|src/backend/services/authenticator/|src/backend/libs/authenticator-sdk/|src/backend/Cargo\.(toml|lock)$|src/ingestion/tools/seed/insight_seed/|\.github/workflows/(gateway|build-images|e2e-stand)\.yml$|scripts/ci/(prebuilt_images|test_prebuilt_images)\.py$)'; then gateway_checks=true; fi
-          if [[ "$GITHUB_EVENT_NAME" == merge_group ]] && \
+          if [[ "$GITHUB_EVENT_NAME" == pull_request || "$GITHUB_EVENT_NAME" == merge_group ]] && \
              [[ "$analytics" == true || "$authenticator" == true || "$identity_resolution" == true || "$gateway" == true ]]; then
             backend_artifacts=true
           fi
@@ -182,7 +184,7 @@ jobs:
   build-pr-images:
     name: Build PR images
     needs: changes
-    if: github.event_name == 'merge_group'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     permissions:
       contents: write
       packages: write
@@ -190,42 +192,47 @@ jobs:
       attestations: write
     uses: ./.github/workflows/build-images.yml
 
+  bronze-to-api:
+    name: Bronze to API
+    needs: build-pr-images
+    if: github.event_name == 'pull_request' && needs.build-pr-images.result == 'success'
+    permissions:
+      contents: read
+      actions: read
+    uses: ./.github/workflows/e2e-bronze-to-api.yml
+
   bronze-to-api-report:
     name: Run E2E suite
-    needs: changes
+    needs: bronze-to-api
     if: github.event_name == 'pull_request' && !cancelled()
     runs-on: ubuntu-latest
     steps:
-      - name: Defer Bronze-to-API to the merge queue
+      - name: Require the Bronze-to-API workflow to pass
         env:
-          CHANGES: ${{ needs.changes.result }}
+          RESULT: ${{ needs.bronze-to-api.result }}
         run: |
-          if [ "$CHANGES" != success ]; then
-            echo "::error::stand relevance could not be evaluated ($CHANGES)."
+          if [ "$RESULT" != success ]; then
+            echo "::error::Bronze-to-API checks did not pass ($RESULT)."
             exit 1
           fi
-          echo "Bronze-to-API is deferred to the merge queue."
 
   gateway:
     name: Gateway checks
     needs: [changes, build-pr-images]
     if: |
       !cancelled()
-      && github.event_name == 'merge_group'
+      && github.event_name == 'pull_request'
       && needs.changes.outputs.gateway_checks == 'true'
       && (needs.build-pr-images.result == 'success' || needs.build-pr-images.result == 'skipped')
     permissions:
       contents: read
       actions: read
     uses: ./.github/workflows/gateway.yml
-    with:
-      gateway_changed: ${{ needs.changes.outputs.gateway == 'true' }}
-      authenticator_changed: ${{ needs.changes.outputs.authenticator == 'true' }}
 
   resolve-target:
     name: resolve-target
     needs: changes
-    if: ${{ github.event_name != 'pull_request' && needs.changes.outputs.relevant == 'true' }}
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -257,7 +264,6 @@ jobs:
     needs: [changes, resolve-target, build-pr-images]
     if: |
       !cancelled()
-      && github.event_name != 'pull_request'
       && needs.resolve-target.result == 'success'
       && needs.resolve-target.outputs.target == 'compose'
       && (needs.build-pr-images.result == 'success' || needs.build-pr-images.result == 'skipped')
@@ -286,7 +292,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Load merge-group backend images
+      - name: Load PR-built backend images
         if: needs.changes.outputs.backend_artifacts == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
@@ -539,7 +545,7 @@ jobs:
   api-smoke:
     name: api-smoke
     needs: [changes, stand-runner]
-    if: ${{ !cancelled() && github.event_name != 'pull_request' }}
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -567,7 +573,7 @@ jobs:
   ui-journeys:
     name: ui-journeys
     needs: [changes, stand-runner]
-    if: ${{ !cancelled() && github.event_name != 'pull_request' }}
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -592,15 +598,17 @@ jobs:
           fi
           echo "UI journeys passed"
 
-  # ─── aggregate result ─────────────────────────────────────────────────────
-  # Merge groups and explicit stand runs get one aggregate result in addition
-  # to the stable lane contexts. Pull requests defer the aggregate with them.
+  # ─── the required check ───────────────────────────────────────────────────
+  # One stable context name for branch protection on both pull_request and
+  # merge_group. It runs whenever the workflow was not cancelled, including
+  # when `changes` deemed the diff irrelevant and the lanes were skipped.
   #
-  # A skipped lane passes only when `changes` reported the diff irrelevant.
+  # A skipped lane is a pass only when `changes` explicitly reported the diff
+  # irrelevant. If relevance is unknown or relevant, every lane must succeed.
   stand-suite:
     name: Stand E2E
     needs: [changes, api-smoke, ui-journeys]
-    if: ${{ !cancelled() && github.event_name != 'pull_request' }}
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -9,15 +9,6 @@ name: Gateway — routegen, config, e2e
 # gateway or the generator changes.
 on:
   workflow_call:
-    inputs:
-      gateway_changed:
-        required: false
-        type: boolean
-        default: false
-      authenticator_changed:
-        required: false
-        type: boolean
-        default: false
   push:
     branches: [main]
     paths:
@@ -67,6 +58,20 @@ jobs:
       - name: Test pre-built image selection
         run: PYTHONPATH=scripts/ci python3 -m unittest scripts/ci/test_prebuilt_images.py
 
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        if: github.event_name == 'pull_request'
+        id: changed
+        with:
+          filters: |
+            gateway:
+              - 'src/backend/services/gateway/**'
+              - 'src/backend/tools/routegen/**'
+              - 'src/backend/Cargo.toml'
+              - 'src/backend/Cargo.lock'
+              - '.github/workflows/gateway.yml'
+              - '.github/workflows/build-images.yml'
+              - 'scripts/ci/prebuilt_images.py'
+
       - name: routegen fmt + clippy + tests
         working-directory: src/backend
         run: |
@@ -75,16 +80,16 @@ jobs:
           cargo test -p routegen
 
       - name: Build the OpenResty gateway image
-        if: github.event_name != 'merge_group'
+        if: github.event_name != 'pull_request'
         working-directory: src/backend
         run: docker build -f services/gateway/Dockerfile -t insight-gateway:ci .
 
-      - name: Load the merge-group gateway image
-        if: github.event_name == 'merge_group'
+      - name: Load the PR-built gateway image
+        if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ github.run_id }}
-          REQUIRED: ${{ inputs.gateway_changed }}
+          REQUIRED: ${{ steps.changed.outputs.gateway }}
         run: |
           policy=unchanged
           if [ "$REQUIRED" = "true" ]; then policy=required; fi
@@ -155,13 +160,35 @@ jobs:
         with:
           save-cache: ${{ github.event_name == 'push' }}
 
-      - name: Load merge-group service images
-        if: github.event_name == 'merge_group'
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        if: github.event_name == 'pull_request'
+        id: changed
+        with:
+          filters: |
+            gateway:
+              - 'src/backend/services/gateway/**'
+              - 'src/backend/tools/routegen/**'
+              - 'src/backend/Cargo.toml'
+              - 'src/backend/Cargo.lock'
+              - '.github/workflows/gateway.yml'
+              - '.github/workflows/build-images.yml'
+              - 'scripts/ci/prebuilt_images.py'
+            authenticator:
+              - 'src/backend/services/authenticator/**'
+              - 'src/backend/libs/authenticator-sdk/**'
+              - 'src/backend/Cargo.toml'
+              - 'src/backend/Cargo.lock'
+              - '.github/workflows/gateway.yml'
+              - '.github/workflows/build-images.yml'
+              - 'scripts/ci/prebuilt_images.py'
+
+      - name: Load PR-built service images
+        if: github.event_name == 'pull_request'
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_ID: ${{ github.run_id }}
-          GATEWAY_REQUIRED: ${{ inputs.gateway_changed }}
-          AUTHENTICATOR_REQUIRED: ${{ inputs.authenticator_changed }}
+          GATEWAY_REQUIRED: ${{ steps.changed.outputs.gateway }}
+          AUTHENTICATOR_REQUIRED: ${{ steps.changed.outputs.authenticator }}
         run: |
           gateway_policy=unchanged
           authenticator_policy=unchanged
@@ -178,5 +205,5 @@ jobs:
 
       - name: Run the gateway e2e
         env:
-          GATEWAY_E2E_PREBUILT: ${{ github.event_name == 'merge_group' && 'true' || 'false' }}
+          GATEWAY_E2E_PREBUILT: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
         run: src/backend/services/gateway/tests/run-e2e.sh


### PR DESCRIPTION
**Why.** Full E2E results appeared only after entering merge queue, so failures could evict an apparently-ready PR.

**What changed.** Restore PR image reuse and run Bronze-to-API, Gateway, and Compose stand checks on pull requests; merge queue still reruns them against its combined commit.

**Verified.** actionlint; CI Python tests (1 + 5); workflow content matches pre-#2703 revision.