### PR TITLE
perf(dbt): materialize the git commit and file-change stages of the evidence build

### DIFF
--- a/src/ingestion/dbt/macros/metric_serving_table.sql
+++ b/src/ingestion/dbt/macros/metric_serving_table.sql
@@ -1,6 +1,6 @@
 {% macro metric_serving_query_settings(join_use_nulls=none) %}
     {% set settings = {
-        'max_memory_usage': 1610612736,
+        'max_memory_usage': 2147483648,
         'max_threads': 2,
         'max_block_size': 32768,
         'max_insert_block_size': 32768,

--- a/src/ingestion/gold/git_authored_commits.sql
+++ b/src/ingestion/gold/git_authored_commits.sql
@@ -1,0 +1,72 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'data_source', 'commit_hash'],
+    schema=var('gold_database'),
+    settings={'allow_nullable_key': 1},
+    tags=['gold'],
+    query_settings=metric_serving_query_settings()
+) }}
+
+-- One row per authored commit, with the dimensions every git commit measure
+-- carries. Materialized so the FINAL read of the commit class and the hash
+-- collapse run once per build in their own query budget, and so the file
+-- change models attach to the surviving commit row without repeating it.
+
+SELECT
+    tenant_id,
+    source_id,
+    project_key,
+    repo_slug,
+    commit_hash,
+    data_source,
+    author_name,
+    message,
+    date AS observed_at,
+    lower(trimBoth(author_email)) AS entity_id,
+    toDate(date) AS metric_date,
+    lines_added,
+    lines_removed,
+    -- A semi-join by tuple rather than a LEFT JOIN: the answer is
+    -- membership, and a nullable joined column would need guarding under
+    -- either join_use_nulls setting.
+    if(
+        is_default_branch = 1
+            OR (tenant_id, source_id, project_key, repo_slug, commit_hash) IN (
+                SELECT tenant_id, source_id, project_key, repo_slug, commit_hash
+                FROM {{ ref('git_default_branch_commits') }}
+            ),
+        'default',
+        'non_default'
+    ) AS branch_scope_value,
+    {{ git_branch_scope_label('branch_scope_value') }} AS branch_scope_label,
+    if(coalesce(project_key, '') = '', '__unknown__', concat(coalesce(toString(source_id), ''), ':', project_key)) AS project_value,
+    if(coalesce(project_key, '') = '', 'Unknown', project_key) AS project_label,
+    concat(coalesce(toString(source_id), ''), ':', coalesce(project_key, ''), '/', coalesce(repo_slug, '')) AS repository_value,
+    if(coalesce(project_key, '') = '', coalesce(repo_slug, ''), concat(project_key, '/', repo_slug)) AS repository_label,
+    replaceOne(data_source, 'insight_', '') AS source_value,
+    {{ git_source_label('source_value') }} AS source_label,
+    CAST(
+        [
+            tuple('branch_scope', branch_scope_value, branch_scope_label),
+            tuple('repository', repository_value, repository_label),
+            tuple('project', project_value, project_label),
+            tuple('source', source_value, source_label)
+        ]
+        AS Array(Tuple(key String, value String, label Nullable(String)))
+    ) AS source_dimensions
+FROM {{ ref('class_git_commits') }} FINAL
+WHERE trimBoth(author_email) != ''
+  AND date IS NOT NULL
+  AND is_merge_commit = 0
+  -- A semi-join by tuple for the same reason as branch scope above: a
+  -- derived commit (a squash/rebase result of a merged request, or a
+  -- later carrier of a patch an earlier commit authored) re-applies work
+  -- counted on another commit, so it contributes neither a commit nor —
+  -- because every file-change CTE attaches through this set — any lines.
+  AND (tenant_id, data_source, commit_hash) NOT IN (
+      SELECT tenant_id, data_source, commit_hash
+      FROM {{ ref('git_derived_commits') }}
+  )
+ORDER BY tenant_id, data_source, commit_hash, source_id, project_key, repo_slug
+LIMIT 1 BY tenant_id, data_source, commit_hash

