### PR TITLE
feat(ingestion): carry default-branch membership into class_git_commits

### DIFF
--- a/.github/trufflehog-allowlist.txt
+++ b/.github/trufflehog-allowlist.txt
@@ -10,6 +10,11 @@ cf6ede857587d567  Gitlab             .github/workflows/ghcr-cleanup.yml  # GHCR 
 bd0c5f545b463920  Gitlab             docs/components/deployment/gitops/SPEC.md  # code identifier / constant name
 bd093b6d7b23051a  Gitlab             docs/components/deployment/specs/PRD.md  # code identifier / constant name
 f805794a8092a445  Gitlab             docs/connectors/gitlab.md  # code identifier / constant name
+68ac8b9bf3049a2b  Gitlab             src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__commits.sql  # bronze column name is_in_default_branch, not a token
+a0cb61bc8b698803  Gitlab             src/ingestion/connectors/git/bitbucket-cloud/descriptor.yaml  # bronze column name is_in_default_branch, not a token
+386dc4480c56ba22  Gitlab             src/ingestion/connectors/git/github/dbt/github__commits.sql  # bronze column name is_in_default_branch, not a token
+900162680ea34d4f  Gitlab             src/ingestion/connectors/git/github/descriptor.yaml  # bronze column name is_in_default_branch, not a token
+65b16a9d3ed875d7  Gitlab             src/ingestion/tests/e2e/metrics/schemas/bronze_github.commits.yaml  # bronze column name is_in_default_branch, not a token
 9a6a2ad8f26d96a0  Gitlab             src/ingestion/connectors/git/gitlab-nocode/descriptor.yaml  # connector name, not a token
 4ccd2051f51a85a9  Gitlab             src/ingestion/connectors/git/gitlab/dbt/gitlab__commits.sql  # code identifier / constant name
 c71d7d6ef85cd006  Gitlab             src/ingestion/connectors/git/gitlab/dbt/gitlab__file_changes.sql  # code identifier / constant name

--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__commits.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__commits.sql
@@ -3,13 +3,18 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    on_schema_change='append_new_columns',
     settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['bitbucket-cloud', 'silver:class_git_commits']
 ) }}
 
 -- branch is '' by construction: the proxy walks a repository once rather than
--- once per branch, so a commit carries no branch name.
+-- once per branch, so a commit carries no branch name, only the membership
+-- flag below.
+-- INVARIANT: is_in_default_branch is reachability AT SYNC TIME. A commit first
+-- seen on a feature branch stays 0 unless a later sync re-reads it, so a merge
+-- outside the connector's lookback_window never corrects it.
 SELECT
     tenant_id,
     source_id,
@@ -18,6 +23,7 @@ SELECT
     replaceRegexpOne(arrayElement(splitByChar('/', COALESCE(repository, '')), -1), '\\.git$', '') AS repo_slug,
     COALESCE(sha, '') AS commit_hash,
     '' AS branch,
+    CAST(is_in_default_branch AS Nullable(UInt8)) AS is_default_branch,
     COALESCE(author_name, '') AS author_name,
     COALESCE(author_email, '') AS author_email,
     COALESCE(committer_name, '') AS committer_name,

--- a/src/ingestion/connectors/git/bitbucket-cloud/descriptor.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/descriptor.yaml
@@ -1,5 +1,11 @@
 name: bitbucket-cloud
-version: "2.1.0"
+# Strict semver per ADR-0015. 3.0.0: dbt staging carries the proxy's
+#   is_in_default_branch into the class-contract column is_default_branch.
+#   MAJOR for the same reason as github 4.0.0 — append_new_columns leaves the
+#   column NULL on rows already in staging, and staging never re-reads Bronze,
+#   so only the one-shot scoped `dbt --full-refresh` a major bump dispatches
+#   re-materializes the history.
+version: "3.0.0"
 # A slot of its own: replication pods sharing a slot with other connector
 # syncs can be starved of workers, which surfaces as startup and activity
 # timeouts rather than as a connector error.

--- a/src/ingestion/connectors/git/github/dbt/github__commits.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__commits.sql
@@ -3,13 +3,18 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    on_schema_change='append_new_columns',
     settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['github', 'silver:class_git_commits']
 ) }}
 
 -- branch is '' by construction: the proxy walks a repository once rather than
