### PR TITLE
fix(ingestion): heal class_git_commits for default-branch membership

### DIFF
--- a/src/ingestion/scripts/migrations/20260824000000_git-commit-default-branch.sql
+++ b/src/ingestion/scripts/migrations/20260824000000_git-commit-default-branch.sql
@@ -1,0 +1,29 @@
+-- Add default-branch membership to the git commit class contract.
+--
+-- The column records whether a commit was reachable from the repository's
+-- default branch at sync time, which gold reads to split commit output by
+-- whether the work landed.
+--
+-- A pre-existing table gets it from nowhere: the DDL snapshot is IF NOT
+-- EXISTS, and on_schema_change=append_new_columns only widens the relation
+-- on a run of the model itself — which the deploy never performs, because
+-- the hook builds tag:gold and the class models are tag:silver. Gold reads
+-- the column in the same run, so without this the deploy fails on
+-- UNKNOWN_IDENTIFIER. The staging halves need no heal: the projections are
+-- rebuilt with the column by the descriptor bump that introduced it.
+--
+-- The AFTER anchor puts it where the staging projections place it and the
+-- positional insert requires; MODIFY converges an instance where an
+-- out-of-band ALTER placed it elsewhere. Shape follows
+-- 20260820000000_git-file-change-blob-oids.sql.
+--
+-- Existing rows read NULL until the class model is re-materialized from
+-- staging; gold resolves NULL as "not on the default branch".
+--
+-- Idempotent: this channel has no ledger and re-runs on every deploy.
+-- The class tables always exist here (placeholders precede migrations).
+ALTER TABLE silver.class_git_commits
+    ADD COLUMN IF NOT EXISTS is_default_branch Nullable(UInt8) AFTER branch;
+
+ALTER TABLE silver.class_git_commits
+    MODIFY COLUMN is_default_branch Nullable(UInt8) AFTER branch;

--- a/src/ingestion/scripts/migrations/20260824000000_git-commit-default-branch.sql
+++ b/src/ingestion/scripts/migrations/20260824000000_git-commit-default-branch.sql
@@ -1,27 +1,9 @@
--- Add default-branch membership to the git commit class contract.
---
--- The column records whether a commit was reachable from the repository's
--- default branch at sync time, which gold reads to split commit output by
--- whether the work landed.
---
--- A pre-existing table gets it from nowhere: the DDL snapshot is IF NOT
--- EXISTS, and on_schema_change=append_new_columns only widens the relation
--- on a run of the model itself — which the deploy never performs, because
--- the hook builds tag:gold and the class models are tag:silver. Gold reads
--- the column in the same run, so without this the deploy fails on
--- UNKNOWN_IDENTIFIER. The staging halves need no heal: the projections are
--- rebuilt with the column by the descriptor bump that introduced it.
---
--- The AFTER anchor puts it where the staging projections place it and the
--- positional insert requires; MODIFY converges an instance where an
--- out-of-band ALTER placed it elsewhere. Shape follows
--- 20260820000000_git-file-change-blob-oids.sql.
---
--- Existing rows read NULL until the class model is re-materialized from
--- staging; gold resolves NULL as "not on the default branch".
---
+-- The class model owns this column but never adds it to a warm relation: the
+-- DDL snapshot is IF NOT EXISTS, and the deploy hook builds tag:gold, not the
+-- tag:silver model that would widen it — so gold reads it in the same run.
+-- AFTER anchors the contract position the positional insert requires; MODIFY
+-- converges an instance where an out-of-band ALTER placed it elsewhere.
 -- Idempotent: this channel has no ledger and re-runs on every deploy.
--- The class tables always exist here (placeholders precede migrations).
 ALTER TABLE silver.class_git_commits
     ADD COLUMN IF NOT EXISTS is_default_branch Nullable(UInt8) AFTER branch;
 


### PR DESCRIPTION
**Why** The git commit class contract gained `is_default_branch`, but a pre-existing relation never gains it: the DDL snapshot is `CREATE TABLE IF NOT EXISTS`, and `on_schema_change=append_new_columns` widens the table only on a run of the class model itself. The deploy hook runs `dbt run --select tag:gold` and the class models are `tag:silver`, so gold reads the column in the same run that never added it and the hook fails with `UNKNOWN_IDENTIFIER`.

**What changed** One numbered migration adds the column at its contract position (`AFTER branch`), with a `MODIFY` to converge an instance where an out-of-band ALTER placed it elsewhere. Migrations run before the gold build, so the column exists by the time gold reads it.

**Out of scope** Staging projections — the descriptor bump that introduced the column rebuilds those. Backfilling values: existing rows read NULL until the class model is re-materialized from staging, and gold resolves NULL as not on the default branch.

**Verified** ALTER executed against ClickHouse 25.7: the column lands at the contract's declared position and a re-run is a no-op. The migration is picked up by the `*.sql` glob — no registry to update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recording whether a Git commit belongs to the default branch.
  * Existing commit records remain compatible because the new value is optional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->