### PR TITLE
feat: link metric evidence to source systems

### DIFF
--- a/.github/trufflehog-allowlist.txt
+++ b/.github/trufflehog-allowlist.txt
@@ -6,6 +6,8 @@
 96923d309cc0326b  Atlassian          docs/connectors/support/jsm.md  # example account id quoted from vendor documentation
 b92efd223e8930c0  CloudflareApiToken STORAGE_TECHNOLOGY_EVALUATION.md  # prose fragment in a document
 cf6ede857587d567  Gitlab             .github/workflows/ghcr-cleanup.yml  # GHCR image name, not a token
+c33b583e8c9da202  Gitlab             src/backend/services/analytics/src/domain/external_links.rs  # external source provider type, not a token
+ef9a241f59d1ac1e  Gitlab             src/backend/services/analytics/src/domain/external_links.rs  # external source provider identifier, not a token
 1c236cb81bf7da61  Gitlab             docs/CONNECTORS_REFERENCE.md  # code identifier / constant name
 bd0c5f545b463920  Gitlab             docs/components/deployment/gitops/SPEC.md  # code identifier / constant name
 bd093b6d7b23051a  Gitlab             docs/components/deployment/specs/PRD.md  # code identifier / constant name

--- a/charts/insight/values.yaml
+++ b/charts/insight/values.yaml
@@ -530,6 +530,7 @@ analytics:
     # installation; when off, the catalog omits them and the CI lens renders
     # its honest not-enabled state.
     tenantMetricsEnabled: false
+  externalSources: []
   # Explaining a metric with an LLM. Off everywhere until an operator turns it
   # on, and turning it on without `tokenEncryptionKey` stops the service at
   # boot rather than accepting keys it cannot seal.

--- a/docs/components/backend/analytics/openapi.json
+++ b/docs/components/backend/analytics/openapi.json
@@ -837,6 +837,12 @@
       },
       "MetricDimensionDto": {
         "properties": {
+          "href": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "key": {
             "type": "string"
           },
@@ -1151,6 +1157,15 @@
       },
       "MetricDrilldownRow": {
         "properties": {
+          "links": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "values": {
             "additionalProperties": {},
             "propertyNames": {
@@ -1160,7 +1175,8 @@
           }
         },
         "required": [
-          "values"
+          "values",
+          "links"
         ],
         "type": "object"
       },

--- a/src/backend/Cargo.lock
+++ b/src/backend/Cargo.lock
@@ -152,6 +152,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "url",
  "utoipa",
  "uuid",
  "zeroize",

--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -63,6 +63,7 @@ sea-orm-migration = { version = "2.0", features = ["runtime-tokio", "sqlx-mysql"
 
 # IDs and time
 uuid = { version = "1.19", features = ["serde", "v7"] }
+url = "2.5"
 chrono = { version = "0.4", features = ["serde"] }
 base64 = "0.23"
 sha2 = "0.11"

--- a/src/backend/services/analytics/Cargo.toml
+++ b/src/backend/services/analytics/Cargo.toml
@@ -54,7 +54,7 @@ redis = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
-url = "2.5"
+url = { workspace = true }
 # OpenAPI schemas for request/response DTOs. Version pinned to 5.5 to match the
 # `utoipa::ToSchema` the toolkit (`OperationBuilder::json_request` /
 # `json_response_with_schema`) is compiled against (already in Cargo.lock via

--- a/src/backend/services/analytics/Cargo.toml
+++ b/src/backend/services/analytics/Cargo.toml
@@ -54,6 +54,7 @@ redis = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+url = "2.5"
 # OpenAPI schemas for request/response DTOs. Version pinned to 5.5 to match the
 # `utoipa::ToSchema` the toolkit (`OperationBuilder::json_request` /
 # `json_response_with_schema`) is compiled against (already in Cargo.lock via

--- a/src/backend/services/analytics/helm/templates/configmap.yaml
+++ b/src/backend/services/analytics/helm/templates/configmap.yaml
@@ -124,3 +124,9 @@ data:
           visibility_policy: {{ .Values.visibilityPolicy | default "org_chart" | quote }}
           metric_catalog:
             tenant_metrics_enabled: {{ .Values.metricCatalog.tenantMetricsEnabled }}
+          external_sources: {{- if not .Values.externalSources }} []{{- end }}
+            {{- range .Values.externalSources }}
+            - id: {{ .id | quote }}
+              provider: {{ .provider | quote }}
+              web_base_url: {{ .webBaseUrl | quote }}
+            {{- end }}

--- a/src/backend/services/analytics/helm/values.yaml
+++ b/src/backend/services/analytics/helm/values.yaml
@@ -22,6 +22,8 @@ resources:
 metricCatalog:
   tenantMetricsEnabled: false
 
+externalSources: []
+
 # Pre-provisioned Secret carrying the gears-rust host's leaf-config overrides
 # (injected via envFrom; they override the mounted config ConfigMap):
 #   APP__gears__analytics__config__database_url

--- a/src/backend/services/analytics/src/api/ai/live_tests/mod.rs
+++ b/src/backend/services/analytics/src/api/ai/live_tests/mod.rs
@@ -111,6 +111,7 @@ fn app_as(db: DatabaseConnection, tenant: Uuid, person: Uuid, config: GearConfig
         anthropic,
         ai_calls: Arc::new(tokio::sync::Semaphore::new(1)),
         config,
+        external_links: crate::domain::external_links::ExternalSourceRegistry::default(),
     });
 
     let openapi = OpenApiRegistryImpl::new();

--- a/src/backend/services/analytics/src/api/http_live_tests.rs
+++ b/src/backend/services/analytics/src/api/http_live_tests.rs
@@ -96,6 +96,7 @@ fn build_state_with_ch(
         anthropic: dead_anthropic(),
         ai_calls: Arc::new(tokio::sync::Semaphore::new(1)),
         config: GearConfig::default(),
+        external_links: crate::domain::external_links::ExternalSourceRegistry::default(),
     }
 }
 
@@ -1020,6 +1021,7 @@ fn app_with_usage_collection_off(db: DatabaseConnection, tenant: Uuid) -> Router
         anthropic: dead_anthropic(),
         ai_calls: Arc::new(tokio::sync::Semaphore::new(1)),
         config,
+        external_links: crate::domain::external_links::ExternalSourceRegistry::default(),
     });
     let api = super::build_operations(Router::new(), &openapi)
         .layer(from_fn_with_state(tenant, inject_host_context))

