### PR TITLE
fix(ingestion): unstick the reconcile loop — argv E2BIG in GC, 409 on manifest version

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -13,3 +13,9 @@ strict = true
 
 [lint.isort]
 split-on-trailing-comma = false
+
+[lint.per-file-ignores]
+# reconcile-connectors/python/* are stdout-contract CLIs that bash invokes as
+# `python3 <script>`: printing the result IS the interface, and the shebang is
+# documentation — the files are never executed directly.
+"src/ingestion/reconcile-connectors/python/*" = ["T201", "EXE001"]

--- a/src/ingestion/reconcile-connectors/lib/airbyte.sh
+++ b/src/ingestion/reconcile-connectors/lib/airbyte.sh
@@ -406,6 +406,10 @@ ab_builder_update_active_manifest() {
   # activeDeclarativeManifestVersion, and create_manifest answers 409 on a
   # duplicate version — permanently, because the active pointer never
   # advances on its own.
+  # Callers wrap this function in `if ! ...`, which disables errexit for the
+  # whole call, so a failed lookup must be caught here: an empty max_version
+  # arithmetic-expands to 0 and would ask for version 1, turning any lookup
+  # failure into a misleading 409 on an existing definition.
   local max_version
   max_version="$(ab__curl POST /api/v1/declarative_source_definitions/list_manifests \
         "$(printf '{"workspaceId":"%s","sourceDefinitionId":"%s"}' \
@@ -417,7 +421,7 @@ versions = [
     for v in json.load(sys.stdin).get("manifestVersions", [])
 ]
 print(max(versions) if versions else 0)
-')"
+')" || return 1
   local next_version=$((max_version + 1))
 
   local body

--- a/src/ingestion/reconcile-connectors/lib/airbyte.sh
+++ b/src/ingestion/reconcile-connectors/lib/airbyte.sh
@@ -385,7 +385,7 @@ print(json.dumps({
 # only flips an existing version pointer; for content updates Airbyte 1.7+
 # routes everything through declarative_source_definitions/create_manifest.
 # Caller passes the source_definition_id (NOT the builder_project_id);
-# function reads current activeDeclarativeManifestVersion to compute the
+# function reads the highest existing manifest version to compute the
 # next integer.
 # ---------------------------------------------------------------------------
 ab_builder_update_active_manifest() {
@@ -400,20 +400,25 @@ ab_builder_update_active_manifest() {
   local manifest_json
   manifest_json="$(python3 "${_AIRBYTE_PY_DIR}/load_connector_manifest.py" "${manifest_path}")" || return 1
 
-  # Look up current active version → next = current + 1.
-  local current_version
-  current_version="$(ab__curl POST /api/v1/connector_builder_projects/list \
-        "$(printf '{"workspaceId":"%s"}' "${workspace_id}")" \
+  # Next version must clear EVERY existing manifest, not just the active one.
+  # A published-but-not-activated manifest (rollback, or an activation that
+  # failed after the create) leaves versions above
+  # activeDeclarativeManifestVersion, and create_manifest answers 409 on a
+  # duplicate version — permanently, because the active pointer never
+  # advances on its own.
+  local max_version
+  max_version="$(ab__curl POST /api/v1/declarative_source_definitions/list_manifests \
+        "$(printf '{"workspaceId":"%s","sourceDefinitionId":"%s"}' \
+             "${workspace_id}" "${source_definition_id}")" \
       | python3 -c '
 import sys, json
-target = sys.argv[1]
-for p in json.load(sys.stdin).get("projects", []):
-    if p.get("sourceDefinitionId") == target:
-        print(int(p.get("activeDeclarativeManifestVersion") or 0)); break
-else:
-    print(0)
-' "${source_definition_id}")"
-  local next_version=$((current_version + 1))
+versions = [
+    int(v.get("version") or 0)
+    for v in json.load(sys.stdin).get("manifestVersions", [])
+]
+print(max(versions) if versions else 0)
+')"
+  local next_version=$((max_version + 1))
 
   local body
   body=$(python3 -c '

--- a/src/ingestion/reconcile-connectors/lib/reconcile.sh
+++ b/src/ingestion/reconcile-connectors/lib/reconcile.sh
@@ -1159,9 +1159,15 @@ reconcile_gc_orphans() {
   sources_json="$(ab_list_sources "${workspace_id}")"
 
   # @cpt-begin:cpt-insightspec-algo-reconcile-gc-orphans:p2:inst-gc-conn-orphan
+  # Hand the payloads over as file descriptors, never as argv: Linux caps a
+  # single argv string at MAX_ARG_STRLEN (128 KiB) and `connections/list`
+  # carries a full syncCatalog per connection, so an inline blob fails
+  # execve with E2BIG (`Argument list too long`) once enough streams exist.
   local orphan_lines
   orphan_lines="$(python3 "${_RECONCILE_PY_DIR}/find_orphan_connections.py" \
-    "${known_names}" "${sources_json}" "${connections_json}")"
+    <(printf '%s' "${known_names}") \
+    <(printf '%s' "${sources_json}") \
+    <(printf '%s' "${connections_json}"))"
   # @cpt-end:cpt-insightspec-algo-reconcile-gc-orphans:p2:inst-gc-conn-orphan
 
   # @cpt-begin:cpt-insightspec-algo-reconcile-gc-orphans:p2:inst-gc-src-loop

--- a/src/ingestion/reconcile-connectors/python/find_orphan_connections.py
+++ b/src/ingestion/reconcile-connectors/python/find_orphan_connections.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
 """Find connections tagged `insight` whose connector is no longer known.
 
-CLI: find_orphan_connections.py <known_names_json> <sources_json> <connections_json>
+CLI: find_orphan_connections.py <known_names_path> <sources_path> <connections_path>
 Stdout: TSV `connection_id\tsource_id\tconnector_slug` per orphan.
 Exit:   0 always; 2 on bad arg count.
+
+The three inputs are read from files, not passed inline: Linux caps a
+single argv string at MAX_ARG_STRLEN (128 KiB), and the workspace-wide
+`connections/list` payload carries a full syncCatalog per connection, so
+an inline blob makes execve fail with E2BIG once enough streams exist.
+Callers hand over paths (a temp file or a `<(...)` process substitution).
 
 Source names follow `{connector}-{source-id}-{tenant}`. Connector slugs
 themselves can contain dashes (e.g. `ms-entra`, `bitbucket-cloud`,
@@ -14,12 +20,19 @@ match** against the `known` set: the connector slug is the longest
 known name for which `<slug>-` is a prefix of the source name. Only
 when nothing matches do we treat the connection as a real orphan.
 """
+
 import json
 import sys
-from typing import Any, Dict, Optional, Set
+from pathlib import Path
+from typing import Any
 
 
-def _resolve_connector(source_name: str, known: Set[str]) -> Optional[str]:
+def _load_json(path: str) -> Any:
+    with Path(path).open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _resolve_connector(source_name: str, known: set[str]) -> str | None:
     """Longest known slug for which `<slug>-` is a prefix of source_name."""
     candidates = [k for k in known if source_name.startswith(f"{k}-")]
     return max(candidates, key=len) if candidates else None
@@ -27,20 +40,14 @@ def _resolve_connector(source_name: str, known: Set[str]) -> Optional[str]:
 
 def main() -> int:
     if len(sys.argv) != 4:
-        sys.stderr.write(
-            "find_orphan_connections: expected 3 args (known, sources, connections)\n"
-        )
+        sys.stderr.write("find_orphan_connections: expected 3 paths (known, sources, connections)\n")
         return 2
-    known: Set[str] = set(json.loads(sys.argv[1]))
-    sources: Dict[str, Any] = {
-        s["sourceId"]: s for s in json.loads(sys.argv[2])
-    }
-    connections = json.loads(sys.argv[3])
+    known: set[str] = set(_load_json(sys.argv[1]))
+    sources: dict[str, Any] = {s["sourceId"]: s for s in _load_json(sys.argv[2])}
+    connections = _load_json(sys.argv[3])
     for c in connections:
         tags = c.get("tags", []) or []
-        tag_names = [
-            t.get("name") if isinstance(t, dict) else t for t in tags
-        ]
+        tag_names = [t.get("name") if isinstance(t, dict) else t for t in tags]
         if "insight" not in tag_names:
             continue
         src = sources.get(c.get("sourceId"))


### PR DESCRIPTION
## Problem

Every reconcile tick on a long-lived cluster fails, for two unrelated reasons that both reproduce as a permanent, self-sustaining state.

**1. `Argument list too long` in orphan GC**

```
/ingestion/reconcile-connectors/lib/reconcile.sh: line 1164: /usr/local/bin/python3: Argument list too long
```

`reconcile_gc_orphans` passed the workspace-wide `sources/list` and `connections/list` payloads to `find_orphan_connections.py` as inline argv strings. Linux caps a *single* argv string at `MAX_ARG_STRLEN` = 128 KiB, and `connections/list` carries a full `syncCatalog` per connection, so the payload grows with every stream added anywhere in the workspace. Past the cap, `execve` fails with `E2BIG`.

Measured on a cluster that is currently failing: `connections/list` = **137 192 bytes** against a **131 072** byte limit. It fails safe — `orphan_lines` comes back empty and nothing is deleted — but orphan collection is dead, and no amount of waiting fixes it.

**2. 409 on every connector-definition update**

```
curl: (22) The requested URL returned error: 409
ERROR   jira: failed to publish connector definition
```

`ab_builder_update_active_manifest` computed the version for `declarative_source_definitions/create_manifest` as `activeDeclarativeManifestVersion + 1`. Manifest versions above the active one exist whenever a manifest was published but never activated — a rollback, or an activation that failed after the create — and `create_manifest` answers 409 on a duplicate version.

The state is absorbing: the active pointer never advances on its own, so every later tick recomputes the same taken version. Observed on a connector whose builder project reports `activeDeclarativeManifestVersion = 4` while versions 1–7 all exist — reconcile asks for 5 forever, the definition never reaches its descriptor version, and the loop exits 2 on every tick.

## Fix

- `find_orphan_connections.py` takes three **file paths** instead of three inline JSON blobs; `reconcile_gc_orphans` supplies them as `<(...)` process substitutions, so no payload rides on argv. `gc_orphans.py` already used this convention.
- `ab_builder_update_active_manifest` takes `max(version)` over `declarative_source_definitions/list_manifests` instead of the active pointer. Free by construction, and correct whether or not the pointer is stale.
- One config commit so the change is committable at all: everything under `reconcile-connectors/python/` is a stdout-contract CLI, so ruff's `T201` (the print that *is* the interface) and `EXE001` (a shebang on files nothing execs) are per-file-ignored for that directory. Without it the pre-commit hook blocks any edit there.

## Verification

- New invocation shape exercised against a 270 KiB synthetic `connections` payload: correct orphan detected, longest-prefix matching still spares `ms-entra`-style slugs, exit 0. Old shape on the same payload is exactly the reported failure.
- New version arithmetic run against a live definition with a stale active pointer: returns 7 where the old code returned 4, i.e. next = 8 (free) instead of 5 (taken → 409).
- `shellcheck -S warning` clean on both libs; `ruff check` / `ruff format --check` clean.

No regression test: `reconcile-connectors/python/` has no test harness at all today, and the E2BIG half is a kernel argv limit that a Python-level test cannot reach. Standing up that harness is worth its own change.

## Deploy note

Once the toolbox image carrying this ships, the stuck connector recovers on its own — the next tick computes a free version and publishes. No manual manifest surgery needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connector reconciliation when processing large connection datasets, preventing failures caused by oversized command inputs.
  * Corrected manifest version selection to account for inactive or orphaned versions and consistently generate the next available version.
  * Preserved existing orphan detection and cleanup behavior while improving reliability for larger environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->