--- once per branch, so a commit carries no branch name. Matches gitlab.
+-- once per branch, so a commit carries no branch name, only the membership
+-- flag below. Matches gitlab.
+-- INVARIANT: is_in_default_branch is reachability AT SYNC TIME. A commit first
+-- seen on a feature branch stays 0 unless a later sync re-reads it, so a merge
+-- outside the connector's lookback_window never corrects it.
 SELECT
     tenant_id,
     source_id,
@@ -18,6 +23,7 @@ SELECT
     replaceRegexpOne(arrayElement(splitByChar('/', COALESCE(repository, '')), -1), '\\.git$', '') AS repo_slug,
     COALESCE(sha, '') AS commit_hash,
     '' AS branch,
+    CAST(is_in_default_branch AS Nullable(UInt8)) AS is_default_branch,
     COALESCE(author_name, '') AS author_name,
     COALESCE(author_email, '') AS author_email,
     COALESCE(committer_name, '') AS committer_name,

--- a/src/ingestion/connectors/git/github/descriptor.yaml
+++ b/src/ingestion/connectors/git/github/descriptor.yaml
@@ -1,5 +1,13 @@
 name: github
-version: "3.0.0"
+# Strict semver per ADR-0015. 4.0.0: dbt staging carries the proxy's
+#   is_in_default_branch into the class-contract column is_default_branch.
+#   MAJOR — on_schema_change=append_new_columns adds the column but leaves it
+#   NULL on rows already in staging, and staging is incremental on
+#   _airbyte_extracted_at, so Bronze is never re-read and the backfill would
+#   never happen. Only the one-shot scoped `dbt --full-refresh` a major bump
+#   dispatches re-materializes the history. Safe: every git staging model is a
+#   pure projection of Bronze, so the rebuild loses nothing.
+version: "4.0.0"
 schedule: "0 */4 * * *"
 workflow: sync
 

--- a/src/ingestion/connectors/git/gitlab/dbt/gitlab__commits.sql
+++ b/src/ingestion/connectors/git/gitlab/dbt/gitlab__commits.sql
@@ -3,6 +3,7 @@
     materialized='incremental',
     unique_key='unique_key',
     order_by=['unique_key'],
+    on_schema_change='append_new_columns',
     settings={'allow_nullable_key': 1},
     schema='staging',
     tags=['gitlab', 'silver:class_git_commits']
@@ -11,7 +12,9 @@
 -- lines_added / lines_removed come from the commit's own stats (present for
 -- every commit). files_changed is the per-commit count from commit_file_changes,
 -- which the connector only collects for default-branch non-merge commits — so
