### PR TITLE
fix(ingestion): unblock the frozen git commit class

### DIFF
--- a/src/backend/services/analytics/src/domain/metric_definitions/passports.md
+++ b/src/backend/services/analytics/src/domain/metric_definitions/passports.md
@@ -354,7 +354,7 @@ this file and the registry disagree.
 - Reads: pr_merged
 - Formula: sum(pr_merged)
 - Shape: integer, higher_is_better, unit PRs
-- Notes: Authored pull requests that merged, dated by the merge.
+- Notes: Authored pull requests that merged, dated by the merge — so a request counts in the period it landed and can carry commits written in earlier ones. Under a branch-scope breakdown the split says where the request was aimed, not where its commits sit.
 
 ## git.default_branch_prs_merged — Pull requests merged into the default branch
 
@@ -362,7 +362,7 @@ this file and the registry disagree.
 - Reads: default_pr_merged
 - Formula: sum(default_pr_merged)
 - Shape: integer, higher_is_better, unit PRs
-- Notes: Pull requests that merged into the repository's default branch, dated by the merge. This is the surface that also promotes a branch's commits and lines into their default-branch metrics.
+- Notes: Pull requests that merged into the repository's default branch, dated by the merge. This is the surface that also promotes a branch's commits and lines into their default-branch metrics. A request counts in the period it merged, so it can carry commits written in earlier ones.
 
 ## git.non_default_branch_prs_merged — Pull requests merged into another branch
 
@@ -370,7 +370,7 @@ this file and the registry disagree.
 - Reads: non_default_pr_merged
 - Formula: sum(non_default_pr_merged)
 - Shape: integer, neutral, unit PRs
-- Notes: Pull requests that merged into something other than the repository's default branch, dated by the merge. Their commits do not count as having reached the default branch on this evidence alone.
+- Notes: Pull requests that merged into something other than the repository's default branch, dated by the merge. Their commits do not count as having reached the default branch on this evidence alone. A request counts in the period it merged, so it can carry commits written in earlier ones.
 
 ## git.merge_rate — PR merge rate
 

--- a/src/backend/services/analytics/src/domain/metric_definitions/passports.md
+++ b/src/backend/services/analytics/src/domain/metric_definitions/passports.md
@@ -228,21 +228,21 @@ this file and the registry disagree.
 - Shape: integer, higher_is_better, unit commits
 - Notes: Distinct authored commits across connected git sources, excluding merge commits.
 
-## git.default_branch_commits — Commits on the default branch
+## git.default_branch_commits — Commits that reached the default branch
 
 - Source: git (git_metric_observations)
 - Reads: default_commit_count
 - Formula: sum(default_commit_count)
 - Shape: integer, higher_is_better, unit commits
-- Notes: Authored commits reachable from the repository's default branch, or carried onto it by a merged pull request. A commit joins this metric when its branch lands, so a past period's figure rises as work merges. Merge commits excluded.
+- Notes: Authored commits reachable from the repository's default branch, or carried onto it by a merged pull request. A commit joins this metric when its branch lands, so a past period's figure rises as work merges. Dated by the commit, so the request that merged it can fall in a later period. Merge commits excluded.
 
-## git.non_default_branch_commits — Commits outside the default branch
+## git.non_default_branch_commits — Commits that have not reached the default branch
 
 - Source: git (git_metric_observations)
 - Reads: non_default_commit_count
 - Formula: sum(non_default_commit_count)
 - Shape: integer, neutral, unit commits
-- Notes: Authored commits not reachable from the repository's default branch — work in flight, or abandoned. A commit leaves this metric when its branch lands, so a past period's figure falls as work merges. A source that does not report branch membership counts here rather than inventing an answer. Merge commits excluded.
+- Notes: Authored commits not reachable from the repository's default branch — work in flight, or abandoned. A commit leaves this metric when its branch lands, so a past period's figure falls as work merges. Dated by the commit, not by the merge. A source reporting no branch membership counts here. Merge commits excluded.
 
 ## git.code_lines — Code lines added
 
@@ -252,21 +252,21 @@ this file and the registry disagree.
 - Shape: integer, higher_is_better, unit lines
 - Notes: Lines added to files classified as code — tests, configuration, and documentation excluded. Each change counts once: when the same content reaches a repository in more than one commit, the lines belong to the commit that introduced them first.
 
-## git.default_branch_code_lines — Code lines added on the default branch
+## git.default_branch_code_lines — Code lines that reached the default branch
 
 - Source: git (git_metric_observations)
 - Reads: default_code_lines_added
 - Formula: sum(default_code_lines_added)
 - Shape: integer, higher_is_better, unit lines
