### PR TITLE
say how a file lands in each git category

### DIFF
--- a/src/frontend/src/components/portal/domain-lens-view.test.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.test.tsx
@@ -564,6 +564,44 @@ describe("composition (rule 7: only real server dimensions)", () => {
     expect(screen.getByText(/75%/)).toBeInTheDocument();
   });
 
+  it("explains a derived dimension under the bars, not above them", () => {
+    // A category label says nothing about how the bucket was decided, and the
+    // explanation belongs after the reading rather than in front of it.
+    const comp = emptyCollection();
+    comp.byKey.set("t.commits", {
+      ...metric("t.commits", []),
+      breakdown: {
+        view: "breakdown",
+        values: IDS.flatMap((id) => [
+          { entity_id: id, dimensions: [{ key: "category", value: "docs" }], value: 30 },
+          { entity_id: id, dimensions: [{ key: "category", value: "code" }], value: 10 },
+        ]),
+      },
+    } as never);
+    mocks.collections = [emptyCollection(), comp, emptyCollection()];
+    render(
+      <DomainLensView
+        config={{
+          title: "T",
+          sections: [
+            { kind: "headline", metrics: ["t.commits"] },
+            {
+              kind: "composition",
+              metric: "t.commits",
+              dimension: "category",
+              title: "Lines by category",
+              notes: ["First rule that matches wins.", "Code — everything else."],
+            },
+          ],
+        }}
+      />,
+    );
+    expect(
+      screen.getByText("First rule that matches wins."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Code — everything else.")).toBeInTheDocument();
+  });
+
   it("shows a retryable error card when the breakdown request fails", () => {
     const comp = emptyCollection();
     comp.isError = true;

--- a/src/frontend/src/components/portal/domain-lens-view.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.tsx
@@ -1738,6 +1738,7 @@ function CompositionSection({
       rows={rows}
       format={r?.format ?? "integer"}
       unit={r?.unit ?? null}
+      notes={spec.notes}
     />
   );
 }
@@ -2046,6 +2047,7 @@ function BarList({
   format,
   unit,
   showShare = true,
+  notes,
 }: {
   title: string;
   rows: BarRow[];
@@ -2053,6 +2055,8 @@ function BarList({
   unit: string | null;
   /** False for per-capita values, where a share-of-total percent would mislead. */
   showShare?: boolean;
+  /** Below the bars, not above: it explains what was read, not what to read. */
+  notes?: readonly string[];
 }) {
   const [expanded, setExpanded] = useState(false);
   const visible = expanded ? rows : rows.slice(0, BAR_LIST_COLLAPSED);
@@ -2183,6 +2187,15 @@ function BarList({
               </button>
             ) : null}
           </TooltipProvider>
+          {notes?.length ? (
+            <div className="mt-4 flex flex-col gap-1 border-t pt-3">
+              {notes.map((note) => (
+                <p key={note} className="text-xs text-muted-foreground">
+                  {note}
+                </p>
+              ))}
+            </div>
+          ) : null}
         </CardContent>
       </Card>
     </section>

--- a/src/frontend/src/lib/portal/lens-configs.test.ts
+++ b/src/frontend/src/lib/portal/lens-configs.test.ts
@@ -59,6 +59,28 @@ describe("DIRECTION_LENSES registry", () => {
     }
   });
 
+  it("explains a derived dimension where a label cannot", () => {
+    const entry = lensEntry("dev", "Overview");
+    const composition = (entry as LensConfig).sections.find(
+      (section): section is Extract<SectionSpec, { kind: "composition" }> =>
+        section.kind === "composition" && section.dimension === "category",
+    );
+
+    // The lead states the precedence, which is the part a reader cannot guess
+    // from the labels, and every category the warehouse can emit is named.
+    const notes = composition?.notes ?? [];
+    expect(notes[0]).toMatch(/first rule that matches wins/i);
+    for (const label of [
+      "Vendored / Generated",
+      "Tests",
+      "Documentation",
+      "Configuration",
+      "Code",
+    ]) {
+      expect(notes.some((note) => note.startsWith(label)), label).toBe(true);
+    }
+  });
+
   it("stays under the API metric cap per lens", () => {
     for (const lenses of Object.values(DIRECTION_LENSES)) {
       for (const entry of Object.values(lenses)) {

--- a/src/frontend/src/lib/portal/lens-configs.ts
+++ b/src/frontend/src/lib/portal/lens-configs.ts
@@ -59,6 +59,12 @@ export type SectionSpec =
       dimension: string;
       title: string;
       splitBy?: string;
+      /**
+       * Lines shown under the bars, for a dimension whose values are derived
+       * rather than reported — a reader cannot tell how a bucket was decided
+       * from its label alone. One line each, the first is the lead.
+       */
+      notes?: readonly string[];
     }
   // Flow-depth sections: event-histogram merges per-entity server bins when
   // edges align (they don't on the current API — honest fallback, see design §7);
@@ -259,6 +265,23 @@ const SCREEN_GAP = (what: string): LensRoadmap => ({
   comingSoon: `${what} — the data is there (git observations carry the dimensions); this view is still in development.`,
 });
 
+/**
+ * How the git file-category taxonomy is decided, in the order the warehouse
+ * applies it (`git_file_category` in the dbt macros). Wording stays behavioural
+ * — what lands in a bucket — rather than quoting the regexes, which change.
+ *
+ * Frontend copy on purpose: a dimension value carries a label over the wire and
+ * nothing else, so there is no server field to put this in.
+ */
+const GIT_CATEGORY_NOTES = [
+  "Every file gets one category, from its path — the first rule that matches wins.",
+  "Vendored / Generated — dependency folders, build output, minified and generated files, lockfiles.",
+  "Tests — files named *.test.* or *.spec.*, and anything under test/, tests/ or __tests__/.",
+  "Documentation — .md, .rst and .adoc files, and anything under docs/.",
+  "Configuration — .yaml, .toml, .cfg and .ini files, and lockfiles not already counted as generated.",
+  "Code — whatever the other categories did not claim.",
+] as const;
+
 const DEV: Record<string, LensEntry> = {
   Overview: {
     title: "Development",
@@ -284,6 +307,11 @@ const DEV: Record<string, LensEntry> = {
         metric: "git.lines_added",
         dimension: "category",
         title: "Lines by category",
+        // The taxonomy is a path match in the warehouse, so the labels alone
+        // do not say what landed where — and the order is the part a reader
+        // cannot guess: one file has one category, decided by the first rule
+        // that matches it.
+        notes: GIT_CATEGORY_NOTES,
       },
     ],
   },

--- a/src/frontend/src/mocks/metric-results-factory.ts
+++ b/src/frontend/src/mocks/metric-results-factory.ts
@@ -64,6 +64,40 @@ const MOCK_TOOLS = [
   { key: "tool", value: "cursor", label: "Cursor" },
 ];
 
+/**
+ * Values a dimension breaks down into, so a mock answers the dimension it was
+ * ASKED for. Returning one fixed set meant a section reading any other
+ * dimension found nothing in its rows and rendered as absent — which reads as
+ * a broken screen rather than as a mock with no fixture.
+ */
+const MOCK_DIMENSION_VALUES: Record<
+  string,
+  { value: string; label: string }[]
+> = {
+  category: [
+    { value: "code", label: "Code" },
+    { value: "test", label: "Tests" },
+    { value: "docs", label: "Documentation" },
+    { value: "config", label: "Configuration" },
+    { value: "vendored", label: "Vendored / Generated" },
+  ],
+  branch_scope: [
+    { value: "default", label: "Default branch" },
+    { value: "non_default", label: "Other branches" },
+  ],
+  source: [
+    { value: "github", label: "GitHub" },
+    { value: "gitlab", label: "GitLab" },
+  ],
+};
+
+function mockDimensionValues(key: string): { value: string; label: string }[] {
+  return (
+    MOCK_DIMENSION_VALUES[key] ??
+    MOCK_TOOLS.map(({ value, label }) => ({ value, label }))
+  );
+}
+
 export function buildMetricResultsResponse(
   request: MetricResultsRequest,
 ): MetricResultsResponse {
@@ -126,18 +160,26 @@ export function buildMetricResultsResponse(
             ),
           };
         }
-        case "breakdown":
+        case "breakdown": {
+          // One row per combination the caller asked for, keyed by the
+          // requested dimension rather than by a fixed one.
+          const axis = view.dimensions[0] ?? "tool";
           return {
             view: "breakdown",
             dimensions: view.dimensions,
             values: ids.flatMap((entityId) =>
-              MOCK_TOOLS.map((dimension) => ({
+              mockDimensionValues(axis).map((dimension) => ({
                 entity_id: entityId,
-                dimensions: [dimension],
+                dimensions: view.dimensions.map((dimensionKey) => ({
+                  key: dimensionKey,
+                  value: dimension.value,
+                  label: dimension.label,
+                })),
                 value: valueFor(entityId, key, dimension.value),
               })),
             ),
           };
+        }
         case "rollup":
           return {
             view: "rollup",


### PR DESCRIPTION
"Lines by category" names five buckets and says nothing about how a file reaches one — to learn what "Documentation" counts you have to find the dbt macro. Adds those rules under the bars, with the part the labels cannot show: one file gets one category, decided by the first rule that matches, so a `.yaml` under `docs/` is documentation and one under `tests/` is a test.

Wording is behavioural rather than a transcription of the regexes, which change. Frontend copy because a dimension value carries a label over the wire and nothing else — no backend change.

Second commit is the mock layer: its breakdown answered with one fixed set of `tool` values whatever dimension was asked for, so **no composition section rendered in mock mode at all** — including this one. Separable, but without it the change cannot be looked at locally.

**Where:** `frontend` (Overview lens config, `BarList`, metric-results mocks).

**Verify:** `pnpm typecheck && pnpm lint && pnpm vitest run` in `src/frontend`; then `VITE_ENABLE_MOCKS=true pnpm dev` and open Directions → Development → Overview.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explanatory notes beneath composition charts, including category matching and precedence details.
  * Added development lens guidance for category-based line breakdowns.

* **Bug Fixes**
  * Improved breakdown previews so displayed values match the selected dimension, including category, branch scope, and source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->