### PR TITLE
test(reports): guard the weekly bucket keying and the granularity clamp

### DIFF
--- a/src/frontend/src/components/portal/report-builder-view.test.tsx
+++ b/src/frontend/src/components/portal/report-builder-view.test.tsx
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   definitions: [] as unknown[],
   computations: new Map<string, string>(),
   scope: {} as Record<string, unknown>,
+  dateRange: { from: "2026-05-13", to: "2026-08-12" },
   run: vi.fn(),
   csv: vi.fn(),
   xlsx: vi.fn(),
@@ -37,7 +38,7 @@ vi.mock("@/lib/portal/use-org-scope", () => ({ useOrgScope: () => mocks.scope })
 vi.mock("@/hooks/use-portal-period", () => ({
   usePortalPeriod: () => ({
     period: "quarter",
-    dateRange: { from: "2026-05-13", to: "2026-08-12" },
+    dateRange: mocks.dateRange,
   }),
 }));
 vi.mock("@/lib/reports/run-report", () => ({ runReport: mocks.run }));
@@ -128,6 +129,7 @@ beforeEach(() => {
     isLoading: false,
     isError: false,
   };
+  mocks.dateRange = { from: "2026-05-13", to: "2026-08-12" };
   mocks.run.mockReset().mockResolvedValue(new Map());
   mocks.csv.mockReset();
   mocks.xlsx.mockReset();
@@ -333,5 +335,54 @@ describe("ReportBuilderView", () => {
     expect(screen.queryByRole("button", { name: /rows ·/ })).toBeNull();
     expect(mocks.csv).not.toHaveBeenCalled();
     expect(mocks.xlsx).not.toHaveBeenCalled();
+  });
+  it("drops a held grain the shortened period cannot carry, and builds at the finer one", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<ReportBuilderView />);
+    await user.click(screen.getByRole("button", { name: "Quarterly" }));
+    expect(screen.getByRole("button", { name: "Quarterly" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+
+    mocks.dateRange = { from: "2026-08-17", to: "2026-08-23" };
+    rerender(<ReportBuilderView />);
+
+    expect(screen.getByRole("button", { name: "Weekly" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Quarterly" })).toBeDisabled();
+
+    await user.click(box("Commits"));
+    await user.click(screen.getByRole("button", { name: "Build report" }));
+    await waitFor(() =>
+      expect(mocks.run).toHaveBeenCalledWith(
+        expect.objectContaining({ granularity: "week" }),
+      ),
+    );
+  });
+
+  it("hands both exporters the table the preview showed, without building again", async () => {
+    const user = userEvent.setup();
+    mocks.run.mockResolvedValueOnce(
+      new Map([["git.commits", decimalResult(1082.1594444444445)]]),
+    );
+    render(<ReportBuilderView />);
+    await user.click(box("Commits"));
+    await user.click(screen.getByRole("button", { name: "Build report" }));
+    expect(await screen.findByText("1,082.2")).toBeInTheDocument();
+    await closeDialog(user);
+    await user.click(await screen.findByRole("button", { name: /rows ·/ }));
+
+    await user.click(await screen.findByRole("button", { name: "CSV" }));
+    await user.click(await screen.findByRole("button", { name: "Excel" }));
+
+    const exported = mocks.csv.mock.calls[0][1];
+    expect(
+      exported.rows.some((row: unknown[]) => row.includes(1082.2)),
+    ).toBe(true);
+    expect(mocks.xlsx.mock.calls[0][2]).toBe(exported);
+    expect(mocks.run).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/frontend/src/lib/reports/reports.test.ts
+++ b/src/frontend/src/lib/reports/reports.test.ts
@@ -593,6 +593,31 @@ describe("bucketsInRange", () => {
     ]);
   });
 
+  it("keys a week the same way whatever weekday the period starts on", () => {
+    for (const from of [
+      "2026-08-03",
+      "2026-08-04",
+      "2026-08-05",
+      "2026-08-06",
+      "2026-08-07",
+      "2026-08-08",
+      "2026-08-09",
+    ]) {
+      expect(bucketsInRange(from, "2026-08-23", "week"), from).toEqual([
+        "2026-08-03",
+        "2026-08-10",
+        "2026-08-17",
+      ]);
+    }
+  });
+
+  it("keys a week that crosses a year boundary to its own Monday", () => {
+    expect(bucketsInRange("2026-12-30", "2027-01-10", "week")).toEqual([
+      "2026-12-28",
+      "2027-01-04",
+    ]);
+  });
+
   it("gives every month of a year its own bucket", () => {
     expect(bucketsInRange("2026-01-01", "2026-12-31", "year")).toEqual(["2026"]);
     expect(bucketsInRange("2026-01-01", "2026-03-31", "month")).toEqual([


### PR DESCRIPTION
Follows the verification of #2794. The fix in #2798 is correct on the deployed build — this adds the coverage that was missing behind it.

## Why

Reverting each thing #2798 turns on, and re-running the frontend suite:

| Broken | Tests red |
|---|---|
| Monday week keying (`mondayOf` in `bucketsInRange`) | 3 |
| Refusal reason (`periodTooShortReason`) | 2 |
| **The `clampGranularity` call site** | **0** |

The clamp drops a held grain when the period shrinks below it. Remove its one call and a week-long period reports a single bucket under a quarterly heading — the second half of what #2794 reported — while all 2,163 tests stay green. The helper is unit-tested; its only call site was not, so a refactor could drop it in silence.

## What this adds

Four tests, each confirmed to fail when the thing it guards is broken:

- **the clamp survives a period change** — holds Quarterly, shrinks the period to a week, asserts the grain clamps to Weekly *and* that the build request carries `granularity: "week"`, not the held value
- **all seven weekday period starts** key to the same Monday buckets
- **a week crossing a year boundary** keys to its own Monday (28 Dec 2026 → 4 Jan 2027)
- **CSV and Excel receive the table the preview rendered**, with no second run

`usePortalPeriod` was mocked with a fixed date range, so the period could never change and the clamp could never fire. It now reads a mutable `mocks.dateRange`, reset in `beforeEach` to the value it always had — every existing test behaves identically.

## Verification

No production code changed. `pnpm test:coverage:ci` → 2,195 passed over 226 files; `pnpm typecheck` and `pnpm lint` clean.

## Not covered here

An end-to-end build at Daily, Monthly, Quarterly and Yearly against a deployed stand. That belongs in the stand UI suite, needs a live stand, and is a separate change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded report builder coverage for automatic adjustment from quarterly to weekly reporting when date ranges are shortened.
  - Verified weekly selections are disabled when unavailable and reports build with the supported granularity.
  - Added coverage confirming CSV and Excel exports use the previewed, rounded table data.
  - Added validation for consistent weekly periods across weekdays and year boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->