--- a/src/ingestion/gold/git_commit_file_changes.sql
+++ b/src/ingestion/gold/git_commit_file_changes.sql
@@ -1,0 +1,47 @@
+{{ config(
+    materialized='table',
+    engine='MergeTree',
+    order_by=['tenant_id', 'data_source', 'commit_hash'],
+    schema=var('gold_database'),
+    settings={'allow_nullable_key': 1},
+    tags=['gold'],
+    query_settings=metric_serving_query_settings()
+) }}
+
+-- File changes attached to the commit row that survived the hash collapse.
+-- The attach key carries NO repository: commit rows collapse across
+-- repositories (a fork and its upstream hold the same hash), and a
+-- repo-qualified attach would leave the rows recorded under the repository
+-- that lost the collapse matching no commit and contributing nothing. One
+-- hash is one diff, so any repository's rows describe the commit — the
+-- LIMIT 1 BY collapses the per-repository copies, and every row carries the
+-- surviving commit's coordinates.
+SELECT
+    commits.tenant_id AS tenant_id,
+    commits.source_id AS source_id,
+    commits.project_key AS project_key,
+    commits.repo_slug AS repo_slug,
+    commits.commit_hash AS commit_hash,
+    commits.observed_at AS observed_at,
+    raw_file_change.data_source AS data_source,
+    raw_file_change.file_path AS file_path,
+    raw_file_change.file_extension AS file_extension,
+    raw_file_change.change_type AS change_type,
+    raw_file_change.lines_added AS lines_added,
+    raw_file_change.lines_removed AS lines_removed,
+    raw_file_change.pre_image_oid AS pre_image_oid,
+    raw_file_change.post_image_oid AS post_image_oid
+FROM {{ ref('class_git_file_changes') }} AS raw_file_change FINAL
+INNER JOIN {{ ref('git_authored_commits') }} AS commits
+    ON commits.tenant_id = raw_file_change.tenant_id
+    AND commits.data_source = raw_file_change.data_source
+    AND commits.commit_hash = raw_file_change.commit_hash
+ORDER BY raw_file_change.source_id, raw_file_change.project_key, raw_file_change.repo_slug
+LIMIT 1 BY
+    tenant_id,
+    data_source,
+    commit_hash,
+    file_path,
+    lower(change_type),
+    pre_image_oid,
+    post_image_oid

--- a/src/ingestion/gold/git_metric_evidence.sql
+++ b/src/ingestion/gold/git_metric_evidence.sql
@@ -70,104 +70,6 @@ repository_default_branches AS (
     WHERE is_default = 1
     GROUP BY tenant_id, source_id, project_key, repo_slug
 ),
