### PR TITLE
fix(ingestion): attribute pull-request metrics through the author's account binding

### DIFF
--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__pull_requests.sql
@@ -59,6 +59,9 @@ SELECT
     COALESCE(pr.author_display_name, '') AS author_name,
     -- Bitbucket exposes no address on the participant object.
     '' AS author_email,
+    -- ADR-0002 account key, normalized the way bitbucket_cloud__identity_inputs
+    -- writes it, so the account binding join matches byte-for-byte.
+    lower(trimBoth(COALESCE(pr.author_account_id, ''))) AS author_account_id,
     COALESCE(pr.source_branch, '') AS source_branch,
     COALESCE(pr.destination_branch, '') AS destination_branch,
     parseDateTimeBestEffortOrNull(pr.created_on) AS created_on,

--- a/src/ingestion/connectors/git/bitbucket-cloud/descriptor.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/descriptor.yaml
@@ -1,11 +1,12 @@
 name: bitbucket-cloud
-# Strict semver per ADR-0015. 3.0.0: dbt staging carries the proxy's
-#   is_in_default_branch into the class-contract column is_default_branch.
-#   MAJOR for the same reason as github 4.0.0 — append_new_columns leaves the
-#   column NULL on rows already in staging, and staging never re-reads Bronze,
-#   so only the one-shot scoped `dbt --full-refresh` a major bump dispatches
+# Strict semver per ADR-0015. 4.0.0: dbt staging carries the pull request's
+#   author account id into the class-contract column author_account_id, the
+#   key person attribution resolves through. MAJOR for the same reason as
+#   github 5.0.0 — the id has been in Bronze all along, but staging never
+#   re-reads Bronze, so the column heals to '' on existing rows and only the
+#   one-shot scoped `dbt --full-refresh` a major bump dispatches
 #   re-materializes the history.
-version: "3.0.0"
+version: "4.0.0"
 # A slot of its own: replication pods sharing a slot with other connector
 # syncs can be starved of workers, which surfaces as startup and activity
 # timeouts rather than as a connector error.

--- a/src/ingestion/connectors/git/github/dbt/github__pull_requests.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__pull_requests.sql
@@ -46,8 +46,11 @@ SELECT
     COALESCE(ds.author_email, '') AS author_email,
     -- The immutable numeric account id, stringified — the same key
     -- github__account_emails binds identities on. '' when the author is a
-    -- deleted or suspended account GraphQL returns as null.
-    if(COALESCE(ds.author_id, 0) > 0, toString(ds.author_id), '') AS author_account_id,
+    -- deleted or suspended account GraphQL returns as null. COALESCE inside
+    -- toString as well as in the guard: the class column must be a plain
+    -- String, and a Nullable one reaches the evidence sort key through
+    -- `concat` and fails the build with a nullable sorting key.
+    if(COALESCE(ds.author_id, 0) > 0, toString(COALESCE(ds.author_id, 0)), '') AS author_account_id,
     COALESCE(pr.head_ref, '') AS source_branch,
     COALESCE(pr.base_ref, '') AS destination_branch,
     parseDateTimeBestEffortOrNull(pr.created_at) AS created_on,

--- a/src/ingestion/connectors/git/github/dbt/github__pull_requests.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__pull_requests.sql
@@ -20,6 +20,7 @@ WITH diff_stats AS (
         deletions,
         changed_files,
         author_email,
+        author_id,
         _airbyte_extracted_at,
         1 AS matched
     FROM {{ source('bronze_github', 'pull_request_diff_stats') }} FINAL
@@ -43,6 +44,10 @@ SELECT
     ) AS state,
     COALESCE(pr.author_login, '') AS author_name,
     COALESCE(ds.author_email, '') AS author_email,
+    -- The immutable numeric account id, stringified — the same key
+    -- github__account_emails binds identities on. '' when the author is a
+    -- deleted or suspended account GraphQL returns as null.
+    if(COALESCE(ds.author_id, 0) > 0, toString(ds.author_id), '') AS author_account_id,
     COALESCE(pr.head_ref, '') AS source_branch,
     COALESCE(pr.base_ref, '') AS destination_branch,
     parseDateTimeBestEffortOrNull(pr.created_at) AS created_on,

--- a/src/ingestion/connectors/git/github/descriptor.yaml
+++ b/src/ingestion/connectors/git/github/descriptor.yaml
@@ -1,13 +1,13 @@
 name: github
-# Strict semver per ADR-0015. 4.0.0: dbt staging carries the proxy's
-#   is_in_default_branch into the class-contract column is_default_branch.
-#   MAJOR — on_schema_change=append_new_columns adds the column but leaves it
-#   NULL on rows already in staging, and staging is incremental on
-#   _airbyte_extracted_at, so Bronze is never re-read and the backfill would
-#   never happen. Only the one-shot scoped `dbt --full-refresh` a major bump
-#   dispatches re-materializes the history. Safe: every git staging model is a
-#   pure projection of Bronze, so the rebuild loses nothing.
-version: "4.0.0"
+# Strict semver per ADR-0015. 5.0.0: dbt staging carries the diff-stats
+#   author account id into the class-contract column author_account_id, the
+#   key pull-request person attribution resolves through. MAJOR — the id has
+#   been in Bronze all along, but staging is incremental on
+#   _airbyte_extracted_at and never re-reads Bronze, so the column heals to ''
+#   on existing rows and history would never attribute. Only the one-shot
+#   scoped `dbt --full-refresh` a major bump dispatches re-materializes it.
+#   Safe: every git staging model is a pure projection of Bronze.
+version: "5.0.0"
 schedule: "0 */4 * * *"
 workflow: sync
 

