### PR TITLE
test(e2e): keep every fixture's assertions on its own seeded rows

### DIFF
--- a/src/ingestion/tests/e2e/README.md
+++ b/src/ingestion/tests/e2e/README.md
@@ -80,6 +80,8 @@ e2e/
 │   ├── clickhouse.py           # CH HTTP client wrapper
 │   ├── mariadb.py              # MariaDB connection helper
 │   ├── migration_applier.py    # applies src/ingestion/scripts/migrations/*.sql
+│   ├── session_reset.py        # empties bronze/staging/silver at session start
+│   ├── tracked_models.py       # dbt builds, with their relations registered for truncation
 │   ├── analytics.py        # builds + spawns the analytics binary
 │   ├── worker.py               # WorkerContext (resolves pytest-xdist worker id)
 │   ├── metric_coverage.py      # builtin metric coverage gate
@@ -134,6 +136,8 @@ These ports avoid conflict with a local gitops dev cluster (which forwards 8123 
 ## Notes for fixture authors
 
 - Auth in `analytics` requires no Bearer token, but its tenant middleware rejects requests without a non-nil tenant. The harness sends `X-Insight-Tenant-Id` with `lib.config.TEST_TENANT_ID` on every request and re-homes seeded metric definitions onto that tenant (`metric_seed.py`). The ClickHouse query path does not filter by tenant yet, so seeded bronze rows may use any tenant value.
+- A fixture's assertions only ever see its own seed, held by two layers: `lib.session_reset` empties every bronze, staging and silver relation once at session start, and `lib.ch_seeder`'s ledger truncates the previous test's relations before the next one seeds. Both are needed — the staging and silver models are incremental behind a watermark over their own target and a fixture pins the value it seeds, so a run against a ClickHouse that still holds an earlier session's rows would admit nothing and assert against that older data. Re-running one fixture with `-k` against a live stack is therefore safe, and no fixture may rely on another's rows.
+- Build dbt models through the `tracked_models` fixture rather than `dbt_runner` directly: it registers each relation the build writes into that ledger, so the derived staging and silver rows are cleaned up alongside the bronze seed. A build that bypasses it leaves its output in place for the next test to read.
 - Metric definitions are auto-seeded by the analytics binary's SeaORM migrations. Look up the metric UUID with `GET /v1/metrics` once the session is up, or add overrides in `seed/metrics.yaml`.
 
 ## `cases` / `expect` (declarative YAML rig)

--- a/src/ingestion/tests/e2e/conftest.py
+++ b/src/ingestion/tests/e2e/conftest.py
@@ -28,8 +28,7 @@ import os
 from pathlib import Path
 
 import pytest
-from lib import clickhouse as ch
-from lib import compose, mariadb
+from lib import compose, mariadb, session_reset
 from lib.analytics import AnalyticsProcess, find_free_port, locate_binary
 from lib.ch_seeder import CHSeeder
 from lib.config import SessionConfig
@@ -39,6 +38,7 @@ from lib.fixture_loader import TestYaml, discover_tests
 from lib.fixture_loader import load as load_test
 from lib.identity_stub import IdentityStub
 from lib.migration_applier import apply_all as apply_ch_migrations
+from lib.tracked_models import TrackedModels
 from lib.worker import WorkerContext
 
 LOG = logging.getLogger("e2e.rig")
@@ -101,103 +101,15 @@ def compose_stack(session_cfg: SessionConfig):
             LOG.info("E2E_KEEP_CONTAINERS=1 — leaving containers up")
 
 
-# Silver/staging tables that a fixture may READ via a gold view but NOT seed
-# (each collab fixture seeds at most one class_collab_* table, yet
-# insight.collab_bullet_rows reads all four — and each class_collab_* unions
-# several per-source staging feeders). The per-test ledger only truncates what a
-# fixture seeds, so on a WARM ClickHouse (re-running `./e2e.sh test` without
-# `down`) the first collab fixture would inherit a prior session's rows in the
-# tables it does not seed — stale rows in a dbt-rebuilt class_collab_* would skew
-# its neighbours. The zoom staging models are also `incremental`/`append`, so a
-# warm rebuild would ALSO accumulate duplicate unique_keys (failing their dbt
-# `unique` test). Truncating these once at session start makes warm re-runs
-# deterministic; CI starts fresh anyway.
-_SESSION_START_TRUNCATE = [
-    ("silver", "class_collab_email_activity"),
-    ("silver", "class_collab_chat_activity"),
-    ("silver", "class_collab_meeting_activity"),
-    ("silver", "class_collab_document_activity"),
-    ("staging", "m365__collab_email_activity"),
-    ("staging", "m365__collab_chat_activity"),
-    ("staging", "m365__collab_meeting_activity"),
-    ("staging", "m365__collab_document_activity_onedrive"),
-    ("staging", "m365__collab_document_activity_sharepoint"),
-    # Zoom feeds class_collab_meeting_activity (cross-source meeting_hours).
-    ("staging", "zoom__collab_meeting_activity"),
-    ("staging", "zoom__meeting_sessions"),
-    # bronze_zoom.meetings is READ (via `+zoom__collab_meeting_activity` pulling
-    # zoom__meeting_sessions) by every test that seeds only participants — so it
-    # is neither seed-truncated by those tests nor ledger-truncated between them
-    # (derive_selectors records only models sourced from SEEDED tables). A prior
-    # session's leftover rows get re-appended into zoom__meeting_sessions on
-    # every such build, tripping its `unique` dbt test on the second one. Bronze
-    # participants added for symmetry.
-    ("bronze_zoom", "meetings"),
-    ("bronze_zoom", "participants"),
-    # Task-tracking: the bullet/MV chain reads class_task_* even when a fixture
-    # seeds only one connector, and the enrich path writes staging.jira__task_*.
-    # Reset them once at session start so warm re-runs are deterministic (CI is
-    # fresh anyway); per-test TRUNCATE handles cross-test isolation.
-    ("silver", "class_task_field_history"),
-    ("silver", "class_task_users"),
-    ("silver", "class_task_field_metadata"),
-    ("silver", "class_task_worklogs"),
-    ("staging", "jira__task_field_history"),
-    ("staging", "jira_issue_field_snapshot"),
-    ("staging", "jira_changelog_items"),
-    ("staging", "jira__task_field_metadata"),
-    # claude_team specs build staging.claude_team__ai_dev_usage — an incremental
-    # `append` model with a dbt `unique` test on unique_key. Session-start reset
-    # keeps warm re-runs (reused CH volume, no `./e2e.sh down`) from accumulating
-    # duplicate keys.
-    ("staging", "claude_team__ai_dev_usage"),
-    # claude_team__ai_overage (cc_overage) is also incremental `append` with a
-    # dbt `unique` test — reset it too for warm-rerun determinism.
-    ("staging", "claude_team__ai_overage"),
-    # claude_team__ai_invoice and its class are both incremental behind a strict
-    # `_airbyte_extracted_at >` watermark. A warm re-run re-seeds the same
-    # timestamps, so without a reset the watermark admits nothing and every
-    # assertion below reads the previous session's rows instead of this one's.
-    ("staging", "claude_team__ai_invoice"),
-    ("silver", "class_ai_invoice"),
-    # claude_enterprise specs build staging.claude_enterprise__ai_dev_usage — an
-    # incremental `append` model with a dbt `unique` test on unique_key.
-    # Session-start reset keeps warm re-runs (reused CH volume, no `./e2e.sh
-    # down`) from accumulating duplicate keys.
-    ("staging", "claude_enterprise__ai_dev_usage"),
-    # Wiki: class_wiki_pages / class_wiki_engagement are incremental
-    # (delete+insert, `_version > max`) and union BOTH outline + confluence. A
-    # warm re-run with the same seed _version produces no new rows, leaving the
-    # prior test's data in place → cross-test contamination. Reset at session
-    # start (max(_version) over the emptied table = 0, so the first test's real
-    # millis _version reloads fully). CI starts fresh anyway.
-    ("silver", "class_wiki_pages"),
-    ("silver", "class_wiki_engagement"),
-    ("silver", "class_wiki_activity"),
-    # ai_smoke (cursor) builds staging.cursor__ai_dev_usage — an incremental
-    # `append` model guarded by a dbt `unique` test on unique_key. Without a
-    # session-start reset, a warm re-run (reused CH volume, no `./e2e.sh down`)
-    # appends the same rows again → duplicate unique_keys → the unique test fails.
-    ("staging", "cursor__ai_dev_usage"),
-    # chatgpt_team specs build staging.chatgpt_team__ai_dev_usage (codex) and
-    # staging.chatgpt_team__ai_assistant_usage (chat) — both incremental `append`
-    # models with a dbt `unique` test on unique_key. Session-start reset keeps
-    # warm re-runs (reused CH volume, no `./e2e.sh down`) from accumulating
-    # duplicate keys.
-    ("staging", "chatgpt_team__ai_dev_usage"),
-    ("staging", "chatgpt_team__ai_assistant_usage"),
-]
-
-
 @pytest.fixture(scope="session")
 def ch_migrations_applied(compose_stack: SessionConfig) -> SessionConfig:
-    """Apply ClickHouse migrations once at session start, then reset the
-    multi-reader silver/staging tables so warm re-runs are deterministic."""
+    """Apply ClickHouse migrations once at session start, then empty every
+    fixture-data relation so a re-run over a live ClickHouse starts where a fresh
+    one does."""
     cfg = compose_stack
     if _IS_PRIMARY:
         apply_ch_migrations(cfg)
-        for schema, table in _SESSION_START_TRUNCATE:
-            ch.execute(cfg, f"TRUNCATE TABLE IF EXISTS `{schema}`.`{table}`")
+        session_reset.truncate_data_tables(cfg)
     return cfg
 
 
@@ -272,6 +184,13 @@ def analytics(
 def ch_seeder(ch_migrations_applied: SessionConfig) -> CHSeeder:
     """Session-scoped seeder so its ledger persists across tests in the same worker."""
     return CHSeeder(ch_migrations_applied)
+
+
+@pytest.fixture
+def tracked_models(dbt_runner: DbtRunner, ch_seeder: CHSeeder) -> TrackedModels:
+    """Per-test dbt builds, with every relation they write registered for the
+    next test to truncate."""
+    return TrackedModels(dbt_runner, ch_seeder)
 
 
 @pytest.fixture(scope="session")

--- a/src/ingestion/tests/e2e/identity/test_github_directory_member_id_binding.py
+++ b/src/ingestion/tests/e2e/identity/test_github_directory_member_id_binding.py
@@ -28,6 +28,7 @@ from lib import identity_seed as seed
 from lib.ch_seeder import CHSeeder
 from lib.config import SessionConfig
 from lib.dbt_runner import DbtRunner
+from lib.tracked_models import TrackedModels
 from lib.worker import WorkerContext
 
 pytestmark = [pytest.mark.identity, pytest.mark.mutating]
@@ -142,6 +143,7 @@ def _org_member(*, run_tag: str, login: str, member_id: int, email: str, display
 def _run_connector_dbt_path(
     ch_seeder: CHSeeder,
     dbt_runner: DbtRunner,
+    tracked_models: TrackedModels,
     worker_ctx: WorkerContext,
     bronze: dict[str, list[dict]],
 ) -> None:
@@ -151,12 +153,12 @@ def _run_connector_dbt_path(
 
     seeded = {tuple(fqn.split(".", 1)) for fqn in bronze}
     staging, silver = dbt_runner.derive_selectors(seeded)
-    dbt_runner.build(" ".join(f"+{m}" for m in staging), worker_ctx=worker_ctx)
+    tracked_models.build(staging, worker_ctx=worker_ctx, with_ancestors=True)
     assert "identity_inputs" in silver, (
         f"github_directory__identity_inputs did not surface a silver:identity_inputs tag "
         f"(silver={silver}) — the connector's identity path is not reachable from its bronze table"
     )
-    dbt_runner.run("identity_inputs", worker_ctx=worker_ctx)
+    tracked_models.run(["identity_inputs"], worker_ctx=worker_ctx)
 
 
 def _resolve_by_external_id(identity_svc, external_id: str) -> str | None:
@@ -178,6 +180,7 @@ def test_github_member_id_resolves_a_person_through_the_real_connector_pipeline(
     identity_svc,
     ch_seeder: CHSeeder,
     dbt_runner: DbtRunner,
+    tracked_models: TrackedModels,
     worker_ctx: WorkerContext,
     compose_stack: SessionConfig,
 ) -> None:
@@ -194,6 +197,7 @@ def test_github_member_id_resolves_a_person_through_the_real_connector_pipeline(
     _run_connector_dbt_path(
         ch_seeder,
         dbt_runner,
+        tracked_models,
         worker_ctx,
         {
             "bronze_github_directory.org_members": [
@@ -245,6 +249,7 @@ def test_the_binding_is_the_member_id_never_the_login(
     identity_svc,
     ch_seeder: CHSeeder,
     dbt_runner: DbtRunner,
+    tracked_models: TrackedModels,
     worker_ctx: WorkerContext,
 ) -> None:
     """GitHub logins are renameable by their owner and re-registrable once
@@ -263,6 +268,7 @@ def test_the_binding_is_the_member_id_never_the_login(
     _run_connector_dbt_path(
         ch_seeder,
         dbt_runner,
+        tracked_models,
         worker_ctx,
         {
             "bronze_github_directory.org_members": [
@@ -294,6 +300,7 @@ def test_the_binding_is_the_member_id_never_the_login(
 def test_directory_and_activity_claims_meet_in_one_account(
     ch_seeder: CHSeeder,
     dbt_runner: DbtRunner,
+    tracked_models: TrackedModels,
     worker_ctx: WorkerContext,
     compose_stack: SessionConfig,
 ) -> None:
@@ -320,6 +327,7 @@ def test_directory_and_activity_claims_meet_in_one_account(
     _run_connector_dbt_path(
         ch_seeder,
         dbt_runner,
+        tracked_models,
         worker_ctx,
         {
             "bronze_github_directory.org_members": [

--- a/src/ingestion/tests/e2e/identity/test_persons_seed_org_chart_gaps.py
+++ b/src/ingestion/tests/e2e/identity/test_persons_seed_org_chart_gaps.py
@@ -18,6 +18,7 @@ from lib import identity_seed as seed
 from lib.ch_seeder import CHSeeder
 from lib.config import SessionConfig
 from lib.dbt_runner import DbtRunner
+from lib.tracked_models import TrackedModels
 from lib.worker import WorkerContext
 
 pytestmark = [pytest.mark.identity, pytest.mark.mutating]
@@ -208,6 +209,7 @@ def test_seed_org_chart_from_real_bamboohr_connector_pipeline(
     identity_svc,
     ch_seeder: CHSeeder,
     dbt_runner: DbtRunner,
+    tracked_models: TrackedModels,
     worker_ctx: WorkerContext,
     compose_stack: SessionConfig,
 ) -> None:
@@ -248,12 +250,12 @@ def test_seed_org_chart_from_real_bamboohr_connector_pipeline(
     )
 
     staging, silver = dbt_runner.derive_selectors({("bronze_bamboohr", "employees")})
-    dbt_runner.build(" ".join(f"+{m}" for m in staging), worker_ctx=worker_ctx)
+    tracked_models.build(staging, worker_ctx=worker_ctx, with_ancestors=True)
     assert "identity_inputs" in silver, (
         f"bamboohr__identity_inputs did not surface a silver:identity_inputs tag (silver={silver}) "
         "— derive_selectors no longer sees the connector's identity path"
     )
-    dbt_runner.run("identity_inputs", worker_ctx=worker_ctx)
+    tracked_models.run(["identity_inputs"], worker_ctx=worker_ctx)
 
     landed = clickhouse.query(
         compose_stack,
@@ -345,6 +347,7 @@ def test_seed_and_subchart_survive_a_circular_manager_chain(identity_svc, compos
 def test_ms_entra_connector_emits_no_org_chart_signal_yet(
     ch_seeder: CHSeeder,
     dbt_runner: DbtRunner,
+    tracked_models: TrackedModels,
     worker_ctx: WorkerContext,
     compose_stack: SessionConfig,
 ) -> None:
@@ -374,9 +377,9 @@ def test_ms_entra_connector_emits_no_org_chart_signal_yet(
     )
 
     staging, silver = dbt_runner.derive_selectors({("bronze_ms_entra", "users")})
-    dbt_runner.build(" ".join(f"+{m}" for m in staging), worker_ctx=worker_ctx)
+    tracked_models.build(staging, worker_ctx=worker_ctx, with_ancestors=True)
     assert "identity_inputs" in silver, f"ms_entra__identity_inputs no longer tags silver:identity_inputs (silver={silver})"
-    dbt_runner.run("identity_inputs", worker_ctx=worker_ctx)
+    tracked_models.run(["identity_inputs"], worker_ctx=worker_ctx)
 
     emitted = clickhouse.query(
         compose_stack,
@@ -396,6 +399,7 @@ def test_seed_and_subchart_project_arbitrary_depth_from_a_synced_chain(
     identity_svc,
     ch_seeder: CHSeeder,
     dbt_runner: DbtRunner,
+    tracked_models: TrackedModels,
     worker_ctx: WorkerContext,
     compose_stack: SessionConfig,
 ) -> None:
@@ -434,9 +438,9 @@ def test_seed_and_subchart_project_arbitrary_depth_from_a_synced_chain(
     )
 
     staging, silver = dbt_runner.derive_selectors({("bronze_bamboohr", "employees")})
-    dbt_runner.build(" ".join(f"+{m}" for m in staging), worker_ctx=worker_ctx)
+    tracked_models.build(staging, worker_ctx=worker_ctx, with_ancestors=True)
     assert "identity_inputs" in silver, f"bamboohr__identity_inputs did not surface a silver:identity_inputs tag (silver={silver})"
-    dbt_runner.run("identity_inputs", worker_ctx=worker_ctx)
+    tracked_models.run(["identity_inputs"], worker_ctx=worker_ctx)
 
     res = identity_svc.run_seed_cli(tenant=str(seed.SEED_TENANT), force=True)
     assert res.returncode == 0, f"rc={res.returncode}\n{res.stdout}\n{res.stderr}"

--- a/src/ingestion/tests/e2e/lib/dbt_runner.py
+++ b/src/ingestion/tests/e2e/lib/dbt_runner.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import json
 import logging
 import shutil
+from collections.abc import Sequence
 
 import yaml
 from dbt.cli.main import dbtRunner
@@ -34,6 +35,11 @@ from lib.config import SessionConfig
 from lib.worker import WorkerContext
 
 LOG = logging.getLogger("e2e.dbt")
+
+# Schema the generated test profile falls back to. A model that configures no
+# `schema` materializes here instead of `staging`/`silver`, out of reach of the
+# per-test truncate ledger — `meta/test_dbt_runner.py` guards against that.
+PROFILE_SCHEMA = "default"
 
 
 class DbtError(RuntimeError):
@@ -190,6 +196,41 @@ class DbtRunner:
                     silver.add(tag.split(":", 1)[1])
         return sorted(set(staging)), sorted(silver)
 
+    def materialized_relations(self, models: Sequence[str]) -> list[tuple[str, str]]:
+        """`(schema, identifier)` that each named model materializes into.
+
+        Read off the manifest rather than assumed by the caller, so a model
+        configuring its own schema (`silver`, `identity`) is reported under the
+        schema dbt actually writes to. Views and ephemeral models resolve to
+        nothing: they hold no rows of their own.
+
+        Raises rather than returning a short list. A caller feeds this the models
+        it is about to build so their relations can be truncated afterwards, and
+        a name that quietly resolved to nothing would leave those rows in place
+        for the next test to read — the failure this exists to prevent.
+        """
+        manifest = json.loads((self.target_dir / "manifest.json").read_text(encoding="utf-8"))
+        wanted = set(models)
+        by_name = {
+            node["name"]: node
+            for node in manifest.get("nodes", {}).values()
+            if node.get("resource_type") == "model" and node.get("name") in wanted
+        }
+        unknown = sorted(wanted - set(by_name))
+        if unknown:
+            raise DbtError(f"no dbt model is named {unknown} — the manifest knows nothing to build or truncate")
+
+        out: set[tuple[str, str]] = set()
+        for name, node in by_name.items():
+            if node.get("config", {}).get("materialized") in ("ephemeral", "view"):
+                continue
+            schema = node.get("schema")
+            identifier = node.get("alias") or name
+            if not schema:
+                raise DbtError(f"model {name} resolved no target schema in the manifest")
+            out.add((schema, identifier))
+        return sorted(out)
+
     def ephemeral_silver_targets(self, tag: str) -> list[str]:
         """Silver class identifiers produced from an EPHEMERAL staging model tagged `tag`.
 
@@ -289,7 +330,7 @@ class DbtRunner:
                         # at the compose service name (`clickhouse`).
                         "host": self.cfg.ch_host,
                         "port": self.cfg.ch_http_port,
-                        "schema": "default",
+                        "schema": PROFILE_SCHEMA,
                         "user": self.cfg.ch_user,
                         "password": self.cfg.ch_password,
                         "secure": False,

--- a/src/ingestion/tests/e2e/lib/session_reset.py
+++ b/src/ingestion/tests/e2e/lib/session_reset.py
@@ -1,0 +1,55 @@
+"""Empty the ClickHouse relations that hold fixture data, once per session.
+
+A session must start from empty bronze/staging/silver. The staging and silver
+models are incremental behind a watermark over their own target
+(`max(_airbyte_extracted_at)`, `max(_version)`), and a fixture pins the value it
+seeds — so against a ClickHouse that already holds a previous session's rows the
+watermark admits nothing and the fixture's assertions read that older data.
+
+The per-test truncate ledger (`lib.ch_seeder`) covers only the tables a fixture
+seeds and the models dbt rebuilds for it, and it is created empty per session, so
+it cannot carry isolation across sessions. This module does.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from lib import clickhouse as ch
+from lib.config import SessionConfig
+
+LOG = logging.getLogger("e2e.reset")
+
+# Every relation in these databases is fixture data: seeded bronze, plus the
+# staging and silver relations dbt derives from it. Migrations and the
+# connectors-ddl snapshot create structure only, so nothing here outlives a
+# session. The gold database is absent because every model serving it is
+# `materialized='table'` and the `tag:gold` build each test runs replaces those
+# wholesale; `identity` is absent because the metrics and identity suites each
+# truncate it per test.
+DATA_DATABASE_PATTERN = "^(bronze_.*|staging|silver)$"
+
+
+def truncate_data_tables(cfg: SessionConfig) -> int:
+    """TRUNCATE every fixture-data table, returning how many were truncated.
+
+    Only the MergeTree family is matched: dbt materializes several staging models
+    as views, which hold no rows of their own and which ClickHouse refuses to
+    truncate (NOT_IMPLEMENTED, code 48). A relation outside that family that does
+    hold rows is a gap — `meta/test_session_reset.py` fails on it rather than
+    letting it silently survive.
+    """
+    tables = ch.query(
+        cfg,
+        f"""
+        SELECT database, name
+        FROM system.tables
+        WHERE match(database, '{DATA_DATABASE_PATTERN}')
+          AND engine LIKE '%MergeTree'
+        ORDER BY database, name
+        """,
+    )
+    for database, table in tables:
+        ch.execute(cfg, f"TRUNCATE TABLE `{database}`.`{table}`")
+    LOG.info("session-start reset: truncated %d bronze/staging/silver tables", len(tables))
+    return len(tables)

--- a/src/ingestion/tests/e2e/lib/tracked_models.py
+++ b/src/ingestion/tests/e2e/lib/tracked_models.py
@@ -1,0 +1,53 @@
+"""Materialize dbt models for one test and register what they wrote.
+
+Every suite that seeds bronze and then builds the models above it needs the same
+pairing: record the relations the build is about to write into the per-test
+truncate ledger, then invoke dbt. Skipping the recording half leaves a test's
+staging and silver rows in place for the next test, and the incremental models
+read them instead of the seed — so the pairing lives here rather than at each
+call site.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from lib.ch_seeder import CHSeeder
+from lib.dbt_runner import DbtRunner
+from lib.worker import WorkerContext
+
+
+class TrackedModels:
+    """dbt builds whose output the next test truncates.
+
+    INVARIANT: every relation a test materializes is in the truncate ledger by
+    the time dbt touches it. Recording precedes the invocation so a build that
+    raises partway still leaves its targets registered for the next test to
+    clean; registering a relation dbt never got to is harmless, since the
+    ledger truncates `IF EXISTS`.
+    """
+
+    def __init__(self, dbt_runner: DbtRunner, seeder: CHSeeder) -> None:
+        self._dbt = dbt_runner
+        self._seeder = seeder
+
+    def build(self, models: Sequence[str], *, worker_ctx: WorkerContext, with_ancestors: bool = False) -> None:
+        """`dbt build` the named models. `with_ancestors` prefixes each with `+`,
+        which pulls the connector's `<connector>__bronze_promoted` view."""
+        if not models:
+            return
+        self._record(models)
+        prefix = "+" if with_ancestors else ""
+        self._dbt.build(" ".join(f"{prefix}{model}" for model in sorted(models)), worker_ctx=worker_ctx)
+
+    def run(self, models: Sequence[str], *, worker_ctx: WorkerContext, full_refresh: bool = False) -> None:
+        """`dbt run` the named models — for models whose own dbt tests a
+        single fixture's partial seed cannot satisfy."""
+        if not models:
+            return
+        self._record(models)
+        self._dbt.run(" ".join(sorted(models)), worker_ctx=worker_ctx, full_refresh=full_refresh)
+
+    def _record(self, models: Sequence[str]) -> None:
+        for schema, table in self._dbt.materialized_relations(models):
+            self._seeder.ledger.record(schema, table)

--- a/src/ingestion/tests/e2e/meta/test_dbt_runner.py
+++ b/src/ingestion/tests/e2e/meta/test_dbt_runner.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 
 import pytest
-from lib.dbt_runner import DbtError, DbtRunner
+from lib.dbt_runner import PROFILE_SCHEMA, DbtError, DbtRunner
 from lib.worker import WorkerContext
 
 pytestmark = pytest.mark.smoke
@@ -196,3 +196,47 @@ def test_dbt_build_with_worker_context_passes_var(dbt_runner: DbtRunner) -> None
     assert n == "0"
     expected_vars = json.dumps({"worker_id": "0"})
     assert "worker_id" in expected_vars
+
+
+def test_materialized_relations_names_the_relation_dbt_writes_to(dbt_runner: DbtRunner) -> None:
+    """The ledger must be told the schema dbt actually materializes into, which
+    for a connector staging model is `staging` and for a class model is `silver`
+    — not the profile's fallback schema."""
+    assert dbt_runner.materialized_relations(["github__commits", "class_git_commits"]) == [
+        ("silver", "class_git_commits"),
+        ("staging", "github__commits"),
+    ]
+
+
+def test_materialized_relations_skips_models_holding_no_rows(dbt_runner: DbtRunner) -> None:
+    """A view or an ephemeral model has nothing to truncate, so it never reaches
+    the ledger: `github__bronze_promoted` is a view, `jira__task_field_history`
+    is ephemeral."""
+    assert dbt_runner.materialized_relations(["github__bronze_promoted", "jira__task_field_history"]) == []
+
+
+def test_every_materialized_model_declares_its_schema(dbt_runner: DbtRunner) -> None:
+    """A model that configures no `schema` lands in the profile's fallback
+    schema, where nothing looks for it: the truncate ledger would register the
+    relation under that fallback while the rest of the project reads `staging`
+    or `silver`, and the model's rows would survive every test.
+    """
+    manifest = json.loads((dbt_runner.target_dir / "manifest.json").read_text(encoding="utf-8"))
+    undeclared = sorted(
+        node["name"]
+        for node in manifest["nodes"].values()
+        if node.get("resource_type") == "model"
+        and node.get("config", {}).get("materialized") not in ("ephemeral", "view")
+        and node.get("schema") == PROFILE_SCHEMA
+    )
+    assert undeclared == [], (
+        f"these models materialize into the fallback schema {PROFILE_SCHEMA!r} because they configure no "
+        f"`schema`: {undeclared}. Add `schema='staging'`/`'silver'` to each config() block."
+    )
+
+
+def test_materialized_relations_rejects_a_name_no_model_answers_to(dbt_runner: DbtRunner) -> None:
+    """A caller naming a model that does not exist gets an error, not an empty
+    list — silently recording nothing is what leaves rows behind."""
+    with pytest.raises(DbtError, match="no dbt model is named"):
+        dbt_runner.materialized_relations(["class_git_commits", "not_a_model"])

--- a/src/ingestion/tests/e2e/meta/test_session_reset.py
+++ b/src/ingestion/tests/e2e/meta/test_session_reset.py
@@ -1,0 +1,40 @@
+"""Guards for the session-start data reset (`lib.session_reset`).
+
+The reset is what keeps a fixture's assertions on its own seed: without it, the
+incremental staging and silver models admit nothing from a fixture that re-seeds
+timestamps a previous session already loaded, and the fixture reads that older
+data instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+from lib import clickhouse, session_reset
+from lib.config import SessionConfig
+
+pytestmark = pytest.mark.smoke
+
+
+def test_reset_covers_the_bronze_staging_silver_relations(ch_migrations_applied: SessionConfig) -> None:
+    """No bronze, staging or silver relation holds rows once the reset has run.
+
+    The reset runs here rather than being taken on trust from session setup, so
+    the guard holds whatever order the suite collects in. A relation still
+    holding rows is one the engine filter in `truncate_data_tables` misses.
+    """
+    cfg = ch_migrations_applied
+
+    truncated = session_reset.truncate_data_tables(cfg)
+    assert truncated > 0, "the reset matched no relations — check DATA_DATABASE_PATTERN"
+
+    holding_rows = clickhouse.query(
+        cfg,
+        f"""
+        SELECT database, name, total_rows
+        FROM system.tables
+        WHERE match(database, '{session_reset.DATA_DATABASE_PATTERN}')
+          AND total_rows > 0
+        ORDER BY database, name
+        """,
+    )
+    assert holding_rows == [], f"relations still holding rows after the reset: {holding_rows}"

--- a/src/ingestion/tests/e2e/metrics/test_fixtures.py
+++ b/src/ingestion/tests/e2e/metrics/test_fixtures.py
@@ -14,6 +14,7 @@ from lib.enrich import EnrichRunner
 from lib.expect_engine import evaluate_case
 from lib.fixture_loader import IdentityAccount, TestYaml
 from lib.identity_stub import IdentityStub, person_id_for
+from lib.tracked_models import TrackedModels
 from lib.worker import WorkerContext
 
 pytestmark = pytest.mark.fixture
@@ -204,6 +205,7 @@ def test_metric_smoke(
     enrich_runner: EnrichRunner,
     analytics: AnalyticsProcess,
     identity_stub: IdentityStub,
+    tracked_models: TrackedModels,
     worker_ctx: WorkerContext,
 ) -> None:
     ch_seeder.truncate_touched()
@@ -214,18 +216,7 @@ def test_metric_smoke(
     # 3. Build the dbt models the seeded tables feed: staging first (the `+`
     #    pulls <connector>__bronze_promoted), then the silver class models.
     staging, silver = dbt_runner.derive_selectors(test_yaml.touched_tables)
-    if staging:
-        # Record staging models in the ledger BEFORE building. They live in the
-        # `staging` schema and are read by the silver models via union_by_tag, so a
-        # prior test's staging rows (e.g. dates this test doesn't re-seed) would
-        # survive into the silver rebuild and contaminate later tests' gold-view
-        # aggregates. Recording up front (not after) means a build that raises
-        # partway still leaves the table in the truncate ledger so the next test
-        # cleans it; recording a model that never materialised is harmless
-        # (truncate_touched uses TRUNCATE TABLE IF EXISTS).
-        for st in staging:
-            ch_seeder.ledger.record("staging", st)
-        dbt_runner.build(" ".join(f"+{m}" for m in staging), worker_ctx=worker_ctx)
+    tracked_models.build(staging, worker_ctx=worker_ctx, with_ancestors=True)
     # 3b. Connector enrich steps (descriptor.images.enrich), between staging and
     #     silver — mirrors prod: dbt(tag:<c>) → <c>-enrich → dbt(silver). Data-driven
     #     from descriptors, so any connector with an enrich step participates (jira
@@ -263,20 +254,10 @@ def test_metric_smoke(
         silver_set.update(dbt_runner.ephemeral_silver_targets(step.name))
     run_only_silver = silver_set & {"class_hr_working_hours"}
     tested_silver = silver_set - run_only_silver
-    if tested_silver:
-        # Record before building (same rationale as staging above): a build that
-        # raises partway still leaves the targets in the truncate ledger for the
-        # next test to clean.
-        for cls in tested_silver:
-            ch_seeder.ledger.record("silver", cls)
-        dbt_runner.build(" ".join(sorted(tested_silver)), worker_ctx=worker_ctx)
-    if run_only_silver:
-        for cls in run_only_silver:
-            ch_seeder.ledger.record("silver", cls)
-        dbt_runner.run(" ".join(sorted(run_only_silver)), worker_ctx=worker_ctx)
+    tracked_models.build(sorted(tested_silver), worker_ctx=worker_ctx)
+    tracked_models.run(sorted(run_only_silver), worker_ctx=worker_ctx)
     if "class_collab_meeting_activity" in silver_set:
-        ch_seeder.ledger.record("silver", "class_focus_metrics")
-        dbt_runner.run("class_focus_metrics", worker_ctx=worker_ctx, full_refresh=True)
+        tracked_models.run(["class_focus_metrics"], worker_ctx=worker_ctx, full_refresh=True)
 
     # 4. Identity bindings for the personas the cases address, BEFORE the
     #    gold build — the resolve macro joins them into person_id during the


### PR DESCRIPTION
**Why:** A fixture's assertions were not guaranteed to be evaluated against the rows that fixture seeded. Staging and silver models are incremental behind a watermark over their own target and a fixture pins the value it seeds, so against a ClickHouse still holding earlier rows the watermark admitted nothing and the fixture read that older data. Session-start cleanup was a hand-kept list of about 25 relations that every new connector had to be added to, and the identity suite never registered the models it built for cleanup at all.

Closes constructorfabric/insight#2698

**What changed:** `lib.session_reset` truncates every MergeTree-family relation in the bronze, staging and silver databases at session start, resolved from `system.tables` instead of a literal list. `lib.tracked_models` pairs registering a build's relations with invoking it, and both the metrics and identity suites build through it. The relations come from each model's resolved schema in the dbt manifest, so a model materializing outside `staging`/`silver` is registered where dbt actually writes it — which is what brings the identity suite's `identity_inputs` builds under cleanup. An unresolvable model name raises instead of recording nothing.

**Out of scope:** `metrics/test_ai_invoice_silver.py` builds through a tag selector and still registers nothing; moving it onto the helper needs selector resolution.

**Verified:** ruff format and lint. Both session-reset selector queries were executed against a local ClickHouse at the pinned version, confirming the engine filter covers every relation in those databases. New guards assert the manifest resolves staging, silver, view and ephemeral models as the ledger expects, and that no model materializes into the profile's fallback schema.