--- a/src/backend/services/analytics/src/api/metric_drilldown.rs
+++ b/src/backend/services/analytics/src/api/metric_drilldown.rs
@@ -51,7 +51,7 @@ pub async fn query_metric_drilldown(
     let rows = fetch_rows(&state, &req, &log_comment).await?;
     verify_evidence_snapshot(&state.ch, &req.plan.relation, &req.snapshot_id).await?;
     let fetched_rows = rows.len();
-    let response = build_response(&req, rows)?;
+    let response = build_response(&req, rows, &state.external_links)?;
     tracing::info!(
         duration_ms = started.elapsed().as_millis(),
         rows = response.rows.len(),

--- a/src/backend/services/analytics/src/api/metric_results.rs
+++ b/src/backend/services/analytics/src/api/metric_results.rs
@@ -309,7 +309,8 @@ async fn build_single_view(
         UnbatchedView::Breakdown { dimensions } => {
             let comment = format!("metric-results:breakdown:{}", def.key());
             let rows = fetch_rows::<BreakdownQueryRow>(state, query, &comment).await?;
-            build_breakdown_view(req, &dimensions, rows).map_err(|e| assembly_failure(&e, &comment))
+            build_breakdown_view(req, &dimensions, rows, &state.external_links)
+                .map_err(|e| assembly_failure(&e, &comment))
         }
         UnbatchedView::Rollup { dimensions } => {
             let comment = format!("metric-results:rollup:{}", def.key());

--- a/src/backend/services/analytics/src/api/mod.rs
+++ b/src/backend/services/analytics/src/api/mod.rs
@@ -36,6 +36,7 @@ use tokio::sync::Semaphore;
 
 use crate::config::GearConfig;
 use crate::domain::ai::dto as ai_dto;
+use crate::domain::external_links::ExternalSourceRegistry;
 use crate::domain::metric_crud;
 use crate::domain::metric_definitions::listing as metric_definitions_listing;
 use crate::domain::saved_query;
@@ -52,6 +53,7 @@ pub struct AppState {
     /// Caps explain calls in flight in this process.
     pub ai_calls: Arc<Semaphore>,
     pub config: GearConfig,
+    pub external_links: ExternalSourceRegistry,
 }
 
 pub(crate) fn forwarded_authorization(headers: &axum::http::HeaderMap) -> Option<&str> {

--- a/src/backend/services/analytics/src/config.rs
+++ b/src/backend/services/analytics/src/config.rs
@@ -11,6 +11,23 @@ use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use serde::Deserialize;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExternalSourceProvider {
+    Github,
+    Gitlab,
+    BitbucketCloud,
+    Jira,
+    Youtrack,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ExternalSourceConfig {
+    pub id: String,
+    pub provider: ExternalSourceProvider,
+    pub web_base_url: String,
+}
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum VisibilityPolicy {
@@ -66,6 +83,8 @@ pub struct GearConfig {
 
     /// AI-assist configuration.
     pub ai_assist: AiAssistConfig,
+
+    pub external_sources: Vec<ExternalSourceConfig>,
 }
 
 impl Default for GearConfig {
@@ -83,6 +102,7 @@ impl Default for GearConfig {
             metric_catalog: MetricCatalogConfig::default(),
             usage: UsageConfig::default(),
             ai_assist: AiAssistConfig::default(),
+            external_sources: Vec::new(),
         }
     }
 }
@@ -335,6 +355,33 @@ mod tests {
                 "should reject: {value}"
             );
         }
+        Ok(())
+    }
+
+    #[test]
+    fn external_sources_default_to_empty() -> anyhow::Result<()> {
+        let config: GearConfig = serde_json::from_value(serde_json::json!({}))?;
+
+        assert!(config.external_sources.is_empty());
+        Ok(())
+    }
+
+    #[test]
+    fn external_sources_deserialize_provider_and_url() -> anyhow::Result<()> {
+        let config: GearConfig = serde_json::from_value(serde_json::json!({
+            "external_sources": [{
+                "id": "source-a",
+                "provider": "gitlab",
+                "web_base_url": "https://code.example.test/platform"
+            }]
+        }))?;
+
+        assert_eq!(config.external_sources.len(), 1);
+        assert_eq!(config.external_sources[0].id, "source-a");
+        assert_eq!(
+            config.external_sources[0].provider,
+            ExternalSourceProvider::Gitlab
+        );
         Ok(())
     }
 }

--- a/src/backend/services/analytics/src/domain/external_links.rs
+++ b/src/backend/services/analytics/src/domain/external_links.rs
@@ -241,7 +241,11 @@ fn append_segments<'a>(base: &Url, segments: impl IntoIterator<Item = &'a str>) 
 }
 
 fn valid_segment(segment: &str) -> bool {
-    !segment.is_empty() && segment != "." && segment != ".." && !segment.contains('/')
+    !segment.is_empty()
+        && segment != "."
+        && segment != ".."
+        && !segment.contains('/')
+        && !segment.contains(':')
 }
 
 #[cfg(test)]
@@ -467,16 +471,68 @@ mod tests {
     fn refuses_links_without_valid_context() -> anyhow::Result<()> {
         let registry = ExternalSourceRegistry::new(&sources())?;
 
-        let links = registry.evidence_links(
-            "github",
-            "missing-source",
-            "commit",
-            Some("group/repository"),
-            Some("a1b2c3"),
-        );
+        for (provider, source_id, kind, repository, reference) in [
+            (
+                "github",
+                "missing-source",
+                "commit",
+                Some("group/repository"),
+                Some("a1b2c3"),
+            ),
+            (
+                "github",
+                "github-source",
+                "commit",
+                Some("source-a:group/repository"),
+                Some("a1b2c3"),
+            ),
+            (
+                "github",
+                "github-source",
+                "commit",
+                Some("repository"),
+                Some("a1b2c3"),
+            ),
+            (
+                "github",
+                "github-source",
+                "commit",
+                Some("group/../repository"),
+                Some("a1b2c3"),
+            ),
+            (
+                "github",
+                "github-source",
+                "commit",
+                Some("group/./repository"),
+                Some("a1b2c3"),
+            ),
+            (
+                "github",
+                "github-source",
+                "commit",
+                Some("group/repository"),
+                Some(""),
+            ),
+            (
+                "github",
+                "github-source",
+                "issue",
+                None,
+                Some("not-an-issue-ref"),
+            ),
+            (
+                "github",
+                "github-source",
+                "unsupported",
+                Some("group/repository"),
+                Some("42"),
+            ),
+        ] {
+            let links = registry.evidence_links(provider, source_id, kind, repository, reference);
 
-        assert!(links.repository.is_none());
-        assert!(links.record.is_none());
+            assert!(links.record.is_none(), "should reject: {kind}");
+        }
         Ok(())
     }
 }

--- a/src/backend/services/analytics/src/domain/external_links.rs
+++ b/src/backend/services/analytics/src/domain/external_links.rs
@@ -1,0 +1,428 @@
+use std::collections::HashMap;
+
+use url::Url;
+
+use crate::config::{ExternalSourceConfig, ExternalSourceProvider};
+
+#[derive(Debug, Clone, Default)]
+pub struct ExternalSourceRegistry {
+    sources: HashMap<(ExternalSourceProvider, String), Url>,
+}
+
+impl ExternalSourceRegistry {
+    pub fn new(sources: &[ExternalSourceConfig]) -> anyhow::Result<Self> {
+        let mut registry = HashMap::with_capacity(sources.len());
+        for source in sources {
+            let id = source.id.trim();
+            if id.is_empty() || id != source.id {
+                anyhow::bail!("external source id must be non-empty and trimmed");
+            }
+
+            let url = parse_web_base_url(&source.web_base_url)?;
+            let key = (source.provider, id.to_owned());
+            if registry.insert(key, url).is_some() {
+                anyhow::bail!("external source provider and id must be unique");
+            }
+        }
+        Ok(Self { sources: registry })
+    }
+
+    pub fn evidence_links(
+        &self,
+        provider: &str,
+        source_id: &str,
+        record_kind: &str,
+        repository: Option<&str>,
+        record_ref: Option<&str>,
+    ) -> ExternalRecordLinks {
+        let Some(provider) = parse_provider(provider) else {
+            return ExternalRecordLinks::default();
+        };
+        let Some(base) = self.sources.get(&(provider, source_id.to_owned())) else {
+            return ExternalRecordLinks::default();
+        };
+
+        let repository = repository.and_then(repository_segments);
+        let repository_href = repository
+            .as_deref()
+            .and_then(|segments| repository_url(base, provider, segments));
+        let record_link = record_url(
+            base,
+            provider,
+            record_kind,
+            repository.as_deref(),
+            record_ref,
+        );
+
+        ExternalRecordLinks {
+            repository: repository_href,
+            record: record_link,
+        }
+    }
+
+    pub fn repository_href(
+        &self,
+        provider: Option<&str>,
+        source_id: Option<&str>,
+        repository: Option<&str>,
+    ) -> Option<String> {
+        let provider = parse_provider(provider?)?;
+        let source_id = source_id?.trim();
+        let base = self.sources.get(&(provider, source_id.to_owned()))?;
+        let repository = repository_segments(repository?)?;
+        repository_url(base, provider, &repository)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ExternalRecordLinks {
+    pub repository: Option<String>,
+    pub record: Option<String>,
+}
+
+fn parse_web_base_url(value: &str) -> anyhow::Result<Url> {
+    let mut url = Url::parse(value.trim())?;
+    if !matches!(url.scheme(), "http" | "https") || url.host().is_none() {
+        anyhow::bail!("external source web_base_url must be an absolute HTTP(S) URL");
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        anyhow::bail!("external source web_base_url must not include userinfo");
+    }
+    if url.query().is_some() || url.fragment().is_some() {
+        anyhow::bail!("external source web_base_url must not include a query or fragment");
+    }
+    let path = url.path().trim_end_matches('/').to_owned();
+    url.set_path(&path);
+    Ok(url)
+}
+
+fn parse_provider(value: &str) -> Option<ExternalSourceProvider> {
+    match value.trim() {
+        "github" => Some(ExternalSourceProvider::Github),
+        "gitlab" => Some(ExternalSourceProvider::Gitlab),
+        "bitbucket_cloud" => Some(ExternalSourceProvider::BitbucketCloud),
+        "jira" => Some(ExternalSourceProvider::Jira),
+        "youtrack" => Some(ExternalSourceProvider::Youtrack),
+        _ => None,
+    }
+}
+
+fn repository_url(
+    base: &Url,
+    provider: ExternalSourceProvider,
+    repository: &[&str],
+) -> Option<String> {
+    match provider {
+        ExternalSourceProvider::Github
+        | ExternalSourceProvider::Gitlab
+        | ExternalSourceProvider::BitbucketCloud => {
+            append_segments(base, repository.iter().copied())
+        }
+        ExternalSourceProvider::Jira | ExternalSourceProvider::Youtrack => None,
+    }
+}
+
+fn record_url(
+    base: &Url,
+    provider: ExternalSourceProvider,
+    record_kind: &str,
+    repository: Option<&[&str]>,
+    record_ref: Option<&str>,
+) -> Option<String> {
+    let record_ref = record_ref?.trim();
+    match (provider, record_kind) {
+        (ExternalSourceProvider::Github, "commit") => append_segments(
+            base,
+            repository?.iter().copied().chain(["commit", record_ref]),
+        ),
+        (ExternalSourceProvider::Gitlab, "commit") => append_segments(
+            base,
+            repository?
+                .iter()
+                .copied()
+                .chain(["-", "commit", record_ref]),
+        ),
+        (ExternalSourceProvider::BitbucketCloud, "commit") => append_segments(
+            base,
+            repository?.iter().copied().chain(["commits", record_ref]),
+        ),
+        (ExternalSourceProvider::Github, "pull_request") => append_segments(
+            base,
+            repository?.iter().copied().chain(["pull", record_ref]),
+        ),
+        (ExternalSourceProvider::Gitlab, "pull_request") => append_segments(
+            base,
+            repository?
+                .iter()
+                .copied()
+                .chain(["-", "merge_requests", record_ref]),
+        ),
+        (ExternalSourceProvider::BitbucketCloud, "pull_request") => append_segments(
+            base,
+            repository?
+                .iter()
+                .copied()
+                .chain(["pull-requests", record_ref]),
+        ),
+        (ExternalSourceProvider::Jira, "issue") => append_segments(base, ["browse", record_ref]),
+        (ExternalSourceProvider::Youtrack, "issue") => append_segments(base, ["issue", record_ref]),
+        (ExternalSourceProvider::Github, "issue") => issue_url(base, &["issues"], record_ref),
+        (ExternalSourceProvider::Gitlab, "issue") => issue_url(base, &["-", "issues"], record_ref),
+        (ExternalSourceProvider::BitbucketCloud, "issue") => {
+            issue_url(base, &["issues"], record_ref)
+        }
+        _ => None,
+    }
+}
+
+fn issue_url(base: &Url, suffix: &[&str], record_ref: &str) -> Option<String> {
+    let (repository, number) = record_ref.rsplit_once('#')?;
+    if number.is_empty() || !number.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    let repository = repository_segments(repository)?;
+    append_segments(
+        base,
+        repository
+            .into_iter()
+            .chain(suffix.iter().copied())
+            .chain([number]),
+    )
+}
+
+fn repository_segments(value: &str) -> Option<Vec<&str>> {
+    let value = value.trim();
+    let segments = value.split('/').collect::<Vec<_>>();
+    if segments.len() < 2 || segments.iter().any(|segment| !valid_segment(segment)) {
+        return None;
+    }
+    Some(segments)
+}
+
+fn append_segments<'a>(base: &Url, segments: impl IntoIterator<Item = &'a str>) -> Option<String> {
+    let mut url = base.clone();
+    let mut path = url.path_segments_mut().ok()?;
+    for segment in segments {
+        if !valid_segment(segment) {
+            return None;
+        }
+        path.push(segment);
+    }
+    drop(path);
+    Some(url.into())
+}
+
+fn valid_segment(segment: &str) -> bool {
+    !segment.is_empty() && segment != "." && segment != ".." && !segment.contains('/')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sources() -> Vec<ExternalSourceConfig> {
+        vec![
+            ExternalSourceConfig {
+                id: "github-source".to_owned(),
+                provider: ExternalSourceProvider::Github,
+                web_base_url: "https://github.example.test/".to_owned(),
+            },
+            ExternalSourceConfig {
+                id: "jira-source".to_owned(),
+                provider: ExternalSourceProvider::Jira,
+                web_base_url: "https://issues.example.test/jira/".to_owned(),
+            },
+        ]
+    }
+
+    #[test]
+    fn resolves_git_repository_and_commit_links() -> anyhow::Result<()> {
+        let registry = ExternalSourceRegistry::new(&sources())?;
+
+        let links = registry.evidence_links(
+            "github",
+            "github-source",
+            "commit",
+            Some("group/repository"),
+            Some("a1b2c3"),
+        );
+
+        assert_eq!(
+            links.repository.as_deref(),
+            Some("https://github.example.test/group/repository")
+        );
+        assert_eq!(
+            links.record.as_deref(),
+            Some("https://github.example.test/group/repository/commit/a1b2c3")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn resolves_jira_issue_link() -> anyhow::Result<()> {
+        let registry = ExternalSourceRegistry::new(&sources())?;
+
+        let links = registry.evidence_links("jira", "jira-source", "issue", None, Some("OPS-42"));
+
+        assert_eq!(
+            links.record.as_deref(),
+            Some("https://issues.example.test/jira/browse/OPS-42")
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn resolves_provider_specific_record_routes() -> anyhow::Result<()> {
+        let entries = [
+            ExternalSourceConfig {
+                id: "github-source".to_owned(),
+                provider: ExternalSourceProvider::Github,
+                web_base_url: "https://github.example.test".to_owned(),
+            },
+            ExternalSourceConfig {
+                id: "gitlab-source".to_owned(),
+                provider: ExternalSourceProvider::Gitlab,
+                web_base_url: "https://gitlab.example.test".to_owned(),
+            },
+            ExternalSourceConfig {
+                id: "bitbucket-source".to_owned(),
+                provider: ExternalSourceProvider::BitbucketCloud,
+                web_base_url: "https://bitbucket.example.test".to_owned(),
+            },
+            ExternalSourceConfig {
+                id: "youtrack-source".to_owned(),
+                provider: ExternalSourceProvider::Youtrack,
+                web_base_url: "https://tracker.example.test/youtrack".to_owned(),
+            },
+        ];
+        let registry = ExternalSourceRegistry::new(&entries)?;
+
+        for (provider, source_id, kind, repository, reference, expected) in [
+            (
+                "github",
+                "github-source",
+                "issue",
+                None,
+                "group/repository#42",
+                "https://github.example.test/group/repository/issues/42",
+            ),
+            (
+                "gitlab",
+                "gitlab-source",
+                "commit",
+                Some("group/subgroup/repository"),
+                "abc123",
+                "https://gitlab.example.test/group/subgroup/repository/-/commit/abc123",
+            ),
+            (
+                "gitlab",
+                "gitlab-source",
+                "pull_request",
+                Some("group/subgroup/repository"),
+                "42",
+                "https://gitlab.example.test/group/subgroup/repository/-/merge_requests/42",
+            ),
+            (
+                "gitlab",
+                "gitlab-source",
+                "issue",
+                None,
+                "group/subgroup/repository#42",
+                "https://gitlab.example.test/group/subgroup/repository/-/issues/42",
+            ),
+            (
+                "bitbucket_cloud",
+                "bitbucket-source",
+                "commit",
+                Some("workspace/repository"),
+                "abc123",
+                "https://bitbucket.example.test/workspace/repository/commits/abc123",
+            ),
+            (
+                "bitbucket_cloud",
+                "bitbucket-source",
+                "pull_request",
+                Some("workspace/repository"),
+                "42",
+                "https://bitbucket.example.test/workspace/repository/pull-requests/42",
+            ),
+            (
+                "bitbucket_cloud",
+                "bitbucket-source",
+                "issue",
+                None,
+                "workspace/repository#42",
+                "https://bitbucket.example.test/workspace/repository/issues/42",
+            ),
+            (
+                "youtrack",
+                "youtrack-source",
+                "issue",
+                None,
+                "APP-42",
+                "https://tracker.example.test/youtrack/issue/APP-42",
+            ),
+        ] {
+            let links =
+                registry.evidence_links(provider, source_id, kind, repository, Some(reference));
+
+            assert_eq!(
+                links.record.as_deref(),
+                Some(expected),
+                "should resolve: {provider}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn rejects_duplicate_provider_and_id() {
+        let mut entries = sources();
+        entries.push(ExternalSourceConfig {
+            id: "github-source".to_owned(),
+            provider: ExternalSourceProvider::Github,
+            web_base_url: "https://alternate.example.test".to_owned(),
+        });
+
+        assert!(ExternalSourceRegistry::new(&entries).is_err());
+    }
+
+    #[test]
+    fn rejects_unsafe_web_base_urls() {
+        for web_base_url in [
+            "github.example.test",
+            "ftp://github.example.test",
+            "https://user@github.example.test",
+            "https://github.example.test?query=yes",
+            "https://github.example.test#fragment",
+        ] {
+            let entry = ExternalSourceConfig {
+                id: "source".to_owned(),
+                provider: ExternalSourceProvider::Github,
+                web_base_url: web_base_url.to_owned(),
+            };
+
+            assert!(
+                ExternalSourceRegistry::new(&[entry]).is_err(),
+                "should reject: {web_base_url}"
+            );
+        }
+    }
+
+    #[test]
+    fn refuses_links_without_valid_context() -> anyhow::Result<()> {
+        let registry = ExternalSourceRegistry::new(&sources())?;
+
+        let links = registry.evidence_links(
+            "github",
+            "missing-source",
+            "commit",
+            Some("group/repository"),
+            Some("a1b2c3"),
+        );
+
+        assert!(links.repository.is_none());
+        assert!(links.record.is_none());
+        Ok(())
+    }
+}

--- a/src/backend/services/analytics/src/domain/external_links.rs
+++ b/src/backend/services/analytics/src/domain/external_links.rs
@@ -9,19 +9,35 @@ pub struct ExternalSourceRegistry {
     sources: HashMap<(ExternalSourceProvider, String), Url>,
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum ExternalSourceRegistryError {
+    #[error("external source id must be non-empty and trimmed")]
+    InvalidId,
+    #[error("external source provider and id must be unique")]
+    DuplicateProviderAndId,
+    #[error("external source web_base_url is not a valid URL")]
+    InvalidWebBaseUrl(#[from] url::ParseError),
+    #[error("external source web_base_url must be an absolute HTTP(S) URL")]
+    InvalidWebBaseUrlSchemeOrHost,
+    #[error("external source web_base_url must not include userinfo")]
+    WebBaseUrlIncludesUserInfo,
+    #[error("external source web_base_url must not include a query or fragment")]
+    WebBaseUrlIncludesQueryOrFragment,
+}
+
 impl ExternalSourceRegistry {
-    pub fn new(sources: &[ExternalSourceConfig]) -> anyhow::Result<Self> {
+    pub fn new(sources: &[ExternalSourceConfig]) -> Result<Self, ExternalSourceRegistryError> {
         let mut registry = HashMap::with_capacity(sources.len());
         for source in sources {
             let id = source.id.trim();
             if id.is_empty() || id != source.id {
-                anyhow::bail!("external source id must be non-empty and trimmed");
+                return Err(ExternalSourceRegistryError::InvalidId);
             }
 
             let url = parse_web_base_url(&source.web_base_url)?;
             let key = (source.provider, id.to_owned());
             if registry.insert(key, url).is_some() {
-                anyhow::bail!("external source provider and id must be unique");
+                return Err(ExternalSourceRegistryError::DuplicateProviderAndId);
             }
         }
         Ok(Self { sources: registry })
@@ -80,16 +96,16 @@ pub struct ExternalRecordLinks {
     pub record: Option<String>,
 }
 
-fn parse_web_base_url(value: &str) -> anyhow::Result<Url> {
+fn parse_web_base_url(value: &str) -> Result<Url, ExternalSourceRegistryError> {
     let mut url = Url::parse(value.trim())?;
     if !matches!(url.scheme(), "http" | "https") || url.host().is_none() {
-        anyhow::bail!("external source web_base_url must be an absolute HTTP(S) URL");
+        return Err(ExternalSourceRegistryError::InvalidWebBaseUrlSchemeOrHost);
     }
     if !url.username().is_empty() || url.password().is_some() {
-        anyhow::bail!("external source web_base_url must not include userinfo");
+        return Err(ExternalSourceRegistryError::WebBaseUrlIncludesUserInfo);
     }
     if url.query().is_some() || url.fragment().is_some() {
-        anyhow::bail!("external source web_base_url must not include a query or fragment");
+        return Err(ExternalSourceRegistryError::WebBaseUrlIncludesQueryOrFragment);
     }
     let path = url.path().trim_end_matches('/').to_owned();
     url.set_path(&path);
@@ -130,48 +146,60 @@ fn record_url(
     record_ref: Option<&str>,
 ) -> Option<String> {
     let record_ref = record_ref?.trim();
-    match (provider, record_kind) {
-        (ExternalSourceProvider::Github, "commit") => append_segments(
-            base,
-            repository?.iter().copied().chain(["commit", record_ref]),
-        ),
-        (ExternalSourceProvider::Gitlab, "commit") => append_segments(
-            base,
-            repository?
-                .iter()
-                .copied()
-                .chain(["-", "commit", record_ref]),
-        ),
-        (ExternalSourceProvider::BitbucketCloud, "commit") => append_segments(
-            base,
-            repository?.iter().copied().chain(["commits", record_ref]),
-        ),
-        (ExternalSourceProvider::Github, "pull_request") => append_segments(
-            base,
-            repository?.iter().copied().chain(["pull", record_ref]),
-        ),
-        (ExternalSourceProvider::Gitlab, "pull_request") => append_segments(
-            base,
-            repository?
-                .iter()
-                .copied()
-                .chain(["-", "merge_requests", record_ref]),
-        ),
-        (ExternalSourceProvider::BitbucketCloud, "pull_request") => append_segments(
-            base,
-            repository?
-                .iter()
-                .copied()
-                .chain(["pull-requests", record_ref]),
-        ),
-        (ExternalSourceProvider::Jira, "issue") => append_segments(base, ["browse", record_ref]),
-        (ExternalSourceProvider::Youtrack, "issue") => append_segments(base, ["issue", record_ref]),
-        (ExternalSourceProvider::Github, "issue") => issue_url(base, &["issues"], record_ref),
-        (ExternalSourceProvider::Gitlab, "issue") => issue_url(base, &["-", "issues"], record_ref),
-        (ExternalSourceProvider::BitbucketCloud, "issue") => {
-            issue_url(base, &["issues"], record_ref)
-        }
-        _ => None,
+    match provider {
+        ExternalSourceProvider::Github => match record_kind {
+            "commit" => append_segments(
+                base,
+                repository?.iter().copied().chain(["commit", record_ref]),
+            ),
+            "pull_request" => append_segments(
+                base,
+                repository?.iter().copied().chain(["pull", record_ref]),
+            ),
+            "issue" => issue_url(base, &["issues"], record_ref),
+            _ => None,
+        },
+        ExternalSourceProvider::Gitlab => match record_kind {
+            "commit" => append_segments(
+                base,
+                repository?
+                    .iter()
+                    .copied()
+                    .chain(["-", "commit", record_ref]),
+            ),
+            "pull_request" => append_segments(
+                base,
+                repository?
+                    .iter()
+                    .copied()
+                    .chain(["-", "merge_requests", record_ref]),
+            ),
+            "issue" => issue_url(base, &["-", "issues"], record_ref),
+            _ => None,
+        },
+        ExternalSourceProvider::BitbucketCloud => match record_kind {
+            "commit" => append_segments(
+                base,
+                repository?.iter().copied().chain(["commits", record_ref]),
+            ),
+            "pull_request" => append_segments(
+                base,
+                repository?
+                    .iter()
+                    .copied()
+                    .chain(["pull-requests", record_ref]),
+            ),
+            "issue" => issue_url(base, &["issues"], record_ref),
+            _ => None,
+        },
+        ExternalSourceProvider::Jira => match record_kind {
+            "issue" => append_segments(base, ["browse", record_ref]),
+            _ => None,
+        },
+        ExternalSourceProvider::Youtrack => match record_kind {
+            "issue" => append_segments(base, ["issue", record_ref]),
+            _ => None,
+        },
     }
 }
 
@@ -384,7 +412,33 @@ mod tests {
             web_base_url: "https://alternate.example.test".to_owned(),
         });
 
-        assert!(ExternalSourceRegistry::new(&entries).is_err());
+        assert!(matches!(
+            ExternalSourceRegistry::new(&entries),
+            Err(ExternalSourceRegistryError::DuplicateProviderAndId)
+        ));
+    }
+
+    #[test]
+    fn reports_invalid_ids_and_unparseable_urls() {
+        let invalid_id = ExternalSourceConfig {
+            id: " github-source".to_owned(),
+            provider: ExternalSourceProvider::Github,
+            web_base_url: "https://github.example.test".to_owned(),
+        };
+        assert!(matches!(
+            ExternalSourceRegistry::new(&[invalid_id]),
+            Err(ExternalSourceRegistryError::InvalidId)
+        ));
+
+        let invalid_url = ExternalSourceConfig {
+            id: "github-source".to_owned(),
+            provider: ExternalSourceProvider::Github,
+            web_base_url: "://".to_owned(),
+        };
+        assert!(matches!(
+            ExternalSourceRegistry::new(&[invalid_url]),
+            Err(ExternalSourceRegistryError::InvalidWebBaseUrl(_))
+        ));
     }
 
     #[test]

--- a/src/backend/services/analytics/src/domain/metric_drilldown/dto.rs
+++ b/src/backend/services/analytics/src/domain/metric_drilldown/dto.rs
@@ -144,6 +144,7 @@ pub struct MetricDrilldownColumn {
 #[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 pub struct MetricDrilldownRow {
     pub values: BTreeMap<String, serde_json::Value>,
+    pub links: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, utoipa::ToSchema)]

--- a/src/backend/services/analytics/src/domain/metric_drilldown/export.rs
+++ b/src/backend/services/analytics/src/domain/metric_drilldown/export.rs
@@ -409,6 +409,7 @@ mod tests {
                 ("value".to_owned(), json!(12.5)),
                 ("active".to_owned(), json!(true)),
             ]),
+            links: BTreeMap::new(),
         }
     }
 
@@ -503,6 +504,7 @@ mod tests {
         ];
         let row = MetricDrilldownRow {
             values: BTreeMap::from([("object".to_owned(), json!({"key": "value"}))]),
+            links: BTreeMap::new(),
         };
         assert_eq!(
             export_values(&columns, &row)
@@ -520,6 +522,7 @@ mod tests {
         }];
         let row = MetricDrilldownRow {
             values: BTreeMap::from([("value".to_owned(), json!("x".repeat(MAX_CELL_BYTES + 1)))]),
+            links: BTreeMap::new(),
         };
         assert!(export_values(&columns, &row).is_err());
     }
@@ -615,6 +618,7 @@ mod tests {
                 ("numeric_date".to_owned(), json!(20_260_728)),
                 ("numeric_text".to_owned(), json!(7)),
             ]),
+            links: BTreeMap::new(),
         };
 
         let bytes = build_xlsx(&columns, &[row], far_deadline())
@@ -631,6 +635,7 @@ mod tests {
         }];
         let row = MetricDrilldownRow {
             values: BTreeMap::from([("date".to_owned(), json!("not-a-date"))]),
+            links: BTreeMap::new(),
         };
         let bytes = build_xlsx(&columns, &[row], far_deadline()).unwrap_or_else(|error| {
             panic!("unparseable warehouse dates must not fail the export: {error}")
@@ -660,6 +665,7 @@ mod tests {
 
         let row = MetricDrilldownRow {
             values: BTreeMap::from([("count".to_owned(), value)]),
+            links: BTreeMap::new(),
         };
         assert!(build_xlsx(&columns, &[row], far_deadline()).is_ok());
     }

--- a/src/backend/services/analytics/src/domain/metric_drilldown/presentation.rs
+++ b/src/backend/services/analytics/src/domain/metric_drilldown/presentation.rs
@@ -275,14 +275,14 @@ fn row_links(
         record_ref,
     );
     let mut links = BTreeMap::new();
-    if values.contains_key("repository")
+    if values.get("repository").is_some_and(visible_value)
         && let Some(href) = resolved.repository
     {
         links.insert("repository".to_owned(), href);
     }
     if let Some(href) = resolved.record {
         for key in ["ref", "title"] {
-            if values.contains_key(key) {
+            if values.get(key).is_some_and(visible_value) {
                 links.insert(key.to_owned(), href.clone());
             }
         }
@@ -630,6 +630,30 @@ mod tests {
             Some("https://code.example.test/org/repo/commit/abc123")
         );
         assert!(!response.rows[0].values.contains_key("source_id"));
+        Ok(())
+    }
+
+    #[test]
+    fn response_does_not_link_empty_record_cells() -> anyhow::Result<()> {
+        let request = validated(commit_plan());
+        let mut evidence = row();
+        evidence.dimensions_json = r#"[
+            {"key":"source","value":"github","label":"GitHub"},
+            {"key":"repository","value":"source-a:group/repository","label":"group/repository"}
+        ]"#
+        .to_owned();
+        evidence.details["source_id"] = serde_json::json!("source-a");
+        evidence.details["title"] = serde_json::json!("");
+        let registry = ExternalSourceRegistry::new(&[ExternalSourceConfig {
+            id: "source-a".to_owned(),
+            provider: ExternalSourceProvider::Github,
+            web_base_url: "https://code.example.test".to_owned(),
+        }])?;
+
+        let response = build_response(&request, vec![evidence], &registry)?;
+
+        assert!(response.rows[0].links.contains_key("ref"));
+        assert!(!response.rows[0].links.contains_key("title"));
         Ok(())
     }
 

--- a/src/backend/services/analytics/src/domain/metric_drilldown/presentation.rs
+++ b/src/backend/services/analytics/src/domain/metric_drilldown/presentation.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 
 use toolkit_canonical_errors::CanonicalError;
 
+use crate::domain::external_links::ExternalSourceRegistry;
 use crate::domain::metric_definitions::ComputationSpec;
 use crate::domain::metric_definitions::definition::MetricInputRole;
 use crate::domain::metric_definitions::{EvidenceColumnType, EvidenceDetailColumn};
@@ -25,6 +26,7 @@ struct EvidenceDimension {
 pub fn build_response(
     req: &ValidatedMetricDrilldown,
     mut rows: Vec<EvidenceQueryRow>,
+    external_links: &ExternalSourceRegistry,
 ) -> Result<MetricDrilldownResponse, CanonicalError> {
     let next_cursor = if rows.len() > req.limit {
         rows.truncate(req.limit);
@@ -34,11 +36,12 @@ pub fn build_response(
     } else {
         None
     };
-    let (columns, rows) = presentation(
+    let (columns, rows) = present(
         &rows,
         &req.plan,
         &req.selection.filters,
         &req.selection.display_dimensions,
+        Some(external_links),
     )?;
     Ok(MetricDrilldownResponse {
         selection: req.selection.clone(),
@@ -54,6 +57,16 @@ pub fn presentation(
     filters: &[MetricDrilldownFilter],
     display_dimensions: &[String],
 ) -> Result<(Vec<MetricDrilldownColumn>, Vec<MetricDrilldownRow>), CanonicalError> {
+    present(rows, plan, filters, display_dimensions, None)
+}
+
+fn present(
+    rows: &[EvidenceQueryRow],
+    plan: &EvidencePlan,
+    filters: &[MetricDrilldownFilter],
+    display_dimensions: &[String],
+    external_links: Option<&ExternalSourceRegistry>,
+) -> Result<(Vec<MetricDrilldownColumn>, Vec<MetricDrilldownRow>), CanonicalError> {
     let details = rows
         .iter()
         .map(|row| row.details.as_object().ok_or_else(config_error))
@@ -65,7 +78,9 @@ pub fn presentation(
         .iter()
         .zip(details)
         .zip(dimensions)
-        .map(|((row, details), dimensions)| project_row(row, details, &dimensions, &columns))
+        .map(|((row, details), dimensions)| {
+            project_row(row, details, &dimensions, &columns, external_links)
+        })
         .collect::<Result<Vec<_>, CanonicalError>>()?;
 
     Ok((columns, projected_rows))
@@ -191,6 +206,7 @@ fn project_row(
     details: &serde_json::Map<String, serde_json::Value>,
     dimensions: &[EvidenceDimension],
     columns: &[MetricDrilldownColumn],
+    external_links: Option<&ExternalSourceRegistry>,
 ) -> Result<MetricDrilldownRow, CanonicalError> {
     let mut values = BTreeMap::new();
     for column in columns {
@@ -224,7 +240,54 @@ fn project_row(
             coerce_to_column_type(column.r#type, value),
         );
     }
-    Ok(MetricDrilldownRow { values })
+    let links = external_links
+        .map(|registry| row_links(registry, row, details, dimensions, &values))
+        .unwrap_or_default();
+    Ok(MetricDrilldownRow { values, links })
+}
+
+fn row_links(
+    registry: &ExternalSourceRegistry,
+    row: &EvidenceQueryRow,
+    details: &serde_json::Map<String, serde_json::Value>,
+    dimensions: &[EvidenceDimension],
+    values: &BTreeMap<String, serde_json::Value>,
+) -> BTreeMap<String, String> {
+    let Some(provider) = dimensions
+        .iter()
+        .find(|dimension| dimension.key == "source")
+        .map(|dimension| dimension.value.as_str())
+    else {
+        return BTreeMap::new();
+    };
+    let Some(source_id) = details.get("source_id").and_then(serde_json::Value::as_str) else {
+        return BTreeMap::new();
+    };
+    let repository = details
+        .get("repository")
+        .and_then(serde_json::Value::as_str);
+    let record_ref = details.get("ref").and_then(serde_json::Value::as_str);
+    let resolved = registry.evidence_links(
+        provider,
+        source_id,
+        &row.record_kind,
+        repository,
+        record_ref,
+    );
+    let mut links = BTreeMap::new();
+    if values.contains_key("repository")
+        && let Some(href) = resolved.repository
+    {
+        links.insert("repository".to_owned(), href);
+    }
+    if let Some(href) = resolved.record {
+        for key in ["ref", "title"] {
+            if values.contains_key(key) {
+                links.insert(key.to_owned(), href.clone());
+            }
+        }
+    }
+    links
 }
 
 fn presentation_dimensions(
@@ -284,6 +347,7 @@ fn humanize_field_name(key: &str) -> String {
 mod tests {
     use super::*;
 
+    use crate::config::{ExternalSourceConfig, ExternalSourceProvider};
     use crate::domain::metric_definitions::EvidencePresentation;
     use crate::domain::metric_definitions::{EvidenceGranularity, RatioDenominatorAggregation};
     use crate::domain::metric_drilldown::cursor::decode_cursor;
@@ -518,8 +582,12 @@ mod tests {
     #[test]
     fn response_pages_with_snapshot_bound_cursor() {
         let request = validated(commit_plan());
-        let response = build_response(&request, vec![row(), row()])
-            .unwrap_or_else(|error| panic!("response must build: {error}"));
+        let response = build_response(
+            &request,
+            vec![row(), row()],
+            &ExternalSourceRegistry::default(),
+        )
+        .unwrap_or_else(|error| panic!("response must build: {error}"));
         let cursor = response
             .next_cursor
             .unwrap_or_else(|| panic!("response must include a next cursor"));
@@ -529,6 +597,40 @@ mod tests {
         assert_eq!(envelope.snapshot_id, "snapshot");
         assert_eq!(envelope.fingerprint, request.fingerprint);
         assert!(decode_cursor("invalid").is_err());
+    }
+
+    #[test]
+    fn response_links_only_visible_columns_from_configured_source() -> anyhow::Result<()> {
+        let request = validated(commit_plan());
+        let mut evidence = row();
+        evidence.dimensions_json = r#"[
+            {"key":"source","value":"github","label":"GitHub"},
+            {"key":"repository","value":"source-a:group/repository","label":"group/repository"}
+        ]"#
+        .to_owned();
+        evidence.details["source_id"] = serde_json::json!("source-a");
+        let registry = ExternalSourceRegistry::new(&[ExternalSourceConfig {
+            id: "source-a".to_owned(),
+            provider: ExternalSourceProvider::Github,
+            web_base_url: "https://code.example.test".to_owned(),
+        }])?;
+
+        let response = build_response(&request, vec![evidence], &registry)?;
+
+        assert_eq!(
+            response.rows[0].links.get("repository").map(String::as_str),
+            Some("https://code.example.test/org/repo")
+        );
+        assert_eq!(
+            response.rows[0].links.get("ref").map(String::as_str),
+            Some("https://code.example.test/org/repo/commit/abc123")
+        );
+        assert_eq!(
+            response.rows[0].links.get("title").map(String::as_str),
+            Some("https://code.example.test/org/repo/commit/abc123")
+        );
+        assert!(!response.rows[0].values.contains_key("source_id"));
+        Ok(())
     }
 
     #[test]

--- a/src/backend/services/analytics/src/domain/metric_results/builder.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/builder.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use toolkit_canonical_errors::CanonicalError;
 
+use crate::domain::external_links::ExternalSourceRegistry;
 use crate::domain::metric_definitions::{ComputationSpec, MetricDefinition};
 
 use super::batch::{RankedDimension, RankedGroup};
@@ -119,7 +120,12 @@ pub fn build_timeseries_view(
                 entity_id,
                 dimensions: dims
                     .into_iter()
-                    .map(|(key, value, label)| MetricDimensionDto { key, value, label })
+                    .map(|(key, value, label)| MetricDimensionDto {
+                        key,
+                        value,
+                        label,
+                        href: None,
+                    })
                     .collect(),
                 total: data.total,
                 rank: data.rank,
@@ -185,16 +191,33 @@ pub fn build_breakdown_view(
     req: &ValidatedMetricResultsRequest,
     dimensions: &[String],
     rows: Vec<BreakdownQueryRow>,
+    external_links: &ExternalSourceRegistry,
 ) -> Result<MetricResultViewDto, CanonicalError> {
     let values = rows
         .into_iter()
         .map(|row| {
+            let mut dimensions = row_dimensions(&row.extra, dimensions)?
+                .into_iter()
+                .map(|(key, value, label)| MetricDimensionDto {
+                    key,
+                    value,
+                    label,
+                    href: None,
+                })
+                .collect::<Vec<_>>();
+            if let Some(repository) = dimensions
+                .iter_mut()
+                .find(|dimension| dimension.key == "repository")
+            {
+                repository.href = external_links.repository_href(
+                    row.source_provider.as_deref(),
+                    row.source_id.as_deref(),
+                    repository.label.as_deref(),
+                );
+            }
             Ok(BreakdownValueDto {
                 entity_id: req.entity.canonicalize_entity_id(row.entity_id),
-                dimensions: row_dimensions(&row.extra, dimensions)?
-                    .into_iter()
-                    .map(|(key, value, label)| MetricDimensionDto { key, value, label })
-                    .collect(),
+                dimensions,
                 value: row.value,
             })
         })
@@ -218,7 +241,12 @@ pub fn build_rollup_view(
             } else {
                 row_dimensions(&row.extra, dimensions)?
                     .into_iter()
-                    .map(|(key, value, label)| MetricDimensionDto { key, value, label })
+                    .map(|(key, value, label)| MetricDimensionDto {
+                        key,
+                        value,
+                        label,
+                        href: None,
+                    })
                     .collect()
             };
             Ok(RollupValueDto {
@@ -888,6 +916,8 @@ mod tests {
         let rows = vec![BreakdownQueryRow {
             entity_id: "00000000-0000-0000-0000-00000000000a".to_owned(),
             value: Some(1.0),
+            source_provider: None,
+            source_id: None,
             extra,
         }];
         let dimensions = vec!["tool".to_owned()];
@@ -897,7 +927,7 @@ mod tests {
             "2026-01-31",
         );
         let Ok(MetricResultViewDto::Breakdown { values, .. }) =
-            build_breakdown_view(&req, &dimensions, rows)
+            build_breakdown_view(&req, &dimensions, rows, &ExternalSourceRegistry::default())
         else {
             panic!("expected breakdown view");
         };
@@ -906,6 +936,49 @@ mod tests {
             values[0].dimensions[0].label.as_deref(),
             Some(UNKNOWN_DIMENSION_LABEL)
         );
+    }
+
+    #[test]
+    fn breakdown_repository_uses_hidden_source_context_for_href() -> anyhow::Result<()> {
+        let mut extra = HashMap::new();
+        extra.insert(
+            "dim_0_value".to_owned(),
+            serde_json::json!("source-a:group/repository"),
+        );
+        extra.insert(
+            "dim_0_label".to_owned(),
+            serde_json::json!("group/repository"),
+        );
+        let rows = vec![BreakdownQueryRow {
+            entity_id: "00000000-0000-0000-0000-00000000000a".to_owned(),
+            value: Some(1.0),
+            source_provider: Some("github".to_owned()),
+            source_id: Some("source-a".to_owned()),
+            extra,
+        }];
+        let dimensions = vec!["repository".to_owned()];
+        let req = request(
+            vec!["00000000-0000-0000-0000-00000000000a"],
+            "2026-01-01",
+            "2026-01-31",
+        );
+        let registry = ExternalSourceRegistry::new(&[crate::config::ExternalSourceConfig {
+            id: "source-a".to_owned(),
+            provider: crate::config::ExternalSourceProvider::Github,
+            web_base_url: "https://code.example.test".to_owned(),
+        }])?;
+
+        let MetricResultViewDto::Breakdown { values, .. } =
+            build_breakdown_view(&req, &dimensions, rows, &registry)?
+        else {
+            panic!("expected breakdown view");
+        };
+
+        assert_eq!(
+            values[0].dimensions[0].href.as_deref(),
+            Some("https://code.example.test/group/repository")
+        );
+        Ok(())
     }
 
     #[test]

--- a/src/backend/services/analytics/src/domain/metric_results/compiler.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/compiler.rs
@@ -73,7 +73,9 @@ pub struct PeerQueryRow {
 pub struct BreakdownQueryRow {
     pub entity_id: String,
     pub value: Option<f64>,
+    #[serde(rename = "link_source_provider")]
     pub source_provider: Option<String>,
+    #[serde(rename = "link_source_id")]
     pub source_id: Option<String>,
     #[serde(flatten)]
     pub extra: HashMap<String, serde_json::Value>,
@@ -1329,8 +1331,8 @@ fn hidden_source_context(dimensions: &[String]) -> (String, String) {
     let provider = dimension_value_expr("source");
     let source_id = dimension_value_expr("source_id");
     (
-        format!(", {provider} AS source_provider, {source_id} AS source_id"),
-        ", source_provider, source_id".to_owned(),
+        format!(", {provider} AS link_source_provider, {source_id} AS link_source_id"),
+        ", link_source_provider, link_source_id".to_owned(),
     )
 }
 
@@ -1913,13 +1915,14 @@ mod tests {
     }
 
     #[test]
-    fn repository_breakdown_selects_hidden_source_context() {
+    fn repository_breakdown_namespaces_hidden_source_context() {
         let query =
             compile_breakdown_query(&sum_metric(), &request(), &["repository".to_owned()], &[]);
 
-        assert!(query.sql.contains("AS source_provider"));
-        assert!(query.sql.contains("AS source_id"));
-        assert!(query.sql.contains("source_provider, source_id"));
+        assert!(query.sql.contains("AS link_source_provider"));
+        assert!(query.sql.contains("AS link_source_id"));
+        assert!(query.sql.contains("link_source_provider, link_source_id"));
+        assert!(!query.sql.contains(" AS source_id"));
     }
 
     #[test]

--- a/src/backend/services/analytics/src/domain/metric_results/compiler.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/compiler.rs
@@ -73,6 +73,8 @@ pub struct PeerQueryRow {
 pub struct BreakdownQueryRow {
     pub entity_id: String,
     pub value: Option<f64>,
+    pub source_provider: Option<String>,
+    pub source_id: Option<String>,
     #[serde(flatten)]
     pub extra: HashMap<String, serde_json::Value>,
 }
@@ -394,18 +396,20 @@ pub(crate) fn compile_breakdown_query(
     let filter_where = dimension_filter_where(filters, &mut params);
     let entity_predicate = selected_entity_predicate(req, &mut params);
     let (dim_select, dim_group) = dimension_select_group(dimensions);
+    let (source_select, source_group) = hidden_source_context(dimensions);
     let group = if dim_group.is_empty() {
         "entity_id".to_owned()
     } else {
         format!("entity_id, {dim_group}")
     };
+    let group = format!("{group}{source_group}");
     let observation_table = observation_table(def.observation_source());
     let limit = query_row_limit();
     let value_expr = grouped_value_expr(def);
     let inner = format!(
         r"
         SELECT
-            entity_id{dim_select},
+            entity_id{dim_select}{source_select},
             {value_expr} AS value
         FROM {observation_table}
         WHERE {metric_where}
@@ -1318,6 +1322,18 @@ fn dimension_select_group(dimensions: &[String]) -> (String, String) {
     (select, groups.join(", "))
 }
 
+fn hidden_source_context(dimensions: &[String]) -> (String, String) {
+    if !dimensions.iter().any(|dimension| dimension == "repository") {
+        return (String::new(), String::new());
+    }
+    let provider = dimension_value_expr("source");
+    let source_id = dimension_value_expr("source_id");
+    (
+        format!(", {provider} AS source_provider, {source_id} AS source_id"),
+        ", source_provider, source_id".to_owned(),
+    )
+}
+
 fn ranking_dimension_select_group(dimensions: &[String]) -> (String, String, String) {
     let mut select = Vec::with_capacity(dimensions.len() * 2);
     let mut group = Vec::with_capacity(dimensions.len());
@@ -1894,6 +1910,16 @@ mod tests {
                 .sql
                 .contains("GROUP BY entity_id, dim_0_value, dim_0_label")
         );
+    }
+
+    #[test]
+    fn repository_breakdown_selects_hidden_source_context() {
+        let query =
+            compile_breakdown_query(&sum_metric(), &request(), &["repository".to_owned()], &[]);
+
+        assert!(query.sql.contains("AS source_provider"));
+        assert!(query.sql.contains("AS source_id"));
+        assert!(query.sql.contains("source_provider, source_id"));
     }
 
     #[test]

--- a/src/backend/services/analytics/src/domain/metric_results/dto.rs
+++ b/src/backend/services/analytics/src/domain/metric_results/dto.rs
@@ -228,6 +228,8 @@ pub struct MetricDimensionDto {
     pub value: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub href: Option<String>,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]

--- a/src/backend/services/analytics/src/domain/mod.rs
+++ b/src/backend/services/analytics/src/domain/mod.rs
@@ -1,6 +1,7 @@
 pub mod ai;
 pub mod contract_version;
 pub(crate) mod date_window;
+pub mod external_links;
 pub(crate) mod metric_access;
 pub mod metric_crud;
 pub mod metric_definitions;

--- a/src/backend/services/analytics/src/gear.rs
+++ b/src/backend/services/analytics/src/gear.rs
@@ -18,6 +18,7 @@ use toolkit::api::OpenApiRegistry;
 use toolkit::{Gear, GearCtx, RestApiCapability};
 
 use crate::config::GearConfig;
+use crate::domain::external_links::ExternalSourceRegistry;
 use crate::{api, infra};
 
 /// Analytics API gear. Capabilities: `rest` only (the background validator and
@@ -45,6 +46,7 @@ impl Default for AnalyticsApiGear {
 impl Gear for AnalyticsApiGear {
     async fn init(&self, ctx: &GearCtx) -> anyhow::Result<()> {
         let cfg: GearConfig = ctx.config()?;
+        let external_links = ExternalSourceRegistry::new(&cfg.external_sources)?;
         tracing::info!("starting analytics gear");
 
         // Connect to MariaDB (self-managed pool — LOCKED DECISION).
@@ -102,6 +104,7 @@ impl Gear for AnalyticsApiGear {
             anthropic,
             ai_calls,
             config: cfg,
+            external_links,
         };
 
         self.state
@@ -220,6 +223,7 @@ pub fn check_config(app: &toolkit::bootstrap::AppConfig) -> anyhow::Result<()> {
              APP__gears__analytics__config__clickhouse_url)"
         );
     }
+    ExternalSourceRegistry::new(&cfg.external_sources)?;
     if cfg.ai_assist.enabled {
         if cfg.ai_assist.max_concurrent == 0 {
             anyhow::bail!(
@@ -274,6 +278,21 @@ mod tests {
             "clickhouse_url": "http://h:8123",
         }));
         assert!(check_config(&c).is_ok());
+    }
+
+    #[test]
+    fn check_config_errs_on_invalid_external_source_url() {
+        let c = cfg(json!({
+            "database_url": "mysql://h:3306/db",
+            "clickhouse_url": "http://h:8123",
+            "external_sources": [{
+                "id": "source-a",
+                "provider": "github",
+                "web_base_url": "https://code.example.test#fragment"
+            }]
+        }));
+
+        assert!(check_config(&c).is_err());
     }
 
     #[test]

--- a/src/backend/services/identity-resolution/helm/tests/test_umbrella_analytics_config_contract.py
+++ b/src/backend/services/identity-resolution/helm/tests/test_umbrella_analytics_config_contract.py
@@ -36,6 +36,7 @@ def test_tenant_metrics_are_opt_in_per_installation(umbrella_deps, extra: tuple[
     assert code == 0, err
 
     assert _analytics_config(out)["metric_catalog"]["tenant_metrics_enabled"] is expected
+    assert _analytics_config(out)["external_sources"] == []
 
 
 def test_analytics_visibility_policy_reuses_identity_resolution_setting(umbrella_deps) -> None:
@@ -51,3 +52,27 @@ def test_analytics_visibility_policy_reuses_identity_resolution_setting(umbrella
 
     key = "APP__gears__analytics__config__visibility_policy"
     assert _analytics_secret(out)[key] == "flat"
+
+
+def test_external_source_registry_reaches_analytics_config(umbrella_deps) -> None:
+    code, out, err = render(
+        umbrella_deps,
+        *UMBRELLA_BASE,
+        "--set",
+        f"global.tenantDefaultId={TENANT}",
+        "--set",
+        "analytics.externalSources[0].id=github-main",
+        "--set",
+        "analytics.externalSources[0].provider=github",
+        "--set",
+        "analytics.externalSources[0].webBaseUrl=https://github.example.com/",
+    )
+    assert code == 0, err
+
+    assert _analytics_config(out)["external_sources"] == [
+        {
+            "id": "github-main",
+            "provider": "github",
+            "web_base_url": "https://github.example.com/",
+        }
+    ]

--- a/src/frontend/src/api/metric-drilldown-client.ts
+++ b/src/frontend/src/api/metric-drilldown-client.ts
@@ -28,6 +28,7 @@ export interface MetricEvidenceColumn {
 
 export interface MetricEvidenceRow {
   values: Record<string, unknown>;
+  links?: Record<string, string>;
 }
 
 export interface MetricDrilldownResponse {

--- a/src/frontend/src/api/metric-results-client.ts
+++ b/src/frontend/src/api/metric-results-client.ts
@@ -87,6 +87,7 @@ export interface MetricDimension {
   key: string;
   value: string;
   label?: string;
+  href?: string;
 }
 
 export type MetricResult =

--- a/src/frontend/src/components/metric-evidence-dialog.test.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog.test.tsx
@@ -332,10 +332,7 @@ describe("MetricEvidenceDialog", () => {
     });
   });
 
-  // The dimension that makes a row linkable is asked for, hidden from the
-  // table, and must not reach the file: an export that carries a column the
-  // screen does not show is not an export OF that screen.
-  it("asks for the source dimension but keeps it out of the export", async () => {
+  it("does not add presentation dimensions for link resolution", async () => {
     const user = userEvent.setup();
     mocks.declaredDimensions = new Map([
       ["git.commits", new Set(["repository", "source"])],
@@ -352,7 +349,7 @@ describe("MetricEvidenceDialog", () => {
     const requested = (mocks.queryOptions?.queryKey as unknown[])[2] as {
       display_dimensions: string[];
     };
-    expect(requested.display_dimensions).toContain("source");
+    expect(requested.display_dimensions).toEqual([]);
 
     await user.click(screen.getByRole("button", { name: /CSV/ }));
     await waitFor(() =>
@@ -365,7 +362,7 @@ describe("MetricEvidenceDialog", () => {
     const [exported] = mocks.downloadMetricDrilldown.mock.calls[0]!;
     expect(
       (exported as { display_dimensions: string[] }).display_dimensions
-    ).not.toContain("source");
+    ).toEqual([]);
   });
 
   it("asks for the issue type and exports it, since the reader can see it", async () => {
@@ -390,14 +387,13 @@ describe("MetricEvidenceDialog", () => {
     const requested = (mocks.queryOptions?.queryKey as unknown[])[2] as {
       display_dimensions: string[];
     };
-    expect(requested.display_dimensions).toEqual(["source", "type"]);
+    expect(requested.display_dimensions).toEqual(["type"]);
 
     await user.click(screen.getByRole("button", { name: /CSV/ }));
     await waitFor(() => expect(mocks.downloadMetricDrilldown).toHaveBeenCalled());
     const [exported] = mocks.downloadMetricDrilldown.mock.calls[0]!;
     const dimensions = (exported as { display_dimensions: string[] })
       .display_dimensions;
-    // The type is a column on screen; the source only backs a link.
     expect(dimensions).toEqual(["type"]);
   });
 

--- a/src/frontend/src/components/metric-evidence-dialog.tsx
+++ b/src/frontend/src/components/metric-evidence-dialog.tsx
@@ -23,11 +23,7 @@ import type {
 } from "@/components/metric-evidence-context";
 import { MetricEvidencePeople } from "@/components/metric-evidence-people";
 import { MetricEvidenceTable } from "@/components/metric-evidence-table";
-import {
-  SOURCE_DIMENSION,
-  withSourceDimension,
-  withTypeDimension,
-} from "@/lib/metrics/provider-links";
+import { withTypeDimension } from "@/lib/metrics/provider-links";
 import { useDeclaredMetricDimensions } from "@/queries/metric-definitions";
 import { Button } from "@/components/ui/button";
 import {
@@ -112,10 +108,7 @@ export function MetricEvidenceDialog({
     ? declaredDimensions.byMetricKey?.get(activeTarget.selection.metric_key)
     : null;
   const selection = activeTarget
-    ? withTypeDimension(
-        withSourceDimension(activeTarget.selection, declared),
-        declared
-      )
+    ? withTypeDimension(activeTarget.selection, declared)
     : null;
   const query = useInfiniteQuery({
     queryKey: ["metric-drilldown", sessionScope, selection],
@@ -142,11 +135,7 @@ export function MetricEvidenceDialog({
     [pages]
   );
   const columns = useMemo(() => {
-    // `source` rides along purely to back a link (see withSourceDimension) —
-    // it is not a column anyone asked to see.
-    const columns = (query.data?.pages[0]?.columns ?? []).filter(
-      (column) => column.key !== SOURCE_DIMENSION
-    );
+    const columns = query.data?.pages[0]?.columns ?? [];
     const order = new Map([
       ["ref", 0],
       ["title", 1],

--- a/src/frontend/src/components/metric-evidence-table.test.tsx
+++ b/src/frontend/src/components/metric-evidence-table.test.tsx
@@ -335,25 +335,28 @@ describe("MetricEvidenceTable", () => {
           ref: SHA,
           title: "the subject line\n\nand a trailer nobody clicks",
           repository: "owner/repo",
-          source: "GitHub",
           ...overrides,
+        },
+        links: {
+          ref: `https://git.example/owner/repo/commit/${SHA}`,
+          title: `https://git.example/owner/repo/commit/${SHA}`,
+          repository: "https://git.example/owner/repo",
         },
       };
     }
 
-    it("addresses the record from its id and its summary, and the repository from its own cell", () => {
+    it("renders links supplied by the API", () => {
       renderTable({
-        metricKey: "git.commits",
         columns: linkColumns,
         rows: [linkRow()],
       });
 
       expect(
         screen.getByRole("link", { name: "the subject line" })
-      ).toHaveAttribute("href", `https://github.com/owner/repo/commit/${SHA}`);
+      ).toHaveAttribute("href", `https://git.example/owner/repo/commit/${SHA}`);
       expect(screen.getByRole("link", { name: "owner/repo" })).toHaveAttribute(
         "href",
-        "https://github.com/owner/repo"
+        "https://git.example/owner/repo"
       );
     });
 
@@ -361,7 +364,6 @@ describe("MetricEvidenceTable", () => {
     // the expanded record, and following a link is not asking for that.
     it("does not expand the row when a link is followed", async () => {
       renderTable({
-        metricKey: "git.commits",
         columns: linkColumns,
         rows: [linkRow()],
       });
@@ -378,7 +380,6 @@ describe("MetricEvidenceTable", () => {
     // title is a paragraph there rather than something to click.
     it("leaves the title unlinked in the expanded record", async () => {
       renderTable({
-        metricKey: "git.commits",
         columns: linkColumns,
         rows: [linkRow()],
       });
@@ -395,25 +396,10 @@ describe("MetricEvidenceTable", () => {
       ).toBeGreaterThan(1);
     });
 
-    it.each([
-      ["the provider's address is not derivable", { source: "gitlab" }],
-      ["the row does not say where it came from", { source: undefined }],
-      ["the repository is not a path", { repository: "Unknown" }],
-    ])("renders plain text when %s", (_case, overrides) => {
+    it("renders plain text without API links", () => {
       renderTable({
-        metricKey: "git.commits",
         columns: linkColumns,
-        rows: [linkRow(overrides)],
-      });
-
-      expect(screen.queryAllByRole("link")).toHaveLength(0);
-    });
-
-    it("renders plain text for a metric of another family", () => {
-      renderTable({
-        metricKey: "tasks.closed",
-        columns: linkColumns,
-        rows: [linkRow()],
+        rows: [{ values: linkRow().values }],
       });
 
       expect(screen.queryAllByRole("link")).toHaveLength(0);

--- a/src/frontend/src/components/metric-evidence-table.test.tsx
+++ b/src/frontend/src/components/metric-evidence-table.test.tsx
@@ -329,13 +329,12 @@ describe("MetricEvidenceTable", () => {
       { key: "repository", label: "Repository", type: "string" as const },
     ];
 
-    function linkRow(overrides: Record<string, unknown> = {}) {
+    function linkRow() {
       return {
         values: {
           ref: SHA,
           title: "the subject line\n\nand a trailer nobody clicks",
           repository: "owner/repo",
-          ...overrides,
         },
         links: {
           ref: `https://git.example/owner/repo/commit/${SHA}`,

--- a/src/frontend/src/components/metric-evidence-table.tsx
+++ b/src/frontend/src/components/metric-evidence-table.tsx
@@ -30,10 +30,7 @@ import {
   summaryLine,
   type EvidenceSort,
 } from "@/lib/metrics/evidence-rows";
-import {
-  evidenceRecordLinks,
-  evidenceRefText,
-} from "@/lib/metrics/provider-links";
+import { evidenceRefText } from "@/lib/metrics/provider-links";
 import { cn } from "@/lib/utils";
 
 function columnLayout(column: MetricEvidenceColumn) {
@@ -76,7 +73,6 @@ export function MetricEvidenceTable({
   nextPageError,
   pageLimitReached,
 }: {
-  /** Null while the metric picker has yet to resolve one — links stay off. */
   metricKey: string | null;
   rows: MetricEvidenceRow[];
   columns: MetricEvidenceColumn[];
@@ -229,7 +225,7 @@ export function MetricEvidenceTable({
             if (!row) return null;
             const key = rowKeys[virtualRow.index]!;
             const isOpen = expanded.has(key);
-            const links = evidenceRecordLinks(metricKey ?? "", row.values);
+            const links = row.links ?? {};
             return (
               <TableRow
                 role="row"

--- a/src/frontend/src/components/portal/domain-lens-view.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.tsx
@@ -57,7 +57,6 @@ import type {
   MetricDirection,
 } from "@/api/metric-results-client";
 import { normalizePersonId } from "@/lib/metrics/entity";
-import { githubRepoUrl } from "@/lib/metrics/provider-links";
 import {
   personsEvidenceSelection,
   type MetricEvidenceSelection,
@@ -1717,14 +1716,7 @@ function CompositionSection({
           });
         }
         const label = dim.label?.trim() || running?.label || dim.value;
-        const href =
-          running?.href ??
-          (spec.dimension === LINKABLE_DIMENSION
-            ? (githubRepoUrl(
-                row.dimensions.find((d) => d.key === SOURCE_DIMENSION)?.value,
-                label
-              ) ?? undefined)
-            : undefined);
+        const href = running?.href ?? dim.href;
         bucket.set(dim.value, {
           label,
           value: (running?.value ?? 0) + row.value,

--- a/src/frontend/src/components/portal/domain-lens-view.tsx
+++ b/src/frontend/src/components/portal/domain-lens-view.tsx
@@ -263,13 +263,7 @@ export function DomainLensView({
         views: [
           {
             view: "breakdown" as const,
-            // `source` rides along so a row knows which provider it came
-            // from — the only thing that makes a link safe to build.
-            dimensions: [
-              s.dimension,
-              ...(s.splitBy ? [s.splitBy] : []),
-              ...(s.dimension === LINKABLE_DIMENSION ? [SOURCE_DIMENSION] : []),
-            ],
+            dimensions: [s.dimension, ...(s.splitBy ? [s.splitBy] : [])],
           },
         ],
       })),
@@ -1980,12 +1974,6 @@ function shareLabel(pct: number): string {
 
 /** Same dwell as every other hover explanation in the product. */
 const HOVER_DELAY_MS = 400;
-
-/** The dimension whose rows can address something outside the product. */
-const LINKABLE_DIMENSION = "repository";
-
-/** Names the provider a git row came from. */
-const SOURCE_DIMENSION = "source";
 
 /** Rows shown before the reader opts into the full list. */
 const BAR_LIST_COLLAPSED = 12;

--- a/src/frontend/src/components/record-link.tsx
+++ b/src/frontend/src/components/record-link.tsx
@@ -1,11 +1,3 @@
-/**
- * A record's text, linked when the record has a page to link to.
- *
- * Metric evidence is only sometimes addressable — it depends on the provider
- * and on what the row carries (see `lib/metrics/provider-links`). Callers pass the
- * href they resolved and this decides nothing except how to render it, so an
- * unlinkable row is plain text rather than a dead anchor.
- */
 export function RecordLink({
   href,
   children,

--- a/src/frontend/src/components/widgets/metric-views/metric-activity.test.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-activity.test.tsx
@@ -133,6 +133,10 @@ describe("MetricActivity", () => {
             repository: "example/app",
             ref: "abc",
           },
+          links: {
+            title: "https://git.example/example/app/commit/abc",
+            repository: "https://git.example/example/app",
+          },
         },
         {
           values: {
@@ -150,6 +154,10 @@ describe("MetricActivity", () => {
     expect(rows[0]).toContain("Fix the thing");
     expect(rows[0]).not.toContain("body");
     expect(rows[1]).toContain("Another change");
+    expect(screen.getByRole("link", { name: "Fix the thing" })).toHaveAttribute(
+      "href",
+      "https://git.example/example/app/commit/abc"
+    );
   });
 
   it("names the kind of issue beside each one", () => {

--- a/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
@@ -33,7 +33,6 @@ import {
 } from "@/lib/metrics/collection";
 import {
   activityEventLabel,
-  evidenceRecordLinks,
   TYPE_DIMENSION,
   withSourceDimension,
   withTypeDimension,
@@ -225,7 +224,7 @@ function EventList({
     <div className="flex flex-col gap-1">
       <ul className="flex flex-col">
         {shown.map((event, index) => {
-          const links = evidenceRecordLinks(metricKey, event.values);
+          const links = event.links ?? {};
           const label = activityEventLabel(metricKey, event.ref, event.title);
           return (
             <li

--- a/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
+++ b/src/frontend/src/components/widgets/metric-views/metric-activity.tsx
@@ -34,7 +34,6 @@ import {
 import {
   activityEventLabel,
   TYPE_DIMENSION,
-  withSourceDimension,
   withTypeDimension,
 } from "@/lib/metrics/provider-links";
 import { RecordLink } from "@/components/record-link";
@@ -75,19 +74,12 @@ export function MetricActivity({
   const base = metric.selection
     ? evidenceSelection(metric.selection, entityId)
     : null;
-  // INVARIANT: the same gate the evidence dialog applies — `source` is what
-  // makes a link safe, `type` is what says which kind of issue a row is, and
-  // asking for either where a metric does not declare it is rejected outright,
+  // INVARIANT: asking for `type` where a metric does not declare it is rejected,
   // so the read waits for the catalogue.
   const declaredForMetric = base
     ? declared.byMetricKey?.get(base.metric_key)
     : null;
-  const selection = base
-    ? withTypeDimension(
-        withSourceDimension(base, declaredForMetric),
-        declaredForMetric
-      )
-    : null;
+  const selection = base ? withTypeDimension(base, declaredForMetric) : null;
   const detail = useMetricDetail(
     selection,
     grain != null && !declared.isPending

--- a/src/frontend/src/lib/insight/metric-grain.test.ts
+++ b/src/frontend/src/lib/insight/metric-grain.test.ts
@@ -110,19 +110,23 @@ describe("activityEvents", () => {
   it("keeps the subject of a title and leaves the body behind", () => {
     // A commit message carries its reasoning after the first line; in a list
     // being scanned that reasoning is noise, and in the export it is intact.
-    const events = activityEvents(
-      rows([
-        {
+    const events = activityEvents([
+      {
+        values: {
           date: "2026-03-01",
           ref: "abc123",
           title: "Fix the thing\n\nThe long why, several paragraphs of it.\n",
           repository: "example/app",
         },
-      ])
-    );
+        links: { title: "https://git.example/example/app/commit/abc123" },
+      },
+    ]);
     expect(events[0]?.title).toBe("Fix the thing");
     expect(events[0]?.context).toBe("example/app");
     expect(events[0]?.ref).toBe("abc123");
+    expect(events[0]?.links).toEqual({
+      title: "https://git.example/example/app/commit/abc123",
+    });
   });
 
   it("puts the newest first — a section is read from now backwards", () => {
@@ -147,8 +151,7 @@ describe("activityEvents", () => {
         title: null,
         context: null,
         value: 3,
-        // Carried so a caller that knows the metric can decide whether the
-        // thing is addressable; nothing here names one.
+        links: {},
         values: { date: "2026-03-01", value: 3 },
       },
     ]);

--- a/src/frontend/src/lib/insight/metric-grain.ts
+++ b/src/frontend/src/lib/insight/metric-grain.ts
@@ -107,11 +107,7 @@ export interface ActivityEvent {
   date: string;
   /** The metric's own reading for this event, when it has one. */
   value: number | null;
-  /**
-   * The evidence row this came from. Whether the thing is addressable depends
-   * on the provider and on columns this shape does not name, so that decision
-   * stays with the caller that knows the metric.
-   */
+  links: Readonly<Record<string, string>>;
   values: Readonly<Record<string, unknown>>;
 }
 
@@ -142,6 +138,7 @@ export function activityEvents(rows: MetricEvidenceRow[]): ActivityEvent[] {
           context: typeof context === "string" ? context : null,
           date,
           value: num(row.values.value),
+          links: row.links ?? {},
           values: row.values,
         },
       ];

--- a/src/frontend/src/lib/metrics/provider-links.test.ts
+++ b/src/frontend/src/lib/metrics/provider-links.test.ts
@@ -5,7 +5,6 @@ import {
   activityEventLabel,
   evidenceRefText,
   isTaskMetric,
-  withSourceDimension,
   withTypeDimension,
 } from "@/lib/metrics/provider-links";
 
@@ -21,23 +20,6 @@ function selection(
     display_dimensions: displayDimensions,
   };
 }
-
-describe("withSourceDimension", () => {
-  it("asks for source only where links may need provider context", () => {
-    expect(
-      withSourceDimension(
-        selection("git.commits", ["repository"]),
-        new Set(["repository", "source"])
-      ).display_dimensions
-    ).toEqual(["repository", "source"]);
-  });
-
-  it("does not request an undeclared source dimension", () => {
-    const original = selection("git.commits");
-
-    expect(withSourceDimension(original, new Set())).toBe(original);
-  });
-});
 
 describe("withTypeDimension", () => {
   it("asks for task types when declared", () => {

--- a/src/frontend/src/lib/metrics/provider-links.test.ts
+++ b/src/frontend/src/lib/metrics/provider-links.test.ts
@@ -1,133 +1,13 @@
-/**
- * When a metric's evidence addresses something outside the product.
- *
- * The rule these pin is that a link is only ever built from what a row
- * actually says. Every case below is a way of NOT knowing: a provider whose
- * address we cannot derive, a repository value that only looks like a path, a
- * ref that names neither a commit nor a pull request, a dimension the metric
- * never declared. Each of those has to come back empty rather than guess,
- * because a link that looks right and goes nowhere is worse than no link.
- */
 import { describe, expect, it } from "vitest";
 
 import type { MetricEvidenceSelection } from "@/api/metric-drilldown-client";
 import {
   activityEventLabel,
-  evidenceRecordLinks,
   evidenceRefText,
-  githubIssueUrl,
-  githubRecordUrl,
-  githubRepoUrl,
-  isGitMetric,
+  isTaskMetric,
   withSourceDimension,
   withTypeDimension,
 } from "@/lib/metrics/provider-links";
-
-const SHA1 = "e0f4823a55ac28276cf068f066ebf66f872a059c";
-const SHA256 = `${SHA1}${SHA1.slice(0, 24)}`;
-
-describe("githubRepoUrl", () => {
-  // The two serving paths spell one connector differently: a breakdown row
-  // carries the dimension's VALUE, an evidence row the LABEL it resolves to.
-  // Both name GitHub, so both have to be accepted — reading only one of them
-  // is why the drilldown silently produced no links at all.
-  it.each([
-    ["the connector key", "github"],
-    ["the display label", "GitHub"],
-    ["either, whatever the casing", "GITHUB"],
-    ["either, padded", "  github  "],
-  ])("accepts %s", (_case, source) => {
-    expect(githubRepoUrl(source, "owner/repo")).toBe(
-      "https://github.com/owner/repo"
-    );
-  });
-
-  it.each([
-    ["a provider that can live at any address", "gitlab"],
-    ["a provider that can live at any address", "bitbucket_cloud"],
-    ["a provider by its label", "Bitbucket Cloud"],
-    ["nothing at all", null],
-    ["nothing at all", undefined],
-    ["something adjacent but not it", "github-enterprise"],
-  ])("refuses %s (%s)", (_case, source) => {
-    expect(githubRepoUrl(source, "owner/repo")).toBeNull();
-  });
-
-  it.each([
-    // The bug this exists to prevent: gold's `repository_value` is account
-    // qualified, and only its LABEL is the addressable path. Feeding the value
-    // in produced a link for every row that pointed nowhere.
-    ["an account-qualified value rather than the label", "12:owner/repo"],
-    ["a slug with no project to pair it with", "repo"],
-    ["the placeholder an absent project leaves", "Unknown"],
-    ["a path with more segments than a repository has", "owner/repo/extra"],
-    ["a path that is only a separator", "/"],
-    ["a half-path", "owner/"],
-    ["nothing at all", ""],
-    ["nothing at all", null],
-    ["nothing at all", undefined],
-  ])("refuses %s (%s)", (_case, repository) => {
-    expect(githubRepoUrl("github", repository)).toBeNull();
-  });
-
-  it("keeps the punctuation a repository name is allowed to carry", () => {
-    expect(githubRepoUrl("github", "my-org/some.repo_name")).toBe(
-      "https://github.com/my-org/some.repo_name"
-    );
-  });
-});
-
-describe("githubRecordUrl", () => {
-  const repo = "https://github.com/owner/repo";
-
-  // A commit hash is fixed-length hex and a pull request number is a short
-  // decimal, so the ref alone separates them — which is what lets this work
-  // without the `record_kind` column the evidence row never projects.
-  it.each([
-    ["a SHA-1 commit", SHA1],
-    ["a SHA-256 commit", SHA256],
-    ["a commit in upper case", SHA1.toUpperCase()],
-  ])("sends %s to its commit page", (_case, ref) => {
-    expect(githubRecordUrl(repo, ref)).toBe(`${repo}/commit/${ref}`);
-  });
-
-  it.each([
-    ["a pull request", "2696"],
-    ["the first pull request", "1"],
-  ])("sends %s to its pull-request page", (_case, ref) => {
-    expect(githubRecordUrl(repo, ref)).toBe(`${repo}/pull/${ref}`);
-  });
-
-  it.each([
-    ["a ref that is neither shape", "not-a-ref"],
-    ["hex of the wrong length", "abc123"],
-    ["hex one short of a SHA-1", SHA1.slice(1)],
-    ["a number that is not one", "12.5"],
-    ["nothing at all", ""],
-    ["nothing at all", null],
-    ["nothing at all", undefined],
-  ])("refuses %s (%s)", (_case, ref) => {
-    expect(githubRecordUrl(repo, ref)).toBeNull();
-  });
-});
-
-describe("isGitMetric", () => {
-  it.each(["git.commits", "git.lines_added", "git.pr_cycle_time_h"])(
-    "claims %s",
-    (key) => {
-      expect(isGitMetric(key)).toBe(true);
-    }
-  );
-
-  // The family prefix is the gate that keeps every other source out, so a key
-  // that merely mentions git is not one.
-  it.each(["tasks.closed", "wiki.pages_created", "ai.adoption", "gitlab.x"])(
-    "disclaims %s",
-    (key) => {
-      expect(isGitMetric(key)).toBe(false);
-    }
-  );
-});
 
 function selection(
   metricKey: string,
@@ -143,252 +23,64 @@ function selection(
 }
 
 describe("withSourceDimension", () => {
-  it("asks for the source a git metric declares", () => {
-    const result = withSourceDimension(
-      selection("git.commits"),
-      new Set(["repository", "source"])
-    );
-
-    expect(result.display_dimensions).toEqual(["source"]);
+  it("asks for source only where links may need provider context", () => {
+    expect(
+      withSourceDimension(
+        selection("git.commits", ["repository"]),
+        new Set(["repository", "source"])
+      ).display_dimensions
+    ).toEqual(["repository", "source"]);
   });
 
-  it("keeps the requested dimensions sorted, so one selection is one query key", () => {
-    const result = withSourceDimension(
-      selection("git.commits", ["repository"]),
-      new Set(["repository", "source"])
-    );
-
-    expect(result.display_dimensions).toEqual(["repository", "source"]);
-  });
-
-  // Asking for an undeclared dimension is refused outright, so asking on spec
-  // would trade a missing link for a dialog that cannot open at all.
-  it("leaves a git metric that declares no source untouched", () => {
-    const original = selection("git.commits_per_active_day");
-
-    expect(withSourceDimension(original, new Set())).toBe(original);
-  });
-
-  it("leaves everything untouched while the catalogue is unknown", () => {
+  it("does not request an undeclared source dimension", () => {
     const original = selection("git.commits");
 
-    expect(withSourceDimension(original, null)).toBe(original);
-    expect(withSourceDimension(original, undefined)).toBe(original);
-  });
-
-  it("leaves a metric of a family that links nothing untouched", () => {
-    const original = selection("wiki.pages_created");
-
-    expect(withSourceDimension(original, new Set(["source"]))).toBe(original);
-  });
-
-  it("asks for source on a task metric too, since its ref links out", () => {
-    const original = selection("tasks.closed");
-
-    expect(
-      withSourceDimension(original, new Set(["source"])).display_dimensions
-    ).toContain("source");
-  });
-
-  it("does not ask twice for a source the caller already wanted", () => {
-    const original = selection("git.commits", ["source"]);
-
-    expect(withSourceDimension(original, new Set(["source"]))).toBe(
-      original
-    );
+    expect(withSourceDimension(original, new Set())).toBe(original);
   });
 });
 
 describe("withTypeDimension", () => {
-  it("asks for the type a task metric declares", () => {
-    const result = withTypeDimension(
-      selection("tasks.closed"),
-      new Set(["source", "type"])
-    );
-
-    expect(result.display_dimensions).toEqual(["type"]);
+  it("asks for task types when declared", () => {
+    expect(
+      withTypeDimension(selection("tasks.closed"), new Set(["type"]))
+        .display_dimensions
+    ).toEqual(["type"]);
   });
 
-  it("keeps the requested dimensions sorted, so one selection is one query key", () => {
-    const result = withTypeDimension(
-      selection("tasks.closed", ["source"]),
-      new Set(["source", "type"])
-    );
-
-    expect(result.display_dimensions).toEqual(["source", "type"]);
-  });
-
-  it("leaves a task metric that declares no type untouched", () => {
-    const original = selection("tasks.flow_efficiency");
-
-    expect(withTypeDimension(original, new Set(["source"]))).toBe(original);
-  });
-
-  it("leaves everything untouched while the catalogue is unknown", () => {
-    const original = selection("tasks.closed");
-
-    expect(withTypeDimension(original, null)).toBe(original);
-    expect(withTypeDimension(original, undefined)).toBe(original);
-  });
-
-  it("leaves a metric of a family that has no issue types untouched", () => {
+  it("leaves other metric families untouched", () => {
     const original = selection("git.commits");
 
     expect(withTypeDimension(original, new Set(["type"]))).toBe(original);
   });
-
-  it("does not ask twice for a type the caller already grouped by", () => {
-    const original = selection("tasks.closed", ["type"]);
-
-    expect(withTypeDimension(original, new Set(["type"]))).toBe(original);
-  });
-});
-
-describe("evidenceRecordLinks", () => {
-  const row = {
-    source: "GitHub",
-    repository: "owner/repo",
-    ref: SHA1,
-  };
-
-  it("addresses the repository and the record from one row", () => {
-    expect(evidenceRecordLinks("git.commits", row)).toEqual({
-      repository: "https://github.com/owner/repo",
-      ref: `https://github.com/owner/repo/commit/${SHA1}`,
-      title: `https://github.com/owner/repo/commit/${SHA1}`,
-    });
-  });
-
-  // The id of a record and the human-readable summary of it are two ways of
-  // naming the same page, so they carry the same link.
-  it("points a record's id and its summary at the same page", () => {
-    const links = evidenceRecordLinks("git.commits", { ...row, ref: "2696" });
-
-    expect(links.ref).toBe("https://github.com/owner/repo/pull/2696");
-    expect(links.title).toBe(links.ref);
-  });
-
-  it("still addresses the repository when the ref names nothing", () => {
-    const links = evidenceRecordLinks("git.commits", { ...row, ref: "" });
-
-    expect(links.repository).toBe("https://github.com/owner/repo");
-    expect(links.ref).toBeUndefined();
-    expect(links.title).toBeUndefined();
-  });
-
-  it.each([
-    ["the metric belongs to another family", "tasks.closed", row],
-    [
-      "the provider's address is not derivable",
-      "git.commits",
-      { ...row, source: "gitlab" },
-    ],
-    [
-      "the row does not say which provider it came from",
-      "git.commits",
-      { repository: "owner/repo", ref: SHA1 },
-    ],
-    [
-      "the repository is not a path",
-      "git.commits",
-      { ...row, repository: "Unknown" },
-    ],
-    ["the row says nothing", "git.commits", {}],
-  ])("says nothing when %s", (_case, metricKey, values) => {
-    expect(evidenceRecordLinks(metricKey, values)).toEqual({});
-  });
-
-  // Row values arrive as `unknown`; a non-string where a string was expected
-  // is a reason to say nothing, not to coerce it into a URL.
-  it("says nothing when a value is not the string it should be", () => {
-    expect(
-      evidenceRecordLinks("git.commits", {
-        source: "github",
-        repository: 42,
-        ref: SHA1,
-      })
-    ).toEqual({});
-  });
-});
-
-describe("githubIssueUrl", () => {
-  it("addresses the issue's own page from the readable key", () => {
-    expect(githubIssueUrl("github", "constructorfabric/insight#2717")).toBe(
-      "https://github.com/constructorfabric/insight/issues/2717"
-    );
-  });
-
-  it("accepts the label form the drilldown projects", () => {
-    expect(githubIssueUrl("GitHub", "owner/repo#1")).toBe(
-      "https://github.com/owner/repo/issues/1"
-    );
-  });
-
-  it("refuses a tracker whose address is not derivable", () => {
-    expect(githubIssueUrl("jira", "PROJ-7")).toBeNull();
-    expect(githubIssueUrl("youtrack", "owner/repo#1")).toBeNull();
-  });
-
-  it("refuses a key that does not name a repository and a number", () => {
-    for (const ref of ["PROJ-7", "4884190007", "owner/repo", "#12", ""]) {
-      expect(githubIssueUrl("github", ref)).toBeNull();
-    }
-  });
 });
 
 describe("evidenceRefText", () => {
-  it("drops the repository prefix a whole drilldown shares", () => {
-    expect(evidenceRefText("tasks.closed", "constructorfabric/insight#2717")).toBe(
-      "#2717"
-    );
+  it("shortens GitHub-style issue refs without changing the copy value", () => {
+    expect(evidenceRefText("tasks.closed", "owner/repo#12")).toBe("#12");
   });
 
-  it("leaves a ref of another shape alone", () => {
+  it("keeps other reference formats intact", () => {
     expect(evidenceRefText("tasks.closed", "PROJ-7")).toBe("PROJ-7");
-  });
-
-  it("leaves other families alone, pull request numbers included", () => {
-    expect(evidenceRefText("git.prs", "2717")).toBe("2717");
-  });
-});
-
-describe("evidenceRecordLinks for task evidence", () => {
-  it("links both the ref and the title at the issue", () => {
-    const issue = "https://github.com/owner/repo/issues/12";
-
-    expect(
-      evidenceRecordLinks("tasks.closed", {
-        source: "github",
-        ref: "owner/repo#12",
-      })
-    ).toEqual({ ref: issue, title: issue });
-  });
-
-  it("says nothing when the row does not carry its source", () => {
-    expect(evidenceRecordLinks("tasks.closed", { ref: "owner/repo#12" })).toEqual(
-      {}
-    );
   });
 });
 
 describe("activityEventLabel", () => {
-  it("names an issue by number and summary", () => {
+  it("names task events by reference and title", () => {
     expect(
-      activityEventLabel("tasks.closed", "owner/repo#12", "Fix the importer")
-    ).toBe("#12: Fix the importer");
+      activityEventLabel("tasks.closed", "owner/repo#12", "Fix login")
+    ).toBe("#12: Fix login");
   });
 
-  it("falls back to whichever half the row has", () => {
-    expect(activityEventLabel("tasks.closed", "owner/repo#12", null)).toBe("#12");
-    expect(activityEventLabel("tasks.closed", null, "Fix the importer")).toBe(
-      "Fix the importer"
+  it("uses the title for non-task events", () => {
+    expect(activityEventLabel("git.commits", "abc", "Fix login")).toBe(
+      "Fix login"
     );
-    expect(activityEventLabel("tasks.closed", null, null)).toBeNull();
   });
+});
 
-  it("leaves other families reading as they did", () => {
-    expect(activityEventLabel("git.commits", "e0f4823", "Fix the importer")).toBe(
-      "Fix the importer"
-    );
+describe("isTaskMetric", () => {
+  it("recognizes the task metric family", () => {
+    expect(isTaskMetric("tasks.closed")).toBe(true);
+    expect(isTaskMetric("git.commits")).toBe(false);
   });
 });

--- a/src/frontend/src/lib/metrics/provider-links.ts
+++ b/src/frontend/src/lib/metrics/provider-links.ts
@@ -1,145 +1,35 @@
-/**
- * Links into the provider a metric's record came from — git records and
- * tracker issues alike.
- *
- * Only GitHub, and only because its web layout is derivable from data we
- * already hold: `https://github.com/{owner}/{repo}`. GitLab and Bitbucket can
- * be self-hosted at any address, and nothing in a metric row says which — so
- * they get no link rather than a guessed one.
- *
- * KNOWN GAP: the `source` dimension names the CONNECTOR, not the host, so a
- * GitHub Enterprise tenant reports `github` while living at its own domain.
- * Those links will point at github.com and miss. Carrying the host (or the
- * `html_url` the API already returns) is what fixes it properly.
- */
-
 import type { MetricEvidenceSelection } from "@/api/metric-drilldown-client";
 
-/**
- * GitHub's `source` dimension, as EITHER serving path spells it: a breakdown
- * row carries the connector key (`github`), while a drilldown row carries the
- * display label the same dimension resolves to (`GitHub`) — it projects a
- * dimension's label in preference to its value. Both name one connector, so
- * both are accepted rather than making callers know which path they are on.
- */
-const GITHUB_SOURCE = "github";
-
-const GITHUB_WEB_BASE = "https://github.com";
-
-/**
- * `owner/repo`, and nothing that only looks like it: gold builds the label from
- * `project_key/repo_slug`, and an absent project leaves the slug alone (no
- * slash) or the `Unknown` placeholder — neither addresses a repository.
- */
-const REPO_PATH = /^[A-Za-z0-9._-]+\/[A-Za-z0-9._-]+$/;
-
-/** The repository's page, or null when the row is not linkable. */
-export function githubRepoUrl(
-  source: string | null | undefined,
-  repository: string | null | undefined
-): string | null {
-  if (source?.trim().toLowerCase() !== GITHUB_SOURCE) return null;
-  const path = repository?.trim();
-  if (!path || !REPO_PATH.test(path)) return null;
-  return `${GITHUB_WEB_BASE}/${path}`;
-}
-
-/**
- * A git commit hash is fixed-length hex (SHA-1: 40, SHA-256: 64); a PR number
- * is a short plain decimal. The two shapes never collide — a repo would need
- * 10^40 PRs — so the ref alone says which URL a record's own page needs,
- * without a `record_kind` column the evidence row does not carry.
- */
-const COMMIT_REF = /^[0-9a-f]{40}$|^[0-9a-f]{64}$/i;
-const PULL_REF = /^[0-9]+$/;
-
-/** The record's own page under a repository, or null when `ref` is neither shape. */
-export function githubRecordUrl(
-  repoUrl: string,
-  ref: string | null | undefined
-): string | null {
-  const value = ref?.trim();
-  if (!value) return null;
-  if (COMMIT_REF.test(value)) return `${repoUrl}/commit/${value}`;
-  if (PULL_REF.test(value)) return `${repoUrl}/pull/${value}`;
-  return null;
-}
-
-/** Two-part `family.name` metric keys namespace by family; these are fixed. */
-const GIT_METRIC_PREFIX = "git.";
 const TASK_METRIC_PREFIX = "tasks.";
-
-/** Whether links are worth attempting at all for this metric's evidence. */
-export function isGitMetric(metricKey: string): boolean {
-  return metricKey.startsWith(GIT_METRIC_PREFIX);
-}
+const GITHUB_STYLE_ISSUE_REF = /^([A-Za-z0-9._-]+\/[A-Za-z0-9._-]+)#([0-9]+)$/;
 
 export function isTaskMetric(metricKey: string): boolean {
   return metricKey.startsWith(TASK_METRIC_PREFIX);
 }
 
-/**
- * A tracker states an issue's readable key its own way — GitHub as
- * `owner/repo#12`, Jira as `PROJ-7` — and only the GitHub shape carries the
- * repository the URL needs. Matching the shape is what keeps a Jira key from
- * being linked to a github.com path that does not exist.
- */
-const GITHUB_ISSUE_REF = /^([A-Za-z0-9._-]+\/[A-Za-z0-9._-]+)#([0-9]+)$/;
-
-/** The issue's own page, or null when the row is not linkable. */
-export function githubIssueUrl(
-  source: string | null | undefined,
-  ref: string | null | undefined
-): string | null {
-  if (source?.trim().toLowerCase() !== GITHUB_SOURCE) return null;
-  const matched = GITHUB_ISSUE_REF.exec(ref?.trim() ?? "");
-  if (!matched) return null;
-  return `${GITHUB_WEB_BASE}/${matched[1]}/issues/${matched[2]}`;
-}
-
-/**
- * How an issue ref reads in a column: the repository prefix is the same for
- * nearly every row of one drilldown, so it costs width and says nothing —
- * `#12` is what distinguishes rows, and the repository stays in the link and
- * in what the copy button yields. A ref of any other shape reads as-is.
- */
-export function evidenceRefText(
-  metricKey: string,
-  value: string
-): string {
+export function evidenceRefText(metricKey: string, value: string): string {
   if (!isTaskMetric(metricKey)) return value;
-  const matched = GITHUB_ISSUE_REF.exec(value.trim());
+  const matched = GITHUB_STYLE_ISSUE_REF.exec(value.trim());
   return matched ? `#${matched[2]}` : value;
 }
 
-/** The dimension key requested so a row's own connector rides along. */
 export const SOURCE_DIMENSION = "source";
 
-/**
- * Adds `source` to a metric's requested display dimensions, so its
- * evidence rows carry the per-row connector a link needs to be safe.
- */
 export function withSourceDimension(
   selection: MetricEvidenceSelection,
   declared: ReadonlySet<string> | null | undefined
 ): MetricEvidenceSelection {
-  if (!isGitMetric(selection.metric_key) && !isTaskMetric(selection.metric_key)) {
+  if (
+    !isTaskMetric(selection.metric_key) &&
+    !selection.metric_key.startsWith("git.")
+  ) {
     return selection;
   }
   return withDimension(selection, SOURCE_DIMENSION, declared);
 }
 
-/** The dimension key naming what kind of issue a row is — "Bug", "Story". */
 export const TYPE_DIMENSION = "type";
 
-/**
- * Adds `type` to a task metric's requested display dimensions, so an issue row
- * says which kind of issue it was.
- *
- * A count of closed issues reads differently once the bugs in it are visible,
- * and the tracker's own type is the only thing on the row that says which is
- * which. Same gate as `withSourceDimension`: only when the metric declares it.
- */
 export function withTypeDimension(
   selection: MetricEvidenceSelection,
   declared: ReadonlySet<string> | null | undefined
@@ -148,12 +38,6 @@ export function withTypeDimension(
   return withDimension(selection, TYPE_DIMENSION, declared);
 }
 
-/**
- * SAFETY: only when the metric DECLARES the dimension — a drilldown that asks
- * for an undeclared one is rejected outright, so asking on spec would trade a
- * missing column for an unopenable dialog. `declared` is null while the catalog
- * is unknown, which is also a no-op.
- */
 function withDimension(
   selection: MetricEvidenceSelection,
   dimension: string,
@@ -167,44 +51,6 @@ function withDimension(
   };
 }
 
-/**
- * Where each of a drilldown row's columns links to, by column key — empty for
- * every row nothing can be said about. The id of a record and the human-readable
- * summary of it address the same page, so both carry it.
- */
-export function evidenceRecordLinks(
-  metricKey: string,
-  values: Readonly<Record<string, unknown>>
-): Readonly<Record<string, string | undefined>> {
-  if (isTaskMetric(metricKey)) {
-    const issue = githubIssueUrl(
-      asString(values[SOURCE_DIMENSION]),
-      asString(values.ref)
-    );
-    return issue ? { ref: issue, title: issue } : {};
-  }
-  if (!isGitMetric(metricKey)) return {};
-  const repoUrl = githubRepoUrl(
-    asString(values[SOURCE_DIMENSION]),
-    asString(values.repository)
-  );
-  if (!repoUrl) return {};
-  const record = githubRecordUrl(repoUrl, asString(values.ref)) ?? undefined;
-  return { repository: repoUrl, ref: record, title: record };
-}
-
-function asString(value: unknown): string | undefined {
-  return typeof value === "string" ? value : undefined;
-}
-
-/**
- * One line naming an issue in an activity list: `#12: what it is about`.
- *
- * The list has one column for the thing itself, so the number and the summary
- * share it — the number alone does not say what the work was, and the summary
- * alone cannot be told apart from another issue with a similar name. Either
- * half may be missing; what is left still reads.
- */
 export function activityEventLabel(
   metricKey: string,
   ref: string | null | undefined,

--- a/src/frontend/src/lib/metrics/provider-links.ts
+++ b/src/frontend/src/lib/metrics/provider-links.ts
@@ -13,21 +13,6 @@ export function evidenceRefText(metricKey: string, value: string): string {
   return matched ? `#${matched[2]}` : value;
 }
 
-export const SOURCE_DIMENSION = "source";
-
-export function withSourceDimension(
-  selection: MetricEvidenceSelection,
-  declared: ReadonlySet<string> | null | undefined
-): MetricEvidenceSelection {
-  if (
-    !isTaskMetric(selection.metric_key) &&
-    !selection.metric_key.startsWith("git.")
-  ) {
-    return selection;
-  }
-  return withDimension(selection, SOURCE_DIMENSION, declared);
-}
-
 export const TYPE_DIMENSION = "type";
 
 export function withTypeDimension(

--- a/src/ingestion/gold/git_authored_commits.sql
+++ b/src/ingestion/gold/git_authored_commits.sql
@@ -51,7 +51,7 @@ SELECT
             tuple('branch_scope', branch_scope_value, branch_scope_label),
             tuple('repository', repository_value, repository_label),
             tuple('project', project_value, project_label),
-            tuple('source_id', toString(source_id), toString(source_id)),
+            tuple('source_id', coalesce(toString(source_id), ''), coalesce(toString(source_id), '')),
             tuple('source', source_value, source_label)
         ]
         AS Array(Tuple(key String, value String, label Nullable(String)))

--- a/src/ingestion/gold/git_authored_commits.sql
+++ b/src/ingestion/gold/git_authored_commits.sql
@@ -51,6 +51,7 @@ SELECT
             tuple('branch_scope', branch_scope_value, branch_scope_label),
             tuple('repository', repository_value, repository_label),
             tuple('project', project_value, project_label),
+            tuple('source_id', toString(source_id), toString(source_id)),
             tuple('source', source_value, source_label)
         ]
         AS Array(Tuple(key String, value String, label Nullable(String)))

--- a/src/ingestion/gold/git_metric_evidence.sql
+++ b/src/ingestion/gold/git_metric_evidence.sql
@@ -221,7 +221,7 @@ file_changes_source AS (
                 tuple('change_type', change_type, change_type_label),
                 tuple('repository', repository_value, repository_label),
                 tuple('project', commits.project_value, commits.project_label),
-                tuple('source_id', toString(commits.source_id), toString(commits.source_id)),
+                tuple('source_id', coalesce(toString(commits.source_id), ''), coalesce(toString(commits.source_id), '')),
                 tuple('source', commits.source_value, commits.source_label)
             ] AS Array(Tuple(key String, value String, label Nullable(String)))
         ) AS file_source_dimensions,
@@ -233,7 +233,7 @@ file_changes_source AS (
                 tuple('change_type', change_type, change_type_label),
                 tuple('repository', repository_value, repository_label),
                 tuple('project', commits.project_value, commits.project_label),
-                tuple('source_id', toString(commits.source_id), toString(commits.source_id)),
+                tuple('source_id', coalesce(toString(commits.source_id), ''), coalesce(toString(commits.source_id), '')),
                 tuple('source', commits.source_value, commits.source_label)
             ] AS Array(Tuple(key String, value String, label Nullable(String)))
         ) AS category_source_dimensions
@@ -408,7 +408,7 @@ pull_requests_source AS (
                 tuple('destination_branch', destination_branch_value, destination_branch_label),
                 tuple('repository', repository_value, repository_label),
                 tuple('project', project_value, project_label),
-                tuple('source_id', toString(source_id), toString(source_id)),
+                tuple('source_id', coalesce(toString(source_id), ''), coalesce(toString(source_id), '')),
                 tuple('source', source_value, source_label)
             ]
             AS Array(Tuple(key String, value String, label Nullable(String)))
@@ -724,7 +724,7 @@ SELECT
     CAST(NULL AS Nullable(String)) AS subject_key,
     source_dimensions AS dimensions,
     map(
-        'source_id', toString(source_id),
+        'source_id', coalesce(toString(source_id), ''),
         'ref', commit_hash,
         'title', message,
         'repository', repository_label,
@@ -770,7 +770,7 @@ SELECT
     CAST(NULL AS Nullable(String)) AS subject_key,
     source_dimensions AS dimensions,
     map(
-        'source_id', toString(source_id),
+        'source_id', coalesce(toString(source_id), ''),
         'ref', toString(pr_number),
         'title', title,
         'repository', repository_label,

--- a/src/ingestion/gold/git_metric_evidence.sql
+++ b/src/ingestion/gold/git_metric_evidence.sql
@@ -146,6 +146,7 @@ authored_commit_file_lines AS (
 authored_commits AS (
     SELECT
         commits.tenant_id AS tenant_id,
+        commits.source_id AS source_id,
         commits.entity_id AS entity_id,
         commits.metric_date AS metric_date,
         commits.observed_at AS observed_at,
@@ -220,6 +221,7 @@ file_changes_source AS (
                 tuple('change_type', change_type, change_type_label),
                 tuple('repository', repository_value, repository_label),
                 tuple('project', commits.project_value, commits.project_label),
+                tuple('source_id', toString(commits.source_id), toString(commits.source_id)),
                 tuple('source', commits.source_value, commits.source_label)
             ] AS Array(Tuple(key String, value String, label Nullable(String)))
         ) AS file_source_dimensions,
@@ -231,6 +233,7 @@ file_changes_source AS (
                 tuple('change_type', change_type, change_type_label),
                 tuple('repository', repository_value, repository_label),
                 tuple('project', commits.project_value, commits.project_label),
+                tuple('source_id', toString(commits.source_id), toString(commits.source_id)),
                 tuple('source', commits.source_value, commits.source_label)
             ] AS Array(Tuple(key String, value String, label Nullable(String)))
         ) AS category_source_dimensions
@@ -405,6 +408,7 @@ pull_requests_source AS (
                 tuple('destination_branch', destination_branch_value, destination_branch_label),
                 tuple('repository', repository_value, repository_label),
                 tuple('project', project_value, project_label),
+                tuple('source_id', toString(source_id), toString(source_id)),
                 tuple('source', source_value, source_label)
             ]
             AS Array(Tuple(key String, value String, label Nullable(String)))
@@ -431,6 +435,7 @@ pull_requests_source AS (
 pull_request_measures AS (
     SELECT
         tenant_id,
+        source_id,
         pr_id,
         pr_number,
         title,
@@ -719,6 +724,7 @@ SELECT
     CAST(NULL AS Nullable(String)) AS subject_key,
     source_dimensions AS dimensions,
     map(
+        'source_id', toString(source_id),
         'ref', commit_hash,
         'title', message,
         'repository', repository_label,
@@ -764,6 +770,7 @@ SELECT
     CAST(NULL AS Nullable(String)) AS subject_key,
     source_dimensions AS dimensions,
     map(
+        'source_id', toString(source_id),
         'ref', toString(pr_number),
         'title', title,
         'repository', repository_label,

--- a/src/ingestion/gold/task_metric_evidence.sql
+++ b/src/ingestion/gold/task_metric_evidence.sql
@@ -309,7 +309,11 @@ SELECT
     toNullable(contribution) AS contribution,
     CAST(NULL AS Nullable(String)) AS subject_key,
     type_dimensions AS dimensions,
-    map('ref', id_readable, 'title', ifNull(title, '')) AS details
+    map(
+        'source_id', toString(insight_source_id),
+        'ref', id_readable,
+        'title', ifNull(title, '')
+    ) AS details
 FROM issue_item_evidence
 WHERE tenant_id IS NOT NULL
   AND entity_id IS NOT NULL
@@ -333,7 +337,11 @@ SELECT
     toNullable(toFloat64(duration_measure.2)) AS contribution,
     CAST(NULL AS Nullable(String)) AS subject_key,
     type_dimensions AS dimensions,
-    map('ref', id_readable, 'title', ifNull(title, '')) AS details
+    map(
+        'source_id', toString(insight_source_id),
+        'ref', id_readable,
+        'title', ifNull(title, '')
+    ) AS details
 FROM issue_facts
 ARRAY JOIN arrayConcat(
     if(ifNull(dev_seconds, 0) > 0, [tuple('dev_time_hours', toFloat64(dev_seconds / 3600.0))], []),

--- a/tests/stand/api/schemas/analytics.py
+++ b/tests/stand/api/schemas/analytics.py
@@ -241,6 +241,7 @@ class MetricDimensionDto(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
+    href: str | None = None
     key: str
     label: str | None = None
     value: str
@@ -363,6 +364,7 @@ class MetricDrilldownRow(BaseModel):
     model_config = ConfigDict(
         extra='forbid',
     )
+    links: dict[str, str]
     values: dict[str, Any]
 
 


### PR DESCRIPTION
**Why.** Metric evidence links are hardcoded to github.com, so self-hosted and non-GitHub records cannot open their source pages.

**What changed.** Analytics now resolves configured per-source URLs for GitHub, GitLab, Bitbucket Cloud, Jira, and YouTrack, returns link metadata through metric APIs, and the frontend renders it without provider-specific routing.

**Backend owns link construction.** This keeps provider routes out of the frontend; leaving the registry empty restores plain-text behavior.

**Evidence.** Synthetic resolver coverage exercises all five provider families; frontend link rendering has 53 passing tests.

**Out of scope.** Connector reconciliation remains unchanged; deployment configuration temporarily duplicates connector URLs and source IDs.

**Verified.** 576 analytics tests, Clippy, 53 frontend tests, typecheck, dbt parse, Helm tests and lint, plus OpenAPI and generated-schema drift checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable external sources for GitHub, GitLab, Bitbucket Cloud, Jira, and YouTrack.
  * Analytics results now provide direct repository, record, and dimension links.
  * Metric drilldown rows and activity events expose relevant link metadata.
  * Links open associated external resources when available.

* **Bug Fixes**
  * Improved link accuracy using source-specific configuration and identifiers.
  * Preserved plain-text display when no link is available.
  * Added validation for external source URLs and duplicate source identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->