--- a/src/ingestion/connectors/git/gitlab/dbt/gitlab__pull_requests.sql
+++ b/src/ingestion/connectors/git/gitlab/dbt/gitlab__pull_requests.sql
@@ -50,6 +50,9 @@ SELECT
     ) AS state,
     COALESCE(mr.author_username, '') AS author_name,
     COALESCE(u.email, '') AS author_email,
+    -- Always '': the GitLab connector emits no identity inputs, so no account
+    -- binding exists to resolve against; attribution stays on author_email.
+    '' AS author_account_id,
     COALESCE(mr.source_branch, '') AS source_branch,
     COALESCE(mr.target_branch, '') AS destination_branch,
     parseDateTimeBestEffortOrNull(mr.created_at) AS created_on,

--- a/src/ingestion/dbt/macros/resolve_person_id.sql
+++ b/src/ingestion/dbt/macros/resolve_person_id.sql
@@ -119,6 +119,81 @@
 {% endmacro %}
 
 {#-
+  The account-first companion of resolve_person_id(): the CURRENT
+  `(source_type, source_id, account_id) -> person_id` map, straight from the
+  bindings — no email hop. For facts that carry the author's source account id
+  (git pull requests), the account is the source's own primary key for the
+  person: it survives an empty or private profile email, a squash-merge that
+  unlinks the PR's commits, and an address change. Same claim semantics as the
+  email map: the latest `value_type='id'` row per account decides, and an
+  account bound to the excluded person claims nothing — the exclusion is
+  applied AFTER the latest-binding pick, so an account whose newest binding is
+  the excluded person attributes nothing rather than falling back to a stale
+  human binding.
+
+  account_id is normalized lower(trimBoth(...)) on BOTH sides of the join
+  (see resolved_person_id_by_account_join): connector identity inputs are not
+  uniform about casing, and the fact side must meet whatever the seed stored.
+
+  Same single-resolve-point rule as the email map: resolution semantics live
+  here and in resolve_person_id() only.
+-#}
+{% macro resolve_person_id_by_account() %}
+{%- set journal = adapter.get_relation(
+        database=target.database, schema='identity', identifier='identity_persons') -%}
+{%- if journal is none -%}
+    {#- The identity journal has never been created: resolve nothing rather
+        than fail the build, mirroring resolve_person_id(). -#}
+    SELECT
+        ''                                   AS source_type,
+        toUUID('00000000-0000-0000-0000-000000000000') AS source_id,
+        ''                                   AS account_id,
+        toUUID('00000000-0000-0000-0000-000000000000') AS person_id
+    WHERE 0
+{%- else -%}
+    SELECT
+        source_type,
+        source_id,
+        account_id,
+        person_id
+    FROM (
+        SELECT
+            insight_source_type              AS source_type,
+            insight_source_id                AS source_id,
+            lower(trimBoth(value_effective)) AS account_id,
+            person_id
+        FROM identity.identity_persons
+        WHERE value_type = 'id'
+          AND value_effective IS NOT NULL
+          AND trimBoth(value_effective) != ''
+        ORDER BY
+            source_type,
+            source_id,
+            account_id,
+            created_at DESC,
+            id DESC
+        LIMIT 1 BY source_type, source_id, account_id
+    )
+    WHERE person_id != {{ excluded_person_id() }}
+{%- endif -%}
+{% endmacro %}
+
+{#-
+  The join for models whose rows carry (account_source_type,
+  account_source_id, account_id). INVARIANT: identity stores
+  insight_source_id as sipHash128 of the connector's raw source_id (see the
+  connectors' identity_inputs models), while class relations carry the raw
+  string — the hash below must stay in lockstep with that minting expression
+  or the join silently matches nothing.
+-#}
+{% macro resolved_person_id_by_account_join(rel) %}
+    LEFT JOIN ({{ resolve_person_id_by_account() }}) AS account_map
+        ON account_map.source_type = {{ rel }}.account_source_type
+       AND account_map.source_id = toUUID(UUIDNumToString(sipHash128(coalesce({{ rel }}.account_source_id, ''))))
+       AND account_map.account_id = lower(trimBoth({{ rel }}.account_id))
+{% endmacro %}
+
+{#-
   The reserved person meaning "not a human" (bots, CI, service accounts). One
   global constant, unmintable — UUIDv7 never produces an all-ones value — and
   the service binds excluded accounts to it. Every consumer reads it as no

--- a/src/ingestion/dbt/macros/resolve_person_id.sql
+++ b/src/ingestion/dbt/macros/resolve_person_id.sql
@@ -125,11 +125,15 @@
   (git pull requests), the account is the source's own primary key for the
   person: it survives an empty or private profile email, a squash-merge that
   unlinks the PR's commits, and an address change. Same claim semantics as the
-  email map: the latest `value_type='id'` row per account decides, and an
-  account bound to the excluded person claims nothing — the exclusion is
-  applied AFTER the latest-binding pick, so an account whose newest binding is
-  the excluded person attributes nothing rather than falling back to a stale
-  human binding.
+  email map: the latest `value_type='id'` row per account decides.
+
+  Excluded bindings STAY in this map, unlike the email map's claims: an
+  operator binding an account to the excluded person is a statement about the
+  account, and it must TERMINATE resolution, not merely decline to help — a
+  bot pull request whose commits carry a human's email would otherwise fall
+  through to the email map and attribute to that human. Consumers read a
+  matched row with person_id = excluded_person_id() as "attribute to nobody,
+  and do not consult any other key".
 
   account_id is normalized lower(trimBoth(...)) on BOTH sides of the join
   (see resolved_person_id_by_account_join): connector identity inputs are not
@@ -152,29 +156,21 @@
     WHERE 0
 {%- else -%}
     SELECT
+        insight_source_type              AS source_type,
+        insight_source_id                AS source_id,
+        lower(trimBoth(value_effective)) AS account_id,
+        person_id
+    FROM identity.identity_persons
+    WHERE value_type = 'id'
+      AND value_effective IS NOT NULL
+      AND trimBoth(value_effective) != ''
+    ORDER BY
         source_type,
         source_id,
         account_id,
-        person_id
-    FROM (
-        SELECT
-            insight_source_type              AS source_type,
-            insight_source_id                AS source_id,
-            lower(trimBoth(value_effective)) AS account_id,
-            person_id
-        FROM identity.identity_persons
-        WHERE value_type = 'id'
-          AND value_effective IS NOT NULL
-          AND trimBoth(value_effective) != ''
-        ORDER BY
-            source_type,
-            source_id,
-            account_id,
-            created_at DESC,
-            id DESC
-        LIMIT 1 BY source_type, source_id, account_id
-    )
-    WHERE person_id != {{ excluded_person_id() }}
+        created_at DESC,
+        id DESC
+    LIMIT 1 BY source_type, source_id, account_id
 {%- endif -%}
 {% endmacro %}
 

--- a/src/ingestion/gold/git_metric_evidence.sql
+++ b/src/ingestion/gold/git_metric_evidence.sql
@@ -18,10 +18,17 @@ SELECT
     -- the matched branch, so entity_id is a plain String fit for the sort key.
     -- Account first: an account binding is the source's own answer to "whose
     -- row is this" and survives an empty profile email; the email map decides
-    -- only when the row carries no resolvable account.
+    -- only when the row carries no bound account. A matched account bound to
+    -- the excluded person terminates resolution — the row attributes to
+    -- nobody even when its emails would resolve, or a bot pull request whose
+    -- commits carry a human's email would attribute to that human.
     multiIf(
         coalesce(account_map.account_id, '') != '',
-        toString(assumeNotNull(account_map.person_id)),
+        if(
+            assumeNotNull(account_map.person_id) = {{ excluded_person_id() }},
+            '',
+            toString(assumeNotNull(account_map.person_id))
+        ),
         coalesce(identity_map.email, '') != '',
         toString(assumeNotNull(identity_map.person_id)),
         ''

--- a/src/ingestion/gold/git_metric_evidence.sql
+++ b/src/ingestion/gold/git_metric_evidence.sql
@@ -1,19 +1,27 @@
 {{ metric_evidence_table(join_use_nulls=1) }}
 
 -- Resolution happens HERE, once per gold build: evidence carries BOTH keys —
--- `entity_id` is the canonical person id (or '' when identity does not know
--- the email: those rows stay for coverage but reach no serving relation), and
--- `source_entity_id` keeps the source-native email for provenance. Everything
--- downstream (observations, cohorts, coverage, drilldown) reads THIS snapshot,
--- so one identity mapping answers for the whole build.
+-- `entity_id` is the canonical person id (or '' when identity cannot place
+-- the row: those rows stay for coverage but reach no serving relation), and
+-- `source_entity_id` keeps the source-native email for provenance. Rows that
+-- carry the author's source account id (pull requests) resolve through the
+-- account binding first and fall back to the email map; everything else is
+-- email-only. Everything downstream (observations, cohorts, coverage,
+-- drilldown) reads THIS snapshot, so one identity mapping answers for the
+-- whole build.
 SELECT
     src.tenant_id,
     src.source_key,
     src.entity_type,
     -- Null-proof under EITHER join_use_nulls setting (models differ): the
-    -- condition is non-Nullable via coalesce, and person_id is read only on
+    -- conditions are non-Nullable via coalesce, and person_id is read only on
     -- the matched branch, so entity_id is a plain String fit for the sort key.
-    if(
+    -- Account first: an account binding is the source's own answer to "whose
+    -- row is this" and survives an empty profile email; the email map decides
+    -- only when the row carries no resolvable account.
+    multiIf(
+        coalesce(account_map.account_id, '') != '',
+        toString(assumeNotNull(account_map.person_id)),
         coalesce(identity_map.email, '') != '',
         toString(assumeNotNull(identity_map.person_id)),
         ''
@@ -26,8 +34,9 @@ SELECT
     -- hash) are identical across one person's accounts once entity_id is
     -- canonical, and both the evidence uniqueness grain and the drilldown
     -- cursor need one row per record key. Hashed, not the raw email — the id
-    -- reaches the client and stays opaque.
-    concat(src.record_id, ':', hex(sipHash64(src.entity_id))) AS record_id,
+    -- reaches the client and stays opaque. The account id joins the salt so
+    -- two email-less accounts cannot collide on one record key.
+    concat(src.record_id, ':', hex(sipHash64(concat(src.entity_id, ':', src.account_id)))) AS record_id,
     src.record_kind,
     src.granularity,
     src.record_label,
@@ -369,6 +378,17 @@ pull_requests_source AS (
             pr_commit_emails.email IS NOT NULL AND pr_commit_emails.email != '', pr_commit_emails.email,
             CAST(NULL AS Nullable(String))
         ) AS entity_id,
+        -- identity's source_type vocabulary, not data_source's: the binding
+        -- rows say 'bitbucket', the class rows say 'insight_bitbucket_cloud'.
+        -- '' (gitlab — no identity inputs exist) keeps the account join
+        -- unmatched and resolution on the email path.
+        multiIf(
+            prs.data_source = 'insight_github', 'github',
+            prs.data_source = 'insight_bitbucket_cloud', 'bitbucket',
+            ''
+        ) AS account_source_type,
+        prs.source_id AS account_source_id,
+        prs.author_account_id AS account_id,
         prs.state AS state,
         prs.created_on AS created_on,
         prs.closed_on AS closed_on,
@@ -463,7 +483,13 @@ pull_request_measures AS (
         pr_number,
         title,
         author_name,
-        assumeNotNull(entity_id) AS entity_id,
+        -- coalesce, not assumeNotNull: an account-only pull request (author
+        -- with no resolvable email anywhere) legitimately carries NULL here
+        -- and resolves through the account join instead.
+        coalesce(entity_id, '') AS entity_id,
+        account_source_type,
+        account_source_id,
+        account_id,
         toDate(pr_measure.3) AS metric_date,
         pr_measure.3 AS observed_at,
         pr_measure.1 AS measure_key,
@@ -573,8 +599,12 @@ pull_request_measures AS (
             []
         )
     ) AS Array(Tuple(measure_key String, contribution Float64, observed_at DateTime64(3)))) AS pr_measure
-    WHERE pull_request.entity_id IS NOT NULL
-      AND pull_request.entity_id != ''
+    -- A row survives on EITHER key: the email (today's path) or the account
+    -- id, which the outer join resolves account-first. Only a pull request
+    -- with neither — no profile email, no attributable commit email, no
+    -- account id — drops here, exactly as before.
+    WHERE (pull_request.entity_id IS NOT NULL AND pull_request.entity_id != '')
+       OR pull_request.account_id != ''
 ),
 file_change_measures AS (
     SELECT
@@ -660,6 +690,9 @@ SELECT
     'git' AS source_key,
     'person' AS entity_type,
     assumeNotNull(entity_id) AS entity_id,
+    '' AS account_source_type,
+    '' AS account_source_id,
+    '' AS account_id,
     assumeNotNull(metric_date) AS metric_date,
     CAST(NULL AS Nullable(DateTime64(3))) AS observed_at,
     measure_key,
@@ -689,6 +722,9 @@ SELECT
     'git' AS source_key,
     'person' AS entity_type,
     assumeNotNull(entity_id) AS entity_id,
+    '' AS account_source_type,
+    '' AS account_source_id,
+    '' AS account_id,
     assumeNotNull(metric_date) AS metric_date,
     CAST(NULL AS Nullable(DateTime64(3))) AS observed_at,
     'commit_day' AS measure_key,
@@ -717,6 +753,9 @@ SELECT
     'git' AS source_key,
     'person' AS entity_type,
     assumeNotNull(entity_id) AS entity_id,
+    '' AS account_source_type,
+    '' AS account_source_id,
+    '' AS account_id,
     assumeNotNull(metric_date) AS metric_date,
     toNullable(toDateTime64(observed_at, 3)) AS observed_at,
     commit_measure.1 AS measure_key,
@@ -759,6 +798,9 @@ SELECT
     'git' AS source_key,
     'person' AS entity_type,
     assumeNotNull(entity_id) AS entity_id,
+    account_source_type,
+    account_source_id,
+    account_id,
     assumeNotNull(metric_date) AS metric_date,
     toNullable(toDateTime64(observed_at, 3)) AS observed_at,
     measure_key,
@@ -781,3 +823,4 @@ WHERE tenant_id IS NOT NULL
   AND metric_date IS NOT NULL
 ) AS src
 {{ resolved_person_id_join('src') }}
+{{ resolved_person_id_by_account_join('src') }}

--- a/src/ingestion/scripts/apply-ch-migrations.sh
+++ b/src/ingestion/scripts/apply-ch-migrations.sh
@@ -241,6 +241,27 @@ for _git_source in github gitlab bitbucket_cloud; do
   heal_git_file_change_oids staging "${_git_source}__file_changes" _airbyte_extracted_at
 done
 
+echo "=== Healing git pull-request author account column ==="
+# Same positional invariant: every projection feeding class_git_pull_requests
+# gained author_account_id after author_email (account-first person
+# attribution, #2819). The silver side heals in migrations/*.sql; staging
+# heals here because these tables exist only after a connector has run.
+# Existing rows heal to '' and carry the account id from the first sync that
+# re-collects them — the rollout's full refresh backfills the rest. Idempotent.
+heal_git_pr_author_account() {
+  local table="$1"
+  ch_table_is_real staging "${table}" || return 0
+  echo "  staging.${table}"
+  run_ch <<SQL
+ALTER TABLE staging.${table} ADD COLUMN IF NOT EXISTS author_account_id String AFTER author_email;
+ALTER TABLE staging.${table} MODIFY COLUMN author_account_id String AFTER author_email;
+SQL
+}
+
+for _git_source in github gitlab bitbucket_cloud; do
+  heal_git_pr_author_account "${_git_source}__pull_requests"
+done
+
 echo "=== Healing jira task id column types (#1743) ==="
 # #1892 retyped the jira staging id projections (worklog_id, comment_id)
 # from raw bronze Decimal(38,9) to toString(...), but pre-existing

--- a/src/ingestion/scripts/connectors-ddl/silver.sql
+++ b/src/ingestion/scripts/connectors-ddl/silver.sql
@@ -501,6 +501,7 @@ CREATE TABLE IF NOT EXISTS silver.class_git_pull_requests
     `state` String,
     `author_name` String,
     `author_email` String,
+    `author_account_id` String,
     `source_branch` String,
     `destination_branch` String,
     `created_on` Nullable(DateTime),

--- a/src/ingestion/scripts/migrations/20260824120000_git-pr-author-account.sql
+++ b/src/ingestion/scripts/migrations/20260824120000_git-pr-author-account.sql
@@ -1,0 +1,11 @@
+-- The class model owns this column but never adds it to a warm relation: the
+-- DDL snapshot is IF NOT EXISTS, and the deploy hook builds tag:gold, not the
+-- tag:silver model that would widen it — so gold reads it in the same run.
+-- AFTER anchors the contract position the positional insert requires; MODIFY
+-- converges an instance where an out-of-band ALTER placed it elsewhere.
+-- Idempotent: this channel has no ledger and re-runs on every deploy.
+ALTER TABLE silver.class_git_pull_requests
+    ADD COLUMN IF NOT EXISTS author_account_id String AFTER author_email;
+
+ALTER TABLE silver.class_git_pull_requests
+    MODIFY COLUMN author_account_id String AFTER author_email;

--- a/src/ingestion/silver/git/schema.yml
+++ b/src/ingestion/silver/git/schema.yml
@@ -110,6 +110,13 @@ models:
         tests:
           - not_null
           - unique
+      - name: author_account_id
+        description: >
+          The author's source account id in the form the connector's identity
+          inputs bind on (GitHub: numeric id as text; Bitbucket: account_id
+          lowercased). '' when the source exposes none — a deleted or suspended
+          author, or a connector without identity inputs — in which case person
+          attribution falls back to author_email.
 
   - name: class_git_pull_requests_reviewers
     description: "Unified git pull request reviewers from all sources (GitHub, Bitbucket, GitLab)"

--- a/src/ingestion/tests/e2e/lib/fixture_loader.py
+++ b/src/ingestion/tests/e2e/lib/fixture_loader.py
@@ -36,6 +36,21 @@ class FixtureError(ValueError):
 
 
 @dataclass(frozen=True)
+class IdentityAccount:
+    """One source-account binding from a fixture's `identity_accounts`.
+
+    `person` is a persona email, or the literal 'excluded' for the reserved
+    bot person. `source_id` is the RAW connector source id; the rig hashes it
+    the way the connectors mint insight_source_id.
+    """
+
+    source_type: str
+    source_id: str
+    account_id: str
+    person: str
+
+
+@dataclass(frozen=True)
 class TestYaml:
     __test__ = False  # not a pytest test class despite the `Test` prefix
     name: str
@@ -57,11 +72,8 @@ class TestYaml:
     # Optional `identity_accounts: [{source_type, source_id, account_id, person}]`.
     # Each entry is a source-account binding (`value_type='id'`) the rig writes
     # into identity_persons beside the synthetic email bindings — the shape the
-    # account-first resolution map reads. `person` is a persona email, or the
-    # literal 'excluded' for the reserved bot person. `source_id` is the RAW
-    # connector source id; the rig hashes it the way the connectors mint
-    # insight_source_id.
-    identity_accounts: list[dict[str, str]] = field(default_factory=list)
+    # account-first resolution map reads.
+    identity_accounts: list[IdentityAccount] = field(default_factory=list)
 
     @property
     def touched_tables(self) -> set[tuple[str, str]]:
@@ -118,7 +130,7 @@ def load(path: Path, *, schemas_dir: Path | None = None) -> TestYaml:
     accounts_doc = doc.get("identity_accounts") or []
     if not isinstance(accounts_doc, list):
         raise FixtureError(f"{path}: `identity_accounts` must be a list of bindings")
-    identity_accounts: list[dict[str, str]] = []
+    identity_accounts: list[IdentityAccount] = []
     for idx, entry in enumerate(accounts_doc):
         if not isinstance(entry, dict) or set(entry) != {"source_type", "source_id", "account_id", "person"}:
             raise FixtureError(
@@ -127,7 +139,7 @@ def load(path: Path, *, schemas_dir: Path | None = None) -> TestYaml:
             )
         if not all(isinstance(v, str) and v for v in entry.values()):
             raise FixtureError(f"{path}: identity_accounts[{idx}] values must be non-empty strings")
-        identity_accounts.append({k: str(v) for k, v in entry.items()})
+        identity_accounts.append(IdentityAccount(**entry))
 
     if "cases" not in doc:
         raise FixtureError(f"{path}: a test must define `cases`")

--- a/src/ingestion/tests/e2e/lib/fixture_loader.py
+++ b/src/ingestion/tests/e2e/lib/fixture_loader.py
@@ -54,6 +54,14 @@ class TestYaml:
     # double-count if gold does not collapse aliases. Without it every email is
     # its own person and no fixture can reach that path.
     identity_aliases: dict[str, list[str]] = field(default_factory=dict)
+    # Optional `identity_accounts: [{source_type, source_id, account_id, person}]`.
+    # Each entry is a source-account binding (`value_type='id'`) the rig writes
+    # into identity_persons beside the synthetic email bindings — the shape the
+    # account-first resolution map reads. `person` is a persona email, or the
+    # literal 'excluded' for the reserved bot person. `source_id` is the RAW
+    # connector source id; the rig hashes it the way the connectors mint
+    # insight_source_id.
+    identity_accounts: list[dict[str, str]] = field(default_factory=list)
 
     @property
     def touched_tables(self) -> set[tuple[str, str]]:
@@ -107,6 +115,20 @@ def load(path: Path, *, schemas_dir: Path | None = None) -> TestYaml:
             raise FixtureError(f"{path}: identity_aliases.{canonical} must be a list of emails")
         identity_aliases[str(canonical)] = list(aliases)
 
+    accounts_doc = doc.get("identity_accounts") or []
+    if not isinstance(accounts_doc, list):
+        raise FixtureError(f"{path}: `identity_accounts` must be a list of bindings")
+    identity_accounts: list[dict[str, str]] = []
+    for idx, entry in enumerate(accounts_doc):
+        if not isinstance(entry, dict) or set(entry) != {"source_type", "source_id", "account_id", "person"}:
+            raise FixtureError(
+                f"{path}: identity_accounts[{idx}] must be a mapping with exactly "
+                "source_type, source_id, account_id, person"
+            )
+        if not all(isinstance(v, str) and v for v in entry.values()):
+            raise FixtureError(f"{path}: identity_accounts[{idx}] values must be non-empty strings")
+        identity_accounts.append({k: str(v) for k, v in entry.items()})
+
     if "cases" not in doc:
         raise FixtureError(f"{path}: a test must define `cases`")
 
@@ -152,6 +174,7 @@ def load(path: Path, *, schemas_dir: Path | None = None) -> TestYaml:
         cases=cases,
         skip=skip,
         identity_aliases=identity_aliases,
+        identity_accounts=identity_accounts,
     )
 
 

--- a/src/ingestion/tests/e2e/metrics/git_pr_account_attribution.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_pr_account_attribution.test.yaml
@@ -1,0 +1,80 @@
+spec_version: 1
+description: >
+  Metric: git.prs_merged — account-first pull-request attribution (#2819).
+  How it's computed (bronze → silver → gold):
+    • bronze: pull requests plus the GraphQL diff-stats row carrying the
+      author's immutable numeric account id and (rarely) a profile email
+    • silver: one row per pull request with author_email and author_account_id
+    • gold:   the author's account binding resolves the person first; the
+      email map (profile email, else the linked commits' one shared email)
+      decides only when no account id exists
+
+  Cases: a squash-merged pull request whose branch commits were never
+  collected attributes through the account id alone; an author whose source
+  account is gone (ghost) still attributes through the linked commit's email;
+  a pull request whose account binding and profile email name DIFFERENT
+  persons follows the account; a bot's pull request (account bound to the
+  excluded person, no email anywhere) attributes to nobody.
+  Expected: alice merged 2 (squash + precedence), bob merged 1 (ghost).
+
+identity_accounts:
+  - {source_type: github, source_id: git-test, account_id: "9001", person: alice@example.com}
+  - {source_type: github, source_id: git-test, account_id: "9002", person: excluded}
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+    - $ref: templates/people.yaml#/templates/bob
+
+  bronze_github.pull_requests:
+    # Squash-merged, source branch deleted: none of its commits were ever
+    # collected and the profile email is private — only the account id can
+    # attribute it. Pre-account-first this row vanished from every PR measure.
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: pr-squash, id: 11, number: 11, author_login: alice-gh, closed_at: "2026-10-01T09:00:00Z", merged_at: "2026-10-01T09:00:00Z", merge_commit_sha: squash-11}
+    # Ghost author: the account was deleted at the source, so no diff-stats
+    # row exists at all — the linked commit's email is the only signal.
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: pr-ghost, id: 12, number: 12, author_login: ghost, closed_at: "2026-10-01T10:00:00Z", merged_at: "2026-10-01T10:00:00Z", merge_commit_sha: merge-12}
+    # Bot: account bound to the excluded person, no email anywhere.
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: pr-bot, id: 13, number: 13, author_login: ci-bot, closed_at: "2026-10-01T11:00:00Z", merged_at: "2026-10-01T11:00:00Z", merge_commit_sha: merge-13}
+    # Precedence: the profile email names BOB while the account binding names
+    # ALICE — the account must win or a recycled/shared address misattributes.
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: pr-precedence, id: 14, number: 14, author_login: alice-gh, closed_at: "2026-10-01T12:00:00Z", merged_at: "2026-10-01T12:00:00Z", merge_commit_sha: merge-14}
+
+  bronze_github.pull_request_diff_stats:
+    - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-squash, pull_number: 11, additions: 10, author_login: alice-gh, author_id: 9001}
+    - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-bot, pull_number: 13, additions: 5, author_login: ci-bot, author_id: 9002}
+    - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-precedence, pull_number: 14, additions: 20, author_login: alice-gh, author_id: 9001, author_email: bob@example.com}
+
+  bronze_github.pull_request_commits:
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: prc-ghost, repo_full_name: constructor/insight, pull_number: 12, sha: hash-ghost, author_email: bob@example.com, is_merge: false}
+
+  bronze_github.commits:
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: commit-ghost, sha: hash-ghost, author_name: bob, author_email: bob@example.com, committer_name: bob, committer_email: bob@example.com, additions: 3}
+
+cases:
+  - name: Account-first attribution decides pull-request measures
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [alice@example.com, bob@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.prs_merged
+            views:
+              - {view: period}
+    expect:
+      - assert: "status == 200"
+      # Squash-merged (no commits collected) + account-over-email precedence:
+      # both attribute to alice through account 9001.
+      - metric: git.prs_merged
+        view: period
+        find: {entity_id: alice@example.com}
+        equal: {value: 2}
+      # Ghost author (no account id anywhere): the linked commit's email still
+      # attributes the pull request. The precedence PR's bob-flavored profile
+      # email must NOT leak here.
+      - metric: git.prs_merged
+        view: period
+        find: {entity_id: bob@example.com}
+        equal: {value: 1}

--- a/src/ingestion/tests/e2e/metrics/git_pr_account_attribution.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_pr_account_attribution.test.yaml
@@ -14,8 +14,10 @@ description: >
   account is gone (ghost) still attributes through the linked commit's email;
   a pull request whose account binding and profile email name DIFFERENT
   persons follows the account; a bot's pull request (account bound to the
-  excluded person, no email anywhere) attributes to nobody.
-  Expected: alice merged 2 (squash + precedence), bob merged 1 (ghost).
+  excluded person) attributes to nobody even though its linked commit carries
+  a human's resolvable email.
+  Expected: alice merged 2 (squash + precedence), bob merged 1 (ghost only —
+  neither the bot's commit email nor the precedence profile email leaks to him).
 
 identity_accounts:
   - {source_type: github, source_id: git-test, account_id: "9001", person: alice@example.com}
@@ -34,7 +36,9 @@ bronze:
     # Ghost author: the account was deleted at the source, so no diff-stats
     # row exists at all — the linked commit's email is the only signal.
     - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: pr-ghost, id: 12, number: 12, author_login: ghost, closed_at: "2026-10-01T10:00:00Z", merged_at: "2026-10-01T10:00:00Z", merge_commit_sha: merge-12}
