### PR TITLE
Recover Jira changelog items lost to double-encoded JSON

### DIFF
--- a/src/ingestion/connectors/task-tracking/jira/connector.yaml
+++ b/src/ingestion/connectors/task-tracking/jira/connector.yaml
@@ -6602,30 +6602,17 @@ streams:
               - string
               - "null"
           items:
-            anyOf:
-              - type: string
-              - type: array
-                items:
-                  type: object
-                  properties:
-                    field:
-                      type: string
-                    fieldId:
-                      type: string
-                    fieldtype:
-                      type: string
-                    from:
-                      type: string
-                    fromString:
-                      type: string
-                    to:
-                      type: string
-                    toString:
-                      type: string
-                    tmpFromAccountId:
-                      type: string
-                    tmpToAccountId:
-                      type: string
+            # Plain string, NOT `anyOf: [string, array]`. The AddFields
+            # transformation renders this column with `| tojson`; the CDK then
+            # re-parses that render with ast.literal_eval, which fails on JSON
+            # `null` and leaves the value a string. Under a string/array union
+            # the destination JSON-encodes that string, storing an escaped blob
+            # `"[{\"field\": ...}]"` that JSONExtractArrayRaw cannot read —
+            # every changelog item whose previous value was empty is lost that
+            # way. A plain string declaration stores the render verbatim.
+            type:
+              - string
+              - "null"
           tenant_id:
             type:
               - string

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__changelog_items.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__changelog_items.sql
@@ -6,7 +6,8 @@
     engine='ReplacingMergeTree(_version)',
     order_by=['unique_key'],
     settings={'allow_nullable_key': 1},
-    tags=['staging', 'jira']
+    tags=['staging', 'jira'],
+    pre_hook="{{ reset_task_field_history_on_full_refresh() }}"
 ) }}
 
 -- Materialized as `table` (not `incremental`) so every dbt run rewrites staging from scratch.

--- a/src/ingestion/connectors/task-tracking/jira/descriptor.yaml
+++ b/src/ingestion/connectors/task-tracking/jira/descriptor.yaml
@@ -9,7 +9,7 @@ name: jira
 # 2.0.2 (patch): widen jira_project_discovery cursor_datetime_formats so it can
 # parse child-stream cursor values carried in parent_state (was crashing with
 # "No format ['%Y-%m-%dT%H:%M:%S.%f%z'] matching 2026-06-15 02:00").
-version: "2.8.0"
+version: "3.0.0"
 schedule: "0 3 * * *"
 workflow: sync
 # CI build metadata + runtime image refs (ADR-0016). The `images:` block is

