### PR TITLE
show how much git output reached the default branch

### DIFF
--- a/src/backend/services/analytics/src/domain/metric_drilldown/presentation.rs
+++ b/src/backend/services/analytics/src/domain/metric_drilldown/presentation.rs
@@ -221,7 +221,13 @@ pub(super) fn evidence_presentation(
     granularity: EvidenceGranularity,
 ) -> EvidencePresentation {
     match (source_key, measure_key) {
-        ("git", "commit_count" | "commit_change_size") => EvidencePresentation {
+        (
+            "git",
+            "commit_count"
+            | "commit_change_size"
+            | "default_commit_count"
+            | "non_default_commit_count",
+        ) => EvidencePresentation {
             detail_keys: &[
                 "ref",
                 "title",
@@ -232,7 +238,16 @@ pub(super) fn evidence_presentation(
             ],
             show_value: false,
         },
-        ("git", "pr_created" | "pr_created_merged" | "pr_merged") => EvidencePresentation {
+        (
+            "git",
+            "pr_created"
+            | "pr_created_merged"
+            | "pr_merged"
+            | "default_pr_created"
+            | "non_default_pr_created"
+            | "default_pr_merged"
+            | "non_default_pr_merged",
+        ) => EvidencePresentation {
             detail_keys: &["ref", "title", "repository", "author"],
             show_value: false,
         },
@@ -326,9 +341,99 @@ mod tests {
     use super::*;
 
     use crate::domain::metric_definitions::RatioDenominatorAggregation;
+    use crate::domain::metric_definitions::builtin::{
+        SeedComputation, builtin_metrics, builtin_sources,
+    };
     use crate::domain::metric_drilldown::cursor::decode_cursor;
     use crate::domain::metric_drilldown::dto::EvidenceInput;
     use crate::domain::metric_drilldown::test_support::{input, plan, row, validated};
+
+    #[test]
+    fn every_event_measure_a_metric_reads_directly_declares_its_columns() {
+        // The dialog's columns come from this match rather than from the row, so
+        // a measure no arm names projects nothing and the reader gets a page of
+        // identical dates. Registering a measure is not enough — it has to be
+        // named here too, and nothing else enforces that.
+        //
+        // Read directly, because a ratio shows its numerator and denominator and
+        // `presentation` clears detail keys for it outright: a measure only
+        // ratios read needs no columns of its own, and demanding them would send
+        // the next such measure looking for an arm that changes nothing.
+        let read_directly: BTreeSet<&str> = builtin_metrics()
+            .iter()
+            .filter(|metric| !matches!(metric.computation, SeedComputation::Ratio { .. }))
+            .flat_map(|metric| &metric.inputs)
+            .map(|input| input.measure_key.as_str())
+            .collect();
+
+        let mut unnamed = Vec::new();
+        for builtin_source in builtin_sources() {
+            let source_key = builtin_source.source.key.as_str();
+            for measure in &builtin_source.measures {
+                if measure.evidence_granularity != EvidenceGranularity::Event
+                    || !read_directly.contains(measure.key.as_str())
+                {
+                    continue;
+                }
+                let presentation =
+                    evidence_presentation(source_key, &measure.key, EvidenceGranularity::Event);
+                if presentation.detail_keys.is_empty() {
+                    unnamed.push(format!("{source_key}/{}", measure.key));
+                }
+            }
+        }
+        assert!(
+            unnamed.is_empty(),
+            "event measures with no detail columns — their drilldown shows only a date: {unnamed:?}"
+        );
+    }
+
+    #[test]
+    fn a_counted_pull_request_reads_its_number_title_repository_and_author() {
+        // Absolute, because the split test below is relative: without this the
+        // whole arm could be trimmed and both would still pass.
+        for measure in [
+            "pr_created",
+            "pr_merged",
+            "default_pr_created",
+            "default_pr_merged",
+        ] {
+            let presentation = evidence_presentation("git", measure, EvidenceGranularity::Event);
+            assert_eq!(
+                presentation.detail_keys,
+                ["ref", "title", "repository", "author"],
+                "{measure} should read the request it counted"
+            );
+            // The row IS the request it counted, so a value column would be 1s.
+            assert!(!presentation.show_value, "{measure} should show no value");
+        }
+    }
+
+    #[test]
+    fn a_branch_scope_split_reads_the_same_columns_as_its_total() {
+        // The split measures count the same commits and requests the totals do,
+        // so a reader who drills into "landed" sees what they saw before, minus
+        // the rows that did not land.
+        for (total, split) in [
+            ("commit_count", "default_commit_count"),
+            ("commit_count", "non_default_commit_count"),
+            ("pr_created", "default_pr_created"),
+            ("pr_created", "non_default_pr_created"),
+            ("pr_merged", "default_pr_merged"),
+            ("pr_merged", "non_default_pr_merged"),
+        ] {
+            let expected = evidence_presentation("git", total, EvidenceGranularity::Event);
+            let actual = evidence_presentation("git", split, EvidenceGranularity::Event);
+            assert_eq!(
+                actual.detail_keys, expected.detail_keys,
+                "{split} should read the same columns as {total}"
+            );
+            assert_eq!(
+                actual.show_value, expected.show_value,
+                "{split} should show a value exactly when {total} does"
+            );
+        }
+    }
 
     #[test]
     fn event_presentation_projects_human_fields_and_dimensions() {

--- a/src/frontend/src/components/widgets/dashboard/members-overview.tsx
+++ b/src/frontend/src/components/widgets/dashboard/members-overview.tsx
@@ -9,6 +9,7 @@ import { TriageList, type TriageRow } from "@/components/widgets/dashboard/triag
 import { HEATMAP_METRIC_KEYS } from "@/lib/insight/groups";
 import type { NormalizedMetricResult } from "@/lib/metrics/collection";
 import { normalizePersonId } from "@/lib/metrics/entity";
+import { dropRedundantMetrics } from "@/lib/insight/metric-containment";
 import { worstEntry, type PeerStoryEntry } from "@/lib/metrics/peer-story";
 import type { PeerCohortLabel } from "@/lib/peers";
 import { rankableCount, rankCounts, type RankCounts } from "@/lib/scoring";
@@ -70,10 +71,11 @@ export function MembersOverview({
     const counts = new Map<string, RankCounts>();
     for (const member of gridMembers) {
       const entries = metricEntriesByPerson.get(member.entityId) ?? [];
-      counts.set(
-        member.entityId,
-        rankCounts(entries.map((entry) => ({ row: entry, rank: entry.status }))),
-      );
+      const ranks = dropRedundantMetrics(entries).map((entry) => ({
+        row: entry,
+        rank: entry.status,
+      }));
+      counts.set(member.entityId, rankCounts(ranks));
     }
     return counts;
   }, [gridMembers, metricEntriesByPerson]);
@@ -83,13 +85,16 @@ export function MembersOverview({
       members.map((member) => {
         const entityId = normalizePersonId(member.person_id);
         const entries = metricEntriesByPerson.get(entityId) ?? [];
+        // Counts and the rankable denominator they are read against both grade
+        // a pattern, so one fact gets one vote in each.
+        const counted = dropRedundantMetrics(entries);
         return {
           member,
           belowCount: metricBelowByMember.get(entityId) ?? 0,
-          topCount: entries.filter((entry) => entry.status === "top").length,
+          topCount: counted.filter((entry) => entry.status === "top").length,
           rankable: rankableCount(
             rankCounts(
-              entries.map((entry) => ({ row: entry, rank: entry.status })),
+              counted.map((entry) => ({ row: entry, rank: entry.status })),
             ),
           ),
           worstMetricLabel: worstEntry(entries)?.label ?? null,

--- a/src/frontend/src/components/widgets/dashboard/members-overview.tsx
+++ b/src/frontend/src/components/widgets/dashboard/members-overview.tsx
@@ -9,7 +9,7 @@ import { TriageList, type TriageRow } from "@/components/widgets/dashboard/triag
 import { HEATMAP_METRIC_KEYS } from "@/lib/insight/groups";
 import type { NormalizedMetricResult } from "@/lib/metrics/collection";
 import { normalizePersonId } from "@/lib/metrics/entity";
-import { dropRedundantMetrics } from "@/lib/insight/metric-containment";
+import { countableSignals } from "@/lib/insight/metric-containment";
 import { worstEntry, type PeerStoryEntry } from "@/lib/metrics/peer-story";
 import type { PeerCohortLabel } from "@/lib/peers";
 import { rankableCount, rankCounts, type RankCounts } from "@/lib/scoring";
@@ -71,10 +71,11 @@ export function MembersOverview({
     const counts = new Map<string, RankCounts>();
     for (const member of gridMembers) {
       const entries = metricEntriesByPerson.get(member.entityId) ?? [];
-      const ranks = dropRedundantMetrics(entries).map((entry) => ({
-        row: entry,
-        rank: entry.status,
-      }));
+      const ranks = countableSignals(
+        entries,
+        (entry) => entry.key,
+        (entry) => entry.status,
+      ).map((entry) => ({ row: entry, rank: entry.status }));
       counts.set(member.entityId, rankCounts(ranks));
     }
     return counts;
@@ -87,7 +88,11 @@ export function MembersOverview({
         const entries = metricEntriesByPerson.get(entityId) ?? [];
         // Counts and the rankable denominator they are read against both grade
         // a pattern, so one fact gets one vote in each.
-        const counted = dropRedundantMetrics(entries);
+        const counted = countableSignals(
+          entries,
+          (entry) => entry.key,
+          (entry) => entry.status,
+        );
         return {
           member,
           belowCount: metricBelowByMember.get(entityId) ?? 0,

--- a/src/frontend/src/components/widgets/metric-views/metric-group-card.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-group-card.test.tsx
@@ -197,4 +197,40 @@ describe("MetricGroupCard", () => {
     screen.getByRole("button").click();
     expect(refetch).toHaveBeenCalled();
   });
+
+  it("counts a contained metric once, so a pair cannot move the stripe", () => {
+    // The stripe turns red on a pattern — two bottoms and more than a quarter
+    // of the rankable set. A total and its default-branch part move together,
+    // so counting both would manufacture that pattern out of one weak fact.
+    const def: MetricGroup = {
+      ...DEF,
+      id: "git_output",
+      title: "Git output",
+      collection: {
+        metrics: [
+          { key: "git.commits", views: [{ view: "period" }, { view: "peer" }] },
+          {
+            key: "git.default_branch_commits",
+            views: [{ view: "period" }, { view: "peer" }],
+          },
+        ],
+      },
+      card: { preview: ["git.commits", "git.default_branch_commits"] },
+    };
+
+    render(
+      <MetricGroupCard
+        def={def}
+        entityId="me@x.com"
+        data={result([
+          aiMetric("git.commits", 1),
+          aiMetric("git.default_branch_commits", 1),
+        ])}
+        onOpen={vi.fn()}
+      />,
+    );
+
+    // Two bottom-quartile readings of one fact: one row behind peers, not two.
+    expect(screen.getByText("1 of 1 behind peers")).toBeInTheDocument();
+  });
 });

--- a/src/frontend/src/components/widgets/metric-views/metric-group-card.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-group-card.test.tsx
@@ -233,4 +233,39 @@ describe("MetricGroupCard", () => {
     // Two bottom-quartile readings of one fact: one row behind peers, not two.
     expect(screen.getByText("1 of 1 behind peers")).toBeInTheDocument();
   });
+
+  it("keeps a total's finding when its part has no comparison", () => {
+    // The part reached the response and says nothing — no value for this
+    // person. Letting it displace the total would delete the only real reading
+    // and leave the card claiming there is nothing to compare.
+    const def: MetricGroup = {
+      ...DEF,
+      id: "git_output",
+      title: "Git output",
+      collection: {
+        metrics: [
+          { key: "git.commits", views: [{ view: "period" }, { view: "peer" }] },
+          {
+            key: "git.default_branch_commits",
+            views: [{ view: "period" }, { view: "peer" }],
+          },
+        ],
+      },
+      card: { preview: ["git.commits"] },
+    };
+
+    render(
+      <MetricGroupCard
+        def={def}
+        entityId="me@x.com"
+        data={result([
+          aiMetric("git.commits", 1),
+          aiMetric("git.default_branch_commits", null),
+        ])}
+        onOpen={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("1 of 1 behind peers")).toBeInTheDocument();
+  });
 });

--- a/src/frontend/src/components/widgets/metric-views/metric-group-card.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-group-card.tsx
@@ -129,7 +129,11 @@ export function MetricGroupCard({
   // twice because a second one contains it moves the section's colour without
   // anything about the person changing. Thinning the tally, not the rows: the
   // list below still names every metric the group measures.
-  const counted = countableSignals(rows, (row) => row.metric.metric_key);
+  const counted = countableSignals(
+    rows,
+    (row) => row.metric.metric_key,
+    (row) => row.rank
+  );
   const counts = rankCounts(counted.map((row) => ({ row, rank: row.rank })));
   const status = applyFocusStatus(gradeSectionStanding(counts), focusMode);
   const badgeText = sectionStandingPhrase(counts);

--- a/src/frontend/src/components/widgets/metric-views/metric-group-card.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-group-card.tsx
@@ -13,7 +13,7 @@ import { GroupCardEmpty } from "@/components/widgets/group-card-empty";
 import { useSettings } from "@/hooks/use-settings";
 import { formatMetricValue } from "@/lib/format";
 import type { MetricGroup } from "@/lib/insight/groups";
-import { dropRedundantMetrics } from "@/lib/insight/metric-containment";
+import { countableSignals } from "@/lib/insight/metric-containment";
 import { peerStatusToStatus } from "@/lib/insight/peer-status";
 import {
   forEntity,
@@ -129,11 +129,8 @@ export function MetricGroupCard({
   // twice because a second one contains it moves the section's colour without
   // anything about the person changing. Thinning the tally, not the rows: the
   // list below still names every metric the group measures.
-  const tallied = dropRedundantMetrics(
-    rows.map((row) => ({ key: row.metric.metric_key, row }))
-  );
-  const ranked = tallied.map(({ row }) => ({ row, rank: row.rank }));
-  const counts = rankCounts(ranked);
+  const counted = countableSignals(rows, (row) => row.metric.metric_key);
+  const counts = rankCounts(counted.map((row) => ({ row, rank: row.rank })));
   const status = applyFocusStatus(gradeSectionStanding(counts), focusMode);
   const badgeText = sectionStandingPhrase(counts);
 

--- a/src/frontend/src/components/widgets/metric-views/metric-group-card.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-group-card.tsx
@@ -13,6 +13,7 @@ import { GroupCardEmpty } from "@/components/widgets/group-card-empty";
 import { useSettings } from "@/hooks/use-settings";
 import { formatMetricValue } from "@/lib/format";
 import type { MetricGroup } from "@/lib/insight/groups";
+import { dropRedundantMetrics } from "@/lib/insight/metric-containment";
 import { peerStatusToStatus } from "@/lib/insight/peer-status";
 import {
   forEntity,
@@ -123,7 +124,16 @@ export function MetricGroupCard({
     return [{ metric, value: entityData.value, rank, standing }];
   });
 
-  const counts = rankCounts(rows.map((row) => ({ row, rank: row.rank })));
+  // One fact, one vote. The stripe turns red on a PATTERN of weakness — two
+  // bottoms and more than a quarter of the rankable set — so a metric counted
+  // twice because a second one contains it moves the section's colour without
+  // anything about the person changing. Thinning the tally, not the rows: the
+  // list below still names every metric the group measures.
+  const tallied = dropRedundantMetrics(
+    rows.map((row) => ({ key: row.metric.metric_key, row }))
+  );
+  const ranked = tallied.map(({ row }) => ({ row, rank: row.rank }));
+  const counts = rankCounts(ranked);
   const status = applyFocusStatus(gradeSectionStanding(counts), focusMode);
   const badgeText = sectionStandingPhrase(counts);
 

--- a/src/frontend/src/components/widgets/metric-views/team-metric-group-card.tsx
+++ b/src/frontend/src/components/widgets/metric-views/team-metric-group-card.tsx
@@ -10,6 +10,7 @@ import { Spinner } from "@/components/ui/spinner";
 import { ComingSoon } from "@/components/widgets/coming-soon";
 import { useSettings } from "@/hooks/use-settings";
 import type { MetricGroup } from "@/lib/insight/groups";
+import { countableSignals } from "@/lib/insight/metric-containment";
 import {
   teamMetricStandings,
   type TeamMetricStanding,
@@ -84,7 +85,9 @@ export function TeamMetricGroupCard({
   const standings = teamMetricStandings(def, data.byKey, memberIds);
   const scored = standings.filter((s) => s.scored > 0);
   const counts = rankCounts(
-    standings.map((standing) => ({ row: standing, rank: standing.verdict }))
+    countableSignals(standings, (standing) => standing.metric.metric_key).map(
+      (standing) => ({ row: standing, rank: standing.verdict })
+    )
   );
   const status = applyFocusStatus(gradeSectionStanding(counts), focusMode);
   const badgeText = sectionStandingPhrase(counts);

--- a/src/frontend/src/components/widgets/metric-views/team-metric-group-card.tsx
+++ b/src/frontend/src/components/widgets/metric-views/team-metric-group-card.tsx
@@ -85,9 +85,11 @@ export function TeamMetricGroupCard({
   const standings = teamMetricStandings(def, data.byKey, memberIds);
   const scored = standings.filter((s) => s.scored > 0);
   const counts = rankCounts(
-    countableSignals(standings, (standing) => standing.metric.metric_key).map(
-      (standing) => ({ row: standing, rank: standing.verdict })
-    )
+    countableSignals(
+      standings,
+      (standing) => standing.metric.metric_key,
+      (standing) => standing.verdict
+    ).map((standing) => ({ row: standing, rank: standing.verdict }))
   );
   const status = applyFocusStatus(gradeSectionStanding(counts), focusMode);
   const badgeText = sectionStandingPhrase(counts);

--- a/src/frontend/src/lib/insight/groups.test.ts
+++ b/src/frontend/src/lib/insight/groups.test.ts
@@ -131,6 +131,22 @@ describe("groups registry", () => {
       "git.prs_created",
     ]);
   });
+
+  it("gives each default-branch split a value and a peer comparison", () => {
+    const git = groupById("git_output");
+    const byKey = new Map(git.collection.metrics.map((m) => [m.key, m]));
+
+    for (const key of [
+      "git.default_branch_commits",
+      "git.default_branch_prs_merged",
+    ]) {
+      // The number alone says nothing: "commits that landed" is only readable
+      // against the pool's middle, which is what the peer view carries. The
+      // sibling test above pins that neither takes a `branch_scope` breakdown.
+      const views = byKey.get(key)?.views.map((view) => view.view);
+      expect(views, key).toEqual(expect.arrayContaining(["period", "peer"]));
+    }
+  });
 });
 
 describe("visibleGroups", () => {

--- a/src/frontend/src/lib/insight/groups.ts
+++ b/src/frontend/src/lib/insight/groups.ts
@@ -190,6 +190,17 @@ const GIT_OUTPUT_COLLECTION: MetricCollectionConfig = {
       ],
     },
     {
+      // INVARIANT: no `branch_scope` breakdown on a metric already scoped to
+      // one branch. Not merely because the dimension would be constant —
+      // `/v1/metric-results` refuses a dimension a metric does not declare,
+      // and the call is all-or-nothing, so it would blank the whole section.
+      //
+      // The split keys stay in this collection even with no block of their
+      // own: `lens-configs.ts` may only name keys a group declares.
+      key: "git.default_branch_commits",
+      views: [{ view: "period" }, { view: "peer" }],
+    },
+    {
       key: "git.prs_merged",
       // `branch_scope` splits landed work from work still in flight. Two
       // groups, so the summary card's ribbon always lights up — and one
@@ -200,6 +211,10 @@ const GIT_OUTPUT_COLLECTION: MetricCollectionConfig = {
         { view: "peer" },
         { view: "breakdown", dimensions: ["branch_scope"] },
       ],
+    },
+    {
+      key: "git.default_branch_prs_merged",
+      views: [{ view: "period" }, { view: "peer" }],
     },
     {
       key: "git.lines_added",

--- a/src/frontend/src/lib/insight/metric-containment.test.ts
+++ b/src/frontend/src/lib/insight/metric-containment.test.ts
@@ -98,31 +98,47 @@ describe("dropRedundantMetrics", () => {
 });
 
 describe("countableSignals", () => {
+  const signal = (metric: string, rank: string | null) => ({ metric, rank });
+  const counted = (entries: ReturnType<typeof signal>[]) =>
+    countableSignals(
+      entries,
+      (entry) => entry.metric,
+      (entry) => entry.rank as never
+    ).map((entry) => entry.metric);
+
   it("gives one fact one vote, whatever shape the caller counts in", () => {
     // Every standing surface counts a different shape — rows, ranks, team
-    // standings — so the rule is reached through a key accessor rather than by
+    // standings — so the rule is reached through accessors rather than by
     // each caller reshaping its data to match it.
-    const signals = countableSignals(
-      [
-        { metric: "git.commits", rank: "bottom" },
-        { metric: "git.default_branch_commits", rank: "bottom" },
-        { metric: "git.pr_size", rank: "top" },
-      ],
-      (signal) => signal.metric
-    );
-
-    expect(signals.map((signal) => signal.metric)).toEqual([
-      "git.default_branch_commits",
-      "git.pr_size",
-    ]);
+    expect(
+      counted([
+        signal("git.commits", "bottom"),
+        signal("git.default_branch_commits", "bottom"),
+        signal("git.pr_size", "top"),
+      ])
+    ).toEqual(["git.default_branch_commits", "git.pr_size"]);
   });
 
   it("leaves a total alone when its part is not among the signals", () => {
-    const signals = countableSignals(
-      [{ metric: "git.commits", rank: "bottom" }],
-      (signal) => signal.metric
-    );
+    expect(counted([signal("git.commits", "bottom")])).toEqual(["git.commits"]);
+  });
 
-    expect(signals).toHaveLength(1);
+  it("keeps the total's vote when a present part has no comparison", () => {
+    // The part reached the response and says nothing — unmeasured for this
+    // person, or a pool too thin to disclose. Letting it displace the total
+    // would delete a real bottom reading and leave the section looking calm.
+    for (const silent of [null, "neutral"]) {
+      expect(
+        counted([
+          signal("git.commits", "bottom"),
+          signal("git.default_branch_commits", silent),
+        ]),
+        `part ranked ${silent}`
+      ).toEqual(["git.commits"]);
+    }
+  });
+
+  it("drops an unranked entry rather than counting it as a signal", () => {
+    expect(counted([signal("git.pr_size", "neutral")])).toEqual([]);
   });
 });

--- a/src/frontend/src/lib/insight/metric-containment.test.ts
+++ b/src/frontend/src/lib/insight/metric-containment.test.ts
@@ -15,6 +15,19 @@ describe("dropRedundantMetrics", () => {
     expect(kept.map((item) => item.key)).toEqual(["git.code_lines"]);
   });
 
+  it("drops a git total when its default-branch part is on screen", () => {
+    // Branch scope partitions the total, so "Commits 12" over "Commits on the
+    // default branch 9" is one fact ranked twice.
+    for (const [total, split] of [
+      ["git.commits", "git.default_branch_commits"],
+      ["git.prs_merged", "git.default_branch_prs_merged"],
+    ]) {
+      const kept = dropRedundantMetrics([item(total), item(split)]);
+      const keys = kept.map((entry) => entry.key);
+      expect(keys, total).toEqual([split]);
+    }
+  });
+
   it("keeps the wider metric when it is the only one there", () => {
     // Nothing is duplicated, and the wider metric is still a real finding.
     const kept = dropRedundantMetrics([item("git.lines_added")]);

--- a/src/frontend/src/lib/insight/metric-containment.test.ts
+++ b/src/frontend/src/lib/insight/metric-containment.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { dropRedundantMetrics } from "./metric-containment";
+import { countableSignals, dropRedundantMetrics } from "./metric-containment";
 
 const item = (key: string) => ({ key });
 
@@ -94,5 +94,35 @@ describe("dropRedundantMetrics", () => {
       new Set(["git.code_lines"])
     );
     expect(kept).toEqual([]);
+  });
+});
+
+describe("countableSignals", () => {
+  it("gives one fact one vote, whatever shape the caller counts in", () => {
+    // Every standing surface counts a different shape — rows, ranks, team
+    // standings — so the rule is reached through a key accessor rather than by
+    // each caller reshaping its data to match it.
+    const signals = countableSignals(
+      [
+        { metric: "git.commits", rank: "bottom" },
+        { metric: "git.default_branch_commits", rank: "bottom" },
+        { metric: "git.pr_size", rank: "top" },
+      ],
+      (signal) => signal.metric
+    );
+
+    expect(signals.map((signal) => signal.metric)).toEqual([
+      "git.default_branch_commits",
+      "git.pr_size",
+    ]);
+  });
+
+  it("leaves a total alone when its part is not among the signals", () => {
+    const signals = countableSignals(
+      [{ metric: "git.commits", rank: "bottom" }],
+      (signal) => signal.metric
+    );
+
+    expect(signals).toHaveLength(1);
   });
 });

--- a/src/frontend/src/lib/insight/metric-containment.ts
+++ b/src/frontend/src/lib/insight/metric-containment.ts
@@ -14,6 +14,10 @@
 export const METRIC_CONTAINS: Readonly<Record<string, readonly string[]>> = {
   // "All lines added, by file category" ⊃ "lines added to code files".
   "git.lines_added": ["git.code_lines"],
+  // Branch scope partitions each total, so the default-branch reading is a
+  // part of it by construction — not a correlated second measurement.
+  "git.commits": ["git.default_branch_commits"],
+  "git.prs_merged": ["git.default_branch_prs_merged"],
   // "Files shared with any recipient" ⊃ inside / outside the organization.
   "collab.files_shared": [
     "collab.files_shared_internal",

--- a/src/frontend/src/lib/insight/metric-containment.ts
+++ b/src/frontend/src/lib/insight/metric-containment.ts
@@ -1,3 +1,6 @@
+import { isRankable } from "@/lib/scoring";
+import type { PeerStatusWithNeutral } from "@/lib/peers";
+
 /**
  * Metrics that count a superset of what another metric counts.
  *
@@ -77,16 +80,20 @@ const RESTATEMENT_GROUP = new Map<string, number>(
  * Displayed rows do not: "what did we measure" and "how many independent
  * things went wrong" are different questions.
  *
- * INVARIANT: thinning is over what actually read for this entity, never over
- * the collection — a total whose narrower part is silent is the only reading
- * there is, and has to keep its vote.
+ * INVARIANT: thinning is over what actually READ for this entity — never over
+ * the collection, and never over a part that is present but unranked. A total
+ * whose narrower part says nothing is the only reading there is and keeps its
+ * vote, which is why the rank is required rather than optional: an entry with
+ * no comparison must not be able to displace one that has it.
  */
 export function countableSignals<T>(
   entries: readonly T[],
-  keyOf: (entry: T) => string
+  keyOf: (entry: T) => string,
+  rankOf: (entry: T) => PeerStatusWithNeutral | null
 ): T[] {
+  const ranked = entries.filter((entry) => isRankable(rankOf(entry)));
   const kept = dropRedundantMetrics(
-    entries.map((entry) => ({ key: keyOf(entry), entry }))
+    ranked.map((entry) => ({ key: keyOf(entry), entry }))
   );
   return kept.map((item) => item.entry);
 }

--- a/src/frontend/src/lib/insight/metric-containment.ts
+++ b/src/frontend/src/lib/insight/metric-containment.ts
@@ -68,6 +68,29 @@ const RESTATEMENT_GROUP = new Map<string, number>(
  * items in the order the reader will meet them — most severe first, or in
  * candidate order for a row that is chosen rather than ranked.
  */
+/**
+ * The entries a standing may count as independent signals.
+ *
+ * A section's status and a person's problem count grade a PATTERN — how many
+ * separate things went wrong — so a metric another one already contains must
+ * not vote twice. Every surface that grades or tallies goes through here.
+ * Displayed rows do not: "what did we measure" and "how many independent
+ * things went wrong" are different questions.
+ *
+ * INVARIANT: thinning is over what actually read for this entity, never over
+ * the collection — a total whose narrower part is silent is the only reading
+ * there is, and has to keep its vote.
+ */
+export function countableSignals<T>(
+  entries: readonly T[],
+  keyOf: (entry: T) => string
+): T[] {
+  const kept = dropRedundantMetrics(
+    entries.map((entry) => ({ key: keyOf(entry), entry }))
+  );
+  return kept.map((item) => item.entry);
+}
+
 export function dropRedundantMetrics<T extends { key: string }>(
   items: readonly T[],
   alreadyShown: ReadonlySet<string> = new Set()

--- a/src/frontend/src/lib/insight/team-metrics.test.ts
+++ b/src/frontend/src/lib/insight/team-metrics.test.ts
@@ -26,10 +26,11 @@ function metricWithPeers(
     suppressed?: boolean;
     unmeasured?: boolean;
   }>,
+  key = "ai.active_days",
 ): MetricResult {
   return {
-    metric_key: "ai.active_days",
-    label: "Active AI days",
+    metric_key: key,
+    label: key,
     unit: "days",
     format: "integer",
     direction: "higher_is_better",
@@ -55,6 +56,21 @@ function metricWithPeers(
         })),
       },
     ],
+  };
+}
+
+function gitDef(keys: readonly string[]): MetricGroup {
+  return {
+    id: "git_output",
+    title: "Git output",
+    collection: {
+      metrics: keys.map((key) => ({
+        key,
+        views: [{ view: "period" }, { view: "peer" }] as const,
+      })),
+    },
+    card: { preview: [keys[0]!] },
+    drilldown: [],
   };
 }
 
@@ -128,6 +144,47 @@ describe("teamMetricStandings / metricBelowCounts", () => {
     const counts = metricBelowCounts(def, byKey, members);
     expect(counts.get("a@x.com")).toBe(1);
     expect(counts.get("c@x.com")).toBeUndefined();
+  });
+
+  it("counts a total and its default-branch part as one problem", () => {
+    // Both readings put the same person at the bottom, because one is part of
+    // the other. Two would overstate how much is wrong with them.
+    const trailing = [
+      { id: "a@x.com", value: 2 },
+      { id: "b@x.com", value: 3 },
+      { id: "c@x.com", value: 20 },
+    ];
+    const pairKeys = ["git.commits", "git.default_branch_commits"];
+    const paired = normalizeMetricResults(
+      pairKeys.map((key) => metricWithPeers(trailing, key)),
+    );
+
+    expect(
+      metricBelowCounts(gitDef(pairKeys), paired, members).get("a@x.com"),
+    ).toBe(1);
+  });
+
+  it("keeps the total's vote when its part reads nothing", () => {
+    // Thinning is over what actually read: with no default-branch reading the
+    // total is the only finding there is.
+    const totalOnly = normalizeMetricResults([
+      metricWithPeers(
+        [
+          { id: "a@x.com", value: 2 },
+          { id: "b@x.com", value: 3 },
+          { id: "c@x.com", value: 20 },
+        ],
+        "git.commits",
+      ),
+    ]);
+
+    expect(
+      metricBelowCounts(
+        gitDef(["git.commits", "git.default_branch_commits"]),
+        totalOnly,
+        members,
+      ).get("a@x.com"),
+    ).toBe(1);
   });
 });
 

--- a/src/frontend/src/lib/insight/team-metrics.ts
+++ b/src/frontend/src/lib/insight/team-metrics.ts
@@ -1,4 +1,5 @@
 import type { MetricGroup } from "@/lib/insight/groups";
+import { dropRedundantMetrics } from "@/lib/insight/metric-containment";
 import {
   forEntity,
   type NormalizedMetricResult,
@@ -110,12 +111,15 @@ export function metricBelowCounts(
 ): Map<string, number> {
   const out = new Map<string, number>();
   for (const memberId of memberIds) {
-    let below = 0;
-    for (const metricConfig of def.collection.metrics) {
+    const read = def.collection.metrics.flatMap((metricConfig) => {
       const metric = byKey.get(metricConfig.key);
-      if (!metric) continue;
-      if (memberMetricStanding(metric, memberId) === "bottom") below += 1;
-    }
+      if (!metric) return [];
+      const standing = memberMetricStanding(metric, memberId);
+      return standing == null ? [] : [{ key: metric.metric_key, standing }];
+    });
+    const below = dropRedundantMetrics(read).filter(
+      (entry) => entry.standing === "bottom",
+    ).length;
     if (below > 0) out.set(memberId, below);
   }
   return out;

--- a/src/frontend/src/lib/insight/team-metrics.ts
+++ b/src/frontend/src/lib/insight/team-metrics.ts
@@ -1,5 +1,5 @@
 import type { MetricGroup } from "@/lib/insight/groups";
-import { dropRedundantMetrics } from "@/lib/insight/metric-containment";
+import { countableSignals } from "@/lib/insight/metric-containment";
 import {
   forEntity,
   type NormalizedMetricResult,
@@ -117,9 +117,11 @@ export function metricBelowCounts(
       const standing = memberMetricStanding(metric, memberId);
       return standing == null ? [] : [{ key: metric.metric_key, standing }];
     });
-    const below = dropRedundantMetrics(read).filter(
-      (entry) => entry.standing === "bottom",
-    ).length;
+    const below = countableSignals(
+      read,
+      (entry) => entry.key,
+      (entry) => entry.standing,
+    ).filter((entry) => entry.standing === "bottom").length;
     if (below > 0) out.set(memberId, below);
   }
   return out;

--- a/src/frontend/src/lib/portal/lens-configs.test.ts
+++ b/src/frontend/src/lib/portal/lens-configs.test.ts
@@ -9,6 +9,7 @@ import {
   lensEntry,
   sectionMetricKeys,
   visibleSections,
+  type LensConfig,
   type SectionSpec,
 } from "./lens-configs";
 
@@ -33,6 +34,28 @@ describe("DIRECTION_LENSES registry", () => {
           expect(KNOWN_KEYS.has(key), `${dir}/${lens}: ${key}`).toBe(true);
         }
       }
+    }
+  });
+
+  it("puts each default-branch reading next to the total it refines", () => {
+    const entry = lensEntry("dev", "Git output");
+    const headline = (entry as LensConfig).sections.find(
+      (section): section is Extract<SectionSpec, { kind: "headline" }> =>
+        section.kind === "headline",
+    );
+    const metrics = headline?.metrics ?? [];
+
+    // Adjacency is the rule, not the exact tile list: a split read apart from
+    // its total says nothing, because "landed" only means something against
+    // the whole. Asserting the whole array instead would fail on any unrelated
+    // tile, under a name that would not explain why.
+    for (const [total, split] of [
+      ["git.commits", "git.default_branch_commits"],
+      ["git.prs_merged", "git.default_branch_prs_merged"],
+    ]) {
+      const at = metrics.indexOf(total);
+      expect(at, `${total} is in the headline`).toBeGreaterThanOrEqual(0);
+      expect(metrics[at + 1], `the tile after ${total}`).toBe(split);
     }
   });
 

--- a/src/frontend/src/lib/portal/lens-configs.ts
+++ b/src/frontend/src/lib/portal/lens-configs.ts
@@ -291,11 +291,21 @@ const DEV: Record<string, LensEntry> = {
     title: "Development · Git output",
     sections: [
       {
+        // Each split key sits beside the total it refines, so a reader meets
+        // the two together rather than as unrelated tiles. Only the
+        // default-branch side is drawn: the other half is the total minus it,
+        // and naming both would spend four tiles on two facts.
+        //
+        // The two big figures are per ACTIVE person, each over its own active
+        // count, so they are not a share of one another — the team totals
+        // under them are what divide.
         kind: "headline",
         metrics: [
           "git.commits",
+          "git.default_branch_commits",
           "git.prs_created",
           "git.prs_merged",
+          "git.default_branch_prs_merged",
           "git.code_lines",
         ],
       },

--- a/src/frontend/src/lib/portal/use-person-sections.ts
+++ b/src/frontend/src/lib/portal/use-person-sections.ts
@@ -113,7 +113,13 @@ export function usePersonSectionStandings(personId: string): SectionStanding[] {
       });
       return [{ row: m.key, rank: standing.rank }];
     });
-    const counts = rankCounts(countableSignals(ranks, (rank) => rank.row));
+    const counts = rankCounts(
+      countableSignals(
+        ranks,
+        (entry) => entry.row,
+        (entry) => entry.rank,
+      ),
+    );
 
     return {
       id: def.id,

--- a/src/frontend/src/lib/portal/use-person-sections.ts
+++ b/src/frontend/src/lib/portal/use-person-sections.ts
@@ -2,6 +2,7 @@ import { visibleGroups, type GroupId } from "@/lib/insight/groups";
 import { groupHasData } from "@/lib/insight/group-data";
 import { partState, reachableMetricKeys } from "@/lib/insight/coverage";
 import { injectCohortPeer } from "@/lib/insight/within-team-peer";
+import { countableSignals } from "@/lib/insight/metric-containment";
 import {
   gradeSectionStanding,
   rankCounts,
@@ -112,7 +113,7 @@ export function usePersonSectionStandings(personId: string): SectionStanding[] {
       });
       return [{ row: m.key, rank: standing.rank }];
     });
-    const counts = rankCounts(ranks);
+    const counts = rankCounts(countableSignals(ranks, (rank) => rank.row));
 
     return {
       id: def.id,

--- a/src/frontend/src/lib/scoring.ts
+++ b/src/frontend/src/lib/scoring.ts
@@ -29,6 +29,16 @@ export function rankableCount(counts: RankCounts): number {
 }
 
 /**
+ * Whether a rank carries a comparison at all — the same set `rankCounts`
+ * tallies as ranked. A metric present in the response but unmeasured for this
+ * person, or measured against a pool too thin to disclose, ranks `neutral`: it
+ * is not a weak reading, it is no reading.
+ */
+export function isRankable(rank: PeerStatusWithNeutral | null): boolean {
+  return rank === "top" || rank === "in_pack" || rank === "bottom"
+}
+
+/**
  * Fraction of the rankable set a rank must clear to count as a section-wide
  * pattern rather than quartile noise. A quartile hands ~25% of any healthy
  * cohort to the bottom by construction, so a lone weak metric is expected, not


### PR DESCRIPTION
Commits and merged pull requests were reported as totals only, so nothing on screen separated work that landed from work still in flight. The metrics for it exist and are already served (#2790) — nothing named them. Adds a tile for each beside the total it refines in the Git output lens, and both as measured metrics in the person zone.

Two fixes fell out of building it: those measures had no entry in the drilldown's column table, so the dialog listed bare dates instead of commits; and a group card counted a total and its own part as two independent signals, which can push a section's standing into red. **The second also affects the lines and collaboration pairs already registered — a section carrying one can lose a false red.** It is a commit of its own, revertable alone.

Refs #2786.

**Where:** `analytics` (drilldown presentation), `frontend` (lens + group config, group card tally).

**Verify:** `cargo test -p analytics` in `src/backend`; `pnpm typecheck && pnpm lint && pnpm vitest run` in `src/frontend`. The drilldown columns are only visible once deployed — the seed leaves `is_default_branch` unset, so `default_*` reads zero locally.

## Screens

Mock mode, so the data is synthetic: labels are derived from metric keys and values are per-key hashes, which is why a pair need not add up.

![Git output lens headline](https://raw.githubusercontent.com/mozhaev-dev/insight/pr-2810-screens/1-lens-tiles.png)

![Person zone, also measured here](https://raw.githubusercontent.com/mozhaev-dev/insight/pr-2810-screens/2-person-index.png)