-    # Bot: account bound to the excluded person, no email anywhere.
+    # Bot: account bound to the excluded person. Its linked commit carries
+    # BOB's email — the excluded binding must terminate resolution, not fall
+    # through to the email map and hand the pull request to bob.
     - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: pr-bot, id: 13, number: 13, author_login: ci-bot, closed_at: "2026-10-01T11:00:00Z", merged_at: "2026-10-01T11:00:00Z", merge_commit_sha: merge-13}
     # Precedence: the profile email names BOB while the account binding names
     # ALICE — the account must win or a recycled/shared address misattributes.
@@ -47,9 +51,11 @@ bronze:
 
   bronze_github.pull_request_commits:
     - {$ref: templates/git_activity.yaml#/templates/base, unique_key: prc-ghost, repo_full_name: constructor/insight, pull_number: 12, sha: hash-ghost, author_email: bob@example.com, is_merge: false}
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: prc-bot, repo_full_name: constructor/insight, pull_number: 13, sha: hash-bot, author_email: bob@example.com, is_merge: false}
 
   bronze_github.commits:
     - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: commit-ghost, sha: hash-ghost, author_name: bob, author_email: bob@example.com, committer_name: bob, committer_email: bob@example.com, additions: 3}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: commit-bot, sha: hash-bot, author_name: bob, author_email: bob@example.com, committer_name: bob, committer_email: bob@example.com, additions: 1}
 
 cases:
   - name: Account-first attribution decides pull-request measures
