### PR TITLE
Open the people behind a distribution band and a busiest tenth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -597,3 +597,6 @@ coverage.md
 # playwright-cli session output: snapshots, console logs and screenshots from
 # driving the UI against a stand.
 .playwright-cli/
+
+# pnpm's local content-addressable store, when configured beside the repo
+.pnpm-store/

--- a/src/frontend/eslint.config.js
+++ b/src/frontend/eslint.config.js
@@ -81,6 +81,7 @@ export default defineConfig([
   {
     // TanStack Virtual returns functions the React Compiler will not memoize.
     files: [
+      "src/components/metric-evidence-people.tsx",
       "src/components/metric-evidence-table.tsx",
       "src/components/portal/usage-table.tsx",
     ],

--- a/src/frontend/src/components/metric-evidence-context.ts
+++ b/src/frontend/src/components/metric-evidence-context.ts
@@ -7,11 +7,44 @@ export interface EvidenceDialogTarget {
   label: string;
 }
 
-export interface EvidenceDialogState {
-  targets: readonly [EvidenceDialogTarget, ...EvidenceDialogTarget[]];
-  activeMetricKey: string;
-  title?: string;
+/** One person behind an aggregate figure, and the records of their own value. */
+export interface EvidencePersonRow {
+  /** Entity id the metric is keyed by — also the row's identity. */
+  entityId: string;
+  /** Person id the Person zone is routed by; absent if the roster has none. */
+  personId: string | null;
+  name: string;
+  value: number;
+  valueText: string;
+  /** Null when the metric carries no readable evidence: the row does not drill. */
+  target: EvidenceDialogTarget | null;
 }
+
+/**
+ * The people a figure was taken over — the drill step between an aggregate and
+ * source records. Rows come from values the caller already holds, so this view
+ * needs no request and always agrees with the figure that opened it.
+ */
+export interface EvidencePeopleView {
+  /** Names the subset, e.g. "Commits · 100–150 commits per person". */
+  title: string;
+  /** The metric the figure came from — the key usage events are counted under. */
+  metricKey: string;
+  /** Column head over the values, e.g. "Commits". */
+  valueLabel: string;
+  rows: readonly EvidencePersonRow[];
+  /** Every row's records at once; null when the set is too wide to read. */
+  allRecords: EvidenceDialogTarget | null;
+}
+
+export type EvidenceDialogState =
+  | {
+      kind: "records";
+      targets: readonly [EvidenceDialogTarget, ...EvidenceDialogTarget[]];
+      activeMetricKey: string;
+      title?: string;
+    }
+  | { kind: "people"; view: EvidencePeopleView };
 
 export interface EvidenceDialogOptions {
   title?: string;
@@ -24,6 +57,8 @@ export interface EvidenceDialogContextValue {
     targets: readonly EvidenceDialogTarget[],
     options?: EvidenceDialogOptions
   ) => void;
+  /** The people behind an aggregate figure, one drill step above their records. */
+  openEvidencePeople: (view: EvidencePeopleView) => void;
 }
 
 /**

--- a/src/frontend/src/components/metric-evidence-dialog-provider.test.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog-provider.test.tsx
@@ -36,18 +36,28 @@ vi.mock("@/components/metric-evidence-dialog", () => ({
     onMetricChange,
     onClose,
   }: {
-    state: {
-      activeMetricKey: string;
-      targets: Array<{ selection: { metric_key: string } }>;
-      title?: string;
-    } | null;
+    state:
+      | {
+          kind: "records";
+          activeMetricKey: string;
+          targets: Array<{ selection: { metric_key: string } }>;
+          title?: string;
+        }
+      | { kind: "people"; view: { title: string; rows: unknown[] } }
+      | null;
     onMetricChange: (key: string) => void;
     onClose: () => void;
   }) => (
     <div>
-      <span>{state?.activeMetricKey ?? "closed"}</span>
-      <span>{state?.targets.length ?? 0}</span>
-      <span>{state?.title}</span>
+      <span>
+        {state == null
+          ? "closed"
+          : state.kind === "people"
+            ? `people:${state.view.title}`
+            : state.activeMetricKey}
+      </span>
+      <span>{state?.kind === "records" ? state.targets.length : 0}</span>
+      <span>{state?.kind === "records" ? state.title : undefined}</span>
       <button type="button" onClick={() => onMetricChange("wiki.pages")}>
         select wiki
       </button>
@@ -120,6 +130,43 @@ function Controls() {
       >
         open on a stranger
       </button>
+      <button
+        type="button"
+        onClick={() =>
+          evidence.openEvidencePeople({
+            title: "Commits · 0–50 commits per person",
+            metricKey: "git.commits",
+            valueLabel: "Commits",
+            rows: [
+              {
+                entityId: "person-a",
+                personId: "person-a",
+                name: "Ada Lovelace",
+                value: 12,
+                valueText: "12",
+                target: { selection: git, label: "Commits · Ada Lovelace" },
+              },
+            ],
+            allRecords: { selection: git, label: "Commits · all records" },
+          })
+        }
+      >
+        open people
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          evidence.openEvidencePeople({
+            title: "Commits · nobody",
+            metricKey: "git.commits",
+            valueLabel: "Commits",
+            rows: [],
+            allRecords: null,
+          })
+        }
+      >
+        open nobody
+      </button>
     </>
   );
 }
@@ -182,6 +229,33 @@ describe("MetricEvidenceDialogProvider", () => {
     expect(mocks.removeQueries).toHaveBeenCalledWith({
       queryKey: ["metric-drilldown"],
     });
+  });
+
+  it("opens the people behind a figure, and never an empty list", async () => {
+    const user = userEvent.setup();
+    render(
+      <MetricEvidenceDialogProvider>
+        <Controls />
+      </MetricEvidenceDialogProvider>
+    );
+
+    await user.click(screen.getByRole("button", { name: "open nobody" }));
+    // A dialog with nothing in it answers nothing.
+    expect(screen.getByText("closed")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "open people" }));
+    expect(
+      screen.getByText("people:Commits · 0–50 commits per person")
+    ).toBeInTheDocument();
+
+    // A metric switch belongs to the records body; it must not disturb a list.
+    await user.click(screen.getByRole("button", { name: "select wiki" }));
+    expect(
+      screen.getByText("people:Commits · 0–50 commits per person")
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "close" }));
+    expect(screen.getByText("closed")).toBeInTheDocument();
   });
 
   it("opens on the metric the caller asked for, not the first one", async () => {

--- a/src/frontend/src/components/metric-evidence-dialog-provider.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog-provider.tsx
@@ -14,6 +14,8 @@ import {
   EvidenceDialogContext,
   type EvidenceDialogOptions,
   type EvidenceDialogState,
+  type EvidenceDialogTarget,
+  type EvidencePeopleView,
 } from "@/components/metric-evidence-context";
 import { MetricEvidenceDialog } from "@/components/metric-evidence-dialog";
 import { recordUsageEvent } from "@/telemetry";
@@ -42,7 +44,7 @@ export function MetricEvidenceDialogProvider({
   }, [queryClient, sessionScope]);
   const openEvidenceTargets = useCallback(
     (
-      targets: readonly EvidenceDialogState["targets"][number][],
+      targets: readonly EvidenceDialogTarget[],
       options?: EvidenceDialogOptions
     ) => {
       const uniqueTargets = [
@@ -60,6 +62,7 @@ export function MetricEvidenceDialogProvider({
         : first.selection.metric_key;
       recordUsageEvent("drill", active);
       setState({
+        kind: "records",
         targets: [first, ...uniqueTargets.slice(1)],
         activeMetricKey: active,
         title: options?.title,
@@ -70,23 +73,33 @@ export function MetricEvidenceDialogProvider({
   );
   const openEvidence = useCallback(
     (
-      selection: EvidenceDialogState["targets"][number]["selection"],
+      selection: EvidenceDialogTarget["selection"],
       label: string
     ) => openEvidenceTargets([{ selection, label }]),
     [openEvidenceTargets]
   );
+  const openEvidencePeople = useCallback(
+    (view: EvidencePeopleView) => {
+      if (!view.rows.length) return;
+      // Same usage event as a records drill: it counts a reader going one step
+      // down from a figure, and under the same metric key, so the series stays
+      // comparable whether or not the metric can be drilled to records.
+      recordUsageEvent("drill", view.metricKey);
+      setState({ kind: "people", view, sessionScope });
+    },
+    [sessionScope]
+  );
   const selectEvidenceMetric = useCallback((metricKey: string) => {
     setState((current) =>
-      current?.targets.some(
-        (target) => target.selection.metric_key === metricKey
-      )
+      current?.kind === "records" &&
+      current.targets.some((target) => target.selection.metric_key === metricKey)
         ? { ...current, activeMetricKey: metricKey }
         : current
     );
   }, []);
   const value = useMemo(
-    () => ({ openEvidence, openEvidenceTargets }),
-    [openEvidence, openEvidenceTargets]
+    () => ({ openEvidence, openEvidenceTargets, openEvidencePeople }),
+    [openEvidence, openEvidenceTargets, openEvidencePeople]
   );
   const visibleState = state?.sessionScope === sessionScope ? state : null;
   return (

--- a/src/frontend/src/components/metric-evidence-dialog.test.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog.test.tsx
@@ -54,6 +54,20 @@ vi.mock("@/api/metric-drilldown-client", async (importOriginal) => {
   };
 });
 
+// The people body virtualizes like the record table does; jsdom measures no
+// viewport, so without this every row would be scrolled out of existence.
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({
+        index,
+        start: index * 44,
+      })),
+    getTotalSize: () => count * 44,
+    measureElement: vi.fn(),
+  }),
+}));
+
 vi.mock("@/components/metric-evidence-table", () => ({
   MetricEvidenceTable: (props: Record<string, unknown>) => {
     mocks.tableProps = props;
@@ -84,6 +98,11 @@ vi.mock("@/components/ui/dialog", () => ({
   ),
   DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
 }));
+
+vi.mock("@tanstack/react-router", async () => {
+  const { portalRouterMock } = await import("@/test/portal-router");
+  return portalRouterMock();
+});
 
 vi.mock("@/components/ui/dropdown-menu", () => ({
   DropdownMenu: ({ children }: { children: ReactNode }) => (
@@ -144,7 +163,10 @@ const selection = {
   display_dimensions: [],
 };
 
+type RecordsState = Extract<EvidenceDialogState, { kind: "records" }>;
+
 const state: EvidenceDialogState = {
+  kind: "records",
   targets: [{ selection, label: "Commits" }],
   activeMetricKey: "git.commits",
 };
@@ -356,6 +378,7 @@ describe("MetricEvidenceDialog", () => {
     render(
       <MetricEvidenceDialog
         state={{
+          kind: "records",
           targets: [{ selection: taskSelection, label: "Issues closed" }],
           activeMetricKey: "tasks.closed",
         }}
@@ -391,7 +414,8 @@ describe("MetricEvidenceDialog", () => {
       render(
         <MetricEvidenceDialog
           state={{
-            targets: [...twoTargets] as EvidenceDialogState["targets"],
+            kind: "records",
+            targets: [...twoTargets] as RecordsState["targets"],
             activeMetricKey: "git.commits",
             title: "Commits & Wiki pages",
           }}
@@ -404,11 +428,32 @@ describe("MetricEvidenceDialog", () => {
       ).toBeInTheDocument();
     });
 
+    it("keeps the caller's name with a single target — it says which subset", () => {
+      render(
+        <MetricEvidenceDialog
+          state={{
+            kind: "records",
+            targets: [twoTargets[0]] as unknown as RecordsState["targets"],
+            activeMetricKey: "git.commits",
+            title: "Commits · 100–150 commits per person",
+          }}
+          onMetricChange={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+      expect(
+        screen.getByRole("heading", {
+          name: "Commits · 100–150 commits per person",
+        })
+      ).toBeInTheDocument();
+    });
+
     it("otherwise names the metric on screen, never a placeholder", () => {
       render(
         <MetricEvidenceDialog
           state={{
-            targets: [...twoTargets] as EvidenceDialogState["targets"],
+            kind: "records",
+            targets: [...twoTargets] as RecordsState["targets"],
             activeMetricKey: "wiki.pages",
           }}
           onMetricChange={vi.fn()}
@@ -424,10 +469,334 @@ describe("MetricEvidenceDialog", () => {
     });
   });
 
+
+  describe("the people behind a figure", () => {
+    const peopleView = {
+      title: "Commits · 100–150 commits per person",
+      metricKey: "git.commits",
+      valueLabel: "Commits",
+      rows: [
+        {
+          entityId: "e1",
+          personId: "p1",
+          name: "Ada Lovelace",
+          value: 142,
+          valueText: "142",
+          target: {
+            selection: {
+              ...selection,
+              entity: { type: "person" as const, id: "e1" },
+            },
+            label: "Commits · Ada Lovelace",
+          },
+        },
+        {
+          entityId: "e2",
+          personId: null,
+          name: "Grace Hopper",
+          value: 131,
+          valueText: "131",
+          target: null,
+        },
+      ],
+      allRecords: {
+        selection: {
+          ...selection,
+          entity: { type: "persons" as const, ids: ["e1", "e2"] },
+        },
+        label: "Commits · 100–150 commits per person",
+      },
+    };
+    const peopleState: EvidenceDialogState = {
+      kind: "people",
+      view: peopleView,
+    };
+
+    it("names who is behind the figure and what each of them did", () => {
+      render(
+        <MetricEvidenceDialog
+          state={peopleState}
+          onMetricChange={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+
+      expect(
+        screen.getByRole("heading", {
+          name: "Commits · 100–150 commits per person",
+        })
+      ).toBeInTheDocument();
+      expect(screen.getByText("2 people")).toBeInTheDocument();
+      expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+      expect(screen.getByText("142")).toBeInTheDocument();
+      // Same table furniture as the records it drills into: a head over the
+      // values, so the number is named rather than floating.
+      expect(
+        screen.getByRole("columnheader", { name: "Commits" })
+      ).toBeInTheDocument();
+      // A list computed from values this session already had is not a server
+      // read, so there is nothing for the export endpoint to produce.
+      expect(
+        screen.queryByRole("button", { name: /export/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("asks for nothing until a row is opened", () => {
+      render(
+        <MetricEvidenceDialog
+          state={peopleState}
+          onMetricChange={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+
+      expect(mocks.queryOptions?.enabled).toBe(false);
+    });
+
+    it("narrows the list by name", async () => {
+      const user = userEvent.setup();
+      render(
+        <MetricEvidenceDialog
+          state={peopleState}
+          onMetricChange={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+
+      await user.type(
+        screen.getByRole("searchbox", { name: "Search people" }),
+        "grace"
+      );
+
+      expect(screen.getByText("1 of 2 people")).toBeInTheDocument();
+      expect(screen.queryByText("Ada Lovelace")).not.toBeInTheDocument();
+    });
+
+    it("takes a row into that person's records, and comes back to the list", async () => {
+      const user = userEvent.setup();
+      render(
+        <MetricEvidenceDialog
+          state={peopleState}
+          onMetricChange={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+
+      await user.click(screen.getByRole("button", { name: /Ada Lovelace/ }));
+
+      expect(
+        screen.getByRole("heading", { name: "Commits · Ada Lovelace" })
+      ).toBeInTheDocument();
+      const key = mocks.queryOptions?.queryKey as unknown[] | undefined;
+      expect((key?.[2] as { entity?: unknown } | undefined)?.entity).toEqual({
+        type: "person",
+        id: "e1",
+      });
+      // The way out of a person's records, for a reader who wants the rest of
+      // what is known about them.
+      expect(
+        screen.getByRole("link", { name: /Person page/ })
+      ).toBeInTheDocument();
+
+      await user.click(
+        screen.getByRole("button", {
+          name: /Commits · 100–150 commits per person/,
+        })
+      );
+
+      expect(screen.getByText("Ada Lovelace")).toBeInTheDocument();
+      expect(screen.getByText("2 people")).toBeInTheDocument();
+    });
+
+    it("keeps a row without evidence unopenable rather than opening nothing", () => {
+      render(
+        <MetricEvidenceDialog
+          state={peopleState}
+          onMetricChange={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+
+      expect(screen.getByText("Grace Hopper")).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: /Grace Hopper/ })
+      ).not.toBeInTheDocument();
+    });
+
+    it("keeps the way back named, and takes focus with the view", async () => {
+      const user = userEvent.setup();
+      render(
+        <MetricEvidenceDialog
+          state={peopleState}
+          onMetricChange={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: "Open records for Ada Lovelace" })
+      );
+
+      // The control that was clicked is gone: focus has to land somewhere that
+      // says where the reader now is.
+      expect(document.activeElement?.textContent).toBe(
+        "Commits · Ada Lovelace"
+      );
+      expect(
+        screen.getByRole("button", {
+          name: "Back to Commits · 100–150 commits per person",
+        })
+      ).toBeInTheDocument();
+    });
+
+    it("leaves an export failure behind with the table it belongs to", async () => {
+      const user = userEvent.setup();
+      mocks.downloadMetricDrilldown.mockRejectedValue(
+        new AnalyticsApiError(500, { detail: "Export failed" })
+      );
+      render(
+        <MetricEvidenceDialog
+          state={peopleState}
+          onMetricChange={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: "Open records for Ada Lovelace" })
+      );
+      await user.click(screen.getByRole("button", { name: /CSV/ }));
+      await waitFor(() =>
+        expect(screen.getByRole("alert")).toBeInTheDocument()
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: /^Back to/ })
+      );
+
+      // A failure reported under a body that has no export control at all, and
+      // then over the NEXT person's table, is a lie about both.
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("offers no person page for a table that is not one person's", async () => {
+      const user = userEvent.setup();
+      render(
+        <MetricEvidenceDialog
+          state={peopleState}
+          onMetricChange={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+
+      await user.click(screen.getByRole("button", { name: "All records" }));
+
+      expect(
+        screen.queryByRole("link", { name: /Person page/ })
+      ).not.toBeInTheDocument();
+    });
+
+    it("closes on the way to the person's own page", async () => {
+      const user = userEvent.setup();
+      const onClose = vi.fn();
+      render(
+        <MetricEvidenceDialog
+          state={peopleState}
+          onMetricChange={vi.fn()}
+          onClose={onClose}
+        />
+      );
+
+      await user.click(
+        screen.getByRole("button", { name: "Open records for Ada Lovelace" })
+      );
+      await user.click(screen.getByRole("link", { name: /Person page/ }));
+
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it("says so when a search matches nobody", async () => {
+      const user = userEvent.setup();
+      render(
+        <MetricEvidenceDialog
+          state={peopleState}
+          onMetricChange={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+
+      await user.type(
+        screen.getByRole("searchbox", { name: "Search people" }),
+        "nobody"
+      );
+      expect(
+        screen.getByText("No people match this search")
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Clear search" }));
+      expect(screen.getByText("2 people")).toBeInTheDocument();
+    });
+
+    it("carries no drill or search into the next figure", async () => {
+      const user = userEvent.setup();
+      const view = render(
+        <MetricEvidenceDialog
+          state={peopleState}
+          onMetricChange={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+
+      await user.type(
+        screen.getByRole("searchbox", { name: "Search people" }),
+        "ada"
+      );
+      await user.click(
+        screen.getByRole("button", { name: "Open records for Ada Lovelace" })
+      );
+
+      view.rerender(
+        <MetricEvidenceDialog
+          state={{
+            kind: "people",
+            view: { ...peopleView, title: "Commits · busiest 2 of 9" },
+          }}
+          onMetricChange={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+
+      expect(
+        screen.getByRole("heading", { name: "Commits · busiest 2 of 9" })
+      ).toBeInTheDocument();
+      expect(screen.getByText("2 people")).toBeInTheDocument();
+    });
+
+    it("opens every row's records at once when asked for all of them", async () => {
+      const user = userEvent.setup();
+      render(
+        <MetricEvidenceDialog
+          state={peopleState}
+          onMetricChange={vi.fn()}
+          onClose={vi.fn()}
+        />
+      );
+
+      await user.click(screen.getByRole("button", { name: "All records" }));
+
+      const key = mocks.queryOptions?.queryKey as unknown[] | undefined;
+      expect((key?.[2] as { entity?: unknown } | undefined)?.entity).toEqual({
+        type: "persons",
+        ids: ["e1", "e2"],
+      });
+    });
+  });
+
   it("switches targets and reports export failures", async () => {
     const user = userEvent.setup();
     const onMetricChange = vi.fn();
     const multiState: EvidenceDialogState = {
+      kind: "records",
       targets: [
         { selection, label: "Commits" },
         {
@@ -642,6 +1011,7 @@ describe("MetricEvidenceDialog", () => {
     it("drops the search and sort when the dialog moves to another metric", async () => {
       const user = userEvent.setup();
       const multiState: EvidenceDialogState = {
+        kind: "records",
         targets: [
           { selection, label: "Commits" },
           {

--- a/src/frontend/src/components/metric-evidence-dialog.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog.tsx
@@ -1,6 +1,14 @@
 import { useInfiniteQuery } from "@tanstack/react-query";
+import { Link } from "@tanstack/react-router";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Download, FileSpreadsheet, FileText, Search } from "lucide-react";
+import {
+  ArrowLeft,
+  ArrowUpRight,
+  Download,
+  FileSpreadsheet,
+  FileText,
+  Search,
+} from "lucide-react";
 
 import {
   downloadMetricDrilldown,
@@ -9,7 +17,11 @@ import {
 import { AnalyticsApiError } from "@/api/analytics-client";
 import { sessionAuthorizationScope } from "@/auth/session-scope";
 import { useAuth } from "@/auth/use-auth";
-import type { EvidenceDialogState } from "@/components/metric-evidence-context";
+import type {
+  EvidenceDialogState,
+  EvidenceDialogTarget,
+} from "@/components/metric-evidence-context";
+import { MetricEvidencePeople } from "@/components/metric-evidence-people";
 import { MetricEvidenceTable } from "@/components/metric-evidence-table";
 import {
   SOURCE_DIMENSION,
@@ -46,6 +58,12 @@ import {
   type EvidenceSort,
 } from "@/lib/metrics/evidence-rows";
 
+/** A records read taken out of a people list, and whose records they are. */
+interface DrillStep {
+  target: EvidenceDialogTarget;
+  personId: string | null;
+}
+
 export function MetricEvidenceDialog({
   state,
   onMetricChange,
@@ -60,12 +78,32 @@ export function MetricEvidenceDialog({
   const exportController = useRef<AbortController | null>(null);
   const [exporting, setExporting] = useState(false);
   const [exportFailure, setExportFailure] = useState<string | null>(null);
-  const activeTarget =
-    state?.targets.find(
-      (target) => target.selection.metric_key === state.activeMetricKey
-    ) ??
-    state?.targets[0] ??
-    null;
+  const records = state?.kind === "records" ? state : null;
+  const people = state?.kind === "people" ? state.view : null;
+  /** The records step taken out of a people list, and whose they are. */
+  const [drilled, setDrilled] = useState<DrillStep | null>(null);
+  const [peopleSearch, setPeopleSearch] = useState("");
+  // A new opening is a new question: the step out of the previous list, and the
+  // search that narrowed it, must not survive into it.
+  const [openedState, setOpenedState] = useState(state);
+  if (openedState !== state) {
+    setOpenedState(state);
+    setDrilled(null);
+    setPeopleSearch("");
+  }
+  const activeTarget = people
+    ? drilled?.target ?? null
+    : records?.targets.find(
+        (target) => target.selection.metric_key === records.activeMetricKey
+      ) ??
+      records?.targets[0] ??
+      null;
+  /** The list itself is on screen only until a row is taken further. */
+  const showPeople = people != null && drilled == null;
+  const allRecords = people?.allRecords ?? null;
+  const headerTitle = drilled
+    ? drilled.target.label
+    : (people?.title ?? records?.title ?? activeTarget?.label ?? "");
   // INVARIANT: the catalog decides which dimensions may be asked for, so the
   // read waits for it — resolving later would change the selection mid-dialog
   // and refetch every row.
@@ -139,6 +177,14 @@ export function MetricEvidenceDialog({
     setSort(null);
   }
 
+  const visiblePeople = useMemo(() => {
+    const needle = peopleSearch.trim().toLowerCase();
+    const rows = people?.rows ?? [];
+    return needle === ""
+      ? rows
+      : rows.filter((row) => row.name.toLowerCase().includes(needle));
+  }, [people, peopleSearch]);
+
   const narrowed = search.trim() !== "" || sort != null;
   const visibleRows = useMemo(
     () => visibleEvidenceRows({ rows, columns, search, sort }),
@@ -164,6 +210,14 @@ export function MetricEvidenceDialog({
     fetchNextPage,
   ]);
 
+  const headingRef = useRef<HTMLSpanElement>(null);
+  const focusedStep = useRef(drilled);
+  useEffect(() => {
+    if (focusedStep.current === drilled) return;
+    focusedStep.current = drilled;
+    headingRef.current?.focus();
+  }, [drilled]);
+
   useEffect(
     () => () => {
       exportController.current?.abort();
@@ -171,12 +225,28 @@ export function MetricEvidenceDialog({
     []
   );
 
-  function closeDialog(): void {
+  /** Whatever the export controls were doing belongs to the table being left. */
+  function resetExport(): void {
     exportController.current?.abort();
     exportController.current = null;
     setExporting(false);
     setExportFailure(null);
+  }
+
+  function closeDialog(): void {
+    resetExport();
     onClose();
+  }
+
+  /**
+   * Move between the people list and one row's records. An export left running
+   * over the table being left would resolve onto the next one — a file for a
+   * person the reader is no longer looking at, or an error under a body that
+   * has no export control at all.
+   */
+  function goToStep(step: DrillStep | null): void {
+    resetExport();
+    setDrilled(step);
   }
 
   async function exportRows(format: "csv" | "xlsx") {
@@ -213,24 +283,36 @@ export function MetricEvidenceDialog({
       open={state != null}
       onOpenChange={(open) => !open && closeDialog()}
     >
-      {state && activeTarget ? (
+      {state && (activeTarget || showPeople) ? (
         <DialogContent className="flex h-[calc(100dvh-2rem)] max-h-[52rem] w-[calc(100vw-2rem)] max-w-none flex-col gap-0 overflow-hidden p-0 sm:h-[calc(100dvh-4rem)] sm:w-[calc(100vw-4rem)] sm:max-w-[90rem] [&_[data-slot=dialog-close]]:top-5">
           <DialogHeader className="shrink-0 border-b p-5 pr-14">
+            {people && drilled ? (
+              <div className="flex">
+                <button
+                  type="button"
+                  onClick={() => goToStep(null)}
+                  aria-label={`Back to ${people.title}`}
+                  className="-ms-1 flex cursor-pointer items-center gap-1 rounded-sm px-1 text-xs text-muted-foreground hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+                >
+                  <ArrowLeft className="size-3.5" aria-hidden />
+                  {people.title}
+                </button>
+              </div>
+            ) : null}
             <div className="flex items-center justify-between gap-4">
-              {state.targets.length > 1 ? (
+              {records && records.targets.length > 1 && activeTarget ? (
                 <>
                   {/* INVARIANT: the dialog is named for what it shows — a
                       caller that names the whole set wins, otherwise the
                       metric on screen. */}
                   <DialogTitle className="sr-only">
-                    {state.title ?? activeTarget.label}
+                    {records.title ?? activeTarget.label}
                   </DialogTitle>
                   <Select
                     value={activeTarget.selection.metric_key}
                     onValueChange={(metricKey) => {
                       if (!metricKey) return;
-                      exportController.current?.abort();
-                      setExportFailure(null);
+                      resetExport();
                       onMetricChange(metricKey);
                     }}
                   >
@@ -242,7 +324,7 @@ export function MetricEvidenceDialog({
                       <SelectValue>{activeTarget.label}</SelectValue>
                     </SelectTrigger>
                     <SelectContent align="start">
-                      {state.targets.map((target) => (
+                      {records.targets.map((target) => (
                         <SelectItem
                           key={target.selection.metric_key}
                           value={target.selection.metric_key}
@@ -254,8 +336,35 @@ export function MetricEvidenceDialog({
                   </Select>
                 </>
               ) : (
-                <DialogTitle>{activeTarget.label}</DialogTitle>
+                // Same invariant with one target: a caller that scoped the
+                // table to a subset of people named it, and the metric label
+                // alone would read as every record of that metric.
+                <DialogTitle>
+                  {/* Focus lands here on a body swap: the control that was
+                      clicked is gone, and the new heading is what says where
+                      the reader now is. */}
+                  <span ref={headingRef} tabIndex={-1} className="outline-none">
+                    {headerTitle}
+                  </span>
+                </DialogTitle>
               )}
+              <div className="flex shrink-0 items-center gap-3">
+                {/* Where the records came from, once the dialog is showing one
+                    person's — the one exit out of the drill. */}
+                {drilled?.personId ? (
+                  <Link
+                    to="/ic/$person/personal"
+                    params={{ person: drilled.personId }}
+                    onClick={closeDialog}
+                    className="flex items-center gap-1 text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+                  >
+                    Person page
+                    <ArrowUpRight className="size-3.5" aria-hidden />
+                  </Link>
+                ) : null}
+                {/* Export serves the record table; a people list is a read of
+                    values this session already had. */}
+                {showPeople ? null : (
               <DropdownMenu>
                 <DropdownMenuTrigger
                   disabled={
@@ -281,13 +390,47 @@ export function MetricEvidenceDialog({
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
+                )}
+              </div>
             </div>
             {exportFailure ? (
               <p role="alert" className="text-sm text-destructive">
                 {exportFailure}
               </p>
             ) : null}
-            {query.isPending || (query.isError && !query.data) ? null : (
+            {showPeople && people ? (
+              <div className="flex flex-wrap items-center gap-3">
+                <div className="relative min-w-0 flex-1 sm:max-w-xs">
+                  <Search className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    type="search"
+                    value={peopleSearch}
+                    onChange={(event) => setPeopleSearch(event.target.value)}
+                    placeholder="Search people"
+                    aria-label="Search people"
+                    className="h-8 ps-8"
+                  />
+                </div>
+                <p
+                  aria-live="polite"
+                  className="text-sm text-muted-foreground tabular-nums"
+                >
+                  {peopleCount(visiblePeople.length, people.rows.length)}
+                </p>
+                {allRecords ? (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="ms-auto"
+                    onClick={() =>
+                      goToStep({ target: allRecords, personId: null })
+                    }
+                  >
+                    All records
+                  </Button>
+                ) : null}
+              </div>
+            ) : query.isPending || (query.isError && !query.data) ? null : (
               <div className="flex flex-wrap items-center gap-3">
                 <div className="relative min-w-0 flex-1 sm:max-w-xs">
                   <Search className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground" />
@@ -315,7 +458,27 @@ export function MetricEvidenceDialog({
               </div>
             )}
           </DialogHeader>
-          {query.isPending ? (
+          {showPeople ? (
+            visiblePeople.length === 0 ? (
+              <div className="flex flex-1 flex-col items-center justify-center gap-3">
+                <p className="text-sm text-muted-foreground">
+                  No people match this search
+                </p>
+                <Button variant="outline" onClick={() => setPeopleSearch("")}>
+                  Clear search
+                </Button>
+              </div>
+            ) : (
+              <MetricEvidencePeople
+                rows={visiblePeople}
+                valueLabel={people.valueLabel}
+                onDrill={(row) =>
+                  row.target &&
+                  goToStep({ target: row.target, personId: row.personId })
+                }
+              />
+            )
+          ) : query.isPending ? (
             <div className="flex flex-1 items-center justify-center">
               <Spinner className="size-10" />
             </div>
@@ -410,6 +573,16 @@ function recordCount({
     ? `${formatMetricNumber(visible, "integer")} of ${formatMetricNumber(loaded, "integer")}`
     : formatMetricNumber(visible, "integer");
   return `${count} ${noun}${partial ? " so far" : ""}`;
+}
+
+/** "5 people", or "2 of 5 people" once a search has narrowed the list. */
+function peopleCount(visible: number, total: number): string {
+  const noun = visible === 1 && visible === total ? "person" : "people";
+  const count =
+    visible === total
+      ? formatMetricNumber(visible, "integer")
+      : `${formatMetricNumber(visible, "integer")} of ${formatMetricNumber(total, "integer")}`;
+  return `${count} ${noun}`;
 }
 
 function errorMessage(error: unknown, fallback: string): string {

--- a/src/frontend/src/components/metric-evidence-people.test.tsx
+++ b/src/frontend/src/components/metric-evidence-people.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import type { EvidencePersonRow } from "@/components/metric-evidence-context";
+import { MetricEvidencePeople } from "@/components/metric-evidence-people";
+
+vi.mock("@tanstack/react-virtual", () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({
+        index,
+        start: index * 44,
+      })),
+    getTotalSize: () => count * 44,
+    measureElement: vi.fn(),
+  }),
+}));
+
+const drillable: EvidencePersonRow = {
+  entityId: "e-ada",
+  personId: "p-ada",
+  name: "Ada Lovelace",
+  value: 142,
+  valueText: "142",
+  target: {
+    selection: {
+      metric_key: "git.commits",
+      entity: { type: "person", id: "e-ada" },
+      period: { from: "2026-07-01", to: "2026-07-31" },
+      filters: [],
+      display_dimensions: [],
+    },
+    label: "Commits · Ada Lovelace",
+  },
+};
+
+const unreadable: EvidencePersonRow = {
+  entityId: "e-grace",
+  personId: null,
+  name: "Grace Hopper",
+  value: 131,
+  valueText: "131",
+  target: null,
+};
+
+function draw(rows: EvidencePersonRow[] = [drillable, unreadable]) {
+  const onDrill = vi.fn();
+  render(
+    <MetricEvidencePeople rows={rows} valueLabel="Commits" onDrill={onDrill} />
+  );
+  return { onDrill };
+}
+
+describe("MetricEvidencePeople", () => {
+  it("maps rows and cells for a screen reader, despite the flex layout", () => {
+    draw();
+
+    // Two people plus the header row they sit under.
+    expect(screen.getByRole("table")).toHaveAttribute("aria-rowcount", "3");
+    expect(
+      screen.getByRole("columnheader", { name: "Person" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("columnheader", { name: "Commits" })
+    ).toBeInTheDocument();
+    // Two people plus the header row.
+    expect(screen.getAllByRole("row")).toHaveLength(3);
+    expect(screen.getAllByRole("cell", { name: "142" })).toHaveLength(1);
+  });
+
+  it("says what the opener opens, rather than repeating the name", () => {
+    draw();
+
+    expect(
+      screen.getByRole("button", { name: "Open records for Ada Lovelace" })
+    ).toBeInTheDocument();
+  });
+
+  it("opens a person from the row and from its opener, once each", async () => {
+    const user = userEvent.setup();
+    const { onDrill } = draw();
+
+    await user.click(screen.getByRole("cell", { name: "Ada Lovelace" }));
+    expect(onDrill).toHaveBeenCalledTimes(1);
+
+    // The opener must not also trigger the row it sits in.
+    await user.click(
+      screen.getByRole("button", { name: "Open records for Ada Lovelace" })
+    );
+    expect(onDrill).toHaveBeenCalledTimes(2);
+    expect(onDrill).toHaveBeenLastCalledWith(drillable);
+  });
+
+  it("leaves a person with no readable records unopenable", async () => {
+    const user = userEvent.setup();
+    const { onDrill } = draw();
+
+    expect(
+      screen.queryByRole("button", { name: /Grace Hopper/ })
+    ).not.toBeInTheDocument();
+    await user.click(screen.getByRole("cell", { name: "Grace Hopper" }));
+
+    expect(onDrill).not.toHaveBeenCalled();
+  });
+});

--- a/src/frontend/src/components/metric-evidence-people.tsx
+++ b/src/frontend/src/components/metric-evidence-people.tsx
@@ -1,0 +1,172 @@
+import { useCallback, useState } from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { ChevronRight } from "lucide-react";
+
+import type { EvidencePersonRow } from "@/components/metric-evidence-context";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+
+/** Same geometry as the record table's: values, then the rail that opens them. */
+const VALUE_REM = 10;
+const OPENER_REM = 2.25;
+const HEADER_PX = 40;
+const ROW_PX = 44;
+
+/**
+ * The people behind one figure: who they are and their own value, in the same
+ * dialog — and the same table — their records live in.
+ *
+ * Values are the ones the surface already holds, so a row never disagrees with
+ * the bar or card that opened it. A row whose metric carries no readable
+ * evidence stays a plain row: nothing to open, so nothing to click.
+ *
+ * INVARIANT: the ARIA roles are spelled out because the layout is flex, not
+ * table — without them a browser drops the row and cell mapping, and every
+ * value reads as a bare number under no column.
+ */
+export function MetricEvidencePeople({
+  rows,
+  valueLabel,
+  onDrill,
+}: {
+  rows: readonly EvidencePersonRow[];
+  valueLabel: string;
+  onDrill: (row: EvidencePersonRow) => void;
+}) {
+  const [viewport, setViewport] = useState<HTMLDivElement | null>(null);
+  const virtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => viewport,
+    estimateSize: () => ROW_PX,
+    overscan: 8,
+    getItemKey: useCallback(
+      (index: number) => rows[index]?.entityId ?? index,
+      [rows]
+    ),
+  });
+  const virtualRows = virtualizer.getVirtualItems();
+  const bodyHeight = virtualizer.getTotalSize();
+
+  return (
+    <div className="relative min-h-0 flex-1">
+      <Table
+        role="table"
+        // The header is row 1 and the data starts at 2 (see `aria-rowindex`
+        // below), so the count has to include it — otherwise the last row
+        // announces itself as one past the end.
+        aria-rowcount={rows.length + 1}
+        containerRef={setViewport}
+        containerClassName="h-full overflow-auto"
+        className="grid min-w-full"
+        style={{
+          height: bodyHeight + HEADER_PX,
+          gridTemplateRows: "2.5rem 1fr",
+        }}
+      >
+        <TableHeader
+          role="rowgroup"
+          className="sticky top-0 z-20 grid bg-card shadow-[inset_0_-1px_0_0_var(--border)] [&_tr]:border-b-0"
+        >
+          <TableRow
+            role="row"
+            className="flex w-full border-b-0 hover:bg-transparent"
+          >
+            <TableHead
+              role="columnheader"
+              className="flex h-10 min-w-0 flex-1 items-center px-3 py-0"
+            >
+              Person
+            </TableHead>
+            <TableHead
+              role="columnheader"
+              className="flex h-10 shrink-0 items-center justify-end px-3 py-0 text-right"
+              style={{ flex: `0 0 ${VALUE_REM}rem` }}
+            >
+              {valueLabel}
+            </TableHead>
+            <TableHead
+              role="columnheader"
+              className="flex h-10 shrink-0 items-center p-0"
+              style={{ flex: `0 0 ${OPENER_REM}rem` }}
+            >
+              <span className="sr-only">Open records</span>
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody
+          role="rowgroup"
+          className="relative grid"
+          style={{ height: bodyHeight }}
+        >
+          {virtualRows.map((virtualRow) => {
+            const row = rows[virtualRow.index];
+            if (!row) return null;
+            const target = row.target;
+            return (
+              <TableRow
+                role="row"
+                key={row.entityId}
+                aria-rowindex={virtualRow.index + 2}
+                // The whole row is the mouse target, as a record row is; the
+                // keyboard path is the button in the rail, which says what it
+                // opens.
+                onClick={target ? () => onDrill(row) : undefined}
+                className={cn(
+                  "absolute top-0 left-0 flex w-full",
+                  target
+                    ? "cursor-pointer hover:bg-muted/20"
+                    : "hover:bg-transparent"
+                )}
+                style={{ transform: `translateY(${virtualRow.start}px)` }}
+              >
+                <TableCell
+                  role="cell"
+                  className="h-11 min-w-0 flex-1 truncate px-3 py-3 font-medium"
+                  title={row.name}
+                >
+                  {row.name}
+                </TableCell>
+                <TableCell
+                  role="cell"
+                  className="h-11 shrink-0 px-3 py-3 text-right tabular-nums"
+                  style={{ flex: `0 0 ${VALUE_REM}rem` }}
+                >
+                  {row.valueText}
+                </TableCell>
+                <TableCell
+                  role="cell"
+                  className="flex h-11 shrink-0 items-center justify-center p-0"
+                  style={{ flex: `0 0 ${OPENER_REM}rem` }}
+                >
+                  {target ? (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-xs"
+                      aria-label={`Open records for ${row.name}`}
+                      className="text-muted-foreground"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        onDrill(row);
+                      }}
+                    >
+                      <ChevronRight aria-hidden />
+                    </Button>
+                  ) : null}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/frontend/src/components/metric-evidence-table.test.tsx
+++ b/src/frontend/src/components/metric-evidence-table.test.tsx
@@ -69,7 +69,7 @@ describe("MetricEvidenceTable", () => {
     renderTable();
 
     const table = screen.getByRole("table");
-    expect(table).toHaveAttribute("aria-rowcount", "2");
+    expect(table).toHaveAttribute("aria-rowcount", "3");
     expect(screen.getAllByRole("rowgroup")).toHaveLength(2);
     expect(screen.getAllByRole("columnheader")).toHaveLength(4);
     expect(screen.getAllByRole("row")[1]).toHaveAttribute("aria-rowindex", "2");

--- a/src/frontend/src/components/metric-evidence-table.tsx
+++ b/src/frontend/src/components/metric-evidence-table.tsx
@@ -140,7 +140,10 @@ export function MetricEvidenceTable({
     <div className="relative min-h-0 flex-1">
       <Table
         role="table"
-        aria-rowcount={rows.length}
+        // Counting the header row, which is row 1: `aria-rowindex` below starts
+        // the data at 2, so a total of `rows.length` would make the last row
+        // "n+1 of n".
+        aria-rowcount={rows.length + 1}
         containerRef={setViewport}
         containerClassName="h-full overflow-auto"
         className="grid min-w-full"

--- a/src/frontend/src/components/portal/domain-lens-view.test.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.test.tsx
@@ -227,11 +227,12 @@ describe("headline (rules 1–2: per-capita + PoP delta)", () => {
 describe("headline cards open the records behind them", () => {
   const openEvidenceTargets = vi.fn();
   const openEvidence = vi.fn();
+  const openEvidencePeople = vi.fn();
 
   function drawWithEvidence(config: LensConfig = HEADLINE_CONFIG) {
     return render(
       <EvidenceDialogContext.Provider
-        value={{ openEvidence, openEvidenceTargets }}
+        value={{ openEvidence, openEvidenceTargets, openEvidencePeople }}
       >
         <DomainLensView config={config} />
       </EvidenceDialogContext.Provider>
@@ -340,6 +341,132 @@ describe("stat-tiles (medians, never sums)", () => {
     // median of 10,20,30,40 = 25
     expect(screen.getByText("25")).toBeInTheDocument();
     expect(screen.getByText(/median \/ person/)).toBeInTheDocument();
+  });
+});
+
+describe("aggregate sections open the people behind them", () => {
+  const openEvidenceTargets = vi.fn();
+  const openEvidence = vi.fn();
+  const openEvidencePeople = vi.fn();
+
+  /** A metric with a real spread: 1, 2, 3 and 9 commits over the four members. */
+  function seedSpread({ drillable }: { drillable: boolean }) {
+    const evidence = drillable
+      ? {
+          drilldown: { granularity: ["event"] },
+          selection: {
+            metric_key: "t.commits",
+            entity: { type: "person", ids: IDS },
+            period: { from: "2026-07-20", to: "2026-07-26" },
+            filters: [],
+          },
+        }
+      : {};
+    mocks.grid.byKey = new Map([
+      [
+        "t.commits",
+        metric(
+          "t.commits",
+          [
+            [pid("a"), 1],
+            [pid("b"), 2],
+            [pid("c"), 3],
+            [pid("d"), 9],
+          ],
+          {
+            label: "Commits",
+            short_label: "Commits",
+            unit: "commits",
+            ...evidence,
+          } as Partial<NormalizedMetricResult>
+        ),
+      ],
+    ]);
+    mocks.grid.previousByKey = new Map();
+  }
+
+  function drawWithEvidence(config: LensConfig) {
+    return render(
+      <EvidenceDialogContext.Provider
+        value={{ openEvidence, openEvidenceTargets, openEvidencePeople }}
+      >
+        <DomainLensView config={config} />
+      </EvidenceDialogContext.Provider>
+    );
+  }
+
+  const SPREAD_CONFIG: LensConfig = {
+    title: "T",
+    sections: [
+      {
+        kind: "distribution",
+        metric: "t.commits",
+        title: "Spread",
+        caption: "spread",
+        unitLabel: "commits per person",
+      },
+    ],
+  };
+
+  const CONCENTRATION_CONFIG: LensConfig = {
+    title: "T",
+    sections: [
+      { kind: "concentration", metrics: ["t.commits"], framing: "bus-factor" },
+    ],
+  };
+
+  it("opens a band's own people, with the values the bars were drawn from", async () => {
+    const user = userEvent.setup();
+    seedSpread({ drillable: true });
+    drawWithEvidence(SPREAD_CONFIG);
+
+    // Step 1 over a maximum of 9 → unit-wide bands, and the top value is
+    // clamped into the last one, so the lone 9 is the whole "8–9" band.
+    await user.click(screen.getByRole("button", { name: /^8–9 commits/ }));
+
+    expect(openEvidencePeople).toHaveBeenCalledTimes(1);
+    const [view] = openEvidencePeople.mock.calls[0]!;
+    expect(view.title).toContain("8–9 commits per person");
+    expect(view.rows.map((row: { entityId: string }) => row.entityId)).toEqual([
+      pid("d"),
+    ]);
+    expect(view.rows[0].value).toBe(9);
+    // The roster's name and its route id, each from its own lookup: this is
+    // what makes the list about people rather than about ids.
+    expect(view.rows[0].name).toBe("d");
+    expect(view.rows[0].personId).toBe(pid("d"));
+    // Every row's records at once stays available, scoped to the same band.
+    expect(view.allRecords.selection.entity).toEqual({
+      type: "persons",
+      ids: [pid("d")],
+    });
+  });
+
+  it("lists the people of a metric whose records cannot be read", async () => {
+    const user = userEvent.setup();
+    seedSpread({ drillable: false });
+    drawWithEvidence(SPREAD_CONFIG);
+
+    await user.click(screen.getByRole("button", { name: /^8–9 commits/ }));
+
+    // The values are the surface's own, so who is in the band is answerable
+    // even where no source backs a record table.
+    const [view] = openEvidencePeople.mock.calls[0]!;
+    expect(view.rows[0].target).toBeNull();
+    expect(view.allRecords).toBeNull();
+  });
+
+  it("opens the busiest tenth from the concentration card, ranked", async () => {
+    const user = userEvent.setup();
+    seedSpread({ drillable: true });
+    drawWithEvidence(CONCENTRATION_CONFIG);
+
+    await user.click(screen.getByRole("button", { name: /carried by/ }));
+
+    const [view] = openEvidencePeople.mock.calls[0]!;
+    expect(view.title).toContain("busiest 1 of 4");
+    // Busiest tenth of 4 contributors = 1 person, and it is the busiest one.
+    expect(view.rows.map((row: { value: number }) => row.value)).toEqual([9]);
   });
 });
 

--- a/src/frontend/src/components/portal/domain-lens-view.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.tsx
@@ -56,19 +56,25 @@ import {
   personsEvidenceSelection,
   type MetricEvidenceSelection,
 } from "@/api/metric-drilldown-client";
-import { useMetricEvidenceOptional } from "@/components/metric-evidence-context";
+import {
+  useMetricEvidenceOptional,
+  type EvidencePeopleView,
+} from "@/components/metric-evidence-context";
+import { peopleEvidenceView } from "@/lib/portal/evidence-people";
 import { formatMetricValue } from "@/lib/format";
 import { seriesColors } from "@/lib/series-colors";
 import { mergeEventHistogram } from "@/lib/portal/event-histogram";
 import { peerPopulationLabel } from "@/lib/portal/use-cohort-label";
 import {
+  bandAtClick,
   distribution,
+  entityValues,
   familyObserved,
   fmtCompact,
   medianAcross,
   perCapita,
   representative,
-  topDecileShare,
+  topDecile,
 } from "@/lib/portal/metric-stats";
 import {
   lensEntry,
@@ -467,11 +473,23 @@ function Section({
       );
     case "distribution":
       return (
-        <DistributionSection spec={spec} grid={grid} memberIds={memberIds} />
+        <DistributionSection
+          spec={spec}
+          grid={grid}
+          memberIds={memberIds}
+          nameByEntity={nameByEntity}
+          personIdByEntity={personIdByEntity}
+        />
       );
     case "concentration":
       return (
-        <ConcentrationSection spec={spec} grid={grid} memberIds={memberIds} />
+        <ConcentrationSection
+          spec={spec}
+          grid={grid}
+          memberIds={memberIds}
+          nameByEntity={nameByEntity}
+          personIdByEntity={personIdByEntity}
+        />
       );
     case "composition":
       return (
@@ -1129,36 +1147,74 @@ function DistributionSection({
   spec,
   grid,
   memberIds,
+  nameByEntity,
+  personIdByEntity,
 }: {
   spec: Extract<SectionSpec, { kind: "distribution" }>;
   grid: GridData;
   memberIds: readonly string[];
+  nameByEntity: Map<string, string>;
+  personIdByEntity: Map<string, string>;
 }) {
+  const evidence = useMetricEvidenceOptional();
   const r = grid.byKey.get(spec.metric);
-  const values = r
-    ? memberIds
-        .map((id) => forEntity(r, id).value)
-        .filter((v): v is number => v != null && Number.isFinite(v) && v >= 0)
-    : [];
+  const entries = entityValues(r, memberIds).filter((e) => e.value >= 0);
   const fmt =
     r?.format === "percent"
       ? (n: number) => formatMetricValue(n, "percent", null)
       : fmtCompact;
-  const rows = distribution(values, fmt);
-  if (!rows.length) return null;
+  const rows = distribution(entries, fmt);
+  if (!rows.length || !r) return null;
+
+  // Per band, because a band IS a set of people: the reader pointing at a bar
+  // is asking who those people are, and the values are already here — the
+  // records behind any one of them are a step further in, inside the dialog.
+  const bandsByRange = new Map(
+    evidence
+      ? rows.flatMap((row) =>
+          row.count
+            ? ([
+                [
+                  row.range,
+                  peopleEvidenceView(
+                    r,
+                    row.ids,
+                    `${r.label} · ${row.range} ${spec.unitLabel}`,
+                    { nameByEntity, personIdByEntity }
+                  ),
+                ],
+              ] as const)
+            : []
+        )
+      : []
+  );
+  const openBand = (range: string) => {
+    const view = bandsByRange.get(range);
+    if (view) evidence?.openEvidencePeople(view);
+  };
 
   return (
     <section className="flex flex-col gap-3">
       <p className="text-xs font-medium tracking-wider text-muted-foreground uppercase">
-        {spec.title} · {values.length} people
+        {spec.title} · {entries.length} people
       </p>
       <Card>
         <CardContent className="p-4">
           <p className="mb-3 text-xs text-muted-foreground">{spec.caption}</p>
-          <ChartContainer config={DIST_CONFIG} className="h-56 w-full">
+          <ChartContainer
+            config={DIST_CONFIG}
+            className={cn("h-56 w-full", bandsByRange.size && "cursor-pointer")}
+          >
             <BarChart
               data={rows}
               margin={{ top: 8, right: 8, left: 0, bottom: 0 }}
+              // The whole column, not the drawn bar: a band holding two people
+              // is a rectangle a pixel tall, and those are the bands a reader
+              // most wants to open.
+              onClick={(next) => {
+                const row = bandAtClick(rows, next);
+                if (row) openBand(row.range);
+              }}
             >
               <CartesianGrid
                 vertical={false}
@@ -1201,6 +1257,35 @@ function DistributionSection({
           <p className="mt-1 text-center text-xs text-muted-foreground">
             {spec.unitLabel}
           </p>
+          {/* The bands again, as buttons. Not decoration: the tail bars of a
+              skewed distribution are a pixel tall, and those are the ones a
+              reader wants to open — and a bar is not reachable by keyboard. */}
+          {bandsByRange.size > 0 && (
+            <div className="mt-3 flex flex-col gap-1.5">
+              <p className="text-xs text-muted-foreground">
+                See who is in a band
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {rows
+                  .filter((row) => bandsByRange.has(row.range))
+                  .map((row) => (
+                    <button
+                      key={row.range}
+                      type="button"
+                      aria-haspopup="dialog"
+                      aria-label={`${row.range} ${spec.unitLabel} · ${row.count} ${row.count === 1 ? "person" : "people"}`}
+                      onClick={() => openBand(row.range)}
+                      className="cursor-pointer rounded-sm border px-2 py-0.5 text-xs hover:bg-muted/60 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+                    >
+                      <span className="tabular-nums">{row.range}</span>
+                      <span className="ml-1.5 text-muted-foreground tabular-nums">
+                        {row.count}
+                      </span>
+                    </button>
+                  ))}
+              </div>
+            </div>
+          )}
         </CardContent>
       </Card>
     </section>
@@ -1330,25 +1415,36 @@ function ConcentrationSection({
   spec,
   grid,
   memberIds,
+  nameByEntity,
+  personIdByEntity,
 }: {
   spec: Extract<SectionSpec, { kind: "concentration" }>;
   grid: GridData;
   memberIds: readonly string[];
+  nameByEntity: Map<string, string>;
+  personIdByEntity: Map<string, string>;
 }) {
   const cards = spec.metrics
     .map((key) => {
       const r = grid.byKey.get(key);
       if (!r) return null;
-      const vals = memberIds
-        .map((id) => forEntity(r, id).value)
-        .filter((v): v is number => v != null && Number.isFinite(v) && v > 0);
-      const share = topDecileShare(vals);
-      if (share == null) return null;
+      const contributors = entityValues(r, memberIds).filter(
+        (e) => e.value > 0
+      );
+      const top = topDecile(contributors);
+      if (!top) return null;
+      const subset = `busiest ${top.ids.length} of ${contributors.length}`;
       return {
         key,
         label: r.short_label ?? r.label,
-        share,
-        contributors: vals.length,
+        share: top.share,
+        subset,
+        // The busiest tenth, not the roster: this card's figure is a statement
+        // about those people only.
+        people: peopleEvidenceView(r, top.ids, `${r.label} · ${subset}`, {
+          nameByEntity,
+          personIdByEntity,
+        }),
       };
     })
     .filter((x): x is NonNullable<typeof x> => x != null);
@@ -1362,24 +1458,59 @@ function ConcentrationSection({
       </p>
       <div className="grid grid-cols-[repeat(auto-fit,minmax(14rem,1fr))] gap-3">
         {cards.map((c) => (
-          <Card key={c.key}>
-            <CardContent className="p-4">
-              <div className="text-xs font-medium text-muted-foreground">
-                {c.label}
-              </div>
-              <div className={cn("mt-1", TEXT_FIGURE)}>
-                {Math.round(c.share * 100)}%
-              </div>
-              <div className="text-xs text-muted-foreground">
-                carried by the busiest{" "}
-                {Math.max(1, Math.ceil(c.contributors * 0.1))} of{" "}
-                {c.contributors} · {copy.note}
-              </div>
-            </CardContent>
-          </Card>
+          <ConcentrationCard key={c.key} card={c} note={copy.note} />
         ))}
       </div>
     </section>
+  );
+}
+
+/**
+ * One concentration figure, and who the busiest tenth actually is.
+ *
+ * The card opens that subset rather than the roster: a list of everyone would
+ * answer a different question from the one the card raises. Names stay inside
+ * the dialog — the card itself still says nothing about any individual.
+ */
+function ConcentrationCard({
+  card,
+  note,
+}: {
+  card: {
+    label: string;
+    share: number;
+    subset: string;
+    people: EvidencePeopleView;
+  };
+  note: string;
+}) {
+  const evidence = useMetricEvidenceOptional();
+  const c = card;
+  const body = (
+    <CardContent className="p-4">
+      <div className="text-xs font-medium text-muted-foreground">{c.label}</div>
+      <div className={cn("mt-1", TEXT_FIGURE)}>
+        {Math.round(c.share * 100)}%
+      </div>
+      <div className="text-xs text-muted-foreground">
+        carried by the {c.subset} · {note}
+      </div>
+    </CardContent>
+  );
+
+  if (!evidence || !c.people.rows.length) return <Card>{body}</Card>;
+
+  return (
+    <Card className="transition-colors hover:bg-muted/40 focus-within:ring-2 focus-within:ring-ring">
+      <button
+        type="button"
+        aria-haspopup="dialog"
+        className="w-full cursor-pointer text-left focus-visible:outline-none"
+        onClick={() => evidence.openEvidencePeople(c.people)}
+      >
+        {body}
+      </button>
+    </Card>
   );
 }
 

--- a/src/frontend/src/components/widgets/metric-views/metric-breakdown.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-breakdown.test.tsx
@@ -65,7 +65,11 @@ describe("MetricBreakdown", () => {
     const openEvidenceTargets = vi.fn();
     render(
       <EvidenceDialogContext.Provider
-        value={{ openEvidence: vi.fn(), openEvidenceTargets }}
+        value={{
+        openEvidence: vi.fn(),
+        openEvidenceTargets,
+        openEvidencePeople: vi.fn(),
+      }}
       >
         <MetricBreakdown
           metric={breakdownMetric([

--- a/src/frontend/src/components/widgets/metric-views/metric-card-actions.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-card-actions.test.tsx
@@ -23,7 +23,11 @@ function renderActions(scope: EvidenceDialogTarget[]) {
   const openEvidenceTargets = vi.fn();
   render(
     <EvidenceDialogContext.Provider
-      value={{ openEvidence: vi.fn(), openEvidenceTargets }}
+      value={{
+        openEvidence: vi.fn(),
+        openEvidenceTargets,
+        openEvidencePeople: vi.fn(),
+      }}
     >
       <EvidenceScopeContext.Provider value={scope}>
         <MetricCardActions
@@ -84,7 +88,11 @@ describe("MetricCardActions", () => {
   it("renders nothing without a drilldown to open", () => {
     render(
       <EvidenceDialogContext.Provider
-        value={{ openEvidence: vi.fn(), openEvidenceTargets: vi.fn() }}
+        value={{
+          openEvidence: vi.fn(),
+          openEvidenceTargets: vi.fn(),
+          openEvidencePeople: vi.fn(),
+        }}
       >
         <MetricCardActions evidence={null} label="Pull requests" />
       </EvidenceDialogContext.Provider>

--- a/src/frontend/src/components/widgets/metric-views/metric-histogram.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-histogram.test.tsx
@@ -108,7 +108,11 @@ describe("MetricHistogram", () => {
       const openEvidenceTargets = vi.fn();
       render(
         <EvidenceDialogContext.Provider
-          value={{ openEvidence: vi.fn(), openEvidenceTargets }}
+          value={{
+        openEvidence: vi.fn(),
+        openEvidenceTargets,
+        openEvidencePeople: vi.fn(),
+      }}
         >
           <MetricHistogram metric={metric} entityId="me@x.com" />
         </EvidenceDialogContext.Provider>

--- a/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-timeseries-view.test.tsx
@@ -494,9 +494,10 @@ describe("MetricTimeseriesView", () => {
     mocks.evidenceColumn = "total";
     const openEvidence = vi.fn();
     const openEvidenceTargets = vi.fn();
+    const openEvidencePeople = vi.fn();
     render(
       <EvidenceDialogContext.Provider
-        value={{ openEvidence, openEvidenceTargets }}
+        value={{ openEvidence, openEvidenceTargets, openEvidencePeople }}
       >
         <MetricTimeseriesView
           id="evidence"
@@ -547,7 +548,11 @@ describe("MetricTimeseriesView", () => {
     const openEvidenceTargets = vi.fn();
     render(
       <EvidenceDialogContext.Provider
-        value={{ openEvidence: vi.fn(), openEvidenceTargets }}
+        value={{
+        openEvidence: vi.fn(),
+        openEvidenceTargets,
+        openEvidencePeople: vi.fn(),
+      }}
       >
         <MetricTimeseriesView
           id="point-evidence"

--- a/src/frontend/src/components/widgets/metric-views/peer-story.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/peer-story.test.tsx
@@ -125,7 +125,11 @@ describe("PeerStory", () => {
     settings.focusMode = "neutral";
     render(
       <EvidenceDialogContext.Provider
-        value={{ openEvidence: vi.fn(), openEvidenceTargets }}
+        value={{
+        openEvidence: vi.fn(),
+        openEvidenceTargets,
+        openEvidencePeople: vi.fn(),
+      }}
       >
         <PeerStory
           entries={entriesFrom([

--- a/src/frontend/src/lib/portal/evidence-people.test.ts
+++ b/src/frontend/src/lib/portal/evidence-people.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+
+import type { NormalizedMetricResult } from "@/lib/metrics/collection";
+import { peopleEvidenceView } from "./evidence-people";
+
+const ROSTER = {
+  nameByEntity: new Map([
+    ["e-ada", "Ada Lovelace"],
+    ["e-grace", "Grace Hopper"],
+    ["e-alan", "Alan Turing"],
+  ]),
+  personIdByEntity: new Map([
+    ["e-ada", "p-ada"],
+    ["e-grace", "p-grace"],
+    ["e-alan", "p-alan"],
+  ]),
+};
+
+function metric(
+  values: Array<[string, number | null]>,
+  over: Partial<NormalizedMetricResult> = {}
+): NormalizedMetricResult {
+  return {
+    metric_key: "t.commits",
+    label: "Commits",
+    short_label: "Commits",
+    unit: "commits",
+    computation: "sum",
+    format: "integer",
+    direction: "higher_is_better",
+    period: {
+      view: "period",
+      values: values.map(([entity_id, value]) => ({ entity_id, value })),
+    },
+    ...over,
+  } as unknown as NormalizedMetricResult;
+}
+
+const DRILLABLE: Partial<NormalizedMetricResult> = {
+  drilldown: { granularity: ["event"] },
+  selection: {
+    metric_key: "t.commits",
+    entity: { type: "person", ids: ["e-ada", "e-grace", "e-alan"] },
+    period: { from: "2026-07-20", to: "2026-07-26" },
+    filters: [],
+  },
+} as Partial<NormalizedMetricResult>;
+
+describe("peopleEvidenceView", () => {
+  it("ranks the busiest first, and names each person's own records", () => {
+    const view = peopleEvidenceView(
+      metric(
+        [
+          ["e-ada", 5],
+          ["e-grace", 12],
+        ],
+        DRILLABLE
+      ),
+      ["e-ada", "e-grace"],
+      "Commits · busiest 2 of 9",
+      ROSTER
+    );
+
+    expect(view.rows.map((row) => row.name)).toEqual([
+      "Grace Hopper",
+      "Ada Lovelace",
+    ]);
+    expect(view.rows[0]?.target?.selection.entity).toEqual({
+      type: "person",
+      id: "e-grace",
+    });
+    expect(view.rows[0]?.target?.label).toBe("Commits · Grace Hopper");
+  });
+
+  it("reads the name and the person id from their own lookups", () => {
+    const view = peopleEvidenceView(
+      metric([["e-ada", 5]], DRILLABLE),
+      ["e-ada"],
+      "Commits · 0–50 commits per person",
+      ROSTER
+    );
+
+    // Two maps of the same shape: this is the assertion that would fail if the
+    // roster's lookups were ever passed the wrong way round.
+    expect(view.rows[0]?.name).toBe("Ada Lovelace");
+    expect(view.rows[0]?.personId).toBe("p-ada");
+  });
+
+  it("orders people on the same value by name, so a list never reshuffles", () => {
+    const view = peopleEvidenceView(
+      metric(
+        [
+          ["e-grace", 7],
+          ["e-alan", 7],
+          ["e-ada", 7],
+        ],
+        DRILLABLE
+      ),
+      ["e-grace", "e-alan", "e-ada"],
+      "Commits · 0–50 commits per person",
+      ROSTER
+    );
+
+    expect(view.rows.map((row) => row.name)).toEqual([
+      "Ada Lovelace",
+      "Alan Turing",
+      "Grace Hopper",
+    ]);
+  });
+
+  it("shows the number alone — the column is already headed by the metric", () => {
+    const counted = peopleEvidenceView(
+      metric([["e-ada", 1234]], DRILLABLE),
+      ["e-ada"],
+      "Commits · 0–50 commits per person",
+      ROSTER
+    );
+    expect(counted.rows[0]?.valueText).toBe("1,234");
+    expect(counted.valueLabel).toBe("Commits");
+
+    // A percent keeps its sign: the sign is the unit, not a suffix beside it.
+    const share = peopleEvidenceView(
+      metric([["e-ada", 42]], {
+        ...DRILLABLE,
+        format: "percent",
+        unit: null,
+        label: "Review coverage",
+        short_label: "Coverage",
+      } as Partial<NormalizedMetricResult>),
+      ["e-ada"],
+      "Review coverage · 0–50%",
+      ROSTER
+    );
+    expect(share.rows[0]?.valueText).toBe("42%");
+    expect(share.valueLabel).toBe("Coverage");
+  });
+
+  it("covers exactly the listed people with its all-records selection", () => {
+    const view = peopleEvidenceView(
+      metric(
+        [
+          ["e-ada", 5],
+          ["e-grace", null],
+        ],
+        DRILLABLE
+      ),
+      ["e-ada", "e-grace"],
+      "Commits · 0–50 commits per person",
+      ROSTER
+    );
+
+    // The person the metric has no value for is in neither the rows nor the
+    // records behind them.
+    expect(view.rows.map((row) => row.entityId)).toEqual(["e-ada"]);
+    expect(view.allRecords?.selection.entity).toEqual({
+      type: "persons",
+      ids: ["e-ada"],
+    });
+  });
+
+  it("still lists people when the metric carries no readable evidence", () => {
+    const view = peopleEvidenceView(
+      metric([["e-ada", 5]]),
+      ["e-ada"],
+      "Commits · 0–50 commits per person",
+      ROSTER
+    );
+
+    expect(view.rows).toHaveLength(1);
+    expect(view.rows[0]?.target).toBeNull();
+    expect(view.allRecords).toBeNull();
+  });
+
+  it("carries the metric key the drill is counted under", () => {
+    const view = peopleEvidenceView(
+      metric([["e-ada", 5]], DRILLABLE),
+      ["e-ada"],
+      "Commits · 0–50 commits per person",
+      ROSTER
+    );
+
+    expect(view.metricKey).toBe("t.commits");
+  });
+
+  it("names a person the roster cannot, and leaves them unroutable", () => {
+    const view = peopleEvidenceView(
+      metric([["e-katherine", 3]], DRILLABLE),
+      ["e-katherine"],
+      "Commits · 0–50 commits per person",
+      ROSTER
+    );
+
+    expect(view.rows[0]?.name).toBe("e-katherine");
+    expect(view.rows[0]?.personId).toBeNull();
+  });
+});

--- a/src/frontend/src/lib/portal/evidence-people.ts
+++ b/src/frontend/src/lib/portal/evidence-people.ts
@@ -1,0 +1,81 @@
+import {
+  evidenceSelection,
+  personsEvidenceSelection,
+} from "@/api/metric-drilldown-client";
+import type {
+  EvidencePeopleView,
+  EvidencePersonRow,
+} from "@/components/metric-evidence-context";
+import { formatMetricValue } from "@/lib/format";
+import type { NormalizedMetricResult } from "@/lib/metrics/collection";
+import { entityValues } from "@/lib/portal/metric-stats";
+
+/**
+ * The roster's two lookups, named rather than positional: both are
+ * `Map<string, string>` over the same keys, and swapping them at a call site
+ * would put person ids in the name column and still typecheck.
+ */
+export interface RosterLookups {
+  nameByEntity: ReadonlyMap<string, string>;
+  personIdByEntity: ReadonlyMap<string, string>;
+}
+
+/**
+ * The people behind an aggregate figure — a distribution band, a busiest
+ * tenth — with the value each of them contributed.
+ *
+ * Values come from the same period result the figure was drawn from, so the
+ * list cannot disagree with the bar or card that opened it, and no request is
+ * made to build it. A metric with no readable evidence still lists its people;
+ * only the step into records is missing, because only that step needs a source.
+ */
+export function peopleEvidenceView(
+  r: NormalizedMetricResult,
+  entityIds: readonly string[],
+  title: string,
+  roster: RosterLookups
+): EvidencePeopleView {
+  const rows: EvidencePersonRow[] = entityValues(r, entityIds).map((entry) => {
+    const name = roster.nameByEntity.get(entry.id) ?? entry.id;
+    const selection = r.drilldown
+      ? evidenceSelection(r.selection, entry.id)
+      : null;
+    return {
+      entityId: entry.id,
+      personId: roster.personIdByEntity.get(entry.id) ?? null,
+      name,
+      value: entry.value,
+      // Unit dropped, sign kept: the column is headed with the metric, so a
+      // unit in every cell would repeat it ("Commits" over "142 commits") —
+      // but a percent's "%" is part of the number, not a unit beside it.
+      valueText: formatMetricValue(entry.value, r.format, null),
+      target: selection ? { selection, label: `${r.label} · ${name}` } : null,
+    };
+  });
+  // Busiest first — the reader opened a band to see who is in it, and within a
+  // band the order that carries information is the value itself. Ties break on
+  // name so the list does not reshuffle between renders.
+  rows.sort(
+    (left, right) =>
+      right.value - left.value || left.name.localeCompare(right.name)
+  );
+
+  // INVARIANT: over the rows, never the caller's ids — a person the metric has
+  // no value for is not in the list, so their records are not behind it either.
+  const allRecords = r.drilldown
+    ? personsEvidenceSelection(
+        r.selection,
+        rows.map((row) => row.entityId)
+      )
+    : null;
+
+  return {
+    title,
+    metricKey: r.metric_key,
+    valueLabel: r.short_label ?? r.label,
+    rows,
+    allRecords: allRecords
+      ? { selection: allRecords, label: `${r.label} · all records` }
+      : null,
+  };
+}

--- a/src/frontend/src/lib/portal/metric-stats.test.ts
+++ b/src/frontend/src/lib/portal/metric-stats.test.ts
@@ -2,15 +2,17 @@ import { describe, expect, it } from "vitest";
 
 import type { NormalizedMetricResult } from "@/lib/metrics/collection";
 import {
+  bandAtClick,
   chooseStep,
   distribution,
+  entityValues,
   familyObserved,
   fmtCompact,
   groupCoverage,
   medianAcross,
   perCapita,
   representative,
-  topDecileShare,
+  topDecile,
 } from "./metric-stats";
 
 /** Minimal NormalizedMetricResult fixture: period values + peer target_values. */
@@ -48,23 +50,87 @@ describe("chooseStep", () => {
   it("scales into hundreds", () => expect(chooseStep(4500, 14)).toBe(500));
 });
 
-describe("distribution", () => {
-  it("suppresses below 4 observations", () =>
-    expect(distribution([1, 2, 3], String)).toEqual([]));
-  it("suppresses when all mass lands in one bin", () =>
-    expect(distribution([5, 5, 5, 5], String)).toEqual([]));
-  it("bins a real spread", () => {
-    const rows = distribution([1, 2, 3, 9], String);
-    expect(rows.length).toBeGreaterThan(1);
-    expect(rows.reduce((a, r) => a + r.count, 0)).toBe(4);
+/** Per-person values as the sections build them, ids legible in assertions. */
+function people(...values: number[]) {
+  return values.map((value, i) => ({ id: `p${i}`, value }));
+}
+
+describe("entityValues", () => {
+  it("skips people the metric has no value for", () => {
+    const r = fixture({ period: [["a", 10], ["b", null], ["c", 30]] });
+    expect(entityValues(r, ["a", "b", "c", "absent"])).toEqual([
+      { id: "a", value: 10 },
+      { id: "c", value: 30 },
+    ]);
   });
 });
 
-describe("topDecileShare", () => {
-  it("needs at least 4 values", () => expect(topDecileShare([1, 2, 3])).toBeNull());
-  it("computes the busiest-decile share", () => {
-    const share = topDecileShare([10, 1, 1, 1, 1, 1, 1, 1, 1, 1]);
-    expect(share).toBeCloseTo(10 / 19, 3);
+describe("distribution", () => {
+  it("suppresses below 4 observations", () =>
+    expect(distribution(people(1, 2, 3), String)).toEqual([]));
+  it("suppresses when all mass lands in one bin", () =>
+    expect(distribution(people(5, 5, 5, 5), String)).toEqual([]));
+  it("bins a real spread", () => {
+    const rows = distribution(people(1, 2, 3, 9), String);
+    expect(rows.length).toBeGreaterThan(1);
+    expect(rows.reduce((a, r) => a + r.count, 0)).toBe(4);
+  });
+  it("names the people of each band, so a band can be read on its own", () => {
+    const rows = distribution(people(1, 2, 3, 9), String);
+    // Every person lands in exactly one band, and the count IS that band's set.
+    expect(rows.flatMap((r) => r.ids).sort()).toEqual(["p0", "p1", "p2", "p3"]);
+    expect(rows.every((r) => r.count === r.ids.length)).toBe(true);
+    expect(rows.at(-1)?.ids).toEqual(["p3"]);
+  });
+});
+
+describe("bandAtClick", () => {
+  const rows = [{ range: "0–5" }, { range: "5–10" }];
+
+  it("has no band when nothing was pointed at", () => {
+    // A click in the axis gutter: recharts snaps the index to the nearest
+    // category (0) with no tooltip showing, so the index alone would open the
+    // first band for a click that pointed at nothing.
+    expect(bandAtClick(rows, { activeIndex: 0, isTooltipActive: false })).toBeNull();
+    expect(bandAtClick(rows, { isTooltipActive: true })).toBeNull();
+    expect(
+      bandAtClick(rows, { activeIndex: null, isTooltipActive: true }),
+    ).toBeNull();
+  });
+  it("resolves the band the tooltip was naming, string index and all", () => {
+    expect(bandAtClick(rows, { activeIndex: 1, isTooltipActive: true })).toBe(
+      rows[1],
+    );
+    expect(
+      bandAtClick(rows, { activeTooltipIndex: "0", isTooltipActive: true }),
+    ).toBe(rows[0]);
+  });
+  it("has no band for an index outside the data", () => {
+    expect(bandAtClick(rows, { activeIndex: 7, isTooltipActive: true })).toBeNull();
+    expect(bandAtClick(rows, { activeIndex: 1.5, isTooltipActive: true })).toBeNull();
+  });
+});
+
+describe("topDecile", () => {
+  it("needs at least 4 contributors", () =>
+    expect(topDecile(people(1, 2, 3))).toBeNull());
+  it("has nothing to say when the total is not positive", () =>
+    expect(topDecile(people(0, 0, 0, 0))).toBeNull());
+  it("computes the busiest-decile share and names who carries it", () => {
+    const top = topDecile(people(10, 1, 1, 1, 1, 1, 1, 1, 1, 1));
+    expect(top?.share).toBeCloseTo(10 / 19, 3);
+    expect(top?.ids).toEqual(["p0"]);
+  });
+  it("names the same person on every render when the boundary is tied", () => {
+    // Four equal contributors: the tenth is one of them, and which one must not
+    // depend on the order the roster happened to arrive in.
+    const ids = topDecile([
+      { id: "p2", value: 5 },
+      { id: "p0", value: 5 },
+      { id: "p3", value: 5 },
+      { id: "p1", value: 5 },
+    ])?.ids;
+    expect(ids).toEqual(["p0"]);
   });
 });
 

--- a/src/frontend/src/lib/portal/metric-stats.ts
+++ b/src/frontend/src/lib/portal/metric-stats.ts
@@ -58,10 +58,28 @@ export function perCapita(r: NormalizedMetricResult, ids: readonly string[]): nu
   return active ? total / active : 0;
 }
 
+/** One person's value for a metric, kept together so a figure can name its people. */
+export interface EntityValue {
+  id: string;
+  value: number;
+}
+
+/** Finite per-person values of a metric over the scope, in roster order. */
+export function entityValues(
+  r: NormalizedMetricResult | undefined,
+  ids: readonly string[],
+): EntityValue[] {
+  if (!r) return [];
+  return ids.flatMap((id) => {
+    const value = forEntity(r, id).value;
+    return value != null && Number.isFinite(value) ? [{ id, value }] : [];
+  });
+}
+
 /**
  * Not exported: nothing outside this module imports the type by name.
  * `DomainLensView` consumes `distribution()`'s return structurally (it reads
- * `.label`/`.range`/`.count` off the inferred row type without naming
+ * `.label`/`.range`/`.count`/`.ids` off the inferred row type without naming
  * `DistRow`) — re-export only if a future consumer needs to name the shape.
  */
 interface DistRow {
@@ -70,6 +88,8 @@ interface DistRow {
   /** Full band for the tooltip, e.g. "10–15". */
   range: string;
   count: number;
+  /** Who landed in the band, so the bar can open the records behind it. */
+  ids: string[];
 }
 
 /**
@@ -79,27 +99,61 @@ interface DistRow {
  * correct-but-meaningless histogram is worse than none.
  */
 export function distribution(
-  values: readonly number[],
+  entries: readonly EntityValue[],
   fmt: (n: number) => string,
 ): DistRow[] {
-  if (values.length < 4) return [];
-  const max = Math.max(...values);
+  if (entries.length < 4) return [];
+  const max = Math.max(...entries.map((e) => e.value));
   if (max <= 0) return [];
   const step = chooseStep(max, 14);
   const nBins = Math.max(1, Math.ceil(max / step));
-  const counts = new Array(nBins).fill(0) as number[];
-  for (const v of values) {
+  const bins: string[][] = Array.from({ length: nBins }, () => []);
+  for (const { id, value } of entries) {
     // Clamped at both ends: a negative value (a delta-shaped metric, a bad
-    // row) would index counts[-1], which lands on a property outside the array
+    // row) would index bins[-1], which lands on a property outside the array
     // and drops the person from the distribution silently.
-    counts[Math.min(nBins - 1, Math.max(0, Math.floor(v / step)))] += 1;
+    bins[Math.min(nBins - 1, Math.max(0, Math.floor(value / step)))]!.push(id);
   }
-  if (counts.filter((c) => c > 0).length < 2) return [];
-  return counts.map((count, i) => ({
+  if (bins.filter((ids) => ids.length > 0).length < 2) return [];
+  return bins.map((ids, i) => ({
     label: fmt(i * step),
     range: `${fmt(i * step)}–${fmt((i + 1) * step)}`,
-    count,
+    count: ids.length,
+    ids,
   }));
+}
+
+/** What a recharts chart-level click hands back, of what this reads. */
+export interface ChartClick {
+  activeIndex?: number | string | null;
+  activeTooltipIndex?: number | string | null;
+  isTooltipActive?: boolean;
+}
+
+/**
+ * The band a chart-level click landed on, or null.
+ *
+ * SAFETY: the click handler is bound to the whole chart, including the axis
+ * gutters, and recharts reports an index whenever the pointer sits anywhere in
+ * the chart. `isTooltipActive` is the chart's own statement that a category is
+ * under the pointer, so what opens is always the band the tooltip was naming —
+ * never a stale index left over from before the pointer left the chart, where
+ * recharts reports `null` and coercing it would land on the first band.
+ *
+ * WORKAROUND: recharts snaps to the NEAREST category, so a click in the axis
+ * gutter opens the band beside it. The tooltip names that band while the
+ * pointer is there, so the two agree; nothing here can tell the gutter from
+ * the column without hit-testing the plot area by hand.
+ */
+export function bandAtClick<Row>(
+  rows: readonly Row[],
+  click: ChartClick,
+): Row | null {
+  if (!click.isTooltipActive) return null;
+  const index = click.activeIndex ?? click.activeTooltipIndex;
+  if (index == null) return null;
+  const at = Number(index);
+  return Number.isInteger(at) ? (rows[at] ?? null) : null;
 }
 
 /** Smallest whole 1/2/5·10ⁿ step whose bin count stays at or under `maxBins`. */
@@ -114,15 +168,28 @@ export function chooseStep(max: number, maxBins: number): number {
   return max;
 }
 
-/** Share of the total held by the busiest 10% of contributors. */
-export function topDecileShare(values: readonly number[]): number | null {
-  if (values.length < 4) return null;
-  const sorted = [...values].sort((a, b) => b - a);
-  const total = sorted.reduce((a, b) => a + b, 0);
+/**
+ * The busiest tenth of contributors: its share of the total, and who is in it.
+ * Null below 4 contributors or on a non-positive total — the same
+ * self-suppression the distribution uses, for the same reason.
+ */
+export function topDecile(
+  entries: readonly EntityValue[],
+): { share: number; ids: string[] } | null {
+  if (entries.length < 4) return null;
+  // INVARIANT: ties break on id, so the people named as the busiest tenth are
+  // the same set on every render and reload. Roster order is not stable enough
+  // to name individuals from.
+  const sorted = [...entries].sort(
+    (a, b) => b.value - a.value || a.id.localeCompare(b.id),
+  );
+  const total = sorted.reduce((sum, e) => sum + e.value, 0);
   if (total <= 0) return null;
-  const topN = Math.max(1, Math.ceil(sorted.length * 0.1));
-  const top = sorted.slice(0, topN).reduce((a, b) => a + b, 0);
-  return top / total;
+  const top = sorted.slice(0, Math.max(1, Math.ceil(sorted.length * 0.1)));
+  return {
+    share: top.reduce((sum, e) => sum + e.value, 0) / total,
+    ids: top.map((e) => e.id),
+  };
 }
 
 /**

--- a/tests/stand/ui/downloads.py
+++ b/tests/stand/ui/downloads.py
@@ -74,11 +74,20 @@ def rendered_rows(table: Locator) -> Table:
 
 
 def claimed_row_count(table: Locator) -> int:
-    """What the grid says its full result set holds, virtualization aside."""
+    """How many DATA rows the grid says its full result set holds.
+
+    `aria-rowcount` counts every row of the full table, its header rows
+    included, while an export writes the header apart from its records — so the
+    headers come off before the two counts are compared. Their number is read
+    from the grid rather than assumed, because a grid that grows a second
+    header row would otherwise shift this by one without failing here.
+    """
     declared = table.get_attribute("aria-rowcount")
     assert declared is not None, "grid declares no aria-rowcount to reconcile the export against"
 
-    return int(declared)
+    headers = table.locator('[role="row"]:has([role="columnheader"]), thead tr').count()
+
+    return int(declared) - headers
 
 
 def data_rows(table: Table, *, after: int) -> Table:


### PR DESCRIPTION
The per-person distribution tiles and the "carried by the busiest tenth" cards were dead ends: they say how many people are in each band, and there was no way to ask who. Clicking a band — anywhere in its column, or its chip — or the card now opens the evidence dialog on a people body: who is in that subset and the value each of them contributed, with a row going on to that person's records in the same dialog. Values come from the period result the figure was drawn from, so a list cannot disagree with the bar that opened it and costs no request; a metric with no readable evidence still answers "who", only the step into records is missing. One component, so it covers every distribution tile and concentration card.

**Where:** `src/frontend` — the shared metric-evidence dialog gains a second body, plus the two aggregate sections of the Directions/Overview lens view.

**Verify:** `pnpm typecheck && pnpm lint && pnpm test` in `src/frontend`. In a browser: click a band and the busiest-tenth card, take a row into that person's records, come back, and check the keyboard path (chips are focusable, the row's opener is labelled).

Two fixes to shared code ride along, both the same defect this change would otherwise have copied: the record table counted `aria-rowcount` without its header row, and an export left running was carried into the next table.

### Screens

Captured in mock mode (`VITE_ENABLE_MOCKS=true`), so every name and number below is synthetic fixture data.

The bands, now with a strip that says who is in each one:

![Distribution tile with a band strip](https://raw.githubusercontent.com/mozhaev-dev/insight/pr-2802-screens/1-band-strip.png)

A band opens the people behind it, ranked, in the dialog its records live in:

![The people behind one band](https://raw.githubusercontent.com/mozhaev-dev/insight/pr-2802-screens/2-people.png)

A row goes on to that person's records, with the way back to the band:

![One person's records](https://raw.githubusercontent.com/mozhaev-dev/insight/pr-2802-screens/3-records.png)