### PR TITLE
fix(keycloak): hand the expired-login page back to the app

### DIFF
--- a/.github/workflows/keycloak-helm.yml
+++ b/.github/workflows/keycloak-helm.yml
@@ -1,0 +1,53 @@
+name: Keycloak — Helm contract
+
+# Render-contract gate for the login theme (#2721). The theme's whole job is
+# to stop a rebuilt login dead-ending on Keycloak's "page expired" screen, and
+# every way it can break — a moved template file, a mount path that no longer
+# matches the theme name, a realm binding a theme that is not shipped — fails
+# silently: Keycloak starts, falls back to the built-in theme, and the dead
+# end simply returns. Pure `helm template` + assertions, no cluster.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/backend/services/keycloak/helm/**"
+      - "deploy/gitops/environments/*/keycloak/realms/**"
+      - "charts/insight/**"
+      - ".github/workflows/keycloak-helm.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  helm-contract:
+    name: render contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # Pinned to full SHAs (mutable tags are repointable — supply-chain
+      # hardening, same as semgrep.yml / trivy.yml).
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install test deps
+        run: pip install --quiet pytest pyyaml
+
+      - name: helm lint
+        run: |
+          helm lint src/backend/services/keycloak/helm
+          helm dependency update charts/insight
+          helm lint charts/insight
+
+      - name: Render-contract tests (login theme, realm binding)
+        run: python -m pytest src/backend/services/keycloak/helm/tests/ -q

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -467,6 +467,13 @@ keycloak:
     passwordSecret: {name: "", key: ""}
   route:
     enabled: false
+  # Login theme, shipped with this Keycloak. Inert until a realm sets
+  # `loginTheme: insight` — never set that when keycloakConfig points at a
+  # Keycloak this chart does not deploy. `returnUrl` is where the overridden
+  # page hands the browser back to (relative to the Gateway host the SPA and
+  # Keycloak share).
+  theme:
+    returnUrl: "/?auth_error=kc_page_expired"
 # ─── keycloakConfig (broker realms as code — ADR-0003, EPIC #2193) ──────────
 # Hook Job applying the env's versioned realm YAML (pre-created ConfigMap from
 # the gitops `keycloak-broker-realms` target) with keycloak-config-cli on every

--- a/deploy/gitops/environments/local/keycloak/realms/insight-broker.yaml
+++ b/deploy/gitops/environments/local/keycloak/realms/insight-broker.yaml
@@ -8,6 +8,15 @@
 # substitution scans comments and an unresolvable placeholder fails the import.
 realm: insight-broker
 enabled: true
+# Shown as the heading on any page Keycloak renders itself; without it the
+# heading is the raw realm name.
+displayName: Insight
+# Overrides the page Keycloak serves when a request names an authentication
+# execution that no longer matches the session — reachable when several logins
+# race in one browser, and a dead end because both of its recovery links depend
+# on state that race has already destroyed. Set it only where the umbrella
+# deploys Keycloak: the theme ships with the server, not with this file.
+loginTheme: insight
 
 clientScopes:
   # The claim allow-list: tokens carry exactly email, single-string tenant_id,
@@ -78,3 +87,9 @@ clients:
     redirectUris:
       - $(env:INSIGHT_AUTHENTICATOR_REDIRECT_URI)
     webOrigins: []
+    # Keycloak's generic error page (error.ftl) renders a way out ONLY when the
+    # client names one, and without this it names none — which is what strands
+    # a login Keycloak rebuilt from KC_RESTART and stamped with a timeout.
+    # Relative with no rootUrl set, so ResolveRelative replaces the path on the
+    # reached host: the app root, not /kc.
+    baseUrl: "/"

--- a/src/backend/services/keycloak/helm/.helmignore
+++ b/src/backend/services/keycloak/helm/.helmignore
@@ -1,0 +1,14 @@
+# Keep the packaged chart to what the cluster needs. The theme under theme/
+# IS chart content — .Files.Get reads it at render time — so it must never be
+# listed here.
+.DS_Store
+.idea/
+.vscode/
+.project
+.git/
+.gitignore
+*.tmproj
+tests/
+__pycache__/
+.pytest_cache/
+*.py[cod]