@@ -72,8 +78,8 @@ cases:
         find: {entity_id: alice@example.com}
         equal: {value: 2}
       # Ghost author (no account id anywhere): the linked commit's email still
-      # attributes the pull request. The precedence PR's bob-flavored profile
-      # email must NOT leak here.
+      # attributes the pull request. Neither the precedence PR's bob-flavored
+      # profile email NOR the excluded bot's bob-authored commit may leak here.
       - metric: git.prs_merged
         view: period
         find: {entity_id: bob@example.com}

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_github.pull_request_diff_stats.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_github.pull_request_diff_stats.yaml
@@ -17,4 +17,13 @@ schemas:
       deletions: {type: integer}
       changed_files: {type: integer}
       updated_at: {type: string}
-      author_email: {type: string}
+      author_email: {type: [string, "null"]}
+      data_source: {type: [string, "null"]}
+      collected_at: {type: [string, "null"]}
+      author_login: {type: [string, "null"]}
+      author_id: {type: [integer, "null"]}
+      merged_by_login: {type: [string, "null"]}
+      merged_by_id: {type: [integer, "null"]}
+      review_decision: {type: [string, "null"]}
+      total_comments_count: {type: [integer, "null"]}
+      is_cross_repository: {type: [boolean, "null"]}

--- a/src/ingestion/tests/e2e/metrics/test_fixtures.py
+++ b/src/ingestion/tests/e2e/metrics/test_fixtures.py
@@ -148,6 +148,38 @@ def _seed_identity_persons(cfg: SessionConfig, person_ids: dict[str, str]) -> No
     )
 
 
