### PR TITLE
ci: gate PRs on deploying onto a warm installation

### DIFF
--- a/.github/workflows/scripts/warm-upgrade-sim.sh
+++ b/.github/workflows/scripts/warm-upgrade-sim.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Simulate deploying this branch onto a WARM installation.
+#
+# A warm installation's ClickHouse relations were created by an earlier
+# release: `CREATE TABLE IF NOT EXISTS` never widens them, and the deploy
+# hook builds only `tag:gold`, so a gold model that references a new
+# silver/staging column deploys fine on a fresh install (the snapshot
+# already carries the new shape) and fails with UNKNOWN_IDENTIFIER on every
+# installation that already holds data — unless the change ships a numbered
+# migration or a guarded heal. This script reproduces that warm deploy:
+#
+#   1. Install BASE_SHA: run the base tree's own deploy hook
+#      (create-bronze-placeholders + migrations + heals + base gold build,
+#      with dbt pinned from the base tree's pins.env) — what an existing
+#      installation's last deploy left behind.
+#   2. Deploy the working tree: run this branch's apply-ch-migrations.sh
+#      end to end with dbt pinned from this tree's pins.env — exactly what
+#      the Helm clickhouse-migrate hook runs.
+#
+# Both phases run against the branch's CLICKHOUSE_SERVER_IMAGE: real
+# installations upgrade the server before or after the app on their own
+# schedule, and one lane cannot hold both positions — new-code-on-new-server
+# is the pair every release must support.
+#
+# A step 2 failure is the forgotten-heal class: see the "Warehouse contract
+# changes" section of AGENTS.md.
+#
+# Required env (same contract as apply-ch-migrations.sh):
+#   CLICKHOUSE_URL, CLICKHOUSE_USER, CLICKHOUSE_PASSWORD, CLICKHOUSE_DATABASE
+#   BASE_SHA  — commit whose tree plays the already-installed release
+# Needs python3 (3.11+) and network access to PyPI; each phase gets its own
+# venv pinned from its tree's pins.env.
+set -euo pipefail
+
+: "${BASE_SHA:?BASE_SHA must be set (the commit playing the installed release)}"
+: "${CLICKHOUSE_URL:?}" "${CLICKHOUSE_USER:?}" "${CLICKHOUSE_PASSWORD:?}" "${CLICKHOUSE_DATABASE:?}"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+if ! git -C "$REPO_ROOT" cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+  echo "::error title=warm-upgrade base unavailable::BASE_SHA ${BASE_SHA} is not a reachable commit — not this PR's fault. On a force-pushed or newly created ref there is no before-state to upgrade from."
+  exit 1
+fi
+
+# Same interpreter preference as bootstrap-db/run-dbt.sh — the pinned dbt
+# does not run on newer interpreters.
+PYTHON_BIN="$(command -v python3.12 || command -v python3.11 || command -v python3)"
+
+# One venv per phase, pinned from that phase's own pins.env — the base
+# deploy ran the base toolbox, the branch deploy runs the branch toolbox.
+dbt_venv_for() {
+  local pins="$1" venv="$2"
+  local core clickhouse
+  core="$(grep '^DBT_CORE_VERSION=' "$pins" | cut -d= -f2)"
+  clickhouse="$(grep '^DBT_CLICKHOUSE_VERSION=' "$pins" | cut -d= -f2)"
+  "$PYTHON_BIN" -m venv "$venv"
+  "$venv/bin/pip" install --quiet \
+    "dbt-core==${core}" "dbt-clickhouse==${clickhouse}" pyyaml
+}
+
+echo "=== Step 1: install base $(git -C "$REPO_ROOT" rev-parse --short "$BASE_SHA") (warm state) ==="
+git -C "$REPO_ROOT" archive "$BASE_SHA" src/ingestion | tar -x -C "$WORKDIR"
+dbt_venv_for "$WORKDIR/src/ingestion/scripts/bootstrap-db/pins.env" "$WORKDIR/base-venv"
+if ! PATH="$WORKDIR/base-venv/bin:$PATH" \
+    bash "$WORKDIR/src/ingestion/scripts/apply-ch-migrations.sh"; then
+  echo "::error title=warm-upgrade base install failed::The BASE deploy (${BASE_SHA}) did not converge — not this PR's fault. Check whether the base tree's apply-ch-migrations.sh is broken on a fresh ClickHouse."
+  exit 1
+fi
+
+echo "=== Step 2: deploy the working tree onto the warm state ==="
+dbt_venv_for "$REPO_ROOT/src/ingestion/scripts/bootstrap-db/pins.env" "$WORKDIR/branch-venv"
+if ! PATH="$WORKDIR/branch-venv/bin:$PATH" \
+    bash "$REPO_ROOT/src/ingestion/scripts/apply-ch-migrations.sh"; then
+  echo "::error title=warm upgrade fails — forgotten migration or heal::This tree's deploy hook fails against relations an earlier release created. A gold model reads a silver/staging column that only exists in the new snapshot: ship the companion ALTER — a numbered migration in src/ingestion/scripts/migrations/ for silver.class_*, a guarded heal in src/ingestion/scripts/apply-ch-migrations.sh for staging.* — per the Warehouse contract changes rules in AGENTS.md."
+  exit 1
+fi
+
+echo "=== Warm upgrade OK: every relation the gold build reads is covered by a migration or heal ==="

