### PR TITLE
fix(bitbucket): skip a repository the vendor refuses instead of truncating every fan-out walk

### DIFF
--- a/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/connector.yaml
@@ -163,6 +163,39 @@ definitions:
         action: RETRY
         error_message: Transient Bitbucket error
 
+  # Per-repository pull-request listings, standalone stream and the fan-out
+  # parents inside every PR child stream alike. Unlike workspace discovery,
+  # a 403/404 here is about ONE repository (suspended, deleted, or denied to
+  # the token) and permanent for it, so the repository is skipped and the
+  # walk continues. Failing instead aborts partition generation and silently
+  # truncates every repository later in the updated_on-ordered walk.
+  prs_listing_error_handler: &prs_listing_error_handler
+    type: DefaultErrorHandler
+    max_retries: 5
+    backoff_strategies: *vendor_backoff
+    response_filters:
+      - type: HttpResponseFilter
+        http_codes: [429]
+        action: RATE_LIMITED
+        error_message: Bitbucket hourly rate budget exhausted
+      - type: HttpResponseFilter
+        http_codes: [403, 404]
+        action: IGNORE
+        error_message: >-
+          Repository not accessible with this token or gone; other repositories continue.
+      - type: HttpResponseFilter
+        http_codes: [401]
+        action: FAIL
+        failure_type: config_error
+        error_message: >-
+          Bitbucket rejected the credentials. Personal API tokens need
+          bitbucket_username set (Basic auth); workspace access tokens must
+          NOT set it (Bearer). Mixing the two is the most common cause.
+      - type: HttpResponseFilter
+        http_codes: [500, 502, 503, 504]
+        action: RETRY
+        error_message: Transient Bitbucket error
+
   proxy_requester: &proxy_requester
     type: HttpRequester
     url_base: "{{ config['git_proxy_url'] }}"
@@ -481,6 +514,7 @@ streams:
                     <<: *repos_since_start
                     fields: >-
                       next,values.uuid,values.slug,values.updated_on,values.links.clone
+                  error_handler: *discovery_error_handler
                 record_selector: *repos_selector
                 paginator:
                   type: DefaultPaginator
@@ -671,6 +705,7 @@ streams:
                     <<: *repos_since_start
                     fields: >-
                       next,values.uuid,values.slug,values.updated_on,values.links.clone
+                  error_handler: *discovery_error_handler
                 record_selector: *repos_selector
                 paginator:
                   type: DefaultPaginator
@@ -842,6 +877,7 @@ streams:
                     <<: *repos_since_start
                     fields: >-
                       next,values.uuid,values.slug,values.links.clone
+                  error_handler: *discovery_error_handler
                 record_selector: *repos_selector
                 paginator:
                   type: DefaultPaginator
@@ -967,32 +1003,7 @@ streams:
             updated_on >= "{{ stream_interval.start_time }}"
           fields: >-
             next,values.id,values.title,values.state,values.draft,values.author.uuid,values.author.display_name,values.author.account_id,values.author.nickname,values.created_on,values.updated_on,values.description,values.reason,values.close_source_branch,values.merge_commit.hash,values.closed_by.uuid,values.closed_by.account_id,values.closed_by.display_name,values.source.branch.name,values.source.commit.hash,values.source.repository.full_name,values.destination.branch.name,values.destination.commit.hash,values.destination.repository.full_name,values.participants.role,values.participants.state,values.participants.approved,values.participants.participated_on,values.participants.user.uuid,values.participants.user.display_name,values.comment_count,values.task_count
-        error_handler:
-          type: DefaultErrorHandler
-          max_retries: 5
-          backoff_strategies: *vendor_backoff
-          response_filters:
-            - type: HttpResponseFilter
-              http_codes: [429]
-              action: RATE_LIMITED
-              error_message: Bitbucket hourly rate budget exhausted
-            - type: HttpResponseFilter
-              http_codes: [403, 404]
-              action: IGNORE
-              error_message: >-
-                Repository not accessible with this token or gone; other repositories continue.
-            - type: HttpResponseFilter
-              http_codes: [401]
-              action: FAIL
-              failure_type: config_error
-              error_message: >-
-                Bitbucket rejected the credentials. Personal API tokens need
-                bitbucket_username set (Basic auth); workspace access tokens must
-                NOT set it (Bearer). Mixing the two is the most common cause.
-            - type: HttpResponseFilter
-              http_codes: [500, 502, 503, 504]
-              action: RETRY
-              error_message: Transient Bitbucket error
+        error_handler: *prs_listing_error_handler
       record_selector:
         type: RecordSelector
         extractor:
@@ -1047,6 +1058,7 @@ streams:
                   request_parameters:
                     <<: *repos_since_start
                     fields: next,values.uuid,values.slug,values.full_name,values.updated_on
+                  error_handler: *discovery_error_handler
                 record_selector: *repos_selector
                 paginator:
                   type: DefaultPaginator
@@ -1338,6 +1350,7 @@ streams:
                     # re-read window.
                     <<: *prs_since_start
                     fields: next,values.id,values.updated_on
