### PR TITLE
fix(git-cli-proxy): default the memory limit to what one repository-cap git operation needs (release-2026.07.1)

### DIFF
--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -557,9 +557,14 @@ gitCliProxy:
     repository: ghcr.io/constructorfabric/insight-git-cli-proxy
     tag: ""
     pullPolicy: IfNotPresent
+  # The git subprocesses (clone, fetch, repack) run in this pod's cgroup and
+  # dominate its memory: peak scales with cache.maxRepoBytes, times
+  # cache.heavyOpsConcurrency when heavy operations overlap. Size the limit
+  # to at least one repository cap with headroom, or a full-history walk of
+  # a workspace holding one large repository OOM-kills the pod in a loop.
   resources:
-    requests: {cpu: 200m, memory: 256Mi}
-    limits: {cpu: "2", memory: 2Gi}
+    requests: {cpu: 200m, memory: 1Gi}
+    limits: {cpu: "2", memory: 8Gi}
   persistence:
     size: 50Gi
     storageClass: ""

--- a/src/backend/services/git-cli-proxy/helm/values.yaml
+++ b/src/backend/services/git-cli-proxy/helm/values.yaml
@@ -22,11 +22,15 @@ service:
 resources:
   requests:
     cpu: 200m
-    memory: 256Mi
+    memory: 1Gi
   limits:
-    # git subprocesses (clone, repack) are the CPU/memory consumers here.
+    # git subprocesses (clone, repack) are the CPU/memory consumers here, and
+    # their peak scales with cache.maxRepoBytes (times cache.heavyOpsConcurrency
+    # when heavy operations overlap). Size the limit to at least one repository
+    # cap with headroom, or a full-history walk of a workspace holding one
+    # large repository OOM-kills the pod in a loop.
     cpu: "2"
-    memory: 2Gi
+    memory: 8Gi
 
 # Repository cache volume. The app budget below MUST stay under this size:
 # kubelet enforcement is pod eviction, which is a crash, not a mechanism.


### PR DESCRIPTION
Cherry-pick of #2840 onto `release-2026.07.1`. Clean pick, both values files parse.
**Why.** The chart's default memory limit (2Gi) is mismatched to its own sibling defaults: the git subprocesses run inside the proxy pod's cgroup, their peak scales with `cache.maxRepoBytes` (default 10Gi), and a clone or repack of one large repository exceeds the limit. A full-history walk of a workspace holding one such repository OOM-kills the pod in a loop — the connector's retry wave reconnects faster than the pod restarts.

**What changed.** The default limit rises to 8Gi (requests 256Mi → 1Gi) in the subchart and the umbrella, with a comment stating the sizing rule: at least one repository cap with headroom, times `heavyOpsConcurrency` when heavy operations overlap. Small deployments idle far below either limit, so the change costs them scheduling headroom only.

**Verified.** Values-only change; both files parse. The 8Gi figure is calibrated from observed behavior of a full-history walk over a large workspace, not from a memory profile.
