### PR TITLE
fix(ingestion): count an authored git change once across squash, rebase and cherry-pick copies

### DIFF
--- a/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__commits.sql
+++ b/src/ingestion/connectors/git/bitbucket-cloud/dbt/bitbucket_cloud__commits.sql
@@ -36,7 +36,8 @@ SELECT
     if(COALESCE(is_merge, false), 1, 0) AS is_merge_commit,
     'insight_bitbucket_cloud' AS data_source,
     toUnixTimestamp64Milli(now64()) AS _version,
-    _airbyte_extracted_at
+    _airbyte_extracted_at,
+    patch_id
 -- FINAL: the lookback window re-reads a commit under the same unique_key, and
 -- its membership flag can differ between the two rows. Without FINAL a
 -- full-refresh build inserts both into staging under one now64() _version, and

--- a/src/ingestion/connectors/git/bitbucket-cloud/descriptor.yaml
+++ b/src/ingestion/connectors/git/bitbucket-cloud/descriptor.yaml
@@ -6,7 +6,13 @@ name: bitbucket-cloud
 #   re-reads Bronze, so the column heals to '' on existing rows and only the
 #   one-shot scoped `dbt --full-refresh` a major bump dispatches
 #   re-materializes the history.
-version: "4.0.1"
+# 5.0.0: dbt staging carries the per-commit patch id into the class-contract
+#   column patch_id, the commit-content identity that folds a rebase copy or a
+#   cherry-pick onto the commit that first authored the change. MAJOR for the
+#   same reason as github 6.0.0 — the patch id has been in Bronze all along,
+#   but staging never re-reads Bronze, so the column heals to NULL on existing
+#   rows and a NULL identity never folds.
+version: "5.0.0"
 # A slot of its own: replication pods sharing a slot with other connector
 # syncs can be starved of workers, which surfaces as startup and activity
 # timeouts rather than as a connector error.

--- a/src/ingestion/connectors/git/github/dbt/github__commits.sql
+++ b/src/ingestion/connectors/git/github/dbt/github__commits.sql
@@ -36,7 +36,8 @@ SELECT
     if(COALESCE(is_merge, false), 1, 0) AS is_merge_commit,
     'insight_github' AS data_source,
     toUnixTimestamp64Milli(now64()) AS _version,
-    _airbyte_extracted_at
+    _airbyte_extracted_at,
+    patch_id
 -- FINAL: the lookback window re-reads a commit under the same unique_key, and
 -- its membership flag can differ between the two rows. Without FINAL a
 -- full-refresh build inserts both into staging under one now64() _version, and

--- a/src/ingestion/connectors/git/github/descriptor.yaml
+++ b/src/ingestion/connectors/git/github/descriptor.yaml
@@ -7,7 +7,14 @@ name: github
 #   on existing rows and history would never attribute. Only the one-shot
 #   scoped `dbt --full-refresh` a major bump dispatches re-materializes it.
 #   Safe: every git staging model is a pure projection of Bronze.
-version: "5.0.0"
+# 6.0.0: dbt staging carries the per-commit patch id into the class-contract
+#   column patch_id, the commit-content identity that folds a rebase copy or a
+#   cherry-pick onto the commit that first authored the change. MAJOR for the
+#   same reason as 5.0.0 — the patch id has been in Bronze all along, but
+#   staging never re-reads Bronze, so the column heals to NULL on existing
+#   rows, and a NULL identity never folds. Only the one-shot scoped
+#   `dbt --full-refresh` a major bump dispatches re-materializes the history.
+version: "6.0.0"
 schedule: "0 */4 * * *"
 workflow: sync
 

--- a/src/ingestion/connectors/git/gitlab/dbt/gitlab__commits.sql
+++ b/src/ingestion/connectors/git/gitlab/dbt/gitlab__commits.sql
@@ -59,7 +59,8 @@ SELECT
     if(COALESCE(c.parent_count, 0) > 1, 1, 0) AS is_merge_commit,
     'insight_gitlab' AS data_source,
     toUnixTimestamp64Milli(now64()) AS _version,
-    c._airbyte_extracted_at
+    c._airbyte_extracted_at,
+    CAST(NULL AS Nullable(String)) AS patch_id
 -- FINAL: a re-walk re-emits a commit under the same unique_key with the
 -- membership flag set, so Bronze holds the old row and the new one. Without
 -- FINAL a full-refresh build inserts both into staging under one now64()

--- a/src/ingestion/connectors/git/gitlab/descriptor.yaml
+++ b/src/ingestion/connectors/git/gitlab/descriptor.yaml
@@ -20,7 +20,10 @@ name: gitlab
 #   counting as a commit. MINOR per ADR-0015: additive, nothing re-materializes.
 #   Branch history arrives as the stream reaches each branch; commits on a
 #   branch whose head has not moved since the last sync are not re-walked.
-version: "1.20.0"
+# 1.21.0: dbt staging declares the class-contract column patch_id. MINOR, not
+#   MAJOR: the commits stream reports no patch id, so the column is NULL
+#   whether a row re-materializes or not and nothing has to be rebuilt.
+version: "1.21.0"
 type: cdk
 schedule: "0 2 * * *"
 workflow: sync

