### PR TITLE
fix(analytics): name the branch on every git record list

### DIFF
--- a/src/backend/services/analytics/src/domain/metric_drilldown/presentation.rs
+++ b/src/backend/services/analytics/src/domain/metric_drilldown/presentation.rs
@@ -196,6 +196,11 @@ fn presentation_column(key: &str, plan: &EvidencePlan) -> MetricDrilldownColumn 
             input_label(plan, MetricInputRole::Denominator),
             MetricDrilldownColumnType::Number,
         ),
+        "branch_scope" => ("Branch scope".to_owned(), MetricDrilldownColumnType::String),
+        "destination_branch" => (
+            "Target branch".to_owned(),
+            MetricDrilldownColumnType::String,
+        ),
         "lines_added" => ("Lines added".to_owned(), MetricDrilldownColumnType::Number),
         "lines_removed" => (
             "Lines removed".to_owned(),
@@ -221,12 +226,19 @@ pub(super) fn evidence_presentation(
     granularity: EvidenceGranularity,
 ) -> EvidencePresentation {
     match (source_key, measure_key) {
+        // Every git row names where the work went, on every path that opens
+        // the dialog (#2806) — a column that only appeared when the reader
+        // happened to arrive through a grouped table left the same record
+        // looking like a different record. A commit knows only whether it is
+        // reachable from the trunk, so `branch_scope` is the honest column
+        // there; a pull request knows the branch it targeted, so it names it.
         ("git", "commit_count" | "commit_change_size") => EvidencePresentation {
             detail_keys: &[
                 "ref",
                 "title",
                 "repository",
                 "author",
+                "branch_scope",
                 "lines_added",
                 "lines_removed",
             ],
@@ -235,11 +247,21 @@ pub(super) fn evidence_presentation(
         // Reviewer-perspective events anchor on the reviewed pull request, so
         // the row reads like the PR measures: the value is always 1 and stays
         // hidden, `author` names whose request was reviewed or commented on.
-        (
-            "git",
-            "pr_created" | "pr_created_merged" | "pr_merged" | "review_submitted" | "pr_comment",
-        ) => EvidencePresentation {
-            detail_keys: &["ref", "title", "repository", "author"],
+        // They carry no `branch_scope` — a review is not classified by where
+        // the request landed, only the request itself is.
+        ("git", "review_submitted" | "pr_comment") => EvidencePresentation {
+            detail_keys: &["ref", "title", "repository", "author", "destination_branch"],
+            show_value: false,
+        },
+        ("git", "pr_created" | "pr_created_merged" | "pr_merged") => EvidencePresentation {
+            detail_keys: &[
+                "ref",
+                "title",
+                "repository",
+                "author",
+                "branch_scope",
+                "destination_branch",
+            ],
             show_value: false,
         },
         (
@@ -252,7 +274,14 @@ pub(super) fn evidence_presentation(
             | "pr_review_to_merge_hours"
             | "pr_approval_to_merge_hours",
         ) => EvidencePresentation {
-            detail_keys: &["ref", "title", "repository", "author"],
+            detail_keys: &[
+                "ref",
+                "title",
+                "repository",
+                "author",
+                "branch_scope",
+                "destination_branch",
+            ],
             show_value: true,
         },
         // A counting measure needs no value column — the row IS the one it
@@ -366,6 +395,7 @@ mod tests {
                 "title",
                 "repository",
                 "author",
+                "branch_scope",
                 "category",
                 "lines_added",
                 "lines_removed",
@@ -520,9 +550,12 @@ mod tests {
         for measure_key in ["review_submitted", "pr_comment"] {
             let event = evidence_presentation("git", measure_key, EvidenceGranularity::Event);
             assert!(!event.show_value, "{measure_key}");
+            // A review event carries the request's target branch but no branch
+            // scope: only the request itself is classified as landing on the
+            // trunk or not.
             assert_eq!(
                 event.detail_keys,
-                &["ref", "title", "repository", "author"],
+                &["ref", "title", "repository", "author", "destination_branch"],
                 "{measure_key}"
             );
         }
@@ -562,7 +595,14 @@ mod tests {
             assert!(presentation.show_value, "{measure_key}");
             assert_eq!(
                 presentation.detail_keys,
-                &["ref", "title", "repository", "author"],
+                &[
+                    "ref",
+                    "title",
+                    "repository",
+                    "author",
+                    "branch_scope",
+                    "destination_branch"
+                ],
                 "{measure_key}"
             );
         }

--- a/src/frontend/src/components/metric-evidence-table.test.tsx
+++ b/src/frontend/src/components/metric-evidence-table.test.tsx
@@ -65,6 +65,22 @@ describe("MetricEvidenceTable", () => {
     });
   });
 
+  it("renders a branch column the server sent, value and header alike", () => {
+    // The branch is server-driven like every other column (#2806): the table
+    // must not need to know the key to show it.
+    renderTable({
+      columns: [
+        { key: "ref", label: "Ref", type: "string" as const },
+        { key: "destination_branch", label: "Target branch", type: "string" as const },
+      ],
+      rows: [{ values: { ref: "42", destination_branch: "release/1.4" } }],
+    });
+    expect(
+      screen.getByRole("columnheader", { name: /Target branch/ }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("release/1.4")).toBeInTheDocument();
+  });
+
   it("preserves table semantics while virtualizing rows", () => {
     renderTable();
 

--- a/src/frontend/src/components/metric-evidence-table.tsx
+++ b/src/frontend/src/components/metric-evidence-table.tsx
@@ -42,6 +42,10 @@ function columnLayout(column: MetricEvidenceColumn) {
   if (column.key === "type") return { basisRem: 8, grow: 0 };
   if (column.key === "repository") return { basisRem: 12, grow: 0.5 };
   if (column.key === "author") return { basisRem: 10, grow: 0.25 };
+  // A branch name is unbounded (`release/1.4`, `feature/long-description`), so
+  // it grows like a title rather than sitting at the generic basis.
+  if (column.key === "destination_branch") return { basisRem: 11, grow: 1 };
+  if (column.key === "branch_scope") return { basisRem: 9, grow: 0.25 };
   if (column.key === "date") return { basisRem: 8, grow: 0 };
   if (column.type === "number") return { basisRem: 7, grow: 0 };
   return { basisRem: 9, grow: 1 };


### PR DESCRIPTION
Closes #2806.

**Why.** A git record list never named the branch the work went to, and the two-valued `Branch scope` column appeared only when the reader happened to arrive through a grouped or filtered table — so the same records read as a different record set depending on which affordance opened the dialog.

**What changed.** The branch is now a column of the measure instead of a column of the path. Pull-request rows (created / merged / cycle time / size / review timings / reviews / comments) carry `destination_branch` — the branch the request targeted, shown as **Target branch** — and commit rows carry `branch_scope`. Both resolve from the dimensions the evidence rows already carry, so no gold change was needed; all six paths now agree, and the dialog's CSV/XLSX export inherits the columns as it always did.

**A commit gets the scope, not a name — deliberately.** Commit evidence carries reachability from the trunk, not the branch it was pushed to; naming a branch there would invent one. Reverting is a one-line change to the measure's key list.

**Review rows get the branch but no scope.** A review is not classified as landing on the trunk — only the request it reviews is, and that row already shows it.

**Out of scope.** Filter- and group-derived columns still ride along on top of these (naming the slice a reader is inside stays useful); this change only makes sure the branch is never one of them.

**Verified.** `cargo test -p analytics` (557), `cargo clippy --all-targets -D warnings`, and the evidence table's own suite (26) with a new case proving a server-sent branch column renders header and value without the client knowing the key. Not run: a stand — the column sets are asserted in unit tests against the measure keys the issue tabulates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
