### PR TITLE
fix(git-cli-proxy): cut off a handler that outlives its budget with a retryable 503

### DIFF
--- a/src/backend/services/git-cli-proxy/src/api/error.rs
+++ b/src/backend/services/git-cli-proxy/src/api/error.rs
@@ -227,6 +227,17 @@ impl ApiError {
     }
 }
 
+/// The answer for a handler that outlived its budget (`api::HANDLER_BUDGET`).
+/// A plain 503 envelope: the connectors' declarative handlers RETRY 503, and
+/// the detail deliberately names no internals — the log line next to it does.
+#[must_use]
+pub fn handler_timed_out() -> Response {
+    CanonicalError::service_unavailable()
+        .with_detail("the request outlived the handler budget")
+        .create()
+        .into_response()
+}
+
 /// Detail naming a path or a git invocation is logged here and never reaches
 /// the wire; the crate additionally `serde(skip)`s an internal description.
 fn internal_error(error: &dyn std::fmt::Display) -> CanonicalError {

--- a/src/backend/services/git-cli-proxy/src/api/mod.rs
+++ b/src/backend/services/git-cli-proxy/src/api/mod.rs
@@ -4,7 +4,7 @@ pub mod error;
 pub mod request;
 
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use axum::extract::{MatchedPath, Request};
 use axum::http::{StatusCode, header};
@@ -46,6 +46,9 @@ pub fn register_routes(
     let bearer = auth::ProxyAuth::new(state.config.proxy_token.clone());
 
     let v1 = build_operations(Router::new(), openapi)
+        // Innermost, so only handler work is on the clock — auth and logging
+        // stay outside the budget.
+        .layer(axum::middleware::from_fn(bound_handler))
         .layer(axum::middleware::from_fn_with_state(
             bearer,
             auth::require_bearer,
@@ -56,6 +59,36 @@ pub fn register_routes(
         .layer(axum::middleware::from_fn(observe));
 
     host_router.merge(v1)
+}
+
+/// Every wait a handler can make is individually bounded (git budgets, the
+/// inline preparation wait, the read-lock wait), but a hold that is never
+/// released — a leaked guard, a wedged permit holder — turns the NEXT
+/// request's wait into forever: the connector has no client timeout, so one
+/// such request froze a multi-day sync invisibly. This ceiling converts that
+/// class into a bounded, retryable answer. It must stay above every legal
+/// inline duration; the longest is a page-serve blob prefetch (10 minutes).
+const HANDLER_BUDGET: Duration = Duration::from_mins(15);
+
+/// Answer 503 when a handler outlives [`HANDLER_BUDGET`].
+///
+/// 503, not 408: the connectors' declarative handlers already RETRY 503 (and
+/// would FAIL on an unlisted status). The dropped future releases whatever
+/// the request itself held via RAII; whatever it was WAITING on stays wedged
+/// and is the defect to find in the log this leaves behind.
+async fn bound_handler(request: Request, next: Next) -> Response {
+    answer_within(HANDLER_BUDGET, request, next).await
+}
+
+async fn answer_within(budget: Duration, request: Request, next: Next) -> Response {
+    let method = request.method().clone();
+    let path = request.uri().path().to_owned();
+    if let Ok(response) = tokio::time::timeout(budget, next.run(request)).await {
+        return response;
+    }
+    tracing::error!(%method, %path, budget_s = budget.as_secs(),
+        "handler exceeded its budget; answering 503");
+    error::handler_timed_out()
 }
 
 /// Record §4.3's per-endpoint histograms for every request that reached a
@@ -562,5 +595,32 @@ mod tests {
             status_of("/healthz", None, false).await,
             StatusCode::UNAUTHORIZED
         );
+    }
+
+    /// The pending handler never resolves, so only the budget can produce an
+    /// answer — and it must be the 503 the connectors RETRY. A tiny budget
+    /// stands in for the real one; `bound_handler` differs only by constant.
+    #[tokio::test]
+    async fn a_handler_that_never_answers_is_cut_off_with_503() {
+        let app = axum::Router::new()
+            .route(
+                "/wedged",
+                axum::routing::get(std::future::pending::<axum::response::Response>),
+            )
+            .layer(axum::middleware::from_fn(
+                |request: axum::extract::Request, next: Next| {
+                    answer_within(Duration::from_millis(20), request, next)
+                },
+            ));
+
+        let request = match Request::builder().uri("/wedged").body(Body::empty()) {
+            Ok(r) => r,
+            Err(e) => panic!("build request: {e}"),
+        };
+        let response = match app.oneshot(request).await {
+            Ok(r) => r,
+            Err(e) => panic!("drive router: {e}"),
+        };
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 }

--- a/src/backend/services/git-cli-proxy/src/api/mod.rs
+++ b/src/backend/services/git-cli-proxy/src/api/mod.rs
@@ -86,6 +86,7 @@ async fn answer_within(budget: Duration, request: Request, next: Next) -> Respon
     if let Ok(response) = tokio::time::timeout(budget, next.run(request)).await {
         return response;
     }
+    metrics::record_handler_timeout();
     tracing::error!(%method, %path, budget_s = budget.as_secs(),
         "handler exceeded its budget; answering 503");
     error::handler_timed_out()

--- a/src/backend/services/git-cli-proxy/src/engine/metrics.rs
+++ b/src/backend/services/git-cli-proxy/src/engine/metrics.rs
@@ -85,6 +85,7 @@ impl RejectReason {
 struct Instruments {
     evictions: Counter<u64>,
     rejections: Counter<u64>,
+    handler_timeouts: Counter<u64>,
     purge_escalations: Counter<u64>,
     cold_clones: Counter<u64>,
     fetches: Counter<u64>,
@@ -107,6 +108,14 @@ fn instruments() -> &'static Instruments {
                     "Requests answered 429, by reason. A sustained rise in admission_exhausted \
                      or prefetch_headroom means the budget is too small for the working set; \
                      preparation_wait is ordinary while a clone runs.",
+                )
+                .build(),
+            handler_timeouts: meter
+                .u64_counter("git_proxy.handler_timeouts")
+                .with_description(
+                    "Requests cut off at the handler budget and answered 503. Zero in \
+                     health; any rise means a hold inside the store is never released \
+                     and the cut-off is containing it — find the wedge in the error log.",
                 )
                 .build(),
             purge_escalations: meter
@@ -149,6 +158,10 @@ pub fn record_rejection(reason: RejectReason) {
     instruments()
         .rejections
         .add(1, &[KeyValue::new("reason", reason.as_str())]);
+}
+
+pub fn record_handler_timeout() {
+    instruments().handler_timeouts.add(1, &[]);
 }
 
 pub fn record_purge_escalation() {


### PR DESCRIPTION
**Why.** Every wait inside a handler is individually bounded, but a hold that is never released — a leaked guard, a wedged permit holder — turns the next request's wait into forever. The connector runtime sets no client timeout and its declarative manifest cannot express one, so one such request silently froze a multi-day sync: the service stayed healthy and responsive while a single `/v1/authors` request sat in flight for hours.

**What changed.** A middleware inside the auth and logging layers cuts off any handler that outlives a 15-minute budget and answers a canonical 503 — a status the connectors' declarative handlers already retry. The budget clears every legal inline duration (the longest is the 10-minute page-serve blob prefetch). The cut-off is logged as an error with method, path and budget, and counted on a `git_proxy.handler_timeouts` counter so the containment is alertable; the wedged hold it reveals stays the defect to find.

**Verified.** `cargo test -p git-cli-proxy` (210 tests, including the new cut-off test driving a never-resolving handler through the middleware), `cargo clippy --all-targets` clean, `cargo fmt`.
