### PR TITLE
fix(metrics): emit one row per task status span

### DIFF
--- a/src/ingestion/gold/task_status_spans.sql
+++ b/src/ingestion/gold/task_status_spans.sql
@@ -48,29 +48,37 @@ SELECT
     st.status_category                                                       AS status_category,
     iv.duration_seconds                                                      AS duration_seconds
 FROM (
+    -- INVARIANT: the arrayJoin stays alone in its own SELECT list. Reading its
+    -- elements beside it re-evaluates it per reference and squares the rows.
     SELECT
-        e.insight_source_id                                                  AS insight_source_id,
-        e.issue_id                                                           AS issue_id,
-        arrayJoin(arrayMap(
-            i -> (
-                (e.evs[i]).1,
-                if(i = length(e.evs),
-                   if(s.status_category = 'done',
-                      ifNull(s.final_close_at, (e.evs[i]).1),
-                      now()),
-                   (e.evs[i + 1]).1),
-                (e.evs[i]).2
-            ),
-            range(1, length(e.evs) + 1)
-        ))                                                                   AS row,
-        row.1                                                                AS interval_start,
-        row.2                                                                AS interval_end,
-        row.3                                                                AS status_id,
-        toFloat64(greatest(toInt64(0), dateDiff('second', row.1, row.2)))    AS duration_seconds,
-        s.created_at                                                         AS issue_created_at
-    FROM status_events AS e
-    INNER JOIN {{ ref('task_issue_state') }} AS s
-        ON s.insight_source_id = e.insight_source_id AND s.issue_id = e.issue_id
+        insight_source_id                                                    AS insight_source_id,
+        issue_id                                                             AS issue_id,
+        span.1                                                               AS interval_start,
+        span.2                                                               AS interval_end,
+        span.3                                                               AS status_id,
+        toFloat64(greatest(toInt64(0), dateDiff('second', span.1, span.2)))  AS duration_seconds,
+        issue_created_at                                                     AS issue_created_at
+    FROM (
+        SELECT
+            e.insight_source_id                                              AS insight_source_id,
+            e.issue_id                                                       AS issue_id,
+            s.created_at                                                     AS issue_created_at,
+            arrayJoin(arrayMap(
+                i -> (
+                    (e.evs[i]).1,
+                    if(i = length(e.evs),
+                       if(s.status_category = 'done',
+                          ifNull(s.final_close_at, (e.evs[i]).1),
+                          now()),
+                       (e.evs[i + 1]).1),
+                    (e.evs[i]).2
+                ),
+                range(1, length(e.evs) + 1)
+            ))                                                               AS span
+        FROM status_events AS e
+        INNER JOIN {{ ref('task_issue_state') }} AS s
+            ON s.insight_source_id = e.insight_source_id AND s.issue_id = e.issue_id
+    ) AS spans
 ) AS iv
 LEFT JOIN {{ ref('class_task_statuses') }} AS st FINAL
     ON st.insight_source_id = iv.insight_source_id AND st.status_id = iv.status_id


### PR DESCRIPTION
**Why.** Measures built on task status spans could report inflated durations — a status span was sometimes emitted once per status event on its issue instead of once, so any sum over span durations scaled with the event count.

**What changed.** `task_status_spans` now computes its `arrayJoin` in its own SELECT level and reads the tuple elements one level up, so the expansion happens exactly once. Reading `row.1`/`row.2`/`row.3` beside the `arrayJoin` that defined them let ClickHouse evaluate it once per reference, and the extra evaluations multiplied rows instead of adding columns.

**No behaviour change beyond the row count.** Span bounds, categories and durations are computed identically; only the duplicate rows disappear.

**Verified.** Metrics e2e `tasks` shard, 4 clean-slate runs of all 12 fixtures, green; the same loop failed 3 times in ~7 runs before the change. Span rows for the bug fixture go 80 → 40 against 40 distinct spans, and the flow fixture holds at 14 against 14.

**Out of scope.** Per-test isolation in the metrics rig, tracked in #2698 — a separate defect that did not cause this one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected status span generation to prevent duplicate rows in issue status history.
  * Ensured each status interval is reported once with accurate start, end, and duration values.
  * Preserved existing handling for completed and ongoing issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->