### PR TITLE
fix(ai-cost): read an invoice's identity past the bytes of its rotating nonce

### DIFF
--- a/src/ingestion/connectors/ai/claude-team-invoices/source_claude_team_invoices/stripe_chain.py
+++ b/src/ingestion/connectors/ai/claude-team-invoices/source_claude_team_invoices/stripe_chain.py
@@ -78,10 +78,12 @@ def stable_invoice_ref(url: str | None) -> str | None:
     The URL's `live_…`/`test_…` segment is base64 of
     `acct_<account>,_<invoiceEntityToken>,<rotating timestamp+nonce>`, and the
     vendor regenerates that trailing part on every list call — so only the first
-    two fields identify the invoice. Everything the wrapper reports beside the URL
-    either changes over an invoice's life (its total, its payment intent) or is
-    shared across a batch issued in the same second, which is why this is the
-    identity to key on and those are only a fallback.
+    two fields identify the invoice. That trailing part is raw bytes rather than
+    text, which is why the payload is split before either field is decoded.
+    Everything the wrapper reports beside the URL either changes over an invoice's
+    life (its total, its payment intent) or is shared across a batch issued in the
+    same second, which is why this is the identity to key on and those are only a
+    fallback.
 
     Returns None when no URL was offered or it does not decode; the caller then
     falls back to what the wrapper reports.
@@ -93,14 +95,20 @@ def stable_invoice_ref(url: str | None) -> str | None:
         return None
     try:
         segment = match.group(3)
-        decoded = base64.urlsafe_b64decode(segment + "=" * (-len(segment) % 4)).decode("utf-8")
-    except (ValueError, UnicodeDecodeError):
+        decoded = base64.urlsafe_b64decode(segment + "=" * (-len(segment) % 4))
+    except ValueError:
         return None
 
-    fields = decoded.split(",")
-    if len(fields) < 2 or not fields[0].startswith("acct_") or not fields[1]:
+    # INVARIANT: split before decoding. Reading the whole payload as text throws
+    # away a well-formed identity over the trailing nonce's bytes, and a run of
+    # those trips the drift guard below rather than reporting one bad URL.
+    fields = decoded.split(b",")
+    if len(fields) < 2 or not fields[0].startswith(b"acct_") or not fields[1]:
         return None
-    return f"{fields[0]},{fields[1]}"
+    try:
+        return f"{fields[0].decode('ascii')},{fields[1].decode('ascii')}"
+    except UnicodeDecodeError:
+        return None
 
 
 def classify_line(line: Mapping[str, Any]) -> str:

--- a/src/ingestion/connectors/ai/claude-team-invoices/tests/test_build_records.py
+++ b/src/ingestion/connectors/ai/claude-team-invoices/tests/test_build_records.py
@@ -26,20 +26,23 @@ from tests.test_stripe_chain import EXTRA_USAGE_LINE, SUBSCRIPTION_LINE
 EPHEMERAL_KEY = "ek_live_super_secret_value"
 
 
-def _hosted(entity: str, nonce: str = "n1", acct: str = "acct_1ABC") -> tuple[str, str]:
+def _hosted(entity: str, nonce: str = "n1", acct: str = "acct_1ABC", tail: bytes = b"") -> tuple[str, str]:
     """A hosted URL shaped the way the vendor's are, plus its path segment.
 
     The segment is base64 of `<acct>,_<entity>,<rotating>`; the vendor regenerates
     that trailing part on every list call, so two calls for one invoice differ in
-    the URL and still decode to the same identity.
+    the URL and still decode to the same identity. `tail` extends that rotating
+    part with the raw bytes the vendor's own nonce carries.
     """
-    payload = f"{acct},_{entity},{nonce}"
-    segment = base64.urlsafe_b64encode(payload.encode()).decode().rstrip("=")
+    payload = f"{acct},_{entity},{nonce}".encode() + tail
+    segment = base64.urlsafe_b64encode(payload).decode().rstrip("=")
     return f"https://invoice.stripe.com/i/{acct}/live_{segment}?s=ap", f"live_{segment}"
 
 
 GOOD_URL, _GOOD_TOKEN = _hosted("ent1ABC")
 FAILING_URL, FAILING_TOKEN = _hosted("entFAILS")
+# What the vendor's rotating nonce carries beyond its timestamp: bytes, not text.
+BINARY_NONCE = b"\xff\xfe\x01"
 
 
 def invoice(url: str | None = GOOD_URL, **over: Any) -> dict[str, Any]:
@@ -228,6 +231,26 @@ def test_the_drift_guard_is_a_majority_not_a_single_failure() -> None:
 
     with pytest.raises(UrlFormatDrift):
         list(build_records([invoice(url="bad")], lines_ok))