+# The reserved not-a-human person (bots, CI): an account bound to it claims
+# nothing in either resolution map. Mirrors excluded_person_id() in dbt.
+_EXCLUDED_PERSON_ID = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+
+
+def _seed_identity_accounts(cfg: SessionConfig, accounts: list[dict[str, str]], start_id: int) -> None:
+    """Source-account bindings from the yaml's `identity_accounts` — the rows
+    the account-first map (resolve_person_id_by_account) resolves pull-request
+    authors through. insight_source_id is hashed from the RAW source id with
+    the same expression the connectors' identity_inputs models use, so the
+    seam under test is the real one.
+    """
+    if not accounts:
+        return
+
+    rows = ", ".join(
+        f"({start_id + index}, 'id', '{entry['source_type']}', "
+        f"toUUID(UUIDNumToString(sipHash128('{entry['source_id']}'))), generateUUIDv4(), "
+        f"'{entry['account_id']}', '{entry['account_id']}', "
+        f"toUUID('{_EXCLUDED_PERSON_ID if entry['person'] == 'excluded' else person_id_for(entry['person'])}'), "
+        f"toUUID('00000000-0000-0000-0000-000000000000'), now64(6), now64(3))"
+        for index, entry in enumerate(accounts)
+    )
+    clickhouse.execute(
+        cfg,
+        "INSERT INTO identity.identity_persons "  # noqa: S608 — values derive from fixture yaml
+        "(id, value_type, insight_source_type, insight_source_id, insight_tenant_id,"
+        " value_id, value_effective, person_id, author_person_id, created_at, _synced_at) "
+        "VALUES " + rows,
+    )
+
+
 # One synthetic connector instance for every rig persona: the account triple is
 # what joins evidence to bindings, so both inserts must name the same source.
 _RIG_SOURCE_ID = "e2e0e2e0-0000-4000-8000-000000000001"