-commits_source AS (
-    SELECT
-        tenant_id,
-        source_id,
-        project_key,
-        repo_slug,
-        commit_hash,
-        data_source,
-        author_name,
-        message,
-        date AS observed_at,
-        lower(trimBoth(author_email)) AS entity_id,
-        toDate(date) AS metric_date,
-        lines_added,
-        lines_removed,
-        -- A semi-join by tuple rather than a LEFT JOIN: the answer is
-        -- membership, and a nullable joined column would need guarding under
-        -- either join_use_nulls setting.
-        if(
-            is_default_branch = 1
-                OR (tenant_id, source_id, project_key, repo_slug, commit_hash) IN (
-                    SELECT tenant_id, source_id, project_key, repo_slug, commit_hash
-                    FROM {{ ref('git_default_branch_commits') }}
-                ),
-            'default',
-            'non_default'
-        ) AS branch_scope_value,
-        {{ git_branch_scope_label('branch_scope_value') }} AS branch_scope_label,
-        if(coalesce(project_key, '') = '', '__unknown__', concat(coalesce(toString(source_id), ''), ':', project_key)) AS project_value,
-        if(coalesce(project_key, '') = '', 'Unknown', project_key) AS project_label,
-        concat(coalesce(toString(source_id), ''), ':', coalesce(project_key, ''), '/', coalesce(repo_slug, '')) AS repository_value,
-        if(coalesce(project_key, '') = '', coalesce(repo_slug, ''), concat(project_key, '/', repo_slug)) AS repository_label,
-        replaceOne(data_source, 'insight_', '') AS source_value,
-        {{ git_source_label('source_value') }} AS source_label,
-        CAST(
-            [
-                tuple('branch_scope', branch_scope_value, branch_scope_label),
-                tuple('repository', repository_value, repository_label),
-                tuple('project', project_value, project_label),
-                tuple('source', source_value, source_label)
-            ]
-            AS Array(Tuple(key String, value String, label Nullable(String)))
-        ) AS source_dimensions
-    FROM {{ ref('class_git_commits') }} FINAL
-    WHERE trimBoth(author_email) != ''
-      AND date IS NOT NULL
-      AND is_merge_commit = 0
-      -- A semi-join by tuple for the same reason as branch scope above: a
-      -- derived commit (a squash/rebase result of a merged request, or a
-      -- later carrier of a patch an earlier commit authored) re-applies work
-      -- counted on another commit, so it contributes neither a commit nor —
-      -- because every file-change CTE attaches through this set — any lines.
-      AND (tenant_id, data_source, commit_hash) NOT IN (
-          SELECT tenant_id, data_source, commit_hash
-          FROM {{ ref('git_derived_commits') }}
-      )
-    ORDER BY tenant_id, data_source, commit_hash, source_id, project_key, repo_slug
-    LIMIT 1 BY tenant_id, data_source, commit_hash
-),
--- File changes attached to the commit row that survived the hash collapse.
--- The attach key carries NO repository: commit rows collapse across
--- repositories (a fork and its upstream hold the same hash), and a
--- repo-qualified attach would leave the rows recorded under the repository
--- that lost the collapse matching no commit and contributing nothing. One
--- hash is one diff, so any repository's rows describe the commit — the
--- LIMIT 1 BY collapses the per-repository copies, and every row carries the
--- surviving commit's coordinates.
-commit_file_changes AS (
-    SELECT
-        commits.tenant_id AS tenant_id,
-        commits.source_id AS source_id,
-        commits.project_key AS project_key,
-        commits.repo_slug AS repo_slug,
-        commits.commit_hash AS commit_hash,
-        commits.observed_at AS observed_at,
-        raw_file_change.data_source AS data_source,
-        raw_file_change.file_path AS file_path,
-        raw_file_change.file_extension AS file_extension,
-        raw_file_change.change_type AS change_type,
-        raw_file_change.lines_added AS lines_added,
-        raw_file_change.lines_removed AS lines_removed,
-        raw_file_change.pre_image_oid AS pre_image_oid,
-        raw_file_change.post_image_oid AS post_image_oid
-    FROM {{ ref('class_git_file_changes') }} AS raw_file_change FINAL
-    INNER JOIN commits_source AS commits
-        ON commits.tenant_id = raw_file_change.tenant_id
-        AND commits.data_source = raw_file_change.data_source
-        AND commits.commit_hash = raw_file_change.commit_hash
-    ORDER BY raw_file_change.source_id, raw_file_change.project_key, raw_file_change.repo_slug
-    LIMIT 1 BY
-        tenant_id,
-        data_source,
-        commit_hash,
-        file_path,
-        lower(change_type),
-        pre_image_oid,
-        post_image_oid
-),
 -- One row per change CONTENT, not per commit that carries it. The same content
 -- entering a repository on two lines of history — a branch whose copy of a
 -- tree also landed on the default branch, a cherry-pick, a