+                  error_handler: *prs_listing_error_handler
                 record_selector:
                   type: RecordSelector
                   extractor:
@@ -1392,6 +1405,7 @@ streams:
                             request_parameters:
                               <<: *repos_since_start
                               fields: next,values.uuid,values.slug,values.full_name,values.updated_on
+                            error_handler: *discovery_error_handler
                           record_selector: *repos_selector
                           paginator:
                             type: DefaultPaginator
@@ -1659,6 +1673,7 @@ streams:
                     # re-read window.
                     <<: *prs_since_start
                     fields: next,values.id,values.updated_on
+                  error_handler: *prs_listing_error_handler
                 record_selector:
                   type: RecordSelector
                   extractor:
@@ -1713,6 +1728,7 @@ streams:
                             request_parameters:
                               <<: *repos_since_start
                               fields: next,values.uuid,values.slug,values.full_name,values.updated_on
+                            error_handler: *discovery_error_handler
                           record_selector: *repos_selector
                           paginator:
                             type: DefaultPaginator
@@ -2018,6 +2034,7 @@ streams:
                     # re-read window.
                     <<: *prs_since_start
                     fields: next,values.id,values.updated_on
+                  error_handler: *prs_listing_error_handler
                 record_selector:
                   type: RecordSelector
                   extractor:
@@ -2072,6 +2089,7 @@ streams:
                             request_parameters:
                               <<: *repos_since_start
                               fields: next,values.uuid,values.slug,values.full_name,values.updated_on
+                            error_handler: *discovery_error_handler
                           record_selector: *repos_selector
                           paginator:
                             type: DefaultPaginator
@@ -2324,6 +2342,7 @@ streams:
                     # re-read window.
                     <<: *prs_since_start
                     fields: next,values.id,values.updated_on
+                  error_handler: *prs_listing_error_handler
                 record_selector:
                   type: RecordSelector
                   extractor:
@@ -2378,6 +2397,7 @@ streams:
                             request_parameters:
                               <<: *repos_since_start
                               fields: next,values.uuid,values.slug,values.full_name,values.updated_on
+                            error_handler: *discovery_error_handler
                           record_selector: *repos_selector
                           paginator:
                             type: DefaultPaginator
@@ -2794,6 +2814,7 @@ streams:
                   request_parameters:
                     <<: *repos_since_start
                     fields: next,values.uuid,values.slug,values.full_name,values.updated_on
+                  error_handler: *discovery_error_handler
                 record_selector: *repos_selector
                 paginator:
                   type: DefaultPaginator
@@ -3031,6 +3052,7 @@ streams:
                   request_parameters:
                     <<: *repos_since_start
                     fields: next,values.uuid,values.slug,values.full_name,values.updated_on
+                  error_handler: *discovery_error_handler
                 record_selector: *repos_selector
                 paginator:
                   type: DefaultPaginator
@@ -3297,6 +3319,7 @@ streams:
                               <<: *repos_since_start
                               fields: >-
                                 next,values.uuid,values.slug,values.full_name,values.updated_on,values.links.clone
+                            error_handler: *discovery_error_handler
                           record_selector: *repos_selector
                           paginator:
                             type: DefaultPaginator

--- a/src/ingestion/connectors/git/bitbucket-cloud/descriptor.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/descriptor.yaml
@@ -6,7 +6,7 @@ name: bitbucket-cloud
 #   re-reads Bronze, so the column heals to '' on existing rows and only the
 #   one-shot scoped `dbt --full-refresh` a major bump dispatches
 #   re-materializes the history.
-version: "4.0.0"
+version: "4.0.1"
 # A slot of its own: replication pods sharing a slot with other connector
 # syncs can be starved of workers, which surfaces as startup and activity
 # timeouts rather than as a connector error.

--- a/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_manifest.py
+++ b/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_manifest.py
@@ -194,3 +194,33 @@ def test_every_repository_listing_projects_the_field_the_exclusion_reads() -> No
         "these repository listings do not project values.slug, so the exclusion "
         f"filter cannot see it: {missing}"
     )
+
+
+def _requesters(node, out=None):
+    """Every HttpRequester mapping anywhere in the manifest tree."""
+    if out is None:
+        out = []
+    if isinstance(node, dict):
+        if node.get("type") == "HttpRequester":
+            out.append(node)
+        for value in node.values():
+            _requesters(value, out)
+    elif isinstance(node, list):
+        for item in node:
+            _requesters(item, out)
+    return out
+
+
+def test_every_requester_declares_an_error_handler() -> None:
+    """The CDK default handler makes a per-repository 403 fatal to the whole
+    stream, and on the fan-out parents that aborts partition generation: every
+    repository later in the updated_on-ordered walk is silently skipped while
+    the sync reports success. A handler on every requester is the invariant;
+    which action it takes per status is the stream's own decision."""
+    manifest = yaml.safe_load((connector_dir(_CONNECTOR) / "connector.yaml").read_text())
+    bare = [
+        requester.get("path", "<no path>")
+        for requester in _requesters(manifest["streams"])
+        if "error_handler" not in requester
+    ]
+    assert not bare, f"requesters relying on the CDK default error handler: {bare}"

