### PR TITLE
fix(chart): stop refusing an install whose IdP emits the email claim unasked

### DIFF
--- a/charts/insight/templates/_helpers.tpl
+++ b/charts/insight/templates/_helpers.tpl
@@ -198,14 +198,6 @@ Invoked from NOTES.txt so they fire on every install.
     {{- if not (default dict .Values.identityResolution).rosterSourceType -}}
       {{- fail "authenticator.oidc.resolveBy=email requires identityResolution.rosterSourceType — the email lookup is confined to the roster, and identity refuses it with no roster declared rather than matching an address any source happened to state. Every sign-in would be denied." -}}
     {{- end -}}
-    {{- /* The mode's one input is the `email` claim, which rides the `email`
-           scope. An explicit scope list that omits it denies every login, and
-           adding it back is harmless — so refuse here rather than at the first
-           sign-in. An empty list means the gear asks for its own default set,
-           which includes `email`. */ -}}
-    {{- if and $aoidc.scopes (not (has "email" $aoidc.scopes)) -}}
-      {{- fail (printf "authenticator.oidc.resolveBy=email needs \"email\" in authenticator.oidc.scopes — the mode resolves by that claim and the IdP only emits it for the scope. Got %v." $aoidc.scopes) -}}
-    {{- end -}}
     {{- /* Minting needs the source-native id the roster observed, and an
            address is not one: no login provisions in this mode. The gear
            refuses the pair at boot; say so at render, where it is cheap. */ -}}

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -398,11 +398,14 @@ authenticator:
     #     set; identity refuses the lookup without one rather than matching an
     #     address any source at all happened to state.
     #
-    # What `email` mode additionally requires, all enforced at render:
-    #   - `email` among `scopes` (below) — it is the mode's only input;
+    # What `email` mode additionally requires, both enforced at render:
     #   - `provisionOnLogin: false` — minting needs a source-native id, so no
     #     login provisions in this mode;
     #   - identityResolution.rosterSourceType set.
+    # NOT enforced: that `scopes` names `email`. The claim need not be
+    # requested to arrive — an IdP may emit it from an always-on client scope,
+    # and Keycloak 26 errors on a scope the client is not assigned, so
+    # demanding it here refuses working installs.
     # It also refuses a token whose `email_verified` is explicitly false: in
     # this mode the address IS the credential. An IdP that lets a user edit
     # their own address unverified must be fixed at the IdP.

--- a/deploy/gitops/scripts/compose-app-secrets.sh
+++ b/deploy/gitops/scripts/compose-app-secrets.sh
@@ -211,18 +211,6 @@ if [ "$AUTH_RESOLVE_BY" = "email" ]; then
     echo "ERROR: authenticator.oidc.provisionOnLogin cannot be used with resolveBy=email in $VALUES — no login provisions in this mode" >&2
     exit 1
   fi
-  # The mode's one input is the `email` claim, which rides the `email` scope. An
-  # explicit list that omits it installs cleanly and denies every login; adding
-  # it back is harmless.
-  AUTH_SCOPE_LIST=$(yq -r '(.authenticator.oidc.scopes // []) | join(" ")' "$VALUES")
-  case " $AUTH_SCOPE_LIST " in
-    "  ") ;;                      # unset — the gear asks for its own default set
-    *" email "*) ;;
-    *)
-      echo "ERROR: authenticator.oidc.resolveBy=email needs \"email\" in authenticator.oidc.scopes in $VALUES (got '$AUTH_SCOPE_LIST')" >&2
-      exit 1
-      ;;
-  esac
 fi
 
 for v in MDB_HOST MDB_USER MDB_DB CH_HOST CH_USER CH_DB RD_HOST; do

--- a/src/backend/services/identity-resolution/helm/tests/test_umbrella_login_resolve_contract.py
+++ b/src/backend/services/identity-resolution/helm/tests/test_umbrella_login_resolve_contract.py
@@ -117,12 +117,14 @@ def test_external_id_mode_still_demands_a_source_type(umbrella_deps) -> None:
     assert "sourceType" in err
 
 
-def test_email_mode_without_the_email_scope_is_refused(umbrella_deps) -> None:
-    """The mode's only input is the claim that scope carries.
+def test_email_mode_accepts_a_scope_list_that_does_not_name_email(umbrella_deps) -> None:
+    """The claim need not be requested to arrive.
 
-    An explicit scope list that omits it installs cleanly and denies every
-    login; adding it back costs nothing, so this is refused while the operator
-    is still editing values.
+    An IdP may emit `email` from an always-on client scope, and Keycloak 26
+    errors on a scope its client is not assigned — so a stand can legitimately
+    request `openid` alone and still carry the claim. Refusing that shape
+    turned a working installation away, which is why the check this replaces
+    is gone.
     """
     code, _, err = render(
         umbrella_deps,
@@ -133,10 +135,9 @@ def test_email_mode_without_the_email_scope_is_refused(umbrella_deps) -> None:
         "--set",
         "authenticator.oidc.resolveBy=email",
         "--set",
-        "authenticator.oidc.scopes={openid,profile}",
+        "authenticator.oidc.scopes={openid,offline_access}",
     )
-    assert code != 0, "render must fail"
-    assert "scopes" in err
+    assert code == 0, err
 
 
 def test_email_mode_refuses_provisioning_rather_than_ignoring_it(umbrella_deps) -> None:


### PR DESCRIPTION
Follow-up to #2867. The render guard that demanded `email` in `authenticator.oidc.scopes` whenever `resolveBy: email` is wrong, and a live stand disproves it: qaclust signs people in through a Keycloak broker requesting `["openid", "offline_access"]`, and the token carries `email` from the realm's always-on client scope. Keycloak 26 also errors on a scope its client is not assigned, so that stand cannot satisfy the guard at all — it refused a working installation and offered no way through.

The other two email-mode guards stay. A missing `rosterSourceType` really does deny every login, and `provisionOnLogin` really is inert in this mode; both are properties of this code rather than predictions about what an IdP will send. Removed from the chart's `insight.validate` and from the gitops sample script, which carried the same check.

Verify: the contract test is inverted rather than deleted, so the refused shape is now pinned as accepted.
```
cd tests && uv run pytest ../src/backend/services/identity-resolution/helm/tests/ -q
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Email-based OIDC identity resolution now works when `email` is not explicitly listed in configured scopes.
  * Email claims can be provided through always-on identity provider client scopes.
  * Existing requirements remain: roster configuration must be set and login provisioning must be disabled.
* **Tests**
  * Updated validation coverage to confirm valid email-resolution configurations render successfully without the `email` scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->