-- Notes: Code lines whose commit is reachable from the repository's default branch, or was carried onto it by a merged pull request. Lines follow their commit, so this rises as work merges. Tests, configuration and documentation excluded.
+- Notes: Code lines whose commit is reachable from the repository's default branch, or was carried onto it by a merged pull request. Lines follow their commit, so this rises as work merges. Dated by the commit, not by the merge. Tests, configuration and documentation excluded.
 
-## git.non_default_branch_code_lines — Code lines added outside the default branch
+## git.non_default_branch_code_lines — Code lines that have not reached the default branch
 
 - Source: git (git_metric_observations)
 - Reads: non_default_code_lines_added
 - Formula: sum(non_default_code_lines_added)
 - Shape: integer, neutral, unit lines
-- Notes: Code lines whose commit has not reached the repository's default branch — work in flight, or abandoned. Lines follow their commit, so this falls as work merges. Tests, configuration and documentation excluded.
+- Notes: Code lines whose commit has not reached the repository's default branch — work in flight, or abandoned. Lines follow their commit, so this falls as work merges. Dated by the commit, not by the merge. Tests, configuration and documentation excluded.
 
 ## git.lines_added — Lines added
 
@@ -276,21 +276,21 @@ this file and the registry disagree.
 - Shape: integer, higher_is_better, unit lines
 - Notes: Lines added across all files, split by file category: code, tests, configuration, documentation. Each change counts once: when the same content reaches a repository in more than one commit, the lines belong to the commit that introduced them first.
 
-## git.default_branch_lines_added — Lines added on the default branch
+## git.default_branch_lines_added — Lines added that reached the default branch
 
 - Source: git (git_metric_observations)
 - Reads: default_lines_added
 - Formula: sum(default_lines_added)
 - Shape: integer, higher_is_better, unit lines
-- Notes: Lines added whose commit is reachable from the repository's default branch, or was carried onto it by a merged pull request. Lines follow their commit, so this rises as work merges.
+- Notes: Lines added whose commit is reachable from the repository's default branch, or was carried onto it by a merged pull request. Lines follow their commit, so this rises as work merges. Dated by the commit, not by the merge.
 
-## git.non_default_branch_lines_added — Lines added outside the default branch
+## git.non_default_branch_lines_added — Lines added that have not reached the default branch
 
 - Source: git (git_metric_observations)
 - Reads: non_default_lines_added
 - Formula: sum(non_default_lines_added)
 - Shape: integer, neutral, unit lines
-- Notes: Lines added whose commit has not reached the repository's default branch — work in flight, or abandoned. Lines follow their commit, so this falls as work merges.
+- Notes: Lines added whose commit has not reached the repository's default branch — work in flight, or abandoned. Lines follow their commit, so this falls as work merges. Dated by the commit, not by the merge.
 
 ## git.test_change_share — Test change share
 
@@ -308,21 +308,21 @@ this file and the registry disagree.
 - Shape: integer, neutral, unit lines
 - Notes: Lines removed across all reported file changes, with file-category, repository, and source breakdowns available. Each change counts once: when the same removal reaches a repository in more than one commit, the lines belong to the commit that made it first.
 
-## git.default_branch_lines_removed — Lines removed on the default branch
+## git.default_branch_lines_removed — Lines removed that reached the default branch
 
 - Source: git (git_metric_observations)
 - Reads: default_lines_removed
 - Formula: sum(default_lines_removed)
 - Shape: integer, neutral, unit lines
-- Notes: Lines removed whose commit is reachable from the repository's default branch, or was carried onto it by a merged pull request. Lines follow their commit, so this rises as work merges.
+- Notes: Lines removed whose commit is reachable from the repository's default branch, or was carried onto it by a merged pull request. Lines follow their commit, so this rises as work merges. Dated by the commit, not by the merge.
 
-## git.non_default_branch_lines_removed — Lines removed outside the default branch
+## git.non_default_branch_lines_removed — Lines removed that have not reached the default branch
 
 - Source: git (git_metric_observations)
 - Reads: non_default_lines_removed
 - Formula: sum(non_default_lines_removed)
 - Shape: integer, neutral, unit lines
-- Notes: Lines removed whose commit has not reached the repository's default branch — work in flight, or abandoned. Lines follow their commit, so this falls as work merges.
+- Notes: Lines removed whose commit has not reached the repository's default branch — work in flight, or abandoned. Lines follow their commit, so this falls as work merges. Dated by the commit, not by the merge.
 
 ## git.prs_created — Pull requests created
 
