### PR TITLE
test(stand): cover the rollup view and the Development lenses

### DIFF
--- a/tests/stand/api/analytics/test_results.py
+++ b/tests/stand/api/analytics/test_results.py
@@ -24,10 +24,12 @@ from insight_stand import ApiClient, ApiResponse, Manifest, analytics_path
 from insight_stand.api import JsonValue
 
 from ..schemas import (
+    BreakdownView,
     MetricDefinitionListResponse,
     MetricResultsResponse,
     PeriodView,
     ProblemDocument,
+    RollupView,
 )
 from . import query_window
 
@@ -281,4 +283,240 @@ def test_one_hidden_person_refuses_the_whole_request(
     assert response.status_code == 403, (
         f"a request naming one hidden person answered {response.status_code} — if it "
         f"succeeded, the hidden entity was silently dropped: {response.text[:300]}"
+    )
+
+
+def _git_metric_keys(api: ApiClient) -> dict[str, str]:
+    """Every git metric the installation offers, keyed by metric_key → computation.
+
+    A rollup asserts different things about a sum than about a median, and the
+    keys this file cares about are recent enough that a stand pinned to an
+    older image simply will not have them — so the catalogue decides, not a
+    hardcoded list.
+    """
+    response = api.get(analytics_path("/v1/metric-definitions"))
+    assert response.status_code == 200, f"definitions: {response.status_code}"
+    return {
+        metric.metric_key: metric.computation.root.computation.value
+        for metric in response.parse(MetricDefinitionListResponse).metrics
+        if metric.metric_key.startswith("git.")
+    }
+
+
+def _rollup_view(response: ApiResponse, metric_key: str) -> RollupView:
+    """The one rollup view the response carries for a metric.
+
+    Narrowing the union IS the assertion, as in `_values`: the request asked
+    for a rollup, so any other variant means the service answered a question
+    nobody asked.
+    """
+    results = response.parse(MetricResultsResponse)
+    views = [view.root for metric in results.metrics for view in metric.root.views]
+    assert len(views) == 1, f"asked for one view of {metric_key} and got {len(views)}"
+    view = views[0]
+    assert isinstance(view, RollupView), f"asked for the rollup view and got {type(view).__name__}"
+    return view
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.reliability
+def test_rollup_answers_per_dimension_without_an_entity_grain(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """A repository rollup: rows keyed by the dimension, never by a person.
+
+    The shape is the whole point. `rollup` is the one view whose rows carry no
+    `entity_id` — the Repositories lens reads it precisely because a
+    per-repository number cannot be assembled from per-person rows without
+    knowing which people to add. A row that grew an entity id back would break
+    that screen while still answering 200.
+
+    `contributing_entity_count` is asserted against the roster it was asked
+    over rather than a number: it counts DISTINCT resolved persons among the
+    entities in the request, so it can never exceed how many were named, and a
+    value above that would mean the count is measuring something else.
+
+    Skipped rather than failed when the installation offers no git metric with
+    a `repository` dimension — a stand seeded without a git connector has
+    nothing to roll up, which is not this test's news to report.
+    """
+    computations = _git_metric_keys(api)
+    metric_key = next(
+        (key for key, computation in computations.items() if computation == "sum"),
+        None,
+    )
+    if metric_key is None:
+        pytest.skip("this installation offers no summed git metric to roll up")
+
+    person = stand_manifest.fixture("dev_lead")
+    start, end = query_window(stand_manifest)
+    response = api.post(
+        METRIC_RESULTS,
+        json_body={
+            "entity": {"type": "person", "ids": [person.uuid]},
+            "period": {"from": start, "to": end},
+            "metrics": [
+                {
+                    "metric_key": metric_key,
+                    "views": [{"view": "rollup", "dimensions": ["repository"]}],
+                }
+            ],
+        },
+    )
+    assert response.status_code == 200, f"status={response.status_code} {response.text[:300]}"
+
+    view = _rollup_view(response, metric_key)
+    assert view.dimensions == ["repository"]
+    for value in view.values:
+        keys = [dimension.key for dimension in value.dimensions]
+        # A remainder row names no dimension value; this request set no group
+        # limit, so every row here is a real repository.
+        assert keys == ["repository"], f"a rollup row named {keys}"
+        assert value.contributing_entity_count <= 1, (
+            f"one person was asked about and the row counted "
+            f"{value.contributing_entity_count} contributors: {value}"
+        )
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.reliability
+def test_a_rollup_totals_the_same_work_the_period_view_reports(
+    api: ApiClient, stand_manifest: Manifest
+) -> None:
+    """Two independent reads of one number have to agree.
+
+    The oracle is the API's own period view rather than an expectation written
+    here: for a summed metric, every repository's share added together IS the
+    person's total over the same window. The two answers travel different SQL
+    (a grouped aggregate against an ungrouped one), so a drift between them is
+    a real defect in one of the two paths — and neither number is hand-authored,
+    which keeps the case honest on any seed.
+
+    A rollup that returns nothing is a skip, not a pass: a metric the stand has
+    no git rows for would otherwise let 0 == 0 through as agreement.
+    """
+    computations = _git_metric_keys(api)
+    metric_key = next(
+        (key for key, computation in computations.items() if computation == "sum"),
+        None,
+    )
+    if metric_key is None:
+        pytest.skip("this installation offers no summed git metric to roll up")
+
+    person = stand_manifest.fixture("dev_lead")
+    start, end = query_window(stand_manifest)
+    body: dict[str, JsonValue] = {
+        "entity": {"type": "person", "ids": [person.uuid]},
+        "period": {"from": start, "to": end},
+        "metrics": [
+            {
+                "metric_key": metric_key,
+                "views": [{"view": "rollup", "dimensions": ["repository"]}],
+            }
+        ],
+    }
+    rolled = api.post(METRIC_RESULTS, json_body=body)
+    assert rolled.status_code == 200, f"status={rolled.status_code} {rolled.text[:300]}"
+    rows = _rollup_view(rolled, metric_key).values
+    if not rows:
+        pytest.skip(f"{metric_key} has no rows on this stand to reconcile")
+
+    period = _ask(api, stand_manifest, person.uuid, metric_key)
+    assert period.status_code == 200, f"status={period.status_code} {period.text[:300]}"
+    total = sum(value or 0 for _, value in _values(period, metric_key))
+    grouped = sum(row.value or 0 for row in rows)
+
+    assert grouped == pytest.approx(total), (
+        f"{metric_key} over {start}..{end}: the repositories add up to {grouped} "
+        f"while the period view reports {total} — the grouped and ungrouped "
+        f"paths disagree about the same work"
+    )
+
+
+@pytest.mark.requires_seed("dev_lead", "sales_ic")
+@pytest.mark.security
+def test_a_rollup_refuses_a_person_out_of_scope(api: ApiClient, stand_manifest: Manifest) -> None:
+    """The visibility gate holds on the view with no entity grain.
+
+    Worth its own case precisely BECAUSE the answer carries no entity ids: a
+    rollup that skipped the gate would leak an outsider's work as an
+    unattributed total, which no reader could trace back to a person and no
+    other assertion in this module would catch.
+    """
+    computations = _git_metric_keys(api)
+    metric_key = next(iter(computations), None)
+    if metric_key is None:
+        pytest.skip("this installation offers no git metric")
+
+    start, end = query_window(stand_manifest)
+    response = api.post(
+        METRIC_RESULTS,
+        json_body={
+            "entity": {
+                "type": "person",
+                "ids": [stand_manifest.fixture("sales_ic").uuid],
+            },
+            "period": {"from": start, "to": end},
+            "metrics": [
+                {
+                    "metric_key": metric_key,
+                    "views": [{"view": "rollup", "dimensions": ["repository"]}],
+                }
+            ],
+        },
+    )
+    assert response.status_code == 403, (
+        f"a rollup over a person outside the caller's scope answered "
+        f"{response.status_code}: {response.text[:300]}"
+    )
+
+
+@pytest.mark.requires_seed("dev_lead")
+@pytest.mark.versatility
+def test_pr_comments_split_into_own_and_others(api: ApiClient, stand_manifest: Manifest) -> None:
+    """`comment_target` is a two-valued dimension, and only those two values.
+
+    The split is what makes the metric readable — reviewing someone else's
+    request is different work from answering on your own — so a third value
+    arriving (an empty string, an `__unknown__` placeholder leaking from gold)
+    would silently turn one of the two columns into a third.
+
+    Skipped where the installation predates the metric: a stand pinned to an
+    older analytics image has no such key, which the catalogue answers for.
+    """
+    if "git.pr_comments" not in _git_metric_keys(api):
+        pytest.skip("this installation does not offer git.pr_comments")
+
+    person = stand_manifest.fixture("dev_lead")
+    start, end = query_window(stand_manifest)
+    response = api.post(
+        METRIC_RESULTS,
+        json_body={
+            "entity": {"type": "person", "ids": [person.uuid]},
+            "period": {"from": start, "to": end},
+            "metrics": [
+                {
+                    "metric_key": "git.pr_comments",
+                    "views": [{"view": "breakdown", "dimensions": ["comment_target"]}],
+                }
+            ],
+        },
+    )
+    assert response.status_code == 200, f"status={response.status_code} {response.text[:300]}"
+
+    results = response.parse(MetricResultsResponse)
+    views = [view.root for metric in results.metrics for view in metric.root.views]
+    assert len(views) == 1 and isinstance(views[0], BreakdownView), (
+        f"asked for the breakdown view and got {[type(v).__name__ for v in views]}"
+    )
+    seen = {
+        dimension.value
+        for value in views[0].values
+        for dimension in value.dimensions
+        if dimension.key == "comment_target"
+    }
+    assert seen <= {"own", "others"}, (
+        f"comment_target answered with {sorted(seen)} — own/others is the whole "
+        f"vocabulary, so a third value means gold classified something it could "
+        f"not name"
     )

--- a/tests/stand/api/schemas/__init__.py
+++ b/tests/stand/api/schemas/__init__.py
@@ -60,6 +60,12 @@ from .analytics import (
 from .analytics import (
     MetricResultViewDto1 as PeriodView,
 )
+from .analytics import (
+    MetricResultViewDto4 as BreakdownView,
+)
+from .analytics import (
+    MetricResultViewDto5 as RollupView,
+)
 from .common import (
     EXTRACTOR_REJECTION_CONTENT_TYPE,
     PROBLEM_CONTENT_TYPE,
@@ -127,6 +133,7 @@ __all__: Sequence[str] = (
     "AccountBindingResponse",
     "AccountSearchResponse",
     "AttentionResponse",
+    "BreakdownView",
     "CorrectionResponse",
     "CustomMetric",
     "CustomMetricInput",
@@ -151,6 +158,7 @@ __all__: Sequence[str] = (
     "Profile",
     "Role",
     "RoleList",
+    "RollupView",
     "RunResponse",
     "SavedQuery",
     "SavedQueryListResponse",

--- a/tests/stand/ui/test_development_lenses.py
+++ b/tests/stand/ui/test_development_lenses.py
@@ -1,0 +1,165 @@
+"""Journey — the Repositories and Quality lenses render their own sections.
+
+Why this is a browser test and not an API test: both lenses are *composed* in
+the client. `POST /v1/metric-results` proves a rollup and a breakdown come back
+(`tests/stand/api/analytics/test_results.py` asserts exactly that), but no API
+call can show that the deployed SPA turns those answers into the sections the
+screens are made of — a repository table with a row per repository, an
+ownership bar per repository, a histogram of pull-request ages — or that the
+nav still routes to a lens that used to be a placeholder. A stand whose API is
+perfect and whose lens still renders the old "in development" note passes every
+contract test in this repository.
+
+**No metric value is asserted.** The manifest declares no golden metrics, so
+what is asserted is composition: which sections a lens draws, and that a
+section either carries rows or says honestly that it has none. Both outcomes
+are correct on a stand seeded without a git connector, which is why the
+journey distinguishes them rather than requiring data.
+
+Both lenses are read in ONE sign-in: the sections are what is under test, and a
+second Keycloak round trip would only re-prove the login journey.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+
+import pytest
+from insight_stand import PersonaSession
+from playwright.sync_api import Page, expect
+
+from .flows import sign_in
+from .pages.portal_shell import PortalShell
+
+# Quality vector of this module's tests.
+pytestmark = pytest.mark.reliability
+
+#: The Development lenses this journey opens: the heading each one renders,
+#: and the section labels it may draw. The heading is asserted, the sections
+#: are asserted as "at least one" — several of them drop themselves by design
+#: (a composition or a table with one row is an empty shell, not a section),
+#: so requiring a specific one would make the journey depend on how many
+#: repositories the stand happens to hold.
+LENSES: dict[str, tuple[str, tuple[re.Pattern[str], ...]]] = {
+    "Repositories": (
+        "Development · Repositories",
+        (
+            re.compile(r"per person", re.IGNORECASE),
+            re.compile(r"ranked by PRs merged", re.IGNORECASE),
+            re.compile(r"ownership concentration", re.IGNORECASE),
+            re.compile(r"how long pull requests stayed open", re.IGNORECASE),
+        ),
+    ),
+    "Quality": (
+        "Development · Quality",
+        (
+            re.compile(r"review hygiene", re.IGNORECASE),
+            re.compile(r"review timing", re.IGNORECASE),
+            re.compile(r"waited for the first review", re.IGNORECASE),
+        ),
+    ),
+}
+
+#: What the lens says when the whole family is unmeasured on this install. A
+#: stand seeded without a git connector is a legitimate outcome for this
+#: journey, but it has to be the HONEST one rather than an empty frame.
+NOT_INGESTED = re.compile(r"not connected yet", re.IGNORECASE)
+
+
+def open_lens(portal: PortalShell, lens: str) -> None:
+    """Open one Development lens by its own URL.
+
+    The lens lives in the query string rather than the path, so a direct visit
+    is the same navigation the pane performs — and it keeps the journey from
+    depending on how the rail happens to collapse at this viewport.
+    """
+    portal.page.goto(
+        f"/portal?zone=directions&dir=dev&lens={lens}",
+        wait_until="domcontentloaded",
+    )
+    portal.wait_url_settled()
+
+
+@pytest.mark.requires_seed("dev_lead")
+def test_the_development_lenses_compose_their_sections(
+    page: Page,
+    base_url: str,
+    session_for: Callable[[str], PersonaSession],
+) -> None:
+    """Each lens is a real screen, and draws sections or an honest absence.
+
+    Both lenses were placeholders until recently, so the heading is the claim
+    that matters most: a nav entry that still routes to the roadmap note would
+    render neither the heading nor any section, and no API test can see that.
+
+    Sections are then asserted as alternatives on purpose — at least one, or
+    the not-connected note. What would be a defect is neither: a lens that
+    renders its frame with no sections and no explanation, which is what a
+    reader sees when every section silently drops the metrics it wanted.
+    """
+    sign_in(page, base_url, session_for("dev_lead"))
+    portal = PortalShell(page)
+
+    for lens, (heading, labels) in LENSES.items():
+        open_lens(portal, lens)
+        content = portal.content()
+
+        expect(
+            content.get_by_text(heading).first,
+            f"the {lens} lens rendered no heading — the nav may still route to "
+            f"the roadmap placeholder",
+        ).to_be_visible()
+
+        if content.get_by_text(NOT_INGESTED).count():
+            # Honest absence: the family is unmeasured here, and the lens says
+            # so instead of drawing empty sections.
+            continue
+
+        drawn = [label.pattern for label in labels if content.get_by_text(label).count()]
+        assert drawn, (
+            f"the {lens} lens drew its heading but none of its sections and no "
+            f"explanation — a reader gets an empty screen"
+        )
+
+
+@pytest.mark.requires_seed("dev_lead")
+def test_the_repository_table_names_repositories_or_stays_absent(
+    page: Page,
+    base_url: str,
+    session_for: Callable[[str], PersonaSession],
+) -> None:
+    """The rollup-backed table is a table of repositories, not of people.
+
+    The lens is the only screen reading the `rollup` view, whose rows carry no
+    entity id — so the check that matters in a browser is that what lands on
+    screen is keyed by repository. Its first column is asserted to be one, and
+    the People column to be a count rather than a name: a regression that fell
+    back to per-person rows would still render a full table, and only the
+    column contents would give it away.
+
+    A stand with no git rows draws no table at all — the section drops itself
+    rather than rendering one row, which the lens does deliberately. That is a
+    skip here, not a failure: this journey cannot seed git data.
+    """
+    sign_in(page, base_url, session_for("dev_lead"))
+    portal = PortalShell(page)
+    open_lens(portal, "Repositories")
+
+    table = portal.content().get_by_role("table").first
+    if not table.count():
+        pytest.skip("no repository table on this stand — the lens drew no rows to check")
+
+    headers = [(text or "").strip() for text in table.get_by_role("columnheader").all_inner_texts()]
+    assert "People" in headers, f"the repository table's columns were {headers}"
+
+    people_column = headers.index("People")
+    first_row = table.get_by_role("row").nth(1)
+    cells = [(text or "").strip() for text in first_row.get_by_role("cell").all_inner_texts()]
+    assert cells, "the repository table rendered a header and no rows"
+    # A count, not a person: the rollup answers how many distinct people
+    # contributed, and a per-person regression would put a name here.
+    assert cells[people_column].isdigit(), (
+        f"the People column read {cells[people_column]!r} — a rollup row counts "
+        f"contributors, so a name there means the table fell back to person rows"
+    )


### PR DESCRIPTION
**Why.** The `rollup` view had no deployed-path test, and the Repositories and Quality lenses none at all — both were placeholders until recently, so a nav entry still routing to the roadmap note would pass every test in the suite.

**What changed.** Four contract cases join `analytics/test_results.py` (the module that owns `POST /v1/metric-results`, per the one-module-per-path-group rule): the rollup's shape, its reconciliation against the period view, its visibility gate, and the `comment_target` vocabulary. One browser journey reads both lenses in a single sign-in.

**The rollup's oracle is the API's own period view, not a written-down number.** For a summed metric, every repository's share added together is the person's total over the same window; the two travel different SQL, so a drift is a real defect in one of them and neither figure is hand-authored — which keeps it honest on any seed.

**The rollup gate gets its own security case even though the 200 already has one.** A rollup row carries no entity id, so a skipped gate would leak an outsider's work as an unattributed total that no other assertion could trace.

**Sections are asserted as "at least one", the heading strictly.** Several sections drop themselves by design — a composition or a table with a single row is an empty shell — so naming one would tie the journey to how many repositories a stand happens to hold. The heading is the claim that catches the regression that matters.

**A stand with no git data skips rather than fails.** Nothing here can seed a git connector, so absence is distinguished from breakage: the lens must say "not connected yet", and the table's absence is a skip with the reason.

**Out of scope.** No new operation rows — every case uses `POST /v1/metric-results`, already catalogued and already swept for 401.

**Verified.** Collection (14 API cases in the module, 2 journeys), ruff check and format. Not run against a stand: none is up here, so the assertions are written from the handlers and the lens configs rather than observed — CI's stand lane is what executes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
