### PR TITLE
fix(analytics): build timeseries views over a nullable metric_date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,8 +223,8 @@ jobs:
 
       # DB-backed components (analytics) run their #[ignore]d live_tests
       # against a real MariaDB. Gated on live_db so only those entries pay the
-      # ~15s startup. ClickHouse is intentionally not provisioned — CH-gated
-      # tests skip themselves (see cf/insight#1564).
+      # ~15s startup. live_ch entries additionally get a ClickHouse for the
+      # CH-gated live tests (see cf/insight#1564).
       - name: Start MariaDB (${{ matrix.entry.name }})
         # live_db is a static per-component flag — only pay the container
         # startup when this run actually executes tests (with or without
@@ -246,6 +246,20 @@ jobs:
             sleep 2
           done
 
+      - name: Start ClickHouse (${{ matrix.entry.name }})
+        if: ${{ matrix.entry.live_ch && (matrix.entry.cover || matrix.entry.test) }}
+        env:
+          CLICKHOUSE_USER: insight
+          CLICKHOUSE_PASSWORD: insight
+          CLICKHOUSE_DATABASE: insight
+        run: |
+          set -euo pipefail
+          # pins.env is plain KEY=VALUE (same load as connectors-ddl), so the
+          # server image stays pinned in exactly one committed place.
+          . src/ingestion/scripts/bootstrap-db/pins.env
+          export CLICKHOUSE_SERVER_IMAGE
+          .github/workflows/scripts/start-clickhouse.sh insight-clickhouse
+
       - name: Coverage (${{ matrix.entry.name }} -> Cobertura)
         if: ${{ matrix.entry.cover }}
         working-directory: ${{ matrix.entry.root }}
@@ -255,6 +269,9 @@ jobs:
         # isolated and never reset the DB, so parallel runs don't collide.
         env:
           INTEGRATION_TESTS_MARIADB_URL: ${{ matrix.entry.live_db && format('mysql://insight:insight@127.0.0.1:3306/{0}', matrix.entry.live_db_name) || '' }}
+          INTEGRATION_TESTS_CLICKHOUSE_URL: ${{ matrix.entry.live_ch && 'http://127.0.0.1:8123' || '' }}
+          INTEGRATION_TESTS_CLICKHOUSE_USER: ${{ matrix.entry.live_ch && 'insight' || '' }}
+          INTEGRATION_TESTS_CLICKHOUSE_PASSWORD: ${{ matrix.entry.live_ch && 'insight' || '' }}
         run: |
           set -euo pipefail
           mkdir -p "$GITHUB_WORKSPACE/coverage"
@@ -290,6 +307,9 @@ jobs:
         working-directory: ${{ matrix.entry.root }}
         env:
           INTEGRATION_TESTS_MARIADB_URL: ${{ matrix.entry.live_db && format('mysql://insight:insight@127.0.0.1:3306/{0}', matrix.entry.live_db_name) || '' }}
+          INTEGRATION_TESTS_CLICKHOUSE_URL: ${{ matrix.entry.live_ch && 'http://127.0.0.1:8123' || '' }}
+          INTEGRATION_TESTS_CLICKHOUSE_USER: ${{ matrix.entry.live_ch && 'insight' || '' }}
+          INTEGRATION_TESTS_CLICKHOUSE_PASSWORD: ${{ matrix.entry.live_ch && 'insight' || '' }}
         run: |
           set -euo pipefail
           feats=""

