### PR TITLE
Restore the connectors-ddl snapshot so main stops failing its own drift gate

### DIFF
--- a/src/ingestion/scripts/connectors-ddl/insight.sql
+++ b/src/ingestion/scripts/connectors-ddl/insight.sql
@@ -168,6 +168,19 @@ ORDER BY (tenant_id, source_key, entity_type, entity_id, measure_key, metric_dat
 SETTINGS replicated_deduplication_window = '0', index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS insight.git_default_branch_commits
+(
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `project_key` String,
+    `repo_slug` String,
+    `commit_hash` String
+)
+ENGINE = MergeTree
+ORDER BY (tenant_id, source_id, project_key, repo_slug, commit_hash)
+SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS insight.git_metric_evidence
 (
     `tenant_id` String,


### PR DESCRIPTION
## What is broken

`connectors-ddl snapshot + field parity` is failing on `main`, and therefore on
every PR opened since, none of which touched the table involved.

#2811 added `insight.git_default_branch_commits` without re-dumping the
committed snapshot under `src/ingestion/scripts/connectors-ddl/`. The lane
re-dumps the warehouse on every `src/ingestion/**` PR and compares, so the
missing block fails runs unrelated to the change that caused it.

This is the gap the lane's push run is documented to catch: two PRs that were
green against their own merge-base can still leave `main` drifted.

## Why it matters beyond the red check

`create-bronze-placeholders.sh` applies this snapshot to fresh clusters, so a
table missing from it is a provisioning hole, not just bookkeeping.

## What changed

The 13-line `CREATE TABLE` block for `insight.git_default_branch_commits`,
taken verbatim from the `connectors-ddl-drift` artifact the failing run
publishes — so it is `dump-ddl.sh` output byte for byte, and lands in the
alphabetical position the dump produces (before `git_metric_evidence`).

No other file changes; nothing about the table's definition is being decided
here, only recorded.
