### PR TITLE
feat(ingestion): add the Compass connector for service ownership

### DIFF
--- a/scripts/ci/components.py
+++ b/scripts/ci/components.py
@@ -239,10 +239,17 @@ COMPONENTS = [
         "pytest_args": "--suites-only",
         "cover": False,
         "triggered_by": ["connector-tests-harness"],
+        # Every nocode connector that ships a tests/ suite belongs here, or a
+        # change to that connector does not re-run its own mock tests. CDK
+        # connectors with suites (hubspot, gitlab, bamboohr, …) are covered by
+        # their own components instead.
         "paths": [
             "src/ingestion/connectors/task-tracking/jira",
             "src/ingestion/connectors/git/github",
             "src/ingestion/connectors/git/bitbucket-cloud",
+            "src/ingestion/connectors/git/github-directory",
+            "src/ingestion/connectors/collaboration/zoom",
+            "src/ingestion/connectors/dev-portal/compass",
         ],
     },
     # `src/frontend/helm` falls under this path but has no measured lines, so it

--- a/src/ingestion/connectors/dev-portal/compass/README.md
+++ b/src/ingestion/connectors/dev-portal/compass/README.md
@@ -140,6 +140,13 @@ this data has to respect them.
   component has exactly one owner.
 - **`teams.member_count` is not populated** by the search field this stream
   uses; count `team_members` rows instead.
+- **A failed catalog query fails the sync; one unreadable component does not.**
+  Most fields return a union, so a refusal arrives as a *successful* body with a
+  `message` and no rows. Where an empty answer would be indistinguishable from
+  "there is nothing" — the catalog, the scorecards, the team directory and its
+  membership — the connector fails loudly. A single component that vanished
+  between the catalog sweep and its event read is skipped instead, and the other
+  components continue.
 - **`component_scorecard_scores` rides an experimental field** and needs the
   `@optIn(to: "compass-beta")` directive. Every other stream is on stable
   fields, so if beta churn breaks it, it can be dropped without affecting the

--- a/src/ingestion/connectors/dev-portal/compass/README.md
+++ b/src/ingestion/connectors/dev-portal/compass/README.md
@@ -1,0 +1,157 @@
+# Compass Connector
+
+Extracts the Atlassian Compass service catalog — components, their owning
+teams, repository links, dependency edges, scorecard results and deployment
+events — plus the Atlassian Teams directory those owners come from. Everything
+is read from one GraphQL endpoint with Basic auth (Atlassian account email +
+API token).
+
+Design rationale, traversal contracts and the history strategy live in
+[SPEC.md](SPEC.md). Read it before changing a query — several fields in this API
+behave in ways that a reasonable reading of the schema does not predict.
+
+## Prerequisites
+
+1. An Atlassian account with **Compass product access** on the site.
+2. An API token for that account: id.atlassian.com → Security → API tokens.
+   No OAuth application and no additional scopes are needed; the Teams streams
+   work on the same credential.
+3. The site's **cloud id**, which every Compass field requires:
+
+   ```bash
+   curl -s https://<your-site>.atlassian.net/_edge/tenant_info
+   ```
+
+   It is not discoverable through the GraphQL gateway, so it is configuration
+   rather than something the connector can look up.
+
+## K8s Secret
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-compass-main
+  labels:
+    app.kubernetes.io/part-of: insight
+  annotations:
+    insight.cyberfabric.com/connector: compass
+    insight.cyberfabric.com/source-id: compass-main
+type: Opaque
+stringData:
+  atlassian_email: "CHANGE_ME"
+  atlassian_api_token: "CHANGE_ME"
+  atlassian_cloud_id: "CHANGE_ME"
+```
+
+### Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `atlassian_email` | Yes | Account email owning the token; the Basic-auth username. |
+| `atlassian_api_token` | Yes | Atlassian account API token. |
+| `atlassian_cloud_id` | Yes | Site identifier (see Prerequisites). Also the basis of the site-scoped ARI the Teams streams pass as `scopeId`. |
+
+> **Note on `username` / `password` spec fields.** This manifest uses
+> `BasicHttpAuthenticator`, so importing it into the Airbyte Builder adds
+> `username` and `password` to `spec.connection_specification`. Those are
+> Builder artifacts mapped from the authenticator's config references — do NOT
+> put them in the Secret. The real credentials are the `atlassian_*` fields.
+
+### Automatically injected
+
+| Field | Source |
+|-------|--------|
+| `insight_tenant_id` | `tenant_id` from tenant YAML |
+| `insight_source_id` | `insight.cyberfabric.com/source-id` annotation |
+
+### Local development
+
+```bash
+cp src/ingestion/secrets/connectors/compass.yaml.example src/ingestion/secrets/connectors/compass.yaml
+# Fill in real values, then apply:
+kubectl apply -f src/ingestion/secrets/connectors/compass.yaml
+```
+
+## Streams
+
+| Stream | Description | Sync Mode |
+|--------|-------------|-----------|
+| `components` | The catalog: id, name, type, description, owning team, plus `labels`, `links`, `event_sources` and `relationships` nested in the same row | Full refresh |
+| `scorecards` | Scorecard definitions with their criteria (weights, comparators, thresholds) as JSON | Full refresh |
+| `component_scorecard_scores` | One row per component × scorecard: total, status band, per-criterion breakdown | Full refresh |
+| `teams` | The Atlassian Teams directory | Full refresh |
+| `team_members` | One row per team × person, with role and membership state | Full refresh |
+| `deployment_events` | Compass events of type `DEPLOYMENT`, per component | Incremental (`last_updated`) |
+
+Nested-in-row rather than separate streams: `links`, `labels`, `event_sources`
+and `relationships` all arrive inside the catalog sweep, so splitting them into
+their own streams would re-query the same data purely to reshape it. Flattening
+belongs in dbt, where `ARRAY JOIN` costs nothing.
+
+### Ownership join
+
+`components.owner_team_id` is an ARI of the form
+`ari:cloud:identity::team/<uuid>`; the UUID inside it is the same identifier
+that `teams.team_id` carries and that Jira's `atlassian-team` custom field
+stores. The three are one directory entity, joinable exactly with no name
+matching.
+
+`links` entries of type `REPOSITORY` are the join to the git sources. The git
+connectors do not persist `html_url` / `web_url` into staging, so the only
+cross-connector repo key is `class_git_repositories.full_name` — the link URL
+has to be parsed (host selects which `data_source` to match, path becomes the
+candidate `full_name`). Treat that parse as lossy and keep the raw URL.
+
+### People join
+
+The Teams API exposes **no `email` field** on the user type, so `team_members`
+joins to people by the Atlassian account id embedded in `member_id`
+(`ari:cloud:identity::user/<accountId>`), not by email as most other connectors
+do. If the target people relation does not carry Atlassian account ids, this
+join cannot be made and the component → team → person chain stops at the team.
+
+## Caveats
+
+These are properties of the source, not bugs to fix here. Anything built on
+this data has to respect them.
+
+- **A `DEPLOYMENT` event does not imply a release.** Any tool can publish
+  events of that type through an external event source, and an integration may
+  map build or artifact events onto it with a non-production
+  `environment_category`. Key release metrics on
+  `environment_category = 'PRODUCTION'`; everything else is build or
+  pre-production activity and must not be presented as a release.
+- **The event feed is a rolling window (~2 weeks) with no backfill.** A missed
+  sync loses events permanently — that is why the schedule is daily and why
+  failures here are not "catch up tomorrow".
+- **Event rows are rewritten in place** as a deployment progresses, so
+  `update_sequence_number` is the dedup discriminator and `completed_at` may
+  never be filled for events whose terminal state never arrives.
+- **Scorecard scores measure integration coverage as much as health.**
+  Metric-backed criteria score zero wherever the integration feeding the metric
+  is absent, which is indistinguishable from genuine failure at the score
+  level. Use `criteria_scores[].dataSourceLastUpdated` to tell them apart, or
+  restrict to criteria that Compass evaluates intrinsically (owner,
+  description, link presence).
+- **Team membership is many-to-many.** A person can belong to several teams, so
+  per-person aggregation through membership needs an explicit apportionment
+  rule or it double-counts. Component ownership has no such problem — a
+  component has exactly one owner.
+- **`teams.member_count` is not populated** by the search field this stream
+  uses; count `team_members` rows instead.
+- **`component_scorecard_scores` rides an experimental field** and needs the
+  `@optIn(to: "compass-beta")` directive. Every other stream is on stable
+  fields, so if beta churn breaks it, it can be dropped without affecting the
+  rest.
+
+## Silver Targets
+
+None yet — this connector is **bronze-only**. `dbt/` carries just the bronze→RMT
+promotion, which makes later `FINAL` reads well-defined (load-bearing for
+`deployment_events`, whose rows are replaced rather than appended).
+
+Proposed silver class families are sketched in [SPEC.md](SPEC.md) §7 and
+deliberately deferred: they introduce a service-ownership concept that does not
+exist in silver today, and the teams half needs a decision from the identity
+owners before a third representation of org structure lands in the warehouse.

--- a/src/ingestion/connectors/dev-portal/compass/SPEC.md
+++ b/src/ingestion/connectors/dev-portal/compass/SPEC.md
@@ -4,27 +4,6 @@ Status: **implemented (bronze-only).** Manifest, descriptor, bronze→RMT
 promotion and mock suites are in place; every stream has been read against a
 live site. Silver is deliberately deferred (see §7).
 
-Deltas from the original design, all forced by what the API actually does — the
-tables below already reflect them:
-
-- `component_links` and `component_relationships` are **not** separate streams.
-  Links, labels, event sources and dependency edges all arrive inside the
-  catalog sweep, so splitting them would re-query the same data to reshape it;
-  they are JSON columns on `components` and flatten in dbt. The nested
-  relationship list cannot be paginated, hence `relationships_truncated`.
-- `appliedToComponents` caps page size at **25**. Asking for more fails the sync
-  outright (HTTP 200 + `errors[]`), it does not clamp.
-- `scorecards.scoringStrategyType` turned out to be beta-gated and was dropped,
-  keeping the `scorecards` stream entirely on stable fields.
-- Teams are enumerated with `teamSearchV3` and a site-scoped ARI derived from the
-  cloud id, so no organization id has to be configured.
-- Paginator path expressions are null-safe. A component that resolves to
-  `QueryError` has no `events` and therefore no `pageInfo`; the naive path
-  raised "'None' has no attribute 'pageInfo'" and killed those partitions.
-- Nullable timestamps carry **no** `value_type`. With it, a Jinja `none` renders
-  as the four-character text "None", so a never-completed deployment would carry
-  a fake timestamp instead of a null.
-
 Source: Atlassian Compass (internal developer portal — a catalog of software
 components) plus the Atlassian Teams directory that Compass uses for component
 ownership. One connector covers both; see [Placement](#8-placement).
@@ -33,7 +12,7 @@ All examples below are synthetic.
 
 ## 1. Scope
 
-In scope — seven streams:
+In scope — six streams:
 
 | Stream | Grain |
 | --- | --- |
@@ -89,8 +68,9 @@ per site:
 GET <atlassian_instance_url>/_edge/tenant_info  ->  {"cloudId": "..."}
 ```
 
-The Teams fields additionally need the organization id, which is read off any
-resolved team (`TeamV2.organizationId`).
+The Teams fields take a site-scoped ARI rather than a second identifier:
+`ari:cloud:platform::site/<cloudId>`. The instance URL is only ever used
+out-of-band, to read the cloud id above — it is not a connector setting.
 
 ### 2.2 Protocol rules that shape the manifest
 
@@ -136,8 +116,7 @@ position nor the `X-ExperimentalApi` header works.
 | `TeamV2.hierarchy` | `Team-hierarchy` | (out of scope for v1) |
 
 **Risk to record explicitly:** experimental fields may change shape without a
-deprecation cycle. `components`, `component_links`,
-`component_relationships`, `scorecards`, `teams`, `team_members` and
+deprecation cycle. `components`, `scorecards`, `teams`, `team_members` and
 `deployment_events` are all reachable on stable fields. Only
 `component_scorecard_scores` (and the optional history backfill) depend on
 beta. If beta stability becomes a problem, that one stream can be dropped
@@ -155,8 +134,8 @@ teams                           [root        · full refresh]
 
 components                      [root        · full refresh]
 │      ownerId ───────────────► teams.id
-│      links[] ────────────────► component_links (flattened from the same response)
-├─► component_relationships     [substream: partition = component_id · full refresh]
+│      links[] · labels[] · event_sources[] · relationships[]  — JSON columns,
+│      all carried by the same catalog response
 ├─► component_scorecard_scores  [traversed via scorecards, not components · full refresh]
 └─► deployment_events           [substream: partition = component_id · INCREMENTAL]
 ```
@@ -205,19 +184,19 @@ query components($cloudId: String!, $after: String) {
 
 Sync: full refresh. `unique_key = id`.
 
-### 3.3 `component_links`
+### 3.3 Links (a column, not a stream)
 
-Flattened from `components.links[]` — no extra requests.
+Links arrive with the catalog sweep and land as the `links` JSON column on
+`components`. Each entry:
 
 | Field | Type | Note |
 | --- | --- | --- |
-| `component_id` | `ID!` | FK |
 | `id` | `ID!` | link id |
 | `type` | `CompassLinkType` | `REPOSITORY` / `PROJECT` / `DASHBOARD` / `CHAT_CHANNEL` / `ON_CALL` / `OTHER_LINK` |
 | `url` | `URL!` | |
 | `name` | `String` | |
 
-`unique_key = (component_id, id)`.
+dbt flattens the column with `ARRAY JOIN`, keyed `(component_id, id)`.
 
 `REPOSITORY` links are the join to the git sources. The git connectors do not
 persist `html_url` / `web_url` into staging, so the only cross-connector repo
@@ -226,13 +205,16 @@ key is `class_git_repositories.full_name` (`owner/repo`,
 host decides which `data_source` to match against, path becomes the candidate
 `full_name`. Treat the parse as lossy and keep the raw URL in bronze.
 
-### 3.4 `component_relationships`
+### 3.4 Dependency edges (a column, not a stream)
+
+Dependency edges are requested inside the catalog sweep and land as the
+`relationships` JSON column on `components`:
 
 ```graphql