+
+
+def test_a_run_whose_nonces_are_not_text_is_not_drift() -> None:
+    """Every vendor nonce carries such bytes, so reading one payload as a single
+    string loses every identity at once and aborts the run before its first hop."""
+    invoices = [invoice(url=_hosted(f"ent{n}", tail=BINARY_NONCE)[0]) for n in range(3)]
+    records = list(build_records(invoices, lines_ok))
+    assert [r["chain_status"] for r in records] == [CHAIN_OK] * 9, "three invoices, each with two lines"
+    own = {unique_key_parts(r)[1] for r in records if r["line_id"] is None}
+    assert own == {"acct_1ABC,_ent0", "acct_1ABC,_ent1", "acct_1ABC,_ent2"}
+
+
+def test_a_run_whose_payloads_name_no_account_still_fails() -> None:
+    """The URL shape can match while the payload identifies nothing. Keying that
+    run on the wrapper's mutable fields would duplicate every invoice later."""
+    segment = base64.urlsafe_b64encode(b"nobody,_ent1ABC,n1").decode().rstrip("=")
+    nameless = invoice(url=f"https://invoice.stripe.com/i/acct_1ABC/live_{segment}?s=ap")
+    with pytest.raises(UrlFormatDrift) as raised:
+        list(build_records([nameless], lines_ok))
+    assert "no decodable invoice identity" in str(raised.value)
 
 
 def test_neither_a_record_nor_a_log_line_carries_the_ephemeral_key(caplog: pytest.LogCaptureFixture) -> None:

--- a/src/ingestion/connectors/ai/claude-team-invoices/tests/test_stripe_chain.py
+++ b/src/ingestion/connectors/ai/claude-team-invoices/tests/test_stripe_chain.py
@@ -5,6 +5,7 @@ subscription line, a proration credit from a mid-period seat change, and a
 prepaid extra-usage purchase.
 """
 
+import base64
 from collections.abc import Mapping
 from typing import Any
 
@@ -19,6 +20,7 @@ from source_claude_team_invoices.stripe_chain import (
     read_bootstrap,
     seat_unit_amount,
     shape_line,
+    stable_invoice_ref,
     unreadable_seat_prices,
 )
 
@@ -54,6 +56,15 @@ EXTRA_USAGE_LINE = {
 }
 
 
+def _hosted_url(payload: bytes, acct: str = "acct_1ABC") -> str:
+    """A hosted URL whose path segment is base64url of `payload`, unpadded."""
+    return f"https://invoice.stripe.com/i/{acct}/live_{base64.urlsafe_b64encode(payload).decode().rstrip('=')}?s=ap"
+
+
+# The rotating part of a payload: a timestamp followed by bytes that are not text.
+BINARY_NONCE = b"1756771200\xff\xfe\x01"
+
+
 @pytest.mark.parametrize(
     "url, acct, token",
     [
@@ -82,6 +93,34 @@ def test_hosted_url_yields_account_and_token(url: str, acct: str, token: str) ->
 )
 def test_unparsable_url_is_absent_not_an_error(url: str) -> None:
     assert parse_hosted_invoice_url(url) is None, f"should not parse: {url!r}"
+
+
+def test_the_identity_is_read_past_a_nonce_that_is_not_text() -> None:
+    """Only the two leading fields identify the invoice, and they are ASCII; the
+    nonce behind them is raw bytes, so the payload is no single string."""
+    assert stable_invoice_ref(_hosted_url(b"acct_1ABC,_ent1ABC," + BINARY_NONCE)) == "acct_1ABC,_ent1ABC"
+
+
+def test_one_invoice_keeps_one_identity_as_its_nonce_rotates() -> None:
+    calls = [b"acct_1ABC,_ent1ABC,1756771200\xff\x01", b"acct_1ABC,_ent1ABC,1756800000\xff\x02"]
+    assert {stable_invoice_ref(_hosted_url(payload)) for payload in calls} == {"acct_1ABC,_ent1ABC"}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"acct_1ABC",
+        b"acct_1ABC,," + BINARY_NONCE,
+        b"1ABC,_ent1ABC," + BINARY_NONCE,
+        b"acct_1ABC,_ent\xff1ABC," + BINARY_NONCE,
+    ],
+)
+def test_no_identity_unless_both_leading_fields_are_readable(payload: bytes) -> None:
+    assert stable_invoice_ref(_hosted_url(payload)) is None, f"should carry no identity: {payload!r}"
+
+
+def test_a_segment_that_is_not_base64_carries_no_identity() -> None:
+    assert stable_invoice_ref("https://invoice.stripe.com/i/acct_1ABC/live_ABCDE") is None
 
 
 def test_category_comes_from_the_parent_not_the_description() -> None:


### PR DESCRIPTION
Closes #2855.

**Why.** Every invoice sync failed before its first Stripe hop, so no row reached bronze and no later sync recovered. The AI cost metrics that read invoiced spend stayed empty.

**What changed.** `stable_invoice_ref` decoded a hosted URL's whole base64 payload as UTF-8; the trailing nonce is raw bytes, so every URL at once reported no identity. It now splits the decoded bytes and decodes only the two ASCII fields that identify the invoice.

**The drift guard stays as it is.** A run carrying no identities must refuse rather than re-key onto the wrapper's mutable fields, which nothing downstream can delete. A new test keeps it firing.

**Verified.** 105 passed across the connector suite. Reverting the fix fails the three new tests with the guard's own message. `ruff check` and `ruff format --check` clean at the pinned v0.15.21.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hosted invoice URL processing when vendor-generated nonce data contains binary characters.
  * Invoice identities now remain stable across rotating nonce values.
  * Invalid, unreadable, or missing invoice identity data is rejected with a clear format error instead of being misclassified.
* **Tests**
  * Added coverage for binary nonce handling, identity stability, invalid encoded URLs, and missing account information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->