--- a/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_vendor_streams.py
+++ b/src/ingestion/connectors/git/bitbucket-cloud/tests/test_bitbucket_vendor_streams.py
@@ -19,6 +19,7 @@ from typing import Any
 from urllib.parse import unquote_plus
 
 import freezegun
+import pytest
 from airbyte_cdk.models import AirbyteMessage
 from config import BB_URL, PROXY_URL, BitbucketCloudConfigBuilder
 
@@ -143,6 +144,75 @@ def test_a_403_repository_is_skipped_not_fatal(http_mocker: HttpMocker) -> None:
 
     assert not output.errors
     assert len(output.records) == 0
+
+
+@freezegun.freeze_time(_FROZEN)
+@pytest.mark.parametrize(
+    ("stream", "endpoint", "body"),
+    [
+        (
+            "pull_request_comments",
+            "comments",
+            {"values": [{"id": 77, "user": None, "content": None, "deleted": False,
+                         "created_on": "2026-06-20T10:00:00.000000+00:00",
+                         "updated_on": "2026-06-20T10:00:00.000000+00:00"}]},
+        ),
+        (
+            "pull_request_commits",
+            "commits",
+            {"values": [{"type": "commit", "hash": "a" * 12,
+                         "date": "2026-06-19T10:00:00+00:00", "message": "feat: x",
+                         "author": {"raw": "Alice <alice@example.com>"},
+                         "parents": [{"hash": "b" * 12}]}]},
+        ),
+        (
+            "pull_request_diffstat",
+            "diffstat",
+            {"values": [{"type": "diffstat", "status": "modified", "lines_added": 1,
+                         "lines_removed": 0, "old": {"path": "src/a.py"},
+                         "new": {"path": "src/a.py"}}]},
+        ),
+        (
+            "pull_request_activity",
+            "activity",
+            {"values": [{"approval": {"date": "2026-06-21T10:00:00+00:00",
+                                      "user": {"uuid": "{u-1}", "display_name": "Alice"}}}]},
+        ),
+    ],
+)
+def test_a_403_repository_does_not_truncate_a_child_streams_walk(
+    http_mocker: HttpMocker, stream: str, endpoint: str, body: dict[str, Any]
+) -> None:
+    """The fan-out parents walk repositories in ascending updated_on order, so
+    a repository the vendor refuses (403) mid-walk must be skipped — failing
+    instead aborts partition generation and silently drops every repository
+    updated after it. The refused repository sorts FIRST here so the healthy
+    one is only reached if the walk survives."""
+    config = BitbucketCloudConfigBuilder().build()
+    dead = {"uuid": "{r-0}", "full_name": "acme/suspended",
+            "updated_on": "2026-06-01T10:00:00.000000+00:00"}
+    http_mocker.get(
+        HttpRequest(_REPOS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"values": [dead, _repo()]}), status_code=200),
+    )
+    http_mocker.get(
+        HttpRequest(f"{BB_URL}/repositories/acme/suspended/pullrequests", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body="Repository currently not available.", status_code=403),
+    )
+    http_mocker.get(
+        HttpRequest(f"{BB_URL}/repositories/acme/app/pullrequests", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"values": [_pr(9, author=None)]}), status_code=200),
+    )
+    http_mocker.get(
+        HttpRequest(f"{BB_URL}/repositories/acme/app/pullrequests/9/{endpoint}", query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps(body), status_code=200),
+    )
+
+    output = read_stream(_CONNECTOR, stream, config)
+
+    assert not output.errors
+    assert output.records, "the walk stopped at the refused repository"
+    assert {r.record.data["repo_full_name"] for r in output.records} == {"acme/app"}
 
 
 @freezegun.freeze_time(_FROZEN)


### PR DESCRIPTION
**Why.** A repository the vendor answers 403 for — suspended, deleted, or denied to the token — aborted partition generation in every pull-request child stream. The fan-out parents walk repositories in ascending `updated_on` order, so every repository updated after the refused one was silently skipped while the stream logged its record count and the sync reported success.

**What changed.** The per-repository pull-request listing's error policy — 403/404 skip that repository, everything else unchanged — now lives in one `prs_listing_error_handler` anchor and applies to the standalone `pull_requests` stream and to all four fan-out copies inside the child streams, which carried no handler at all and fell through to the CDK default of failing the stream. The eleven inline workspace repository listings get the existing `*discovery_error_handler`, matching the top-level `repositories` stream they are copies of.

**A skipped repository stays silent, deliberately.** The `IGNORE` message in the log is the only trace, which is the trade-off the standalone stream already made; failing instead is what caused this.

**Out of scope.** Each child stream still walks its own private copy of the repository and pull-request listings rather than sharing one, so a full refresh pays that cost four times. Tracked separately.

**Verified.** Bitbucket mock suite 28/28. The five new tests fail against the previous manifest and pass with this one. `scripts/ci/connector_wiring.py` clean. Descriptor bumped 4.0.0 → 4.0.1 so `bump-descriptors` patches the image on merge.