--- it is 0 for commits outside that set. branch is not stored on the commit row.
+-- it is 0 for commits outside that set. branch is not stored on the commit row,
+-- and neither is default-branch membership: the stream knows which ref it
+-- walked but does not project it, so is_default_branch is NULL here.
 WITH proj AS (
     SELECT
         tenant_id,
@@ -41,6 +44,7 @@ SELECT
     COALESCE(p.repo_slug, '') AS repo_slug,
     COALESCE(c.id, '') AS commit_hash,
     '' AS branch,
+    CAST(NULL AS Nullable(UInt8)) AS is_default_branch,
     COALESCE(c.author_name, '') AS author_name,
     COALESCE(c.author_email, '') AS author_email,
     COALESCE(c.committer_name, '') AS committer_name,

--- a/src/ingestion/connectors/git/gitlab/descriptor.yaml
+++ b/src/ingestion/connectors/git/gitlab/descriptor.yaml
@@ -1,5 +1,9 @@
 name: gitlab
-version: "1.14.0"
+# Strict semver per ADR-0015. 1.15.0: dbt staging declares the class-contract
+#   column is_default_branch. MINOR, not MAJOR: the commits stream reports no
+#   branch membership, so the column is NULL whether a row re-materializes or
+#   not and nothing has to be rebuilt.
+version: "1.15.0"
 type: cdk
 schedule: "0 2 * * *"
 workflow: sync

--- a/src/ingestion/scripts/connectors-ddl/silver.sql
+++ b/src/ingestion/scripts/connectors-ddl/silver.sql
@@ -415,6 +415,7 @@ CREATE TABLE IF NOT EXISTS silver.class_git_commits
     `repo_slug` String,
     `commit_hash` String,
     `branch` String,
+    `is_default_branch` Nullable(UInt8),
     `author_name` String,
     `author_email` String,
     `committer_name` String,

--- a/src/ingestion/silver/git/class_git_commits.sql
+++ b/src/ingestion/silver/git/class_git_commits.sql
@@ -7,6 +7,7 @@
     incremental_strategy='delete+insert',
     engine='ReplacingMergeTree(_version)',
     order_by=['unique_key'],
+    on_schema_change='append_new_columns',
     settings={'allow_nullable_key': 1},
     schema='silver',
     tags=['silver']

--- a/src/ingestion/silver/git/schema.yml
+++ b/src/ingestion/silver/git/schema.yml
@@ -64,6 +64,16 @@ models:
         tests:
           - not_null
           - unique
+      - name: is_default_branch
+        description: >
+          Whether the commit is reachable from the repository's default branch:
+          1 yes, 0 no, NULL the source does not report it. Reachability is as of
+          the sync that saw the commit, so a commit merged into the default
+          branch after the connector's lookback window keeps 0.
+        tests:
+          - accepted_values:
+              arguments:
+                values: [0, 1]
 
   - name: class_git_file_changes
     description: "Unified git file changes from all sources (GitHub, Bitbucket, GitLab)"

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_github.commits.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_github.commits.yaml
@@ -23,3 +23,4 @@ schemas:
       additions: {type: integer}
       deletions: {type: integer}
       is_merge: {type: boolean}
+      is_in_default_branch: {type: [boolean, "null"]}


### PR DESCRIPTION
Sub-task 1 of #2786.

**Why.** Git metrics cannot tell work on a repository's default branch from work anywhere else, because no silver relation records which branch a commit belongs to.

**What changed.** `class_git_commits` gains `is_default_branch`; the GitHub and Bitbucket Cloud staging models carry the git-cli-proxy's `is_in_default_branch` into it, and GitLab emits NULL because its commits stream reports no membership.

**NULL, not 0, when a source stays silent — three-valued on purpose.** "Not reported" and "not on the default branch" are different facts, and collapsing them would hide which sources are covered. Gold decides how NULL reads.

**MAJOR bumps on github (4.0.0) and bitbucket-cloud (3.0.0) — the only way to backfill.** `append_new_columns` adds the column but leaves it NULL on rows already in staging, and staging never re-reads bronze, so a plain deploy would classify all history as "unknown" forever. A major bump dispatches the one-shot scoped `dbt --full-refresh`. Safe here: every git staging model is a pure projection of bronze and none carries a `full_refresh=false` guard. GitLab takes a MINOR — its column is NULL either way.

**Out of scope.** No metric reads the column yet, and GitLab has no membership signal to read; sub-tasks 2 and 5 of #2786.

**Known gap, fixed in #2788 rather than here.** The two commit models read bronze without FINAL. Bronze holds more than one row per commit whenever the lookback window re-reads it, and a build with no incremental predicate — including the `--full-refresh` the major bumps above dispatch — inserts every version under one `now64()` `_version`, which is a tie the `union_by_tag` dedup orders by and cannot break. It was harmless while duplicate rows agreed on every column; `is_default_branch` is the first that can differ. #2788 adds the FINAL, and this branch is left alone because it is ready to merge.

**Verified.** Throwaway ClickHouse on the pinned 25.7.5: `dbt parse` exit 0, `dbt build` 12/12 across three warehouse states — fresh, an existing table upgraded, and old staging beside one freshly created connector. A plain build left pre-existing rows NULL; `--full-refresh` restored 1/0. `scripts/ci/connector_wiring.py` OK.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `is_default_branch` to Git commit data, indicating whether a commit is reachable from the repository’s default branch.
  * The field supports true, false, or unavailable values depending on source data.
* **Improvements**
  * Connector updates now safely accommodate newly added commit fields without disrupting existing data.
  * Historical records are refreshed when required so the new field is populated consistently.
  * Documentation now clarifies branch and default-branch availability across supported providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
