### PR TITLE
perf(dbt): build the default-branch commit set outside the git evidence query

### DIFF
--- a/src/ingestion/gold/git_default_branch_commits.sql
+++ b/src/ingestion/gold/git_default_branch_commits.sql
@@ -1,0 +1,61 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'source_id', 'project_key', 'repo_slug', 'commit_hash'],
+    schema=var('gold_database'),
+    settings={'allow_nullable_key': 1},
+    tags=['gold'],
+    query_settings=metric_serving_query_settings()
+) }}
+
+-- Commits that reached the default branch through a merged pull request.
+-- Materialized so the PR-membership joins run once per build in their own
+-- query budget instead of inside the evidence build.
+--
+-- `is_default_branch` alone is reachability AT SYNC TIME: a commit first seen
+-- on a feature branch stays 0, and only a re-read corrects it. That is the
+-- wrong tense for a `branch_scope` that means "did this work land". A merged
+-- request whose destination IS the default branch is standing proof that its
+-- commits landed, and it is proof the sources keep indefinitely.
+--
+-- INVARIANT: this cannot see a branch merged by a fast-forward push with no
+-- pull request. GitLab still corrects those itself (advancing the default head
+-- re-walks the range), the proxy-backed sources only within their lookback
+-- window.
+WITH
+-- The default branch NAME per repository, which is what a pull request's
+-- destination has to be compared against. Every git connector reports it.
+-- min() rather than any() so a repository that somehow claims two default
+-- branches resolves the same way on every read.
+repository_default_branches AS (
+    SELECT
+        tenant_id,
+        source_id,
+        project_key,
+        repo_slug,
+        min(branch_name) AS branch_name
+    FROM {{ ref('class_git_repository_branches') }} FINAL
+    WHERE is_default = 1
+    GROUP BY tenant_id, source_id, project_key, repo_slug
+)
+
+SELECT DISTINCT
+    links.tenant_id AS tenant_id,
+    links.source_id AS source_id,
+    links.project_key AS project_key,
+    links.repo_slug AS repo_slug,
+    links.commit_hash AS commit_hash
+FROM {{ ref('class_git_pull_requests_commits') }} AS links FINAL
+INNER JOIN {{ ref('class_git_pull_requests') }} AS prs FINAL
+    ON prs.tenant_id = links.tenant_id
+    AND prs.source_id = links.source_id
+    AND prs.project_key = links.project_key
+    AND prs.repo_slug = links.repo_slug
+    AND prs.pr_id = links.pr_id
+INNER JOIN repository_default_branches AS defaults
+    ON defaults.tenant_id = links.tenant_id
+    AND defaults.source_id = links.source_id
+    AND defaults.project_key = links.project_key
+    AND defaults.repo_slug = links.repo_slug
+WHERE prs.state = 'MERGED'
+  AND prs.destination_branch = defaults.branch_name

--- a/src/ingestion/gold/git_metric_evidence.sql
+++ b/src/ingestion/gold/git_metric_evidence.sql
@@ -54,40 +54,6 @@ repository_default_branches AS (
     WHERE is_default = 1
     GROUP BY tenant_id, source_id, project_key, repo_slug
 ),
--- Commits that reached the default branch through a merged pull request.
---
--- `is_default_branch` alone is reachability AT SYNC TIME: a commit first seen
--- on a feature branch stays 0, and only a re-read corrects it. That is the
--- wrong tense for a `branch_scope` that means "did this work land". A merged
--- request whose destination IS the default branch is standing proof that its
--- commits landed, and it is proof the sources keep indefinitely.
---
--- INVARIANT: this cannot see a branch merged by a fast-forward push with no
--- pull request. GitLab still corrects those itself (advancing the default head
--- re-walks the range), the proxy-backed sources only within their lookback
--- window.
-merged_default_branch_commits AS (
-    SELECT DISTINCT
-        links.tenant_id AS tenant_id,
-        links.source_id AS source_id,
-        links.project_key AS project_key,
-        links.repo_slug AS repo_slug,
-        links.commit_hash AS commit_hash
-    FROM {{ ref('class_git_pull_requests_commits') }} AS links FINAL
-    INNER JOIN {{ ref('class_git_pull_requests') }} AS prs FINAL
-        ON prs.tenant_id = links.tenant_id
-        AND prs.source_id = links.source_id
-        AND prs.project_key = links.project_key
-        AND prs.repo_slug = links.repo_slug
-        AND prs.pr_id = links.pr_id
-    INNER JOIN repository_default_branches AS defaults
-        ON defaults.tenant_id = links.tenant_id
-        AND defaults.source_id = links.source_id
-        AND defaults.project_key = links.project_key
-        AND defaults.repo_slug = links.repo_slug
-    WHERE prs.state = 'MERGED'
-      AND prs.destination_branch = defaults.branch_name
-),
 commits_source AS (
     SELECT
         tenant_id,
@@ -109,7 +75,7 @@ commits_source AS (
             is_default_branch = 1
                 OR (tenant_id, source_id, project_key, repo_slug, commit_hash) IN (
                     SELECT tenant_id, source_id, project_key, repo_slug, commit_hash
-                    FROM merged_default_branch_commits
+                    FROM {{ ref('git_default_branch_commits') }}
                 ),
             'default',
             'non_default'

--- a/src/ingestion/gold/schema.yml
+++ b/src/ingestion/gold/schema.yml
@@ -75,6 +75,19 @@ models:
       - name: details
         description: "Additional display fields keyed by stable field name"
 
+  - name: git_default_branch_commits
+    description: >
+      Commits that reached a repository's default branch through a merged pull
+      request: one row per tenant/source/project/repo/commit. Materialized so
+      the pull-request membership joins run once per build in their own query
+      budget; the git evidence build reads it as a semi-join set alongside the
+      sync-time is_default_branch flag.
+    columns:
+      - name: commit_hash
+        description: "Commit identifier within the repository"
+        tests:
+          - not_null
+
   - name: git_metric_evidence
     description: >
       Materialized MergeTree evidence serving table for Git source measures.


### PR DESCRIPTION
**Why.** The deploy hook's `dbt run --select tag:gold` fails building `git_metric_evidence` with `MEMORY_LIMIT_EXCEEDED` at the model's 1.5 GiB cap since the branch-scope split landed, blocking upgrades.

**What changed.** The merged-pull-request default-branch commit set moves out of the evidence query into its own gold table, `git_default_branch_commits`, so its two `FINAL` joins run in a separate query with its own budget; the evidence build reads the set back as an `IN` semi-join over the table. **The `repository_default_branches` CTE now exists in both models** — the evidence query still needs it for the pull-request branch scope; materializing it too would be a second new relation for a GROUP BY that is cheap in place.

**Verified.** `dbt parse` and `dbt ls` confirm the graph (`git_default_branch_commits` → `git_metric_evidence` → observations/coverage). Not verified here: peak memory of the remaining evidence query — measured next on a stand carrying this build.