--- a/src/ingestion/dbt/macros/reset_task_field_history_on_full_refresh.sql
+++ b/src/ingestion/dbt/macros/reset_task_field_history_on_full_refresh.sql
@@ -1,0 +1,24 @@
+{#-
+  Pre-hook for `jira__changelog_items`: on a full refresh, empty the Rust-owned
+  `staging.jira__task_field_history` so `jira-enrich` re-derives it from scratch.
+
+  Without this, `--full-refresh` cannot reach that table at all: its DDL macro
+  is CREATE TABLE IF NOT EXISTS, and jira-enrich keeps ONE high-water mark per
+  issue across all fields, dropping every event at or below it. Any event that
+  reaches Bronze late — a repaired row, a backfilled project — would stay
+  invisible forever while the rest of the pipeline reported success.
+
+  It hangs off `jira__changelog_items` (tags staging+jira) rather than
+  on-run-start because the Jira pipeline invokes dbt twice, staging then silver,
+  and passes --full-refresh to both. An on-run-start reset would fire again on
+  the silver pass, wiping what enrich had just written. This model belongs to
+  the staging selection only, so the reset lands exactly once, before enrich.
+-#}
+
+{% macro reset_task_field_history_on_full_refresh() %}
+    {%- if flags.FULL_REFRESH -%}
+        TRUNCATE TABLE IF EXISTS staging.jira__task_field_history
+    {%- else -%}
+        SELECT 1
+    {%- endif -%}
+{% endmacro %}

--- a/src/ingestion/dbt/tests/task/assert_changelog_items_not_double_encoded.sql
+++ b/src/ingestion/dbt/tests/task/assert_changelog_items_not_double_encoded.sql
@@ -1,0 +1,14 @@
+-- Regression guard for the `items` double-encoding defect: a changelog row
+-- whose `items` is an escaped JSON string instead of an array reads as a scalar
+-- through JSONExtractArrayRaw, so jira__changelog_items skips it and the field
+-- history silently loses every affected event. The stream declares `items` as
+-- a plain string to prevent this; the failure was invisible because the
+-- pipeline stays green while the journal quietly shrinks.
+
+SELECT
+    unique_key,
+    id_readable,
+    created,
+    substring(items, 1, 80) AS items_head
+FROM {{ source('bronze_jira', 'jira_issue_history') }}
+WHERE startsWith(items, '"')

--- a/src/ingestion/scripts/migrations/20260824000000_jira-history-items-unescape.sql
+++ b/src/ingestion/scripts/migrations/20260824000000_jira-history-items-unescape.sql
@@ -1,0 +1,28 @@
+-- Heal double-encoded `items` in bronze_jira.jira_issue_history.
+--
+-- Why: the jira_issue_history stream renders `items` with `| tojson`, and the
+-- CDK re-parses that render with ast.literal_eval. JSON `null` is not a Python
+-- literal, so any changelog entry whose previous value was empty stayed a
+-- string; under the stream's former `anyOf: [string, array]` declaration the
+-- ClickHouse destination JSON-encoded that string, storing an escaped blob:
+--
+--   "[{\"field\": \"status\", \"from\": null, \"toString\": \"Open\"}]"
+--
+-- JSONExtractArrayRaw reads such a value as a scalar, not an array, so
+-- staging.jira_changelog_items silently skipped every affected row and the
+-- whole field-history journal lost each field's first value. The stream now
+-- declares `items` as a plain string, which stores the render verbatim; this
+-- migration repairs the rows written before that fix.
+--
+-- Idempotent: after the first pass no value starts with a quote, so re-runs
+-- (apply-ch-migrations.sh keeps no bookkeeping and replays every file) match
+-- nothing. `items` is not part of the sorting key, so the column is mutable.
+--
+-- mutations_sync=1 keeps the deploy deterministic: the hook returns only once
+-- the rewrite is applied, so the first transform after deploy reads healed
+-- rows rather than racing a background mutation.
+
+ALTER TABLE bronze_jira.jira_issue_history
+    UPDATE items = JSONExtractString(items)
+    WHERE startsWith(items, '"')
+    SETTINGS mutations_sync = 1;


### PR DESCRIPTION
## What is broken

`jira_issue_history` renders its `items` column with `| tojson`, and the CDK
re-parses that render with `ast.literal_eval`. JSON `null` is not a Python
literal, so any changelog entry carrying one fails the parse and stays a
string. Under the stream's `anyOf: [string, array]` declaration the ClickHouse
destination then JSON-encodes that string, storing an escaped blob:

```
"[{\"field\": \"status\", \"from\": null, \"toString\": \"Open\"}]"
```

`JSONExtractArrayRaw` reads that as a scalar rather than an array, so
`jira__changelog_items` skips the row and the field-history journal never sees
the event.

Entries with no `null` in them round-trip through `literal_eval` as real
arrays and parse fine, so the loss is **silent and partial**: the pipeline
stays green while every field's *first* value — the transition out of empty,
which always carries `"from": null` — disappears. Status transitions,
resolutions and worklog references are all affected, and any metric over the
task event journal is computed on an incomplete changelog.

## What changed

| Change | Role |
|---|---|
| `items` declared `type: [string, "null"]` | new rows store the render verbatim, whichever type the CDK hands over — the shape `custom_fields_json` and the other `\| tojson` columns already use |
| `20260824000000_jira-history-items-unescape.sql` | repairs rows written before the fix |
| `reset_task_field_history_on_full_refresh` pre-hook | lets a full refresh reach the Rust-owned enrich staging table |
| `assert_changelog_items_not_double_encoded` | fails on any row that regresses |
| descriptor `2.8.0` → `3.0.0` | major bump, so reconcile dispatches `dbt --full-refresh` |

Repairing Bronze alone is not enough. `jira-enrich` keeps one high-water mark
per issue **across all fields** and drops events at or below it, so recovered
history stays invisible until its staging table is re-derived — and
`--full-refresh` cannot reach that table, whose DDL macro is
`CREATE TABLE IF NOT EXISTS`. The pre-hook empties it on a full refresh.

It hangs off `jira__changelog_items` rather than `on-run-start` because the
Jira pipeline invokes dbt twice — staging, then silver — and passes
`--full-refresh` to both. An `on-run-start` reset would fire again on the
silver pass, after enrich, wiping what it had just written. That model belongs
to the staging selection only, so the reset lands exactly once, before enrich.

## Rollout

Deploying is self-healing end to end, with no manual step:

1. the migration hook repairs Bronze (`mutations_sync = 1`, so it waits);
2. reconcile sees the major bump, republishes the manifest and dispatches the
   pipeline with `DBT_FULL_REFRESH=true`;
3. the staging pass resets the enrich table and rebuilds
   `jira_changelog_items` from repaired Bronze;
4. enrich re-derives the journal from scratch;
5. the silver pass rebuilds on the complete journal.

Expect a long run: enrich re-derives the whole journal rather than appending
to it, and silver is rebuilt from scratch, so schedule the deploy accordingly.
Any future major bump of this connector will re-derive the journal the same
way — correct `--full-refresh` semantics, but not cheap.

## Verification

- `source.sh validate` — manifest valid; `connector_wiring.py` — OK.
- Jira mock suite green.
- Migration exercised against a throwaway ClickHouse 25.7.5 using the
  `connectors-ddl` DDL, seeded with both encodings: double-encoded rows are
  repaired and become parseable, already-valid and empty rows are untouched,
  and the extracted field/value content matches the source. Re-running it twice
  more left every value byte-identical, confirming idempotence. The regression
  test matched before the migration and matched nothing after.
- Macro renders to `TRUNCATE TABLE IF EXISTS ...` under full refresh and
  `SELECT 1` otherwise; `TRUNCATE ... IF EXISTS` verified against a missing
  table so the first run on a fresh environment cannot fail.

Not covered locally: the combined `--full-refresh` → pre-hook → enrich run,
which needs the toolbox image and a full dbt project. Each link is verified
separately; the combination is left to CI and the stand.

## Follow-up

#2815 — remove the one-shot migration once every environment has applied it.

Note on versioning: #2510 also carries `3.0.0` for this connector. Whichever
lands second needs a rebase onto the next major.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Jira issue history changelog items are now preserved as valid JSON, including `null` values, without double encoding.
  * Existing affected records are automatically corrected during migration.
  * Full refreshes now properly reset task field history to prevent stale or duplicated data.

* **Tests**
  * Added validation to detect incorrectly double-encoded changelog items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->