@@ -346,7 +346,7 @@ this file and the registry disagree.
 - Reads: non_default_pr_created
 - Formula: sum(non_default_pr_created)
 - Shape: integer, neutral, unit PRs
-- Notes: Pull requests opened against something other than the repository's default branch — a release branch, a stacked request, an integration branch. A request whose destination the source does not report counts here rather than inventing an answer.
+- Notes: Pull requests opened against something other than the repository's default branch — a release branch, a stacked request, an integration branch. Dated by creation. A request whose destination the source does not report counts here rather than inventing an answer.
 
 ## git.prs_merged — Pull requests merged
 

--- a/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
+++ b/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
@@ -849,14 +849,15 @@ metrics:
   - metric_key: git.default_branch_commits
     source_key: git
     subject: commits
-    label: Commits on the default branch
+    label: Commits that reached the default branch
     short_label: Commits (default)
     description: Authored commits that reached the default branch
     explanation: >-
       Authored commits reachable from the repository's default branch, or
       carried onto it by a merged pull request. A commit joins this metric when
-      its branch lands, so a past period's figure rises as work merges. Merge
-      commits excluded.
+      its branch lands, so a past period's figure rises as work merges. Dated by
+      the commit, so the request that merged it can fall in a later period.
+      Merge commits excluded.
     unit: commits
     format: integer
     direction: higher_is_better
@@ -873,15 +874,15 @@ metrics:
   - metric_key: git.non_default_branch_commits
     source_key: git
     subject: commits
-    label: Commits outside the default branch
+    label: Commits that have not reached the default branch
     short_label: Commits (other)
     description: Authored commits that have not reached the default branch
     explanation: >-
       Authored commits not reachable from the repository's default branch —
       work in flight, or abandoned. A commit leaves this metric when its branch
-      lands, so a past period's figure falls as work merges. A source that does
-      not report branch membership counts here rather than inventing an answer.
-      Merge commits excluded.
+      lands, so a past period's figure falls as work merges. Dated by the
+      commit, not by the merge. A source reporting no branch membership counts
+      here. Merge commits excluded.
     unit: commits
     format: integer
     direction: neutral
@@ -925,14 +926,14 @@ metrics:
   - metric_key: git.default_branch_code_lines
     source_key: git
     subject: code_changes
-    label: Code lines added on the default branch
+    label: Code lines that reached the default branch
     short_label: Code lines (default)
     description: Lines added to code files that reached the default branch
     explanation: >-
       Code lines whose commit is reachable from the repository's default
       branch, or was carried onto it by a merged pull request. Lines follow
-      their commit, so this rises as work merges. Tests, configuration and
-      documentation excluded.
+      their commit, so this rises as work merges. Dated by the commit, not by
+      the merge. Tests, configuration and documentation excluded.
     unit: lines
     format: integer
     direction: higher_is_better
@@ -951,13 +952,14 @@ metrics:
   - metric_key: git.non_default_branch_code_lines
     source_key: git
     subject: code_changes
-    label: Code lines added outside the default branch
+    label: Code lines that have not reached the default branch
     short_label: Code lines (other)
     description: Lines added to code files that have not reached the default branch
     explanation: >-
       Code lines whose commit has not reached the repository's default branch —
       work in flight, or abandoned. Lines follow their commit, so this falls as
-      work merges. Tests, configuration and documentation excluded.
+      work merges. Dated by the commit, not by the merge. Tests, configuration
+      and documentation excluded.
     unit: lines
     format: integer
     direction: neutral
@@ -1004,13 +1006,14 @@ metrics:
   - metric_key: git.default_branch_lines_added
     source_key: git
     subject: code_changes
-    label: Lines added on the default branch
+    label: Lines added that reached the default branch
     short_label: Lines + (default)
     description: All lines added that reached the default branch
     explanation: >-
       Lines added whose commit is reachable from the repository's default
       branch, or was carried onto it by a merged pull request. Lines follow
-      their commit, so this rises as work merges.
+      their commit, so this rises as work merges. Dated by the commit, not by
+      the merge.
     unit: lines
     format: integer
     direction: higher_is_better
@@ -1030,13 +1033,13 @@ metrics:
   - metric_key: git.non_default_branch_lines_added
     source_key: git
     subject: code_changes
-    label: Lines added outside the default branch
+    label: Lines added that have not reached the default branch
     short_label: Lines + (other)
     description: All lines added that have not reached the default branch
     explanation: >-
       Lines added whose commit has not reached the repository's default branch —
       work in flight, or abandoned. Lines follow their commit, so this falls as