@@ -194,7 +96,7 @@ deduplicated_file_changes AS (
         change_type,
         lines_added,
         lines_removed
-    FROM commit_file_changes
+    FROM {{ ref('git_commit_file_changes') }}
     ORDER BY observed_at, commit_hash
     LIMIT 1 BY
         tenant_id,
@@ -226,7 +128,7 @@ reported_commit_file_lines AS (
         commit_hash,
         sum(lines_added) AS lines_added,
         sum(lines_removed) AS lines_removed
-    FROM commit_file_changes
+    FROM {{ ref('git_commit_file_changes') }}
     GROUP BY tenant_id, source_id, project_key, repo_slug, commit_hash
 ),
 authored_commit_file_lines AS (
@@ -277,7 +179,7 @@ authored_commits AS (
                     - (coalesce(reported.lines_removed, 0) - coalesce(authored.lines_removed, 0))
             ))
         ) AS lines_removed
-    FROM commits_source AS commits
+    FROM {{ ref('git_authored_commits') }} AS commits
     LEFT JOIN reported_commit_file_lines AS reported
         ON reported.tenant_id = commits.tenant_id
         AND reported.source_id = commits.source_id
@@ -356,7 +258,7 @@ file_changes_source AS (
         FROM deduplicated_file_changes AS raw_file_change
         GROUP BY tenant_id, source_id, project_key, repo_slug, commit_hash, category, file_extension_value, file_extension_label, change_type_value, change_type_label
     ) AS file_changes
-    INNER JOIN commits_source AS commits
+    INNER JOIN {{ ref('git_authored_commits') }} AS commits
         ON commits.tenant_id = file_changes.tenant_id
         AND commits.source_id = file_changes.source_id
         AND commits.project_key = file_changes.project_key
@@ -790,7 +692,7 @@ SELECT
     toNullable(toString(metric_date)) AS subject_key,
     source_dimensions AS dimensions,
     CAST(map() AS Map(String, String)) AS details
-FROM commits_source
+FROM {{ ref('git_authored_commits') }}
 WHERE tenant_id IS NOT NULL
   AND entity_id IS NOT NULL
   AND metric_date IS NOT NULL

--- a/src/ingestion/gold/schema.yml
+++ b/src/ingestion/gold/schema.yml
@@ -75,6 +75,29 @@ models:
       - name: details
         description: "Additional display fields keyed by stable field name"
 
+  - name: git_authored_commits
+    description: >
+      One row per authored commit that reaches a git measure: the surviving row
+      of the commit-hash collapse, with branch scope, repository, project and
+      source dimensions already resolved. Materialized so the commit class read
+      and the collapse run once per build in their own query budget.
+    columns:
+      - name: commit_hash
+        description: "Commit identifier; one row per tenant, data source and hash"
+        tests:
+          - not_null
+
+  - name: git_commit_file_changes
+    description: >
+      File changes attached to the commit row that survived the hash collapse,
+      one row per commit, path, change type and object id pair. Materialized so
+      the file-change class read runs in its own query budget.
+    columns:
+      - name: commit_hash
+        description: "Commit the change is attached to"
+        tests:
+          - not_null
+
   - name: git_default_branch_commits
     description: >
       Commits that reached a repository's default branch through a merged pull


### PR DESCRIPTION
**Why.** The gold build still fails with `MEMORY_LIMIT_EXCEEDED` on `git_metric_evidence`, now while reading `silver.class_git_file_changes` — the evidence query carries a `FINAL` read of the commit class, a `FINAL` read of the file-change class and two `LIMIT 1 BY` collapses in one budget.

**What changed.** The two heaviest stages become their own gold tables: `git_authored_commits` (the commit-hash collapse with its dimensions) and `git_commit_file_changes` (the file-change attach, reading the first). The evidence model reads both instead of rebuilding them, so each `FINAL` scan gets its own query budget.

**The evidence models' memory ceiling goes from 1.5 GiB to 2 GiB.** The split alone was not proven sufficient, and the ceiling applies to all six evidence models; reversible in one line.

**Out of scope.** `deduplicated_file_changes` stays a CTE — it now reads a plain MergeTree rather than a `FINAL` scan, so it is no longer a candidate for its own table.

**Verified.** `dbt parse` (234 models) and `dbt ls` confirm the chain `git_authored_commits` → `git_commit_file_changes` → `git_metric_evidence` → observations and coverage. Peak memory of the split build is not measured — no ClickHouse instance was available to this branch.
