### PR TITLE
backport(jira): #2613 + #2816 + #2510 onto release-2026.07.1

### DIFF
--- a/.claude/skills/connector/workflows/create.md
+++ b/.claude/skills/connector/workflows/create.md
@@ -144,6 +144,13 @@ transformations:
 
 Only inject: `tenant_id`, `source_id`, `unique_key`, and optionally `raw_data` for configurable streams. Do NOT add `_source` or `_extracted_at` — dbt models handle source tagging, and Airbyte auto-generates `_airbyte_extracted_at`.
 
+Two hard rules for every `AddFields` target, each learned from silent data loss:
+
+- **Declare every `AddFields` target as `string` in the inline schema** (plus `"null"`). Jinja renders to a string, and the destination's typing step coerces it into the declared type: numbers and booleans coerce fine, but a declared `object`/deep ADF shape cannot be built from a string — the destination NULLs the field and records `{"change":"NULLED","reason":"DESTINATION_SERIALIZATION_ERROR"}` in `_airbyte_meta`, on every sync, while the source still has the data. A `tojson` projection is a string; declare it `string`, never the shape of the JSON inside it.
+- **Do not re-project payload fields the record already carries** (`email` ← `emailAddress`-style snake_case aliases). It doubles storage, forces the schema to describe the same value twice, and creates exactly the type-mismatch surface above. Renames and typing belong in the dbt staging model. The only values that may be injected are the ones that exist solely at extraction time: config values (`tenant_id`, `source_id`), `unique_key`, `stream_partition.*` context (a substream's parent id), and cursor hoists for nested `cursor_field` (see Common failure modes).
+
+Detection for the first rule on a live instance: `SELECT count() FROM <bronze_table> WHERE position(_airbyte_meta, 'NULLED') > 0` — anything non-zero means the destination is dropping fields.
+
 **Schema rules** — must match Builder output format:
 
 ```yaml

--- a/.claude/skills/connector/workflows/validate.md
+++ b/.claude/skills/connector/workflows/validate.md
@@ -88,6 +88,8 @@ Read connector package files and verify each item:
 - [ ] AddFields includes `source_id` from `config['insight_source_id']`
 - [ ] AddFields includes `unique_key` with pattern: `{tenant_id}-{source_id}-{natural_key}`
 - [ ] InlineSchemaLoader has `additionalProperties: true`
+- [ ] Every `AddFields` target is declared `string` (+ `"null"`) in the inline schema — Jinja emits strings; a target declared `object` gets NULLED by the destination (`DESTINATION_SERIALIZATION_ERROR` in `_airbyte_meta`) on every sync.
+- [ ] No `AddFields` re-projects a field the payload already carries (snake_case aliases of `emailAddress`, `displayName`, ...). Injected fields are limited to extraction-time values: config, `unique_key`, `stream_partition.*`, cursor hoists. Renames live in dbt.
 - [ ] Schema includes `tenant_id`, `source_id`, `unique_key` as string fields
 - [ ] Nullable types used only where API actually returns null (not all fields)
 - [ ] EVERY top-level stream — including lightweight substream parents added for cache hygiene — carries the full identity stamp and a `promote_bronze_to_rmt` line. Reconcile (ADR-0015) auto-selects every discovered stream, so "helper" top-level streams land as real bronze tables; without the stamp + RMT promotion they accumulate unbounded duplicates. Parent streams that must NOT become tables go inline inside `partition_router.parent_stream_configs[].stream` instead (invisible to discover).

--- a/src/ingestion/connectors/task-tracking/jira/README.md
+++ b/src/ingestion/connectors/task-tracking/jira/README.md
@@ -6,6 +6,12 @@ Extracts projects, users, issues, issue history (changelog), comments, worklogs,
 
 - **PRD**: [../../../../../docs/components/connectors/task-tracking/jira/specs/PRD.md](../../../../../docs/components/connectors/task-tracking/jira/specs/PRD.md)
 - **DESIGN**: [../../../../../docs/components/connectors/task-tracking/jira/specs/DESIGN.md](../../../../../docs/components/connectors/task-tracking/jira/specs/DESIGN.md)
+- [Deletion & visibility mechanism](specs/DELETION-AND-VISIBILITY.md) — how
+  deleted Jira entities are detected, distinguished from lost access, and
+  recorded as history events.
+- [Data completeness](specs/DATA-COMPLETENESS.md) — metadata-driven
+  story-points resolution, board configuration, project lead, and the
+  automated API-to-Bronze completeness checks.
 
 ## Prerequisites
 
@@ -42,6 +48,7 @@ stringData:
 | `jira_email` | Yes | Atlassian account email for Basic Auth |
 | `jira_api_token` | Yes | Atlassian API token. Marked `airbyte_secret: true` — never logged |
 | `jira_start_date` | No | Earliest date to sync issues from, `YYYY-MM-DD`. Default `2020-01-01` |
+| `jira_story_points_field_id` | No | Explicit override for the Story Points custom-field id. Leave unset — dbt resolves it from `/rest/api/3/field` metadata (see [specs/DATA-COMPLETENESS.md](specs/DATA-COMPLETENESS.md)) |
 
 ### Automatically injected
 
@@ -75,6 +82,10 @@ kubectl apply -f src/ingestion/secrets/connectors/jira.yaml
 | `jira_comments` | `GET /rest/api/3/issue/{key}/comment` | Substream of `jira_issue` | — | Offset |
 | `jira_worklogs` | `GET /rest/api/3/issue/{key}/worklog` | Substream of `jira_issue` | — | Offset |
 | `jira_sprints` | `GET /rest/agile/1.0/board/{board_id}/sprint` | Substream of boards | — | Offset |
+| `jira_project_visibility` | `GET /rest/api/3/project/search?status=<live\|archived\|deleted>` | Full refresh | — | Offset |
+| `jira_issue_census` | `GET /rest/api/3/search/jql` (`fields=id`) | Full refresh | — | Cursor (`nextPageToken`) |
+| `jira_worklog_deleted` | `GET /rest/api/3/worklog/deleted` | Full refresh | — | `nextPage` URL |
+| `jira_board_configuration` | `GET /rest/agile/1.0/board/{board_id}/configuration` | Substream of boards | — | None |
 
 The `jira_boards` stream (`GET /rest/agile/1.0/board`) is the substream parent for `jira_sprints` and materializes its own Bronze table.
 
@@ -94,6 +105,7 @@ The `jira_boards` stream (`GET /rest/agile/1.0/board`) is the substream parent f
 - **Rate limits**: Atlassian caps per-user and per-IP API calls. The connector honours `Retry-After` on HTTP 429 and 503 (both used by Atlassian for throttling) with backoff.
 - **Project scope**: projects are auto-discovered each sync via `/rest/api/3/project/search` (every project visible to the API token) and scanned per project (`project = "<KEY>"` JQL — Jira Cloud rejects unbounded queries). An incremental gate on `insight.lastIssueUpdateTime` (with a 3-day lookback) skips projects with no issue changes since the previous sync, so idle projects cost zero requests. New projects are picked up automatically on the next scheduled sync.
 - **Custom fields**: all custom fields are preserved in `jira_issue.custom_fields_json` for downstream dbt extraction.
+- **Deletions & lost access**: incremental sync cannot observe entities disappearing. The `jira_project_visibility` + `jira_issue_census` full-refresh streams re-observe the visible surface every sync; dbt classifies absences as `deleted` / `archived` / `trashed` / `access_lost` / `unobserved` and records each transition as a permanent history event. See [specs/DELETION-AND-VISIBILITY.md](specs/DELETION-AND-VISIBILITY.md).
 
 ## Related
 

--- a/src/ingestion/connectors/task-tracking/jira/connector.yaml
+++ b/src/ingestion/connectors/task-tracking/jira/connector.yaml
@@ -6589,30 +6589,17 @@ streams:
               - string
               - "null"
           items:
-            anyOf:
-              - type: string
-              - type: array
-                items:
-                  type: object
-                  properties:
-                    field:
-                      type: string
-                    fieldId:
-                      type: string
-                    fieldtype:
-                      type: string
-                    from:
-                      type: string
-                    fromString:
-                      type: string
-                    to:
-                      type: string
-                    toString:
-                      type: string
-                    tmpFromAccountId:
-                      type: string
-                    tmpToAccountId:
-                      type: string
+            # Plain string, NOT `anyOf: [string, array]`. The AddFields
+            # transformation renders this column with `| tojson`; the CDK then
+            # re-parses that render with ast.literal_eval, which fails on JSON
+            # `null` and leaves the value a string. Under a string/array union
+            # the destination JSON-encodes that string, storing an escaped blob
+            # `"[{\"field\": ...}]"` that JSONExtractArrayRaw cannot read —
+            # every changelog item whose previous value was empty is lost that
+            # way. A plain string declaration stores the render verbatim.
+            type:
+              - string
+              - "null"
           tenant_id:
             type:
               - string

--- a/src/ingestion/connectors/task-tracking/jira/connector.yaml
+++ b/src/ingestion/connectors/task-tracking/jira/connector.yaml
@@ -40,9 +40,7 @@ definitions:
         # jira_project_discovery partition router (see definitions), not from
         # config — the manual jira_project_keys allowlist is gone.
         jql: >-
-          project = "{{ stream_partition.project_key }}" AND updated >= "{{
-          stream_slice.start_time }}" AND updated <= "{{ stream_slice.end_time
-          }}" ORDER BY updated ASC
+          project = "{{ stream_partition.project_key }}" AND updated >= "{{ stream_slice.start_time }}" AND updated <= "{{ stream_slice.end_time }}" ORDER BY updated ASC
         expand: names
         fields: "*all"
     SimpleRetriever:
@@ -123,8 +121,7 @@ definitions:
             path:
               - last_issue_update_time
             value: >-
-              {{ (record.get('insight') or {}).get('lastIssueUpdateTime') or
-              '1970-01-01T00:00:00.000+0000' }}
+              {{ (record.get('insight') or {}).get('lastIssueUpdateTime') or '1970-01-01T00:00:00.000+0000' }}
     incremental_sync:
       type: DatetimeBasedCursor
       cursor_field: last_issue_update_time
@@ -254,6 +251,22 @@ streams:
             type:
               - boolean
               - "null"
+          tenant_id:
+            type:
+              - string
+              - "null"
+          source_id:
+            type:
+              - string
+              - "null"
+          unique_key:
+            type:
+              - string
+              - "null"
+          collected_at:
+            type:
+              - string
+              - "null"
         required:
           - id
         additionalProperties: true
@@ -274,8 +287,7 @@ streams:
             path:
               - unique_key
             value: >-
-              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record['id'] }}
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}
           - type: AddedFieldDefinition
             path:
               - collected_at
@@ -318,8 +330,7 @@ streams:
             path:
               - unique_key
             value: >-
-              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record['id'] }}
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}
           - type: AddedFieldDefinition
             path:
               - field_id
@@ -522,8 +533,7 @@ streams:
             path:
               - unique_key
             value: >-
-              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record['id'] }}
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}
           - type: AddedFieldDefinition
             path:
               - project_id
@@ -730,8 +740,7 @@ streams:
             path:
               - unique_key
             value: >-
-              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record['accountId'] }}
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['accountId'] }}
           - type: AddedFieldDefinition
             path:
               - account_id
@@ -949,8 +958,7 @@ streams:
             path:
               - unique_key
             value: >-
-              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record['key'] }}
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['key'] }}
           - type: AddedFieldDefinition
             path:
               - jira_id
@@ -983,14 +991,12 @@ streams:
             path:
               - assignee_id
             value: >-
-              {{ ((record.get('fields') or {}).get('assignee') or
-              {}).get('accountId') }}
+              {{ ((record.get('fields') or {}).get('assignee') or {}).get('accountId') }}
           - type: AddedFieldDefinition
             path:
               - reporter_id
             value: >-
-              {{ ((record.get('fields') or {}).get('reporter') or
-              {}).get('accountId') }}
+              {{ ((record.get('fields') or {}).get('reporter') or {}).get('accountId') }}
           - type: AddedFieldDefinition
             path:
               - parent_id
@@ -1003,8 +1009,7 @@ streams:
             path:
               - story_points
             value: >-
-              {{ (record.get('fields') or {}).get(config.get('jira_story_points_field_id',
-              'customfield_10016')) or (record.get('fields') or {}).get('story_points') }}
+              {{ (record.get('fields') or {}).get(config.get('jira_story_points_field_id', 'customfield_10016')) or (record.get('fields') or {}).get('story_points') }}
           - type: AddedFieldDefinition
             path:
               - due_date
@@ -6447,8 +6452,7 @@ streams:
         error_handler:
           $ref: "#/definitions/linked/HttpRequester/error_handler"
         url: >-
-          {{ config['jira_instance_url'] }}/rest/api/3/issue/{{
-          stream_partition.id_readable }}/changelog
+          {{ config['jira_instance_url'] }}/rest/api/3/issue/{{ stream_partition.id_readable }}/changelog
       partition_router:
         type: SubstreamPartitionRouter
         parent_stream_configs:
@@ -6491,8 +6495,7 @@ streams:
             path:
               - unique_key
             value: >-
-              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record['id'] }}
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}
           - type: AddedFieldDefinition
             path:
               - id_readable
@@ -6665,8 +6668,7 @@ streams:
         error_handler:
           $ref: "#/definitions/linked/HttpRequester/error_handler"
         url: >-
-          {{ config['jira_instance_url'] }}/rest/api/3/issue/{{
-          stream_partition.id_readable }}/comment
+          {{ config['jira_instance_url'] }}/rest/api/3/issue/{{ stream_partition.id_readable }}/comment
       partition_router:
         type: SubstreamPartitionRouter
         parent_stream_configs:
@@ -6709,8 +6711,7 @@ streams:
             path:
               - unique_key
             value: >-
-              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record['id'] }}
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}
           - type: AddedFieldDefinition
             path:
               - comment_id
@@ -6809,134 +6810,8 @@ streams:
                   - "null"
           body:
             type:
-              - object
+              - string
               - "null"
-            properties:
-              version:
-                type:
-                  - number
-                  - "null"
-              type:
-                type:
-                  - string
-                  - "null"
-              content:
-                type:
-                  - array
-                  - "null"
-                items:
-                  type:
-                    - object
-                    - "null"
-                  properties:
-                    type:
-                      type:
-                        - string
-                        - "null"
-                    content:
-                      type:
-                        - array
-                        - "null"
-                      items:
-                        type:
-                          - object
-                          - "null"
-                        properties:
-                          type:
-                            type:
-                              - string
-                              - "null"
-                          text:
-                            type:
-                              - string
-                              - "null"
-                          marks:
-                            type:
-                              - array
-                              - "null"
-                            items:
-                              type:
-                                - object
-                                - "null"
-                              properties:
-                                type:
-                                  type:
-                                    - string
-                                    - "null"
-                                attrs:
-                                  type:
-                                    - object
-                                    - "null"
-                                  properties:
-                                    href:
-                                      type:
-                                        - string
-                                        - "null"
-                          attrs:
-                            type:
-                              - object
-                              - "null"
-                            properties:
-                              url:
-                                type:
-                                  - string
-                                  - "null"
-                          content:
-                            type:
-                              - array
-                              - "null"
-                            items:
-                              type:
-                                - object
-                                - "null"
-                              properties:
-                                type:
-                                  type:
-                                    - string
-                                    - "null"
-                                content:
-                                  type:
-                                    - array
-                                    - "null"
-                                  items:
-                                    type:
-                                      - object
-                                      - "null"
-                                    properties:
-                                      type:
-                                        type:
-                                          - string
-                                          - "null"
-                                      text:
-                                        type:
-                                          - string
-                                          - "null"
-                                      marks:
-                                        type:
-                                          - array
-                                          - "null"
-                                        items:
-                                          type:
-                                            - object
-                                            - "null"
-                                          properties:
-                                            type:
-                                              type:
-                                                - string
-                                                - "null"
-                    attrs:
-                      type:
-                        - object
-                        - "null"
-                      properties:
-                        level:
-                          type:
-                            - number
-                            - "null"
-                        order:
-                          type:
-                            - number
-                            - "null"
           updateAuthor:
             type:
               - object
@@ -7065,8 +6940,7 @@ streams:
         error_handler:
           $ref: "#/definitions/linked/HttpRequester/error_handler"
         url: >-
-          {{ config['jira_instance_url'] }}/rest/api/3/issue/{{
-          stream_partition.id_readable }}/worklog
+          {{ config['jira_instance_url'] }}/rest/api/3/issue/{{ stream_partition.id_readable }}/worklog
       partition_router:
         type: SubstreamPartitionRouter
         parent_stream_configs:
@@ -7109,8 +6983,7 @@ streams:
             path:
               - unique_key
             value: >-
-              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record['id'] }}
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}
           - type: AddedFieldDefinition
             path:
               - worklog_id
@@ -7135,8 +7008,7 @@ streams:
             path:
               - comment
             value: >-
-              {{ record.get('comment', '') | tojson if record.get('comment') is
-              mapping else record.get('comment', '') }}
+              {{ record.get('comment', '') | tojson if record.get('comment') is mapping else record.get('comment', '') }}
           - type: AddedFieldDefinition
             path:
               - collected_at
@@ -7346,8 +7218,7 @@ streams:
         error_handler:
           $ref: "#/definitions/linked/HttpRequester/error_handler"
         url: >-
-          {{ config['jira_instance_url'] }}/rest/agile/1.0/board/{{
-          stream_partition.board_id }}/sprint
+          {{ config['jira_instance_url'] }}/rest/agile/1.0/board/{{ stream_partition.board_id }}/sprint
       partition_router:
         type: SubstreamPartitionRouter
         parent_stream_configs:
@@ -7399,8 +7270,7 @@ streams:
             path:
               - unique_key
             value: >-
-              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record['id'] }}
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}
           - type: AddedFieldDefinition
             path:
               - sprint_id
@@ -7559,8 +7429,7 @@ streams:
             path:
               - unique_key
             value: >-
-              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record['id'] }}
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}
           - type: AddedFieldDefinition
             path:
               - status_id
@@ -7729,8 +7598,7 @@ streams:
             path:
               - unique_key
             value: >-
-              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record['id'] }}
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}
           - type: AddedFieldDefinition
             path:
               - priority_id
@@ -7832,8 +7700,7 @@ streams:
             path:
               - unique_key
             value: >-
-              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record['id'] }}
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}
           - type: AddedFieldDefinition
             path:
               - issuetype_id
@@ -7977,8 +7844,7 @@ streams:
             path:
               - unique_key
             value: >-
-              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record['id'] }}
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}
           - type: AddedFieldDefinition
             path:
               - resolution_id
@@ -8088,9 +7954,7 @@ streams:
           $ref: "#/definitions/linked/HttpRequester/error_handler"
         request_parameters:
           jql: >-
-            project = "{{ stream_partition.project_key }}" AND updated >= "{{
-            stream_slice.start_time }}" AND updated <= "{{ stream_slice.end_time
-            }}" ORDER BY updated ASC
+            project = "{{ stream_partition.project_key }}" AND updated >= "{{ stream_slice.start_time }}" AND updated <= "{{ stream_slice.end_time }}" ORDER BY updated ASC
           fields: updated
         url: "{{ config['jira_instance_url'] }}/rest/api/3/search/jql"
       partition_router:
@@ -8157,8 +8021,7 @@ streams:
             path:
               - unique_key
             value: >-
-              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id']
-              }}-{{ record['key'] }}
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['key'] }}
           - type: AddedFieldDefinition
             path:
               - id_readable
@@ -8267,8 +8130,7 @@ spec:
       jira_story_points_field_id:
         type: string
         description: >-
-          Instance-specific custom field ID for Story Points (e.g.,
-          customfield_10016 for Next-gen). Leave default if unsure.
+          Instance-specific custom field ID for Story Points (e.g., customfield_10016 for Next-gen). Leave default if unsure.
         title: Story Points Field ID
         default: customfield_10016
         order: 8

--- a/src/ingestion/connectors/task-tracking/jira/connector.yaml
+++ b/src/ingestion/connectors/task-tracking/jira/connector.yaml
@@ -163,6 +163,56 @@ definitions:
               - "null"
         additionalProperties: true
 
+  # ─── Census parent (specs/DELETION-AND-VISIBILITY.md) ──────────────────
+  # Inline-only parent for jira_issue_census: lists every live project the
+  # account can browse, with NO incremental gate. jira_project_discovery must
+  # never drive the census — its insight.lastIssueUpdateTime gate skips idle
+  # projects, and a deletion does not reliably bump that aggregate, so a
+  # gated census would miss exactly the disappearances it exists to observe.
+  # Parent responses are tiny (id/key per project), so the CDK's SQLite
+  # substream-parent cache stays small.
+  jira_census_projects:
+    type: DeclarativeStream
+    name: jira_census_projects
+    primary_key:
+      - project_key
+    retriever:
+      type: SimpleRetriever
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - values
+      paginator:
+        $ref: "#/definitions/linked/SimpleRetriever/paginator"
+      requester:
+        type: HttpRequester
+        http_method: GET
+        authenticator:
+          $ref: "#/definitions/linked/HttpRequester/authenticator"
+        error_handler:
+          $ref: "#/definitions/linked/HttpRequester/error_handler"
+        url: "{{ config['jira_instance_url'] }}/rest/api/3/project/search"
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - project_key
+            value: "{{ record['key'] }}"
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          project_key:
+            type:
+              - string
+              - "null"
+        additionalProperties: true
+
 streams:
   - type: DeclarativeStream
     name: jira_boards
@@ -515,6 +565,10 @@ streams:
           $ref: "#/definitions/linked/HttpRequester/authenticator"
         error_handler:
           $ref: "#/definitions/linked/HttpRequester/error_handler"
+        # expand=lead: without it /project/search omits the lead object and
+        # the lead_account_id stamp below is always empty (bronze gap, #2419).
+        request_parameters:
+          expand: lead
         url: "{{ config['jira_instance_url'] }}/rest/api/3/project/search"
     transformations:
       - type: AddFields
@@ -675,6 +729,14 @@ streams:
           archived:
             type:
               - boolean
+              - "null"
+          lead:
+            type:
+              - object
+              - "null"
+          lead_account_id:
+            type:
+              - string
               - "null"
           collected_at:
             type:
@@ -1005,11 +1067,16 @@ streams:
             path:
               - labels_csv
             value: "{{ ((record.get('fields') or {}).get('labels') or []) | join(',') }}"
+          # No hardcoded field-id fallback: story-points custom-field ids are
+          # instance-specific and a wrong guess silently reads the wrong field
+          # (or nothing). The config key remains as an explicit operator
+          # override; the authoritative resolution happens in dbt from
+          # bronze_jira.jira_fields metadata (specs/DATA-COMPLETENESS.md).
           - type: AddedFieldDefinition
             path:
               - story_points
             value: >-
-              {{ (record.get('fields') or {}).get(config.get('jira_story_points_field_id', 'customfield_10016')) or (record.get('fields') or {}).get('story_points') }}
+              {{ (record.get('fields') or {}).get(config.get('jira_story_points_field_id', '')) or (record.get('fields') or {}).get('story_points') }}
           - type: AddedFieldDefinition
             path:
               - due_date
@@ -8071,6 +8138,579 @@ streams:
           - updated
         additionalProperties: true
 
+  # ─── Deletion & visibility censuses (specs/DELETION-AND-VISIBILITY.md) ──
+  # Both streams are full-refresh: each sync re-observes the complete visible
+  # surface. After RMT promotion (version = _airbyte_extracted_at) each row's
+  # extracted-at is the entity's last-seen timestamp; dbt classifies absences
+  # against the census high-water mark (deleted / archived / trashed /
+  # access_lost / unobserved) — see dbt/jira__issue_availability_state.sql.
+
+  # Roster of every project the account can see, per lifecycle status.
+  # Presence in /project/search IS the Browse-permission check: the endpoint
+  # returns only projects the caller can browse. status=deleted means the
+  # project sits in Jira's trash (retention window before permanent purge).
+  - type: DeclarativeStream
+    name: jira_project_visibility
+    primary_key:
+      - unique_key
+    retriever:
+      type: SimpleRetriever
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - values
+      paginator:
+        $ref: "#/definitions/linked/SimpleRetriever/paginator"
+      requester:
+        type: HttpRequester
+        http_method: GET
+        authenticator:
+          $ref: "#/definitions/linked/HttpRequester/authenticator"
+        error_handler:
+          $ref: "#/definitions/linked/HttpRequester/error_handler"
+        request_parameters:
+          status: "{{ stream_partition.project_status }}"
+        url: "{{ config['jira_instance_url'] }}/rest/api/3/project/search"
+      partition_router:
+        type: ListPartitionRouter
+        cursor_field: project_status
+        values:
+          - live
+          - archived
+          - deleted
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - tenant_id
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - source_id
+            value: "{{ config['insight_source_id'] }}"
+      - type: AddFields
+        fields:
+          # Keyed by immutable numeric project id, not by key: project keys
+          # can be renamed, and a rename must not look like access loss.
+          - type: AddedFieldDefinition
+            path:
+              - unique_key
+            value: >-
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}
+          - type: AddedFieldDefinition
+            path:
+              - project_id
+            value: "{{ record['id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - project_key
+            value: "{{ record['key'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - project_status
+            value: "{{ stream_partition.project_status }}"
+          - type: AddedFieldDefinition
+            path:
+              - is_private
+            value: "{{ record.get('isPrivate', false) }}"
+          - type: AddedFieldDefinition
+            path:
+              - collected_at
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z' }}"
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          expand:
+            type:
+              - string
+              - "null"
+          self:
+            type:
+              - string
+              - "null"
+          id:
+            type:
+              - string
+              - "null"
+          key:
+            type:
+              - string
+              - "null"
+          name:
+            type:
+              - string
+              - "null"
+          avatarUrls:
+            type:
+              - object
+              - "null"
+          projectCategory:
+            type:
+              - object
+              - "null"
+          projectTypeKey:
+            type:
+              - string
+              - "null"
+          simplified:
+            type:
+              - boolean
+              - "null"
+          style:
+            type:
+              - string
+              - "null"
+          isPrivate:
+            type:
+              - boolean
+              - "null"
+          properties:
+            type:
+              - object
+              - "null"
+          tenant_id:
+            type:
+              - string
+              - "null"
+          source_id:
+            type:
+              - string
+              - "null"
+          unique_key:
+            type: string
+          # CDK interpolation literal-evals the rendered Jinja value, so the
+          # numeric-string API id becomes an int — declared number, like
+          # jira_projects.project_id.
+          project_id:
+            type:
+              - number
+              - "null"
+          project_key:
+            type:
+              - string
+              - "null"
+          project_status:
+            type: string
+          is_private:
+            type:
+              - boolean
+              - "null"
+          collected_at:
+            type:
+              - string
+              - "null"
+        required:
+          - unique_key
+          - project_status
+        additionalProperties: true
+
+  # Id-only sweep of ALL issues in every visible live project. Jira Cloud
+  # serves large pages when only `id` is requested (maxResults up to 5000),
+  # so the census costs ceil(issues/5000) requests per
+  # project. Keyed by numeric issue id, never by key: moving an issue between
+  # projects changes its key but not its id — a key-based census would report
+  # every moved issue as deleted.
+  - type: DeclarativeStream
+    name: jira_issue_census
+    primary_key:
+      - unique_key
+    retriever:
+      type: SimpleRetriever
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - issues
+      paginator:
+        type: DefaultPaginator
+        page_size_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: maxResults
+        page_token_option:
+          type: RequestOption
+          inject_into: request_parameter
+          field_name: nextPageToken
+        pagination_strategy:
+          type: CursorPagination
+          page_size: 5000
+          cursor_value: "{{ response.get('nextPageToken', '') }}"
+          stop_condition: "{{ not response.get('nextPageToken') }}"
+      requester:
+        type: HttpRequester
+        http_method: GET
+        authenticator:
+          $ref: "#/definitions/linked/HttpRequester/authenticator"
+        error_handler:
+          $ref: "#/definitions/linked/HttpRequester/error_handler"
+        request_parameters:
+          jql: >-
+            project = "{{ stream_partition.project_key }}" ORDER BY created ASC
+          fields: id
+        url: "{{ config['jira_instance_url'] }}/rest/api/3/search/jql"
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: project_key
+            partition_field: project_key
+            stream:
+              $ref: "#/definitions/jira_census_projects"
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - tenant_id
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - source_id
+            value: "{{ config['insight_source_id'] }}"
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - unique_key
+            value: >-
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['id'] }}
+          - type: AddedFieldDefinition
+            path:
+              - jira_id
+            value: "{{ record['id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - project_key
+            value: "{{ stream_partition.project_key }}"
+          - type: AddedFieldDefinition
+            path:
+              - collected_at
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z' }}"
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          id:
+            type:
+              - string
+              - "null"
+          tenant_id:
+            type:
+              - string
+              - "null"
+          source_id:
+            type:
+              - string
+              - "null"
+          unique_key:
+            type: string
+          # Declared string like every other stream carrying jira_id (the
+          # 2.4.0 consistency rule — see migration 20260723000000): bronze
+          # jira_issue.jira_id is String and dbt joins the two directly.
+          jira_id:
+            type:
+              - string
+              - "null"
+          project_key:
+            type:
+              - string
+              - "null"
+          collected_at:
+            type:
+              - string
+              - "null"
+        required:
+          - unique_key
+        additionalProperties: true
+
+  # ─── Worklog deletion tombstones (specs/DELETION-AND-VISIBILITY.md) ─────
+  # /rest/api/3/worklog/deleted is the one Jira surface where deletions are
+  # first-class: every deleted worklog id with its deletion timestamp. The
+  # list is small and bounded (one row per ever-deleted worklog), so the
+  # stream re-reads it in full each sync — same census philosophy as
+  # jira_issue_census, no cursor state to corrupt. Pagination: the API pages
+  # via a `nextPage` URL that carries since=<until>; the paginator swaps the
+  # request URL wholesale (RequestPath token), so the initial `since=0` baked
+  # into the url never conflicts with the page token.
+  - type: DeclarativeStream
+    name: jira_worklog_deleted
+    primary_key:
+      - unique_key
+    retriever:
+      type: SimpleRetriever
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path:
+            - values
+      paginator:
+        type: DefaultPaginator
+        page_token_option:
+          type: RequestPath
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ response.get('nextPage', '') }}"
+          stop_condition: "{{ response.get('lastPage', true) }}"
+      requester:
+        type: HttpRequester
+        http_method: GET
+        authenticator:
+          $ref: "#/definitions/linked/HttpRequester/authenticator"
+        error_handler:
+          $ref: "#/definitions/linked/HttpRequester/error_handler"
+        url: "{{ config['jira_instance_url'] }}/rest/api/3/worklog/deleted?since=0"
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - tenant_id
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - source_id
+            value: "{{ config['insight_source_id'] }}"
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - unique_key
+            value: >-
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ record['worklogId'] }}
+          - type: AddedFieldDefinition
+            path:
+              - worklog_id
+            value: "{{ record['worklogId'] }}"
+          # The API calls it updatedTime, but on this endpoint it IS the
+          # deletion timestamp (epoch millis).
+          - type: AddedFieldDefinition
+            path:
+              - deleted_at_ms
+            value: "{{ record['updatedTime'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - collected_at
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z' }}"
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          worklogId:
+            type:
+              - number
+              - "null"
+          updatedTime:
+            type:
+              - number
+              - "null"
+          properties:
+            type:
+              - array
+              - "null"
+          tenant_id:
+            type:
+              - string
+              - "null"
+          source_id:
+            type:
+              - string
+              - "null"
+          unique_key:
+            type: string
+          worklog_id:
+            type:
+              - number
+              - "null"
+          deleted_at_ms:
+            type:
+              - number
+              - "null"
+          collected_at:
+            type:
+              - string
+              - "null"
+        required:
+          - unique_key
+        additionalProperties: true
+
+  # ─── Board configuration (specs/DATA-COMPLETENESS.md) ──────────────────
+  # /board/{id}/configuration carries the board's estimation field (the
+  # instance's actual Story Points custom-field id), the column-to-status
+  # mapping and the board location. One request per board.
+  - type: DeclarativeStream
+    name: jira_board_configuration
+    primary_key:
+      - unique_key
+    retriever:
+      type: SimpleRetriever
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: []
+      paginator:
+        type: NoPagination
+      requester:
+        type: HttpRequester
+        http_method: GET
+        authenticator:
+          $ref: "#/definitions/linked/HttpRequester/authenticator"
+        error_handler:
+          $ref: "#/definitions/linked/HttpRequester/error_handler"
+        url: >-
+          {{ config['jira_instance_url'] }}/rest/agile/1.0/board/{{ stream_partition.board_id }}/configuration
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: id
+            partition_field: board_id
+            stream:
+              $ref: "#/streams/0"
+    transformations:
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - tenant_id
+            value: "{{ config['insight_tenant_id'] }}"
+          - type: AddedFieldDefinition
+            path:
+              - source_id
+            value: "{{ config['insight_source_id'] }}"
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path:
+              - unique_key
+            value: >-
+              {{ config['insight_tenant_id'] }}-{{ config['insight_source_id'] }}-{{ stream_partition.board_id }}
+          - type: AddedFieldDefinition
+            path:
+              - board_id
+            value: "{{ stream_partition.board_id }}"
+          - type: AddedFieldDefinition
+            path:
+              - board_type
+            value: "{{ record.get('type') }}"
+          - type: AddedFieldDefinition
+            path:
+              - estimation_field_id
+            value: >-
+              {{ ((record.get('estimation') or {}).get('field') or {}).get('fieldId') }}
+          - type: AddedFieldDefinition
+            path:
+              - estimation_field_name
+            value: >-
+              {{ ((record.get('estimation') or {}).get('field') or {}).get('displayName') }}
+          - type: AddedFieldDefinition
+            path:
+              - column_config
+            value: "{{ (record.get('columnConfig') or {}) | tojson }}"
+          - type: AddedFieldDefinition
+            path:
+              - board_location
+            value: "{{ (record.get('location') or {}) | tojson }}"
+          - type: AddedFieldDefinition
+            path:
+              - collected_at
+            value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%S.%f')[:-3] + 'Z' }}"
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        type: object
+        $schema: http://json-schema.org/schema#
+        properties:
+          id:
+            type:
+              - number
+              - "null"
+          name:
+            type:
+              - string
+              - "null"
+          type:
+            type:
+              - string
+              - "null"
+          self:
+            type:
+              - string
+              - "null"
+          filter:
+            type:
+              - object
+              - "null"
+          columnConfig:
+            type:
+              - object
+              - "null"
+          estimation:
+            type:
+              - object
+              - "null"
+          ranking:
+            type:
+              - object
+              - "null"
+          location:
+            type:
+              - object
+              - "null"
+          tenant_id:
+            type:
+              - string
+              - "null"
+          source_id:
+            type:
+              - string
+              - "null"
+          unique_key:
+            type: string
+          board_id:
+            type:
+              - number
+              - "null"
+          board_type:
+            type:
+              - string
+              - "null"
+          estimation_field_id:
+            type:
+              - string
+              - "null"
+          estimation_field_name:
+            type:
+              - string
+              - "null"
+          column_config:
+            type:
+              - string
+              - "null"
+          board_location:
+            type:
+              - string
+              - "null"
+          collected_at:
+            type:
+              - string
+              - "null"
+        required:
+          - unique_key
+        additionalProperties: true
+
 spec:
   type: Spec
   connection_specification:
@@ -8117,9 +8757,8 @@ spec:
       jira_story_points_field_id:
         type: string
         description: >-
-          Instance-specific custom field ID for Story Points (e.g., customfield_10016 for Next-gen). Leave default if unsure.
-        title: Story Points Field ID
-        default: customfield_10016
+          Optional operator override for the instance-specific Story Points custom field ID (e.g., customfield_10016). Leave unset to let dbt resolve it automatically from the /rest/api/3/field metadata.
+        title: Story Points Field ID (override)
         order: 8
     additionalProperties: true
 

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__availability_events.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__availability_events.sql
@@ -1,0 +1,69 @@
+-- depends_on: {{ ref('jira__bronze_promoted') }}
+{{ config(
+    materialized='incremental',
+    alias='jira__availability_events',
+    incremental_strategy='append',
+    schema='staging',
+    engine='ReplacingMergeTree(_version)',
+    order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
+    tags=['jira', 'silver', 'silver:class_task_field_history'],
+    query_settings={'join_use_nulls': 1}
+) }}
+
+-- Availability transitions as synthetic field-history events
+-- (specs/DELETION-AND-VISIBILITY.md). Deletion, lost access and re-appearance
+-- enter silver.class_task_field_history exactly like any other field change
+-- (field_id = 'availability', event_kind = 'availability'), so the entire
+-- lifecycle of an issue — including how it disappeared — lives in ONE
+-- source-agnostic table. How absence is DETECTED is a per-connector detail
+-- (here: the census streams); other task trackers emit the same events from
+-- whatever deletion signal their API exposes.
+--
+-- Column order must match staging.jira__task_field_history exactly:
+-- union_by_tag concatenates the arms positionally.
+
+SELECT
+    concat(COALESCE(h.source_id, ''), '-jira-', COALESCE(h.entity_id, ''),
+           '-availability-', event_id)                          AS unique_key,
+    COALESCE(h.source_id, '')                                   AS insight_source_id,
+    CAST('jira' AS String)                                      AS data_source,
+    COALESCE(h.entity_id, '')                                   AS issue_id,
+    COALESCE(st.id_readable, '')                                AS id_readable,
+    CAST(NULL AS Nullable(String))                              AS title,
+    event_id                                                    AS event_id,
+    toDateTime64(h.updated_at, 3)                               AS event_at,
+    CAST('availability', 'Enum8(\'changelog\' = 1, \'synthetic_initial\' = 2, \'availability\' = 3, \'lifecycle\' = 4)')
+                                                                AS event_kind,
+    toUInt32(0)                                                 AS _seq,
+    CAST(NULL AS Nullable(String))                              AS author_id,
+    CAST(NULL AS Nullable(String))                              AS author_display,
+    CAST('availability' AS String)                              AS field_id,
+    CAST('Availability' AS String)                              AS field_name,
+    CAST('single', 'Enum8(\'single\' = 1, \'multi\' = 2)')      AS field_cardinality,
+    CAST('set', 'Enum8(\'set\' = 1, \'add\' = 2, \'remove\' = 3)') AS delta_action,
+    CAST(NULL AS Nullable(String))                              AS delta_value_id,
+    toNullable(h.new_value)                                     AS delta_value_display,
+    CAST([h.new_value] AS Array(String))                        AS value_ids,
+    CAST([h.new_value] AS Array(String))                        AS value_displays,
+    CAST('string_literal', 'Enum8(\'opaque_id\' = 1, \'account_id\' = 2, \'string_literal\' = 3, \'path\' = 4, \'none\' = 5)')
+                                                                AS value_id_type,
+    toDateTime64(h.updated_at, 3)                               AS collected_at,
+    -- UInt64 like the Rust-written staging table; the union arms must agree.
+    toUInt64(toUnixTimestamp64Milli(now64(3)))                  AS _version
+FROM (
+    -- event_id carries the issue id: the ADR-005 audit grain is
+    -- (insight_source_id, data_source, id_readable, field_id, event_id), and
+    -- census-only issues have an empty id_readable — without the issue id in
+    -- event_id, every detection of one run would collapse into one grain.
+    SELECT
+        *,
+        concat('availability:', COALESCE(entity_id, ''), ':',
+               toString(toUnixTimestamp64Milli(toDateTime64(updated_at, 3)))) AS event_id
+    FROM {{ ref('jira__issue_availability_history') }}
+    WHERE field_name = 'availability'
+) AS h
+LEFT JOIN {{ ref('jira__issue_availability_state') }} AS st FINAL
+    ON st.tenant_id = h.tenant_id
+    AND st.source_id = h.source_id
+    AND st.jira_id = h.entity_id

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__bronze_promoted.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__bronze_promoted.sql
@@ -74,5 +74,13 @@
 {% do promote_bronze_to_rmt(table='bronze_jira.jira_issuetypes',    order_by='unique_key') %}
 {% do promote_bronze_to_rmt(table='bronze_jira.jira_priorities',    order_by='unique_key') %}
 {% do promote_bronze_to_rmt(table='bronze_jira.jira_resolutions',   order_by='unique_key') %}
+{# Census tables (specs/DELETION-AND-VISIBILITY.md): full-refresh streams that
+   re-observe the whole visible surface each sync. RMT(_airbyte_extracted_at)
+   keyed by unique_key collapses them to one row per entity whose version IS
+   the last-seen timestamp — the absence classifier reads exactly that. #}
+{% do promote_bronze_to_rmt(table='bronze_jira.jira_project_visibility', order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_jira.jira_issue_census',       order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_jira.jira_worklog_deleted',    order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_jira.jira_board_configuration', order_by='unique_key') %}
 
 SELECT 1 AS promoted

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__bronze_promoted.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__bronze_promoted.sql
@@ -60,5 +60,19 @@
    it lands as a real bronze table and needs the same RMT dedup. No staging
    model reads it — promotion only caps its growth. #}
 {% do promote_bronze_to_rmt(table='bronze_jira.jira_issue_keys',    order_by='unique_key') %}
+{# Boards and the four Jira catalogues are full-refresh streams: every sync
+   re-appends the whole set, so a plain MergeTree grows by one copy per sync
+   and `FINAL` on it raises `Storage MergeTree doesn't support FINAL` (#1886).
+   They were absent from this list, so they never left MergeTree.
+   jira_boards additionally needs the NULL-key filter: its inline schema only
+   just gained the AddFields columns, so rows synced before that carry a NULL
+   unique_key — and RMT treats NULL keys as equal, which would collapse them
+   into one phantom row. The stream is full refresh, so the first post-deploy
+   sync rewrites the complete keyed set and the filtered rows lose nothing. #}
+{% do promote_bronze_to_rmt(table='bronze_jira.jira_boards',        order_by='unique_key', where='unique_key IS NOT NULL') %}
+{% do promote_bronze_to_rmt(table='bronze_jira.jira_statuses',      order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_jira.jira_issuetypes',    order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_jira.jira_priorities',    order_by='unique_key') %}
+{% do promote_bronze_to_rmt(table='bronze_jira.jira_resolutions',   order_by='unique_key') %}
 
 SELECT 1 AS promoted

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__changelog_items.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__changelog_items.sql
@@ -6,7 +6,8 @@
     engine='ReplacingMergeTree(_version)',
     order_by=['unique_key'],
     settings={'allow_nullable_key': 1},
-    tags=['staging', 'jira']
+    tags=['staging', 'jira'],
+    pre_hook="{{ reset_task_field_history_on_full_refresh() }}"
 ) }}
 
 -- Materialized as `table` (not `incremental`) so every dbt run rewrites staging from scratch.

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__comment_lifecycle_events.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__comment_lifecycle_events.sql
@@ -1,0 +1,99 @@
+-- depends_on: {{ ref('jira__bronze_promoted') }}
+{{ config(
+    materialized='incremental',
+    alias='jira__comment_lifecycle_events',
+    incremental_strategy='append',
+    schema='staging',
+    engine='ReplacingMergeTree(_version)',
+    order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
+    tags=['jira', 'silver', 'silver:class_task_field_history'],
+    query_settings={'join_use_nulls': 1}
+) }}
+
+-- Comment lifecycle as field-history events (specs/DELETION-AND-VISIBILITY.md):
+-- add / set / remove enter silver.class_task_field_history like any other
+-- change (field_id='comment', event_kind='lifecycle'). The event carries the
+-- comment id — the lookup key into class_task_comments — not the payload.
+-- add/set are dated by the comment's own updated timestamp (real time);
+-- remove by detection (Jira has no comment-deletion timestamp).
+-- Column order must match staging.jira__task_field_history exactly:
+-- union_by_tag concatenates the arms positionally.
+
+WITH transitions AS (
+    SELECT
+        entity_id                                               AS comment_id,
+        tenant_id,
+        source_id,
+        multiIf(
+            field_name = 'is_deleted' AND new_value = '1',          'remove',
+            field_name = 'edited_at' AND old_value = '',            'add',
+            field_name = 'edited_at',                               'set',
+                                                                    ''
+        )                                                       AS action,
+        old_value,
+        new_value,
+        updated_at                                              AS detected_at
+    FROM {{ ref('jira__comment_lifecycle_history') }}
+),
+
+-- The identity timestamp is event_at, not detection time: detection time comes
+-- from the snapshot's _tracked_at, which is second-resolution, so two
+-- transitions of one comment inside the same second would share unique_key and
+-- collapse under ReplacingMergeTree. event_at carries the comment's own
+-- millisecond timestamp for add/set; a comment is removed at most once.
+resolved AS (
+    SELECT
+        t.source_id                                             AS source_id,
+        t.comment_id                                            AS comment_id,
+        t.action                                                AS action,
+        t.detected_at                                           AS detected_at,
+        st.id_readable                                          AS id_readable,
+        st.author_id                                            AS author_id,
+        av.jira_id                                              AS jira_id,
+        if(t.action IN ('add', 'set'),
+           COALESCE(parseDateTime64BestEffortOrNull(t.new_value, 3),
+                    toDateTime64(t.detected_at, 3)),
+           toDateTime64(t.detected_at, 3))                      AS event_at
+    FROM transitions AS t
+    LEFT JOIN {{ ref('jira__comment_state') }} AS st FINAL
+        ON st.tenant_id = t.tenant_id
+        AND st.source_id = t.source_id
+        AND st.comment_id = t.comment_id
+    LEFT JOIN {{ ref('jira__issue_availability_state') }} AS av FINAL
+        ON av.tenant_id = t.tenant_id
+        AND av.source_id = t.source_id
+        AND av.id_readable = st.id_readable
+    WHERE t.action != ''
+)
+
+SELECT
+    concat(COALESCE(t.source_id, ''), '-jira-comment-', COALESCE(t.comment_id, ''),
+           '-', t.action, '-',
+           toString(toUnixTimestamp64Milli(t.event_at)))         AS unique_key,
+    COALESCE(t.source_id, '')                                   AS insight_source_id,
+    CAST('jira' AS String)                                      AS data_source,
+    COALESCE(t.jira_id, '')                                     AS issue_id,
+    COALESCE(t.id_readable, '')                                 AS id_readable,
+    CAST(NULL AS Nullable(String))                              AS title,
+    concat('comment:', COALESCE(t.comment_id, ''), ':', t.action, ':',
+           toString(toUnixTimestamp64Milli(t.event_at)))         AS event_id,
+    t.event_at                                                  AS event_at,
+    CAST('lifecycle', 'Enum8(\'changelog\' = 1, \'synthetic_initial\' = 2, \'availability\' = 3, \'lifecycle\' = 4)')
+                                                                AS event_kind,
+    toUInt32(0)                                                 AS _seq,
+    t.author_id                                                 AS author_id,
+    CAST(NULL AS Nullable(String))                              AS author_display,
+    CAST('comment' AS String)                                   AS field_id,
+    CAST('Comment' AS String)                                   AS field_name,
+    CAST('single', 'Enum8(\'single\' = 1, \'multi\' = 2)')      AS field_cardinality,
+    CAST(t.action, 'Enum8(\'set\' = 1, \'add\' = 2, \'remove\' = 3)') AS delta_action,
+    toNullable(t.comment_id)                                    AS delta_value_id,
+    CAST(NULL AS Nullable(String))                              AS delta_value_display,
+    CAST([COALESCE(t.comment_id, '')] AS Array(String))         AS value_ids,
+    CAST([COALESCE(t.comment_id, '')] AS Array(String))         AS value_displays,
+    CAST('opaque_id', 'Enum8(\'opaque_id\' = 1, \'account_id\' = 2, \'string_literal\' = 3, \'path\' = 4, \'none\' = 5)')
+                                                                AS value_id_type,
+    toDateTime64(t.detected_at, 3)                              AS collected_at,
+    toUInt64(toUnixTimestamp64Milli(now64(3)))                  AS _version
+FROM resolved AS t

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__comment_lifecycle_history.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__comment_lifecycle_history.sql
@@ -1,0 +1,14 @@
+-- depends_on: {{ ref('jira__bronze_promoted') }}
+{{ config(
+    materialized='table',
+    schema='staging',
+    tags=['jira', 'silver']
+) }}
+
+{{ fields_history(
+    snapshot_ref=ref('jira__comment_snapshot'),
+    entity_id_col='comment_id',
+    fields=[
+        'edited_at', 'is_deleted'
+    ]
+) }}

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__comment_snapshot.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__comment_snapshot.sql
@@ -1,0 +1,15 @@
+-- depends_on: {{ ref('jira__bronze_promoted') }}
+{{ config(
+    materialized='incremental',
+    incremental_strategy='append',
+    schema='staging',
+    tags=['jira', 'staging']
+) }}
+
+{{ snapshot(
+    source_ref=ref('jira__comment_state'),
+    unique_key_col='unique_key',
+    check_cols=[
+        'edited_at', 'is_deleted'
+    ]
+) }}

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__comment_state.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__comment_state.sql
@@ -1,0 +1,71 @@
+-- depends_on: {{ ref('jira__bronze_promoted') }}
+{{ config(
+    materialized='table',
+    schema='staging',
+    engine='ReplacingMergeTree',
+    order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
+    tags=['jira', 'staging'],
+    query_settings={'join_use_nulls': 1}
+) }}
+
+-- Current state per comment, deletion included (specs/DELETION-AND-VISIBILITY.md).
+-- is_deleted: deleting a comment bumps the issue's `updated`, which re-syncs
+-- the issue's FULL comment list — a comment whose last observation predates
+-- its issue's last re-fetch was deleted at the source; comments of
+-- deleted/trashed issues are marked through the availability state (their
+-- list is never re-fetched). Feeds both the class projection
+-- (jira__task_comments) and the lifecycle snapshot chain.
+
+WITH comments AS (
+    SELECT *
+    FROM {{ source('bronze_jira', 'jira_comments') }}
+    ORDER BY _airbyte_extracted_at DESC
+    LIMIT 1 BY unique_key
+),
+
+issue_fetch AS (
+    SELECT
+        tenant_id,
+        source_id,
+        id_readable,
+        max(_airbyte_extracted_at)                      AS last_fetched_at
+    FROM {{ source('bronze_jira', 'jira_issue_keys') }} FINAL
+    GROUP BY tenant_id, source_id, id_readable
+),
+
+unavailable_issues AS (
+    SELECT
+        tenant_id,
+        source_id,
+        id_readable
+    FROM {{ ref('jira__issue_availability_state') }} FINAL
+    WHERE availability IN ('deleted', 'trashed')
+      AND id_readable IS NOT NULL
+)
+
+SELECT
+    c.unique_key                                        AS unique_key,
+    c.tenant_id                                         AS tenant_id,
+    c.source_id                                         AS source_id,
+    toString(c.comment_id)                              AS comment_id,
+    c.id_readable                                       AS id_readable,
+    c.author_account_id                                 AS author_id,
+    parseDateTime64BestEffortOrNull(c.created, 3)       AS created_at,
+    parseDateTime64BestEffortOrNull(c.updated, 3)       AS edited_at,
+    c.body                                              AS body,
+    toUInt8(
+        (f.last_fetched_at IS NOT NULL
+         AND c._airbyte_extracted_at < f.last_fetched_at
+             - INTERVAL {{ var('jira_comment_refetch_tolerance_hours', 6) }} HOUR)
+        OR ui.id_readable IS NOT NULL
+    )                                                   AS is_deleted
+FROM comments AS c
+LEFT JOIN issue_fetch AS f
+    ON f.tenant_id = c.tenant_id
+    AND f.source_id = c.source_id
+    AND f.id_readable = c.id_readable
+LEFT JOIN unavailable_issues AS ui
+    ON ui.tenant_id = c.tenant_id
+    AND ui.source_id = c.source_id
+    AND ui.id_readable = c.id_readable

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__issue_availability_history.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__issue_availability_history.sql
@@ -1,0 +1,14 @@
+-- depends_on: {{ ref('jira__bronze_promoted') }}
+{{ config(
+    materialized='table',
+    schema='staging',
+    tags=['jira', 'silver']
+) }}
+
+{{ fields_history(
+    snapshot_ref=ref('jira__issue_availability_snapshot'),
+    entity_id_col='jira_id',
+    fields=[
+        'availability'
+    ]
+) }}

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__issue_availability_snapshot.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__issue_availability_snapshot.sql
@@ -1,0 +1,15 @@
+-- depends_on: {{ ref('jira__bronze_promoted') }}
+{{ config(
+    materialized='incremental',
+    incremental_strategy='append',
+    schema='staging',
+    tags=['jira', 'staging']
+) }}
+
+{{ snapshot(
+    source_ref=ref('jira__issue_availability_state'),
+    unique_key_col='unique_key',
+    check_cols=[
+        'availability'
+    ]
+) }}

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__issue_availability_state.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__issue_availability_state.sql
@@ -1,0 +1,163 @@
+-- depends_on: {{ ref('jira__bronze_promoted') }}
+{{ config(
+    materialized='table',
+    schema='staging',
+    engine='ReplacingMergeTree',
+    order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
+    tags=['jira', 'staging'],
+    query_settings={'join_use_nulls': 1}
+) }}
+
+-- Current availability per ever-seen issue (specs/DELETION-AND-VISIBILITY.md).
+-- An issue is absent when its last census observation is older than the
+-- census high-water mark minus a one-sync tolerance. Absence is then
+-- classified against the project visibility roster of the same generation:
+--
+--   present     seen in the latest census generation
+--   deleted     absent, project live and visible, below the mass threshold
+--   unobserved  absent, project live, but >= threshold of the project's known
+--               issues vanished at once — a partial sync or permission edge,
+--               not a plausible mass deletion; reclassifies on a later run
+--   archived    absent, project archived
+--   trashed     absent, project in Jira's project trash
+--   access_lost absent, project no longer visible to the account at all
+--
+-- Issues known only from bronze_jira.jira_issue (never censused) enter the
+-- universe with an epoch last-seen: absent from the very first census means
+-- deleted before the mechanism landed — the intended historical backfill.
+
+WITH census AS (
+    SELECT
+        unique_key,
+        tenant_id,
+        source_id,
+        jira_id,
+        project_key,
+        CAST(NULL AS Nullable(String))                       AS id_readable,
+        _airbyte_extracted_at                                AS seen_at
+    FROM {{ source('bronze_jira', 'jira_issue_census') }} FINAL
+),
+
+known AS (
+    SELECT
+        unique_key,
+        tenant_id,
+        source_id,
+        jira_id,
+        project_key,
+        id_readable,
+        seen_at
+    FROM census
+
+    UNION ALL
+
+    -- COALESCE keeps the key well-defined when a stamp column is NULL;
+    -- otherwise every unstamped row would collapse into one NULL-key group.
+    SELECT
+        concat(COALESCE(tenant_id, ''), '-', COALESCE(source_id, ''), '-',
+               COALESCE(jira_id, ''))                        AS unique_key,
+        tenant_id,
+        source_id,
+        jira_id,
+        project_key,
+        id_readable,
+        toDateTime64(0, 3)                                   AS seen_at
+    FROM {{ source('bronze_jira', 'jira_issue') }} FINAL
+    WHERE jira_id IS NOT NULL
+
+    UNION ALL
+
+    -- Jira project keys cannot contain '-', so the key prefix is the project.
+    SELECT
+        concat(COALESCE(tenant_id, ''), '-', COALESCE(source_id, ''), '-',
+               COALESCE(jira_id, ''))                        AS unique_key,
+        tenant_id,
+        source_id,
+        jira_id,
+        splitByChar('-', assumeNotNull(id_readable))[1]      AS project_key,
+        id_readable,
+        toDateTime64(0, 3)                                   AS seen_at
+    FROM {{ source('bronze_jira', 'jira_issue_keys') }} FINAL
+    WHERE jira_id IS NOT NULL AND id_readable IS NOT NULL
+),
+
+issues AS (
+    SELECT
+        unique_key,
+        any(tenant_id)                                       AS tenant_id,
+        any(source_id)                                       AS source_id,
+        any(jira_id)                                         AS jira_id,
+        argMax(project_key, seen_at)                         AS project_key,
+        any(id_readable)                                     AS id_readable,
+        max(seen_at)                                         AS last_seen_at
+    FROM known
+    GROUP BY unique_key
+),
+
+generation AS (
+    SELECT
+        tenant_id,
+        source_id,
+        max(seen_at)
+            - INTERVAL {{ var('jira_census_tolerance_hours', 12) }} HOUR
+                                                             AS observed_after
+    FROM census
+    GROUP BY tenant_id, source_id
+),
+
+observed AS (
+    SELECT
+        i.unique_key                                         AS unique_key,
+        i.tenant_id                                          AS tenant_id,
+        i.source_id                                          AS source_id,
+        i.jira_id                                            AS jira_id,
+        i.project_key                                        AS project_key,
+        i.id_readable                                        AS id_readable,
+        i.last_seen_at                                       AS last_seen_at,
+        g.observed_after IS NOT NULL                         AS has_census,
+        i.last_seen_at >= g.observed_after                   AS is_present
+    FROM issues AS i
+    LEFT JOIN generation AS g
+        ON g.tenant_id = i.tenant_id AND g.source_id = i.source_id
+),
+
+project_absence AS (
+    SELECT
+        tenant_id,
+        source_id,
+        project_key,
+        avg(NOT is_present)                                  AS absent_share
+    FROM observed
+    GROUP BY tenant_id, source_id, project_key
+)
+
+SELECT
+    o.unique_key                                             AS unique_key,
+    o.tenant_id                                              AS tenant_id,
+    o.source_id                                              AS source_id,
+    o.jira_id                                                AS jira_id,
+    o.project_key                                            AS project_key,
+    o.id_readable                                            AS id_readable,
+    multiIf(
+        NOT o.has_census,                       'present',
+        o.is_present,                           'present',
+        p.project_key IS NULL
+            OR ifNull(p.is_visible, 0) = 0,     'access_lost',
+        p.project_status = 'archived',          'archived',
+        p.project_status = 'deleted',           'trashed',
+        pa.absent_share >=
+            {{ var('jira_availability_mass_threshold', 0.5) }},
+                                                'unobserved',
+                                                'deleted'
+    )                                                        AS availability,
+    o.last_seen_at                                           AS last_seen_at
+FROM observed AS o
+LEFT JOIN {{ ref('jira__project_visibility_state') }} AS p FINAL
+    ON p.tenant_id = o.tenant_id
+    AND p.source_id = o.source_id
+    AND p.project_key = o.project_key
+LEFT JOIN project_absence AS pa
+    ON pa.tenant_id = o.tenant_id
+    AND pa.source_id = o.source_id
+    AND pa.project_key = o.project_key

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__issue_field_snapshot.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__issue_field_snapshot.sql
@@ -42,10 +42,43 @@
 -- extracted tuple is kept per issue (~0.6 GiB peak, single scan). The ARRAY JOIN
 -- unpivot keeps it to one scan instead of one per field.
 
