### PR TITLE
feat(analytics): bin a histogram per dimension tuple, pooled across entities

### DIFF
--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -624,20 +624,29 @@
         "type": "object"
       },
       "HistogramValueDto": {
+        "description": "One histogram row. Per-entity shape: `entity_id` set, `dimensions` absent,\nevery requested entity listed. Pooled shape (dimensioned request):\n`dimensions` set, `entity_id` absent, one row per observed dimension tuple\nover all selected entities' events — no entity grain, like rollup.",
         "properties": {
           "bins": {
-            "description": "Empty when the entity has no events in the period — the entity is\nstill listed, mirroring the period view's every-requested-entity rule.",
+            "description": "Empty when a listed entity has no events in the period — the entity is\nstill listed, mirroring the period view's every-requested-entity rule.",
             "items": {
               "$ref": "#/components/schemas/HistogramBinDto"
             },
             "type": "array"
           },
+          "dimensions": {
+            "items": {
+              "$ref": "#/components/schemas/MetricDimensionDto"
+            },
+            "type": "array"
+          },
           "entity_id": {
-            "type": "string"
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [
-          "entity_id",
           "bins"
         ],
         "type": "object"
@@ -1488,6 +1497,13 @@
           },
           {
             "properties": {
+              "dimensions": {
+                "description": "Present only for the pooled (dimensioned) shape; absent for the\nper-entity shape, keeping that wire form unchanged.",
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
               "values": {
                 "items": {
                   "$ref": "#/components/schemas/HistogramValueDto"
@@ -1871,6 +1887,12 @@
           },
           {
             "properties": {
+              "dimensions": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
               "view": {
                 "enum": [
                   "histogram"

--- a/src/backend/services/analytics/src/api/metric_results.rs
+++ b/src/backend/services/analytics/src/api/metric_results.rs
@@ -18,11 +18,11 @@ use crate::domain::metric_drilldown::load_capabilities;
 use crate::domain::metric_results::{
     BatchItem, BreakdownQueryRow, CompiledQuery, HistogramQueryRow, MetricResultViewDto,
     MetricResultsRequest, MetricResultsResponse, PeerPopulation, PeerWideRow, PeriodWideRow,
-    PlannedQuery, RankingQueryRow, RollupQueryRow, TimeseriesQueryRow, UnbatchedView,
-    ValidatedMetricResultsRequest, build_breakdown_view, build_histogram_view, build_metric_result,
-    build_peer_view, build_period_view, build_ranked_groups, build_rollup_view,
-    build_timeseries_view, demux_peer_rows, demux_period_rows, enforce_view_row_limit,
-    plan_queries, plan_rankings, validate_request,
+    PlannedQuery, PooledHistogramQueryRow, RankingQueryRow, RollupQueryRow, TimeseriesQueryRow,
+    UnbatchedView, ValidatedMetricResultsRequest, build_breakdown_view, build_histogram_view,
+    build_metric_result, build_peer_view, build_period_view, build_pooled_histogram_view,
+    build_ranked_groups, build_rollup_view, build_timeseries_view, demux_peer_rows,
+    demux_period_rows, enforce_view_row_limit, plan_queries, plan_rankings, validate_request,
 };
 use crate::domain::person_visibility::authorize_person_ids;
 
@@ -242,6 +242,12 @@ async fn execute_planned(
                     let comment = format!("metric-results:histogram:{}", def.key());
                     let rows = fetch_rows::<HistogramQueryRow>(state, query, &comment).await?;
                     build_histogram_view(req, rows)
+                }
+                UnbatchedView::PooledHistogram { dimensions } => {
+                    let comment = format!("metric-results:pooled-histogram:{}", def.key());
+                    let rows =
+                        fetch_rows::<PooledHistogramQueryRow>(state, query, &comment).await?;
+                    build_pooled_histogram_view(rows, &dimensions)?
                 }
             };
             Ok(vec![MetricViewResult {

--- a/src/backend/services/analytics/src/domain/metric_results/batch.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/batch.rs
@@ -10,7 +10,8 @@ use crate::domain::metric_definitions::MetricDefinition;
 use super::compiler::{
     CompiledQuery, PeerQueryRow, PeriodQueryRow, compile_breakdown_query,
     compile_group_ranking_query, compile_histogram_query, compile_peer_batch_query,
-    compile_period_batch_query, compile_rollup_query, compile_timeseries_query,
+    compile_period_batch_query, compile_pooled_histogram_query, compile_rollup_query,
+    compile_timeseries_query,
 };
 use super::validation::{
     ValidatedDimensionFilter, ValidatedGroupLimit, ValidatedMetricRequest,
@@ -46,6 +47,11 @@ pub enum UnbatchedView {
     // Histogram bins one entity's own per-event values; it never batches with
     // other metrics (per-entity bin membership is metric-specific).
     Histogram,
+    // The pooled shape bins the same values per dimension tuple instead, with
+    // no entity grain — same reason it cannot batch.
+    PooledHistogram {
+        dimensions: Vec<String>,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -138,6 +144,37 @@ pub fn plan_rankings(req: &ValidatedMetricResultsRequest) -> Vec<PlannedRanking>
         .collect()
 }
 
+/// Both histogram shapes are single (never batched) queries; which one is
+/// planned is decided by whether the request asked to bin per dimension tuple
+/// instead of per entity.
+fn plan_histogram(
+    req: &ValidatedMetricResultsRequest,
+    metric: &ValidatedMetricRequest,
+    (metric_index, view_index): (usize, usize),
+    dimensions: &[String],
+) -> PlannedQuery {
+    let (view, query) = if dimensions.is_empty() {
+        (
+            UnbatchedView::Histogram,
+            compile_histogram_query(&metric.def, req, &metric.filters),
+        )
+    } else {
+        (
+            UnbatchedView::PooledHistogram {
+                dimensions: dimensions.to_vec(),
+            },
+            compile_pooled_histogram_query(&metric.def, req, dimensions, &metric.filters),
+        )
+    };
+    PlannedQuery::Single {
+        metric_index,
+        view_index,
+        def: Box::new(metric.def.clone()),
+        view,
+        query,
+    }
+}
+
 pub fn plan_queries(
     req: &ValidatedMetricResultsRequest,
     rankings: &BTreeMap<RankingPolicyKey, Vec<RankedGroup>>,
@@ -210,14 +247,13 @@ pub fn plan_queries(
                         view,
                     )?);
                 }
-                ValidatedMetricView::Histogram => {
-                    singles.push(PlannedQuery::Single {
-                        metric_index,
-                        view_index,
-                        def: Box::new(metric.def.clone()),
-                        view: UnbatchedView::Histogram,
-                        query: compile_histogram_query(&metric.def, req, &metric.filters),
-                    });
+                ValidatedMetricView::Histogram { dimensions } => {
+                    singles.push(plan_histogram(
+                        req,
+                        metric,
+                        (metric_index, view_index),
+                        dimensions,
+                    ));
                 }
             }
         }

--- a/src/backend/services/analytics/src/domain/metric_results/builder.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/builder.rs
@@ -6,9 +6,9 @@ use crate::domain::metric_definitions::{ComputationSpec, MetricDefinition};
 
 use super::batch::{RankedDimension, RankedGroup};
 use super::compiler::{
-    BreakdownQueryRow, HistogramQueryRow, PeerQueryRow, PeriodQueryRow, RankingQueryRow,
-    RollupQueryRow, TimeseriesQueryRow, UNKNOWN_DIMENSION_LABEL, UNKNOWN_DIMENSION_VALUE,
-    dimension_aliases,
+    BreakdownQueryRow, HistogramQueryRow, PeerQueryRow, PeriodQueryRow, PooledHistogramQueryRow,
+    RankingQueryRow, RollupQueryRow, TimeseriesQueryRow, UNKNOWN_DIMENSION_LABEL,
+    UNKNOWN_DIMENSION_VALUE, dimension_aliases,
 };
 use super::dto::{
     BreakdownValueDto, ComputationDto, HistogramBinDto, HistogramValueDto, MetricDimensionDto,
@@ -246,61 +246,124 @@ pub fn build_histogram_view(
     req: &ValidatedMetricResultsRequest,
     rows: Vec<HistogramQueryRow>,
 ) -> MetricResultViewDto {
-    struct EntityBins {
-        lo: f64,
-        hi: f64,
-        counts: HashMap<u32, u64>,
-    }
-
-    let mut by_entity: HashMap<String, EntityBins> = HashMap::new();
+    let mut by_entity: HashMap<String, GroupBins> = HashMap::new();
     for row in rows {
         let entity_id = req.entity.canonicalize_entity_id(row.entity_id);
-        let entry = by_entity.entry(entity_id).or_insert(EntityBins {
-            lo: row.entity_lo,
-            hi: row.entity_hi,
-            counts: HashMap::new(),
-        });
-        let count = entry.counts.entry(row.bin_idx).or_insert(0);
-        *count += row.bin_count.unwrap_or(0);
+        by_entity
+            .entry(entity_id)
+            .or_insert_with(|| GroupBins::new(row.entity_lo, row.entity_hi))
+            .add(row.bin_idx, row.bin_count.unwrap_or(0));
     }
 
-    let bin_total = u32::try_from(HISTOGRAM_BINS).unwrap_or(u32::MAX);
     let values = req
         .entity
         .entity_ids()
         .into_iter()
-        .map(|person_id| {
-            let bins = match by_entity.get(&person_id) {
-                None => Vec::new(),
-                // Bounds satisfy hi >= lo by construction; a collapsed range
-                // (all values identical) renders as one [v, v] bin.
-                Some(entity) if entity.hi <= entity.lo => vec![HistogramBinDto {
-                    lo: entity.lo,
-                    hi: entity.hi,
-                    count: entity.counts.values().sum(),
-                }],
-                Some(entity) => {
-                    let width = (entity.hi - entity.lo) / f64::from(bin_total);
-                    (0..bin_total)
-                        .map(|idx| HistogramBinDto {
-                            lo: entity.lo + f64::from(idx) * width,
-                            hi: if idx == bin_total - 1 {
-                                entity.hi
-                            } else {
-                                entity.lo + f64::from(idx + 1) * width
-                            },
-                            count: entity.counts.get(&idx).copied().unwrap_or(0),
-                        })
-                        .collect()
-                }
-            };
-            HistogramValueDto {
-                entity_id: person_id,
-                bins,
-            }
+        .map(|person_id| HistogramValueDto {
+            bins: by_entity
+                .get(&person_id)
+                .map_or_else(Vec::new, GroupBins::densify),
+            entity_id: Some(person_id),
+            dimensions: Vec::new(),
         })
         .collect();
-    MetricResultViewDto::Histogram { values }
+    MetricResultViewDto::Histogram {
+        dimensions: Vec::new(),
+        values,
+    }
+}
+
+/// The pooled counterpart: one row per observed dimension tuple, binned over
+/// every selected entity's events together. Unlike the per-entity shape there
+/// is no roster to list against, so a tuple with no events simply has no row —
+/// the same absence rule rollup follows.
+pub fn build_pooled_histogram_view(
+    rows: Vec<PooledHistogramQueryRow>,
+    dimensions: &[String],
+) -> Result<MetricResultViewDto, CanonicalError> {
+    let mut by_group: Vec<(Vec<MetricDimensionDto>, GroupBins)> = Vec::new();
+    let mut index: HashMap<Vec<String>, usize> = HashMap::new();
+    for row in rows {
+        let dims = row_dimensions(&row.extra, dimensions)?;
+        let key: Vec<String> = dims.iter().map(|(_, value, _)| value.clone()).collect();
+        let position = if let Some(position) = index.get(&key) {
+            *position
+        } else {
+            by_group.push((
+                dims.into_iter()
+                    .map(|(key, value, label)| MetricDimensionDto { key, value, label })
+                    .collect(),
+                GroupBins::new(row.group_lo, row.group_hi),
+            ));
+            index.insert(key, by_group.len() - 1);
+            by_group.len() - 1
+        };
+        by_group[position]
+            .1
+            .add(row.bin_idx, row.bin_count.unwrap_or(0));
+    }
+
+    let values = by_group
+        .into_iter()
+        .map(|(dims, bins)| HistogramValueDto {
+            entity_id: None,
+            dimensions: dims,
+            bins: bins.densify(),
+        })
+        .collect();
+    Ok(MetricResultViewDto::Histogram {
+        dimensions: dimensions.to_vec(),
+        values,
+    })
+}
+
+/// One partition's exact value bounds plus its observed bin counts. The SQL
+/// reports only observed (partition, bin) pairs, so the edge math that turns
+/// them into the full fixed-bin shape lives here alone — empty and observed
+/// bins can never disagree about a boundary.
+struct GroupBins {
+    lo: f64,
+    hi: f64,
+    counts: HashMap<u32, u64>,
+}
+
+impl GroupBins {
+    fn new(lo: f64, hi: f64) -> Self {
+        Self {
+            lo,
+            hi,
+            counts: HashMap::new(),
+        }
+    }
+
+    fn add(&mut self, bin_idx: u32, count: u64) {
+        *self.counts.entry(bin_idx).or_insert(0) += count;
+    }
+
+    fn densify(&self) -> Vec<HistogramBinDto> {
+        let bin_total = u32::try_from(HISTOGRAM_BINS).unwrap_or(u32::MAX);
+        // Bounds satisfy hi >= lo by construction; a collapsed range (all
+        // values identical) renders as one [v, v] bin.
+        if self.hi <= self.lo {
+            return vec![HistogramBinDto {
+                lo: self.lo,
+                hi: self.hi,
+                count: self.counts.values().sum(),
+            }];
+        }
+        let width = (self.hi - self.lo) / f64::from(bin_total);
+        (0..bin_total)
+            .map(|idx| HistogramBinDto {
+                lo: self.lo + f64::from(idx) * width,
+                hi: if idx == bin_total - 1 {
+                    self.hi
+                } else {
+                    self.lo + f64::from(idx + 1) * width
+                },
+                count: self.counts.get(&idx).copied().unwrap_or(0),
+            })
+            .collect()
+    }
 }
 
 pub fn build_metric_result(
@@ -350,7 +413,7 @@ fn view_size(view: &MetricResultViewDto) -> usize {
         MetricResultViewDto::Peer { values } => values.len(),
         MetricResultViewDto::Breakdown { values, .. } => values.len(),
         MetricResultViewDto::Rollup { values, .. } => values.len(),
-        MetricResultViewDto::Histogram { values } => {
+        MetricResultViewDto::Histogram { values, .. } => {
             values.iter().map(|value| value.bins.len()).sum()
         }
     }
@@ -635,13 +698,16 @@ mod tests {
             histogram_row("00000000-0000-0000-0000-00000000000a", 0, 0.0, 100.0, 3),
             histogram_row("00000000-0000-0000-0000-00000000000a", 9, 0.0, 100.0, 1),
         ];
-        let MetricResultViewDto::Histogram { values } = build_histogram_view(&req, rows) else {
+        let MetricResultViewDto::Histogram { values, .. } = build_histogram_view(&req, rows) else {
             panic!("expected histogram view");
         };
         assert_eq!(values.len(), 2);
 
         let a = &values[0];
-        assert_eq!(a.entity_id, "00000000-0000-0000-0000-00000000000a");
+        assert_eq!(
+            a.entity_id.as_deref(),
+            Some("00000000-0000-0000-0000-00000000000a")
+        );
         assert_eq!(a.bins.len(), 10);
         assert_eq!(a.bins[0].count, 3);
         assert!((a.bins[0].lo - 0.0).abs() < f64::EPSILON);
@@ -655,8 +721,62 @@ mod tests {
 
         // Entity with no events stays listed with honest empty bins.
         let b = &values[1];
-        assert_eq!(b.entity_id, "00000000-0000-0000-0000-00000000000b");
+        assert_eq!(
+            b.entity_id.as_deref(),
+            Some("00000000-0000-0000-0000-00000000000b")
+        );
         assert!(b.bins.is_empty());
+    }
+
+    fn pooled_histogram_row(
+        repository: &str,
+        bin_idx: u32,
+        lo: f64,
+        hi: f64,
+        count: u64,
+    ) -> PooledHistogramQueryRow {
+        PooledHistogramQueryRow {
+            bin_idx,
+            group_lo: lo,
+            group_hi: hi,
+            bin_count: Some(count),
+            extra: HashMap::from([
+                ("dim_0_value".to_owned(), json!(repository)),
+                ("dim_0_label".to_owned(), json!(repository)),
+            ]),
+        }
+    }
+
+    #[test]
+    fn pooled_histogram_bins_per_dimension_tuple_without_entity_grain() {
+        let rows = vec![
+            pooled_histogram_row("acme/api", 0, 0.0, 100.0, 3),
+            pooled_histogram_row("acme/api", 9, 0.0, 100.0, 1),
+            pooled_histogram_row("acme/web", 0, 5.0, 5.0, 2),
+        ];
+        let Ok(view) = build_pooled_histogram_view(rows, &["repository".to_owned()]) else {
+            panic!("expected the pooled histogram to build");
+        };
+        let MetricResultViewDto::Histogram { dimensions, values } = view else {
+            panic!("expected histogram view");
+        };
+        assert_eq!(dimensions, vec!["repository".to_owned()]);
+        assert_eq!(values.len(), 2);
+
+        let api = &values[0];
+        // No entity grain: a pooled row answers for the tuple, not a person.
+        assert!(api.entity_id.is_none());
+        assert_eq!(api.dimensions[0].value, "acme/api");
+        assert_eq!(api.bins.len(), 10);
+        assert_eq!(api.bins[0].count, 3);
+        assert_eq!(api.bins[9].count, 1);
+        assert!((api.bins[9].hi - 100.0).abs() < f64::EPSILON);
+
+        // A tuple whose events all share one value collapses to a single bin,
+        // exactly as the per-entity shape does.
+        let web = &values[1];
+        assert_eq!(web.bins.len(), 1);
+        assert_eq!(web.bins[0].count, 2);
     }
 
     #[test]
@@ -673,7 +793,7 @@ mod tests {
             7.5,
             4,
         )];
-        let MetricResultViewDto::Histogram { values } = build_histogram_view(&req, rows) else {
+        let MetricResultViewDto::Histogram { values, .. } = build_histogram_view(&req, rows) else {
             panic!("expected histogram view");
         };
         assert_eq!(values[0].bins.len(), 1);

--- a/src/backend/services/analytics/src/domain/metric_results/compiler.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/compiler.rs
@@ -102,6 +102,21 @@ pub struct HistogramQueryRow {
     pub bin_count: Option<u64>,
 }
 
+/// One observed (dimension tuple, bin) pair plus the tuple's exact value
+/// bounds, pooled over all selected entities' events — the dimensioned
+/// counterpart of [`HistogramQueryRow`], with the dimension value/label
+/// aliases arriving through `extra` like every dimensioned row shape.
+#[derive(Debug, Deserialize)]
+pub struct PooledHistogramQueryRow {
+    pub bin_idx: u32,
+    pub group_lo: f64,
+    pub group_hi: f64,
+    #[serde(default, deserialize_with = "optional_u64")]
+    pub bin_count: Option<u64>,
+    #[serde(flatten)]
+    pub extra: HashMap<String, serde_json::Value>,
+}
+
 pub(crate) fn compile_period_batch_query(
     defs: &[&MetricDefinition],
     req: &ValidatedMetricResultsRequest,
@@ -648,6 +663,68 @@ pub(crate) fn compile_histogram_query(
         FROM events
         GROUP BY entity_id, bin_idx
         ORDER BY entity_id, bin_idx
+        LIMIT {limit}
+        ",
+        metric_where = metric_where(def, req.enforce_tenant_scope),
+        event_value = transformed(def, "value".to_owned()),
+    );
+    CompiledQuery { sql, params }
+}
+
+// The pooled counterpart of `compile_histogram_query`: same deterministic
+// fixed-width binning, but the partition (and the [min, max] bounds) is the
+// dimension tuple instead of the entity — all selected entities' events pool
+// into one distribution per tuple, mirroring how rollup drops the entity
+// grain. Grouping by (value, label) alias pairs matches the breakdown /
+// timeseries dimension shape. Group cardinality is unbounded like an
+// uncapped rollup's, so the query carries the same row limit.
+pub(crate) fn compile_pooled_histogram_query(
+    def: &MetricDefinition,
+    req: &ValidatedMetricResultsRequest,
+    dimensions: &[String],
+    filters: &[ValidatedDimensionFilter],
+) -> CompiledQuery {
+    let mut params = metric_params(def, req);
+    let filter_where = dimension_filter_where(filters, &mut params);
+    let entity_predicate = selected_entity_predicate(req, &mut params);
+    let observation_table = observation_table(def.observation_source());
+    let (dim_select, dim_group) = dimension_select_group(dimensions);
+    let bins = HISTOGRAM_BINS;
+    let max_bin = HISTOGRAM_BINS - 1;
+    let limit = query_row_limit();
+    let sql = format!(
+        r"
+        WITH raw_events AS (
+            SELECT
+                assumeNotNull({event_value}) AS event_value{dim_select}
+            FROM {observation_table}
+            WHERE {metric_where}
+              {filter_where}
+              AND {entity_predicate}
+              AND value IS NOT NULL
+        ),
+        events AS (
+            SELECT
+                *,
+                min(event_value) OVER (PARTITION BY {dim_group}) AS group_lo,
+                max(event_value) OVER (PARTITION BY {dim_group}) AS group_hi
+            FROM raw_events
+        )
+        SELECT
+            {dim_group},
+            if(
+                events.group_hi = events.group_lo,
+                0,
+                toUInt32(least({max_bin}, toInt64(floor(
+                    (events.event_value - events.group_lo) * {bins} / (events.group_hi - events.group_lo)
+                ))))
+            ) AS bin_idx,
+            any(events.group_lo) AS group_lo,
+            any(events.group_hi) AS group_hi,
+            toUInt64(count()) AS bin_count
+        FROM events
+        GROUP BY {dim_group}, bin_idx
+        ORDER BY {dim_group}, bin_idx
         LIMIT {limit}
         ",
         metric_where = metric_where(def, req.enforce_tenant_scope),
@@ -2286,6 +2363,42 @@ mod tests {
     }
 
     #[test]
+    fn pooled_histogram_query_bins_per_dimension_tuple_without_entity_grain() {
+        let query = compile_pooled_histogram_query(
+            &percentile_metric(),
+            &request(),
+            &["source".to_owned()],
+            &[],
+        );
+        // Bounds and bins partition/group by the dimension aliases — the
+        // entity only scopes which rows enter the pool.
+        assert!(
+            query
+                .sql
+                .contains("min(event_value) OVER (PARTITION BY dim_0_value, dim_0_label)")
+        );
+        assert!(
+            query
+                .sql
+                .contains("max(event_value) OVER (PARTITION BY dim_0_value, dim_0_label)")
+        );
+        assert!(
+            query
+                .sql
+                .contains("GROUP BY dim_0_value, dim_0_label, bin_idx")
+        );
+        assert!(!query.sql.contains("PARTITION BY entity_id"));
+        assert!(query.sql.contains("entity_id IN (?, ?)"));
+        // Same deterministic fixed-width arithmetic as the per-entity shape.
+        assert!(query.sql.contains("least(9,"));
+        assert!(query.sql.contains("* 10 /"));
+        assert!(!query.sql.contains("histogram("));
+        // Unbounded group cardinality rides the shared row limit.
+        assert!(query.sql.contains(&format!("LIMIT {}", query_row_limit())));
+        assert_eq!(query.sql.matches('?').count(), query.params.len());
+    }
+
+    #[test]
     fn transform_wraps_every_query_shape() {
         let mut def = ratio_metric();
         def.transform = Some(ValueTransform {
@@ -2326,6 +2439,18 @@ mod tests {
             hist.sql
         );
         assert_eq!(hist.sql.matches('?').count(), hist.params.len());
+        // The pooled shape bins the same transformed alias.
+        let pooled =
+            compile_pooled_histogram_query(&median, &request(), &["source".to_owned()], &[]);
+        assert!(
+            pooled
+                .sql
+                .contains("if((value) IS NULL, NULL, least(100.0, value))")
+                && pooled.sql.contains("AS event_value"),
+            "pooled histogram must transform into the event_value alias: {}",
+            pooled.sql
+        );
+        assert_eq!(pooled.sql.matches('?').count(), pooled.params.len());
         let period = compile_period_batch_query(&[&def], &request(), &[]);
         assert!(
             period

--- a/src/backend/services/analytics/src/domain/metric_results/dto.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/dto.rs
@@ -78,7 +78,10 @@ pub enum MetricViewRequest {
         dimensions: Vec<String>,
         group_limit: Option<MetricGroupLimitRequest>,
     },
-    Histogram,
+    Histogram {
+        #[serde(default)]
+        dimensions: Vec<String>,
+    },
 }
 
 impl MetricViewRequest {
@@ -89,7 +92,7 @@ impl MetricViewRequest {
             Self::Timeseries { .. } => MetricResultViewKind::Timeseries,
             Self::Breakdown { .. } => MetricResultViewKind::Breakdown,
             Self::Rollup { .. } => MetricResultViewKind::Rollup,
-            Self::Histogram => MetricResultViewKind::Histogram,
+            Self::Histogram { .. } => MetricResultViewKind::Histogram,
         }
     }
 }
@@ -185,14 +188,25 @@ pub enum MetricResultViewDto {
         values: Vec<RollupValueDto>,
     },
     Histogram {
+        /// Present only for the pooled (dimensioned) shape; absent for the
+        /// per-entity shape, keeping that wire form unchanged.
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        dimensions: Vec<String>,
         values: Vec<HistogramValueDto>,
     },
 }
 
+/// One histogram row. Per-entity shape: `entity_id` set, `dimensions` absent,
+/// every requested entity listed. Pooled shape (dimensioned request):
+/// `dimensions` set, `entity_id` absent, one row per observed dimension tuple
+/// over all selected entities' events — no entity grain, like rollup.
 #[derive(Debug, Serialize, utoipa::ToSchema)]
 pub struct HistogramValueDto {
-    pub entity_id: String,
-    /// Empty when the entity has no events in the period — the entity is
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entity_id: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub dimensions: Vec<MetricDimensionDto>,
+    /// Empty when a listed entity has no events in the period — the entity is
     /// still listed, mirroring the period view's every-requested-entity rule.
     pub bins: Vec<HistogramBinDto>,
 }
@@ -311,6 +325,28 @@ mod tests {
         }));
 
         assert!(request.is_ok());
+    }
+
+    #[test]
+    fn histogram_view_deserializes_with_and_without_dimensions() {
+        // Bare `{"view": "histogram"}` must keep parsing exactly as before the
+        // pooled shape existed (dimensions default to empty).
+        let bare = serde_json::from_value::<MetricResultsRequest>(json!({
+            "entity": { "type": "person", "ids": ["019e27bc-dec0-7626-81a9-c5524662a6a9"] },
+            "period": { "from": "2026-01-01", "to": "2026-01-31" },
+            "metrics": [{ "metric_key": "git.x", "views": [{ "view": "histogram" }] }]
+        }));
+        assert!(bare.is_ok());
+
+        let pooled = serde_json::from_value::<MetricResultsRequest>(json!({
+            "entity": { "type": "person", "ids": ["019e27bc-dec0-7626-81a9-c5524662a6a9"] },
+            "period": { "from": "2026-01-01", "to": "2026-01-31" },
+            "metrics": [{
+                "metric_key": "git.x",
+                "views": [{ "view": "histogram", "dimensions": ["repository"] }]
+            }]
+        }));
+        assert!(pooled.is_ok());
     }
 
     #[test]

--- a/src/backend/services/analytics/src/domain/metric_results/mod.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/mod.rs
@@ -11,12 +11,12 @@ pub use batch::{
 };
 pub use builder::{
     build_breakdown_view, build_histogram_view, build_metric_result, build_peer_view,
-    build_period_view, build_ranked_groups, build_rollup_view, build_timeseries_view,
-    enforce_view_row_limit,
+    build_period_view, build_pooled_histogram_view, build_ranked_groups, build_rollup_view,
+    build_timeseries_view, enforce_view_row_limit,
 };
 pub use compiler::{
-    BreakdownQueryRow, CompiledQuery, HistogramQueryRow, RankingQueryRow, RollupQueryRow,
-    TimeseriesQueryRow,
+    BreakdownQueryRow, CompiledQuery, HistogramQueryRow, PooledHistogramQueryRow, RankingQueryRow,
+    RollupQueryRow, TimeseriesQueryRow,
 };
 pub use dto::{
     MetricDimensionFilterDto, MetricResultSelectionDto, MetricResultViewDto,

--- a/src/backend/services/analytics/src/domain/metric_results/validation.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/validation.rs
@@ -141,7 +141,11 @@ pub enum ValidatedMetricView {
         dimensions: Vec<String>,
         group_limit: Option<ValidatedGroupLimit>,
     },
-    Histogram,
+    Histogram {
+        /// Empty: per-entity bins. Non-empty: bins pooled per dimension tuple
+        /// over all selected entities' events (no entity grain), like rollup.
+        dimensions: Vec<String>,
+    },
 }
 
 struct RequestShape {
@@ -434,7 +438,7 @@ fn validate_view_with_context(
                 group_limit,
             })
         }
-        MetricViewRequest::Histogram => {
+        MetricViewRequest::Histogram { dimensions } => {
             // Histograms bin per-event observation values; only median and
             // percentile metrics have event-grain observations to bin.
             if !matches!(
@@ -449,7 +453,9 @@ fn validate_view_with_context(
                     ),
                 );
             }
-            Ok(ValidatedMetricView::Histogram)
+            Ok(ValidatedMetricView::Histogram {
+                dimensions: validate_dimensions(def, "metrics.views.dimensions", dimensions)?,
+            })
         }
     }
 }
@@ -696,8 +702,14 @@ fn validate_projected_view_limits(
                         .saturating_mul(groups)
                         .saturating_mul(enumerate_buckets(req.from, req.to, *bucket).len() + 1)
                 }
-                ValidatedMetricView::Histogram => req.entity.len().saturating_mul(HISTOGRAM_BINS),
-                ValidatedMetricView::Breakdown { .. } => 0,
+                ValidatedMetricView::Histogram { dimensions } if dimensions.is_empty() => {
+                    req.entity.len().saturating_mul(HISTOGRAM_BINS)
+                }
+                // A pooled histogram's groups are data-dependent, like an
+                // uncapped rollup's and a breakdown's: not projectable here,
+                // capped by the query's row limit and the post-hoc view row
+                // limit instead.
+                ValidatedMetricView::Histogram { .. } | ValidatedMetricView::Breakdown { .. } => 0,
                 ValidatedMetricView::Rollup { group_limit, .. } => {
                     group_limit.as_ref().map_or(0, |limit| {
                         limit.count + usize::from(limit.include_remainder)
@@ -1315,16 +1327,58 @@ mod tests {
         // Histograms bin per-event values; sum/ratio observations are
         // day-aggregated, so binning them would present aggregates as events.
         // Median and percentile share the per-event observation shape.
-        assert!(validate_view(&sum_definition(vec![]), MetricViewRequest::Histogram).is_err());
-        assert!(validate_view(&ratio_definition(), MetricViewRequest::Histogram).is_err());
+        let histogram = || MetricViewRequest::Histogram { dimensions: vec![] };
+        assert!(validate_view(&sum_definition(vec![]), histogram()).is_err());
+        assert!(validate_view(&ratio_definition(), histogram()).is_err());
         assert!(matches!(
-            validate_view(&median_definition(), MetricViewRequest::Histogram),
-            Ok(ValidatedMetricView::Histogram)
+            validate_view(&median_definition(), histogram()),
+            Ok(ValidatedMetricView::Histogram { dimensions }) if dimensions.is_empty()
         ));
         assert!(matches!(
-            validate_view(&percentile_definition(), MetricViewRequest::Histogram),
-            Ok(ValidatedMetricView::Histogram)
+            validate_view(&percentile_definition(), histogram()),
+            Ok(ValidatedMetricView::Histogram { dimensions }) if dimensions.is_empty()
         ));
+    }
+
+    #[test]
+    fn validate_view_pools_histogram_only_over_declared_dimensions() {
+        // The pooled shape reuses the breakdown/rollup dimension rule: every
+        // requested dimension must be declared on the metric.
+        let mut def = median_definition();
+        def.base.allowed_dimensions = vec!["repository".to_owned()];
+
+        match validate_view(
+            &def,
+            MetricViewRequest::Histogram {
+                dimensions: vec![" Repository ".to_owned()],
+            },
+        ) {
+            Ok(ValidatedMetricView::Histogram { dimensions }) => {
+                assert_eq!(dimensions, vec!["repository"]);
+            }
+            other => panic!("expected pooled histogram, got {other:?}"),
+        }
+
+        assert!(
+            validate_view(
+                &def,
+                MetricViewRequest::Histogram {
+                    dimensions: vec!["surface".to_owned()],
+                },
+            )
+            .is_err()
+        );
+
+        // The computation gate still holds for the pooled shape.
+        assert!(
+            validate_view(
+                &sum_definition(vec!["repository"]),
+                MetricViewRequest::Histogram {
+                    dimensions: vec!["repository".to_owned()],
+                },
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -1433,11 +1487,19 @@ mod tests {
             metrics: vec![ValidatedMetricRequest {
                 def: median_definition(),
                 filters: vec![],
-                views: vec![ValidatedMetricView::Histogram],
+                views: vec![ValidatedMetricView::Histogram { dimensions: vec![] }],
             }],
             enforce_tenant_scope: false,
         };
         assert!(validate_projected_view_limits(&validated).is_err());
+
+        // The pooled shape carries no entity grain, so entity count does not
+        // project rows for it — group cardinality is capped at query time.
+        let mut pooled = validated;
+        pooled.metrics[0].views = vec![ValidatedMetricView::Histogram {
+            dimensions: vec!["repository".to_owned()],
+        }];
+        assert!(validate_projected_view_limits(&pooled).is_ok());
     }
 
     #[test]

--- a/src/frontend/src/api/metric-results-client.ts
+++ b/src/frontend/src/api/metric-results-client.ts
@@ -205,8 +205,12 @@ interface HistogramBin {
 
 export interface HistogramView {
   view: "histogram";
+  /** Set only on the pooled shape — the dimensions the request asked to bin by. */
+  dimensions?: string[];
   values: Array<{
-    entity_id: string;
+    /** Per-entity shape only; a pooled row is keyed by `dimensions` instead. */
+    entity_id?: string;
+    dimensions?: MetricDimension[];
     bins: HistogramBin[];
   }>;
 }

--- a/src/ingestion/tests/e2e/metrics/git_pr_cycle_time_pooled_histogram.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/git_pr_cycle_time_pooled_histogram.test.yaml
@@ -1,0 +1,104 @@
+spec_version: 1
+description: >
+  View: the POOLED histogram — `{view: histogram, dimensions: [repository]}`
+  bins one distribution per dimension tuple over every selected entity's
+  events, instead of one distribution per entity.
+
+  Seeded over git.pr_cycle_time_h (hours from open to merge, one event per
+  merged request):
+    • acme/api  — alice merges at 10 h and 30 h, bob at 20 h and 40 h
+    • acme/web  — alice and bob each merge at 5 h
+
+  What the numbers prove:
+    • acme/api pools to [10, 40] across BOTH people, so its last bin closes at
+      40. Per-entity binning would close alice's own distribution at 30 —
+      the assertion fails if the pooling is dropped.
+    • acme/web's four-way-identical values collapse to a single [5, 5] bin
+      whose count is 2, one per person: a per-entity shape would report two
+      rows of count 1.
+    • Bins are fixed-width over the tuple's own [min, max]: 10 bins of width
+      3 over [10, 40], so a bin starts exactly at 10 and the last closes at 40.
+
+  Cases: pooled bins per repository, the dimensionless request still answering
+  per entity (unchanged wire shape), empty window.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+    - $ref: templates/people.yaml#/templates/bob
+  bronze_github.pull_requests:
+    # acme/api: alice 10 h and 30 h, bob 20 h and 40 h — all open at
+    # 2026-10-01T00:00 and dated at their merge.
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: pr-api-a1, id: 101, number: 101, repo_full_name: acme/api, author_login: alice, created_at: "2026-10-01T00:00:00Z", closed_at: "2026-10-01T10:00:00Z", merged_at: "2026-10-01T10:00:00Z", merge_commit_sha: merge-api-a1}
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: pr-api-a2, id: 102, number: 102, repo_full_name: acme/api, author_login: alice, created_at: "2026-10-01T00:00:00Z", closed_at: "2026-10-02T06:00:00Z", merged_at: "2026-10-02T06:00:00Z", merge_commit_sha: merge-api-a2}
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: pr-api-b1, id: 103, number: 103, repo_full_name: acme/api, author_login: bob, created_at: "2026-10-01T00:00:00Z", closed_at: "2026-10-01T20:00:00Z", merged_at: "2026-10-01T20:00:00Z", merge_commit_sha: merge-api-b1}
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: pr-api-b2, id: 104, number: 104, repo_full_name: acme/api, author_login: bob, created_at: "2026-10-01T00:00:00Z", closed_at: "2026-10-02T16:00:00Z", merged_at: "2026-10-02T16:00:00Z", merge_commit_sha: merge-api-b2}
+    # acme/web: both merge at 5 h, so the tuple's range collapses.
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: pr-web-a1, id: 105, number: 105, repo_full_name: acme/web, author_login: alice, created_at: "2026-10-01T00:00:00Z", closed_at: "2026-10-01T05:00:00Z", merged_at: "2026-10-01T05:00:00Z", merge_commit_sha: merge-web-a1}
+    - {$ref: templates/git_activity.yaml#/templates/pull_request, unique_key: pr-web-b1, id: 106, number: 106, repo_full_name: acme/web, author_login: bob, created_at: "2026-10-01T00:00:00Z", closed_at: "2026-10-01T05:00:00Z", merged_at: "2026-10-01T05:00:00Z", merge_commit_sha: merge-web-b1}
+  bronze_github.pull_request_diff_stats:
+    # GitHub staging reads a request's author_email from here and nowhere else.
+    - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-api-a1, pull_number: 101, additions: 10, author_email: alice@example.com}
+    - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-api-a2, pull_number: 102, additions: 10, author_email: alice@example.com}
+    - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-api-b1, pull_number: 103, additions: 10, author_email: bob@example.com}
+    - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-api-b2, pull_number: 104, additions: 10, author_email: bob@example.com}
+    - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-web-a1, pull_number: 105, additions: 10, author_email: alice@example.com}
+    - {$ref: templates/git_activity.yaml#/templates/diff_stat, unique_key: ds-web-b1, pull_number: 106, additions: 10, author_email: bob@example.com}
+
+cases:
+  - name: Pooled bins per repository
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [alice@example.com, bob@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-03"}
+        metrics:
+          - metric_key: git.pr_cycle_time_h
+            views:
+              - {view: histogram, dimensions: [repository]}
+    expect:
+      - assert: "status == 200"
+      # acme/api pools alice's [10, 30] with bob's [20, 40]: the distribution
+      # starts at 10 and closes at 40. A per-entity shape closes at 30.
+      - {metric: git.pr_cycle_time_h, view: histogram, find: {dimensions: {key: repository, value: acme/api}}, contains: {bins: {lo: 10, count: 1}}}
+      - {metric: git.pr_cycle_time_h, view: histogram, find: {dimensions: {key: repository, value: acme/api}}, contains: {bins: {hi: 40, count: 1}}}
+      # Identical values collapse to one bin, and its count is BOTH people's.
+      - {metric: git.pr_cycle_time_h, view: histogram, find: {dimensions: {key: repository, value: acme/web}}, contains: {bins: {lo: 5, hi: 5, count: 2}}}
+      # Pooled rows carry no entity grain, exactly like rollup rows.
+      - {metric: git.pr_cycle_time_h, view: histogram, find: {dimensions: {key: repository, value: acme/web}}, assert: "!has(it.entity_id)"}
+
+  - name: The dimensionless request still bins per entity
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [alice@example.com, bob@example.com]}
+        period: {from: "2026-10-01", to: "2026-10-03"}
+        metrics:
+          - metric_key: git.pr_cycle_time_h
+            views:
+              - {view: histogram}
+    expect:
+      - assert: "status == 200"
+      # alice's own three merges span [5, 30] — bob's 40 h is not hers.
+      - {metric: git.pr_cycle_time_h, view: histogram, find: {entity_id: alice@example.com}, contains: {bins: {lo: 5, count: 1}}}
+      - {metric: git.pr_cycle_time_h, view: histogram, find: {entity_id: alice@example.com}, contains: {bins: {hi: 30, count: 1}}}
+      - {metric: git.pr_cycle_time_h, view: histogram, find: {entity_id: bob@example.com}, contains: {bins: {hi: 40, count: 1}}}
+
+  - name: Empty window
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: {type: person, ids: [alice@example.com, bob@example.com]}
+        period: {from: "2025-01-01", to: "2025-01-31"}
+        metrics:
+          - metric_key: git.pr_cycle_time_h
+            views:
+              - {view: histogram, dimensions: [repository]}
+    expect:
+      - assert: "status == 200"
+      # No events, so no tuple has a row — pooled absence, unlike the
+      # per-entity shape which still lists every requested entity.
+      - {metric: git.pr_cycle_time_h, view: histogram, assert: "size(view.values) == 0"}

--- a/tests/stand/api/schemas/analytics.py
+++ b/tests/stand/api/schemas/analytics.py
@@ -201,14 +201,6 @@ class HistogramBinDto(BaseModel):
     lo: float
 
 
-class HistogramValueDto(BaseModel):
-    model_config = ConfigDict(
-        extra='forbid',
-    )
-    bins: list[HistogramBinDto] = Field(..., description="Empty when the entity has no events in the period — the entity is\nstill listed, mirroring the period view's every-requested-entity rule.")
-    entity_id: str
-
-
 class ImportCustomMetricsResponse(BaseModel):
     """
     `POST /v1/metrics/import` result — counts landed and the `metric_key`s
@@ -481,14 +473,6 @@ class View5(StrEnum):
     histogram = 'histogram'
 
 
-class MetricResultViewDto6(BaseModel):
-    model_config = ConfigDict(
-        extra='forbid',
-    )
-    values: list[HistogramValueDto]
-    view: View5
-
-
 class Type3(StrEnum):
     person = 'person'
 
@@ -636,6 +620,7 @@ class MetricViewRequest6(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
+    dimensions: list[str] | None = None
     view: View11
 
 
@@ -984,6 +969,21 @@ class CustomMetricSummary(BaseModel):
     subject: str | None = Field(None, description='Grouping subject, so the management list can partition custom metrics\nby topic like the definitions listing; absent when none is declared.')
 
 
+class HistogramValueDto(BaseModel):
+    """
+    One histogram row. Per-entity shape: `entity_id` set, `dimensions` absent,
+    every requested entity listed. Pooled shape (dimensioned request):
+    `dimensions` set, `entity_id` absent, one row per observed dimension tuple
+    over all selected entities' events — no entity grain, like rollup.
+    """
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    bins: list[HistogramBinDto] = Field(..., description="Empty when a listed entity has no events in the period — the entity is\nstill listed, mirroring the period view's every-requested-entity rule.")
+    dimensions: list[MetricDimensionDto] | None = None
+    entity_id: str | None = None
+
+
 class MetricDefinitionView(BaseModel):
     """
     One metric definition, display fields only.
@@ -1094,6 +1094,15 @@ class MetricResultViewDto5(BaseModel):
     dimensions: list[str]
     values: list[RollupValueDto]
     view: View4
+
+
+class MetricResultViewDto6(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    dimensions: list[str] | None = Field(None, description='Present only for the pooled (dimensioned) shape; absent for the\nper-entity shape, keeping that wire form unchanged.')
+    values: list[HistogramValueDto]
+    view: View5
 
 
 class MetricResultsRequest(BaseModel):


### PR DESCRIPTION
**Why.** The histogram view bins one distribution per entity, so "how long do pull requests in this repository stay open" has no shape today — binning per person and merging the bins is not the repository's distribution.

**What changed.** `{view: "histogram"}` takes optional `dimensions`. With them, every selected entity's events pool into one distribution per dimension tuple and rows carry `dimensions` instead of an `entity_id` — the same no-entity-grain shape rollup already returns. The bin math is unchanged: fixed width over the partition's own `[min, max]`, the partition being the tuple rather than the person.

**The dimensionless request is byte-identical to before.** `{"view": "histogram"}` still parses, still bins per entity, still lists every requested entity — pinned by a deserialization test and the untouched per-entity tests.

**A pooled tuple with no events has no row,** where the per-entity shape lists every requested entity with empty bins. There is no roster to list tuples against, so absence is absence — rollup's rule.

**No group-limit support.** Group cardinality is bounded by the query row limit and the post-hoc view row limit, as it is for an uncapped rollup; a cap can be added when a caller needs one.

**Out of scope.** The frontend only gains the response type — no UI reads pooled bins yet; the Repositories lens small-multiples that motivated this ship separately.

**Verified.** `cargo test -p analytics` (561), `cargo clippy --all-targets -D warnings`, the OpenAPI drift gate regenerated, and the generated stand schemas refreshed. The compiled SQL was run against ClickHouse 25.7.5 on synthetic rows: two people's events in one repository pool to a shared `[10, 40]` range, and a repository whose values are all identical collapses to a single bin whose count is both people's — the two facts the new e2e fixture asserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
