### PR TITLE
ci(release): publish the chart for proxy-only changes, and count handler cut-offs

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1376,6 +1376,7 @@ jobs:
       - merge-gateway
       - merge-identity
       - merge-identity-resolution
+      - merge-git-cli-proxy
       - merge-toolbox
       - merge-image
       - bump-descriptors
@@ -1388,6 +1389,7 @@ jobs:
       && (needs.merge-gateway.result       == 'success' || needs.merge-gateway.result       == 'skipped')
       && (needs.merge-identity.result      == 'success' || needs.merge-identity.result      == 'skipped')
       && (needs.merge-identity-resolution.result == 'success' || needs.merge-identity-resolution.result == 'skipped')
+      && (needs.merge-git-cli-proxy.result == 'success' || needs.merge-git-cli-proxy.result == 'skipped')
       && (needs.merge-toolbox.result       == 'success' || needs.merge-toolbox.result       == 'skipped')
       && (needs.merge-image.result         == 'success' || needs.merge-image.result         == 'skipped')
       && (needs.bump-descriptors.result    == 'success' || needs.bump-descriptors.result    == 'skipped')
@@ -1398,6 +1400,7 @@ jobs:
         || needs.changes.outputs.gateway      == 'true'
         || needs.changes.outputs.identity     == 'true'
         || needs.changes.outputs.identity_resolution == 'true'
+        || needs.changes.outputs.git_cli_proxy == 'true'
         || needs.changes.outputs.toolbox      == 'true'
         || needs.changes.outputs.umbrella     == 'true'
         || inputs.frontend_tag != ''

--- a/src/backend/services/git-cli-proxy/src/api/mod.rs
+++ b/src/backend/services/git-cli-proxy/src/api/mod.rs
@@ -86,6 +86,7 @@ async fn answer_within(budget: Duration, request: Request, next: Next) -> Respon
     if let Ok(response) = tokio::time::timeout(budget, next.run(request)).await {
         return response;
     }
+    metrics::record_handler_timeout();
     tracing::error!(%method, %path, budget_s = budget.as_secs(),
         "handler exceeded its budget; answering 503");
     error::handler_timed_out()

--- a/src/backend/services/git-cli-proxy/src/engine/metrics.rs
+++ b/src/backend/services/git-cli-proxy/src/engine/metrics.rs
@@ -86,6 +86,7 @@ struct Instruments {
     evictions: Counter<u64>,
     rejections: Counter<u64>,
     origin_unavailable: Counter<u64>,
+    handler_timeouts: Counter<u64>,
     purge_escalations: Counter<u64>,
     cold_clones: Counter<u64>,
     fetches: Counter<u64>,
@@ -117,6 +118,14 @@ fn instruments() -> &'static Instruments {
                      (suspended, disabled, or over the vendor's own limit). Permanent per \
                      repository: the connector skips it, so a non-zero value means \
                      repositories are absent from bronze until the origin state changes.",
+                )
+                .build(),
+            handler_timeouts: meter
+                .u64_counter("git_proxy.handler_timeouts")
+                .with_description(
+                    "Requests cut off at the handler budget and answered 503. Zero in \
+                     health; any rise means a hold inside the store is never released \
+                     and the cut-off is containing it — find the wedge in the error log.",
                 )
                 .build(),
             purge_escalations: meter
@@ -159,6 +168,10 @@ pub fn record_rejection(reason: RejectReason) {
     instruments()
         .rejections
         .add(1, &[KeyValue::new("reason", reason.as_str())]);
+}
+
+pub fn record_handler_timeout() {
+    instruments().handler_timeouts.add(1, &[]);
 }
 
 pub fn record_origin_unavailable() {


### PR DESCRIPTION
**Why.** A commit touching only the git proxy builds and pushes its image but never publishes an umbrella chart: this branch's `publish-chart` job neither depends on `merge-git-cli-proxy` nor checks `changes.git_cli_proxy`, so #2836 produced an image no chart references. `main` already carries the fix; this branch lagged.

**What changed.** Backport of main's `publish-chart` wiring: `merge-git-cli-proxy` joins the job's `needs` and its `success || skipped` guard, and `changes.git_cli_proxy` joins the trigger set. Alongside it, a `git_proxy.handler_timeouts` counter on the handler cut-off from #2836 — the containment now has an alertable signal instead of only an error log line. The proxy commit also makes this merge itself trip the new trigger, so the chart the branch owes for #2836 publishes on merge.

**Verified.** `cargo test -p git-cli-proxy` (211 tests), `cargo clippy --all-targets` clean, `cargo fmt`. The workflow edit mirrors main's shape line for line.