--- a/src/backend/services/keycloak/helm/templates/configmap-theme.yaml
+++ b/src/backend/services/keycloak/helm/templates/configmap-theme.yaml
@@ -1,0 +1,30 @@
+{{- /*
+  The `insight` login theme. Overrides exactly one template — the page
+  Keycloak serves when a request names an authentication execution that no
+  longer matches the session — and inherits every other template from the
+  built-in theme via `parent`.
+
+  The parent is `keycloak.v2`, the KC 26 default (Profile.LOGIN_V2 is on by
+  default; plain `keycloak` is LOGIN_V1, Type.DEPRECATED). Naming the
+  deprecated one would silently downgrade every OTHER page in a realm that
+  binds this theme, and would break outright once it is removed.
+
+  Shipped with this Keycloak but inert: a realm reaches it only by setting
+  `loginTheme: insight`. An install whose keycloakConfig points at a Keycloak
+  this chart does NOT deploy must therefore leave loginTheme unset — the theme
+  ships with the server, not with the realm.
+*/}}
+{{- $theme := default dict .Values.theme }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "insight-keycloak.fullname" . }}-theme
+  labels:
+    {{- include "insight-keycloak.labels" . | nindent 4 }}
+data:
+  theme.properties: |
+    parent=keycloak.v2
+    insightReturnUrl={{ required "keycloak.theme.returnUrl must be a non-empty URL: the overridden page has nowhere to send the browser without one" $theme.returnUrl }}
+  login-page-expired.ftl: |
+    {{- required "theme/insight/login/login-page-expired.ftl is missing from the chart"
+          (.Files.Get "theme/insight/login/login-page-expired.ftl") | nindent 4 }}

--- a/src/backend/services/keycloak/helm/templates/configmap-theme.yaml
+++ b/src/backend/services/keycloak/helm/templates/configmap-theme.yaml
@@ -15,6 +15,16 @@
   ships with the server, not with the realm.
 */}}
 {{- $theme := default dict .Values.theme }}