-WITH issue AS (
+-- Story-points resolution (specs/DATA-COMPLETENESS.md): the field id is
+-- instance-specific, so it is resolved from bronze_jira.jira_fields metadata —
+-- the canonical greenhopper story-points schema marker first, then the exact
+-- field names — and the snapshot emits the RESOLVED Jira-native field_id
+-- (matching the changelog's fieldId, same rule as duedate below). Company- and
+-- team-managed projects store the value in different fields, so extraction
+-- coalesces over all candidates per issue.
+WITH sp_fields AS (
+    -- arraySort over the aggregated tuples, not ORDER BY before groupArray:
+    -- parallel aggregation does not preserve input order, and a
+    -- non-deterministic candidate order could resolve a different field id
+    -- per run for issues valued in more than one candidate.
     SELECT
         COALESCE(source_id, '')                                       AS insight_source_id,
-        COALESCE(toString(jira_id), '')                               AS issue_id,
+        arrayMap(t -> t.2, arraySort(groupArray((priority, candidate_field_id))))
+                                                                      AS sp_field_ids
+    FROM (
+        SELECT
+            source_id,
+            assumeNotNull(field_id)                                   AS candidate_field_id,
+            multiIf(
+                schema_custom = 'com.pyxis.greenhopper.jira:jsw-story-points', 1,
+                lowerUTF8(COALESCE(name, '')) = 'story points',            2,
+                                                                           3
+            )                                                         AS priority
+        FROM {{ source('bronze_jira', 'jira_fields') }} FINAL
+        WHERE field_id IS NOT NULL
+          AND (schema_custom = 'com.pyxis.greenhopper.jira:jsw-story-points'
+               OR lowerUTF8(COALESCE(name, '')) IN ('story points', 'story point estimate'))
+    )
+    GROUP BY source_id
+),
+
+issue AS (
+    SELECT
+        COALESCE(b.source_id, '')                                     AS insight_source_id,
+        COALESCE(toString(b.jira_id), '')                             AS issue_id,
         -- Latest bronze row per issue, projected down to the small extracted tuple.
         -- Tuple indexes: 1 id_readable, 2 created_at, 3/4 status id/name,
         -- 5/6 priority, 7/8 issuetype, 9/10 resolution, 11/12 assignee,
@@ -73,11 +106,25 @@ WITH issue AS (
                 -- returns '', so take the raw JSON and parse it as Array(String)
                 -- in the unpivot below.
                 JSONExtractRaw(custom_fields_json, 'labels'),
-                due_date
+                due_date,
+                -- 19/20: resolved story-points (field_id, raw numeric value) —
+                -- first candidate field that holds a value on this issue.
+                arrayFirst(
+                    x -> x.2 NOT IN ('', 'null'),
+                    arrayMap(fid -> (fid, JSONExtractRaw(custom_fields_json, fid)),
+                             sp.sp_field_ids)
+                ).1,
+                arrayFirst(
+                    x -> x.2 NOT IN ('', 'null'),
+                    arrayMap(fid -> (fid, JSONExtractRaw(custom_fields_json, fid)),
+                             sp.sp_field_ids)
+                ).2
             ),
             _airbyte_extracted_at
         ) AS t
-    FROM {{ source('bronze_jira', 'jira_issue') }}
+    FROM {{ source('bronze_jira', 'jira_issue') }} AS b
+    LEFT JOIN sp_fields AS sp
+        ON sp.insight_source_id = COALESCE(b.source_id, '')
     GROUP BY insight_source_id, issue_id
 )
 
@@ -139,5 +186,14 @@ ARRAY JOIN [
         due_date_compliance. -#}
     ('duedate',
      if(t.18 IS NULL OR t.18 = '', [], [toString(t.18)]),
-     if(t.18 IS NULL OR t.18 = '', [], [toString(t.18)]))
+     if(t.18 IS NULL OR t.18 = '', [], [toString(t.18)])),
+
+    {#- story points: field_id is the RESOLVED instance-specific customfield id
+        (t.19), so snapshot rows merge with changelog rows for the same field.
+        Issues with no story points resolve to field_id '' and are dropped by
+        the WHERE below. -#}
+    (t.19,
+     if(t.20 = '', [], [t.20]),
+     if(t.20 = '', [], [t.20]))
 ] AS f
+WHERE f.1 != ''

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__project_visibility_history.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__project_visibility_history.sql
@@ -1,0 +1,14 @@
+-- depends_on: {{ ref('jira__bronze_promoted') }}
+{{ config(
+    materialized='table',
+    schema='staging',
+    tags=['jira', 'silver']
+) }}
+
+{{ fields_history(
+    snapshot_ref=ref('jira__project_visibility_snapshot'),
+    entity_id_col='project_id',
+    fields=[
+        'is_visible', 'project_status'
+    ]
+) }}

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__project_visibility_snapshot.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__project_visibility_snapshot.sql
@@ -1,0 +1,15 @@
+-- depends_on: {{ ref('jira__bronze_promoted') }}
+{{ config(
+    materialized='incremental',
+    incremental_strategy='append',
+    schema='staging',
+    tags=['jira', 'staging']
+) }}
+
+{{ snapshot(
+    source_ref=ref('jira__project_visibility_state'),
+    unique_key_col='unique_key',
+    check_cols=[
+        'is_visible', 'project_status'
+    ]
+) }}

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__project_visibility_state.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__project_visibility_state.sql
@@ -1,0 +1,53 @@
+-- depends_on: {{ ref('jira__bronze_promoted') }}
+{{ config(
+    materialized='table',
+    schema='staging',
+    engine='ReplacingMergeTree',
+    order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
+    tags=['jira', 'staging']
+) }}
+
+-- Current visibility per ever-seen project (specs/DELETION-AND-VISIBILITY.md).
+-- The census stream is full-refresh, so after RMT promotion each project's
+-- _airbyte_extracted_at is its last observation; a project absent from the
+-- latest census generation (watermark minus a one-sync tolerance) is no
+-- longer visible to the service account.
+
+WITH roster AS (
+    SELECT
+        unique_key,
+        tenant_id,
+        source_id,
+        toString(toInt64(project_id))                       AS project_id,
+        project_key,
+        project_status,
+        _airbyte_extracted_at                               AS seen_at
+    FROM {{ source('bronze_jira', 'jira_project_visibility') }} FINAL
+),
+
+-- Per (tenant, source): each source instance censuses on its own clock, and
+-- one instance's fresher watermark must not mark another's projects stale.
+generation AS (
+    SELECT
+        tenant_id,
+        source_id,
+        max(seen_at) AS watermark
+    FROM roster
+    GROUP BY tenant_id, source_id
+)
+
+SELECT
+    r.unique_key                                            AS unique_key,
+    r.tenant_id                                             AS tenant_id,
+    r.source_id                                             AS source_id,
+    r.project_id                                            AS project_id,
+    r.project_key                                           AS project_key,
+    toUInt8(r.seen_at >= g.watermark
+        - INTERVAL {{ var('jira_census_tolerance_hours', 12) }} HOUR) AS is_visible,
+    r.project_status                                        AS project_status,
+    r.seen_at                                               AS last_seen_at
+FROM roster AS r
+INNER JOIN generation AS g
+    ON g.tenant_id = r.tenant_id
+    AND g.source_id = r.source_id

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__task_comments.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__task_comments.sql
@@ -27,5 +27,5 @@ SELECT
 FROM (
     SELECT * FROM {{ source('bronze_jira', 'jira_comments') }}
     ORDER BY _airbyte_extracted_at DESC
-    LIMIT 1 BY _airbyte_raw_id
+    LIMIT 1 BY unique_key
 ) c

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__task_comments.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__task_comments.sql
@@ -11,21 +11,19 @@
 ) }}
 
 -- `body` is raw ADF JSON at Bronze level; plaintext extraction deferred.
