### PR TITLE
feat(ai-cost): bind an invoice line's tier to the tier a seat carries

### DIFF
--- a/src/ingestion/connectors/ai/claude-team-invoices/dbt/claude_team__ai_invoice.sql
+++ b/src/ingestion/connectors/ai/claude-team-invoices/dbt/claude_team__ai_invoice.sql
@@ -73,6 +73,10 @@ SELECT
     chain_status,
     category,
     tier_label,
+    -- The vendor's own stable identifier for the tier this line prices. A
+    -- contract column, not an extra: gold resolves a seat's price through it,
+    -- and unlike the display name it survives a rename or a localisation.
+    product_id                                          AS tier_ref,
     toUInt8(coalesce(is_proration, false))              AS is_proration,
     coalesce(currency, invoice_currency, 'usd')         AS currency,
     toStartOfMonth(toDateTime(toInt64(coalesce(period_start_ts, invoice_created_ts, 0)))) AS period_month,
@@ -82,14 +86,17 @@ SELECT
     toInt64OrNull(toString(round(seat_unit_amount)))    AS seat_unit_cents,
     toInt64OrNull(toString(round(quantity)))            AS seat_quantity,
     toInt64OrNull(toString(round(invoice_total_excluding_tax))) AS invoice_net_cents,
-    -- Vendor extras kept out of the positional contract.
+    -- Vendor extras kept out of the positional contract. product_name is what
+    -- an operator reads to decide which seat tier an unmapped tier_ref is;
+    -- price_id moves when the price does, so it identifies a price, not a tier.
     toJSONString(map(
         'product_name',  ifNull(toString(product_name), ''),
         'description',   ifNull(toString(description), ''),
         'invoice_ref',   ifNull(toString(invoice_ref), ''),
         'num_seats',     ifNull(toString(invoice_num_seats), ''),
         'invoice_total', ifNull(toString(invoice_total), ''),
-        'period_end_ts', ifNull(toString(period_end_ts), '')
+        'period_end_ts', ifNull(toString(period_end_ts), ''),
+        'price_id',      ifNull(toString(price_id), '')
     ))                                                  AS invoice_metrics_json,
     'claude_team'                                       AS source,
     data_source,

--- a/src/ingestion/connectors/ai/claude-team-invoices/dbt/schema.yml
+++ b/src/ingestion/connectors/ai/claude-team-invoices/dbt/schema.yml
@@ -85,6 +85,8 @@ models:
                 values: ['subscriptions', 'overusage']
       - name: tier_label
         description: "Seat tier the line prices (hosted_invoice_tier_label). One invoice can carry several."
+      - name: tier_ref
+        description: "The vendor's own catalogue identifier for the tier this line prices (Stripe product). What config.ai_seat_tier_map binds to a seat's tier."
       - name: is_proration
         description: >
           1 when the line is a mid-period adjustment. Prorations are real money
@@ -113,7 +115,7 @@ models:
           NULL on every line row. Summing it over a tenant-month is therefore the
           invoice-level spend with no dedup needed.
       - name: invoice_metrics_json
-        description: "Raw vendor extras: product_name, description, num_seats, invoice_total, period_end_ts. The invoice-level ones are empty on a line row."
+        description: "Raw vendor extras: product_name, description, num_seats, invoice_total, period_end_ts, price_id. The invoice-level ones are empty on a line row."
       - name: source
         description: "Always 'claude_team'"
         tests:

--- a/src/ingestion/connectors/ai/claude-team-invoices/source_claude_team_invoices/schemas/claude_team_invoice_lines.json
+++ b/src/ingestion/connectors/ai/claude-team-invoices/source_claude_team_invoices/schemas/claude_team_invoice_lines.json
@@ -24,6 +24,8 @@
     "description": { "type": ["string", "null"] },
     "product_name": { "type": ["string", "null"] },
     "tier_label": { "type": ["string", "null"] },
+    "price_id": { "type": ["string", "null"] },
+    "product_id": { "type": ["string", "null"] },
     "category": { "type": ["string", "null"] },
     "is_proration": { "type": ["boolean", "null"] },
     "amount": { "type": ["number", "null"] },

--- a/src/ingestion/connectors/ai/claude-team-invoices/source_claude_team_invoices/stripe_chain.py
+++ b/src/ingestion/connectors/ai/claude-team-invoices/source_claude_team_invoices/stripe_chain.py
@@ -180,17 +180,25 @@ def unreadable_seat_prices(lines: Sequence[Mapping[str, Any]]) -> list[str]:
     return sorted(set(offenders))
 
 
-def price_details(line: Mapping[str, Any]) -> tuple[str | None, str | None]:
-    """The line's price and product ids, or absence when it prices nothing.
+@dataclass(frozen=True)
+class PriceRef:
+    """The catalogue ids a line's `pricing.price_details` resolves to.
 
     These name the tier the way the vendor's own catalogue does: they survive a
     renamed or localised `hosted_invoice_product_name`, which the display fields
-    do not.
+    do not. Either field is absent on a line that prices nothing.
     """
+
+    price: str | None
+    product: str | None
+
+
+def price_details(line: Mapping[str, Any]) -> PriceRef:
+    """The line's price and product ids, absent where it names no tier."""
     pricing = line.get("pricing") or {}
     details = pricing.get("price_details") or {}
     price, product = details.get("price"), details.get("product")
-    return (str(price) if price else None, str(product) if product else None)
+    return PriceRef(str(price) if price else None, str(product) if product else None)
 
 
 def shape_line(line: Mapping[str, Any], invoice_key: str) -> dict[str, Any]:
@@ -200,15 +208,15 @@ def shape_line(line: Mapping[str, Any], invoice_key: str) -> dict[str, Any]:
     the window the invoice was issued in.
     """
     period = line.get("period") or {}
-    price_id, product_id = price_details(line)
+    price = price_details(line)
     return {
         "invoice_key": invoice_key,
         "line_id": line.get("id"),
         "description": line.get("description"),
         "product_name": line.get("hosted_invoice_product_name"),
         "tier_label": line.get("hosted_invoice_tier_label"),
-        "price_id": price_id,
-        "product_id": product_id,
+        "price_id": price.price,
+        "product_id": price.product,
         "category": classify_line(line),
         "is_proration": is_proration(line),
         "amount": line.get("amount"),

--- a/src/ingestion/connectors/ai/claude-team-invoices/source_claude_team_invoices/stripe_chain.py
+++ b/src/ingestion/connectors/ai/claude-team-invoices/source_claude_team_invoices/stripe_chain.py
@@ -180,6 +180,19 @@ def unreadable_seat_prices(lines: Sequence[Mapping[str, Any]]) -> list[str]:
     return sorted(set(offenders))
 
 
+def price_details(line: Mapping[str, Any]) -> tuple[str | None, str | None]:
+    """The line's price and product ids, or absence when it prices nothing.
+
+    These name the tier the way the vendor's own catalogue does: they survive a
+    renamed or localised `hosted_invoice_product_name`, which the display fields
+    do not.
+    """
+    pricing = line.get("pricing") or {}
+    details = pricing.get("price_details") or {}
+    price, product = details.get("price"), details.get("product")
+    return (str(price) if price else None, str(product) if product else None)
+
+
 def shape_line(line: Mapping[str, Any], invoice_key: str) -> dict[str, Any]:
     """Project one Stripe line onto the columns bronze keeps.
 
