### PR TITLE
feat(frontend): build a report whose rows are repositories

### DIFF
--- a/src/frontend/src/components/portal/report-builder-view.test.tsx
+++ b/src/frontend/src/components/portal/report-builder-view.test.tsx
@@ -164,6 +164,25 @@ describe("ReportBuilderView", () => {
     expect(isDisabled("Commits")).toBe(false);
   });
 
+  it("refuses a non-additive metric in repository rows at any grain", async () => {
+    // Per repository every row is people added up, so the additivity question
+    // arrives immediately rather than only at a quarter.
+    const user = userEvent.setup();
+    render(<ReportBuilderView />);
+    expect(isDisabled("Merge rate")).toBe(false);
+
+    await user.click(screen.getByRole("button", { name: "Repositories" }));
+    expect(isDisabled("Merge rate")).toBe(true);
+    expect(screen.getByText("Merge rate").closest("label")).toHaveAttribute(
+      "title",
+      expect.stringMatching(/cannot be totalled per repository/),
+    );
+    expect(isDisabled("Commits")).toBe(false);
+    expect(
+      screen.getByText(/one row per repository per period/),
+    ).toBeInTheDocument();
+  });
+
   it("refuses a grain longer than the period, and says which to pick", async () => {
     const user = userEvent.setup();
     render(<ReportBuilderView />);

--- a/src/frontend/src/components/portal/report-builder-view.tsx
+++ b/src/frontend/src/components/portal/report-builder-view.tsx
@@ -40,6 +40,7 @@ import {
   periodTooShortReason,
 } from "@/lib/reports/granularity-for-period";
 import { buildReportTable, type ReportTable } from "@/lib/reports/report-table";
+import { ROW_MODES, type ReportRows } from "@/lib/reports/rows";
 import { recordUsageEvent } from "@/telemetry";
 import {
   bucketsInRange,
@@ -73,6 +74,7 @@ export function ReportBuilderView() {
   const [selected, setSelected] = useState<string[]>([]);
   const [pickedGranularity, setPickedGranularity] =
     useState<ReportGranularity>("month");
+  const [rows, setRows] = useState<ReportRows>("people");
   const granularity = clampGranularity(pickedGranularity, dateRange);
   const [progress, setProgress] = useState<{ done: number; total: number } | null>(
     null,
@@ -118,9 +120,10 @@ export function ReportBuilderView() {
           metric,
           granularity,
           computations.data ?? new Map(),
+          rows,
         ),
       })),
-    [catalogue, computations.data, granularity],
+    [catalogue, computations.data, granularity, rows],
   );
 
   const people = scope.reportPeople ?? [];
@@ -139,6 +142,7 @@ export function ReportBuilderView() {
   // rather than merely old: build it monthly, switch to yearly, and the button
   // would still offer the monthly file under the new heading.
   const recipe = [
+    rows,
     granularity,
     dateRange.from,
     dateRange.to,
@@ -180,6 +184,7 @@ export function ReportBuilderView() {
           dateRange.to,
           requestBucket(granularity),
         ).length,
+        rows,
         onProgress: (done, total) => setProgress({ done, total }),
         signal: controller.signal,
       });
@@ -201,6 +206,7 @@ export function ReportBuilderView() {
           results,
           range: dateRange,
           granularity,
+          rows,
         }),
       );
     } catch (error) {
@@ -237,13 +243,39 @@ export function ReportBuilderView() {
         <h1 className={TEXT_TITLE}>Report builder</h1>
         <p className="text-sm text-muted-foreground">
           {scope.label ? `${scope.label} · ` : ""}
-          {people.length} {people.length === 1 ? "person" : "people"} · one row
-          per person per period
+          {people.length} {people.length === 1 ? "person" : "people"} ·{" "}
+          {rows === "people"
+            ? "one row per person per period"
+            : "one row per repository per period"}
         </p>
       </div>
 
       <Card>
         <CardContent className="flex flex-col gap-4 p-4">
+          <div className="flex flex-wrap items-center gap-3">
+            <span className={TEXT_LABEL}>Rows</span>
+            <ToggleGroup
+              value={[rows]}
+              onValueChange={(value) => {
+                const next = Array.isArray(value) ? value[0] : value;
+                if (next) setRows(next as ReportRows);
+              }}
+              variant="outline"
+              size="sm"
+            >
+              {ROW_MODES.map((option) => (
+                <ToggleGroupItem key={option.value} value={option.value}>
+                  {option.label}
+                </ToggleGroupItem>
+              ))}
+            </ToggleGroup>
+            <span className="text-xs text-muted-foreground">
+              {rows === "people"
+                ? "Each person's own values."
+                : "Everyone's work added up per repository — totals only."}
+            </span>
+          </div>
+
           <div className="flex flex-wrap items-center gap-3">
             <span className={TEXT_LABEL}>Granularity</span>
             <TooltipProvider delay={300}>
@@ -291,11 +323,14 @@ export function ReportBuilderView() {
 
           <div className="flex flex-col gap-2">
             <span className={TEXT_LABEL}>
-              {needsRollup(granularity)
-                ? "Metrics that can be totalled — a quarter is its months added up"
-                : "Metrics"}
+              {rows !== "people"
+                ? "Metrics that can be totalled — a repository is its people added up"
+                : needsRollup(granularity)
+                  ? "Metrics that can be totalled — a quarter is its months added up"
+                  : "Metrics"}
             </span>
-            {needsRollup(granularity) && computations.isPending ? (
+            {(rows !== "people" || needsRollup(granularity)) &&
+            computations.isPending ? (
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Spinner className="size-4" /> Reading the catalogue…
               </div>

--- a/src/frontend/src/lib/reports/availability.ts
+++ b/src/frontend/src/lib/reports/availability.ts
@@ -2,6 +2,7 @@ import type { MetricComputation } from "@/api/metric-results-client";
 import type { MetricDefinition } from "@/api/metric-definitions-client";
 import { NOT_ADDITIVE_REASON } from "@/lib/reports/additive";
 import { needsRollup, type ReportGranularity } from "@/lib/reports/rollup";
+import type { ReportRows } from "@/lib/reports/rows";
 
 /**
  * Why a metric cannot be put in this report, or null when it can.
@@ -14,6 +15,7 @@ export function unavailableReason(
   metric: Pick<MetricDefinition, "metric_key" | "schema_status" | "last_observed_date" | "origin">,
   granularity: ReportGranularity,
   computationByKey: ReadonlyMap<string, MetricComputation>,
+  rows: ReportRows = "people",
 ): string | null {
   if (metric.schema_status === "error") {
     return "This metric is not computing on this installation";
@@ -21,7 +23,11 @@ export function unavailableReason(
   if (metric.origin !== "custom" && metric.last_observed_date == null) {
     return "No data source is connected for this metric yet";
   }
-  if (!needsRollup(granularity)) return null;
+  // Rows that are not people are people's values added up, so the additivity
+  // question arrives at every granularity rather than only at the ones the
+  // client rolls up itself.
+  const adding = rows !== "people" || needsRollup(granularity);
+  if (!adding) return null;
 
   const computation = computationByKey.get(metric.metric_key);
   // Unknown is not the same as additive. The probe may still be in flight, and
@@ -31,7 +37,8 @@ export function unavailableReason(
     return "Still checking whether this can be totalled over a period";
   }
   const reason = NOT_ADDITIVE_REASON[computation];
-  return reason == null
-    ? null
-    : `${reason} — pick monthly or finer to include it`;
+  if (reason == null) return null;
+  return rows === "people"
+    ? `${reason} — pick monthly or finer to include it`
+    : `${reason} — it cannot be totalled per repository`;
 }

--- a/src/frontend/src/lib/reports/batching.ts
+++ b/src/frontend/src/lib/reports/batching.ts
@@ -12,6 +12,15 @@ export const MAX_METRICS_PER_REQUEST = 50;
  */
 export const MAX_VALUES_PER_REQUEST = 4500;
 
+/**
+ * How many dimension groups one entity is budgeted for when the request asks
+ * for a grouped series. The real count is data (how many repositories a person
+ * touched) and cannot be known before asking, so this is a budget, not a
+ * bound: it keeps grouped requests roughly as heavy as ungrouped ones, and
+ * the server's own row limit is what actually refuses an oversized answer.
+ */
+export const ASSUMED_GROUPS_PER_ENTITY = 8;
+
 export interface RequestBatch {
   metricKeys: string[];
   entityIds: string[];
@@ -33,11 +42,15 @@ export function planRequests(
   metricKeys: readonly string[],
   entityIds: readonly string[],
   bucketCount: number,
+  groupsPerEntity = 1,
 ): RequestBatch[] {
   if (metricKeys.length === 0 || entityIds.length === 0) return [];
   const metricBatches = chunk([...metricKeys], MAX_METRICS_PER_REQUEST);
   return metricBatches.flatMap((keys) => {
-    const perEntity = Math.max(1, keys.length * (bucketCount + 1));
+    const perEntity = Math.max(
+      1,
+      keys.length * (bucketCount + 1) * Math.max(1, groupsPerEntity),
+    );
     const entitiesPerRequest = Math.max(
       1,
       Math.floor(MAX_VALUES_PER_REQUEST / perEntity),

--- a/src/frontend/src/lib/reports/report-table.ts
+++ b/src/frontend/src/lib/reports/report-table.ts
@@ -12,6 +12,7 @@ import {
   type ReportGranularity,
 } from "@/lib/reports/rollup";
 import { reportPersonColumns } from "@/lib/reports/roster-columns";
+import type { ReportRows } from "@/lib/reports/rows";
 
 export type ReportCell = string | number | null;
 
@@ -28,6 +29,7 @@ export interface ReportInput {
   results: ReadonlyMap<string, MetricResult>;
   range: { from: string; to: string };
   granularity: ReportGranularity;
+  rows?: ReportRows;
 }
 
 function timeseriesOf(result: MetricResult | undefined): TimeseriesView | null {
@@ -46,6 +48,9 @@ const cellKey = (metricKey: string, entityId: string, bucket: string): string =>
  * for.
  */
 export function buildReportTable(input: ReportInput): ReportTable {
+  if ((input.rows ?? "people") === "repositories") {
+    return buildDimensionTable(input, "repository", "Repository");
+  }
   const personColumns = reportPersonColumns(input.people);
   const metrics = input.metrics.map((metric) => ({
     ...metric,
@@ -103,6 +108,80 @@ export function buildReportTable(input: ReportInput): ReportTable {
           return value == null || metric.format == null
             ? value ?? null
             : roundMetricValue(value, metric.format);
+        }),
+      ]),
+    ),
+  };
+}
+
+/**
+ * One row per dimension value per bucket, every person's contribution summed
+ * into it.
+ *
+ * Summing is why only additive metrics reach here: the picker refuses the
+ * others in this mode, because a repository's median is not the median of the
+ * medians of the people who worked in it. A value carries the dimension's
+ * LABEL where the response gave one and its raw value otherwise — the value
+ * is an id (a source joined to `owner/repo`) that no reader recognises.
+ */
+function buildDimensionTable(
+  input: ReportInput,
+  dimension: string,
+  header: string,
+): ReportTable {
+  const metrics = input.metrics.map((metric) => ({
+    ...metric,
+    format: input.results.get(metric.metric_key)?.format ?? null,
+  }));
+  const buckets = bucketsInRange(
+    input.range.from,
+    input.range.to,
+    input.granularity,
+  );
+
+  const labels = new Map<string, string>();
+  const cells = new Map<string, number>();
+  for (const metric of input.metrics) {
+    const series = timeseriesOf(input.results.get(metric.metric_key))?.series;
+    for (const entry of series ?? []) {
+      const dim = entry.dimensions.find((d) => d.key === dimension);
+      // A remainder series carries no dimension value to name, and an
+      // ungrouped one is not this table's shape.
+      if (!dim?.value) continue;
+      const label = dim.label?.trim() || labels.get(dim.value) || dim.value;
+      labels.set(dim.value, label);
+      for (const [bucket, value] of rollUp(entry.points, input.granularity)) {
+        if (value == null) continue;
+        const key = cellKey(metric.metric_key, dim.value, bucket);
+        cells.set(key, (cells.get(key) ?? 0) + value);
+      }
+    }
+  }
+
+  const spans = new Map(
+    buckets.map((bucket) => [
+      bucket,
+      bucketSpan(bucket, input.granularity, input.range),
+    ]),
+  );
+  const values = [...labels.entries()].sort((left, right) =>
+    left[1].localeCompare(right[1]),
+  );
+
+  return {
+    columns: [header, "Period", "From", "To", ...metrics.map((m) => m.label)],
+    formats: [null, null, null, null, ...metrics.map((m) => m.format)],
+    rows: values.flatMap(([value, label]) =>
+      buckets.map((bucket) => [
+        label,
+        bucket,
+        spans.get(bucket)?.from ?? "",
+        spans.get(bucket)?.to ?? "",
+        ...metrics.map((metric) => {
+          const cell = cells.get(cellKey(metric.metric_key, value, bucket));
+          return cell == null || metric.format == null
+            ? cell ?? null
+            : roundMetricValue(cell, metric.format);
         }),
       ]),
     ),

--- a/src/frontend/src/lib/reports/reports.test.ts
+++ b/src/frontend/src/lib/reports/reports.test.ts
@@ -371,6 +371,143 @@ describe("buildReportTable", () => {
   });
 });
 
+
+function dimensionedResult(
+  metricKey: string,
+  entries: Array<{
+    entityId: string;
+    value: string;
+    label?: string;
+    points: Array<[string, number | null]>;
+  }>,
+): MetricResult {
+  return {
+    metric_key: metricKey,
+    label: metricKey,
+    computation: "sum",
+    views: [
+      {
+        view: "timeseries",
+        bucket: "month",
+        series: entries.map((entry) => ({
+          entity_id: entry.entityId,
+          dimensions: [
+            { key: "repository", value: entry.value, label: entry.label },
+          ],
+          points: months(...entry.points),
+        })),
+      },
+    ],
+  } as unknown as MetricResult;
+}
+
+describe("buildReportTable — repository rows", () => {
+  const input = {
+    people: [person()],
+    metrics: [{ metric_key: "git.commits", label: "Commits" }],
+    range: { from: "2026-01-01", to: "2026-02-28" },
+    granularity: "month" as const,
+    rows: "repositories" as const,
+  };
+
+  it("adds every person's work into the repository's own row", () => {
+    const table = buildReportTable({
+      ...input,
+      results: new Map([
+        [
+          "git.commits",
+          dimensionedResult("git.commits", [
+            {
+              entityId: "p1",
+              value: "src:acme/api",
+              label: "acme/api",
+              points: [["2026-01-01", 4]],
+            },
+            {
+              entityId: "p2",
+              value: "src:acme/api",
+              label: "acme/api",
+              points: [["2026-01-01", 6]],
+            },
+          ]),
+        ],
+      ]),
+    });
+
+    expect(table.columns).toEqual([
+      "Repository",
+      "Period",
+      "From",
+      "To",
+      "Commits",
+    ]);
+    // 4 + 6: the row is the repository's, not either person's.
+    expect(table.rows[0]?.[0]).toBe("acme/api");
+    expect(table.rows[0]?.[4]).toBe(10);
+    // A bucket nobody worked in stays empty rather than reading as zero work.
+    expect(table.rows[1]?.[4]).toBeNull();
+  });
+
+  it("names a repository by its label and orders rows by it", () => {
+    const table = buildReportTable({
+      ...input,
+      results: new Map([
+        [
+          "git.commits",
+          dimensionedResult("git.commits", [
+            {
+              entityId: "p1",
+              value: "src:acme/web",
+              label: "acme/web",
+              points: [["2026-01-01", 1]],
+            },
+            {
+              entityId: "p1",
+              value: "src:acme/api",
+              label: "acme/api",
+              points: [["2026-01-01", 1]],
+            },
+          ]),
+        ],
+      ]),
+    });
+
+    expect(table.rows.map((row) => row[0])).toEqual([
+      "acme/api",
+      "acme/api",
+      "acme/web",
+      "acme/web",
+    ]);
+  });
+
+  it("falls back to the dimension value when the response labelled nothing", () => {
+    const table = buildReportTable({
+      ...input,
+      results: new Map([
+        [
+          "git.commits",
+          dimensionedResult("git.commits", [
+            { entityId: "p1", value: "src:acme/api", points: [["2026-01-01", 2]] },
+          ]),
+        ],
+      ]),
+    });
+
+    expect(table.rows[0]?.[0]).toBe("src:acme/api");
+  });
+
+  it("ignores an ungrouped series — it belongs to the people shape", () => {
+    const table = buildReportTable({
+      ...input,
+      results: new Map([
+        ["git.commits", seriesResult("git.commits", "p1", [["2026-01-01", 9]])],
+      ]),
+    });
+
+    expect(table.rows).toEqual([]);
+  });
+});
+
 describe("byFamily", () => {
   it("groups by the key's family, in the order a reader meets them", () => {
     const grouped = byFamily([
@@ -464,6 +601,21 @@ describe("unavailableReason", () => {
     for (const g of ["day", "week", "month", "quarter", "year"] as const) {
       expect(unavailableReason(enabled, g, sums)).toBeNull();
     }
+  });
+
+  it("refuses a non-additive metric in repository rows at any granularity", () => {
+    const medians = new Map([["git.commits", "median" as const]]);
+    for (const g of ["day", "week", "month"] as const) {
+      expect(unavailableReason(enabled, g, medians, "repositories")).toMatch(
+        /cannot be totalled per repository/,
+      );
+      // The same metric is fine per person at a bucket the server computed.
+      expect(unavailableReason(enabled, g, medians, "people")).toBeNull();
+    }
+  });
+
+  it("lets a sum through in repository rows", () => {
+    expect(unavailableReason(enabled, "day", sums, "repositories")).toBeNull();
   });
 
   it("names a broken metric before anything else", () => {

--- a/src/frontend/src/lib/reports/rows.ts
+++ b/src/frontend/src/lib/reports/rows.ts
@@ -1,0 +1,19 @@
+/**
+ * What one row of a report is.
+ *
+ * `people` is the report's original shape: a person per bucket, their org
+ * attributes repeated. `repositories` keeps the bucket axis and swaps the
+ * other one for a dimension value, summing every person's contribution into
+ * it — the roster is still what is asked for, it just stops being the axis.
+ */
+export type ReportRows = "people" | "repositories";
+
+/** The dimension a row mode groups by, or null when rows are people. */
+export function rowDimension(rows: ReportRows): string | null {
+  return rows === "repositories" ? "repository" : null;
+}
+
+export const ROW_MODES: ReadonlyArray<{ value: ReportRows; label: string }> = [
+  { value: "people", label: "People" },
+  { value: "repositories", label: "Repositories" },
+];

--- a/src/frontend/src/lib/reports/run-report.test.ts
+++ b/src/frontend/src/lib/reports/run-report.test.ts
@@ -104,4 +104,35 @@ describe("runReport", () => {
       { view: "timeseries", bucket },
     ]);
   });
+
+  it("groups by repository only when rows are repositories", async () => {
+    await runReport({
+      metricKeys: ["a"],
+      entityIds: people(1),
+      range: { from: "2026-01-01", to: "2026-12-31" },
+      granularity: "month",
+      bucketCount: 4,
+      rows: "repositories",
+    });
+    expect(mocks.query.mock.calls[0]?.[0].metrics[0].views).toEqual([
+      { view: "timeseries", bucket: "month", dimensions: ["repository"] },
+    ]);
+  });
+
+  it("budgets grouped requests for several groups per person", async () => {
+    // A grouped series answers once per repository a person touched, so the
+    // same roster has to be split into more requests than it would ungrouped.
+    const run = {
+      metricKeys: ["a"],
+      entityIds: people(300),
+      range: { from: "2026-01-01", to: "2026-12-31" },
+      granularity: "month" as const,
+      bucketCount: 12,
+    };
+    await runReport(run);
+    const ungrouped = mocks.query.mock.calls.length;
+    mocks.query.mockClear();
+    await runReport({ ...run, rows: "repositories" });
+    expect(mocks.query.mock.calls.length).toBeGreaterThan(ungrouped);
+  });
 });

--- a/src/frontend/src/lib/reports/run-report.ts
+++ b/src/frontend/src/lib/reports/run-report.ts
@@ -2,8 +2,12 @@ import {
   queryMetricResults,
   type MetricResult,
 } from "@/api/metric-results-client";
-import { planRequests } from "@/lib/reports/batching";
+import {
+  ASSUMED_GROUPS_PER_ENTITY,
+  planRequests,
+} from "@/lib/reports/batching";
 import { requestBucket, type ReportGranularity } from "@/lib/reports/rollup";
+import { rowDimension, type ReportRows } from "@/lib/reports/rows";
 
 export interface ReportRun {
   metricKeys: readonly string[];
@@ -11,6 +15,8 @@ export interface ReportRun {
   range: { from: string; to: string };
   granularity: ReportGranularity;
   bucketCount: number;
+  /** Defaults to the person-per-bucket shape the report started as. */
+  rows?: ReportRows;
   onProgress?: (done: number, total: number) => void;
   signal?: AbortSignal;
 }
@@ -28,7 +34,13 @@ export interface ReportRun {
 export async function runReport(
   run: ReportRun,
 ): Promise<Map<string, MetricResult>> {
-  const batches = planRequests(run.metricKeys, run.entityIds, run.bucketCount);
+  const dimension = rowDimension(run.rows ?? "people");
+  const batches = planRequests(
+    run.metricKeys,
+    run.entityIds,
+    run.bucketCount,
+    dimension ? ASSUMED_GROUPS_PER_ENTITY : 1,
+  );
   const merged = new Map<string, MetricResult>();
   let done = 0;
   run.onProgress?.(0, batches.length);
@@ -40,7 +52,16 @@ export async function runReport(
         period: run.range,
         metrics: batch.metricKeys.map((metric_key) => ({
           metric_key,
-          views: [{ view: "timeseries", bucket: requestBucket(run.granularity) }],
+          views: [
+            {
+              view: "timeseries",
+              bucket: requestBucket(run.granularity),
+              // No group limit: repositories are few enough to name them all,
+              // and a capped request would fold the tail into a remainder row
+              // that a per-repository table cannot label.
+              ...(dimension ? { dimensions: [dimension] } : {}),
+            },
+          ],
         })),
       },
       run.signal,


### PR DESCRIPTION
**Why.** A report could only be a person per period. Asking "what happened in each repository" had nowhere to go: the table skipped every dimensioned series and keyed each row on a person.

**What changed.** A **Rows** control picks between People (unchanged) and Repositories. The repository shape asks for the same timeseries grouped by `repository` and sums every person's contribution into the repository's own row, so a row is one repository per period with no person columns. CSV and XLSX export the table they are given, so both shapes download the same way.

![Report builder in repository mode: the Rows control, the changed subtitle, and non-additive metrics greyed out](https://raw.githubusercontent.com/constructorfabric/insight/pr-2859-assets/reports-repos-mode.png)

**Only additive metrics are offered per repository.** Every row there is people added up, so the question the quarterly rollup already asks arrives at every granularity — a repository's median is not the median of its people's medians. The picker states that per metric instead of hiding it.

**No group limit on the request.** Repositories are few enough to name them all, and a capped request folds the tail into a remainder series a per-repository table cannot label.

**Grouped requests carry a budget, not a bound.** How many repositories a person touched is data, so batching assumes a small number per person to keep grouped requests about as heavy as ungrouped ones; the server's row limit is what actually refuses an oversized answer.

**Out of scope.** Other dimensions (project, team) — the row mode is written as a dimension so adding one is a list entry, but only repositories are wired.

**Verified.** The full frontend suite (2136), `tsc -b`, and eslint. New cases cover the summing across people, the label-over-id naming, the ordering, the ignored ungrouped series, the availability gate in both modes, and the grouped request shape. The screenshot is a local mock-data stand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
