### PR TITLE
fix(frontend): keep the distribution card's median clear of its ⋯ button

### DIFF
--- a/src/frontend/src/components/widgets/metric-views/metric-card-actions.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-card-actions.tsx
@@ -13,13 +13,17 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
 
 export function MetricCardActions({
   evidence,
   label,
+  placement = "overlay",
 }: {
   evidence: MetricEvidenceSelection | null | undefined;
   label: string;
+  // `overlay` takes the button out of flow, so the call site owes it clear space.
+  placement?: "overlay" | "inline";
 }) {
   const evidenceContext = useMetricEvidenceOptional();
   const scope = useEvidenceScope();
@@ -33,7 +37,10 @@ export function MetricCardActions({
             type="button"
             variant="ghost"
             size="icon-xs"
-            className="absolute top-4 right-4 z-10 text-muted-foreground"
+            className={cn(
+              "text-muted-foreground",
+              placement === "overlay" && "absolute top-4 right-4 z-10"
+            )}
             aria-label={`More actions for ${label}`}
             onClick={(event) => event.stopPropagation()}
           >

--- a/src/frontend/src/components/widgets/metric-views/metric-card-actions.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-card-actions.tsx
@@ -43,9 +43,8 @@ export function MetricCardActions({
             )}
             aria-label={`More actions for ${label}`}
             onClick={(event) => event.stopPropagation()}
-          >
-            <Ellipsis />
-          </Button>
+            icon={<Ellipsis />}
+          />
         }
       />
       <DropdownMenuContent align="end" className="w-48">

--- a/src/frontend/src/components/widgets/metric-views/metric-histogram.stories.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-histogram.stories.tsx
@@ -105,6 +105,17 @@ function expectHeadlineClearOfActions(canvasElement: HTMLElement) {
   expect(button, "the card renders its actions button").not.toBeNull();
   expect(headline, "the card renders its median headline").not.toBeUndefined();
 
+  // A flex or grid headline draws no box for the whitespace between the label
+  // and the value, while textContent still reads "Median 749 hours".
+  const label = document.createRange();
+  label.selectNodeContents(headline!.firstChild!);
+  const value = headline!.querySelector("span")!.getBoundingClientRect();
+
+  expect(
+    value.left - label.getBoundingClientRect().right,
+    'the space between "Median" and its value is drawn',
+  ).toBeGreaterThan(1);
+
   const buttonBox = button!.getBoundingClientRect();
   const headlineBox = headline!.getBoundingClientRect();
 
@@ -116,6 +127,29 @@ function expectHeadlineClearOfActions(canvasElement: HTMLElement) {
       headlineBox.left,
     )}–${Math.round(headlineBox.right)})`,
   ).toBeGreaterThan(0);
+
+  const glyph = button!.querySelector("svg")!.getBoundingClientRect();
+  const centre = (box: DOMRect) => box.top + box.height / 2;
+
+  expect(
+    Math.round(Math.abs(centre(glyph) - centre(headlineBox))),
+    `the ⋯ glyph sits on the median's centre line (glyph ${Math.round(
+      centre(glyph),
+    )}, value ${Math.round(centre(headlineBox))})`,
+  ).toBeLessThanOrEqual(1);
+}
+
+/** The ⋯ column takes its width from the subtitle's line. */
+function expectSubtitleOnOneLine(canvasElement: HTMLElement) {
+  const subtitle = canvasElement.querySelector<HTMLElement>(
+    '[data-slot="card-header"] span.truncate + span',
+  )!;
+  const lineHeight = parseFloat(getComputedStyle(subtitle).lineHeight);
+
+  expect(
+    Math.round(subtitle.getBoundingClientRect().height / lineHeight),
+    `the subtitle "${subtitle.textContent}" stays on one line`,
+  ).toBe(1);
 }
 
 /** Measured card width in the three-up grid at a 1280 px viewport. */
@@ -129,6 +163,7 @@ export const TestHeadlineClearOfActionsWide: Story = {
     ),
   ],
   play: async ({ canvasElement }) => {
+    expectSubtitleOnOneLine(canvasElement);
     expectHeadlineClearOfActions(canvasElement);
   },
 };

--- a/src/frontend/src/components/widgets/metric-views/metric-histogram.stories.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-histogram.stories.tsx
@@ -1,0 +1,149 @@
+/**
+ * Stories + browser component tests for `<MetricHistogram>`.
+ *
+ * These assertions read box geometry, which jsdom never lays out — they only
+ * mean anything in the browser project.
+ *
+ * See docs/testing/storybook-component-tests.md.
+ */
+
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn } from "storybook/test";
+
+import type { MetricResult } from "@/api/metric-results-client";
+import { EvidenceDialogContext } from "@/components/metric-evidence-context";
+import { MetricHistogram } from "@/components/widgets/metric-views/metric-histogram";
+import { normalizeMetricResults } from "@/lib/metrics/collection";
+
+const ENTITY_ID = "me@example.com";
+
+const BINS = [
+  { lo: 0, hi: 10, count: 3 },
+  { lo: 10, hi: 20, count: 5 },
+  { lo: 20, hi: 30, count: 2 },
+  { lo: 30, hi: 40, count: 1 },
+];
+
+/**
+ * Narrowing the 749 value stops the headline reaching the button, and the
+ * overlap these tests cover disappears.
+ */
+function drilldownMetric() {
+  const result: MetricResult = {
+    metric_key: "git.pr_cycle_time_h",
+    label: "PR cycle time",
+    unit: "hours",
+    format: "decimal",
+    direction: "lower_is_better",
+    computation: "median",
+    drilldown: { granularity: ["event"] },
+    selection: {
+      metric_key: "git.pr_cycle_time_h",
+      entity: { type: "person", ids: [ENTITY_ID] },
+      period: { from: "2026-07-01", to: "2026-07-31" },
+      filters: [],
+    },
+    views: [
+      { view: "period", values: [{ entity_id: ENTITY_ID, value: 749 }] },
+      {
+        view: "peer",
+        values: [
+          {
+            entity_id: ENTITY_ID,
+            target_value: 749,
+            p25: null,
+            median: 157,
+            p75: null,
+            min: null,
+            max: null,
+            n: 10,
+          },
+        ],
+      },
+      { view: "histogram", values: [{ entity_id: ENTITY_ID, bins: BINS }] },
+    ],
+  };
+  return normalizeMetricResults([result]).get("git.pr_cycle_time_h")!;
+}
+
+const meta: Meta<typeof MetricHistogram> = {
+  title: "Widgets/MetricViews/MetricHistogram",
+  component: MetricHistogram,
+  args: { metric: drilldownMetric(), entityId: ENTITY_ID },
+  decorators: [
+    (Story) => (
+      <EvidenceDialogContext.Provider
+        value={{
+          openEvidence: fn(),
+          openEvidenceTargets: fn(),
+          openEvidencePeople: fn(),
+        }}
+      >
+        <Story />
+      </EvidenceDialogContext.Provider>
+    ),
+  ],
+};
+export default meta;
+
+type Story = StoryObj<typeof MetricHistogram>;
+
+export const Default: Story = {};
+
+/**
+ * Queries alone cannot catch this: both nodes stay present and readable while
+ * one is drawn over the other.
+ */
+function expectHeadlineClearOfActions(canvasElement: HTMLElement) {
+  const button = canvasElement.querySelector<HTMLElement>(
+    '[aria-label^="More actions for"]',
+  );
+  const headline = [
+    ...canvasElement.querySelectorAll<HTMLElement>("span"),
+  ].find((span) => span.textContent?.trim().startsWith("Median"));
+
+  expect(button, "the card renders its actions button").not.toBeNull();
+  expect(headline, "the card renders its median headline").not.toBeUndefined();
+
+  const buttonBox = button!.getBoundingClientRect();
+  const headlineBox = headline!.getBoundingClientRect();
+
+  expect(
+    Math.round(buttonBox.left - headlineBox.right),
+    `the ⋯ button starts after the median value ends (button ${Math.round(
+      buttonBox.left,
+    )}–${Math.round(buttonBox.right)}, value ${Math.round(
+      headlineBox.left,
+    )}–${Math.round(headlineBox.right)})`,
+  ).toBeGreaterThan(0);
+}
+
+/** Measured card width in the three-up grid at a 1280 px viewport. */
+export const TestHeadlineClearOfActionsWide: Story = {
+  tags: ["test"],
+  decorators: [
+    (Story) => (
+      <div className="w-[428px]">
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    expectHeadlineClearOfActions(canvasElement);
+  },
+};
+
+/** Measured card width in the single-column stack at a 390 px viewport. */
+export const TestHeadlineClearOfActionsNarrow: Story = {
+  tags: ["test"],
+  decorators: [
+    (Story) => (
+      <div className="w-[326px]">
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    expectHeadlineClearOfActions(canvasElement);
+  },
+};

--- a/src/frontend/src/components/widgets/metric-views/metric-histogram.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-histogram.tsx
@@ -12,13 +12,17 @@ import {
   type ChartConfig,
 } from "@/components/ui/chart";
 import { evidenceSelection } from "@/api/metric-drilldown-client";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardHeader,
+} from "@/components/ui/card";
 import { ChartEmpty } from "@/components/widgets/metric-views/chart-empty";
 import { MetricCardActions } from "@/components/widgets/metric-views/metric-card-actions";
 import { formatMetricNumber } from "@/lib/format";
 import { forEntity, type NormalizedMetricResult } from "@/lib/metrics/collection";
 import { STATUS_COLOR_VAR, statusVsMedian, type Status } from "@/lib/status";
-import { cn } from "@/lib/utils";
 
 export interface MetricHistogramProps {
   metric: NormalizedMetricResult;
@@ -110,12 +114,11 @@ export function MetricHistogram({ metric, entityId }: MetricHistogramProps) {
   const evidence = metric.drilldown
     ? evidenceSelection(metric.selection, entityId)
     : null;
-  const actions = <MetricCardActions evidence={evidence} label={metric.label} />;
 
   // Shared header so an empty tile reads as the same chart, laid out to match
   // its populated neighbours in the grid rather than collapsing to a corner.
   const header = (
-    <CardHeader className={cn("pb-2", evidence && "pr-10")}>
+    <CardHeader className="pb-2">
       <div className="flex items-start justify-between gap-2">
         <div className="flex min-w-0 flex-col">
           <span className="truncate text-sm font-semibold">{metric.label}</span>
@@ -140,13 +143,21 @@ export function MetricHistogram({ metric, entityId }: MetricHistogramProps) {
           </span>
         ) : null}
       </div>
+      {evidence ? (
+        <CardAction>
+          <MetricCardActions
+            evidence={evidence}
+            label={metric.label}
+            placement="inline"
+          />
+        </CardAction>
+      ) : null}
     </CardHeader>
   );
 
   if (bins.length === 0) {
     return (
-      <Card className="relative shrink-0">
-        {actions}
+      <Card className="shrink-0">
         {header}
         <CardContent>
           <ChartEmpty message="No values in this period" />
@@ -158,8 +169,7 @@ export function MetricHistogram({ metric, entityId }: MetricHistogramProps) {
   const { rows, pivotLabel } = buildRows(bins, peerMedian, metric);
 
   return (
-    <Card className="relative shrink-0">
-      {actions}
+    <Card className="shrink-0">
       {header}
       <CardContent>
         <ChartContainer config={CONFIG} className="h-48 min-h-48 w-full">

--- a/src/frontend/src/components/widgets/metric-views/metric-histogram.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-histogram.tsx
@@ -134,7 +134,8 @@ export function MetricHistogram({ metric, entityId }: MetricHistogramProps) {
           </span>
         </div>
         {ownMedian != null ? (
-          <span className="shrink-0 text-xs text-muted-foreground">
+          // 24px matches the ⋯ box beside it, so both sit on one centre line.
+          <span className="shrink-0 text-xs leading-6 text-muted-foreground">
             Median{" "}
             <span className="font-semibold text-foreground tabular-nums">
               {formatMetricNumber(ownMedian, metric.format)}
@@ -144,7 +145,9 @@ export function MetricHistogram({ metric, entityId }: MetricHistogramProps) {
         ) : null}
       </div>
       {evidence ? (
-        <CardAction>
+        // Pulls the ⋯ out to the card's 16px corner inset, so laying it out in
+        // flow costs the title column nothing.
+        <CardAction className="-mr-2">
           <MetricCardActions
             evidence={evidence}
             label={metric.label}


### PR DESCRIPTION
Closes #2804.

**Why.** Every distribution card drew its headline median under its own ⋯ button — the button's box covered the last 14px of the value, at 390, 768 and 1280px alike.

**What changed.** The ⋯ moves into the header's `CardAction` column, so the header grid reserves the width the button occupies instead of the hand-picked `pr-10` (40px) that never matched its 54px reach. Its icon moves to the kit's `icon` slot, which is what makes an icon-only button square — 24×24 rather than 38×24 — so being in flow costs the title column nothing, and the headline takes a matching 24px line box to share the glyph's centre line.

**Overlay stays the default — `placement="inline"` is opt-in.** The three other cards that float this button still position it themselves; switching them is a per-card layout change. Reversible by dropping the prop.

The card at its real widths — 428px in the three-up grid, 326px in the single-column stack:

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/hello1101n/insight/pr-2813-screens/428-before.png" width="380"> | <img src="https://raw.githubusercontent.com/hello1101n/insight/pr-2813-screens/428-after.png" width="380"> |
| <img src="https://raw.githubusercontent.com/hello1101n/insight/pr-2813-screens/326-before.png" width="290"> | <img src="https://raw.githubusercontent.com/hello1101n/insight/pr-2813-screens/326-after.png" width="290"> |

Measured on the 428px card, before → after: median-to-⋯ gap −14px → +4px, glyph off the value's centre line 4px → 0px, subtitle 240px on one line either way, ⋯ still at the card's 16px corner inset.

**Out of scope.** Every other icon-only button in the app is still wide — `Button` marks them with a `data-icon-only` attribute nothing styles and passes the icon as children (the sidebar toggle is 50×32). Squaring them all touches 15 call sites, some pairing the icon with an `sr-only` label. Unfiled.

**Verified.** `tsc -b`, lint, `pnpm test` (2150) and `test:storybook:ci` (18) clean. New browser tests measure the gap, the centre line and the drawn space between "Median" and its value; each was watched failing on this branch before the code that fixes it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metric card actions can now appear inline within card headers, improving layout flexibility.

* **Bug Fixes**
  * Improved histogram card layout so action buttons no longer overlap median values.
  * Improved headline alignment and preserved subtitle readability across wide and narrow card sizes.

* **Tests**
  * Added visual and layout coverage for histogram cards in multiple responsive widths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->