@@ -187,12 +200,15 @@ def shape_line(line: Mapping[str, Any], invoice_key: str) -> dict[str, Any]:
     the window the invoice was issued in.
     """
     period = line.get("period") or {}
+    price_id, product_id = price_details(line)
     return {
         "invoice_key": invoice_key,
         "line_id": line.get("id"),
         "description": line.get("description"),
         "product_name": line.get("hosted_invoice_product_name"),
         "tier_label": line.get("hosted_invoice_tier_label"),
+        "price_id": price_id,
+        "product_id": product_id,
         "category": classify_line(line),
         "is_proration": is_proration(line),
         "amount": line.get("amount"),
@@ -237,6 +253,8 @@ _EMPTY_LINE: Mapping[str, Any] = {
     "description": None,
     "product_name": None,
     "tier_label": None,
+    "price_id": None,
+    "product_id": None,
     "category": None,
     "is_proration": None,
     "amount": None,

--- a/src/ingestion/connectors/ai/claude-team-invoices/tests/test_stripe_chain.py
+++ b/src/ingestion/connectors/ai/claude-team-invoices/tests/test_stripe_chain.py
@@ -17,6 +17,7 @@ from source_claude_team_invoices.stripe_chain import (
     classify_line,
     is_proration,
     parse_hosted_invoice_url,
+    price_details,
     read_bootstrap,
     seat_unit_amount,
     shape_line,
@@ -121,6 +122,22 @@ def test_no_identity_unless_both_leading_fields_are_readable(payload: bytes) -> 
 
 def test_a_segment_that_is_not_base64_carries_no_identity() -> None:
     assert stable_invoice_ref("https://invoice.stripe.com/i/acct_1ABC/live_ABCDE") is None
+
+
+def test_a_line_names_its_tier_by_the_vendors_own_price_and_product() -> None:
+    """The display name is localised marketing copy; these two are catalogue ids."""
+    line = dict(SUBSCRIPTION_LINE, pricing={"price_details": {"price": "price_1ABC", "product": "prod_1ABC"}})
+    assert price_details(line) == ("price_1ABC", "prod_1ABC")
+    shaped = shape_line(line, "in_1ABC")
+    assert (shaped["price_id"], shaped["product_id"]) == ("price_1ABC", "prod_1ABC")
+
+
+@pytest.mark.parametrize(
+    "pricing",
+    [None, {}, {"price_details": None}, {"price_details": {}}, {"price_details": {"price": "", "product": ""}}],
+)
+def test_a_line_naming_no_tier_carries_absence_not_an_empty_string(pricing: Any) -> None:
+    assert price_details(dict(SUBSCRIPTION_LINE, pricing=pricing)) == (None, None), f"should be absent: {pricing!r}"
 
 
 def test_category_comes_from_the_parent_not_the_description() -> None:

--- a/src/ingestion/connectors/ai/claude-team-invoices/tests/test_stripe_chain.py
+++ b/src/ingestion/connectors/ai/claude-team-invoices/tests/test_stripe_chain.py
@@ -13,6 +13,7 @@ import pytest
 from source_claude_team_invoices.stripe_chain import (
     CATEGORY_OVERUSAGE,
     CATEGORY_SUBSCRIPTIONS,
+    PriceRef,
     StripeChainError,
     classify_line,
     is_proration,
@@ -127,7 +128,7 @@ def test_a_segment_that_is_not_base64_carries_no_identity() -> None:
 def test_a_line_names_its_tier_by_the_vendors_own_price_and_product() -> None:
     """The display name is localised marketing copy; these two are catalogue ids."""
     line = dict(SUBSCRIPTION_LINE, pricing={"price_details": {"price": "price_1ABC", "product": "prod_1ABC"}})
-    assert price_details(line) == ("price_1ABC", "prod_1ABC")
+    assert price_details(line) == PriceRef("price_1ABC", "prod_1ABC")
     shaped = shape_line(line, "in_1ABC")
     assert (shaped["price_id"], shaped["product_id"]) == ("price_1ABC", "prod_1ABC")
 
@@ -136,8 +137,10 @@ def test_a_line_names_its_tier_by_the_vendors_own_price_and_product() -> None:
     "pricing",
     [None, {}, {"price_details": None}, {"price_details": {}}, {"price_details": {"price": "", "product": ""}}],
 )
-def test_a_line_naming_no_tier_carries_absence_not_an_empty_string(pricing: Any) -> None:
-    assert price_details(dict(SUBSCRIPTION_LINE, pricing=pricing)) == (None, None), f"should be absent: {pricing!r}"
+def test_a_line_naming_no_tier_carries_absence_not_an_empty_string(pricing: Mapping[str, Any] | None) -> None:
+    assert price_details(dict(SUBSCRIPTION_LINE, pricing=pricing)) == PriceRef(None, None), (
+        f"should be absent: {pricing!r}"
+    )
 
 
 def test_category_comes_from_the_parent_not_the_description() -> None:

--- a/src/ingestion/dbt/dbt_project.yml
+++ b/src/ingestion/dbt/dbt_project.yml
@@ -124,6 +124,10 @@ on-run-start:
   # consumes. dbt guarantees the relations exist and reads them as sources; the
   # rows are written by an operator, so no model may own them.
   - "{{ create_task_config_tables() }}"
+  # config.ai_seat_tier_map — the operator-authored binding from an invoice
+  # line's tier identifier to the tier a seat carries. Same ownership rule: dbt
+  # guarantees the relation exists, an operator writes the rows.
+  - "{{ create_ai_config_tables() }}"
   # identity.identity_persons — the persons-log copy the identity-resolution
   # service's persons-sync fills; gold models resolve email → person_id
   # against it. The hook only guarantees the (possibly empty) table exists

--- a/src/ingestion/dbt/macros/create_ai_config_tables.sql
+++ b/src/ingestion/dbt/macros/create_ai_config_tables.sql
@@ -1,0 +1,44 @@
+{#-
+  Creates the operator-authored AI configuration relation. dbt does NOT own its
+  contents: an operator writes the rows, dbt only guarantees the table exists and
+  reads it as a source. A dbt-owned model would recreate it on every run and wipe
+  the decisions it holds.
+
+  It answers what no vendor states. An invoice line names the tier it prices with
+  the vendor's own catalogue identifier; a seat names its tier with an identifier
+  from a different API. Nothing in either payload says the two are the same tier,
+  and the two vocabularies need not even resemble each other — so the binding is
+  a decision, and it is made per installation.
+
+  Keyed on the vendor's identifier rather than the plan's display name: the name
+  is localised marketing copy and moves without notice, the catalogue identifier
+  does not. Empty is the correct initial state — with no binding, gold prices a
+  seat only where a month leaves no ambiguity to resolve.
+
+  Called from `on-run-start` so the table exists before any model reads it.
+-#}
+
+{% macro create_ai_config_tables() %}
+    {% do run_query("CREATE DATABASE IF NOT EXISTS config") %}
+
+    {% do run_query("
+        CREATE TABLE IF NOT EXISTS config.ai_seat_tier_map
+        (
+            tenant_id         String,
+            insight_source_id String,
+            -- The class's own `source` value ('claude_team'), not its data_source:
+            -- the binding is per vendor, and that is the column gold joins on.
+            source            LowCardinality(String),
+            tier_ref          String,
+            unique_key        String DEFAULT concat(tenant_id, ':', insight_source_id, ':',
+                                                    source, ':', tier_ref),
+            seat_tier         String,
+            is_deleted        UInt8   DEFAULT 0,
+            note              String  DEFAULT '',
+            recorded_by       String  DEFAULT '',
+            _version          DateTime64(3) DEFAULT now64(3)
+        )
+        ENGINE = ReplacingMergeTree(_version)
+        ORDER BY (unique_key)
+    ") %}
+{% endmacro %}

--- a/src/ingestion/dbt/macros/create_ai_config_tables.sql
+++ b/src/ingestion/dbt/macros/create_ai_config_tables.sql
@@ -15,6 +15,13 @@
   does not. Empty is the correct initial state — with no binding, gold prices a
   seat only where a month leaves no ambiguity to resolve.
 
+  A row also names the seat population its prices reach, in `seat_source_id`.
+  The invoice and the seats arrive through separate connector instances whose
+  `insight_source_id` never matches, so nothing in the data says which seats an
+  invoice billed; a tenant running two instances of one vendor needs that said
+  out loud. Left empty it means the tenant's only seat instance, which is why a
+  single-install tenant needs no row at all to keep its seats priced.
+
   Called from `on-run-start` so the table exists before any model reads it.
 -#}
 
@@ -32,6 +39,7 @@
             tier_ref          String,
             unique_key        String DEFAULT concat(tenant_id, ':', insight_source_id, ':',
                                                     source, ':', tier_ref),
+            seat_source_id    String DEFAULT '',
             seat_tier         String,
             is_deleted        UInt8   DEFAULT 0,
             note              String  DEFAULT '',

--- a/src/ingestion/dbt/macros/create_ai_config_tables.sql
+++ b/src/ingestion/dbt/macros/create_ai_config_tables.sql
@@ -19,8 +19,10 @@
   The invoice and the seats arrive through separate connector instances whose
   `insight_source_id` never matches, so nothing in the data says which seats an
   invoice billed; a tenant running two instances of one vendor needs that said
-  out loud. Left empty it means the tenant's only seat instance, which is why a
-  single-install tenant needs no row at all to keep its seats priced.
+  out loud. Left empty a row reaches seats only where the tenant runs one
+  instance on each side, which is why a single-install tenant needs no row at all
+  to keep its seats priced, and why a tenant with two gets no price from an
+  unbound row even in a month when only one of them invoiced.
 
   Called from `on-run-start` so the table exists before any model reads it.
 -#}

--- a/src/ingestion/gold/ai_cost_metric_evidence.sql
+++ b/src/ingestion/gold/ai_cost_metric_evidence.sql
@@ -41,16 +41,33 @@ month_seat_prices AS (
         groupUniqArray(tuple(tier, price))      AS tier_prices
     FROM (
         SELECT
-            insight_tenant_id                   AS tenant_id,
-            source,
-            period_month,
-            coalesce(tier_label, '')            AS tier,
-            seat_unit_cents                     AS price
-        FROM {{ ref('class_ai_invoice') }} FINAL
-        WHERE line_id IS NOT NULL
-          AND category = 'subscriptions'
-          AND is_proration = 0
-          AND seat_unit_cents IS NOT NULL
+            invoice.insight_tenant_id           AS tenant_id,
+            invoice.source                      AS source,
+            invoice.period_month                AS period_month,
+            -- What a seat would call this line's tier, per the operator's
+            -- binding. Unbound leaves it empty, and no seat tier is empty, so an
+            -- unrecognised plan prices nothing rather than pricing a guess.
+            coalesce(binding.seat_tier, '')      AS tier,
+            invoice.seat_unit_cents             AS price
+        FROM {{ ref('class_ai_invoice') }} AS invoice FINAL
+        LEFT JOIN (
+            SELECT
+                tenant_id,
+                insight_source_id,
+                source,
+                tier_ref,
+                seat_tier
+            FROM {{ source('config', 'ai_seat_tier_map') }} FINAL
+            WHERE is_deleted = 0
+        ) AS binding
+            ON  binding.tenant_id = invoice.insight_tenant_id
+            AND binding.insight_source_id = invoice.source_id
+            AND binding.source = invoice.source
+            AND binding.tier_ref = invoice.tier_ref
+        WHERE invoice.line_id IS NOT NULL
+          AND invoice.category = 'subscriptions'
+          AND invoice.is_proration = 0
+          AND invoice.seat_unit_cents IS NOT NULL
         GROUP BY tenant_id, source, period_month, tier, price
     )
     GROUP BY tenant_id, source, period_month
@@ -84,9 +101,9 @@ seat_month_source AS (
 -- The price this seat was billed at. One priced tier in the month prices every
 -- seat billed in it, which is the common shape and the only one the vendor
 -- states unambiguously. With several, the seat's own tier has to name one of
--- them: the two vocabularies come from different APIs and need not agree, so a
--- seat that names none is left without a price rather than given a share of the
--- invoice total.
+-- them, which needs the operator's binding above: no vendor states that an
+-- invoice line's tier and a seat's tier are the same tier. A seat that names
+-- none is left without a price rather than given a share of the invoice total.
 seat_month_priced AS (
     SELECT
         seat.*,

--- a/src/ingestion/gold/ai_cost_metric_evidence.sql
+++ b/src/ingestion/gold/ai_cost_metric_evidence.sql
@@ -111,15 +111,29 @@ seat_month_source AS (
       AND email != ''
       AND collected_at IS NOT NULL
 ),
+-- How many seat populations the tenant holds for this vendor in this month. An
+-- unscoped price may only be taken when there is exactly one, because with two
+-- nothing says which of them the invoice billed — not even when only one of them
+-- produced an invoice at all.
+month_seat_populations AS (
+    SELECT
+        tenant_id,
+        source,
+        period_month,
+        uniqExact(source_id)                    AS seat_sources
+    FROM seat_month_source
+    GROUP BY tenant_id, source, period_month
+),
 -- The prices that can reach this seat: those the operator bound to the seat's
--- own connector instance, plus the unscoped ones when a single invoice instance
--- priced anything that month. A tenant running two instances therefore never
--- lends one instance's price to the other's seats.
+-- own connector instance, plus the unscoped ones when the tenant runs a single
+-- instance on both sides. A tenant running two therefore never lends one
+-- instance's price to the other's seats, whichever of them the invoice came from.
 seat_month_offers AS (
     SELECT
         seat.*,
         arrayFilter(
-            p -> p.1 = seat.source_id OR (p.1 = '' AND prices.invoice_sources = 1),
+            p -> p.1 = seat.source_id
+                 OR (p.1 = '' AND prices.invoice_sources = 1 AND populations.seat_sources = 1),
             prices.scoped_prices
         )                                       AS offers
     FROM seat_month_source AS seat
@@ -127,6 +141,10 @@ seat_month_offers AS (
         ON  prices.tenant_id = seat.tenant_id
         AND prices.source = seat.source
         AND prices.period_month = seat.period_month
+    LEFT JOIN month_seat_populations AS populations
+        ON  populations.tenant_id = seat.tenant_id
+        AND populations.source = seat.source
+        AND populations.period_month = seat.period_month
 ),
 -- The price this seat was billed at. One priced tier among the offers prices
 -- every seat billed in it, which is the common shape and the only one the vendor

--- a/src/ingestion/gold/ai_cost_metric_evidence.sql
+++ b/src/ingestion/gold/ai_cost_metric_evidence.sql
@@ -124,27 +124,38 @@ month_seat_populations AS (
     FROM seat_month_source
     GROUP BY tenant_id, source, period_month
 ),
+-- How many populations the seat's own month holds, carried onto the seat.
+--
+-- INVARIANT: one join per level. Two joins in one SELECT beside `seat.*`, where
+-- both joined relations carry a `tenant_id` of their own, leave the unqualified
+-- name unresolvable and the model fails to build.
+seat_month_scoped AS (
+    SELECT
+        seat.*,
+        populations.seat_sources                AS seat_sources
+    FROM seat_month_source AS seat
+    LEFT JOIN month_seat_populations AS populations
+        ON  populations.tenant_id = seat.tenant_id
+        AND populations.source = seat.source
+        AND populations.period_month = seat.period_month
+),
 -- The prices that can reach this seat: those the operator bound to the seat's
 -- own connector instance, plus the unscoped ones when the tenant runs a single
 -- instance on both sides. A tenant running two therefore never lends one
 -- instance's price to the other's seats, whichever of them the invoice came from.
 seat_month_offers AS (
     SELECT
-        seat.*,
+        scoped.* EXCEPT (seat_sources),
         arrayFilter(
-            p -> p.1 = seat.source_id
-                 OR (p.1 = '' AND prices.invoice_sources = 1 AND populations.seat_sources = 1),
+            p -> p.1 = scoped.source_id
+                 OR (p.1 = '' AND prices.invoice_sources = 1 AND scoped.seat_sources = 1),
             prices.scoped_prices
         )                                       AS offers
-    FROM seat_month_source AS seat
+    FROM seat_month_scoped AS scoped
     LEFT JOIN month_seat_prices AS prices
-        ON  prices.tenant_id = seat.tenant_id
-        AND prices.source = seat.source
-        AND prices.period_month = seat.period_month
-    LEFT JOIN month_seat_populations AS populations
-        ON  populations.tenant_id = seat.tenant_id
-        AND populations.source = seat.source
-        AND populations.period_month = seat.period_month
+        ON  prices.tenant_id = scoped.tenant_id
+        AND prices.source = scoped.source
+        AND prices.period_month = scoped.period_month
 ),
 -- The price this seat was billed at. One priced tier among the offers prices
 -- every seat billed in it, which is the common shape and the only one the vendor

--- a/src/ingestion/gold/ai_cost_metric_evidence.sql
+++ b/src/ingestion/gold/ai_cost_metric_evidence.sql
@@ -33,17 +33,29 @@ WITH
 -- seat and every proration together, and `num_seats` reports one line's quantity
 -- while an invoice can price several tiers. Collected per tier so a month with
 -- more than one priced tier stays distinguishable from an unambiguous one.
+--
+-- Each price carries the seat population it may reach. One tenant can hold
+-- several instances of a vendor's connector, and the invoice instance and the
+-- seat instance are separate connectors whose source_id never matches — so the
+-- only thing that can say which seats an invoice billed is the operator's
+-- binding. `invoice_sources` counts the instances that priced anything, which is
+-- what tells an unscoped price whether it is the tenant's only one.
 month_seat_prices AS (
     SELECT
         tenant_id,
         source,
         period_month,
-        groupUniqArray(tuple(tier, price))      AS tier_prices
+        groupUniqArray(tuple(seat_source_id, tier, price)) AS scoped_prices,
+        uniqExact(invoice_source_id)            AS invoice_sources
     FROM (
         SELECT
             invoice.insight_tenant_id           AS tenant_id,
             invoice.source                      AS source,
             invoice.period_month                AS period_month,
+            invoice.source_id                   AS invoice_source_id,
+            -- The seat connector instance this price applies to. Empty when the
+            -- binding names none, which only a single-instance tenant can use.
+            coalesce(binding.seat_source_id, '') AS seat_source_id,
             -- What a seat would call this line's tier, per the operator's
             -- binding. Unbound leaves it empty, and no seat tier is empty, so an
             -- unrecognised plan prices nothing rather than pricing a guess.
@@ -56,6 +68,7 @@ month_seat_prices AS (
                 insight_source_id,
                 source,
                 tier_ref,
+                seat_source_id,
                 seat_tier
             FROM {{ source('config', 'ai_seat_tier_map') }} FINAL
             WHERE is_deleted = 0
@@ -68,7 +81,7 @@ month_seat_prices AS (
           AND invoice.category = 'subscriptions'
           AND invoice.is_proration = 0
           AND invoice.seat_unit_cents IS NOT NULL
-        GROUP BY tenant_id, source, period_month, tier, price
+        GROUP BY tenant_id, source, period_month, invoice_source_id, seat_source_id, tier, price
     )
     GROUP BY tenant_id, source, period_month
 ),
@@ -98,27 +111,40 @@ seat_month_source AS (
       AND email != ''
       AND collected_at IS NOT NULL
 ),
--- The price this seat was billed at. One priced tier in the month prices every
--- seat billed in it, which is the common shape and the only one the vendor
+-- The prices that can reach this seat: those the operator bound to the seat's
+-- own connector instance, plus the unscoped ones when a single invoice instance
+-- priced anything that month. A tenant running two instances therefore never
+-- lends one instance's price to the other's seats.
+seat_month_offers AS (
+    SELECT
+        seat.*,
+        arrayFilter(
+            p -> p.1 = seat.source_id OR (p.1 = '' AND prices.invoice_sources = 1),
+            prices.scoped_prices
+        )                                       AS offers
+    FROM seat_month_source AS seat
+    LEFT JOIN month_seat_prices AS prices
+        ON  prices.tenant_id = seat.tenant_id
+        AND prices.source = seat.source
+        AND prices.period_month = seat.period_month
+),
+-- The price this seat was billed at. One priced tier among the offers prices
+-- every seat billed in it, which is the common shape and the only one the vendor
 -- states unambiguously. With several, the seat's own tier has to name one of
 -- them, which needs the operator's binding above: no vendor states that an
 -- invoice line's tier and a seat's tier are the same tier. A seat that names
 -- none is left without a price rather than given a share of the invoice total.
 seat_month_priced AS (
     SELECT
-        seat.*,
+        * EXCEPT (offers),
         multiIf(
-            length(prices.tier_prices) = 1,
-            prices.tier_prices[1].2,
-            length(arrayFilter(p -> p.1 = coalesce(seat.seat_tier, ''), prices.tier_prices)) = 1,
-            arrayFilter(p -> p.1 = coalesce(seat.seat_tier, ''), prices.tier_prices)[1].2,
+            length(offers) = 1,
+            offers[1].3,
+            length(arrayFilter(p -> p.2 = coalesce(seat_tier, ''), offers)) = 1,
+            arrayFilter(p -> p.2 = coalesce(seat_tier, ''), offers)[1].3,
             CAST(NULL AS Nullable(Int64))
         )                                       AS seat_price_cents
-    FROM seat_month_source AS seat
-    LEFT JOIN month_seat_prices AS prices
-        ON  prices.tenant_id = seat.tenant_id
-        AND prices.source = seat.source
-        AND prices.period_month = seat.period_month
+    FROM seat_month_offers
 ),
 -- Every reading of a seat inside its billing month. The vendor reports a
 -- cumulative month-to-date figure, so a day's spend is the step between two

--- a/src/ingestion/scripts/apply-ch-migrations.sh
+++ b/src/ingestion/scripts/apply-ch-migrations.sh
@@ -109,12 +109,23 @@ ALTER TABLE staging.${table} DROP COLUMN IF EXISTS surface_label;
 SQL
 }
 
+heal_ai_invoice_staging() {
+  local table="$1"
+  ch_table_exists staging "${table}" || return 0
+  echo "  staging.${table}"
+  run_ch <<SQL
+ALTER TABLE staging.${table} ADD COLUMN IF NOT EXISTS tier_ref Nullable(String) AFTER tier_label;
+ALTER TABLE staging.${table} MODIFY COLUMN tier_ref Nullable(String) AFTER tier_label;
+SQL
+}
+
 heal_ai_dev_staging cursor__ai_dev_usage
 heal_ai_dev_staging claude_enterprise__ai_dev_usage
 heal_ai_dev_staging claude_team__ai_dev_usage
 heal_ai_dev_staging chatgpt_team__ai_dev_usage
 heal_ai_assistant_staging claude_enterprise__ai_assistant_usage
 heal_ai_assistant_staging chatgpt_team__ai_assistant_usage
+heal_ai_invoice_staging claude_team__ai_invoice
 
 echo "=== Healing CRM staging contract schemas ==="
 # The CRM overflow blob left the contract — the connectors carry the

--- a/src/ingestion/scripts/connectors-ddl/claude-team-invoices.sql
+++ b/src/ingestion/scripts/connectors-ddl/claude-team-invoices.sql
@@ -26,6 +26,8 @@ CREATE TABLE IF NOT EXISTS bronze_claude_team_invoices.claude_team_invoice_lines
     `description` Nullable(String),
     `product_name` Nullable(String),
     `tier_label` Nullable(String),
+    `price_id` Nullable(String),
+    `product_id` Nullable(String),
     `category` Nullable(String),
     `is_proration` Nullable(Bool),
     `amount` Nullable(Decimal(38, 9)),

--- a/src/ingestion/scripts/connectors-ddl/silver.sql
+++ b/src/ingestion/scripts/connectors-ddl/silver.sql
@@ -82,6 +82,7 @@ CREATE TABLE IF NOT EXISTS silver.class_ai_invoice
     `chain_status` Nullable(String),
     `category` Nullable(String),
     `tier_label` Nullable(String),
+    `tier_ref` Nullable(String),
     `is_proration` UInt8,
     `currency` String,
     `period_month` Date,

--- a/src/ingestion/scripts/migrations/20260826020000_ai-invoice-tier-ref.sql
+++ b/src/ingestion/scripts/migrations/20260826020000_ai-invoice-tier-ref.sql
@@ -1,0 +1,19 @@
+-- Add the vendor's stable identifier for a priced tier to the invoice class.
+--
+-- Gold resolves a seat's price by binding the tier an invoice line prices to the
+-- tier the seat carries, and it reads only class-contract columns to do it. The
+-- display name cannot carry that binding — it is localised copy that moves
+-- without notice — so the vendor's catalogue identifier becomes a column.
+--
+-- AFTER tier_label on both statements: dbt-clickhouse inserts positionally and
+-- union_by_tag is a positional UNION ALL, so the physical order has to match the
+-- staging model's SELECT. The staging half converges in apply-ch-migrations.sh —
+-- that relation is absent from the snapshot until a first sync.
+--
+-- Idempotent: this channel has no ledger and re-runs on every deploy. The class
+-- tables always exist here (placeholders precede migrations).
+ALTER TABLE silver.class_ai_invoice
+    ADD COLUMN IF NOT EXISTS tier_ref Nullable(String) AFTER tier_label;
+
+ALTER TABLE silver.class_ai_invoice
+    MODIFY COLUMN tier_ref Nullable(String) AFTER tier_label;

--- a/src/ingestion/silver/ai/schema.yml
+++ b/src/ingestion/silver/ai/schema.yml
@@ -1,5 +1,17 @@
 version: 2
 
+sources:
+  # Operator-authored binding: which seat tier an invoice line's catalogue
+  # identifier prices, and which seat population its prices reach. dbt guarantees
+  # the relation exists via the `create_ai_config_tables` on-run-start hook but
+  # owns none of the rows — a model materializing over it would wipe the
+  # decisions it holds. No vendor states the correspondence, so nothing can
+  # derive it.
+  - name: config
+    schema: config
+    tables:
+      - name: ai_seat_tier_map
+
 models:
   - name: class_ai_dev_usage
     description: >

--- a/src/ingestion/silver/ai/schema.yml
+++ b/src/ingestion/silver/ai/schema.yml
@@ -354,6 +354,8 @@ models:
         description: "'ok' | 'failed' | 'unparsable_url' — how far the enrichment got for the invoice this line belongs to"
         tests:
           - not_null
+      - name: tier_ref
+        description: "The vendor's own stable identifier for the tier this line prices. config.ai_seat_tier_map binds it to the tier a seat carries; the two vocabularies come from different APIs and no vendor states the correspondence."
       - name: currency
         tests:
           - not_null

--- a/src/ingestion/silver/task-tracking/schema.yml
+++ b/src/ingestion/silver/task-tracking/schema.yml
@@ -7,11 +7,14 @@ sources:
   # model materializing over them would wipe the decisions they hold. Declared
   # in the task-tracking domain rather than under one connector, because every
   # task source and gold itself read them.
+  # One `config` source serves every domain — a dbt source name is declared once
+  # project-wide, so the AI binding is listed here beside the task ones.
   - name: config
     schema: config
     tables:
       - name: task_field_roles
       - name: task_value_map
+      - name: ai_seat_tier_map
 
 models:
   - name: class_task_field_history

--- a/src/ingestion/silver/task-tracking/schema.yml
+++ b/src/ingestion/silver/task-tracking/schema.yml
@@ -7,14 +7,11 @@ sources:
   # model materializing over them would wipe the decisions they hold. Declared
   # in the task-tracking domain rather than under one connector, because every
   # task source and gold itself read them.
-  # One `config` source serves every domain — a dbt source name is declared once
-  # project-wide, so the AI binding is listed here beside the task ones.
   - name: config
     schema: config
     tables:
       - name: task_field_roles
       - name: task_value_map
-      - name: ai_seat_tier_map
 
 models:
   - name: class_task_field_history

--- a/src/ingestion/tests/e2e/metrics/ai_seat_cost.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/ai_seat_cost.test.yaml
@@ -82,8 +82,8 @@ bronze:
 
   # ── The operator's binding: two tiers bound, team_legacy deliberately absent ──
   config.ai_seat_tier_map:
-    - { tenant_id: "11111111-1111-1111-1111-111111111111", insight_source_id: "claude-team-invoices-test", source: claude_team, tier_ref: prod_EXAMPLE_STD,  unique_key: tier-std,  seat_tier: team_standard, is_deleted: 0, note: "", recorded_by: "", _version: "2026-12-01 00:00:00.000" }
-    - { tenant_id: "11111111-1111-1111-1111-111111111111", insight_source_id: "claude-team-invoices-test", source: claude_team, tier_ref: prod_EXAMPLE_PREM, unique_key: tier-prem, seat_tier: team_tier_1,   is_deleted: 0, note: "", recorded_by: "", _version: "2026-12-01 00:00:00.000" }
+    - { tenant_id: "11111111-1111-1111-1111-111111111111", insight_source_id: "claude-team-invoices-test", source: claude_team, tier_ref: prod_EXAMPLE_STD,  unique_key: tier-std,  seat_source_id: claude-team-test, seat_tier: team_standard, is_deleted: 0, note: "", recorded_by: "", _version: "2026-12-01 00:00:00.000" }
+    - { tenant_id: "11111111-1111-1111-1111-111111111111", insight_source_id: "claude-team-invoices-test", source: claude_team, tier_ref: prod_EXAMPLE_PREM, unique_key: tier-prem, seat_source_id: claude-team-test, seat_tier: team_tier_1,   is_deleted: 0, note: "", recorded_by: "", _version: "2026-12-01 00:00:00.000" }
 
 cases:
   # ── A Standard seat, and the peer spread across both tiers ───────────────────

--- a/src/ingestion/tests/e2e/metrics/ai_seat_cost.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/ai_seat_cost.test.yaml
@@ -82,8 +82,8 @@ bronze:
 
   # ── The operator's binding: two tiers bound, team_legacy deliberately absent ──
   config.ai_seat_tier_map:
-    - { tenant_id: "11111111-1111-1111-1111-111111111111", insight_source_id: "claude-team-invoices-test", source: claude_team, tier_ref: prod_EXAMPLE_STD,  unique_key: tier-std,  seat_source_id: claude-team-test, seat_tier: team_standard, is_deleted: 0, note: "", recorded_by: "", _version: "2026-12-01 00:00:00.000" }
-    - { tenant_id: "11111111-1111-1111-1111-111111111111", insight_source_id: "claude-team-invoices-test", source: claude_team, tier_ref: prod_EXAMPLE_PREM, unique_key: tier-prem, seat_source_id: claude-team-test, seat_tier: team_tier_1,   is_deleted: 0, note: "", recorded_by: "", _version: "2026-12-01 00:00:00.000" }
+    - { tenant_id: "11111111-1111-1111-1111-111111111111", insight_source_id: "claude-team-invoices-test", source: claude_team, tier_ref: prod_EXAMPLE_STD,  unique_key: tier-std,  seat_source_id: claude-team-test, seat_tier: team_standard, is_deleted: 0, note: "", recorded_by: "", _version: "2026-12-01T00:00:00.000Z" }
+    - { tenant_id: "11111111-1111-1111-1111-111111111111", insight_source_id: "claude-team-invoices-test", source: claude_team, tier_ref: prod_EXAMPLE_PREM, unique_key: tier-prem, seat_source_id: claude-team-test, seat_tier: team_tier_1,   is_deleted: 0, note: "", recorded_by: "", _version: "2026-12-01T00:00:00.000Z" }
 
 cases:
   # ── A Standard seat, and the peer spread across both tiers ───────────────────

--- a/src/ingestion/tests/e2e/metrics/ai_seat_cost.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/ai_seat_cost.test.yaml
@@ -8,22 +8,29 @@ description: >
     • silver: invoice lines keep their own per-seat amount and the billing month they
               charge for; seat snapshots keep the latest state per seat per month
     • gold:   the seat price is read ONLY from a non-proration subscription line, and
-              reaches a person through the tier their seat carries. Dated at the first
-              day of the billing month it charges for, so the date never moves with the
-              sync schedule. A seat with no tier gets no price, and neither does a
-              seat whose tier the invoice never priced — a share of the invoice total
-              would be an invention.
+              reaches a person through the tier their seat carries. An invoice line
+              names its tier with the vendor's catalogue identifier and a seat names
+              its tier with an identifier from another API, so the two are joined
+              through config.ai_seat_tier_map, which an operator writes. Dated at the
+              first day of the billing month it charges for, so the date never moves
+              with the sync schedule. A seat with no tier gets no price, and neither
+              does a seat whose tier no priced line binds to — a share of the invoice
+              total would be an invention.
+
+  The two vocabularies deliberately do not resemble each other here, exactly as they
+  do not at the vendor: nothing in either payload says prod_EXAMPLE_STD and
+  team_standard are one tier, and the invoice states no tier_label at all.
 
   Department: 6 Engineering members, plus a seventh seat holder outside the HR feed.
   December prices two tiers, so the tier a seat carries decides its fee:
 
     person   seat tier      ceiling   seat cost
-    alice    Standard         1000¢     $12.00
-    bob      Standard         1000¢     $12.00
-    carol    Standard         1000¢     $12.00
-    dave     Premium          1000¢     $25.00
-    erin     Premium          1000¢     $25.00
-    heidi    team_tier_1      1000¢     absent — the invoice priced no such tier
+    alice    team_standard    1000¢     $12.00
+    bob      team_standard    1000¢     $12.00
+    carol    team_standard    1000¢     $12.00
+    dave     team_tier_1      1000¢     $25.00
+    erin     team_tier_1      1000¢     $25.00
+    heidi    team_legacy      1000¢     absent — no priced line binds to that tier
     frank    unassigned        none     absent — no tier, so no seat was billed
 
   Five values [12, 12, 12, 25, 25]: median 12.00 against a mean of 17.20, so the
@@ -37,7 +44,7 @@ description: >
   extra-usage line at another. Either one counted would leave the Standard tier priced
   twice, and every Standard seat would fall to absent.
 
-  Cases: the two tiers · a tier the invoice never priced · a seat with no tier ·
+  Cases: the two bound tiers · a tier no priced line binds to · a seat with no tier ·
   breakdown by seat tier · empty window.
 
 bronze:
@@ -51,13 +58,13 @@ bronze:
 
   # Which seats carry a tier, and which tier. Read once, on Dec 10.
   bronze_claude_team.claude_team_overage_spend:
-    - { $ref: templates/claude_team_overage.yaml#/templates/alice, _airbyte_extracted_at: "2026-12-10T00:00:00Z", unique_key: seat-alice, used_credits: 50,  monthly_credit_limit: 1000, seat_tier: Standard }
-    - { $ref: templates/claude_team_overage.yaml#/templates/bob,   _airbyte_extracted_at: "2026-12-10T00:00:00Z", unique_key: seat-bob,   used_credits: 100, monthly_credit_limit: 1000, seat_tier: Standard }
-    - { $ref: templates/claude_team_overage.yaml#/templates/carol, _airbyte_extracted_at: "2026-12-10T00:00:00Z", unique_key: seat-carol, used_credits: 150, monthly_credit_limit: 1000, seat_tier: Standard }
-    - { $ref: templates/claude_team_overage.yaml#/templates/dave,  _airbyte_extracted_at: "2026-12-10T00:00:00Z", unique_key: seat-dave,  used_credits: 200, monthly_credit_limit: 1000, seat_tier: Premium }
-    - { $ref: templates/claude_team_overage.yaml#/templates/erin,  _airbyte_extracted_at: "2026-12-10T00:00:00Z", unique_key: seat-erin,  used_credits: 250, monthly_credit_limit: 1000, seat_tier: Premium }
-    # ── heidi — a tier the December invoice never priced ─────────────────────────
-    - { $ref: templates/claude_team_overage.yaml#/templates/heidi, _airbyte_extracted_at: "2026-12-10T00:00:00Z", unique_key: seat-heidi, used_credits: 300, monthly_credit_limit: 1000, seat_tier: team_tier_1 }
+    - { $ref: templates/claude_team_overage.yaml#/templates/alice, _airbyte_extracted_at: "2026-12-10T00:00:00Z", unique_key: seat-alice, used_credits: 50,  monthly_credit_limit: 1000, seat_tier: team_standard }
+    - { $ref: templates/claude_team_overage.yaml#/templates/bob,   _airbyte_extracted_at: "2026-12-10T00:00:00Z", unique_key: seat-bob,   used_credits: 100, monthly_credit_limit: 1000, seat_tier: team_standard }
+    - { $ref: templates/claude_team_overage.yaml#/templates/carol, _airbyte_extracted_at: "2026-12-10T00:00:00Z", unique_key: seat-carol, used_credits: 150, monthly_credit_limit: 1000, seat_tier: team_standard }
+    - { $ref: templates/claude_team_overage.yaml#/templates/dave,  _airbyte_extracted_at: "2026-12-10T00:00:00Z", unique_key: seat-dave,  used_credits: 200, monthly_credit_limit: 1000, seat_tier: team_tier_1 }
+    - { $ref: templates/claude_team_overage.yaml#/templates/erin,  _airbyte_extracted_at: "2026-12-10T00:00:00Z", unique_key: seat-erin,  used_credits: 250, monthly_credit_limit: 1000, seat_tier: team_tier_1 }
+    # ── heidi — a tier no priced line binds to ──────────────────────────────────
+    - { $ref: templates/claude_team_overage.yaml#/templates/heidi, _airbyte_extracted_at: "2026-12-10T00:00:00Z", unique_key: seat-heidi, used_credits: 300, monthly_credit_limit: 1000, seat_tier: team_legacy }
     # ── frank — no ceiling, so no tier and no seat the invoice billed ────────────
     - { $ref: templates/claude_team_overage.yaml#/templates/frank, _airbyte_extracted_at: "2026-12-10T00:00:00Z", unique_key: seat-frank, used_credits: 350, monthly_credit_limit: null, seat_tier: unassigned, limit_type: null }
 
@@ -65,13 +72,18 @@ bronze:
     # The invoice's own row: money, no line, no seat price.
     - $ref: templates/claude_team_invoice.yaml#/templates/december_invoice
 
-    # The two priced tiers.
-    - { $ref: templates/claude_team_invoice.yaml#/templates/december_line, unique_key: line-standard, line_id: il_standard, category: subscriptions, tier_label: Standard, product_name: "Example plan - Standard", description: "3 x Example plan - Standard", amount: 3600, quantity: 3, unit_amount: 1200, seat_unit_amount: 1200 }
-    - { $ref: templates/claude_team_invoice.yaml#/templates/december_line, unique_key: line-premium,  line_id: il_premium,  category: subscriptions, tier_label: Premium,  product_name: "Example plan - Premium",  description: "2 x Example plan - Premium",  amount: 5000, quantity: 2, unit_amount: 2500, seat_unit_amount: 2500 }
+    # The two priced tiers. The vendor states no tier_label on any of them.
+    - { $ref: templates/claude_team_invoice.yaml#/templates/december_line, unique_key: line-standard, line_id: il_standard, category: subscriptions, product_id: prod_EXAMPLE_STD,  price_id: price_EXAMPLE_STD,  product_name: "Example plan - Standard", description: "3 x Example plan - Standard", amount: 3600, quantity: 3, unit_amount: 1200, seat_unit_amount: 1200 }
+    - { $ref: templates/claude_team_invoice.yaml#/templates/december_line, unique_key: line-premium,  line_id: il_premium,  category: subscriptions, product_id: prod_EXAMPLE_PREM, price_id: price_EXAMPLE_PREM, product_name: "Example plan - Premium",  description: "2 x Example plan - Premium",  amount: 5000, quantity: 2, unit_amount: 2500, seat_unit_amount: 2500 }
 
     # ── Excluded, and load-bearing: counted, either would price Standard twice ───
-    - { $ref: templates/claude_team_invoice.yaml#/templates/december_line, unique_key: line-proration, line_id: il_proration, category: subscriptions, tier_label: Standard, description: "Unused time on 1 x Example plan - Standard", amount: -900, quantity: 1, unit_amount: 900, seat_unit_amount: 900, is_proration: true }
-    - { $ref: templates/claude_team_invoice.yaml#/templates/december_line, unique_key: line-extra,     line_id: il_extra,     category: overusage,     tier_label: Standard, description: "Prepaid extra usage, Example plan", amount: 5000, quantity: 1, unit_amount: 5000, seat_unit_amount: 5000 }
+    - { $ref: templates/claude_team_invoice.yaml#/templates/december_line, unique_key: line-proration, line_id: il_proration, category: subscriptions, product_id: prod_EXAMPLE_STD, description: "Unused time on 1 x Example plan - Standard", amount: -900, quantity: 1, unit_amount: 900, seat_unit_amount: 900, is_proration: true }
+    - { $ref: templates/claude_team_invoice.yaml#/templates/december_line, unique_key: line-extra,     line_id: il_extra,     category: overusage,     product_id: prod_EXAMPLE_STD, description: "Prepaid extra usage, Example plan", amount: 5000, quantity: 1, unit_amount: 5000, seat_unit_amount: 5000 }
+
+  # ── The operator's binding: two tiers bound, team_legacy deliberately absent ──
+  config.ai_seat_tier_map:
+    - { tenant_id: "11111111-1111-1111-1111-111111111111", insight_source_id: "claude-team-invoices-test", source: claude_team, tier_ref: prod_EXAMPLE_STD,  unique_key: tier-std,  seat_tier: team_standard, is_deleted: 0, note: "", recorded_by: "", _version: "2026-12-01 00:00:00.000" }
+    - { tenant_id: "11111111-1111-1111-1111-111111111111", insight_source_id: "claude-team-invoices-test", source: claude_team, tier_ref: prod_EXAMPLE_PREM, unique_key: tier-prem, seat_tier: team_tier_1,   is_deleted: 0, note: "", recorded_by: "", _version: "2026-12-01 00:00:00.000" }
 
 cases:
   # ── A Standard seat, and the peer spread across both tiers ───────────────────
@@ -104,7 +116,7 @@ cases:
         assert: "items.exists(s, s.entity_id == 'alice@example.com' && s.points.exists(p, p.bucket_start == '2026-12-01' && double(p.value) == 12.0))"
       - metric: ai.seat_cost
         view: breakdown
-        assert: "items.exists(v, v.entity_id == 'alice@example.com' && v.dimensions.exists(d, d.key == 'seat_tier' && d.value == 'Standard') && double(v.value) == 12.0)"
+        assert: "items.exists(v, v.entity_id == 'alice@example.com' && v.dimensions.exists(d, d.key == 'seat_tier' && d.value == 'team_standard') && double(v.value) == 12.0)"
 
   # ── The other priced tier costs the other amount ─────────────────────────────
   - name: AI seat cost on the Premium tier
@@ -125,8 +137,8 @@ cases:
         find: { entity_id: dave@example.com }
         equal: { value: 25.0 }
 
-  # ── A tier the invoice never priced: absent, not a share of the total ────────
-  - name: AI seat cost for a tier the invoice never priced
+  # ── A tier no priced line binds to: absent, not a share of the total ─────────
+  - name: AI seat cost for a tier no priced line binds to
     request:
       url: /v1/metric-results
       method: POST

--- a/src/ingestion/tests/e2e/metrics/ai_seat_cost_partial_invoice.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/ai_seat_cost_partial_invoice.test.yaml
@@ -1,0 +1,79 @@
+spec_version: 1
+description: >
+  Metric: ai.seat_cost — two seat populations, one invoice, and no binding.
+
+  A tenant holds two organisations of the vendor, so two seat connector instances
+  report seats. Only one of them produced an invoice this month: the other's
+  connector has not run yet, or the vendor has not issued its invoice. The
+  binding table is still empty.
+
+  Counting invoice instances is not enough to make that month unambiguous. There
+  is exactly one price, but nothing says which of the two seat populations it was
+  charged for, so it reaches neither — not the organisation that did not invoice,
+  and not even the one that did. Lending it to the other population would put a
+  price the vendor never charged on somebody's seat.
+
+    person   seat instance   invoiced   seat cost
+    alice    claude-team-a   yes        absent — nothing says the price is for A's seats
+    carol    claude-team-b   no         absent — and it is certainly not B's price
+
+  An operator resolves this by binding the invoice instance to its seat instance;
+  ai_seat_cost_two_instances.test.yaml is that state. With one organisation the
+  same seed prices every seat — ai_seat_cost_unbound.test.yaml is that state.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+    - $ref: templates/people.yaml#/templates/carol
+
+  # Two seat populations, one per organisation.
+  bronze_claude_team.claude_team_overage_spend:
+    - { $ref: templates/claude_team_overage.yaml#/templates/alice, source_id: claude-team-a, _airbyte_extracted_at: "2026-12-10T00:00:00Z", unique_key: seat-alice, used_credits: 50, monthly_credit_limit: 1000, seat_tier: team_standard }
+    - { $ref: templates/claude_team_overage.yaml#/templates/carol, source_id: claude-team-b, _airbyte_extracted_at: "2026-12-10T00:00:00Z", unique_key: seat-carol, used_credits: 70, monthly_credit_limit: 1000, seat_tier: team_standard }
+
+  # Only organisation A invoiced this month.
+  bronze_claude_team_invoices.claude_team_invoice_lines:
+    - { $ref: templates/claude_team_invoice.yaml#/templates/december_invoice, source_id: claude-team-invoices-a, unique_key: invoice-a, invoice_id: in_a, invoice_payment_intent: pi_a }
+    - { $ref: templates/claude_team_invoice.yaml#/templates/december_line, source_id: claude-team-invoices-a, invoice_id: in_a, unique_key: line-a, line_id: il_a, category: subscriptions, product_id: prod_A, product_name: "Example plan - Standard", description: "2 x Example plan - Standard", amount: 5000, quantity: 2, unit_amount: 2500, seat_unit_amount: 2500 }
+
+  # Nothing bound yet.
+  config.ai_seat_tier_map: []
+
+cases:
+  # ── The organisation with no invoice is not given the other's price ───────────
+  - name: AI seat cost does not lend one organisation's price to another's seats
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: { type: person, ids: [carol@example.com] }
+        period: { from: "2026-11-01", to: "2026-12-12" }
+        metrics:
+          - metric_key: ai.seat_cost
+            views:
+              - { view: period }
+    expect:
+      - assert: "status == 200"
+      - metric: ai.seat_cost
+        view: period
+        find: { entity_id: carol@example.com }
+        equal: { value: null }
+
+  # ── Nor is the invoicing organisation's own seat priced on a guess ───────────
+  - name: AI seat cost withholds an unbound price while two seat populations exist
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: { type: person, ids: [alice@example.com] }
+        period: { from: "2026-11-01", to: "2026-12-12" }
+        metrics:
+          - metric_key: ai.seat_cost
+            views:
+              - { view: period }
+    expect:
+      - assert: "status == 200"
+      - metric: ai.seat_cost
+        view: period
+        find: { entity_id: alice@example.com }
+        equal: { value: null }

--- a/src/ingestion/tests/e2e/metrics/ai_seat_cost_two_instances.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/ai_seat_cost_two_instances.test.yaml
@@ -44,8 +44,8 @@ bronze:
 
   # Each binding names the seat instance its organisation's prices reach.
   config.ai_seat_tier_map:
-    - { tenant_id: "11111111-1111-1111-1111-111111111111", insight_source_id: claude-team-invoices-a, source: claude_team, tier_ref: prod_A, unique_key: bind-a, seat_source_id: claude-team-a, seat_tier: team_standard, is_deleted: 0, note: "", recorded_by: "", _version: "2026-12-01 00:00:00.000" }
-    - { tenant_id: "11111111-1111-1111-1111-111111111111", insight_source_id: claude-team-invoices-b, source: claude_team, tier_ref: prod_B, unique_key: bind-b, seat_source_id: claude-team-b, seat_tier: team_standard, is_deleted: 0, note: "", recorded_by: "", _version: "2026-12-01 00:00:00.000" }
+    - { tenant_id: "11111111-1111-1111-1111-111111111111", insight_source_id: claude-team-invoices-a, source: claude_team, tier_ref: prod_A, unique_key: bind-a, seat_source_id: claude-team-a, seat_tier: team_standard, is_deleted: 0, note: "", recorded_by: "", _version: "2026-12-01T00:00:00.000Z" }
+    - { tenant_id: "11111111-1111-1111-1111-111111111111", insight_source_id: claude-team-invoices-b, source: claude_team, tier_ref: prod_B, unique_key: bind-b, seat_source_id: claude-team-b, seat_tier: team_standard, is_deleted: 0, note: "", recorded_by: "", _version: "2026-12-01T00:00:00.000Z" }
 
 cases:
   # ── A seat of organisation A takes A's price, never B's ──────────────────────

--- a/src/ingestion/tests/e2e/metrics/ai_seat_cost_two_instances.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/ai_seat_cost_two_instances.test.yaml
@@ -1,0 +1,87 @@
+spec_version: 1
+description: >
+  Metric: ai.seat_cost — two instances of one vendor's connectors in one tenant.
+
+  A tenant can hold several organisations of the same vendor, each with its own
+  invoice connector instance and its own seat connector instance. The invoice and
+  the seats arrive through separate connectors, so their insight_source_id never
+  matches and nothing in the data says which seats an invoice billed. The
+  operator's binding says it, by naming the seat instance its prices reach.
+
+  Both organisations price a tier of the same name at different amounts, which is
+  the case that goes wrong when the price grain forgets which instance produced
+  it: one seat population then takes the other's price, or the pair collapses to
+  two same-named tiers and every seat falls to absent.
+
+    person   seat instance     invoiced by        seat cost
+    alice    claude-team-a     invoices-a           $25.00
+    bob      claude-team-a     invoices-a           $25.00
+    carol    claude-team-b     invoices-b           $30.00
+    dave     claude-team-b     invoices-b           $30.00
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+    - $ref: templates/people.yaml#/templates/bob
+    - $ref: templates/people.yaml#/templates/carol
+    - $ref: templates/people.yaml#/templates/dave
+
+  # Two seat populations, one per organisation, on the same tier name.
+  bronze_claude_team.claude_team_overage_spend:
+    - { $ref: templates/claude_team_overage.yaml#/templates/alice, source_id: claude-team-a, _airbyte_extracted_at: "2026-12-10T00:00:00Z", unique_key: seat-alice, used_credits: 50, monthly_credit_limit: 1000, seat_tier: team_standard }
+    - { $ref: templates/claude_team_overage.yaml#/templates/bob,   source_id: claude-team-a, _airbyte_extracted_at: "2026-12-10T00:00:00Z", unique_key: seat-bob,   used_credits: 60, monthly_credit_limit: 1000, seat_tier: team_standard }
+    - { $ref: templates/claude_team_overage.yaml#/templates/carol, source_id: claude-team-b, _airbyte_extracted_at: "2026-12-10T00:00:00Z", unique_key: seat-carol, used_credits: 70, monthly_credit_limit: 1000, seat_tier: team_standard }
+    - { $ref: templates/claude_team_overage.yaml#/templates/dave,  source_id: claude-team-b, _airbyte_extracted_at: "2026-12-10T00:00:00Z", unique_key: seat-dave,  used_credits: 80, monthly_credit_limit: 1000, seat_tier: team_standard }
+
+  bronze_claude_team_invoices.claude_team_invoice_lines:
+    # Organisation A: its own invoice, its own catalogue, $25.00 a seat.
+    - { $ref: templates/claude_team_invoice.yaml#/templates/december_invoice, source_id: claude-team-invoices-a, unique_key: invoice-a, invoice_id: in_a, invoice_payment_intent: pi_a }
+    - { $ref: templates/claude_team_invoice.yaml#/templates/december_line, source_id: claude-team-invoices-a, invoice_id: in_a, unique_key: line-a, line_id: il_a, category: subscriptions, product_id: prod_A, product_name: "Example plan - Standard", description: "2 x Example plan - Standard", amount: 5000, quantity: 2, unit_amount: 2500, seat_unit_amount: 2500 }
+
+    # Organisation B: same plan name, its own catalogue, $30.00 a seat.
+    - { $ref: templates/claude_team_invoice.yaml#/templates/december_invoice, source_id: claude-team-invoices-b, unique_key: invoice-b, invoice_id: in_b, invoice_payment_intent: pi_b }
+    - { $ref: templates/claude_team_invoice.yaml#/templates/december_line, source_id: claude-team-invoices-b, invoice_id: in_b, unique_key: line-b, line_id: il_b, category: subscriptions, product_id: prod_B, product_name: "Example plan - Standard", description: "2 x Example plan - Standard", amount: 6000, quantity: 2, unit_amount: 3000, seat_unit_amount: 3000 }
+
+  # Each binding names the seat instance its organisation's prices reach.
+  config.ai_seat_tier_map:
+    - { tenant_id: "11111111-1111-1111-1111-111111111111", insight_source_id: claude-team-invoices-a, source: claude_team, tier_ref: prod_A, unique_key: bind-a, seat_source_id: claude-team-a, seat_tier: team_standard, is_deleted: 0, note: "", recorded_by: "", _version: "2026-12-01 00:00:00.000" }
+    - { tenant_id: "11111111-1111-1111-1111-111111111111", insight_source_id: claude-team-invoices-b, source: claude_team, tier_ref: prod_B, unique_key: bind-b, seat_source_id: claude-team-b, seat_tier: team_standard, is_deleted: 0, note: "", recorded_by: "", _version: "2026-12-01 00:00:00.000" }
+
+cases:
+  # ── A seat of organisation A takes A's price, never B's ──────────────────────
+  - name: AI seat cost takes the price of the organisation that billed the seat
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: { type: person, ids: [alice@example.com] }
+        period: { from: "2026-11-01", to: "2026-12-12" }
+        metrics:
+          - metric_key: ai.seat_cost
+            views:
+              - { view: period }
+    expect:
+      - assert: "status == 200"
+      - metric: ai.seat_cost
+        view: period
+        find: { entity_id: alice@example.com }
+        equal: { value: 25.0 }
+
+  # ── The other organisation's seat takes the other price ─────────────────────
+  - name: AI seat cost keeps the two organisations' prices apart
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: { type: person, ids: [carol@example.com] }
+        period: { from: "2026-11-01", to: "2026-12-12" }
+        metrics:
+          - metric_key: ai.seat_cost
+            views:
+              - { view: period }
+    expect:
+      - assert: "status == 200"
+      - metric: ai.seat_cost
+        view: period
+        find: { entity_id: carol@example.com }
+        equal: { value: 30.0 }

--- a/src/ingestion/tests/e2e/metrics/ai_seat_cost_unbound.test.yaml
+++ b/src/ingestion/tests/e2e/metrics/ai_seat_cost_unbound.test.yaml
@@ -1,0 +1,75 @@
+spec_version: 1
+description: >
+  Metric: ai.seat_cost — the path an installation takes before an operator has
+  written any tier binding.
+
+  config.ai_seat_tier_map ships empty, so nothing says which seat tier an invoice
+  line prices. A month that prices exactly one tier needs nobody to say it: that
+  amount is the only per-seat price the vendor stated, so every billable seat
+  takes it whatever tier the seat carries. This is the path every install runs on
+  the day the binding table arrives, and it is why the table can arrive empty.
+
+    person   seat tier        seat cost
+    alice    team_tier_1        $18.00
+    bob      team_standard      $18.00   — a different tier, the same single price
+
+  One priced line only. A second priced tier would make the month ambiguous, and
+  with no binding to resolve it both seats would fall to absent — that case is
+  ai_seat_cost.test.yaml's subject, and this file is deliberately its opposite.
+
+bronze:
+  bronze_bamboohr.employees:
+    - $ref: templates/people.yaml#/templates/alice
+    - $ref: templates/people.yaml#/templates/bob
+
+  # Two seats on two different tiers, both billable.
+  bronze_claude_team.claude_team_overage_spend:
+    - { $ref: templates/claude_team_overage.yaml#/templates/alice, _airbyte_extracted_at: "2026-12-10T00:00:00Z", unique_key: seat-alice, used_credits: 50, monthly_credit_limit: 1000, seat_tier: team_tier_1 }
+    - { $ref: templates/claude_team_overage.yaml#/templates/bob,   _airbyte_extracted_at: "2026-12-10T00:00:00Z", unique_key: seat-bob,   used_credits: 60, monthly_credit_limit: 1000, seat_tier: team_standard }
+
+  bronze_claude_team_invoices.claude_team_invoice_lines:
+    - $ref: templates/claude_team_invoice.yaml#/templates/december_invoice
+    # The month's only priced tier.
+    - { $ref: templates/claude_team_invoice.yaml#/templates/december_line, unique_key: line-only, line_id: il_only, category: subscriptions, product_id: prod_EXAMPLE_ONE, product_name: "Example plan - Only", description: "2 x Example plan - Only", amount: 3600, quantity: 2, unit_amount: 1800, seat_unit_amount: 1800 }
+
+  # Deliberately empty: no operator has bound anything on this installation.
+  config.ai_seat_tier_map: []
+
+cases:
+  # ── The seat whose tier the single price does not name ────────────────────────
+  - name: AI seat cost with no binding takes the month's only price
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: { type: person, ids: [alice@example.com] }
+        period: { from: "2026-11-01", to: "2026-12-12" }
+        metrics:
+          - metric_key: ai.seat_cost
+            views:
+              - { view: period }
+    expect:
+      - assert: "status == 200"
+      - metric: ai.seat_cost
+        view: period
+        find: { entity_id: alice@example.com }
+        equal: { value: 18.0 }
+
+  # ── A seat on another tier takes the same price, because there is only one ───
+  - name: AI seat cost with no binding does not depend on the seat's tier
+    request:
+      url: /v1/metric-results
+      method: POST
+      body:
+        entity: { type: person, ids: [bob@example.com] }
+        period: { from: "2026-11-01", to: "2026-12-12" }
+        metrics:
+          - metric_key: ai.seat_cost
+            views:
+              - { view: period }
+    expect:
+      - assert: "status == 200"
+      - metric: ai.seat_cost
+        view: period
+        find: { entity_id: bob@example.com }
+        equal: { value: 18.0 }

--- a/src/ingestion/tests/e2e/metrics/schemas/bronze_claude_team_invoices.claude_team_invoice_lines.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/bronze_claude_team_invoices.claude_team_invoice_lines.yaml
@@ -33,6 +33,8 @@ schemas:
       description: { type: [string, "null"] }
       product_name: { type: [string, "null"] }
       tier_label: { type: [string, "null"] }
+      price_id: { type: [string, "null"] }
+      product_id: { type: [string, "null"] }
       category: { type: [string, "null"] }
       is_proration: { type: [boolean, "null"] }
       amount: { type: [number, "null"] }

--- a/src/ingestion/tests/e2e/metrics/schemas/config.ai_seat_tier_map.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/config.ai_seat_tier_map.yaml
@@ -1,0 +1,21 @@
+# Operator-authored tier bindings; DDL owned by the create_ai_config_tables macro.
+schemas:
+  config.ai_seat_tier_map:
+    $schema: http://json-schema.org/draft-07/schema#
+    type: object
+    additionalProperties: false
+    properties:
+      tenant_id: &id001
+        type: string
+      insight_source_id: *id001
+      source: *id001
+      tier_ref: *id001
+      unique_key: *id001
+      seat_tier: *id001
+      is_deleted:
+        type: integer
+      note: *id001
+      recorded_by: *id001
+      _version:
+        type: string
+        format: date-time

--- a/src/ingestion/tests/e2e/metrics/schemas/config.ai_seat_tier_map.yaml
+++ b/src/ingestion/tests/e2e/metrics/schemas/config.ai_seat_tier_map.yaml
@@ -11,6 +11,7 @@ schemas:
       source: *id001
       tier_ref: *id001
       unique_key: *id001
+      seat_source_id: *id001
       seat_tier: *id001
       is_deleted:
         type: integer

--- a/src/ingestion/tests/e2e/metrics/templates/claude_team_invoice.yaml
+++ b/src/ingestion/tests/e2e/metrics/templates/claude_team_invoice.yaml
@@ -35,6 +35,8 @@ templates:
     description: null
     product_name: null
     tier_label: null
+    price_id: null
+    product_id: null
     category: null
     is_proration: null
     amount: null


### PR DESCRIPTION
Closes #2620.

**Why.** A month that prices more than one tier emits no `seat_cost_usd`: the invoice names its tier with the vendor's catalogue identifier, the seat with one from another API, and nothing says they are the same tier.

**What changed.** The connector carries Stripe's `price`/`product` ids into bronze, the class contract gains `tier_ref` for the vendor's stable tier identifier, and gold resolves a seat's price by joining it through `config.ai_seat_tier_map`. The display name stays in the vendor-extras blob.

**The binding is operator-authored configuration, not code.** Its keys are one account's catalogue identifiers, which a public repo must not carry. Ownership follows `config.task_value_map` — dbt guarantees the relation, an operator writes the rows.

**An unbound month still prices when it leaves no ambiguity.** One priced tier prices every seat billed in it, unchanged — so the table ships empty and no existing install moves until a binding is written.

**A binding also names the seat instance its prices reach.** The invoice and the seats arrive through separate connectors whose `source_id` never matches, so a tenant running two organisations of one vendor cannot be resolved from the data alone.

**Evidence.** The seat-cost fixture spelled a seat's tier with the invoice's own word for its plan and set a `tier_label` the vendor never sends — the invented agreement is why its assertions passed. Both gone; the connector suite goes 105 → 111 tests.

**Verified.** `dbt parse` clean, 111 connector tests pass, three seat-cost fixtures resolve and schema-validate, and the new price selection was run against ClickHouse across its three branches. Ruff clean at the pinned v0.15.21; the `connectors-ddl` snapshot carries the three new columns.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added stable product and price identifiers to AI invoice data.
  * Added configurable mappings between invoice tiers and seat populations.
  * Added support for separate tier pricing across connector instances.

* **Bug Fixes**
  * Improved AI seat-cost attribution when invoices contain multiple tiers.
  * Unmapped or ambiguous tiers are no longer assigned an incorrect price.
  * Preserved correct handling for missing pricing metadata and partial invoices.

* **Tests**
  * Expanded end-to-end coverage for mapped, unmapped, partial, and multi-instance pricing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->