+-- State (including is_deleted — specs/DELETION-AND-VISIBILITY.md) is computed
+-- once in jira__comment_state; this is the class-contract projection.
 
 SELECT
-    c.unique_key                                        AS unique_key,
-    c.source_id                                         AS insight_source_id,
+    s.unique_key                                        AS unique_key,
+    s.source_id                                         AS insight_source_id,
     CAST('jira' AS String)                              AS data_source,
-    toString(c.comment_id)                              AS comment_id,
-    c.id_readable                                       AS id_readable,
-    c.author_account_id                                 AS author_id,
-    parseDateTime64BestEffortOrNull(c.created, 3)       AS created_at,
-    parseDateTime64BestEffortOrNull(c.updated, 3)       AS updated_at,
-    c.body                                              AS body,
-    toUInt8(0)                                          AS is_deleted,
+    s.comment_id                                        AS comment_id,
+    s.id_readable                                       AS id_readable,
+    s.author_id                                         AS author_id,
+    s.created_at                                        AS created_at,
+    s.edited_at                                         AS updated_at,
+    s.body                                              AS body,
+    toNullable(s.is_deleted)                            AS is_deleted,
     toUnixTimestamp64Milli(now64(3))                    AS _version
-FROM (
-    SELECT * FROM {{ source('bronze_jira', 'jira_comments') }}
-    ORDER BY _airbyte_extracted_at DESC
-    LIMIT 1 BY unique_key
-) c
+FROM {{ ref('jira__comment_state') }} AS s FINAL

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__task_field_history.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__task_field_history.sql
@@ -15,5 +15,34 @@
 -- `dbt_project.yml`). Rust populates `unique_key` per the convention
 -- `{insight_source_id}-{data_source}-{id_readable}-{field_id}-{event_id}`
 -- — see src/ingestion/connectors/task-tracking/jira/enrich/src/io/writer.rs.
+--
+-- event_kind is recast to the class contract's superset enum: the Rust table
+-- keeps its two values, but the union sibling jira__availability_events also
+-- emits 'availability' rows and UNION ALL needs one common enum type.
 
-SELECT * FROM {{ source('staging_jira', 'jira__task_field_history') }}
+SELECT
+    unique_key,
+    insight_source_id,
+    data_source,
+    issue_id,
+    id_readable,
+    title,
+    event_id,
+    event_at,
+    CAST(event_kind, 'Enum8(\'changelog\' = 1, \'synthetic_initial\' = 2, \'availability\' = 3, \'lifecycle\' = 4)')
+                        AS event_kind,
+    _seq,
+    author_id,
+    author_display,
+    field_id,
+    field_name,
+    field_cardinality,
+    delta_action,
+    delta_value_id,
+    delta_value_display,
+    value_ids,
+    value_displays,
+    value_id_type,
+    collected_at,
+    _version
+FROM {{ source('staging_jira', 'jira__task_field_history') }}

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__task_worklogs.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__task_worklogs.sql
@@ -25,5 +25,5 @@ SELECT
 FROM (
     SELECT * FROM {{ source('bronze_jira', 'jira_worklogs') }}
     ORDER BY _airbyte_extracted_at DESC
-    LIMIT 1 BY _airbyte_raw_id
+    LIMIT 1 BY unique_key
 ) w

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__task_worklogs.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__task_worklogs.sql
@@ -10,20 +10,20 @@
     tags=['jira', 'staging', 'silver:class_task_worklogs']
 ) }}
 
+-- State (including is_deleted — specs/DELETION-AND-VISIBILITY.md) is computed
+-- once in jira__worklog_state; this is the class-contract projection.
+
 SELECT
-    w.unique_key                                      AS unique_key,
-    w.source_id                                       AS insight_source_id,
-    CAST('jira' AS String)                            AS data_source,
-    toString(w.worklog_id)                            AS worklog_id,
-    w.id_readable                                     AS id_readable,
-    w.author_account_id                               AS author_id,
-    parseDateTime64BestEffortOrNull(w.started, 3)     AS work_date,
-    toFloat64OrNull(toString(w.time_spent_seconds))   AS duration_seconds,
-    w.comment                                         AS description,
-    parseDateTime64BestEffortOrNull(w.collected_at, 3) AS collected_at,
-    toUnixTimestamp64Milli(now64(3))                  AS _version
-FROM (
-    SELECT * FROM {{ source('bronze_jira', 'jira_worklogs') }}
-    ORDER BY _airbyte_extracted_at DESC
-    LIMIT 1 BY unique_key
-) w
+    s.unique_key                                        AS unique_key,
+    s.source_id                                         AS insight_source_id,
+    CAST('jira' AS String)                              AS data_source,
+    s.worklog_id                                        AS worklog_id,
+    s.id_readable                                       AS id_readable,
+    s.author_id                                         AS author_id,
+    s.work_date                                         AS work_date,
+    s.duration_seconds                                  AS duration_seconds,
+    s.description                                       AS description,
+    s.collected_at                                      AS collected_at,
+    toNullable(s.is_deleted)                            AS is_deleted,
+    toUnixTimestamp64Milli(now64(3))                    AS _version
+FROM {{ ref('jira__worklog_state') }} AS s FINAL

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__worklog_lifecycle_events.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__worklog_lifecycle_events.sql
@@ -1,0 +1,103 @@
+-- depends_on: {{ ref('jira__bronze_promoted') }}
+{{ config(
+    materialized='incremental',
+    alias='jira__worklog_lifecycle_events',
+    incremental_strategy='append',
+    schema='staging',
+    engine='ReplacingMergeTree(_version)',
+    order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
+    tags=['jira', 'silver', 'silver:class_task_field_history'],
+    query_settings={'join_use_nulls': 1}
+) }}
+
+-- Worklog lifecycle as field-history events (specs/DELETION-AND-VISIBILITY.md):
+-- add / set / remove enter silver.class_task_field_history like any other
+-- change (field_id='worklog', event_kind='lifecycle'). The event carries the
+-- worklog id — the lookup key into class_task_worklogs — not the payload.
+-- add/set are dated by the worklog's own updated timestamp; remove by the
+-- /worklog/deleted tombstone timestamp (real deletion time) when present,
+-- detection time otherwise. Column order must match
+-- staging.jira__task_field_history exactly: union_by_tag is positional.
+
+WITH transitions AS (
+    SELECT
+        entity_id                                               AS worklog_id,
+        tenant_id,
+        source_id,
+        multiIf(
+            field_name = 'is_deleted' AND new_value = '1',          'remove',
+            field_name = 'edited_at' AND old_value = '',            'add',
+            field_name = 'edited_at',                               'set',
+                                                                    ''
+        )                                                       AS action,
+        old_value,
+        new_value,
+        updated_at                                              AS detected_at
+    FROM {{ ref('jira__worklog_lifecycle_history') }}
+),
+
+-- The identity timestamp is event_at, not detection time: detection time comes
+-- from the snapshot's _tracked_at, which is second-resolution, so two
+-- transitions of one worklog inside the same second would share unique_key and
+-- collapse under ReplacingMergeTree. event_at carries the worklog's own
+-- millisecond timestamp for add/set and the tombstone's for remove.
+resolved AS (
+    SELECT
+        t.source_id                                             AS source_id,
+        t.worklog_id                                            AS worklog_id,
+        t.action                                                AS action,
+        t.detected_at                                           AS detected_at,
+        st.id_readable                                          AS id_readable,
+        st.author_id                                            AS author_id,
+        av.jira_id                                              AS jira_id,
+        multiIf(
+            t.action = 'remove' AND st.deleted_at_ms IS NOT NULL,
+                fromUnixTimestamp64Milli(assumeNotNull(st.deleted_at_ms)),
+            t.action IN ('add', 'set'),
+                COALESCE(parseDateTime64BestEffortOrNull(t.new_value, 3),
+                         toDateTime64(t.detected_at, 3)),
+            toDateTime64(t.detected_at, 3)
+        )                                                       AS event_at
+    FROM transitions AS t
+    LEFT JOIN {{ ref('jira__worklog_state') }} AS st FINAL
+        ON st.tenant_id = t.tenant_id
+        AND st.source_id = t.source_id
+        AND st.worklog_id = t.worklog_id
+    LEFT JOIN {{ ref('jira__issue_availability_state') }} AS av FINAL
+        ON av.tenant_id = t.tenant_id
+        AND av.source_id = t.source_id
+        AND av.id_readable = st.id_readable
+    WHERE t.action != ''
+)
+
+SELECT
+    concat(COALESCE(t.source_id, ''), '-jira-worklog-', COALESCE(t.worklog_id, ''),
+           '-', t.action, '-',
+           toString(toUnixTimestamp64Milli(t.event_at)))         AS unique_key,
+    COALESCE(t.source_id, '')                                   AS insight_source_id,
+    CAST('jira' AS String)                                      AS data_source,
+    COALESCE(t.jira_id, '')                                     AS issue_id,
+    COALESCE(t.id_readable, '')                                 AS id_readable,
+    CAST(NULL AS Nullable(String))                              AS title,
+    concat('worklog:', COALESCE(t.worklog_id, ''), ':', t.action, ':',
+           toString(toUnixTimestamp64Milli(t.event_at)))         AS event_id,
+    t.event_at                                                  AS event_at,
+    CAST('lifecycle', 'Enum8(\'changelog\' = 1, \'synthetic_initial\' = 2, \'availability\' = 3, \'lifecycle\' = 4)')
+                                                                AS event_kind,
+    toUInt32(0)                                                 AS _seq,
+    t.author_id                                                 AS author_id,
+    CAST(NULL AS Nullable(String))                              AS author_display,
+    CAST('worklog' AS String)                                   AS field_id,
+    CAST('Worklog' AS String)                                   AS field_name,
+    CAST('single', 'Enum8(\'single\' = 1, \'multi\' = 2)')      AS field_cardinality,
+    CAST(t.action, 'Enum8(\'set\' = 1, \'add\' = 2, \'remove\' = 3)') AS delta_action,
+    toNullable(t.worklog_id)                                    AS delta_value_id,
+    CAST(NULL AS Nullable(String))                              AS delta_value_display,
+    CAST([COALESCE(t.worklog_id, '')] AS Array(String))         AS value_ids,
+    CAST([COALESCE(t.worklog_id, '')] AS Array(String))         AS value_displays,
+    CAST('opaque_id', 'Enum8(\'opaque_id\' = 1, \'account_id\' = 2, \'string_literal\' = 3, \'path\' = 4, \'none\' = 5)')
+                                                                AS value_id_type,
+    toDateTime64(t.detected_at, 3)                              AS collected_at,
+    toUInt64(toUnixTimestamp64Milli(now64(3)))                  AS _version
+FROM resolved AS t

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__worklog_lifecycle_history.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__worklog_lifecycle_history.sql
@@ -1,0 +1,14 @@
+-- depends_on: {{ ref('jira__bronze_promoted') }}
+{{ config(
+    materialized='table',
+    schema='staging',
+    tags=['jira', 'silver']
+) }}
+
+{{ fields_history(
+    snapshot_ref=ref('jira__worklog_snapshot'),
+    entity_id_col='worklog_id',
+    fields=[
+        'edited_at', 'is_deleted'
+    ]
+) }}

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__worklog_snapshot.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__worklog_snapshot.sql
@@ -1,0 +1,15 @@
+-- depends_on: {{ ref('jira__bronze_promoted') }}
+{{ config(
+    materialized='incremental',
+    incremental_strategy='append',
+    schema='staging',
+    tags=['jira', 'staging']
+) }}
+
+{{ snapshot(
+    source_ref=ref('jira__worklog_state'),
+    unique_key_col='unique_key',
+    check_cols=[
+        'edited_at', 'duration_seconds', 'work_date', 'is_deleted'
+    ]
+) }}

--- a/src/ingestion/connectors/task-tracking/jira/dbt/jira__worklog_state.sql
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/jira__worklog_state.sql
@@ -1,0 +1,91 @@
+-- depends_on: {{ ref('jira__bronze_promoted') }}
+{{ config(
+    materialized='table',
+    schema='staging',
+    engine='ReplacingMergeTree',
+    order_by=['unique_key'],
+    settings={'allow_nullable_key': 1},
+    tags=['jira', 'staging'],
+    query_settings={'join_use_nulls': 1}
+) }}
+
+-- Current state per worklog, deletion included (specs/DELETION-AND-VISIBILITY.md).
+-- is_deleted, three signals OR-ed: an authoritative /worklog/deleted tombstone;
+-- the re-fetch generation diff (editing/deleting a worklog bumps the issue's
+-- `updated`, re-syncing its full worklog list); a deleted/trashed parent
+-- issue. Feeds both the class projection (jira__task_worklogs) and the
+-- lifecycle snapshot chain.
+
+WITH worklogs AS (
+    SELECT *
+    FROM {{ source('bronze_jira', 'jira_worklogs') }}
+    ORDER BY _airbyte_extracted_at DESC
+    LIMIT 1 BY unique_key
+),
+
+tombstones AS (
+    SELECT
+        tenant_id,
+        source_id,
+        toString(toInt64(worklog_id))                   AS worklog_id,
+        max(toInt64(deleted_at_ms))                     AS deleted_at_ms
+    FROM {{ source('bronze_jira', 'jira_worklog_deleted') }} FINAL
+    GROUP BY tenant_id, source_id, worklog_id
+),
+
+issue_fetch AS (
+    SELECT
+        tenant_id,
+        source_id,
+        id_readable,
+        max(_airbyte_extracted_at)                      AS last_fetched_at
+    FROM {{ source('bronze_jira', 'jira_issue_keys') }} FINAL
+    GROUP BY tenant_id, source_id, id_readable
+),
+
+unavailable_issues AS (
+    SELECT
+        tenant_id,
+        source_id,
+        id_readable
+    FROM {{ ref('jira__issue_availability_state') }} FINAL
+    WHERE availability IN ('deleted', 'trashed')
+      AND id_readable IS NOT NULL
+)
+
+SELECT
+    w.unique_key                                        AS unique_key,
+    w.tenant_id                                         AS tenant_id,
+    w.source_id                                         AS source_id,
+    toString(w.worklog_id)                              AS worklog_id,
+    w.id_readable                                       AS id_readable,
+    w.author_account_id                                 AS author_id,
+    parseDateTime64BestEffortOrNull(w.started, 3)       AS work_date,
+    toFloat64OrNull(toString(w.time_spent_seconds))     AS duration_seconds,
+    w.comment                                           AS description,
+    parseDateTime64BestEffortOrNull(w.created, 3)       AS created_at,
+    parseDateTime64BestEffortOrNull(w.updated, 3)       AS edited_at,
+    parseDateTime64BestEffortOrNull(w.collected_at, 3)  AS collected_at,
+    toUInt8(
+        ts.worklog_id IS NOT NULL
+        OR (f.last_fetched_at IS NOT NULL
+            AND w._airbyte_extracted_at < f.last_fetched_at
+                - INTERVAL {{ var('jira_comment_refetch_tolerance_hours', 6) }} HOUR)
+        OR ui.id_readable IS NOT NULL
+    )                                                   AS is_deleted,
+    -- Real deletion time when the tombstone carries it; NULL otherwise
+    -- (generation-diff / parent-issue deletions are dated at detection).
+    ts.deleted_at_ms                                    AS deleted_at_ms
+FROM worklogs AS w
+LEFT JOIN tombstones AS ts
+    ON ts.tenant_id = w.tenant_id
+    AND ts.source_id = w.source_id
+    AND ts.worklog_id = toString(w.worklog_id)
+LEFT JOIN issue_fetch AS f
+    ON f.tenant_id = w.tenant_id
+    AND f.source_id = w.source_id
+    AND f.id_readable = w.id_readable
+LEFT JOIN unavailable_issues AS ui
+    ON ui.tenant_id = w.tenant_id
+    AND ui.source_id = w.source_id
+    AND ui.id_readable = w.id_readable

--- a/src/ingestion/connectors/task-tracking/jira/dbt/schema.yml
+++ b/src/ingestion/connectors/task-tracking/jira/dbt/schema.yml
@@ -23,12 +23,25 @@ sources:
       - name: jira_worklogs
       - name: jira_sprints
       - name: jira_boards
+      # Lightweight substream parent (issue key + updated). Also read by the
+      # availability classifier (id↔key mapping + issue re-fetch generation
+      # for comment deletion detection).
+      - name: jira_issue_keys
       # Normalized lookup streams — populated globally per source instance.
       # `jira_issue` references these by ID only; display names come from JOIN.
       - name: jira_statuses
       - name: jira_priorities
       - name: jira_issuetypes
       - name: jira_resolutions
+      # Deletion/visibility censuses (specs/DELETION-AND-VISIBILITY.md):
+      # full-refresh streams; after RMT promotion each row's
+      # _airbyte_extracted_at is the entity's last-seen timestamp.
+      - name: jira_project_visibility
+      - name: jira_issue_census
+      # Worklog deletion tombstones from /rest/api/3/worklog/deleted.
+      - name: jira_worklog_deleted
+      # Per-board estimation field + column-to-status mapping.
+      - name: jira_board_configuration
 
   # Staging tables written by the Rust `jira-enrich` binary (not by dbt). DDL is
   # managed by the `create_task_field_history_staging` macro in `on-run-start`.
@@ -65,3 +78,33 @@ models:
     description: "Thin view over the Rust-written staging.jira__task_field_history, so dbt can union it into silver.class_task_field_history."
   - name: jira__identity_inputs
     description: "Identity-resolution inputs from the Jira user profile history (email, display_name, id binding). Unioned into silver.identity_inputs via the silver:identity_inputs tag."
