### PR TITLE
feat(chart): supply the AI credentials from a Secret the repo never holds

### DIFF
--- a/charts/insight/templates/secrets.yaml
+++ b/charts/insight/templates/secrets.yaml
@@ -186,10 +186,10 @@ stringData:
   APP__gears__analytics__config__identity_url:        {{ printf "http://%s:8082" (include "insight.identityResolution.host" .) | quote }}
   APP__gears__analytics__config__visibility_policy:   {{ .Values.identityResolution.visibilityPolicy | default "org_chart" | quote }}
   APP__gears__analytics__config__ai_assist__enabled:  {{ .Values.analytics.aiAssist.enabled | default false | quote }}
-  APP__gears__analytics__config__ai_assist__admin_only: {{ .Values.analytics.aiAssist.adminOnly | quote }}
+  APP__gears__analytics__config__ai_assist__admin_only: {{ required "analytics.aiAssist.adminOnly must be true or false" .Values.analytics.aiAssist.adminOnly | quote }}
   APP__gears__analytics__config__ai_assist__model:    {{ .Values.analytics.aiAssist.model | default "claude-sonnet-5" | quote }}
-  {{- if .Values.analytics.aiAssist.enabled }}
-  APP__gears__analytics__config__ai_assist__token_encryption_key: {{ required "analytics.aiAssist.tokenEncryptionKey is required when analytics.aiAssist.enabled is true (openssl rand -base64 32)" .Values.analytics.aiAssist.tokenEncryptionKey | quote }}
+  {{- if and .Values.analytics.aiAssist.enabled (not .Values.analytics.aiAssist.existingSecret) }}
+  APP__gears__analytics__config__ai_assist__token_encryption_key: {{ required "analytics.aiAssist.tokenEncryptionKey is required when analytics.aiAssist.enabled is true and no aiAssist.existingSecret is named (openssl rand -base64 32)" .Values.analytics.aiAssist.tokenEncryptionKey | quote }}
   {{- with .Values.analytics.aiAssist.apiKey }}
   APP__gears__analytics__config__ai_assist__api_key: {{ . | quote }}
   {{- end }}

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -502,6 +502,14 @@ analytics:
     # the common setup is a stand key and then every call spends the
     # deployment's own money. Off for a stand where people bring their own.
     adminOnly: true
+    # Name of a Secret carrying `apiKey` and `tokenEncryptionKey` as whole env
+    # vars, applied out of band (a SealedSecret on a GitOps stand). Set it and
+    # neither value is read from — or rendered into — chart values, so a key
+    # cannot reach the repository by being written here.
+    #
+    #   APP__gears__analytics__config__ai_assist__api_key
+    #   APP__gears__analytics__config__ai_assist__token_encryption_key
+    existingSecret: ""
     model: "claude-sonnet-5"
   # The umbrella generates `insight-analytics-config` with every
   # APP__gears__analytics__config__* env var filled in from the

--- a/src/backend/services/analytics/helm/templates/deployment.yaml
+++ b/src/backend/services/analytics/helm/templates/deployment.yaml
@@ -75,6 +75,13 @@ spec:
             # APP__gears__analytics__config__* leaf overrides.
             - secretRef:
                 name: {{ required "existingSecret is required (umbrella provides `insight-analytics-config`; standalone installs supply their own)" .Values.existingSecret | quote }}
+            {{- with .Values.aiAssist.existingSecret }}
+            # Second and last, so it wins: the credentials a GitOps stand
+            # cannot keep in chart values. Absent on stands that pass the key
+            # as a plain value (compose, laptops).
+            - secretRef:
+                name: {{ . | quote }}
+            {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/src/backend/services/analytics/helm/values.yaml
+++ b/src/backend/services/analytics/helm/values.yaml
@@ -34,6 +34,21 @@ metricCatalog:
 # sets `existingSecret` to its name.
 existingSecret: ""
 
+# A SECOND Secret of `APP__gears__analytics__config__*` overrides, layered over
+# `existingSecret`. For values an operator must not commit: on a GitOps stand
+# the umbrella's chart values live in git, so the Anthropic key and the token
+# sealing key have to arrive by another route — a SealedSecret applied out of
+# band, named here.
+#
+# Keys are whole env vars, same as `existingSecret`:
+#   APP__gears__analytics__config__ai_assist__api_key
+#   APP__gears__analytics__config__ai_assist__token_encryption_key
+#
+# Listed after `existingSecret` in `envFrom`, so where both carry a key this
+# one wins.
+aiAssist:
+  existingSecret: ""
+
 visibilityPolicy: "org_chart"
 
 # Gateway-JWT verification (cf-gears-oidc-authn-plugin, NGINX_BFF R1). These


### PR DESCRIPTION
**Why.** Turning AI explanations on at cfabric means committing a live Anthropic key: `aiAssist.apiKey` and `tokenEncryptionKey` are read from chart values, and that stand's values live in git. Every other credential there goes Passbolt → `kubeseal` → committed SealedSecret.

**What changed.** `analytics.aiAssist.existingSecret` names a Secret applied out of band. The analytics Deployment layers it after `existingSecret` in `envFrom` — later entries win — and the umbrella stops rendering `api_key` / `token_encryption_key` into the config Secret while it is set, so a key cannot reach the repository by being written into values.

**Only the serving container gets it.** `migrate` runs the same binary with the `migrate` subcommand, which never reads `ai_assist` and never validates it — `check_config` is reached only by `Commands::Check`. Handing the migration job a model key would widen where it exists and buy nothing.

**`adminOnly` gains a `required`, which reads like belt-and-braces and is not.** It cannot take `| default true`: Helm's `default` swallows `false`, the one value anyone would set it to. But a nil then rendered as `""`, and serde cannot read that as a bool — every analytics pod would fail to start on a typo. Refusing at render time says which value is wrong.

**The plain-value path is untouched.** Compose and laptop stands keep passing the key as a value, which is where that is appropriate.

The Secret's keys are whole env vars:

```
APP__gears__analytics__config__ai_assist__api_key
APP__gears__analytics__config__ai_assist__token_encryption_key
```

**Verified.** `helm template` over five cases:

| case | result |
| --- | --- |
| enabled + `existingSecret` | no key in the config Secret; serving container has both `envFrom` entries, migrate has one |
| enabled, no secret, no sealing key | refused, message naming both routes |
| enabled + plain values | renders `api_key` and `token_encryption_key` as today |
| feature off (default) | renders neither |
| `adminOnly: false` / `adminOnly: null` | `"false"` survives; nil is refused |

There is no analytics Helm contract job in CI (identity-resolution and preview-env have one), so those renders are the evidence.

**Out of scope.** Adding an analytics Helm contract job, and the cfabric values change that turns the feature on — that is a gitops-repo commit once this chart is released and pinned.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for supplying AI Assist credentials through an existing external Kubernetes Secret.
  - External Secret values can override credentials provided through the default configuration.
- **Bug Fixes**
  - Improved AI Assist configuration validation by requiring `adminOnly` to be explicitly boolean.
  - Token-encryption key validation is skipped when credentials are supplied through an existing Secret, while remaining required for enabled AI assistance without one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->