### PR TITLE
fix(git-cli-proxy): answer a repository the origin declines with 404, not 500 (release-2026.07.1)

### DIFF
--- a/src/backend/services/git-cli-proxy/src/api/error.rs
+++ b/src/backend/services/git-cli-proxy/src/api/error.rs
@@ -64,6 +64,9 @@ impl IntoResponse for ApiError {
             Self::Store(StoreError::Throttled) | Self::Git(GitError::Throttled) => {
                 metrics::record_rejection(metrics::RejectReason::OriginThrottled);
             }
+            Self::Store(StoreError::OriginUnavailable) | Self::Git(GitError::OriginUnavailable) => {
+                metrics::record_origin_unavailable();
+            }
             _ => {}
         }
 
@@ -110,7 +113,8 @@ impl ApiError {
             Self::ProxyTokenRejected
             | Self::Store(StoreError::AuthRejected)
             | Self::Git(GitError::AuthRejected) => StatusCode::UNAUTHORIZED.as_u16(),
-            Self::Store(StoreError::NotFound) | Self::Git(GitError::NotFound) => {
+            Self::Store(StoreError::NotFound | StoreError::OriginUnavailable)
+            | Self::Git(GitError::NotFound | GitError::OriginUnavailable) => {
                 StatusCode::NOT_FOUND.as_u16()
             }
             Self::Store(StoreError::SnapshotChanged { .. }) => StatusCode::CONFLICT.as_u16(),
@@ -169,6 +173,15 @@ impl ApiError {
                     // The caller's own `repo` value is not echoed back: the
                     // envelope names the kind of thing, the detail says what
                     // happened, and the request already carries the URL.
+                    .with_resource("repository")
+                    .create()
+            }
+            // Suspended, disabled, or over the vendor's own limit at origin.
+            // The same 404 the connector already skips a deleted repository
+            // on, with a distinct detail so an operator can tell the two
+            // apart in logs and problem bodies.
+            Self::Store(StoreError::OriginUnavailable) | Self::Git(GitError::OriginUnavailable) => {
+                RepositoryError::not_found("origin declines to serve the repository")
                     .with_resource("repository")
                     .create()
             }
@@ -319,9 +332,13 @@ mod tests {
                 StoreError::Git("boom".to_owned()).into(),
                 StatusCode::INTERNAL_SERVER_ERROR,
             ),
+            // A repository the origin refuses to serve: permanent for that
+            // repository, so the connector must see the skippable 404.
+            (StoreError::OriginUnavailable.into(), StatusCode::NOT_FOUND),
             // The same failures raised by a reader step, not by the clone.
             (GitError::AuthRejected.into(), StatusCode::UNAUTHORIZED),
             (GitError::NotFound.into(), StatusCode::NOT_FOUND),
+            (GitError::OriginUnavailable.into(), StatusCode::NOT_FOUND),
             (
                 GitError::TooLarge { cap_bytes: 1024 }.into(),
                 StatusCode::PAYLOAD_TOO_LARGE,

--- a/src/backend/services/git-cli-proxy/src/engine/metrics.rs
+++ b/src/backend/services/git-cli-proxy/src/engine/metrics.rs
@@ -85,6 +85,7 @@ impl RejectReason {
 struct Instruments {
     evictions: Counter<u64>,
     rejections: Counter<u64>,
+    origin_unavailable: Counter<u64>,
     purge_escalations: Counter<u64>,
     cold_clones: Counter<u64>,
     fetches: Counter<u64>,
@@ -107,6 +108,15 @@ fn instruments() -> &'static Instruments {
                     "Requests answered 429, by reason. A sustained rise in admission_exhausted \
                      or prefetch_headroom means the budget is too small for the working set; \
                      preparation_wait is ordinary while a clone runs.",
+                )
+                .build(),
+            origin_unavailable: meter
+                .u64_counter("git_proxy.origin_unavailable")
+                .with_description(
+                    "Requests refused because the origin declines to serve the repository \
+                     (suspended, disabled, or over the vendor's own limit). Permanent per \
+                     repository: the connector skips it, so a non-zero value means \
+                     repositories are absent from bronze until the origin state changes.",
                 )
                 .build(),
             purge_escalations: meter
@@ -149,6 +159,10 @@ pub fn record_rejection(reason: RejectReason) {
     instruments()
         .rejections
         .add(1, &[KeyValue::new("reason", reason.as_str())]);
+}
+
+pub fn record_origin_unavailable() {
+    instruments().origin_unavailable.add(1, &[]);
 }
 
 pub fn record_purge_escalation() {

--- a/src/backend/services/git-cli-proxy/src/engine/runner.rs
+++ b/src/backend/services/git-cli-proxy/src/engine/runner.rs
@@ -53,6 +53,8 @@ pub enum GitError {
     AuthRejected,
     #[error("repository not found at origin")]
     NotFound,
+    #[error("origin declines to serve the repository")]
+    OriginUnavailable,
     #[error("origin refuses to serve explicitly requested objects")]
     PromisorRefused,
     #[error("the cache cannot take more disk right now")]
@@ -472,6 +474,13 @@ fn classify_failure(output: &Output) -> GitError {
         return GitError::Throttled;
     }
 
+    // Before `auth`: Bitbucket announces a suspended or disabled repository
+    // with this remote line plus a bare 403; reading that as a credential
+    // failure would fail the whole sync over one repository no retry can fix.
+    if lower.contains("this repository is currently not available") {
+        return GitError::OriginUnavailable;
+    }
+
     let auth = [
         "authentication failed",
         "http 401",
@@ -576,6 +585,14 @@ mod tests {
             (
                 "fatal: unable to access 'https://x/': The requested URL returned error: 429",
                 |e| matches!(e, GitError::Throttled),
+            ),
+            // A suspended or disabled repository: the origin refuses it with
+            // a bare 403, which is neither a credential failure nor a rate
+            // limit.
+            (
+                "remote: This repository is currently not available.\n\
+                 fatal: unable to access 'https://x/': The requested URL returned error: 403",
+                |e| matches!(e, GitError::OriginUnavailable),
             ),
             // A transport fault is not a missing repository: answering `404`
             // tells the connector its parent record is stale.

--- a/src/backend/services/git-cli-proxy/src/engine/store.rs
+++ b/src/backend/services/git-cli-proxy/src/engine/store.rs
@@ -29,6 +29,7 @@ const PURGE_ESCALATION_AFTER: u32 = 3;
 pub enum RefreshFailure {
     Auth,
     NotFound,
+    OriginUnavailable,
     PromisorRefused,
     AdmissionRejected,
     Throttled,
@@ -42,6 +43,7 @@ impl From<&GitError> for RefreshFailure {
         match error {
             GitError::AuthRejected => Self::Auth,
             GitError::NotFound => Self::NotFound,
+            GitError::OriginUnavailable => Self::OriginUnavailable,
             GitError::PromisorRefused => Self::PromisorRefused,
             GitError::AdmissionRejected | GitError::TransientlyOverCap => Self::AdmissionRejected,
             GitError::Throttled => Self::Throttled,
@@ -61,6 +63,8 @@ pub enum StoreError {
     AuthRejected,
     #[error("repository not found at origin")]
     NotFound,
+    #[error("origin declines to serve the repository")]
+    OriginUnavailable,
     #[error("origin refuses to serve explicitly requested objects")]
     PromisorRefused,
     #[error("repository is being prepared; retry in {}s", retry_after.as_secs())]
@@ -82,6 +86,7 @@ impl From<RefreshFailure> for StoreError {
         match failure {
             RefreshFailure::Auth => Self::AuthRejected,
             RefreshFailure::NotFound => Self::NotFound,
+            RefreshFailure::OriginUnavailable => Self::OriginUnavailable,
             RefreshFailure::PromisorRefused => Self::PromisorRefused,
             // §3.6: nothing could be freed, so the caller is asked to come
             // back rather than being served a half-prepared cache.

--- a/src/backend/services/git-cli-proxy/src/engine/store.rs
+++ b/src/backend/services/git-cli-proxy/src/engine/store.rs
@@ -107,6 +107,16 @@ impl From<GitError> for StoreError {
     }
 }
 
+/// What a reclaim-path blob purge did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BlobPurge {
+    Purged,
+    /// Nothing to purge, or the entry has readers right now.
+    Skipped,
+    /// The heavy permit is busy with a clone or fetch.
+    PermitBusy,
+}
+
 /// How a caller wants the snapshot resolved.
 ///
 /// INVARIANT: `Pinned` never contacts origin — a paginating caller stays on
@@ -1332,33 +1342,27 @@ impl RepoStore {
 
         for step in plan {
             match step {
+                // A purge that cannot run or cannot finish must not leave the
+                // space unreclaimed: eviction frees it with no git involved.
                 Reclaim::PurgeBlobs { dir_name, frees } => {
                     match self.purge_blobs_by_dir(&dir_name).await {
-                        Ok(()) => {
+                        Ok(BlobPurge::Purged) => {
                             metrics::record_eviction(EvictionTier::Blob);
                             tracing::info!(dir = %dir_name, freed_bytes = frees, "purged blobs");
                         }
-                        Err(e) => tracing::warn!(error = %e, dir = %dir_name, "blob purge failed"),
+                        Ok(BlobPurge::Skipped) => {}
+                        Ok(BlobPurge::PermitBusy) => {
+                            tracing::info!(dir = %dir_name, "blob purge would wait for the heavy permit; evicting instead");
+                            self.evict_dir(&dir_name, frees).await;
+                        }
+                        Err(e) => {
+                            tracing::warn!(error = %e, dir = %dir_name, "blob purge failed; evicting instead");
+                            self.evict_dir(&dir_name, frees).await;
+                        }
                     }
                 }
                 Reclaim::Evict { dir_name, frees } => {
-                    let path = self.data_dir.join("repos").join(&dir_name);
-                    let lock = self.lock_for_dir(&dir_name).await;
-                    // INVARIANT: only a writer may delete an entry — a reader
-                    // must never observe a partially deleted repository.
-                    let Ok(_write) = lock.try_write() else {
-                        continue;
-                    };
-                    match remove_tree_off_reactor(path.clone()).await {
-                        Ok(()) => {
-                            // A re-clone must not inherit the evicted entry's
-                            // drift throttle or escalation losses.
-                            self.drift.lock().await.remove(&dir_name);
-                            metrics::record_eviction(EvictionTier::Full);
-                            tracing::info!(dir = %dir_name, freed_bytes = frees, "evicted repo");
-                        }
-                        Err(e) => tracing::warn!(error = %e, dir = %dir_name, "eviction failed"),
-                    }
+                    self.evict_dir(&dir_name, frees).await;
                 }
             }
         }
@@ -1381,6 +1385,28 @@ impl RepoStore {
             return None;
         }
         Some(self.reserve(want))
+    }
+
+    /// Evict one idle entry. A refused write lock means a reader or a writer
+    /// holds it — the entry is skipped, never deleted under a reader.
+    async fn evict_dir(&self, dir_name: &str, frees: u64) {
+        let path = self.data_dir.join("repos").join(dir_name);
+        let lock = self.lock_for_dir(dir_name).await;
+        // INVARIANT: only a writer may delete an entry — a reader must never
+        // observe a partially deleted repository.
+        let Ok(_write) = lock.try_write() else {
+            return;
+        };
+        match remove_tree_off_reactor(path).await {
+            Ok(()) => {
+                // A re-clone must not inherit the evicted entry's drift
+                // throttle or escalation losses.
+                self.drift.lock().await.remove(dir_name);
+                metrics::record_eviction(EvictionTier::Full);
+                tracing::info!(dir = %dir_name, freed_bytes = frees, "evicted repo");
+            }
+            Err(e) => tracing::warn!(error = %e, dir = %dir_name, "eviction failed"),
+        }
     }
 
     /// The most this operation can still add to the entry: everything between
@@ -1561,26 +1587,32 @@ impl RepoStore {
         entries.entry(dir_name.to_owned()).or_default().clone()
     }
 
-    pub(crate) async fn purge_blobs_by_dir(&self, dir_name: &str) -> Result<(), StoreError> {
+    pub(crate) async fn purge_blobs_by_dir(&self, dir_name: &str) -> Result<BlobPurge, StoreError> {
         let entry_dir = self.data_dir.join("repos").join(dir_name);
         if !entry_dir.join("repo.git").is_dir() {
-            return Ok(());
+            return Ok(BlobPurge::Skipped);
         }
 
         // A promoted entry has no promisor remote behind it: re-marking its
         // packs would make git tolerate blobs nothing can serve again.
         if RepoMeta::load(&entry_dir).is_none_or(|meta| meta.full_clone) {
-            return Ok(());
+            return Ok(BlobPurge::Skipped);
         }
 
         let lock = self.lock_for_dir(dir_name).await;
         // INVARIANT: repack DELETES packs — it must run with zero readers.
         let Ok(_write) = lock.try_write() else {
-            return Ok(());
+            return Ok(BlobPurge::Skipped);
         };
 
-        let permit = self.heavy_permit().await;
-        self.repack_blobless(&entry_dir, &permit).await.map(|_| ())
+        // Never wait: the only caller holds the admission lock, and a permit
+        // held by a clone would stall every admission behind that clone.
+        let Ok(permit) = self.heavy.try_acquire() else {
+            return Ok(BlobPurge::PermitBusy);
+        };
+        self.repack_blobless(&entry_dir, &permit)
+            .await
+            .map(|_| BlobPurge::Purged)
     }
 
     /// Current cache usage, as accounted per entry.
@@ -3220,6 +3252,24 @@ pub(crate) mod tests {
             guard.git_dir().is_dir(),
             "a repository with a live reader must never be deleted"
         );
+    }
+
+    #[tokio::test]
+    async fn a_reclaim_purge_never_waits_for_the_heavy_permit() {
+        let f = fixture("permit-busy-purge");
+        let k = key(&f);
+        let guard = open_until_ready(&f, &k, refresh()).await;
+        drop(guard);
+
+        // Clones or fetches elsewhere hold every heavy permit.
+        let Ok(_held) = f.store.heavy.try_acquire_many(2) else {
+            panic!("the fixture's heavy permits must be free")
+        };
+
+        match f.store.purge_blobs_by_dir(&k.dir_name()).await {
+            Ok(BlobPurge::PermitBusy) => {}
+            other => panic!("a busy permit must be reported, not waited on: {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
@@ -111,8 +111,8 @@ definitions:
         http_codes: [404, 413]
         action: IGNORE
         error_message: >-
-          Skipping this repository: gone at origin (404), or larger than
-          cache.maxRepoBytes (413). Other repositories continue.
+          Skipping this repository: gone or refused at origin (404), or
+          larger than cache.maxRepoBytes (413). Other repositories continue.
       # The pinned snapshot was superseded mid-walk. RETRY would replay
       # the same dead page token and 409 again; a response filter cannot
       # reset it. Rerunning the sync resumes each partition from its own


### PR DESCRIPTION
Cherry-pick of #2805 (`5d1513839`, `3cf47a387`) onto `release-2026.07.1`; the github connector.yaml hunk is dropped — that connector does not exist on this branch.

**Why.** Two ways the proxy turned one bad repository into a stalled fleet. A repository the origin refuses to serve — Bitbucket's `remote: This repository is currently not available.` with a bare 403 — came back as a 500 the connector retries forever. And a reclaim-path blob purge ran under the admission lock, waiting on the heavy permit and then on a full repack, so one slow or failing purge victim held every admission behind it, re-picked every cycle.

**What changed.** `classify_failure` fingerprints that remote line as `GitError::OriginUnavailable`, threaded through `RefreshFailure`/`StoreError` to the 404 the connector already skips, with a distinct problem detail and a dedicated `git_proxy.origin_unavailable` counter. A reclaim purge now `try_acquire`s the heavy permit instead of waiting, and a purge that cannot run or fails falls back to full eviction — the space is always freed, and a failing victim cannot be re-planned forever.

**Verified.** `cargo test -p git-cli-proxy` (210 tests) on this branch.