+  - name: jira__project_visibility_state
+    description: "Current visibility per ever-seen project: is_visible + project_status derived from the jira_project_visibility census (absent from the latest generation = not visible). Input to the SCD2 snapshot."
+  - name: jira__project_visibility_snapshot
+    description: "Append-only SCD2 over project visibility — a version per is_visible/project_status flip. Permanent record of when the account gained or lost sight of a project."
+  - name: jira__project_visibility_history
+    description: "Per-field change events (is_visible, project_status: old → new @ ts) derived from the visibility snapshot."
+  - name: jira__issue_availability_state
+    description: "Current availability per ever-seen issue (present / deleted / archived / trashed / access_lost / unobserved), classified from the jira_issue_census absence against the project visibility roster. See specs/DELETION-AND-VISIBILITY.md."
+  - name: jira__issue_availability_snapshot
+    description: "Append-only SCD2 over issue availability — a version per state flip. Deletion is recorded here as an event in the issue's history, never as a physical delete."
+  - name: jira__issue_availability_history
+    description: "Per-issue availability transition events (availability: old → new @ detection time) derived from the availability snapshot."
+  - name: jira__availability_events
+    description: "Availability transitions as synthetic field-history events (field_id='availability', event_kind='availability'). Unioned into silver.class_task_field_history so an issue's whole lifecycle — including deletion and lost access — lives in one source-agnostic table."
+  - name: jira__comment_state
+    description: "Current state per comment including is_deleted (re-fetch generation diff + parent-issue availability). Feeds the class projection and the lifecycle snapshot chain."
+  - name: jira__comment_snapshot
+    description: "Append-only SCD2 over comment state — a version per edit (updated_at) or deletion flip."
+  - name: jira__comment_lifecycle_history
+    description: "Per-field transitions derived from the comment snapshot; raw input for the lifecycle events."
+  - name: jira__comment_lifecycle_events
+    description: "Comment add/set/remove as field-history events (field_id='comment', event_kind='lifecycle'); value carries the comment id — the lookup key into class_task_comments. Unioned into silver.class_task_field_history."
+  - name: jira__worklog_state
+    description: "Current state per worklog including is_deleted (tombstone + generation diff + parent-issue availability) and the tombstone's real deletion timestamp. Feeds the class projection and the lifecycle snapshot chain."
+  - name: jira__worklog_snapshot
+    description: "Append-only SCD2 over worklog state — a version per edit (updated_at / seconds / started) or deletion flip."
+  - name: jira__worklog_lifecycle_history
+    description: "Per-field transitions derived from the worklog snapshot; raw input for the lifecycle events."
+  - name: jira__worklog_lifecycle_events
+    description: "Worklog add/set/remove as field-history events (field_id='worklog', event_kind='lifecycle'); value carries the worklog id — the lookup key into class_task_worklogs; remove is dated by the /worklog/deleted tombstone when available. Unioned into silver.class_task_field_history."

--- a/src/ingestion/connectors/task-tracking/jira/descriptor.yaml
+++ b/src/ingestion/connectors/task-tracking/jira/descriptor.yaml
@@ -9,7 +9,20 @@ name: jira
 # 2.0.2 (patch): widen jira_project_discovery cursor_datetime_formats so it can
 # parse child-stream cursor values carried in parent_state (was crashing with
 # "No format ['%Y-%m-%dT%H:%M:%S.%f%z'] matching 2026-06-15 02:00").
-version: "3.0.0"
+# 3.0.0 (major): declare jira_issue_history.items as a plain string so the
+# CDK's literal-eval render survives, and repair the rows already stored
+# double-encoded; the full refresh a major dispatches is what re-derives the
+# field-history journal from the repaired Bronze.
+# 4.0.0 (major): deletion/visibility + data-completeness scope (#2419).
+# New streams: jira_project_visibility, jira_issue_census (absence censuses),
+# jira_worklog_deleted (tombstones), jira_board_configuration; expand=lead on
+# jira_projects; story-points field id resolved from /field metadata instead
+# of a hardcoded default. MAJOR because the silver contract changes shape —
+# class_task_worklogs gains is_deleted and class_task_field_history's
+# event_kind gains the 'availability' and 'lifecycle' values — and per
+# ADR-0015 a major bump dispatches the one-shot sync with dbt --full-refresh
+# that rebuilds those tables; no ALTER migrations are shipped.
+version: "4.0.0"
 schedule: "0 3 * * *"
 workflow: sync
 # CI build metadata + runtime image refs (ADR-0016). The `images:` block is

--- a/src/ingestion/connectors/task-tracking/jira/descriptor.yaml
+++ b/src/ingestion/connectors/task-tracking/jira/descriptor.yaml
@@ -9,7 +9,7 @@ name: jira
 # 2.0.2 (patch): widen jira_project_discovery cursor_datetime_formats so it can
 # parse child-stream cursor values carried in parent_state (was crashing with
 # "No format ['%Y-%m-%dT%H:%M:%S.%f%z'] matching 2026-06-15 02:00").
-version: "2.7.0"
+version: "3.0.0"
 schedule: "0 3 * * *"
 workflow: sync
 # CI build metadata + runtime image refs (ADR-0016). The `images:` block is
@@ -24,7 +24,7 @@ images:
     name: insight-jira-enrich
     dockerfile: ./enrich/Dockerfile
     context: ./enrich
-    image: "ghcr.io/constructorfabric/insight-jira-enrich:2026.07.31.12.44-afd0cbb.release-2026.07.1"
+    image: "ghcr.io/constructorfabric/insight-jira-enrich:2026.08.12.03.58-5772f43"
 # Silver routing (class_task_*) is delivered by the task-tracking Silver layer
 # package, not by this connector. The pipeline runs the jira-rust path:
 # dbt(tag:jira) → tt-enrich-jira-run → dbt(<selector below>). The selector is

