### PR TITLE
fix(reports): key weekly report buckets to the server's week start

### DIFF
--- a/src/frontend/src/components/portal/report-builder-view.test.tsx
+++ b/src/frontend/src/components/portal/report-builder-view.test.tsx
@@ -159,9 +159,27 @@ describe("ReportBuilderView", () => {
     render(<ReportBuilderView />);
     expect(isDisabled("Merge rate")).toBe(false);
 
-    await user.click(screen.getByRole("button", { name: "Yearly" }));
+    await user.click(screen.getByRole("button", { name: "Quarterly" }));
     expect(isDisabled("Merge rate")).toBe(true);
     expect(isDisabled("Commits")).toBe(false);
+  });
+
+  it("refuses a grain longer than the period, and says which to pick", async () => {
+    const user = userEvent.setup();
+    render(<ReportBuilderView />);
+
+    const yearly = screen.getByRole("button", { name: "Yearly" });
+    expect(yearly).toBeDisabled();
+    expect(yearly).toHaveAttribute(
+      "title",
+      expect.stringMatching(/at least a year — pick quarterly or finer/),
+    );
+
+    await user.click(screen.getByRole("button", { name: "Quarterly" }));
+    expect(screen.getByRole("button", { name: "Quarterly" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
   });
 
   it("says why it cannot build yet, rather than greying out in silence", async () => {

--- a/src/frontend/src/components/portal/report-builder-view.tsx
+++ b/src/frontend/src/components/portal/report-builder-view.tsx
@@ -35,6 +35,10 @@ import { usePortalShowPlanned } from "@/lib/portal/portal-store";
 import { useOrgScope } from "@/lib/portal/use-org-scope";
 import { unavailableReason } from "@/lib/reports/availability";
 import { byFamily } from "@/lib/reports/families";
+import {
+  clampGranularity,
+  periodTooShortReason,
+} from "@/lib/reports/granularity-for-period";
 import { buildReportTable, type ReportTable } from "@/lib/reports/report-table";
 import { recordUsageEvent } from "@/telemetry";
 import {
@@ -67,7 +71,9 @@ export function ReportBuilderView() {
   const computations = useMetricComputations();
 
   const [selected, setSelected] = useState<string[]>([]);
-  const [granularity, setGranularity] = useState<ReportGranularity>("month");
+  const [pickedGranularity, setPickedGranularity] =
+    useState<ReportGranularity>("month");
+  const granularity = clampGranularity(pickedGranularity, dateRange);
   const [progress, setProgress] = useState<{ done: number; total: number } | null>(
     null,
   );
@@ -240,21 +246,44 @@ export function ReportBuilderView() {
         <CardContent className="flex flex-col gap-4 p-4">
           <div className="flex flex-wrap items-center gap-3">
             <span className={TEXT_LABEL}>Granularity</span>
-            <ToggleGroup
-              value={[granularity]}
-              onValueChange={(value) => {
-                const next = Array.isArray(value) ? value[0] : value;
-                if (next) setGranularity(next as ReportGranularity);
-              }}
-              variant="outline"
-              size="sm"
-            >
-              {GRANULARITIES.map((option) => (
-                <ToggleGroupItem key={option.value} value={option.value}>
-                  {option.label}
-                </ToggleGroupItem>
-              ))}
-            </ToggleGroup>
+            <TooltipProvider delay={300}>
+              <ToggleGroup
+                value={[granularity]}
+                onValueChange={(value) => {
+                  const next = Array.isArray(value) ? value[0] : value;
+                  if (next) setPickedGranularity(next as ReportGranularity);
+                }}
+                variant="outline"
+                size="sm"
+              >
+                {GRANULARITIES.map((option) => {
+                  const reason = periodTooShortReason(option.value, dateRange);
+                  return (
+                    <Tooltip key={option.value}>
+                      <TooltipTrigger
+                        render={
+                          <ToggleGroupItem
+                            value={option.value}
+                            disabled={Boolean(reason)}
+                            title={reason ?? undefined}
+                          >
+                            {option.label}
+                          </ToggleGroupItem>
+                        }
+                      />
+                      {reason ? (
+                        <TooltipContent
+                          side="top"
+                          className="max-w-xs text-xs leading-relaxed"
+                        >
+                          {reason}
+                        </TooltipContent>
+                      ) : null}
+                    </Tooltip>
+                  );
+                })}
+              </ToggleGroup>
+            </TooltipProvider>
             <span className="text-xs text-muted-foreground">
               The period comes from the bar above.
             </span>

--- a/src/frontend/src/lib/reports/granularity-for-period.ts
+++ b/src/frontend/src/lib/reports/granularity-for-period.ts
@@ -1,0 +1,72 @@
+import { differenceInCalendarDays, parseISO } from "date-fns";
+
+import type { DateRange } from "@/api/period-to-date-range";
+import type { ReportGranularity } from "@/lib/reports/rollup";
+
+// The shortest a rolling window of each grain can be, so every period preset
+// admits its own grain: February makes a month 28 days and a quarter 89.
+const MIN_PERIOD_DAYS: Record<ReportGranularity, number> = {
+  day: 1,
+  week: 7,
+  month: 28,
+  quarter: 89,
+  year: 365,
+};
+
+const COARSEST_FIRST: ReadonlyArray<ReportGranularity> = [
+  "year",
+  "quarter",
+  "month",
+  "week",
+  "day",
+];
+
+const SPLIT_NAME: Record<ReportGranularity, string> = {
+  day: "daily",
+  week: "weekly",
+  month: "monthly",
+  quarter: "quarterly",
+  year: "yearly",
+};
+
+const PERIOD_NAME: Record<ReportGranularity, string> = {
+  day: "a day",
+  week: "a week",
+  month: "a month",
+  quarter: "a quarter",
+  year: "a year",
+};
+
+function periodDays(range: DateRange): number {
+  return differenceInCalendarDays(parseISO(range.to), parseISO(range.from)) + 1;
+}
+
+export function granularityFitsPeriod(
+  granularity: ReportGranularity,
+  range: DateRange,
+): boolean {
+  return periodDays(range) >= MIN_PERIOD_DAYS[granularity];
+}
+
+function coarsestGranularity(range: DateRange): ReportGranularity {
+  return (
+    COARSEST_FIRST.find((grain) => granularityFitsPeriod(grain, range)) ?? "day"
+  );
+}
+
+export function clampGranularity(
+  granularity: ReportGranularity,
+  range: DateRange,
+): ReportGranularity {
+  return granularityFitsPeriod(granularity, range)
+    ? granularity
+    : coarsestGranularity(range);
+}
+
+export function periodTooShortReason(
+  granularity: ReportGranularity,
+  range: DateRange,
+): string | null {
+  if (granularityFitsPeriod(granularity, range)) return null;
+  return `A ${SPLIT_NAME[granularity]} split needs a period of at least ${PERIOD_NAME[granularity]} — pick ${SPLIT_NAME[coarsestGranularity(range)]} or finer`;
+}

--- a/src/frontend/src/lib/reports/reports.test.ts
+++ b/src/frontend/src/lib/reports/reports.test.ts
@@ -232,6 +232,35 @@ describe("buildReportTable", () => {
     ]);
   });
 
+  it("reads a weekly value into the week the server bucketed it by", () => {
+    const table = buildReportTable({
+      people: [person()],
+      metrics: [{ metric_key: "git.commits", label: "Commits" }],
+      results: new Map([
+        [
+          "git.commits",
+          seriesResult("git.commits", "p1", [
+            ["2026-07-20", 3],
+            ["2026-07-27", 2],
+            ["2026-08-03", 1],
+            ["2026-08-10", 4],
+            ["2026-08-17", 2],
+          ]),
+        ],
+      ]),
+      range: { from: "2026-07-24", to: "2026-08-23" },
+      granularity: "week",
+    });
+
+    expect(table.rows.map((row) => row.slice(-4))).toEqual([
+      ["2026-07-20", "2026-07-24", "2026-07-26", 3],
+      ["2026-07-27", "2026-07-27", "2026-08-02", 2],
+      ["2026-08-03", "2026-08-03", "2026-08-09", 1],
+      ["2026-08-10", "2026-08-10", "2026-08-16", 4],
+      ["2026-08-17", "2026-08-17", "2026-08-23", 2],
+    ]);
+  });
+
   it("omits person columns absent from the selected roster", () => {
     const table = buildReportTable({
       people: [
@@ -409,6 +438,12 @@ describe("bucketSpan", () => {
       to: "2026-06-01",
     });
   });
+
+  it("clips a week that opened before the period", () => {
+    expect(
+      bucketSpan("2026-07-20", "week", { from: "2026-07-24", to: "2026-08-23" }),
+    ).toEqual({ from: "2026-07-24", to: "2026-07-26" });
+  });
 });
 
 describe("unavailableReason", () => {
@@ -530,6 +565,26 @@ describe("bucketsInRange", () => {
       "2026-05-11",
       "2026-05-18",
       "2026-05-25",
+    ]);
+  });
+
+  it("starts every week on the Monday the server bucketed it by", () => {
+    expect(bucketsInRange("2026-07-24", "2026-08-23", "week")).toEqual([
+      "2026-07-20",
+      "2026-07-27",
+      "2026-08-03",
+      "2026-08-10",
+      "2026-08-17",
+    ]);
+  });
+
+  it("takes the week containing the last day, and no week beyond it", () => {
+    expect(bucketsInRange("2026-08-16", "2026-08-16", "week")).toEqual([
+      "2026-08-10",
+    ]);
+    expect(bucketsInRange("2026-08-16", "2026-08-17", "week")).toEqual([
+      "2026-08-10",
+      "2026-08-17",
     ]);
   });
 

--- a/src/frontend/src/lib/reports/reports.test.ts
+++ b/src/frontend/src/lib/reports/reports.test.ts
@@ -7,6 +7,11 @@ import {
   planRequests,
 } from "@/lib/reports/batching";
 import { unavailableReason } from "@/lib/reports/availability";
+import {
+  clampGranularity,
+  granularityFitsPeriod,
+  periodTooShortReason,
+} from "@/lib/reports/granularity-for-period";
 import { byFamily } from "@/lib/reports/families";
 import { buildReportTable } from "@/lib/reports/report-table";
 import {
@@ -595,5 +600,57 @@ describe("bucketsInRange", () => {
       "2026-02",
       "2026-03",
     ]);
+  });
+});
+
+describe("granularityFitsPeriod", () => {
+  const week = { from: "2026-08-17", to: "2026-08-23" };
+  const month = { from: "2026-07-24", to: "2026-08-23" };
+  const quarter = { from: "2026-05-24", to: "2026-08-23" };
+  const year = { from: "2025-08-24", to: "2026-08-23" };
+
+  it("offers a week the grains a week can be split into", () => {
+    expect(granularityFitsPeriod("day", week)).toBe(true);
+    expect(granularityFitsPeriod("week", week)).toBe(true);
+    expect(granularityFitsPeriod("month", week)).toBe(false);
+    expect(granularityFitsPeriod("quarter", week)).toBe(false);
+    expect(granularityFitsPeriod("year", week)).toBe(false);
+  });
+
+  it("admits a grain once the period is at least that long", () => {
+    expect(granularityFitsPeriod("month", month)).toBe(true);
+    expect(granularityFitsPeriod("quarter", month)).toBe(false);
+
+    expect(granularityFitsPeriod("quarter", quarter)).toBe(true);
+    expect(granularityFitsPeriod("year", quarter)).toBe(false);
+
+    expect(granularityFitsPeriod("year", year)).toBe(true);
+  });
+
+  it("measures the shortest calendar span a grain can occupy", () => {
+    expect(granularityFitsPeriod("month", { from: "2026-02-24", to: "2026-03-23" })).toBe(true);
+    expect(granularityFitsPeriod("quarter", { from: "2026-12-24", to: "2027-03-23" })).toBe(true);
+    expect(granularityFitsPeriod("quarter", { from: "2026-06-24", to: "2026-09-19" })).toBe(false);
+  });
+
+  it("states why a grain is refused, and names the grain to pick instead", () => {
+    expect(periodTooShortReason("day", month)).toBeNull();
+    expect(periodTooShortReason("quarter", month)).toBe(
+      "A quarterly split needs a period of at least a quarter — pick monthly or finer",
+    );
+    expect(periodTooShortReason("year", week)).toBe(
+      "A yearly split needs a period of at least a year — pick weekly or finer",
+    );
+  });
+});
+
+describe("clampGranularity", () => {
+  it("leaves a grain the period can carry alone", () => {
+    expect(clampGranularity("week", { from: "2026-07-24", to: "2026-08-23" })).toBe("week");
+  });
+
+  it("falls back to the coarsest grain the period can carry", () => {
+    expect(clampGranularity("year", { from: "2026-07-24", to: "2026-08-23" })).toBe("month");
+    expect(clampGranularity("quarter", { from: "2026-08-17", to: "2026-08-23" })).toBe("week");
   });
 });

--- a/src/frontend/src/lib/reports/rollup.ts
+++ b/src/frontend/src/lib/reports/rollup.ts
@@ -64,6 +64,14 @@ export function rollUp(
 
 const STEP_DAYS: Partial<Record<ReportGranularity, number>> = { day: 1, week: 7 };
 
+// INVARIANT: must agree with the server's `toStartOfWeek(date, 1)` — cells are
+// keyed by the `bucket_start` it returns.
+function mondayOf(date: Date): Date {
+  const monday = new Date(date);
+  monday.setUTCDate(monday.getUTCDate() - ((monday.getUTCDay() + 6) % 7));
+  return monday;
+}
+
 /** Every bucket the period covers, so a gap renders as an empty cell in place. */
 export function bucketsInRange(
   from: string,
@@ -73,8 +81,9 @@ export function bucketsInRange(
   const labels: string[] = [];
   const step = STEP_DAYS[granularity];
   if (step) {
+    const start = new Date(`${from}T00:00:00Z`);
     for (
-      let d = new Date(`${from}T00:00:00Z`);
+      let d = granularity === "week" ? mondayOf(start) : start;
       d <= new Date(`${to}T00:00:00Z`);
       d.setUTCDate(d.getUTCDate() + step)
     ) {


### PR DESCRIPTION
Closes #2794.

**Why.** A weekly report over any period not beginning on a Monday reported no value in any cell — every row present, every figure `—` in the preview and empty in the CSV.

**What changed.** Week buckets now start on the Monday the server keys them to, `toStartOfWeek(date, 1)`. Separately, a grain coarser than the period is disabled with the requirement stated on the control, and a period change clamps a held grain that no longer fits.

**The granularity gate ships here — the same defect's other half.** A month split quarterly gave one bucket of whole-period figures under a heading reading as a quarter. Reversible: drop the one `clampGranularity` call.

A fixture month period built weekly carried a value in 0 of its 5 week rows before, 5 of 5 after.

**Out of scope.** Year × Daily still offers no export control; tracked separately.

**Verified.** `npm test` (2047), `npx tsc -b`, `npm run lint` clean locally; each change's tests failed before it. No browser check, so the disabled control has no screenshot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Report granularity options now adapt to the selected date range.
  - Unsupported granularities are disabled with guidance explaining how to choose a compatible period.
  - Short reporting periods automatically use an appropriate fallback granularity.

- **Bug Fixes**
  - Weekly reports now align consistently to Monday-based calendar weeks, including partial weeks.
  - Improved handling of quarterly and yearly granularity restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->