--- a/.github/workflows/warm-upgrade.yml
+++ b/.github/workflows/warm-upgrade.yml
@@ -1,0 +1,205 @@
+name: warm-upgrade
+
+# Validates the one contract the fresh-install lanes cannot see: deploying
+# this branch onto an installation that ALREADY holds data.
+#
+# On a fresh install the committed connectors-ddl snapshot carries the new
+# relation shapes, so a gold model that references a new silver/staging
+# column always builds. On a warm installation the relations already exist,
+# `CREATE TABLE IF NOT EXISTS` never widens them, and the deploy hook builds
+# only `tag:gold` — so the same gold model fails the deploy with
+# UNKNOWN_IDENTIFIER unless the change also ships a numbered migration
+# (silver.class_*) or a guarded heal (staging.*): the "Warehouse contract
+# changes" rule in AGENTS.md, enforced here instead of at deploy time.
+#
+# The simulation runs the base commit's own deploy hook first (placeholders,
+# migrations, heals, base gold build — what an existing installation's last
+# deploy left behind), then this branch's apply-ch-migrations.sh end to end,
+# exactly like the Helm clickhouse-migrate hook.
+#
+# Built to be a required check: no `on: paths` filter — the `changes` job
+# decides relevance from the merge-base diff, the simulation runs only when
+# the warehouse path moved, and the `warm-upgrade-gate` job always reports
+# (green when there was nothing to prove, red when relevance is unknown or
+# the simulation failed). `merge_group` is a trigger for the same reason.
+#
+# The push run is not redundant: a PR is validated against its own base, so
+# two PRs green apart can still leave main uncovered, and only a run on the
+# merged tree — upgrading from the commit just before it — sees that.
+#
+# Needs no secrets; fork PRs validate like any other. The trigger is
+# `pull_request`, never `pull_request_target`.
+
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  # PRs supersede per ref — cancelling an outdated run is free. Every main
+  # push and merge-group entry gets its OWN group: a shared group would let a
+  # newer queued run replace an older one, and the replaced A→B transition
+  # would never be validated — run B→C installs B's own fresh snapshot as the
+  # base, so B's missing migration is exactly what it cannot see.
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  # Relevance from the merge-base diff, not `on: paths` — a required check
+  # must report on every PR, including ones that never touch the warehouse.
+  changes:
+    name: changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The diff needs both endpoints; the default shallow fetch has
+          # neither the base nor enough history to reach a merge base.
+          fetch-depth: 0
+          persist-credentials: false
+      - id: filter
+        env:
+          BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          # No usable base (a manual dispatch, a forced or brand-new ref):
+          # assume relevant rather than skipping a required gate on a guess.
+          if [ -z "${BASE:-}" ] || [ "${BASE}" = "0000000000000000000000000000000000000000" ] \
+              || ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "no usable base sha — running"
+            exit 0
+          fi
+          # Diff from the MERGE BASE, not the base tip: a two-dot diff against
+          # the tip attributes everything that landed on main since the fork
+          # point to this PR, and the gate would never skip anything.
+          base_point="$(git merge-base "$BASE" "$HEAD" 2>/dev/null || true)"
+          if [ -z "$base_point" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "no merge base between $BASE and $HEAD — running"
+            exit 0
+          fi
+          changed="$(git diff --name-only "$base_point" "$HEAD")"
+          echo "$changed" | awk '{ print "  " $0 }'
+          if echo "$changed" | grep -qE '^(src/ingestion/(gold|silver|connectors|dbt|scripts)/|\.github/workflows/warm-upgrade\.yml|\.github/workflows/scripts/(warm-upgrade-sim|start-clickhouse)\.sh)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "nothing on the warehouse path changed"
+          fi
+
+  warm-upgrade:
+    name: deploy onto a warm installation
+    needs: changes
+    if: ${{ needs.changes.outputs.relevant == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      CLICKHOUSE_CONTAINER: warm-upgrade-clickhouse
+      CLICKHOUSE_USER: insight
+      CLICKHOUSE_PASSWORD: insight
+      CLICKHOUSE_DATABASE: insight
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false # don't leave the token in .git/config
+          # The sim replays the base commit's tree as the installed release,
+          # so that commit's objects must be present.
+          fetch-depth: 0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          # Same major as the toolbox image that runs the real deploy hook.
+          # The sim builds one dbt venv per phase, pinned from that phase's
+          # own pins.env.
+          python-version: "3.12"
+
+      - name: Start an empty ClickHouse
+        run: |
+          set -euo pipefail
+          # pins.env is plain KEY=VALUE, so it doubles as a $GITHUB_ENV fragment.
+          cat src/ingestion/scripts/bootstrap-db/pins.env >> "$GITHUB_ENV"
+          source src/ingestion/scripts/bootstrap-db/pins.env
+          echo "CLICKHOUSE_URL=http://127.0.0.1:8123" >> "$GITHUB_ENV"
+          CLICKHOUSE_SERVER_IMAGE="$CLICKHOUSE_SERVER_IMAGE" \
+            .github/workflows/scripts/start-clickhouse.sh "${CLICKHOUSE_CONTAINER}"
+
+      - name: Resolve the installed-release commit
+        run: |
+          set -euo pipefail
+          # PR / merge group: the base the branch merges onto — the release a
+          # warm installation would be on when this change deploys.
+          # Push to main: the commit just before this one; after a force-push
+          # or on ref creation `event.before` is unusable, so fall back to
+          # the first parent of the pushed commit.
+          if [ -n "${PR_OR_MQ_BASE_SHA}" ]; then
+            echo "BASE_SHA=${PR_OR_MQ_BASE_SHA}" >> "$GITHUB_ENV"
+          elif [ "${GITHUB_EVENT_NAME}" = "push" ] \
+              && [ "${PUSH_BEFORE_SHA}" != "0000000000000000000000000000000000000000" ] \
+              && git cat-file -e "${PUSH_BEFORE_SHA}^{commit}" 2>/dev/null; then
+            echo "BASE_SHA=${PUSH_BEFORE_SHA}" >> "$GITHUB_ENV"
+          elif [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            echo "BASE_SHA=$(git rev-parse HEAD^)" >> "$GITHUB_ENV"
+          else
+            echo "BASE_SHA=$(git rev-parse origin/main)" >> "$GITHUB_ENV"
+          fi
+        env:
+          PR_OR_MQ_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+
+      - name: Install the base release, then deploy this tree onto it
+        run: .github/workflows/scripts/warm-upgrade-sim.sh
+
+      - name: ClickHouse logs on failure
+        if: failure()
+        run: docker logs --tail 200 "${CLICKHOUSE_CONTAINER}" || true
+
+  warm-upgrade-gate:
+    # The required check the ruleset should name — always reports, so a
+    # PR that never touches the warehouse is not blocked and a skipped
+    # simulation cannot green a run whose relevance is unknown.
+    name: warm-upgrade gate
+    needs:
+      - changes
+      - warm-upgrade
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require the simulation to have succeeded when relevant
+        env:
+          CHANGES: ${{ needs.changes.result }}
+          RELEVANT: ${{ needs.changes.outputs.relevant }}
+          SIM: ${{ needs.warm-upgrade.result }}
+        run: |
+          set -euo pipefail
+          echo "changes=$CHANGES relevant=$RELEVANT sim=$SIM"
+
+          # Fail closed. A `changes` job that did not succeed leaves
+          # `relevant` empty, which would otherwise read as "irrelevant" and
+          # green a required check that proved nothing.
+          if [ "$CHANGES" != "success" ]; then
+            echo "::error::the changes job did not succeed ($CHANGES) — relevance is unknown, so the warm upgrade is unproven."
+            exit 1
+          fi
+
+          if [ "$RELEVANT" != "true" ]; then
+            echo "nothing on the warehouse path changed — nothing to prove."
+            exit 0
+          fi
+
+          if [ "$SIM" != "success" ]; then
+            echo "::error::the warm-upgrade simulation did not succeed ($SIM)."
+            exit 1
+          fi
+          echo "warm upgrade proven."


### PR DESCRIPTION
**Why.** A gold model referencing a new silver/staging column builds fine on fresh installs but fails every warm deploy with `UNKNOWN_IDENTIFIER` when the companion migration/heal is forgotten — the AGENTS.md warehouse-contract rule had no automated check, so it kept surfacing at deploy time as failed releases and rollbacks.

**What changed.** New `warm-upgrade` lane: install the base commit's own deploy state (snapshot placeholders, migrations, heals, base gold build), then run the branch's `apply-ch-migrations.sh` end to end — the exact Helm clickhouse-migrate hook path. PRs upgrade base→branch; pushes to main upgrade before→merged, catching two individually-green PRs that interleave.

**Each phase runs its own pinned dbt.** Venv per phase from that tree's `pins.env` — the base deploy ran the base toolbox.

**Both phases run on the branch's ClickHouse image.** One lane can't hold both server positions; new-code-on-new-server is the pair every release must support.

**Built as a required check.** No `on: paths`; a `changes` job decides relevance from the merge-base diff and the always-reporting `warm-upgrade gate` job aggregates fail-closed — name that job in the ruleset. Each main push/merge-group run gets its own concurrency group so no before→merged transition is skipped.

**Verified.** Local positive run green (base + branch deploy, 19 gold models); negative run with a planted nonexistent column fails with the annotated forgotten-heal error; `actionlint` and `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated warm-upgrade validation for deployments across pull requests, main-branch updates, and manual runs.
  * Added actionable checks for installation failures, missing migrations, and incomplete recovery steps.

* **Bug Fixes**
  * Improved Git-based metric accuracy by excluding temporary warm-upgrade probe records from commit results.

* **Chores**
  * Added failure diagnostics and cleanup to make deployment validation more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