--- a/src/ingestion/connectors/task-tracking/jira/specs/DATA-COMPLETENESS.md
+++ b/src/ingestion/connectors/task-tracking/jira/specs/DATA-COMPLETENESS.md
@@ -1,0 +1,70 @@
+# Jira Data Completeness: Custom Fields, Board Metadata, Validation
+
+Status: implemented. Part of the data-completeness scope of issue #2419.
+Deletion and visibility handling lives in
+[DELETION-AND-VISIBILITY.md](DELETION-AND-VISIBILITY.md); JSM SLA support is
+tracked separately (#1834).
+
+## Story-points resolution
+
+Jira stores story points in an instance-specific `customfield_NNNNN` whose id
+differs between deployments and even between project styles inside one
+deployment (company-managed vs team-managed projects use different fields).
+A hardcoded id silently reads the wrong field — or nothing.
+
+Resolution is metadata-driven, in dbt, from `bronze_jira.jira_fields`
+(`GET /rest/api/3/field`):
+
+1. fields whose `schema.custom` is the canonical greenhopper marker
+   `com.pyxis.greenhopper.jira:jsw-story-points`;
+2. fields named exactly `Story Points` (case-insensitive);
+3. fields named exactly `Story point estimate`.
+
+All matches become an ordered candidate list per source instance;
+`jira__issue_field_snapshot` extracts the value per issue by coalescing over
+the candidates in `custom_fields_json` — an issue holds a value only in the
+field its project style actually uses, so per-issue coalescing is the correct
+merge of the company-/team-managed split.
+
+The snapshot emits the **resolved Jira-native field id** as `field_id` (not a
+synthetic `story_points` label), so snapshot rows merge with changelog rows
+for the same field — the same rule that governs `duedate`.
+
+Connector-side, the `jira_story_points_field_id` config key no longer has a
+hardcoded default; it remains as an explicit operator override that lands in
+`bronze_jira.jira_issue.story_points`.
+
+## Board configuration
+
+`jira_board_configuration` (`GET /rest/agile/1.0/board/{id}/configuration`,
+substream of `jira_boards`, one request per board) fills the board-metadata
+Bronze gap:
+
+- `estimation_field_id` / `estimation_field_name` — the board's estimation
+  field. Scrum boards carry it, kanban boards do not. Serves as per-board
+  corroboration of the metadata-resolved story-points field.
+- `column_config` — the column-to-status mapping (JSON), the board's own
+  definition of its workflow lanes.
+- `board_location` — project the board belongs to (JSON).
+
+## Project lead
+
+`/rest/api/3/project/search` omits the `lead` object unless asked;
+`jira_projects` now requests `expand=lead`, so the (previously always-empty)
+`lead_account_id` Bronze column is populated.
+
+## API-to-Bronze completeness checks
+
+dbt singular tests (`src/ingestion/dbt/tests/task/`) validate, on every run,
+that what the API reported actually landed:
+
+| test | catches |
+|------|---------|
+| `assert_census_issue_has_full_record` | an issue the census observed as present and the incremental scan enumerated, but whose full `jira_issue` record is missing — the sync committed the lightweight parent row and lost the payload (the green-but-empty failure mode) |
+| `assert_availability_ids_and_timestamps` | availability rows with missing ids, empty state, or a present issue without a last-seen timestamp — malformed census emissions |
+| `assert_worklog_deletion_state_consistent` | a worklog with an authoritative deletion tombstone still flagged alive in the class contract — a regression in the deletion signals |
+
+Together with the source-freshness gates already declared on `bronze_jira`
+(warn 36h / error 72h, now covering the census tables too) these are the
+automated "missing IDs, values, timestamps, or deletion state" validation
+required by #2419's definition of done.

--- a/src/ingestion/connectors/task-tracking/jira/specs/DELETION-AND-VISIBILITY.md
+++ b/src/ingestion/connectors/task-tracking/jira/specs/DELETION-AND-VISIBILITY.md
@@ -1,0 +1,279 @@
+# Jira Deletion & Visibility Mechanism
+
+Status: implemented. Part of the data-completeness scope of issue #2419.
+
+## Problem
+
+The ingestion pipeline is incremental and append-only:
+
+- Incremental streams query `updated >= <cursor>`. A deleted Jira entity never
+  matches such a query again — it does not "update", it stops existing. Its
+  last known version stays in Bronze (and everything downstream) as if alive.
+- Jira's changelog records field-value changes only. Entity deletion is not a
+  changelog event; deleting an issue destroys its changelog entirely.
+- Bronze is `ReplacingMergeTree` keyed by `unique_key`: rows are versioned and
+  replaced, never compared against "what the API returned last time". The
+  pipeline has no step that observes *absence*.
+
+The same blind spot hides a different, non-destructive cause: the service
+account can lose **Browse Projects** on a project (permission change, project
+archived or moved to trash). Every entity of that project disappears from the
+API identically to deletion. The two must not be conflated.
+
+## Principles
+
+1. **Nothing is ever physically deleted from the warehouse.** Bronze rows,
+   snapshots, and history are retained forever. Deletion is recorded as an
+   *event in the entity's history*, exactly like any field change.
+2. **Absence must be observed, then classified.** An entity disappearing from
+   the API is a fact; *why* it disappeared is an inference. When the cause
+   cannot be determined, the event gets an honest name (`unobserved`) rather
+   than a guessed one.
+3. **Access is assumed stable.** Losing Browse permission is the exceptional
+   path; the classifier still detects it, but thresholds are tuned for the
+   normal world where a disappearance inside a visible project is a deletion.
+
+## Mechanism overview
+
+```text
+connector (per sync)                      dbt (per run)
+────────────────────                      ─────────────────────────────────────
+jira_project_visibility  ──────────────►  jira__project_visibility_state
+  full roster of projects per status        is_visible per ever-seen project
+  (live / archived / deleted)             ► jira__project_visibility_snapshot   (SCD2, snapshot())
+                                          ► jira__project_visibility_history    (events, fields_history())
+
+jira_issue_census        ──────────────►  jira__issue_availability_state
+  id-only sweep of ALL issues               availability per ever-seen issue
+  in every visible live project           ► jira__issue_availability_snapshot   (SCD2, snapshot())
+                                          ► jira__issue_availability_history    (events, fields_history())
+                                          ► jira__availability_events           (staging → silver)
+                                            └─► silver.class_task_field_history (union_by_tag,
+                                                 event_kind='availability')
+                                                 └─► gold task models filter on it
+```
+
+Both new streams are **full-refresh censuses**: each sync re-observes the
+complete set. Bronze RMT promotion (`ReplacingMergeTree(_airbyte_extracted_at)`
+keyed by `unique_key`) collapses them to one row per entity whose
+`_airbyte_extracted_at` is the **last time the entity was observed**. Absence
+detection is then a comparison of each entity's last-seen timestamp against
+the census high-water mark — no row diffing, no state files.
+
+## Streams
+
+### `jira_project_visibility`
+
+Roster of every project the service account can currently see, per lifecycle
+status.
+
+- Endpoint: `GET /rest/api/3/project/search?status=<s>` partitioned over
+  `s ∈ {live, archived, deleted}` (`deleted` = in Jira's project trash).
+  Presence in the response *is* the Browse permission check: `project/search`
+  returns only projects the caller can browse, so no separate
+  `permissions/project` call is needed.
+- Sync mode: full refresh, every sync. Cost: one page per ~50 projects per
+  status — negligible.
+- Record: `project_id`, `project_key`, `project_status` (stamped from the
+  partition), `is_private`, plus the standard identity stamp.
+  `unique_key = {tenant}-{source}-{project_id}` — keyed by immutable numeric
+  id, not by key (project keys can be renamed).
+
+### `jira_issue_census`
+
+Id-only sweep of **all** issues in every visible live project.
+
+- Endpoint: `GET /rest/api/3/search/jql` with `fields=id` and
+  `maxResults=5000`. Jira Cloud serves multi-thousand-id pages for id-only
+  queries, so a census of even hundreds of thousands of issues is a few
+  hundred requests.
+- Partitioned per project (Jira Cloud rejects unbounded JQL) via a dedicated
+  inline parent (`jira_census_projects`) that lists live projects with **no
+  incremental gate** — unlike `jira_project_discovery`, which skips idle
+  projects and therefore must never drive the census: a deletion does not
+  reliably bump the project's `insight.lastIssueUpdateTime` aggregate.
+- Sync mode: full refresh, every sync.
+- Record: `jira_id` (numeric issue id), `project_key`, identity stamp.
+  `unique_key = {tenant}-{source}-{jira_id}` — keyed by **numeric id, never by
+  issue key**: moving an issue between projects changes its key but not its
+  id; a key-based census would report every moved issue as deleted.
+
+## Classification
+
+`jira__issue_availability_state` recomputes, on every dbt run, one row per
+issue ever seen (union of the census and `bronze_jira.jira_issue`):
+
+| # | Observed | Project state (from visibility roster) | `availability` |
+|---|----------|----------------------------------------|-----------------|
+| 1 | in latest census generation | — | `present` |
+| 2 | absent | live, absence below mass threshold | `deleted` |
+| 3 | absent | live, absence ≥ mass threshold | `unobserved` |
+| 4 | absent | archived | `archived` |
+| 5 | absent | in project trash | `trashed` |
+| 6 | absent | project gone from the roster entirely | `access_lost` |
+
+- "Latest census generation": `max(_airbyte_extracted_at)` over the census
+  table minus a tolerance window (`jira_census_tolerance_hours`, default 12)
+  that absorbs the duration of a single sync. An issue whose last observation
+  is older than that is *absent*.
+- **Mass threshold** (rule 3, `jira_availability_mass_threshold`, default
+  0.5): if half or more of a live project's known issues vanish in one
+  generation, that is almost never a real mass deletion — it is a partial
+  sync, an issue-security change, or a permission edge the roster did not
+  catch. Such issues are honestly labelled `unobserved`, not `deleted`.
+  They reclassify automatically on a later run: back to `present` if
+  re-observed, or to `deleted` once the project's census looks sane again.
+- `access_lost` vs `archived`/`trashed`: the roster queries all three
+  lifecycle statuses, so a project that is merely archived or trashed is still
+  *in* the roster with that status. Only a project absent from all three
+  partitions has actually become invisible to the account (permission loss,
+  or permanent purge after trash retention).
+
+Why classification lives in dbt and not in the connector: the connector only
+*observes* (present-in-response); inference needs the warehouse's memory of
+what used to exist, which only Bronze has.
+
+### Known residual ambiguity
+
+- Issue-level security can hide a single issue inside a browsable project
+  without any deletion. Indistinguishable from deletion via the REST API
+  (Jira intentionally returns identical 404s). Mitigated by the mass
+  threshold only when it changes in bulk; a single issue hidden this way will
+  be classified `deleted`. Accepted: a misclassification is reversible — the
+  raw data stays in Bronze, and the issue reclassifies to `present` as soon
+  as it becomes observable again.
+- Deletion cannot be distinguished from "hidden" retroactively: permission
+  APIs (`mypermissions`, `permissions/check`) cannot be asked about an entity
+  that no longer appears. Hence the roster is captured *every* sync — the
+  classifier always compares against the visibility surface of the same
+  generation, never post-hoc.
+
+## History: deletion is an event
+
+Availability state feeds the same SCD2 machinery as user profiles
+(`snapshot()` + `fields_history()` macros):
+
+- `jira__issue_availability_snapshot` — appends a version whenever an issue's
+  `availability` flips. Never rewritten, retained forever.
+- `jira__issue_availability_history` — one row per transition:
+  `field_name='availability', old_value='present', new_value='deleted',
+  updated_at=<detection time>`. This is the durable "the entity was deleted"
+  event. Transitions back (`unobserved → present`) are recorded the same way.
+- `jira__project_visibility_snapshot` / `jira__project_visibility_history` —
+  the same pair for project visibility (`is_visible`, `project_status`), so
+  "the account lost access to project X on date D" is itself a permanent,
+  queryable event.
+
+`updated_at` on these events is the **detection** time (census generation),
+not the moment the user clicked delete in Jira — the REST API does not expose
+the latter for hard-deleted entities.
+
+### Sub-entity lifecycle events
+
+Comments and worklogs are the two issue sub-entities the changelog does not
+cover, so their lifecycle enters the same journal as synthetic events
+(`event_kind='lifecycle'`, `field_id='comment'|'worklog'`, `delta_action`
+add/set/remove). The event carries the **entity id** (`value_ids[1]`) — the
+lookup key into `class_task_comments` / `class_task_worklogs` — not the
+payload: the class tables stay the materialized current state (typed columns,
+cheap aggregates), the journal holds the history. Sources with a native event
+log (e.g. YouTrack activities) can emit these events directly; for Jira they
+are derived from the entity snapshots:
+
+- **add** — first observation; dated by the entity's own `updated` timestamp
+  (real time).
+- **set** — the entity's `updated` (worklogs: also seconds/started) changed
+  between syncs; dated by the new `updated`. Multiple edits between two syncs
+  collapse into one event — the API exposes no intermediate states.
+- **remove** — the deletion signals of this spec flip `is_deleted`; worklog
+  removals are dated by the `/worklog/deleted` tombstone (real deletion
+  time), comment removals by detection.
+
+## Downstream contract
+
+Availability transitions enter silver as **synthetic field-history events** in
+`class_task_field_history` — the same table, shape and machinery as every
+other field change. `jira__availability_events` maps the transitions from the
+availability SCD2 snapshot into the contract and unions in via
+`union_by_tag('silver:class_task_field_history')`:
+
+| field-history column | value for availability events |
+|----------------------|--------------------------------|
+| `field_id` / `field_name` | `availability` / `Availability` |
+| `event_kind` | `availability` (new enum value alongside `changelog`, `synthetic_initial`) |
+| `event_id` | `availability:<detection epoch ms>` |
+| `event_at` | detection time (census generation) |
+| `value_ids` / `value_displays` | the new state — enum from the classification table above |
+| `value_id_type` | `string_literal` |
+
+This keeps the contract **source-agnostic**: the census streams and the
+classifier are Jira's way of *detecting* absence, but the silver surface only
+says "this issue's availability changed at T" — a YouTrack, GitHub or any
+other task-tracker connector emits identical events from whatever deletion
+signal its API exposes (soft-delete flags, activity logs, webhooks), and every
+consumer reads one table for the entire issue lifecycle, deletion included.
+
+Consumption policy (implemented):
+
+- `gold/task_issue_state.sql` — pivots `field_id = 'availability'` alongside
+  the other fields and filters out issues whose latest availability is
+  `deleted` or `trashed`. Deleted issues therefore leave every task metric on
+  the next build (`task_status_spans`, `task_worklog_flow`,
+  `task_metric_evidence` all derive from `task_issue_state`, so the filter
+  propagates through the whole gold layer). `archived`, `access_lost` and
+  `unobserved` issues stay **in**: the entity still exists at the source;
+  its data is merely stale — excluding it would silently shrink history.
+- `jira__task_comments.sql` — the class contract's `is_deleted` column
+  (previously a constant 0) is now real. A comment is deleted when its issue
+  was re-fetched but the comment was not re-emitted (deleting a comment bumps
+  the issue's `updated`, which re-syncs the issue's full comment list), or
+  when its parent issue is `deleted`/`trashed`.
+- `class_task_worklogs.is_deleted` — real, from three OR-ed signals in
+  `jira__task_worklogs`: an authoritative tombstone from the
+  `jira_worklog_deleted` stream (`GET /rest/api/3/worklog/deleted` — the one
+  Jira surface where deletions are first-class; the whole bounded tombstone
+  list is re-read every sync, census-style), the same re-fetch generation
+  diff as comments (editing or deleting a worklog bumps the issue's
+  `updated`, re-syncing its full worklog list), and a deleted/trashed parent
+  issue. *Updated* worklogs need no extra stream: the per-issue re-fetch
+  already re-emits them — the same `updated`-bump assumption the project
+  discovery gate has relied on all along.
+- `gold/task_worklog_flow.sql` — the in-progress side inherits the filter
+  through its `task_issue_state` join; the worklog side filters
+  `ifNull(is_deleted, 0) = 0` from the class contract.
+
+Changing the policy (e.g. excluding deleted issues from historical throughput
+vs only from open-issue counts) is a one-line change in the gold filter; the
+availability data supports either choice.
+
+## Operational constraints
+
+- The census adds one id-only scan of every live project per sync. Requests
+  scale with `ceil(issues / 5000)` per project plus one project-roster page
+  per ~50 projects per status.
+- A failed sync does not corrupt classification: dbt runs only after a
+  successful sync in the Argo DAG, and the mass threshold catches
+  partially-committed censuses if dbt is run manually against one.
+- First census run: issues present in `bronze_jira.jira_issue` but absent
+  from the very first census were deleted before the mechanism landed; they
+  classify as `deleted` (or `unobserved` where they exceed the mass
+  threshold) on that first run — this is the intended backfill of
+  historical deletions.
+- Webhook-based deletion events (`jira:issue_deleted`, `comment_deleted`)
+  would add immediacy but require an inbound endpoint the batch-pull
+  architecture does not have; the census is the guaranteed path. If webhooks
+  are added later they emit into the same availability model.
+- Known limitation — total access loss is not classified: if the account
+  loses Browse on *every* project, the roster and the census return zero
+  rows, no new generation appears, and every issue stays frozen at its last
+  state (`present`). This fails safe — nothing is misclassified as deleted —
+  and the same event empties every stream of the connector, so the existing
+  `bronze_jira` source-freshness gates (warn 36h / error 72h) raise the alarm
+  operationally. A per-generation completion marker could classify this case
+  explicitly; deliberately not built here.
+- The silver contract changes this mechanism ships (`event_kind` gains
+  `availability`, `class_task_worklogs` gains `is_deleted`) are deployed via
+  the **major descriptor bump**: per ADR-0015 reconcile dispatches a one-shot
+  sync with `dbt --full-refresh` on the connector's selector, which rebuilds
+  the affected staging/silver tables from bronze. No ALTER migrations are
+  shipped for staging/silver.

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_board_configuration.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_board_configuration.py
@@ -1,0 +1,102 @@
+"""Mock-server tests for the `jira_board_configuration` stream.
+
+Substream of jira_boards: GET /rest/agile/1.0/board/{board_id}/configuration,
+one single-object request per board. Flattens the estimation field (the
+instance's actual Story Points custom-field id), the column-to-status mapping
+and the board location. See specs/DATA-COMPLETENESS.md.
+
+Coverage matrix rows: per_board_fan_out, estimation_flattening,
+tenant_source_stamping, kanban_without_estimation.
+"""
+
+from __future__ import annotations
+
+import json
+
+from config import JIRA_URL, JiraConfigBuilder
+from connector_tests import ANY_QUERY_PARAMS, HttpMocker, HttpRequest, HttpResponse, read_stream
+
+_STREAM = "jira_board_configuration"
+_CONNECTOR = "task-tracking/jira"
+_BOARDS_URL = f"{JIRA_URL}/rest/agile/1.0/board"
+
+
+def _mock_boards(http_mocker: HttpMocker, board_ids: list[int]) -> None:
+    http_mocker.get(
+        HttpRequest(_BOARDS_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps(
+                {"values": [{"id": bid, "name": f"Board {bid}", "type": "scrum"} for bid in board_ids], "isLast": True}
+            ),
+            status_code=200,
+        ),
+    )
+
+
+def _config_response(board_id: int, *, estimation: bool = True) -> HttpResponse:
+    body: dict = {
+        "id": board_id,
+        "name": f"Board {board_id}",
+        "type": "scrum" if estimation else "kanban",
+        "columnConfig": {
+            "columns": [{"name": "To Do", "statuses": [{"id": "1"}]}, {"name": "Done", "statuses": [{"id": "6"}]}]
+        },
+        "location": {"type": "project", "key": "PROJ1"},
+    }
+    if estimation:
+        body["estimation"] = {"type": "field", "field": {"fieldId": "customfield_10101", "displayName": "Story Points"}}
+    return HttpResponse(body=json.dumps(body), status_code=200)
+
+
+def test_per_board_fan_out(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    _mock_boards(http_mocker, [7, 8])
+    http_mocker.get(HttpRequest(f"{_BOARDS_URL}/7/configuration"), _config_response(7))
+    http_mocker.get(HttpRequest(f"{_BOARDS_URL}/8/configuration"), _config_response(8))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 2
+    assert not output.errors
+    assert sorted(r.record.data["board_id"] for r in output.records) == [7, 8]
+
+
+def test_estimation_flattening(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    _mock_boards(http_mocker, [7])
+    http_mocker.get(HttpRequest(f"{_BOARDS_URL}/7/configuration"), _config_response(7))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    rec = output.records[0].record.data
+    assert rec["estimation_field_id"] == "customfield_10101"
+    assert rec["estimation_field_name"] == "Story Points"
+    assert rec["board_type"] == "scrum"
+
+
+def test_tenant_source_stamping(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    _mock_boards(http_mocker, [7])
+    http_mocker.get(HttpRequest(f"{_BOARDS_URL}/7/configuration"), _config_response(7))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    rec = output.records[0].record.data
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["source_id"] == config["insight_source_id"]
+    assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-7")
+
+
+def test_kanban_without_estimation(http_mocker: HttpMocker) -> None:
+    """Kanban boards carry no estimation block; the flattened fields must be
+    empty, not crash the slice."""
+    config = JiraConfigBuilder().build()
+    _mock_boards(http_mocker, [9])
+    http_mocker.get(HttpRequest(f"{_BOARDS_URL}/9/configuration"), _config_response(9, estimation=False))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 1
+    rec = output.records[0].record.data
+    assert not rec.get("estimation_field_id")
+    assert rec["board_type"] == "kanban"

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_boards.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_boards.py
@@ -1,0 +1,64 @@
+"""Mock-server tests for the `jira_boards` stream.
+
+Plain paginated stream: GET /rest/agile/1.0/board, `values` extraction, linked
+OffsetIncrement paginator (page_size 50). Also the substream parent for
+jira_board_configuration.
+
+Coverage matrix rows: full_refresh_read, tenant_source_stamping,
+pagination_offset_50.
+"""
+
+from __future__ import annotations
+
+import json
+
+from config import JIRA_URL, JiraConfigBuilder
+from connector_tests import ANY_QUERY_PARAMS, HttpMocker, HttpRequest, HttpResponse, read_stream
+
+_STREAM = "jira_boards"
+_CONNECTOR = "task-tracking/jira"
+_URL = f"{JIRA_URL}/rest/agile/1.0/board"
+
+
+def _board(bid: int) -> dict[str, object]:
+    return {"id": bid, "name": f"Board {bid}", "type": "scrum"}
+
+
+def _page(boards: list[dict[str, object]], *, is_last: bool = True) -> HttpResponse:
+    return HttpResponse(body=json.dumps({"values": boards, "isLast": is_last}), status_code=200)
+
+
+def test_full_refresh_read(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    http_mocker.get(HttpRequest(_URL, query_params=ANY_QUERY_PARAMS), _page([_board(1), _board(2)]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 2
+    assert not output.errors
+
+
+def test_tenant_source_stamping(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    http_mocker.get(HttpRequest(_URL, query_params=ANY_QUERY_PARAMS), _page([_board(7)]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    rec = output.records[0].record.data
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["source_id"] == config["insight_source_id"]
+    assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-7")
+
+
+def test_reads_the_next_page_after_a_non_final_response(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    page1 = [_board(i) for i in range(50)]
+    page2 = [_board(100)]
+
+    http_mocker.get(HttpRequest(_URL, query_params={"maxResults": "50"}), _page(page1, is_last=False))
+    http_mocker.get(HttpRequest(_URL, query_params={"maxResults": "50", "startAt": "50"}), _page(page2))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 51
+    assert output.records[-1].record.data["id"] == 100

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_comments.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_comments.py
@@ -1,0 +1,102 @@
+"""Mock-server tests for the `jira_comments` stream.
+
+Substream of the lightweight jira_issue_keys parent: one
+GET /rest/api/3/issue/{key}/comment per issue partition, `comments`
+extraction, ADF body serialized to JSON.
+
+Coverage matrix rows: parent_chain_fan_out, tenant_source_stamping
+(body tojson).
+
+The clock is frozen at 2026-07-01 00:00 UTC and jira_start_date is 2026-06-01,
+so the parent gets exactly one 30-day slice.
+"""
+
+from __future__ import annotations
+
+import json
+
+import freezegun
+from config import JIRA_URL, JiraConfigBuilder
+from connector_tests import ANY_QUERY_PARAMS, HttpMocker, HttpRequest, HttpResponse, load_fixture, read_stream
+
+_STREAM = "jira_comments"
+_CONNECTOR = "task-tracking/jira"
+_PROJECT_SEARCH_URL = f"{JIRA_URL}/rest/api/3/project/search"
+_JQL_URL = f"{JIRA_URL}/rest/api/3/search/jql"
+_NOW = "2026-07-01T00:00:00Z"
+
+_ADF_BODY = {"type": "doc", "version": 1, "content": []}
+
+
+def _mock_parent_chain(http_mocker: HttpMocker, issue_keys: list[str]) -> None:
+    projects = [load_fixture(__file__, "discovery_project.json", id="10000", key="PROJ1", name="Project PROJ1")]
+    http_mocker.get(
+        HttpRequest(_PROJECT_SEARCH_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"values": projects, "isLast": True}), status_code=200),
+    )
+    issues = [
+        load_fixture(
+            __file__, "issue.json", id=str(20000 + i), key=key, fields={"updated": "2026-06-15T10:00:00.000+0000"}
+        )
+        for i, key in enumerate(issue_keys)
+    ]
+    http_mocker.get(
+        HttpRequest(_JQL_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"issues": issues}), status_code=200),
+    )
+
+
+def _comments_response(ids: list[str]) -> HttpResponse:
+    comments = [
+        {
+            "id": cid,
+            "author": {"accountId": "acc-1"},
+            "created": "2026-06-15T10:00:00.000+0000",
+            "updated": "2026-06-15T11:00:00.000+0000",
+            "body": _ADF_BODY,
+        }
+        for cid in ids
+    ]
+    return HttpResponse(body=json.dumps({"comments": comments}), status_code=200)
+
+
+@freezegun.freeze_time(_NOW)
+def test_parent_chain_fan_out(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    _mock_parent_chain(http_mocker, ["PROJ1-1", "PROJ1-2"])
+    http_mocker.get(
+        HttpRequest(f"{JIRA_URL}/rest/api/3/issue/PROJ1-1/comment", query_params=ANY_QUERY_PARAMS),
+        _comments_response(["701"]),
+    )
+    http_mocker.get(
+        HttpRequest(f"{JIRA_URL}/rest/api/3/issue/PROJ1-2/comment", query_params=ANY_QUERY_PARAMS),
+        _comments_response(["702"]),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    # The lookback slice may re-emit a partition; bronze dedups by unique_key.
+    assert not output.errors
+    assert sorted({r.record.data["comment_id"] for r in output.records}) == [701, 702]
+
+
+@freezegun.freeze_time(_NOW)
+def test_tenant_source_stamping(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    _mock_parent_chain(http_mocker, ["PROJ1-1"])
+    http_mocker.get(
+        HttpRequest(f"{JIRA_URL}/rest/api/3/issue/PROJ1-1/comment", query_params=ANY_QUERY_PARAMS),
+        _comments_response(["701"]),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    rec = output.records[0].record.data
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["source_id"] == config["insight_source_id"]
+    assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-701")
+    assert rec["id_readable"] == "PROJ1-1"
+    assert rec["author_account_id"] == "acc-1"
+    assert rec["updated"] == "2026-06-15T11:00:00.000+0000"
+    # Raw ADF body rides along as JSON; plaintext extraction is deferred to dbt.
+    assert rec["body"] == _ADF_BODY

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_fields.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_fields.py
@@ -1,0 +1,74 @@
+"""Mock-server tests for the `jira_fields` stream.
+
+Root-array lookup: GET /rest/api/3/field, no pagination. Flattens the nested
+schema object into schema_type / schema_items / schema_custom — the columns
+the dbt story-points resolution reads.
+
+Coverage matrix rows: full_refresh_read, schema_flattening_and_stamping.
+"""
+
+from __future__ import annotations
+
+import json
+
+from config import JIRA_URL, JiraConfigBuilder
+from connector_tests import ANY_QUERY_PARAMS, HttpMocker, HttpRequest, HttpResponse, read_stream
+
+_STREAM = "jira_fields"
+_CONNECTOR = "task-tracking/jira"
+_URL = f"{JIRA_URL}/rest/api/3/field"
+
+
+def _fields_response() -> HttpResponse:
+    return HttpResponse(
+        body=json.dumps(
+            [
+                {"id": "summary", "name": "Summary", "custom": False, "schema": {"type": "string"}},
+                {
+                    "id": "customfield_10101",
+                    "name": "Story Points",
+                    "custom": True,
+                    "schema": {"type": "number", "custom": "com.pyxis.greenhopper.jira:jsw-story-points"},
+                },
+                {
+                    "id": "customfield_10202",
+                    "name": "Sprints",
+                    "custom": True,
+                    "schema": {"type": "array", "items": "string", "custom": "com.example.jira:sprint"},
+                },
+            ]
+        ),
+        status_code=200,
+    )
+
+
+def test_full_refresh_read(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    http_mocker.get(HttpRequest(_URL, query_params=ANY_QUERY_PARAMS), _fields_response())
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 3
+    assert not output.errors
+
+
+def test_schema_flattening_and_stamping(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    http_mocker.get(HttpRequest(_URL, query_params=ANY_QUERY_PARAMS), _fields_response())
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    by_id = {r.record.data["field_id"]: r.record.data for r in output.records}
+    sp = by_id["customfield_10101"]
+    assert sp["tenant_id"] == config["insight_tenant_id"]
+    assert sp["source_id"] == config["insight_source_id"]
+    assert sp["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-customfield_10101")
+    assert sp["custom"] is True
+    assert sp["schema_type"] == "number"
+    # The dbt story-points resolution keys on this canonical marker.
+    assert sp["schema_custom"] == "com.pyxis.greenhopper.jira:jsw-story-points"
+    # None-valued AddFields stamps are dropped from the record entirely.
+    assert by_id["summary"].get("schema_custom") in (None, "")
+    # An array field carries the element type the flattened contract declares.
+    assert by_id["customfield_10202"]["schema_type"] == "array"
+    assert by_id["customfield_10202"]["schema_items"] == "string"

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_issue.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_issue.py
@@ -1,0 +1,116 @@
+"""Mock-server tests for the `jira_issue` stream.
+
+Full-record emitter: one JQL search per jira_project_discovery partition
+(GET /rest/api/3/search/jql, fields=*all + expand=names, nextPageToken
+pagination) with the same DatetimeBasedCursor window as jira_issue_keys.
+
+Coverage matrix rows: full_record_read (field flattening + custom_fields_json),
+story_points_no_default (the hardcoded field-id fallback is gone),
+story_points_operator_override.
+
+The clock is frozen at 2026-07-01 00:00 UTC and jira_start_date is 2026-06-01,
+so each partition gets exactly one 30-day slice.
+"""
+
+from __future__ import annotations
+
+import json
+
+import freezegun
+from config import JIRA_URL, JiraConfigBuilder
+from connector_tests import ANY_QUERY_PARAMS, HttpMocker, HttpRequest, HttpResponse, load_fixture, read_stream
+
+_STREAM = "jira_issue"
+_CONNECTOR = "task-tracking/jira"
+_PROJECT_SEARCH_URL = f"{JIRA_URL}/rest/api/3/project/search"
+_JQL_URL = f"{JIRA_URL}/rest/api/3/search/jql"
+_NOW = "2026-07-01T00:00:00Z"
+
+
+def _projects_response(keys: list[str]) -> HttpResponse:
+    values = [
+        load_fixture(__file__, "discovery_project.json", id=str(10000 + i), key=key, name=f"Project {key}")
+        for i, key in enumerate(keys)
+    ]
+    return HttpResponse(body=json.dumps({"values": values, "isLast": True}), status_code=200)
+
+
+def _issue_fields(**extra: object) -> dict[str, object]:
+    fields = {
+        "updated": "2026-06-15T10:00:00.000+0000",
+        "created": "2026-06-01T09:00:00.000+0000",
+        "project": {"key": "PROJ1"},
+        "status": {"id": "3", "name": "In Progress"},
+        "issuetype": {"id": "10001", "name": "Story"},
+        "assignee": {"accountId": "acc-1"},
+        "reporter": {"accountId": "acc-2"},
+        "labels": ["backend", "urgent"],
+    }
+    fields.update(extra)
+    return fields
+
+
+def _issues_response(issues: list[dict[str, object]]) -> HttpResponse:
+    return HttpResponse(body=json.dumps({"issues": issues}), status_code=200)
+
+
+@freezegun.freeze_time(_NOW)
+def test_full_record_read(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    http_mocker.get(HttpRequest(_PROJECT_SEARCH_URL, query_params=ANY_QUERY_PARAMS), _projects_response(["PROJ1"]))
+    http_mocker.get(
+        HttpRequest(_JQL_URL, query_params=ANY_QUERY_PARAMS),
+        _issues_response([{"id": "10001", "key": "PROJ1-1", "fields": _issue_fields()}]),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 1
+    assert not output.errors
+    rec = output.records[0].record.data
+    assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-PROJ1-1")
+    assert rec["jira_id"] == 10001
+    assert rec["id_readable"] == "PROJ1-1"
+    assert rec["project_key"] == "PROJ1"
+    assert rec["status_id"] == 3
+    assert rec["assignee_id"] == "acc-1"
+    assert rec["labels_csv"] == "backend,urgent"
+    # The full fields payload rides along for dbt extraction.
+    # tojson stamps literal-eval back into a dict; the destination re-serializes
+    # per the declared string schema.
+    assert rec["custom_fields_json"]["status"]["name"] == "In Progress"
+
+
+@freezegun.freeze_time(_NOW)
+def test_story_points_no_hardcoded_default(http_mocker: HttpMocker) -> None:
+    """Without an operator override the connector must NOT guess a field id:
+    a value sitting in some instance's customfield must stay out of
+    story_points (dbt resolves it from /field metadata instead)."""
+    config = JiraConfigBuilder().build()
+    http_mocker.get(HttpRequest(_PROJECT_SEARCH_URL, query_params=ANY_QUERY_PARAMS), _projects_response(["PROJ1"]))
+    http_mocker.get(
+        HttpRequest(_JQL_URL, query_params=ANY_QUERY_PARAMS),
+        _issues_response([{"id": "10001", "key": "PROJ1-1", "fields": _issue_fields(customfield_10016=5)}]),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    rec = output.records[0].record.data
+    assert not rec.get("story_points")
+    assert rec["custom_fields_json"]["customfield_10016"] == 5
+
+
+@freezegun.freeze_time(_NOW)
+def test_story_points_operator_override(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    config["jira_story_points_field_id"] = "customfield_777"
+    http_mocker.get(HttpRequest(_PROJECT_SEARCH_URL, query_params=ANY_QUERY_PARAMS), _projects_response(["PROJ1"]))
+    http_mocker.get(
+        HttpRequest(_JQL_URL, query_params=ANY_QUERY_PARAMS),
+        _issues_response([{"id": "10001", "key": "PROJ1-1", "fields": _issue_fields(customfield_777=8)}]),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    rec = output.records[0].record.data
+    assert rec["story_points"] == 8

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_issue_census.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_issue_census.py
@@ -1,0 +1,125 @@
+"""Mock-server tests for the `jira_issue_census` stream.
+
+Full-refresh id-only sweep of every issue in every visible live project:
+GET /rest/api/3/search/jql with `fields=id` / `maxResults=5000`, nextPageToken
+cursor pagination, partitioned per project via the inline (non-gated)
+jira_census_projects parent. See specs/DELETION-AND-VISIBILITY.md.
+
+Coverage matrix rows: full_sweep_single_page, pagination_next_page_token,
+tenant_source_stamping, schema_conformance, empty_project.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from config import JIRA_URL, JiraConfigBuilder
+from connector_tests import ANY_QUERY_PARAMS, HttpMocker, HttpRequest, HttpResponse, load_fixture, read_stream
+
+_STREAM = "jira_issue_census"
+_CONNECTOR = "task-tracking/jira"
+_PROJECT_URL = f"{JIRA_URL}/rest/api/3/project/search"
+_SEARCH_URL = f"{JIRA_URL}/rest/api/3/search/jql"
+
+
+def _mock_parent(http_mocker: HttpMocker, keys: list[str]) -> None:
+    projects = [
+        load_fixture(
+            __file__,
+            "project.json",
+            id=str(20000 + i),
+            key=key,
+            name=f"Project {key}",
+            self=f"{JIRA_URL}/rest/api/3/project/{20000 + i}",
+        )
+        for i, key in enumerate(keys)
+    ]
+    http_mocker.get(
+        HttpRequest(_PROJECT_URL, query_params={"maxResults": "50"}),
+        HttpResponse(body=json.dumps({"values": projects, "isLast": True}), status_code=200),
+    )
+
+
+def _census_page(ids: list[int], next_token: str | None = None) -> HttpResponse:
+    body: dict = {"issues": [{"id": str(i)} for i in ids]}
+    if next_token:
+        body["nextPageToken"] = next_token
+    return HttpResponse(body=json.dumps(body), status_code=200)
+
+
+def _jql(project_key: str) -> str:
+    return f'project = "{project_key}" ORDER BY created ASC'
+
+
+def test_full_sweep_single_page(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    _mock_parent(http_mocker, ["PROJ1"])
+    http_mocker.get(HttpRequest(_SEARCH_URL, query_params=ANY_QUERY_PARAMS), _census_page([101, 102, 103]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 3
+    assert not output.errors
+    assert [r.record.data["jira_id"] for r in output.records] == [101, 102, 103]
+
+
+def test_pagination_next_page_token(http_mocker: HttpMocker) -> None:
+    """CursorPagination: a nextPageToken in the response triggers the next
+    request; its absence stops the sweep."""
+    config = JiraConfigBuilder().build()
+    _mock_parent(http_mocker, ["PROJ1"])
+    http_mocker.get(
+        HttpRequest(_SEARCH_URL, query_params={"jql": _jql("PROJ1"), "fields": "id", "maxResults": "5000"}),
+        _census_page([101], next_token="tok-1"),
+    )
+    http_mocker.get(
+        HttpRequest(
+            _SEARCH_URL,
+            query_params={"jql": _jql("PROJ1"), "fields": "id", "maxResults": "5000", "nextPageToken": "tok-1"},
+        ),
+        _census_page([102]),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 2
+    assert [r.record.data["jira_id"] for r in output.records] == [101, 102]
+
+
+def test_tenant_source_stamping(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    _mock_parent(http_mocker, ["PROJ1"])
+    http_mocker.get(HttpRequest(_SEARCH_URL, query_params=ANY_QUERY_PARAMS), _census_page([101]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    rec = output.records[0].record.data
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["source_id"] == config["insight_source_id"]
+    # Keyed by immutable numeric issue id: a moved issue changes its key but
+    # not its id, and must not be reported as deleted.
+    assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-101")
+    assert rec["project_key"] == "PROJ1"
+
+
+@pytest.mark.skip(
+    reason="same known drift as jira_issue_keys: jira_id is declared "
+    "['string','null'] for consistency with every other jira_id column (the "
+    "2.4.0 rule, migration 20260723000000), but the AddFields Jinja "
+    "literal-eval emits int for numeric ids. The ClickHouse destination "
+    "coerces per the declared schema, so bronze stays String."
+)
+def test_schema_conformance() -> None:
+    pass
+
+
+def test_empty_project(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    _mock_parent(http_mocker, ["EMPTY"])
+    http_mocker.get(HttpRequest(_SEARCH_URL, query_params=ANY_QUERY_PARAMS), _census_page([]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 0
+    assert not output.errors

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_issue_history.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_issue_history.py
@@ -1,0 +1,95 @@
+"""Mock-server tests for the `jira_issue_history` stream.
+
+Substream of the lightweight jira_issue_keys parent (itself a substream of
+jira_project_discovery): one GET /rest/api/3/issue/{key}/changelog per issue
+partition, `values` extraction, items[] serialized to JSON.
+
+Coverage matrix rows: parent_chain_fan_out, tenant_source_stamping
+(items tojson + changelog_id).
+
+The clock is frozen at 2026-07-01 00:00 UTC and jira_start_date is 2026-06-01,
+so the parent gets exactly one 30-day slice.
+"""
+
+from __future__ import annotations
+
+import json
+
+import freezegun
+from config import JIRA_URL, JiraConfigBuilder
+from connector_tests import ANY_QUERY_PARAMS, HttpMocker, HttpRequest, HttpResponse, load_fixture, read_stream
+
+_STREAM = "jira_issue_history"
+_CONNECTOR = "task-tracking/jira"
+_PROJECT_SEARCH_URL = f"{JIRA_URL}/rest/api/3/project/search"
+_JQL_URL = f"{JIRA_URL}/rest/api/3/search/jql"
+_NOW = "2026-07-01T00:00:00Z"
+
+_ITEMS = [{"field": "status", "fieldId": "status", "from": "1", "to": "3"}]
+
+
+def _mock_parent_chain(http_mocker: HttpMocker, issue_keys: list[str]) -> None:
+    projects = [load_fixture(__file__, "discovery_project.json", id="10000", key="PROJ1", name="Project PROJ1")]
+    http_mocker.get(
+        HttpRequest(_PROJECT_SEARCH_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"values": projects, "isLast": True}), status_code=200),
+    )
+    issues = [
+        load_fixture(
+            __file__, "issue.json", id=str(20000 + i), key=key, fields={"updated": "2026-06-15T10:00:00.000+0000"}
+        )
+        for i, key in enumerate(issue_keys)
+    ]
+    http_mocker.get(
+        HttpRequest(_JQL_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"issues": issues}), status_code=200),
+    )
+
+
+def _changelog_response(entries: list[tuple[str, str]]) -> HttpResponse:
+    values = [
+        {"id": cid, "author": {"accountId": "acc-1"}, "created": created, "items": _ITEMS} for cid, created in entries
+    ]
+    return HttpResponse(body=json.dumps({"values": values, "isLast": True}), status_code=200)
+
+
+@freezegun.freeze_time(_NOW)
+def test_parent_chain_fan_out(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    _mock_parent_chain(http_mocker, ["PROJ1-1", "PROJ1-2"])
+    http_mocker.get(
+        HttpRequest(f"{JIRA_URL}/rest/api/3/issue/PROJ1-1/changelog", query_params=ANY_QUERY_PARAMS),
+        _changelog_response([("501", "2026-06-15T10:00:00.000+0000")]),
+    )
+    http_mocker.get(
+        HttpRequest(f"{JIRA_URL}/rest/api/3/issue/PROJ1-2/changelog", query_params=ANY_QUERY_PARAMS),
+        _changelog_response([("502", "2026-06-16T10:00:00.000+0000")]),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    # The lookback slice may re-emit a partition; bronze dedups by unique_key.
+    assert not output.errors
+    assert sorted({r.record.data["changelog_id"] for r in output.records}) == [501, 502]
+
+
+@freezegun.freeze_time(_NOW)
+def test_tenant_source_stamping(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    _mock_parent_chain(http_mocker, ["PROJ1-1"])
+    http_mocker.get(
+        HttpRequest(f"{JIRA_URL}/rest/api/3/issue/PROJ1-1/changelog", query_params=ANY_QUERY_PARAMS),
+        _changelog_response([("501", "2026-06-15T10:00:00.000+0000")]),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    rec = output.records[0].record.data
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["source_id"] == config["insight_source_id"]
+    assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-501")
+    assert rec["id_readable"] == "PROJ1-1"
+    assert rec["author_account_id"] == "acc-1"
+    assert rec["created_at"] == "2026-06-15T10:00:00.000+0000"
+    # items[] rides along as JSON for the dbt changelog explode.
+    assert rec["items"] == _ITEMS

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_issuetypes.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_issuetypes.py
@@ -1,0 +1,61 @@
+"""Mock-server tests for the `jira_issuetypes` stream.
+
+Root-array lookup: GET /rest/api/3/issuetype, no pagination.
+
+Coverage matrix rows: full_refresh_read, tenant_source_stamping (subtask +
+hierarchyLevel flatten).
+"""
+
+from __future__ import annotations
+
+import json
+
+from config import JIRA_URL, JiraConfigBuilder
+from connector_tests import ANY_QUERY_PARAMS, HttpMocker, HttpRequest, HttpResponse, read_stream
+
+_STREAM = "jira_issuetypes"
+_CONNECTOR = "task-tracking/jira"
+_URL = f"{JIRA_URL}/rest/api/3/issuetype"
+
+
+def test_full_refresh_read(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps(
+                [
+                    {"id": "10001", "name": "Story", "subtask": False, "hierarchyLevel": 0},
+                    {"id": "10003", "name": "Sub-task", "subtask": True, "hierarchyLevel": -1},
+                ]
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 2
+    assert not output.errors
+    assert sorted(r.record.data["name"] for r in output.records) == ["Story", "Sub-task"]
+
+
+def test_tenant_source_stamping(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps([{"id": "10003", "name": "Sub-task", "subtask": True, "hierarchyLevel": -1}]),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    rec = output.records[0].record.data
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["source_id"] == config["insight_source_id"]
+    assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-10003")
+    assert rec["issuetype_id"] == 10003
+    assert rec["subtask"] is True
+    assert rec["hierarchy_level"] == -1

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_priorities.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_priorities.py
@@ -1,0 +1,47 @@
+"""Mock-server tests for the `jira_priorities` stream.
+
+Root-array lookup: GET /rest/api/3/priority, no pagination.
+
+Coverage matrix rows: full_refresh_read, tenant_source_stamping.
+"""
+
+from __future__ import annotations
+
+import json
+
+from config import JIRA_URL, JiraConfigBuilder
+from connector_tests import ANY_QUERY_PARAMS, HttpMocker, HttpRequest, HttpResponse, read_stream
+
+_STREAM = "jira_priorities"
+_CONNECTOR = "task-tracking/jira"
+_URL = f"{JIRA_URL}/rest/api/3/priority"
+
+
+def test_full_refresh_read(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps([{"id": "1", "name": "Highest"}, {"id": "3", "name": "Medium"}]), status_code=200),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 2
+    assert not output.errors
+    assert sorted(r.record.data["name"] for r in output.records) == ["Highest", "Medium"]
+
+
+def test_tenant_source_stamping(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps([{"id": "3", "name": "Medium"}]), status_code=200),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    rec = output.records[0].record.data
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["source_id"] == config["insight_source_id"]
+    assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-3")
+    assert rec["priority_id"] == 3

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_project_visibility.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_project_visibility.py
@@ -1,0 +1,94 @@
+"""Mock-server tests for the `jira_project_visibility` stream.
+
+Full-refresh census of the projects the account can browse, partitioned over
+project lifecycle status (live / archived / deleted) via ListPartitionRouter;
+each partition injects `status=<s>` into GET /rest/api/3/project/search and
+stamps `project_status` from the partition. See specs/DELETION-AND-VISIBILITY.md.
+
+Coverage matrix rows: partition_fan_out, tenant_source_stamping,
+schema_conformance, empty_page.
+"""
+
+from __future__ import annotations
+
+import json
+
+from config import JIRA_URL, JiraConfigBuilder
+from connector_tests import HttpMocker, HttpRequest, HttpResponse, assert_records_conform, load_fixture, read_stream
+
+_STREAM = "jira_project_visibility"
+_CONNECTOR = "task-tracking/jira"
+_SEARCH_URL = f"{JIRA_URL}/rest/api/3/project/search"
+
+
+def _project(pid: int, key: str) -> dict[str, object]:
+    return load_fixture(
+        __file__,
+        "project.json",
+        id=str(pid),
+        key=key,
+        name=f"Project {key}",
+        self=f"{JIRA_URL}/rest/api/3/project/{pid}",
+    )
+
+
+def _page(records: list[dict[str, object]]) -> HttpResponse:
+    return HttpResponse(body=json.dumps({"values": records, "isLast": True}), status_code=200)
+
+
+def _mock_status(http_mocker: HttpMocker, status: str, records: list[dict[str, object]]) -> None:
+    http_mocker.get(HttpRequest(_SEARCH_URL, query_params={"status": status, "maxResults": "50"}), _page(records))
+
+
+def test_partition_fan_out(http_mocker: HttpMocker) -> None:
+    """One request per lifecycle status; project_status is stamped from the
+    partition, so the same endpoint yields distinguishable rows."""
+    config = JiraConfigBuilder().build()
+    _mock_status(http_mocker, "live", [_project(10001, "LIVE1")])
+    _mock_status(http_mocker, "archived", [_project(10002, "ARCH1")])
+    _mock_status(http_mocker, "deleted", [_project(10003, "TRASH1")])
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 3
+    assert not output.errors
+    by_status = {r.record.data["project_status"]: r.record.data["project_key"] for r in output.records}
+    assert by_status == {"live": "LIVE1", "archived": "ARCH1", "deleted": "TRASH1"}
+
+
+def test_tenant_source_stamping(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    _mock_status(http_mocker, "live", [_project(10001, "PROJ1")])
+    _mock_status(http_mocker, "archived", [])
+    _mock_status(http_mocker, "deleted", [])
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    rec = output.records[0].record.data
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["source_id"] == config["insight_source_id"]
+    # Keyed by immutable numeric project id (project keys can be renamed).
+    assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-10001")
+    assert rec["project_key"] == "PROJ1"
+
+
+def test_schema_conformance(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    _mock_status(http_mocker, "live", [_project(10001, "PROJ1")])
+    _mock_status(http_mocker, "archived", [_project(10002, "ARCH1")])
+    _mock_status(http_mocker, "deleted", [])
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert_records_conform(output.records, _CONNECTOR, _STREAM)
+
+
+def test_empty_page(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    for status in ("live", "archived", "deleted"):
+        _mock_status(http_mocker, status, [])
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 0
+    assert not output.errors

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_projects.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_projects.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import json
 
 from config import JIRA_URL, JiraConfigBuilder
-
 from connector_tests import (
     ANY_QUERY_PARAMS,
     HttpMocker,
@@ -31,7 +30,7 @@ _CONNECTOR = "task-tracking/jira"
 _SEARCH_URL = f"{JIRA_URL}/rest/api/3/project/search"
 
 
-def _project(pid: int, key: str) -> dict:
+def _project(pid: int, key: str) -> dict[str, object]:
     """The fixtures/project.json record with only the case-relevant overrides."""
     return load_fixture(
         __file__,
@@ -43,10 +42,8 @@ def _project(pid: int, key: str) -> dict:
     )
 
 
-def _page(records: list[dict], *, is_last: bool = True) -> HttpResponse:
-    return HttpResponse(
-        body=json.dumps({"values": records, "isLast": is_last}), status_code=200
-    )
+def _page(records: list[dict[str, object]], *, is_last: bool = True) -> HttpResponse:
+    return HttpResponse(body=json.dumps({"values": records, "isLast": is_last}), status_code=200)
 
 
 def test_full_refresh_single_page(http_mocker: HttpMocker) -> None:
@@ -66,19 +63,14 @@ def test_full_refresh_single_page(http_mocker: HttpMocker) -> None:
 
 def test_tenant_source_stamping(http_mocker: HttpMocker) -> None:
     config = JiraConfigBuilder().build()
-    http_mocker.get(
-        HttpRequest(_SEARCH_URL, query_params=ANY_QUERY_PARAMS),
-        _page([_project(10001, "PROJ1")]),
-    )
+    http_mocker.get(HttpRequest(_SEARCH_URL, query_params=ANY_QUERY_PARAMS), _page([_project(10001, "PROJ1")]))
 
     output = read_stream(_CONNECTOR, _STREAM, config)
 
     rec = output.records[0].record.data
     assert rec["tenant_id"] == config["insight_tenant_id"]
     assert rec["source_id"] == config["insight_source_id"]
-    assert rec["unique_key"] == (
-        f"{config['insight_tenant_id']}-{config['insight_source_id']}-10001"
-    )
+    assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-10001")
     # Flattening transformations declared in the manifest. CDK interpolation
     # literal-evals the rendered Jinja value, so the numeric-string API id
     # becomes an int — the schema accordingly declares project_id as number.
@@ -107,12 +99,10 @@ def test_pagination_multi_page(http_mocker: HttpMocker) -> None:
     page2 = [_project(10100, "LAST")]
 
     http_mocker.get(
-        HttpRequest(_SEARCH_URL, query_params={"maxResults": "50"}),
-        _page(page1, is_last=False),
+        HttpRequest(_SEARCH_URL, query_params={"expand": "lead", "maxResults": "50"}), _page(page1, is_last=False)
     )
     http_mocker.get(
-        HttpRequest(_SEARCH_URL, query_params={"maxResults": "50", "startAt": "50"}),
-        _page(page2),
+        HttpRequest(_SEARCH_URL, query_params={"expand": "lead", "maxResults": "50", "startAt": "50"}), _page(page2)
     )
 
     output = read_stream(_CONNECTOR, _STREAM, config)
@@ -123,9 +113,7 @@ def test_pagination_multi_page(http_mocker: HttpMocker) -> None:
 
 def test_empty_page(http_mocker: HttpMocker) -> None:
     config = JiraConfigBuilder().build()
-    http_mocker.get(
-        HttpRequest(_SEARCH_URL, query_params=ANY_QUERY_PARAMS), _page([])
-    )
+    http_mocker.get(HttpRequest(_SEARCH_URL, query_params=ANY_QUERY_PARAMS), _page([]))
 
     output = read_stream(_CONNECTOR, _STREAM, config)
 
@@ -141,9 +129,7 @@ def test_error_retry_429(http_mocker: HttpMocker) -> None:
         HttpRequest(_SEARCH_URL, query_params=ANY_QUERY_PARAMS),
         [
             HttpResponse(
-                body=json.dumps({"errorMessages": ["rate limited"]}),
-                status_code=429,
-                headers={"Retry-After": "0"},
+                body=json.dumps({"errorMessages": ["rate limited"]}), status_code=429, headers={"Retry-After": "0"}
             ),
             _page([_project(10001, "PROJ1")]),
         ],
@@ -160,9 +146,7 @@ def test_error_ignore_400(http_mocker: HttpMocker) -> None:
     config = JiraConfigBuilder().build()
     http_mocker.get(
         HttpRequest(_SEARCH_URL, query_params=ANY_QUERY_PARAMS),
-        HttpResponse(
-            body=json.dumps({"errorMessages": ["bad request"]}), status_code=400
-        ),
+        HttpResponse(body=json.dumps({"errorMessages": ["bad request"]}), status_code=400),
     )
 
     output = read_stream(_CONNECTOR, _STREAM, config)

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_resolutions.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_resolutions.py
@@ -1,0 +1,49 @@
+"""Mock-server tests for the `jira_resolutions` stream.
+
+Root-array lookup: GET /rest/api/3/resolution, no pagination.
+
+Coverage matrix rows: full_refresh_read, tenant_source_stamping.
+"""
+
+from __future__ import annotations
+
+import json
+
+from config import JIRA_URL, JiraConfigBuilder
+from connector_tests import ANY_QUERY_PARAMS, HttpMocker, HttpRequest, HttpResponse, read_stream
+
+_STREAM = "jira_resolutions"
+_CONNECTOR = "task-tracking/jira"
+_URL = f"{JIRA_URL}/rest/api/3/resolution"
+
+
+def test_full_refresh_read(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps([{"id": "10000", "name": "Done"}, {"id": "10001", "name": "Won't Do"}]), status_code=200
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 2
+    assert not output.errors
+
+
+def test_tenant_source_stamping(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps([{"id": "10000", "name": "Done"}]), status_code=200),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    rec = output.records[0].record.data
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["source_id"] == config["insight_source_id"]
+    assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-10000")
+    assert rec["resolution_id"] == 10000
+    assert rec["name"] == "Done"

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_sprints.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_sprints.py
@@ -1,0 +1,84 @@
+"""Mock-server tests for the `jira_sprints` stream.
+
+Substream of the inline `_scrum_boards` parent (GET /rest/agile/1.0/board
+?type=scrum — sprints exist only on scrum boards): one
+GET /rest/agile/1.0/board/{board_id}/sprint per board partition.
+
+Coverage matrix rows: per_board_fan_out, tenant_source_stamping.
+"""
+
+from __future__ import annotations
+
+import json
+
+from config import JIRA_URL, JiraConfigBuilder
+from connector_tests import HttpMocker, HttpRequest, HttpResponse, read_stream
+
+_STREAM = "jira_sprints"
+_CONNECTOR = "task-tracking/jira"
+_BOARDS_URL = f"{JIRA_URL}/rest/agile/1.0/board"
+
+
+def _mock_scrum_boards(http_mocker: HttpMocker, board_ids: list[int]) -> None:
+    http_mocker.get(
+        HttpRequest(_BOARDS_URL, query_params={"type": "scrum", "maxResults": "50"}),
+        HttpResponse(
+            body=json.dumps(
+                {"values": [{"id": bid, "name": f"Board {bid}", "type": "scrum"} for bid in board_ids], "isLast": True}
+            ),
+            status_code=200,
+        ),
+    )
+
+
+def _sprints_response(sprints: list[dict[str, object]]) -> HttpResponse:
+    return HttpResponse(body=json.dumps({"values": sprints, "isLast": True}), status_code=200)
+
+
+def _sprint(sid: int, state: str) -> dict[str, object]:
+    return {
+        "id": sid,
+        "name": f"Sprint {sid}",
+        "state": state,
+        "startDate": "2026-06-01T00:00:00.000Z",
+        "endDate": "2026-06-14T00:00:00.000Z",
+    }
+
+
+def test_per_board_fan_out(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    _mock_scrum_boards(http_mocker, [7, 8])
+    http_mocker.get(
+        HttpRequest(f"{_BOARDS_URL}/7/sprint", query_params={"maxResults": "50"}),
+        _sprints_response([_sprint(70, "closed")]),
+    )
+    http_mocker.get(
+        HttpRequest(f"{_BOARDS_URL}/8/sprint", query_params={"maxResults": "50"}),
+        _sprints_response([_sprint(80, "active")]),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 2
+    assert not output.errors
+    assert sorted(r.record.data["sprint_id"] for r in output.records) == [70, 80]
+
+
+def test_tenant_source_stamping(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    _mock_scrum_boards(http_mocker, [7])
+    http_mocker.get(
+        HttpRequest(f"{_BOARDS_URL}/7/sprint", query_params={"maxResults": "50"}),
+        _sprints_response([_sprint(70, "active")]),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    rec = output.records[0].record.data
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["source_id"] == config["insight_source_id"]
+    assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-70")
+    assert rec["board_id"] == 7
+    assert rec["sprint_name"] == "Sprint 70"
+    assert rec["state"] == "active"
+    assert rec["start_date"] == "2026-06-01T00:00:00.000Z"

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_statuses.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_statuses.py
@@ -1,0 +1,66 @@
+"""Mock-server tests for the `jira_statuses` stream.
+
+Root-array lookup: GET /rest/api/3/status, no pagination, statusCategory
+flattened into category_id / category_name / category_key.
+
+Coverage matrix rows: full_refresh_read, tenant_source_stamping, empty_list.
+"""
+
+from __future__ import annotations
+
+import json
+
+from config import JIRA_URL, JiraConfigBuilder
+from connector_tests import ANY_QUERY_PARAMS, HttpMocker, HttpRequest, HttpResponse, read_stream
+
+_STREAM = "jira_statuses"
+_CONNECTOR = "task-tracking/jira"
+_URL = f"{JIRA_URL}/rest/api/3/status"
+
+
+def _status(sid: str, name: str, category_key: str) -> dict[str, object]:
+    return {"id": sid, "name": name, "statusCategory": {"id": 3, "key": category_key, "name": category_key.title()}}
+
+
+def test_full_refresh_read(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps([_status("1", "Open", "new"), _status("6", "Closed", "done")]), status_code=200),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 2
+    assert not output.errors
+    assert sorted(r.record.data["name"] for r in output.records) == ["Closed", "Open"]
+
+
+def test_tenant_source_stamping(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps([_status("6", "Done", "done")]), status_code=200),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    rec = output.records[0].record.data
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["source_id"] == config["insight_source_id"]
+    assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-6")
+    assert rec["status_id"] == 6
+    # statusCategory flattening — the done-category detection downstream
+    # (issue #1541) reads category_key, never the display name.
+    assert rec["category_key"] == "done"
+    assert rec["category_name"] == "Done"
+
+
+def test_empty_list(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    http_mocker.get(HttpRequest(_URL, query_params=ANY_QUERY_PARAMS), HttpResponse(body="[]", status_code=200))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 0
+    assert not output.errors

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_user.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_user.py
@@ -1,0 +1,84 @@
+"""Mock-server tests for the `jira_user` stream.
+
+Root-array read: GET /rest/api/3/users/search, OffsetIncrement paginator with
+page_size 200 (maxResults / startAt).
+
+Coverage matrix rows: full_refresh_read, tenant_source_stamping,
+pagination_offset_200.
+"""
+
+from __future__ import annotations
+
+import json
+
+from config import JIRA_URL, JiraConfigBuilder
+from connector_tests import ANY_QUERY_PARAMS, HttpMocker, HttpRequest, HttpResponse, read_stream
+
+_STREAM = "jira_user"
+_CONNECTOR = "task-tracking/jira"
+_URL = f"{JIRA_URL}/rest/api/3/users/search"
+
+
+def _user(account_id: str, email: str) -> dict[str, object]:
+    return {
+        "accountId": account_id,
+        "emailAddress": email,
+        "displayName": f"User {account_id}",
+        "accountType": "atlassian",
+        "active": True,
+    }
+
+
+def test_full_refresh_read(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(
+            body=json.dumps([_user("acc-1", "a@example.com"), _user("acc-2", "b@example.com")]), status_code=200
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 2
+    assert not output.errors
+
+
+def test_tenant_source_stamping(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps([_user("acc-1", "a@example.com")]), status_code=200),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    rec = output.records[0].record.data
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["source_id"] == config["insight_source_id"]
+    assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-acc-1")
+    assert rec["account_id"] == "acc-1"
+    assert rec["email"] == "a@example.com"
+    assert rec["account_type"] == "atlassian"
+    assert rec["active"] is True
+
+
+def test_pagination_offset_200(http_mocker: HttpMocker) -> None:
+    """A full page (200 = page_size) triggers a second request with
+    startAt=200; a short page stops pagination."""
+    config = JiraConfigBuilder().build()
+    page1 = [_user(f"acc-{i}", f"u{i}@example.com") for i in range(200)]
+    page2 = [_user("acc-last", "last@example.com")]
+
+    http_mocker.get(
+        HttpRequest(_URL, query_params={"maxResults": "200"}), HttpResponse(body=json.dumps(page1), status_code=200)
+    )
+    http_mocker.get(
+        HttpRequest(_URL, query_params={"maxResults": "200", "startAt": "200"}),
+        HttpResponse(body=json.dumps(page2), status_code=200),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 201
+    assert output.records[-1].record.data["account_id"] == "acc-last"

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_worklog_deleted.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_worklog_deleted.py
@@ -1,0 +1,81 @@
+"""Mock-server tests for the `jira_worklog_deleted` stream.
+
+Full re-read of Jira's deleted-worklog tombstone list:
+GET /rest/api/3/worklog/deleted?since=0, paged via the response's `nextPage`
+URL (RequestPath token swaps the request URL wholesale) until lastPage.
+See specs/DELETION-AND-VISIBILITY.md.
+
+Coverage matrix rows: full_read_single_page, pagination_next_page_url,
+tenant_source_stamping, empty_list.
+"""
+
+from __future__ import annotations
+
+import json
+
+from config import JIRA_URL, JiraConfigBuilder
+from connector_tests import HttpMocker, HttpRequest, HttpResponse, read_stream
+
+_STREAM = "jira_worklog_deleted"
+_CONNECTOR = "task-tracking/jira"
+_URL = f"{JIRA_URL}/rest/api/3/worklog/deleted"
+
+
+def _page(entries: list[tuple[int, int]], *, next_since: int | None = None) -> HttpResponse:
+    body: dict = {
+        "values": [{"worklogId": wid, "updatedTime": ts, "properties": []} for wid, ts in entries],
+        "lastPage": next_since is None,
+    }
+    if next_since is not None:
+        body["nextPage"] = f"{_URL}?since={next_since}"
+    return HttpResponse(body=json.dumps(body), status_code=200)
+
+
+def test_full_read_single_page(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    http_mocker.get(HttpRequest(_URL, query_params={"since": "0"}), _page([(101, 1700000000000), (102, 1700000001000)]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 2
+    assert not output.errors
+    assert [r.record.data["worklog_id"] for r in output.records] == [101, 102]
+
+
+def test_pagination_next_page_url(http_mocker: HttpMocker) -> None:
+    """The paginator follows the response's nextPage URL (which carries
+    since=<until>) until lastPage=true."""
+    config = JiraConfigBuilder().build()
+    http_mocker.get(
+        HttpRequest(_URL, query_params={"since": "0"}), _page([(101, 1700000000000)], next_since=1700000000000)
+    )
+    http_mocker.get(HttpRequest(_URL, query_params={"since": "1700000000000"}), _page([(102, 1700000002000)]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 2
+    assert [r.record.data["worklog_id"] for r in output.records] == [101, 102]
+
+
+def test_tenant_source_stamping(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    http_mocker.get(HttpRequest(_URL, query_params={"since": "0"}), _page([(101, 1700000000000)]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    rec = output.records[0].record.data
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["source_id"] == config["insight_source_id"]
+    assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-101")
+    # updatedTime on this endpoint IS the deletion timestamp.
+    assert rec["deleted_at_ms"] == 1700000000000
+
+
+def test_empty_list(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    http_mocker.get(HttpRequest(_URL, query_params={"since": "0"}), _page([]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 0
+    assert not output.errors

--- a/src/ingestion/connectors/task-tracking/jira/tests/test_jira_worklogs.py
+++ b/src/ingestion/connectors/task-tracking/jira/tests/test_jira_worklogs.py
@@ -1,0 +1,100 @@
+"""Mock-server tests for the `jira_worklogs` stream.
+
+Substream of the lightweight jira_issue_keys parent: one
+GET /rest/api/3/issue/{key}/worklog per issue partition, `worklogs`
+extraction.
+
+Coverage matrix rows: parent_chain_fan_out, tenant_source_stamping.
+
+The clock is frozen at 2026-07-01 00:00 UTC and jira_start_date is 2026-06-01,
+so the parent gets exactly one 30-day slice.
+"""
+
+from __future__ import annotations
+
+import json
+
+import freezegun
+from config import JIRA_URL, JiraConfigBuilder
+from connector_tests import ANY_QUERY_PARAMS, HttpMocker, HttpRequest, HttpResponse, load_fixture, read_stream
+
+_STREAM = "jira_worklogs"
+_CONNECTOR = "task-tracking/jira"
+_PROJECT_SEARCH_URL = f"{JIRA_URL}/rest/api/3/project/search"
+_JQL_URL = f"{JIRA_URL}/rest/api/3/search/jql"
+_NOW = "2026-07-01T00:00:00Z"
+
+
+def _mock_parent_chain(http_mocker: HttpMocker, issue_keys: list[str]) -> None:
+    projects = [load_fixture(__file__, "discovery_project.json", id="10000", key="PROJ1", name="Project PROJ1")]
+    http_mocker.get(
+        HttpRequest(_PROJECT_SEARCH_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"values": projects, "isLast": True}), status_code=200),
+    )
+    issues = [
+        load_fixture(
+            __file__, "issue.json", id=str(20000 + i), key=key, fields={"updated": "2026-06-15T10:00:00.000+0000"}
+        )
+        for i, key in enumerate(issue_keys)
+    ]
+    http_mocker.get(
+        HttpRequest(_JQL_URL, query_params=ANY_QUERY_PARAMS),
+        HttpResponse(body=json.dumps({"issues": issues}), status_code=200),
+    )
+
+
+def _worklogs_response(ids: list[str]) -> HttpResponse:
+    worklogs = [
+        {
+            "id": wid,
+            "author": {"accountId": "acc-1"},
+            "started": "2026-06-15T09:00:00.000+0000",
+            "updated": "2026-06-15T10:00:00.000+0000",
+            "timeSpentSeconds": 3600,
+            "comment": "worked",
+        }
+        for wid in ids
+    ]
+    return HttpResponse(body=json.dumps({"worklogs": worklogs}), status_code=200)
+
+
+@freezegun.freeze_time(_NOW)
+def test_parent_chain_fan_out(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    _mock_parent_chain(http_mocker, ["PROJ1-1", "PROJ1-2"])
+    http_mocker.get(
+        HttpRequest(f"{JIRA_URL}/rest/api/3/issue/PROJ1-1/worklog", query_params=ANY_QUERY_PARAMS),
+        _worklogs_response(["801"]),
+    )
+    http_mocker.get(
+        HttpRequest(f"{JIRA_URL}/rest/api/3/issue/PROJ1-2/worklog", query_params=ANY_QUERY_PARAMS),
+        _worklogs_response(["802"]),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    # The lookback slice may re-emit a partition; bronze dedups by unique_key.
+    assert not output.errors
+    assert sorted({r.record.data["worklog_id"] for r in output.records}) == [801, 802]
+
+
+@freezegun.freeze_time(_NOW)
+def test_tenant_source_stamping(http_mocker: HttpMocker) -> None:
+    config = JiraConfigBuilder().build()
+    _mock_parent_chain(http_mocker, ["PROJ1-1"])
+    http_mocker.get(
+        HttpRequest(f"{JIRA_URL}/rest/api/3/issue/PROJ1-1/worklog", query_params=ANY_QUERY_PARAMS),
+        _worklogs_response(["801"]),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    rec = output.records[0].record.data
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["source_id"] == config["insight_source_id"]
+    assert rec["unique_key"] == (f"{config['insight_tenant_id']}-{config['insight_source_id']}-801")
+    assert rec["id_readable"] == "PROJ1-1"
+    assert rec["author_account_id"] == "acc-1"
+    assert rec["started"] == "2026-06-15T09:00:00.000+0000"
+    assert rec["time_spent_seconds"] == 3600
+    assert rec["comment"] == "worked"

--- a/src/ingestion/dbt/macros/promote_bronze_to_rmt.sql
+++ b/src/ingestion/dbt/macros/promote_bronze_to_rmt.sql
@@ -28,6 +28,10 @@
                   `_airbyte_extracted_at` (added by Airbyte to every row, monotonic
                   across syncs). Pass '' for versionless RMT.
     partition_by: Optional PARTITION BY expression. Defaults to none.
+    where:        Optional filter applied during the CTAS copy. Use it to drop
+                  rows whose dedup key is NULL when the key column was added
+                  after rows already existed - RMT treats NULL keys as equal
+                  and would collapse them into one row.
 
   Caveats:
     - Race with concurrent Airbyte sync: rows inserted into the original table
@@ -63,7 +67,7 @@
 -#}
 
 -- @cpt-principle:cpt-dataflow-principle-promote-bronze:p1
-{% macro promote_bronze_to_rmt(table, order_by, version_col='_airbyte_extracted_at', partition_by=none) %}
+{% macro promote_bronze_to_rmt(table, order_by, version_col='_airbyte_extracted_at', partition_by=none, where=none) %}
     {%- set parts = table.split('.') -%}
     {%- if parts | length != 2 -%}
         {{ exceptions.raise_compiler_error(
@@ -113,6 +117,7 @@
         ORDER BY {{ order_by }}
         SETTINGS allow_nullable_key = 1
         AS SELECT * FROM `{{ db }}`.`{{ tbl }}`
+        {{ ('WHERE ' ~ where) if where else '' }}
     {% endset %}
     {% do run_query(ctas) %}
 

--- a/src/ingestion/dbt/macros/reset_task_field_history_on_full_refresh.sql
+++ b/src/ingestion/dbt/macros/reset_task_field_history_on_full_refresh.sql
@@ -1,0 +1,24 @@
+{#-
+  Pre-hook for `jira__changelog_items`: on a full refresh, empty the Rust-owned
+  `staging.jira__task_field_history` so `jira-enrich` re-derives it from scratch.
+
+  Without this, `--full-refresh` cannot reach that table at all: its DDL macro
+  is CREATE TABLE IF NOT EXISTS, and jira-enrich keeps ONE high-water mark per
+  issue across all fields, dropping every event at or below it. Any event that
+  reaches Bronze late — a repaired row, a backfilled project — would stay
+  invisible forever while the rest of the pipeline reported success.
+
+  It hangs off `jira__changelog_items` (tags staging+jira) rather than
+  on-run-start because the Jira pipeline invokes dbt twice, staging then silver,
+  and passes --full-refresh to both. An on-run-start reset would fire again on
+  the silver pass, wiping what enrich had just written. This model belongs to
+  the staging selection only, so the reset lands exactly once, before enrich.
+-#}
+
+{% macro reset_task_field_history_on_full_refresh() %}
+    {%- if flags.FULL_REFRESH -%}
+        TRUNCATE TABLE IF EXISTS staging.jira__task_field_history
+    {%- else -%}
+        SELECT 1
+    {%- endif -%}
+{% endmacro %}

--- a/src/ingestion/dbt/tests/task/assert_availability_ids_and_timestamps.sql
+++ b/src/ingestion/dbt/tests/task/assert_availability_ids_and_timestamps.sql
@@ -1,0 +1,16 @@
+-- API-to-Bronze completeness (#2419): every availability row must carry the
+-- identifiers and timestamps downstream classification depends on. A NULL/empty
+-- jira_id or a missing last_seen_at for a PRESENT issue means the census
+-- emitted a malformed record (missing id, value, or timestamp) — the exact
+-- defect class the epic's automated validation is required to detect.
+
+SELECT
+    tenant_id,
+    source_id,
+    jira_id,
+    availability
+FROM staging.jira__issue_availability_state FINAL
+WHERE jira_id IS NULL
+   OR jira_id = ''
+   OR availability = ''
+   OR (availability = 'present' AND last_seen_at = toDateTime64(0, 3))

--- a/src/ingestion/dbt/tests/task/assert_census_issue_has_full_record.sql
+++ b/src/ingestion/dbt/tests/task/assert_census_issue_has_full_record.sql
@@ -1,0 +1,45 @@
+-- API-to-Bronze completeness (#2419): an issue the census observed as present
+-- AND that the incremental scan enumerated (a jira_issue_keys row exists) must
+-- have its full bronze_jira.jira_issue record. A violation means the sync
+-- committed the lightweight parent row but lost the full-record emission —
+-- exactly the green-but-empty failure mode this check exists to catch.
+--
+-- The census alone is not enough to demand a full record: issues untouched
+-- since jira_start_date are censused but legitimately never scanned in full.
+--
+-- The two streams scan a project at slightly different moments inside one
+-- sync, so an issue updated mid-sync can land in jira_issue_keys before
+-- jira_issue has seen it — the next incremental sync closes that gap on its
+-- own. Only flag issues whose key-row `updated` predates the full stream's
+-- last scan by more than the race window.
+
+WITH issue_scan AS (
+    -- Per (tenant, source): each source instance scans on its own clock, so a
+    -- global watermark would judge one instance's issues against another's
+    -- scan time and report rows inside their own race window.
+    SELECT
+        tenant_id,
+        source_id,
+        max(_airbyte_extracted_at) AS scanned_at
+    FROM bronze_jira.jira_issue
+    GROUP BY tenant_id, source_id
+)
+
+SELECT
+    av.tenant_id,
+    av.source_id,
+    av.jira_id
+FROM staging.jira__issue_availability_state AS av FINAL
+INNER JOIN bronze_jira.jira_issue_keys AS ik FINAL
+    ON ik.tenant_id = av.tenant_id
+    AND ik.source_id = av.source_id
+    AND ik.jira_id = av.jira_id
+LEFT ANTI JOIN bronze_jira.jira_issue AS i FINAL
+    ON i.tenant_id = av.tenant_id
+    AND i.source_id = av.source_id
+    AND i.jira_id = av.jira_id
+INNER JOIN issue_scan AS scan
+    ON scan.tenant_id = av.tenant_id
+    AND scan.source_id = av.source_id
+WHERE av.availability = 'present'
+  AND parseDateTime64BestEffortOrNull(ik.updated, 3) < scan.scanned_at - INTERVAL 1 HOUR

--- a/src/ingestion/dbt/tests/task/assert_changelog_items_not_double_encoded.sql
+++ b/src/ingestion/dbt/tests/task/assert_changelog_items_not_double_encoded.sql
@@ -1,0 +1,14 @@
+-- Regression guard for the `items` double-encoding defect: a changelog row
+-- whose `items` is an escaped JSON string instead of an array reads as a scalar
+-- through JSONExtractArrayRaw, so jira__changelog_items skips it and the field
+-- history silently loses every affected event. The stream declares `items` as
+-- a plain string to prevent this; the failure was invisible because the
+-- pipeline stays green while the journal quietly shrinks.
+
+SELECT
+    unique_key,
+    id_readable,
+    created,
+    substring(items, 1, 80) AS items_head
+FROM {{ source('bronze_jira', 'jira_issue_history') }}
+WHERE startsWith(items, '"')

--- a/src/ingestion/dbt/tests/task/assert_event_kind_matches_event_id.sql
+++ b/src/ingestion/dbt/tests/task/assert_event_kind_matches_event_id.sql
@@ -1,6 +1,8 @@
 -- Convention (ADR-005-event-id-traceability):
 --   event_kind='synthetic_initial' ⇔ event_id LIKE 'initial:%'
---   event_kind='changelog'         ⇔ event_id NOT LIKE 'initial:%'
+--   event_kind='availability'      ⇔ event_id LIKE 'availability:%'
+--   event_kind='lifecycle'         ⇔ event_id LIKE 'comment:%' OR 'worklog:%'
+--   event_kind='changelog'         ⇔ event_id matches no prefix above
 -- Any violation means the writer got the kind vs id wrong.
 
 SELECT
@@ -12,5 +14,8 @@ SELECT
     event_kind
 FROM silver.class_task_field_history FINAL
 WHERE (event_kind = 'synthetic_initial' AND event_id NOT LIKE 'initial:%')
-   OR (event_kind = 'changelog'         AND event_id LIKE 'initial:%')
+   OR (event_kind = 'changelog'         AND (event_id LIKE 'initial:%' OR event_id LIKE 'availability:%'
+                                             OR event_id LIKE 'comment:%' OR event_id LIKE 'worklog:%'))
+   OR (event_kind = 'availability'      AND event_id NOT LIKE 'availability:%')
+   OR (event_kind = 'lifecycle'         AND event_id NOT LIKE 'comment:%' AND event_id NOT LIKE 'worklog:%')
 LIMIT 100

--- a/src/ingestion/dbt/tests/task/assert_worklog_deletion_state_consistent.sql
+++ b/src/ingestion/dbt/tests/task/assert_worklog_deletion_state_consistent.sql
@@ -1,0 +1,14 @@
+-- API-to-Bronze completeness (#2419): a worklog with an authoritative
+-- /worklog/deleted tombstone must be flagged is_deleted in the class contract.
+-- A violation means the staging model's deletion signals regressed and gold
+-- metrics are counting time logged on worklogs Jira no longer has.
+
+SELECT
+    w.insight_source_id,
+    w.worklog_id
+FROM silver.class_task_worklogs AS w FINAL
+INNER JOIN bronze_jira.jira_worklog_deleted AS t FINAL
+    ON t.source_id = w.insight_source_id
+    AND toString(toInt64(t.worklog_id)) = w.worklog_id
+WHERE w.data_source = 'jira'
+  AND ifNull(w.is_deleted, 0) = 0

--- a/src/ingestion/gold/task_issue_state.sql
+++ b/src/ingestion/gold/task_issue_state.sql
@@ -54,10 +54,14 @@ issue_pivot AS (
         toFloat64OrNull(argMaxIf(value_displays[1], (event_at, _version),
                  field_id = 'timespent' AND delta_action = 'set'))           AS time_spent_seconds,
         minIf(event_at, event_kind = 'synthetic_initial')                    AS created_at,
-        maxIf(event_at, field_id = 'status' AND delta_action = 'set')        AS last_status_event_at
+        maxIf(event_at, field_id = 'status' AND delta_action = 'set')        AS last_status_event_at,
+        -- Availability lives in the same history as every other field
+        -- (synthetic 'availability' events; see the jira deletion spec).
+        argMaxIf(value_ids[1], (event_at, _version),
+                 field_id = 'availability')                                  AS availability
     FROM {{ ref('class_task_field_history') }} FINAL
     WHERE field_id IN ('status', 'assignee', 'issuetype', 'duedate',
-                       'timeoriginalestimate', 'timespent')
+                       'timeoriginalestimate', 'timespent', 'availability')
        OR event_kind = 'synthetic_initial'
     GROUP BY insight_source_id, issue_id
 ),
@@ -99,3 +103,9 @@ LEFT JOIN issue_close AS c
     ON c.insight_source_id = p.insight_source_id AND c.issue_id = p.issue_id
 LEFT JOIN {{ ref('class_task_statuses') }} AS cur FINAL
     ON cur.insight_source_id = p.insight_source_id AND cur.status_id = p.status_id
+-- Issues deleted at the source (or in the project trash) leave every task
+-- metric: this table is the root of the gold task chain, so the filter
+-- propagates to spans, worklog flow and evidence. archived / access_lost /
+-- unobserved issues stay in — the entity still exists, its data is merely
+-- stale. Issues with no availability events default to present ('').
+WHERE p.availability NOT IN ('deleted', 'trashed')

--- a/src/ingestion/gold/task_metric_observations.sql
+++ b/src/ingestion/gold/task_metric_observations.sql
@@ -167,7 +167,11 @@ worklog_per_day AS (
     FROM {{ ref('class_task_worklogs') }} AS w FINAL
     INNER JOIN task_users AS u
         ON u.insight_source_id = w.insight_source_id AND u.user_id = w.author_id
+    -- Deletion awareness comes from the class contract's is_deleted (worklog
+    -- tombstones + issue re-fetch diff + deleted parent issue) — see
+    -- specs/DELETION-AND-VISIBILITY.md in the jira connector.
     WHERE w.work_date IS NOT NULL
+      AND ifNull(w.is_deleted, 0) = 0
     GROUP BY u.tenant_id, u.email, toDate(w.work_date)
 ),
 -- Both sides of the accuracy ratio are gated to days with in-progress time —

--- a/src/ingestion/scripts/connectors-ddl/jira.sql
+++ b/src/ingestion/scripts/connectors-ddl/jira.sql
@@ -11,11 +11,15 @@ CREATE TABLE IF NOT EXISTS bronze_jira.jira_boards
     `self` Nullable(String),
     `name` Nullable(String),
     `location` Nullable(String),
-    `isPrivate` Nullable(Bool)
+    `isPrivate` Nullable(Bool),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `unique_key` Nullable(String),
+    `collected_at` Nullable(String)
 )
-ENGINE = MergeTree
-ORDER BY _airbyte_raw_id
-SETTINGS index_granularity = 8192
+ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
+ORDER BY unique_key
+SETTINGS allow_nullable_key = 1, index_granularity = 8192
 ;
 
 CREATE TABLE IF NOT EXISTS bronze_jira.jira_comments
@@ -180,9 +184,9 @@ CREATE TABLE IF NOT EXISTS bronze_jira.jira_issuetypes
     `collected_at` Nullable(String),
     `scope` Nullable(String)
 )
-ENGINE = MergeTree
-ORDER BY _airbyte_raw_id
-SETTINGS index_granularity = 8192
+ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
+ORDER BY unique_key
+SETTINGS allow_nullable_key = 1, index_granularity = 8192
 ;
 
 CREATE TABLE IF NOT EXISTS bronze_jira.jira_priorities
@@ -203,9 +207,9 @@ CREATE TABLE IF NOT EXISTS bronze_jira.jira_priorities
     `priority_id` Nullable(Decimal(38, 9)),
     `collected_at` Nullable(String)
 )
-ENGINE = MergeTree
-ORDER BY _airbyte_raw_id
-SETTINGS index_granularity = 8192
+ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
+ORDER BY unique_key
+SETTINGS allow_nullable_key = 1, index_granularity = 8192
 ;
 
 CREATE TABLE IF NOT EXISTS bronze_jira.jira_projects
@@ -258,9 +262,9 @@ CREATE TABLE IF NOT EXISTS bronze_jira.jira_resolutions
     `resolution_id` Nullable(Decimal(38, 9)),
     `collected_at` Nullable(String)
 )
-ENGINE = MergeTree
-ORDER BY _airbyte_raw_id
-SETTINGS index_granularity = 8192
+ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
+ORDER BY unique_key
+SETTINGS allow_nullable_key = 1, index_granularity = 8192
 ;
 
 CREATE TABLE IF NOT EXISTS bronze_jira.jira_sprints
@@ -318,9 +322,9 @@ CREATE TABLE IF NOT EXISTS bronze_jira.jira_statuses
     `category_key` Nullable(String),
     `collected_at` Nullable(String)
 )
-ENGINE = MergeTree
-ORDER BY _airbyte_raw_id
-SETTINGS index_granularity = 8192
+ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
+ORDER BY unique_key
+SETTINGS allow_nullable_key = 1, index_granularity = 8192
 ;
 
 CREATE TABLE IF NOT EXISTS bronze_jira.jira_user

--- a/src/ingestion/scripts/connectors-ddl/jira.sql
+++ b/src/ingestion/scripts/connectors-ddl/jira.sql
@@ -1,5 +1,36 @@
 CREATE DATABASE IF NOT EXISTS `bronze_jira`;
 
+CREATE TABLE IF NOT EXISTS bronze_jira.jira_board_configuration
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `id` Nullable(Decimal(38, 9)),
+    `name` Nullable(String),
+    `type` Nullable(String),
+    `self` Nullable(String),
+    `filter` Nullable(String),
+    `columnConfig` Nullable(String),
+    `estimation` Nullable(String),
+    `ranking` Nullable(String),
+    `location` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `unique_key` Nullable(String),
+    `board_id` Nullable(Decimal(38, 9)),
+    `board_type` Nullable(String),
+    `estimation_field_id` Nullable(String),
+    `estimation_field_name` Nullable(String),
+    `column_config` Nullable(String),
+    `board_location` Nullable(String),
+    `collected_at` Nullable(String)
+)
+ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
+ORDER BY unique_key
+SETTINGS allow_nullable_key = 1, index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS bronze_jira.jira_boards
 (
     `_airbyte_raw_id` String,
@@ -116,6 +147,25 @@ ORDER BY unique_key
 SETTINGS allow_nullable_key = 1, index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS bronze_jira.jira_issue_census
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `id` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `unique_key` Nullable(String),
+    `jira_id` Nullable(String),
+    `project_key` Nullable(String),
+    `collected_at` Nullable(String)
+)
+ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
+ORDER BY unique_key
+SETTINGS allow_nullable_key = 1, index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS bronze_jira.jira_issue_history
 (
     `_airbyte_raw_id` String,
@@ -212,6 +262,38 @@ ORDER BY unique_key
 SETTINGS allow_nullable_key = 1, index_granularity = 8192
 ;
 
+CREATE TABLE IF NOT EXISTS bronze_jira.jira_project_visibility
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `expand` Nullable(String),
+    `self` Nullable(String),
+    `id` Nullable(String),
+    `key` Nullable(String),
+    `name` Nullable(String),
+    `avatarUrls` Nullable(String),
+    `projectCategory` Nullable(String),
+    `projectTypeKey` Nullable(String),
+    `simplified` Nullable(Bool),
+    `style` Nullable(String),
+    `isPrivate` Nullable(Bool),
+    `properties` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `unique_key` Nullable(String),
+    `project_id` Nullable(Decimal(38, 9)),
+    `project_key` Nullable(String),
+    `project_status` Nullable(String),
+    `is_private` Nullable(Bool),
+    `collected_at` Nullable(String)
+)
+ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
+ORDER BY unique_key
+SETTINGS allow_nullable_key = 1, index_granularity = 8192
+;
+
 CREATE TABLE IF NOT EXISTS bronze_jira.jira_projects
 (
     `_airbyte_raw_id` String,
@@ -237,6 +319,8 @@ CREATE TABLE IF NOT EXISTS bronze_jira.jira_projects
     `project_key` Nullable(String),
     `project_type` Nullable(String),
     `archived` Nullable(Bool),
+    `lead` Nullable(String),
+    `lead_account_id` Nullable(String),
     `collected_at` Nullable(String),
     `entityId` Nullable(String),
     `uuid` Nullable(String)
@@ -350,6 +434,27 @@ CREATE TABLE IF NOT EXISTS bronze_jira.jira_user
     `collected_at` Nullable(String),
     `locale` Nullable(String),
     `timeZone` Nullable(String)
+)
+ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
+ORDER BY unique_key
+SETTINGS allow_nullable_key = 1, index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_jira.jira_worklog_deleted
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `worklogId` Nullable(Decimal(38, 9)),
+    `updatedTime` Nullable(Decimal(38, 9)),
+    `properties` Nullable(String),
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `unique_key` Nullable(String),
+    `worklog_id` Nullable(Decimal(38, 9)),
+    `deleted_at_ms` Nullable(Decimal(38, 9)),
+    `collected_at` Nullable(String)
 )
 ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
 ORDER BY unique_key

--- a/src/ingestion/scripts/connectors-ddl/silver.sql
+++ b/src/ingestion/scripts/connectors-ddl/silver.sql
@@ -711,7 +711,7 @@ CREATE TABLE IF NOT EXISTS silver.class_task_field_history
     `id_readable` String,
     `event_id` String,
     `event_at` DateTime64(3),
-    `event_kind` Enum8('changelog' = 1, 'synthetic_initial' = 2),
+    `event_kind` Enum8('changelog' = 1, 'synthetic_initial' = 2, 'availability' = 3, 'lifecycle' = 4),
     `_seq` UInt32,
     `author_id` Nullable(String),
     `author_display` Nullable(String),
@@ -843,6 +843,7 @@ CREATE TABLE IF NOT EXISTS silver.class_task_worklogs
     `duration_seconds` Nullable(Float64),
     `description` Nullable(String),
     `collected_at` Nullable(DateTime64(3)),
+    `is_deleted` Nullable(UInt8),
     `_version` Int64
 )
 ENGINE = ReplacingMergeTree(_version)

--- a/src/ingestion/scripts/migrations/20260817000000_drop-jira-boards-parent-artifact.sql
+++ b/src/ingestion/scripts/migrations/20260817000000_drop-jira-boards-parent-artifact.sql
@@ -1,0 +1,12 @@
+-- Drop bronze_jira._boards, a substream-parent table left behind by an
+-- earlier shape of the Jira connector.
+--
+-- jira_sprints needs a parent stream to enumerate board ids. When that parent
+-- is visible to discover, reconcile (ADR-0015) auto-selects every discovered
+-- stream, so the parent lands as a real bronze table. The current manifest
+-- declares it inline under parent_stream_configs[].stream, which keeps it out
+-- of the catalog entirely, so nothing writes to this table any more and no
+-- model reads it. Board data lives in bronze_jira.jira_boards.
+--
+-- Idempotent: this channel has no ledger and re-runs on every deploy.
+DROP TABLE IF EXISTS bronze_jira._boards;

--- a/src/ingestion/scripts/migrations/20260824000000_jira-history-items-unescape.sql
+++ b/src/ingestion/scripts/migrations/20260824000000_jira-history-items-unescape.sql
@@ -1,0 +1,28 @@
+-- Heal double-encoded `items` in bronze_jira.jira_issue_history.
+--
+-- Why: the jira_issue_history stream renders `items` with `| tojson`, and the
+-- CDK re-parses that render with ast.literal_eval. JSON `null` is not a Python
+-- literal, so any changelog entry whose previous value was empty stayed a
+-- string; under the stream's former `anyOf: [string, array]` declaration the
+-- ClickHouse destination JSON-encoded that string, storing an escaped blob:
+--
+--   "[{\"field\": \"status\", \"from\": null, \"toString\": \"Open\"}]"
+--
+-- JSONExtractArrayRaw reads such a value as a scalar, not an array, so
+-- staging.jira_changelog_items silently skipped every affected row and the
+-- whole field-history journal lost each field's first value. The stream now
+-- declares `items` as a plain string, which stores the render verbatim; this
+-- migration repairs the rows written before that fix.
+--
+-- Idempotent: after the first pass no value starts with a quote, so re-runs
+-- (apply-ch-migrations.sh keeps no bookkeeping and replays every file) match
+-- nothing. `items` is not part of the sorting key, so the column is mutable.
+--
+-- mutations_sync=1 keeps the deploy deterministic: the hook returns only once
+-- the rewrite is applied, so the first transform after deploy reads healed
+-- rows rather than racing a background mutation.
+
+ALTER TABLE bronze_jira.jira_issue_history
+    UPDATE items = JSONExtractString(items)
+    WHERE startsWith(items, '"')
+    SETTINGS mutations_sync = 1;

--- a/src/ingestion/silver/task-tracking/class_task_field_history.sql
+++ b/src/ingestion/silver/task-tracking/class_task_field_history.sql
@@ -1,4 +1,7 @@
 -- depends_on: {{ ref('jira__task_field_history') }}
+-- depends_on: {{ ref('jira__availability_events') }}
+-- depends_on: {{ ref('jira__comment_lifecycle_events') }}
+-- depends_on: {{ ref('jira__worklog_lifecycle_events') }}
 {{ config(
     materialized='incremental',
     incremental_strategy='delete+insert',
@@ -19,9 +22,9 @@
 -- the staging view (`jira__task_field_history.sql`), and that single column is the
 -- ORDER BY here.
 
--- Source of truth is the Rust `jira-enrich` binary, which writes
--- `staging.jira__task_field_history` — see `jira__task_field_history.sql` for
--- the thin view that exposes it here.
+-- Producers union in via the `silver:class_task_field_history` tag: the Rust
+-- `jira-enrich` output (changelog + synthetic_initial), the jira availability
+-- and comment/worklog lifecycle event models, and the GitHub Issues arm.
 
 SELECT * FROM (
     {{ union_by_tag('silver:class_task_field_history') }}

--- a/src/ingestion/silver/task-tracking/schema.yml
+++ b/src/ingestion/silver/task-tracking/schema.yml
@@ -13,15 +13,15 @@ models:
         tests:
           - not_null
       - name: event_id
-        description: "Natural identifier of the event. For `event_kind='changelog'` this is `jira_issue_history.changelog_id` (shared across all fields changed in one changelog). For `event_kind='synthetic_initial'` it is `'initial:<issue_id>'` (shared across all initial fields of one issue). Per ADR-005, operator audit JOIN key is (insight_source_id, id_readable, event_id, field_id)."
+        description: "Natural identifier of the event. For `event_kind='changelog'` this is `jira_issue_history.changelog_id` (shared across all fields changed in one changelog). For `event_kind='synthetic_initial'` it is `'initial:<issue_id>'` (shared across all initial fields of one issue). For `event_kind='availability'` it is `'availability:<issue_id>:<detection epoch ms>'` (issue id included because census-only issues have an empty `id_readable`, and the audit grain needs event_id to disambiguate them). Per ADR-005, operator audit JOIN key is (insight_source_id, id_readable, event_id, field_id)."
         tests:
           - not_null
       - name: event_kind
-        description: "Discriminator for event origin. Enum8: `changelog` = real field change from jira_issue_history; `synthetic_initial` = bootstrap row emitted for every tracked field on first observation of an issue."
+        description: "Discriminator for event origin. Enum8: `changelog` = real field change from jira_issue_history; `synthetic_initial` = bootstrap row emitted for every tracked field on first observation of an issue; `availability` = synthetic availability transition (present / deleted / archived / trashed / access_lost / unobserved) detected by the source's census streams; `lifecycle` = sub-entity lifecycle (field_id `comment` / `worklog`, delta_action add/set/remove) — value_ids[1] is the entity id, the lookup key into class_task_comments / class_task_worklogs. The issue's entire history, including deletions of the issue and of its sub-entities, lives in this one table."
         tests:
           - not_null
           - accepted_values:
-              values: ['changelog', 'synthetic_initial']
+              values: ['changelog', 'synthetic_initial', 'availability', 'lifecycle']
       - name: field_id
         description: "Field identifier (e.g. 'status', 'assignee', 'customfield_10020'). Part of the ReplacingMergeTree ORDER BY together with (insight_source_id, data_source, id_readable, event_id) — see ADR-005."
         tests:
@@ -56,6 +56,8 @@ models:
       - name: worklog_id
         tests:
           - not_null
+      - name: is_deleted
+        description: "1 when the worklog was deleted at the source: an authoritative /worklog/deleted tombstone, absence from the issue's re-fetched worklog list, or a deleted/trashed parent issue. Gold consumers must filter ifNull(is_deleted, 0) = 0."
 
   - name: class_task_users
     description: "Unified task-tracker user directory (anchor for identity resolution)."

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_jira.jira_issue.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_jira.jira_issue.yaml
@@ -11,6 +11,7 @@ schemas:
       id: {type: string}
       source_id: {type: string}
       jira_id: {type: string}
+      tenant_id: {type: [string, "null"]}
       unique_key: {type: string}
       id_readable: {type: string}
       created: {type: string}

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_jira.jira_issue_census.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_jira.jira_issue_census.yaml
@@ -1,0 +1,20 @@
+# Reusable JSON schema for the table (all real fields). Resolved by table name.
+# Mirrors the bronze_jira.jira_issue_census DDL (the id-only absence census —
+# read by jira__issue_availability_state.sql; specs/DELETION-AND-VISIBILITY.md).
+schemas:
+  bronze_jira.jira_issue_census:
+    $schema: http://json-schema.org/draft-07/schema#
+    type: object
+    additionalProperties: false
+    properties:
+      id: {type: [string, "null"]}
+      tenant_id: {type: [string, "null"]}
+      source_id: {type: [string, "null"]}
+      unique_key: {type: string}
+      jira_id: {type: [string, "null"]}
+      project_key: {type: [string, "null"]}
+      collected_at: {type: [string, "null"]}
+      _airbyte_raw_id: {type: string}
+      _airbyte_extracted_at: {type: string, format: date-time}
+      _airbyte_meta: {type: string}
+      _airbyte_generation_id: {type: integer}

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_jira.jira_issuetypes.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_jira.jira_issuetypes.yaml
@@ -1,0 +1,21 @@
+# Reusable JSON schema for bronze_jira.jira_issuetypes (the issue-type lookup
+# from GET /rest/api/3/issuetype): the API fields jira__task_issuetypes.sql
+# reads to build silver.class_task_issuetypes, plus the connector's identity
+# columns.
+schemas:
+  bronze_jira.jira_issuetypes:
+    $schema: http://json-schema.org/draft-07/schema#
+    type: object
+    additionalProperties: false
+    properties:
+      unique_key: {type: string}
+      source_id: {type: string}
+      tenant_id: {type: [string, "null"]}
+      id: {type: [string, "null"]}
+      name: {type: string}
+      untranslatedName: {type: [string, "null"]}
+      collected_at: {type: [string, "null"]}
+      _airbyte_raw_id: {type: string}
+      _airbyte_extracted_at: {type: string, format: date-time}
+      _airbyte_meta: {type: string}
+      _airbyte_generation_id: {type: integer}

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_jira.jira_project_visibility.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_jira.jira_project_visibility.yaml
@@ -1,0 +1,33 @@
+# Reusable JSON schema for the table (all real fields). Resolved by table name.
+# Mirrors the bronze_jira.jira_project_visibility DDL (per-status project
+# roster — read by jira__project_visibility_state.sql).
+schemas:
+  bronze_jira.jira_project_visibility:
+    $schema: http://json-schema.org/draft-07/schema#
+    type: object
+    additionalProperties: false
+    properties:
+      expand: {type: [string, "null"]}
+      self: {type: [string, "null"]}
+      id: {type: [string, "null"]}
+      key: {type: [string, "null"]}
+      name: {type: [string, "null"]}
+      avatarUrls: {type: [string, "null"]}
+      projectCategory: {type: [string, "null"]}
+      projectTypeKey: {type: [string, "null"]}
+      simplified: {type: [boolean, "null"]}
+      style: {type: [string, "null"]}
+      isPrivate: {type: [boolean, "null"]}
+      properties: {type: [string, "null"]}
+      tenant_id: {type: [string, "null"]}
+      source_id: {type: [string, "null"]}
+      unique_key: {type: string}
+      project_id: {type: [number, string, "null"]}
+      project_key: {type: [string, "null"]}
+      project_status: {type: [string, "null"]}
+      is_private: {type: [boolean, "null"]}
+      collected_at: {type: [string, "null"]}
+      _airbyte_raw_id: {type: string}
+      _airbyte_extracted_at: {type: string, format: date-time}
+      _airbyte_meta: {type: string}
+      _airbyte_generation_id: {type: integer}

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_jira.jira_worklog_deleted.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_jira.jira_worklog_deleted.yaml
@@ -1,0 +1,22 @@
+# Reusable JSON schema for the table (all real fields). Resolved by table name.
+# Mirrors the bronze_jira.jira_worklog_deleted DDL (deletion tombstones from
+# GET /rest/api/3/worklog/deleted — read by jira__task_worklogs.sql).
+schemas:
+  bronze_jira.jira_worklog_deleted:
+    $schema: http://json-schema.org/draft-07/schema#
+    type: object
+    additionalProperties: false
+    properties:
+      worklogId: {type: [number, string, "null"]}
+      updatedTime: {type: [number, string, "null"]}
+      properties: {type: [string, "null"]}
+      tenant_id: {type: [string, "null"]}
+      source_id: {type: [string, "null"]}
+      unique_key: {type: string}
+      worklog_id: {type: [number, string, "null"]}
+      deleted_at_ms: {type: [number, string, "null"]}
+      collected_at: {type: [string, "null"]}
+      _airbyte_raw_id: {type: string}
+      _airbyte_extracted_at: {type: string, format: date-time}
+      _airbyte_meta: {type: string}
+      _airbyte_generation_id: {type: integer}

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_jira.jira_worklogs.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_jira.jira_worklogs.yaml
@@ -7,6 +7,7 @@ schemas:
     type: object
     additionalProperties: false
     properties:
+      tenant_id: {type: [string, "null"]}
       unique_key: {type: string}
       source_id: {type: string}
       # Numeric JSON ids/counts the connector stores as Decimal(38,9); accept

--- a/src/ingestion/tests/e2e/metrics/tasks_closed_deleted_excluded.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/tasks_closed_deleted_excluded.test.yaml
@@ -1,0 +1,145 @@
+spec_version: 1
+description: >
+  Task Delivery - tasks.closed with the deletion/visibility mechanism (#2419): issues deleted at the source leave the metric; issues whose whole project merely became invisible (lost access) stay counted. #magic___^_^___line bronze -> silver -> gold: jira_issue + jira_issue_history close events as in tasks_closed, PLUS the absence censuses — jira_issue_census (ids observed alive) and jira_project_visibility (the project roster). An issue present in bronze but absent from the census classifies as: deleted (its project is still in the roster) or access_lost (project gone from the roster). The classification lands in silver as synthetic availability events in the same field history as every other change; gold excludes ONLY deleted/trashed. #magic___^_^___line Department: 5 Engineering members alice..erin of rank r in 1..5, each closing r issues in project TST on 2026-12-25; the census observes all 15. On top: erin closed DELX-1 (TST) which is MISSING from the census while TST is visible -> deleted -> excluded (erin stays 5, not 6); carol closed LSTC-1 in project LOST which is absent from the roster entirely -> access_lost -> still counted (carol 3+1=4). Per-person sums {1,2,4,4,5} -> median 4, p25 2, p75 4. Cases: erin IC (deleted excluded), carol IC (access_lost counted), peer stats. #magic___^_^___line
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+    - $ref: templates/people.yaml#/templates/bob
+    - $ref: templates/people.yaml#/templates/carol
+    - $ref: templates/people.yaml#/templates/dave
+    - $ref: templates/people.yaml#/templates/erin
+
+  bronze_jira.jira_user:
+    - {$ref: templates/jira_task.yaml#/templates/jira_user, unique_key: jira-test-alice-jira-acct, account_id: alice-jira-acct, email: alice@example.com, display_name: Alice Alpha}
+    - {$ref: templates/jira_task.yaml#/templates/jira_user, unique_key: jira-test-bob-jira-acct, account_id: bob-jira-acct, email: bob@example.com, display_name: Bob Beta}
+    - {$ref: templates/jira_task.yaml#/templates/jira_user, unique_key: jira-test-carol-jira-acct, account_id: carol-jira-acct, email: carol@example.com, display_name: Carol Gamma}
+    - {$ref: templates/jira_task.yaml#/templates/jira_user, unique_key: jira-test-dave-jira-acct, account_id: dave-jira-acct, email: dave@example.com, display_name: Dave Delta}
+    - {$ref: templates/jira_task.yaml#/templates/jira_user, unique_key: jira-test-erin-jira-acct, account_id: erin-jira-acct, email: erin@example.com, display_name: Erin Epsilon,}
+
+  bronze_jira.jira_statuses:
+    - $ref: templates/jira_task.yaml#/templates/status_open
+    - $ref: templates/jira_task.yaml#/templates/status_in_progress
+    - $ref: templates/jira_task.yaml#/templates/status_closed
+
+  bronze_jira.jira_issuetypes:
+    - $ref: templates/jira_task.yaml#/templates/issuetype_task
+
+  bronze_jira.jira_fields:
+    - $ref: templates/jira_task.yaml#/templates/field_status
+    - $ref: templates/jira_task.yaml#/templates/field_assignee
+    - $ref: templates/jira_task.yaml#/templates/field_issuetype
+
+  # tenant_id is stamped explicitly: the availability entity key is
+  # {tenant}-{source}-{jira_id}, and the census rows below must merge with
+  # these bronze rows into one entity each.
+  bronze_jira.jira_issue:
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, tenant_id: "11111111-1111-1111-1111-111111111111", id: DELA-1, jira_id: DELA-1, unique_key: jira-test-DELA-1, id_readable: TSTA1, created: "2026-12-20T09:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"alice-jira-acct","displayName":"Alice Alpha"}}'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, tenant_id: "11111111-1111-1111-1111-111111111111", id: DELB-1, jira_id: DELB-1, unique_key: jira-test-DELB-1, id_readable: TSTB1, created: "2026-12-20T09:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"bob-jira-acct","displayName":"Bob Beta"}}'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, tenant_id: "11111111-1111-1111-1111-111111111111", id: DELB-2, jira_id: DELB-2, unique_key: jira-test-DELB-2, id_readable: TSTB2, created: "2026-12-20T09:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"bob-jira-acct","displayName":"Bob Beta"}}'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, tenant_id: "11111111-1111-1111-1111-111111111111", id: DELC-1, jira_id: DELC-1, unique_key: jira-test-DELC-1, id_readable: TSTC1, created: "2026-12-20T09:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"carol-jira-acct","displayName":"Carol Gamma"}}'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, tenant_id: "11111111-1111-1111-1111-111111111111", id: DELC-2, jira_id: DELC-2, unique_key: jira-test-DELC-2, id_readable: TSTC2, created: "2026-12-20T09:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"carol-jira-acct","displayName":"Carol Gamma"}}'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, tenant_id: "11111111-1111-1111-1111-111111111111", id: DELC-3, jira_id: DELC-3, unique_key: jira-test-DELC-3, id_readable: TSTC3, created: "2026-12-20T09:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"carol-jira-acct","displayName":"Carol Gamma"}}'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, tenant_id: "11111111-1111-1111-1111-111111111111", id: DELD-1, jira_id: DELD-1, unique_key: jira-test-DELD-1, id_readable: TSTD1, created: "2026-12-20T09:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"dave-jira-acct","displayName":"Dave Delta"}}'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, tenant_id: "11111111-1111-1111-1111-111111111111", id: DELD-2, jira_id: DELD-2, unique_key: jira-test-DELD-2, id_readable: TSTD2, created: "2026-12-20T09:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"dave-jira-acct","displayName":"Dave Delta"}}'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, tenant_id: "11111111-1111-1111-1111-111111111111", id: DELD-3, jira_id: DELD-3, unique_key: jira-test-DELD-3, id_readable: TSTD3, created: "2026-12-20T09:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"dave-jira-acct","displayName":"Dave Delta"}}'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, tenant_id: "11111111-1111-1111-1111-111111111111", id: DELD-4, jira_id: DELD-4, unique_key: jira-test-DELD-4, id_readable: TSTD4, created: "2026-12-20T09:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"dave-jira-acct","displayName":"Dave Delta"}}'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, tenant_id: "11111111-1111-1111-1111-111111111111", id: DELE-1, jira_id: DELE-1, unique_key: jira-test-DELE-1, id_readable: TSTE1, created: "2026-12-20T09:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"erin-jira-acct","displayName":"Erin Epsilon"}}'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, tenant_id: "11111111-1111-1111-1111-111111111111", id: DELE-2, jira_id: DELE-2, unique_key: jira-test-DELE-2, id_readable: TSTE2, created: "2026-12-20T09:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"erin-jira-acct","displayName":"Erin Epsilon"}}'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, tenant_id: "11111111-1111-1111-1111-111111111111", id: DELE-3, jira_id: DELE-3, unique_key: jira-test-DELE-3, id_readable: TSTE3, created: "2026-12-20T09:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"erin-jira-acct","displayName":"Erin Epsilon"}}'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, tenant_id: "11111111-1111-1111-1111-111111111111", id: DELE-4, jira_id: DELE-4, unique_key: jira-test-DELE-4, id_readable: TSTE4, created: "2026-12-20T09:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"erin-jira-acct","displayName":"Erin Epsilon"}}'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, tenant_id: "11111111-1111-1111-1111-111111111111", id: DELE-5, jira_id: DELE-5, unique_key: jira-test-DELE-5, id_readable: TSTE5, created: "2026-12-20T09:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"erin-jira-acct","displayName":"Erin Epsilon"}}'}
+    # Deleted at the source: closed by erin, in bronze, ABSENT from the census
+    # below while project TST stays in the roster -> availability=deleted.
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, tenant_id: "11111111-1111-1111-1111-111111111111", id: DELX-1, jira_id: DELX-1, unique_key: jira-test-DELX-1, id_readable: TSTX1, created: "2026-12-20T09:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"erin-jira-acct","displayName":"Erin Epsilon"}}'}
+    # Lost access: closed by carol in project LOST, which is absent from the
+    # visibility roster entirely -> availability=access_lost -> still counted.
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, tenant_id: "11111111-1111-1111-1111-111111111111", id: LSTC-1, jira_id: LSTC-1, unique_key: jira-test-LSTC-1, id_readable: LOST1, project_key: LOST, created: "2026-12-20T09:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"carol-jira-acct","displayName":"Carol Gamma"}}',}
+
+  bronze_jira.jira_issue_history:
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: TSTA1, changelog_id: "57001", unique_key: jira-test-TSTA1-57001, created_at: "2026-12-25T14:00:00.000+0000", author_account_id: alice-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: TSTB1, changelog_id: "57002", unique_key: jira-test-TSTB1-57002, created_at: "2026-12-25T14:00:00.000+0000", author_account_id: bob-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: TSTB2, changelog_id: "57003", unique_key: jira-test-TSTB2-57003, created_at: "2026-12-25T14:00:00.000+0000", author_account_id: bob-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: TSTC1, changelog_id: "57004", unique_key: jira-test-TSTC1-57004, created_at: "2026-12-25T14:00:00.000+0000", author_account_id: carol-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: TSTC2, changelog_id: "57005", unique_key: jira-test-TSTC2-57005, created_at: "2026-12-25T14:00:00.000+0000", author_account_id: carol-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: TSTC3, changelog_id: "57006", unique_key: jira-test-TSTC3-57006, created_at: "2026-12-25T14:00:00.000+0000", author_account_id: carol-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: TSTD1, changelog_id: "57007", unique_key: jira-test-TSTD1-57007, created_at: "2026-12-25T14:00:00.000+0000", author_account_id: dave-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: TSTD2, changelog_id: "57008", unique_key: jira-test-TSTD2-57008, created_at: "2026-12-25T14:00:00.000+0000", author_account_id: dave-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: TSTD3, changelog_id: "57009", unique_key: jira-test-TSTD3-57009, created_at: "2026-12-25T14:00:00.000+0000", author_account_id: dave-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: TSTD4, changelog_id: "57010", unique_key: jira-test-TSTD4-57010, created_at: "2026-12-25T14:00:00.000+0000", author_account_id: dave-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: TSTE1, changelog_id: "57011", unique_key: jira-test-TSTE1-57011, created_at: "2026-12-25T14:00:00.000+0000", author_account_id: erin-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: TSTE2, changelog_id: "57012", unique_key: jira-test-TSTE2-57012, created_at: "2026-12-25T14:00:00.000+0000", author_account_id: erin-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: TSTE3, changelog_id: "57013", unique_key: jira-test-TSTE3-57013, created_at: "2026-12-25T14:00:00.000+0000", author_account_id: erin-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: TSTE4, changelog_id: "57014", unique_key: jira-test-TSTE4-57014, created_at: "2026-12-25T14:00:00.000+0000", author_account_id: erin-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: TSTE5, changelog_id: "57015", unique_key: jira-test-TSTE5-57015, created_at: "2026-12-25T14:00:00.000+0000", author_account_id: erin-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'}
+    # Close events for the deleted and the access-lost issues: both were
+    # legitimately closed in the window — availability decides the counting.
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: TSTX1, changelog_id: "57016", unique_key: jira-test-TSTX1-57016, created_at: "2026-12-25T14:00:00.000+0000", author_account_id: erin-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: LOST1, changelog_id: "57017", unique_key: jira-test-LOST1-57017, created_at: "2026-12-25T14:00:00.000+0000", author_account_id: carol-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]',}
+
+  # The census: the 15 rank issues observed alive. DELX-1 (deleted) and LSTC-1
+  # (its whole project lost) are NOT here.
+  bronze_jira.jira_issue_census:
+    - {$ref: templates/jira_task.yaml#/templates/jira_census, jira_id: DELA-1, unique_key: 11111111-1111-1111-1111-111111111111-jira-test-DELA-1}
+    - {$ref: templates/jira_task.yaml#/templates/jira_census, jira_id: DELB-1, unique_key: 11111111-1111-1111-1111-111111111111-jira-test-DELB-1}
+    - {$ref: templates/jira_task.yaml#/templates/jira_census, jira_id: DELB-2, unique_key: 11111111-1111-1111-1111-111111111111-jira-test-DELB-2}
+    - {$ref: templates/jira_task.yaml#/templates/jira_census, jira_id: DELC-1, unique_key: 11111111-1111-1111-1111-111111111111-jira-test-DELC-1}
+    - {$ref: templates/jira_task.yaml#/templates/jira_census, jira_id: DELC-2, unique_key: 11111111-1111-1111-1111-111111111111-jira-test-DELC-2}
+    - {$ref: templates/jira_task.yaml#/templates/jira_census, jira_id: DELC-3, unique_key: 11111111-1111-1111-1111-111111111111-jira-test-DELC-3}
+    - {$ref: templates/jira_task.yaml#/templates/jira_census, jira_id: DELD-1, unique_key: 11111111-1111-1111-1111-111111111111-jira-test-DELD-1}
+    - {$ref: templates/jira_task.yaml#/templates/jira_census, jira_id: DELD-2, unique_key: 11111111-1111-1111-1111-111111111111-jira-test-DELD-2}
+    - {$ref: templates/jira_task.yaml#/templates/jira_census, jira_id: DELD-3, unique_key: 11111111-1111-1111-1111-111111111111-jira-test-DELD-3}
+    - {$ref: templates/jira_task.yaml#/templates/jira_census, jira_id: DELD-4, unique_key: 11111111-1111-1111-1111-111111111111-jira-test-DELD-4}
+    - {$ref: templates/jira_task.yaml#/templates/jira_census, jira_id: DELE-1, unique_key: 11111111-1111-1111-1111-111111111111-jira-test-DELE-1}
+    - {$ref: templates/jira_task.yaml#/templates/jira_census, jira_id: DELE-2, unique_key: 11111111-1111-1111-1111-111111111111-jira-test-DELE-2}
+    - {$ref: templates/jira_task.yaml#/templates/jira_census, jira_id: DELE-3, unique_key: 11111111-1111-1111-1111-111111111111-jira-test-DELE-3}
+    - {$ref: templates/jira_task.yaml#/templates/jira_census, jira_id: DELE-4, unique_key: 11111111-1111-1111-1111-111111111111-jira-test-DELE-4}
+    - {$ref: templates/jira_task.yaml#/templates/jira_census, jira_id: DELE-5, unique_key: 11111111-1111-1111-1111-111111111111-jira-test-DELE-5,}
+
+  # The roster: TST is visible and live; project LOST is absent entirely.
+  bronze_jira.jira_project_visibility:
+    - {$ref: templates/jira_task.yaml#/templates/jira_visibility, id: "100", key: TST, name: Test Project, unique_key: 11111111-1111-1111-1111-111111111111-jira-test-100, project_id: 100, project_key: TST,}
+
+cases:
+  - name: deleted issue leaves tasks.closed, access_lost issue stays
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com, carol@example.com]}
+        period: {from: "2026-12-20", to: "2026-12-31"}
+        metrics:
+          - metric_key: tasks.closed
+            views:
+              - {view: period}
+              - {view: peer}
+    expect:
+      - assert: "status == 200"
+      # Erin closed 5 rank issues + DELX-1; DELX-1 is deleted -> 5, not 6.
+      - metric: tasks.closed
+        view: period
+        find: {entity_id: erin@example.com}
+        equal: {value: 5}
+      # Carol closed 3 rank issues + LSTC-1 in the lost project; access_lost
+      # is NOT a deletion -> 4.
+      - metric: tasks.closed
+        view: period
+        find: {entity_id: carol@example.com}
+        equal: {value: 4}
+      # Department distribution {1,2,4,4,5}: the deleted issue is out of the
+      # peer stats too, the access_lost one is in.
+      - metric: tasks.closed
+        view: peer
+        find: {entity_id: erin@example.com}
+        equal: {target_value: 5, p25: 2, median: 4, p75: 4, min: 1, max: 5, n: 5}
+
+  - name: tasks.closed empty window
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2025-01-01", to: "2025-01-31"}
+        metrics: [{metric_key: tasks.closed, views: [{view: period}]}]
+    expect:
+      - assert: "status == 200"
+      - {metric: tasks.closed, view: period, find: {entity_id: erin@example.com}, equal: {value: null}}

--- a/src/ingestion/tests/e2e/metrics/tasks_worklog_deleted_excluded.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/tasks_worklog_deleted_excluded.test.yaml
@@ -1,0 +1,100 @@
+spec_version: 1
+description: >
+  Task Delivery - tasks.worklog_accuracy with worklog deletion tombstones (#2419): a worklog deleted at the source (GET /rest/api/3/worklog/deleted) must not count toward the logged seconds. #magic___^_^___line bronze -> silver -> gold: identical to tasks_worklog_accuracy — jira_issue (Closed) + jira_issue_history (1-day In Progress interval = 86400 s denominator) + jira_worklogs (logged seconds numerator) — PLUS jira_worklog_deleted tombstones. A tombstoned worklog flips is_deleted on its class row (join by tenant/source/worklog_id) and gold sums only is_deleted = 0. #magic___^_^___line Department: 5 Engineering members alice..erin of rank r in 1..5 logging r*17280 s = {20,40,60,80,100}% of the 86400 s in-progress day. Dave has an EXTRA 17280 s worklog (61001) that would lift him 80 -> 100, but it carries a deletion tombstone -> dave stays 80. Erin (100) proves untouched worklogs still count. Cases: dave IC (tombstoned worklog excluded), erin IC + peer stats (distribution unchanged). #magic___^_^___line
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+    - $ref: templates/people.yaml#/templates/bob
+    - $ref: templates/people.yaml#/templates/carol
+    - $ref: templates/people.yaml#/templates/dave
+    - $ref: templates/people.yaml#/templates/erin
+
+  bronze_jira.jira_user:
+    - {$ref: templates/jira_task.yaml#/templates/jira_user, unique_key: jira-test-alice-jira-acct, account_id: alice-jira-acct, email: alice@example.com, display_name: Alice Alpha}
+    - {$ref: templates/jira_task.yaml#/templates/jira_user, unique_key: jira-test-bob-jira-acct, account_id: bob-jira-acct, email: bob@example.com, display_name: Bob Beta}
+    - {$ref: templates/jira_task.yaml#/templates/jira_user, unique_key: jira-test-carol-jira-acct, account_id: carol-jira-acct, email: carol@example.com, display_name: Carol Gamma}
+    - {$ref: templates/jira_task.yaml#/templates/jira_user, unique_key: jira-test-dave-jira-acct, account_id: dave-jira-acct, email: dave@example.com, display_name: Dave Delta}
+    - {$ref: templates/jira_task.yaml#/templates/jira_user, unique_key: jira-test-erin-jira-acct, account_id: erin-jira-acct, email: erin@example.com, display_name: Erin Epsilon,}
+
+  bronze_jira.jira_statuses:
+    - $ref: templates/jira_task.yaml#/templates/status_open
+    - $ref: templates/jira_task.yaml#/templates/status_in_progress
+    - $ref: templates/jira_task.yaml#/templates/status_closed
+
+  bronze_jira.jira_fields:
+    - $ref: templates/jira_task.yaml#/templates/field_status
+    - $ref: templates/jira_task.yaml#/templates/field_assignee
+    - $ref: templates/jira_task.yaml#/templates/field_issuetype
+
+  bronze_jira.jira_issue:
+    # Each member: created In Progress 2026-03-25T00:00, Closed 2026-03-26T00:00 -> 86400 s in progress.
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, id: WDA-1, jira_id: WDA-1, unique_key: jira-test-WDA-1, id_readable: WDA1, created: "2026-03-25T00:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"alice-jira-acct","displayName":"Alice Alpha"}}'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, id: WDB-1, jira_id: WDB-1, unique_key: jira-test-WDB-1, id_readable: WDB1, created: "2026-03-25T00:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"bob-jira-acct","displayName":"Bob Beta"}}'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, id: WDC-1, jira_id: WDC-1, unique_key: jira-test-WDC-1, id_readable: WDC1, created: "2026-03-25T00:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"carol-jira-acct","displayName":"Carol Gamma"}}'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, id: WDD-1, jira_id: WDD-1, unique_key: jira-test-WDD-1, id_readable: WDD1, created: "2026-03-25T00:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"dave-jira-acct","displayName":"Dave Delta"}}'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_issue, id: WDE-1, jira_id: WDE-1, unique_key: jira-test-WDE-1, id_readable: WDE1, created: "2026-03-25T00:00:00", custom_fields_json: '{"status":{"id":"6","name":"Closed"},"issuetype":{"id":"10001","name":"Task"},"assignee":{"accountId":"erin-jira-acct","displayName":"Erin Epsilon"}}',}
+
+  bronze_jira.jira_issue_history:
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: WDA1, changelog_id: "58001", unique_key: jira-test-WDA1-58001, created_at: "2026-03-26T00:00:00.000+0000", author_account_id: alice-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: WDB1, changelog_id: "58002", unique_key: jira-test-WDB1-58002, created_at: "2026-03-26T00:00:00.000+0000", author_account_id: bob-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: WDC1, changelog_id: "58003", unique_key: jira-test-WDC1-58003, created_at: "2026-03-26T00:00:00.000+0000", author_account_id: carol-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: WDD1, changelog_id: "58004", unique_key: jira-test-WDD1-58004, created_at: "2026-03-26T00:00:00.000+0000", author_account_id: dave-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]'}
+    - {$ref: templates/jira_task.yaml#/templates/jira_history, id_readable: WDE1, changelog_id: "58005", unique_key: jira-test-WDE1-58005, created_at: "2026-03-26T00:00:00.000+0000", author_account_id: erin-jira-acct, items: '[{"field":"Status","fieldId":"status","fromString":"In Progress","from":"3","toString":"Closed","to":"6"}]',}
+
+  # tenant_id stamped explicitly: the tombstone join is by tenant/source/worklog_id.
+  bronze_jira.jira_worklogs:
+    - {$ref: templates/jira_task.yaml#/templates/jira_worklog, tenant_id: "11111111-1111-1111-1111-111111111111", worklog_id: 11001, id_readable: WDA1, unique_key: jira-test-worklog-WDA-1, author_account_id: alice-jira-acct, started: "2026-03-25T10:00:00.000+0000", time_spent_seconds: 17280, _airbyte_raw_id: "00000000-0000-0000-0000-000000000001"}
+    - {$ref: templates/jira_task.yaml#/templates/jira_worklog, tenant_id: "11111111-1111-1111-1111-111111111111", worklog_id: 21001, id_readable: WDB1, unique_key: jira-test-worklog-WDB-1, author_account_id: bob-jira-acct, started: "2026-03-25T10:00:00.000+0000", time_spent_seconds: 34560, _airbyte_raw_id: "00000000-0000-0000-0000-000000000002"}
+    - {$ref: templates/jira_task.yaml#/templates/jira_worklog, tenant_id: "11111111-1111-1111-1111-111111111111", worklog_id: 31001, id_readable: WDC1, unique_key: jira-test-worklog-WDC-1, author_account_id: carol-jira-acct, started: "2026-03-25T10:00:00.000+0000", time_spent_seconds: 51840, _airbyte_raw_id: "00000000-0000-0000-0000-000000000003"}
+    - {$ref: templates/jira_task.yaml#/templates/jira_worklog, tenant_id: "11111111-1111-1111-1111-111111111111", worklog_id: 41001, id_readable: WDD1, unique_key: jira-test-worklog-WDD-1, author_account_id: dave-jira-acct, started: "2026-03-25T10:00:00.000+0000", time_spent_seconds: 69120, _airbyte_raw_id: "00000000-0000-0000-0000-000000000004"}
+    - {$ref: templates/jira_task.yaml#/templates/jira_worklog, tenant_id: "11111111-1111-1111-1111-111111111111", worklog_id: 51001, id_readable: WDE1, unique_key: jira-test-worklog-WDE-1, author_account_id: erin-jira-acct, started: "2026-03-25T10:00:00.000+0000", time_spent_seconds: 86400, _airbyte_raw_id: "00000000-0000-0000-0000-000000000005"}
+    # Dave's extra worklog — would lift him to 86400 s (100%), but it is
+    # tombstoned below and must be excluded.
+    - {$ref: templates/jira_task.yaml#/templates/jira_worklog, tenant_id: "11111111-1111-1111-1111-111111111111", worklog_id: 61001, id_readable: WDD1, unique_key: jira-test-worklog-WDD-2, author_account_id: dave-jira-acct, started: "2026-03-25T12:00:00.000+0000", time_spent_seconds: 17280, _airbyte_raw_id: "00000000-0000-0000-0000-000000000006",}
+
+  bronze_jira.jira_worklog_deleted:
+    - {$ref: templates/jira_task.yaml#/templates/jira_worklog_tombstone, worklogId: 61001, worklog_id: 61001, unique_key: 11111111-1111-1111-1111-111111111111-jira-test-61001,}
+
+cases:
+  - name: tombstoned worklog leaves tasks.worklog_accuracy
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [dave@example.com, erin@example.com]}
+        period: {from: "2026-03-20", to: "2026-03-31"}
+        metrics:
+          - metric_key: tasks.worklog_accuracy
+            views:
+              - {view: period}
+              - {view: peer}
+    expect:
+      - assert: "status == 200"
+      # Dave logged 69120 + a tombstoned 17280: only the live seconds count ->
+      # 80, not 100.
+      - metric: tasks.worklog_accuracy
+        view: period
+        find: {entity_id: dave@example.com}
+        equal: {value: 80}
+      # Erin's untombstoned 86400 s still counts in full.
+      - metric: tasks.worklog_accuracy
+        view: period
+        find: {entity_id: erin@example.com}
+        equal: {value: 100}
+      # Department distribution {20,40,60,80,100} — unchanged by the tombstone.
+      - metric: tasks.worklog_accuracy
+        view: peer
+        find: {entity_id: erin@example.com}
+        equal: {target_value: 100, p25: 40, median: 60, p75: 80, min: 20, max: 100, n: 5}
+
+  - name: tasks.worklog_accuracy empty window
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [erin@example.com]}
+        period: {from: "2025-01-01", to: "2025-01-31"}
+        metrics: [{metric_key: tasks.worklog_accuracy, views: [{view: period}]}]
+    expect:
+      - assert: "status == 200"
+      - {metric: tasks.worklog_accuracy, view: period, find: {entity_id: erin@example.com}, equal: {value: null}}

--- a/src/ingestion/tests/e2e/metrics/templates/jira_task.yaml
+++ b/src/ingestion/tests/e2e/metrics/templates/jira_task.yaml
@@ -34,7 +34,7 @@ templates:
   jira_user:
     unique_key: null
     source_id: jira-test
-    tenant_id: "00000000-0000-0000-0000-000000000000"
+    tenant_id: "11111111-1111-1111-1111-111111111111"
     account_id: null
     email: null
     display_name: null
@@ -79,7 +79,7 @@ templates:
   jira_history:
     unique_key: null
     source_id: jira-test
-    tenant_id: "00000000-0000-0000-0000-000000000000"
+    tenant_id: "11111111-1111-1111-1111-111111111111"
     id_readable: null
     changelog_id: null
     created_at: ""
@@ -273,3 +273,107 @@ templates:
     category_id: 3
     category_name: Done
     category_key: done
+
+  # ── Issue-type lookup (bronze_jira.jira_issuetypes) ──────────────────────
+  # Drives jira__task_issuetypes → silver.class_task_issuetypes. Each seeded
+  # issue references one of these ids in custom_fields_json `issuetype.id`.
+  jira_issuetype:
+    unique_key: null
+    source_id: jira-test
+    tenant_id: "00000000-0000-0000-0000-000000000000"
+    id: null
+    name: null
+    untranslatedName: null
+    collected_at: "2026-01-15T18:00:00.000+0000"
+    _airbyte_raw_id: "00000000-0000-0000-0000-000000000000"
+    _airbyte_extracted_at: "2026-01-15T18:00:00"
+    _airbyte_meta: "{}"
+    _airbyte_generation_id: 0
+
+  issuetype_task:
+    $ref: "#/templates/jira_issuetype"
+    unique_key: jira-test-issuetype-10001
+    id: "10001"
+    name: Task
+    untranslatedName: Task
+
+  # Id ends in zero on purpose: a normalising regex over the id would truncate
+  # it and silently drop every bug.
+  issuetype_bug:
+    $ref: "#/templates/jira_issuetype"
+    unique_key: jira-test-issuetype-10000
+    id: "10000"
+    name: Bug
+    untranslatedName: Bug
+
+  issuetype_unclassified:
+    $ref: "#/templates/jira_issuetype"
+    unique_key: jira-test-issuetype-10099
+    id: "10099"
+    name: Incident
+    untranslatedName: Incident
+
+  # ── Deletion / visibility censuses (specs/DELETION-AND-VISIBILITY.md) ────
+  # jira_census: one row per issue observed alive by the id-only sweep. An
+  # issue present in bronze_jira.jira_issue but ABSENT from the census
+  # classifies as deleted (project visible) or access_lost (project gone from
+  # the roster). unique_key must equal `{tenant}-{source}-{jira_id}` so the
+  # census row and the bronze-issue row merge into one availability entity.
+  jira_census:
+    id: null
+    tenant_id: "11111111-1111-1111-1111-111111111111"
+    source_id: jira-test
+    unique_key: null
+    jira_id: null
+    project_key: TST
+    collected_at: "2026-12-26T00:00:00.000Z"
+    _airbyte_raw_id: "00000000-0000-0000-0000-000000000000"
+    _airbyte_extracted_at: "2026-12-26T00:00:00"
+    _airbyte_meta: "{}"
+    _airbyte_generation_id: 0
+
+  # jira_visibility: the project roster per lifecycle status. A project absent
+  # from the roster entirely means the account lost sight of it (access_lost).
+  jira_visibility:
+    expand: ""
+    self: ""
+    id: null
+    key: null
+    name: null
+    avatarUrls: "{}"
+    projectCategory: "{}"
+    projectTypeKey: software
+    simplified: false
+    style: classic
+    isPrivate: false
+    properties: "{}"
+    tenant_id: "11111111-1111-1111-1111-111111111111"
+    source_id: jira-test
+    unique_key: null
+    project_id: null
+    project_key: null
+    project_status: live
+    is_private: false
+    collected_at: "2026-12-26T00:00:00.000Z"
+    _airbyte_raw_id: "00000000-0000-0000-0000-000000000000"
+    _airbyte_extracted_at: "2026-12-26T00:00:00"
+    _airbyte_meta: "{}"
+    _airbyte_generation_id: 0
+
+  # jira_worklog_tombstone: an authoritative deletion record from
+  # GET /rest/api/3/worklog/deleted — flips is_deleted on the matching
+  # class_task_worklogs row (join by tenant/source/worklog_id).
+  jira_worklog_tombstone:
+    worklogId: null
+    updatedTime: 1766700000000
+    properties: "[]"
+    tenant_id: "11111111-1111-1111-1111-111111111111"
+    source_id: jira-test
+    unique_key: null
+    worklog_id: null
+    deleted_at_ms: 1766700000000
+    collected_at: "2026-12-26T00:00:00.000Z"
+    _airbyte_raw_id: "00000000-0000-0000-0000-000000000000"
+    _airbyte_extracted_at: "2026-12-26T00:00:00"
+    _airbyte_meta: "{}"
+    _airbyte_generation_id: 0


### PR DESCRIPTION
Backport of three merged Jira fixes to the release line running on virtuozzo, cherry-picked in main merge order:

- [#2613](https://github.com/constructorfabric/insight/pull/2613) — bronze promotion gaps, comment bodies nulled on ingest, staging dedup by the natural key
- [#2816](https://github.com/constructorfabric/insight/pull/2816) — recover Jira changelog items lost to double-encoded JSON
- [#2510](https://github.com/constructorfabric/insight/pull/2510) — data completeness: deletions, lost access, worklog tombstones, custom fields, board metadata

None applied cleanly; every deviation from the original commits is listed below so it can be reviewed as a diff-against-intent.

## Adaptations to the release line

**Dropped (the target does not exist on this branch):**
- `src/ingestion/connectors/git/github/**` hunks (mock-test tweak in #2613, `event_kind` enum widening in #2510) — the legacy `github` connector is not on this branch (`github-v2` has no `task_field_history` model), and the `class_task_field_history` union here has only the jira arm, which recasts to the 4-value enum itself.
- `src/ingestion/gold/task_worklog_flow.sql` (#2510) — the model does not exist here; its `is_deleted` filter is ported into `worklog_per_day` in `gold/task_metric_observations.sql`, which is where this branch computes `worklog_seconds`.
- `.github/trufflehog-allowlist.txt` — no trufflehog config on this branch.

**Adapted:**
- `gold/task_issue_state.sql` — main's version had the field-roles refactor (`task_field_roles_current`) and the `class_task_issuetypes` join from [#2245](https://github.com/constructorfabric/insight/pull/2245), neither of which is on this branch. The availability mechanism is grafted onto the branch's `field_id`-keyed pivot instead: the pivot aggregates `availability` from the same history, and the final `WHERE p.availability NOT IN ('deleted', 'trashed')` filter is kept verbatim.
- `descriptor.yaml` — this branch was at `2.7.0` (main was at `2.8.0`); it moves straight to `4.0.0` as on main, so one major-bump full refresh covers both #2816 and #2510.
- `schemas/bronze_jira.jira_issuetypes.yaml` (e2e rig) — copied from main (originally added by #2245): the new `tasks_closed_deleted_excluded` test seeds `bronze_jira.jira_issuetypes`.
- `jira/README.md` — kept this branch's PRD/DESIGN links and added the new spec links.
- yamlfmt on this branch unwraps folded scalars in `connector.yaml` (formatting only, same YAML values).

**Superseded rather than merged:** `jira__task_comments.sql` — #2613's bronze-side dedup version is replaced by #2510's `jira__comment_state` projection, same as the sequence on main.

## Rollout notes (virtuozzo)

Deploying this release is self-rolling for #2816/#2510 (migration job repairs bronze, the 2.7.0→4.0.0 major bump makes reconcile dispatch `dbt --full-refresh`; expect a long enrich run). The #2613 comment-body recovery still needs the manual step after deploy: reset the `jira_comments` connection state (empty `streamState`, not `not_set`), then run a sync and check `argMax(body, _airbyte_extracted_at)` has no NULLs left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
