### PR TITLE
fix(ingestion): converge the task class relations on their contract column set

### DIFF
--- a/src/ingestion/scripts/migrations/20260826000000_task-class-contract-heal.sql
+++ b/src/ingestion/scripts/migrations/20260826000000_task-class-contract-heal.sql
@@ -1,0 +1,76 @@
+-- Converge the task class relations on their contract column set.
+--
+-- The DDL snapshot only CREATEs IF NOT EXISTS and the deploy hook builds
+-- tag:gold, so a relation that already holds data keeps whatever column list
+-- it was created with: gold fails resolving `is_deleted` on class_task_worklogs,
+-- and the columns added to the class contracts since never arrive.
+--
+-- dbt-clickhouse incremental inserts are positional and union_by_tag is a
+-- positional SELECT * UNION ALL, so physical column order must equal the
+-- staging projections' SELECT order. ADD places a missing column correctly;
+-- MODIFY moves one an earlier out-of-band ADD appended at the tail. DROP
+-- removes what left the contract, preserving the order of what remains.
+--
+-- Idempotent: this channel has no ledger and re-runs on every deploy.
+-- The class tables always exist here (placeholders precede migrations).
+ALTER TABLE silver.class_task_worklogs DROP COLUMN IF EXISTS insight_tenant_id;
+ALTER TABLE silver.class_task_worklogs DROP COLUMN IF EXISTS issue_id;
+ALTER TABLE silver.class_task_worklogs DROP COLUMN IF EXISTS author_email;
+ALTER TABLE silver.class_task_worklogs DROP COLUMN IF EXISTS worklog_seconds;
+
+ALTER TABLE silver.class_task_worklogs
+    ADD COLUMN IF NOT EXISTS data_source String AFTER insight_source_id;
+ALTER TABLE silver.class_task_worklogs
+    MODIFY COLUMN data_source String AFTER insight_source_id;
+
+ALTER TABLE silver.class_task_worklogs
+    ADD COLUMN IF NOT EXISTS id_readable Nullable(String) AFTER worklog_id;
+ALTER TABLE silver.class_task_worklogs
+    MODIFY COLUMN id_readable Nullable(String) AFTER worklog_id;
+
+ALTER TABLE silver.class_task_worklogs
+    ADD COLUMN IF NOT EXISTS description Nullable(String) AFTER duration_seconds;
+ALTER TABLE silver.class_task_worklogs
+    MODIFY COLUMN description Nullable(String) AFTER duration_seconds;
+
+ALTER TABLE silver.class_task_worklogs
+    ADD COLUMN IF NOT EXISTS collected_at Nullable(DateTime64(3)) AFTER description;
+ALTER TABLE silver.class_task_worklogs
+    MODIFY COLUMN collected_at Nullable(DateTime64(3)) AFTER description;
+
+ALTER TABLE silver.class_task_worklogs
+    ADD COLUMN IF NOT EXISTS is_deleted Nullable(UInt8) AFTER collected_at;
+ALTER TABLE silver.class_task_worklogs
+    MODIFY COLUMN is_deleted Nullable(UInt8) AFTER collected_at;
+
+ALTER TABLE silver.class_task_users DROP COLUMN IF EXISTS insight_tenant_id;
+
+ALTER TABLE silver.class_task_users
+    ADD COLUMN IF NOT EXISTS data_source String AFTER insight_source_id;
+ALTER TABLE silver.class_task_users
+    MODIFY COLUMN data_source String AFTER insight_source_id;
+
+ALTER TABLE silver.class_task_users
+    ADD COLUMN IF NOT EXISTS display_name Nullable(String) AFTER email;
+ALTER TABLE silver.class_task_users
+    MODIFY COLUMN display_name Nullable(String) AFTER email;
+
+ALTER TABLE silver.class_task_users
+    ADD COLUMN IF NOT EXISTS username Nullable(String) AFTER display_name;
+ALTER TABLE silver.class_task_users
+    MODIFY COLUMN username Nullable(String) AFTER display_name;
+
+ALTER TABLE silver.class_task_users
+    ADD COLUMN IF NOT EXISTS account_type Nullable(String) AFTER username;
+ALTER TABLE silver.class_task_users
+    MODIFY COLUMN account_type Nullable(String) AFTER username;
+
+ALTER TABLE silver.class_task_users
+    ADD COLUMN IF NOT EXISTS is_active Nullable(UInt8) AFTER account_type;
+ALTER TABLE silver.class_task_users
+    MODIFY COLUMN is_active Nullable(UInt8) AFTER account_type;
+
+ALTER TABLE silver.class_task_users
+    ADD COLUMN IF NOT EXISTS collected_at DateTime64(3) AFTER is_active;
+ALTER TABLE silver.class_task_users
+    MODIFY COLUMN collected_at DateTime64(3) AFTER is_active;


### PR DESCRIPTION
**Why.** The gold build fails with `Identifier 'w.is_deleted' cannot be resolved` on `silver.class_task_worklogs`: the column joined the class contract without a companion ALTER, so a relation that already holds data never gains it. Five more contract columns across the task classes have the same gap.

**What changed.** A numbered migration converges `class_task_worklogs` and `class_task_users` on their contract column set — ADD/MODIFY places each missing column at its contract position, DROP removes what left the contract. `class_task_worklogs` gains `data_source`, `id_readable`, `description`, `collected_at`, `is_deleted` and loses `insight_tenant_id`, `issue_id`, `author_email`, `worklog_seconds`; `class_task_users` gains `data_source`, `display_name`, `username`, `account_type`, `is_active`, `collected_at` and loses `insight_tenant_id`.

**Existing columns keep their type.** Positional inserts cast, and retyping a column carries its own risk.

**Out of scope.** `unique_key` sits at the tail rather than first on both relations and on `class_task_statuses`; it is the sorting key, so repositioning it is an ALTER of a key column and needs its own verification.

**Verified.** Every relation in `scripts/connectors-ddl/*.sql` was checked for the same gap, not just the failing one: `class_git_commits.patch_id` was the only other and already has its migration. The ALTER statements have not been executed.