-      work merges.
+      work merges. Dated by the commit, not by the merge.
     unit: lines
     format: integer
     direction: neutral
@@ -1110,13 +1113,14 @@ metrics:
   - metric_key: git.default_branch_lines_removed
     source_key: git
     subject: code_changes
-    label: Lines removed on the default branch
+    label: Lines removed that reached the default branch
     short_label: Lines − (default)
     description: All lines removed that reached the default branch
     explanation: >-
       Lines removed whose commit is reachable from the repository's default
       branch, or was carried onto it by a merged pull request. Lines follow
-      their commit, so this rises as work merges.
+      their commit, so this rises as work merges. Dated by the commit, not by
+      the merge.
     unit: lines
     format: integer
     direction: neutral
@@ -1136,13 +1140,13 @@ metrics:
   - metric_key: git.non_default_branch_lines_removed
     source_key: git
     subject: code_changes
-    label: Lines removed outside the default branch
+    label: Lines removed that have not reached the default branch
     short_label: Lines − (other)
     description: All lines removed that have not reached the default branch
     explanation: >-
       Lines removed whose commit has not reached the repository's default
       branch — work in flight, or abandoned. Lines follow their commit, so this
-      falls as work merges.
+      falls as work merges. Dated by the commit, not by the merge.
     unit: lines
     format: integer
     direction: neutral
@@ -1214,8 +1218,8 @@ metrics:
     explanation: >-
       Pull requests opened against something other than the repository's
       default branch — a release branch, a stacked request, an integration
-      branch. A request whose destination the source does not report counts
-      here rather than inventing an answer.
+      branch. Dated by creation. A request whose destination the source does
+      not report counts here rather than inventing an answer.
     unit: PRs
     format: integer
     direction: neutral

--- a/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
+++ b/src/backend/services/analytics/src/domain/metric_definitions/registry.yaml
@@ -1240,7 +1240,11 @@ metrics:
     label: Pull requests merged
     short_label: PRs merged
     description: Authored pull requests merged
-    explanation: Authored pull requests that merged, dated by the merge.
+    explanation: >-
+      Authored pull requests that merged, dated by the merge — so a request
+      counts in the period it landed and can carry commits written in earlier
+      ones. Under a branch-scope breakdown the split says where the request was
+      aimed, not where its commits sit.
     unit: PRs
     format: integer
     direction: higher_is_better
@@ -1265,7 +1269,8 @@ metrics:
     explanation: >-
       Pull requests that merged into the repository's default branch, dated by
       the merge. This is the surface that also promotes a branch's commits and
-      lines into their default-branch metrics.
+      lines into their default-branch metrics. A request counts in the period
+      it merged, so it can carry commits written in earlier ones.
     unit: PRs
     format: integer
     direction: higher_is_better
@@ -1289,7 +1294,8 @@ metrics:
     explanation: >-
       Pull requests that merged into something other than the repository's
       default branch, dated by the merge. Their commits do not count as having
-      reached the default branch on this evidence alone.
+      reached the default branch on this evidence alone. A request counts in the
+      period it merged, so it can carry commits written in earlier ones.
     unit: PRs
     format: integer
     direction: neutral

--- a/src/ingestion/scripts/apply-ch-migrations.sh
+++ b/src/ingestion/scripts/apply-ch-migrations.sh
@@ -302,6 +302,34 @@ for _git_source in github gitlab bitbucket_cloud; do
   heal_git_repository_default_branch staging "${_git_source}__repositories"
 done
 
+echo "=== Healing git size column types ==="
+# Every projection feeding the git classes wraps its size columns in
+# toNullable(), so the model's type is Nullable(Int64). A table created before
+# that keeps the narrower non-null type ClickHouse inferred from the values it
+# then held, and dbt aborts an incremental model whose source and target types
+# differ — freezing the relation at its last successful build. MODIFY converges
+# warm tables; non-null to Nullable is lossless. Type only, no AFTER anchor:
+# the columns already sit at their contract positions. Guarded: staging tables
+# exist only after the connector's first run. Idempotent.
+heal_git_size_column() {
+  local table="$1" column="$2"
+  ch_table_exists staging "$table" || return 0
+  echo "  staging.${table}.${column}"
+  run_ch <<SQL
+ALTER TABLE staging.${table} MODIFY COLUMN IF EXISTS ${column} Nullable(Int64);
+SQL
+}
+
+for _git_source in github gitlab bitbucket_cloud; do
+  for _size_column in files_changed lines_added lines_removed; do
+    heal_git_size_column "${_git_source}__commits" "${_size_column}"
+    heal_git_size_column "${_git_source}__pull_requests" "${_size_column}"
+  done
+  for _size_column in lines_added lines_removed; do
+    heal_git_size_column "${_git_source}__file_changes" "${_size_column}"
+  done
+done
+
 echo "=== Healing jira task id column types (#1743) ==="
 # #1892 retyped the jira staging id projections (worklog_id, comment_id)
 # from raw bronze Decimal(38,9) to toString(...), but pre-existing