@@ -257,6 +289,7 @@ def test_metric_smoke(
     # a new persona could fall outside of (that reads as an authz bug).
     identity_stub.allow_visible(persona_emails)
     _seed_identity_persons(ch_seeder.cfg, all_person_ids)
+    _seed_identity_accounts(ch_seeder.cfg, test_yaml.identity_accounts, start_id=len(all_person_ids) + 1)
 
     if staging or silver_set or ran_enrich_steps:
         dbt_runner.run("tag:gold", worker_ctx=worker_ctx)

--- a/src/ingestion/tests/e2e/metrics/test_fixtures.py
+++ b/src/ingestion/tests/e2e/metrics/test_fixtures.py
@@ -12,7 +12,7 @@ from lib.config import SessionConfig
 from lib.dbt_runner import DbtRunner
 from lib.enrich import EnrichRunner
 from lib.expect_engine import evaluate_case
-from lib.fixture_loader import TestYaml
+from lib.fixture_loader import IdentityAccount, TestYaml
 from lib.identity_stub import IdentityStub, person_id_for
 from lib.worker import WorkerContext
 
@@ -153,7 +153,7 @@ def _seed_identity_persons(cfg: SessionConfig, person_ids: dict[str, str]) -> No
 _EXCLUDED_PERSON_ID = "ffffffff-ffff-ffff-ffff-ffffffffffff"
 
 
-def _seed_identity_accounts(cfg: SessionConfig, accounts: list[dict[str, str]], start_id: int) -> None:
+def _seed_identity_accounts(cfg: SessionConfig, accounts: list[IdentityAccount], start_id: int) -> None:
     """Source-account bindings from the yaml's `identity_accounts` — the rows
     the account-first map (resolve_person_id_by_account) resolves pull-request
     authors through. insight_source_id is hashed from the RAW source id with
@@ -164,10 +164,10 @@ def _seed_identity_accounts(cfg: SessionConfig, accounts: list[dict[str, str]], 
         return
 
     rows = ", ".join(
-        f"({start_id + index}, 'id', '{entry['source_type']}', "
-        f"toUUID(UUIDNumToString(sipHash128('{entry['source_id']}'))), generateUUIDv4(), "
-        f"'{entry['account_id']}', '{entry['account_id']}', "
-        f"toUUID('{_EXCLUDED_PERSON_ID if entry['person'] == 'excluded' else person_id_for(entry['person'])}'), "
+        f"({start_id + index}, 'id', '{entry.source_type}', "
+        f"toUUID(UUIDNumToString(sipHash128('{entry.source_id}'))), generateUUIDv4(), "
+        f"'{entry.account_id}', '{entry.account_id}', "
+        f"toUUID('{_EXCLUDED_PERSON_ID if entry.person == 'excluded' else person_id_for(entry.person)}'), "
         f"toUUID('00000000-0000-0000-0000-000000000000'), now64(6), now64(3))"
         for index, entry in enumerate(accounts)
     )


### PR DESCRIPTION
Closes #2819.

**Why.** A person's pull-request measures count only the pull requests whose author email is discoverable — a squash-merge with a deleted branch, a co-authored branch, or a private profile email silently removes the pull request from every `pr_*` measure while the same person's commit measures stay complete.

**What changed.** `class_git_pull_requests` now carries `author_account_id`, and gold resolves pull-request measures through the account's identity binding first — the email path (profile email, else the linked commits' one shared email) decides only when no account id exists: authors deleted at the source, and GitLab, which emits no identity inputs yet.

**The email fallback is permanent, not transitional.** Ghost authors have no account id ever, and GitLab has no account bindings; per row exactly one rule applies, account when present.

**Major descriptor bumps dispatch the backfill.** The account id has always been in bronze (GitHub diff-stats `author_id`, Bitbucket `author_account_id`), so github 5.0.0 and bitbucket-cloud 4.0.0 make the reconcile loop fire the one-shot scoped `dbt --full-refresh` (ADR-0015) that rewrites every historical row — no re-sync, no operator step. GitLab stays unbumped: it projects `''` and the heal's column default already agrees.

**Warm instances.** Numbered silver migration plus guarded staging heals add the column `AFTER author_email` on both layers; the DDL snapshot carries it for fresh installs.

**Verified.** New e2e fixture proves: account-only attribution (squash, no commits collected), ghost fallback via commit email, account-over-email precedence, excluded-person (bot) accounts attribute nothing; `git_metrics`, `git_branch_scope`, `git_commits_bitbucket`, `git_file_change_content_identity` green on a fresh stack. `dbt parse` green. `ai_pr_attribution` fails identically on clean main (its data test needs a staging table only the cursor fixtures create) — pre-existing, untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Pull requests now support author account IDs from GitHub, Bitbucket Cloud, and GitLab.
  - Git activity attribution can resolve people by account ID, with email fallback when appropriate.
  - Account IDs are normalized consistently across supported sources.

- **Bug Fixes**
  - Excluded or deleted accounts are no longer incorrectly attributed through alternate identity details.
  - Existing pull-request data is prepared for accurate account-based attribution after refresh.

- **Documentation**
  - Connector and schema documentation now describes author account ID behavior and supported values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->