+{{- $returnUrl := required "keycloak.theme.returnUrl must be a non-empty URL: the overridden page has nowhere to send the browser without one" $theme.returnUrl }}
+{{- /* SAFETY: Keycloak resolves ${...} in EVERY theme property against the
+       server's own environment and system properties, and the resolved value
+       is served in the page's HTML. This pod's environment carries the
+       database password. A newline is refused for the same reason: the value
+       lands inside theme.properties, where a second line is a second
+       property. */}}
+{{- if or (contains "${" $returnUrl) (contains "\n" $returnUrl) }}
+{{- fail "keycloak.theme.returnUrl must be a literal URL: Keycloak resolves ${...} against the server environment and serves the result in the page, and a newline injects a second theme property" }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -24,7 +34,7 @@ metadata:
 data:
   theme.properties: |
     parent=keycloak.v2
-    insightReturnUrl={{ required "keycloak.theme.returnUrl must be a non-empty URL: the overridden page has nowhere to send the browser without one" $theme.returnUrl }}
+    insightReturnUrl={{ $returnUrl }}
   login-page-expired.ftl: |
     {{- required "theme/insight/login/login-page-expired.ftl is missing from the chart"
           (.Files.Get "theme/insight/login/login-page-expired.ftl") | nindent 4 }}

--- a/src/backend/services/keycloak/helm/templates/deployment.yaml
+++ b/src/backend/services/keycloak/helm/templates/deployment.yaml
@@ -11,6 +11,10 @@ spec:
       {{- include "insight-keycloak.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        # Roll pods when the login theme changes: `start` caches themes, so a
+        # ConfigMap update alone would not reach a running Keycloak.
+        checksum/theme: {{ include (print $.Template.BasePath "/configmap-theme.yaml") . | sha256sum }}
       labels:
         {{- include "insight-keycloak.selectorLabels" . | nindent 8 }}
     spec:
@@ -88,6 +92,12 @@ spec:
             # No readOnlyRootFilesystem: Keycloak re-augments Quarkus into
             # /opt/keycloak/lib/quarkus on boot, and an emptyDir there hides
             # quarkus-application.dat from the image. See #2084.
+          volumeMounts:
+            # Flat ConfigMap keys land as themes/insight/login/<key>, which is
+            # exactly the layout Keycloak discovers a theme from.
+            - name: theme
+              mountPath: /opt/keycloak/themes/insight/login
+              readOnly: true
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           # Health lives on the management interface (KC 25+); its path
@@ -102,3 +112,7 @@ spec:
           readinessProbe:
             httpGet: {path: /kc/health/ready, port: mgmt}
             periodSeconds: 10
+      volumes:
+        - name: theme
+          configMap:
+            name: {{ include "insight-keycloak.fullname" . }}-theme

--- a/src/backend/services/keycloak/helm/tests/conftest.py
+++ b/src/backend/services/keycloak/helm/tests/conftest.py
@@ -1,0 +1,32 @@
+"""Pytest fixtures for the Keycloak Helm contract tests.
+
+The render helpers live in `theme_harness` — see the note there on why they
+are not in this file.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+from theme_harness import UMBRELLA
+
+
+@pytest.fixture(scope="session")
+def umbrella_deps() -> Path:
+    """Vendor the subcharts once per session.
+
+    Session-scoped on purpose: every module that renders the umbrella needs
+    this, and each run rewrites `charts/insight/charts/` — so this suite and
+    the other helm suites must not share a working tree concurrently.
+    """
+    proc = subprocess.run(
+        ["helm", "dependency", "update", str(UMBRELLA)],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return UMBRELLA

--- a/src/backend/services/keycloak/helm/tests/test_login_theme_contract.py
+++ b/src/backend/services/keycloak/helm/tests/test_login_theme_contract.py
@@ -1,0 +1,125 @@
+"""Render contract for the `insight` login theme.
+
+The theme stops one login dead end (insight#2721). Every assertion here
+guards a way the change can fail SILENTLY — Keycloak starts, falls back to a
+built-in theme, logs one line, and the dead end simply returns.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+import yaml
+from theme_harness import (
+    CANONICAL_REALMS,
+    MOUNT_PATH,
+    SUBCHART,
+    SUBCHART_BASE,
+    THEME_NAME,
+    THEME_ROOT,
+    THEME_SOURCE,
+    UMBRELLA_BASE,
+    assert_theme_payload,
+    keycloak_pod,
+    render,
+    theme_configmap,
+    theme_properties,
+)
+
+
+def test_theme_source_is_where_the_chart_looks_for_it() -> None:
+    # `.Files.Get` is now guarded, but this names the file so a rename fails
+    # with the reason rather than as a mismatched blob.
+    assert THEME_SOURCE.is_file(), f"missing {THEME_SOURCE}"
+
+
+def test_subchart_renders_a_usable_theme() -> None:
+    assert_theme_payload(render(SUBCHART, *SUBCHART_BASE))
+
+
+def test_return_url_is_configurable() -> None:
+    docs = render(SUBCHART, *SUBCHART_BASE, "--set", "theme.returnUrl=https://app.test/")
+    assert theme_properties(docs)["insightReturnUrl"] == "https://app.test/"
+
+
+def test_shipped_default_carries_the_marker_the_spa_retries_on() -> None:
+    # src/frontend/src/auth/auth-error.ts reads exactly `auth_error` and
+    # auto-retries every code except access_denied. A typo here means no retry
+    # is counted and the browser bounces back into the login it just failed.
+    default = theme_properties(render(SUBCHART, *SUBCHART_BASE))["insightReturnUrl"]
+    assert parse_qs(urlsplit(default).query)["auth_error"] == ["kc_page_expired"]
+
+
+def test_theme_mounts_where_keycloak_discovers_it() -> None:
+    docs = render(SUBCHART, *SUBCHART_BASE)
+    pod = keycloak_pod(docs)
+    (container,) = pod["spec"]["containers"]
+
+    mounts = {m["mountPath"]: m for m in container["volumeMounts"]}
+    assert MOUNT_PATH in mounts, f"theme must mount at {MOUNT_PATH}, got {list(mounts)}"
+    assert mounts[MOUNT_PATH]["readOnly"] is True
+
+    # A mount at the theme root would hide the theme with no error anywhere.
+    shadowing = [path for path in mounts if path != MOUNT_PATH and MOUNT_PATH.startswith(path)]
+    assert not shadowing, f"{shadowing} would shadow {THEME_ROOT}"
+
+    volume = next(v for v in pod["spec"]["volumes"] if v["name"] == mounts[MOUNT_PATH]["name"])
+    assert volume["configMap"]["name"] == theme_configmap(docs)["metadata"]["name"]
+
+
+def test_theme_change_rolls_the_pods() -> None:
+    # Keycloak caches themes under `start`, so a checksum that does not track
+    # the ConfigMap means an edited theme never reaches a running pod. Assert
+    # the value moves, not merely that the key exists.
+    def checksum(*extra: str) -> str:
+        return keycloak_pod(render(SUBCHART, *SUBCHART_BASE, *extra))["metadata"][
+            "annotations"
+        ]["checksum/theme"]
+
+    assert checksum() == checksum()
+    assert checksum() != checksum("--set", "theme.returnUrl=https://other.test/")
+
+
+def test_canonical_realms_agree_with_what_the_chart_ships() -> None:
+    assert CANONICAL_REALMS, "no canonical broker realm found to check"
+
+    bound = []
+    for path in CANONICAL_REALMS:
+        realm = yaml.safe_load(path.read_text())
+
+        # error.ftl — the page the timeout path actually renders — offers a way
+        # out only when the client names one. Pure realm config with no chart
+        # dependency, so it holds for every realm.
+        clients = [c for c in realm.get("clients", []) if c["clientId"] == "insight-authenticator"]
+        assert clients, f"insight-authenticator missing from {path}"
+        assert clients[0].get("baseUrl") == "/", path
+
+        # Binding the theme is opt-in: an install whose Keycloak this chart does
+        # not deploy must leave it unset. A realm that DOES bind it has to name
+        # the theme that ships, or Keycloak silently falls back to the built-in.
+        theme = realm.get("loginTheme")
+        if theme is not None:
+            assert theme == THEME_NAME, path
+            bound.append(path)
+
+    assert bound, "the chart ships a login theme no canonical realm binds"
+
+
+def test_umbrella_ships_a_usable_theme(umbrella_deps: Path) -> None:
+    # The umbrella is the unit of distribution, and the only render where
+    # `.Files.Get` resolves against the PACKAGED subchart.
+    assert_theme_payload(render(umbrella_deps, *UMBRELLA_BASE))
+
+    docs = render(
+        umbrella_deps, *UMBRELLA_BASE, "--set", "keycloak.theme.returnUrl=https://app.test/"
+    )
+    assert theme_properties(docs)["insightReturnUrl"] == "https://app.test/"
+
+
+def test_subchart_and_umbrella_defaults_agree(umbrella_deps: Path) -> None:
+    # Umbrella values win at render time, so a maintainer who fixes only the
+    # subchart default ships nothing.
+    subchart = theme_properties(render(SUBCHART, *SUBCHART_BASE))["insightReturnUrl"]
+    umbrella = theme_properties(render(umbrella_deps, *UMBRELLA_BASE))["insightReturnUrl"]
+    assert subchart == umbrella

--- a/src/backend/services/keycloak/helm/tests/test_login_theme_contract.py
+++ b/src/backend/services/keycloak/helm/tests/test_login_theme_contract.py
@@ -23,6 +23,7 @@ from theme_harness import (
     assert_theme_payload,
     keycloak_pod,
     render,
+    render_error,
     theme_configmap,
     theme_properties,
 )
@@ -49,6 +50,22 @@ def test_shipped_default_carries_the_marker_the_spa_retries_on() -> None:
     # is counted and the browser bounces back into the login it just failed.
     default = theme_properties(render(SUBCHART, *SUBCHART_BASE))["insightReturnUrl"]
     assert parse_qs(urlsplit(default).query)["auth_error"] == ["kc_page_expired"]
+
+
+def test_return_url_cannot_smuggle_a_theme_property_expression() -> None:
+    # Keycloak resolves ${...} in every theme property against the server's own
+    # environment — which on this pod carries the database password — and serves
+    # the result in the page. A newline would inject a second property. Both are
+    # refused at render time rather than documented.
+    for hostile in (
+        "${env.KC_BOOTSTRAP_ADMIN_PASSWORD}",
+        "/?next=${env.KC_DB_PASSWORD}",
+        "/?a=b\nparent=base",
+    ):
+        message = render_error(
+            SUBCHART, *SUBCHART_BASE, "--set-string", f"theme.returnUrl={hostile}"
+        )
+        assert "must be a literal URL" in message, hostile
 
 
 def test_theme_mounts_where_keycloak_discovers_it() -> None:

--- a/src/backend/services/keycloak/helm/tests/theme_harness.py
+++ b/src/backend/services/keycloak/helm/tests/theme_harness.py
@@ -121,6 +121,19 @@ def render(chart: Path, *extra: str) -> list[dict]:
     return [doc for doc in yaml.safe_load_all(proc.stdout) if doc]
 
 
+def render_error(chart: Path, *extra: str) -> str:
+    """`helm template` a chart that must NOT render; returns the message."""
+    proc = subprocess.run(
+        ["helm", "template", RELEASE, str(chart), *extra],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+    assert proc.returncode != 0, f"expected a render failure, got:\n{proc.stdout[:400]}"
+    return proc.stderr
+
+
 def one(docs: list[dict], kind: str, name: str) -> dict:
     """The single `kind` named `<release>-<name>`."""
     want = f"{RELEASE}-{name}"

--- a/src/backend/services/keycloak/helm/tests/theme_harness.py
+++ b/src/backend/services/keycloak/helm/tests/theme_harness.py
@@ -1,0 +1,168 @@
+"""Render harness shared by the Helm contract tests in this directory.
+
+Rendered from a SYNTHETIC values set, never from a
+`deploy/gitops/environments/*` overlay: an overlay is free to change what it
+enables, and a contract test that follows it stops asserting silently instead
+of failing.
+
+Named `theme_harness` rather than living in `conftest.py` because pytest
+imports a bare `conftest` by module name — a second helm suite with its own
+`conftest.py` (identity-resolution) then collides on any invocation that
+collects both.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import yaml
+
+HERE = Path(__file__).resolve()
+SUBCHART = HERE.parents[1]  # .../keycloak/helm
+REPO_ROOT = HERE.parents[6]
+UMBRELLA = REPO_ROOT / "charts" / "insight"
+CANONICAL_REALMS = sorted(
+    (REPO_ROOT / "deploy" / "gitops" / "environments").glob(
+        "*/keycloak/realms/insight-broker.yaml"
+    )
+)
+
+RELEASE = "contract-test"
+
+THEME_NAME = "insight"
+THEME_SOURCE = SUBCHART / "theme" / THEME_NAME / "login" / "login-page-expired.ftl"
+MOUNT_PATH = f"/opt/keycloak/themes/{THEME_NAME}/login"
+THEME_ROOT = "/opt/keycloak/themes"
+
+# Every value the subchart declares `required` — enough to render, nothing
+# that the assertions then read back.
+SUBCHART_BASE = [
+    "--set",
+    "admin.existingSecret=kc-admin",
+    "--set",
+    "database.host=mariadb",
+    "--set",
+    "database.username=keycloak",
+    "--set",
+    "database.passwordSecret.name=kc-db",
+    "--set",
+    "database.passwordSecret.key=password",
+    "--set",
+    "hostname=https://example.test/kc",
+]
+
+# The umbrella's own required wiring (infra dials, authenticator OIDC) plus
+# the Keycloak block — the minimum that renders, nothing the assertions read.
+UMBRELLA_BASE = [
+    "--set",
+    "clickhouse.host=ch",
+    "--set",
+    "clickhouse.username=u",
+    "--set",
+    "clickhouse.password=p",
+    "--set",
+    "clickhouse.database=insight",
+    "--set",
+    "mariadb.host=m",
+    "--set",
+    "mariadb.username=insight",
+    "--set",
+    "mariadb.password=pw",
+    "--set",
+    "mariadb.database=insight",
+    "--set",
+    "redis.host=redis",
+    "--set",
+    "redis.password=rp",
+    "--set",
+    "redpanda.brokers=rp:9092",
+    "--set",
+    "ingestion.reconcile.tenantId=default",
+    "--set",
+    "global.tenantDefaultId=3e1d5a65-434c-95b4-8c1b-eb8f53a39bab",
+    "--set",
+    "authenticator.oidc.issuerUrl=https://idp",
+    "--set",
+    "authenticator.oidc.clientId=c",
+    "--set",
+    "authenticator.oidc.clientSecret=s",
+    "--set",
+    "authenticator.oidc.redirectUri=https://x/cb",
+    "--set",
+    "authenticator.oidc.sourceType=ms-entra",
+    "--set",
+    "keycloak.deploy=true",
+    "--set",
+    "keycloak.admin.existingSecret=kc-admin",
+    "--set",
+    "keycloak.database.host=mariadb",
+    "--set",
+    "keycloak.database.username=keycloak",
+    "--set",
+    "keycloak.database.passwordSecret.name=kc-db",
+    "--set",
+    "keycloak.database.passwordSecret.key=password",
+    "--set",
+    "keycloak.hostname=https://example.test/kc",
+]
+
+
+def render(chart: Path, *extra: str) -> list[dict]:
+    """`helm template` a chart into its parsed documents."""
+    proc = subprocess.run(
+        ["helm", "template", RELEASE, str(chart), *extra],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return [doc for doc in yaml.safe_load_all(proc.stdout) if doc]
+
+
+def one(docs: list[dict], kind: str, name: str) -> dict:
+    """The single `kind` named `<release>-<name>`."""
+    want = f"{RELEASE}-{name}"
+    found = [d for d in docs if d.get("kind") == kind and d["metadata"]["name"] == want]
+    assert len(found) == 1, f"expected one {kind} named {want!r}, got {len(found)}"
+    return found[0]
+
+
+def theme_configmap(docs: list[dict]) -> dict:
+    return one(docs, "ConfigMap", "keycloak-theme")
+
+
+def keycloak_pod(docs: list[dict]) -> dict:
+    return one(docs, "Deployment", "keycloak")["spec"]["template"]
+
+
+def theme_properties(docs: list[dict]) -> dict[str, str]:
+    raw = theme_configmap(docs)["data"]["theme.properties"]
+    return dict(
+        line.split("=", 1) for line in raw.splitlines() if line and "=" in line
+    )
+
+
+def assert_theme_payload(docs: list[dict]) -> None:
+    """The theme is only useful if all three of its parts survive rendering."""
+    data = theme_configmap(docs)["data"]
+    ftl = data["login-page-expired.ftl"]
+
+    # `.Files.Get` returns "" on a miss and the install still succeeds, so the
+    # transport is pinned to the source rather than sampled for a substring.
+    assert ftl.rstrip("\n") == THEME_SOURCE.read_text().rstrip("\n")
+
+    # Without a parent the theme owns no other login template and every other
+    # Keycloak-rendered page in the realm 500s. `keycloak` (LOGIN_V1) is
+    # deprecated in KC 26 and would downgrade those pages.
+    assert theme_properties(docs)["parent"] == "keycloak.v2"
+
+    # The knob is only live while the template reads the key the chart writes.
+    assert "properties.insightReturnUrl" in ftl
+
+    # Three mechanisms, all load-bearing: no-JS fallback, the JS path that
+    # keeps this page out of history, and the visible link the JS reads.
+    assert 'http-equiv="refresh"' in ftl
+    assert "window.location.replace" in ftl
+    assert ftl.count("${returnUrl}") >= 2

--- a/src/backend/services/keycloak/helm/theme/insight/login/login-page-expired.ftl
+++ b/src/backend/services/keycloak/helm/theme/insight/login/login-page-expired.ftl
@@ -1,0 +1,69 @@
+<#--
+  Hands the browser back to the application instead of Keycloak's two stock
+  recovery links.
+
+  Keycloak renders this page from AuthenticationFlowURLHelper.showPageExpired()
+  — reached when a request carries an `execution` that no longer matches the
+  authentication session's current one (a returning IdP callback whose
+  tab-scoped session was torn down or rotated while several logins raced in one
+  browser), and when a required-action session goes stale. Its "restart" link
+  needs the browser-wide KC_RESTART cookie, which a completed sibling login
+  deletes, and its "continue" link points at the execution that already failed
+  to match. When both hold there is no way off the page.
+
+  This is NOT the page Keycloak renders when it rebuilds a login from KC_RESTART
+  and stamps `loginTimeout` on it. That path ends in
+  AuthenticationProcessor.authenticateOnly(), which calls createErrorPage() and
+  serves `error.ftl`. That page is left stock on purpose: its message already
+  explains the timeout, and the client's `baseUrl` in the realm gives it a
+  working way out. Overriding it would auto-redirect every Keycloak error,
+  masking the ones a user needs to read.
+
+  A fresh visit to the application always succeeds, so that is where this goes.
+  The `auth_error` marker in the target drives the SPA's existing
+  retry-once-then-stop guard, so a persistent failure stops on the login error
+  screen instead of looping browser -> IdP.
+-->
+<#assign returnUrl = (properties.insightReturnUrl)!"/?auth_error=kc_page_expired">
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex, nofollow">
+  <meta http-equiv="refresh" content="0; url=${returnUrl}">
+  <title>Signing you back in</title>
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      font-size: 15px;
+      line-height: 1.5;
+      color: #1b1b1f;
+      background: #f4f4f6;
+    }
+    @media (prefers-color-scheme: dark) {
+      body { color: #e8e8ec; background: #16161a; }
+    }
+    main { text-align: center; padding: 24px; }
+    a { color: inherit; }
+  </style>
+</head>
+<body>
+  <main>
+    <p>That sign-in took too long. Taking you back to Insight&hellip;</p>
+    <p><a id="continue" href="${returnUrl}">Continue</a></p>
+  </main>
+  <#-- Read the target off the anchor rather than interpolating it into JS:
+       one escaping context instead of two, and `replace` keeps this page out
+       of history so Back cannot land on it again. -->
+  <script>
+    var link = document.getElementById("continue");
+    if (link) { window.location.replace(link.href); }
+  </script>
+</body>
+</html>

--- a/src/backend/services/keycloak/helm/values.yaml
+++ b/src/backend/services/keycloak/helm/values.yaml
@@ -61,8 +61,9 @@ theme:
   # install that splits the two hosts must set an absolute URL. The
   # `auth_error` marker drives the SPA's retry-once-then-stop guard.
   #
-  # SAFETY: Keycloak runs every theme property through env substitution, so a
-  # `${env.NAME}` here would interpolate that variable into served HTML.
+  # SAFETY: Keycloak resolves ${...} in theme properties against the server's
+  # own environment and serves the result in the page, so such a value is
+  # refused at render time rather than published.
   returnUrl: "/?auth_error=kc_page_expired"
 
 resources:

--- a/src/backend/services/keycloak/helm/values.yaml
+++ b/src/backend/services/keycloak/helm/values.yaml
@@ -49,6 +49,22 @@ route:
   host: ""
   annotations: {}
 
+# The `insight` login theme, mounted at /opt/keycloak/themes/insight. It
+# overrides only the page Keycloak serves when a request names an execution
+# that no longer matches the authentication session, and inherits everything
+# else from `keycloak.v2`. Always mounted, but inert until a realm binds it
+# with `loginTheme: insight` — so bind it only on a Keycloak this chart
+# deploys.
+theme:
+  # Where that page hands the browser back to. Relative on purpose: Keycloak
+  # rides /kc on the same Gateway host as the SPA, so "/" is the app. An
+  # install that splits the two hosts must set an absolute URL. The
+  # `auth_error` marker drives the SPA's retry-once-then-stop guard.
+  #
+  # SAFETY: Keycloak runs every theme property through env substitution, so a
+  # `${env.NAME}` here would interpolate that variable into served HTML.
+  returnUrl: "/?auth_error=kc_page_expired"
+
 resources:
   requests: {cpu: 100m, memory: 384Mi}
   limits: {cpu: "1", memory: 768Mi}


### PR DESCRIPTION
Closes #2721.

Two different Keycloak pages can strand a sign-in on the broker realm, and the issue's evidence covers both.

**The frequent one is `error.ftl`.** Keycloak stamps `loginTimeout` on any login it rebuilds from `KC_RESTART`; `identity-provider-redirector` then declines (it expects a login form to render the message, and this realm deliberately has none — #2325), no execution succeeds, and `AuthenticationProcessor.authenticateOnly()` falls into its forwarded-error branch → `createErrorPage()`. That page offers a way out only when the client names one, and ours named none. **A relative `baseUrl` on the client fixes it with no chart change at all.**

**The one in the screenshot is `login-page-expired.ftl`,** served from `showPageExpired()` when a request names an execution that no longer matches the session — what a returning IdP callback hits after several logins raced in one browser. Both its links depend on state that race already destroyed. An `insight` login theme overrides that one template and hands the browser back to the app; the `auth_error` marker drives the SPA's existing retry-once-then-stop guard, so no frontend change is needed.

**Deliberate calls** — `error.ftl` stays stock: it is the realm's generic error page, its timeout message is the right thing to read, and auto-redirecting it would swallow errors users need to see. An ALTERNATIVE `forms` subflow would also clear the forwarded error, so the page is not the only lever; it is rejected because it restores the password field #2325 removed. The theme parents `keycloak.v2` (the KC 26 default) — plain `keycloak` is LOGIN_V1 and deprecated. Binding the theme is opt-in per realm, so an install whose Keycloak this chart does not deploy leaves `loginTheme` unset.

**Where** — Keycloak subchart (theme, ConfigMap, mount, `.helmignore`), umbrella values, reference broker realm, a render-contract suite and its workflow.

**Verified on the real image** (`quay.io/keycloak/keycloak:26.4`, ConfigMap projected the way kubelet does it, `--user 1000:1000 --cap-drop ALL`): the built-in themes live in a jar, not under `/opt/keycloak/themes`, so the mount hides nothing and `keycloak.v2` resolves as a parent; a stale `execution` serves the override; nothing writes under the theme dir; the checksum annotation moves when the `.ftl` changes.

**Nothing deploys from merging this.** The theme is inert until a realm sets `loginTheme: insight`. The gitops MR that binds it on dev and cfabric is `insight-gitops!116`, also draft.

**Known gaps** — cfabric pins its own `chartVersion`, so it needs a deliberate pin bump on top of that MR. `functional-ci` and `test-stand` deploy Keycloak but bind their realms from generated JSON / outside this repo, so neither exercises the theme; the dead end stays reachable on the shared stand until its realm binds it.

**Verify**

```bash
helm lint src/backend/services/keycloak/helm
python -m pytest src/backend/services/keycloak/helm/tests/ -q
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a custom Keycloak login theme that redirects expired authentication sessions back to the application.
  * Added a configurable return URL with an authentication error marker for controlled retry behavior.
  * Enabled the theme for the Insight realm and ensured it is packaged and mounted automatically.
  * Keycloak pods now restart when the login theme changes.

* **Tests**
  * Added automated Helm contract validation for theme rendering, configuration, packaging, and deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->