--- a/src/ingestion/gold/git_derived_commits.sql
+++ b/src/ingestion/gold/git_derived_commits.sql
@@ -1,0 +1,158 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'data_source', 'commit_hash'],
+    schema=var('gold_database'),
+    settings={'allow_nullable_key': 1},
+    tags=['gold'],
+    query_settings=metric_serving_query_settings()
+) }}
+
+-- Commits whose work is already counted on another commit. The evidence build
+-- excludes them from both the commit and the line figures, so the two
+-- describe the same set of authored changes and one change counts once.
+--
+-- Two reasons, one grain — (tenant_id, data_source, commit_hash, reason):
+--
+-- * merge_result: the commit a merged pull request produced on its
+--   destination — a squash result, or the last rebased copy. Its content is
+--   the request's branch commits, which carry the credit. Marked only when
+--   EVERY linked commit was collected: with partial coverage the result
+--   commit is the only complete record of the work, so it stays counted
+--   (the overlap with the collected originals over-counts until coverage
+--   completes, which never loses work or per-author credit — the content
+--   dedup on file oids still folds the overlapping lines). The result hash
+--   is never marked when it is itself a linked commit: a fast-forward merge
+--   promotes an original, which stays authored.
+--
+-- * patch_duplicate: a commit whose diff content (patch id) an earlier commit
+--   IN THE SAME REPOSITORY already carries — a rebase copy or a cherry-pick.
+--   Scoped to the repository because a patch id identifies likely-duplicate
+--   content, not lineage: the same small diff applied independently to two
+--   unrelated repositories is two authored changes. The earliest commit
+--   wins, so the work lands in the period it was first authored; a
+--   merge-result commit never wins, so a same-day squash cannot displace its
+--   original. Commits without a patch id (a source that reports none, or a
+--   row collected before the source did) have unknown identity and are never
+--   collapsed.
+--
+-- Merge commits themselves (two parents) never enter the evidence commit set,
+-- so they need no row here.
+
+WITH
+collected_branch_commits AS (
+    SELECT DISTINCT
+        tenant_id,
+        source_id,
+        project_key,
+        repo_slug,
+        commit_hash
+    FROM {{ ref('class_git_commits') }} FINAL
+    WHERE is_merge_commit = 0
+),
+pull_request_links AS (
+    SELECT
+        tenant_id,
+        source_id,
+        project_key,
+        repo_slug,
+        pr_id,
+        groupUniqArray(commit_hash) AS linked_hashes,
+        uniqExactIf(
+            commit_hash,
+            (tenant_id, source_id, project_key, repo_slug, commit_hash) IN (
+                SELECT tenant_id, source_id, project_key, repo_slug, commit_hash
+                FROM collected_branch_commits
+            )
+        ) AS collected_branch_commit_count
+    FROM {{ ref('class_git_pull_requests_commits') }} FINAL
+    GROUP BY tenant_id, source_id, project_key, repo_slug, pr_id
+),
+merge_results AS (
+    SELECT DISTINCT
+        prs.tenant_id AS tenant_id,
+        prs.data_source AS data_source,
+        prs.merge_commit_hash AS commit_hash
+    FROM {{ ref('class_git_pull_requests') }} AS prs FINAL
+    INNER JOIN pull_request_links AS links
+        ON links.tenant_id = prs.tenant_id
+        AND links.source_id = prs.source_id
+        AND links.project_key = prs.project_key
+        AND links.repo_slug = prs.repo_slug
+        AND links.pr_id = prs.pr_id
+    WHERE prs.state = 'MERGED'
+      AND prs.merge_commit_hash != ''
+      AND links.collected_branch_commit_count = length(links.linked_hashes)
+      AND NOT has(links.linked_hashes, prs.merge_commit_hash)
+),
+-- One row per commit per repository: patch ids rank within a repository, so a
+-- duplicate patch in an unrelated repository is untouched. A hash present in
+-- two connected repositories ranks once per repository; DISTINCT below folds
+-- the outcome back to the hash grain the anti-join reads.
+commit_patches AS (
+    SELECT
+        tenant_id,
+        data_source,
+        project_key,
+        repo_slug,
+        commit_hash,
+        min(patch_id) AS commit_patch_id,
+        min(date) AS first_seen_date
+    FROM {{ ref('class_git_commits') }} FINAL
+    WHERE is_merge_commit = 0
+      AND coalesce(patch_id, '') != ''
+      AND date IS NOT NULL
+    GROUP BY tenant_id, data_source, project_key, repo_slug, commit_hash
+),
+patch_duplicates AS (
+    SELECT DISTINCT
+        tenant_id,
+        data_source,
+        commit_hash
+    FROM (
+        SELECT
+            tenant_id,
+            data_source,
+            commit_hash,
+            row_number() OVER (
+                PARTITION BY tenant_id, data_source, project_key, repo_slug, commit_patch_id
+                ORDER BY is_merge_result, first_seen_date, commit_hash
+            ) AS authored_rank
+        FROM (
+            SELECT
+                tenant_id,
+                data_source,
+                project_key,
+                repo_slug,
+                commit_hash,
+                commit_patch_id,
+                first_seen_date,
+                if(
+                    (tenant_id, data_source, commit_hash) IN (
+                        SELECT tenant_id, data_source, commit_hash
+                        FROM merge_results
+                    ),
+                    1,
+                    0
+                ) AS is_merge_result
+            FROM commit_patches
+        )
+    )
+    WHERE authored_rank > 1
+)
+
+SELECT
+    tenant_id,
+    data_source,
+    commit_hash,
+    'merge_result' AS reason
+FROM merge_results
+
+UNION ALL
+
+SELECT
+    tenant_id,
+    data_source,
+    commit_hash,
+    'patch_duplicate' AS reason
+FROM patch_duplicates

