### PR TITLE
fix(git-cli-proxy): bound git pack memory so a repack cannot outgrow the pod

### DIFF
--- a/src/backend/services/git-cli-proxy/src/engine/runner.rs
+++ b/src/backend/services/git-cli-proxy/src/engine/runner.rs
@@ -114,6 +114,18 @@ pub struct GitRunner {
 }
 
 const STDERR_TAIL_BYTES: usize = 4096;
+/// Delta-search threads per git invocation. Deliberately small and fixed:
+/// git's default is one per host CPU, which ignores the container's own CPU
+/// limit, so the default multiplies the per-thread memory budget below by a
+/// number this service does not control.
+const PACK_THREADS: usize = 2;
+/// Per-thread delta window budget. Peak pack memory is roughly
+/// `PACK_THREADS * PACK_WINDOW_MEMORY_MB + PACK_DELTA_CACHE_MB` plus object
+/// bookkeeping, which keeps the whole operation inside a low-single-digit-GiB
+/// pod limit on any repository size.
+const PACK_WINDOW_MEMORY_MB: usize = 256;
+/// Delta cache budget, shared across threads.
+const PACK_DELTA_CACHE_MB: usize = 256;
 const READ_TIMEOUT: Duration = Duration::from_mins(5);
 const PREFETCH_TIMEOUT: Duration = Duration::from_mins(10);
 const HEAVY_OP_TIMEOUT: Duration = Duration::from_mins(30);
@@ -448,6 +460,16 @@ impl GitRunner {
         // the store's own repack, on its schedule.
         pairs.push(("maintenance.auto", "false".to_owned()));
         pairs.push(("gc.auto", "0".to_owned()));
+        // Delta search is what makes a repack of a large repository expensive,
+        // and its budget is PER THREAD — with `pack.threads` unset git uses
+        // one per host CPU, which a container limit does not shrink. Left
+        // unbounded, a single `git` process on a large-object repository can
+        // outgrow any memory limit the pod is given and take the service with
+        // it. These caps trade pack density and repack time, neither of which
+        // a blob-purge cache depends on, for a bounded peak.
+        pairs.push(("pack.threads", PACK_THREADS.to_string()));
+        pairs.push(("pack.windowMemory", format!("{PACK_WINDOW_MEMORY_MB}m")));
+        pairs.push(("pack.deltaCacheSize", format!("{PACK_DELTA_CACHE_MB}m")));
         pairs
     }
 }
@@ -674,6 +696,20 @@ mod tests {
         for (key, expected) in [("maintenance.auto", "false"), ("gc.auto", "0")] {
             assert!(
                 pairs.iter().any(|(k, v)| *k == key && v == expected),
+                "{key} must be pinned, got: {pairs:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn every_invocation_bounds_pack_memory() {
+        // An unbounded delta search on a large-object repository grows past
+        // any pod memory limit and the kernel kills the whole service, not
+        // just the git process.
+        let pairs = GitRunner::new().config_pairs(None);
+        for key in ["pack.threads", "pack.windowMemory", "pack.deltaCacheSize"] {
+            assert!(
+                pairs.iter().any(|(k, v)| *k == key && !v.is_empty()),
                 "{key} must be pinned, got: {pairs:?}"
             );
         }


### PR DESCRIPTION
**Why.** A blob purge forks `git repack`, whose delta search is budgeted per thread — and with `pack.threads` unset git spawns one thread per host CPU, a number a container limit does not shrink. On a large-object repository a single `git` process reached 8.2 GiB resident and the kernel killed the cgroup, taking the proxy with it. Raising the pod's memory limit does not close this: the peak scales with the repository, not with a constant.

**What changed.** Every git invocation now carries `pack.threads=2`, `pack.windowMemory=256m` and `pack.deltaCacheSize=256m` through the same config-pair seam that already pins `maintenance.auto` and `gc.auto`. Peak pack memory becomes roughly threads × window + cache plus object bookkeeping — a low single-digit GiB ceiling independent of repository size.

**The cost is pack density and repack time, deliberately.** Neither matters to a cache whose repacks exist to drop blobs; dying mid-serve does.

**Verified.** `cargo test -p git-cli-proxy` (210 tests, including a new one pinning the three settings), `cargo clippy --all-targets` clean, `cargo fmt`. The 8.2 GiB figure is from a kernel OOM record naming the `git` process; the resulting ceiling is derived from git's documented budgets, not measured on a repack of that repository.