--- a/src/ingestion/scripts/migrations/20260826010000_git-stats-nullable.sql
+++ b/src/ingestion/scripts/migrations/20260826010000_git-stats-nullable.sql
@@ -1,0 +1,43 @@
+-- Widen the git class contract's size columns to the Nullable type every
+-- staging projection emits.
+--
+-- The projections wrap these in toNullable(), so the type the model produces
+-- is Nullable(Int64). A relation created before that carries the narrower
+-- non-null type ClickHouse inferred from the values it held at creation, and
+-- the two never converge on their own: the DDL snapshot is IF NOT EXISTS, and
+-- on_schema_change='append_new_columns' adds columns but cannot reconcile a
+-- changed type. dbt compares source against target on every incremental build
+-- and aborts the model when they differ, so a warm relation stops building and
+-- its class freezes at the last successful run while its neighbours keep
+-- moving. A warehouse built from scratch never reaches that state: the table
+-- is created from the model, so the types already agree.
+--
+-- Type only, no AFTER anchor — the columns already sit at their contract
+-- positions and the positional insert needs them left alone. Shape follows the
+-- retype heals in apply-ch-migrations.sh, where the staging halves converge.
+--
+-- Idempotent: this channel has no ledger and re-runs on every deploy.
+-- The class tables always exist here (placeholders precede migrations).
+ALTER TABLE silver.class_git_commits
+    MODIFY COLUMN IF EXISTS files_changed Nullable(Int64);
+
+ALTER TABLE silver.class_git_commits
+    MODIFY COLUMN IF EXISTS lines_added Nullable(Int64);
+
+ALTER TABLE silver.class_git_commits
+    MODIFY COLUMN IF EXISTS lines_removed Nullable(Int64);
+
+ALTER TABLE silver.class_git_file_changes
+    MODIFY COLUMN IF EXISTS lines_added Nullable(Int64);
+
+ALTER TABLE silver.class_git_file_changes
+    MODIFY COLUMN IF EXISTS lines_removed Nullable(Int64);
+
+ALTER TABLE silver.class_git_pull_requests
+    MODIFY COLUMN IF EXISTS files_changed Nullable(Int64);
+
+ALTER TABLE silver.class_git_pull_requests
+    MODIFY COLUMN IF EXISTS lines_added Nullable(Int64);
+
+ALTER TABLE silver.class_git_pull_requests
+    MODIFY COLUMN IF EXISTS lines_removed Nullable(Int64);


### PR DESCRIPTION
Refs #2786, #2464.

**Why.** An installation that already holds data can stop building `silver.class_git_commits` altogether: the class freezes at its last successful run, so neither new commits nor the branch-membership flag its readers need ever arrive, while every neighbouring class keeps moving.

**What changed.** The class contract's size columns converge on the `Nullable(Int64)` the staging projections emit — six columns across three git class relations — which is what unblocks the model.

**A changed type, not a missing column — which is why it hides.** `on_schema_change='append_new_columns'` cannot reconcile a type, so dbt aborts the model; a warehouse built from scratch creates the table from the model and stays green, so a from-scratch gate never sees it.

**Silver heals in a migration, staging in the deploy hook.** A staging table exists only after its connector's first run, so it is skipped when absent rather than aborting the hook. Non-null to Nullable is lossless and re-runs are no-ops.

**Metric text now names what each side of the branch split is bucketed and dated by.** A commit: whether the work reached the default branch, dated by the commit. A request: its destination, dated by the merge — so a merge can carry commits written earlier.

**Out of scope.** Reporting a commit's own size when no file change was collected for it — that is #2904, deliberately separate so this unblock can ship on its own. The same nullability drift on `class_people`, `class_task_users` and `class_task_worklogs` comes from a different origin and is untouched.

**Verified.** `cargo test -p analytics metric_definitions` (69 passed, incl. `passports_md_is_in_sync`). The upgrade path is what CI's `warm-upgrade` job exercises; a from-scratch build cannot reach the state this fixes.