--- a/scripts/ci/changed.py
+++ b/scripts/ci/changed.py
@@ -43,6 +43,7 @@ def _matrix_entry(comp: dict, *, lint: bool = False, cover: bool = True, test: b
         entry["test"] = test
         entry["clippy"] = comp.get("clippy", True)  # False ⇒ fmt-only (see #1512)
         entry["live_db"] = comp.get("live_db", False)  # DB-backed live_tests (see #1564)
+        entry["live_ch"] = comp.get("live_ch", False)  # ClickHouse-backed live_tests (see #1564)
         # MariaDB database the CI provisions for live_db entries (defaults to
         # the component name — analytics owns `analytics`, identity-resolution
         # owns `identity`).
@@ -134,9 +135,7 @@ def main() -> int:
     ap = argparse.ArgumentParser(description="Emit the CI component matrix as JSON.")
     ap.add_argument("--all", action="store_true", help="emit ALL components, ignoring the diff (manual full run)")
     ap.add_argument(
-        "--compare-ref",
-        default=COMPARE_BRANCH,
-        help="compare HEAD with the merge-base of REF (default: origin/main)",
+        "--compare-ref", default=COMPARE_BRANCH, help="compare HEAD with the merge-base of REF (default: origin/main)"
     )
     args = ap.parse_args()
     matrix = all_components(COMPONENTS) if args.all else changed_components(args.compare_ref, COMPONENTS)

--- a/scripts/ci/components.py
+++ b/scripts/ci/components.py
@@ -42,9 +42,11 @@ COMPONENTS = [
         "package": "analytics",
         # DB-backed integration tests: the CI rust job provisions a MariaDB
         # service, runs `analytics migrate` once up front, then runs the
-        # `#[ignore]`d live_tests (INTEGRATION_TESTS_MARIADB_URL). ClickHouse
-        # tests skip (no INTEGRATION_TESTS_CLICKHOUSE_URL — see cf/insight#1564).
+        # `#[ignore]`d live_tests (INTEGRATION_TESTS_MARIADB_URL). live_ch
+        # additionally provisions a ClickHouse for the CH-gated live tests
+        # (INTEGRATION_TESTS_CLICKHOUSE_URL — see cf/insight#1564).
         "live_db": True,
+        "live_ch": True,
         # llvm-cov reports every instrumented file, including path-dependency
         # crates (insight-clickhouse) compiled into this binary. Those crates are
         # their OWN components with their own coverage jobs — counting them here

--- a/src/backend/services/analytics/src/api/metrics.rs
+++ b/src/backend/services/analytics/src/api/metrics.rs
@@ -279,16 +279,20 @@ mod probe_live_tests {
 
     const URL_VAR: &str = "INTEGRATION_TESTS_CLICKHOUSE_URL";
 
+    // Empty counts as unset: the CI matrix passes '' to entries without a
+    // provisioned ClickHouse, and set-but-empty must skip exactly like absent.
     fn client_or_skip() -> Option<insight_clickhouse::Client> {
-        let Ok(url) = std::env::var(URL_VAR) else {
+        let url = std::env::var(URL_VAR).unwrap_or_default();
+        if url.is_empty() {
             eprintln!("skipping: {URL_VAR} not set");
             return None;
-        };
+        }
         let mut config = insight_clickhouse::Config::new(url, "default");
         if let (Ok(user), Ok(password)) = (
             std::env::var("INTEGRATION_TESTS_CLICKHOUSE_USER"),
             std::env::var("INTEGRATION_TESTS_CLICKHOUSE_PASSWORD"),
-        ) {
+        ) && !user.is_empty()
+        {
             config = config.with_auth(user, password);
         }
         Some(insight_clickhouse::Client::new(config))

--- a/src/backend/services/analytics/src/domain/metric_results/compiler.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/compiler.rs
@@ -1218,11 +1218,16 @@ fn selected_entity_predicate(
     }
 }
 
+// INVARIANT: the bucket key must be non-nullable — a custom source may
+// declare `metric_date` as `Nullable(Date)`, and GROUPING SETS fills the
+// totals row's absent key with NULL instead of the default date, which the
+// row parser rejects. The date-range predicate has already dropped NULL
+// dates, so `assumeNotNull` never sees one.
 fn bucket_expr(bucket: Bucket) -> &'static str {
     match bucket {
-        Bucket::Day => "metric_date",
-        Bucket::Week => "toStartOfWeek(metric_date, 1)",
-        Bucket::Month => "toStartOfMonth(metric_date)",
+        Bucket::Day => "assumeNotNull(metric_date)",
+        Bucket::Week => "toStartOfWeek(assumeNotNull(metric_date), 1)",
+        Bucket::Month => "toStartOfMonth(assumeNotNull(metric_date))",
     }
 }
 
@@ -1658,11 +1663,11 @@ mod tests {
     }
 
     #[test]
-    fn timeseries_query_uses_bucket_expression() {
+    fn timeseries_query_buckets_on_a_non_nullable_date() {
         for (bucket, expr) in [
-            (Bucket::Day, "metric_date"),
-            (Bucket::Week, "toStartOfWeek(metric_date, 1)"),
-            (Bucket::Month, "toStartOfMonth(metric_date)"),
+            (Bucket::Day, "assumeNotNull(metric_date)"),
+            (Bucket::Week, "toStartOfWeek(assumeNotNull(metric_date), 1)"),
+            (Bucket::Month, "toStartOfMonth(assumeNotNull(metric_date))"),
         ] {
             let query = compile_timeseries_query(&sum_metric(), &request(), bucket, &[], &[], None);
             assert!(

--- a/src/backend/services/analytics/src/domain/metric_results/live_tests.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/live_tests.rs
@@ -1,0 +1,204 @@
+//! Live ClickHouse integration tests for the metric-results query path:
+//! compiled SQL executed for real, rows parsed exactly as the handler parses
+//! them (`JSONEachRow` lines into the typed query rows).
+//!
+//! `#[ignore]`d and skip silently when `INTEGRATION_TESTS_CLICKHOUSE_URL` is
+//! unset (same convention as the `probe_live_tests` in `api/metrics.rs`);
+//! optional auth via `INTEGRATION_TESTS_CLICKHOUSE_USER` /
+//! `INTEGRATION_TESTS_CLICKHOUSE_PASSWORD`.
+
+use chrono::NaiveDate;
+use serde::de::DeserializeOwned;
+use uuid::Uuid;
+
+use super::batch::{RankedDimension, RankedGroup, ResolvedGroupLimit};
+use super::builder::build_timeseries_view;
+use super::compiler::{CompiledQuery, TimeseriesQueryRow, compile_timeseries_query};
+use super::dto::MetricResultViewDto;
+use super::validation::{ValidatedEntitySelection, ValidatedMetricResultsRequest};
+use super::view::Bucket;
+use crate::domain::metric_definitions::definition::{
+    ComputationSpec, CustomObservationSql, MetricBase, MetricDefinition, MetricDirection,
+    MetricFormat, MetricInput, MetricInputRole, ObservationSource,
+};
+
+const URL_VAR: &str = "INTEGRATION_TESTS_CLICKHOUSE_URL";
+
+const TENANT: Uuid = Uuid::from_u128(0x2581);
+const PERSON: Uuid = Uuid::from_u128(0xfeed);
+
+fn client_or_skip() -> Option<insight_clickhouse::Client> {
+    let Ok(url) = std::env::var(URL_VAR) else {
+        eprintln!("skipping: {URL_VAR} not set");
+        return None;
+    };
+    let mut config = insight_clickhouse::Config::new(url, "default");
+    if let (Ok(user), Ok(password)) = (
+        std::env::var("INTEGRATION_TESTS_CLICKHOUSE_USER"),
+        std::env::var("INTEGRATION_TESTS_CLICKHOUSE_PASSWORD"),
+    ) {
+        config = config.with_auth(user, password);
+    }
+    Some(insight_clickhouse::Client::new(config))
+}
+
+/// A self-contained observation source projecting the full contract, with
+/// `metric_date` declared `Nullable(Date)` — the shape a custom metric's SQL
+/// is free to produce. Four rows, values 1..=4, one person.
+fn nullable_date_sql() -> String {
+    format!(
+        "SELECT \
+            '{TENANT}' AS tenant_id, \
+            'custom_repro' AS source_key, \
+            'person' AS entity_type, \
+            '{PERSON}' AS entity_id, \
+            CAST(toDate('2026-08-13') + number AS Nullable(Date)) AS metric_date, \
+            'repro_value' AS measure_key, \
+            now() AS observed_at, \
+            toFloat64(number + 1) AS value, \
+            CAST(NULL AS Nullable(String)) AS subject_key, \
+            CAST([] AS Array(Tuple(key String, value String, label Nullable(String)))) AS dimensions \
+        FROM numbers(4)"
+    )
+}
+
+fn nullable_date_metric() -> MetricDefinition {
+    MetricDefinition {
+        transform: None,
+        base: MetricBase {
+            key: "custom.nullable_date_repro".to_owned(),
+            label: "Nullable date repro".to_owned(),
+            short_label: None,
+            description: None,
+            explanation: None,
+            entity_type: "person".to_owned(),
+            format: MetricFormat::Integer,
+            unit: None,
+            direction: MetricDirection::HigherIsBetter,
+            peer_cohort_key: None,
+            allowed_dimensions: Vec::new(),
+        },
+        spec: ComputationSpec::Sum {
+            value: MetricInput {
+                role: MetricInputRole::Value,
+                observation: ObservationSource::Custom(CustomObservationSql::new(
+                    nullable_date_sql(),
+                )),
+                source_key: "custom_repro".to_owned(),
+                measure_key: "repro_value".to_owned(),
+            },
+        },
+    }
+}
+
+fn request() -> ValidatedMetricResultsRequest {
+    ValidatedMetricResultsRequest {
+        tenant_id: TENANT,
+        entity: ValidatedEntitySelection::Person { ids: vec![PERSON] },
+        from: NaiveDate::from_ymd_opt(2026, 8, 13).unwrap_or_default(),
+        to: NaiveDate::from_ymd_opt(2026, 8, 16).unwrap_or_default(),
+        metrics: Vec::new(),
+        enforce_tenant_scope: true,
+    }
+}
+
+/// The handler's row path: bind the compiled params, fetch `JSONEachRow`,
+/// parse each line into the typed row (`api/metric_results.rs::fetch_rows`).
+async fn fetch_rows<T: DeserializeOwned>(
+    ch: &insight_clickhouse::Client,
+    query: &CompiledQuery,
+) -> anyhow::Result<Vec<T>> {
+    let mut ch_query = ch.query(&query.sql);
+    for param in &query.params {
+        ch_query = ch_query.bind(param.as_str());
+    }
+
+    let raw_bytes = ch_query.fetch_bytes("JSONEachRow")?.collect().await?;
+    raw_bytes
+        .split(|&b| b == b'\n')
+        .filter(|line| !line.is_empty())
+        .map(|line| serde_json::from_slice(line).map_err(Into::into))
+        .collect()
+}
+
+#[tokio::test]
+#[ignore = "requires live ClickHouse; set INTEGRATION_TESTS_CLICKHOUSE_URL to enable"]
+async fn timeseries_over_nullable_metric_date_builds_every_bucket() -> anyhow::Result<()> {
+    let Some(ch) = client_or_skip() else {
+        return Ok(());
+    };
+    let def = nullable_date_metric();
+    let req = request();
+
+    for bucket in [Bucket::Day, Bucket::Week, Bucket::Month] {
+        let query = compile_timeseries_query(&def, &req, bucket, &[], &[], None);
+        let rows: Vec<TimeseriesQueryRow> = fetch_rows(&ch, &query)
+            .await
+            .map_err(|e| anyhow::anyhow!("bucket {bucket:?}: {e}"))?;
+
+        let view = build_timeseries_view(&def, &req, bucket, &[], rows)?;
+        let MetricResultViewDto::Timeseries { series, .. } = view else {
+            anyhow::bail!("bucket {bucket:?}: expected a timeseries view");
+        };
+        let [ref one] = series[..] else {
+            anyhow::bail!(
+                "bucket {bucket:?}: expected one series, got {}",
+                series.len()
+            );
+        };
+        anyhow::ensure!(
+            one.total == Some(10.0),
+            "bucket {bucket:?}: total must sum all four observations, got {:?}",
+            one.total
+        );
+        let observed: f64 = one.points.iter().filter_map(|point| point.value).sum();
+        anyhow::ensure!(
+            (observed - 10.0).abs() < f64::EPSILON,
+            "bucket {bucket:?}: bucketed points must carry the observations, got {observed}"
+        );
+    }
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore = "requires live ClickHouse; set INTEGRATION_TESTS_CLICKHOUSE_URL to enable"]
+async fn capped_timeseries_over_nullable_metric_date_builds() -> anyhow::Result<()> {
+    let Some(ch) = client_or_skip() else {
+        return Ok(());
+    };
+    let mut def = nullable_date_metric();
+    def.base.allowed_dimensions = vec!["tool".to_owned()];
+    let req = request();
+    let dimensions = vec!["tool".to_owned()];
+    let group_limit = ResolvedGroupLimit {
+        groups: vec![RankedGroup {
+            rank: 1,
+            dimensions: vec![RankedDimension {
+                value: "__unknown__".to_owned(),
+                label: None,
+            }],
+        }],
+        include_remainder: true,
+    };
+
+    let query = compile_timeseries_query(
+        &def,
+        &req,
+        Bucket::Day,
+        &dimensions,
+        &[],
+        Some(&group_limit),
+    );
+    let rows: Vec<TimeseriesQueryRow> = fetch_rows(&ch, &query).await?;
+
+    let view = build_timeseries_view(&def, &req, Bucket::Day, &dimensions, rows)?;
+    let MetricResultViewDto::Timeseries { series, .. } = view else {
+        anyhow::bail!("expected a timeseries view");
+    };
+    let total: f64 = series.iter().filter_map(|s| s.total).sum();
+    anyhow::ensure!(
+        (total - 10.0).abs() < f64::EPSILON,
+        "capped series totals must sum all four observations, got {total}"
+    );
+    Ok(())
+}

--- a/src/backend/services/analytics/src/domain/metric_results/live_tests.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/live_tests.rs
@@ -27,16 +27,20 @@ const URL_VAR: &str = "INTEGRATION_TESTS_CLICKHOUSE_URL";
 const TENANT: Uuid = Uuid::from_u128(0x2581);
 const PERSON: Uuid = Uuid::from_u128(0xfeed);
 
+// Empty counts as unset: the CI matrix passes '' to entries without a
+// provisioned ClickHouse, and set-but-empty must skip exactly like absent.
 fn client_or_skip() -> Option<insight_clickhouse::Client> {
-    let Ok(url) = std::env::var(URL_VAR) else {
+    let url = std::env::var(URL_VAR).unwrap_or_default();
+    if url.is_empty() {
         eprintln!("skipping: {URL_VAR} not set");
         return None;
-    };
+    }
     let mut config = insight_clickhouse::Config::new(url, "default");
     if let (Ok(user), Ok(password)) = (
         std::env::var("INTEGRATION_TESTS_CLICKHOUSE_USER"),
         std::env::var("INTEGRATION_TESTS_CLICKHOUSE_PASSWORD"),
-    ) {
+    ) && !user.is_empty()
+    {
         config = config.with_auth(user, password);
     }
     Some(insight_clickhouse::Client::new(config))

--- a/src/backend/services/analytics/src/domain/metric_results/mod.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/mod.rs
@@ -2,6 +2,8 @@ mod batch;
 mod builder;
 pub(crate) mod compiler;
 mod dto;
+#[cfg(test)]
+mod live_tests;
 mod validation;
 mod view;
 


### PR DESCRIPTION
Closes #2581.

**Why.** Selecting a custom metric whose observation SQL declares `metric_date` as `Nullable(Date)` turned every timeseries view into a 500, so the report never built — while `period` views for the same metric worked.

**What changed.** Timeseries queries now bucket on `assumeNotNull(metric_date)`. On a nullable column, GROUPING SETS fills the totals row's absent bucket key with NULL instead of the default date, which the `bucket_start: String` row parser rejects; the date-range predicate has already dropped NULL dates, so the wrap is safe and the totals row fills exactly as for a non-nullable column. Existing metrics start working without re-creation.

**CI now provisions ClickHouse for the analytics lane — the open half of #1564.** Without it the new live tests would skip silently; reuses `start-clickhouse.sh` and the `pins.env` image pin, mirroring the MariaDB wiring.

**Verified.** New `#[ignore]`d live ClickHouse tests reproduce the issue's exact parse error pre-fix (plain and capped timeseries, day/week/month buckets, synthetic `numbers(4)` source) and pass post-fix; the full analytics suite is green locally against a CI-shaped ClickHouse 25.7.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved analytics time-series results when metric dates are nullable.
  - Day, week, and month grouping now consistently handles missing dates.
  - Improved reliability when returning capped dimension results.

- **Tests**
  - Added integration coverage for ClickHouse-backed analytics queries, including date bucketing, authentication, and typed result handling.

- **Chores**
  - Updated continuous integration to provision ClickHouse for relevant analytics checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->