--- a/src/ingestion/gold/git_metric_evidence.sql
+++ b/src/ingestion/gold/git_metric_evidence.sql
@@ -77,6 +77,7 @@ commits_source AS (
         project_key,
         repo_slug,
         commit_hash,
+        data_source,
         author_name,
         message,
         date AS observed_at,
@@ -116,12 +117,60 @@ commits_source AS (
     WHERE trimBoth(author_email) != ''
       AND date IS NOT NULL
       AND is_merge_commit = 0
+      -- A semi-join by tuple for the same reason as branch scope above: a
+      -- derived commit (a squash/rebase result of a merged request, or a
+      -- later carrier of a patch an earlier commit authored) re-applies work
+      -- counted on another commit, so it contributes neither a commit nor —
+      -- because every file-change CTE attaches through this set — any lines.
+      AND (tenant_id, data_source, commit_hash) NOT IN (
+          SELECT tenant_id, data_source, commit_hash
+          FROM {{ ref('git_derived_commits') }}
+      )
     ORDER BY tenant_id, data_source, commit_hash, source_id, project_key, repo_slug
     LIMIT 1 BY tenant_id, data_source, commit_hash
 ),
+-- File changes attached to the commit row that survived the hash collapse.
+-- The attach key carries NO repository: commit rows collapse across
+-- repositories (a fork and its upstream hold the same hash), and a
+-- repo-qualified attach would leave the rows recorded under the repository
+-- that lost the collapse matching no commit and contributing nothing. One
+-- hash is one diff, so any repository's rows describe the commit — the
+-- LIMIT 1 BY collapses the per-repository copies, and every row carries the
+-- surviving commit's coordinates.
+commit_file_changes AS (
+    SELECT
+        commits.tenant_id AS tenant_id,
+        commits.source_id AS source_id,
+        commits.project_key AS project_key,
+        commits.repo_slug AS repo_slug,
+        commits.commit_hash AS commit_hash,
+        commits.observed_at AS observed_at,
+        raw_file_change.data_source AS data_source,
+        raw_file_change.file_path AS file_path,
+        raw_file_change.file_extension AS file_extension,
+        raw_file_change.change_type AS change_type,
+        raw_file_change.lines_added AS lines_added,
+        raw_file_change.lines_removed AS lines_removed,
+        raw_file_change.pre_image_oid AS pre_image_oid,
+        raw_file_change.post_image_oid AS post_image_oid
+    FROM {{ ref('class_git_file_changes') }} AS raw_file_change FINAL
+    INNER JOIN commits_source AS commits
+        ON commits.tenant_id = raw_file_change.tenant_id
+        AND commits.data_source = raw_file_change.data_source
+        AND commits.commit_hash = raw_file_change.commit_hash
+    ORDER BY raw_file_change.source_id, raw_file_change.project_key, raw_file_change.repo_slug
+    LIMIT 1 BY
+        tenant_id,
+        data_source,
+        commit_hash,
+        file_path,
+        lower(change_type),
+        pre_image_oid,
+        post_image_oid
+),
 -- One row per change CONTENT, not per commit that carries it. The same content
 -- entering a repository on two lines of history — a branch whose copy of a
--- tree was squashed onto the default branch as well, a cherry-pick, a
+-- tree also landed on the default branch, a cherry-pick, a
 -- reverted-then-restored file — is one authored change with one oid pair, and
 -- summing both commits' diffs would count those lines twice.
 --
@@ -134,38 +183,32 @@ commits_source AS (
 -- because LIMIT 1 BY reads their NULL keys as equal.
 deduplicated_file_changes AS (
     SELECT
-        raw_file_change.tenant_id AS tenant_id,
-        raw_file_change.source_id AS source_id,
-        raw_file_change.project_key AS project_key,
-        raw_file_change.repo_slug AS repo_slug,
-        raw_file_change.commit_hash AS commit_hash,
-        raw_file_change.data_source AS data_source,
-        raw_file_change.file_path AS file_path,
-        raw_file_change.file_extension AS file_extension,
-        raw_file_change.change_type AS change_type,
-        raw_file_change.lines_added AS lines_added,
-        raw_file_change.lines_removed AS lines_removed
-    FROM {{ ref('class_git_file_changes') }} AS raw_file_change FINAL
-    INNER JOIN commits_source AS commits
-        ON commits.tenant_id = raw_file_change.tenant_id
-        AND commits.source_id = raw_file_change.source_id
-        AND commits.project_key = raw_file_change.project_key
-        AND commits.repo_slug = raw_file_change.repo_slug
-        AND commits.commit_hash = raw_file_change.commit_hash
-    ORDER BY commits.observed_at, raw_file_change.commit_hash
+        tenant_id,
+        source_id,
+        project_key,
+        repo_slug,
+        commit_hash,
+        data_source,
+        file_path,
+        file_extension,
+        change_type,
+        lines_added,
+        lines_removed
+    FROM commit_file_changes
+    ORDER BY observed_at, commit_hash
     LIMIT 1 BY
-        raw_file_change.tenant_id,
-        raw_file_change.data_source,
-        raw_file_change.project_key,
-        raw_file_change.repo_slug,
-        raw_file_change.file_path,
-        lower(raw_file_change.change_type),
-        raw_file_change.pre_image_oid,
-        raw_file_change.post_image_oid,
+        tenant_id,
+        data_source,
+        project_key,
+        repo_slug,
+        file_path,
+        lower(change_type),
+        pre_image_oid,
+        post_image_oid,
         if(
-            coalesce(raw_file_change.pre_image_oid, '') = ''
-                AND coalesce(raw_file_change.post_image_oid, '') = '',
-            raw_file_change.commit_hash,
+            coalesce(pre_image_oid, '') = ''
+                AND coalesce(post_image_oid, '') = '',
+            commit_hash,
             ''
         )
 ),
@@ -183,7 +226,7 @@ reported_commit_file_lines AS (
         commit_hash,
         sum(lines_added) AS lines_added,
         sum(lines_removed) AS lines_removed
-    FROM {{ ref('class_git_file_changes') }} FINAL
+    FROM commit_file_changes
     GROUP BY tenant_id, source_id, project_key, repo_slug, commit_hash
 ),
 authored_commit_file_lines AS (

--- a/src/ingestion/gold/schema.yml
+++ b/src/ingestion/gold/schema.yml
@@ -88,6 +88,30 @@ models:
         tests:
           - not_null
 
+  - name: git_derived_commits
+    description: >
+      Commits whose work is already counted on another commit, one row per
+      tenant/data_source/commit_hash/reason. merge_result is the commit a
+      merged pull request produced on its destination (a squash result or the
+      last rebased copy), marked only when every linked branch commit was
+      collected; patch_duplicate is a later carrier of a patch id an earlier
+      commit in the same repository authored (a rebase copy or a cherry-pick).
+      The git
+      evidence build excludes these from both the commit and the line figures,
+      so one authored change counts once and the two figures describe the same
+      set of commits.
+    columns:
+      - name: commit_hash
+        description: "Commit identifier within the source"
+        tests:
+          - not_null
+      - name: reason
+        description: "Why the commit is derived"
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['merge_result', 'patch_duplicate']
+
   - name: git_metric_evidence
     description: >
       Materialized MergeTree evidence serving table for Git source measures.

--- a/src/ingestion/scripts/apply-ch-migrations.sh
+++ b/src/ingestion/scripts/apply-ch-migrations.sh
@@ -241,6 +241,27 @@ for _git_source in github gitlab bitbucket_cloud; do
   heal_git_file_change_oids staging "${_git_source}__file_changes" _airbyte_extracted_at
 done
 
+echo "=== Healing git commit patch id column ==="
+# Same positional invariant: every projection feeding class_git_commits gained
+# patch_id at the tail (commit-content identity for counting an authored
+# change once, #2792). The silver side heals in migrations/*.sql; staging
+# heals here because these tables exist only after a connector has run.
+# Existing rows heal to NULL and carry a patch id from the first sync that
+# re-collects them. Idempotent.
+heal_git_commit_patch_id() {
+  local table="$1"
+  ch_table_is_real staging "${table}" || return 0
+  echo "  staging.${table}"
+  run_ch <<SQL
+ALTER TABLE staging.${table} ADD COLUMN IF NOT EXISTS patch_id Nullable(String) AFTER _airbyte_extracted_at;
+ALTER TABLE staging.${table} MODIFY COLUMN patch_id Nullable(String) AFTER _airbyte_extracted_at;
+SQL
+}
+
+for _git_source in github gitlab bitbucket_cloud; do
+  heal_git_commit_patch_id "${_git_source}__commits"
+done
+
 echo "=== Healing git pull-request author account column ==="
 # Same positional invariant: every projection feeding class_git_pull_requests
 # gained author_account_id after author_email (account-first person

--- a/src/ingestion/scripts/connectors-ddl/insight.sql
+++ b/src/ingestion/scripts/connectors-ddl/insight.sql
@@ -181,6 +181,18 @@ ORDER BY (tenant_id, source_id, project_key, repo_slug, commit_hash)
 SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS insight.git_derived_commits
+(
+    `tenant_id` Nullable(String),
+    `data_source` String,
+    `commit_hash` String,
+    `reason` String
+)
+ENGINE = MergeTree
+ORDER BY (tenant_id, data_source, commit_hash)
+SETTINGS allow_nullable_key = 1, replicated_deduplication_window = '0', index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS insight.git_metric_evidence
 (
     `tenant_id` String,

--- a/src/ingestion/scripts/connectors-ddl/silver.sql
+++ b/src/ingestion/scripts/connectors-ddl/silver.sql
@@ -428,7 +428,8 @@ CREATE TABLE IF NOT EXISTS silver.class_git_commits
     `is_merge_commit` UInt8,
     `data_source` String,
     `_version` Int64,
-    `_airbyte_extracted_at` DateTime64(3)
+    `_airbyte_extracted_at` DateTime64(3),
+    `patch_id` Nullable(String)
 )
 ENGINE = ReplacingMergeTree(_version)
 ORDER BY unique_key

--- a/src/ingestion/scripts/migrations/20260825000000_git-commit-patch-id.sql
+++ b/src/ingestion/scripts/migrations/20260825000000_git-commit-patch-id.sql
@@ -1,0 +1,26 @@
+-- Add the per-commit patch id to the git class contract.
+--
+-- The patch id is the content identity of a commit's diff: a rebase copy or a
+-- cherry-pick carries a new hash but the same patch id, and readers
+-- deduplicate on it so one authored change counts once however many lines of
+-- history re-apply it.
+--
+-- A pre-existing table gets it from nowhere: the DDL snapshot is
+-- IF NOT EXISTS, and this model runs with dbt's default
+-- on_schema_change semantics for warm tables, so an existing relation never
+-- gains a column the model started projecting. The staging halves of the same
+-- contract heal in apply-ch-migrations.sh, where a table that no connector has
+-- built yet can be skipped.
+--
+-- AFTER anchors put it at the tail, the position the staging projections use
+-- and the positional insert requires; MODIFY converges an instance where an
+-- out-of-band ALTER placed it elsewhere. Shape follows
+-- 20260820000000_git-file-change-blob-oids.sql.
+--
+-- Idempotent: this channel has no ledger and re-runs on every deploy.
+-- The class tables always exist here (placeholders precede migrations).
+ALTER TABLE silver.class_git_commits
+    ADD COLUMN IF NOT EXISTS patch_id Nullable(String) AFTER _airbyte_extracted_at;
+
+ALTER TABLE silver.class_git_commits
+    MODIFY COLUMN patch_id Nullable(String) AFTER _airbyte_extracted_at;

--- a/src/ingestion/silver/git/schema.yml
+++ b/src/ingestion/silver/git/schema.yml
@@ -74,6 +74,11 @@ models:
           - accepted_values:
               arguments:
                 values: [0, 1]
+      - name: patch_id
+        description: >
+          Content identity of the commit's diff: a rebase copy or a cherry-pick
+          carries a new hash but the same patch id. NULL for a source that does
+          not report it and for rows collected before the source did.
 
   - name: class_git_file_changes
     description: "Unified git file changes from all sources (GitHub, Bitbucket, GitLab)"

--- a/src/ingestion/tests/e2e/metrics/git_commit_work_identity.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_commit_work_identity.test.yaml
@@ -1,0 +1,346 @@
+spec_version: 1
+description: >
+  Commit metrics count an authored change once, however many commits re-apply
+  it, and the commit and line figures describe the same set of commits.
+
+  A merged pull request's result commit (a squash, or the last rebased copy)
+  re-applies the branch commits' work, so it contributes neither a commit nor
+  lines — including the squash's own A-to-C file rows, which match no branch
+  transition and would otherwise count a twice-touched path's lines again. A
+  commit carrying a patch id an earlier commit already carries (a rebase copy,
+  a cherry-pick) is the same authored change: the earliest commit keeps it.
+  When one hash is present in two connected repositories, its file rows attach
+  to whichever commit row survives the collapse instead of vanishing with the
+  losing repository.
+
+  Fixtures isolate per repository:
+    * squash-merge: three branch commits, one path touched twice (A-to-B then
+      B-to-C), and the squash result carrying A-to-C. Three commits, the
+      branch's lines once, nothing from the squash.
+    * fast-forward: the merged request's result hash IS a branch commit. It
+      stays authored — excluding it would lose real work.
+    * patch-copy: the same patch id on an October and a November commit with
+      different blob oids (a rebase moves the base, so line identity alone
+      cannot fold them). October keeps the work, November reports nothing.
+    * unseen-branch: a merged request whose branch commits were never
+      collected. Its result commit is the only record of the work and stays.
+    * partial-branch: a merged request with two linked commits of which one
+      was collected. Coverage is incomplete, so the result commit stays the
+      complete record and both count; the overlapping lines still fold
+      through blob-oid content identity.
+    * indep-a / indep-b: the same patch id on commits in two unrelated
+      repositories — two independent authored changes, both count. Patch
+      identity folds within a repository only.
+    * xr-fork / xr-upstream: one hash in two repositories, file rows recorded
+      only under the repository that loses the commit collapse. The lines
+      count once, under the surviving repository.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/erin
+
+  bronze_github.commits:
+    # squash-merge: the three branch originals and the squash result.
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: wi-c-sq-b1, repository: "https://github.com/constructor/squash-merge.git", sha: wi-sq-b1, committed_date: "2026-10-01T09:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 10}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: wi-c-sq-b2, repository: "https://github.com/constructor/squash-merge.git", sha: wi-sq-b2, committed_date: "2026-10-01T10:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 8, deletions: 2}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: wi-c-sq-b3, repository: "https://github.com/constructor/squash-merge.git", sha: wi-sq-b3, committed_date: "2026-10-01T11:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 5, deletions: 1}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: wi-c-sq-result, repository: "https://github.com/constructor/squash-merge.git", sha: wi-sq-result, committed_date: "2026-10-01T12:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 23, deletions: 3}
+    # fast-forward: the merged request promotes this very commit.
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: wi-c-ff-head, repository: "https://github.com/constructor/fast-forward.git", sha: wi-ff-head, committed_date: "2026-10-01T09:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 7}
+    # patch-copy: one patch id, two commits, two months.
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: wi-c-pc-orig, repository: "https://github.com/constructor/patch-copy.git", sha: wi-pc-orig, committed_date: "2026-10-01T09:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 6, deletions: 1, patch_id: wi-patch-aaa}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: wi-c-pc-copy, repository: "https://github.com/constructor/patch-copy.git", sha: wi-pc-copy, committed_date: "2026-11-02T09:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 6, deletions: 1, patch_id: wi-patch-aaa}
+    # unseen-branch: only the squash result was ever collected.
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: wi-c-un-result, repository: "https://github.com/constructor/unseen-branch.git", sha: wi-un-result, committed_date: "2026-10-01T09:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 9}
+    # partial-branch: one of the two linked commits, plus the squash result.
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: wi-c-pt-b1, repository: "https://github.com/constructor/partial-branch.git", sha: wi-pt-b1, committed_date: "2026-10-01T09:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 3}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: wi-c-pt-result, repository: "https://github.com/constructor/partial-branch.git", sha: wi-pt-result, committed_date: "2026-10-01T12:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 5}
+    # indep: one patch id, two unrelated repositories.
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: wi-c-ia, repository: "https://github.com/constructor/indep-a.git", sha: wi-ia-1, committed_date: "2026-10-01T09:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 2, patch_id: wi-patch-shared}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: wi-c-ib, repository: "https://github.com/constructor/indep-b.git", sha: wi-ib-1, committed_date: "2026-10-01T10:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 2, patch_id: wi-patch-shared}
+    # xr: the same hash in two connected repositories.
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: wi-c-xr-fork, repository: "https://github.com/constructor/xr-fork.git", sha: wi-xr-1, committed_date: "2026-10-01T09:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 4}
+    - {$ref: templates/git_activity.yaml#/templates/commit, unique_key: wi-c-xr-upstream, repository: "https://github.com/constructor/xr-upstream.git", sha: wi-xr-1, committed_date: "2026-10-01T09:00:00Z", author_name: erin, author_email: erin@example.com, committer_name: erin, committer_email: erin@example.com, additions: 4}
+
+  bronze_github.file_changes:
+    # squash-merge branch rows: src/app.rs makes two transitions.
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: wi-f-sq-b1, repository: "https://github.com/constructor/squash-merge.git", sha: wi-sq-b1, filename: src/one.rs, status: added, additions: 10, deletions: 0, pre_image_oid: null, post_image_oid: 11111111111111111111111111111111111111a1}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: wi-f-sq-b2, repository: "https://github.com/constructor/squash-merge.git", sha: wi-sq-b2, filename: src/app.rs, status: modified, additions: 8, deletions: 2, pre_image_oid: 22222222222222222222222222222222222222b0, post_image_oid: 22222222222222222222222222222222222222b1}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: wi-f-sq-b3, repository: "https://github.com/constructor/squash-merge.git", sha: wi-sq-b3, filename: src/app.rs, status: modified, additions: 5, deletions: 1, pre_image_oid: 22222222222222222222222222222222222222b1, post_image_oid: 22222222222222222222222222222222222222b2}
+    # The squash's rows: the add repeats an oid October already carries, and
+    # the A-to-C transition on src/app.rs matches NEITHER branch transition —
+    # only the commit-level exclusion keeps its 13 lines from counting again.
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: wi-f-sq-r1, repository: "https://github.com/constructor/squash-merge.git", sha: wi-sq-result, filename: src/one.rs, status: added, additions: 10, deletions: 0, pre_image_oid: null, post_image_oid: 11111111111111111111111111111111111111a1}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: wi-f-sq-r2, repository: "https://github.com/constructor/squash-merge.git", sha: wi-sq-result, filename: src/app.rs, status: modified, additions: 13, deletions: 3, pre_image_oid: 22222222222222222222222222222222222222b0, post_image_oid: 22222222222222222222222222222222222222b2}
+    # fast-forward.
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: wi-f-ff, repository: "https://github.com/constructor/fast-forward.git", sha: wi-ff-head, filename: src/ff.rs, status: added, additions: 7, deletions: 0, pre_image_oid: null, post_image_oid: 33333333333333333333333333333333333333c1}
+    # patch-copy: the copy's oids differ (rebased base), so only the commit's
+    # patch identity can fold it.
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: wi-f-pc-orig, repository: "https://github.com/constructor/patch-copy.git", sha: wi-pc-orig, filename: src/pick.rs, status: modified, additions: 6, deletions: 1, pre_image_oid: 44444444444444444444444444444444444444d0, post_image_oid: 44444444444444444444444444444444444444d1}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: wi-f-pc-copy, repository: "https://github.com/constructor/patch-copy.git", sha: wi-pc-copy, filename: src/pick.rs, status: modified, additions: 6, deletions: 1, pre_image_oid: 44444444444444444444444444444444444444d2, post_image_oid: 44444444444444444444444444444444444444d3}
+    # unseen-branch.
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: wi-f-un, repository: "https://github.com/constructor/unseen-branch.git", sha: wi-un-result, filename: src/unseen.rs, status: added, additions: 9, deletions: 0, pre_image_oid: null, post_image_oid: 55555555555555555555555555555555555555e1}
+    # partial-branch: the squash repeats the collected commit's blob (folds by
+    # oid, earliest wins) and carries the uncollected commit's content.
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: wi-f-pt-b1, repository: "https://github.com/constructor/partial-branch.git", sha: wi-pt-b1, filename: src/p1.rs, status: added, additions: 3, deletions: 0, pre_image_oid: null, post_image_oid: 77777777777777777777777777777777777777a1}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: wi-f-pt-r1, repository: "https://github.com/constructor/partial-branch.git", sha: wi-pt-result, filename: src/p1.rs, status: added, additions: 3, deletions: 0, pre_image_oid: null, post_image_oid: 77777777777777777777777777777777777777a1}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: wi-f-pt-r2, repository: "https://github.com/constructor/partial-branch.git", sha: wi-pt-result, filename: src/p2.rs, status: added, additions: 2, deletions: 0, pre_image_oid: null, post_image_oid: 77777777777777777777777777777777777777a2}
+    # indep: different paths and oids; only the patch id coincides.
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: wi-f-ia, repository: "https://github.com/constructor/indep-a.git", sha: wi-ia-1, filename: src/a.rs, status: modified, additions: 2, deletions: 0, pre_image_oid: 88888888888888888888888888888888888888b0, post_image_oid: 88888888888888888888888888888888888888b1}
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: wi-f-ib, repository: "https://github.com/constructor/indep-b.git", sha: wi-ib-1, filename: src/b.rs, status: modified, additions: 2, deletions: 0, pre_image_oid: 99999999999999999999999999999999999999c0, post_image_oid: 99999999999999999999999999999999999999c1}
+    # xr: rows recorded ONLY under xr-upstream, which loses the commit
+    # collapse to xr-fork (lexicographic repo order).
+    - {$ref: templates/git_activity.yaml#/templates/file_change, unique_key: wi-f-xr, repository: "https://github.com/constructor/xr-upstream.git", sha: wi-xr-1, filename: src/x.rs, status: added, additions: 4, deletions: 0, pre_image_oid: null, post_image_oid: 66666666666666666666666666666666666666f1}
+
+  bronze_github.pull_requests:
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: wi-pr-sq, repo_full_name: constructor/squash-merge, id: 41, number: 41, author_login: erin, closed_at: "2026-10-01T12:00:00Z", merged_at: "2026-10-01T12:00:00Z", merge_commit_sha: wi-sq-result}
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: wi-pr-ff, repo_full_name: constructor/fast-forward, id: 42, number: 42, author_login: erin, closed_at: "2026-10-01T12:00:00Z", merged_at: "2026-10-01T12:00:00Z", merge_commit_sha: wi-ff-head}
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: wi-pr-un, repo_full_name: constructor/unseen-branch, id: 43, number: 43, author_login: erin, closed_at: "2026-10-01T12:00:00Z", merged_at: "2026-10-01T12:00:00Z", merge_commit_sha: wi-un-result}
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: wi-pr-pt, repo_full_name: constructor/partial-branch, id: 44, number: 44, author_login: erin, closed_at: "2026-10-01T12:00:00Z", merged_at: "2026-10-01T12:00:00Z", merge_commit_sha: wi-pt-result}
+
+  bronze_github.pull_request_commits:
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: wi-lnk-sq-b1, sha: wi-sq-b1, pull_number: 41, repo_full_name: constructor/squash-merge, author_email: erin@example.com, is_merge: false}
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: wi-lnk-sq-b2, sha: wi-sq-b2, pull_number: 41, repo_full_name: constructor/squash-merge, author_email: erin@example.com, is_merge: false}
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: wi-lnk-sq-b3, sha: wi-sq-b3, pull_number: 41, repo_full_name: constructor/squash-merge, author_email: erin@example.com, is_merge: false}
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: wi-lnk-ff, sha: wi-ff-head, pull_number: 42, repo_full_name: constructor/fast-forward, author_email: erin@example.com, is_merge: false}
+    # unseen-branch: the linked commits were never collected into the commits
+    # stream, so the result commit stays the only record of the work.
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: wi-lnk-un-b1, sha: wi-un-b1, pull_number: 43, repo_full_name: constructor/unseen-branch, author_email: erin@example.com, is_merge: false}
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: wi-lnk-un-b2, sha: wi-un-b2, pull_number: 43, repo_full_name: constructor/unseen-branch, author_email: erin@example.com, is_merge: false}
+    # partial-branch: two linked commits, only wi-pt-b1 exists in the commits
+    # stream — coverage is incomplete.
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: wi-lnk-pt-b1, sha: wi-pt-b1, pull_number: 44, repo_full_name: constructor/partial-branch, author_email: erin@example.com, is_merge: false}
+    - {$ref: templates/git_activity.yaml#/templates/base, unique_key: wi-lnk-pt-b2, sha: wi-pt-b2, pull_number: 44, repo_full_name: constructor/partial-branch, author_email: erin@example.com, is_merge: false}
+
+cases:
+  - name: A squash result contributes neither a commit nor its recombined lines
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.commits
+            views:
+              - {view: breakdown, dimensions: [repository]}
+          - metric_key: git.lines_added
+            views:
+              - {view: breakdown, dimensions: [repository]}
+          - metric_key: git.lines_removed
+            views:
+              - {view: breakdown, dimensions: [repository]}
+    expect:
+      - assert: "status == 200"
+      # The three branch originals; the squash result is the fourth sha and
+      # must not appear as a commit.
+      - metric: git.commits
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/squash-merge"}}
+        equal: {value: 3}
+      # 10 + 8 + 5: the branch's own transitions once each. The squash's
+      # A-to-C row (13) matches neither and is excluded with its commit.
+      - metric: git.lines_added
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/squash-merge"}}
+        equal: {value: 23}
+      - metric: git.lines_removed
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/squash-merge"}}
+        equal: {value: 3}
+
+  - name: A fast-forward merge promotes an original, which stays authored
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.commits
+            views:
+              - {view: breakdown, dimensions: [repository]}
+          - metric_key: git.lines_added
+            views:
+              - {view: breakdown, dimensions: [repository]}
+    expect:
+      - assert: "status == 200"
+      - metric: git.commits
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/fast-forward"}}
+        equal: {value: 1}
+      - metric: git.lines_added
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/fast-forward"}}
+        equal: {value: 7}
+
+  - name: One patch id is one authored change, kept by the earliest commit
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.commits
+            views:
+              - {view: breakdown, dimensions: [repository]}
+          - metric_key: git.lines_added
+            views:
+              - {view: breakdown, dimensions: [repository]}
+    expect:
+      - assert: "status == 200"
+      - metric: git.commits
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/patch-copy"}}
+        equal: {value: 1}
+      - metric: git.lines_added
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/patch-copy"}}
+        equal: {value: 6}
+
+  - name: The later carrier of an already-authored patch reports nothing
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-11-01", to: "2026-11-30"}
+        metrics:
+          - metric_key: git.commits
+            views:
+              - {view: breakdown, dimensions: [repository]}
+          - metric_key: git.lines_added
+            views:
+              - {view: breakdown, dimensions: [repository]}
+    expect:
+      - assert: "status == 200"
+      # The November copy carries the October patch: no commit row and no
+      # lines at all for the repository in November.
+      - metric: git.commits
+        view: breakdown
+        assert: "!items.exists(v, v.dimensions.exists(d, d.key == 'repository' && d.value == 'git-test:constructor/patch-copy'))"
+      - metric: git.lines_added
+        view: breakdown
+        assert: "!items.exists(v, v.dimensions.exists(d, d.key == 'repository' && d.value == 'git-test:constructor/patch-copy'))"
+
+  - name: A merge result whose branch commits were never collected stays counted
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.commits
+            views:
+              - {view: breakdown, dimensions: [repository]}
+          - metric_key: git.lines_added
+            views:
+              - {view: breakdown, dimensions: [repository]}
+    expect:
+      - assert: "status == 200"
+      - metric: git.commits
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/unseen-branch"}}
+        equal: {value: 1}
+      - metric: git.lines_added
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/unseen-branch"}}
+        equal: {value: 9}
+
+  - name: File rows under the repository that lost the hash collapse still count
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.commits
+            views:
+              - {view: breakdown, dimensions: [repository]}
+          - metric_key: git.lines_added
+            views:
+              - {view: breakdown, dimensions: [repository]}
+    expect:
+      - assert: "status == 200"
+      # One hash, one commit, counted under the surviving repository.
+      - metric: git.commits
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/xr-fork"}}
+        equal: {value: 1}
+      - metric: git.commits
+        view: breakdown
+        assert: "!items.exists(v, v.dimensions.exists(d, d.key == 'repository' && d.value == 'git-test:constructor/xr-upstream'))"
+      # The lines were recorded only under xr-upstream, whose commit row lost
+      # the collapse — they attach to the surviving row instead of vanishing.
+      - metric: git.lines_added
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/xr-fork"}}
+        equal: {value: 4}
+
+  - name: A merge result with partially collected branch commits stays counted
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.commits
+            views:
+              - {view: breakdown, dimensions: [repository]}
+          - metric_key: git.lines_added
+            views:
+              - {view: breakdown, dimensions: [repository]}
+    expect:
+      - assert: "status == 200"
+      # One of the two linked commits was collected, so coverage is incomplete
+      # and the result commit stays the complete record: both count.
+      - metric: git.commits
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/partial-branch"}}
+        equal: {value: 2}
+      # 3 (the collected original, whose blob the squash repeats — folded by
+      # oid, earliest wins) + 2 (the uncollected commit's content, present
+      # only on the squash). The overlap does not double.
+      - metric: git.lines_added
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/partial-branch"}}
+        equal: {value: 5}
+
+  - name: The same patch id in unrelated repositories is two authored changes
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-02"}
+        metrics:
+          - metric_key: git.commits
+            views:
+              - {view: breakdown, dimensions: [repository]}
+          - metric_key: git.lines_added
+            views:
+              - {view: breakdown, dimensions: [repository]}
+    expect:
+      - assert: "status == 200"
+      # Patch identity folds within a repository only: neither independent
+      # change loses to the other.
+      - metric: git.commits
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/indep-a"}}
+        equal: {value: 1}
+      - metric: git.commits
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/indep-b"}}
+        equal: {value: 1}
+      - metric: git.lines_added
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/indep-a"}}
+        equal: {value: 2}
+      - metric: git.lines_added
+        view: breakdown
+        find: {entity_id: erin@example.com, dimensions: {key: repository, value: "git-test:constructor/indep-b"}}
+        equal: {value: 2}

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_github.commits.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_github.commits.yaml
@@ -24,3 +24,4 @@ schemas:
       deletions: {type: integer}
       is_merge: {type: boolean}
       is_in_default_branch: {type: [boolean, "null"]}
+      patch_id: {type: [string, "null"]}


### PR DESCRIPTION
Closes constructorfabric/insight#2792.

**Why.** Commit counts include every copy of the same work — N+1 after a squash-merge, 2N after a rebase — a twice-touched path's lines count again through the squash's combined row, and file rows under the repository that loses the cross-repo commit collapse add nothing.

**What changed.** A gold `git_derived_commits` table lists commits that re-apply counted work — merged requests' result commits and later carriers of an already-seen `patch_id`, now carried bronze→silver for GitHub and Bitbucket. The evidence build excludes them and attaches file rows to commits by hash, not repository.

**A merged request's result commit is excluded only when every linked branch commit was collected.** With partial coverage it is the only complete record of the work, so it and the collected originals both stay — over-counting their overlap beats losing the uncollected work, and the blob-oid content dedup still folds the overlapping lines. Self-corrects once coverage completes.

**A result hash that is itself a linked branch commit is never excluded.** A fast-forward merge promotes an original; excluding it would drop real work.

**Patch identity folds within one repository only, the earliest commit keeps it, and merge results never win the ranking.** A patch id marks likely-duplicate content, not lineage: the same small diff applied independently to unrelated repositories is two authored changes.

**The GitHub and Bitbucket descriptors take a MAJOR bump to dispatch a one-shot scoped `dbt --full-refresh`.** The patch id sits in Bronze already, but staging never re-reads it, so without the refresh every existing commit row keeps a NULL identity and only new syncs would fold. Safe — every git staging model is a pure projection of Bronze. GitLab takes a MINOR: it reports no patch id, so the column is NULL either way.

**Out of scope.** Branch-membership staleness — tracked in #2846. GitLab squash and rebase dedup — lands with the GitLab proxy migration, which supplies its patch and squash identities.

**Verified.** New `git_commit_work_identity` e2e fixture (squash, fast-forward, patch copy, uncollected branch, cross-repo); the git e2e set passes 13/13 twice; `dbt parse` and `connector_wiring.py` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added patch identity tracking for Git commits across GitHub, GitLab, and Bitbucket Cloud.
  - Improved metrics to avoid double-counting rebased, cherry-picked, squash-merge, and duplicate commits.
  - Added derived commit classifications for excluded merge results and duplicate patches.
  - Preserved repository-specific handling when identical patches appear independently.

- **Bug Fixes**
  - Corrected commit and file-line totals by associating changes with the surviving commit.

- **Tests**
  - Added end-to-end coverage for merge, rebase, duplicate, and cross-repository scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->