-relationships(query: {first: 100, after: $after}) {
+relationships(query: {first: 100}) {
   ... on CompassRelationshipConnection {
     nodes { relationshipType startNode { id } endNode { id } }
-    pageInfo { hasNextPage endCursor }
+    pageInfo { hasNextPage }
   }
 }
 ```
@@ -243,7 +225,13 @@ relationships(query: {first: 100, after: $after}) {
 | `startNode.id` | `ID` |
 | `endNode.id` | `ID` |
 
-Sync: full refresh. `unique_key = (start_node_id, end_node_id, relationship_type)`.
+Asking each component for its edges separately would cost one request per
+component for data the catalog query already returns. The trade is that a
+nested list cannot be paginated: `pageInfo.hasNextPage` is therefore carried
+out as the `relationships_truncated` column, so a component with more edges
+than the query asked for is a visible row rather than silent edge loss. Nothing
+in the catalog is expected to approach that bound; if the column is ever true,
+the edges want a substream of their own.
 
 ### 3.5 `scorecards`
 
@@ -282,7 +270,7 @@ query scores($cloudId: ID!, $after: String) {
       ... on CompassScorecardConnection {
         nodes {
           id
-          appliedToComponents(query: {first: 100, after: $after}) @optIn(to: "compass-beta") {
+          appliedToComponents(query: {first: 25, after: $after}) @optIn(to: "compass-beta") {
             ... on CompassScorecardAppliedToComponentsConnection {
               totalCount
               edges {
@@ -298,8 +286,10 @@ query scores($cloudId: ID!, $after: String) {
               }
               pageInfo { hasNextPage endCursor }
             }
+            ... on QueryError { message }
           }
         }
+        ... on QueryError { message }
       }
     }
   }
@@ -342,23 +332,25 @@ Compass concept and not a Jira concept: Compass references it from
 the Jira field — how densely it is populated is a per-site configuration
 choice, whereas Compass ownership is enforced by scorecards.
 
-Enumeration (stable, no opt-in):
+Enumeration (stable, no opt-in). The scope is an ARI built from the configured
+cloud id, so no separate organization id has to be supplied:
 
 ```graphql
-query teams($organizationId: ID!, $siteId: String!, $after: String) {
+query insightTeams($scopeId: ID!, $cursor: String) {
   team {
-    teamSearchV2(organizationId: $organizationId, siteId: $siteId,
-                 first: 50, after: $after,
+    teamSearchV3(scopeId: $scopeId, first: 50, after: $cursor,
                  enablePagination: true, showEmptyTeams: true) {
-      nodes { team { id displayName state } }
       pageInfo { hasNextPage endCursor }
+      nodes { team { id displayName description state organizationId memberCount isVerified } }
     }
   }
 }
 ```
 
-`teamSearchV2` does not populate `memberCount`; resolve details either in bulk
-via `teamsV2(ids, siteId) @optIn(to: "Team")` or per team via `teamV2`.
+with `scopeId = ari:cloud:platform::site/<atlassian_cloud_id>`.
+
+The search field does not populate `memberCount`; count `team_members` rows, or
+resolve details per team via `teamV2`.
 
 | Field | Type | Note |
 | --- | --- | --- |
@@ -373,8 +365,10 @@ via `teamsV2(ids, siteId) @optIn(to: "Team")` or per team via `teamV2`.
 
 Sync: full refresh. `unique_key = id`. Dated snapshots required.
 
-`teamsTql` / `teamSearchV3` are alternative listing fields; `teamsTql` needs its
-own opt-in and rejects a site-scoped ARI as `scopeId`. Prefer `teamSearchV2`.
+`teamSearchV2` and `teamsTql` are the alternatives. `teamSearchV2` works but
+requires an organization id the connector would otherwise have no way to
+obtain; `teamsTql` needs its own opt-in *and* rejects a site-scoped ARI as
+`scopeId`. Neither is worth the extra configuration.
 
 **A team directory may be fed by an external HR system.** Where it is, team
 names, membership and hierarchy are managed by that sync and are read-only in
@@ -458,7 +452,7 @@ query events($id: ID!, $after: String) {
 | `deploymentProperties.state` | enum | String | `PENDING` / `IN_PROGRESS` / `SUCCESSFUL` / `CANCELLED` / `FAILED` / `ROLLED_BACK` / `UNKNOWN` |
 | `deploymentProperties.environment.category` | enum | String | `PRODUCTION` / `STAGING` / `TESTING` / `DEVELOPMENT` / `UNMAPPED` |
 | `deploymentProperties.environment.displayName`, `.environmentId` | `String` | String | |
-| `deploymentProperties.startedAt`, `.completedAt` | `DateTime` | Nullable(DateTime64) | duration; `completedAt` may stay null |
+| `deploymentProperties.startedAt`, `.completedAt` | `DateTime` | Nullable(DateTime64) | duration; `completedAt` may stay null — see the `value_type` note below |
 | `deploymentProperties.sequenceNumber` | `Long` | UInt64 | source-side ordinal |
 | `deploymentProperties.pipeline` | object | JSON | `{pipelineId, displayName, url}` |
 
@@ -466,6 +460,12 @@ Sync: incremental on `lastUpdated`. `unique_key = (component_id,
 update_sequence_number)`. One event is updated in place as it progresses, so the
 ReplacingMergeTree version must be `lastUpdated` (or the sequence number), and
 read-time dedup must pick the latest.
+
+A nullable timestamp must be added **without** `value_type: string`. With it, a
+Jinja `none` renders as the four-character text `"None"` and is stored as a
+value, so a deployment that never completed would carry a fake timestamp rather
+than a null. Without it the CDK literal-evaluates `"None"` back to a null, and a
+real timestamp — which is not a Python literal — stays the string it was.
 
 Three properties of this stream that the manifest and the silver models both
 have to respect:
@@ -510,6 +510,13 @@ back truncated with `hasNextPage: true` on every team, including teams whose
 members all fit. Per-team `teamV2(...).members(...)` paginates exactly and
 reconciles with `memberCount`. Enumerate teams in bulk; fetch members per team.
 
+**Every paginator path expression must be null-safe.** The cursor is read out of
+the response by path, and a union that resolved to `QueryError` has no
+connection under it — so a plain `response['data'][...]['pageInfo']` raises
+`'None' has no attribute 'pageInfo'` and kills that partition. Guard each hop
+(`(… or {}).get(…)`), and let the stream's error handler (§2.2) decide whether
+the union error is fatal or skippable.
+
 ## 5. History
 
 Compass and Teams emit **no change events and no field-level audit**. Scorecard
@@ -529,7 +536,7 @@ diffs to **materialise in silver**.
 | `teams` | diff on `displayName`, `state` | renames must not retroactively rename history |
 | `scorecards` | **dated snapshots of the definition** | weights renormalise to 100, so a score drop is ambiguous — a service degrading and a criterion being added look identical. Only a definition snapshot for the same date separates them |
 | `component_scorecard_scores` | dated snapshots, never collapsed | the series *is* the deliverable |
-| `component_relationships` | latest only | no historical metric depends on past dependency graphs |
+| `components.relationships` | latest only | no historical metric depends on past dependency graphs |
 | `deployment_events` | events, RMT by `update_sequence_number` | not applicable — already a log |
 
 **Asymmetry to plan around:** score history is backfillable from the API (see
@@ -557,10 +564,9 @@ Per daily sync, as a function of catalog size:
 
 | Stream | Requests |
 | --- | --- |
-| `components` (+ links, labels, event sources) | `ceil(N_components / 100)` |
-| `component_relationships` | `O(N_components)` — batch inside the component sweep where the response size allows |
+| `components` (+ links, labels, event sources, dependency edges) | `ceil(N_components / 100)` |
 | `scorecards` | 1 |
-| `component_scorecard_scores` | `sum over scorecards of ceil(applied_components / 100)` |
+| `component_scorecard_scores` | `sum over scorecards of ceil(applied_components / 25)` — the field caps page size at 25 |
 | `teams` | `ceil(N_teams / 50)` + 1 bulk resolve |
 | `team_members` | `O(N_teams)` |
 | `deployment_events` | `O(N_components)` — one page for a quiet component, several for a busy one |
@@ -604,7 +610,7 @@ matches and keep the unmatched rows visible rather than dropping them.
 | Descriptor version | `1.0.0`, strict semver |
 | Bronze namespace | `bronze_compass` |
 | Schedule | daily; `deployment_events` sets the floor, since a missed run loses events |
-| Secret fields | `atlassian_instance_url`, `atlassian_email`, `atlassian_api_token` |
+| Secret fields | `atlassian_email`, `atlassian_api_token`, `atlassian_cloud_id` |
 | `dbt_select` | `tag:compass+` |
 
 Teams streams live in this connector rather than in their own: same host, same

--- a/src/ingestion/connectors/dev-portal/compass/SPEC.md
+++ b/src/ingestion/connectors/dev-portal/compass/SPEC.md
@@ -1,0 +1,646 @@
+# Compass + Atlassian Teams connector — design spec
+
+Status: **implemented (bronze-only).** Manifest, descriptor, bronze→RMT
+promotion and mock suites are in place; every stream has been read against a
+live site. Silver is deliberately deferred (see §7).
+
+Deltas from the original design, all forced by what the API actually does — the
+tables below already reflect them:
+
+- `component_links` and `component_relationships` are **not** separate streams.
+  Links, labels, event sources and dependency edges all arrive inside the
+  catalog sweep, so splitting them would re-query the same data to reshape it;
+  they are JSON columns on `components` and flatten in dbt. The nested
+  relationship list cannot be paginated, hence `relationships_truncated`.
+- `appliedToComponents` caps page size at **25**. Asking for more fails the sync
+  outright (HTTP 200 + `errors[]`), it does not clamp.
+- `scorecards.scoringStrategyType` turned out to be beta-gated and was dropped,
+  keeping the `scorecards` stream entirely on stable fields.
+- Teams are enumerated with `teamSearchV3` and a site-scoped ARI derived from the
+  cloud id, so no organization id has to be configured.
+- Paginator path expressions are null-safe. A component that resolves to
+  `QueryError` has no `events` and therefore no `pageInfo`; the naive path
+  raised "'None' has no attribute 'pageInfo'" and killed those partitions.
+- Nullable timestamps carry **no** `value_type`. With it, a Jinja `none` renders
+  as the four-character text "None", so a never-completed deployment would carry
+  a fake timestamp instead of a null.
+
+Source: Atlassian Compass (internal developer portal — a catalog of software
+components) plus the Atlassian Teams directory that Compass uses for component
+ownership. One connector covers both; see [Placement](#8-placement).
+
+All examples below are synthetic.
+
+## 1. Scope
+
+In scope — seven streams:
+
+| Stream | Grain |
+| --- | --- |
+| `components` | one component (service / library / application / other) |
+| `scorecards` | one scorecard definition, with its criteria |
+| `component_scorecard_scores` | one component x scorecard result |
+| `teams` | one team in the Atlassian Teams directory |
+| `team_members` | one team x person membership |
+| `deployment_events` | one event of Compass type `DEPLOYMENT` on a component |
+
+`links`, `labels`, `event_sources` and `relationships` are JSON columns on
+`components` rather than streams of their own — see the deltas above.
+
+Out of scope for v1, with reasons:
+
+- **Metric time series** (`metricValuesTimeSeries`). Compass computes
+  DORA-adjacent metrics per component, but reading them costs one query per
+  metric source per component, and most of these quantities are derivable from
+  data the git and CI sources already deliver.
+- **`PUSH` / `BUILD` / `INCIDENT` events.** Push and build duplicate, at lower
+  fidelity, what the git connectors already carry. Incident coverage depends on
+  an incident-tool integration being wired up; revisit when one is.
+- **Atlassian groups.** A group is an access-control primitive carrying only a
+  name and an id — no owner, no hierarchy, no typed relationship to a team.
+  Group names may resemble team names, but no id linkage exists, so any join
+  would be fuzzy string matching. Groups answer "who has access", which is a
+  different question from ownership.
+- **Team hierarchy** (`TeamV2.hierarchy`). Useful, but adds a fourth
+  experimental opt-in (see [Beta surface](#24-beta-surface)). Add once the
+  base streams are stable.
+
+## 2. Transport
+
+### 2.1 Endpoint and auth
+
+Single GraphQL gateway for every stream:
+
+```
+POST https://api.atlassian.com/graphql
+Authorization: Basic base64(<atlassian_email>:<atlassian_api_token>)
+Content-Type: application/json
+```
+
+An Atlassian account email plus API token is sufficient; no OAuth app and no
+additional grants are required. The token is the same *kind* of credential the
+Jira and Confluence connectors use, but this connector declares its own secret
+(see [Placement](#8-placement)) — the repo has no shared-secret mechanism.
+
+`cloudId` is a required argument on most Compass fields and is discovered once
+per site:
+
+```
+GET <atlassian_instance_url>/_edge/tenant_info  ->  {"cloudId": "..."}
+```
+
+The Teams fields additionally need the organization id, which is read off any
+resolved team (`TeamV2.organizationId`).
+
+### 2.2 Protocol rules that shape the manifest
+
+1. **Operation names are mandatory.** Anonymous queries return a warning that
+   they will be rejected in future. Every `request_body_json.query` must be a
+   named operation.
+2. **Errors arrive as HTTP 200** with a top-level `errors[]` array. The
+   requester needs `HttpResponseFilter` entries keyed on `response['errors']` —
+   the same treatment `git/github-directory` already applies to the GitHub
+   GraphQL API. A predicate that only inspects the status code will treat every
+   failure as a successful empty page.
+3. **Unions everywhere.** Most fields return a union of a connection type and
+   `QueryError`, so every selection needs `... on <Connection>` plus
+   `... on QueryError { message }`. A `QueryError` payload is a *successful*
+   response body carrying a business error — record selectors must not mistake
+   it for data.
+4. **Argument types are inconsistent** between sibling fields (the same logical
+   `cloudId` is `String!` on one field and `ID!` on another). Validate each
+   query against introspection rather than by analogy.
+
+### 2.3 Rate budget
+
+The gateway applies cost-based per-user limiting (points per minute) and
+answers `429` above it. Costs are not published per field, so treat the budget
+as an unknown to be measured, not modelled. Consequences for the manifest:
+
+- keep a conservative `max_concurrency` and a `429` backoff filter;
+- the request count is dominated entirely by `deployment_events`
+  (see [Volume](#6-volume)), so pace that stream rather than the cheap ones.
+
+### 2.4 Beta surface
+
+Several required fields are experimental and need a **field-level** directive —
+`@optIn(to: "<key>")` on the field itself. Neither the query-level directive
+position nor the `X-ExperimentalApi` header works.
+
+| Field | Opt-in key | Needed for |
+| --- | --- | --- |
+| `scorecards(...).appliedToComponents` | `compass-beta` | `component_scorecard_scores` |
+| `componentScorecardRelationship` | `compass-beta` | score history backfill |
+| `scorecardScoreHistories` | `compass-beta` | score history backfill |
+| `teamsV2` | `Team` | bulk team resolve |
+| `TeamV2.hierarchy` | `Team-hierarchy` | (out of scope for v1) |
+
+**Risk to record explicitly:** experimental fields may change shape without a
+deprecation cycle. `components`, `component_links`,
+`component_relationships`, `scorecards`, `teams`, `team_members` and
+`deployment_events` are all reachable on stable fields. Only
+`component_scorecard_scores` (and the optional history backfill) depend on
+beta. If beta stability becomes a problem, that one stream can be dropped
+without touching the rest.
+
+## 3. Streams
+
+### 3.1 Dependency graph
+
+```text
+scorecards                      [dictionary  · full refresh]
+│
+teams                           [root        · full refresh]
+└─► team_members                [substream: partition = team_id · full refresh]
+
+components                      [root        · full refresh]
+│      ownerId ───────────────► teams.id
+│      links[] ────────────────► component_links (flattened from the same response)
+├─► component_relationships     [substream: partition = component_id · full refresh]
+├─► component_scorecard_scores  [traversed via scorecards, not components · full refresh]
+└─► deployment_events           [substream: partition = component_id · INCREMENTAL]
+```
+
+`component_scorecard_scores` is the one substream that is **not** partitioned by
+component: iterating scorecards and reading each scorecard's applied components
+costs `O(scorecards)` requests, whereas asking each component for its scores
+costs `O(components)` — three orders of magnitude apart.
+
+### 3.2 `components`
+
+Root stream. `ownerId`, `links`, `labels` and `eventSources` all come back
+inside the same `searchComponents` sweep, so no per-component follow-up is
+needed for the catalog itself.
+
+```graphql
+query components($cloudId: String!, $after: String) {
+  compass {
+    searchComponents(cloudId: $cloudId, query: {first: 100, after: $after}) {
+      ... on CompassSearchComponentConnection {
+        nodes { component {
+          id name slug type description url ownerId
+          labels { name }
+          links { id type url name }
+          eventSources { id eventType externalEventSourceId }
+        } }
+        pageInfo { hasNextPage endCursor }
+      }
+      ... on QueryError { message }
+    }
+  }
+}
+```
+
+| Field | GraphQL type | Bronze | Note |
+| --- | --- | --- | --- |
+| `id` | `ID!` | String | `ari:cloud:compass:<cloudId>:component/<...>` |
+| `name` | `String!` | String | |
+| `slug` | `String` | String | |
+| `type` | `CompassComponentType` | String | `APPLICATION` / `LIBRARY` / `SERVICE` / `OTHER` |
+| `description` | `String` | Nullable(String) | |
+| `url` | `URL` | Nullable(String) | component page in Compass |
+| `ownerId` | `ID` | Nullable(String) | `ari:cloud:identity::team/<uuid>` — FK to `teams` |
+| `labels[].name` | `String` | Array(String) | |
+| `eventSources[]` | `EventSource` | JSON | `{id, eventType, externalEventSourceId}` — records which event feeds are wired |
+
+Sync: full refresh. `unique_key = id`.
+
+### 3.3 `component_links`
+
+Flattened from `components.links[]` — no extra requests.
+
+| Field | Type | Note |
+| --- | --- | --- |
+| `component_id` | `ID!` | FK |
+| `id` | `ID!` | link id |
+| `type` | `CompassLinkType` | `REPOSITORY` / `PROJECT` / `DASHBOARD` / `CHAT_CHANNEL` / `ON_CALL` / `OTHER_LINK` |
+| `url` | `URL!` | |
+| `name` | `String` | |
+
+`unique_key = (component_id, id)`.
+
+`REPOSITORY` links are the join to the git sources. The git connectors do not
+persist `html_url` / `web_url` into staging, so the only cross-connector repo
+key is `class_git_repositories.full_name` (`owner/repo`,
+`group/subgroup/repo`, `workspace/repo`). The URL therefore has to be parsed:
+host decides which `data_source` to match against, path becomes the candidate
+`full_name`. Treat the parse as lossy and keep the raw URL in bronze.
+
+### 3.4 `component_relationships`
+
+```graphql
+relationships(query: {first: 100, after: $after}) {
+  ... on CompassRelationshipConnection {
+    nodes { relationshipType startNode { id } endNode { id } }
+    pageInfo { hasNextPage endCursor }
+  }
+}
+```
+
+| Field | Type |
+| --- | --- |
+| `relationshipType` | `String!` (enum currently has a single member, `DEPENDS_ON`) |
+| `startNode.id` | `ID` |
+| `endNode.id` | `ID` |
+
+Sync: full refresh. `unique_key = (start_node_id, end_node_id, relationship_type)`.
+
+### 3.5 `scorecards`
+
+A scorecard is a weighted checklist evaluated automatically against a
+component: criteria assert that a field is filled, that an owner or a link of a
+given type exists, or that a metric satisfies a comparator. Criterion weights
+are normalised to a total of 100.
+
+| Field | Type | Note |
+| --- | --- | --- |
+| `id` | `ID!` | |
+| `name` | `String!` | |
+| `description` | `String` | |
+| `state` | enum | `PUBLISHED` / `DRAFT` |
+| `importance` | enum | `REQUIRED` / `RECOMMENDED` / `USER_DEFINED` |
+| `scoringStrategyType`, `scoreSystem` | | keep as raw strings |
+| `changeMetadata` | object | `createdAt`, `createdBy`, `lastUserModificationAt`, `lastUserModificationBy` |
+| `criterias[]` | interface | per criterion: `id: ID!`, `weight: Int!`, `name: String`, `__typename` (the check kind), plus kind-specific fields — `linkType` for link checks, `comparator` + `comparatorValue` + `metricDefinition.name` for metric checks |
+
+Store `criterias[]` as JSON in bronze and flatten in silver: the criterion
+subtypes are an open set (`HasOwner`, `HasDescription`, `HasLink`,
+`HasMetricValue`, `HasCustom*Field`, ...) and a typed column per subtype would
+churn.
+
+`criterias[].description` is beta-gated — omit it.
+
+Sync: full refresh. `unique_key = id`. **Dated snapshots required** — see
+[History](#5-history).
+
+### 3.6 `component_scorecard_scores`
+
+```graphql
+query scores($cloudId: ID!, $after: String) {
+  compass {
+    scorecards(cloudId: $cloudId) {
+      ... on CompassScorecardConnection {
+        nodes {
+          id
+          appliedToComponents(query: {first: 100, after: $after}) @optIn(to: "compass-beta") {
+            ... on CompassScorecardAppliedToComponentsConnection {
+              totalCount
+              edges {
+                node { id }
+                score {
+                  ... on CompassScorecardScore {
+                    totalScore maxTotalScore
+                    status { name lowerBound upperBound }
+                    criteriaScores { criterionId score maxScore status dataSourceLastUpdated }
+                  }
+                  ... on QueryError { message }
+                }
+              }
+              pageInfo { hasNextPage endCursor }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Note the score hangs off the **edge**, not the node.
+
+| Field | Type | Note |
+| --- | --- | --- |
+| `component_id`, `scorecard_id` | `ID!` | |
+| `totalScore` / `maxTotalScore` | `Int!` | normalised to 100 |
+| `status.name` | `String` | `PASSING` / `NEEDS_ATTENTION` / `FAILING` |
+| `criteriaScores[]` | array | `{criterionId, score, maxScore, status, dataSourceLastUpdated}` |
+| `snapshot_date` | Date | stamped by the connector, part of the key |
+
+`dataSourceLastUpdated` says when the metric underneath a criterion last
+refreshed. It is the only way to tell "the criterion genuinely fails" from "the
+metric feeding it went stale", so it must survive into silver.
+
+Sync: full refresh, one snapshot per run. `unique_key = (component_id,
+scorecard_id, snapshot_date)` — snapshots are **not** collapsed; the series is
+the product value.
+
+**Interpretation constraint for downstream consumers.** Metric-backed criteria
+depend on external integrations (coverage, vulnerabilities, quality gates)
+being wired per component. Where such an integration is absent the criterion
+scores zero, which is indistinguishable at the score level from a genuinely
+failing component. Consumers must therefore either restrict to criteria whose
+inputs are Compass-intrinsic (owner / description / link presence), or filter
+on `dataSourceLastUpdated` freshness. A raw average across all scorecards
+measures integration coverage as much as engineering health.
+
+### 3.7 `teams`
+
+The Atlassian Teams directory is an organization-level entity. It is not a
+Compass concept and not a Jira concept: Compass references it from
+`component.ownerId`, and Jira surfaces it as a custom field of type
+`atlassian-team`, both by the same team UUID. Do not plan team attribution off
+the Jira field — how densely it is populated is a per-site configuration
+choice, whereas Compass ownership is enforced by scorecards.
+
+Enumeration (stable, no opt-in):
+
+```graphql
+query teams($organizationId: ID!, $siteId: String!, $after: String) {
+  team {
+    teamSearchV2(organizationId: $organizationId, siteId: $siteId,
+                 first: 50, after: $after,
+                 enablePagination: true, showEmptyTeams: true) {
+      nodes { team { id displayName state } }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+}
+```
+
+`teamSearchV2` does not populate `memberCount`; resolve details either in bulk
+via `teamsV2(ids, siteId) @optIn(to: "Team")` or per team via `teamV2`.
+
+| Field | Type | Note |
+| --- | --- | --- |
+| `id` | `ID!` | `ari:cloud:identity::team/<uuid>` — the same UUID Compass and Jira both reference |
+| `displayName` | `String` | |
+| `description` | `String` | |
+| `state` | `TeamStateV2` | |
+| `organizationId` | `ID` | |
+| `isVerified` | `Boolean` | |
+| `memberCount` | `Int` | not returned by the search field |
+| `type` | `TeamType` | |
+
+Sync: full refresh. `unique_key = id`. Dated snapshots required.
+
+`teamsTql` / `teamSearchV3` are alternative listing fields; `teamsTql` needs its
+own opt-in and rejects a site-scoped ARI as `scopeId`. Prefer `teamSearchV2`.
+
+**A team directory may be fed by an external HR system.** Where it is, team
+names, membership and hierarchy are managed by that sync and are read-only in
+Atlassian. Do not model provenance in this connector: it is a per-deployment
+integration choice, not a property of the entity. Reconciling teams against an
+HR-derived people set is a silver-layer concern.
+
+### 3.8 `team_members`
+
+Per team, paginated:
+
+```graphql
+members(first: 50, after: $after, state: [FULL_MEMBER, ALUMNI, REQUESTING_TO_JOIN]) {
+  nodes { role state member { id name accountStatus } }
+  pageInfo { hasNextPage endCursor }
+}
+```
+
+| Field | Type | Note |
+| --- | --- | --- |
+| `team_id` | `ID!` | FK |
+| `member.id` | `ID!` | `ari:cloud:identity::user/<accountId>` |
+| `member.name` | `String` | |
+| `member.accountStatus` | `String` | deactivated and closed accounts remain listed as members |
+| `role` | enum | `REGULAR` / `ADMIN` |
+| `state` | `TeamMembershipState` | `FULL_MEMBER` / `ALUMNI` / `REQUESTING_TO_JOIN` |
+
+Sync: full refresh, partitioned by `team_id`. `unique_key = (team_id,
+member_id)`. Dated snapshots required.
+
+Two constraints for whoever writes the silver models:
+
+1. **`User` has no `email` field on this API.** The join key to people is the
+   account id. If the target people relation does not carry Atlassian account
+   ids, this stream cannot be joined to it — resolve that before building on it.
+2. **Membership is many-to-many.** A person can belong to several teams, so
+   "a person's team" is a relation, not a function; any per-person aggregation
+   through membership needs an explicit apportionment rule or it double-counts.
+   Ownership does not have this problem: a component has exactly one owner.
+
+### 3.9 `deployment_events`
+
+The only incremental stream.
+
+```graphql
+query events($id: ID!, $after: String) {
+  compass {
+    component(id: $id) {
+      ... on CompassComponent {
+        events(query: {first: 50, after: $after, eventTypes: [DEPLOYMENT]}) {
+          ... on CompassEventConnection {
+            nodes {
+              ... on CompassDeploymentEvent {
+                displayName description url lastUpdated updateSequenceNumber
+                deploymentProperties {
+                  sequenceNumber state startedAt completedAt
+                  environment { category displayName environmentId }
+                  pipeline { pipelineId displayName url }
+                }
+              }
+            }
+            pageInfo { hasNextPage endCursor }
+          }
+          ... on QueryError { message }
+        }
+      }
+    }
+  }
+}
+```
+
+| Field | Type | Bronze | Note |
+| --- | --- | --- | --- |
+| `component_id` | `ID!` | String | from the partition |
+| `eventType` | enum | String | `DEPLOYMENT` for this stream |
+| `displayName` | `String!` | String | |
+| `description` | `String` | Nullable(String) | |
+| `url` | `URL` | Nullable(String) | |
+| `lastUpdated` | `DateTime!` | DateTime64 | **cursor** |
+| `updateSequenceNumber` | `Long!` | UInt64 | monotonic per event; the dedup discriminator |
+| `deploymentProperties.state` | enum | String | `PENDING` / `IN_PROGRESS` / `SUCCESSFUL` / `CANCELLED` / `FAILED` / `ROLLED_BACK` / `UNKNOWN` |
+| `deploymentProperties.environment.category` | enum | String | `PRODUCTION` / `STAGING` / `TESTING` / `DEVELOPMENT` / `UNMAPPED` |
+| `deploymentProperties.environment.displayName`, `.environmentId` | `String` | String | |
+| `deploymentProperties.startedAt`, `.completedAt` | `DateTime` | Nullable(DateTime64) | duration; `completedAt` may stay null |
+| `deploymentProperties.sequenceNumber` | `Long` | UInt64 | source-side ordinal |
+| `deploymentProperties.pipeline` | object | JSON | `{pipelineId, displayName, url}` |
+
+Sync: incremental on `lastUpdated`. `unique_key = (component_id,
+update_sequence_number)`. One event is updated in place as it progresses, so the
+ReplacingMergeTree version must be `lastUpdated` (or the sequence number), and
+read-time dedup must pick the latest.
+
+Three properties of this stream that the manifest and the silver models both
+have to respect:
+
+1. **No server-side date filter is usable.** `timeParameters {startFrom,
+   endAt}` rejects every window tried — 7 days, 90 days, a year, with and
+   without millisecond precision — with a complaint that `endAt` must be within
+   one year of `startFrom`. `startFrom` alone returns nothing; `endAt` alone
+   returns only events on that boundary date. Incremental must therefore be
+   **client-side** on `lastUpdated` (`is_client_side_incremental`), i.e. pages
+   are fetched and records filtered against state. Revisit if Atlassian fixes
+   the filter — a server-side window would cut the request count sharply.
+2. **The feed is a rolling window, roughly two weeks wide.** There is no
+   deeper backfill: whatever is older than the window is gone. A missed sync
+   loses events permanently, so this stream must run at least daily and its
+   failures are not "catch up next run".
+3. **`DEPLOYMENT` does not imply a release.** Any tool can publish events of
+   this type through an external event source, and an integration may
+   legitimately map build or artifact events onto it with a non-production
+   `environment.category`. Both kinds can coexist in one feed, with the
+   non-production ones dominating by volume. Deployment-frequency and lead-time metrics must
+   therefore be keyed on `environment.category = PRODUCTION`; everything else
+   is build or pre-production activity and must not be labelled as releases in
+   any product surface. Check the category distribution before publishing any
+   DORA-shaped metric from this stream.
+
+Pagination is newest-first and the cursor behaves correctly.
+
+## 4. Traversal contracts
+
+Three different mechanisms coexist in this one API. Getting them confused is the
+most likely source of silent data loss.
+
+| Data | Traversal | Trap |
+| --- | --- | --- |
+| components, links, relationships, teams, members, events | `first` / `after` cursor, `pageInfo.hasNextPage` | none — behaves normally |
+| scorecard applied-components | `query: {first, after}` (nested in an input object, not top-level args) | passing `first` as a sibling argument is a validation error |
+| scorecard score history | `query: {filter: {startFrom, periodicity}}` — a **window ending at `startFrom`**; walk backwards by setting the next `startFrom` to (earliest date returned − 1 day) | the `after` cursor is inert here: it returns the same window forever with `hasNextPage: true`. A paginator that trusts `hasNextPage` loops indefinitely |
+
+One further trap: in the **bulk** `teamsV2` form the nested `members` list comes
+back truncated with `hasNextPage: true` on every team, including teams whose
+members all fit. Per-team `teamV2(...).members(...)` paginates exactly and
+reconciles with `memberCount`. Enumerate teams in bulk; fetch members per team.
+
+## 5. History
+
+Compass and Teams emit **no change events and no field-level audit**. Scorecard
+definitions expose only `changeMetadata` — a single "someone changed something"
+timestamp with no diff and no version. Everything historical is therefore
+either a Compass-served series or our own snapshots.
+
+Bronze is append-only with a per-sync `_version`, so a full-refresh stream
+already accumulates dated snapshots for free. The design decision is which
+diffs to **materialise in silver**.
+
+| Stream | Silver treatment | Why |
+| --- | --- | --- |
+| `components.ownerId` | **SCD intervals** `(component_id, owner_team_id, valid_from, valid_to)` | attribution axis: "team X owned component Y at time T". Without it, re-assigning a component silently rewrites all historical attribution |
+| `component_links` (REPOSITORY) | **SCD intervals** | same argument one hop out: commits and PRs attribute to a component through the repo link, so the link must be time-bounded. Can start latest-only and be upgraded later — bronze snapshots accumulate regardless |
+| `team_members` | **SCD intervals** | "person P was in team X at time T"; the same failure mode as ownership |
+| `teams` | diff on `displayName`, `state` | renames must not retroactively rename history |
+| `scorecards` | **dated snapshots of the definition** | weights renormalise to 100, so a score drop is ambiguous — a service degrading and a criterion being added look identical. Only a definition snapshot for the same date separates them |
+| `component_scorecard_scores` | dated snapshots, never collapsed | the series *is* the deliverable |
+| `component_relationships` | latest only | no historical metric depends on past dependency graphs |
+| `deployment_events` | events, RMT by `update_sequence_number` | not applicable — already a log |
+
+**Asymmetry to plan around:** score history is backfillable from the API (see
+below), definition history is not. Definition snapshots therefore start on day
+one of ingestion, and any backfilled score older than that has no matching
+definition — those rows must be marked "criteria set unknown" rather than
+silently compared against today's definition.
+
+### 5.1 Optional one-off score backfill
+
+`componentScorecardRelationship.scorecardScoreHistories` serves
+`{date, totalScore}` per component x scorecard back to `appliedSince`, at
+`DAILY` or `WEEKLY` periodicity, via the windowed traversal described in
+[Traversal](#4-traversal-contracts). `criteriaScoreHistories` serves per-criterion
+`{criterionId, scoreStatus, explanation}` — statuses only, no numbers.
+
+Worth one bootstrap run so the product does not start from an empty series;
+not worth running on a schedule, because the current score already arrives with
+full per-criterion detail in `component_scorecard_scores` at no extra cost.
+Both fields are beta-gated.
+
+## 6. Volume
+
+Per daily sync, as a function of catalog size:
+
+| Stream | Requests |
+| --- | --- |
+| `components` (+ links, labels, event sources) | `ceil(N_components / 100)` |
+| `component_relationships` | `O(N_components)` — batch inside the component sweep where the response size allows |
+| `scorecards` | 1 |
+| `component_scorecard_scores` | `sum over scorecards of ceil(applied_components / 100)` |
+| `teams` | `ceil(N_teams / 50)` + 1 bulk resolve |
+| `team_members` | `O(N_teams)` |
+| `deployment_events` | `O(N_components)` — one page for a quiet component, several for a busy one |
+
+Everything except `deployment_events` lands in the low hundreds of requests
+for a catalog of a few thousand components. `deployment_events` is
+`O(N_components)` with no server-side filter, so it dominates the sync by
+roughly an order of magnitude and sets both the runtime and the rate-limit
+exposure. It is the reason this connector is separate from a heavy tracker
+connector rather than merged into one: the failure domains and the cadences do
+not match.
+
+## 7. Silver
+
+No component or service-ownership concept exists in silver today; this
+introduces one. Proposed families, following the established thin
+`union_by_tag` + `ReplacingMergeTree(_version)` + `order_by=['unique_key']`
++ `delete+insert` shape:
+
+- `class_component_catalog` — components with type, name, description
+- `class_component_ownership` — the SCD ownership intervals
+- `class_component_links` — links, with the parsed repo identity for the git join
+- `class_component_dependencies` — the dependency edges
+- `class_component_scorecards` — definitions (dated) and scores (dated)
+- `class_component_events` — deployment events
+- teams and membership: extend the existing people/org families rather than
+  inventing a parallel org structure — decide with the identity owners before
+  building, since a third representation of org structure is a liability
+
+The repo join is `class_component_links` (parsed `full_name` + host-derived
+`data_source`) against `class_git_repositories.full_name`. Expect partial
+matches and keep the unmatched rows visible rather than dropping them.
+
+## 8. Placement
+
+| Item | Value |
+| --- | --- |
+| Path | `src/ingestion/connectors/dev-portal/compass/` |
+| Category | `dev-portal` — **new**; no existing category covers a developer portal / service catalog. The choice also needs adding to the connector skill's category list |
+| Type | `nocode` (declarative manifest) |
+| Descriptor version | `1.0.0`, strict semver |
+| Bronze namespace | `bronze_compass` |
+| Schedule | daily; `deployment_events` sets the floor, since a missed run loses events |
+| Secret fields | `atlassian_instance_url`, `atlassian_email`, `atlassian_api_token` |
+| `dbt_select` | `tag:compass+` |
+
+Teams streams live in this connector rather than in their own: same host, same
+credential, same cadence, same trivial volume. The connector boundary is a
+sync/deploy/failure boundary, not a consumption boundary — silver models read
+bronze tables, so a future consumer (for example a Jira model that wants the
+Team field resolved) can join these tables regardless of which connector
+produced them.
+
+## 9. Open questions
+
+1. **Category name.** `dev-portal` is proposed; it adds the first new source
+   category in a while and touches the connector skill's fixed list.
+2. **Teams in silver.** Extend the existing people/org families, or a separate
+   `class_team_*` family? Needs the identity owners' call — three
+   representations of org structure in one warehouse is a maintenance risk.
+3. **Account-id join.** Does the target people relation carry Atlassian account
+   ids? If not, `team_members` cannot be joined to people and the
+   component → team → person chain stops at the team.
+4. **`environment.category` distribution.** Decides whether
+   `deployment_events` can support release metrics at all, or only build
+   activity. Answer before any DORA-shaped product surface is built on it.
+5. **Criterion id stability.** Does editing a scorecard criterion preserve its
+   id? If not, "threshold retuned" is indistinguishable from "criterion
+   replaced" in a snapshot diff. Verify on a throwaway scorecard rather than by
+   mutating a live one.
+
+## 10. Delivery checklist
+
+Per the connector skill:
+
+- [ ] `descriptor.yaml` with strict semver, `type: nocode`, namespace, schedule, secret fields, `dbt_select`
+- [ ] `connector.yaml` — declarative manifest; named operations; `errors[]` response filters; per-stream traversal per [Traversal](#4-traversal-contracts)
+- [ ] `connectors-config.yaml` entry (bootstrap-db) — without it the bronze database is never created
+- [ ] `class_people.sql` `depends_on` entry, if any stream feeds people
+- [ ] connectors-ddl snapshot regenerated per the bootstrap-db README
+- [ ] per-stream mock tests — 100% stream coverage, including a `QueryError`-in-200 case and a `hasNextPage`-lies case per [Traversal](#4-traversal-contracts)
+- [ ] `scripts/ci/connector_wiring.py` green
+- [ ] dbt conventions checked (RMT engine, `order_by=['unique_key']`, read-time dedup, `delete+insert` on silver)

--- a/src/ingestion/connectors/dev-portal/compass/SPEC.md
+++ b/src/ingestion/connectors/dev-portal/compass/SPEC.md
@@ -24,7 +24,8 @@ In scope — six streams:
 | `deployment_events` | one event of Compass type `DEPLOYMENT` on a component |
 
 `links`, `labels`, `event_sources` and `relationships` are JSON columns on
-`components` rather than streams of their own — see the deltas above.
+`components` rather than streams of their own — see [Links](#33-links-a-column-not-a-stream)
+and [Dependency edges](#34-dependency-edges-a-column-not-a-stream).
 
 Out of scope for v1, with reasons:
 
@@ -361,7 +362,9 @@ resolve details per team via `teamV2`.
 | `organizationId` | `ID` | |
 | `isVerified` | `Boolean` | |
 | `memberCount` | `Int` | not returned by the search field |
-| `type` | `TeamType` | |
+
+`TeamV2.type` is deliberately not selected: it is an object needing its own
+subselection, and nothing downstream asks what kind of team a team is.
 
 Sync: full refresh. `unique_key = id`. Dated snapshots required.
 
@@ -642,11 +645,12 @@ produced them.
 
 Per the connector skill:
 
-- [ ] `descriptor.yaml` with strict semver, `type: nocode`, namespace, schedule, secret fields, `dbt_select`
-- [ ] `connector.yaml` — declarative manifest; named operations; `errors[]` response filters; per-stream traversal per [Traversal](#4-traversal-contracts)
-- [ ] `connectors-config.yaml` entry (bootstrap-db) — without it the bronze database is never created
-- [ ] `class_people.sql` `depends_on` entry, if any stream feeds people
-- [ ] connectors-ddl snapshot regenerated per the bootstrap-db README
-- [ ] per-stream mock tests — 100% stream coverage, including a `QueryError`-in-200 case and a `hasNextPage`-lies case per [Traversal](#4-traversal-contracts)
-- [ ] `scripts/ci/connector_wiring.py` green
-- [ ] dbt conventions checked (RMT engine, `order_by=['unique_key']`, read-time dedup, `delete+insert` on silver)
+- [x] `descriptor.yaml` with strict semver, `type: nocode`, namespace, schedule, secret fields, `dbt_select`
+- [x] `connector.yaml` — declarative manifest; named operations; `errors[]` response filters; per-stream traversal per [Traversal](#4-traversal-contracts)
+- [x] `connectors-config.yaml` entry (bootstrap-db) — without it the bronze database is never created
+- [x] connectors-ddl snapshot regenerated per the bootstrap-db README
+- [x] per-stream mock tests — 100% stream coverage, including a `QueryError`-in-200 case and a `hasNextPage`-lies case per [Traversal](#4-traversal-contracts)
+- [x] `scripts/ci/connector_wiring.py` green
+- [x] bronze dbt conventions (RMT engine, `order_by=['unique_key']`) — the promotion model
+- [ ] `class_people.sql` `depends_on` entry — not applicable while no stream feeds people; revisit with the account-id join in §9
+- [ ] silver dbt conventions (read-time dedup, `delete+insert`) — deferred with silver itself (§7)

--- a/src/ingestion/connectors/dev-portal/compass/connector.yaml
+++ b/src/ingestion/connectors/dev-portal/compass/connector.yaml
@@ -1,0 +1,1147 @@
+# Atlassian Compass — service catalog, ownership, scorecards and deployment events.
+#
+# Compass is an internal developer portal: a catalog of software components,
+# each owned by a team from the Atlassian Teams directory, linked to its
+# repository, scored by scorecards and fed events by external tools. The Teams
+# streams live here rather than in their own connector because they share this
+# connector's host, credential and cadence; see SPEC.md §8.
+#
+# API facts that shape this manifest:
+#   - Everything is one GraphQL endpoint (api.atlassian.com/graphql) reached
+#     with an Atlassian account email + API token over Basic auth. No OAuth.
+#   - `cloudId` is a required argument on the Compass fields and is NOT
+#     discoverable from this endpoint; the operator supplies it (README says
+#     how to read it off the site). The Teams fields take a site-scoped ARI
+#     built from the same value.
+#   - GraphQL errors arrive as HTTP 200 with `errors[]`, so no status-code
+#     filter can see them. Worse, most fields return a UNION of a connection
+#     and `QueryError`, so a business error is a *successful* body with a
+#     `message` where the extractor expected `nodes`.
+#   - Several fields are experimental and need a FIELD-LEVEL
+#     `@optIn(to: "...")` directive. The `X-ExperimentalApi` header does not
+#     work and the directive is rejected at query level. Only
+#     `component_scorecard_scores` depends on this; every other stream is on
+#     stable fields.
+#   - Component `relationships` can be nested inside the catalog sweep, which
+#     avoids one request per component. The nested list cannot be paginated, so
+#     `relationships_truncated` carries `pageInfo.hasNextPage` — truncation
+#     stays visible in bronze instead of silently losing edges.
+#
+# Substream parents are inlined and request ids only: inline parents are
+# invisible to `discover` (no duplicate bronze table) and the CDK caches every
+# parent response, so a heavy parent would balloon the cache and stall the read.
+
+version: "7.0.4"
+type: DeclarativeSource
+
+definitions:
+  graphql_requester: &graphql_requester
+    type: HttpRequester
+    url_base: "https://api.atlassian.com/"
+    path: "graphql"
+    http_method: POST
+    authenticator:
+      type: BasicHttpAuthenticator
+      username: "{{ config['atlassian_email'] }}"
+      password: "{{ config['atlassian_api_token'] }}"
+    request_headers:
+      Accept: "application/json"
+    error_handler:
+      type: DefaultErrorHandler
+      max_retries: 5
+      backoff_strategies:
+        - type: WaitTimeFromHeader
+          header: Retry-After
+          max_waiting_time_in_seconds: 600
+        - type: ExponentialBackoffStrategy
+          factor: 5
+      response_filters:
+        - type: HttpResponseFilter
+          action: RATE_LIMITED
+          http_codes: [429]
+        # A GraphQL-level error (bad credentials, missing product access,
+        # malformed query) is HTTP 200 with no `data`. Without this filter the
+        # extractor finds nothing, the stream reports zero records, and the
+        # sync looks green while collecting nothing.
+        - type: HttpResponseFilter
+          action: FAIL
+          predicate: "{{ (response.get('errors') or []) | length > 0 }}"
+          error_message: "Atlassian GraphQL error: {{ (response.get('errors') or []) | map(attribute='message') | join('; ') }}"
+        - type: HttpResponseFilter
+          action: RETRY
+          http_codes: [500, 502, 503, 504]
+
+  standard_fields: &standard_fields
+    - type: AddedFieldDefinition
+      path: [tenant_id]
+      value: "{{ config['insight_tenant_id'] }}"
+      value_type: string
+    - type: AddedFieldDefinition
+      path: [source_id]
+      value: "{{ config['insight_source_id'] }}"
+      value_type: string
+    - type: AddedFieldDefinition
+      path: [collected_at]
+      value: "{{ now_utc().strftime('%Y-%m-%dT%H:%M:%SZ') }}"
+      value_type: string
+    - type: AddedFieldDefinition
+      path: [data_source]
+      value: insight_compass
+      value_type: string
+
+check:
+  type: CheckStream
+  stream_names:
+    - scorecards
+
+streams:
+  # ── components ───────────────────────────────────────────────────────
+  # The catalog sweep. Links, labels, event sources and dependency edges all
+  # arrive inside this one query, so the whole catalog costs
+  # ceil(N_components / 100) requests and no per-component follow-up.
+  #
+  # Full refresh: `searchComponents` offers no change filter, and a deleted
+  # component simply stops appearing.
+  - type: DeclarativeStream
+    name: components
+    primary_key: [unique_key]
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: http://json-schema.org/schema#
+        type: object
+        additionalProperties: true
+        properties:
+          tenant_id: { type: string }
+          source_id: { type: string }
+          unique_key: { type: string }
+          collected_at: { type: string }
+          data_source: { type: string }
+          component_id: { type: string }
+          name: { type: ["string", "null"] }
+          slug: { type: ["string", "null"] }
+          component_type: { type: ["string", "null"] }
+          description: { type: ["string", "null"] }
+          component_url: { type: ["string", "null"] }
+          owner_team_id: { type: ["string", "null"] }
+          labels: { type: ["array", "null"], items: { type: string } }
+          links: { type: ["array", "null"], items: { type: object, additionalProperties: true } }
+          event_sources: { type: ["array", "null"], items: { type: object, additionalProperties: true } }
+          relationships: { type: ["array", "null"], items: { type: object, additionalProperties: true } }
+          relationships_truncated: { type: ["boolean", "null"] }
+        required:
+          - unique_key
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *graphql_requester
+        request_body_json:
+          query: |
+            query insightComponents($cloudId: String!, $cursor: String) {
+              compass {
+                searchComponents(cloudId: $cloudId, query: {first: 100, after: $cursor}) {
+                  ... on CompassSearchComponentConnection {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      component {
+                        id
+                        name
+                        slug
+                        type
+                        description
+                        url
+                        ownerId
+                        labels { name }
+                        links { id type url name }
+                        eventSources { id eventType externalEventSourceId }
+                        relationships(query: {first: 100}) {
+                          ... on CompassRelationshipConnection {
+                            nodes {
+                              relationshipType
+                              startNode { id }
+                              endNode { id }
+                            }
+                            pageInfo { hasNextPage }
+                          }
+                        }
+                      }
+                    }
+                  }
+                  ... on QueryError { message }
+                }
+              }
+            }
+          variables:
+            cloudId: "{{ config['atlassian_cloud_id'] }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [data, compass, searchComponents, nodes]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ ((((response.get('data') or {}).get('compass') or {}).get('searchComponents') or {}).get('pageInfo') or {}).get('endCursor') }}"
+          stop_condition: "{{ not ((((response.get('data') or {}).get('compass') or {}).get('searchComponents') or {}).get('pageInfo') or {}).get('hasNextPage') }}"
+        page_token_option:
+          type: RequestOption
+          inject_into: body_json
+          field_path: [variables, cursor]
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [component_id]
+            value: "{{ (record.get('component') or {}).get('id') }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [name]
+            value: "{{ (record.get('component') or {}).get('name') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [slug]
+            value: "{{ (record.get('component') or {}).get('slug') or '' }}"
+            value_type: string
+          # `type` is a Compass field name that collides with nothing in bronze,
+          # but `component_type` reads unambiguously next to `component_id`.
+          - type: AddedFieldDefinition
+            path: [component_type]
+            value: "{{ (record.get('component') or {}).get('type') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [description]
+            value: "{{ (record.get('component') or {}).get('description') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [component_url]
+            value: "{{ (record.get('component') or {}).get('url') or '' }}"
+            value_type: string
+          # The FK into `teams`. Empty string rather than a Jinja `none`: with
+          # value_type string a none renders as the literal text "None" and
+          # would become a shared fake owner for every unowned component.
+          - type: AddedFieldDefinition
+            path: [owner_team_id]
+            value: "{{ (record.get('component') or {}).get('ownerId') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [labels]
+            value: "{{ ((record.get('component') or {}).get('labels') or []) | map(attribute='name') | list }}"
+          - type: AddedFieldDefinition
+            path: [links]
+            value: "{{ (record.get('component') or {}).get('links') or [] }}"
+          - type: AddedFieldDefinition
+            path: [event_sources]
+            value: "{{ (record.get('component') or {}).get('eventSources') or [] }}"
+          - type: AddedFieldDefinition
+            path: [relationships]
+            value: "{{ (((record.get('component') or {}).get('relationships') or {}).get('nodes')) or [] }}"
+          # Nested lists cannot be paginated, so record whether Compass had more
+          # edges than the query asked for. A truncated component is then a
+          # visible row in bronze rather than silent edge loss.
+          - type: AddedFieldDefinition
+            path: [relationships_truncated]
+            value: "{{ ((((record.get('component') or {}).get('relationships') or {}).get('pageInfo')) or {}).get('hasNextPage') or false }}"
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: "{{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ (record.get('component') or {}).get('id') }}"
+            value_type: string
+      - type: RemoveFields
+        field_pointers:
+          - [component]
+
+  # ── scorecards ───────────────────────────────────────────────────────
+  # Scorecard definitions with their criteria. Ten-ish rows; also the check
+  # stream, because it is a single request with no side effects.
+  #
+  # `criterias` stays JSON: the criterion subtypes are an open set
+  # (HasOwner / HasDescription / HasLink / HasMetricValue / HasCustom*Field …)
+  # and a typed column per subtype would churn on every Compass release.
+  #
+  # Dated snapshots of this stream are load-bearing, not bookkeeping: criterion
+  # weights renormalise to 100, so a component's score dropping is ambiguous
+  # between "the component got worse" and "a criterion was added" unless the
+  # definition for the same date is available. See SPEC.md §5.
+  - type: DeclarativeStream
+    name: scorecards
+    primary_key: [unique_key]
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: http://json-schema.org/schema#
+        type: object
+        additionalProperties: true
+        properties:
+          tenant_id: { type: string }
+          source_id: { type: string }
+          unique_key: { type: string }
+          collected_at: { type: string }
+          data_source: { type: string }
+          scorecard_id: { type: string }
+          name: { type: ["string", "null"] }
+          description: { type: ["string", "null"] }
+          state: { type: ["string", "null"] }
+          importance: { type: ["string", "null"] }
+          created_at: { type: ["string", "null"] }
+          last_user_modification_at: { type: ["string", "null"] }
+          criterias: { type: ["array", "null"], items: { type: object, additionalProperties: true } }
+        required:
+          - unique_key
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *graphql_requester
+        request_body_json:
+          query: |
+            query insightScorecards($cloudId: ID!) {
+              compass {
+                scorecards(cloudId: $cloudId) {
+                  ... on CompassScorecardConnection {
+                    nodes {
+                      id
+                      name
+                      description
+                      state
+                      importance
+                      changeMetadata {
+                        createdAt
+                        lastUserModificationAt
+                      }
+                      criterias {
+                        __typename
+                        id
+                        weight
+                        name
+                        ... on CompassHasLinkScorecardCriteria { linkType }
+                        ... on CompassHasMetricValueScorecardCriteria {
+                          comparator
+                          comparatorValue
+                          metricDefinition { name }
+                        }
+                      }
+                    }
+                  }
+                  ... on QueryError { message }
+                }
+              }
+            }
+          variables:
+            cloudId: "{{ config['atlassian_cloud_id'] }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [data, compass, scorecards, nodes]
+      paginator:
+        type: NoPagination
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [scorecard_id]
+            value: "{{ record.get('id') }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [created_at]
+            value: "{{ (record.get('changeMetadata') or {}).get('createdAt') or none }}"
+          - type: AddedFieldDefinition
+            path: [last_user_modification_at]
+            value: "{{ (record.get('changeMetadata') or {}).get('lastUserModificationAt') or none }}"
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: "{{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ record.get('id') }}"
+            value_type: string
+      - type: RemoveFields
+        field_pointers:
+          - [changeMetadata]
+          - [id]
+
+  # ── component_scorecard_scores ───────────────────────────────────────
+  # One row per component × scorecard: the total, the status band, and the
+  # per-criterion breakdown. Traversed scorecard-first — each scorecard knows
+  # which components it applies to — so the cost is O(scorecards) requests
+  # rather than O(components).
+  #
+  # The score hangs off the EDGE, not the node.
+  #
+  # This is the only stream that needs the experimental `compass-beta` opt-in.
+  # If beta churn ever breaks it, it can be dropped without touching the rest.
+  #
+  # `appliedToComponents` caps page size at 25 — asking for more fails with
+  # HTTP 200 + errors[] ("must be between [1] to [25]"), i.e. as a hard sync
+  # failure, not a clamped page. Every other connection here takes 50-100.
+  - type: DeclarativeStream
+    name: component_scorecard_scores
+    primary_key: [unique_key]
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: http://json-schema.org/schema#
+        type: object
+        additionalProperties: true
+        properties:
+          tenant_id: { type: string }
+          source_id: { type: string }
+          unique_key: { type: string }
+          collected_at: { type: string }
+          data_source: { type: string }
+          scorecard_id: { type: string }
+          component_id: { type: string }
+          total_score: { type: ["integer", "null"] }
+          max_total_score: { type: ["integer", "null"] }
+          status: { type: ["string", "null"] }
+          criteria_scores: { type: ["array", "null"], items: { type: object, additionalProperties: true } }
+        required:
+          - unique_key
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *graphql_requester
+        request_body_json:
+          query: |
+            query insightScorecardScores($scorecardId: ID!, $cursor: String) {
+              compass {
+                scorecard(id: $scorecardId) {
+                  ... on CompassScorecard {
+                    id
+                    appliedToComponents(query: {first: 25, after: $cursor}) @optIn(to: "compass-beta") {
+                      ... on CompassScorecardAppliedToComponentsConnection {
+                        pageInfo { hasNextPage endCursor }
+                        edges {
+                          node { id }
+                          score {
+                            ... on CompassScorecardScore {
+                              totalScore
+                              maxTotalScore
+                              status { name }
+                              criteriaScores {
+                                criterionId
+                                score
+                                maxScore
+                                status
+                                dataSourceLastUpdated
+                              }
+                            }
+                            ... on QueryError { message }
+                          }
+                        }
+                      }
+                      ... on QueryError { message }
+                    }
+                  }
+                  ... on QueryError { message }
+                }
+              }
+            }
+          variables:
+            scorecardId: "{{ stream_partition.scorecard_id }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [data, compass, scorecard, appliedToComponents, edges]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ (((((response.get('data') or {}).get('compass') or {}).get('scorecard') or {}).get('appliedToComponents') or {}).get('pageInfo') or {}).get('endCursor') }}"
+          stop_condition: "{{ not (((((response.get('data') or {}).get('compass') or {}).get('scorecard') or {}).get('appliedToComponents') or {}).get('pageInfo') or {}).get('hasNextPage') }}"
+        page_token_option:
+          type: RequestOption
+          inject_into: body_json
+          field_path: [variables, cursor]
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: id
+            partition_field: scorecard_id
+            # Inlined and ids-only on purpose: an inline parent is invisible to
+            # `discover` (so no second scorecards bronze table) and every parent
+            # response is cached by the CDK, so it must stay small.
+            stream:
+              type: DeclarativeStream
+              name: _scorecard_ids
+              primary_key: [id]
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  $schema: http://json-schema.org/schema#
+                  type: object
+                  additionalProperties: true
+                  properties:
+                    id: { type: string }
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  <<: *graphql_requester
+                  request_body_json:
+                    query: |
+                      query insightScorecardIds($cloudId: ID!) {
+                        compass {
+                          scorecards(cloudId: $cloudId) {
+                            ... on CompassScorecardConnection {
+                              nodes { id }
+                            }
+                            ... on QueryError { message }
+                          }
+                        }
+                      }
+                    variables:
+                      cloudId: "{{ config['atlassian_cloud_id'] }}"
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: [data, compass, scorecards, nodes]
+                paginator:
+                  type: NoPagination
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [scorecard_id]
+            value: "{{ stream_partition.scorecard_id }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [component_id]
+            value: "{{ (record.get('node') or {}).get('id') }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [total_score]
+            value: "{{ (record.get('score') or {}).get('totalScore') }}"
+          - type: AddedFieldDefinition
+            path: [max_total_score]
+            value: "{{ (record.get('score') or {}).get('maxTotalScore') }}"
+          - type: AddedFieldDefinition
+            path: [status]
+            value: "{{ (((record.get('score') or {}).get('status')) or {}).get('name') or '' }}"
+            value_type: string
+          # Carries `dataSourceLastUpdated` per criterion — the only way to tell
+          # "this criterion genuinely fails" from "the metric feeding it is
+          # stale". Must survive into any downstream reading.
+          - type: AddedFieldDefinition
+            path: [criteria_scores]
+            value: "{{ ((record.get('score') or {}).get('criteriaScores')) or [] }}"
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: "{{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.scorecard_id }}:{{ (record.get('node') or {}).get('id') }}"
+            value_type: string
+      - type: RemoveFields
+        field_pointers:
+          - [node]
+          - [score]
+
+  # ── teams ────────────────────────────────────────────────────────────
+  # The Atlassian Teams directory — the entity Compass component ownership and
+  # Jira's Team field both point at, by the same UUID.
+  #
+  # `teamSearchV3` takes a site-scoped ARI, which is derivable from the cloud
+  # id, so no separate organization id has to be configured. `teamsTql` needs
+  # its own opt-in and rejects the site ARI; do not switch to it.
+  - type: DeclarativeStream
+    name: teams
+    primary_key: [unique_key]
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: http://json-schema.org/schema#
+        type: object
+        additionalProperties: true
+        properties:
+          tenant_id: { type: string }
+          source_id: { type: string }
+          unique_key: { type: string }
+          collected_at: { type: string }
+          data_source: { type: string }
+          team_id: { type: string }
+          display_name: { type: ["string", "null"] }
+          description: { type: ["string", "null"] }
+          state: { type: ["string", "null"] }
+          organization_id: { type: ["string", "null"] }
+          member_count: { type: ["integer", "null"] }
+          is_verified: { type: ["boolean", "null"] }
+        required:
+          - unique_key
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *graphql_requester
+        request_body_json:
+          query: |
+            query insightTeams($scopeId: ID!, $cursor: String) {
+              team {
+                teamSearchV3(scopeId: $scopeId, first: 50, after: $cursor,
+                             enablePagination: true, showEmptyTeams: true) {
+                  pageInfo { hasNextPage endCursor }
+                  nodes {
+                    team {
+                      id
+                      displayName
+                      description
+                      state
+                      organizationId
+                      memberCount
+                      isVerified
+                    }
+                  }
+                }
+              }
+            }
+          variables:
+            scopeId: "ari:cloud:platform::site/{{ config['atlassian_cloud_id'] }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [data, team, teamSearchV3, nodes]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ ((((response.get('data') or {}).get('team') or {}).get('teamSearchV3') or {}).get('pageInfo') or {}).get('endCursor') }}"
+          stop_condition: "{{ not ((((response.get('data') or {}).get('team') or {}).get('teamSearchV3') or {}).get('pageInfo') or {}).get('hasNextPage') }}"
+        page_token_option:
+          type: RequestOption
+          inject_into: body_json
+          field_path: [variables, cursor]
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [team_id]
+            value: "{{ (record.get('team') or {}).get('id') }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [display_name]
+            value: "{{ (record.get('team') or {}).get('displayName') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [description]
+            value: "{{ (record.get('team') or {}).get('description') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [state]
+            value: "{{ (record.get('team') or {}).get('state') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [organization_id]
+            value: "{{ (record.get('team') or {}).get('organizationId') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [member_count]
+            value: "{{ (record.get('team') or {}).get('memberCount') }}"
+          - type: AddedFieldDefinition
+            path: [is_verified]
+            value: "{{ (record.get('team') or {}).get('isVerified') or false }}"
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: "{{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ (record.get('team') or {}).get('id') }}"
+            value_type: string
+      - type: RemoveFields
+        field_pointers:
+          - [team]
+
+  # ── team_members ─────────────────────────────────────────────────────
+  # Membership, per team. Fetched per team rather than through the bulk
+  # `teamsV2` form: in bulk the nested member list comes back truncated with
+  # `hasNextPage` true for every team, including teams whose members all fit.
+  # Per-team pagination is exact and reconciles with `memberCount`.
+  #
+  # There is no `email` field on the user type — the join key to people is the
+  # account id inside `member.id`.
+  - type: DeclarativeStream
+    name: team_members
+    primary_key: [unique_key]
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: http://json-schema.org/schema#
+        type: object
+        additionalProperties: true
+        properties:
+          tenant_id: { type: string }
+          source_id: { type: string }
+          unique_key: { type: string }
+          collected_at: { type: string }
+          data_source: { type: string }
+          team_id: { type: string }
+          member_id: { type: string }
+          member_name: { type: ["string", "null"] }
+          account_status: { type: ["string", "null"] }
+          role: { type: ["string", "null"] }
+          membership_state: { type: ["string", "null"] }
+        required:
+          - unique_key
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *graphql_requester
+        request_body_json:
+          query: |
+            query insightTeamMembers($teamId: ID!, $siteId: String!, $cursor: String) {
+              team {
+                teamV2(id: $teamId, siteId: $siteId) {
+                  id
+                  members(first: 50, after: $cursor,
+                          state: [FULL_MEMBER, ALUMNI, REQUESTING_TO_JOIN]) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      role
+                      state
+                      member {
+                        id
+                        name
+                        accountStatus
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          variables:
+            teamId: "{{ stream_partition.team_id }}"
+            siteId: "{{ config['atlassian_cloud_id'] }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [data, team, teamV2, members, nodes]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ (((((response.get('data') or {}).get('team') or {}).get('teamV2') or {}).get('members') or {}).get('pageInfo') or {}).get('endCursor') }}"
+          stop_condition: "{{ not (((((response.get('data') or {}).get('team') or {}).get('teamV2') or {}).get('members') or {}).get('pageInfo') or {}).get('hasNextPage') }}"
+        page_token_option:
+          type: RequestOption
+          inject_into: body_json
+          field_path: [variables, cursor]
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: id
+            partition_field: team_id
+            stream:
+              type: DeclarativeStream
+              name: _team_ids
+              primary_key: [id]
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  $schema: http://json-schema.org/schema#
+                  type: object
+                  additionalProperties: true
+                  properties:
+                    id: { type: string }
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  <<: *graphql_requester
+                  request_body_json:
+                    query: |
+                      query insightTeamIds($scopeId: ID!, $cursor: String) {
+                        team {
+                          teamSearchV3(scopeId: $scopeId, first: 50, after: $cursor,
+                                       enablePagination: true, showEmptyTeams: true) {
+                            pageInfo { hasNextPage endCursor }
+                            nodes { team { id } }
+                          }
+                        }
+                      }
+                    variables:
+                      scopeId: "ari:cloud:platform::site/{{ config['atlassian_cloud_id'] }}"
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: [data, team, teamSearchV3, nodes, "*", team]
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: CursorPagination
+                    cursor_value: "{{ ((((response.get('data') or {}).get('team') or {}).get('teamSearchV3') or {}).get('pageInfo') or {}).get('endCursor') }}"
+                    stop_condition: "{{ not ((((response.get('data') or {}).get('team') or {}).get('teamSearchV3') or {}).get('pageInfo') or {}).get('hasNextPage') }}"
+                  page_token_option:
+                    type: RequestOption
+                    inject_into: body_json
+                    field_path: [variables, cursor]
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [team_id]
+            value: "{{ stream_partition.team_id }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [member_id]
+            value: "{{ (record.get('member') or {}).get('id') }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [member_name]
+            value: "{{ (record.get('member') or {}).get('name') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [account_status]
+            value: "{{ (record.get('member') or {}).get('accountStatus') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [role]
+            value: "{{ record.get('role') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [membership_state]
+            value: "{{ record.get('state') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: "{{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.team_id }}:{{ (record.get('member') or {}).get('id') }}"
+            value_type: string
+      - type: RemoveFields
+        field_pointers:
+          - [member]
+          - [state]
+
+  # ── deployment_events ────────────────────────────────────────────────
+  # Compass events of type DEPLOYMENT, per component. The only incremental
+  # stream, and the one that dominates the sync: there is one query per
+  # component and no usable server-side date filter.
+  #
+  # `timeParameters {startFrom, endAt}` rejects every window with a complaint
+  # that endAt must be within a year of startFrom — regardless of the width
+  # actually passed. `startFrom` alone returns nothing; `endAt` alone returns
+  # only the boundary date. Hence `is_client_side_incremental`: pages come back
+  # newest-first and the CDK filters them against state. Revisit if Atlassian
+  # fixes the filter — a server-side window would cut this cost sharply.
+  #
+  # The feed is a rolling window roughly two weeks wide with no deeper
+  # backfill, so a missed sync loses events permanently. That is what sets the
+  # daily floor on this connector's schedule.
+  #
+  # CAUTION for anyone building metrics on this: an event of type DEPLOYMENT
+  # does not imply a release. Any tool can publish these through an external
+  # event source, and an integration may map build or artifact events onto the
+  # type with a non-production `environment_category`. Key release metrics on
+  # `environment_category = 'PRODUCTION'`; everything else is build or
+  # pre-production activity. One event is also updated in place as it
+  # progresses, so `update_sequence_number` is the dedup discriminator and a
+  # terminal state may never arrive (`completed_at` stays null).
+  - type: DeclarativeStream
+    name: deployment_events
+    primary_key: [unique_key]
+    schema_loader:
+      type: InlineSchemaLoader
+      schema:
+        $schema: http://json-schema.org/schema#
+        type: object
+        additionalProperties: true
+        properties:
+          tenant_id: { type: string }
+          source_id: { type: string }
+          unique_key: { type: string }
+          collected_at: { type: string }
+          data_source: { type: string }
+          component_id: { type: string }
+          event_type: { type: ["string", "null"] }
+          display_name: { type: ["string", "null"] }
+          description: { type: ["string", "null"] }
+          event_url: { type: ["string", "null"] }
+          last_updated: { type: ["string", "null"] }
+          update_sequence_number: { type: ["integer", "null"] }
+          state: { type: ["string", "null"] }
+          environment_category: { type: ["string", "null"] }
+          environment_display_name: { type: ["string", "null"] }
+          environment_id: { type: ["string", "null"] }
+          started_at: { type: ["string", "null"] }
+          completed_at: { type: ["string", "null"] }
+          sequence_number: { type: ["integer", "null"] }
+          pipeline: { type: ["object", "null"], additionalProperties: true }
+        required:
+          - unique_key
+    retriever:
+      type: SimpleRetriever
+      requester:
+        <<: *graphql_requester
+        request_body_json:
+          query: |
+            query insightDeploymentEvents($componentId: ID!, $cursor: String) {
+              compass {
+                component(id: $componentId) {
+                  ... on CompassComponent {
+                    id
+                    events(query: {first: 50, after: $cursor, eventTypes: [DEPLOYMENT]}) {
+                      ... on CompassEventConnection {
+                        pageInfo { hasNextPage endCursor }
+                        nodes {
+                          ... on CompassDeploymentEvent {
+                            eventType
+                            displayName
+                            description
+                            url
+                            lastUpdated
+                            updateSequenceNumber
+                            deploymentProperties {
+                              sequenceNumber
+                              state
+                              startedAt
+                              completedAt
+                              environment {
+                                category
+                                displayName
+                                environmentId
+                              }
+                              pipeline {
+                                pipelineId
+                                displayName
+                                url
+                              }
+                            }
+                          }
+                        }
+                      }
+                      ... on QueryError { message }
+                    }
+                  }
+                  ... on QueryError { message }
+                }
+              }
+            }
+          variables:
+            componentId: "{{ stream_partition.component_id }}"
+      record_selector:
+        type: RecordSelector
+        extractor:
+          type: DpathExtractor
+          field_path: [data, compass, component, events, nodes]
+      paginator:
+        type: DefaultPaginator
+        pagination_strategy:
+          type: CursorPagination
+          cursor_value: "{{ (((((response.get('data') or {}).get('compass') or {}).get('component') or {}).get('events') or {}).get('pageInfo') or {}).get('endCursor') }}"
+          stop_condition: "{{ not (((((response.get('data') or {}).get('compass') or {}).get('component') or {}).get('events') or {}).get('pageInfo') or {}).get('hasNextPage') }}"
+        page_token_option:
+          type: RequestOption
+          inject_into: body_json
+          field_path: [variables, cursor]
+      partition_router:
+        type: SubstreamPartitionRouter
+        parent_stream_configs:
+          - type: ParentStreamConfig
+            parent_key: id
+            partition_field: component_id
+            # ids only: the full catalog sweep carries links, labels, event
+            # sources and dependency edges, and every parent response is cached
+            # by the CDK. Pointing this at the heavy query would grow the cache
+            # until the read stalls with zero records emitted.
+            stream:
+              type: DeclarativeStream
+              name: _component_ids
+              primary_key: [id]
+              schema_loader:
+                type: InlineSchemaLoader
+                schema:
+                  $schema: http://json-schema.org/schema#
+                  type: object
+                  additionalProperties: true
+                  properties:
+                    id: { type: string }
+              retriever:
+                type: SimpleRetriever
+                requester:
+                  <<: *graphql_requester
+                  request_body_json:
+                    query: |
+                      query insightComponentIds($cloudId: String!, $cursor: String) {
+                        compass {
+                          searchComponents(cloudId: $cloudId, query: {first: 100, after: $cursor}) {
+                            ... on CompassSearchComponentConnection {
+                              pageInfo { hasNextPage endCursor }
+                              nodes { component { id } }
+                            }
+                            ... on QueryError { message }
+                          }
+                        }
+                      }
+                    variables:
+                      cloudId: "{{ config['atlassian_cloud_id'] }}"
+                record_selector:
+                  type: RecordSelector
+                  extractor:
+                    type: DpathExtractor
+                    field_path: [data, compass, searchComponents, nodes, "*", component]
+                paginator:
+                  type: DefaultPaginator
+                  pagination_strategy:
+                    type: CursorPagination
+                    cursor_value: "{{ ((((response.get('data') or {}).get('compass') or {}).get('searchComponents') or {}).get('pageInfo') or {}).get('endCursor') }}"
+                    stop_condition: "{{ not ((((response.get('data') or {}).get('compass') or {}).get('searchComponents') or {}).get('pageInfo') or {}).get('hasNextPage') }}"
+                  page_token_option:
+                    type: RequestOption
+                    inject_into: body_json
+                    field_path: [variables, cursor]
+    incremental_sync:
+      type: DatetimeBasedCursor
+      cursor_field: last_updated
+      cursor_datetime_formats:
+        - "%Y-%m-%dT%H:%M:%S.%fZ"
+        - "%Y-%m-%dT%H:%M:%SZ"
+      datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
+      start_datetime:
+        type: MinMaxDatetime
+        datetime: "{{ (now_utc() - duration('P30D')).strftime('%Y-%m-%dT%H:%M:%S.000Z') }}"
+        datetime_format: "%Y-%m-%dT%H:%M:%S.%fZ"
+      is_client_side_incremental: true
+    transformations:
+      - type: AddFields
+        fields: *standard_fields
+      - type: AddFields
+        fields:
+          - type: AddedFieldDefinition
+            path: [component_id]
+            value: "{{ stream_partition.component_id }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [event_type]
+            value: "{{ record.get('eventType') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [display_name]
+            value: "{{ record.get('displayName') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [event_url]
+            value: "{{ record.get('url') or '' }}"
+            value_type: string
+          # Hoisted to the top level because DatetimeBasedCursor reads its
+          # cursor field from there. Left nested, the cursor never observes a
+          # value and state never advances.
+          - type: AddedFieldDefinition
+            path: [last_updated]
+            value: "{{ record.get('lastUpdated') }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [update_sequence_number]
+            value: "{{ record.get('updateSequenceNumber') }}"
+          - type: AddedFieldDefinition
+            path: [state]
+            value: "{{ (record.get('deploymentProperties') or {}).get('state') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [environment_category]
+            value: "{{ (((record.get('deploymentProperties') or {}).get('environment')) or {}).get('category') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [environment_display_name]
+            value: "{{ (((record.get('deploymentProperties') or {}).get('environment')) or {}).get('displayName') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [environment_id]
+            value: "{{ (((record.get('deploymentProperties') or {}).get('environment')) or {}).get('environmentId') or '' }}"
+            value_type: string
+          - type: AddedFieldDefinition
+            path: [started_at]
+            value: "{{ (record.get('deploymentProperties') or {}).get('startedAt') or none }}"
+          - type: AddedFieldDefinition
+            # No value_type: with one, a Jinja `none` renders as the text "None"
+            # and a never-completed deployment would carry a fake timestamp
+            # string instead of a null. Without it the CDK literal-evals "None"
+            # back to null, while a real timestamp stays a string.
+            path: [completed_at]
+            value: "{{ (record.get('deploymentProperties') or {}).get('completedAt') or none }}"
+          - type: AddedFieldDefinition
+            path: [sequence_number]
+            value: "{{ (record.get('deploymentProperties') or {}).get('sequenceNumber') }}"
+          - type: AddedFieldDefinition
+            path: [pipeline]
+            value: "{{ ((record.get('deploymentProperties') or {}).get('pipeline')) or {} }}"
+          # An event is updated in place as the deployment progresses, so the
+          # key must NOT include lastUpdated — otherwise each progress update
+          # forks into a new bronze row instead of replacing the previous one.
+          - type: AddedFieldDefinition
+            path: [unique_key]
+            value: "{{ config['insight_tenant_id'] }}:{{ config['insight_source_id'] }}:{{ stream_partition.component_id }}:{{ record.get('updateSequenceNumber') }}"
+            value_type: string
+      - type: RemoveFields
+        field_pointers:
+          - [deploymentProperties]
+          - [displayName]
+          - [eventType]
+          - [lastUpdated]
+          - [updateSequenceNumber]
+          - [url]
+
+concurrency_level:
+  type: ConcurrencyLevel
+  default_concurrency: 4
+
+spec:
+  type: Spec
+  connection_specification:
+    $schema: http://json-schema.org/draft-07/schema#
+    type: object
+    required:
+      - insight_tenant_id
+      - insight_source_id
+      - atlassian_email
+      - atlassian_api_token
+      - atlassian_cloud_id
+    properties:
+      insight_tenant_id:
+        type: string
+        minLength: 1
+        title: Insight Tenant ID
+        description: Tenant isolation identifier, injected as `tenant_id` on every record.
+        order: 0
+      insight_source_id:
+        type: string
+        title: Source Instance ID
+        description: Connector instance identifier (e.g. `compass-main`). Set by the reconcile loop from the K8s Secret annotation `insight.cyberfabric.com/source-id`.
+        default: ""
+        order: 1
+      atlassian_email:
+        type: string
+        minLength: 1
+        title: Atlassian Account Email
+        description: Email of the Atlassian account owning the API token. Used as the Basic-auth username.
+        order: 2
+      atlassian_api_token:
+        type: string
+        minLength: 1
+        title: Atlassian API Token
+        airbyte_secret: true
+        description: |
+          Atlassian account API token (id.atlassian.com → Security → API tokens).
+          The account needs Compass product access; the Teams streams need no
+          extra grant. No OAuth application is required.
+        order: 3
+      atlassian_cloud_id:
+        type: string
+        minLength: 1
+        title: Atlassian Cloud ID
+        description: |
+          Site identifier required by every Compass field, and the basis of the
+          site-scoped ARI the Teams streams use. Read it from the site itself:
+          `curl -s https://<your-site>.atlassian.net/_edge/tenant_info`.
+          Not discoverable through the GraphQL gateway, so it must be supplied.
+        order: 4
+    additionalProperties: true
+
+metadata:
+  autoImportSchema:
+    components: false
+    scorecards: false
+    component_scorecard_scores: false
+    teams: false
+    team_members: false
+    deployment_events: false

--- a/src/ingestion/connectors/dev-portal/compass/connector.yaml
+++ b/src/ingestion/connectors/dev-portal/compass/connector.yaml
@@ -35,6 +35,131 @@ version: "7.0.4"
 type: DeclarativeSource
 
 definitions:
+  # ORDER MATTERS. The catch-all FAIL matches any body carrying `errors[]`,
+  # including a 5xx whose body happens to be a GraphQL error document, so the
+  # transient and throttle filters have to run first or a retryable failure
+  # becomes a hard one.
+  response_filters:
+    f_rate_limited_429: &f_rate_limited_429
+      type: HttpResponseFilter
+      action: RATE_LIMITED
+      http_codes: [429]
+    # The gateway limits by cost, and a body-level throttle answer is not
+    # guaranteed to carry a 429.
+    f_rate_limited_body: &f_rate_limited_body
+      type: HttpResponseFilter
+      action: RATE_LIMITED
+      predicate: "{{ 'rate limit' in ((response.get('errors') or []) | map(attribute='message') | join(' ') | lower) }}"
+    f_retry_5xx: &f_retry_5xx
+      type: HttpResponseFilter
+      action: RETRY
+      http_codes: [500, 502, 503, 504]
+    # A GraphQL-level error (bad credentials, missing product access,
+    # malformed query) is HTTP 200 with no `data`. Without this filter the
+    # extractor finds nothing, the stream reports zero records, and the
+    # sync looks green while collecting nothing.
+    f_graphql_error: &f_graphql_error
+      type: HttpResponseFilter
+      action: FAIL
+      predicate: "{{ (response.get('errors') or []) | length > 0 }}"
+      error_message: "Atlassian GraphQL error: {{ (response.get('errors') or []) | map(attribute='message') | join('; ') }}"
+
+  base_error_handler: &base_error_handler
+    type: DefaultErrorHandler
+    max_retries: 5
+    backoff_strategies: &backoff_strategies
+      - type: WaitTimeFromHeader
+        header: Retry-After
+        max_waiting_time_in_seconds: 600
+      - type: ExponentialBackoffStrategy
+        factor: 5
+    response_filters: &base_response_filters
+      - *f_rate_limited_429
+      - *f_rate_limited_body
+      - *f_retry_5xx
+      - *f_graphql_error
+
+  # Per-stream union handling. Most Compass fields return a union of a
+  # connection and `QueryError`, and a `QueryError` member is a SUCCESSFUL body
+  # with no top-level `errors[]`: the catch-all above cannot see it, the
+  # extractor finds no nodes, and the stream would report zero records. These
+  # filters run after the catch-all so a query-level error still fails with the
+  # message the API gave.
+  stream_error_handlers:
+    catalog: &h_catalog
+      <<: *base_error_handler
+      response_filters:
+        - *f_rate_limited_429
+        - *f_rate_limited_body
+        - *f_retry_5xx
+        - *f_graphql_error
+        - type: HttpResponseFilter
+          action: FAIL
+          predicate: "{{ (((response.get('data') or {}).get('compass') or {}).get('searchComponents') or {}).get('message') is not none }}"
+          error_message: "Compass rejected the component catalog query: {{ (((response.get('data') or {}).get('compass') or {}).get('searchComponents') or {}).get('message') }}"
+    scorecards: &h_scorecards
+      <<: *base_error_handler
+      response_filters:
+        - *f_rate_limited_429
+        - *f_rate_limited_body
+        - *f_retry_5xx
+        - *f_graphql_error
+        - type: HttpResponseFilter
+          action: FAIL
+          predicate: "{{ (((response.get('data') or {}).get('compass') or {}).get('scorecards') or {}).get('message') is not none }}"
+          error_message: "Compass rejected the scorecards query: {{ (((response.get('data') or {}).get('compass') or {}).get('scorecards') or {}).get('message') }}"
+    scores: &h_scores
+      <<: *base_error_handler
+      response_filters:
+        - *f_rate_limited_429
+        - *f_rate_limited_body
+        - *f_retry_5xx
+        - *f_graphql_error
+        # Also covers the beta opt-in being withdrawn, which surfaces on
+        # appliedToComponents rather than on the scorecard itself.
+        - type: HttpResponseFilter
+          action: FAIL
+          predicate: "{{ ((((response.get('data') or {}).get('compass') or {}).get('scorecard') or {}).get('message') is not none) or (((((response.get('data') or {}).get('compass') or {}).get('scorecard') or {}).get('appliedToComponents') or {}).get('message') is not none) }}"
+          error_message: "Compass rejected a scorecard score query: {{ (((response.get('data') or {}).get('compass') or {}).get('scorecard') or {}).get('message') or ((((response.get('data') or {}).get('compass') or {}).get('scorecard') or {}).get('appliedToComponents') or {}).get('message') }}"
+    teams: &h_teams
+      <<: *base_error_handler
+      response_filters:
+        - *f_rate_limited_429
+        - *f_rate_limited_body
+        - *f_retry_5xx
+        - *f_graphql_error
+        # teamSearchV3 is not a union, so an unusable scope comes back as a
+        # null connection rather than an error object.
+        - type: HttpResponseFilter
+          action: FAIL
+          predicate: "{{ (response.get('data') or {}).get('team') is not none and ((response.get('data') or {}).get('team') or {}).get('teamSearchV3') is none }}"
+          error_message: The Teams directory returned no connection for this site scope; check atlassian_cloud_id.
+    team_members: &h_team_members
+      <<: *base_error_handler
+      response_filters:
+        - *f_rate_limited_429
+        - *f_rate_limited_body
+        - *f_retry_5xx
+        - *f_graphql_error
+        - type: HttpResponseFilter
+          action: FAIL
+          predicate: "{{ (response.get('data') or {}).get('team') is not none and ((response.get('data') or {}).get('team') or {}).get('teamV2') is none }}"
+          error_message: A team enumerated moments earlier is no longer readable; membership would be silently empty.
+    events: &h_events
+      <<: *base_error_handler
+      response_filters:
+        - *f_rate_limited_429
+        - *f_rate_limited_body
+        - *f_retry_5xx
+        - *f_graphql_error
+        # IGNORE, not FAIL: across a catalog of thousands, a component deleted
+        # between the parent sweep and this read is ordinary. The partition
+        # yields nothing and the sync continues.
+        - type: HttpResponseFilter
+          action: IGNORE
+          predicate: "{{ (((response.get('data') or {}).get('compass') or {}).get('component') or {}).get('message') is not none }}"
+          error_message: Component no longer readable; its events are skipped and other components continue.
+
   graphql_requester: &graphql_requester
     type: HttpRequester
     url_base: "https://api.atlassian.com/"
@@ -46,30 +171,7 @@ definitions:
       password: "{{ config['atlassian_api_token'] }}"
     request_headers:
       Accept: "application/json"
-    error_handler:
-      type: DefaultErrorHandler
-      max_retries: 5
-      backoff_strategies:
-        - type: WaitTimeFromHeader
-          header: Retry-After
-          max_waiting_time_in_seconds: 600
-        - type: ExponentialBackoffStrategy
-          factor: 5
-      response_filters:
-        - type: HttpResponseFilter
-          action: RATE_LIMITED
-          http_codes: [429]
-        # A GraphQL-level error (bad credentials, missing product access,
-        # malformed query) is HTTP 200 with no `data`. Without this filter the
-        # extractor finds nothing, the stream reports zero records, and the
-        # sync looks green while collecting nothing.
-        - type: HttpResponseFilter
-          action: FAIL
-          predicate: "{{ (response.get('errors') or []) | length > 0 }}"
-          error_message: "Atlassian GraphQL error: {{ (response.get('errors') or []) | map(attribute='message') | join('; ') }}"
-        - type: HttpResponseFilter
-          action: RETRY
-          http_codes: [500, 502, 503, 504]
+    error_handler: *base_error_handler
 
   standard_fields: &standard_fields
     - type: AddedFieldDefinition
@@ -135,6 +237,7 @@ streams:
       type: SimpleRetriever
       requester:
         <<: *graphql_requester
+        error_handler: *h_catalog
         request_body_json:
           query: |
             query insightComponents($cloudId: String!, $cursor: String) {
@@ -293,6 +396,7 @@ streams:
       type: SimpleRetriever
       requester:
         <<: *graphql_requester
+        error_handler: *h_scorecards
         request_body_json:
           query: |
             query insightScorecards($cloudId: ID!) {
@@ -401,6 +505,7 @@ streams:
       type: SimpleRetriever
       requester:
         <<: *graphql_requester
+        error_handler: *h_scores
         request_body_json:
           query: |
             query insightScorecardScores($scorecardId: ID!, $cursor: String) {
@@ -479,6 +584,7 @@ streams:
                 type: SimpleRetriever
                 requester:
                   <<: *graphql_requester
+                  error_handler: *h_scorecards
                   request_body_json:
                     query: |
                       query insightScorecardIds($cloudId: ID!) {
@@ -573,6 +679,7 @@ streams:
       type: SimpleRetriever
       requester:
         <<: *graphql_requester
+        error_handler: *h_teams
         request_body_json:
           query: |
             query insightTeams($scopeId: ID!, $cursor: String) {
@@ -685,6 +792,7 @@ streams:
       type: SimpleRetriever
       requester:
         <<: *graphql_requester
+        error_handler: *h_team_members
         request_body_json:
           query: |
             query insightTeamMembers($teamId: ID!, $siteId: String!, $cursor: String) {
@@ -747,6 +855,7 @@ streams:
                 type: SimpleRetriever
                 requester:
                   <<: *graphql_requester
+                  error_handler: *h_teams
                   request_body_json:
                     query: |
                       query insightTeamIds($scopeId: ID!, $cursor: String) {
@@ -873,6 +982,7 @@ streams:
       type: SimpleRetriever
       requester:
         <<: *graphql_requester
+        error_handler: *h_events
         request_body_json:
           query: |
             query insightDeploymentEvents($componentId: ID!, $cursor: String) {
@@ -960,6 +1070,7 @@ streams:
                 type: SimpleRetriever
                 requester:
                   <<: *graphql_requester
+                  error_handler: *h_catalog
                   request_body_json:
                     query: |
                       query insightComponentIds($cloudId: String!, $cursor: String) {

--- a/src/ingestion/connectors/dev-portal/compass/dbt/compass__bronze_promoted.sql
+++ b/src/ingestion/connectors/dev-portal/compass/dbt/compass__bronze_promoted.sql
@@ -1,0 +1,32 @@
+{# -------------------------------------------------------------------------
+   Bootstrap model for Compass bronze -> RMT promotion.
+
+   Airbyte writes bronze append-only, so every read needs deduplication by
+   `unique_key`. Promotion is what makes a later `FINAL` read well-defined —
+   in particular for `deployment_events`, where one event is rewritten in place
+   as the deployment progresses and the latest version is the correct one.
+
+   The `promote_bronze_to_rmt` macro is idempotent: already-RMT tables are
+   detected and skipped on subsequent runs.
+   ------------------------------------------------------------------------- #}
+
+{{ config(
+    materialized='view',
+    schema='staging',
+    tags=['compass']
+) }}
+
+{% set compass_tables = [
+    'components',
+    'scorecards',
+    'component_scorecard_scores',
+    'teams',
+    'team_members',
+    'deployment_events',
+] %}
+
+{% for table in compass_tables %}
+  {% do promote_bronze_to_rmt(table='bronze_compass.' ~ table, order_by='unique_key') %}
+{% endfor %}
+
+SELECT 1 AS promoted

--- a/src/ingestion/connectors/dev-portal/compass/dbt/schema.yml
+++ b/src/ingestion/connectors/dev-portal/compass/dbt/schema.yml
@@ -1,0 +1,23 @@
+version: 2
+
+sources:
+  - name: bronze_compass
+    # The deployment-event feed is a rolling ~2-week window with no backfill,
+    # so a stalled sync is not recoverable by catching up later. Warn well
+    # inside that window.
+    freshness:
+      warn_after: {count: 36, period: hour}
+      error_after: {count: 72, period: hour}
+    loaded_at_field: _airbyte_extracted_at
+    schema: bronze_compass
+    tables:
+      - name: components
+      - name: scorecards
+      - name: component_scorecard_scores
+      - name: teams
+      - name: team_members
+      - name: deployment_events
+
+models:
+  - name: compass__bronze_promoted
+    description: "Promotes every bronze_compass table to ReplacingMergeTree ordered by unique_key, so later FINAL reads are well-defined. Required for deployment_events, whose rows are rewritten in place as a deployment progresses."

--- a/src/ingestion/connectors/dev-portal/compass/descriptor.yaml
+++ b/src/ingestion/connectors/dev-portal/compass/descriptor.yaml
@@ -1,0 +1,23 @@
+# Atlassian Compass — service catalog, ownership, scorecards, deployment events.
+#
+# Bronze-only for now: no silver models beyond the bronze→RMT promotion, so
+# `dbt_select` currently resolves to that promotion view alone. Silver class
+# families are sketched in SPEC.md §7 and deliberately deferred.
+name: compass
+type: nocode
+# Strict semver per ADR-0015 — three components, no leading zeros.
+version: "1.0.0"
+# Daily is a floor, not a preference: the Compass event feed is a rolling
+# window with no backfill, so a skipped run loses deployment events for good.
+schedule: "0 2 * * *"
+workflow: sync
+dbt_select: "tag:compass+"
+
+connection:
+  namespace: "bronze_compass"
+
+secret:
+  required_fields:
+    - atlassian_email
+    - atlassian_api_token
+    - atlassian_cloud_id

--- a/src/ingestion/connectors/dev-portal/compass/tests/config.py
+++ b/src/ingestion/connectors/dev-portal/compass/tests/config.py
@@ -1,0 +1,84 @@
+"""Compass connector test config builder and GraphQL request helpers.
+
+Every stream POSTs to the same URL, so a matcher can only tell requests apart by
+their body — and `HttpRequest` compares bodies exactly. That is a feature here:
+the queries are read back out of `connector.yaml`, so a matcher asserts the
+manifest's real query text, and passing `cursor=` asserts that the paginator
+injected the cursor into `variables` rather than somewhere else.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+from connector_tests import ConfigBuilder, HttpRequest
+
+GRAPHQL_URL = "https://api.atlassian.com/graphql"
+CLOUD_ID = "11111111-2222-3333-4444-555555555555"
+SITE_SCOPE = f"ari:cloud:platform::site/{CLOUD_ID}"
+
+_MANIFEST = yaml.safe_load((Path(__file__).resolve().parents[1] / "connector.yaml").read_text())
+
+
+def component_ari(suffix: str) -> str:
+    return f"ari:cloud:compass:{CLOUD_ID}:component/aaaaaaaa-0000-0000-0000-000000000000/{suffix}"
+
+
+def scorecard_ari(suffix: str) -> str:
+    return f"ari:cloud:compass:{CLOUD_ID}:scorecard/aaaaaaaa-0000-0000-0000-000000000000/{suffix}"
+
+
+def team_ari(suffix: str) -> str:
+    return f"ari:cloud:identity::team/{suffix}"
+
+
+def user_ari(suffix: str) -> str:
+    return f"ari:cloud:identity::user/{suffix}"
+
+
+def _stream(name: str) -> dict:
+    for stream in _MANIFEST["streams"]:
+        if stream["name"] == name:
+            return stream
+    raise AssertionError(f"stream {name!r} is not in the manifest")
+
+
+def _as_sent(query: str) -> str:
+    """The manifest's query text as the CDK actually transmits it.
+
+    A YAML block scalar keeps its trailing newline; interpolation drops it. The
+    matcher compares bodies byte-exactly, so the newline has to go here too.
+    """
+    return query.rstrip("\n")
+
+
+def child_query(stream: str) -> str:
+    """The GraphQL document the stream itself sends."""
+    return _as_sent(_stream(stream)["retriever"]["requester"]["request_body_json"]["query"])
+
+
+def parent_query(stream: str) -> str:
+    """The GraphQL document the stream's inline substream parent sends."""
+    router = _stream(stream)["retriever"]["partition_router"]
+    return _as_sent(
+        router["parent_stream_configs"][0]["stream"]["retriever"]["requester"]["request_body_json"]["query"]
+    )
+
+
+def request(query: str, **variables: Any) -> HttpRequest:
+    """A matcher for one GraphQL POST.
+
+    Variables are compared exactly, so omitting `cursor` matches only the first
+    page and passing it matches only the follow-up page.
+    """
+    return HttpRequest(GRAPHQL_URL, body={"query": query, "variables": variables})
+
+
+class CompassConfigBuilder(ConfigBuilder):
+    def __init__(self) -> None:
+        super().__init__()
+        self._config.update(
+            {"atlassian_email": "bot@example.com", "atlassian_api_token": "test-token", "atlassian_cloud_id": CLOUD_ID}
+        )

--- a/src/ingestion/connectors/dev-portal/compass/tests/conftest.py
+++ b/src/ingestion/connectors/dev-portal/compass/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Local builder modules (config.py) are importable under --import-mode=importlib.
+sys.path.insert(0, str(Path(__file__).parent))
+
+from connector_tests.plugin import *  # noqa: E402,F401,F403 — http_mocker fixture + hooks

--- a/src/ingestion/connectors/dev-portal/compass/tests/fixtures/component.json
+++ b/src/ingestion/connectors/dev-portal/compass/tests/fixtures/component.json
@@ -1,0 +1,26 @@
+{
+  "id": "ari:cloud:compass:11111111-2222-3333-4444-555555555555:component/aaaaaaaa-0000-0000-0000-000000000000/c1",
+  "name": "billing-api",
+  "slug": "billing-api",
+  "type": "SERVICE",
+  "description": "Handles invoices.",
+  "url": "https://example.atlassian.net/compass/component/c1",
+  "ownerId": "ari:cloud:identity::team/t1",
+  "labels": [{"name": "tier-1"}],
+  "links": [
+    {"id": "l1", "type": "REPOSITORY", "url": "https://github.com/example-org/billing-api", "name": null}
+  ],
+  "eventSources": [
+    {"id": "es1", "eventType": "DEPLOYMENT", "externalEventSourceId": "{00000000-0000-0000-0000-00000000es01}"}
+  ],
+  "relationships": {
+    "nodes": [
+      {
+        "relationshipType": "DEPENDS_ON",
+        "startNode": {"id": "ari:cloud:compass:11111111-2222-3333-4444-555555555555:component/aaaaaaaa-0000-0000-0000-000000000000/c1"},
+        "endNode": {"id": "ari:cloud:compass:11111111-2222-3333-4444-555555555555:component/aaaaaaaa-0000-0000-0000-000000000000/c2"}
+      }
+    ],
+    "pageInfo": {"hasNextPage": false}
+  }
+}

--- a/src/ingestion/connectors/dev-portal/compass/tests/fixtures/deployment_event.json
+++ b/src/ingestion/connectors/dev-portal/compass/tests/fixtures/deployment_event.json
@@ -1,0 +1,16 @@
+{
+  "eventType": "DEPLOYMENT",
+  "displayName": "billing-api 1.4.2",
+  "description": "release pipeline",
+  "url": "https://ci.example.com/builds/4242",
+  "lastUpdated": "2026-06-15T10:20:30.123Z",
+  "updateSequenceNumber": 1750000000123,
+  "deploymentProperties": {
+    "sequenceNumber": 4242,
+    "state": "SUCCESSFUL",
+    "startedAt": "2026-06-15T10:15:00.000Z",
+    "completedAt": "2026-06-15T10:20:30.123Z",
+    "environment": {"category": "PRODUCTION", "displayName": "Production", "environmentId": "prod"},
+    "pipeline": {"pipelineId": "4242", "displayName": "release", "url": "https://ci.example.com/pipelines/release"}
+  }
+}

--- a/src/ingestion/connectors/dev-portal/compass/tests/fixtures/score_edge.json
+++ b/src/ingestion/connectors/dev-portal/compass/tests/fixtures/score_edge.json
@@ -1,0 +1,13 @@
+{
+  "node": {"id": "ari:cloud:compass:11111111-2222-3333-4444-555555555555:component/aaaaaaaa-0000-0000-0000-000000000000/c1"},
+  "score": {
+    "totalScore": 67,
+    "maxTotalScore": 100,
+    "status": {"name": "NEEDS_ATTENTION"},
+    "criteriaScores": [
+      {"criterionId": "cr1", "score": 34, "maxScore": 34, "status": "PASSING", "dataSourceLastUpdated": "2026-08-10T14:51:00.233Z"},
+      {"criterionId": "cr2", "score": 33, "maxScore": 33, "status": "PASSING", "dataSourceLastUpdated": null},
+      {"criterionId": "cr3", "score": 0, "maxScore": 33, "status": "FAILING", "dataSourceLastUpdated": null}
+    ]
+  }
+}

--- a/src/ingestion/connectors/dev-portal/compass/tests/fixtures/scorecard.json
+++ b/src/ingestion/connectors/dev-portal/compass/tests/fixtures/scorecard.json
@@ -1,0 +1,16 @@
+{
+  "id": "ari:cloud:compass:11111111-2222-3333-4444-555555555555:scorecard/aaaaaaaa-0000-0000-0000-000000000000/s1",
+  "name": "Component Readiness",
+  "description": "Baseline catalog hygiene.",
+  "state": "PUBLISHED",
+  "importance": "REQUIRED",
+  "changeMetadata": {
+    "createdAt": "2025-11-10T16:39:15.852Z",
+    "lastUserModificationAt": "2026-01-04T09:12:00.000Z"
+  },
+  "criterias": [
+    {"__typename": "CompassHasOwnerScorecardCriteria", "id": "cr1", "weight": 34, "name": null},
+    {"__typename": "CompassHasLinkScorecardCriteria", "id": "cr2", "weight": 33, "name": null, "linkType": "REPOSITORY"},
+    {"__typename": "CompassHasDescriptionScorecardCriteria", "id": "cr3", "weight": 33, "name": null}
+  ]
+}

--- a/src/ingestion/connectors/dev-portal/compass/tests/fixtures/team.json
+++ b/src/ingestion/connectors/dev-portal/compass/tests/fixtures/team.json
@@ -1,0 +1,9 @@
+{
+  "id": "ari:cloud:identity::team/t1",
+  "displayName": "Platform",
+  "description": "Owns shared services.",
+  "state": "ACTIVE",
+  "organizationId": "ari:cloud:platform::org/99999999-8888-7777-6666-555555555555",
+  "memberCount": null,
+  "isVerified": false
+}

--- a/src/ingestion/connectors/dev-portal/compass/tests/fixtures/team_member.json
+++ b/src/ingestion/connectors/dev-portal/compass/tests/fixtures/team_member.json
@@ -1,0 +1,9 @@
+{
+  "role": "REGULAR",
+  "state": "FULL_MEMBER",
+  "member": {
+    "id": "ari:cloud:identity::user/u1",
+    "name": "Alex Example",
+    "accountStatus": "active"
+  }
+}

--- a/src/ingestion/connectors/dev-portal/compass/tests/test_component_scorecard_scores.py
+++ b/src/ingestion/connectors/dev-portal/compass/tests/test_component_scorecard_scores.py
@@ -1,0 +1,174 @@
+"""Mock-server tests for the `component_scorecard_scores` stream.
+
+Substream over an inline ids-only scorecards parent, paginated on the child.
+Records are extracted from `...appliedToComponents.edges`, where the score
+hangs off the EDGE rather than the node.
+
+Coverage matrix rows: full_refresh_single_page, pagination_multi_page,
+empty_page, tenant_source_stamping, schema_conformance, transformations,
+substream_partition, error_retry (429), GraphQL-error-in-200.
+
+Not applicable: incremental_state (full refresh), record_filter / error_ignore
+(not declared).
+"""
+
+from __future__ import annotations
+
+import json
+
+from config import CLOUD_ID, CompassConfigBuilder, child_query, component_ari, parent_query, request, scorecard_ari
+from connector_tests import HttpMocker, HttpResponse, assert_records_conform, load_fixture, read_stream
+
+_STREAM = "component_scorecard_scores"
+_CONNECTOR = "dev-portal/compass"
+
+
+def _parent_req():
+    return request(parent_query(_STREAM), cloudId=CLOUD_ID)
+
+
+def _child_req(scorecard_suffix: str, **variables):
+    return request(child_query(_STREAM), scorecardId=scorecard_ari(scorecard_suffix), **variables)
+
+
+def _parent(*suffixes: str) -> HttpResponse:
+    """The inline ids-only parent response: scorecard ids and nothing else."""
+    return HttpResponse(
+        body=json.dumps({"data": {"compass": {"scorecards": {"nodes": [{"id": scorecard_ari(s)} for s in suffixes]}}}}),
+        status_code=200,
+    )
+
+
+def _edge(component_suffix: str, **overrides: object) -> dict:
+    edge = load_fixture(__file__, "score_edge.json", **overrides)
+    edge["node"] = {"id": component_ari(component_suffix)}
+    return edge
+
+
+def _child(scorecard_suffix: str, edges: list[dict], *, cursor: str | None = None) -> HttpResponse:
+    return HttpResponse(
+        body=json.dumps(
+            {
+                "data": {
+                    "compass": {
+                        "scorecard": {
+                            "id": scorecard_ari(scorecard_suffix),
+                            "appliedToComponents": {
+                                "pageInfo": {"hasNextPage": cursor is not None, "endCursor": cursor},
+                                "edges": edges,
+                            },
+                        }
+                    }
+                }
+            }
+        ),
+        status_code=200,
+    )
+
+
+def test_full_refresh_single_page(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_parent_req(), _parent("s1"))
+    http_mocker.post(_child_req("s1"), _child("s1", [_edge("c1")]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 1
+    rec = output.records[0].record.data
+    assert rec["scorecard_id"] == scorecard_ari("s1")
+    assert rec["component_id"] == component_ari("c1")
+    assert rec["total_score"] == 67
+    assert rec["max_total_score"] == 100
+    assert rec["status"] == "NEEDS_ATTENTION"
+    assert_records_conform(output.records, _CONNECTOR, _STREAM)
+
+
+def test_criteria_scores_carry_data_source_freshness(http_mocker: HttpMocker):
+    """`dataSourceLastUpdated` must survive per criterion.
+
+    A metric-backed criterion scores zero both when the component genuinely
+    fails it and when the integration feeding the metric is absent. This
+    timestamp is the only field that separates the two, so losing it would make
+    every score unreadable downstream.
+    """
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_parent_req(), _parent("s1"))
+    http_mocker.post(_child_req("s1"), _child("s1", [_edge("c1")]))
+
+    rec = read_stream(_CONNECTOR, _STREAM, config).records[0].record.data
+
+    assert [c["criterionId"] for c in rec["criteria_scores"]] == ["cr1", "cr2", "cr3"]
+    assert rec["criteria_scores"][0]["dataSourceLastUpdated"] == "2026-08-10T14:51:00.233Z"
+    assert rec["criteria_scores"][2]["status"] == "FAILING"
+    # The raw union members are dropped once flattened.
+    assert "node" not in rec
+    assert "score" not in rec
+
+
+def test_substream_partition_one_request_per_scorecard(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_parent_req(), _parent("s1", "s2"))
+    http_mocker.post(_child_req("s1"), _child("s1", [_edge("c1")]))
+    http_mocker.post(_child_req("s2"), _child("s2", [_edge("c2")]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    pairs = {(r.record.data["scorecard_id"], r.record.data["component_id"]) for r in output.records}
+    assert pairs == {(scorecard_ari("s1"), component_ari("c1")), (scorecard_ari("s2"), component_ari("c2"))}
+
+
+def test_pagination_multi_page(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_parent_req(), _parent("s1"))
+    http_mocker.post(_child_req("s1"), _child("s1", [_edge("c1")], cursor="CURSOR_1"))
+    http_mocker.post(_child_req("s1", cursor="CURSOR_1"), _child("s1", [_edge("c2")]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert {r.record.data["component_id"] for r in output.records} == {component_ari("c1"), component_ari("c2")}
+
+
+def test_empty_page(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_parent_req(), _parent("s1"))
+    http_mocker.post(_child_req("s1"), _child("s1", []))
+
+    assert read_stream(_CONNECTOR, _STREAM, config).records == []
+
+
+def test_tenant_source_stamping(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_parent_req(), _parent("s1"))
+    http_mocker.post(_child_req("s1"), _child("s1", [_edge("c1")]))
+
+    rec = read_stream(_CONNECTOR, _STREAM, config).records[0].record.data
+
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["source_id"] == config["insight_source_id"]
+    # Keyed on the pair, so one component scored by several scorecards does not collide.
+    assert rec["unique_key"] == (
+        f"{config['insight_tenant_id']}:{config['insight_source_id']}:{scorecard_ari('s1')}:{component_ari('c1')}"
+    )
+
+
+def test_graphql_error_in_http_200_fails_the_read(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(
+        _parent_req(),
+        HttpResponse(body=json.dumps({"errors": [{"message": "OptInException"}], "data": None}), status_code=200),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config, expecting_exception=True)
+
+    assert output.records == []
+    assert output.errors
+
+
+def test_error_retry_on_429(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(
+        _parent_req(), [HttpResponse(body="{}", status_code=429, headers={"Retry-After": "0"}), _parent("s1")]
+    )
+    http_mocker.post(_child_req("s1"), _child("s1", [_edge("c1")]))
+
+    assert len(read_stream(_CONNECTOR, _STREAM, config).records) == 1

--- a/src/ingestion/connectors/dev-portal/compass/tests/test_component_scorecard_scores.py
+++ b/src/ingestion/connectors/dev-portal/compass/tests/test_component_scorecard_scores.py
@@ -164,6 +164,40 @@ def test_graphql_error_in_http_200_fails_the_read(http_mocker: HttpMocker):
     assert output.errors
 
 
+def test_union_error_on_applied_components_fails(http_mocker: HttpMocker):
+    """The beta opt-in being withdrawn surfaces here, not as a top-level error.
+
+    `appliedToComponents` is a union, so a refusal is a successful body with a
+    `message` and no `edges`. Left unhandled the stream would report zero
+    scores for every scorecard and look healthy.
+    """
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_parent_req(), _parent("s1"))
+    http_mocker.post(
+        _child_req("s1"),
+        HttpResponse(
+            body=json.dumps(
+                {
+                    "data": {
+                        "compass": {
+                            "scorecard": {
+                                "id": scorecard_ari("s1"),
+                                "appliedToComponents": {"message": "EXPERIMENTAL field requires opt-in"},
+                            }
+                        }
+                    }
+                }
+            ),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config, expecting_exception=True)
+
+    assert output.records == []
+    assert output.errors
+
+
 def test_error_retry_on_429(http_mocker: HttpMocker):
     config = CompassConfigBuilder().build()
     http_mocker.post(

--- a/src/ingestion/connectors/dev-portal/compass/tests/test_components.py
+++ b/src/ingestion/connectors/dev-portal/compass/tests/test_components.py
@@ -155,12 +155,13 @@ def test_graphql_error_in_http_200_fails_the_read(http_mocker: HttpMocker):
     assert output.errors, "a GraphQL error served as HTTP 200 must fail the stream"
 
 
-def test_query_error_union_member_yields_no_records(http_mocker: HttpMocker):
-    """`searchComponents` returns a union; the error member has no `nodes`.
+def test_query_error_union_member_fails_the_catalog(http_mocker: HttpMocker):
+    """`searchComponents` returns a union, and its error member has no `nodes`.
 
-    Unlike the case above this is a legitimate 200 with no top-level `errors`,
-    so the stream must simply produce nothing rather than crash while walking
-    the response for a paginator cursor.
+    This body carries no top-level `errors`, so the catch-all filter cannot see
+    it; without the per-stream filter the extractor would find nothing and the
+    whole catalog would report zero components as a successful sync. For the
+    catalog that is never an acceptable outcome, so it must fail loudly.
     """
     config = CompassConfigBuilder().build()
     http_mocker.post(
@@ -170,9 +171,10 @@ def test_query_error_union_member_yields_no_records(http_mocker: HttpMocker):
         ),
     )
 
-    output = read_stream(_CONNECTOR, _STREAM, config)
+    output = read_stream(_CONNECTOR, _STREAM, config, expecting_exception=True)
 
     assert output.records == []
+    assert output.errors, "a union QueryError on the catalog must fail the stream"
 
 
 def test_error_retry_on_429(http_mocker: HttpMocker):

--- a/src/ingestion/connectors/dev-portal/compass/tests/test_components.py
+++ b/src/ingestion/connectors/dev-portal/compass/tests/test_components.py
@@ -1,0 +1,186 @@
+"""Mock-server tests for the `components` stream.
+
+Paginated GraphQL POST: cursor injected into `variables.cursor`, records
+extracted from `data.compass.searchComponents.nodes`, the nested `component`
+object hoisted into flat columns with links / labels / event sources /
+relationships carried as JSON.
+
+Coverage matrix rows: full_refresh_single_page, pagination_multi_page,
+empty_page, tenant_source_stamping, schema_conformance, transformations,
+error_retry (429), plus the two GraphQL-specific hazards: an error body served
+with HTTP 200, and a `QueryError` union member where a connection was expected.
+
+Not applicable: incremental_state (stream is full refresh),
+substream_partition (no parent), record_filter (none declared),
+error_ignore (the manifest ignores no status codes — a GraphQL error must fail
+loudly, not be swallowed).
+"""
+
+from __future__ import annotations
+
+import json
+
+from config import CLOUD_ID, CompassConfigBuilder, child_query, component_ari, request
+from connector_tests import HttpMocker, HttpResponse, assert_records_conform, load_fixture, read_stream
+
+_STREAM = "components"
+_CONNECTOR = "dev-portal/compass"
+_QUERY = child_query(_STREAM)
+
+
+def _req(**variables):
+    """Matcher for one catalog page — pass `cursor` to match the follow-up page."""
+    return request(_QUERY, cloudId=CLOUD_ID, **variables)
+
+
+def _component(suffix: str, **overrides: object) -> dict:
+    return load_fixture(__file__, "component.json", id=component_ari(suffix), **overrides)
+
+
+def _page(components: list[dict], *, cursor: str | None = None) -> HttpResponse:
+    return HttpResponse(
+        body=json.dumps(
+            {
+                "data": {
+                    "compass": {
+                        "searchComponents": {
+                            "pageInfo": {"hasNextPage": cursor is not None, "endCursor": cursor},
+                            "nodes": [{"component": c} for c in components],
+                        }
+                    }
+                }
+            }
+        ),
+        status_code=200,
+    )
+
+
+def test_full_refresh_single_page(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_req(), _page([_component("c1")]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 1
+    rec = output.records[0].record.data
+    assert rec["component_id"] == component_ari("c1")
+    assert rec["name"] == "billing-api"
+    assert rec["component_type"] == "SERVICE"
+    assert rec["owner_team_id"] == "ari:cloud:identity::team/t1"
+    assert_records_conform(output.records, _CONNECTOR, _STREAM)
+
+
+def test_transformations_flatten_nested_collections(http_mocker: HttpMocker):
+    """links / labels / event_sources / relationships survive as structured JSON."""
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_req(), _page([_component("c1")]))
+
+    rec = read_stream(_CONNECTOR, _STREAM, config).records[0].record.data
+
+    assert rec["labels"] == ["tier-1"]
+    assert [link["type"] for link in rec["links"]] == ["REPOSITORY"]
+    assert rec["links"][0]["url"] == "https://github.com/example-org/billing-api"
+    assert [src["eventType"] for src in rec["event_sources"]] == ["DEPLOYMENT"]
+    assert [rel["relationshipType"] for rel in rec["relationships"]] == ["DEPENDS_ON"]
+    # The nested relationship list cannot be paginated, so the truncation flag is
+    # the only signal that edges were dropped. It must never be silently absent.
+    assert rec["relationships_truncated"] is False
+    # The raw nested object is removed rather than duplicated alongside the flat columns.
+    assert "component" not in rec
+
+
+def test_truncated_relationships_stay_visible(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    component = _component("c1")
+    component["relationships"]["pageInfo"]["hasNextPage"] = True
+    http_mocker.post(_req(), _page([component]))
+
+    rec = read_stream(_CONNECTOR, _STREAM, config).records[0].record.data
+
+    assert rec["relationships_truncated"] is True
+
+
+def test_pagination_multi_page(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    # Every page hits the same URL; the cursor travels in the POST body. Two
+    # separate body matchers are therefore the assertion that the paginator
+    # injected the cursor into `variables` and not somewhere else.
+    http_mocker.post(_req(), _page([_component("c1")], cursor="CURSOR_1"))
+    http_mocker.post(_req(cursor="CURSOR_1"), _page([_component("c2")]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    ids = [r.record.data["component_id"] for r in output.records]
+    assert ids == [component_ari("c1"), component_ari("c2")]
+
+
+def test_empty_page(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_req(), _page([]))
+
+    assert read_stream(_CONNECTOR, _STREAM, config).records == []
+
+
+def test_tenant_source_stamping(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_req(), _page([_component("c1")]))
+
+    rec = read_stream(_CONNECTOR, _STREAM, config).records[0].record.data
+
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["source_id"] == config["insight_source_id"]
+    assert rec["data_source"] == "insight_compass"
+    assert rec["unique_key"] == (f"{config['insight_tenant_id']}:{config['insight_source_id']}:{component_ari('c1')}")
+
+
+def test_graphql_error_in_http_200_fails_the_read(http_mocker: HttpMocker):
+    """The whole point of the body-predicate response filter.
+
+    Atlassian answers a rejected query with HTTP 200 and an `errors[]` array. A
+    status-code-only error handler sees success, the extractor finds no `nodes`,
+    and the sync reports zero records while the real cause never surfaces.
+    """
+    config = CompassConfigBuilder().build()
+    http_mocker.post(
+        _req(),
+        HttpResponse(
+            body=json.dumps({"errors": [{"message": "Field 'x' is marked as EXPERIMENTAL"}], "data": None}),
+            status_code=200,
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config, expecting_exception=True)
+
+    assert output.records == []
+    assert output.errors, "a GraphQL error served as HTTP 200 must fail the stream"
+
+
+def test_query_error_union_member_yields_no_records(http_mocker: HttpMocker):
+    """`searchComponents` returns a union; the error member has no `nodes`.
+
+    Unlike the case above this is a legitimate 200 with no top-level `errors`,
+    so the stream must simply produce nothing rather than crash while walking
+    the response for a paginator cursor.
+    """
+    config = CompassConfigBuilder().build()
+    http_mocker.post(
+        _req(),
+        HttpResponse(
+            body=json.dumps({"data": {"compass": {"searchComponents": {"message": "Not found"}}}}), status_code=200
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert output.records == []
+
+
+def test_error_retry_on_429(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(
+        _req(), [HttpResponse(body="{}", status_code=429, headers={"Retry-After": "0"}), _page([_component("c1")])]
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 1

--- a/src/ingestion/connectors/dev-portal/compass/tests/test_deployment_events.py
+++ b/src/ingestion/connectors/dev-portal/compass/tests/test_deployment_events.py
@@ -247,26 +247,29 @@ def test_graphql_error_in_http_200_fails_the_read(http_mocker: HttpMocker):
 
 
 @freeze_time(_NOW)
-def test_query_error_union_member_does_not_crash_the_paginator(http_mocker: HttpMocker):
-    """A component resolving to `QueryError` has no `events` and no `pageInfo`.
+def test_unreadable_component_is_skipped_not_fatal(http_mocker: HttpMocker):
+    """A component deleted between the parent sweep and this read is ordinary.
 
-    The paginator walks the response for a cursor, so a naive path expression
-    raises "'None' has no attribute 'pageInfo'" and kills the partition. The
-    null-safe expressions must turn this into a clean zero-record partition.
+    It comes back as a `QueryError` union member with no `events` and no
+    `pageInfo` — so the paginator paths have to be null-safe, and the stream
+    handler IGNOREs it rather than failing. Unlike the catalog query, one
+    unreadable component out of thousands must not take the sync down: the
+    remaining partitions still have to produce their events.
     """
     config = CompassConfigBuilder().build()
-    http_mocker.post(_parent_req(), _parent("c1"))
+    http_mocker.post(_parent_req(), _parent("c1", "c2"))
     http_mocker.post(
         _child_req("c1"),
         HttpResponse(
             body=json.dumps({"data": {"compass": {"component": {"message": "Component not found"}}}}), status_code=200
         ),
     )
+    http_mocker.post(_child_req("c2"), _child("c2", [_event(7, "2026-06-15T10:00:00.000Z")]))
 
     output = read_stream(_CONNECTOR, _STREAM, config)
 
-    assert output.records == []
     assert not output.errors
+    assert [r.record.data["component_id"] for r in output.records] == [component_ari("c2")]
 
 
 @freeze_time(_NOW)

--- a/src/ingestion/connectors/dev-portal/compass/tests/test_deployment_events.py
+++ b/src/ingestion/connectors/dev-portal/compass/tests/test_deployment_events.py
@@ -1,0 +1,280 @@
+"""Mock-server tests for the `deployment_events` stream.
+
+Substream over an inline ids-only components parent, incremental on
+`last_updated`. The cursor is client-side: the source exposes no usable
+server-side date filter, so pages come back newest-first and the CDK filters
+them against state.
+
+Coverage matrix rows: full_refresh_single_page, pagination_multi_page,
+empty_page, tenant_source_stamping, schema_conformance, transformations,
+substream_partition, incremental_state, error_retry (429),
+GraphQL-error-in-200.
+
+Not applicable: record_filter (none declared beyond the cursor filter),
+error_ignore (the manifest ignores no status codes).
+"""
+
+from __future__ import annotations
+
+import json
+
+from config import CLOUD_ID, CompassConfigBuilder, child_query, component_ari, parent_query, request
+from connector_tests import HttpMocker, HttpResponse, assert_records_conform, load_fixture, read_stream
+from freezegun import freeze_time
+
+_STREAM = "deployment_events"
+_CONNECTOR = "dev-portal/compass"
+_NOW = "2026-06-20T00:00:00Z"
+
+
+def _parent_req():
+    return request(parent_query(_STREAM), cloudId=CLOUD_ID)
+
+
+def _child_req(component_suffix: str, **variables):
+    return request(child_query(_STREAM), componentId=component_ari(component_suffix), **variables)
+
+
+def _parent(*suffixes: str) -> HttpResponse:
+    return HttpResponse(
+        body=json.dumps(
+            {
+                "data": {
+                    "compass": {
+                        "searchComponents": {
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                            "nodes": [{"component": {"id": component_ari(s)}} for s in suffixes],
+                        }
+                    }
+                }
+            }
+        ),
+        status_code=200,
+    )
+
+
+def _event(usn: int, last_updated: str, **overrides: object) -> dict:
+    return load_fixture(
+        __file__, "deployment_event.json", updateSequenceNumber=usn, lastUpdated=last_updated, **overrides
+    )
+
+
+def _child(component_suffix: str, events: list[dict], *, cursor: str | None = None) -> HttpResponse:
+    return HttpResponse(
+        body=json.dumps(
+            {
+                "data": {
+                    "compass": {
+                        "component": {
+                            "id": component_ari(component_suffix),
+                            "events": {
+                                "pageInfo": {"hasNextPage": cursor is not None, "endCursor": cursor},
+                                "nodes": events,
+                            },
+                        }
+                    }
+                }
+            }
+        ),
+        status_code=200,
+    )
+
+
+@freeze_time(_NOW)
+def test_full_refresh_single_page(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_parent_req(), _parent("c1"))
+    http_mocker.post(_child_req("c1"), _child("c1", [_event(1750000000123, "2026-06-15T10:20:30.123Z")]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 1
+    rec = output.records[0].record.data
+    assert rec["component_id"] == component_ari("c1")
+    assert rec["event_type"] == "DEPLOYMENT"
+    assert rec["last_updated"] == "2026-06-15T10:20:30.123Z"
+    assert rec["update_sequence_number"] == 1750000000123
+    assert_records_conform(output.records, _CONNECTOR, _STREAM)
+
+
+@freeze_time(_NOW)
+def test_transformations_flatten_deployment_properties(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_parent_req(), _parent("c1"))
+    http_mocker.post(_child_req("c1"), _child("c1", [_event(1750000000123, "2026-06-15T10:20:30.123Z")]))
+
+    rec = read_stream(_CONNECTOR, _STREAM, config).records[0].record.data
+
+    assert rec["state"] == "SUCCESSFUL"
+    # Release metrics must key on this column — a DEPLOYMENT event with a
+    # non-production category is build or pre-production activity, not a release.
+    assert rec["environment_category"] == "PRODUCTION"
+    assert rec["environment_id"] == "prod"
+    assert rec["started_at"] == "2026-06-15T10:15:00.000Z"
+    assert rec["completed_at"] == "2026-06-15T10:20:30.123Z"
+    assert rec["sequence_number"] == 4242
+    assert rec["pipeline"]["pipelineId"] == "4242"
+    assert "deploymentProperties" not in rec
+
+
+@freeze_time(_NOW)
+def test_in_progress_event_keeps_null_completion(http_mocker: HttpMocker):
+    """A terminal state may never arrive; the row must still be emitted."""
+    config = CompassConfigBuilder().build()
+    event = _event(1750000000999, "2026-06-16T08:00:00.000Z")
+    event["deploymentProperties"]["state"] = "IN_PROGRESS"
+    event["deploymentProperties"]["completedAt"] = None
+    http_mocker.post(_parent_req(), _parent("c1"))
+    http_mocker.post(_child_req("c1"), _child("c1", [event]))
+
+    rec = read_stream(_CONNECTOR, _STREAM, config).records[0].record.data
+
+    assert rec["state"] == "IN_PROGRESS"
+    assert rec.get("completed_at") is None
+
+
+@freeze_time(_NOW)
+def test_unique_key_excludes_the_cursor(http_mocker: HttpMocker):
+    """One event rewritten in place must replace its row, not fork a new one.
+
+    Compass updates an event as the deployment progresses, so the key is
+    (component, updateSequenceNumber). Including `last_updated` would make every
+    progress update a separate bronze row.
+    """
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_parent_req(), _parent("c1"))
+    http_mocker.post(_child_req("c1"), _child("c1", [_event(1750000000123, "2026-06-15T10:20:30.123Z")]))
+
+    rec = read_stream(_CONNECTOR, _STREAM, config).records[0].record.data
+
+    assert rec["unique_key"] == (
+        f"{config['insight_tenant_id']}:{config['insight_source_id']}:{component_ari('c1')}:1750000000123"
+    )
+    assert "2026-06-15" not in rec["unique_key"]
+
+
+@freeze_time(_NOW)
+def test_substream_partition_one_request_per_component(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_parent_req(), _parent("c1", "c2"))
+    http_mocker.post(_child_req("c1"), _child("c1", [_event(1, "2026-06-15T10:00:00.000Z")]))
+    http_mocker.post(_child_req("c2"), _child("c2", [_event(2, "2026-06-16T10:00:00.000Z")]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert {r.record.data["component_id"] for r in output.records} == {component_ari("c1"), component_ari("c2")}
+
+
+@freeze_time(_NOW)
+def test_pagination_multi_page(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_parent_req(), _parent("c1"))
+    http_mocker.post(_child_req("c1"), _child("c1", [_event(2, "2026-06-16T10:00:00.000Z")], cursor="CURSOR_1"))
+    http_mocker.post(_child_req("c1", cursor="CURSOR_1"), _child("c1", [_event(1, "2026-06-15T10:00:00.000Z")]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert {r.record.data["update_sequence_number"] for r in output.records} == {1, 2}
+
+
+@freeze_time(_NOW)
+def test_incremental_state_emitted_and_resume_filters(http_mocker: HttpMocker):
+    """State advances, and a resumed read drops events at or below the cursor.
+
+    The filtering is client-side by construction: the source's own
+    `timeParameters` window is unusable, so the manifest sets
+    `is_client_side_incremental` and the CDK does the comparison. This test is
+    what proves the cursor is actually observed — without the AddFields hoist of
+    `lastUpdated` to a top-level column the cursor sees nothing and every sync
+    re-reads the whole window.
+    """
+    config = CompassConfigBuilder().build()
+    old = _event(1, "2026-06-10T00:00:00.000Z")
+    new = _event(2, "2026-06-18T00:00:00.000Z")
+
+    http_mocker.post(_parent_req(), _parent("c1"))
+    http_mocker.post(_child_req("c1"), _child("c1", [new, old]))
+    first = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert {r.record.data["update_sequence_number"] for r in first.records} == {1, 2}
+    assert first.state_messages, "an incremental stream must emit state"
+
+    http_mocker.clear_all_matchers()
+    http_mocker.post(_parent_req(), _parent("c1"))
+    http_mocker.post(_child_req("c1"), _child("c1", [new, old]))
+    state = [m.state for m in first.state_messages][-1:]
+    resumed = read_stream(_CONNECTOR, _STREAM, config, state=state)
+
+    resumed_usns = {r.record.data["update_sequence_number"] for r in resumed.records}
+    assert 1 not in resumed_usns, "an event older than the cursor must be filtered out"
+    assert len(resumed.records) < len(first.records)
+
+
+@freeze_time(_NOW)
+def test_empty_page(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_parent_req(), _parent("c1"))
+    http_mocker.post(_child_req("c1"), _child("c1", []))
+
+    assert read_stream(_CONNECTOR, _STREAM, config).records == []
+
+
+@freeze_time(_NOW)
+def test_tenant_source_stamping(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_parent_req(), _parent("c1"))
+    http_mocker.post(_child_req("c1"), _child("c1", [_event(1, "2026-06-15T10:00:00.000Z")]))
+
+    rec = read_stream(_CONNECTOR, _STREAM, config).records[0].record.data
+
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["source_id"] == config["insight_source_id"]
+    assert rec["data_source"] == "insight_compass"
+
+
+@freeze_time(_NOW)
+def test_graphql_error_in_http_200_fails_the_read(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(
+        _parent_req(),
+        HttpResponse(body=json.dumps({"errors": [{"message": "component not found"}], "data": None}), status_code=200),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config, expecting_exception=True)
+
+    assert output.records == []
+    assert output.errors
+
+
+@freeze_time(_NOW)
+def test_query_error_union_member_does_not_crash_the_paginator(http_mocker: HttpMocker):
+    """A component resolving to `QueryError` has no `events` and no `pageInfo`.
+
+    The paginator walks the response for a cursor, so a naive path expression
+    raises "'None' has no attribute 'pageInfo'" and kills the partition. The
+    null-safe expressions must turn this into a clean zero-record partition.
+    """
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_parent_req(), _parent("c1"))
+    http_mocker.post(
+        _child_req("c1"),
+        HttpResponse(
+            body=json.dumps({"data": {"compass": {"component": {"message": "Component not found"}}}}), status_code=200
+        ),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert output.records == []
+    assert not output.errors
+
+
+@freeze_time(_NOW)
+def test_error_retry_on_429(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(
+        _parent_req(), [HttpResponse(body="{}", status_code=429, headers={"Retry-After": "0"}), _parent("c1")]
+    )
+    http_mocker.post(_child_req("c1"), _child("c1", [_event(1, "2026-06-15T10:00:00.000Z")]))
+
+    assert len(read_stream(_CONNECTOR, _STREAM, config).records) == 1

--- a/src/ingestion/connectors/dev-portal/compass/tests/test_scorecards.py
+++ b/src/ingestion/connectors/dev-portal/compass/tests/test_scorecards.py
@@ -1,0 +1,114 @@
+"""Mock-server tests for the `scorecards` stream.
+
+Unpaginated GraphQL POST (the field takes no cursor), records extracted from
+`data.compass.scorecards.nodes`, `changeMetadata` hoisted into flat timestamp
+columns and `criterias` kept as JSON.
+
+Coverage matrix rows: full_refresh_single_page, empty_page,
+tenant_source_stamping, schema_conformance, transformations, error_retry (429),
+GraphQL-error-in-200.
+
+Not applicable: pagination_multi_page (the field exposes no cursor — see the
+NoPagination paginator), incremental_state (full refresh), substream_partition
+(no parent), record_filter / error_ignore (not declared).
+"""
+
+from __future__ import annotations
+
+import json
+
+from config import CLOUD_ID, CompassConfigBuilder, child_query, request, scorecard_ari
+from connector_tests import HttpMocker, HttpResponse, assert_records_conform, load_fixture, read_stream
+
+_STREAM = "scorecards"
+_CONNECTOR = "dev-portal/compass"
+
+
+def _req():
+    return request(child_query(_STREAM), cloudId=CLOUD_ID)
+
+
+def _scorecard(suffix: str, **overrides: object) -> dict:
+    return load_fixture(__file__, "scorecard.json", id=scorecard_ari(suffix), **overrides)
+
+
+def _response(scorecards: list[dict]) -> HttpResponse:
+    return HttpResponse(body=json.dumps({"data": {"compass": {"scorecards": {"nodes": scorecards}}}}), status_code=200)
+
+
+def test_full_refresh_single_page(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_req(), _response([_scorecard("s1")]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 1
+    rec = output.records[0].record.data
+    assert rec["scorecard_id"] == scorecard_ari("s1")
+    assert rec["state"] == "PUBLISHED"
+    assert rec["importance"] == "REQUIRED"
+    assert_records_conform(output.records, _CONNECTOR, _STREAM)
+
+
+def test_criteria_and_change_metadata(http_mocker: HttpMocker):
+    """Criteria stay JSON; the change timestamps become columns.
+
+    `criterias` is deliberately not exploded into typed columns: the criterion
+    subtypes are an open set. `last_user_modification_at` is the only signal the
+    API gives that a definition changed at all — there is no diff and no version.
+    """
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_req(), _response([_scorecard("s1")]))
+
+    rec = read_stream(_CONNECTOR, _STREAM, config).records[0].record.data
+
+    assert rec["created_at"] == "2025-11-10T16:39:15.852Z"
+    assert rec["last_user_modification_at"] == "2026-01-04T09:12:00.000Z"
+    assert "changeMetadata" not in rec
+    weights = [c["weight"] for c in rec["criterias"]]
+    assert sum(weights) == 100, "criterion weights are normalised to 100 — the reason a bare score is ambiguous"
+    assert {c["__typename"] for c in rec["criterias"]} == {
+        "CompassHasOwnerScorecardCriteria",
+        "CompassHasLinkScorecardCriteria",
+        "CompassHasDescriptionScorecardCriteria",
+    }
+
+
+def test_empty_page(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_req(), _response([]))
+
+    assert read_stream(_CONNECTOR, _STREAM, config).records == []
+
+
+def test_tenant_source_stamping(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_req(), _response([_scorecard("s1")]))
+
+    rec = read_stream(_CONNECTOR, _STREAM, config).records[0].record.data
+
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["source_id"] == config["insight_source_id"]
+    assert rec["unique_key"] == (f"{config['insight_tenant_id']}:{config['insight_source_id']}:{scorecard_ari('s1')}")
+
+
+def test_graphql_error_in_http_200_fails_the_read(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(
+        _req(),
+        HttpResponse(body=json.dumps({"errors": [{"message": "OptInException"}], "data": None}), status_code=200),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config, expecting_exception=True)
+
+    assert output.records == []
+    assert output.errors
+
+
+def test_error_retry_on_429(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(
+        _req(), [HttpResponse(body="{}", status_code=429, headers={"Retry-After": "0"}), _response([_scorecard("s1")])]
+    )
+
+    assert len(read_stream(_CONNECTOR, _STREAM, config).records) == 1

--- a/src/ingestion/connectors/dev-portal/compass/tests/test_team_members.py
+++ b/src/ingestion/connectors/dev-portal/compass/tests/test_team_members.py
@@ -1,0 +1,190 @@
+"""Mock-server tests for the `team_members` stream.
+
+Substream over an inline ids-only teams parent, paginated per team. Fetching
+members per team rather than through the bulk resolve is deliberate: in the bulk
+form the nested member list is truncated and `hasNextPage` is true for every
+team, including teams whose members all fit.
+
+Coverage matrix rows: full_refresh_single_page, pagination_multi_page,
+empty_page, tenant_source_stamping, schema_conformance, transformations,
+substream_partition, error_retry (429), GraphQL-error-in-200.
+
+Not applicable: incremental_state (full refresh), record_filter / error_ignore
+(not declared).
+"""
+
+from __future__ import annotations
+
+import json
+
+from config import CLOUD_ID, SITE_SCOPE, CompassConfigBuilder, child_query, parent_query, request, team_ari, user_ari
+from connector_tests import HttpMocker, HttpResponse, assert_records_conform, load_fixture, read_stream
+
+_STREAM = "team_members"
+_CONNECTOR = "dev-portal/compass"
+
+
+def _parent_req():
+    return request(parent_query(_STREAM), scopeId=SITE_SCOPE)
+
+
+def _child_req(team_suffix: str, **variables):
+    return request(child_query(_STREAM), teamId=team_ari(team_suffix), siteId=CLOUD_ID, **variables)
+
+
+def _parent(*suffixes: str) -> HttpResponse:
+    return HttpResponse(
+        body=json.dumps(
+            {
+                "data": {
+                    "team": {
+                        "teamSearchV3": {
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                            "nodes": [{"team": {"id": team_ari(s)}} for s in suffixes],
+                        }
+                    }
+                }
+            }
+        ),
+        status_code=200,
+    )
+
+
+def _member(user_suffix: str, **overrides: object) -> dict:
+    member = load_fixture(__file__, "team_member.json", **overrides)
+    member["member"] = dict(member["member"], id=user_ari(user_suffix))
+    return member
+
+
+def _child(team_suffix: str, members: list[dict], *, cursor: str | None = None) -> HttpResponse:
+    return HttpResponse(
+        body=json.dumps(
+            {
+                "data": {
+                    "team": {
+                        "teamV2": {
+                            "id": team_ari(team_suffix),
+                            "members": {
+                                "pageInfo": {"hasNextPage": cursor is not None, "endCursor": cursor},
+                                "nodes": members,
+                            },
+                        }
+                    }
+                }
+            }
+        ),
+        status_code=200,
+    )
+
+
+def test_full_refresh_single_page(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_parent_req(), _parent("t1"))
+    http_mocker.post(_child_req("t1"), _child("t1", [_member("u1")]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 1
+    rec = output.records[0].record.data
+    assert rec["team_id"] == team_ari("t1")
+    assert rec["member_id"] == user_ari("u1")
+    assert rec["role"] == "REGULAR"
+    assert rec["membership_state"] == "FULL_MEMBER"
+    assert "member" not in rec
+    assert_records_conform(output.records, _CONNECTOR, _STREAM)
+
+
+def test_member_id_is_the_account_join_key(http_mocker: HttpMocker):
+    """People must be joinable by account id — the API exposes no email here."""
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_parent_req(), _parent("t1"))
+    http_mocker.post(_child_req("t1"), _child("t1", [_member("u1")]))
+
+    rec = read_stream(_CONNECTOR, _STREAM, config).records[0].record.data
+
+    assert rec["member_id"].startswith("ari:cloud:identity::user/")
+    assert "email" not in rec
+
+
+def test_inactive_accounts_are_kept(http_mocker: HttpMocker):
+    """Deactivated accounts stay listed as members; the status must be preserved."""
+    config = CompassConfigBuilder().build()
+    inactive = _member("u2")
+    inactive["member"]["accountStatus"] = "inactive"
+    http_mocker.post(_parent_req(), _parent("t1"))
+    http_mocker.post(_child_req("t1"), _child("t1", [inactive]))
+
+    rec = read_stream(_CONNECTOR, _STREAM, config).records[0].record.data
+
+    assert rec["account_status"] == "inactive"
+
+
+def test_substream_partition_one_request_per_team(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_parent_req(), _parent("t1", "t2"))
+    http_mocker.post(_child_req("t1"), _child("t1", [_member("u1")]))
+    http_mocker.post(_child_req("t2"), _child("t2", [_member("u1")]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    # The same person in two teams yields two rows with distinct keys —
+    # membership is many-to-many, so a person-keyed row would lose one.
+    keys = {r.record.data["unique_key"] for r in output.records}
+    assert len(keys) == 2
+    assert {r.record.data["team_id"] for r in output.records} == {team_ari("t1"), team_ari("t2")}
+
+
+def test_pagination_multi_page(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_parent_req(), _parent("t1"))
+    http_mocker.post(_child_req("t1"), _child("t1", [_member("u1")], cursor="CURSOR_1"))
+    http_mocker.post(_child_req("t1", cursor="CURSOR_1"), _child("t1", [_member("u2")]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert {r.record.data["member_id"] for r in output.records} == {user_ari("u1"), user_ari("u2")}
+
+
+def test_empty_page(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_parent_req(), _parent("t1"))
+    http_mocker.post(_child_req("t1"), _child("t1", []))
+
+    assert read_stream(_CONNECTOR, _STREAM, config).records == []
+
+
+def test_tenant_source_stamping(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_parent_req(), _parent("t1"))
+    http_mocker.post(_child_req("t1"), _child("t1", [_member("u1")]))
+
+    rec = read_stream(_CONNECTOR, _STREAM, config).records[0].record.data
+
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["source_id"] == config["insight_source_id"]
+    assert rec["unique_key"] == (
+        f"{config['insight_tenant_id']}:{config['insight_source_id']}:{team_ari('t1')}:{user_ari('u1')}"
+    )
+
+
+def test_graphql_error_in_http_200_fails_the_read(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(
+        _parent_req(),
+        HttpResponse(body=json.dumps({"errors": [{"message": "team not visible"}], "data": None}), status_code=200),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config, expecting_exception=True)
+
+    assert output.records == []
+    assert output.errors
+
+
+def test_error_retry_on_429(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(
+        _parent_req(), [HttpResponse(body="{}", status_code=429, headers={"Retry-After": "0"}), _parent("t1")]
+    )
+    http_mocker.post(_child_req("t1"), _child("t1", [_member("u1")]))
+
+    assert len(read_stream(_CONNECTOR, _STREAM, config).records) == 1

--- a/src/ingestion/connectors/dev-portal/compass/tests/test_teams.py
+++ b/src/ingestion/connectors/dev-portal/compass/tests/test_teams.py
@@ -1,0 +1,141 @@
+"""Mock-server tests for the `teams` stream.
+
+Paginated GraphQL POST against the Teams namespace; the site scope is an ARI
+derived from the configured cloud id, so no separate organization id is needed.
+
+Coverage matrix rows: full_refresh_single_page, pagination_multi_page,
+empty_page, tenant_source_stamping, schema_conformance, transformations,
+error_retry (429), GraphQL-error-in-200.
+
+Not applicable: incremental_state (full refresh — the Teams API exposes no
+cursor anywhere), substream_partition (no parent), record_filter / error_ignore
+(not declared).
+"""
+
+from __future__ import annotations
+
+import json
+
+from config import SITE_SCOPE, CompassConfigBuilder, child_query, request, team_ari
+from connector_tests import HttpMocker, HttpResponse, assert_records_conform, load_fixture, read_stream
+
+_STREAM = "teams"
+_CONNECTOR = "dev-portal/compass"
+_QUERY = child_query(_STREAM)
+
+
+def _req(**variables):
+    return request(_QUERY, scopeId=SITE_SCOPE, **variables)
+
+
+def _team(suffix: str, **overrides: object) -> dict:
+    return load_fixture(__file__, "team.json", id=team_ari(suffix), **overrides)
+
+
+def _page(teams: list[dict], *, cursor: str | None = None) -> HttpResponse:
+    return HttpResponse(
+        body=json.dumps(
+            {
+                "data": {
+                    "team": {
+                        "teamSearchV3": {
+                            "pageInfo": {"hasNextPage": cursor is not None, "endCursor": cursor},
+                            "nodes": [{"team": t} for t in teams],
+                        }
+                    }
+                }
+            }
+        ),
+        status_code=200,
+    )
+
+
+def test_full_refresh_single_page(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_req(), _page([_team("t1")]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert len(output.records) == 1
+    rec = output.records[0].record.data
+    assert rec["team_id"] == team_ari("t1")
+    assert rec["display_name"] == "Platform"
+    assert rec["state"] == "ACTIVE"
+    assert "team" not in rec
+    assert_records_conform(output.records, _CONNECTOR, _STREAM)
+
+
+def test_team_id_is_the_directory_join_key(http_mocker: HttpMocker):
+    """`team_id` must stay the full ARI, unmodified.
+
+    The UUID inside it is what Compass component ownership and Jira's
+    atlassian-team field both reference, so this column is the join key for
+    ownership across sources — rewriting or trimming it would break that join.
+    """
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_req(), _page([_team("t1")]))
+
+    rec = read_stream(_CONNECTOR, _STREAM, config).records[0].record.data
+
+    assert rec["team_id"].startswith("ari:cloud:identity::team/")
+
+
+def test_member_count_absent_from_search_is_tolerated(http_mocker: HttpMocker):
+    """The search field does not populate memberCount; that must not break the row."""
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_req(), _page([_team("t1")]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert output.records[0].record.data.get("member_count") in (None, 0, "")
+    assert_records_conform(output.records, _CONNECTOR, _STREAM)
+
+
+def test_pagination_multi_page(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_req(), _page([_team("t1")], cursor="CURSOR_1"))
+    http_mocker.post(_req(cursor="CURSOR_1"), _page([_team("t2")]))
+
+    output = read_stream(_CONNECTOR, _STREAM, config)
+
+    assert [r.record.data["team_id"] for r in output.records] == [team_ari("t1"), team_ari("t2")]
+
+
+def test_empty_page(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_req(), _page([]))
+
+    assert read_stream(_CONNECTOR, _STREAM, config).records == []
+
+
+def test_tenant_source_stamping(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_req(), _page([_team("t1")]))
+
+    rec = read_stream(_CONNECTOR, _STREAM, config).records[0].record.data
+
+    assert rec["tenant_id"] == config["insight_tenant_id"]
+    assert rec["source_id"] == config["insight_source_id"]
+    assert rec["unique_key"] == (f"{config['insight_tenant_id']}:{config['insight_source_id']}:{team_ari('t1')}")
+
+
+def test_graphql_error_in_http_200_fails_the_read(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(
+        _req(),
+        HttpResponse(body=json.dumps({"errors": [{"message": "scopeId rejected"}], "data": None}), status_code=200),
+    )
+
+    output = read_stream(_CONNECTOR, _STREAM, config, expecting_exception=True)
+
+    assert output.records == []
+    assert output.errors
+
+
+def test_error_retry_on_429(http_mocker: HttpMocker):
+    config = CompassConfigBuilder().build()
+    http_mocker.post(
+        _req(), [HttpResponse(body="{}", status_code=429, headers={"Retry-After": "0"}), _page([_team("t1")])]
+    )
+
+    assert len(read_stream(_CONNECTOR, _STREAM, config).records) == 1

--- a/src/ingestion/connectors/dev-portal/compass/tests/test_teams.py
+++ b/src/ingestion/connectors/dev-portal/compass/tests/test_teams.py
@@ -132,6 +132,21 @@ def test_graphql_error_in_http_200_fails_the_read(http_mocker: HttpMocker):
     assert output.errors
 
 
+def test_null_connection_fails_the_stream(http_mocker: HttpMocker):
+    """`teamSearchV3` is not a union: an unusable scope returns a null connection.
+
+    There is no error object to key on, so without the per-stream filter the
+    directory would come back empty and the sync would look successful.
+    """
+    config = CompassConfigBuilder().build()
+    http_mocker.post(_req(), HttpResponse(body=json.dumps({"data": {"team": {"teamSearchV3": None}}}), status_code=200))
+
+    output = read_stream(_CONNECTOR, _STREAM, config, expecting_exception=True)
+
+    assert output.records == []
+    assert output.errors
+
+
 def test_error_retry_on_429(http_mocker: HttpMocker):
     config = CompassConfigBuilder().build()
     http_mocker.post(

--- a/src/ingestion/scripts/bootstrap-db/connectors-config.yaml
+++ b/src/ingestion/scripts/bootstrap-db/connectors-config.yaml
@@ -115,6 +115,19 @@ connectors:
         value: hubspot-acme-prod
       insight_tenant_id:
         value: fake
+  compass:
+    path: dev-portal/compass
+    config:
+      atlassian_api_token:
+        value: fake
+      atlassian_cloud_id:
+        value: fake
+      atlassian_email:
+        value: fake
+      insight_source_id:
+        value: fake
+      insight_tenant_id:
+        value: fake
   bitbucket-cloud:
     path: git/bitbucket-cloud
     config:

--- a/src/ingestion/scripts/connectors-ddl/compass.sql
+++ b/src/ingestion/scripts/connectors-ddl/compass.sql
@@ -1,0 +1,158 @@
+CREATE DATABASE IF NOT EXISTS `bronze_compass`;
+
+CREATE TABLE IF NOT EXISTS bronze_compass.component_scorecard_scores
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `unique_key` Nullable(String),
+    `collected_at` Nullable(String),
+    `data_source` Nullable(String),
+    `scorecard_id` Nullable(String),
+    `component_id` Nullable(String),
+    `total_score` Nullable(Int64),
+    `max_total_score` Nullable(Int64),
+    `status` Nullable(String),
+    `criteria_scores` Nullable(String)
+)
+ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
+ORDER BY unique_key
+SETTINGS allow_nullable_key = 1, index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_compass.components
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `unique_key` Nullable(String),
+    `collected_at` Nullable(String),
+    `data_source` Nullable(String),
+    `component_id` Nullable(String),
+    `name` Nullable(String),
+    `slug` Nullable(String),
+    `component_type` Nullable(String),
+    `description` Nullable(String),
+    `component_url` Nullable(String),
+    `owner_team_id` Nullable(String),
+    `labels` Nullable(String),
+    `links` Nullable(String),
+    `event_sources` Nullable(String),
+    `relationships` Nullable(String),
+    `relationships_truncated` Nullable(Bool)
+)
+ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
+ORDER BY unique_key
+SETTINGS allow_nullable_key = 1, index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_compass.deployment_events
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `unique_key` Nullable(String),
+    `collected_at` Nullable(String),
+    `data_source` Nullable(String),
+    `component_id` Nullable(String),
+    `event_type` Nullable(String),
+    `display_name` Nullable(String),
+    `description` Nullable(String),
+    `event_url` Nullable(String),
+    `last_updated` Nullable(String),
+    `update_sequence_number` Nullable(Int64),
+    `state` Nullable(String),
+    `environment_category` Nullable(String),
+    `environment_display_name` Nullable(String),
+    `environment_id` Nullable(String),
+    `started_at` Nullable(String),
+    `completed_at` Nullable(String),
+    `sequence_number` Nullable(Int64),
+    `pipeline` Nullable(String)
+)
+ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
+ORDER BY unique_key
+SETTINGS allow_nullable_key = 1, index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_compass.scorecards
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `unique_key` Nullable(String),
+    `collected_at` Nullable(String),
+    `data_source` Nullable(String),
+    `scorecard_id` Nullable(String),
+    `name` Nullable(String),
+    `description` Nullable(String),
+    `state` Nullable(String),
+    `importance` Nullable(String),
+    `created_at` Nullable(String),
+    `last_user_modification_at` Nullable(String),
+    `criterias` Nullable(String)
+)
+ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
+ORDER BY unique_key
+SETTINGS allow_nullable_key = 1, index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_compass.team_members
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `unique_key` Nullable(String),
+    `collected_at` Nullable(String),
+    `data_source` Nullable(String),
+    `team_id` Nullable(String),
+    `member_id` Nullable(String),
+    `member_name` Nullable(String),
+    `account_status` Nullable(String),
+    `role` Nullable(String),
+    `membership_state` Nullable(String)
+)
+ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
+ORDER BY unique_key
+SETTINGS allow_nullable_key = 1, index_granularity = 8192
+;
+
+CREATE TABLE IF NOT EXISTS bronze_compass.teams
+(
+    `_airbyte_raw_id` String,
+    `_airbyte_extracted_at` DateTime64(3),
+    `_airbyte_meta` String,
+    `_airbyte_generation_id` UInt32,
+    `tenant_id` Nullable(String),
+    `source_id` Nullable(String),
+    `unique_key` Nullable(String),
+    `collected_at` Nullable(String),
+    `data_source` Nullable(String),
+    `team_id` Nullable(String),
+    `display_name` Nullable(String),
+    `description` Nullable(String),
+    `state` Nullable(String),
+    `organization_id` Nullable(String),
+    `member_count` Nullable(Int64),
+    `is_verified` Nullable(Bool)
+)
+ENGINE = ReplacingMergeTree(_airbyte_extracted_at)
+ORDER BY unique_key
+SETTINGS allow_nullable_key = 1, index_granularity = 8192
+;
+

--- a/src/ingestion/secrets/connectors/compass.yaml.example
+++ b/src/ingestion/secrets/connectors/compass.yaml.example
@@ -1,0 +1,23 @@
+# Atlassian Compass connector credentials.
+#
+# Copy to compass.yaml (gitignored), fill in real values, then:
+#   kubectl apply -f src/ingestion/secrets/connectors/compass.yaml
+#
+# The same Atlassian account email + API token that a Jira or Confluence
+# connector would use also works here — Compass and the Teams directory are on
+# the same account credential. Each connector still carries its own Secret.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: insight-compass-main
+  labels:
+    app.kubernetes.io/part-of: insight
+  annotations:
+    insight.cyberfabric.com/connector: compass
+    insight.cyberfabric.com/source-id: compass-main
+type: Opaque
+stringData:
+  atlassian_email: "CHANGE_ME"
+  atlassian_api_token: "CHANGE_ME"
+  # curl -s https://<your-site>.atlassian.net/_edge/tenant_info
+  atlassian_cloud_id: "CHANGE_ME"


### PR DESCRIPTION
Closes #2708.

**Why.** Nothing in Insight maps a repository to the team that owns it. Compass holds that mapping, and its owners are the same directory entities Jira's Team field points at.

**What changed.** A new `dev-portal/compass` nocode connector reads six streams — component catalog, scorecard definitions and results, the Atlassian Teams directory with membership, deployment events — from one GraphQL endpoint. Bronze-only; `dbt/` carries just the bronze→RMT promotion.

**Teams ship inside this connector, not their own.** Same host, credential and cadence; silver reads bronze tables rather than connectors, so later consumers still join them. Reversible by moving two streams.

**Not folded into the jira connector.** A descriptor is one version, schedule, namespace and secret, so folding would couple a tiny full-refresh source to a heavy tracker's blast radius — the rule `git/github-directory` records.

**The requester filters on the response body, and every paginator path is null-safe.** This API answers a rejected query with HTTP 200 plus `errors[]`, and returns unions where a `QueryError` member has no `pageInfo`. Both bit during live reads; SPEC.md carries the rest.

**Also fixes a wiring gap.** `collaboration/zoom` and `git/github-directory` ship mock suites but were missing from `connector-mock-tests` paths, so changing either did not re-run its own tests.

**Out of scope.** Silver — it needs a service-ownership concept silver lacks, plus the identity owners' call on a third org-structure representation. SPEC.md §7; tracked in #2708.

**Verified.** Both manifest validators pass, `connector_wiring.py` clean, 52 mock tests green, all six streams read against a live site. No deploy attempted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Atlassian Compass connector for components, scorecards, teams, team members, and deployment events.
  * Added daily synchronization, pagination, authentication, incremental deployment-event updates, and bronze data promotion.
  * Added connection configuration and example secret manifests.

* **Documentation**
  * Added setup, authentication, stream, synchronization, and data-model documentation.

* **Tests**
  * Added comprehensive mock coverage for pagination, retries, error handling, transformations, and incremental synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->