### PR TITLE
fix(frontend): send an unknown address to the default page

### DIFF
--- a/src/frontend/src/routeTree.gen.ts
+++ b/src/frontend/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as SplatRouteImport } from './routes/$'
 import { Route as CustomMetricsRouteImport } from './routes/custom-metrics'
 import { Route as MetricsRouteImport } from './routes/metrics'
 import { Route as PortalRouteImport } from './routes/portal'
@@ -23,6 +24,11 @@ import { Route as IcPersonTeamRouteImport } from './routes/ic.$person.team'
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SplatRoute = SplatRouteImport.update({
+  id: '/$',
+  path: '/$',
   getParentRoute: () => rootRouteImport,
 } as any)
 const CustomMetricsRoute = CustomMetricsRouteImport.update({
@@ -73,6 +79,7 @@ const IcPersonTeamRoute = IcPersonTeamRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/$': typeof SplatRoute
   '/custom-metrics': typeof CustomMetricsRoute
   '/metrics': typeof MetricsRoute
   '/portal': typeof PortalRoute
@@ -85,6 +92,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/$': typeof SplatRoute
   '/custom-metrics': typeof CustomMetricsRoute
   '/metrics': typeof MetricsRoute
   '/portal': typeof PortalRoute
@@ -97,6 +105,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/$': typeof SplatRoute
   '/custom-metrics': typeof CustomMetricsRoute
   '/metrics': typeof MetricsRoute
   '/portal': typeof PortalRoute
@@ -111,6 +120,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/$'
     | '/custom-metrics'
     | '/metrics'
     | '/portal'
@@ -123,6 +133,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/$'
     | '/custom-metrics'
     | '/metrics'
     | '/portal'
@@ -134,6 +145,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/$'
     | '/custom-metrics'
     | '/metrics'
     | '/portal'
@@ -147,6 +159,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  SplatRoute: typeof SplatRoute
   CustomMetricsRoute: typeof CustomMetricsRoute
   MetricsRoute: typeof MetricsRoute
   PortalRoute: typeof PortalRoute
@@ -162,6 +175,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/$': {
+      id: '/$'
+      path: '/$'
+      fullPath: '/$'
+      preLoaderRoute: typeof SplatRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/custom-metrics': {
@@ -248,6 +268,7 @@ const IcPersonRouteWithChildren = IcPersonRoute._addFileChildren(
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  SplatRoute: SplatRoute,
   CustomMetricsRoute: CustomMetricsRoute,
   MetricsRoute: MetricsRoute,
   PortalRoute: PortalRoute,

--- a/src/frontend/src/routes/$.test.ts
+++ b/src/frontend/src/routes/$.test.ts
@@ -1,0 +1,32 @@
+/**
+ * An address the app has no route for is a bounce to the default page rather
+ * than a surface of its own, so a mistyped or stale link leaves the reader a
+ * way forward. "/" owns which page that is.
+ */
+vi.mock("@tanstack/react-router", () => ({
+  // The real one throws its own control-flow object; this stands in for it so
+  // the test can read the destination back off what was thrown.
+  redirect: vi.fn((options: unknown) => ({ redirect: options })),
+  createFileRoute: () => (options: Record<string, unknown>) => options,
+}));
+
+import { describe, expect, it, vi } from "vitest";
+
+import { Route } from "./$";
+
+const route = Route as unknown as { beforeLoad: () => void };
+
+function thrownByBeforeLoad(): unknown {
+  try {
+    route.beforeLoad();
+  } catch (error) {
+    return error;
+  }
+  return undefined;
+}
+
+describe("/$", () => {
+  it("sends an unmatched address to the default page", () => {
+    expect(thrownByBeforeLoad()).toEqual({ redirect: { to: "/" } });
+  });
+});

--- a/src/frontend/src/routes/$.tsx
+++ b/src/frontend/src/routes/$.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/$")({
+  beforeLoad: () => {
+    throw redirect({ to: "/" });
+  },
+});


### PR DESCRIPTION
Closes #2649.

**Why.** An address the app has no route for renders a bare `Not Found` line with nothing to click, so a mistyped or stale link strands the reader on a dead end.

**What changed.** A root splat route `/$` catches every unmatched path, nested ones included, and redirects to `/` — which already owns the default-page choice.

**Redirect rather than a not-found page.** The issue allows either; a bounce leaves one destination to maintain. Reversible — the route body is three lines.

**Verified.** `tsc -b`, `eslint --max-warnings 0`, and the four `src/routes` unit test files pass locally. `routeTree.gen.ts` is the router plugin's own output, not hand-edited.
